### PR TITLE
Remove transport client service

### DIFF
--- a/operators/pkg/controller/elasticsearch/network/ports.go
+++ b/operators/pkg/controller/elasticsearch/network/ports.go
@@ -7,8 +7,6 @@ package network
 const (
 	// HTTPPort used by Elasticsearch for the REST API
 	HTTPPort = 9200
-	// TransportPort used by Elasticsearch for the Transport protocol
+	// TransportPort used by Elasticsearch for the Transport protocol in node to node communication
 	TransportPort = 9300
-	// TransportClientPort used by Elasticsearch for the Transport protocol for client-only connections
-	TransportClientPort = 9400
 )

--- a/operators/pkg/controller/elasticsearch/pod/pod.go
+++ b/operators/pkg/controller/elasticsearch/pod/pod.go
@@ -31,7 +31,6 @@ var (
 	DefaultContainerPorts = []corev1.ContainerPort{
 		{Name: "http", ContainerPort: network.HTTPPort, Protocol: corev1.ProtocolTCP},
 		{Name: "transport", ContainerPort: network.TransportPort, Protocol: corev1.ProtocolTCP},
-		{Name: "client", ContainerPort: network.TransportClientPort, Protocol: corev1.ProtocolTCP},
 	}
 )
 

--- a/operators/pkg/controller/elasticsearch/services/services.go
+++ b/operators/pkg/controller/elasticsearch/services/services.go
@@ -92,11 +92,6 @@ func NewExternalService(es v1alpha1.Elasticsearch) *corev1.Service {
 					Protocol: corev1.ProtocolTCP,
 					Port:     network.HTTPPort,
 				},
-				corev1.ServicePort{
-					Name:     "transport",
-					Protocol: corev1.ProtocolTCP,
-					Port:     network.TransportClientPort,
-				},
 			},
 			SessionAffinity: corev1.ServiceAffinityNone,
 			Type:            common.GetServiceType(es.Spec.Expose),

--- a/operators/pkg/controller/elasticsearch/settings/default_config.go
+++ b/operators/pkg/controller/elasticsearch/settings/default_config.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/services"
 
-	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/network"
-
 	"github.com/elastic/k8s-operators/operators/pkg/controller/common/certificates"
 	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/initcontainer"
 	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/nodecerts"
@@ -44,9 +42,8 @@ func baseConfig(clusterName string, minMasterNodes int) FlatConfig {
 		DiscoveryZenMinimumMasterNodes: strconv.Itoa(minMasterNodes),
 
 		// derive IP dynamically from the pod IP, injected as env var
-		NetworkPublishHost:          "${" + EnvPodIP + "}",
-		NetworkHost:                 "0.0.0.0",
-		TransportProfilesClientPort: strconv.Itoa(network.TransportClientPort),
+		NetworkPublishHost: "${" + EnvPodIP + "}",
+		NetworkHost:        "0.0.0.0",
 
 		PathData: initcontainer.DataSharedVolume.EsContainerMountPath,
 		PathLogs: initcontainer.LogsSharedVolume.EsContainerMountPath,
@@ -79,10 +76,6 @@ func xpackConfig(licenseType v1alpha1.LicenseType) FlatConfig {
 		XPackSecurityEnabled:                      "true",
 		XPackSecurityAuthcReservedRealmEnabled:    "false",
 		XPackSecurityTransportSslVerificationMode: "certificate",
-
-		// client profiles
-		TransportProfilesClientXPackSecurityType:                    "client",
-		TransportProfilesClientXPackSecuritySslClientAuthentication: "none",
 
 		// x-pack security http settings
 		XPackSecurityHttpSslEnabled:                "true",

--- a/operators/pkg/controller/elasticsearch/settings/fields.go
+++ b/operators/pkg/controller/elasticsearch/settings/fields.go
@@ -24,10 +24,6 @@ const (
 	PathData = "path.data"
 	PathLogs = "path.logs"
 
-	TransportProfilesClientPort                                 = "transport.profiles.client.port"
-	TransportProfilesClientXPackSecuritySslClientAuthentication = "transport.profiles.client.xpack.security.ssl.client_authentication"
-	TransportProfilesClientXPackSecurityType                    = "transport.profiles.client.xpack.security.type"
-
 	XPackLicenseSelfGeneratedType                   = "xpack.license.self_generated.type"
 	XPackSecurityAuthcReservedRealmEnabled          = "xpack.security.authc.reserved_realm.enabled"
 	XPackSecurityEnabled                            = "xpack.security.enabled"


### PR DESCRIPTION
Fixes #616

The transport client usage is considered deprecated in Elasticsearch.
No need to spin up a dedicated service for it. Let's also remove the
associated specific Elasticsearch configuration bit.

Sad reality: no single test modification required.