### PR TITLE
Close pod port forwarder when the target pod is deleted.

### DIFF
--- a/operators/pkg/dev/portforward/dialer.go
+++ b/operators/pkg/dev/portforward/dialer.go
@@ -43,7 +43,11 @@ var defaultForwarderFactory = ForwardingDialerForwarderFactory(
 			// it looks like a service url, so forward as a service
 			return NewServiceForwarder(client, network, addr)
 		}
-		return NewPodForwarder(network, addr)
+		clientset, err := newDefaultKubernetesClientset()
+		if err != nil {
+			return nil, err
+		}
+		return NewPodForwarder(network, addr, clientset)
 	},
 )
 

--- a/operators/pkg/dev/portforward/pod_forwarder_test.go
+++ b/operators/pkg/dev/portforward/pod_forwarder_test.go
@@ -34,7 +34,7 @@ func (d *capturingDialer) DialContext(ctx context.Context, network, address stri
 }
 
 func NewPodForwarderWithTest(t *testing.T, network, addr string) *podForwarder {
-	fwd, err := NewPodForwarder(network, addr)
+	fwd, err := NewPodForwarder(network, addr, nil)
 	require.NoError(t, err)
 	return fwd
 }
@@ -151,7 +151,7 @@ func Test_parsePodAddr(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parsePodAddr(tt.args.addr)
+			got, err := parsePodAddr(tt.args.addr, nil)
 
 			if tt.wantErr != nil {
 				assert.Equal(t, tt.wantErr, err)

--- a/operators/pkg/dev/portforward/service_forwarder.go
+++ b/operators/pkg/dev/portforward/service_forwarder.go
@@ -37,7 +37,11 @@ var _ Forwarder = &serviceForwarder{}
 
 // defaultPodForwarderFactory is the default pod forwarder factory used outside of tests
 var defaultPodForwarderFactory = ForwarderFactory(func(network, addr string) (Forwarder, error) {
-	return NewPodForwarder(network, addr)
+	clientset, err := newDefaultKubernetesClientset()
+	if err != nil {
+		return nil, err
+	}
+	return NewPodForwarder(network, addr, clientset)
 })
 
 // NewServiceForwarder returns a new initialized service forwarder


### PR DESCRIPTION
This is accomplished by starting a watch when the port forwarder is started.
If a deletion or error event is received or the watch closes, the port forwarder closed.