### PR TITLE
Update PR job on CI

### DIFF
--- a/.ci/jobs/pr.yml
+++ b/.ci/jobs/pr.yml
@@ -20,8 +20,6 @@
       lightweight-checkout: true
     triggers:
       - github-pull-request:
-          white-list-target-branches:
-            - master
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true


### PR DESCRIPTION
This update will help with moving project to open. 
It's changing PR job type from multibranch to pipeline and using plugin for Github PR's as we discussed with `infra` team.