### PR TITLE
[#47] Support for temporarily pausing the stack operator

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,23 @@
+## Troubleshooting
+
+### Pause the controllers
+
+In case of trouble it might be useful to pause a controller for a particular resource.
+It can be achieved by setting the annotation `common.k8s.elastic.co/pause` to `true` to any resource controlled by the operator :
+- Stack
+- ElasticsearchCluster
+- Kibana
+
+```yaml
+metadata:
+  annotations:
+    common.k8s.elastic.co/pause: "true"
+```
+
+Or in one line:
+
+```bash
+$ kubectl annotate stack stack-sample --overwrite common.k8s.elastic.co/pause=true
+```
+
+Please note that if the annotation is set on the Stack all the dependents *(kibana, elasticsearchcluster)* are also paused.

--- a/stack-operator/pkg/controller/common/pause.go
+++ b/stack-operator/pkg/controller/common/pause.go
@@ -1,0 +1,68 @@
+package common
+
+import (
+	"context"
+	deploymentsv1alpha1 "github.com/elastic/stack-operators/stack-operator/pkg/apis/deployments/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"strconv"
+	"time"
+)
+
+const (
+	// PauseAnnotationName annotation
+	PauseAnnotationName = "common.k8s.elastic.co/pause"
+)
+
+var (
+	stack        = reflect.TypeOf(deploymentsv1alpha1.Stack{}).Name()
+
+	// PauseRequeue is the default requeue result if controller is paused
+	PauseRequeue = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
+)
+
+// IsPaused computes if a given controller is paused.
+func IsPaused(meta v1.ObjectMeta, client client.Client) bool {
+	return getBoolFromAnnotation(meta.Annotations) || IsStackOwnerPaused(meta.Namespace, meta.OwnerReferences, client)
+}
+
+// IsStackOwnerPaused checks if the parent Stack is paused.
+func IsStackOwnerPaused(namespace string, owners []v1.OwnerReference, client client.Client) bool {
+	// Check if annotation is set on owner.
+	for _, owner := range owners {
+		if owner.Kind == stack {
+			var stackInstance deploymentsv1alpha1.Stack
+			name := types.NamespacedName{Namespace: namespace, Name: owner.Name}
+			if err := client.Get(context.TODO(), name, &stackInstance); err != nil {
+				log.Error(err, "Cannot retrieve stack instance")
+				return false
+			}
+			return getBoolFromAnnotation(stackInstance.Annotations)
+		}
+	}
+	return false
+}
+
+// Extract the desired state from the map that contains annotations.
+func getBoolFromAnnotation(annotations map[string]string) bool {
+	if annotations == nil {
+		return false
+	}
+
+	stateAsString, exists := annotations[PauseAnnotationName]
+
+	if !exists {
+		return false
+	}
+
+	expectedState, err := strconv.ParseBool(stateAsString)
+	if err != nil {
+		log.Error(err, "Cannot parse %s as a bool, defaulting to %s: \"false\"", annotations[PauseAnnotationName], PauseAnnotationName)
+		return false
+	}
+
+	return expectedState
+}

--- a/stack-operator/pkg/controller/common/pause_test.go
+++ b/stack-operator/pkg/controller/common/pause_test.go
@@ -1,0 +1,137 @@
+package common
+
+import (
+	"fmt"
+	"github.com/elastic/stack-operators/stack-operator/pkg/apis/deployments/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	apiV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+// Create a fake client that will return some owners
+func ownerClient(sc *runtime.Scheme, ownerAnnotationSequence []map[string]string) client.Client {
+	var stacks []runtime.Object
+	for i, annotation := range ownerAnnotationSequence {
+		stack := &v1alpha1.Stack{
+			ObjectMeta: apiV1.ObjectMeta{
+				Name:        fmt.Sprintf("a-stack-%d", i),
+				Namespace:   "foo",
+				Annotations: annotation,
+			},
+			TypeMeta: apiV1.TypeMeta{
+				Kind:       "Stack",
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			},
+		}
+		stacks = append(stacks, stack)
+	}
+	return fake.NewFakeClientWithScheme(sc, stacks...)
+}
+
+type testcase struct {
+	name string
+
+	// annotationSequence is list of annotations that are simulated.
+	annotationSequence []map[string]string
+
+	// ownerAnnotationSequence is list of annotations that are apply on the owner (the Stack)
+	ownerAnnotationSequence []map[string]string
+
+	// Expected pause status.
+	expectedState []bool
+}
+
+func registerScheme(t *testing.T) *runtime.Scheme {
+	sc := scheme.Scheme
+	if err := v1alpha1.SchemeBuilder.AddToScheme(sc); err != nil {
+		assert.Fail(t, "failed to build custom scheme")
+	}
+	return sc
+}
+
+func TestPauseCondition(t *testing.T) {
+	tests := []testcase{
+		{
+			name:           "Simple pause/resume simulation (a.k.a the Happy Path)",
+			annotationSequence: []map[string]string{
+				{PauseAnnotationName: "true"},
+				{PauseAnnotationName: "false"},
+				{PauseAnnotationName: "true"},
+				{PauseAnnotationName: "false"},
+			},
+			ownerAnnotationSequence: []map[string]string{
+				{}, {}, {}, {},
+			},
+			expectedState: []bool{
+				true,
+				false,
+				true,
+				false,
+			},
+		},
+		{
+			name:           "Can't parse or empty annotation",
+			annotationSequence: []map[string]string{
+				{PauseAnnotationName: ""}, // empty annotation
+				{PauseAnnotationName: "true"},
+				{PauseAnnotationName: "XXXX"}, // unable to parse this one
+				{PauseAnnotationName: "1"},    // 1 == true
+				{PauseAnnotationName: "0"},    // 0 == false
+			},
+			ownerAnnotationSequence: []map[string]string{
+				{}, {}, {}, {},
+			},
+			expectedState: []bool{
+				false,
+				true,
+				false,
+				true,
+				false,
+			},
+		},
+		{
+			name:           "Owner (Stack) is paused",
+			annotationSequence: []map[string]string{
+				{PauseAnnotationName: ""},
+				{PauseAnnotationName: ""},
+				{PauseAnnotationName: ""},
+				{PauseAnnotationName: ""},
+			},
+			ownerAnnotationSequence: []map[string]string{
+				{PauseAnnotationName: "true"},
+				{PauseAnnotationName: "false"},
+				{PauseAnnotationName: "true"},
+				{PauseAnnotationName: "false"},
+			},
+			expectedState: []bool{
+				true,
+				false,
+				true,
+				false,
+			},
+		},
+	}
+
+	sc := registerScheme(t)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for i, expectedState := range test.expectedState {
+				meta := apiV1.ObjectMeta{
+					Name:        "bar",
+					Namespace:   "foo",
+					Annotations: test.annotationSequence[i],
+				}
+				if len(test.ownerAnnotationSequence) > 0 {
+					meta.OwnerReferences = []apiV1.OwnerReference{{Kind: "Stack", Name: fmt.Sprintf("a-stack-%d", i)}}
+				}
+				actualPauseState := IsPaused(meta, ownerClient(sc, test.ownerAnnotationSequence))
+				assert.Equal(t, expectedState, actualPauseState)
+			}
+		})
+	}
+}

--- a/stack-operator/pkg/controller/kibana/kibana_controller.go
+++ b/stack-operator/pkg/controller/kibana/kibana_controller.go
@@ -118,6 +118,12 @@ func (r *ReconcileKibana) Reconcile(request reconcile.Request) (reconcile.Result
 	// Fetch the Kibana instance
 	kb := &kibanav1alpha1.Kibana{}
 	err := r.Get(context.TODO(), request.NamespacedName, kb)
+
+	if common.IsPaused(kb.ObjectMeta, r.Client) {
+		log.Info("Paused : skipping reconciliation", "iteration", currentIteration)
+		return common.PauseRequeue, nil
+	}
+
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Object not found, return.  Created objects are automatically garbage collected.

--- a/stack-operator/pkg/controller/stack/stack_controller.go
+++ b/stack-operator/pkg/controller/stack/stack_controller.go
@@ -15,6 +15,7 @@ import (
 	deploymentsv1alpha1 "github.com/elastic/stack-operators/stack-operator/pkg/apis/deployments/v1alpha1"
 	"github.com/elastic/stack-operators/stack-operator/pkg/apis/elasticsearch/v1alpha1"
 	v1alpha12 "github.com/elastic/stack-operators/stack-operator/pkg/apis/kibana/v1alpha1"
+	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common"
 	"github.com/elastic/stack-operators/stack-operator/pkg/controller/common/nodecerts"
 	"github.com/elastic/stack-operators/stack-operator/pkg/utils/diff"
 	"github.com/elastic/stack-operators/stack-operator/pkg/utils/k8s"
@@ -142,6 +143,11 @@ func (r *ReconcileStack) Reconcile(request reconcile.Request) (reconcile.Result,
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
+	}
+
+	if common.IsPaused(stack.ObjectMeta, r.Client) {
+		log.Info("Paused : skipping reconciliation", "iteration", currentIteration)
+		return common.PauseRequeue, nil
 	}
 
 	// use the same name for es and kibana resources for now


### PR DESCRIPTION
Add an annotation that can be used to pause the operators.
If the annotation is set on the owner **all the dependents are also paused**.

e.g.

```yaml
metadata:
  annotations:
    common.k8s.elastic.co/pause: "true"
```

Or in one line :

```bash
$ kubectl annotate stack stack-sample --overwrite common.k8s.elastic.co/pause=true
```

Events are generated when transitioning from a state to an other : 

```
$ kubectl get event -w
LAST SEEN   FIRST SEEN   COUNT     NAME                             KIND                   SUBOBJECT   TYPE      REASON             SOURCE                     MESSAGE
default   0s        0s        1         stack-sample.157df53478b384b0   Stack               Normal    ControllerPaused   stack-controller   Controller for default/stack-sample paused
```

To resume a controller just remove the annotation or set it to `"false"`

```
$ kubectl get event
default   0s        0s        1         stack-sample.157df54be08d3ec0   Stack               Normal    ControllerResumed   stack-controller   Controller for default/stack-sample resumed
```