### PR TITLE
remove liveness probe from kibana podspec

### DIFF
--- a/pkg/controller/stack/kibana/pod.go
+++ b/pkg/controller/stack/kibana/pod.go
@@ -78,7 +78,6 @@ func NewPodSpec(p PodSpecParams) corev1.PodSpec {
 			Ports: []corev1.ContainerPort{
 				{Name: "http", ContainerPort: int32(HTTPPort), Protocol: corev1.ProtocolTCP},
 			},
-			LivenessProbe:  probe,
 			ReadinessProbe: probe,
 		}},
 	}


### PR DESCRIPTION
This currently keeps crashing Kibana if e.g ES fails behind the scenes.