### PR TITLE
Remove default discovery service

### DIFF
--- a/operators/pkg/controller/elasticsearch/driver/default.go
+++ b/operators/pkg/controller/elasticsearch/driver/default.go
@@ -142,7 +142,7 @@ func (d *defaultDriver) Reconcile(
 		d.Scheme,
 		d.CSRClient,
 		es,
-		[]corev1.Service{genericResources.DiscoveryService, genericResources.ExternalService},
+		[]corev1.Service{genericResources.ExternalService},
 		d.Parameters.CACertValidity,
 		d.Parameters.CACertRotateBefore,
 		d.Parameters.CertValidity,

--- a/operators/pkg/controller/elasticsearch/driver/generic_resources.go
+++ b/operators/pkg/controller/elasticsearch/driver/generic_resources.go
@@ -18,8 +18,6 @@ import (
 type GenericResources struct {
 	// ExternalService is the user-facing service
 	ExternalService corev1.Service
-	// DiscoveryService is the service used by ES for discovery purposes
-	DiscoveryService corev1.Service
 }
 
 // reconcileGenericResources reconciles the expected generic resources of a cluster.
@@ -32,20 +30,13 @@ func reconcileGenericResources(
 	// TODO: consider removing the "res" bits of the ReconcileService signature?
 	results := &reconciler.Results{}
 
-	discoveryService := services.NewDiscoveryService(es)
-	_, err := common.ReconcileService(c, scheme, discoveryService, &es)
-	if err != nil {
-		return nil, results.WithError(err)
-	}
-
 	externalService := services.NewExternalService(es)
-	_, err = common.ReconcileService(c, scheme, externalService, &es)
+	_, err := common.ReconcileService(c, scheme, externalService, &es)
 	if err != nil {
 		return nil, results.WithError(err)
 	}
 
 	return &GenericResources{
-		DiscoveryService: *discoveryService,
-		ExternalService:  *externalService,
+		ExternalService: *externalService,
 	}, results
 }

--- a/operators/pkg/controller/elasticsearch/name/name.go
+++ b/operators/pkg/controller/elasticsearch/name/name.go
@@ -27,7 +27,6 @@ const (
 	configSecretSuffix          = "config"
 	secureSettingsSecretSuffix  = "secure-settings"
 	certsSecretSuffix           = "certs"
-	discoveryServiceSuffix      = "discovery"
 	elasticUserSecretSuffix     = "elastic-user"
 	esRolesUsersSecretSuffix    = "roles-users"
 	clusterSecretsSecretSuffix  = "secrets"
@@ -99,10 +98,6 @@ func TransportCertsSecret(podName string) string {
 
 func Service(esName string) string {
 	return ESNamer.Suffix(esName)
-}
-
-func DiscoveryService(esName string) string {
-	return ESNamer.Suffix(esName, discoveryServiceSuffix)
 }
 
 func ElasticUserSecret(esName string) string {

--- a/operators/pkg/controller/elasticsearch/pod/pod.go
+++ b/operators/pkg/controller/elasticsearch/pod/pod.go
@@ -58,8 +58,6 @@ type NewPodSpecParams struct {
 	CustomImageName string
 	// ClusterName is the name of the Elasticsearch cluster
 	ClusterName string
-	// DiscoveryServiceName is the name of the Service that should be used for discovery.
-	DiscoveryServiceName string
 	// DiscoveryZenMinimumMasterNodes is the setting for minimum master node in Zen Discovery
 	DiscoveryZenMinimumMasterNodes int
 

--- a/operators/pkg/controller/elasticsearch/version/common.go
+++ b/operators/pkg/controller/elasticsearch/version/common.go
@@ -15,7 +15,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/name"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/pod"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/processmanager"
-	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/services"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/settings"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/volume"
@@ -45,11 +44,10 @@ func NewExpectedPodSpecs(
 		for i := int32(0); i < node.NodeCount; i++ {
 			params := pod.NewPodSpecParams{
 				// cluster-wide params
-				Version:              es.Spec.Version,
-				CustomImageName:      es.Spec.Image,
-				ClusterName:          es.Name,
-				DiscoveryServiceName: services.DiscoveryServiceName(es.Name),
-				SetVMMaxMapCount:     es.Spec.SetVMMaxMapCount,
+				Version:          es.Spec.Version,
+				CustomImageName:  es.Spec.Image,
+				ClusterName:      es.Name,
+				SetVMMaxMapCount: es.Spec.SetVMMaxMapCount,
 				// volumes
 				UsersSecretVolume:  paramsTmpl.UsersSecretVolume,
 				ConfigMapVolume:    paramsTmpl.ConfigMapVolume,

--- a/operators/pkg/controller/remotecluster/driver_incluster_test.go
+++ b/operators/pkg/controller/remotecluster/driver_incluster_test.go
@@ -153,13 +153,18 @@ func Test_apply(t *testing.T) {
 					},
 					RemoteTrustRelationship: "rcr-remotecluster-sample-1-2-default",
 				},
-				SeedHosts: []string{"trust-two-es-es-discovery.default.svc.cluster.local:9300"},
+				SeedHosts: []string{"trust-two-es-es-remote-cluster-seed.default.svc:9300"},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.NoError(t, tt.args.rca.watches.InjectScheme(sc))
+			if tt.args.rca.scheme == nil {
+				tt.args.rca.scheme = sc
+			}
+
+			assert.NoError(t, tt.args.rca.watches.InjectScheme(tt.args.rca.scheme))
+
 			got, err := doReconcile(tt.args.rca, tt.args.remoteCluster)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("apply() error = %v, wantErr %v", err, tt.wantErr)

--- a/operators/pkg/controller/remotecluster/finalizers.go
+++ b/operators/pkg/controller/remotecluster/finalizers.go
@@ -9,6 +9,10 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/finalizer"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/watches"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // watchFinalizer ensure that we remove watches for Secrets  we are no longer interested in
@@ -22,6 +26,29 @@ func watchFinalizer(
 		Execute: func() error {
 			w.Secrets.RemoveHandlerForKey(watchName(clusterAssociation, local))
 			w.Secrets.RemoveHandlerForKey(watchName(clusterAssociation, remote))
+			return nil
+		},
+	}
+}
+
+// seedServiceFinalizer ensures that we remove the seed service if it's no longer required
+func seedServiceFinalizer(c k8s.Client, remoteCluster v1alpha1.RemoteCluster) finalizer.Finalizer {
+	return finalizer.Finalizer{
+		Name: RemoteClusterSeedServiceFinalizer,
+		Execute: func() error {
+			svc := v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: remoteCluster.Spec.Remote.K8sLocalRef.Namespace,
+					Name:      remoteClusterSeedServiceName(remoteCluster.Spec.Remote.K8sLocalRef.Name),
+				},
+			}
+			if svc.Namespace == "" {
+				svc.Namespace = remoteCluster.Namespace
+			}
+
+			if err := c.Delete(&svc); err != nil && errors.IsNotFound(err) {
+				return err
+			}
 			return nil
 		},
 	}

--- a/operators/pkg/controller/remotecluster/labels.go
+++ b/operators/pkg/controller/remotecluster/labels.go
@@ -14,6 +14,8 @@ import (
 const (
 	// RemoteClusterDynamicWatchesFinalizer designates a finalizer to clean up unused watches.
 	RemoteClusterDynamicWatchesFinalizer = "dynamic-watches.remotecluster.k8s.elastic.co"
+	// RemoteClusterSeedServiceFinalizer designates a finalizer to clean up a seed Service.
+	RemoteClusterSeedServiceFinalizer = "seed-service.remotecluster.k8s.elastic.co"
 	// RemoteClusterNamespaceLabelName used to represent the namespace of the RemoteCluster in a TrustRelationship.
 	RemoteClusterNamespaceLabelName = "remotecluster.k8s.elastic.co/namespace"
 	// RemoteClusterNameLabelName used to represent the name of the RemoteCluster in a TrustRelationship.

--- a/operators/pkg/controller/remotecluster/watches.go
+++ b/operators/pkg/controller/remotecluster/watches.go
@@ -6,6 +6,7 @@ package remotecluster
 
 import (
 	"fmt"
+	"strings"
 
 	commonv1alpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/common/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
@@ -47,15 +48,69 @@ func addWatches(c controller.Controller, r *ReconcileRemoteCluster) error {
 		return err
 	}
 
+	// Watch licenses in order to enable functionality if license status changes
+	if err := c.Watch(&source.Kind{Type: &v1alpha1.EnterpriseLicense{}}, &handler.EnqueueRequestsFromMapFunc{
+		ToRequests: reconcileAllRemoteClusters(r.Client),
+	}); err != nil {
+		return err
+	}
+
+	// Watch Service resources in order to reconcile related remote clusters if it changes.
+	if err := c.Watch(&source.Kind{Type: &v1.Service{}}, &handler.EnqueueRequestsFromMapFunc{
+		// if it's a remote cluster seed service, we need to enqueue requests for any relevant remote clusters
+		ToRequests: handler.ToRequestsFunc(func(object handler.MapObject) []reconcile.Request {
+			if !strings.HasSuffix(object.Meta.GetName(), remoteClusterSeedServiceSuffix) {
+				// not a remote cluster seed service, safe to ignore
+				return nil
+			}
+
+			svcNamespace := object.Meta.GetNamespace()
+			svcName := object.Meta.GetName()
+
+			var list v1alpha1.RemoteClusterList
+			if err := r.List(&client.ListOptions{}, &list); err != nil {
+				log.Error(err, "failed to list remote clusters in watch handler")
+				// dropping any errors on the floor here
+				return nil
+			}
+
+			var reqs []reconcile.Request
+			for _, rc := range list.Items {
+				// compare service name
+				if remoteClusterSeedServiceName(rc.Spec.Remote.K8sLocalRef.Name) != svcName {
+					continue
+				}
+
+				// compare service namespace
+				ns := rc.Spec.Remote.K8sLocalRef.Namespace
+				if ns == "" {
+					ns = rc.Namespace
+				}
+				if ns != svcNamespace {
+					// Service and remote namespace in different namespaces, so not relevant
+					continue
+				}
+
+				log.Info("Synthesizing reconcile for ", "resource", k8s.ExtractNamespacedName(&rc))
+				reqs = append(reqs, reconcile.Request{
+					NamespacedName: k8s.ExtractNamespacedName(&rc),
+				})
+			}
+			return reqs
+		}),
+	}); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // reconcileAllRemoteClusters creates a reconcile request for each currently existing remote cluster resource.
 func reconcileAllRemoteClusters(c k8s.Client) handler.ToRequestsFunc {
-	return handler.ToRequestsFunc(func(object handler.MapObject) []reconcile.Request {
+	return handler.ToRequestsFunc(func(_ handler.MapObject) []reconcile.Request {
 		var list v1alpha1.RemoteClusterList
 		if err := c.List(&client.ListOptions{}, &list); err != nil {
-			log.Error(err, "failed to list remote clusters in watch handler for enterprise licenses")
+			log.Error(err, "failed to list remote clusters in watch handler")
 			// dropping any errors on the floor here
 			return nil
 		}

--- a/operators/test/e2e/failure_test.go
+++ b/operators/test/e2e/failure_test.go
@@ -150,15 +150,6 @@ func TestDeleteServices(t *testing.T) {
 	RunFailureTest(t, s, func(k *helpers.K8sHelper) helpers.TestStepList {
 		return helpers.TestStepList{
 			{
-				Name: "Delete discovery service",
-				Test: func(t *testing.T) {
-					s, err := k.GetService(s.Elasticsearch.Name + "-es-discovery")
-					require.NoError(t, err)
-					err = k.Client.Delete(s)
-					require.NoError(t, err)
-				},
-			},
-			{
 				Name: "Delete external service",
 				Test: func(t *testing.T) {
 					s, err := k.GetService(s.Elasticsearch.Name + "-es")

--- a/operators/test/e2e/stack/checks_k8s.go
+++ b/operators/test/e2e/stack/checks_k8s.go
@@ -280,7 +280,6 @@ func CheckServices(stack Builder, k *helpers.K8sHelper) helpers.TestStep {
 		Name: "Services should be created",
 		Test: helpers.Eventually(func() error {
 			for _, s := range []string{
-				stack.Elasticsearch.Name + "-es-discovery",
 				stack.Elasticsearch.Name + "-es",
 				stack.Kibana.Name + "-kibana",
 			} {
@@ -299,7 +298,6 @@ func CheckServicesEndpoints(stack Builder, k *helpers.K8sHelper) helpers.TestSte
 		Name: "Services should have endpoints",
 		Test: helpers.Eventually(func() error {
 			for endpointName, addrCount := range map[string]int{
-				stack.Elasticsearch.Name + "-es-discovery": int(stack.Elasticsearch.Spec.NodeCount()),
 				stack.Kibana.Name + "-kibana":              int(stack.Kibana.Spec.NodeCount),
 				stack.Elasticsearch.Name + "-es":           int(stack.Elasticsearch.Spec.NodeCount()),
 			} {


### PR DESCRIPTION
Leaves remote clusters in a working state by reconciling a `{remote}-es-remote-cluster-seed` Service in the remote namespace so we have something to give to Elasticsearch through `seed_hosts`.

Since we cannot set owners across namespaces, and this same service could be used by multiple remote clusters, we have to deal with its lifecycle a bit differently:

1. All remote cluster resources reconcile this service to ensure it exists.
2. When a RemoteCluster resource is deleted, a finalizer deletes the Service to clean up.
3. The remote cluster controller watches services and reconciles all related remote cluster resources upon changes (including deletion) to the services. This causes the service to be deleted when it /might/ not be required anymore, and re-created immediately if it is still required.