### PR TITLE
Tweaks volumeClaimTemplate in Quickstart guide

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -299,7 +299,7 @@ spec:
         resources:
           requests:
             storage: 10Gi
-        storageClassName: Local # can be any available storage class
+        storageClassName: gcePersistentDisk # can be any available storage class
 EOF
 ----
 


### PR DESCRIPTION
- In keeping with the `name: quickstart` series of examples, adds heredoc to the persistent storage example yaml.
- It appears the unit for storage in volumeClaimTemplate should be `Gi`, rather than `GB`, based on this example in the [k8s statefulset documentation](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/).
    When using the example with volumeClaimTemplate, the following error is seen:
```for: "STDIN": admission webhook "validation.elasticsearch.elastic.co" denied the request: v1alpha1.Elasticsearch.Spec: v1alpha1.ElasticsearchSpec.Nodes: []v1alpha1.NodeSpec: v1alpha1.NodeSpec.VolumeClaimTemplates: []v1.PersistentVolumeClaim: v1.PersistentVolumeClaim.Spec: v1.PersistentVolumeClaimSpec.StorageClassName: Resources: v1.ResourceRequirements.Requests: unmarshalerDecoder: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$', error found in #10 byte of ...|ge":"100GB"}},"storag|..., bigger context ...|teOnce"],"resources":{"requests":{"storage":"100GB"}},"storageClassName":"Local"}}]}],"updateStrategy|...```



