### PR TITLE
Increase trial timestamp delta precision in a flaky integration test

### DIFF
--- a/operators/pkg/controller/license/trial/trial_controller_integration_test.go
+++ b/operators/pkg/controller/license/trial/trial_controller_integration_test.go
@@ -110,7 +110,7 @@ func TestReconcile(t *testing.T) {
 
 	// test trial initialisation on create
 	validateStatus(t, licenseKey, &createdLicense, v1alpha1.LicenseStatusValid)
-	validateTrialDuration(t, createdLicense, now, time.Second)
+	validateTrialDuration(t, createdLicense, now, time.Minute)
 
 	// tamper with the trial status
 	var trialStatus corev1.Secret


### PR DESCRIPTION
This is an attempt to fix the following flaky integration test:

```
[2019-04-24T04:43:01.741Z] --- FAIL: TestReconcile (6.68s)
[2019-04-24T04:43:01.741Z]     trial_controller_integration_test.go:55:
[2019-04-24T04:43:01.741Z]             Error Trace:
trial_controller_integration_test.go:55
[2019-04-24T04:43:01.741Z]
trial_controller_integration_test.go:113
[2019-04-24T04:43:01.741Z]             Error:          Should be true
[2019-04-24T04:43:01.741Z]             Test:           TestReconcile
[2019-04-24T04:43:01.741Z]             Messages:       start date should
be within 1s, but was 1.069601007s
[2019-04-24T04:43:01.741Z]     trial_controller_integration_test.go:57:
[2019-04-24T04:43:01.741Z]             Error Trace:
trial_controller_integration_test.go:57
[2019-04-24T04:43:01.741Z]
trial_controller_integration_test.go:113
[2019-04-24T04:43:01.741Z]             Error:          Should be true
[2019-04-24T04:43:01.741Z]             Test:           TestReconcile
[2019-04-24T04:43:01.741Z]             Messages:       end date should
be within 1s, but was 1.069601007s
```

I think it just fails whenever the test is executed in an environment
slow enough for the 1.Second delta not to be respected.

This commit increases it to 1 minute: that's rather arbitrary, but
reasonnable imho.

Relates #623.