### PR TITLE
Combine all crds into one for easy installation

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -62,7 +62,7 @@ generate:
 	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
 	# combine all crds into one for easy installation
 	for yaml in $$(ls config/crds/*); do \
-		cat $$yaml && echo --- ; \
+		cat $$yaml && echo -e "\n---\n" ; \
 	done > config/crds.yaml
 
 elastic-operator: generate

--- a/operators/config/crds.yaml
+++ b/operators/config/crds.yaml
@@ -140,7 +140,9 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -222,7 +224,9 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -311,7 +315,9 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -379,7 +385,9 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -615,7 +623,9 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -729,7 +739,9 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -787,7 +799,9 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -846,7 +860,9 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -915,7 +931,9 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -1043,4 +1061,6 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
+


### PR DESCRIPTION
Combine all crds into one for easy installation in the `generate` make target.

Resolves #658.