### PR TITLE
Set operator docker image to v 0.8.0

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -33,7 +33,7 @@ IMG ?= $(REGISTRY)/$(REPOSITORY)/$(IMG_NAME)$(IMG_SUFFIX)
 TAG ?= $(shell git rev-parse --verify HEAD)
 OPERATOR_IMAGE ?= $(IMG):$(TAG)
 OPERATOR_IMAGE_LATEST ?= $(IMG):latest
-LATEST_RELEASED_IMG ?= "docker.elastic.co/eck/eck-operator:0.8.0-alpha4"
+LATEST_RELEASED_IMG ?= "docker.elastic.co/eck/eck-operator:0.8.0"
 
 ## -- Namespaces
 

--- a/operators/config/all-in-one.yaml
+++ b/operators/config/all-in-one.yaml
@@ -1189,7 +1189,7 @@ spec:
     spec:
       serviceAccountName: elastic-operator
       containers:
-      - image: docker.elastic.co/eck/eck-operator:0.8.0-alpha4
+      - image: docker.elastic.co/eck/eck-operator:0.8.0
         name: manager
         args: ["manager", "--operator-roles", "all"]
         env:
@@ -1202,7 +1202,7 @@ spec:
           - name: WEBHOOK_PODS_LABEL
             value: elastic-operator
           - name: OPERATOR_IMAGE
-            value: docker.elastic.co/eck/eck-operator:0.8.0-alpha4
+            value: docker.elastic.co/eck/eck-operator:0.8.0
         resources:
           limits:
             cpu: 1


### PR DESCRIPTION
Should match our expected alpha release.

This docker image does not exist (yet) though, please use a recent build candidate in the meantime.