### PR TITLE
Make TestObserver_Stop more resilient

### DIFF
--- a/stack-operator/pkg/controller/elasticsearch/observer/observer_test.go
+++ b/stack-operator/pkg/controller/elasticsearch/observer/observer_test.go
@@ -67,9 +67,13 @@ func TestObserver_Stop(t *testing.T) {
 	// should be safe to call multiple times
 	observer.Stop()
 	// should stop running at some point
-	time.Sleep(1 * time.Millisecond)
-	observationTime := observer.LastObservationTime()
-	// optimistically check nothing new happened after 10ms
-	time.Sleep(10 * time.Millisecond)
-	require.Equal(t, observationTime, observer.LastObservationTime())
+	test.RetryUntilSuccess(t, func() error {
+		observationTime := observer.LastObservationTime()
+		// optimistically check nothing new happened after 50ms
+		time.Sleep(50 * time.Millisecond)
+		if observationTime != observer.LastObservationTime() {
+			return errors.New("Observer does not seem to be stopped yet")
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
Testing async stuff that should not happen is hard :-(
Looks like this test did fail randomly, this should at least make it
more resilient, even though not a perfect solution since it involves
waiting a bit (hoping for condition to be met) and retrying.