### PR TITLE
Add Jenkins pipeline description to E2E tests

### DIFF
--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -8,6 +8,10 @@ pipeline {
         timeout(time: 1, unit: 'HOURS')
     }
 
+    environment {
+        REGISTRY = "eu.gcr.io"
+    }
+
     stages {
         stage('Checkout from GitHub') {
             steps {
@@ -16,7 +20,14 @@ pipeline {
         }
         stage("Run E2E tests") {
             steps {
-                sh 'make -C build/ci ci-e2e'
+                withCredentials([
+                    string(credentialsId: 'vault-addr', variable: 'VAULT_ADDR'),
+                    string(credentialsId: 'vault-role-id', variable: 'VAULT_ROLE_ID'),
+                    string(credentialsId: 'vault-secret-id', variable: 'VAULT_SECRET_ID'),
+                    string(credentialsId: 'k8s-operators-gcloud-project', variable: 'GCLOUD_PROJECT'),
+                ]) {
+                    sh 'make -C build/ci ci-e2e'
+                }
             }
         }
     }
@@ -24,7 +35,7 @@ pipeline {
     post {
         unsuccessful {
             slackSend botUser: true,
-                      channel: '???',
+                      channel: '#cloud-k8s',
                       color: 'danger',
                       message: 'E2E tests build ${env.BUILD_NUMBER} failed!',
                       tokenCredentialId: 'cloud-ci-slack-integration-token'


### PR DESCRIPTION
- [x] E2E tests job conversion from freestyle to pipeline https://github.com/elastic/infra/pull/11265
- [x] Add Slack notifications https://github.com/elastic/cloud-on-k8s/issues/504
- [x] We need to decide on channel for Slack notifications