### PR TITLE
Check that cluster can be reached before allocation exclude

### DIFF
--- a/pkg/controller/stack/service_control.go
+++ b/pkg/controller/stack/service_control.go
@@ -6,6 +6,7 @@ import (
 
 	deploymentsv1alpha1 "github.com/elastic/stack-operators/pkg/apis/deployments/v1alpha1"
 	"github.com/elastic/stack-operators/pkg/controller/stack/common"
+	"github.com/elastic/stack-operators/pkg/controller/stack/elasticsearch"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -67,4 +68,23 @@ func (r *ReconcileStack) reconcileService(stack *deploymentsv1alpha1.Stack, serv
 		}
 	}
 	return reconcile.Result{}, nil
+}
+
+// IsPublicServiceReady checks if Elasticsearch public service is ready,
+// so that the ES cluster can respond to HTTP requests.
+// Here we just check that the service has endpoints to route requests to.
+func (r *ReconcileStack) IsPublicServiceReady(s deploymentsv1alpha1.Stack) (bool, error) {
+	endpoints := corev1.Endpoints{}
+	publicService := elasticsearch.NewPublicService(s).ObjectMeta
+	namespacedName := types.NamespacedName{Namespace: publicService.Namespace, Name: publicService.Name}
+	err := r.Get(context.TODO(), namespacedName, &endpoints)
+	if err != nil {
+		return false, err
+	}
+	for _, subs := range endpoints.Subsets {
+		if len(subs.Addresses) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }


### PR DESCRIPTION
When a cluster was just created, we return an error for trying to set
the shard allocation exclude setting:

"error":"Error during migrate data: Put http://192.168.99.100:30212/_cluster/settings: dial tcp 192.168.99.100:30212: connect: connection refused"

This adds a way to check that the service is ready, and requeue the reconciliation
if the service is not ready yet, instead of throwing an error.

#### Related issues
Closes #73