### PR TITLE
handle or comment previously unhandled errors

### DIFF
--- a/stack-operator/cmd/main.go
+++ b/stack-operator/cmd/main.go
@@ -8,9 +8,14 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
+var log = logf.KBLog.WithName("main")
+
 func main() {
 	logf.SetLogger(logf.ZapLogger(false))
 	var rootCmd = &cobra.Command{Use: "stack-operator"}
 	rootCmd.AddCommand(manager.Cmd, snapshotter.Cmd)
-	rootCmd.Execute()
+
+	if err := rootCmd.Execute(); err != nil {
+		log.Error(err, "Unexpected error while running executing command")
+	}
 }

--- a/stack-operator/cmd/manager/main.go
+++ b/stack-operator/cmd/manager/main.go
@@ -34,18 +34,23 @@ var (
 			execute()
 		},
 	}
+
+	log = logf.Log.WithName("manager")
 )
 
 func init() {
 	Cmd.Flags().StringP(elasticsearch.SnapshotterImageFlag, "s", "", "image to use for the snappshotter application")
 	Cmd.Flags().Int(MetricsPortFlag, DefaultMetricPort, "Port to use for exposing metrics in the Prometheus format (set 0 to disable)")
-	viper.BindPFlags(Cmd.Flags())
+
+	if err := viper.BindPFlags(Cmd.Flags()); err != nil {
+		log.Error(err, "Unexpected error while binding flags")
+		os.Exit(1)
+	}
+
 	viper.AutomaticEnv()
 }
 
 func execute() {
-	log := logf.Log.WithName("manager")
-
 	if viper.GetString(elasticsearch.SnapshotterImageFlag) == "" {
 		log.Error(fmt.Errorf("%s is a required flag", elasticsearch.SnapshotterImageFlag),
 			"required configuration missing")

--- a/stack-operator/cmd/snapshotter/main.go
+++ b/stack-operator/cmd/snapshotter/main.go
@@ -51,7 +51,11 @@ func init() {
 	Cmd.Flags().DurationP(intervalFlag, "d", 30*time.Minute, "Snapshot interval")
 	Cmd.Flags().IntP(maxFlag, "m", 100, "Max number of snaphshots retained")
 
-	viper.BindPFlags(Cmd.Flags())
+	if err := viper.BindPFlags(Cmd.Flags()); err != nil {
+		log.Error(err, "Unexpected error while binding flags")
+		os.Exit(1)
+	}
+
 	viper.AutomaticEnv()
 }
 

--- a/stack-operator/pkg/controller/common/strings.go
+++ b/stack-operator/pkg/controller/common/strings.go
@@ -9,7 +9,8 @@ import (
 func Concat(args ...string) string {
 	var result strings.Builder
 	for _, arg := range args {
-		result.WriteString(arg)
+		// it's safe to ignore the result here as strings.Builder cannot error on result.WriteString
+		result.WriteString(arg) // #nosec G104
 	}
 	return result.String()
 }

--- a/stack-operator/pkg/controller/elasticsearch/support/comparison.go
+++ b/stack-operator/pkg/controller/elasticsearch/support/comparison.go
@@ -241,7 +241,7 @@ func templateMatchesActualVolumeAndPvc(pvcTemplate corev1.PersistentVolumeClaim,
 }
 func IsTainted(pod corev1.Pod) bool {
 	if v, ok := pod.Annotations[TaintedAnnotationName]; ok {
-		tainted, _ := strconv.ParseBool(v)
+		tainted, _ := strconv.ParseBool(v) // #nosec G104 // ignore unhandled error because we want to default to false
 		return tainted
 	}
 	return false

--- a/stack-operator/pkg/controller/elasticsearch/support/node.go
+++ b/stack-operator/pkg/controller/elasticsearch/support/node.go
@@ -1,8 +1,7 @@
 package support
 
 import (
-	"strings"
-
+	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common"
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
@@ -20,16 +19,17 @@ const (
 )
 
 // NewNodeName forms an Elasticsearch node name. Returning a unique node
-// node name to be used for the Elaticsearch cluster node.
+// node name to be used for the Elasticsearch cluster node.
 func NewNodeName(clusterName string) string {
 	var prefix = clusterName
 	if len(prefix) > maxPrefixLength {
 		prefix = prefix[:maxPrefixLength]
 	}
-	var nodeName strings.Builder
-	nodeName.WriteString(prefix)
-	nodeName.WriteString(typeSuffix)
-	nodeName.WriteString("-")
-	nodeName.WriteString(rand.String(randomSuffixLength))
-	return nodeName.String()
+
+	return common.Concat(
+		prefix,
+		typeSuffix,
+		"-",
+		rand.String(randomSuffixLength),
+	)
 }

--- a/stack-operator/pkg/controller/stack/stack_controller.go
+++ b/stack-operator/pkg/controller/stack/stack_controller.go
@@ -189,14 +189,12 @@ func (r *ReconcileStack) Reconcile(request reconcile.Request) (reconcile.Result,
 		currentEs = es
 	} else {
 		// TODO: this is a bit rough
-		if !reflect.DeepEqual(currentEs.Spec, es.Spec) {
+		if err := diff.NewDiffAsError(currentEs.Spec, es.Spec); err != nil {
 			log.Info("Updating ElasticsearchCluster spec")
 
 			log.V(4).Info(
-				fmt.Sprintf(
-					"Updating ElasticsearchCluster spec due to changes: %s",
-					diff.NewDiff(currentEs.Spec, es.Spec),
-				),
+				"Updating ElasticsearchCluster spec due to changes",
+				"diff_err", err,
 			)
 
 			currentEs.Spec = es.Spec

--- a/stack-operator/pkg/utils/diff/diff.go
+++ b/stack-operator/pkg/utils/diff/diff.go
@@ -4,94 +4,26 @@ package diff
 
 import (
 	"fmt"
-	"reflect"
 
-	"github.com/davecgh/go-spew/spew"
-	"github.com/pmezard/go-difflib/difflib"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/errors"
 )
 
-var spewConfig = spew.ConfigState{
-	Indent:                  " ",
-	DisablePointerAddresses: true,
-	DisableCapacities:       true,
-	SortKeys:                true,
+type testifyAdapter struct {
+	errs []error
+}
+
+func (t *testifyAdapter) Errorf(format string, args ...interface{}) {
+	t.errs = append(t.errs, fmt.Errorf(format, args...))
+}
+
+func (t *testifyAdapter) ErrOrNil() error {
+	return errors.NewAggregate(t.errs)
 }
 
 // NewDiff returns the difference between two objects, suitable for debugging.
-func NewDiff(expected, actual interface{}) string {
-	if reflect.DeepEqual(expected, actual) {
-		return ""
-	}
-
-	diff := diff(expected, actual)
-	expected, actual = formatUnequalValues(expected, actual)
-
-	return fmt.Sprintf("expected: %s\nactual: %s%s\n", expected, actual, diff)
-}
-
-func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
-	t := reflect.TypeOf(v)
-	k := t.Kind()
-
-	if k == reflect.Ptr {
-		t = t.Elem()
-		k = t.Kind()
-	}
-	return t, k
-}
-
-// diff returns a diff of both values as long as both are of the same type and
-// are a struct, map, slice or array. Otherwise it returns an empty string.
-func diff(expected interface{}, actual interface{}) string {
-	if expected == nil || actual == nil {
-		return ""
-	}
-
-	et, ek := typeAndKind(expected)
-	at, _ := typeAndKind(actual)
-
-	if et != at {
-		return ""
-	}
-
-	if ek != reflect.Struct && ek != reflect.Map && ek != reflect.Slice && ek != reflect.Array && ek != reflect.String {
-		return ""
-	}
-
-	var e, a string
-	if ek != reflect.String {
-		e = spewConfig.Sdump(expected)
-		a = spewConfig.Sdump(actual)
-	} else {
-		e = expected.(string)
-		a = actual.(string)
-	}
-
-	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
-		A:        difflib.SplitLines(e),
-		B:        difflib.SplitLines(a),
-		FromFile: "Expected",
-		FromDate: "",
-		ToFile:   "Actual",
-		ToDate:   "",
-		Context:  1,
-	})
-
-	return "\n\nDiff:\n" + diff
-}
-
-// formatUnequalValues takes two values of arbitrary types and returns string
-// representations appropriate to be presented to the user.
-//
-// If the values are not of like type, the returned strings will be prefixed
-// with the type name, and the value will be enclosed in parenthesis similar
-// to a type conversion in the Go grammar.
-func formatUnequalValues(expected, actual interface{}) (e string, a string) {
-	if reflect.TypeOf(expected) != reflect.TypeOf(actual) {
-		return fmt.Sprintf("%T(%#v)", expected, expected),
-			fmt.Sprintf("%T(%#v)", actual, actual)
-	}
-
-	return fmt.Sprintf("%#v", expected),
-		fmt.Sprintf("%#v", actual)
+func NewDiffAsError(expected, actual interface{}) error {
+	adapter := &testifyAdapter{}
+	assert.Equal(adapter, expected, actual)
+	return adapter.ErrOrNil()
 }

--- a/stack-operator/test/e2e/helpers/k8s.go
+++ b/stack-operator/test/e2e/helpers/k8s.go
@@ -47,7 +47,9 @@ func CreateClient() (client.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	v1alpha1.AddToScheme(scheme.Scheme)
+	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		return nil, err
+	}
 	client, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Found with https://github.com/securego/gosec, which I think we should consider adding to our project on a general basis soonish. (Do I understand correctly if you're a committer here @gcmurphy ?)

Most of them were innocent (which is now ignored via the `// #nosec G104` marker), some could happen.

@sebgl I realize there's some duplication here re my `testifyAdapter` and your other e2e adapter, but we can deal with that later? :)