### PR TITLE
Disable unit tests for disabled plugins

### DIFF
--- a/pkg/controller/stack/elasticsearch/initcontainer/script_test.go
+++ b/pkg/controller/stack/elasticsearch/initcontainer/script_test.go
@@ -25,8 +25,9 @@ func TestRenderScriptTemplate(t *testing.T) {
 							Target: "/usr/share/elasticsearch/users"}}},
 			},
 			wantSubstr: []string{
-				"$PLUGIN_BIN install --batch repository-s3",
-				"$PLUGIN_BIN install --batch repository-gcs",
+				// TODO: re-enable when these are used
+				// "$PLUGIN_BIN install --batch repository-s3",
+				// "$PLUGIN_BIN install --batch repository-gcs",
 				"mv /usr/share/elasticsearch/config/* /volume/config/",
 				"mv /usr/share/elasticsearch/bin/* /volume/bin/",
 				"mv /usr/share/elasticsearch/plugins/* /volume/plugins/",


### PR DESCRIPTION
A previous commit disabled the plugins from the script, let's also
disable them in unit tests.