### PR TITLE
Fix flaky csr server unit test

### DIFF
--- a/operators/cmd/cert-initializer/server_test.go
+++ b/operators/cmd/cert-initializer/server_test.go
@@ -30,7 +30,10 @@ func waitForServer(t *testing.T, port int) {
 			t.Fatal("server not reachable after 30sec.")
 		case <-retryEvery:
 			// check if TCP port listens to connections
-			_, err := net.DialTimeout("tcp", net.JoinHostPort("", fmt.Sprintf("%d", port)), reqTimeout)
+			conn, err := net.DialTimeout("tcp", net.JoinHostPort("", fmt.Sprintf("%d", port)), reqTimeout)
+			if conn != nil {
+				conn.Close()
+			}
 			if err == nil {
 				return
 			}


### PR DESCRIPTION
The request to get the CSR could actually fail before the server was
started in a separate goroutine.
Let's wait for the server to be reachable before going on, with some
retry logic.