### PR TITLE
Run the keystore updater at least once at startup

### DIFF
--- a/operators/pkg/controller/elasticsearch/keystore/updater.go
+++ b/operators/pkg/controller/elasticsearch/keystore/updater.go
@@ -75,6 +75,12 @@ func (u Updater) watchForUpdate() {
 		log.Error(err, "Cannot watch filesystem", "path", u.config.SecretsSourceDir)
 		return
 	}
+	// execute at least once with the initial fs content
+	err, msg := u.updateKeystore()
+	if err != nil {
+		log.Error(err, "Cannot update keystore", "msg", msg)
+	}
+	// then run on files change
 	if err := watcher.Run(); err != nil {
 		log.Error(err, "Cannot watch filesystem", "path", u.config.SecretsSourceDir)
 	}


### PR DESCRIPTION
This fixes a bug that was probably introduced while refactoring the fs
watcher.

If an ES cluster is initially created with snapshot credentials
configured (not changed later on), it would never reload the keystore
with the existing initial secret, since it would have waited until there is
some changes on the filesystem.

I raised a second issue about how we're spamming startup logs: #602.