### PR TITLE
Also look for Exited registry-port-forwarder container

### DIFF
--- a/operators/hack/registry.sh
+++ b/operators/hack/registry.sh
@@ -31,7 +31,7 @@ kubectl-in-docker() {
   fi
 
   # Remove potential existing container
-  if [[ "$(docker ps --filter=name=registry-port-forwarder -q)" != "" ]]; then
+  if [[ "$(docker ps -a --filter=name=registry-port-forwarder -q)" != "" ]]; then
     docker rm --force registry-port-forwarder
   fi
 
@@ -57,7 +57,7 @@ main() {
     ;;
     "port-forward stop")
       # Delete the container if it exists
-      if [[ "$(docker ps --filter=name=registry-port-forwarder -q)" != "" ]]; then
+      if [[ "$(docker ps -a --filter=name=registry-port-forwarder -q)" != "" ]]; then
         docker rm --force registry-port-forwarder
       fi
     ;;


### PR DESCRIPTION
I'm not sure to know why my deployment was in this state but the `registry-port-forwarder` exited with code `1` and `hack/registry.sh` was unable to see it because it is only looking for running containers.