### PR TITLE
Removed duplications, updated requirements & commands

### DIFF
--- a/operators/README.md
+++ b/operators/README.md
@@ -38,12 +38,9 @@ Run `make check-requisites` to check that all dependencies are installed.
    ```
 2. Deploy the operator.
 
-   Use either `make run` to run the operator locally, or `make deploy` to deploy the operators into the configured k8s cluster.
-
-3. Proceed with the following commands:
-
-   * `make dep-vendor-only`: Downloads extra Go libraries needed to compile the project and stores them in the vendor directory.
-   * `make samples`: Apply a sample stack resource.
+   * `make dep-vendor-only` to download extra Go libraries needed to compile the project and stores them in the vendor directory.
+   *  `make run` to run the operator locally, or `make deploy` to deploy the operators into the configured k8s cluster.
+   * `make samples` to apply a sample stack resource.
 
 ### Running E2E tests
 


### PR DESCRIPTION
Proposed rewording of this section to remove duplicated info:

_## Development

To start, get a working development Kubernetes cluster using [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/#install-minikube) or [GKE](https://cloud.google.com/kubernetes-engine/):

```bash
make bootstrap-minikube
# or
GCLOUD_PROJECT=my-project-id make bootstrap-gke
```

Then, use either `make run` to run the operator locally, or `make deploy` to deploy the operators on the cluster.

### Useful development targets

* `make bootstrap-minikube`: Sets up a Minikube cluster with required resources.
* `make bootstrap-gke`: Sets up a GKE cluster with required resources.
* `make dep-vendor-only`: Downloads extra GO libraries needed to compile the project and stores them in the vendor directory.
* `make run`: Run the operator locally.
* `make deploy`: Deploy the operators into the configured k8s cluster.
* `make samples`: Apply a sample stack resource._

===>

_## Development

To start, get a working development Kubernetes cluster using [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/#install-minikube) or [GKE](https://cloud.google.com/kubernetes-engine/):

* `make bootstrap-minikube`: Sets up a Minikube cluster with required resources
or
* `make bootstrap-gke`: Sets up a GKE cluster with required resources

Then, proceed as follows:

* `make dep-vendor-only`: Downloads extra GO libraries needed to compile the project and stores them in the vendor directory.
* `make run`: Run the operator locally.
* `make deploy`: Deploy the operators into the configured k8s cluster.
* `make samples`: Apply a sample stack resource._

