### PR TITLE
Fix secure settings prefix doc

### DIFF
--- a/operators/config/all-in-one.yaml
+++ b/operators/config/all-in-one.yaml
@@ -417,10 +417,10 @@ spec:
               type: array
             secureSettings:
               description: SecureSettings reference a secret containing secure settings,
-                to be injected into Elasticsearch keystore on each node. It must exist
-                in the same namespace as the Elasticsearch resource. Secret keys must
-                start with `es.file.` or `es.string.` according to the secure setting
-                type.
+                to be injected into Elasticsearch keystore on each node. Each individual
+                key/value entry in the referenced secret is considered as an individual
+                secure setting to be injected. The secret must exist in the same namespace
+                as the Elasticsearch resource.
               properties:
                 secretName:
                   type: string

--- a/operators/config/crds/elasticsearch_v1alpha1_elasticsearch.yaml
+++ b/operators/config/crds/elasticsearch_v1alpha1_elasticsearch.yaml
@@ -147,10 +147,10 @@ spec:
               type: array
             secureSettings:
               description: SecureSettings reference a secret containing secure settings,
-                to be injected into Elasticsearch keystore on each node. It must exist
-                in the same namespace as the Elasticsearch resource. Secret keys must
-                start with `es.file.` or `es.string.` according to the secure setting
-                type.
+                to be injected into Elasticsearch keystore on each node. Each individual
+                key/value entry in the referenced secret is considered as an individual
+                secure setting to be injected. The secret must exist in the same namespace
+                as the Elasticsearch resource.
               properties:
                 secretName:
                   type: string

--- a/operators/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
+++ b/operators/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
@@ -41,9 +41,9 @@ type ElasticsearchSpec struct {
 
 	// SecureSettings reference a secret containing secure settings, to be injected
 	// into Elasticsearch keystore on each node.
-	// It must exist in the same namespace as the Elasticsearch resource.
-	// Secret keys must start with `es.file.` or `es.string.` according to the
-	// secure setting type.
+	// Each individual key/value entry in the referenced secret is considered as an
+	// individual secure setting to be injected.
+	// The secret must exist in the same namespace as the Elasticsearch resource.
 	SecureSettings *commonv1alpha1.SecretRef `json:"secureSettings,omitempty"`
 }
 


### PR DESCRIPTION
We don't use those prefix anymore. Also, let's be more specific about
how each entry in the secret is an individual secure setting.

Fixes https://github.com/elastic/cloud-on-k8s/issues/848.