### PR TITLE
Do not check for guaranteed qos in e2e tests

### DIFF
--- a/operators/test/e2e/stack/checks_k8s.go
+++ b/operators/test/e2e/stack/checks_k8s.go
@@ -255,10 +255,6 @@ func CheckESPodsResources(stack Builder, k *helpers.K8sHelper) helpers.TestStep 
 				}
 				esContainer := p.Spec.Containers[0]
 				limits = append(limits, esContainer.Resources.Limits)
-
-				if p.Status.QOSClass != corev1.PodQOSGuaranteed {
-					return fmt.Errorf("Pod QoS class should be Guaranteed")
-				}
 			}
 			if err := helpers.ElementsMatch(expectedLimits, limits); err != nil {
 				return err


### PR DESCRIPTION
Our current approach is to enforce a default on memory limit only (not
cpu): pods end up with a Burstable QoS if CPU is not specified in the
spec.

This PR adapts E2E tests accordingly, to not check for guaranteed QoS in
all cases.