### PR TITLE
Fix E2E test to use default resources if not specified in the spec

### DIFF
--- a/operators/pkg/controller/elasticsearch/version/common.go
+++ b/operators/pkg/controller/elasticsearch/version/common.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	defaultMemoryLimits = resource.MustParse("2Gi")
+	DefaultMemoryLimits = resource.MustParse("2Gi")
 	SecurityPropsFile   = path.Join(settings.ManagedConfigPath, settings.SecurityPropsFile)
 )
 
@@ -139,7 +139,7 @@ func podSpec(
 	)
 
 	resourceLimits := corev1.ResourceList{
-		corev1.ResourceMemory: nonZeroQuantityOrDefault(*p.Resources.Limits.Memory(), defaultMemoryLimits),
+		corev1.ResourceMemory: nonZeroQuantityOrDefault(*p.Resources.Limits.Memory(), DefaultMemoryLimits),
 	}
 	if !p.Resources.Limits.Cpu().IsZero() {
 		resourceLimits[corev1.ResourceCPU] = *p.Resources.Limits.Cpu()
@@ -253,7 +253,7 @@ func NewPod(
 // MemoryLimitsToHeapSize converts a memory limit to the heap size (in megabytes) for the JVM
 func MemoryLimitsToHeapSize(memoryLimit resource.Quantity) int {
 	// use half the available memory as heap
-	return quantityToMegabytes(nonZeroQuantityOrDefault(memoryLimit, defaultMemoryLimits)) / 2
+	return quantityToMegabytes(nonZeroQuantityOrDefault(memoryLimit, DefaultMemoryLimits)) / 2
 }
 
 // nonZeroQuantityOrDefault returns q if it is nonzero, defaultQuantity otherwise

--- a/operators/test/e2e/stack/checks_k8s.go
+++ b/operators/test/e2e/stack/checks_k8s.go
@@ -9,6 +9,7 @@ import (
 
 	estype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/version"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/helpers"
 	appsv1 "k8s.io/api/apps/v1"
@@ -245,7 +246,12 @@ func CheckESPodsResources(stack Builder, k *helpers.K8sHelper) helpers.TestStep 
 			var expectedLimits []corev1.ResourceList
 			for _, topoElem := range stack.Elasticsearch.Spec.Nodes {
 				for i := 0; i < int(topoElem.NodeCount); i++ {
-					expectedLimits = append(expectedLimits, topoElem.GetESContainerTemplate().Resources.Limits)
+					esContainer := topoElem.GetESContainerTemplate()
+					if esContainer != nil && esContainer.Resources.Limits != nil {
+						expectedLimits = append(expectedLimits, esContainer.Resources.Limits)
+					} else {
+						expectedLimits = append(expectedLimits, corev1.ResourceList{corev1.ResourceMemory: version.DefaultMemoryLimits})
+					}
 				}
 			}
 			var limits []corev1.ResourceList


### PR DESCRIPTION
We had a bug where `topoElem.GetESContainerTemplate().Resources.Limits` could be nil if not specified in the Elasticsearch spec.

Lets use the default limit in this case.

Fixes https://github.com/elastic/cloud-on-k8s/issues/816.