### PR TITLE
Reduce the number of status updates by diffing against the current state

### DIFF
--- a/pkg/controller/stack/state/state.go
+++ b/pkg/controller/stack/state/state.go
@@ -55,15 +55,15 @@ func availableElasticsearchNodes(pods []corev1.Pod) int {
 // UpdateElasticsearchState updates the Elasticsearch section of the state resource status based on the given pods.
 func (s ReconcileState) UpdateElasticsearchState(pods []corev1.Pod, esClient *client.Client) error {
 	s.Stack.Status.Elasticsearch.AvailableNodes = availableElasticsearchNodes(pods)
-	s.Stack.Status.Elasticsearch.Health = v1alpha1.ElasticsearchHealth("Unknown")
-	health, err := esClient.GetClusterHealth(context.TODO())
-	if err == nil {
-		s.Stack.Status.Elasticsearch.Health = v1alpha1.ElasticsearchHealth(health.Status)
-	}
-
+	s.Stack.Status.Elasticsearch.Health = v1alpha1.ElasticsearchHealth("unknown")
 	if s.Stack.Status.Elasticsearch.Phase == "" {
 		s.Stack.Status.Elasticsearch.Phase = v1alpha1.ElasticsearchOperationalPhase
 	}
+	health, err := esClient.GetClusterHealth(context.TODO())
+	if err != nil {
+		return err
+	}
+	s.Stack.Status.Elasticsearch.Health = v1alpha1.ElasticsearchHealth(health.Status)
 	return nil
 
 }


### PR DESCRIPTION
Currently we are doing a status update on every iteration. 

This PR changes this by re-fetching the current state and comparing with the accumulated state.