### PR TITLE
Specify storageClassName in pvc samples

### DIFF
--- a/operators/config/samples/elasticsearch/elasticsearch.yaml
+++ b/operators/config/samples/elasticsearch/elasticsearch.yaml
@@ -36,6 +36,7 @@ spec:
     #    resources:
     #      requests:
     #        storage: 2Gi
+    #    storageClassName: elastic-local # or eg. gcePersistentDisk
   ## Inject secure settings into Elasticsearch nodes from a k8s secret reference
   # secureSettings:
   #   secretName: "ref-to-secret"

--- a/operators/config/samples/kibana/kibana_es.yaml
+++ b/operators/config/samples/kibana/kibana_es.yaml
@@ -51,6 +51,7 @@ spec:
     #    resources:
     #      requests:
     #        storage: 2Gi
+    #    storageClassName: elastic-local # or eg. gcePersistentDisk
   # dedicated masters:
   - config:
       node.master: true


### PR DESCRIPTION
Not sure when/why this has disappeared, but it seems pretty important to specify
the storage class here in our samples.