### PR TITLE
Set correct values in e2e test CI job for generating Docker image for GKE

### DIFF
--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -5,6 +5,8 @@ node('swarm') {
 	    checkout scm
     }
     stage("Make ci-e2e") {
-        sh 'make -C build/ci ci-e2e'
+        withEnv(["REPOSITORY=${GCLOUD_PROJECT}", "REGISTRY=eu.gcr.io"]) {
+            sh 'make -C build/ci ci-e2e'
+        }
     }
 }


### PR DESCRIPTION
e2e tests still failing after https://github.com/elastic/k8s-operators/commit/e81018cf63d0b299708c541c3387aff161ff25cf because they incorrectly creating Docker image for GKE