### PR TITLE
Don't override user-provided labels

### DIFF
--- a/operators/pkg/controller/elasticsearch/label/label.go
+++ b/operators/pkg/controller/elasticsearch/label/label.go
@@ -10,6 +10,8 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,6 +71,21 @@ func NewLabels(es types.NamespacedName) map[string]string {
 		ClusterNameLabelName: es.Name,
 		common.TypeLabelName: Type,
 	}
+}
+
+// NewPodLabels returns labels to apply for a new Elasticsearch pod.
+func NewPodLabels(es v1alpha1.Elasticsearch, version version.Version, cfg v1alpha1.ElasticsearchSettings) map[string]string {
+	// cluster name based labels
+	labels := NewLabels(k8s.ExtractNamespacedName(&es))
+	// version label
+	labels[VersionLabelName] = version.String()
+	// node types labels
+	NodeTypesMasterLabelName.Set(cfg.Node.Master, labels)
+	NodeTypesDataLabelName.Set(cfg.Node.Data, labels)
+	NodeTypesIngestLabelName.Set(cfg.Node.Ingest, labels)
+	NodeTypesMLLabelName.Set(cfg.Node.ML, labels)
+
+	return labels
 }
 
 // NewLabelSelectorForElasticsearch returns a labels.Selector that matches the labels as constructed by NewLabels

--- a/operators/pkg/controller/elasticsearch/version/common_test.go
+++ b/operators/pkg/controller/elasticsearch/version/common_test.go
@@ -113,9 +113,8 @@ func TestNewPod(t *testing.T) {
 							Name:      "should-be-ignored",
 							Namespace: "should-be-ignored",
 							Labels: map[string]string{
-								"foo":                      "bar",
-								"bar":                      "baz",
-								label.ClusterNameLabelName: "will-be-overridden",
+								"foo": "bar",
+								"bar": "baz",
 							},
 							Annotations: map[string]string{
 								"annotation1": "foo",
@@ -143,6 +142,48 @@ func TestNewPod(t *testing.T) {
 					Annotations: map[string]string{
 						"annotation1": "foo",
 						"annotation2": "bar",
+					},
+				},
+				Spec: podSpec,
+			},
+		},
+		{
+			name:    "with podTemplate: should not override user-provided labels",
+			version: version.MustParse("7.1.0"),
+			es: v1alpha1.Elasticsearch{
+				ObjectMeta: esMeta,
+			},
+			podSpecCtx: pod.PodSpecContext{
+				PodSpec: podSpec,
+				Config:  masterCfg,
+				NodeSpec: v1alpha1.NodeSpec{
+					PodTemplate: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "should-be-ignored",
+							Namespace: "should-be-ignored",
+							Labels: map[string]string{
+								label.ClusterNameLabelName: "override-operator-value",
+								"foo":                      "bar",
+								"bar":                      "baz",
+							},
+						},
+					},
+				},
+			},
+			want: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: esMeta.Namespace,
+					Name:      esMeta.Name,
+					Labels: map[string]string{
+						common.TypeLabelName:                   label.Type,
+						label.ClusterNameLabelName:             "override-operator-value",
+						string(label.NodeTypesDataLabelName):   "false",
+						string(label.NodeTypesIngestLabelName): "false",
+						string(label.NodeTypesMasterLabelName): "true",
+						string(label.NodeTypesMLLabelName):     "false",
+						string(label.VersionLabelName):         "7.1.0",
+						"foo":                                  "bar",
+						"bar":                                  "baz",
 					},
 				},
 				Spec: podSpec,


### PR DESCRIPTION
We decided we should keep whatever labels users apply in the podTemplate
section of the spec. Even though this may lead to issues for conflicting
labels with the ones we set. Label names are very explicit so this kind
of conflict probably originates from users desire, we should not work
against that.