### PR TITLE
Fix broken link and correct versions

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -312,10 +312,10 @@ To aim for the best performance, the operator supports persistent volumes local 
 [float]
 === Check out the samples
 
-You can find a set of sample resources link:https://github.com/elastic/cloud-on-k8s/tree/master/operators/config/samples[in the project repository].
-To customize the Elasticsearch resource, check the link:https://github.com/elastic/cloud-on-k8s/blob/v0.8.0/operators/config/samples/elasticsearch/elasticsearch.yaml[Elasticsearch sample] .
+You can find a set of sample resources link:https://github.com/elastic/cloud-on-k8s/tree/0.8/operators/config/samples[in the project repository].
+To customize the Elasticsearch resource, check the link:https://github.com/elastic/cloud-on-k8s/blob/0.8/operators/config/samples/elasticsearch/elasticsearch.yaml[Elasticsearch sample] .
 
-For a full description of each `CustomResourceDefinition`, go to link:https://github.com/elastic/cloud-on-k8s/tree/master/operators/config/crds[the project repository].
+For a full description of each `CustomResourceDefinition`, go to link:https://github.com/elastic/cloud-on-k8s/tree/0.8/operators/config/crds[the project repository].
 You can also retrieve it from the cluster. For example, describe the Elasticsearch CRD specification with:
 
 [source,sh]


### PR DESCRIPTION
We have a broken link in the quickstart and the 0.8 links point to master 😞 