### PR TITLE
Change version of k8s for GKE to fix cluster creation issue

### DIFF
--- a/operators/hack/gke-cluster.sh
+++ b/operators/hack/gke-cluster.sh
@@ -17,7 +17,7 @@ set -eu
 : "${GKE_CLUSTER_NAME:=${USER//_}-dev-cluster}"
 : "${GKE_CLUSTER_REGION:=europe-west3}"
 : "${GKE_ADMIN_USERNAME:=admin}"
-: "${GKE_CLUSTER_VERSION:=1.11.6}"
+: "${GKE_CLUSTER_VERSION:=1.11}"
 : "${GKE_MACHINE_TYPE:=n1-highmem-4}"
 : "${GKE_LOCAL_SSD_COUNT:=1}"
 : "${GKE_NODE_COUNT_PER_ZONE:=1}"


### PR DESCRIPTION
We can't bootstrap k8s cluster in GKE again with error `No valid versions with the prefix "1.11.6"`. I changed the version to `1.11`, based on docs, it will use version with the latest available patchset automatically. Locally this fix works fine.