### PR TITLE
Speedup cert secret propagation by also updating the pod

### DIFF
--- a/operators/pkg/controller/elasticsearch/nodecerts/reconcile_test.go
+++ b/operators/pkg/controller/elasticsearch/nodecerts/reconcile_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/pem"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/elastic/k8s-operators/operators/pkg/controller/common/certificates"
 	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/initcontainer"
@@ -254,13 +255,18 @@ func Test_doReconcile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := k8s.WrapClient(fake.NewFakeClient(&tt.secret))
+			err := fakeClient.Create(&tt.pod)
+			require.NoError(t, err)
 
-			_, err := doReconcile(fakeClient, tt.secret, tt.pod, fakeCSRClient, "cluster", "namespace", []corev1.Service{testSvc}, testCa, nil)
+			_, err = doReconcile(fakeClient, tt.secret, tt.pod, fakeCSRClient, "cluster", "namespace", []corev1.Service{testSvc}, testCa, nil)
 			require.NoError(t, err)
 
 			var updatedSecret corev1.Secret
 			err = fakeClient.Get(k8s.ExtractNamespacedName(&objMeta), &updatedSecret)
 			require.NoError(t, err)
+
+			var updatedPod corev1.Pod
+			err = fakeClient.Get(k8s.ExtractNamespacedName(&tt.pod), &updatedPod)
 
 			isUpdated := !reflect.DeepEqual(tt.secret, updatedSecret)
 			require.Equal(t, tt.wantSecretUpdated, isUpdated)
@@ -269,6 +275,9 @@ func Test_doReconcile(t *testing.T) {
 				assert.NotEmpty(t, updatedSecret.Data[certificates.CAFileName])
 				assert.NotEmpty(t, updatedSecret.Data[CSRFileName])
 				assert.NotEmpty(t, updatedSecret.Data[CertFileName])
+				lastCertUpdate, err := time.Parse(time.RFC3339, updatedPod.Annotations[lastCertUpdateAnnotation])
+				require.NoError(t, err)
+				assert.True(t, lastCertUpdate.Add(-5*time.Minute).Before(time.Now()))
 			}
 		})
 	}


### PR DESCRIPTION
Until now, propagating a signed cert to the ES pod's cert-initializer
would take more than 1 minute, since kubelet does sync secret and
configmap volume mount contents every 1 min by default.

A workaround to speedup things is to also modify the pod itself, so that
kubelet immediately reloads the pod's secret volume mounts.

Here we do it with an annotation containing the last cert update
timestamp.

Fixes #486.