### PR TITLE
Block integration tests reconciliations until consumed

### DIFF
--- a/operators/pkg/controller/kibana/kibana_controller_test.go
+++ b/operators/pkg/controller/kibana/kibana_controller_test.go
@@ -7,6 +7,7 @@
 package kibana
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/certificates"
@@ -72,6 +73,9 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, c.Get(k8s.ExtractNamespacedName(instance), instance))
 		if err != nil {
 			return err
+		}
+		if len(instance.Finalizers) == 0 {
+			return fmt.Errorf("kibana finalizers not registered yet")
 		}
 		instance.Spec.Elasticsearch = kbtype.BackendElasticsearch{
 			URL: "http://127.0.0.1:9200",

--- a/operators/pkg/controller/license/trial/trial_controller_suite_test.go
+++ b/operators/pkg/controller/license/trial/trial_controller_suite_test.go
@@ -32,9 +32,8 @@ func TestMain(m *testing.M) {
 func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan reconcile.Request) {
 	requests := make(chan reconcile.Request)
 	fn := reconcile.Func(func(req reconcile.Request) (reconcile.Result, error) {
-		result, err := inner.Reconcile(req)
 		requests <- req
-		return result, err
+		return inner.Reconcile(req)
 	})
 	return fn, requests
 }


### PR DESCRIPTION
In our integration tests we rely a lot on `CheckReconcileCalled()`,
in which we consume a channel of reconciliation events to make sure
a reconciliation did happen, and unlock following reconciliations.

In some places in the code, we sometimes perform more than one
operation that would trigger a reconciliation, then consume the channel.

For instance: https://github.com/elastic/cloud-on-k8s/blob/52695895e4b60a9e664093c782af53a71982415d/operators/pkg/controller/license/trial/trial_controller_integration_test.go#L66-L71

Here we update finalizers for the deletion to go through, then perform
the deletion. In theory we
should consume the reconciliation channel in between since a reconciliation
is triggered, but we probably don't want it to happen since it would
re-add finalizers. (As a side note this makes the test a bit convoluted,
but that's not the purpose of that PR).

This commit slightly reverses our testing logic from:
* execute the reconciliation, then wait until chan is consumed
to:
* wait until chan is consumed, then execute reconciliation

This way, it becomes possible to stack several changes into a single
reconciliation that we expect to happen next, instead of hoping for the
best case scenario where our changes triggers a single reconciliation to
consume, and not multiple ones. I believe this is the source of multiple
flaky integration tests.

One big difference here is that the reconciliation happens asynchronously
after `CheckReconcileCalled()` is called: we cannot rely on reconciliation
to have happened immediately after we unlock it in the tests.
To workaround this, we should then retry checking k8s state
on a condition (`test.RetryUntil()`):
this is what most tests already do, which should play nicely with this reversed
logic.

Should help with fixing flaky integration tests https://github.com/elastic/cloud-on-k8s/issues/623.