### PR TITLE
rearrange the steps to access Elasticsearch in Quckstart.md

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -119,33 +119,33 @@ You can access Elasticsearch from the Kubernetes cluster, using the URL `https:/
 
     * A default user named `elastic` was automatically created. Its password is stored as a Kubernetes secret:
 
-    ```bash
-    PASSWORD=$(kubectl get secret quickstart-elastic-user -o=jsonpath='{.data.elastic}' | base64 --decode)
-    ```
+        ```bash
+        PASSWORD=$(kubectl get secret quickstart-elastic-user -o=jsonpath='{.data.elastic}' | base64 --decode)
+        ```
 
     * Request the Elasticsearch endpoint (skipping the certificate verification for now)
-    ```bash
-    curl -u "elastic:$PASSWORD" -k "https://localhost:9200"
-    ```
-    ```
-    {
-      "name" : "quickstart-es-5zctxpn8nd",
-      "cluster_name" : "quickstart",
-      "cluster_uuid" : "2sUV1IUEQ5SA5ZSkhznCHA",
-      "version" : {
-        "number" : "7.0.0",
-        "build_flavor" : "default",
-        "build_type" : "docker",
-        "build_hash" : "b7e28a7",
-        "build_date" : "2019-04-05T22:55:32.697037Z",
-        "build_snapshot" : false,
-        "lucene_version" : "8.0.0",
-        "minimum_wire_compatibility_version" : "6.7.0",
-        "minimum_index_compatibility_version" : "6.0.0-beta1"
-      },
-      "tagline" : "You Know, for Search"
-    }
-    ```
+        ```bash
+        curl -u "elastic:$PASSWORD" -k "https://localhost:9200"
+        ```
+        ```
+        {
+          "name" : "quickstart-es-5zctxpn8nd",
+          "cluster_name" : "quickstart",
+          "cluster_uuid" : "2sUV1IUEQ5SA5ZSkhznCHA",
+          "version" : {
+            "number" : "7.0.0",
+            "build_flavor" : "default",
+            "build_type" : "docker",
+            "build_hash" : "b7e28a7",
+            "build_date" : "2019-04-05T22:55:32.697037Z",
+            "build_snapshot" : false,
+            "lucene_version" : "8.0.0",
+            "minimum_wire_compatibility_version" : "6.7.0",
+            "minimum_index_compatibility_version" : "6.0.0-beta1"
+          },
+          "tagline" : "You Know, for Search"
+        }
+        ```
 
 ## Deploy the Kibana instance
 


### PR DESCRIPTION
The elastic password should be decoded in the same shell as used to access the ES cluster (port-forward is done in the original terminal)

