### PR TITLE
Push latest operator image when bootstraping gke

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -154,6 +154,8 @@ set-context-gke:
 bootstrap-gke:
 	./hack/gke-cluster.sh create
 	$(MAKE) set-context-gke cluster-bootstrap
+	# push "latest" operator image to be used for init containers when running the operator locally
+	$(MAKE) docker-build docker-push OPERATOR_IMAGE=$(OPERATOR_IMAGE_LATEST)
 
 delete-gke:
 	./hack/gke-cluster.sh delete


### PR DESCRIPTION
When running the operator locally with `make run`, we implicitly rely on
the "latest" docker image of the operator for init containers.
On minikube we push it to a local registry when bootstraping the
cluster.
This PR does the same with GKE: build and push the "latest" image to
GCR.

Fixes #423.