### PR TITLE
Re-enable the S3 plugin

### DIFF
--- a/operators/pkg/controller/elasticsearch/initcontainer/script.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/script.go
@@ -11,8 +11,7 @@ import (
 
 // List of plugins to be installed on the ES instance
 var defaultInstalledPlugins = []string{
-	// TODO: enable when useful :)
-	// "repository-s3",  // S3 snapshots
+	"repository-s3",  // S3 snapshots
 	"repository-gcs", // gcp snapshots
 }
 

--- a/operators/pkg/controller/elasticsearch/initcontainer/script_test.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/script_test.go
@@ -29,9 +29,8 @@ func TestRenderScriptTemplate(t *testing.T) {
 							Target: "/usr/share/elasticsearch/users"}}},
 			},
 			wantSubstr: []string{
-				// TODO: re-enable when these are used
-				// "$PLUGIN_BIN install --batch repository-s3",
-				// "$PLUGIN_BIN install --batch repository-gcs",
+				"$PLUGIN_BIN install --batch repository-s3",
+				"$PLUGIN_BIN install --batch repository-gcs",
 				"mv /usr/share/elasticsearch/config/* /volume/config/",
 				"mv /usr/share/elasticsearch/bin/* /volume/bin/",
 				"mv /usr/share/elasticsearch/plugins/* /volume/plugins/",


### PR DESCRIPTION
We decided it's worth having it by default, until we move on with
supporting a user-provided list of arbitrary plugins.