### PR TITLE
Reuse PVC when re-creating a pod that has been killed

### DIFF
--- a/operators/pkg/controller/elasticsearch/driver/pods.go
+++ b/operators/pkg/controller/elasticsearch/driver/pods.go
@@ -174,7 +174,7 @@ func newPVCFromTemplate(claimTemplate corev1.PersistentVolumeClaim, pod *corev1.
 	// reflecting state from K8s.
 	pvc.Labels = pod.Labels
 	// Add the current pod name as a label
-	pvc.Labels[label.NodeNameLabelName] = pod.Name
+	pvc.Labels[label.PodNameLabelName] = pod.Name
 	pvc.Annotations = pod.Annotations
 	// TODO: add more labels or annotations?
 	return pvc

--- a/operators/pkg/controller/elasticsearch/driver/pods_test.go
+++ b/operators/pkg/controller/elasticsearch/driver/pods_test.go
@@ -45,9 +45,9 @@ func Test_newPVCFromTemplate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "elasticsearch-sample-es-6bw9qkw77k-data",
 					Labels: map[string]string{
-						"l1":                    "v1",
-						"l2":                    "v2",
-						label.NodeNameLabelName: "elasticsearch-sample-es-6bw9qkw77k",
+						"l1":                   "v1",
+						"l2":                   "v2",
+						label.PodNameLabelName: "elasticsearch-sample-es-6bw9qkw77k",
 					},
 				},
 			},

--- a/operators/pkg/controller/elasticsearch/label/label.go
+++ b/operators/pkg/controller/elasticsearch/label/label.go
@@ -17,8 +17,8 @@ const (
 	// ClusterNameLabelName used to represent a cluster in k8s resources
 	ClusterNameLabelName = "elasticsearch.k8s.elastic.co/cluster-name"
 
-	// NodeName is used to store the name of the node on other objects
-	NodeNameLabelName = "elasticsearch.k8s.elastic.co/node-name"
+	// PodNameLabelName is used to store the name of the pod on other objects
+	PodNameLabelName = "elasticsearch.k8s.elastic.co/node-name"
 
 	// Type represents the elasticsearch type
 	Type = "elasticsearch"

--- a/operators/pkg/controller/elasticsearch/pvc/pvc.go
+++ b/operators/pkg/controller/elasticsearch/pvc/pvc.go
@@ -114,7 +114,7 @@ func compareStorageClass(claim, candidate *corev1.PersistentVolumeClaim) bool {
 	return standardStorageClassname == *candidate.Spec.StorageClassName
 }
 
-// compare two maps but ignore the label.NodeNameLabelName key
+// compare two maps but ignore the label.PodNameLabelName key
 // TODO : do we really need a strict comparison ?
 func compareLabels(labels1 map[string]string, labels2 map[string]string) bool {
 	if labels1 == nil || labels2 == nil {
@@ -124,7 +124,7 @@ func compareLabels(labels1 map[string]string, labels2 map[string]string) bool {
 		return false
 	}
 	for key1, val1 := range labels1 {
-		if key1 == label.NodeNameLabelName {
+		if key1 == label.PodNameLabelName {
 			continue
 		}
 		if val2, ok := labels2[key1]; !ok || val2 != val1 {
@@ -135,7 +135,7 @@ func compareLabels(labels1 map[string]string, labels2 map[string]string) bool {
 }
 
 func GetPodNameFromLabels(pvc *corev1.PersistentVolumeClaim) (string, error) {
-	if name, ok := pvc.Labels[label.NodeNameLabelName]; ok {
+	if name, ok := pvc.Labels[label.PodNameLabelName]; ok {
 		return name, nil
 	}
 	return "", ErrNotNodeNameLabelNotFound

--- a/operators/pkg/controller/elasticsearch/pvc/pvc_test.go
+++ b/operators/pkg/controller/elasticsearch/pvc/pvc_test.go
@@ -63,7 +63,7 @@ func newPodLabel(podName string, sourceLabels map[string]string) map[string]stri
 	for key, value := range sourceLabels {
 		newMap[key] = value
 	}
-	newMap[label.NodeNameLabelName] = podName
+	newMap[label.PodNameLabelName] = podName
 	newMap[label.ClusterNameLabelName] = "elasticsearch-sample"
 	return newMap
 }


### PR DESCRIPTION
Fix #311

# Overview of the proposed changes

1. For each pod that needs to be created we seek for a matching orphan PVC. For the moment a
matching PVC is a one with exactly the same labels
_(version, cluster-name, node-data, node-ingest, node-master, etc...)_.

2. If we have a match then the new POD reuses the PVC. For consistency the name of the POD is
changed according to the name of the PVC.

# Known limitations

* Only one PVC per Pod is managed for the moment _(data)_.

