### PR TITLE
Document how to perform snapshots with an example

### DIFF
--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -1,6 +1,6 @@
-# How to perform automated snapshots
+# How to create automated snapshots
 
-To perform automated snapshots for Elasticsearch in Kubernetes you have to:
+To create automated snapshots for Elasticsearch in Kubernetes you have to:
 
 1. Provide snapshot repository credentials in Elasticsearch keystore.
 2. Register the snapshot repository with Elasticsearch API.
@@ -12,11 +12,11 @@ For more information on Elasticsearch snapshots, see [Snapshot and Restore](http
 
 ## Provide GCS credentials to Elasticsearch keystore
 
-Elasticsearch GCS repository plugin requires a JSON file containing service account credentials in Elasticsearch keystore (see [the documentation for more details](https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-gcs-usage.html)).
+Elasticsearch GCS repository plugin requires a JSON file that contains service account credentials in Elasticsearch keystore. For more details, see [Google Cloud Storage Repository Plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-gcs-usage.html)).
 
-Using the operator, you can automatically inject secure settings into a cluster nodes by providing them through a secret in the Elasticsearch Spec.
+Using the operator, you can automatically inject secure settings into a cluster node by providing them through a secret in the Elasticsearch Spec.
 
-First, create a file containing GCS credentials, that we'll name `es.file.gcs.client.default.credentials_file`:
+1. Create a file containing GCS credentials. For this exercise, name it `es.file.gcs.client.default.credentials_file`:
 
 ```json
 {
@@ -33,14 +33,14 @@ First, create a file containing GCS credentials, that we'll name `es.file.gcs.cl
 }
 ```
 
-The `es.file` prefix indicates this file will be used as an Elasticsearch secure setting with the `file` type.
+The `es.file` prefix indicates that this file is used as an Elasticsearch secure setting with the `file` type.
 
-Create a Kubernetes secret from that file:
+2. Create a Kubernetes secret from that file:
 ```bash
 kubectl create secret generic gcs-credentials --from-file=es.file.gcs.client.default.credentials_file
 ```
 
-Then, edit the `secureSettings` section of the Elasticsearch resource:
+3. Edit the `secureSettings` section of the Elasticsearch resource:
 
 ```yaml
 kind: Elasticsearch
@@ -51,17 +51,17 @@ spec:
       secretName: "gcs-credentials"
 ```
 
-And apply the modifications:
+4. Apply the modifications:
 
 ````bash
 kubectl apply -f elasticsearch.yml
 ````
 
-GCS credentials will be propagated into each node's keystore automatically. It can take up to a few minutes, depending the number of secrets in the keystore. Nodes don't need to be restarted. 
+GCS credentials are automatically propagated into each node keystore. It can take up to a few minutes, depending on the number of secrets in the keystore. You don't have to restart the nodes. 
 
 ## Register the repository in Elasticsearch
 
-Following the [snapshot documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html), create the GCS snapshot repository in Elasticsearch:
+1. Create the GCS snapshot repository in Elasticsearch according to the procedure described in [Snapshot and Restore](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html):
 
 ```
 PUT /_snapshot/my_gcs_repository
@@ -74,7 +74,7 @@ PUT /_snapshot/my_gcs_repository
 }
 ```
 
-You can then perform a snapshot via a simple http request:
+2. Perform a snapshot with the following HTTP request:
 
 ```
 PUT /_snapshot/my_gcs_repository/test-snapshot
@@ -82,7 +82,9 @@ PUT /_snapshot/my_gcs_repository/test-snapshot
 
 ## Periodic snapshots with a CronJob
 
-You can specify a simple CronJob to perform a snapshot every day. We simply perform an HTTP request against the appropriate endpoint, using a daily snapshot naming format. Elasticsearch credentials are mounted as a volume into the job's pod:
+You can specify a simple CronJob to perform a snapshot every day.
+
+1. Make an HTTP request against the appropriate endpoint, using a daily snapshot naming format. Elasticsearch credentials are mounted as a volume into the job's pod:
 
 ```yml
 # snapshotter.yml
@@ -115,10 +117,10 @@ spec:
               secretName: elasticsearch-sample-elastic-user
 ```
 
-Then apply it to the Kubernetes cluster:
+2. Apply it to the Kubernetes cluster:
 
 ```
 kubectl apply -f snapshotter.yml
 ```
 
-For more details on Kubernetes CronJobs, please visit the [official documentation](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/).
+For more details see [Kubernetes CronJobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/).


### PR DESCRIPTION
This doc provides an example to:

* inject GCS credentials into ES keystore using the secureSettings spec
* register the repository in Elasticsearch API
* setup a simple CronJob to perform snapshots automatically on a daily
basis

Fixes #635 .