### PR TITLE
Target GKE doc link to the right section

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -21,7 +21,7 @@ This quickstart assumes you already have Kubernetes 1.11+.
 [id="{p}-deploy-eck"]
 == Deploy ECK in your Kubernetes cluster
 
-NOTE: If you are using GKE, make sure your user has `cluster-admin` permissions. For more information, see link:https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control[Prerequisites for using Kubernetes RBAC on GKE].
+NOTE: If you are using GKE, make sure your user has `cluster-admin` permissions. For more information, see link:https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#iam-rolebinding-bootstrap[Prerequisites for using Kubernetes RBAC on GKE].
 
 . Install link:https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/[custom resource definitions] and the operator with its RBAC rules:
 +


### PR DESCRIPTION
Backport https://github.com/elastic/cloud-on-k8s/commit/e657bb1001de0354d688a7bc53dffcae7c8d2e8e into 0.8.

Let's provide users a link to the exact section of GKE docs that gives
an example of a command to setup the right RBAC.
