### PR TITLE
optionally delete the created deployment at the end of the test

### DIFF
--- a/pkg/apis/deployments/v1alpha1/v1alpha1_suite_test.go
+++ b/pkg/apis/deployments/v1alpha1/v1alpha1_suite_test.go
@@ -10,12 +10,15 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 var cfg *rest.Config
 var c client.Client
 
 func TestMain(m *testing.M) {
+	logf.SetLogger(logf.ZapLogger(false))
+
 	t := &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "..", "config", "crds")},
 	}

--- a/pkg/controller/stack/stack_controller_suite_test.go
+++ b/pkg/controller/stack/stack_controller_suite_test.go
@@ -14,11 +14,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 var cfg *rest.Config
 
 func TestMain(m *testing.M) {
+	logf.SetLogger(logf.ZapLogger(false))
+
 	t := &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
 	}

--- a/pkg/controller/stack/stack_controller_test.go
+++ b/pkg/controller/stack/stack_controller_test.go
@@ -72,7 +72,10 @@ func TestReconcile(t *testing.T) {
 	g.Eventually(func() error { return c.Get(context.TODO(), depKey, deploy) }, timeout).
 		Should(gomega.Succeed())
 
-	// Manually delete Deployment since GC isn't enabled in the test control plane
-	g.Expect(c.Delete(context.TODO(), deploy)).To(gomega.Succeed())
-
+	// Manually delete Deployment since GC might not be enabled in the test control plane
+	err = c.Delete(context.TODO(), deploy)
+	// If the resource is already deleted, we don't care, but any other error is important
+	if !apierrors.IsNotFound(err) {
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+	}
 }


### PR DESCRIPTION
Currently we're racing what /seems/ to be GC, this makes the delete optional.

Aaand as a side effect it also sets up logging for the integration tests, which is kind of nice to have if they are failing.