### PR TITLE
Fix make target inconsistencies

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -45,7 +45,7 @@ MANAGED_NAMESPACE ?= default
 ##  --       Development       --  ##
 #####################################
 
-all: dep-vendor-only unit integration e2e-compile check-fmt elastic-operator process-manager check-license-header
+all: dep-vendor-only unit integration e2e-compile check-fmt elastic-operator process-manager cert-initializer check-license-header
 
 ## -- build
 
@@ -67,7 +67,7 @@ elastic-operator: generate
 process-manager:
 	go build -o bin/process-manager github.com/elastic/k8s-operators/operators/cmd/process-manager
 
-cert-initializer: generate
+cert-initializer:
 	go build -o bin/cert-initializer github.com/elastic/k8s-operators/operators/cmd/cert-initializer
 
 fmt:


### PR DESCRIPTION
We have a few inconsistencies in the Makefile:

* `make keystore-updater` does not make sense anymore
* `make all` is missing some build targets