### PR TITLE
Build ES pod on top of user-provided podTemplate

### DIFF
--- a/operators/config/all-in-one.yaml
+++ b/operators/config/all-in-one.yaml
@@ -404,8 +404,9 @@ spec:
                     type: integer
                   podTemplate:
                     description: PodTemplate can be used to propagate configuration
-                      to Elasticsearch pods. So far, only labels, Affinity and `Containers["elasticsearch"].Resources.Limits`
-                      are applied.
+                      to Elasticsearch pods. This allows specifying custom annotations,
+                      labels, environment variables, volumes, affinity, resources,
+                      etc. to the pod.
                     type: object
                   volumeClaimTemplates:
                     description: 'VolumeClaimTemplates is a list of claims that pods

--- a/operators/config/all-in-one.yaml
+++ b/operators/config/all-in-one.yaml
@@ -406,7 +406,7 @@ spec:
                     description: PodTemplate can be used to propagate configuration
                       to Elasticsearch pods. This allows specifying custom annotations,
                       labels, environment variables, volumes, affinity, resources,
-                      etc. to the pod.
+                      etc. for the pods created from this NodeSpec.
                     type: object
                   volumeClaimTemplates:
                     description: 'VolumeClaimTemplates is a list of claims that pods

--- a/operators/config/crds/elasticsearch_v1alpha1_elasticsearch.yaml
+++ b/operators/config/crds/elasticsearch_v1alpha1_elasticsearch.yaml
@@ -134,8 +134,9 @@ spec:
                     type: integer
                   podTemplate:
                     description: PodTemplate can be used to propagate configuration
-                      to Elasticsearch pods. So far, only labels, Affinity and `Containers["elasticsearch"].Resources.Limits`
-                      are applied.
+                      to Elasticsearch pods. This allows specifying custom annotations,
+                      labels, environment variables, volumes, affinity, resources,
+                      etc. to the pod.
                     type: object
                   volumeClaimTemplates:
                     description: 'VolumeClaimTemplates is a list of claims that pods

--- a/operators/config/crds/elasticsearch_v1alpha1_elasticsearch.yaml
+++ b/operators/config/crds/elasticsearch_v1alpha1_elasticsearch.yaml
@@ -136,7 +136,7 @@ spec:
                     description: PodTemplate can be used to propagate configuration
                       to Elasticsearch pods. This allows specifying custom annotations,
                       labels, environment variables, volumes, affinity, resources,
-                      etc. to the pod.
+                      etc. for the pods created from this NodeSpec.
                     type: object
                   volumeClaimTemplates:
                     description: 'VolumeClaimTemplates is a list of claims that pods

--- a/operators/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
+++ b/operators/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
@@ -70,7 +70,8 @@ type NodeSpec struct {
 	NodeCount int32 `json:"nodeCount,omitempty"`
 
 	// PodTemplate can be used to propagate configuration to Elasticsearch pods.
-	// So far, only labels, Affinity and `Containers["elasticsearch"].Resources.Limits` are applied.
+	// This allows specifying custom annotations, labels, environment variables,
+	// volumes, affinity, resources, etc. to the pod.
 	// +optional
 	PodTemplate corev1.PodTemplateSpec `json:"podTemplate,omitempty"`
 

--- a/operators/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
+++ b/operators/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
@@ -71,7 +71,7 @@ type NodeSpec struct {
 
 	// PodTemplate can be used to propagate configuration to Elasticsearch pods.
 	// This allows specifying custom annotations, labels, environment variables,
-	// volumes, affinity, resources, etc. to the pod.
+	// volumes, affinity, resources, etc. for the pods created from this NodeSpec.
 	// +optional
 	PodTemplate corev1.PodTemplateSpec `json:"podTemplate,omitempty"`
 

--- a/operators/pkg/controller/elasticsearch/pod/pod.go
+++ b/operators/pkg/controller/elasticsearch/pod/pod.go
@@ -62,11 +62,6 @@ type NewPodSpecParams struct {
 	DiscoveryServiceName string
 	// DiscoveryZenMinimumMasterNodes is the setting for minimum master node in Zen Discovery
 	DiscoveryZenMinimumMasterNodes int
-	// Config is the user provided Elasticsearch configuration.
-	Config v1alpha1.Config
-
-	// Affinity is the pod's scheduling constraints
-	Affinity *corev1.Affinity
 
 	// SetVMMaxMapCount indicates whether a init container should be used to ensure that the `vm.max_map_count`
 	// is set according to https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html.
@@ -74,8 +69,8 @@ type NewPodSpecParams struct {
 	// Defaults to true if not specified. To be disabled, it must be explicitly set to false.
 	SetVMMaxMapCount *bool
 
-	// Resources is the memory/cpu resources the pod wants
-	Resources corev1.ResourceRequirements
+	// NodeSpec is the user-provided spec to apply on the target pod
+	NodeSpec v1alpha1.NodeSpec
 
 	// ESConfigVolume is the secret volume that contains elasticsearch.yml configuration
 	ESConfigVolume volume.SecretVolume

--- a/operators/pkg/controller/elasticsearch/version/common.go
+++ b/operators/pkg/controller/elasticsearch/version/common.go
@@ -20,9 +20,9 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/volume"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/stringsutil"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -34,7 +34,7 @@ var (
 func NewExpectedPodSpecs(
 	es v1alpha1.Elasticsearch,
 	paramsTmpl pod.NewPodSpecParams,
-	newEnvironmentVarsFn func(p pod.NewPodSpecParams, certs, key, creds, secureSettings volume.SecretVolume) []corev1.EnvVar,
+	newEnvironmentVarsFn func(p pod.NewPodSpecParams, heapSize int, certs, key, creds, secureSettings volume.SecretVolume) []corev1.EnvVar,
 	newESConfigFn func(clusterName string, config v1alpha1.Config) (*settings.CanonicalConfig, error),
 	newInitContainersFn func(imageName string, operatorImage string, setVMMaxMapCount *bool, nodeCertificatesVolume volume.SecretVolume) ([]corev1.Container, error),
 	operatorImage string,
@@ -43,32 +43,22 @@ func NewExpectedPodSpecs(
 
 	for _, node := range es.Spec.Nodes {
 		for i := int32(0); i < node.NodeCount; i++ {
-			cfg := v1alpha1.Config{}
-			if node.Config != nil {
-				cfg = *node.Config
-			}
-
-			esContainerResources := corev1.ResourceRequirements{}
-			esContainerTpl := node.GetESContainerTemplate()
-			if esContainerTpl != nil {
-				esContainerResources = esContainerTpl.Resources
-			}
-
 			params := pod.NewPodSpecParams{
+				// cluster-wide params
 				Version:              es.Spec.Version,
 				CustomImageName:      es.Spec.Image,
 				ClusterName:          es.Name,
 				DiscoveryServiceName: services.DiscoveryServiceName(es.Name),
-				Config:               cfg,
-				Affinity:             node.PodTemplate.Spec.Affinity,
 				SetVMMaxMapCount:     es.Spec.SetVMMaxMapCount,
-				Resources:            esContainerResources,
-				UsersSecretVolume:    paramsTmpl.UsersSecretVolume,
-				ConfigMapVolume:      paramsTmpl.ConfigMapVolume,
-				ClusterSecretsRef:    paramsTmpl.ClusterSecretsRef,
-				ProbeUser:            paramsTmpl.ProbeUser,
-				ReloadCredsUser:      paramsTmpl.ReloadCredsUser,
-				UnicastHostsVolume:   paramsTmpl.UnicastHostsVolume,
+				// volumes
+				UsersSecretVolume:  paramsTmpl.UsersSecretVolume,
+				ConfigMapVolume:    paramsTmpl.ConfigMapVolume,
+				ClusterSecretsRef:  paramsTmpl.ClusterSecretsRef,
+				ProbeUser:          paramsTmpl.ProbeUser,
+				ReloadCredsUser:    paramsTmpl.ReloadCredsUser,
+				UnicastHostsVolume: paramsTmpl.UnicastHostsVolume,
+				// pod params
+				NodeSpec: node,
 			}
 			podSpec, config, err := podSpec(
 				params,
@@ -92,17 +82,30 @@ func NewExpectedPodSpecs(
 func podSpec(
 	p pod.NewPodSpecParams,
 	operatorImage string,
-	newEnvironmentVarsFn func(p pod.NewPodSpecParams, certs, key, creds, keystore volume.SecretVolume) []corev1.EnvVar,
+	newEnvironmentVarsFn func(p pod.NewPodSpecParams, heapSize int, certs, key, creds, keystore volume.SecretVolume) []corev1.EnvVar,
 	newESConfigFn func(clusterName string, config v1alpha1.Config) (*settings.CanonicalConfig, error),
 	newInitContainersFn func(elasticsearchImage string, operatorImage string, setVMMaxMapCount *bool, nodeCertificatesVolume volume.SecretVolume) ([]corev1.Container, error),
 ) (corev1.PodSpec, *settings.CanonicalConfig, error) {
+	// build on top of the user-provided pod template spec
+	podSpec := p.NodeSpec.PodTemplate.Spec.DeepCopy()
 
-	elasticsearchImage := stringsutil.Concat(pod.DefaultImageRepository, ":", p.Version)
+	// build image name from version, or use custom user-provided one
+	image := stringsutil.Concat(pod.DefaultImageRepository, ":", p.Version)
 	if p.CustomImageName != "" {
-		elasticsearchImage = p.CustomImageName
+		image = p.CustomImageName
 	}
 
-	terminationGracePeriodSeconds := pod.DefaultTerminationGracePeriodSeconds
+	// override pod spec fields with our defaults if not provided by the user
+	if podSpec.TerminationGracePeriodSeconds == nil {
+		period := pod.DefaultTerminationGracePeriodSeconds
+		podSpec.TerminationGracePeriodSeconds = &period
+	}
+	if podSpec.AutomountServiceAccountToken == nil {
+		automountSA := false
+		podSpec.AutomountServiceAccountToken = &automountSA
+	}
+
+	// setup volumes
 
 	probeSecret := volume.NewSelectiveSecretVolumeWithMountPath(
 		user.ElasticInternalUsersSecretName(p.ClusterName), volume.ProbeUserVolumeName,
@@ -138,46 +141,10 @@ func podSpec(
 		volume.SecureSettingsVolumeMountPath,
 	)
 
-	resourceLimits := corev1.ResourceList{
-		corev1.ResourceMemory: nonZeroQuantityOrDefault(*p.Resources.Limits.Memory(), DefaultMemoryLimits),
-	}
-	if !p.Resources.Limits.Cpu().IsZero() {
-		resourceLimits[corev1.ResourceCPU] = *p.Resources.Limits.Cpu()
-	}
-
-	// TODO: Security Context
-	automountServiceAccountToken := false
-	podSpec := corev1.PodSpec{
-		Affinity: p.Affinity,
-		Containers: []corev1.Container{{
-			Env:             newEnvironmentVarsFn(p, nodeCertificatesVolume, privateKeyVolume, reloadCredsSecret, secureSettingsVolume),
-			Image:           elasticsearchImage,
-			ImagePullPolicy: corev1.PullIfNotPresent,
-			Name:            v1alpha1.ElasticsearchContainerName,
-			Ports:           pod.DefaultContainerPorts,
-			Resources: corev1.ResourceRequirements{
-				Limits: resourceLimits,
-				// we do not specify Requests here in order to end up in the qosClass of Guaranteed.
-				// see https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/ for more details
-			},
-			ReadinessProbe: pod.NewReadinessProbe(),
-			VolumeMounts: append(
-				initcontainer.PrepareFsSharedVolumes.EsContainerVolumeMounts(),
-				initcontainer.PrivateKeySharedVolume.EsContainerVolumeMount(),
-				initcontainer.ProcessManagerVolume.EsContainerVolumeMount(),
-				p.UsersSecretVolume.VolumeMount(),
-				p.ConfigMapVolume.VolumeMount(),
-				p.UnicastHostsVolume.VolumeMount(),
-				probeSecret.VolumeMount(),
-				clusterSecretsSecretVolume.VolumeMount(),
-				nodeCertificatesVolume.VolumeMount(),
-				reloadCredsSecret.VolumeMount(),
-				secureSettingsVolume.VolumeMount(),
-			),
-			Command: []string{processmanager.CommandPath},
-		}},
-		TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
-		Volumes: append(
+	// append our volumes to user-provided ones
+	podSpec.Volumes = append(
+		podSpec.Volumes,
+		append(
 			initcontainer.PrepareFsSharedVolumes.Volumes(),
 			initcontainer.PrivateKeySharedVolume.Volume(),
 			initcontainer.ProcessManagerVolume.Volume(),
@@ -188,25 +155,94 @@ func podSpec(
 			clusterSecretsSecretVolume.Volume(),
 			reloadCredsSecret.Volume(),
 			secureSettingsVolume.Volume(),
-		),
-		AutomountServiceAccountToken: &automountServiceAccountToken,
-	}
+		)...,
+	)
 
-	// Setup init containers
-	initContainers, err := newInitContainersFn(elasticsearchImage, operatorImage, p.SetVMMaxMapCount, nodeCertificatesVolume)
+	// append out init containers to user-provided ones
+	initContainers, err := newInitContainersFn(image, operatorImage, p.SetVMMaxMapCount, nodeCertificatesVolume)
 	if err != nil {
 		return corev1.PodSpec{}, nil, err
 	}
-	podSpec.InitContainers = initContainers
+	podSpec.InitContainers = append(podSpec.InitContainers, initContainers...)
+
+	// build on top of the user-provided ES container spec, or create a new one
+	containerSpec := p.NodeSpec.GetESContainerTemplate().DeepCopy()
+	userProvidedContainerSpec := containerSpec != nil
+	if !userProvidedContainerSpec {
+		containerSpec = &corev1.Container{
+			Name: v1alpha1.ElasticsearchContainerName,
+		}
+	}
+
+	// set memory resource limits if not provided by the user
+	containerSpec.Resources.Limits = buildResourceLimits(containerSpec)
+	// we do not override resource Requests here in order to end up in the qosClass of Guaranteed by default
+	// see https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/ for more details
+
+	// augment user-provided env vars with our own
+	// TODO: deal with conflicts here (eg. JVM_OPTIONS)
+	heapSize := MemoryLimitsToHeapSize(*containerSpec.Resources.Limits.Memory())
+	containerSpec.Env = append(containerSpec.Env, newEnvironmentVarsFn(p, heapSize, nodeCertificatesVolume, privateKeyVolume, reloadCredsSecret, secureSettingsVolume)...)
+
+	// set the container image to our own if not provided by the user
+	if containerSpec.Image == "" {
+		containerSpec.Image = image
+	}
+	// ImagePullPolicy is kept either user-provided or defaulted
+
+	// override ports
+	containerSpec.Ports = pod.DefaultContainerPorts
+
+	// override readiness probe
+	containerSpec.ReadinessProbe = pod.NewReadinessProbe()
+
+	// append our volume mounts to user-provided ones
+	containerSpec.VolumeMounts = append(
+		containerSpec.VolumeMounts,
+		append(
+			initcontainer.PrepareFsSharedVolumes.EsContainerVolumeMounts(),
+			[]corev1.VolumeMount{
+				initcontainer.PrivateKeySharedVolume.EsContainerVolumeMount(),
+				initcontainer.ProcessManagerVolume.EsContainerVolumeMount(),
+				p.UsersSecretVolume.VolumeMount(),
+				p.ConfigMapVolume.VolumeMount(),
+				p.UnicastHostsVolume.VolumeMount(),
+				probeSecret.VolumeMount(),
+				clusterSecretsSecretVolume.VolumeMount(),
+				nodeCertificatesVolume.VolumeMount(),
+				reloadCredsSecret.VolumeMount(),
+				secureSettingsVolume.VolumeMount(),
+			}...,
+		)...,
+	)
+
+	// override command
+	containerSpec.Command = []string{processmanager.CommandPath}
+
+	// set the container spec back into the podSpec container list
+	if userProvidedContainerSpec {
+		// replace existing one
+		for i, c := range podSpec.Containers {
+			if c.Name == v1alpha1.ElasticsearchContainerName {
+				podSpec.Containers[i] = *containerSpec
+			}
+		}
+	} else {
+		podSpec.Containers = append(podSpec.Containers, *containerSpec)
+	}
 
 	// generate the configuration
 	// actual volumes to propagate it will be created later on
-	esConfig, err := newESConfigFn(p.ClusterName, p.Config)
+	config := p.NodeSpec.Config
+	if config == nil {
+		config = &v1alpha1.Config{}
+	}
+	esConfig, err := newESConfigFn(p.ClusterName, *config)
 	if err != nil {
 		return corev1.PodSpec{}, nil, err
 	}
 
-	return podSpec, esConfig, nil
+	return *podSpec, esConfig, nil
 }
 
 // NewPod constructs a pod from the given parameters.
@@ -215,39 +251,36 @@ func NewPod(
 	es v1alpha1.Elasticsearch,
 	podSpecCtx pod.PodSpecContext,
 ) (corev1.Pod, error) {
-	labels := label.NewLabels(k8s.ExtractNamespacedName(&es))
-	// add labels from the version
-	labels[label.VersionLabelName] = version.String()
+	// build on top of user-provided objectMeta to reuse labels, annotations, etc.
+	objectMeta := podSpecCtx.NodeSpec.PodTemplate.ObjectMeta
+
+	// set our own name & namespace
+	objectMeta.Name = name.NewPodName(es.Name, podSpecCtx.NodeSpec)
+	objectMeta.Namespace = es.Namespace
+
+	// build labels on top of user-provided ones
+	if objectMeta.Labels == nil {
+		objectMeta.Labels = map[string]string{}
+	}
+	// add (or override) with our own labels
+	for k, v := range label.NewLabels(k8s.ExtractNamespacedName(&es)) {
+		objectMeta.Labels[k] = v
+	}
+	objectMeta.Labels[label.VersionLabelName] = version.String()
+	// set labels for node types
 	cfg, err := podSpecCtx.Config.Unpack()
 	if err != nil {
 		return corev1.Pod{}, err
 	}
+	label.NodeTypesMasterLabelName.Set(cfg.Node.Master, objectMeta.Labels)
+	label.NodeTypesDataLabelName.Set(cfg.Node.Data, objectMeta.Labels)
+	label.NodeTypesIngestLabelName.Set(cfg.Node.Ingest, objectMeta.Labels)
+	label.NodeTypesMLLabelName.Set(cfg.Node.ML, objectMeta.Labels)
 
-	// add labels for node types
-	label.NodeTypesMasterLabelName.Set(cfg.Node.Master, labels)
-	label.NodeTypesDataLabelName.Set(cfg.Node.Data, labels)
-	label.NodeTypesIngestLabelName.Set(cfg.Node.Ingest, labels)
-	label.NodeTypesMLLabelName.Set(cfg.Node.ML, labels)
-
-	// add user-defined labels, unless we already manage a label matching the same key. we might want to consider
-	// issuing at least a warning in this case due to the potential for unexpected behavior
-	for k, v := range podSpecCtx.NodeSpec.PodTemplate.Labels {
-		if _, ok := labels[k]; !ok {
-			labels[k] = v
-		}
-	}
-
-	pod := corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name.NewPodName(es.Name, podSpecCtx.NodeSpec),
-			Namespace:   es.Namespace,
-			Labels:      labels,
-			Annotations: podSpecCtx.NodeSpec.PodTemplate.Annotations,
-		},
-		Spec: podSpecCtx.PodSpec,
-	}
-
-	return pod, nil
+	return corev1.Pod{
+		ObjectMeta: objectMeta,
+		Spec:       podSpecCtx.PodSpec,
+	}, nil
 }
 
 // MemoryLimitsToHeapSize converts a memory limit to the heap size (in megabytes) for the JVM
@@ -267,4 +300,13 @@ func nonZeroQuantityOrDefault(q, defaultQuantity resource.Quantity) resource.Qua
 // quantityToMegabytes returns the megabyte value of the provided resource.Quantity
 func quantityToMegabytes(q resource.Quantity) int {
 	return int(q.Value()) / 1024 / 1024
+}
+
+func buildResourceLimits(esContainer *corev1.Container) corev1.ResourceList {
+	resourceLimits := corev1.ResourceList{}
+	if esContainer != nil && esContainer.Resources.Limits != nil {
+		resourceLimits = esContainer.Resources.Limits
+	}
+	resourceLimits[corev1.ResourceMemory] = nonZeroQuantityOrDefault(*resourceLimits.Memory(), DefaultMemoryLimits)
+	return resourceLimits
 }

--- a/operators/pkg/controller/elasticsearch/version/common_test.go
+++ b/operators/pkg/controller/elasticsearch/version/common_test.go
@@ -231,15 +231,6 @@ func Test_podSpec(t *testing.T) {
 			},
 		},
 		{
-			name: "custom image",
-			params: pod.NewPodSpecParams{
-				CustomImageName: "customImageName",
-			},
-			assertions: func(t *testing.T, podSpec corev1.PodSpec) {
-				require.Equal(t, "customImageName", podSpec.Containers[0].Image)
-			},
-		},
-		{
 			name: "custom termination grace period & automount sa token",
 			params: pod.NewPodSpecParams{
 				NodeSpec: v1alpha1.NodeSpec{

--- a/operators/pkg/controller/elasticsearch/version/common_test.go
+++ b/operators/pkg/controller/elasticsearch/version/common_test.go
@@ -5,9 +5,23 @@
 package version
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/pod"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/processmanager"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/settings"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/volume"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_quantityToMegabytes(t *testing.T) {
@@ -28,6 +42,356 @@ func Test_quantityToMegabytes(t *testing.T) {
 			if got := quantityToMegabytes(tt.args.q); got != tt.want {
 				t.Errorf("quantityToMegabytes() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestNewPod(t *testing.T) {
+	podSpec := corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name: "container1",
+			},
+		},
+	}
+	esMeta := metav1.ObjectMeta{
+		Namespace: "ns",
+		Name:      "name",
+	}
+	masterCfg := settings.MustCanonicalConfig(map[string]interface{}{
+		"node.master": true,
+		"node.data":   false,
+		"node.ingest": false,
+		"node.ml":     false,
+	})
+	tests := []struct {
+		name       string
+		version    version.Version
+		es         v1alpha1.Elasticsearch
+		podSpecCtx pod.PodSpecContext
+		want       corev1.Pod
+	}{
+		{
+			name:    "no podTemplate",
+			version: version.MustParse("7.1.0"),
+			es: v1alpha1.Elasticsearch{
+				ObjectMeta: esMeta,
+			},
+			podSpecCtx: pod.PodSpecContext{
+				PodSpec: podSpec,
+				Config:  masterCfg,
+			},
+			want: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: esMeta.Namespace,
+					Name:      esMeta.Name,
+					Labels: map[string]string{
+						common.TypeLabelName:                   label.Type,
+						label.ClusterNameLabelName:             esMeta.Name,
+						string(label.NodeTypesDataLabelName):   "false",
+						string(label.NodeTypesIngestLabelName): "false",
+						string(label.NodeTypesMasterLabelName): "true",
+						string(label.NodeTypesMLLabelName):     "false",
+						string(label.VersionLabelName):         "7.1.0",
+					},
+				},
+				Spec: podSpec,
+			},
+		},
+		{
+			name:    "with podTemplate: should propagate labels and annotations",
+			version: version.MustParse("7.1.0"),
+			es: v1alpha1.Elasticsearch{
+				ObjectMeta: esMeta,
+			},
+			podSpecCtx: pod.PodSpecContext{
+				PodSpec: podSpec,
+				Config:  masterCfg,
+				NodeSpec: v1alpha1.NodeSpec{
+					PodTemplate: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "should-be-ignored",
+							Namespace: "should-be-ignored",
+							Labels: map[string]string{
+								"foo":                      "bar",
+								"bar":                      "baz",
+								label.ClusterNameLabelName: "will-be-overridden",
+							},
+							Annotations: map[string]string{
+								"annotation1": "foo",
+								"annotation2": "bar",
+							},
+						},
+					},
+				},
+			},
+			want: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: esMeta.Namespace,
+					Name:      esMeta.Name,
+					Labels: map[string]string{
+						common.TypeLabelName:                   label.Type,
+						label.ClusterNameLabelName:             esMeta.Name,
+						string(label.NodeTypesDataLabelName):   "false",
+						string(label.NodeTypesIngestLabelName): "false",
+						string(label.NodeTypesMasterLabelName): "true",
+						string(label.NodeTypesMLLabelName):     "false",
+						string(label.VersionLabelName):         "7.1.0",
+						"foo":                                  "bar",
+						"bar":                                  "baz",
+					},
+					Annotations: map[string]string{
+						"annotation1": "foo",
+						"annotation2": "bar",
+					},
+				},
+				Spec: podSpec,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewPod(tt.version, tt.es, tt.podSpecCtx)
+			require.NoError(t, err)
+			// since the name is random, don't test its equality and inject it to the expected output
+			tt.want.Name = got.Name
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewPod() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_podSpec(t *testing.T) {
+	// this test focuses on testing user-provided pod template overrides
+	// setup mocks for env vars func, es config func and init-containers func
+	newEnvVarsFn := func(p pod.NewPodSpecParams, heapSize int, certs, key, creds, keystore volume.SecretVolume) []corev1.EnvVar {
+		return []corev1.EnvVar{
+			{
+				Name:  "var1",
+				Value: "value1",
+			},
+			{
+				Name:  "var2",
+				Value: "value2",
+			},
+		}
+	}
+	newESConfigFn := func(clusterName string, config v1alpha1.Config) (*settings.CanonicalConfig, error) {
+		return nil, nil
+	}
+	newInitContainersFn := func(elasticsearchImage string, operatorImage string, setVMMaxMapCount *bool, nodeCertificatesVolume volume.SecretVolume) ([]corev1.Container, error) {
+		return []corev1.Container{
+			{
+				Name: "init-container1",
+			},
+			{
+				Name: "init-container2",
+			},
+		}, nil
+	}
+	varFalse := false
+	varTrue := true
+	varInt64 := int64(12)
+
+	tests := []struct {
+		name       string
+		params     pod.NewPodSpecParams
+		assertions func(t *testing.T, podSpec corev1.PodSpec)
+	}{
+		{
+			name: "no podTemplate: default happy path",
+			params: pod.NewPodSpecParams{
+				Version: "7.1.0",
+			},
+			assertions: func(t *testing.T, podSpec corev1.PodSpec) {
+				require.Equal(t, fmt.Sprintf("%s:%s", pod.DefaultImageRepository, "7.1.0"), podSpec.Containers[0].Image)
+				require.Equal(t, pod.DefaultTerminationGracePeriodSeconds, *podSpec.TerminationGracePeriodSeconds)
+				require.Equal(t, &varFalse, podSpec.AutomountServiceAccountToken)
+				require.NotEmpty(t, podSpec.Volumes)
+				require.Len(t, podSpec.InitContainers, 2)
+				require.Len(t, podSpec.Containers, 1)
+				esContainer := podSpec.Containers[0]
+				require.NotEmpty(t, esContainer.VolumeMounts)
+				require.Len(t, esContainer.Env, 2)
+				require.Equal(t, corev1.ResourceList{corev1.ResourceMemory: DefaultMemoryLimits}, esContainer.Resources.Limits)
+				require.Nil(t, esContainer.Resources.Requests)
+				require.Equal(t, pod.DefaultContainerPorts, esContainer.Ports)
+				require.Equal(t, pod.NewReadinessProbe(), esContainer.ReadinessProbe)
+				require.Equal(t, []string{processmanager.CommandPath}, esContainer.Command)
+			},
+		},
+		{
+			name: "custom image",
+			params: pod.NewPodSpecParams{
+				CustomImageName: "customImageName",
+			},
+			assertions: func(t *testing.T, podSpec corev1.PodSpec) {
+				require.Equal(t, "customImageName", podSpec.Containers[0].Image)
+			},
+		},
+		{
+			name: "custom image",
+			params: pod.NewPodSpecParams{
+				CustomImageName: "customImageName",
+			},
+			assertions: func(t *testing.T, podSpec corev1.PodSpec) {
+				require.Equal(t, "customImageName", podSpec.Containers[0].Image)
+			},
+		},
+		{
+			name: "custom termination grace period & automount sa token",
+			params: pod.NewPodSpecParams{
+				NodeSpec: v1alpha1.NodeSpec{
+					PodTemplate: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							TerminationGracePeriodSeconds: &varInt64,
+							AutomountServiceAccountToken:  &varTrue,
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, podSpec corev1.PodSpec) {
+				require.Equal(t, &varInt64, podSpec.TerminationGracePeriodSeconds)
+				require.Equal(t, &varTrue, podSpec.AutomountServiceAccountToken)
+			},
+		},
+		{
+			name: "user-provided volumes & volume mounts",
+			params: pod.NewPodSpecParams{
+				NodeSpec: v1alpha1.NodeSpec{
+					PodTemplate: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "user-volume-1",
+								},
+								{
+									Name: "user-volume-2",
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Name: v1alpha1.ElasticsearchContainerName,
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name: "user-volume-mount-1",
+										},
+										{
+											Name: "user-volume-mount-2",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, podSpec corev1.PodSpec) {
+				require.True(t, len(podSpec.Volumes) > 1)
+				foundUserVolumes := 0
+				for _, v := range podSpec.Volumes {
+					if v.Name == "user-volume-1" || v.Name == "user-volume-2" {
+						foundUserVolumes++
+					}
+				}
+				require.Equal(t, 2, foundUserVolumes)
+				foundUserVolumeMounts := 0
+				for _, v := range podSpec.Containers[0].VolumeMounts {
+					if v.Name == "user-volume-mount-1" || v.Name == "user-volume-mount-2" {
+						foundUserVolumeMounts++
+					}
+				}
+				require.Equal(t, 2, foundUserVolumeMounts)
+			},
+		},
+		{
+			name: "user-provided init containers",
+			params: pod.NewPodSpecParams{
+				NodeSpec: v1alpha1.NodeSpec{
+					PodTemplate: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name: "user-init-container-1",
+								},
+								{
+									Name: "user-init-container-2",
+								},
+							},
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, podSpec corev1.PodSpec) {
+				require.Equal(t, []corev1.Container{
+					{
+						Name: "user-init-container-1",
+					},
+					{
+						Name: "user-init-container-2",
+					},
+					{
+						Name: "init-container1",
+					},
+					{
+						Name: "init-container2",
+					},
+				}, podSpec.InitContainers)
+			},
+		},
+		{
+			name: "user-provided environment",
+			params: pod.NewPodSpecParams{
+				NodeSpec: v1alpha1.NodeSpec{
+					PodTemplate: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: v1alpha1.ElasticsearchContainerName,
+									Env: []corev1.EnvVar{
+										{
+											Name:  "user-env-1",
+											Value: "user-env-1-value",
+										},
+										{
+											Name:  "user-env-2",
+											Value: "user-env-2-value",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, podSpec corev1.PodSpec) {
+				require.Equal(t, []corev1.EnvVar{
+					{
+						Name:  "user-env-1",
+						Value: "user-env-1-value",
+					},
+					{
+						Name:  "user-env-2",
+						Value: "user-env-2-value",
+					},
+					{
+						Name:  "var1",
+						Value: "value1",
+					},
+					{
+						Name:  "var2",
+						Value: "value2",
+					},
+				}, podSpec.Containers[0].Env)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec, _, err := podSpec(tt.params, "operator-image", newEnvVarsFn, newESConfigFn, newInitContainersFn)
+			require.NoError(t, err)
+			tt.assertions(t, spec)
 		})
 	}
 }

--- a/operators/pkg/controller/elasticsearch/version/version6/podspecs.go
+++ b/operators/pkg/controller/elasticsearch/version/version6/podspecs.go
@@ -94,13 +94,12 @@ func newInitContainers(
 // newEnvironmentVars returns the environment vars to be associated to a pod
 func newEnvironmentVars(
 	p pod.NewPodSpecParams,
+	heapSize int,
 	nodeCertificatesVolume volume.SecretVolume,
 	privateKeySecretVolume volume.SecretVolume,
 	reloadCredsUserSecretVolume volume.SecretVolume,
 	secureSettingsSecretVolume volume.SecretVolume,
 ) []corev1.EnvVar {
-	heapSize := version.MemoryLimitsToHeapSize(*p.Resources.Limits.Memory())
-
 	vars := []corev1.EnvVar{
 		// inject pod name and IP as environment variables dynamically,
 		// to be referenced in elasticsearch configuration file

--- a/operators/pkg/controller/elasticsearch/version/version6/podspecs_test.go
+++ b/operators/pkg/controller/elasticsearch/version/version6/podspecs_test.go
@@ -32,6 +32,7 @@ var testObjectMeta = metav1.ObjectMeta{
 func TestNewEnvironmentVars(t *testing.T) {
 	type args struct {
 		p                      pod.NewPodSpecParams
+		heapSize               int
 		nodeCertificatesVolume volume.SecretVolume
 		privateKeyVolume       volume.SecretVolume
 		reloadCredsUserVolume  volume.SecretVolume
@@ -50,6 +51,7 @@ func TestNewEnvironmentVars(t *testing.T) {
 					ReloadCredsUser: testReloadCredsUser,
 					Version:         "6",
 				},
+				heapSize:               1024,
 				nodeCertificatesVolume: volume.NewSecretVolumeWithMountPath("certs", "/certs", "/certs"),
 				privateKeyVolume:       volume.NewSecretVolumeWithMountPath("key", "/key", "/key"),
 				reloadCredsUserVolume:  volume.NewSecretVolumeWithMountPath("creds", "/creds", "/creds"),
@@ -83,7 +85,7 @@ func TestNewEnvironmentVars(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := newEnvironmentVars(tt.args.p, tt.args.nodeCertificatesVolume, tt.args.privateKeyVolume,
+			got := newEnvironmentVars(tt.args.p, tt.args.heapSize, tt.args.nodeCertificatesVolume, tt.args.privateKeyVolume,
 				tt.args.reloadCredsUserVolume, tt.args.secureSettingsVolume)
 			assert.Equal(t, tt.wantEnv, got)
 		})


### PR DESCRIPTION
Make the elasticsearch pod and container inherit user-provided
podTemplate from the Elasticsearch spec.

It allows the user to pass-in custom annotations, labels, init
containers, environment variables, volumes, volume mounts, etc.

We append our own spec on top of the user's one, or set defaults in case
the user has not provided a particular field.

When dealing with list of items (eg. volumes, volume mounts,
environment), this commit does not attempt to deal with conflicts,
but only append our own items to the user-provided ones.
In practice, that means:
- setting a volume mount path conflicting with ours will return an error
at pod creation time
- setting an environment var conflicting with ours will lead to the pod
having both env vars defined in the spec, but the final container env
will only see the last-defined variable (ours, not the user's one)

Partially solves https://github.com/elastic/cloud-on-k8s/issues/765 (for ES only).