### PR TITLE
Increase E2E tests timeout

### DIFF
--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 2, unit: 'HOURS')
+        timeout(time: 150, unit: 'MINUTES')
     }
 
     environment {

--- a/operators/test/e2e/Dockerfile
+++ b/operators/test/e2e/Dockerfile
@@ -9,4 +9,4 @@ COPY test/   test/
 COPY vendor/ vendor/
 
 # Run the tests
-ENTRYPOINT ["go", "test", "-v", "-failfast", "-timeout", "1h", "-tags=e2e", "./test/e2e"]
+ENTRYPOINT ["go", "test", "-v", "-failfast", "-timeout", "2h", "-tags=e2e", "./test/e2e"]


### PR DESCRIPTION
Currently, there is 1 hour timeout for e2e tests execution. Based on first successful run, it seems that we may need to increase timeout to prevent job failing because of it
