### PR TITLE
Check for local changes after go generation

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -248,6 +248,7 @@ check-requisites:
 check-license-header:
 	../build/check-license-header.sh
 
+# Check if some changes exist in the workspace (eg. `make generate` added some changes)
 check-local-changes:
 	@ [[ "$$(git status --porcelain)" == "" ]] \
 		|| ( echo -e "\nError: dirty local changes"; git status --porcelain; exit 1 )


### PR DESCRIPTION
Resolves #435.

Verify that generated files that are/should be committed are up to date by checking that the output of the `git status --porcelain` command is empty.