### PR TITLE
Setup Jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,10 @@
+#!/usr/bin/env groovy
+
+node('swarm') {
+    stage('Checkout from GitHub') {
+	    checkout scm
+    }
+    stage("Make ci") {
+        sh 'make ci'
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+MOUNT_PATH ?= /go/src/github.com/elastic/stack-operators
+BASE_IMAGE ?= golang:1.11
+
+ci:
+	docker run --rm -t \
+		-v $(CURDIR):$(MOUNT_PATH) \
+		-w $(MOUNT_PATH) \
+		$(BASE_IMAGE) \
+		make -C stack-operator ci && \
+		make -C local-volume ci

--- a/local-volume/Makefile
+++ b/local-volume/Makefile
@@ -27,6 +27,9 @@ endif
 unit:
 	@ go test -cover ./...
 
+.PHONY: ci
+ci: build unit
+
 ##
 ## Docker stuff
 ## ------------

--- a/stack-operator/Makefile
+++ b/stack-operator/Makefile
@@ -56,6 +56,12 @@ stack-operator: generate fmt vet
 keystore-updater: generate fmt vet
 	go build -o bin/keystore-updater github.com/elastic/stack-operators/stack-operator/cmd/keystore-updater
 
+# CI job
+ci-prereq:
+	go get -u github.com/golang/dep/cmd/dep golang.org/x/tools/cmd/goimports
+
+.PHONY: ci
+ci: ci-prereq dep-vendor-only stack-operator unit keystore-updater
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 SNAPSHOTTER_IMAGE?=no-snapshotter-image
@@ -124,6 +130,10 @@ docker-push:
 requisites:
 ifndef GO
 	@ echo "-> go binary missing, $(INSTALL_HELP)"
+	@ exit 1
+endif
+ifndef DEP
+	@ echo "-> dep binary missing, $(INSTALL_HELP)"
 	@ exit 1
 endif
 ifndef GOIMPORTS
@@ -213,14 +223,13 @@ samples: requisites generate
 	@ echo "-> Pushing samples to Kubernetes cluster..."
 	@ kubectl --cluster=$(KUBECTL_CONFIG) apply -f config/samples/deployments_v1alpha1_stack.yaml
 
-.PHONY: vendor
-vendor:
-ifndef DEP
-	@ echo "-> dep binary missing, $(INSTALL_HELP)"
-	@ exit 5
-endif
-	@ echo "-> Running dep..."
-	@ dep ensure
+.PHONY: dep
+dep:
+	dep ensure -v
+
+dep-vendor-only:
+	# don't attempt to upgrade Gopkg.lock
+	dep ensure --vendor-only -v
 
 .PHONY: set-dev-gke
 set-dev-gke:


### PR DESCRIPTION
Sets up everything required in the stack-operators project to use Jenkins as CI, including:

* a Jenkinsfile at the root, which just does the git checkout then runs `make ci`
* a makefile at the root, with a `ci` target that runs stuff in a Docker container
* a `ci` target in our 2 projects to run the vendoring, compilation and unit tests

Fixes #49.