### PR TITLE
Run as unprivileged if VMMaxMapCount does not need to be tweaked

### DIFF
--- a/pkg/controller/stack/elasticsearch/initcontainer/container.go
+++ b/pkg/controller/stack/elasticsearch/initcontainer/container.go
@@ -16,6 +16,11 @@ const (
 // - install extra plugins
 func NewInitContainer(imageName string, setVMMaxMapCount bool, linkedFiles LinkedFilesArray) (corev1.Container, error) {
 	initContainerPrivileged := defaultInitContainerPrivileged
+	if !setVMMaxMapCount {
+		// No need to run as privileged container if VMMaxMapCount
+		// should not be tweaked
+		initContainerPrivileged = false
+	}
 	initContainerRunAsUser := defaultInitContainerRunAsUser
 	script, err := RenderScriptTemplate(TemplateParams{
 		SetVMMaxMapCount: setVMMaxMapCount,


### PR DESCRIPTION
This should fix the following error on integration tests:
```
"error":"Pod \"foo-es-9qzk98k4rt\" is i
nvalid: spec.initContainers[0].securityContext.privileged: Forbidden: disallowed by cluster policy"
```

Note that another way to solve that issue would be to pass the `--allow-privileged`
flag to kubebuilder apiserver test binary.
Overriding the apiserver flags is supported since commit
https://github.com/kubernetes-sigs/controller-runtime/commit/d0ead8189cd314afc9d430bd19c09ab610464050
This commit should probably come with controller-runtime v0.1.8 (not released yet).