### PR TITLE
Fix driver client socket init

### DIFF
--- a/local-volume/cmd/driverclient/init.go
+++ b/local-volume/cmd/driverclient/init.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/elastic/stack-operators/local-volume/pkg/driver/client"
 	"github.com/spf13/cobra"
@@ -15,6 +14,6 @@ func init() {
 var initCmd = &cobra.Command{
 	Use: "init",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(client.Init(client.NewCaller(&http.Client{})))
+		fmt.Println(client.Init(client.NewCaller()))
 	},
 }

--- a/local-volume/cmd/driverclient/mount.go
+++ b/local-volume/cmd/driverclient/mount.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/elastic/stack-operators/local-volume/pkg/driver/client"
 	"github.com/spf13/cobra"
@@ -17,7 +16,7 @@ var mountCmd = &cobra.Command{
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(
-			client.Mount(client.NewCaller(&http.Client{}), args),
+			client.Mount(client.NewCaller(), args),
 		)
 	},
 }

--- a/local-volume/cmd/driverclient/unmount.go
+++ b/local-volume/cmd/driverclient/unmount.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/elastic/stack-operators/local-volume/pkg/driver/client"
 	"github.com/spf13/cobra"
@@ -17,7 +16,7 @@ var unmountCmd = &cobra.Command{
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(
-			client.Unmount(client.NewCaller(&http.Client{}), args),
+			client.Unmount(client.NewCaller(), args),
 		)
 	},
 }

--- a/local-volume/pkg/driver/client/caller.go
+++ b/local-volume/pkg/driver/client/caller.go
@@ -27,8 +27,8 @@ type Caller struct {
 }
 
 // NewCaller returns a fully initialized HTTP Caller
-func NewCaller(c *http.Client) Caller {
-	return Caller{client: c}
+func NewCaller() Caller {
+	return Caller{client: NewSocketHTTPClient(nil)}
 }
 
 // NewSocketHTTPClient creates a new http.Client with either an explicit set of


### PR DESCRIPTION
Funny that adding some unit tests actually broke the client 😄

NewSocketHTTPClient() was never called, so the client never used the correct socket configuration.