### PR TITLE
Set AutomountServiceAccountToken to false for pods

### DIFF
--- a/operators/pkg/controller/elasticsearch/snapshot/cronjob.go
+++ b/operators/pkg/controller/elasticsearch/snapshot/cronjob.go
@@ -82,6 +82,7 @@ func NewCronJob(params CronJobParams) *batchv1beta1.CronJob {
 		Labels:    NewLabels(params.Elasticsearch),
 	}
 
+	automountServiceAccountToken := false
 	return &batchv1beta1.CronJob{
 		ObjectMeta: meta,
 		Spec: batchv1beta1.CronJobSpec{
@@ -121,6 +122,7 @@ func NewCronJob(params CronJobParams) *batchv1beta1.CronJob {
 							Volumes: []corev1.Volume{
 								caCertSecret.Volume(),
 							},
+							AutomountServiceAccountToken: &automountServiceAccountToken,
 						},
 					},
 				},

--- a/operators/pkg/controller/elasticsearch/version/common.go
+++ b/operators/pkg/controller/elasticsearch/version/common.go
@@ -140,6 +140,7 @@ func podSpec(
 	}
 
 	// TODO: Security Context
+	automountServiceAccountToken := false
 	podSpec := corev1.PodSpec{
 		Affinity: p.Affinity,
 
@@ -188,6 +189,7 @@ func podSpec(
 			extraFilesSecretVolume.Volume(),
 			keystoreVolume.Volume(),
 		),
+		AutomountServiceAccountToken: &automountServiceAccountToken,
 	}
 
 	podSpec.Volumes = append(podSpec.Volumes, additionalVolumes...)

--- a/operators/pkg/controller/kibana/pod.go
+++ b/operators/pkg/controller/kibana/pod.go
@@ -51,6 +51,7 @@ func NewPodSpec(p PodSpecParams) corev1.PodSpec {
 		},
 	}
 
+	automountServiceAccountToken := false
 	return corev1.PodSpec{
 		Containers: []corev1.Container{{
 			Resources: corev1.ResourceRequirements{
@@ -68,6 +69,7 @@ func NewPodSpec(p PodSpecParams) corev1.PodSpec {
 			},
 			ReadinessProbe: probe,
 		}},
+		AutomountServiceAccountToken: &automountServiceAccountToken,
 	}
 
 }


### PR DESCRIPTION
Resolves #346.

Set `AutomountServiceAccountToken` to `false` for the pods specs of the snapshot cron job, Kibana and Elasticsearch.