### PR TITLE
Make the keystore updater start non blocking

### DIFF
--- a/operators/pkg/controller/elasticsearch/processmanager/manager.go
+++ b/operators/pkg/controller/elasticsearch/processmanager/manager.go
@@ -77,7 +77,7 @@ func (pm ProcessManager) Start(done chan ExitStatus) error {
 	}
 
 	if pm.keystoreUpdater != nil {
-		pm.keystoreUpdater.Start()
+		go pm.keystoreUpdater.Start()
 	}
 
 	log.Info("Started")


### PR DESCRIPTION
Fixes #756.

Start the keystore updater in a go routine to avoid to block the process manager start-up.