### PR TITLE
Parameterize E2E Elastic Stack version

### DIFF
--- a/operators/test/e2e/apm/checks_k8s.go
+++ b/operators/test/e2e/apm/checks_k8s.go
@@ -6,7 +6,9 @@ package apm
 
 import (
 	"fmt"
+
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/helpers"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/params"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -32,7 +34,7 @@ func CheckApmServerDeployment(stack Builder, k *helpers.K8sHelper) helpers.TestS
 		Test: helpers.Eventually(func() error {
 			var dep appsv1.Deployment
 			err := k.Client.Get(types.NamespacedName{
-				Namespace: helpers.DefaultNamespace,
+				Namespace: params.Namespace,
 				Name:      stack.ApmServer.Name + "-apm-server",
 			}, &dep)
 			if stack.ApmServer.Spec.NodeCount == 0 && apierrors.IsNotFound(err) {

--- a/operators/test/e2e/apm_es_kibana_sample_test.go
+++ b/operators/test/e2e/apm_es_kibana_sample_test.go
@@ -51,8 +51,6 @@ func TestApmEsKibanaSample(t *testing.T) {
 		WithSteps(apm.InitTestSteps(sampleApm, k)...).
 		WithSteps(stack.CreationTestSteps(sampleStack, k)...).
 		WithSteps(apm.CreationTestSteps(sampleApm, sampleStack.Elasticsearch, k)...).
-		WithSteps(stack.CheckStackSteps(sampleStack, k)...).
-		WithSteps(apm.CheckStackSteps(sampleApm, sampleStack.Elasticsearch, k)...).
 		WithSteps(stack.DeletionTestSteps(sampleStack, k)...).
 		WithSteps(apm.DeletionTestSteps(sampleApm, k)...).
 		RunSequential(t)

--- a/operators/test/e2e/apm_es_kibana_sample_test.go
+++ b/operators/test/e2e/apm_es_kibana_sample_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/params"
+
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/apm"
@@ -37,11 +39,11 @@ func TestApmEsKibanaSample(t *testing.T) {
 
 	// set namespace and version
 	sampleStack = sampleStack.
-		WithNamespace(helpers.DefaultNamespace).
-		WithVersion(stack.ElasticStackVersion)
+		WithNamespace(params.Namespace).
+		WithVersion(params.ElasticStackVersion)
 	sampleApm = sampleApm.
-		WithNamespace(helpers.DefaultNamespace).
-		WithVersion(stack.ElasticStackVersion)
+		WithNamespace(params.Namespace).
+		WithVersion(params.ElasticStackVersion)
 
 	k := helpers.NewK8sClientOrFatal()
 	helpers.TestStepList{}.

--- a/operators/test/e2e/failure_test.go
+++ b/operators/test/e2e/failure_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/helpers"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/params"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/stack"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -131,7 +132,7 @@ func TestKillKibanaDeployment(t *testing.T) {
 				Test: func(t *testing.T) {
 					var dep appsv1.Deployment
 					err := k.Client.Get(types.NamespacedName{
-						Namespace: helpers.DefaultNamespace,
+						Namespace: params.Namespace,
 						Name:      s.Kibana.Name + "-kibana",
 					}, &dep)
 					require.NoError(t, err)
@@ -179,7 +180,7 @@ func TestDeleteElasticUserSecret(t *testing.T) {
 				Name: "Delete elastic user secret",
 				Test: func(t *testing.T) {
 					key := types.NamespacedName{
-						Namespace: helpers.DefaultNamespace,
+						Namespace: params.Namespace,
 						Name:      s.Elasticsearch.Name + "-elastic-user",
 					}
 					var secret corev1.Secret
@@ -201,7 +202,7 @@ func TestDeleteCACert(t *testing.T) {
 				Name: "Delete CA cert",
 				Test: func(t *testing.T) {
 					key := types.NamespacedName{
-						Namespace: helpers.DefaultNamespace,
+						Namespace: params.Namespace,
 						Name:      s.Elasticsearch.Name + "-ca", // ~that's the CA cert secret name \o/~ ... oops not anymore
 					}
 					var secret corev1.Secret

--- a/operators/test/e2e/helpers/elasticsearch.go
+++ b/operators/test/e2e/helpers/elasticsearch.go
@@ -16,10 +16,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/net"
 )
 
-// if `--auto-port-forward` is passed to `go test`, then use a custom
-// dialer that sets up port-forwarding to services running within k8s
-// (useful when running tests on a dev env instead of as a batch job)
-
 // NewElasticsearchClient returns an ES client for the given stack's ES cluster
 func NewElasticsearchClient(es v1alpha1.Elasticsearch, k *K8sHelper) (client.Client, error) {
 	password, err := k.GetElasticPassword(es.Name)

--- a/operators/test/e2e/helpers/elasticsearch.go
+++ b/operators/test/e2e/helpers/elasticsearch.go
@@ -5,12 +5,12 @@
 package helpers
 
 import (
-	"flag"
 	"fmt"
 
-	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/params"
 
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/dev/portforward"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/net"
@@ -19,10 +19,6 @@ import (
 // if `--auto-port-forward` is passed to `go test`, then use a custom
 // dialer that sets up port-forwarding to services running within k8s
 // (useful when running tests on a dev env instead of as a batch job)
-var autoPortForward = flag.Bool(
-	"auto-port-forward", false,
-	"enables automatic port-forwarding (for dev use only as it exposes "+
-		"k8s resources on ephemeral ports to localhost)")
 
 // NewElasticsearchClient returns an ES client for the given stack's ES cluster
 func NewElasticsearchClient(es v1alpha1.Elasticsearch, k *K8sHelper) (client.Client, error) {
@@ -37,7 +33,7 @@ func NewElasticsearchClient(es v1alpha1.Elasticsearch, k *K8sHelper) (client.Cli
 	}
 	inClusterURL := fmt.Sprintf("https://%s-es.%s.svc.cluster.local:9200", es.Name, es.Namespace)
 	var dialer net.Dialer
-	if *autoPortForward {
+	if params.AutoPortForward {
 		dialer = portforward.NewForwardingDialer()
 	}
 	v, err := version.Parse(es.Spec.Version)

--- a/operators/test/e2e/helpers/http.go
+++ b/operators/test/e2e/helpers/http.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/elastic/cloud-on-k8s/operators/pkg/dev/portforward"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/params"
 )
 
 // NewHTTPClient creates a new HTTP client that is aware of any port forwarding configuration.
@@ -16,7 +17,7 @@ func NewHTTPClient() http.Client {
 	client := http.Client{
 		Timeout: 60 * time.Second,
 	}
-	if *autoPortForward {
+	if params.AutoPortForward {
 		client.Transport = &http.Transport{
 			DialContext: portforward.NewForwardingDialer().DialContext,
 		}

--- a/operators/test/e2e/helpers/k8s.go
+++ b/operators/test/e2e/helpers/k8s.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/nodecerts"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/kibana"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/params"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,8 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
-
-const DefaultNamespace = "e2e"
 
 type K8sHelper struct {
 	Client k8s.Client
@@ -94,7 +93,7 @@ func (k *K8sHelper) GetPods(listOpts client.ListOptions) ([]corev1.Pod, error) {
 
 func (k *K8sHelper) GetPod(name string) (corev1.Pod, error) {
 	var pod corev1.Pod
-	if err := k.Client.Get(types.NamespacedName{Namespace: DefaultNamespace, Name: name}, &pod); err != nil {
+	if err := k.Client.Get(types.NamespacedName{Namespace: params.Namespace, Name: name}, &pod); err != nil {
 		return corev1.Pod{}, err
 	}
 	return pod, nil
@@ -119,7 +118,7 @@ func (k *K8sHelper) CheckPodCount(listOpts client.ListOptions, expectedCount int
 func (k *K8sHelper) GetService(name string) (*corev1.Service, error) {
 	var service corev1.Service
 	key := types.NamespacedName{
-		Namespace: DefaultNamespace,
+		Namespace: params.Namespace,
 		Name:      name,
 	}
 	if err := k.Client.Get(key, &service); err != nil {
@@ -131,7 +130,7 @@ func (k *K8sHelper) GetService(name string) (*corev1.Service, error) {
 func (k *K8sHelper) GetEndpoints(name string) (*corev1.Endpoints, error) {
 	var endpoints corev1.Endpoints
 	key := types.NamespacedName{
-		Namespace: DefaultNamespace,
+		Namespace: params.Namespace,
 		Name:      name,
 	}
 	if err := k.Client.Get(key, &endpoints); err != nil {
@@ -145,7 +144,7 @@ func (k *K8sHelper) GetElasticPassword(stackName string) (string, error) {
 	elasticUserKey := "elastic"
 	var secret corev1.Secret
 	key := types.NamespacedName{
-		Namespace: DefaultNamespace,
+		Namespace: params.Namespace,
 		Name:      secretName,
 	}
 	if err := k.Client.Get(key, &secret); err != nil {
@@ -162,7 +161,7 @@ func (k *K8sHelper) GetCACert(stackName string) ([]*x509.Certificate, error) {
 	secretName := nodecerts.CACertSecretName(stackName)
 	var secret corev1.Secret
 	key := types.NamespacedName{
-		Namespace: DefaultNamespace,
+		Namespace: params.Namespace,
 		Name:      secretName,
 	}
 	if err := k.Client.Get(key, &secret); err != nil {
@@ -179,7 +178,7 @@ func (k *K8sHelper) GetCACert(stackName string) ([]*x509.Certificate, error) {
 func (k *K8sHelper) GetCAPrivateKey(stackName string) (*rsa.PrivateKey, error) {
 	var secret corev1.Secret
 	key := types.NamespacedName{
-		Namespace: DefaultNamespace,
+		Namespace: params.Namespace,
 		Name:      name.CAPrivateKeySecret(stackName),
 	}
 	if err := k.Client.Get(key, &secret); err != nil {
@@ -196,7 +195,7 @@ func (k *K8sHelper) GetCAPrivateKey(stackName string) (*rsa.PrivateKey, error) {
 func (k *K8sHelper) GetNodeCert(podName string) (caCert, nodeCert []*x509.Certificate, err error) {
 	var secret corev1.Secret
 	key := types.NamespacedName{
-		Namespace: DefaultNamespace,
+		Namespace: params.Namespace,
 		Name:      name.CertsSecret(podName),
 	}
 	if err = k.Client.Get(key, &secret); err != nil {
@@ -265,7 +264,7 @@ func (k *K8sHelper) Exec(pod types.NamespacedName, cmd []string) (string, string
 
 func ESPodListOptions(stackName string) client.ListOptions {
 	return client.ListOptions{
-		Namespace: DefaultNamespace,
+		Namespace: params.Namespace,
 		LabelSelector: labels.SelectorFromSet(labels.Set(map[string]string{
 			common.TypeLabelName:       label.Type,
 			label.ClusterNameLabelName: stackName,
@@ -274,7 +273,7 @@ func ESPodListOptions(stackName string) client.ListOptions {
 
 func KibanaPodListOptions(stackName string) client.ListOptions {
 	return client.ListOptions{
-		Namespace: DefaultNamespace,
+		Namespace: params.Namespace,
 		LabelSelector: labels.SelectorFromSet(labels.Set(map[string]string{
 			kibana.KibanaNameLabelName: stackName,
 		}))}
@@ -282,7 +281,7 @@ func KibanaPodListOptions(stackName string) client.ListOptions {
 
 func ApmServerPodListOptions(stackName string) client.ListOptions {
 	return client.ListOptions{
-		Namespace: DefaultNamespace,
+		Namespace: params.Namespace,
 		LabelSelector: labels.SelectorFromSet(labels.Set(map[string]string{
 			common.TypeLabelName:             apmserver.Type,
 			apmserver.ApmServerNameLabelName: stackName,

--- a/operators/test/e2e/params/params.go
+++ b/operators/test/e2e/params/params.go
@@ -1,0 +1,35 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package params
+
+import (
+	"flag"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+const (
+	defaultElasticStackVersion = "7.1.0"
+	defaultNamespace           = "e2e"
+)
+
+var (
+	log = logf.Log.WithName("e2e-params")
+
+	ElasticStackVersion string
+	Namespace           string
+	AutoPortForward     bool
+)
+
+func init() {
+	flag.StringVar(&ElasticStackVersion, "version", defaultElasticStackVersion, "Elastic Stack version")
+	flag.StringVar(&Namespace, "namespace", defaultNamespace, "Namespace")
+	flag.BoolVar(&AutoPortForward, "auto-port-forward", false, "enables automatic port-forwarding "+
+		"(for dev use only as it exposes k8s resources on ephemeral ports to localhost)")
+	flag.Parse()
+
+	logf.SetLogger(logf.ZapLogger(true))
+	log.Info("Info", "version", ElasticStackVersion, "ns", Namespace)
+}

--- a/operators/test/e2e/sample_test.go
+++ b/operators/test/e2e/sample_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/yaml"
-
 	estype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	kbtype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/kibana/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/helpers"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/params"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/stack"
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 // Re-use the sample stack for e2e tests.
@@ -37,7 +37,7 @@ func readSampleStack() stack.Builder {
 	sampleStack.Kibana = kb
 
 	// set namespace
-	return sampleStack.WithNamespace(helpers.DefaultNamespace)
+	return sampleStack.WithNamespace(params.Namespace)
 }
 
 // TestStackSample runs a test suite using the sample stack

--- a/operators/test/e2e/sample_test.go
+++ b/operators/test/e2e/sample_test.go
@@ -36,8 +36,10 @@ func readSampleStack() stack.Builder {
 	sampleStack.Elasticsearch = es
 	sampleStack.Kibana = kb
 
-	// set namespace
-	return sampleStack.WithNamespace(params.Namespace)
+	// set namespace and version
+	return sampleStack.
+		WithNamespace(params.Namespace).
+		WithVersion(params.ElasticStackVersion)
 }
 
 // TestStackSample runs a test suite using the sample stack

--- a/operators/test/e2e/stack/builder.go
+++ b/operators/test/e2e/stack/builder.go
@@ -5,6 +5,8 @@
 package stack
 
 import (
+	"flag"
+
 	commonv1alpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/common/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	estype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
@@ -14,9 +16,23 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-const defaultVersion = "7.1.0"
+const defaultElasticStackVersion = "7.1.0"
+
+var (
+	log = logf.Log.WithName("e2e-stack-builder")
+
+	ElasticStackVersion string
+)
+
+func init() {
+	flag.StringVar(&ElasticStackVersion, "version", defaultElasticStackVersion, "Elastic Stack version")
+	flag.Parse()
+	logf.SetLogger(logf.ZapLogger(true))
+	log.Info("Elastic stack", "version", ElasticStackVersion)
+}
 
 var DefaultResources = corev1.ResourceRequirements{
 	Limits: map[corev1.ResourceName]resource.Quantity{
@@ -55,13 +71,13 @@ func NewStackBuilder(name string) Builder {
 		Elasticsearch: estype.Elasticsearch{
 			ObjectMeta: meta,
 			Spec: estype.ElasticsearchSpec{
-				Version: defaultVersion,
+				Version: ElasticStackVersion,
 			},
 		},
 		Kibana: kbtype.Kibana{
 			ObjectMeta: meta,
 			Spec: kbtype.KibanaSpec{
-				Version: defaultVersion,
+				Version: ElasticStackVersion,
 				ElasticsearchRef: commonv1alpha1.ObjectSelector{
 					Name:      name,
 					Namespace: helpers.DefaultNamespace,

--- a/operators/test/e2e/stack/builder.go
+++ b/operators/test/e2e/stack/builder.go
@@ -5,34 +5,16 @@
 package stack
 
 import (
-	"flag"
-
 	commonv1alpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/common/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	estype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	kbtype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/kibana/v1alpha1"
-	"github.com/elastic/cloud-on-k8s/operators/test/e2e/helpers"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/params"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
-
-const defaultElasticStackVersion = "7.1.0"
-
-var (
-	log = logf.Log.WithName("e2e-stack-builder")
-
-	ElasticStackVersion string
-)
-
-func init() {
-	flag.StringVar(&ElasticStackVersion, "version", defaultElasticStackVersion, "Elastic Stack version")
-	flag.Parse()
-	logf.SetLogger(logf.ZapLogger(true))
-	log.Info("Elastic stack", "version", ElasticStackVersion)
-}
 
 var DefaultResources = corev1.ResourceRequirements{
 	Limits: map[corev1.ResourceName]resource.Quantity{
@@ -64,23 +46,23 @@ type Builder struct {
 func NewStackBuilder(name string) Builder {
 	meta := metav1.ObjectMeta{
 		Name:      name,
-		Namespace: helpers.DefaultNamespace,
+		Namespace: params.Namespace,
 	}
 
 	return Builder{
 		Elasticsearch: estype.Elasticsearch{
 			ObjectMeta: meta,
 			Spec: estype.ElasticsearchSpec{
-				Version: ElasticStackVersion,
+				Version: params.ElasticStackVersion,
 			},
 		},
 		Kibana: kbtype.Kibana{
 			ObjectMeta: meta,
 			Spec: kbtype.KibanaSpec{
-				Version: ElasticStackVersion,
+				Version: params.ElasticStackVersion,
 				ElasticsearchRef: commonv1alpha1.ObjectSelector{
 					Name:      name,
-					Namespace: helpers.DefaultNamespace,
+					Namespace: params.Namespace,
 				},
 			},
 		},

--- a/operators/test/e2e/stack/checks_k8s.go
+++ b/operators/test/e2e/stack/checks_k8s.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/version"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/helpers"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/params"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -86,7 +87,7 @@ func CheckKibanaDeployment(stack Builder, k *helpers.K8sHelper) helpers.TestStep
 		Test: helpers.Eventually(func() error {
 			var dep appsv1.Deployment
 			err := k.Client.Get(types.NamespacedName{
-				Namespace: helpers.DefaultNamespace,
+				Namespace: params.Namespace,
 				Name:      stack.Kibana.Name + "-kibana",
 			}, &dep)
 			if stack.Kibana.Spec.NodeCount == 0 && apierrors.IsNotFound(err) {


### PR DESCRIPTION
Fixes #753.

- Add `-version` flag to test any Elastic Stack version (default: 7.1.0)
- Add `-namespace` flag to execute a test in a given namespace (default: e2e) (a bit out-of-scope but useful to run different tests or the same test with different versions in parallel in one single k8s cluster)  
- Rename the test to better reflect what it does (`s|TestEsApmServerSample|TestApmEsKibanaSample|`)
- Move all flags in a `params` package