### PR TITLE
Display kibana password info when relevant

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -232,7 +232,7 @@ Login with the `elastic` user. Retrieve its password with:
 +
 [source,sh]
 ----
-kubectl get secret quickstart-elastic-user -o=jsonpath='{.data.elastic}' | base64 --decode
+echo $(kubectl get secret quickstart-elastic-user -o=jsonpath='{.data.elastic}' | base64 --decode)
 ----
 
 [float]


### PR DESCRIPTION
This is moving the "get the elastic password" section of the Kibana
quickstart to where we actually need it, and fix wording accordingly.
