### PR TITLE
Fix a race condition in IT reconciliation calls

### DIFF
--- a/operators/pkg/controller/license/trial/trial_controller_integration_test.go
+++ b/operators/pkg/controller/license/trial/trial_controller_integration_test.go
@@ -132,12 +132,12 @@ func TestReconcile(t *testing.T) {
 
 	// Delete the trial license
 	require.NoError(t, deleteTrial())
+	test.CheckReconcileCalled(t, requests, expectedRequest)
 	// recreate it
 	require.NoError(t, c.Create(trialLicense))
 	test.CheckReconcileCalled(t, requests, expectedRequest)
 	// expect an invalid license
 	validateStatus(t, licenseKey, &createdLicense, v1alpha1.LicenseStatusInvalid)
 
-	test.CheckReconcileCalled(t, requests, expectedRequest)
 	// ClusterLicense should be GC'ed but can't be tested here
 }


### PR DESCRIPTION
I think we have a potential race condition here: we delete a resource,
then create one, then we check for the reconciliation to be called (only
once) before we check a status.

Reconciliation does happen both on delete and create. When we check that
the reconciliation was called, we consume a channel of requests: no more
reconciliations are executed until this channel is consumed.

What can happen here is that we prevent reconciliation from happening,
hence we can never get the newer license. A single reconciliation is
enough if the deletion/creation are super fast. Two reconciliations may
be required if they are slow enough.

Here we now force wait for 2 reconciliations to happen (one after
deletion, another one after creation).

I hope this can help with this error observed in some failing builds:

```
[2019-04-24T04:42:52.866Z] --- FAIL: TestReconcile (5.72s)
[2019-04-24T04:42:52.866Z]     require.go:794:
[2019-04-24T04:42:52.866Z]             Error Trace:    retry.go:24
[2019-04-24T04:42:52.866Z]
trial_controller_integration_test.go:41
[2019-04-24T04:42:52.866Z]
trial_controller_integration_test.go:139
[2019-04-24T04:42:52.866Z]             Error:          Received
unexpected error:
[2019-04-24T04:42:52.866Z]                             expected Invalid
license but was
[2019-04-24T04:42:52.866Z]             Test:           TestReconcile
```

but I'm not 100% sure since I can't reproduce it locally.

Relates #623.