### PR TITLE
Refactor ExtraFiles to ClusterSecrets

### DIFF
--- a/operators/pkg/controller/elasticsearch/driver/default.go
+++ b/operators/pkg/controller/elasticsearch/driver/default.go
@@ -526,7 +526,7 @@ func (d *defaultDriver) calculateChanges(
 			ClusterSecretsRef:  k8s.ExtractNamespacedName(&versionWideResources.ClusterSecrets),
 			ProbeUser:          internalUsers.ProbeUser.Auth(),
 			ReloadCredsUser:    internalUsers.ReloadCredsUser.Auth(),
-			ConfigMapVolume:    volume.NewConfigMapVolume(versionWideResources.GenericUnecryptedConfigurationFiles.Name, settings.ManagedConfigPath),
+			ConfigMapVolume:    volume.NewConfigMapVolume(versionWideResources.GenericUnencryptedConfigurationFiles.Name, settings.ManagedConfigPath),
 			UnicastHostsVolume: volume.NewConfigMapVolume(name.UnicastHostsConfigMap(es.Name), volume.UnicastHostsVolumeMountPath),
 		},
 		d.OperatorImage,

--- a/operators/pkg/controller/elasticsearch/driver/default.go
+++ b/operators/pkg/controller/elasticsearch/driver/default.go
@@ -81,7 +81,6 @@ type defaultDriver struct {
 		c k8s.Client,
 		scheme *runtime.Scheme,
 		es v1alpha1.Elasticsearch,
-		trustRelationships []v1alpha1.TrustRelationship,
 	) (*VersionWideResources, error)
 
 	// expectedPodsAndResourcesResolver returns a list of pod specs with context that we would expect to find in the
@@ -224,7 +223,7 @@ func (d *defaultDriver) Reconcile(
 		return results.WithError(err)
 	}
 
-	versionWideResources, err := d.versionWideResourcesReconciler(d.Client, d.Scheme, es, trustRelationships)
+	versionWideResources, err := d.versionWideResourcesReconciler(d.Client, d.Scheme, es)
 	if err != nil {
 		return results.WithError(err)
 	}

--- a/operators/pkg/controller/elasticsearch/driver/default.go
+++ b/operators/pkg/controller/elasticsearch/driver/default.go
@@ -524,7 +524,7 @@ func (d *defaultDriver) calculateChanges(
 	expectedPodSpecCtxs, err := d.expectedPodsAndResourcesResolver(
 		es,
 		pod.NewPodSpecParams{
-			ExtraFilesRef:      k8s.ExtractNamespacedName(&versionWideResources.ExtraFilesSecret),
+			ClusterSecretsRef:  k8s.ExtractNamespacedName(&versionWideResources.ClusterSecrets),
 			ProbeUser:          internalUsers.ProbeUser.Auth(),
 			ReloadCredsUser:    internalUsers.ReloadCredsUser.Auth(),
 			ConfigMapVolume:    volume.NewConfigMapVolume(versionWideResources.GenericUnecryptedConfigurationFiles.Name, settings.ManagedConfigPath),

--- a/operators/pkg/controller/elasticsearch/driver/version_wide_resources.go
+++ b/operators/pkg/controller/elasticsearch/driver/version_wide_resources.go
@@ -23,8 +23,8 @@ import (
 type VersionWideResources struct {
 	// ClusterSecrets contains possible user-defined secret files we want to have access to in the containers.
 	ClusterSecrets corev1.Secret
-	// GenericUnecryptedConfigurationFiles contains non-secret files Pods with this version should have access to.
-	GenericUnecryptedConfigurationFiles corev1.ConfigMap
+	// GenericUnencryptedConfigurationFiles contains non-secret files Pods with this version should have access to.
+	GenericUnencryptedConfigurationFiles corev1.ConfigMap
 }
 
 func reconcileVersionWideResources(
@@ -80,7 +80,7 @@ func reconcileVersionWideResources(
 	}
 
 	return &VersionWideResources{
-		GenericUnecryptedConfigurationFiles: expectedConfigMap,
-		ClusterSecrets:                      reconciledClusterSecretsSecret,
+		GenericUnencryptedConfigurationFiles: expectedConfigMap,
+		ClusterSecrets:                       reconciledClusterSecretsSecret,
 	}, nil
 }

--- a/operators/pkg/controller/elasticsearch/driver/version_wide_resources.go
+++ b/operators/pkg/controller/elasticsearch/driver/version_wide_resources.go
@@ -5,16 +5,12 @@
 package driver
 
 import (
-	"bytes"
-	"encoding/json"
-
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/configmap"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/name"
-	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/nodecerts"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/settings"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
@@ -25,8 +21,7 @@ import (
 
 // VersionWideResources are resources that are tied to a version, but no specific pod within that version
 type VersionWideResources struct {
-	// ClusterSecrets contains some extra files we want to have access to in the containers, but had nowhere we wanted
-	// it to call home, so they ended up here.
+	// ClusterSecrets contains possible user-defined secret files we want to have access to in the containers.
 	ClusterSecrets corev1.Secret
 	// GenericUnecryptedConfigurationFiles contains non-secret files Pods with this version should have access to.
 	GenericUnecryptedConfigurationFiles corev1.ConfigMap
@@ -36,7 +31,6 @@ func reconcileVersionWideResources(
 	c k8s.Client,
 	scheme *runtime.Scheme,
 	es v1alpha1.Elasticsearch,
-	trustRelationships []v1alpha1.TrustRelationship,
 ) (*VersionWideResources, error) {
 	expectedConfigMap := configmap.NewConfigMapWithData(k8s.ExtractNamespacedName(&es), settings.DefaultConfigMapData)
 	err := configmap.ReconcileConfigMap(c, scheme, es, expectedConfigMap)
@@ -44,26 +38,13 @@ func reconcileVersionWideResources(
 		return nil, err
 	}
 
-	trustRootCfg := nodecerts.NewTrustRootConfig(es.Name, es.Namespace)
-
-	// include the trust restrictions from the trust relationships into the trust restrictions config
-	for _, trustRelationship := range trustRelationships {
-		trustRootCfg.Include(trustRelationship.Spec.TrustRestrictions)
-	}
-
-	trustRootCfgData, err := json.Marshal(&trustRootCfg)
-	if err != nil {
-		return nil, err
-	}
-
+	// TODO: this may not exactly fit the bill of being specific to a version
 	expectedClusterSecretsSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: es.Namespace,
 			Name:      name.ClusterSecretsSecret(es.Name),
 		},
-		Data: map[string][]byte{
-			nodecerts.TrustRestrictionsFilename: trustRootCfgData,
-		},
+		Data: map[string][]byte{},
 	}
 
 	var reconciledClusterSecretsSecret corev1.Secret
@@ -77,14 +58,15 @@ func reconcileVersionWideResources(
 		NeedsUpdate: func() bool {
 			// .Data might be nil in the secret, so make sure to initialize it
 			if reconciledClusterSecretsSecret.Data == nil {
-				reconciledClusterSecretsSecret.Data = make(map[string][]byte, 1)
+				reconciledClusterSecretsSecret.Data = make(map[string][]byte, 0)
 			}
-			currentTrustConfig, ok := reconciledClusterSecretsSecret.Data[nodecerts.TrustRestrictionsFilename]
 
-			return !ok || !bytes.Equal(currentTrustConfig, trustRootCfgData)
+			// TODO: compare items that we may want to reconcile here
+
+			return false
 		},
 		UpdateReconciled: func() {
-			reconciledClusterSecretsSecret.Data[nodecerts.TrustRestrictionsFilename] = trustRootCfgData
+			// TODO: add items to reconcile here
 		},
 		PostUpdate: func() {
 			annotation.MarkPodsAsUpdated(c,

--- a/operators/pkg/controller/elasticsearch/name/name.go
+++ b/operators/pkg/controller/elasticsearch/name/name.go
@@ -38,7 +38,7 @@ const (
 	cAPrivateKeySecretSuffix    = "-ca-private-key"
 	elasticUserSecretSuffix     = "-elastic-user"
 	esRolesUsersSecretSuffix    = "-es-roles-users"
-	extraFilesSecretSuffix      = "-extrafiles"
+	clusterSecretsSecretSuffix  = "-secrets"
 	internalUsersSecretSuffix   = "-internal-users"
 	unicastHostsConfigMapSuffix = "-unicast-hosts"
 )
@@ -141,8 +141,8 @@ func EsRolesUsersSecret(esName string) string {
 	return suffix(esName, esRolesUsersSecretSuffix)
 }
 
-func ExtraFilesSecret(esName string) string {
-	return suffix(esName, extraFilesSecretSuffix)
+func ClusterSecretsSecret(esName string) string {
+	return suffix(esName, clusterSecretsSecretSuffix)
 }
 
 func InternalUsersSecret(esName string) string {

--- a/operators/pkg/controller/elasticsearch/pod/pod.go
+++ b/operators/pkg/controller/elasticsearch/pod/pod.go
@@ -83,8 +83,8 @@ type NewPodSpecParams struct {
 	UsersSecretVolume volume.SecretVolume
 	// ConfigMapVolume is a volume containing a config map with configuration files
 	ConfigMapVolume volume.ConfigMapVolume
-	// ExtraFilesRef is a reference to a secret containing generic extra resources for the pod.
-	ExtraFilesRef types.NamespacedName
+	// ClusterSecretsRef is a reference to a secret containing generic secrets shared between pods in the cluster.
+	ClusterSecretsRef types.NamespacedName
 	// ProbeUser is the user that should be used for the readiness probes.
 	ProbeUser client.UserAuth
 	// ReloadCredsUser is the user that should be used for reloading the credentials.

--- a/operators/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/operators/pkg/controller/elasticsearch/settings/merged_config.go
@@ -5,7 +5,6 @@
 package settings
 
 import (
-	"fmt"
 	"path"
 
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
@@ -74,12 +73,9 @@ func xpackConfig() *CanonicalConfig {
 		XPackSecurityTransportSslCertificate:            path.Join(volume.NodeCertificatesSecretVolumeMountPath, nodecerts.CertFileName),
 		XPackSecurityTransportSslCertificateAuthorities: path.Join(volume.NodeCertificatesSecretVolumeMountPath, certificates.CAFileName),
 
-		// TODO: it would be great if we could move this out of "generic extra files" and into a more scoped secret
-		//       alternatively, we could rename extra files to be a bit more specific and make it more of a
-		//       reusable component somehow.
-		XPackSecurityTransportSslTrustRestrictionsPath: fmt.Sprintf(
-			"%s/%s",
-			volume.ClusterSecretsVolumeMountPath,
+		// x-pack security transport ssl trust restrictions settings
+		XPackSecurityTransportSslTrustRestrictionsPath: path.Join(
+			volume.NodeCertificatesSecretVolumeMountPath,
 			nodecerts.TrustRestrictionsFilename,
 		),
 	}

--- a/operators/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/operators/pkg/controller/elasticsearch/settings/merged_config.go
@@ -79,7 +79,7 @@ func xpackConfig() *CanonicalConfig {
 		//       reusable component somehow.
 		XPackSecurityTransportSslTrustRestrictionsPath: fmt.Sprintf(
 			"%s/%s",
-			volume.ExtraFilesSecretVolumeMountPath,
+			volume.ClusterSecretsVolumeMountPath,
 			nodecerts.TrustRestrictionsFilename,
 		),
 	}

--- a/operators/pkg/controller/elasticsearch/version/common.go
+++ b/operators/pkg/controller/elasticsearch/version/common.go
@@ -65,7 +65,7 @@ func NewExpectedPodSpecs(
 				Resources:            esContainerResources,
 				UsersSecretVolume:    paramsTmpl.UsersSecretVolume,
 				ConfigMapVolume:      paramsTmpl.ConfigMapVolume,
-				ExtraFilesRef:        paramsTmpl.ExtraFilesRef,
+				ClusterSecretsRef:    paramsTmpl.ClusterSecretsRef,
 				ProbeUser:            paramsTmpl.ProbeUser,
 				ReloadCredsUser:      paramsTmpl.ReloadCredsUser,
 				UnicastHostsVolume:   paramsTmpl.UnicastHostsVolume,
@@ -114,10 +114,10 @@ func podSpec(
 		volume.ReloadCredsUserSecretMountPath, []string{p.ReloadCredsUser.Name},
 	)
 
-	extraFilesSecretVolume := volume.NewSecretVolumeWithMountPath(
-		p.ExtraFilesRef.Name,
-		"extrafiles",
-		volume.ExtraFilesSecretVolumeMountPath,
+	clusterSecretsSecretVolume := volume.NewSecretVolumeWithMountPath(
+		p.ClusterSecretsRef.Name,
+		"secrets",
+		volume.ClusterSecretsVolumeMountPath,
 	)
 
 	// we don't have a secret name for this, this will be injected as a volume for us upon creation, this is fine
@@ -169,7 +169,7 @@ func podSpec(
 				p.ConfigMapVolume.VolumeMount(),
 				p.UnicastHostsVolume.VolumeMount(),
 				probeSecret.VolumeMount(),
-				extraFilesSecretVolume.VolumeMount(),
+				clusterSecretsSecretVolume.VolumeMount(),
 				nodeCertificatesVolume.VolumeMount(),
 				reloadCredsSecret.VolumeMount(),
 				secureSettingsVolume.VolumeMount(),
@@ -185,7 +185,7 @@ func podSpec(
 			p.ConfigMapVolume.Volume(),
 			p.UnicastHostsVolume.Volume(),
 			probeSecret.Volume(),
-			extraFilesSecretVolume.Volume(),
+			clusterSecretsSecretVolume.Volume(),
 			reloadCredsSecret.Volume(),
 			secureSettingsVolume.Volume(),
 		),

--- a/operators/pkg/controller/elasticsearch/volume/volume.go
+++ b/operators/pkg/controller/elasticsearch/volume/volume.go
@@ -25,7 +25,7 @@ const (
 	SecureSettingsVolumeName      = "secure-settings"
 	SecureSettingsVolumeMountPath = "/mnt/elastic/secure-settings"
 
-	ExtraFilesSecretVolumeMountPath = "/usr/share/elasticsearch/config/extrafiles"
+	ClusterSecretsVolumeMountPath = "/usr/share/elasticsearch/config/secrets"
 
 	UnicastHostsVolumeMountPath = "/mnt/elastic/unicast-hosts"
 	UnicastHostsFile            = "unicast_hosts.txt"


### PR DESCRIPTION
This refactors `ExtraFiles` which is perhaps too generically named into a `ClusterSecrets`, which is intended to be used as a generic/default way of making some secrets available to all ES nodes in a cluster.

It also moves the `trust.yml` file from this `extrafiles` secret to the more suitable `{pod.name}-certs` secret, which clears up an outstanding TODO about finding a better home for this. Since the trust restrictions from `trust.yml` file is used to validate certificates using the `ca.pem` file in the `-certs` secret, it makes sense to co-locate these.

Relates to: https://github.com/elastic/cloud-on-k8s/issues/776