### PR TITLE
Add .Name to NodeSpec

### DIFF
--- a/operators/config/all-in-one.yaml
+++ b/operators/config/all-in-one.yaml
@@ -392,6 +392,12 @@ spec:
                   config:
                     description: Config represents Elasticsearch configuration.
                     type: object
+                  name:
+                    description: Name is a logical name for this set of nodes. Used
+                      as a part of the managed Elasticsearch node.name setting.
+                    maxLength: 12
+                    pattern: '[a-zA-Z0-9-]*'
+                    type: string
                   nodeCount:
                     description: NodeCount defines how many nodes have this topology
                     format: int32

--- a/operators/config/crds/elasticsearch_v1alpha1_elasticsearch.yaml
+++ b/operators/config/crds/elasticsearch_v1alpha1_elasticsearch.yaml
@@ -122,6 +122,12 @@ spec:
                   config:
                     description: Config represents Elasticsearch configuration.
                     type: object
+                  name:
+                    description: Name is a logical name for this set of nodes. Used
+                      as a part of the managed Elasticsearch node.name setting.
+                    maxLength: 12
+                    pattern: '[a-zA-Z0-9-]*'
+                    type: string
                   nodeCount:
                     description: NodeCount defines how many nodes have this topology
                     format: int32

--- a/operators/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
+++ b/operators/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
@@ -58,6 +58,11 @@ func (es ElasticsearchSpec) NodeCount() int32 {
 
 // NodeSpec defines a common topology for a set of Elasticsearch nodes
 type NodeSpec struct {
+	// Name is a logical name for this set of nodes. Used as a part of the managed Elasticsearch node.name setting.
+	// +kubebuilder:validation:Pattern=[a-zA-Z0-9-]*
+	// +kubebuilder:validation:MaxLength=12
+	Name string `json:"name,omitempty"`
+
 	// Config represents Elasticsearch configuration.
 	Config *Config `json:"config,omitempty"`
 

--- a/operators/pkg/controller/elasticsearch/driver/default.go
+++ b/operators/pkg/controller/elasticsearch/driver/default.go
@@ -537,6 +537,7 @@ func (d *defaultDriver) calculateChanges(
 	}
 
 	changes, err := mutation.CalculateChanges(
+		es,
 		expectedPodSpecCtxs,
 		resourcesState,
 		func(ctx pod.PodSpecContext) (corev1.Pod, error) {

--- a/operators/pkg/controller/elasticsearch/mutation/comparison/pod.go
+++ b/operators/pkg/controller/elasticsearch/mutation/comparison/pod.go
@@ -8,12 +8,18 @@ import (
 	"fmt"
 
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/name"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/pod"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/reconcile"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func PodMatchesSpec(podWithConfig pod.PodWithConfig, spec pod.PodSpecContext, state reconcile.ResourcesState) (bool, []string, error) {
+func PodMatchesSpec(
+	es v1alpha1.Elasticsearch,
+	podWithConfig pod.PodWithConfig,
+	spec pod.PodSpecContext,
+	state reconcile.ResourcesState,
+) (bool, []string, error) {
 	pod := podWithConfig.Pod
 	config := podWithConfig.Config
 
@@ -27,6 +33,7 @@ func PodMatchesSpec(podWithConfig pod.PodWithConfig, spec pod.PodSpecContext, st
 	}
 
 	comparisons := []Comparison{
+		NewStringComparison(name.Basename(name.NewPodName(es.Name, spec.NodeSpec)), name.Basename(pod.Name), "Pod base name"),
 		NewStringComparison(expectedContainer.Image, actualContainer.Image, "Docker image"),
 		NewStringComparison(expectedContainer.Name, actualContainer.Name, "Container name"),
 		compareEnvironmentVariables(actualContainer.Env, expectedContainer.Env),

--- a/operators/pkg/controller/elasticsearch/name/name.go
+++ b/operators/pkg/controller/elasticsearch/name/name.go
@@ -82,10 +82,14 @@ func NewPodName(esName string, nodeSpec v1alpha1.NodeSpec) string {
 }
 
 // Basename returns the base name (without the random suffix) for the provided pod.
-// E.g: A pod named foo-bar-baz-{suffix} has a basename of "foo-bar-baz"
+// E.g: A pod named foo-bar-baz-{suffix} has a basename of "foo-bar-baz".
 func Basename(podName string) string {
-	podNameParts := strings.Split(podName, "-")
-	return strings.Join(podNameParts[:len(podNameParts)-1], "-")
+	idx := strings.LastIndex(podName, "-")
+	if idx == -1 {
+		// no segments in the provided pod name, so return the full pod name
+		return podName
+	}
+	return podName[0:idx]
 }
 
 // NewPVCName returns a unique PVC name given a pod name and a PVC template name.

--- a/operators/pkg/controller/elasticsearch/name/name.go
+++ b/operators/pkg/controller/elasticsearch/name/name.go
@@ -64,6 +64,7 @@ func suffix(name string, sfx string) string {
 
 // NewPodName returns a unique name to be used for the pod name and the
 // Elasticsearch cluster node name.
+// The generated pod name follows the pattern "{esName}-es-[{nodeSpec.Name}-]{random suffix}".
 func NewPodName(esName string, nodeSpec v1alpha1.NodeSpec) string {
 	var sfx strings.Builder
 

--- a/operators/pkg/controller/elasticsearch/name/name.go
+++ b/operators/pkg/controller/elasticsearch/name/name.go
@@ -6,7 +6,9 @@ package name
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/stringsutil"
 	"k8s.io/apimachinery/pkg/util/rand"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -62,13 +64,28 @@ func suffix(name string, sfx string) string {
 
 // NewPodName returns a unique name to be used for the pod name and the
 // Elasticsearch cluster node name.
-func NewPodName(esName string) string {
-	sfx := stringsutil.Concat(
-		string(podSuffix),
-		"-",
-		rand.String(podRandomSuffixLength),
-	)
-	return suffix(esName, sfx)
+func NewPodName(esName string, nodeSpec v1alpha1.NodeSpec) string {
+	var sfx strings.Builder
+
+	// it's safe to ignore the result here as strings.Builder cannot error on sfx.WriteString
+	sfx.WriteString(podSuffix) // #nosec G104
+	sfx.WriteString("-")       // #nosec G104
+
+	if nodeSpec.Name != "" {
+		sfx.WriteString(nodeSpec.Name) // #nosec G104
+		sfx.WriteString("-")           // #nosec G104
+	}
+
+	sfx.WriteString(rand.String(podRandomSuffixLength)) // #nosec G104
+
+	return suffix(esName, sfx.String())
+}
+
+// Basename returns the base name (without the random suffix) for the provided pod.
+// E.g: A pod named foo-bar-baz-{suffix} has a basename of "foo-bar-baz"
+func Basename(podName string) string {
+	podNameParts := strings.Split(podName, "-")
+	return strings.Join(podNameParts[:len(podNameParts)-1], "-")
 }
 
 // NewPVCName returns a unique PVC name given a pod name and a PVC template name.

--- a/operators/pkg/controller/elasticsearch/name/name_test.go
+++ b/operators/pkg/controller/elasticsearch/name/name_test.go
@@ -141,6 +141,13 @@ func TestBasename(t *testing.T) {
 		want string
 	}{
 		{
+			name: "pod name with no segments",
+			args: args{
+				podName: "foo",
+			},
+			want: "foo",
+		},
+		{
 			name: "sample pod name",
 			args: args{
 				podName: "sample-1-es-mqjcddtv6g",

--- a/operators/pkg/controller/elasticsearch/name/name_test.go
+++ b/operators/pkg/controller/elasticsearch/name/name_test.go
@@ -8,12 +8,19 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var es = v1alpha1.Elasticsearch{
+	ObjectMeta: v1.ObjectMeta{Name: "elasticsearch"},
+}
 
 func TestNewNodeName(t *testing.T) {
 	type args struct {
 		clusterName string
+		nodeSpec    v1alpha1.NodeSpec
 	}
 	tests := []struct {
 		name string
@@ -34,10 +41,30 @@ func TestNewNodeName(t *testing.T) {
 			},
 			want: "some-es-name-that-is-quite-long-and-will-be-trimm-es-(.*)",
 		},
+		{
+			name: "Generates a random name from a short elasticsearch name with a nodeSpec.Name",
+			args: args{
+				clusterName: "some-es-name",
+				nodeSpec: v1alpha1.NodeSpec{
+					Name: "foo",
+				},
+			},
+			want: "some-es-name-es-foo-(.*)",
+		},
+		{
+			name: "Generates a random name from a long elasticsearch name with a nodeSpec.Name",
+			args: args{
+				clusterName: "some-es-name-that-is-quite-long-and-will-be-trimmed",
+				nodeSpec: v1alpha1.NodeSpec{
+					Name: "foo",
+				},
+			},
+			want: "some-es-name-that-is-quite-long-and-will-be-t-es-foo-(.*)",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NewPodName(tt.args.clusterName)
+			got := NewPodName(tt.args.clusterName, tt.args.nodeSpec)
 			if len(got) > MaxLabelLength {
 				assert.Len(t, got, MaxLabelLength,
 					got, fmt.Sprintf("should be maximum %d characters long", MaxLabelLength))
@@ -100,6 +127,53 @@ func TestNewPVCName(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBasename(t *testing.T) {
+	type args struct {
+		podName string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "sample pod name",
+			args: args{
+				podName: "sample-1-es-mqjcddtv6g",
+			},
+			want: "sample-1-es",
+		},
+		{
+			name: "sample pod name with nodespec name",
+			args: args{
+				podName: "sample-1-es-foo-mqjcddtv6g",
+			},
+			want: "sample-1-es-foo",
+		},
+		{
+			name: "new pod",
+			args: args{
+				podName: NewPodName(es.Name, v1alpha1.NodeSpec{}),
+			},
+			want: "elasticsearch-es",
+		},
+		{
+			name: "new pod with nodespec name",
+			args: args{
+				podName: NewPodName(es.Name, v1alpha1.NodeSpec{Name: "foo"}),
+			},
+			want: "elasticsearch-es-foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Basename(tt.args.podName); got != tt.want {
+				t.Errorf("Basename() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/operators/pkg/controller/elasticsearch/version/common.go
+++ b/operators/pkg/controller/elasticsearch/version/common.go
@@ -239,7 +239,7 @@ func NewPod(
 
 	pod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name.NewPodName(es.Name),
+			Name:        name.NewPodName(es.Name, podSpecCtx.NodeSpec),
 			Namespace:   es.Namespace,
 			Labels:      labels,
 			Annotations: podSpecCtx.NodeSpec.PodTemplate.Annotations,

--- a/operators/test/e2e/stack/checks_es.go
+++ b/operators/test/e2e/stack/checks_es.go
@@ -10,14 +10,14 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	estype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/client"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/name"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/helpers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 type esClusterChecks struct {
@@ -133,7 +133,13 @@ func (e *esClusterChecks) CheckESNodesTopology(es estype.Elasticsearch) helpers.
 				for i, topoElem := range expectedTopology {
 					cfg, err := topoElem.Config.Unpack()
 					require.NoError(t, err)
-					if cfg.Node == nodeRoles && compareMemoryLimit(topoElem, node.JVM.Mem.HeapMaxInBytes) {
+
+					podNameExample := name.NewPodName(es.Name, topoElem)
+
+					if cfg.Node == nodeRoles &&
+						compareMemoryLimit(topoElem, node.JVM.Mem.HeapMaxInBytes) &&
+						// compare the base names of the pod and topology to ensure they're from the same nodespec
+						name.Basename(node.Name) == name.Basename(podNameExample) {
 						// no need to match this topology anymore
 						expectedTopology = append(expectedTopology[:i], expectedTopology[i+1:]...)
 						break


### PR DESCRIPTION
This enables users to provide a short `Name` in each `NodeSpec` which is used in the `node.name` for Elasticsearch and the corresponding pod name. This is useful for quickly gauging node configuration / node type / warmness etc from the name. More advanced use-cases and longer logical names should be using the `podTemplate.metadata.labels` sub-section for now.

The new node name prefix is considered when comparing pods, so if there's no matching pods for a name prefix, a new one is created.

Known limitations:
- `.Name` cannot be longer than 12 characters because we need to fit `{ES.Name}-es-{.NodeSpec.Name}-{suffix}` into 63 characters in the current implementation, ES.Name uses up to 36 characters, suffix is 10 characters and we have 5 static chars, leaving `63 - 36 - 10 - 5 = 12` characters before truncation. This limitation is enforced and lifting it / increasing the max length should be deferred to another issue.

Closes https://github.com/elastic/cloud-on-k8s/issues/882