### PR TITLE
Add show-credentials target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,3 +212,8 @@ start-port-forward:
 stop-port-forward:
 	@ kill -9 $$(ps -ef | grep 'kubectl port-forward' | grep -v 'grep ' | awk '{print $$2}')
 	@ echo "-> Stopped."
+
+.PHONY: show-credentials
+show-credentials:
+	@ echo "elastic:"$$(kubectl get secret $(DEV_STACK_NAME)-elastic-user -o json | jq -r '.data.elastic' | base64  -D)
+


### PR DESCRIPTION
Shows the current credentials for the built-in `elastic` user in the dev stack deployment