### PR TITLE
enable age as dates in our CRDs

### DIFF
--- a/stack-operator/config/crds/deployments_v1alpha1_stack.yaml
+++ b/stack-operator/config/crds/deployments_v1alpha1_stack.yaml
@@ -17,7 +17,7 @@ spec:
     type: string
   - JSONPath: .metadata.creationTimestamp
     name: age
-    type: string
+    type: date
   group: deployments.k8s.elastic.co
   names:
     categories:

--- a/stack-operator/config/crds/elasticsearch_v1alpha1_elasticsearchcluster.yaml
+++ b/stack-operator/config/crds/elasticsearch_v1alpha1_elasticsearchcluster.yaml
@@ -19,7 +19,7 @@ spec:
     type: string
   - JSONPath: .metadata.creationTimestamp
     name: age
-    type: string
+    type: date
   group: elasticsearch.k8s.elastic.co
   names:
     categories:

--- a/stack-operator/config/crds/kibana_v1alpha1_kibana.yaml
+++ b/stack-operator/config/crds/kibana_v1alpha1_kibana.yaml
@@ -16,7 +16,7 @@ spec:
     type: integer
   - JSONPath: .metadata.creationTimestamp
     name: age
-    type: string
+    type: date
   group: kibana.k8s.elastic.co
   names:
     categories:

--- a/stack-operator/pkg/apis/deployments/v1alpha1/stack_types.go
+++ b/stack-operator/pkg/apis/deployments/v1alpha1/stack_types.go
@@ -42,7 +42,7 @@ type StackStatus struct {
 // +kubebuilder:categories=elastic
 // +kubebuilder:printcolumn:name="es",type="string",JSONPath=".status.elasticsearch.health",description="Elasticsearch health"
 // +kubebuilder:printcolumn:name="kibana",type="string",JSONPath=".status.kibana.health",description="Kibana health"
-// +kubebuilder:printcolumn:name="age",type="string",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 type Stack struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/stack-operator/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
+++ b/stack-operator/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
@@ -258,7 +258,7 @@ func (es ElasticsearchStatus) IsDegraded(prev ElasticsearchStatus) bool {
 // +kubebuilder:printcolumn:name="health",type="string",JSONPath=".status.health"
 // +kubebuilder:printcolumn:name="nodes",type="integer",JSONPath=".status.availableNodes",description="Available nodes"
 // +kubebuilder:printcolumn:name="phase",type="string",JSONPath=".status.phase"
-// +kubebuilder:printcolumn:name="age",type="string",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 type ElasticsearchCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/stack-operator/pkg/apis/kibana/v1alpha1/kibana_types.go
+++ b/stack-operator/pkg/apis/kibana/v1alpha1/kibana_types.go
@@ -87,7 +87,7 @@ func (ks KibanaStatus) IsDegraded(prev KibanaStatus) bool {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="health",type="string",JSONPath=".status.health"
 // +kubebuilder:printcolumn:name="nodes",type="integer",JSONPath=".status.availableNodes",description="Available nodes"
-// +kubebuilder:printcolumn:name="age",type="string",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 type Kibana struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
since controller-tools noew support it, we now should get age shown in
kubectl in a more regular relative form