### PR TITLE
Fix ES sample http options

### DIFF
--- a/operators/config/samples/elasticsearch/elasticsearch.yaml
+++ b/operators/config/samples/elasticsearch/elasticsearch.yaml
@@ -41,14 +41,13 @@ spec:
   # secureSettings:
   #   secretName: "ref-to-secret"
   ## Add a list of SANs into the nodes certificates
-  http:
-    service:
-      spec:
-        type: LoadBalancer
-    tls:
-      selfSignedCertificate:
-        subjectAltNames:
-        - ip: 35.198.85.171
-        - ip: 4.3.2.2
-        - dns: my.domain.name.com
-        - dns: my.second.domain
+  # http:
+  #   service:
+  #     spec:
+  #       type: LoadBalancer
+  #   tls:
+  #     selfSignedCertificate:
+  #       subjectAltNames:
+  #       - ip: 192.168.1.2
+  #       - ip: 192.168.1.3
+  #       - dns: elasticsearch-sample.example.com


### PR DESCRIPTION
Let's use more appropriate SANs, and comment that entire http section to
serve as an "example" but not as the thing we deploy by default.
