### PR TITLE
Fix quickstart link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Supported versions:
 *  Kubernetes: 1.11+
 *  Elasticsearch: 6.8+, 7.1+
 
-Check the [Quickstart](https://www.elastic.co/guide/en/k8s/current/index.html) if you want to deploy you first cluster with ECK.
+Check the [Quickstart](https://www.elastic.co/guide/en/cloud-on-k8s/current/index.html) if you want to deploy you first cluster with ECK.


### PR DESCRIPTION
We moved the docs to a different prefix to be consistent with the product name and repo