### PR TITLE
Set a default subdomain=es.name and name=pod.name on new Pods

### DIFF
--- a/operators/pkg/controller/elasticsearch/version/common.go
+++ b/operators/pkg/controller/elasticsearch/version/common.go
@@ -277,6 +277,14 @@ func NewPod(
 		}
 	}
 
+	if podSpecCtx.PodSpec.Hostname == "" {
+		podSpecCtx.PodSpec.Hostname = objectMeta.Name
+	}
+
+	if podSpecCtx.PodSpec.Subdomain == "" {
+		podSpecCtx.PodSpec.Subdomain = es.Name
+	}
+
 	return corev1.Pod{
 		ObjectMeta: objectMeta,
 		Spec:       podSpecCtx.PodSpec,

--- a/operators/pkg/controller/elasticsearch/version/common_test.go
+++ b/operators/pkg/controller/elasticsearch/version/common_test.go
@@ -6,7 +6,6 @@ package version
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
@@ -47,17 +46,28 @@ func Test_quantityToMegabytes(t *testing.T) {
 }
 
 func TestNewPod(t *testing.T) {
+	esMeta := metav1.ObjectMeta{
+		Namespace: "ns",
+		Name:      "name",
+	}
+
 	podSpec := corev1.PodSpec{
 		Containers: []corev1.Container{
 			{
 				Name: "container1",
 			},
 		},
+		Subdomain: esMeta.Namespace,
+		Hostname:  esMeta.Name,
 	}
-	esMeta := metav1.ObjectMeta{
-		Namespace: "ns",
-		Name:      "name",
+
+	// configurePodSpec is a helper method to set attributes on a pod spec without modifying the original
+	configurePodSpec := func(spec corev1.PodSpec, configure func(*corev1.PodSpec)) corev1.PodSpec {
+		s := spec.DeepCopy()
+		configure(s)
+		return *s
 	}
+
 	masterCfg := settings.MustCanonicalConfig(map[string]interface{}{
 		"node.master": true,
 		"node.data":   false,
@@ -99,19 +109,19 @@ func TestNewPod(t *testing.T) {
 			},
 		},
 		{
-			name:    "with podTemplate: should propagate labels and annotations",
+			name:    "with podTemplate: should propagate labels, annotations and subdomain",
 			version: version.MustParse("7.1.0"),
 			es: v1alpha1.Elasticsearch{
 				ObjectMeta: esMeta,
 			},
 			podSpecCtx: pod.PodSpecContext{
-				PodSpec: podSpec,
-				Config:  masterCfg,
+				PodSpec: configurePodSpec(podSpec, func(spec *corev1.PodSpec) {
+					spec.Subdomain = "my-subdomain"
+				}),
+				Config: masterCfg,
 				NodeSpec: v1alpha1.NodeSpec{
 					PodTemplate: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "should-be-ignored",
-							Namespace: "should-be-ignored",
 							Labels: map[string]string{
 								"foo": "bar",
 								"bar": "baz",
@@ -144,7 +154,9 @@ func TestNewPod(t *testing.T) {
 						"annotation2": "bar",
 					},
 				},
-				Spec: podSpec,
+				Spec: configurePodSpec(podSpec, func(spec *corev1.PodSpec) {
+					spec.Subdomain = "my-subdomain"
+				}),
 			},
 		},
 		{
@@ -159,8 +171,6 @@ func TestNewPod(t *testing.T) {
 				NodeSpec: v1alpha1.NodeSpec{
 					PodTemplate: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "should-be-ignored",
-							Namespace: "should-be-ignored",
 							Labels: map[string]string{
 								label.ClusterNameLabelName: "override-operator-value",
 								"foo":                      "bar",
@@ -196,9 +206,8 @@ func TestNewPod(t *testing.T) {
 			require.NoError(t, err)
 			// since the name is random, don't test its equality and inject it to the expected output
 			tt.want.Name = got.Name
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewPod() = %v, want %v", got, tt.want)
-			}
+
+			require.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
This facilitates creating a headless service in the future, whether it happens
as part of the operator itself or by a the user.