### PR TITLE
Simplify ES readiness by requesting / instead of /_cat/master

### DIFF
--- a/operators/pkg/controller/elasticsearch/version/common.go
+++ b/operators/pkg/controller/elasticsearch/version/common.go
@@ -156,22 +156,7 @@ func podSpec(
 				// we do not specify Requests here in order to end up in the qosClass of Guaranteed.
 				// see https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/ for more details
 			},
-			ReadinessProbe: &corev1.Probe{
-				FailureThreshold:    3,
-				InitialDelaySeconds: 10,
-				PeriodSeconds:       10,
-				SuccessThreshold:    3,
-				TimeoutSeconds:      5,
-				Handler: corev1.Handler{
-					Exec: &corev1.ExecAction{
-						Command: []string{
-							"sh",
-							"-c",
-							pod.DefaultReadinessProbeScript,
-						},
-					},
-				},
-			},
+			ReadinessProbe: pod.NewReadinessProbe(),
 			VolumeMounts: append(
 				initcontainer.PrepareFsSharedVolumes.EsContainerVolumeMounts(),
 				initcontainer.PrivateKeySharedVolume.EsContainerVolumeMount(),


### PR DESCRIPTION
This changes the way we run the readiness probe, by requesting `/` instead of `/_cat/master`.

The intent here is to make sure Elasticsearch can still respond to
requests when no master is available.
Also, it does simplify the readiness check a bit.

Fixes #617.