### PR TITLE
Update default elasticsearch sample description wording.

### DIFF
--- a/operators/config/samples/elasticsearch/elasticsearch.yaml
+++ b/operators/config/samples/elasticsearch/elasticsearch.yaml
@@ -1,5 +1,4 @@
-# This sample sets up an Elasticsearch cluster with 3 nodes,
-# exposed through a LoadBalancer
+# This sample sets up an Elasticsearch cluster with 3 nodes.
 apiVersion: elasticsearch.k8s.elastic.co/v1alpha1
 kind: Elasticsearch
 metadata:


### PR DESCRIPTION
These erroneously state we expose the Service as a LoadBalancer which the sample doesn't.