### PR TITLE
Proper checkout of PR in Jenkins build

### DIFF
--- a/.ci/jobs/pr.yml
+++ b/.ci/jobs/pr.yml
@@ -14,10 +14,11 @@
         - git:
             url: https://github.com/elastic/cloud-on-k8s
             branches:
-              - master
+              - ${sha1}
             credentials-id: 'f3af1bfb-d48e-48d1-82a2-acca009c1b23'
+            refspec: '+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*'
       script-path: build/ci/pr/Jenkinsfile
-      lightweight-checkout: true
+      lightweight-checkout: false
     triggers:
       - github-pull-request:
           org-list:


### PR DESCRIPTION
We had an issue after switching to another Jenkins plugin for PR's. Checkout of PR was done incorrectly. 
Also looks like `lightweight-checkout: false` will made PR build a little bit slower, around 1-2 min. 