### PR TITLE
Use a more explicit name for pod certs secret

### DIFF
--- a/operators/pkg/controller/elasticsearch/name/name.go
+++ b/operators/pkg/controller/elasticsearch/name/name.go
@@ -28,6 +28,7 @@ const (
 
 	podSuffix                 = "-es"
 	configSecretSuffix        = "-config"
+	certsSecretSuffix         = "-certs"
 	serviceSuffix             = "-es"
 	discoveryServiceSuffix    = "-es-discovery"
 	cASecretSuffix            = "-ca"
@@ -83,6 +84,10 @@ func NewPVCName(podName string, pvcTemplateName string) string {
 
 func ConfigSecret(podName string) string {
 	return suffix(podName, configSecretSuffix)
+}
+
+func CertsSecret(podName string) string {
+	return suffix(podName, certsSecretSuffix)
 }
 
 func Service(esName string) string {

--- a/operators/pkg/controller/elasticsearch/nodecerts/cert_secrets.go
+++ b/operators/pkg/controller/elasticsearch/nodecerts/cert_secrets.go
@@ -7,6 +7,7 @@ package nodecerts
 import (
 	"github.com/elastic/k8s-operators/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/label"
+	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/name"
 	"github.com/elastic/k8s-operators/operators/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -63,13 +64,6 @@ func findNodeCertificateSecrets(
 	return nodeCertificateSecrets.Items, nil
 }
 
-// NodeCertificateSecretObjectKeyForPod returns the object key for the secret containing the node certificates for
-// a given pod.
-func NodeCertificateSecretObjectKeyForPod(pod corev1.Pod) types.NamespacedName {
-	// At this point, Pod name is already trimmed and suffixed. So it's safe to reuse it for the secret name.
-	return k8s.ExtractNamespacedName(&pod)
-}
-
 // EnsureNodeCertificateSecretExists ensures the existence of the corev1.Secret that at a later point in time will
 // contain the node certificates.
 func EnsureNodeCertificateSecretExists(
@@ -80,16 +74,19 @@ func EnsureNodeCertificateSecretExists(
 	nodeCertificateType string,
 	labels map[string]string,
 ) (*corev1.Secret, error) {
-	secretObjectKey := NodeCertificateSecretObjectKeyForPod(pod)
+	secretRef := types.NamespacedName{
+		Namespace: pod.Namespace,
+		Name:      name.CertsSecret(pod.Name),
+	}
 
 	var secret corev1.Secret
-	if err := c.Get(secretObjectKey, &secret); err != nil && !apierrors.IsNotFound(err) {
+	if err := c.Get(secretRef, &secret); err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
 	} else if apierrors.IsNotFound(err) {
 		secret = corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretObjectKey.Name,
-				Namespace: secretObjectKey.Namespace,
+				Name:      secretRef.Name,
+				Namespace: secretRef.Namespace,
 
 				Labels: map[string]string{
 					// store the pod that this Secret will be mounted to so we can traverse from secret -> pod


### PR DESCRIPTION
We used the pod name as secret name for Elasticsearch TLS certs. Which
does not make much sense now that we have several secrets for the pod
(config, secure settings, etc.).

This commit renames the certs secret to <pod-name>-certs.