### PR TITLE
Enable race condition detection in unit tests and run targets

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -88,7 +88,7 @@ unit: clean
 
 integration: GO_TAGS += integration
 integration: clean generate
-	go test -tags='$(GO_TAGS)' ./pkg/... ./cmd/... -coverprofile cover.out -race
+	go test -tags='$(GO_TAGS)' ./pkg/... ./cmd/... -coverprofile cover.out
 
 check-fmt:
 ifneq ($(shell goimports -l pkg cmd),)


### PR DESCRIPTION
The go tool chain has a race condition detection mechanism that we can
use to detect race conditions in the code. See
https://blog.golang.org/race-detector for more details.

This commit enables it on both the "unit" and "run" make targets.

I initially also enabled it on the "integration" target, then realized we have many tests failing because of race condition detected. Follow-up issue: https://github.com/elastic/cloud-on-k8s/issues/857 to fix race conditions in integration tests and enable the flag.

Thanks @dtuck9 for reminding me we should enable this flag!