### PR TITLE
Give gke admin cluster role binding a more generic name

### DIFF
--- a/operators/hack/gke-cluster.sh
+++ b/operators/hack/gke-cluster.sh
@@ -53,7 +53,7 @@ create_cluster() {
     gcloud beta container --project ${GCLOUD_PROJECT} clusters get-credentials ${GKE_CLUSTER_NAME} --region ${GKE_CLUSTER_REGION}
 
     # Create required role binding between the GCP account and the K8s cluster.
-    kubectl create clusterrolebinding elastic-operators--manager-rolebinding --clusterrole=cluster-admin --user=$(gcloud auth list --filter=status:ACTIVE --format="value(account)")
+    kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user=$(gcloud auth list --filter=status:ACTIVE --format="value(account)")
 }
 
 delete_cluster() {


### PR DESCRIPTION
The name we used was pretty strange. Moreover this rbac role is not
particularly specific to the operator. It's required for cluster role
rbac changes on gke in general.

Let's change it to `cluster-admin-binding`, similar to what GKE doc
specifies.

I tested this manually on a fresh GKE cluster.