### PR TITLE
Fix CI build for e2e smoke tests

### DIFF
--- a/operators/test/e2e/smoke_test.go
+++ b/operators/test/e2e/smoke_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package e2e
 
 import (


### PR DESCRIPTION
I missed a header in smoke e2e test. It's strange that those PR https://github.com/elastic/cloud-on-k8s/pull/903 passed CI. I will look into it.