### PR TITLE
Fix release job

### DIFF
--- a/build/ci/release/Jenkinsfile
+++ b/build/ci/release/Jenkinsfile
@@ -15,12 +15,26 @@ pipeline {
     stages {
         stage('Build and push release image') {
             steps {
-                sh 'make -C build/ci ci-release'
+                withCredentials([
+                    string(credentialsId: 'vault-addr', variable: 'VAULT_ADDR'),
+                    string(credentialsId: 'vault-role-id', variable: 'VAULT_ROLE_ID'),
+                    string(credentialsId: 'vault-secret-id', variable: 'VAULT_SECRET_ID'),
+                    string(credentialsId: 'k8s-operators-gcloud-project', variable: 'GCLOUD_PROJECT'),
+                ]) {
+                    sh 'make -C build/ci ci-release'
+                }
             }
         }
     }
 
     post {
+        unsuccessful {
+            slackSend botUser: true,
+                      channel: '#cloud-k8s',
+                      color: 'danger',
+                      message: 'Release build ${env.JOB_NAME}#${env.BUILD_NUMBER} failed!',
+                      tokenCredentialId: 'cloud-ci-slack-integration-token'
+        }
         cleanup {
             cleanWs()
         }


### PR DESCRIPTION
This change fixing release job providing credentials as environment variables.
Also, it's enabling Slack messaging in case of job fail.