### PR TITLE
Extracting Elastic public key from Vault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ bin
 vendor/
 
 # Elastic public key
-*license.key
+license.key

--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -26,7 +26,6 @@ vault-gke-creds:
 
 # reads Elastic public key from Vault into $PUBLIC_KEY_FILE
 vault-public-key:
-	@ echo $(shell pwd)
 	VAULT_TOKEN=$$(vault write -field=token auth/approle/login role_id=$(VAULT_ROLE_ID) secret_id=$(VAULT_SECRET_ID)) \
     	vault read \
     		-address=$(VAULT_ADDR) \


### PR DESCRIPTION
This is step 1. We are extracting public key before release build and put it into a file

Next step will be to run https://github.com/elastic/k8s-operators/pull/653 in `operators/Makefile` during build