### PR TITLE
Add e2e tests for secure settings & keystore

### DIFF
--- a/operators/pkg/controller/elasticsearch/keystore/config.go
+++ b/operators/pkg/controller/elasticsearch/keystore/config.go
@@ -19,6 +19,10 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
+const (
+	KeystoreBinPath = "/usr/share/elasticsearch/bin/elasticsearch-keystore"
+)
+
 var (
 	sourceDirFlag         = envToFlag(EnvSourceDir)
 	keystoreBinaryFlag    = envToFlag(EnvKeystoreBinary)
@@ -66,7 +70,7 @@ func envToFlag(env string) string {
 // BindEnvToFlags binds flags to environment variables.
 func BindEnvToFlags(cmd *cobra.Command) error {
 	cmd.Flags().StringP(sourceDirFlag, "s", "/volumes/secrets", "directory containing keystore settings source files")
-	cmd.Flags().StringP(keystoreBinaryFlag, "b", "/usr/share/elasticsearch/bin/elasticsearch-keystore", "path to keystore binary")
+	cmd.Flags().StringP(keystoreBinaryFlag, "b", KeystoreBinPath, "path to keystore binary")
 	cmd.Flags().StringP(keystorePathFlag, "k", "/usr/share/elasticsearch/config/elasticsearch.keystore", "path to keystore file")
 	cmd.Flags().BoolP(reloadCredentialsFlag, "r", false, "whether or not to trigger a credential reload in Elasticsearch")
 	cmd.Flags().StringP(esUsernameFlag, "u", "", "Elasticsearch username to reload credentials")

--- a/operators/pkg/controller/elasticsearch/processmanager/manager.go
+++ b/operators/pkg/controller/elasticsearch/processmanager/manager.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/keystore"
-	"github.com/hashicorp/go-reap"
+	reap "github.com/hashicorp/go-reap"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 

--- a/operators/test/e2e/keystore_test.go
+++ b/operators/test/e2e/keystore_test.go
@@ -1,0 +1,107 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/elastic/k8s-operators/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/k8s-operators/operators/pkg/utils/k8s"
+	"github.com/elastic/k8s-operators/operators/test/e2e/helpers"
+	"github.com/elastic/k8s-operators/operators/test/e2e/stack"
+)
+
+func TestUpdateSecureSettings(t *testing.T) {
+	k := helpers.NewK8sClientOrFatal()
+
+	// user-provided secure settings secret
+	secureSettingsSecretName := "secure-settings-secret"
+	secureSettings := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secureSettingsSecretName,
+			Namespace: helpers.DefaultNamespace,
+		},
+		Data: map[string][]byte{
+			"key1": []byte("initialValue1"),
+			"key2": []byte("initialValue2"),
+		},
+	}
+
+	// set up a 3-nodes cluster with secure settings
+	s := stack.NewStackBuilder("test-keystore").
+		WithESMasterDataNodes(3, stack.DefaultResources).
+		WithSecureSettings(secureSettings.Name)
+
+	helpers.TestStepList{}.
+		// create secure settings secret
+		WithSteps(helpers.TestStep{
+			Name: "Create secure settings secret",
+			Test: func(t *testing.T) {
+				// remove if already exists (ignoring errors)
+				_ = k.Client.Delete(&secureSettings)
+				// and create a fresh one
+				err := k.Client.Create(&secureSettings)
+				require.NoError(t, err)
+			},
+		}).
+
+		// create the cluster
+		WithSteps(stack.InitTestSteps(s, k)...).
+		WithSteps(stack.CreationTestSteps(s, k)...).
+		WithSteps(
+
+			// initial secure settings should be there in all nodes keystore
+			stack.CheckKeystoreEntries(k, s.Elasticsearch, []string{"key1", "key2"}),
+
+			// modify the secure settings secret
+			helpers.TestStep{
+				Name: "Modify secure settings secret",
+				Test: func(t *testing.T) {
+					// remove key2, add key3
+					secureSettings.Data = map[string][]byte{
+						"key1": []byte("updatedValue1"), // the actual value update cannot be checked :(
+						"key3": []byte("initialValue3"),
+					}
+					err := k.Client.Update(&secureSettings)
+					require.NoError(t, err)
+				},
+			},
+
+			// keystore should be updated accordingly
+			stack.CheckKeystoreEntries(k, s.Elasticsearch, []string{"key1", "key3"}),
+
+			// remove the secure settings reference
+			helpers.TestStep{
+				Name: "Remove secure settings from the spec",
+				Test: func(t *testing.T) {
+					// retrieve current resource version
+					var es v1alpha1.Elasticsearch
+					err := k.Client.Get(k8s.ExtractNamespacedName(&s.Elasticsearch), &es)
+					require.NoError(t, err)
+					// set its secure settings to nil
+					es.Spec.SecureSettings = nil
+					err = k.Client.Update(&es)
+					require.NoError(t, err)
+				},
+			},
+
+			// keystore should be updated accordingly
+			stack.CheckKeystoreEntries(k, s.Elasticsearch, nil),
+
+			// cleanup extra resources
+			helpers.TestStep{
+				Name: "Delete secure settings secret",
+				Test: func(t *testing.T) {
+					err := k.Client.Delete(&secureSettings)
+					require.NoError(t, err)
+				},
+			},
+		).
+		RunSequential(t)
+}

--- a/operators/test/e2e/stack/builder.go
+++ b/operators/test/e2e/stack/builder.go
@@ -7,6 +7,7 @@ package stack
 import (
 	"github.com/elastic/k8s-operators/operators/pkg/apis/associations/v1alpha1"
 	common "github.com/elastic/k8s-operators/operators/pkg/apis/common/v1alpha1"
+	commonv1alpha1 "github.com/elastic/k8s-operators/operators/pkg/apis/common/v1alpha1"
 	estype "github.com/elastic/k8s-operators/operators/pkg/apis/elasticsearch/v1alpha1"
 	kbtype "github.com/elastic/k8s-operators/operators/pkg/apis/kibana/v1alpha1"
 	"github.com/elastic/k8s-operators/operators/test/e2e/helpers"
@@ -114,6 +115,13 @@ func (b Builder) WithESMasterDataNodes(count int, resources common.ResourcesSpec
 
 func (b Builder) withESTopologyElement(topologyElement estype.TopologyElementSpec) Builder {
 	b.Elasticsearch.Spec.Topology = append(b.Elasticsearch.Spec.Topology, topologyElement)
+	return b
+}
+
+func (b Builder) WithSecureSettings(secretName string) Builder {
+	b.Elasticsearch.Spec.SecureSettings = &commonv1alpha1.ResourceNameReference{
+		Name: secretName,
+	}
 	return b
 }
 

--- a/operators/test/e2e/stack/keystore.go
+++ b/operators/test/e2e/stack/keystore.go
@@ -1,0 +1,72 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package stack
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/elastic/k8s-operators/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/keystore"
+	"github.com/elastic/k8s-operators/operators/pkg/utils/k8s"
+	"github.com/elastic/k8s-operators/operators/test/e2e/helpers"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func CheckKeystoreEntries(k *helpers.K8sHelper, es v1alpha1.Elasticsearch, expectedKeys []string) helpers.TestStep {
+	return helpers.TestStep{
+		Name: "Secure settings should eventually be set in all nodes keystore",
+		Test: helpers.Eventually(func() error {
+			pods, err := k.GetPods(helpers.ESPodListOptions(es.Name))
+			if err != nil {
+				return err
+			}
+			return onAllPods(pods, func(p corev1.Pod) error {
+				// exec into the pod to list keystore entries
+				stdout, stderr, err := k.Exec(k8s.ExtractNamespacedName(&p), []string{keystore.KeystoreBinPath, "list"})
+				if err != nil {
+					return errors.Wrap(err, fmt.Sprintf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+				}
+
+				// parse entries from stdout
+				var entries []string
+				// the keystore contains a "keystore.seed" entry we don't want to include in the comparison
+				noKeystoreSeeds := strings.Replace(stdout, "keystore.seed", "", 1)
+				// remove trailing newlines and whitespaces
+				trimmed := strings.TrimSpace(noKeystoreSeeds)
+				// split by lines, unless no output
+				if trimmed != "" {
+					entries = strings.Split(trimmed, "\n")
+				}
+
+				if !reflect.DeepEqual(expectedKeys, entries) {
+					return fmt.Errorf("invalid keystore entries. Expected: %s. Actual: %s", expectedKeys, entries)
+				}
+				return nil
+			})
+		}),
+	}
+}
+
+func onAllPods(pods []corev1.Pod, f func(corev1.Pod) error) error {
+	// map phase: execute a function on all pods in parallel
+	fResults := make(chan error, len(pods))
+	for _, p := range pods {
+		go func(pod corev1.Pod) {
+			fResults <- f(pod)
+		}(p)
+	}
+	// reduce phase: aggregate errors (simply return the last one seen)
+	var err error
+	for range pods {
+		podErr := <-fResults
+		if podErr != nil {
+			err = podErr
+		}
+	}
+	return err
+}


### PR DESCRIPTION
This test verifies that secureSettings set in the Elasticsearch spec are
correctly propagated into each ES pod keystore.