### PR TITLE
Keystore updater status

### DIFF
--- a/operators/pkg/controller/elasticsearch/keystore/status.go
+++ b/operators/pkg/controller/elasticsearch/keystore/status.go
@@ -21,10 +21,3 @@ type Status struct {
 	Reason string
 	At     time.Time
 }
-
-// Status returns the Keystore updater status
-func (u *Updater) Status() (Status, error) {
-	u.lock.RLock()
-	defer u.lock.RUnlock()
-	return u.status, nil
-}

--- a/operators/pkg/controller/elasticsearch/keystore/updater.go
+++ b/operators/pkg/controller/elasticsearch/keystore/updater.go
@@ -45,6 +45,14 @@ func NewUpdater(cfg Config) *Updater {
 	}
 }
 
+// Status returns the Keystore updater status
+func (u *Updater) Status() (Status, error) {
+	u.lock.RLock()
+	defer u.lock.RUnlock()
+	return u.status, nil
+}
+
+// updateStatus updates the Keystore updater status
 func (u *Updater) updateStatus(s State, msg string, err error) {
 	u.lock.Lock()
 	defer u.lock.Unlock()


### PR DESCRIPTION
Implement the Keystore updater status, updated when `watchForUpdate()` and `coalescingRetry()` succeed or fail.

Related to #580.