### PR TITLE
Use version 7.1.0 with basic license by default in e2e tests

### DIFF
--- a/operators/test/e2e/apm_sample_test.go
+++ b/operators/test/e2e/apm_sample_test.go
@@ -9,11 +9,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/apm"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/helpers"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/stack"
-	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 // Re-use the sample stack for e2e tests.
@@ -38,22 +38,6 @@ func TestEsApmServerSample(t *testing.T) {
 	// set namespace
 	namespacedSampleStack := sampleStack.WithNamespace(helpers.DefaultNamespace)
 	namespacedSampleApm := sampleApm.WithNamespace(helpers.DefaultNamespace)
-
-	// override version to 7.0.1 until 7.1.0 is out
-	// TODO remove once 7.1.0 is out
-	namespacedSampleStack.Elasticsearch.Spec.Version = "7.0.1"
-	namespacedSampleStack.Kibana.Spec.Version = "7.0.1"
-	namespacedSampleApm.ApmServer.Spec.Version = "7.0.1"
-	// use a trial license until 7.1.0 is out
-	// TODO remove once 7.1.0 is out
-	for i, n := range namespacedSampleStack.Elasticsearch.Spec.Nodes {
-		config := n.Config
-		if config == nil {
-			config = &v1alpha1.Config{}
-		}
-		config.Data["xpack.license.self_generated.type"] = "trial"
-		namespacedSampleStack.Elasticsearch.Spec.Nodes[i].Config = config
-	}
 
 	k := helpers.NewK8sClientOrFatal()
 	helpers.TestStepList{}.

--- a/operators/test/e2e/sample_test.go
+++ b/operators/test/e2e/sample_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
 	estype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	kbtype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/kibana/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/helpers"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/stack"
-	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 // Re-use the sample stack for e2e tests.
@@ -37,24 +37,7 @@ func readSampleStack() stack.Builder {
 	sampleStack.Kibana = kb
 
 	// set namespace
-	namespaced := sampleStack.WithNamespace(helpers.DefaultNamespace)
-
-	// override version to 7.0.1 until 7.1.0 is out
-	// TODO remove once 7.1.0 is out
-	namespaced.Elasticsearch.Spec.Version = "7.0.1"
-	namespaced.Kibana.Spec.Version = "7.0.1"
-	// use a trial license until 7.1.0 is out
-	// TODO remove once 7.1.0 is out
-	for i, n := range namespaced.Elasticsearch.Spec.Nodes {
-		config := n.Config
-		if config == nil {
-			config = &v1alpha1.Config{}
-		}
-		config.Data["xpack.license.self_generated.type"] = "trial"
-		namespaced.Elasticsearch.Spec.Nodes[i].Config = config
-	}
-
-	return namespaced
+	return sampleStack.WithNamespace(helpers.DefaultNamespace)
 }
 
 // TestStackSample runs a test suite using the sample stack

--- a/operators/test/e2e/stack/builder.go
+++ b/operators/test/e2e/stack/builder.go
@@ -126,8 +126,6 @@ func (b Builder) WithESMasterDataNodes(count int, resources corev1.ResourceRequi
 }
 
 func (b Builder) withESTopologyElement(topologyElement estype.NodeSpec) Builder {
-	// automatically self-gen a trial license
-	topologyElement.Config.Data["xpack.license.self_generated.type"] = "trial"
 	b.Elasticsearch.Spec.Nodes = append(b.Elasticsearch.Spec.Nodes, topologyElement)
 	return b
 }

--- a/operators/test/e2e/stack/builder.go
+++ b/operators/test/e2e/stack/builder.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-const defaultVersion = "6.7.2"
+const defaultVersion = "7.1.0"
 
 var DefaultResources = corev1.ResourceRequirements{
 	Limits: map[corev1.ResourceName]resource.Quantity{

--- a/operators/test/e2e/stack/checks_es.go
+++ b/operators/test/e2e/stack/checks_es.go
@@ -32,7 +32,6 @@ func ESClusterChecks(es estype.Elasticsearch, k *helpers.K8sHelper) helpers.Test
 		e.BuildESClient(es, k),
 		e.CheckESReachable(),
 		e.CheckESVersion(es),
-		e.CheckESLicense(es),
 		e.CheckESHealthGreen(),
 		e.CheckESNodesTopology(es),
 	}
@@ -72,21 +71,6 @@ func (e *esClusterChecks) CheckESVersion(es estype.Elasticsearch) helpers.TestSt
 			info, err := e.client.GetClusterInfo(ctx)
 			require.NoError(t, err)
 			require.Equal(t, es.Spec.Version, info.Version.Number)
-		},
-	}
-}
-
-func (e *esClusterChecks) CheckESLicense(es estype.Elasticsearch) helpers.TestStep {
-	return helpers.TestStep{
-		Name: "Elasticsearch license type should be the expected one",
-		Test: func(t *testing.T) {
-			expected := "trial" // TODO add tests for other license types
-			ctx, cancel := context.WithTimeout(context.Background(), client.DefaultReqTimeout)
-			defer cancel()
-			license, err := e.client.GetLicense(ctx)
-			require.NoError(t, err)
-			assert.Equal(t, expected, license.Type)
-			assert.Equal(t, "active", license.Status)
 		},
 	}
 }


### PR DESCRIPTION
We no longer need to test an "old" version with a trial license in our E2E tests.
Let's default to 7.1.0 with a basic license.

This PR removes the automatic trial license configuration item, along with the trial license check, and uses 7.1.0 as default version for the Elastic stack.

