### PR TITLE
rolling update the Kibana deployment when the cluster ca changes

### DIFF
--- a/pkg/controller/stack/deployment_control.go
+++ b/pkg/controller/stack/deployment_control.go
@@ -27,6 +27,7 @@ type DeploymentParams struct {
 	Namespace string
 	Selector  map[string]string
 	Labels    map[string]string
+	PodLabels map[string]string
 	Replicas  int32
 	PodSpec   corev1.PodSpec
 }
@@ -54,7 +55,7 @@ func NewDeployment(params DeploymentParams) appsv1.Deployment {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: params.Labels,
+					Labels: params.PodLabels,
 				},
 				Spec: params.PodSpec,
 			},


### PR DESCRIPTION
Kibana does not support reloading this without a restart.

This PR adds a hash of the ca.pem file to the env variables of the instances, causing it to perform a rolling update if the ca changes.