### PR TITLE
Fix kibana e2e check for basic licensed clusters

### DIFF
--- a/operators/test/e2e/stack/checks.go
+++ b/operators/test/e2e/stack/checks.go
@@ -13,5 +13,5 @@ func CheckStackSteps(stack Builder, k8sClient *helpers.K8sHelper) helpers.TestSt
 	return helpers.TestStepList{}.
 		WithSteps(K8sStackChecks(stack, k8sClient)...).
 		WithSteps(ESClusterChecks(stack.Elasticsearch, k8sClient)...).
-		WithSteps(KibanaChecks(stack.Kibana, k8sClient)...)
+		WithSteps(KibanaChecks(stack.Kibana, stack.Elasticsearch.Spec.GetLicenseType())...)
 }

--- a/operators/test/e2e/stack/checks_kb.go
+++ b/operators/test/e2e/stack/checks_kb.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strings"
 
+	estype "github.com/elastic/k8s-operators/operators/pkg/apis/elasticsearch/v1alpha1"
 	kbtype "github.com/elastic/k8s-operators/operators/pkg/apis/kibana/v1alpha1"
 	"github.com/elastic/k8s-operators/operators/test/e2e/helpers"
 	"github.com/pkg/errors"
@@ -21,17 +22,22 @@ type kbChecks struct {
 
 // Kibana checks returns all test steps to verify the given stack's Kibana
 // deployment is running as expected.
-func KibanaChecks(kb kbtype.Kibana, k *helpers.K8sHelper) helpers.TestStepList {
+func KibanaChecks(kb kbtype.Kibana, licenseType estype.LicenseType) helpers.TestStepList {
 	checks := kbChecks{
 		client: helpers.NewHTTPClient(),
 	}
+	if licenseType == estype.LicenseTypeBasic {
+		return helpers.TestStepList{
+			checks.CheckKbStatusHealthy(kb),
+		}
+	}
 	return helpers.TestStepList{
-		checks.CheckKbLoginHealthy(kb, k),
+		checks.CheckKbLoginHealthy(kb),
 	}
 }
 
 // CheckKbLoginHealthy checks that Kibana is able to connect to Elasticsearch by inspecting its login page.
-func (check *kbChecks) CheckKbLoginHealthy(kb kbtype.Kibana, k *helpers.K8sHelper) helpers.TestStep {
+func (check *kbChecks) CheckKbLoginHealthy(kb kbtype.Kibana) helpers.TestStep {
 	return helpers.TestStep{
 		Name: "Kibana should be able to connect to Elasticsearch",
 		Test: helpers.Eventually(func() error {
@@ -47,6 +53,18 @@ func (check *kbChecks) CheckKbLoginHealthy(kb kbtype.Kibana, k *helpers.K8sHelpe
 				return errors.New("Initial Kibana UI state forbids login which indicates an error in the ES/Kibana setup")
 			}
 			return nil
+		}),
+	}
+}
+
+// CheckKbStatusHealthy checks that Kibana is able to connect to Elasticsearch when x-pack security is off.
+func (check *kbChecks) CheckKbStatusHealthy(kb kbtype.Kibana) helpers.TestStep {
+	return helpers.TestStep{
+		Name: "Kibana should be able to connect to Elasticsearch",
+		Test: helpers.Eventually(func() error {
+			// this will return a 503 on connectivity problems in 6.x and 7.x
+			_, err := check.client.Get(fmt.Sprintf("http://%s-kibana.%s.svc.cluster.local:5601/app/kibana", kb.Name, kb.Namespace))
+			return err
 		}),
 	}
 }


### PR DESCRIPTION
This was broken since the introduction of basic license support.