### PR TITLE
Report keystore updater statuses

### DIFF
--- a/operators/pkg/controller/elasticsearch/driver/default.go
+++ b/operators/pkg/controller/elasticsearch/driver/default.go
@@ -95,7 +95,7 @@ type defaultDriver struct {
 	) ([]pod.PodSpecContext, error)
 
 	// observedStateResolver resolves the currently observed state of Elasticsearch from the ES API
-	observedStateResolver func(clusterName types.NamespacedName, esClient esclient.Client) observer.State
+	observedStateResolver func(clusterName types.NamespacedName, caCerts []*x509.Certificate, esClient esclient.Client) observer.State
 
 	// resourcesStateResolver resolves the current state of the K8s resources from the K8s API
 	resourcesStateResolver func(
@@ -208,7 +208,10 @@ func (d *defaultDriver) Reconcile(
 		caCert,
 	)
 
-	observedState := d.observedStateResolver(k8s.ExtractNamespacedName(&es), esClient)
+	observedState := d.observedStateResolver(
+		k8s.ExtractNamespacedName(&es),
+		[]*x509.Certificate{caCert},
+		esClient)
 
 	// always update the elasticsearch state bits
 	if observedState.ClusterState != nil && observedState.ClusterHealth != nil {

--- a/operators/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/operators/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -65,7 +65,7 @@ func newReconciler(mgr manager.Manager, params operator.Parameters) (*ReconcileE
 		recorder: mgr.GetRecorder("elasticsearch-controller"),
 
 		csrClient:   certificates.NewCertInitializerCSRClient(params.Dialer, certificates.CSRRequestTimeout),
-		esObservers: observer.NewManager(observer.DefaultSettings),
+		esObservers: observer.NewManager(params.Dialer, client, observer.DefaultSettings),
 
 		finalizers:       finalizer.NewHandler(client),
 		dynamicWatches:   watches.NewDynamicWatches(),

--- a/operators/pkg/controller/elasticsearch/keystore/status.go
+++ b/operators/pkg/controller/elasticsearch/keystore/status.go
@@ -11,11 +11,11 @@ type State string
 
 const (
 	notInitializedState State = "notInitialized"
-	waitingState        State = "waiting"
+	WaitingState        State = "waiting"
 	runningState        State = "running"
 	failedState         State = "failed"
 
-	keystoreUpdatedReason        = "Keystore updated"
+	KeystoreUpdatedReason        = "Keystore updated"
 	secureSettingsReloadedReason = "Secure settings reloaded"
 )
 

--- a/operators/pkg/controller/elasticsearch/keystore/updater.go
+++ b/operators/pkg/controller/elasticsearch/keystore/updater.go
@@ -70,7 +70,7 @@ func (u *Updater) updateStatus(s State, msg string, err error) {
 
 // Start updates the keystore once and then starts a watcher on source dir to update again on file changes.
 func (u *Updater) Start() {
-	u.updateStatus(waitingState, "Waiting for Elasticsearch to be ready", nil)
+	u.updateStatus(WaitingState, "Waiting for Elasticsearch to be ready", nil)
 	u.esClient.WaitForEsReady()
 
 	if u.config.ReloadCredentials {
@@ -89,7 +89,7 @@ func (u *Updater) watchForUpdate() {
 			log.Error(err, "Cannot update keystore", "msg", msg)
 			u.updateStatus(failedState, msg, err)
 		} else {
-			u.updateStatus(runningState, keystoreUpdatedReason, nil)
+			u.updateStatus(runningState, KeystoreUpdatedReason, nil)
 		}
 		return false, nil // run forever
 	}
@@ -108,7 +108,7 @@ func (u *Updater) watchForUpdate() {
 		log.Error(err, "Cannot update keystore", "msg", msg)
 		u.updateStatus(failedState, msg, err)
 	} else {
-		u.updateStatus(runningState, keystoreUpdatedReason, err)
+		u.updateStatus(runningState, KeystoreUpdatedReason, err)
 	}
 
 	// then run on files change

--- a/operators/pkg/controller/elasticsearch/keystore/updater_test.go
+++ b/operators/pkg/controller/elasticsearch/keystore/updater_test.go
@@ -147,7 +147,7 @@ func TestWatchForUpdate(t *testing.T) {
 	s, err := updater.Status()
 	assert.NoError(t, err)
 	assert.Equal(t, string(runningState), string(s.State))
-	assert.Equal(t, string(keystoreUpdatedReason), string(s.Reason))
+	assert.Equal(t, string(KeystoreUpdatedReason), string(s.Reason))
 }
 
 func TestStart_WaitingEs(t *testing.T) {
@@ -167,7 +167,7 @@ func TestStart_WaitingEs(t *testing.T) {
 		s, err := updater.Status()
 		assert.NoError(t, err)
 
-		if s.State != waitingState {
+		if s.State != WaitingState {
 			return errors.New("state must be waiting")
 		}
 		return nil
@@ -194,7 +194,7 @@ func TestStart_UpdatedAtLeastOnce(t *testing.T) {
 		if s.State != runningState {
 			return errors.New("status must be running")
 		}
-		if s.Reason != keystoreUpdatedReason {
+		if s.Reason != KeystoreUpdatedReason {
 			return errors.New("keystore must be updated")
 		}
 		return nil
@@ -249,7 +249,7 @@ func TestStart_ReloadAndWatchUpdate(t *testing.T) {
 		if s.State != runningState {
 			return errors.New("status must be running")
 		}
-		if s.Reason != keystoreUpdatedReason {
+		if s.Reason != KeystoreUpdatedReason {
 			return errors.New("keystore must be updated")
 		}
 		return nil
@@ -265,7 +265,7 @@ func TestStart_ReloadAndWatchUpdate(t *testing.T) {
 		if s.State != runningState {
 			return errors.New("status must be running")
 		}
-		if s.Reason != keystoreUpdatedReason {
+		if s.Reason != KeystoreUpdatedReason {
 			return errors.New("keystore must be updated")
 		}
 		return nil

--- a/operators/pkg/controller/elasticsearch/observer/manager.go
+++ b/operators/pkg/controller/elasticsearch/observer/manager.go
@@ -5,14 +5,19 @@
 package observer
 
 import (
+	"crypto/x509"
 	"sync"
 
 	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/client"
+	"github.com/elastic/k8s-operators/operators/pkg/utils/k8s"
+	"github.com/elastic/k8s-operators/operators/pkg/utils/net"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 // Manager for a set of observers
 type Manager struct {
+	k8sClient k8s.Client
+	dialer    net.Dialer
 	observers map[types.NamespacedName]*Observer
 	listeners []OnObservation // invoked on each observation event
 	lock      sync.RWMutex
@@ -20,8 +25,10 @@ type Manager struct {
 }
 
 // NewManager returns a new manager
-func NewManager(settings Settings) *Manager {
+func NewManager(dialer net.Dialer, k8sClient k8s.Client, settings Settings) *Manager {
 	return &Manager{
+		k8sClient: k8sClient,
+		dialer:    dialer,
 		observers: make(map[types.NamespacedName]*Observer),
 		lock:      sync.RWMutex{},
 		settings:  settings,
@@ -30,24 +37,24 @@ func NewManager(settings Settings) *Manager {
 
 // ObservedStateResolver returns the last known state of the given cluster,
 // as expected by the main reconciliation driver
-func (m *Manager) ObservedStateResolver(cluster types.NamespacedName, esClient client.Client) State {
-	return m.Observe(cluster, esClient).LastState()
+func (m *Manager) ObservedStateResolver(cluster types.NamespacedName, caCerts []*x509.Certificate, esClient client.Client) State {
+	return m.Observe(cluster, caCerts, esClient).LastState()
 }
 
 // Observe gets or create a cluster state observer for the given cluster
 // In case something has changed in the given esClient (eg. different caCert), the observer is recreated accordingly
-func (m *Manager) Observe(cluster types.NamespacedName, esClient client.Client) *Observer {
+func (m *Manager) Observe(cluster types.NamespacedName, caCerts []*x509.Certificate, esClient client.Client) *Observer {
 	m.lock.RLock()
 	observer, exists := m.observers[cluster]
 	m.lock.RUnlock()
 
 	switch {
 	case !exists:
-		return m.createObserver(cluster, esClient)
+		return m.createObserver(cluster, caCerts, esClient)
 	case exists && !observer.esClient.Equal(esClient):
 		log.Info("Replacing observer HTTP client", "cluster", cluster)
 		m.StopObserving(cluster)
-		return m.createObserver(cluster, esClient)
+		return m.createObserver(cluster, caCerts, esClient)
 	default:
 		return observer
 	}
@@ -55,8 +62,8 @@ func (m *Manager) Observe(cluster types.NamespacedName, esClient client.Client) 
 
 // createObserver creates a new observer according to the given arguments,
 // and create/replace its entry in the observers map
-func (m *Manager) createObserver(cluster types.NamespacedName, esClient client.Client) *Observer {
-	observer := NewObserver(cluster, esClient, m.settings, m.notifyListeners)
+func (m *Manager) createObserver(cluster types.NamespacedName, caCerts []*x509.Certificate, esClient client.Client) *Observer {
+	observer := NewObserver(m.k8sClient, m.dialer, caCerts, cluster, esClient, m.settings, m.notifyListeners)
 	observer.Start()
 	m.lock.Lock()
 	m.observers[cluster] = observer
@@ -83,11 +90,13 @@ func (m *Manager) StopObserving(cluster types.NamespacedName) {
 func (m *Manager) List() []types.NamespacedName {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
-	list := []types.NamespacedName{}
+	names := make([]types.NamespacedName, len(m.observers))
+	i := 0
 	for name := range m.observers {
-		list = append(list, name)
+		names[i] = name
+		i++
 	}
-	return list
+	return names
 }
 
 // AddObservationListener adds the given listener to the list of listeners notified

--- a/operators/pkg/controller/elasticsearch/observer/manager_test.go
+++ b/operators/pkg/controller/elasticsearch/observer/manager_test.go
@@ -9,8 +9,10 @@ import (
 	"time"
 
 	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/client"
+	"github.com/elastic/k8s-operators/operators/pkg/utils/k8s"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestManager_List(t *testing.T) {
@@ -33,9 +35,10 @@ func TestManager_List(t *testing.T) {
 			want: []types.NamespacedName{cluster("first"), cluster("second")},
 		},
 	}
+	fakeK8sClient := k8s.WrapClient(fake.NewFakeClient())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := NewManager(DefaultSettings)
+			m := NewManager(nil, fakeK8sClient, DefaultSettings)
 			m.observers = tt.observers
 			require.ElementsMatch(t, tt.want, m.List())
 		})
@@ -44,6 +47,15 @@ func TestManager_List(t *testing.T) {
 
 func cluster(name string) types.NamespacedName {
 	return types.NamespacedName{Namespace: "ns", Name: name}
+}
+
+func newObserver() map[types.NamespacedName]*Observer {
+	c := cluster("cluster")
+	fakeK8sClient := k8s.WrapClient(fake.NewFakeClient())
+	fakeEsClient := fakeEsClient200(client.UserAuth{})
+	observer := NewObserver(fakeK8sClient, nil, nil, c, fakeEsClient, DefaultSettings, nil)
+	return map[types.NamespacedName]*Observer{
+		c: observer}
 }
 
 func TestManager_Observe(t *testing.T) {
@@ -66,14 +78,14 @@ func TestManager_Observe(t *testing.T) {
 		},
 		{
 			name:                   "Observe a second cluster",
-			initiallyObserved:      map[types.NamespacedName]*Observer{cluster("cluster"): NewObserver(cluster("cluster"), fakeClient, DefaultSettings, nil)},
+			initiallyObserved:      newObserver(),
 			clusterToObserve:       cluster("cluster2"),
 			clusterToObserveClient: fakeClient,
 			expectedObservers:      []types.NamespacedName{cluster("cluster"), cluster("cluster2")},
 		},
 		{
 			name:                   "Observe twice the same cluster (idempotent)",
-			initiallyObserved:      map[types.NamespacedName]*Observer{cluster("cluster"): NewObserver(cluster("cluster"), fakeClient, DefaultSettings, nil)},
+			initiallyObserved:      newObserver(),
 			clusterToObserve:       cluster("cluster"),
 			clusterToObserveClient: fakeClient,
 			expectedObservers:      []types.NamespacedName{cluster("cluster")},
@@ -81,7 +93,7 @@ func TestManager_Observe(t *testing.T) {
 		},
 		{
 			name:              "Observe twice the same cluster with a different client",
-			initiallyObserved: map[types.NamespacedName]*Observer{cluster("cluster"): NewObserver(cluster("cluster"), fakeClient, DefaultSettings, nil)},
+			initiallyObserved: newObserver(),
 			clusterToObserve:  cluster("cluster"),
 			// more client comparison tests in client_test.go
 			clusterToObserveClient: fakeClientWithDifferentUser,
@@ -89,15 +101,17 @@ func TestManager_Observe(t *testing.T) {
 			expectNewObserver:      true,
 		},
 	}
+
+	fakeK8sClient := k8s.WrapClient(fake.NewFakeClient())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := NewManager(DefaultSettings)
+			m := NewManager(nil, fakeK8sClient, DefaultSettings)
 			m.observers = tt.initiallyObserved
 			var initialCreationTime time.Time
 			if initial, exists := tt.initiallyObserved[tt.clusterToObserve]; exists {
 				initialCreationTime = initial.creationTime
 			}
-			observer := m.Observe(tt.clusterToObserve, tt.clusterToObserveClient)
+			observer := m.Observe(tt.clusterToObserve, nil, tt.clusterToObserveClient)
 			// returned observer should be the correct one
 			require.Equal(t, tt.clusterToObserve, observer.cluster)
 			// list of observers should have been updated
@@ -150,9 +164,11 @@ func TestManager_StopObserving(t *testing.T) {
 			expectedAfterStopObserving: []types.NamespacedName{cluster("cluster2")},
 		},
 	}
+
+	fakeK8sClient := k8s.WrapClient(fake.NewFakeClient())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := NewManager(DefaultSettings)
+			m := NewManager(nil, fakeK8sClient, DefaultSettings)
 			m.observers = tt.observed
 			for _, name := range tt.stopObserving {
 				m.StopObserving(name)
@@ -163,15 +179,16 @@ func TestManager_StopObserving(t *testing.T) {
 }
 
 func TestManager_AddObservationListener(t *testing.T) {
-	m := NewManager(Settings{
+	fakeK8sClient := k8s.WrapClient(fake.NewFakeClient())
+	m := NewManager(nil, fakeK8sClient, Settings{
 		ObservationInterval: 1 * time.Microsecond,
 		RequestTimeout:      1 * time.Second,
 	})
 
 	// observe 2 clusters
-	obs1 := m.Observe(cluster("cluster1"), fakeEsClient200(client.UserAuth{}))
+	obs1 := m.Observe(cluster("cluster1"), nil, fakeEsClient200(client.UserAuth{}))
 	defer obs1.Stop()
-	obs2 := m.Observe(cluster("cluster2"), fakeEsClient200(client.UserAuth{}))
+	obs2 := m.Observe(cluster("cluster2"), nil, fakeEsClient200(client.UserAuth{}))
 	defer obs2.Stop()
 
 	// add a listener that is only interested in cluster1

--- a/operators/pkg/controller/elasticsearch/observer/state.go
+++ b/operators/pkg/controller/elasticsearch/observer/state.go
@@ -6,9 +6,20 @@ package observer
 
 import (
 	"context"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"sync"
 
 	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/client"
 	esclient "github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/client"
+	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/keystore"
+	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/label"
+	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/processmanager"
+	"github.com/elastic/k8s-operators/operators/pkg/utils/k8s"
+	netutils "github.com/elastic/k8s-operators/operators/pkg/utils/net"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // State contains information about an observed state of Elasticsearch.
@@ -22,14 +33,21 @@ type State struct {
 	// TODO should probably be a separate observer
 	// ClusterLicense is the current license applied to this cluster
 	ClusterLicense *esclient.License
+	// KeystoreStatuses are the status of the keystore updater of each pods
+	KeystoreStatuses []keystore.Status
 }
 
 // RetrieveState returns the current Elasticsearch cluster state
-func RetrieveState(ctx context.Context, esClient esclient.Client) State {
+func RetrieveState(
+	ctx context.Context, k8sClient k8s.Client,
+	cluster types.NamespacedName, esClient esclient.Client,
+	caCerts []*x509.Certificate, dialer netutils.Dialer,
+) State {
 	// retrieve both cluster state and health in parallel
 	clusterStateChan := make(chan *client.ClusterState)
 	healthChan := make(chan *client.Health)
 	licenseChan := make(chan *client.License)
+	keystoreStatusesChan := make(chan []keystore.Status)
 
 	go func() {
 		clusterState, err := esClient.GetClusterState(ctx)
@@ -61,10 +79,54 @@ func RetrieveState(ctx context.Context, esClient esclient.Client) State {
 		licenseChan <- &license
 	}()
 
+	go func() {
+		// fetch pods
+		labelSelector := label.NewLabelSelectorForElasticsearchClusterName(cluster.Name)
+		pods, err := k8s.GetPods(k8sClient, cluster.Namespace, labelSelector, nil)
+		if err != nil {
+			keystoreStatusesChan <- nil
+			return
+		}
+
+		keystoreStatuses := make([]keystore.Status, len(pods))
+		wg := sync.WaitGroup{}
+		// request the process manager API for each pod
+		for i, pod := range pods {
+			wg.Add(1)
+			go func(idx int, p corev1.Pod) {
+				defer wg.Done()
+				status := getKeystoreStatus(ctx, caCerts, dialer, p)
+				keystoreStatuses[idx] = status
+			}(i, pod)
+		}
+		wg.Wait()
+		keystoreStatusesChan <- keystoreStatuses
+	}()
+
 	// return the state when ready, may contain nil values
 	return State{
-		ClusterHealth:  <-healthChan,
-		ClusterState:   <-clusterStateChan,
-		ClusterLicense: <-licenseChan,
+		ClusterHealth:    <-healthChan,
+		ClusterState:     <-clusterStateChan,
+		ClusterLicense:   <-licenseChan,
+		KeystoreStatuses: <-keystoreStatusesChan,
 	}
+}
+
+func getKeystoreStatus(ctx context.Context, caCerts []*x509.Certificate, dialer netutils.Dialer, pod corev1.Pod) keystore.Status {
+	if !k8s.IsPodReady(pod) {
+		log.V(3).Info("Pod not ready to retrieve keystore status", "name", pod.Name)
+		return keystore.Status{State: keystore.WaitingState}
+	}
+
+	podIP := net.ParseIP(pod.Status.PodIP)
+	endpoint := fmt.Sprintf("https://%s:%d", podIP.String(), processmanager.DefaultPort)
+	pmClient := processmanager.NewClient(endpoint, caCerts, dialer)
+	status, err := pmClient.KeystoreStatus(ctx)
+	if err != nil {
+		log.V(3).Info("Unable to retrieve keystore status", "name", pod.Name, "error", err)
+		return keystore.Status{State: keystore.State("Unreachable")}
+	}
+
+	log.V(3).Info("Keystore updater", "name", pod.Name, "status", status)
+	return status
 }

--- a/operators/pkg/controller/elasticsearch/processmanager/client.go
+++ b/operators/pkg/controller/elasticsearch/processmanager/client.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/keystore"
 	"github.com/elastic/k8s-operators/operators/pkg/utils/net"
 )
 
@@ -25,6 +26,7 @@ type Client interface {
 	Stop(ctx context.Context) (ProcessStatus, error)
 	Kill(ctx context.Context) (ProcessStatus, error)
 	Status(ctx context.Context) (ProcessStatus, error)
+	KeystoreStatus(ctx context.Context) (keystore.Status, error)
 }
 
 type DefaultClient struct {
@@ -87,6 +89,12 @@ func (c *DefaultClient) Kill(ctx context.Context) (ProcessStatus, error) {
 func (c *DefaultClient) Status(ctx context.Context) (ProcessStatus, error) {
 	var status ProcessStatus
 	err := c.doRequest(ctx, "GET", "/es/status", &status)
+	return status, err
+}
+
+func (c *DefaultClient) KeystoreStatus(ctx context.Context) (keystore.Status, error) {
+	var status keystore.Status
+	err := c.doRequest(ctx, "GET", "/keystore/status", &status)
 	return status, err
 }
 

--- a/operators/pkg/controller/elasticsearch/processmanager/client_mock.go
+++ b/operators/pkg/controller/elasticsearch/processmanager/client_mock.go
@@ -4,7 +4,11 @@
 
 package processmanager
 
-import "context"
+import (
+	"context"
+
+	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/keystore"
+)
 
 type MockClient struct {
 	status ProcessStatus
@@ -29,4 +33,7 @@ func (m *MockClient) Kill(ctx context.Context) (ProcessStatus, error) {
 }
 func (m *MockClient) Status(ctx context.Context) (ProcessStatus, error) {
 	return m.status, m.err
+}
+func (m *MockClient) KeystoreStatus(ctx context.Context) (keystore.Status, error) {
+	return keystore.Status{Reason: keystore.KeystoreUpdatedReason}, m.err
 }

--- a/operators/pkg/controller/elasticsearch/reconcile/state.go
+++ b/operators/pkg/controller/elasticsearch/reconcile/state.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elastic/k8s-operators/operators/pkg/controller/common/events"
 	"github.com/elastic/k8s-operators/operators/pkg/controller/common/validation"
 	"github.com/elastic/k8s-operators/operators/pkg/controller/elasticsearch/observer"
+	"github.com/elastic/k8s-operators/operators/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -32,22 +33,11 @@ func NewState(c v1alpha1.Elasticsearch) *State {
 func AvailableElasticsearchNodes(pods []corev1.Pod) []corev1.Pod {
 	var nodesAvailable []corev1.Pod
 	for _, pod := range pods {
-		if IsAvailable(pod) {
+		if k8s.IsPodReady(pod) {
 			nodesAvailable = append(nodesAvailable, pod)
 		}
 	}
 	return nodesAvailable
-}
-
-// IsAvailable checks if both conditions ContainersReady and PodReady of a Pod are true.
-func IsAvailable(pod corev1.Pod) bool {
-	conditionsTrue := 0
-	for _, cond := range pod.Status.Conditions {
-		if cond.Status == corev1.ConditionTrue && (cond.Type == corev1.ContainersReady || cond.Type == corev1.PodReady) {
-			conditionsTrue++
-		}
-	}
-	return conditionsTrue == 2
 }
 
 func (s *State) updateWithPhase(

--- a/operators/pkg/controller/elasticsearch/version/version6/zen1.go
+++ b/operators/pkg/controller/elasticsearch/version/version6/zen1.go
@@ -42,7 +42,7 @@ func UpdateZen1Discovery(
 	for _, p := range allPods {
 		if label.IsMasterNode(p) {
 			currentMasterCount++
-			if reconcile.IsAvailable(p) {
+			if k8s.IsPodReady(p) {
 				currentAvailableMasterCount++
 			}
 		}

--- a/operators/pkg/utils/k8s/k8sutils.go
+++ b/operators/pkg/utils/k8s/k8sutils.go
@@ -5,8 +5,12 @@
 package k8s
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ToObjectMeta returns an ObjectMeta based on the given NamespacedName.
@@ -23,4 +27,37 @@ func ExtractNamespacedName(object metav1.Object) types.NamespacedName {
 		Namespace: object.GetNamespace(),
 		Name:      object.GetName(),
 	}
+}
+
+// IsAvailable checks if both conditions ContainersReady and PodReady of a Pod are true.
+func IsPodReady(pod corev1.Pod) bool {
+	conditionsTrue := 0
+	for _, cond := range pod.Status.Conditions {
+		if cond.Status == corev1.ConditionTrue && (cond.Type == corev1.ContainersReady || cond.Type == corev1.PodReady) {
+			conditionsTrue++
+		}
+	}
+	return conditionsTrue == 2
+}
+
+// GetPods returns the list of pods given a NamespacedName and a field selector.
+func GetPods(
+	c Client,
+	namespace string,
+	labelSelector labels.Selector,
+	fieldSelector fields.Selector,
+) ([]corev1.Pod, error) {
+	var podList corev1.PodList
+
+	listOpts := client.ListOptions{
+		Namespace:     namespace,
+		LabelSelector: labelSelector,
+		FieldSelector: fieldSelector,
+	}
+
+	if err := c.List(&listOpts, &podList); err != nil {
+		return nil, err
+	}
+
+	return podList.Items, nil
 }


### PR DESCRIPTION
This commit adds the polling of the process manager API to request the keystore updater status for each pod of an Elasticsearch cluster in the existing Elasticsearch observer.

I hesitated between:
- create a new observer and make the existing one more generic (the Manager could support several observer per cluster `observers map[types.NamespacedName][]Observer`)
- reuse the existing one

I started with the first but finally implemented the second which is much simpler.
For the first the coupling between the manager and the observer is a little bigger than I thought. So, making it more generic is more difficult than expected.

This is an early PR to open the discussion.

Relates to #630.