### PR TITLE
Increase resource limit for the all-in-one operator example

### DIFF
--- a/operators/config/all-in-one.yaml
+++ b/operators/config/all-in-one.yaml
@@ -179,8 +179,8 @@ spec:
             value: eu.gcr.io/elastic-cloud-dev/eck-operators:latest
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 1
+            memory: 100Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/operators/config/operator/all-in-one/operator.template.yaml
+++ b/operators/config/operator/all-in-one/operator.template.yaml
@@ -36,8 +36,8 @@ spec:
             value: <OPERATOR_IMAGE>
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 1
+            memory: 100Mi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
Applies the same limits for the all-in-one as for the global and namepaced operators:
- Increase mem limit from 30 Mi to 100 Mi
- Increase cpu limit from 100m to 1000m

Relates to #797.