### PR TITLE
Override APM sample e2e test version to 7.0.1

### DIFF
--- a/operators/test/e2e/apm_sample_test.go
+++ b/operators/test/e2e/apm_sample_test.go
@@ -43,6 +43,7 @@ func TestEsApmServerSample(t *testing.T) {
 	// TODO remove once 7.1.0 is out
 	namespacedSampleStack.Elasticsearch.Spec.Version = "7.0.1"
 	namespacedSampleStack.Kibana.Spec.Version = "7.0.1"
+	namespacedSampleApm.ApmServer.Spec.Version = "7.0.1"
 	// use a trial license until 7.1.0 is out
 	// TODO remove once 7.1.0 is out
 	for i, n := range namespacedSampleStack.Elasticsearch.Spec.Nodes {


### PR DESCRIPTION
I missed the APM version patch.