### PR TITLE
Update GKE cluster version

### DIFF
--- a/operators/hack/gke-cluster.sh
+++ b/operators/hack/gke-cluster.sh
@@ -17,7 +17,7 @@ set -eu
 : "${GKE_CLUSTER_NAME:=${USER//_}-dev-cluster}"
 : "${GKE_CLUSTER_REGION:=europe-west3}"
 : "${GKE_ADMIN_USERNAME:=admin}"
-: "${GKE_CLUSTER_VERSION:=1.11.6-gke.2}"
+: "${GKE_CLUSTER_VERSION:=1.11.6}"
 : "${GKE_MACHINE_TYPE:=n1-highmem-4}"
 : "${GKE_LOCAL_SSD_COUNT:=1}"
 : "${GKE_NODE_COUNT_PER_ZONE:=1}"


### PR DESCRIPTION
E2E tests start failing because:
```
ERROR: (gcloud.beta.container.clusters.create) ResponseError: code=400, message=Master version "1.11.6-gke.2" is unsupported.
```
Based on https://cloud.google.com/kubernetes-engine/versioning-and-upgrades#specifying_cluster_version, it will be enough to set version as `x.y.z`. It will get the latest available patchset (like x.y.z-gke.N) automatically.