### PR TITLE
Fix quickstart JSON indentation

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -118,23 +118,23 @@ A default user named `elastic` is automatically created. Its password is stored 
 NOTE: For testing purposes only, you can specify the `-k` option to turn off certificate verification.
 
 ----
-    {
-      "name" : "quickstart-es-r56c9dzzcr",
-      "cluster_name" : "quickstart",
-      "cluster_uuid" : "XqWg0xIiRmmEBg4NMhnYPg",
-      "version" : {
-        "number" : "7.1.0",
-        "build_flavor" : "default",
-        "build_type" : "docker",
-        "build_hash" : "04116c9",
-        "build_date" : "2019-05-08T06:20:03.781729Z",
-        "build_snapshot" : true,
-        "lucene_version" : "8.0.0",
-        "minimum_wire_compatibility_version" : "6.8.0",
-        "minimum_index_compatibility_version" : "6.0.0-beta1"
-      },
-      "tagline" : "You Know, for Search"
-    }
+{
+  "name" : "quickstart-es-r56c9dzzcr",
+  "cluster_name" : "quickstart",
+  "cluster_uuid" : "XqWg0xIiRmmEBg4NMhnYPg",
+  "version" : {
+    "number" : "7.1.0",
+    "build_flavor" : "default",
+    "build_type" : "docker",
+    "build_hash" : "04116c9",
+    "build_date" : "2019-05-08T06:20:03.781729Z",
+    "build_snapshot" : true,
+    "lucene_version" : "8.0.0",
+    "minimum_wire_compatibility_version" : "6.8.0",
+    "minimum_index_compatibility_version" : "6.0.0-beta1"
+  },
+  "tagline" : "You Know, for Search"
+}
 ----
 
 [float]


### PR DESCRIPTION
Let's indent it like the rest of the terminal outputs in that doc.