### PR TITLE
Fix associations garbage collection

### DIFF
--- a/operators/pkg/controller/association/association_controller_test.go
+++ b/operators/pkg/controller/association/association_controller_test.go
@@ -40,12 +40,18 @@ func Test_deleteOrphanedResources(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceNameFixture,
 						Namespace: associationFixture.Namespace,
+						OwnerReferences: []metav1.OwnerReference{
+							ownerRefFixture,
+						},
 					},
 				},
 				&estype.User{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceNameFixture,
 						Namespace: associationFixture.Namespace,
+						OwnerReferences: []metav1.OwnerReference{
+							ownerRefFixture,
+						},
 					},
 				},
 			},
@@ -65,6 +71,9 @@ func Test_deleteOrphanedResources(t *testing.T) {
 						Labels: map[string]string{
 							AssociationLabelName: associationFixture.Name,
 						},
+						OwnerReferences: []metav1.OwnerReference{
+							ownerRefFixture,
+						},
 					},
 				},
 				&estype.User{
@@ -73,6 +82,9 @@ func Test_deleteOrphanedResources(t *testing.T) {
 						Namespace: associationFixture.Namespace,
 						Labels: map[string]string{
 							AssociationLabelName: associationFixture.Name,
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							ownerRefFixture,
 						},
 					},
 				},
@@ -83,6 +95,9 @@ func Test_deleteOrphanedResources(t *testing.T) {
 						Labels: map[string]string{
 							AssociationLabelName: associationFixture.Name,
 						},
+						OwnerReferences: []metav1.OwnerReference{
+							ownerRefFixture,
+						},
 					},
 				},
 				&estype.User{
@@ -91,6 +106,9 @@ func Test_deleteOrphanedResources(t *testing.T) {
 						Namespace: "other-ns",
 						Labels: map[string]string{
 							AssociationLabelName: associationFixture.Name,
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							ownerRefFixture,
 						},
 					},
 				},

--- a/operators/pkg/controller/association/user_test.go
+++ b/operators/pkg/controller/association/user_test.go
@@ -42,6 +42,16 @@ var associationFixture = assoctype.KibanaElasticsearchAssociation{
 	},
 }
 
+var t = true
+var ownerRefFixture = metav1.OwnerReference{
+	APIVersion:         "associations.k8s.elastic.co/v1alpha1",
+	Kind:               "KibanaElasticsearchAssociation",
+	Name:               "foo",
+	UID:                "",
+	Controller:         &t,
+	BlockOwnerDeletion: &t,
+}
+
 func setupScheme(t *testing.T) *runtime.Scheme {
 	sc := scheme.Scheme
 	if err := assoctype.SchemeBuilder.AddToScheme(sc); err != nil {


### PR DESCRIPTION
Do only gc left over resources owned by the association. Previously it would aggressively gc secrets and users of other associations leading a feedback loop of creation/deletion.