### PR TITLE
Create public transport service

### DIFF
--- a/operators/pkg/controller/elasticsearch/services/services.go
+++ b/operators/pkg/controller/elasticsearch/services/services.go
@@ -80,8 +80,14 @@ func NewPublicService(es v1alpha1.ElasticsearchCluster) *corev1.Service {
 			Selector: label.NewLabels(es),
 			Ports: []corev1.ServicePort{
 				corev1.ServicePort{
+					Name:     "https",
 					Protocol: corev1.ProtocolTCP,
 					Port:     pod.HTTPPort,
+				},
+				corev1.ServicePort{
+					Name:     "transport",
+					Protocol: corev1.ProtocolTCP,
+					Port:     pod.TransportClientPort,
 				},
 			},
 			SessionAffinity: corev1.ServiceAffinityNone,


### PR DESCRIPTION
Resolves https://github.com/elastic/k8s-operators/issues/307 .

- Update the `PublicService` to add the transport client port