### PR TITLE
deploy does not make use of the NAMESPACE_OPERATOR_NAMESPACE variable

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -107,7 +107,8 @@ run: install-crds
 deploy: install-crds docker-build docker-push
 	kustomize build config/global-operator | sed -e 's|$$OPERATOR_IMAGE|$(OPERATOR_IMAGE)|g' | kubectl apply -f -
 	kustomize build config/namespace-operator | sed -e 's|$$OPERATOR_IMAGE|$(OPERATOR_IMAGE)|g' \
-		-e 's|$$MANAGED_NAMESPACE|$(MANAGED_NAMESPACE)|g' | kubectl apply -f -
+		-e 's|$$MANAGED_NAMESPACE|$(MANAGED_NAMESPACE)|g' \
+	        -e 's|$$NAMESPACE_OPERATOR_NAMESPACE|$(NAMESPACE_OPERATOR_NAMESPACE)|g' | kubectl apply -f -
 
 logs-namespace-operator:
 	@ kubectl --namespace=$(NAMESPACE_OPERATOR_NAMESPACE) logs -f statefulset.apps/elastic-namespace-operator

--- a/operators/config/namespace-operator/namespace.yaml
+++ b/operators/config/namespace-operator/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: elastic-namespace-operators
+  name: $NAMESPACE_OPERATOR_NAMESPACE

--- a/operators/config/namespace-operator/operator.yaml
+++ b/operators/config/namespace-operator/operator.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: elastic-namespace-operator
-  namespace: elastic-namespace-operators
+  namespace: $NAMESPACE_OPERATOR_NAMESPACE
   labels:
     control-plane: elastic-namespace-operator
     controller-tools.k8s.io: "1.0"
@@ -19,7 +19,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: elastic-namespace-operator
-  namespace: elastic-namespace-operators
+  namespace: $NAMESPACE_OPERATOR_NAMESPACE
   labels:
     control-plane: elastic-namespace-operator
     controller-tools.k8s.io: "1.0"
@@ -76,4 +76,4 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: webhook-server-secret
-  namespace: elastic-namespace-operators
+  namespace: $NAMESPACE_OPERATOR_NAMESPACE

--- a/operators/config/namespace-operator/role_bindings.yaml
+++ b/operators/config/namespace-operator/role_bindings.yaml
@@ -16,4 +16,4 @@ subjects:
 - kind: ServiceAccount
   name: elastic-namespace-operator
   # namespace the operator is running in
-  namespace: elastic-namespace-operators
+  namespace: $NAMESPACE_OPERATOR_NAMESPACE

--- a/operators/config/namespace-operator/service_account.yaml
+++ b/operators/config/namespace-operator/service_account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: elastic-namespace-operator
-  namespace: elastic-namespace-operators
+  namespace: $NAMESPACE_OPERATOR_NAMESPACE


### PR DESCRIPTION
When running `make deploy` the `NAMESPACE_OPERATOR_NAMESPACE` variable is not used.