### PR TITLE
Rename `make ci` relative directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,5 @@ ci: build-image
 		-w $(MOUNT_PATH) \
 		$(CI_IMAGE_NAME) \
 		bash -c \
-			"make -C elastic-operator ci && \
+			"make -C operators ci && \
 			 make -C local-volume ci"


### PR DESCRIPTION
Small renaming to reflect that the directory `stack-operator` has been renamed `operators`.