### PR TITLE
[DOCS] Adds partintro

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -2,6 +2,8 @@
 
 = Quickstart
 
+[partintro]
+--
 In this quickstart, you will learn how to:
 
 * Deploy the operator in your Kubernetes cluster
@@ -12,6 +14,7 @@ In this quickstart, you will learn how to:
   - Secure your cluster
   - Use persistent storage
   - Additional features
+--
 
 == Requirements
 


### PR DESCRIPTION
This PR addresses the following documentation build error:

INFO:build_docs:/out/html_docs/index.xml:381: element part: validity error : Element part content does not follow the DTD, expecting (beginpage? , partinfo? , (title , subtitle? , titleabbrev?) , partintro? , (appendix | chapter | toc | lot | index | glossary | bibliography | article | preface | refentry | reference)+), got (title simpara itemizedlist chapter chapter chapter chapter chapter chapter )
INFO:build_docs:</part>

Related to https://github.com/elastic/docs/pull/863