### PR TITLE
Replace global secret watches variable with parameter

### DIFF
--- a/stack-operator/pkg/controller/common/watches/handler.go
+++ b/stack-operator/pkg/controller/common/watches/handler.go
@@ -13,9 +13,7 @@ import (
 )
 
 var (
-	//SecretWatch TODO don't use a global variable for this.
-	SecretWatch = NewDynamicEnqueueRequest()
-	log         = logf.Log.WithName("dynamic-enqueue-request")
+	log = logf.Log.WithName("dynamic-enqueue-request")
 )
 
 // HandlerRegistration is the event handler registration that can be added or removed

--- a/stack-operator/pkg/controller/common/watches/state.go
+++ b/stack-operator/pkg/controller/common/watches/state.go
@@ -1,0 +1,30 @@
+package watches
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+// NewDynamicWatches creates an initialized DynamicWatches container.
+func NewDynamicWatches() DynamicWatches {
+	return DynamicWatches{
+		Secrets: NewDynamicEnqueueRequest(),
+	}
+}
+
+// DynamicWatches contains stateful dynamic watches. Intended as facility to pass around stateful dynamic watches and
+// give each of them an identity.
+type DynamicWatches struct {
+	Secrets *DynamicEnqueueRequest
+}
+
+// InjectScheme is used by the ControllerManager to inject Scheme into Sources, EventHandlers, Predicates, and
+// Reconciles
+func (w DynamicWatches) InjectScheme(scheme *runtime.Scheme) error {
+	w.Secrets.InjectScheme(scheme)
+	return nil
+}
+
+// DynamicWatches implements inject.Scheme mostly to facilitate testing. In production code injection happens on
+// the individual watch level.
+var _ inject.Scheme = DynamicWatches{}

--- a/stack-operator/pkg/controller/elasticsearch/driver/default.go
+++ b/stack-operator/pkg/controller/elasticsearch/driver/default.go
@@ -8,6 +8,7 @@ import (
 	"github.com/elastic/stack-operators/stack-operator/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common/events"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common/nodecerts"
+	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common/watches"
 	esclient "github.com/elastic/stack-operators/stack-operator/pkg/controller/elasticsearch/client"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/elasticsearch/migration"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/elasticsearch/mutation"
@@ -64,6 +65,7 @@ type defaultDriver struct {
 		c client.Client,
 		scheme *runtime.Scheme,
 		es v1alpha1.ElasticsearchCluster,
+		w watches.DynamicWatches,
 	) (*VersionWideResources, error)
 
 	// expectedPodsAndResourcesResolver returns a list of pod specs with context that we would expect to find in the
@@ -160,7 +162,7 @@ func (d *defaultDriver) Reconcile(
 		return results.WithError(err)
 	}
 
-	versionWideResources, err := d.versionWideResourcesReconciler(d.Client, d.Scheme, es)
+	versionWideResources, err := d.versionWideResourcesReconciler(d.Client, d.Scheme, es, d.DynamicWatches)
 	if err != nil {
 		return results.WithError(err)
 	}

--- a/stack-operator/pkg/controller/elasticsearch/driver/driver.go
+++ b/stack-operator/pkg/controller/elasticsearch/driver/driver.go
@@ -7,6 +7,7 @@ import (
 	"github.com/elastic/stack-operators/stack-operator/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common/nodecerts"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common/version"
+	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common/watches"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/elasticsearch/observer"
 	esreconcile "github.com/elastic/stack-operators/stack-operator/pkg/controller/elasticsearch/reconcile"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/elasticsearch/user"
@@ -49,6 +50,8 @@ type Options struct {
 	Dialer net.Dialer
 	// Observers that observe es clusters state
 	Observers *observer.Manager
+	// DynamicWatches are handles to currently registered dynamic watches.
+	DynamicWatches watches.DynamicWatches
 }
 
 // NewDriver returns a Driver that can operate the provided version

--- a/stack-operator/pkg/controller/elasticsearch/driver/version_wide_resources.go
+++ b/stack-operator/pkg/controller/elasticsearch/driver/version_wide_resources.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/elastic/stack-operators/stack-operator/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common/nodecerts"
+	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common/watches"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/elasticsearch/configmap"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/elasticsearch/settings"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/elasticsearch/snapshot"
@@ -34,8 +35,9 @@ func reconcileVersionWideResources(
 	c client.Client,
 	scheme *runtime.Scheme,
 	es v1alpha1.ElasticsearchCluster,
+	w watches.DynamicWatches,
 ) (*VersionWideResources, error) {
-	keystoreConfig, err := snapshot.ReconcileSnapshotCredentials(c, scheme, es, es.Spec.SnapshotRepository)
+	keystoreConfig, err := snapshot.ReconcileSnapshotCredentials(c, scheme, es, es.Spec.SnapshotRepository, w)
 	if err != nil {
 		return nil, err
 	}

--- a/stack-operator/pkg/controller/elasticsearch/elasticsearch_controller_test.go
+++ b/stack-operator/pkg/controller/elasticsearch/elasticsearch_controller_test.go
@@ -66,7 +66,9 @@ func TestReconcile(t *testing.T) {
 	r, err := newReconciler(mgr, nil)
 	require.NoError(t, err)
 	recFn, requests := SetupTestReconcile(r)
-	assert.NoError(t, add(mgr, recFn))
+	controller, err := add(mgr, recFn)
+	assert.NoError(t, err)
+	assert.NoError(t, addWatches(controller, r.dynamicWatches))
 
 	stopMgr, mgrStopped := StartTestManager(mgr, t)
 

--- a/stack-operator/pkg/controller/elasticsearch/snapshot/snapshot_control_test.go
+++ b/stack-operator/pkg/controller/elasticsearch/snapshot/snapshot_control_test.go
@@ -109,7 +109,6 @@ func TestReconcileStack_ReconcileSnapshotterCronJob(t *testing.T) {
 	}
 
 	scheme := registerScheme(t)
-	watches.SecretWatch.InjectScheme(scheme) // TODO remove global watches
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := fake.NewFakeClient(tt.args.initialObjects...)
@@ -194,10 +193,12 @@ func TestReconcileElasticsearch_ReconcileSnapshotCredentials(t *testing.T) {
 	}
 
 	scheme := registerScheme(t)
+	watches := watches.NewDynamicWatches()
+	watches.InjectScheme(scheme)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ReconcileSnapshotCredentials(
-				fake.NewFakeClientWithScheme(scheme, tt.args.initialObjects...), scheme, owner, tt.args.repoConfig,
+				fake.NewFakeClientWithScheme(scheme, tt.args.initialObjects...), scheme, owner, tt.args.repoConfig, watches,
 			)
 
 			if err != nil {


### PR DESCRIPTION
A left-over from the dynamic watches PR. This removes a global variable which was used to hold the state of the dynamic watch registrations and replaces it with a parameter passed into the reconciler/driver.

