### PR TITLE
Replace top-level mount paths with /mnt/elastic

### DIFF
--- a/operators/pkg/controller/elasticsearch/keystore/keystore.go
+++ b/operators/pkg/controller/elasticsearch/keystore/keystore.go
@@ -7,7 +7,7 @@ package keystore
 const (
 	managedSecretSuffix = "-keystore"
 	// SecretMountPath is the mount path for keystore secrets in the init container.
-	SecretMountPath = "/keystore-secrets"
+	SecretMountPath = "/mnt/elastic/keystore-secrets"
 	// SecretVolumeName is the name of the volume where the keystore secret is referenced.
 	SecretVolumeName = "keystore"
 )

--- a/operators/pkg/controller/elasticsearch/version/version6/podspecs_test.go
+++ b/operators/pkg/controller/elasticsearch/version/version6/podspecs_test.go
@@ -242,7 +242,7 @@ func Test_newSidecarContainers(t *testing.T) {
 						{Name: "SOURCE_DIR", Value: "/keystore"},
 						{Name: "RELOAD_CREDENTIALS", Value: "true"},
 						{Name: "USERNAME", Value: ""}, // because dummy probe user is used
-						{Name: "PASSWORD_FILE", Value: "/probe-user"},
+						{Name: "PASSWORD_FILE", Value: "/mnt/elastic/probe-user"},
 						{Name: "CERTIFICATES_PATH", Value: "/certs/ca.pem"},
 					},
 					VolumeMounts: []corev1.VolumeMount{

--- a/operators/pkg/controller/elasticsearch/volume/volume.go
+++ b/operators/pkg/controller/elasticsearch/volume/volume.go
@@ -11,8 +11,8 @@ import (
 // Default values for the volume name and paths
 const (
 	// DefaultSecretMountPath where secrets are mounted if not specified otherwise.
-	DefaultSecretMountPath                = "/secrets"
-	ProbeUserSecretMountPath              = "/probe-user"
+	DefaultSecretMountPath                = "/mnt/elastic/secrets"
+	ProbeUserSecretMountPath              = "/mnt/elastic/probe-user"
 	ProbeUserVolumeName                   = "probe-user"
 	NodeCertificatesSecretVolumeName      = "node-certificates"
 	NodeCertificatesSecretVolumeMountPath = "/usr/share/elasticsearch/config/node-certs"


### PR DESCRIPTION
Fixes #379 

