### PR TITLE
Change quickstart yaml manifest URL for the release

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -25,7 +25,7 @@ NOTE: If you are using GKE, make sure your user has `cluster-admin` permissions.
 
 . Install link:https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/[custom resource definitions] and the operator with its RBAC rules:
 
-  kubectl apply -f https://raw.githubusercontent.com/elastic/cloud-on-k8s/master/operators/config/all-in-one.yaml
+  kubectl apply -f https://download.elastic.co/downloads/eck/0.8.0/all-in-one.yaml
 
 . Monitor the operator logs:
 


### PR DESCRIPTION
The quickstart should point to the correct release of our yaml manifests.
(which doesn't exist yet, but will pretty soon)

@pebrc please confirm this is the correct URL :)