### PR TITLE
Check for public key size

### DIFF
--- a/operators/cmd/license-initializer/main.go
+++ b/operators/cmd/license-initializer/main.go
@@ -90,6 +90,9 @@ var publicKeyBytes = []byte{
 	if err != nil {
 		handleErr(errors.Wrapf(err, "Failed to read %v", pubkeyFile))
 	}
+	if len(bytes) == 0 {
+		handleErr(errors.Wrapf(err, "%v shouldn't have size 0", pubkeyFile))
+	}
 	t := template.Must(template.New("license").Parse(tmpl))
 	err = t.Execute(out, params{
 		Bytes: bytes,


### PR DESCRIPTION
Currently, if key size will be 0, then we will proceed and will generate an empty
```
var publicKeyBytes = []byte{

}
```
I think it may sense to throw an error in such cases.