### PR TITLE
Move directories only if not empty in prepare-fs script

### DIFF
--- a/operators/pkg/controller/elasticsearch/initcontainer/script.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/script.go
@@ -100,8 +100,12 @@ var scriptTemplate = template.Must(template.New("").Parse(
 	# to a volume, to be used by the ES container
 	mv_start=$(date +%s)
 	{{range .SharedVolumes.Array}}
-		echo "Moving {{.EsContainerMountPath}}/* to {{.InitContainerMountPath}}/"
-		mv {{.EsContainerMountPath}}/* {{.InitContainerMountPath}}/
+		if [[ -z "$(ls -A {{.EsContainerMountPath}})" ]]; then
+			echo "Empty dir {{.EsContainerMountPath}}"
+		else
+			echo "Moving {{.EsContainerMountPath}}/* to {{.InitContainerMountPath}}/"
+			mv {{.EsContainerMountPath}}/* {{.InitContainerMountPath}}/
+		fi
 	{{end}}
 	echo "Files copy duration: $(duration $mv_start) sec."
 


### PR DESCRIPTION
Because the globbing (use of * in the `mv` command) fails when there is no match.

Fixes #801.