### PR TITLE
Check if we can replace a pod that is dying

### DIFF
--- a/operators/pkg/controller/elasticsearch/mutation/comparison.go
+++ b/operators/pkg/controller/elasticsearch/mutation/comparison.go
@@ -217,6 +217,12 @@ ExpectedTemplates:
 
 // templateMatchesActualVolumeAndPvc returns true if the pvc matches the volumeAndPVC
 func templateMatchesActualVolumeAndPvc(pvcTemplate corev1.PersistentVolumeClaim, actualVolumeAndPVC volumeAndPVC) bool {
+
+	if actualVolumeAndPVC.pvc.DeletionTimestamp != nil {
+		// PVC is being deleted
+		return false
+	}
+
 	if pvcTemplate.Name != actualVolumeAndPVC.volume.Name {
 		// name from template does not match actual, no match
 		return false


### PR DESCRIPTION
An attempt to address partially #366 

This a very simple implementation, it's minimalist but I think it does the job for some simple use-cases.
The drawback of this PR is that a strict "equality" between the deleted pod and the new one is expected, we will have to change it when we want to support "inline" updates.

Last Friday  @nkvoll said that we may need an other state while computing "mutations", I'm not sure but may be I'm missing something.
I think we need a kind of "pod and pvc lifecycles" specification and expectations, maybe a good candidate for an ADR ?
Some of the questions I would like to address :
* What changes can be done "inline" ? (Disclaimer : I'm still not familiar with what is done with ESS/ECE)
* What should be done if :
  * All Pods are deleted and in the mean time the spec the `ElasticsearchCluster` is changed ?
  * A PVC is still orphaned after a reconciliation loop ? Does it mean we lose some data ?