### PR TITLE
Add support for Elastic Docker registry login

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -231,7 +231,7 @@ docker-build:
 
 docker-push:
 ifeq ($(RELEASE), true)
-	docker login -u $(ELASTIC_DOCKER_LOGIN) -p $(ELASTIC_DOCKER_PASSWORD) push.docker.elastic.co
+	@ docker login -u $(ELASTIC_DOCKER_LOGIN) -p $(ELASTIC_DOCKER_PASSWORD) push.docker.elastic.co
 endif
 ifeq ($(KUBECTL_CLUSTER), minikube)
 	# use the minikube registry


### PR DESCRIPTION
Related to https://github.com/elastic/k8s-operators/issues/666
Adds support to login to Elastic Docker registry. We will need that for pushing release.