### PR TITLE
Design proposal on pods reuse and Elasticsearch restarts

### DIFF
--- a/docs/design/009-pod-reuse-es-restart.md
+++ b/docs/design/009-pod-reuse-es-restart.md
@@ -19,7 +19,6 @@ Reusing pods may also be useful in other situations, where simply restarting Ela
 
 * It must be possible to perform a "full cluster restart" and reuse existing pods.
 * Configuration changes should be propagated through a volume mount, not through the pod spec.
-* It must be eventually consistent. For example, it should not end up leaving a pod in a "stopped" state forever.
 * Operator client cache inconsistencies must be taken into consideration (eg. don't restart a pod 3 times because of a stale cache).
 * Volume propagation time must be taken into consideration (it can take more than 1 minute, the ES restart must not happen before the new configuration is there).
 * It should be resilient to operator restart.


### PR DESCRIPTION
This is a design proposal to cover:

- migration from TLS clusters to non-TLS clusters (and vice-versa)
- reusing pods when there's a configuration change
- implementing cluster restarts (full and rolling)

Related to https://github.com/elastic/k8s-operators/issues/454.

I **think** the solution outlined there **should** work (it's the best one I have so far :)) to handle full cluster restarts for our TLS needs.
Feedbacks are welcome. Please try to pay attention to what can go wrong when reviewing. For examples:
- what if the operator restarts at this point?
- what if the user deletes a pod at this point?
- what if the reconciliation loop is triggered again at this point?
- what if the user modifies the ES spec again at this point?
- can we loose some data here?
- are we provoking downtime here?