### PR TITLE
kibana: Add deployment spec defaults.

### DIFF
--- a/pkg/controller/stack/common/int.go
+++ b/pkg/controller/stack/common/int.go
@@ -1,0 +1,7 @@
+package common
+
+// Int32 returns a pointer to an Int32
+func Int32(v int32) *int32 { return &v }
+
+// Int64 returns a pointer to an Int64
+func Int64(v int32) *int32 { return &v }


### PR DESCRIPTION
This change updates the Kibana Deployment spec so that it includes the
default fields that weren't explicitly specified until now, which caused
the deployment to be updated on each reconcile cycle.
