### PR TITLE
Fix wrong function call in integration test

### DIFF
--- a/operators/pkg/controller/elasticsearch/nodecerts/cert_test.go
+++ b/operators/pkg/controller/elasticsearch/nodecerts/cert_test.go
@@ -393,6 +393,7 @@ func Test_doReconcile(t *testing.T) {
 				testCluster,
 				[]corev1.Service{testSvc},
 				testCA, tt.additionalTrustedCAsPemEncoded,
+				nil,
 				certificates.DefaultCertValidity,
 				certificates.DefaultRotateBefore,
 			)


### PR DESCRIPTION
This is just fixing a call with a missing parameter, following
https://github.com/elastic/cloud-on-k8s/pull/917.