### PR TITLE
Handle different image pull policies on minikube vs gke

### DIFF
--- a/stack-operator/Makefile
+++ b/stack-operator/Makefile
@@ -276,7 +276,13 @@ TESTS_MATCH ?= ""
 # can be overriden with the name of the test to run, eg.:
 # make e2e TESTS_MATCH=TestMutationMoreNodes
 e2e: docker-e2e
-	./hack/run_e2e.sh "$(E2E_IMG):$(IMG_TAG)" "$(TESTS_MATCH)"
+ifeq ($(KUBECTL_CONFIG),$(GKE_KUBECTL_CONFIG))
+	# always pull latest img on gke
+	./hack/run_e2e.sh "$(E2E_IMG):$(IMG_TAG)" Always "$(TESTS_MATCH)"
+else
+	# never pull on minikube (no registry)
+	./hack/run_e2e.sh "$(E2E_IMG):$(IMG_TAG)" Never "$(TESTS_MATCH)"
+endif
 
 # Build and (maybe) push e2e tests Docker image
 docker-e2e:

--- a/stack-operator/config/e2e/batch_job.yaml
+++ b/stack-operator/config/e2e/batch_job.yaml
@@ -10,6 +10,7 @@ spec:
       containers:
       - name: e2e
         image: $IMG
+        imagePullPolicy: $PULL_POLICY
         args: ["-run", "$TESTS_MATCH"] # optionally limit tests to run
       restartPolicy: Never
   backoffLimit: 0 # don't retry a failed test

--- a/stack-operator/hack/run_e2e.sh
+++ b/stack-operator/hack/run_e2e.sh
@@ -2,11 +2,12 @@
 
 #
 # Run end-to-end tests as a K8s batch job
-# Usage: ./hack/run_e2e.sh <e2e_docker_image_name> <go_tests_matcher>
+# Usage: ./hack/run_e2e.sh <e2e_docker_image_name> <image_pull_policy> <go_tests_matcher>
 #
 
 IMG="$1" # Docker image name
-TESTS_MATCH="$2" # Expression to match go test names (can be "")
+PULL_POLICY="$2"
+TESTS_MATCH="$3" # Expression to match go test names (can be "")
 
 JOB_NAME="stack-operator-e2e-tests"
 NAMESPACE="e2e"
@@ -25,6 +26,7 @@ set -e
 cat config/e2e/batch_job.yaml |  \
     sed "s;\$IMG;$IMG;g" | \
     sed "s;\$TESTS_MATCH;$TESTS_MATCH;g" | \
+    sed "s;\$PULL_POLICY;$PULL_POLICY;g" | \
     kubectl apply -f -
 
 # retrieve pod responsible for running the job


### PR DESCRIPTION
Problem:
If we never pull on GKE, we run an out-of-date version of the
e2e tests while developing locally on a same commit/branch.

This adds support for passing in the desired policy according to the env.