### PR TITLE
Add support for the elastic category.

### DIFF
--- a/stack-operator/config/crds/deployments_v1alpha1_stack.yaml
+++ b/stack-operator/config/crds/deployments_v1alpha1_stack.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: deployments.k8s.elastic.co
   names:
+    categories:
+    - elastic
     kind: Stack
     plural: stacks
   scope: Namespaced

--- a/stack-operator/config/crds/elasticsearch_v1alpha1_elasticsearchcluster.yaml
+++ b/stack-operator/config/crds/elasticsearch_v1alpha1_elasticsearchcluster.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: elasticsearch.k8s.elastic.co
   names:
+    categories:
+    - elastic
     kind: ElasticsearchCluster
     plural: elasticsearchclusters
   scope: Namespaced

--- a/stack-operator/config/crds/kibana_v1alpha1_kibana.yaml
+++ b/stack-operator/config/crds/kibana_v1alpha1_kibana.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: kibana.k8s.elastic.co
   names:
+    categories:
+    - elastic
     kind: Kibana
     plural: kibanas
   scope: Namespaced

--- a/stack-operator/pkg/apis/deployments/v1alpha1/stack_types.go
+++ b/stack-operator/pkg/apis/deployments/v1alpha1/stack_types.go
@@ -39,6 +39,10 @@ type StackStatus struct {
 // Stack is the Schema for the stacks API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:categories=elastic
+// +kubebuilder:printcolumn:name="es",type="string",JSONPath=".status.elasticsearch.health",description="Elasticsearch health"
+// +kubebuilder:printcolumn:name="kibana",type="string",JSONPath=".status.kibana.health",description="Kibana health"
+// +kubebuilder:printcolumn:name="age",type="string",JSONPath=".metadata.creationTimestamp"
 type Stack struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/stack-operator/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
+++ b/stack-operator/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
@@ -180,6 +180,11 @@ func (es ElasticsearchStatus) IsDegraded(prev ElasticsearchStatus) bool {
 // ElasticsearchCluster is the Schema for the elasticsearches API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:categories=elastic
+// +kubebuilder:printcolumn:name="health",type="string",JSONPath=".status.health"
+// +kubebuilder:printcolumn:name="nodes",type="integer",JSONPath=".status.availableNodes",description="Available nodes"
+// +kubebuilder:printcolumn:name="phase",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="age",type="string",JSONPath=".metadata.creationTimestamp"
 type ElasticsearchCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/stack-operator/pkg/apis/kibana/v1alpha1/kibana_types.go
+++ b/stack-operator/pkg/apis/kibana/v1alpha1/kibana_types.go
@@ -83,7 +83,11 @@ func (ks KibanaStatus) IsDegraded(prev KibanaStatus) bool {
 
 // Kibana is the Schema for the kibanas API
 // +k8s:openapi-gen=true
+// +kubebuilder:categories=elastic
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="health",type="string",JSONPath=".status.health"
+// +kubebuilder:printcolumn:name="nodes",type="integer",JSONPath=".status.availableNodes",description="Available nodes"
+// +kubebuilder:printcolumn:name="age",type="string",JSONPath=".metadata.creationTimestamp"
 type Kibana struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
This enables using `kubectl get elastic` to list our CRDs easily as a single category:

```
$ kubectl get elastic
NAME                                            AGE
stack.deployments.k8s.elastic.co/stack-sample   17h

NAME                                                             AGE
elasticsearchcluster.elasticsearch.k8s.elastic.co/stack-sample   17h

NAME                                        AGE
kibana.kibana.k8s.elastic.co/stack-sample   17h
```

Once `printcolumns` support lands in a release (it's in master of controller-tools), we'll also get some more details out of this. Age is still not relative until `printcolumns` gets support for the `date` type, so it's a string for now.

```
$ kubectl get elastic
NAME                                            ES      KIBANA   AGE
stack.deployments.k8s.elastic.co/stack-sample   green   green    2018-11-29T20:39:02Z

NAME                                                             HEALTH   NODES   PHASE         AGE
elasticsearchcluster.elasticsearch.k8s.elastic.co/stack-sample   green    3       Operational   2018-11-29T20:44:07Z

NAME                                        HEALTH   NODES   AGE
kibana.kibana.k8s.elastic.co/stack-sample   green    1       2018-11-29T20:48:52Z
```