### PR TITLE
Remove self gen trial from quickstart cluster

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -68,7 +68,6 @@ spec:
       node.master: true
       node.data: true
       node.ingest: true
-      xpack.license.self_generated.type: trial
 EOF
 ----
 
@@ -235,7 +234,6 @@ spec:
       node.master: true
       node.data: true
       node.ingest: true
-      xpack.license.self_generated.type: trial
 EOF
 ----
 
@@ -266,7 +264,6 @@ spec:
       node.master: true
       node.data: true
       node.ingest: true
-      xpack.license.self_generated.type: trial
     volumeClaimTemplates:
     - metadata:
         name: data


### PR DESCRIPTION
Let's use basic by default.