### PR TITLE
Use the default image pull policy for the sidecar init and the cron snapshotter

### DIFF
--- a/stack-operator/pkg/controller/elasticsearch/initcontainer/sidecar_init.go
+++ b/stack-operator/pkg/controller/elasticsearch/initcontainer/sidecar_init.go
@@ -13,9 +13,8 @@ var script = `
 
 func NewSidecarInitContainer(sharedVolume volume.VolumeLike, operatorImage string) corev1.Container {
 	return corev1.Container{
-		Name:            "sidecar-init",
-		Image:           operatorImage,
-		ImagePullPolicy: corev1.PullAlways,
+		Name:  "sidecar-init",
+		Image: operatorImage,
 		Env: []corev1.EnvVar{
 			{Name: "SHARED_BIN", Value: sharedVolume.VolumeMount().MountPath},
 		},

--- a/stack-operator/pkg/controller/elasticsearch/snapshot/cronjob.go
+++ b/stack-operator/pkg/controller/elasticsearch/snapshot/cronjob.go
@@ -106,10 +106,9 @@ func NewCronJob(params CronJobParams) *batchv1beta1.CronJob {
 										},
 									}},
 								},
-								Image:           params.SnapshotterImage,
-								ImagePullPolicy: corev1.PullAlways,
-								Args:            []string{"snapshotter"},
-								Name:            CronJobName(params.Parent),
+								Image: params.SnapshotterImage,
+								Args:  []string{"snapshotter"},
+								Name:  CronJobName(params.Parent),
 								VolumeMounts: []corev1.VolumeMount{
 									caCertSecret.VolumeMount(),
 								},


### PR DESCRIPTION
Resolves https://github.com/elastic/stack-operators/issues/293.

Remove `ImagePullPolicy: corev1.PullAlways,` to use the default image pull policy for the sidecar init and the cron snapshotter container which is:
- when the image tag is present but not :latest: `IfNotPresent` is applied
- either the image tag is :latest or it is omitted: `Always` is applied
