### PR TITLE
Fix integration tests for ES pods

### DIFF
--- a/pkg/controller/stack/stack_controller_test.go
+++ b/pkg/controller/stack/stack_controller_test.go
@@ -25,7 +25,7 @@ import (
 var c client.Client
 
 var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "default"}}
-var depKey = types.NamespacedName{Name: "foo-es", Namespace: "default"}
+var kibanaDeploymentKey = types.NamespacedName{Name: "foo-kibana", Namespace: "default"}
 var discoveryServiceKey = types.NamespacedName{Name: "foo-es-discovery", Namespace: "default"}
 var publicServiceKey = types.NamespacedName{Name: "foo-es-public", Namespace: "default"}
 
@@ -44,12 +44,24 @@ func checkResourceDeletionTriggersReconcile(t *testing.T, requests chan reconcil
 	test.RetryUntilSuccess(t, func() error { return c.Get(context.TODO(), objKey, obj) })
 }
 
+func getESPods(t *testing.T) []corev1.Pod {
+	esPods := &corev1.PodList{}
+	esPodSelector := client.ListOptions{Namespace: "default"}
+	err := esPodSelector.SetLabelSelector("stack.k8s.elastic.co/type=elasticsearch")
+	assert.NoError(t, err)
+	test.RetryUntilSuccess(t, func() error {
+		return c.List(context.TODO(), &esPodSelector, esPods)
+	})
+	return esPods.Items
+}
+
 func TestReconcile(t *testing.T) {
 	instance := &deploymentsv1alpha1.Stack{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
 		Spec: deploymentsv1alpha1.StackSpec{
 			Elasticsearch: deploymentsv1alpha1.ElasticsearchSpec{
 				SetVMMaxMapCount: false,
+				NodeCount:        3,
 			},
 		},
 	}
@@ -83,9 +95,13 @@ func TestReconcile(t *testing.T) {
 
 	checkReconcileCalled(t, requests)
 
-	// Deployment should be created
+	// Elasticsearch pods should be created
+	esPods := getESPods(t)
+	assert.Equal(t, 3, len(esPods))
+
+	// Kibana deployment should be created
 	deploy := &appsv1.Deployment{}
-	test.RetryUntilSuccess(t, func() error { return c.Get(context.TODO(), depKey, deploy) })
+	test.RetryUntilSuccess(t, func() error { return c.Get(context.TODO(), kibanaDeploymentKey, deploy) })
 
 	// Services should be created
 	discoveryService := &corev1.Service{}
@@ -93,9 +109,20 @@ func TestReconcile(t *testing.T) {
 	publicService := &corev1.Service{}
 	test.RetryUntilSuccess(t, func() error { return c.Get(context.TODO(), publicServiceKey, publicService) })
 
-	// Delete the Deployment and expect Reconcile to be called for Deployment deletion
-	checkResourceDeletionTriggersReconcile(t, requests, depKey, deploy)
-	// Same for services
+	// Delete resources and expect Reconcile to be called and eventually recreate them
+	// ES pod
+	assert.NoError(t, c.Delete(context.TODO(), &esPods[0]))
+	checkReconcileCalled(t, requests)
+	test.RetryUntilSuccess(t, func() error {
+		nPods := len(getESPods(t))
+		if nPods != 3 {
+			return fmt.Errorf("Got %d pods out of 3", nPods)
+		}
+		return nil
+	})
+	// Kibana
+	checkResourceDeletionTriggersReconcile(t, requests, kibanaDeploymentKey, deploy)
+	// Services
 	checkResourceDeletionTriggersReconcile(t, requests, publicServiceKey, publicService)
 	checkResourceDeletionTriggersReconcile(t, requests, discoveryServiceKey, discoveryService)
 


### PR DESCRIPTION
Integration tests were broken, since we replaced ES deployments by a set of pods.
This should fix that by correctly checking for ES pods.
We now also check Kibana deployment.