### PR TITLE
Override sample versions to 7.0.1 and use trial license in e2e tests

### DIFF
--- a/operators/test/e2e/apm_sample_test.go
+++ b/operators/test/e2e/apm_sample_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/apm"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/helpers"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/stack"
@@ -37,6 +38,21 @@ func TestEsApmServerSample(t *testing.T) {
 	// set namespace
 	namespacedSampleStack := sampleStack.WithNamespace(helpers.DefaultNamespace)
 	namespacedSampleApm := sampleApm.WithNamespace(helpers.DefaultNamespace)
+
+	// override version to 7.0.1 until 7.1.0 is out
+	// TODO remove once 7.1.0 is out
+	namespacedSampleStack.Elasticsearch.Spec.Version = "7.0.1"
+	namespacedSampleStack.Kibana.Spec.Version = "7.0.1"
+	// use a trial license until 7.1.0 is out
+	// TODO remove once 7.1.0 is out
+	for i, n := range namespacedSampleStack.Elasticsearch.Spec.Nodes {
+		config := n.Config
+		if config == nil {
+			config = &v1alpha1.Config{}
+		}
+		config.Data["xpack.license.self_generated.type"] = "trial"
+		namespacedSampleStack.Elasticsearch.Spec.Nodes[i].Config = config
+	}
 
 	k := helpers.NewK8sClientOrFatal()
 	helpers.TestStepList{}.

--- a/operators/test/e2e/sample_test.go
+++ b/operators/test/e2e/sample_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	estype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	kbtype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/kibana/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/helpers"
@@ -37,6 +38,21 @@ func readSampleStack() stack.Builder {
 
 	// set namespace
 	namespaced := sampleStack.WithNamespace(helpers.DefaultNamespace)
+
+	// override version to 7.0.1 until 7.1.0 is out
+	// TODO remove once 7.1.0 is out
+	namespaced.Elasticsearch.Spec.Version = "7.0.1"
+	namespaced.Kibana.Spec.Version = "7.0.1"
+	// use a trial license until 7.1.0 is out
+	// TODO remove once 7.1.0 is out
+	for i, n := range namespaced.Elasticsearch.Spec.Nodes {
+		config := n.Config
+		if config == nil {
+			config = &v1alpha1.Config{}
+		}
+		config.Data["xpack.license.self_generated.type"] = "trial"
+		namespaced.Elasticsearch.Spec.Nodes[i].Config = config
+	}
 
 	return namespaced
 }


### PR DESCRIPTION
Until 7.1.0 (referenced in samples used by e2e tests) is out, let's use
7.0.1 with a trial license.
