### PR TITLE
add optional "lint" make target

### DIFF
--- a/stack-operator/Makefile
+++ b/stack-operator/Makefile
@@ -9,7 +9,7 @@ KUSTOMIZE := $(shell command -v kustomize)
 SHA1SUM := $(shell command -v sha1sum)
 DEP := $(shell command -v dep)
 GCLOUD := $(shell command -v gcloud)
-REVIVE_LINTER := $(shell command -v revive)
+GOLANGCI_LINTER := $(shell command -v golangci-lint)
 
 KUBECTL_CONFIG ?= $(shell cat $(CONFIG_FILE) 2> /dev/null)
 CONFIG_FILE ?= .devenv
@@ -269,8 +269,8 @@ stop-port-forward:
 
 .PHONY: lint
 lint:
-ifndef REVIVE_LINTER
-	@ echo "-> linter (revive) binary missing, install via \"go get -u github.com/mgechev/revive\""
+ifndef GOLANGCI_LINTER
+	@ echo "-> linter (golangci-lint) binary missing, install via \"https://github.com/golangci/golangci-lint#install\""
 	@ exit 5
 endif
-	@ $(REVIVE_LINTER) -formatter stylish ./pkg/... ./cmd/... ./test/...
+	@ $(GOLANGCI_LINTER) run $(LINTER_ARGS) ./pkg/... ./cmd/... ./test/...


### PR DESCRIPTION
It flags down a lot of errors right now, so keeping it optional until we decide to put some effort into making it happy.

https://github.com/golangci/golangci-lint#comparison contains some info about why this one might be a good choice. It's worth nothing that this is a GPL 3 project, but I don't think it matters much for our use case: we'll be running it, not embedding it.

Closes: https://github.com/elastic/stack-operators/issues/229 (which contains links to linters considered)