### PR TITLE
Fix Makefile for release build

### DIFF
--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -72,7 +72,7 @@ ci-release: vault-public-key vault-docker-creds
     	-e "REGISTRY=$(REGISTRY)" \
     	-e "REPOSITORY=$(REPOSITORY)" \
     	-e "ELASTIC_DOCKER_LOGIN=$(DOCKER_LOGIN)" \
-    	-e "ELASTIC_DOCKER_PASSWORD=$(file < $(DOCKER_CREDENTIALS_FILE))" \
+    	-e "ELASTIC_DOCKER_PASSWORD=$(shell cat $(DOCKER_CREDENTIALS_FILE))" \
     	-e "RELEASE=true" \
     	cloud-on-k8s-ci-release \
     	bash -c "make -C operators ci-release"


### PR DESCRIPTION
Looks like we have an old version of `make` on CI which not support `$(file < $(filename))` syntax