### PR TITLE
Parametrize version of k8s cluster in GKE

### DIFF
--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -124,5 +124,6 @@ ci-e2e: vault-gke-creds
 		-e "GKE_CLUSTER_NAME=e2e-qa-$(shell date +'%Y%m%d-%H%M%S')" \
 		-e "GKE_SERVICE_ACCOUNT_KEY_FILE=$(GO_MOUNT_PATH)/build/ci/$(GKE_CREDS_FILE)" \
 		-e "TESTS_MATCH=$(TESTS_MATCH)" \
+		-e "GKE_CLUSTER_VERSION=$(GKE_CLUSTER_VERSION)" \
 		cloud-on-k8s-ci-e2e \
 		bash -c "make -C operators ci-e2e GKE_MACHINE_TYPE=n1-standard-8"

--- a/operators/Makefile
+++ b/operators/Makefile
@@ -12,6 +12,7 @@ ROOT_DIR = $(shell dirname $(CURDIR))
 export SHELL := /bin/bash
 
 KUBECTL_CLUSTER := $(shell kubectl config current-context 2> /dev/null)
+GKE_CLUSTER_VERSION ?= 1.11
 
 ## -- Docker image
 
@@ -206,7 +207,7 @@ set-context-gke: require-gcloud-project
 	$(eval KUBECTL_CLUSTER=$(shell hack/gke-cluster.sh name))
 
 bootstrap-gke: require-gcloud-project
-	./hack/gke-cluster.sh create
+	GKE_CLUSTER_VERSION=$(GKE_CLUSTER_VERSION) ./hack/gke-cluster.sh create
 	$(MAKE) set-context-gke cluster-bootstrap
 	# push "latest" operator image to be used for init containers when running the operator locally
 	$(MAKE) docker-build docker-push OPERATOR_IMAGE=$(OPERATOR_IMAGE_LATEST)

--- a/operators/hack/gke-cluster.sh
+++ b/operators/hack/gke-cluster.sh
@@ -17,7 +17,7 @@ set -eu
 : "${GKE_CLUSTER_NAME:=${USER//_}-dev-cluster}"
 : "${GKE_CLUSTER_REGION:=europe-west3}"
 : "${GKE_ADMIN_USERNAME:=admin}"
-: "${GKE_CLUSTER_VERSION:=1.11}"
+: "${GKE_CLUSTER_VERSION}"
 : "${GKE_MACHINE_TYPE:=n1-highmem-4}"
 : "${GKE_LOCAL_SSD_COUNT:=1}"
 : "${GKE_NODE_COUNT_PER_ZONE:=1}"


### PR DESCRIPTION
This allows in the future to run different versions of k8s clusters in GKE. By default, version `1.11` will be used if other not specified