### PR TITLE
Handle resources conflict

### DIFF
--- a/operators/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/operators/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -228,7 +228,7 @@ func (r *ReconcileElasticsearch) Reconcile(request reconcile.Request) (reconcile
 	results := r.internalReconcile(es, state)
 	err = r.updateStatus(es, state)
 	if err != nil && apierrors.IsConflict(err) {
-		log.Info("Conflict while updating status")
+		log.V(1).Info("Conflict while updating status")
 		return reconcile.Result{Requeue: true}, nil
 	}
 	return results.WithError(err).Aggregate()

--- a/operators/pkg/controller/kibana/kibana_controller.go
+++ b/operators/pkg/controller/kibana/kibana_controller.go
@@ -151,7 +151,7 @@ func (r *ReconcileKibana) Reconcile(request reconcile.Request) (reconcile.Result
 
 	if err := r.finalizers.Handle(kb, secretWatchFinalizer(*kb, r.dynamicWatches)); err != nil {
 		if errors.IsConflict(err) {
-			log.Info("Conflict while handling secret watch finalizer")
+			log.V(1).Info("Conflict while handling secret watch finalizer")
 			return reconcile.Result{Requeue: true}, nil
 		}
 		return reconcile.Result{}, err
@@ -176,7 +176,7 @@ func (r *ReconcileKibana) Reconcile(request reconcile.Request) (reconcile.Result
 	// update status
 	err = r.updateStatus(state)
 	if err != nil && errors.IsConflict(err) {
-		log.Info("Conflict while updating status")
+		log.V(1).Info("Conflict while updating status")
 		return reconcile.Result{Requeue: true}, nil
 	}
 	return results.WithError(err).Aggregate()

--- a/operators/pkg/controller/kibanaassociation/association_controller.go
+++ b/operators/pkg/controller/kibanaassociation/association_controller.go
@@ -128,7 +128,7 @@ func (r *ReconcileAssociation) Reconcile(request reconcile.Request) (reconcile.R
 	err = h.Handle(&kibana, watchFinalizer(k8s.ExtractNamespacedName(&kibana), r.watches))
 	if err != nil {
 		if apierrors.IsConflict(err) {
-			log.Info("Conflict while handling finalizer")
+			log.V(1).Info("Conflict while handling finalizer")
 			return reconcile.Result{Requeue: true}, nil
 		}
 		// failed to prepare or run finalizer: retry
@@ -151,7 +151,7 @@ func (r *ReconcileAssociation) Reconcile(request reconcile.Request) (reconcile.R
 		kibana.Status.AssociationStatus = newStatus
 		if err := r.Status().Update(&kibana); err != nil {
 			if apierrors.IsConflict(err) {
-				log.Info("Conflict while updating status")
+				log.V(1).Info("Conflict while updating status")
 				return reconcile.Result{Requeue: true}, nil
 			}
 


### PR DESCRIPTION
Check for conflict error to requeue immediately the reconciliation loop and avoid to log a useless error.

Fixes #477.