### PR TITLE
Document `kustomize` as requirement

### DIFF
--- a/stack-operator/README.md
+++ b/stack-operator/README.md
@@ -7,6 +7,7 @@ Manage an Elastic stack in Kubernetes.
 * [go](https://golang.org/dl/)
 * [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports)
 * [dep](https://github.com/golang/dep)
+* [kustomize](https://github.com/kubernetes-sigs/kustomize)
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 * [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder)
 * [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/)


### PR DESCRIPTION
The [`deploy`](https://github.com/elastic/stack-operators/blob/master/stack-operator/Makefile#L86-L88) make target depends on the `kustomize` binary.
This PR adds the missing `kustomize` requirements in the README.