### PR TITLE
Fix for e2e tests

### DIFF
--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -50,7 +50,7 @@ ci-e2e: vault-gke-creds
 		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
 		-w $(GO_MOUNT_PATH) \
 		-e "IMG_SUFFIX=-ci" \
-		-e "GCLOUD_PROJECT=${GCLOUD_PROJECT}" \
+		-e "GCLOUD_PROJECT=$(GCLOUD_PROJECT)" \
 		-e "GKE_CLUSTER_NAME=e2e-qa-$(shell date +'%Y%m%d-%H%M%S')" \
 		-e "GKE_SERVICE_ACCOUNT_KEY_FILE=$(GO_MOUNT_PATH)/build/ci/$(GKE_CREDS_FILE)" \
 		k8s-operators-ci-e2e \


### PR DESCRIPTION
Currently, e2e tests are failing because of https://github.com/elastic/k8s-operators/commit/3bc60e2a1f9f9a254797d099eaea2f24c7cf0f5b
This fix should be merged only after https://github.com/elastic/infra/pull/10798