### PR TITLE
Dont panic if no kubeconfig available in unit tests

### DIFF
--- a/stack-operator/pkg/dev/portforward/dialer_test.go
+++ b/stack-operator/pkg/dev/portforward/dialer_test.go
@@ -43,6 +43,7 @@ func TestForwardingDialer_DialContext(t *testing.T) {
 			},
 		}, nil
 	}
+	d.initOnce.Do(func() {}) // don't init with kubeconfig
 
 	_, err := d.DialContext(context.TODO(), "tcp", "localhost:8080")
 	assert.Equal(t, customError, err)


### PR DESCRIPTION
The dev port forwarder does require a local kubeconfig, otherwise
it fails with a panic. This does not play well with running unit tests
in Docker.

This small patch will prevent the stub forwarder from loading the local
kubeconfig, as not really required for the test.