### PR TITLE
Add an example of how to deploy an nginx ingress with TLS and basic auth

### DIFF
--- a/operators/config/samples/ingress/nginx-ingress.yaml
+++ b/operators/config/samples/ingress/nginx-ingress.yaml
@@ -7,7 +7,7 @@
 # - (optional) deploy the cert-manager to auto-generate Let's encrypt certificates: https://docs.cert-manager.io/en/latest/getting-started/install.html
 #
 # Optional:
-# - setup basic auth (see annotations
+# - setup basic auth (see annotations)
 # - setup TLS termination from a TLS certificate (see tls spec)
 # - setup TLS termination from a Let's Encrypt auto-generated TLS certificate (see annotations)
 # - use https to communicate from NGINX to Elasticsearch (see annotations)


### PR DESCRIPTION
The sample provides a working example that sets up an ingress in front of both elasticsearch and
kibana.

It supports:
- TLS termination at the NGINX level (optional)
- TLS cert auto-generation from Let's Encrypt (optional)
- Basic auth at the NGINX level (optional)
- Routes rewriting
- IP filtering (whitelist)
- HTTPS communication from NGINX to ES (if using XPack security): this
is done in "insecure" mode. There is a `secure-verify-ca-secret:
secret-name` annotation that we could use to provide a key and cert, but
it requires some extra changes in the way we store the secret. Follow-up issue: #572.

The goal here is not to demonstrate how exposing ES *must* be done, but
one way to do it nicely.

I tested it manually, using my own domain name:
* using a basic license with basic auth + let's encrypt tls at the NGINX level
* using a trial license with let's encrypt tls at the NGINX level + tls and basic auth at the cluster level

Fixes #465.
Related to #356 and #48.