### PR TITLE
Remove the validation webhook when the cluster is cleaned

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -66,8 +66,6 @@ generate:
 		cat $$yaml && echo -e "\n---\n" ; \
 	done > config/crds.yaml
 	$(MAKE) generate-all-in-one
-	git --no-pager diff
-
 
 elastic-operator: generate
 	go build -o bin/elastic-operator github.com/elastic/k8s-operators/operators/cmd


### PR DESCRIPTION
Just a PR to remove the validation webhook along with the other resources when the cluster is cleaned.