### PR TITLE
Fixes several golangic-lint issues in local-volume

### DIFF
--- a/local-volume/pkg/k8s/pv.go
+++ b/local-volume/pkg/k8s/pv.go
@@ -49,17 +49,13 @@ func updatePVNodeAffinity(pv *v1.PersistentVolume, nodeName string) bool {
 	// many things can be nil, so this does not look very beautiful :)
 	if na := pv.Spec.NodeAffinity; na != nil {
 		if required := na.Required; required != nil {
-			if terms := required.NodeSelectorTerms; terms != nil {
-				for _, t := range terms {
-					if req := t.MatchExpressions; req != nil {
-						for _, r := range req {
-							if r.Key == expected.Key &&
-								r.Operator == expected.Operator &&
-								len(r.Values) == 1 && r.Values[0] == expected.Values[0] {
-								// value already updated, nothing to do here
-								return false
-							}
-						}
+			for _, t := range required.NodeSelectorTerms {
+				for _, r := range t.MatchExpressions {
+					if r.Key == expected.Key &&
+						r.Operator == expected.Operator &&
+						len(r.Values) == 1 && r.Values[0] == expected.Values[0] {
+						// value already updated, nothing to do here
+						return false
 					}
 				}
 			}

--- a/local-volume/pkg/provisioner/provisioner_test.go
+++ b/local-volume/pkg/provisioner/provisioner_test.go
@@ -5,11 +5,12 @@
 package provisioner
 
 import (
+	"testing"
+
 	"github.com/elastic/k8s-operators/local-volume/pkg/driver/protocol"
 	"github.com/elastic/k8s-operators/local-volume/pkg/provider"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"testing"
 
 	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
@@ -22,7 +23,6 @@ func Test_flexProvisioner_Provision(t *testing.T) {
 	}
 	tests := []struct {
 		name string
-		p    flexProvisioner
 		args args
 		want *v1.PersistentVolume
 		err  error


### PR DESCRIPTION
Fixes several golangic-lint issues in `local-volume`

Issues descriptions from the tool:
```
pkg/k8s/pv.go:52:4: S1031: unnecessary nil check around range (gosimple)
			if terms := required.NodeSelectorTerms; terms != nil {
			^
pkg/k8s/pv.go:54:6: S1031: unnecessary nil check around range (gosimple)
					if req := t.MatchExpressions; req != nil {
					^
pkg/provisioner/provisioner_test.go:25:3: U1000: field `p` is unused (unused)
		p    flexProvisioner
		^
```