### PR TITLE
Temporarily disable snapshots plugins

### DIFF
--- a/pkg/controller/stack/elasticsearch/initcontainer/script.go
+++ b/pkg/controller/stack/elasticsearch/initcontainer/script.go
@@ -7,8 +7,9 @@ import (
 
 // List of plugins to be installed on the ES instance
 var defaultInstalledPlugins = []string{
-	"repository-s3",  // S3 snapshots
-	"repository-gcs", // gcp snapshots
+	// TODO: enable when useful :)
+	// "repository-s3",  // S3 snapshots
+	// "repository-gcs", // gcp snapshots
 }
 
 // TemplateParams are the parameters manipulated in the scriptTemplate


### PR DESCRIPTION
These could be re-enabled when needed.
Meanwhile, this will speed up ES container startup time.