### PR TITLE
Improve error output in pm IT if Docker unavailable

### DIFF
--- a/operators/pkg/controller/elasticsearch/processmanager/manager_test.go
+++ b/operators/pkg/controller/elasticsearch/processmanager/manager_test.go
@@ -43,8 +43,8 @@ func setup() {
 		"-f", "tests/Dockerfile",
 		"-t", imageName, "../../../..").Run()
 	if err != nil {
-		log.Error(err, "Failed to build docker image")
-		os.Exit(1)
+		fmt.Println("Failed to build docker image. Is Docker available?")
+		panic(err)
 	}
 }
 


### PR DESCRIPTION
When the Docker daemon is not started (quite common on OSX to save
battery life :D), the PM integration tests fail with "exit status 1".

This makes the error output more explicit, by:

* using `fmt.Println` instead of `log.Error`: this last one does not
flush on stdout when the test immediately exits
* using `panic` instead of `os.Exit(1)` to get the stack trace with line
number where we failed
* adding more context to the error message
