### PR TITLE
[DOCS] Fix broken links

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -36,7 +36,7 @@ In this quickstart, you will learn how to:
 
 == Deploy the Elasticsearch cluster
 
-Let's apply a simple link:{ref}getting-started.html[Elasticsearch] cluster specification, with one node:
+Let's apply a simple link:{ref}/getting-started.html[Elasticsearch] cluster specification, with one node:
 
 ----
 cat <<EOF | kubectl apply -f -
@@ -139,7 +139,7 @@ NOTE: For testing purposes only, you can specify the `-k` option to turn off cer
 
 == Deploy the Kibana instance
 
-To deploy your link:{kibana-ref}introduction.html#introduction[Kibana] instance go through the following steps.
+To deploy your link:{kibana-ref}/introduction.html#introduction[Kibana] instance go through the following steps.
 
 1. Specify a Kibana instance and associate it with your quickstart Elasticsearch cluster:
 


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/863

This PR addresses the following broken links:

> INFO:build_docs:Bad cross-document links:
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/k8s/current/k8s-deploy_the_elasticsearch_cluster.html:
INFO:build_docs:   - en/elasticsearch/reference/7.0getting-started.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/k8s/current/k8s-deploy_the_kibana_instance.html:
INFO:build_docs:   - en/kibana/7.0introduction.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/k8s/master/k8s-deploy_the_elasticsearch_cluster.html:
INFO:build_docs:   - en/elasticsearch/reference/7.0getting-started.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/k8s/master/k8s-deploy_the_kibana_instance.html:
INFO:build_docs:   - en/kibana/7.0introduction.html