### PR TITLE
Update Makefile to work with Minikube 0.31

### DIFF
--- a/stack-operator/Makefile
+++ b/stack-operator/Makefile
@@ -194,7 +194,7 @@ gke:
 # minikube ensures that there's a local minikube environment running
 .PHONY: minikube
 minikube: requisites
-ifneq ($(shell minikube status --format '{{.MinikubeStatus}}'),Running)
+ifneq ($(shell minikube status --format '{{.ApiServer}}'),Running)
 	@ echo "-> Starting minikube..."
 	@ minikube start --kubernetes-version $(MINIKUBE_KUBERNETES_VERSION) --memory ${MINIKUBE_MEMORY}
 else
@@ -220,7 +220,7 @@ endif
 .PHONY: set-dev-gke
 set-dev-gke:
 ifdef MINIKUBE
-ifeq ($(shell minikube status --format '{{.MinikubeStatus}}'),Running)
+ifeq ($(shell minikube status --format '{{.Host}}'),Running)
 	minikube stop
 endif
 endif


### PR DESCRIPTION
0.30 -> 0.31 contains a change to the Status: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status

Before this change, 0.31 does not work, after this change 0.30 does not work.