### PR TITLE
Fix APM sample resources spec

### DIFF
--- a/operators/config/samples/apm/apm_es_kibana.yaml
+++ b/operators/config/samples/apm/apm_es_kibana.yaml
@@ -9,16 +9,19 @@ metadata:
 spec:
   version: "6.7.2"
   nodes:
-    - config:
-        node.master: true
-        node.data: true
-        node.ingest: true
-        xpack.license.self_generated.type: trial
-      resources:
-        limits:
-          memory: 2Gi
-          cpu: 500m
-      nodeCount: 3
+  - config:
+      node.master: true
+      node.data: true
+      node.ingest: true
+      xpack.license.self_generated.type: trial
+    podTemplate:
+      spec:
+        containers:
+          - name: elasticsearch
+            resources:
+              limits:
+                memory: 2Gi
+    nodeCount: 3
 ---
 apiVersion: apm.k8s.elastic.co/v1alpha1
 kind: ApmServer


### PR DESCRIPTION
We now handle resource limits in the podTemplate section.