### PR TITLE
Enable blacklisted setting validation

### DIFF
--- a/operators/pkg/controller/elasticsearch/validation/validations.go
+++ b/operators/pkg/controller/elasticsearch/validation/validations.go
@@ -23,6 +23,7 @@ var Validations = []Validation{
 	supportedVersion,
 	noDowngrades,
 	validUpgradePath,
+	noBlacklistedSettings,
 }
 
 // nameLength checks the length of the Elasticsearch name.


### PR DESCRIPTION
This validation wasn't added to the main list. Let's add it!
Also, this commit adds a few unit tests to make sure some validation are
actually called by the main validate function.