### PR TITLE
Export shell to sub-make/shells

### DIFF
--- a/local-volume/Makefile
+++ b/local-volume/Makefile
@@ -1,3 +1,4 @@
+export SHELL := /bin/bash
 DEP := $(shell command -v dep)
 IMG_TAG ?= latest
 IMG_MINIKUBE = localhost:5000/elastic-cloud-dev/elastic-local

--- a/stack-operator/Makefile
+++ b/stack-operator/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+export SHELL := /bin/bash
 INSTALL_HELP = "please refer to the README.md for how to install it."
 GO := $(shell command -v go)
 GOIMPORTS := $(shell command -v goimports)


### PR DESCRIPTION
From the make manual:
```
Furthermore, when you do set SHELL in your makefile that value is not exported in the environment to recipe lines that make invokes. Instead, the value inherited from the user's environment, if any, is exported. You can override this behavior by explicitly exporting SHELL (see Communicating Variables to a Sub-make), forcing it to be passed in the environment to recipe lines. 
```

Fixes: 
(when using a non-POSIX shell like `fish`)
```
make run
-> Checking existence of the operator image in minikube...
/bin/bash: line 0: set: -g: invalid option
set: usage: set [--abefhkmnptuvxBCHP] [-o option] [arg ...]
/bin/bash: line 0: set: -g: invalid option
set: usage: set [--abefhkmnptuvxBCHP] [-o option] [arg ...]
/bin/bash: line 0: set: -g: invalid option
set: usage: set [--abefhkmnptuvxBCHP] [-o option] [arg ...]
/bin/bash: line 0: set: -g: invalid option
set: usage: set [--abefhkmnptuvxBCHP] [-o option] [arg ...]
make: *** [run] Error 1
```