### PR TITLE
fix scaffolding allowing updating in same iteration as the create

### DIFF
--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -136,11 +136,8 @@ func (r *ReconcileStack) Reconcile(request reconcile.Request) (reconcile.Result,
 		}
 	} else if err != nil {
 		return reconcile.Result{}, err
-	}
-
-	// TODO(user): Change this for the object type created by your controller
-	// Update the found object and write the result back if there are any changes
-	if !reflect.DeepEqual(deploy.Spec, found.Spec) {
+	} else if !reflect.DeepEqual(deploy.Spec, found.Spec) {
+		// Update the found object and write the result back if there are any changes
 		found.Spec = deploy.Spec
 		log.Printf("Updating Deployment %s/%s\n", deploy.Namespace, deploy.Name)
 		err = r.Update(context.TODO(), found)
@@ -148,5 +145,6 @@ func (r *ReconcileStack) Reconcile(request reconcile.Request) (reconcile.Result,
 			return reconcile.Result{}, err
 		}
 	}
+
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
This would show up as an error on the form
```
{"level":"error","ts":1540996997.5346713,"logger":"kubebuilder.controller","caller":"controller/controller.go:209","msg":"Reconciler error","Controller":"stack-controller","Request":"default/stack-sample","error":"resource name may not be empty","stacktrace":"github.com/elastic/stack-operators/vendor/github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/nkvoll/Dev/go/stack-operators/src/github.com/elastic/stack-operators/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/elastic/stack-operators/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/nkvoll/Dev/go/stack-operators/src/github.com/elastic/stack-operators/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\ngithub.com/elastic/stack-operators/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/home/nkvoll/Dev/go/stack-operators/src/github.com/elastic/stack-operators/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:157\ngithub.com/elastic/stack-operators/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/home/nkvoll/Dev/go/stack-operators/src/github.com/elastic/stack-operators/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\ngithub.com/elastic/stack-operators/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/nkvoll/Dev/go/stack-operators/src/github.com/elastic/stack-operators/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\ngithub.com/elastic/stack-operators/vendor/k8s.io/apimachinery/pkg/util/wait.Until\n\t/home/nkvoll/Dev/go/stack-operators/src/github.com/elastic/stack-operators/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```

Because even if the resource was not found (thus created), the controller would attempt an update using an empty/invalid resource.