### PR TITLE
Add timeout to HTTP client in e2e tests

### DIFF
--- a/operators/test/e2e/helpers/http.go
+++ b/operators/test/e2e/helpers/http.go
@@ -6,13 +6,16 @@ package helpers
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/elastic/k8s-operators/operators/pkg/dev/portforward"
 )
 
 // NewHTTPClient creates a new HTTP client that is aware of any port forwarding configuration.
 func NewHTTPClient() http.Client {
-	client := http.Client{}
+	client := http.Client{
+		Timeout: 60 * time.Second,
+	}
 	if *autoPortForward {
 		client.Transport = &http.Transport{
 			DialContext: portforward.NewForwardingDialer().DialContext,


### PR DESCRIPTION
By default, the HTTP client in Go doesn't set any timeouts.  I'm proposing to set the timeout to 60 sec.