### PR TITLE
Add NamespacedName and ObjectMeta utils

### DIFF
--- a/stack-operator/cmd/certificate-initializer/main.go
+++ b/stack-operator/cmd/certificate-initializer/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	certs "k8s.io/api/certificates/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -110,10 +111,7 @@ func main() {
 	}
 
 	csr := certs.CertificateSigningRequest{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      podName,
-			Namespace: namespace,
-		},
+		ObjectMeta: k8s.ObjectMeta(namespace, podName),
 		Spec: certs.CertificateSigningRequestSpec{
 			Request: csrBytes,
 		},

--- a/stack-operator/pkg/apis/deployments/v1alpha1/stack_types.go
+++ b/stack-operator/pkg/apis/deployments/v1alpha1/stack_types.go
@@ -4,7 +4,9 @@ import (
 	commonv1alpha1 "github.com/elastic/stack-operators/stack-operator/pkg/apis/common/v1alpha1"
 	elasticsearchv1alpha1 "github.com/elastic/stack-operators/stack-operator/pkg/apis/elasticsearch/v1alpha1"
 	kibanav1alpha1 "github.com/elastic/stack-operators/stack-operator/pkg/apis/kibana/v1alpha1"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // StackSpec defines the desired state of a Stack
@@ -49,6 +51,11 @@ type Stack struct {
 
 	Spec   StackSpec   `json:"spec,omitempty"`
 	Status StackStatus `json:"status,omitempty"`
+}
+
+// NamespacedName returns a NamespacedName to reference this stack
+func (s Stack) NamespacedName() types.NamespacedName {
+	return k8s.ToNamespacedName(s.ObjectMeta)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/stack-operator/pkg/apis/deployments/v1alpha1/stack_types_test.go
+++ b/stack-operator/pkg/apis/deployments/v1alpha1/stack_types_test.go
@@ -5,22 +5,14 @@ package v1alpha1
 import (
 	"testing"
 
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestStorageStack(t *testing.T) {
-	key := types.NamespacedName{
-		Name:      "foo",
-		Namespace: "default",
-	}
-	created := &Stack{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo",
-			Namespace: "default",
-		}}
+	key := k8s.NamespacedName(k8s.DefaultNamespace, "foo")
+	created := &Stack{ObjectMeta: k8s.ObjectMeta(k8s.DefaultNamespace, "foo")}
 
 	// Test Create
 	fetched := &Stack{}

--- a/stack-operator/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types_test.go
+++ b/stack-operator/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types_test.go
@@ -5,25 +5,18 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestStorageElasticsearch(t *testing.T) {
-	key := types.NamespacedName{
-		Name:      "foo",
-		Namespace: "default",
-	}
+	key := k8s.NamespacedName(k8s.DefaultNamespace, "foo")
 	created := &ElasticsearchCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo",
-			Namespace: "default",
-		},
-		Spec: ElasticsearchSpec{},
+		ObjectMeta: k8s.ObjectMeta(k8s.DefaultNamespace, "foo"),
+		Spec:       ElasticsearchSpec{},
 	}
 	g := gomega.NewGomegaWithT(t)
 

--- a/stack-operator/pkg/apis/kibana/v1alpha1/kibana_types_test.go
+++ b/stack-operator/pkg/apis/kibana/v1alpha1/kibana_types_test.go
@@ -3,22 +3,16 @@ package v1alpha1
 import (
 	"testing"
 
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestStorageKibana(t *testing.T) {
-	key := types.NamespacedName{
-		Name:      "foo",
-		Namespace: "default",
-	}
+	key := k8s.NamespacedName(k8s.DefaultNamespace, "foo")
 	created := &Kibana{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo",
-			Namespace: "default",
-		}}
+		ObjectMeta: k8s.ObjectMeta(k8s.DefaultNamespace, "foo"),
+	}
 	g := gomega.NewGomegaWithT(t)
 
 	// Test Create

--- a/stack-operator/pkg/controller/common/nodecerts/ca.go
+++ b/stack-operator/pkg/controller/common/nodecerts/ca.go
@@ -12,6 +12,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -132,10 +133,7 @@ func (c *Ca) ReconcilePublicCertsSecret(
 		return err
 	} else if apierrors.IsNotFound(err) {
 		clusterCASecret = corev1.Secret{
-			ObjectMeta: v1.ObjectMeta{
-				Name:      objectKey.Name,
-				Namespace: objectKey.Namespace,
-			},
+			ObjectMeta: k8s.ToObjectMeta(objectKey),
 			Data: map[string][]byte{
 				SecretCAKey: expectedCaKeyBytes,
 			},

--- a/stack-operator/pkg/controller/common/nodecerts/secrets.go
+++ b/stack-operator/pkg/controller/common/nodecerts/secrets.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common/nodecerts/certutil"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -64,7 +65,7 @@ const (
 // a given pod.
 func NodeCertificateSecretObjectKeyForPod(pod corev1.Pod) types.NamespacedName {
 	// TODO: trim and suffix?
-	return types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
+	return k8s.NamespacedName(pod.Namespace, pod.Name)
 }
 
 // EnsureNodeCertificateSecretExists ensures that the corev1.Secret that at a later point in time will contain the node

--- a/stack-operator/pkg/controller/common/nodecerts/secrets_test.go
+++ b/stack-operator/pkg/controller/common/nodecerts/secrets_test.go
@@ -7,24 +7,19 @@ import (
 
 	"github.com/elastic/stack-operators/stack-operator/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common/nodecerts/certutil"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_createValidatedCertificateTemplate(t *testing.T) {
 	es := v1alpha1.ElasticsearchCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-es-name",
-			Namespace: "test-namespace",
-		},
+		ObjectMeta: k8s.ObjectMeta("test-namespace", "test-es-name"),
 	}
 	testIp := "1.2.3.4"
 	pod := v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-pod-name",
-		},
+		ObjectMeta: k8s.ObjectMeta("", "test-pod-name"),
 		Status: v1.PodStatus{
 			PodIP: testIp,
 		},
@@ -35,10 +30,7 @@ func Test_createValidatedCertificateTemplate(t *testing.T) {
 	}
 
 	svc := v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-service",
-			Namespace: "default",
-		},
+		ObjectMeta: k8s.ObjectMeta(k8s.DefaultNamespace, "test-service"),
 		Spec: v1.ServiceSpec{
 			ClusterIP: "2.2.3.3",
 		},

--- a/stack-operator/pkg/controller/common/service_control.go
+++ b/stack-operator/pkg/controller/common/service_control.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -30,7 +30,7 @@ func ReconcileService(
 	// Check if already exists
 	expected := service
 	found := &corev1.Service{}
-	err := c.Get(context.TODO(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, found)
+	err := c.Get(context.TODO(), k8s.ToNamespacedName(expected.ObjectMeta), found)
 	if err != nil && errors.IsNotFound(err) {
 		// Create if needed
 		log.Info(Concat("Creating service ", expected.Namespace, "/", expected.Name))

--- a/stack-operator/pkg/controller/common/stack_test.go
+++ b/stack-operator/pkg/controller/common/stack_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	deploymentsv1alpha1 "github.com/elastic/stack-operators/stack-operator/pkg/apis/deployments/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 )
 
 func TestStackID(t *testing.T) {
@@ -20,19 +20,13 @@ func TestStackID(t *testing.T) {
 	}{
 		{
 			args: args{s: deploymentsv1alpha1.Stack{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "my-stack",
-					Namespace: "default",
-				},
+				ObjectMeta: k8s.ObjectMeta(k8s.DefaultNamespace, "my-stack"),
 			}},
 			want: "default-my-stack",
 		},
 		{
 			args: args{s: deploymentsv1alpha1.Stack{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "my-other-stack",
-					Namespace: "default",
-				},
+				ObjectMeta: k8s.ObjectMeta(k8s.DefaultNamespace, "my-other-stack"),
 			}},
 			want: "default-my-other-stack",
 		},

--- a/stack-operator/pkg/controller/elasticsearch/elasticsearch_controller_test.go
+++ b/stack-operator/pkg/controller/elasticsearch/elasticsearch_controller_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/elastic/stack-operators/stack-operator/pkg/apis/elasticsearch/v1alpha1"
 	elasticsearchv1alpha1 "github.com/elastic/stack-operators/stack-operator/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	"github.com/elastic/stack-operators/stack-operator/pkg/utils/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,7 +16,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -23,9 +23,9 @@ import (
 
 var c client.Client
 
-var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "default"}}
-var discoveryServiceKey = types.NamespacedName{Name: "foo-es-discovery", Namespace: "default"}
-var publicServiceKey = types.NamespacedName{Name: "foo-es-public", Namespace: "default"}
+var expectedRequest = reconcile.Request{NamespacedName: k8s.NamespacedName(k8s.DefaultNamespace, "foo")}
+var discoveryServiceKey = k8s.NamespacedName(k8s.DefaultNamespace, "foo-es-discovery")
+var publicServiceKey = k8s.NamespacedName(k8s.DefaultNamespace, "foo-es-public")
 
 func getESPods(t *testing.T) []corev1.Pod {
 	esPods := &corev1.PodList{}
@@ -40,7 +40,7 @@ func getESPods(t *testing.T) []corev1.Pod {
 
 func TestReconcile(t *testing.T) {
 	instance := &elasticsearchv1alpha1.ElasticsearchCluster{
-		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+		ObjectMeta: k8s.ObjectMeta(k8s.DefaultNamespace, "foo")
 		Spec: elasticsearchv1alpha1.ElasticsearchSpec{
 			Version:          "7.0.0",
 			SetVMMaxMapCount: false,
@@ -72,7 +72,7 @@ func TestReconcile(t *testing.T) {
 	}()
 
 	// Pre-create dependent Endpoint which will not be created automatically as only the Elasticsearch controller is running.
-	endpoints := &corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "foo-es-public", Namespace: "default"}}
+	endpoints := &corev1.Endpoints{ObjectMeta: k8s.ObjectMeta(k8s.DefaultNamespace, "foo-es-public")}
 	err = c.Create(context.TODO(), endpoints)
 	assert.NoError(t, err)
 	// Create the Elasticsearch object and expect the Reconcile and Deployment to be created

--- a/stack-operator/pkg/controller/elasticsearch/mutation/changeset_test.go
+++ b/stack-operator/pkg/controller/elasticsearch/mutation/changeset_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/elastic/stack-operators/stack-operator/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/elasticsearch/support"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -22,9 +23,7 @@ func init() {
 
 func namedPod(name string) corev1.Pod {
 	return corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{
-			Name: name,
-		},
+		ObjectMeta: k8s.ObjectMeta("", name),
 	}
 }
 

--- a/stack-operator/pkg/controller/elasticsearch/support/comparison_test.go
+++ b/stack-operator/pkg/controller/elasticsearch/support/comparison_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 
 	"github.com/elastic/stack-operators/stack-operator/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func ESPod(image string, cpuLimit string) corev1.Pod {
@@ -190,9 +190,7 @@ func Test_podMatchesSpec(t *testing.T) {
 					TopologySpec: v1alpha1.ElasticsearchTopologySpec{
 						VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
 							{
-								ObjectMeta: v1.ObjectMeta{
-									Name: "test",
-								},
+								ObjectMeta: k8s.ObjectMeta("", "test"),
 							},
 						},
 					},
@@ -211,9 +209,7 @@ func Test_podMatchesSpec(t *testing.T) {
 					TopologySpec: v1alpha1.ElasticsearchTopologySpec{
 						VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
 							{
-								ObjectMeta: v1.ObjectMeta{
-									Name: "test",
-								},
+								ObjectMeta: k8s.ObjectMeta("", "test"),
 							},
 						},
 					},
@@ -221,7 +217,7 @@ func Test_podMatchesSpec(t *testing.T) {
 				state: ResourcesState{
 					PVCs: []corev1.PersistentVolumeClaim{
 						{
-							ObjectMeta: v1.ObjectMeta{Name: "claim-foo"},
+							ObjectMeta: k8s.ObjectMeta("", "claim-foo"),
 						},
 					},
 				},
@@ -239,9 +235,7 @@ func Test_podMatchesSpec(t *testing.T) {
 					TopologySpec: v1alpha1.ElasticsearchTopologySpec{
 						VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
 							{
-								ObjectMeta: v1.ObjectMeta{
-									Name: "foo",
-								},
+								ObjectMeta: k8s.ObjectMeta("", "foo"),
 							},
 						},
 					},
@@ -249,7 +243,7 @@ func Test_podMatchesSpec(t *testing.T) {
 				state: ResourcesState{
 					PVCs: []corev1.PersistentVolumeClaim{
 						{
-							ObjectMeta: v1.ObjectMeta{Name: "claim-foo"},
+							ObjectMeta: k8s.ObjectMeta("", "claim-foo"),
 						},
 					},
 				},
@@ -266,9 +260,7 @@ func Test_podMatchesSpec(t *testing.T) {
 					TopologySpec: v1alpha1.ElasticsearchTopologySpec{
 						VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
 							{
-								ObjectMeta: v1.ObjectMeta{
-									Name: "foo",
-								},
+								ObjectMeta: k8s.ObjectMeta("", "foo"),
 								Spec: corev1.PersistentVolumeClaimSpec{
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
@@ -283,7 +275,7 @@ func Test_podMatchesSpec(t *testing.T) {
 				state: ResourcesState{
 					PVCs: []corev1.PersistentVolumeClaim{
 						{
-							ObjectMeta: v1.ObjectMeta{Name: "claim-foo"},
+							ObjectMeta: k8s.ObjectMeta("", "claim-foo"),
 						},
 					},
 				},

--- a/stack-operator/pkg/controller/elasticsearch/support/secret_test.go
+++ b/stack-operator/pkg/controller/elasticsearch/support/secret_test.go
@@ -6,20 +6,18 @@ import (
 	"testing"
 
 	"github.com/elastic/stack-operators/stack-operator/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/elasticsearch/client"
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
 	testES = v1alpha1.ElasticsearchCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-es",
-			Namespace: "default",
-		}}
+		ObjectMeta: k8s.ObjectMeta(k8s.DefaultNamespace, "my-es"),
+	}
 	testUser = []client.User{client.User{Name: "foo", Password: "bar"}}
 )
 

--- a/stack-operator/pkg/controller/elasticsearch/support/services_test.go
+++ b/stack-operator/pkg/controller/elasticsearch/support/services_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/elastic/stack-operators/stack-operator/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestPublicServiceURL(t *testing.T) {
@@ -21,20 +21,14 @@ func TestPublicServiceURL(t *testing.T) {
 		{
 			name: "A service URL",
 			args: args{es: v1alpha1.ElasticsearchCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "an-es-name",
-					Namespace: "default",
-				},
+				ObjectMeta: k8s.ObjectMeta(k8s.DefaultNamespace, "an-es-name"),
 			}},
 			want: "https://an-es-name-es-public.default.svc.cluster.local:9200",
 		},
 		{
 			name: "Another Service URL",
 			args: args{es: v1alpha1.ElasticsearchCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "another-es-name",
-					Namespace: "default",
-				},
+				ObjectMeta: k8s.ObjectMeta(k8s.DefaultNamespace, "another-es-name"),
 			}},
 			want: "https://another-es-name-es-public.default.svc.cluster.local:9200",
 		},

--- a/stack-operator/pkg/controller/elasticsearch/user_control.go
+++ b/stack-operator/pkg/controller/elasticsearch/user_control.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/elastic/stack-operators/stack-operator/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/elasticsearch/support"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/elasticsearch/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -12,7 +13,6 @@ import (
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 // InternalUsers are Elasticsearch users intended for system use.
@@ -78,7 +78,7 @@ func (r *ReconcileElasticsearch) reconcileSecret(es *v1alpha1.ElasticsearchClust
 		return err
 	}
 	found := &corev1.Secret{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, found)
+	err := r.Get(context.TODO(), k8s.ToNamespacedName(expected.ObjectMeta), found)
 	if err != nil && errors.IsNotFound(err) {
 		log.Info(common.Concat("Creating secret ", expected.Namespace, "/", expected.Name),
 			"iteration", r.iteration,

--- a/stack-operator/pkg/controller/elasticsearch/version/strategy_6_4_0_test.go
+++ b/stack-operator/pkg/controller/elasticsearch/version/strategy_6_4_0_test.go
@@ -7,16 +7,13 @@ import (
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common/version"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/elasticsearch/client"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/elasticsearch/support"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var testProbeUser = client.User{Name: "username", Password: "supersecure"}
-var testObjectMeta = v1.ObjectMeta{
-	Name:      "my-es",
-	Namespace: "default",
-}
+var testObjectMeta = k8s.ObjectMeta(k8s.DefaultNamespace, "my-es")
 
 var testStrategy_6_4_0 = newStrategy_6_4_0(version.Version{Major: 6, Minor: 4, Patch: 2})
 

--- a/stack-operator/pkg/controller/kibana/deployment_control.go
+++ b/stack-operator/pkg/controller/kibana/deployment_control.go
@@ -5,11 +5,11 @@ import (
 	"reflect"
 
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -59,7 +59,7 @@ func (r *ReconcileKibana) ReconcileDeployment(deploy appsv1.Deployment, owner me
 
 	// Check if the Deployment already exists
 	found := appsv1.Deployment{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}, &found)
+	err := r.Get(context.TODO(), k8s.ToNamespacedName(deploy.ObjectMeta), &found)
 	if err != nil && errors.IsNotFound(err) {
 		log.Info(
 			common.Concat("Creating Deployment ", deploy.Namespace, "/", deploy.Name),

--- a/stack-operator/pkg/controller/kibana/deployment_test.go
+++ b/stack-operator/pkg/controller/kibana/deployment_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/elastic/stack-operators/stack-operator/pkg/apis/kibana/v1alpha1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 )
 
 func TestPseudoNamespacedResourceName(t *testing.T) {
@@ -17,11 +17,11 @@ func TestPseudoNamespacedResourceName(t *testing.T) {
 		want string
 	}{
 		{
-			args: args{kibana: v1alpha1.Kibana{ObjectMeta: v1.ObjectMeta{Name: "a-name"}}},
+			args: args{kibana: v1alpha1.Kibana{ObjectMeta: k8s.ObjectMeta("", "a-name")}},
 			want: "a-name-kibana",
 		},
 		{
-			args: args{kibana: v1alpha1.Kibana{ObjectMeta: v1.ObjectMeta{Name: "another-name"}}},
+			args: args{kibana: v1alpha1.Kibana{ObjectMeta: k8s.ObjectMeta("", "another-name")}},
 			want: "another-name-kibana",
 		},
 	}

--- a/stack-operator/pkg/controller/kibana/kibana_controller.go
+++ b/stack-operator/pkg/controller/kibana/kibana_controller.go
@@ -13,7 +13,7 @@ import (
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common/events"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common/nodecerts"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/elasticsearch/support"
-	"k8s.io/apimachinery/pkg/types"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	"k8s.io/client-go/tools/record"
 
 	kibanav1alpha1 "github.com/elastic/stack-operators/stack-operator/pkg/apis/kibana/v1alpha1"
@@ -180,7 +180,7 @@ func (r *ReconcileKibana) reconcileKibanaDeployment(
 		// updating the ca.pem file contents without restarting the process.
 		caChecksum := ""
 		var esPublicCASecret corev1.Secret
-		key := types.NamespacedName{Namespace: kb.Namespace, Name: *kb.Spec.Elasticsearch.CaCertSecret}
+		key := k8s.NamespacedName(kb.Namespace, *kb.Spec.Elasticsearch.CaCertSecret)
 		if err := r.Get(context.TODO(), key, &esPublicCASecret); err != nil {
 			return state, err
 		}

--- a/stack-operator/pkg/controller/kibana/kibana_controller_test.go
+++ b/stack-operator/pkg/controller/kibana/kibana_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	"github.com/elastic/stack-operators/stack-operator/pkg/utils/test"
 	"github.com/stretchr/testify/assert"
 
@@ -13,8 +14,6 @@ import (
 	"golang.org/x/net/context"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -22,14 +21,14 @@ import (
 
 var c client.Client
 
-var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "default"}}
-var depKey = types.NamespacedName{Name: "foo-kibana", Namespace: "default"}
+var expectedRequest = reconcile.Request{NamespacedName: k8s.NamespacedName(k8s.DefaultNamespace, "foo")}
+var depKey = k8s.NamespacedName(k8s.DefaultNamespace, "foo-kibana")
 
 const timeout = time.Second * 5
 
 func TestReconcile(t *testing.T) {
 
-	instance := &kibanav1alpha1.Kibana{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
+	instance := &kibanav1alpha1.Kibana{ObjectMeta: k8s.ObjectMeta(k8s.DefaultNamespace, "foo")}
 
 	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
 	// channel when it is finished.

--- a/stack-operator/pkg/controller/stack/stack_controller_test.go
+++ b/stack-operator/pkg/controller/stack/stack_controller_test.go
@@ -9,6 +9,7 @@ import (
 	esv1alpha1 "github.com/elastic/stack-operators/stack-operator/pkg/apis/elasticsearch/v1alpha1"
 	kbv1alpha1 "github.com/elastic/stack-operators/stack-operator/pkg/apis/kibana/v1alpha1"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/elasticsearch/support"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	"github.com/elastic/stack-operators/stack-operator/pkg/utils/test"
 
 	"github.com/stretchr/testify/assert"
@@ -16,8 +17,6 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -25,12 +24,12 @@ import (
 
 var c client.Client
 
-var resourceKey = types.NamespacedName{Name: "foo", Namespace: "default"}
+var resourceKey = k8s.NamespacedName(k8s.DefaultNamespce, "foo")
 var expectedRequest = reconcile.Request{NamespacedName: resourceKey}
 
 func TestReconcile(t *testing.T) {
 	instance := &deploymentsv1alpha1.Stack{
-		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+		ObjectMeta: k8s.ObjectMeta(k8s.DefaultNamespce, "foo"),
 		Spec: deploymentsv1alpha1.StackSpec{
 			Elasticsearch: esv1alpha1.ElasticsearchSpec{
 				SetVMMaxMapCount: false,
@@ -65,10 +64,7 @@ func TestReconcile(t *testing.T) {
 	err = c.Create(context.TODO(), instance)
 	// Manually create users secret as Elasticsearch controller is not running
 	userSecret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      support.ElasticInternalUsersSecretName("foo"),
-			Namespace: "default",
-		},
+		ObjectMeta: k8s.ObjectMeta(k8s.DefaultNamespace, support.ElasticInternalUsersSecretName("foo")),
 		Data: map[string][]byte{
 			support.InternalKibanaServerUserName: []byte("blub"),
 		},

--- a/stack-operator/pkg/utils/k8s/k8sutils.go
+++ b/stack-operator/pkg/utils/k8s/k8sutils.go
@@ -1,0 +1,37 @@
+package k8s
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	// DefaultNamespace is k8s default namespace
+	DefaultNamespace = "default"
+)
+
+// NamespacedName builds a NamespacedName from the given args
+func NamespacedName(namespace string, name string) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+}
+
+// ObjectMeta builds an ObjectMeta from the given args
+func ObjectMeta(namespace string, name string) v1.ObjectMeta {
+	return v1.ObjectMeta{
+		Namespace: namespace,
+		Name:      name,
+	}
+}
+
+// ToObjectMeta returns an ObjectMeta based on the given NamespacedName
+func ToObjectMeta(namespacedName types.NamespacedName) v1.ObjectMeta {
+	return ObjectMeta(namespacedName.Namespace, namespacedName.Name)
+}
+
+// ToNamespacedName returns an NamespacedName based on the given ObjectMeta
+func ToNamespacedName(objectMeta v1.ObjectMeta) types.NamespacedName {
+	return NamespacedName(objectMeta.Namespace, objectMeta.Name)
+}

--- a/stack-operator/test/e2e/helpers/k8s.go
+++ b/stack-operator/test/e2e/helpers/k8s.go
@@ -6,9 +6,9 @@ import (
 	"os"
 
 	"github.com/elastic/stack-operators/stack-operator/pkg/apis/deployments/v1alpha1"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // auth on gke
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -77,10 +77,7 @@ func (k *K8sHelper) CheckPodCount(listOpts client.ListOptions, expectedCount int
 
 func (k *K8sHelper) GetService(name string) (*corev1.Service, error) {
 	var service corev1.Service
-	key := types.NamespacedName{
-		Namespace: DefaultNamespace,
-		Name:      name,
-	}
+	key := k8s.NamespacedName(DefaultNamespace, name)
 	if err := k.Client.Get(DefaultCtx, key, &service); err != nil {
 		return nil, err
 	}
@@ -89,10 +86,7 @@ func (k *K8sHelper) GetService(name string) (*corev1.Service, error) {
 
 func (k *K8sHelper) GetEndpoints(name string) (*corev1.Endpoints, error) {
 	var endpoints corev1.Endpoints
-	key := types.NamespacedName{
-		Namespace: DefaultNamespace,
-		Name:      name,
-	}
+	key := k8s.NamespacedName(DefaultNamespace, name)
 	if err := k.Client.Get(DefaultCtx, key, &endpoints); err != nil {
 		return nil, err
 	}
@@ -103,10 +97,7 @@ func (k *K8sHelper) GetElasticPassword(stackName string) (string, error) {
 	secretName := stackName + "-elastic-user"
 	elasticUserKey := "elastic"
 	var secret corev1.Secret
-	key := types.NamespacedName{
-		Namespace: DefaultNamespace,
-		Name:      secretName,
-	}
+	key := k8s.NamespacedName(DefaultNamespace, secretName)
 	if err := k.Client.Get(DefaultCtx, key, &secret); err != nil {
 		return "", err
 	}

--- a/stack-operator/test/e2e/sample_test.go
+++ b/stack-operator/test/e2e/sample_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/elastic/stack-operators/stack-operator/pkg/apis/deployments/v1alpha1"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	"github.com/elastic/stack-operators/stack-operator/test/e2e/helpers"
 	"github.com/elastic/stack-operators/stack-operator/test/e2e/stack"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -26,7 +27,7 @@ func TestStackSample(t *testing.T) {
 	helpers.ExitOnErr(err)
 
 	// set namespace
-	sampleStack.ObjectMeta.Namespace = helpers.DefaultNamespace
+	sampleStack.ObjectMeta.Namespace = k8s.DefaultNamespace
 
 	// run, with mutation to the same stack (should work and do nothing)
 	stack.RunCreationMutationDeletionTests(t, sampleStack, sampleStack)

--- a/stack-operator/test/e2e/stack/builder.go
+++ b/stack-operator/test/e2e/stack/builder.go
@@ -5,11 +5,10 @@ import (
 	stacktype "github.com/elastic/stack-operators/stack-operator/pkg/apis/deployments/v1alpha1"
 	estype "github.com/elastic/stack-operators/stack-operator/pkg/apis/elasticsearch/v1alpha1"
 	kbtype "github.com/elastic/stack-operators/stack-operator/pkg/apis/kibana/v1alpha1"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	"github.com/elastic/stack-operators/stack-operator/test/e2e/helpers"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 const defaultVersion = "6.4.2"
@@ -29,10 +28,7 @@ type Builder struct {
 func NewStackBuilder(name string) Builder {
 	return Builder{
 		stacktype.Stack{
-			ObjectMeta: v1.ObjectMeta{
-				Name:      name,
-				Namespace: helpers.DefaultNamespace,
-			},
+			ObjectMeta: k8s.ObjectMeta(helpers.DefaultNamespace, name),
 			Spec: stacktype.StackSpec{
 				Elasticsearch: estype.ElasticsearchSpec{},
 				Kibana:        kbtype.KibanaSpec{},
@@ -86,13 +82,4 @@ func (b Builder) WithESMasterDataNodes(count int, resources common.ResourcesSpec
 func (b Builder) WithESTopology(topology estype.ElasticsearchTopologySpec) Builder {
 	b.Spec.Elasticsearch.Topologies = append(b.Spec.Elasticsearch.Topologies, topology)
 	return b
-}
-
-// -- Helper functions
-
-func GetNamespacedName(stack stacktype.Stack) types.NamespacedName {
-	return types.NamespacedName{
-		Name:      stack.GetName(),
-		Namespace: stack.GetNamespace(),
-	}
 }

--- a/stack-operator/test/e2e/stack/checks.go
+++ b/stack-operator/test/e2e/stack/checks.go
@@ -183,7 +183,7 @@ func CheckClusterHealth(stack v1alpha1.Stack, k *helpers.K8sHelper) helpers.Test
 		Name: "Cluster health should eventually be green",
 		Test: helpers.Eventually(func() error {
 			var stackRes v1alpha1.Stack
-			err := k.Client.Get(helpers.DefaultCtx, GetNamespacedName(stack), &stackRes)
+			err := k.Client.Get(helpers.DefaultCtx, stack.NamespacedName(), &stackRes)
 			if err != nil {
 				return err
 			}
@@ -281,7 +281,7 @@ func CheckClusterUUID(stack v1alpha1.Stack, k *helpers.K8sHelper) helpers.TestSt
 		Name: "Cluster UUID should eventually appear in the stack status",
 		Test: helpers.Eventually(func() error {
 			var s v1alpha1.Stack
-			err := k.Client.Get(helpers.DefaultCtx, GetNamespacedName(stack), &s)
+			err := k.Client.Get(helpers.DefaultCtx, stack.NamespacedName(), &s)
 			if err != nil {
 				return err
 			}

--- a/stack-operator/test/e2e/stack/creation.go
+++ b/stack-operator/test/e2e/stack/creation.go
@@ -25,7 +25,7 @@ func CreationTestSteps(stack v1alpha1.Stack, k *helpers.K8sHelper) helpers.TestS
 				Name: "Stack should be created",
 				Test: func(t *testing.T) {
 					var createdStack v1alpha1.Stack
-					err := k.Client.Get(helpers.DefaultCtx, GetNamespacedName(stack), &createdStack)
+					err := k.Client.Get(helpers.DefaultCtx, stack.NamespacedName(), &createdStack)
 					require.NoError(t, err)
 					require.Equal(t, stack.Spec.Elasticsearch.Version, createdStack.Spec.Elasticsearch.Version)
 				},

--- a/stack-operator/test/e2e/stack/deletion.go
+++ b/stack-operator/test/e2e/stack/deletion.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/elastic/stack-operators/stack-operator/pkg/apis/deployments/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 // DeletionTestSteps tests the deletion of the given stack
@@ -25,10 +24,7 @@ func DeletionTestSteps(stack v1alpha1.Stack, k *helpers.K8sHelper) []helpers.Tes
 			Name: "Stack should not be there anymore",
 			Test: func(t *testing.T) {
 				var s v1alpha1.Stack
-				err := k.Client.Get(helpers.DefaultCtx, types.NamespacedName{
-					Name:      stack.GetName(),
-					Namespace: stack.GetNamespace(),
-				}, &s)
+				err := k.Client.Get(helpers.DefaultCtx, stack.NamespacedName(), &s)
 				require.Error(t, err)
 				require.True(t, apierrors.IsNotFound(err))
 			},

--- a/stack-operator/test/e2e/stack/init.go
+++ b/stack-operator/test/e2e/stack/init.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/elastic/stack-operators/stack-operator/pkg/apis/deployments/v1alpha1"
+	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
 	"github.com/elastic/stack-operators/stack-operator/test/e2e/helpers"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -39,9 +39,7 @@ func InitTestSteps(stack v1alpha1.Stack, k *helpers.K8sHelper) []helpers.TestSte
 			Name: "Create e2e namespace unless already exists",
 			Test: func(t *testing.T) {
 				ns := corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: helpers.DefaultNamespace,
-					},
+					ObjectMeta: k8s.ObjectMeta("", k8s.DefaultNamespace),
 				}
 				err := k.Client.Create(helpers.DefaultCtx, &ns)
 				if err != nil && !apierrors.IsAlreadyExists(err) {

--- a/stack-operator/test/e2e/stack/mutation.go
+++ b/stack-operator/test/e2e/stack/mutation.go
@@ -25,7 +25,7 @@ func MutationTestSteps(stack v1alpha1.Stack, k *helpers.K8sHelper) []helpers.Tes
 				Name: "Retrieve cluster ID before mutation for comparison purpose",
 				Test: helpers.Eventually(func() error {
 					var s v1alpha1.Stack
-					err := k.Client.Get(helpers.DefaultCtx, GetNamespacedName(stack), &s)
+					err := k.Client.Get(helpers.DefaultCtx, stack.NamespacedName(), &s)
 					if err != nil {
 						return err
 					}
@@ -41,7 +41,7 @@ func MutationTestSteps(stack v1alpha1.Stack, k *helpers.K8sHelper) []helpers.Tes
 				Test: func(t *testing.T) {
 					// get stack so we have a versioned k8s resource we can update
 					var stackRes v1alpha1.Stack
-					err := k.Client.Get(helpers.DefaultCtx, GetNamespacedName(stack), &stackRes)
+					err := k.Client.Get(helpers.DefaultCtx, stack.NamespacedName(), &stackRes)
 					require.NoError(t, err)
 					// update with new stack spec
 					stackRes.Spec = stack.Spec
@@ -55,7 +55,7 @@ func MutationTestSteps(stack v1alpha1.Stack, k *helpers.K8sHelper) []helpers.Tes
 				Name: "Cluster UUID should be preserved after mutation is done",
 				Test: func(t *testing.T) {
 					var s v1alpha1.Stack
-					err := k.Client.Get(helpers.DefaultCtx, GetNamespacedName(stack), &s)
+					err := k.Client.Get(helpers.DefaultCtx, stack.NamespacedName(), &s)
 					require.NoError(t, err)
 					clusterIDAfterMutation := s.Status.Elasticsearch.ClusterUUID
 					require.NotEmpty(t, clusterIDBeforeMutation)


### PR DESCRIPTION
We end up using those everywhere (especially in tests), so let's have
builders and converters for these types in a common place.