### PR TITLE
Rename public service

### DIFF
--- a/operators/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
+++ b/operators/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
@@ -241,11 +241,11 @@ const (
 // ElasticsearchStatus defines the observed state of Elasticsearch
 type ElasticsearchStatus struct {
 	commonv1alpha1.ReconcilerStatus
-	Health        ElasticsearchHealth             `json:"health,omitempty"`
-	Phase         ElasticsearchOrchestrationPhase `json:"phase,omitempty"`
-	ClusterUUID   string                          `json:"clusterUUID,omitempty"`
-	MasterNode    string                          `json:"masterNode,omitempty"`
-	PublicService string                          `json:"publicService,omitempty"`
+	Health          ElasticsearchHealth             `json:"health,omitempty"`
+	Phase           ElasticsearchOrchestrationPhase `json:"phase,omitempty"`
+	ClusterUUID     string                          `json:"clusterUUID,omitempty"`
+	MasterNode      string                          `json:"masterNode,omitempty"`
+	ExternalService string                          `json:"service,omitempty"`
 }
 
 // IsDegraded returns true if the current status is worse than the previous.

--- a/operators/pkg/controller/elasticsearch/driver/default.go
+++ b/operators/pkg/controller/elasticsearch/driver/default.go
@@ -146,7 +146,7 @@ func (d *defaultDriver) Reconcile(
 		d.Scheme,
 		d.ClusterCa,
 		es,
-		[]corev1.Service{genericResources.PublicService, genericResources.DiscoveryService},
+		[]corev1.Service{genericResources.ExternalService, genericResources.DiscoveryService},
 		trustRelationships,
 	); err != nil {
 		return results.WithError(err)
@@ -156,7 +156,7 @@ func (d *defaultDriver) Reconcile(
 	if err != nil {
 		return results.WithError(err)
 	}
-	esClient := d.newElasticsearchClient(genericResources.PublicService, internalUsers.ControllerUser)
+	esClient := d.newElasticsearchClient(genericResources.ExternalService, internalUsers.ControllerUser)
 
 	observedState := d.observedStateResolver(k8s.ExtractNamespacedName(&es), esClient)
 
@@ -194,7 +194,7 @@ func (d *defaultDriver) Reconcile(
 		results.WithError(err)
 	}
 
-	esReachable, err := services.IsServiceReady(d.Client, genericResources.PublicService)
+	esReachable, err := services.IsServiceReady(d.Client, genericResources.ExternalService)
 	if err != nil {
 		return results.WithError(err)
 	}
@@ -297,7 +297,7 @@ func (d *defaultDriver) Reconcile(
 		// cannot be reached, hence we cannot delete pods.
 		// Probably it was just created and is not ready yet.
 		// Let's retry in a while.
-		log.Info("ES public service not ready yet for shard migration reconciliation. Requeuing.")
+		log.Info("ES external service not ready yet for shard migration reconciliation. Requeuing.")
 
 		reconcileState.UpdateElasticsearchPending(resourcesState.CurrentPods)
 

--- a/operators/pkg/controller/elasticsearch/driver/generic_resources.go
+++ b/operators/pkg/controller/elasticsearch/driver/generic_resources.go
@@ -15,8 +15,8 @@ import (
 
 // GenericResources are resources that all clusters have.
 type GenericResources struct {
-	// PublicService is the user-facing service
-	PublicService corev1.Service
+	// ExternalService is the user-facing service
+	ExternalService corev1.Service
 	// DiscoveryService is the service used by ES for discovery purposes
 	DiscoveryService corev1.Service
 }
@@ -36,11 +36,11 @@ func reconcileGenericResources(
 		return nil, err
 	}
 
-	publicService := services.NewPublicService(es)
-	_, err = common.ReconcileService(c, scheme, publicService, &es)
+	externalService := services.NewExternalService(es)
+	_, err = common.ReconcileService(c, scheme, externalService, &es)
 	if err != nil {
 		return nil, err
 	}
 
-	return &GenericResources{DiscoveryService: *discoveryService, PublicService: *publicService}, nil
+	return &GenericResources{DiscoveryService: *discoveryService, ExternalService: *externalService}, nil
 }

--- a/operators/pkg/controller/elasticsearch/reconcile/resources_state.go
+++ b/operators/pkg/controller/elasticsearch/reconcile/resources_state.go
@@ -31,8 +31,8 @@ type ResourcesState struct {
 	DeletingPods []corev1.Pod
 	// PVCs are all the PVCs related to this deployment.
 	PVCs []corev1.PersistentVolumeClaim
-	// PublicService is the public service related to the Elasticsearch cluster.
-	PublicService corev1.Service
+	// ExternalService is the user-facing service related to the Elasticsearch cluster.
+	ExternalService corev1.Service
 }
 
 // NewResourcesStateFromAPI reflects the current ResourcesState from the API
@@ -69,7 +69,7 @@ func NewResourcesStateFromAPI(c k8s.Client, es v1alpha1.ElasticsearchCluster) (*
 		return nil, err
 	}
 
-	publicService, err := services.GetPublicService(c, es)
+	externalService, err := services.GetExternalService(c, es)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func NewResourcesStateFromAPI(c k8s.Client, es v1alpha1.ElasticsearchCluster) (*
 		CurrentPodsByPhase: currentPodsByPhase,
 		DeletingPods:       deletingPods,
 		PVCs:               pvcs,
-		PublicService:      publicService,
+		ExternalService:    externalService,
 	}
 
 	return &state, nil

--- a/operators/pkg/controller/elasticsearch/reconcile/state.go
+++ b/operators/pkg/controller/elasticsearch/reconcile/state.go
@@ -66,7 +66,7 @@ func (s *State) updateWithPhase(
 
 	s.status.AvailableNodes = len(AvailableElasticsearchNodes(resourcesState.CurrentPods))
 	s.status.Phase = phase
-	s.status.PublicService = resourcesState.PublicService.Name
+	s.status.ExternalService = resourcesState.ExternalService.Name
 
 	s.status.Health = v1alpha1.ElasticsearchHealth("unknown")
 	if observedState.ClusterHealth != nil && observedState.ClusterHealth.Status != "" {

--- a/operators/pkg/controller/elasticsearch/services/services.go
+++ b/operators/pkg/controller/elasticsearch/services/services.go
@@ -56,24 +56,24 @@ func NewDiscoveryService(es v1alpha1.ElasticsearchCluster) *corev1.Service {
 	}
 }
 
-// PublicServiceName returns the name for the public service
+// ExternalServiceName returns the name for the external service
 // associated to this cluster
-func PublicServiceName(esName string) string {
-	return stringsutil.Concat(esName, "-es-public")
+func ExternalServiceName(esName string) string {
+	return stringsutil.Concat(esName, "-es")
 }
 
-// PublicServiceURL returns the URL used to reach Elasticsearch public endpoint
-func PublicServiceURL(es v1alpha1.ElasticsearchCluster) string {
-	return stringsutil.Concat("https://", PublicServiceName(es.Name), ".", es.Namespace, globalServiceSuffix, ":", strconv.Itoa(pod.HTTPPort))
+// ExternalServiceURL returns the URL used to reach Elasticsearch external endpoint
+func ExternalServiceURL(es v1alpha1.ElasticsearchCluster) string {
+	return stringsutil.Concat("https://", ExternalServiceName(es.Name), ".", es.Namespace, globalServiceSuffix, ":", strconv.Itoa(pod.HTTPPort))
 }
 
-// NewPublicService returns the public service associated to the given cluster
+// NewExternalService returns the external service associated to the given cluster
 // It is used by users to perform requests against one of the cluster nodes.
-func NewPublicService(es v1alpha1.ElasticsearchCluster) *corev1.Service {
+func NewExternalService(es v1alpha1.ElasticsearchCluster) *corev1.Service {
 	var svc = corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: es.Namespace,
-			Name:      PublicServiceName(es.Name),
+			Name:      ExternalServiceName(es.Name),
 			Labels:    label.NewLabels(es),
 		},
 		Spec: corev1.ServiceSpec{
@@ -116,13 +116,13 @@ func IsServiceReady(c k8s.Client, service corev1.Service) (bool, error) {
 	return false, nil
 }
 
-// GetPublicService returns the public service associated to the given Elasticsearch cluster.
-func GetPublicService(c k8s.Client, es v1alpha1.ElasticsearchCluster) (corev1.Service, error) {
+// GetExternalService returns the external service associated to the given Elasticsearch cluster.
+func GetExternalService(c k8s.Client, es v1alpha1.ElasticsearchCluster) (corev1.Service, error) {
 	var svc corev1.Service
 
 	namespacedName := types.NamespacedName{
 		Namespace: es.Namespace,
-		Name:      PublicServiceName(es.Name),
+		Name:      ExternalServiceName(es.Name),
 	}
 
 	if err := c.Get(namespacedName, &svc); err != nil {

--- a/operators/pkg/controller/elasticsearch/services/services_test.go
+++ b/operators/pkg/controller/elasticsearch/services/services_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestPublicServiceURL(t *testing.T) {
+func TestExternalServiceURL(t *testing.T) {
 	type args struct {
 		es v1alpha1.ElasticsearchCluster
 	}
@@ -30,7 +30,7 @@ func TestPublicServiceURL(t *testing.T) {
 					Namespace: "default",
 				},
 			}},
-			want: "https://an-es-name-es-public.default.svc.cluster.local:9200",
+			want: "https://an-es-name-es.default.svc.cluster.local:9200",
 		},
 		{
 			name: "Another Service URL",
@@ -40,12 +40,12 @@ func TestPublicServiceURL(t *testing.T) {
 					Namespace: "default",
 				},
 			}},
-			want: "https://another-es-name-es-public.default.svc.cluster.local:9200",
+			want: "https://another-es-name-es.default.svc.cluster.local:9200",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := PublicServiceURL(tt.args.es)
+			got := ExternalServiceURL(tt.args.es)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/operators/pkg/controller/elasticsearch/snapshot/snapshot_control.go
+++ b/operators/pkg/controller/elasticsearch/snapshot/snapshot_control.go
@@ -153,7 +153,7 @@ func ReconcileSnapshotterCronJob(
 		Elasticsearch:    es,
 		SnapshotterImage: operatorImage,
 		User:             user,
-		EsURL:            services.PublicServiceURL(es),
+		EsURL:            services.ExternalServiceURL(es),
 	}
 	expected := NewCronJob(params)
 	if err := controllerutil.SetControllerReference(&es, expected, scheme); err != nil {

--- a/operators/pkg/controller/stack/stack_controller.go
+++ b/operators/pkg/controller/stack/stack_controller.go
@@ -239,7 +239,7 @@ func (r *ReconcileStack) Reconcile(request reconcile.Request) (reconcile.Result,
 	}
 
 	// TODO: be dynamic wrt to the service name
-	kb.Spec.Elasticsearch.URL = fmt.Sprintf("https://%s:9200", services.PublicServiceName(es.Name))
+	kb.Spec.Elasticsearch.URL = fmt.Sprintf("https://%s:9200", services.ExternalServiceName(es.Name))
 
 	internalUsersSecretName := secret.ElasticInternalUsersSecretName(es.Name)
 	var internalUsersSecret corev1.Secret

--- a/operators/test/e2e/failure_test.go
+++ b/operators/test/e2e/failure_test.go
@@ -164,9 +164,9 @@ func TestDeleteServices(t *testing.T) {
 				},
 			},
 			{
-				Name: "Delete public service",
+				Name: "Delete external service",
 				Test: func(t *testing.T) {
-					s, err := k.GetService(s.Name + "-es-public")
+					s, err := k.GetService(s.Name + "-es")
 					require.NoError(t, err)
 					err = k.Client.Delete(s)
 					require.NoError(t, err)

--- a/operators/test/e2e/helpers/elasticsearch.go
+++ b/operators/test/e2e/helpers/elasticsearch.go
@@ -36,7 +36,7 @@ func NewElasticsearchClient(stack v1alpha1.Stack, k *K8sHelper) (*client.Client,
 	if err != nil {
 		return nil, err
 	}
-	inClusterURL := fmt.Sprintf("https://%s-es-public.%s.svc.cluster.local:9200", stack.Name, stack.Namespace)
+	inClusterURL := fmt.Sprintf("https://%s-es.%s.svc.cluster.local:9200", stack.Name, stack.Namespace)
 	var dialer net.Dialer
 	if *autoPortForward {
 		dialer = portforward.NewForwardingDialer()

--- a/operators/test/e2e/stack/checks_k8s.go
+++ b/operators/test/e2e/stack/checks_k8s.go
@@ -230,7 +230,7 @@ func CheckServices(stack v1alpha1.Stack, k *helpers.K8sHelper) helpers.TestStep 
 		Test: helpers.Eventually(func() error {
 			for _, s := range []string{
 				stack.Name + "-es-discovery",
-				stack.Name + "-es-public",
+				stack.Name + "-es",
 				stack.Name + "-kibana",
 			} {
 				if _, err := k.GetService(s); err != nil {
@@ -250,7 +250,7 @@ func CheckServicesEndpoints(stack v1alpha1.Stack, k *helpers.K8sHelper) helpers.
 			for endpointName, addrCount := range map[string]int{
 				stack.Name + "-es-discovery": int(stack.Spec.Elasticsearch.NodeCount()),
 				stack.Name + "-kibana":       int(stack.Spec.Kibana.NodeCount),
-				stack.Name + "-es-public":    int(stack.Spec.Elasticsearch.NodeCount()),
+				stack.Name + "-es":           int(stack.Spec.Elasticsearch.NodeCount()),
 			} {
 				if addrCount == 0 {
 					continue // maybe no Kibana in this stack


### PR DESCRIPTION
Resolves #384.

- Rename `PublicService` in `ExternalService`.
- Remove the `-public` suffix from the k8s service name and `public` from the
service field of the ES cluster status.