### PR TITLE
Setup codeowners for default PR reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Request a review from all team members
+* @nkvoll @marclop @pebrc @sebgl


### PR DESCRIPTION
This should make all team members be default reviewers for all PRs, according to https://help.github.com/articles/about-codeowners/