### PR TITLE
Fix issue with QoS in e2e tests

### DIFF
--- a/operators/test/e2e/stack/builder.go
+++ b/operators/test/e2e/stack/builder.go
@@ -21,7 +21,7 @@ const defaultVersion = "6.4.2"
 var DefaultResources = common.ResourcesSpec{
 	Limits: map[corev1.ResourceName]resource.Quantity{
 		corev1.ResourceMemory: resource.MustParse("1G"),
-		corev1.ResourceCPU:    resource.MustParse("100m"),
+		corev1.ResourceCPU:    resource.MustParse("500m"),
 	},
 }
 


### PR DESCRIPTION
Currently there might be an issue with tests with an error:
```
 --- FAIL: TestKillOneDataNode/Pods_should_eventually_have_the_expected_resources (180.00s)
        require.go:794: 
            	Error Trace:	testutils.go:42
            	Error:      	Received unexpected error:
            	            	Pod QoS class should be Guaranteed
            	Test:       	TestKillOneDataNode/Pods_should_eventually_have_the_expected_resources
```