### PR TITLE
Remove cluster local suffixes where possible

### DIFF
--- a/operators/config/dev/registry.yaml
+++ b/operators/config/dev/registry.yaml
@@ -89,7 +89,7 @@ spec:
             memory: 50Mi
         env:
         - name: REGISTRY_HOST
-          value: kube-registry.kube-system.svc.cluster.local
+          value: kube-registry.kube-system.svc
         - name: REGISTRY_PORT
           value: "5000"
         ports:

--- a/operators/config/samples/elasticsearch/cross-cluster/README.md
+++ b/operators/config/samples/elasticsearch/cross-cluster/README.md
@@ -51,7 +51,7 @@ status:
     remoteTrustRelationship: rcr-remotecluster-sample-1-2-default
   localTrustRelationship: rc-remotecluster-sample-1-2
   seedHosts:
-  - trust-two-es-discovery.default.svc.cluster.local:9300
+  - trust-two-es-discovery.default.svc:9300
   state: Propagated
 ```
 

--- a/operators/pkg/controller/apmserver/config/config_test.go
+++ b/operators/pkg/controller/apmserver/config/config_test.go
@@ -44,7 +44,7 @@ func Test_getCredentials(t *testing.T) {
 					Spec: v1alpha1.ApmServerSpec{
 						Output: v1alpha1.Output{
 							Elasticsearch: v1alpha1.ElasticsearchOutput{
-								Hosts: []string{"https://elasticsearch-sample-es-http.default.svc.cluster.local:9200"},
+								Hosts: []string{"https://elasticsearch-sample-es-http.default.svc:9200"},
 								Auth: v1alpha1.ElasticsearchAuth{
 									SecretKeyRef: &corev1.SecretKeySelector{
 										Key: "elastic-internal-apm",

--- a/operators/pkg/controller/elasticsearch/certificates/http/reconcile.go
+++ b/operators/pkg/controller/elasticsearch/certificates/http/reconcile.go
@@ -290,7 +290,8 @@ func createValidatedHTTPCertificateTemplate(
 	csr *x509.CertificateRequest,
 	certValidity time.Duration,
 ) (*certificates.ValidatedCertificateTemplate, error) {
-	certCommonName := fmt.Sprintf("%s.%s.es.local", es.Name, es.Namespace)
+	// add .cluster.local to the certificate name to avoid issuing certificates signed for .es by default
+	certCommonName := fmt.Sprintf("%s.%s.es.cluster.local", es.Name, es.Namespace)
 
 	dnsNames := []string{
 		certCommonName,
@@ -298,7 +299,7 @@ func createValidatedHTTPCertificateTemplate(
 	var ipAddresses []net.IP
 
 	for _, svc := range svcs {
-		dnsNames = append(dnsNames, k8s.GetServiceFullyQualifiedHostname(svc))
+		dnsNames = append(dnsNames, k8s.GetServiceDNSName(svc))
 	}
 
 	if selfSignedCerts := es.Spec.HTTP.TLS.SelfSignedCertificate; selfSignedCerts != nil {

--- a/operators/pkg/controller/elasticsearch/certificates/http/reconcile_test.go
+++ b/operators/pkg/controller/elasticsearch/certificates/http/reconcile_test.go
@@ -152,9 +152,9 @@ func Test_createValidatedHTTPCertificateTemplate(t *testing.T) {
 				},
 			},
 			want: func(t *testing.T, cert *certificates.ValidatedCertificateTemplate) {
-				expectedCommonName := "test.test.es.local"
+				expectedCommonName := "test.test.es.cluster.local"
 				assert.Contains(t, cert.DNSNames, expectedCommonName)
-				assert.Contains(t, cert.DNSNames, "svc-name.svc-namespace.svc.cluster.local")
+				assert.Contains(t, cert.DNSNames, "svc-name.svc-namespace.svc")
 				assert.Contains(t, cert.DNSNames, sanDNS1)
 				assert.Contains(t, cert.DNSNames, sanDNS2)
 				assert.Contains(t, cert.IPAddresses, net.ParseIP(sanIP1).To4())

--- a/operators/pkg/controller/elasticsearch/driver/default.go
+++ b/operators/pkg/controller/elasticsearch/driver/default.go
@@ -523,6 +523,6 @@ func (d *defaultDriver) calculateChanges(
 
 // newElasticsearchClient creates a new Elasticsearch HTTP client for this cluster using the provided user
 func (d *defaultDriver) newElasticsearchClient(service corev1.Service, user user.User, v version.Version, caCert *x509.Certificate) esclient.Client {
-	url := fmt.Sprintf("https://%s.%s.svc.cluster.local:%d", service.Name, service.Namespace, network.HTTPPort)
+	url := fmt.Sprintf("https://%s.%s.svc:%d", service.Name, service.Namespace, network.HTTPPort)
 	return esclient.NewElasticsearchClient(d.Dialer, url, user.Auth(), v, []*x509.Certificate{caCert})
 }

--- a/operators/pkg/controller/elasticsearch/services/services.go
+++ b/operators/pkg/controller/elasticsearch/services/services.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	globalServiceSuffix = ".svc.cluster.local"
+	globalServiceSuffix = ".svc"
 )
 
 // ExternalServiceName returns the name for the external service

--- a/operators/pkg/controller/elasticsearch/services/services_test.go
+++ b/operators/pkg/controller/elasticsearch/services/services_test.go
@@ -30,7 +30,7 @@ func TestExternalServiceURL(t *testing.T) {
 					Namespace: "default",
 				},
 			}},
-			want: "https://an-es-name-es-http.default.svc.cluster.local:9200",
+			want: "https://an-es-name-es-http.default.svc:9200",
 		},
 		{
 			name: "Another Service URL",
@@ -40,7 +40,7 @@ func TestExternalServiceURL(t *testing.T) {
 					Namespace: "default",
 				},
 			}},
-			want: "https://another-es-name-es-http.default.svc.cluster.local:9200",
+			want: "https://another-es-name-es-http.default.svc:9200",
 		},
 	}
 	for _, tt := range tests {

--- a/operators/pkg/dev/portforward/dialer.go
+++ b/operators/pkg/dev/portforward/dialer.go
@@ -39,7 +39,7 @@ func NewForwardingDialer() *ForwardingDialer {
 // defaultForwarderFactory is the default podForwarder factory used outside of tests
 var defaultForwarderFactory = ForwardingDialerForwarderFactory(
 	func(client client.Client, network, addr string) (Forwarder, error) {
-		if strings.Contains(addr, ".svc.cluster.local:") {
+		if strings.Contains(addr, ".svc:") || strings.Contains(addr, ".svc.") {
 			// it looks like a service url, so forward as a service
 			return NewServiceForwarder(client, network, addr)
 		}

--- a/operators/pkg/dev/portforward/pod_forwarder.go
+++ b/operators/pkg/dev/portforward/pod_forwarder.go
@@ -97,7 +97,7 @@ func newDefaultKubernetesClientset() (*kubernetes.Clientset, error) {
 	return kubernetes.NewForConfig(cfg)
 }
 
-// podDNSRegex matches pods FQDN such as {name}.{namespace}.pod.cluster.local.
+// podDNSRegex matches pods FQDN such as {name}.{namespace}.pod
 var podDNSRegex = regexp.MustCompile(`^.+\..+\..*$`)
 
 // podIPRegex matches any ipv4 address.

--- a/operators/pkg/dev/portforward/pod_forwarder_test.go
+++ b/operators/pkg/dev/portforward/pod_forwarder_test.go
@@ -62,7 +62,7 @@ func Test_podForwarder_DialContext(t *testing.T) {
 	}{
 		{
 			name:      "pod should be forwarded",
-			forwarder: NewPodForwarderWithTest(t, "tcp", "foo.bar.pod.cluster.local:9200"),
+			forwarder: NewPodForwarderWithTest(t, "tcp", "foo.bar.pod:9200"),
 			tweaks: func(t *testing.T, f *podForwarder) {
 				f.ephemeralPortFinder = func() (string, error) {
 					return "12345", nil
@@ -140,7 +140,7 @@ func Test_parsePodAddr(t *testing.T) {
 	}{
 		{
 			name: "pod DNS without subdomain",
-			args: args{addr: "foo.bar.pod.cluster.local:1234"},
+			args: args{addr: "foo.bar.pod:1234"},
 			want: types.NamespacedName{Namespace: "bar", Name: "foo"},
 		},
 		{
@@ -186,7 +186,7 @@ func Test_podIPv4Regex(t *testing.T) {
 		},
 		{
 			name: "dns",
-			addr: "name.namespace.pod.cluster.local",
+			addr: "name.namespace.pod",
 			want: false,
 		},
 	}

--- a/operators/pkg/dev/portforward/service_forwarder.go
+++ b/operators/pkg/dev/portforward/service_forwarder.go
@@ -66,7 +66,7 @@ func NewServiceForwarder(client client.Client, network, addr string) (*serviceFo
 
 // parseServiceAddr parses the service name and namespace from a connection address
 func parseServiceAddr(addr string) (*types.NamespacedName, error) {
-	// services generally look like this (as FQDN): {name}.{namespace}.svc.cluster.local
+	// services generally look like this (as FQDN): {name}.{namespace}.svc
 	parts := strings.SplitN(addr, ".", 3)
 
 	if len(parts) <= 2 {
@@ -157,7 +157,7 @@ func (f *serviceForwarder) DialContext(ctx context.Context) (net.Conn, error) {
 	pod := podTargets[rand.Intn(len(podTargets))]
 
 	// this should match a supported format of parsePodAddr(addr string)
-	podAddr := fmt.Sprintf("%s.%s.pod.cluster.local:%s", pod.Name, pod.Namespace, targetPort.String())
+	podAddr := fmt.Sprintf("%s.%s.pod:%s", pod.Name, pod.Namespace, targetPort.String())
 	forwarder, err := f.store.GetOrCreateForwarder(f.network, podAddr, f.podForwarderFactory)
 	if err != nil {
 		return nil, err

--- a/operators/pkg/dev/portforward/service_forwarder_test.go
+++ b/operators/pkg/dev/portforward/service_forwarder_test.go
@@ -32,7 +32,7 @@ func Test_parseServiceAddr(t *testing.T) {
 	}{
 		{
 			name: "service with namespace",
-			args: args{addr: "foo.bar.svc.cluster.local"},
+			args: args{addr: "foo.bar.svc"},
 			want: types.NamespacedName{Namespace: "bar", Name: "foo"},
 		},
 		{
@@ -79,7 +79,7 @@ func Test_serviceForwarder_DialContext(t *testing.T) {
 			name: "should forward to a ready endpoint address with Kind=Pod",
 			fields: fields{
 				network: "tcp",
-				addr:    "foo.bar.svc.cluster.local:9200",
+				addr:    "foo.bar.svc:9200",
 				client: fake.NewFakeClient(
 					&corev1.Service{
 						ObjectMeta: metav1.ObjectMeta{
@@ -126,13 +126,13 @@ func Test_serviceForwarder_DialContext(t *testing.T) {
 					}, nil
 				}
 			},
-			wantErr: errors.New("would dial: some-pod-name.bar.pod.cluster.local:9200"),
+			wantErr: errors.New("would dial: some-pod-name.bar.pod:9200"),
 		},
 		{
 			name: "should fail if the service is not listening on the specified port",
 			fields: fields{
 				network: "tcp",
-				addr:    "foo.bar.svc.cluster.local:1234",
+				addr:    "foo.bar.svc:1234",
 				client: fake.NewFakeClient(
 					&corev1.Service{
 						ObjectMeta: metav1.ObjectMeta{

--- a/operators/pkg/utils/k8s/k8sutils.go
+++ b/operators/pkg/utils/k8s/k8sutils.go
@@ -64,8 +64,7 @@ func GetPods(
 	return podList.Items, nil
 }
 
-// GetServiceFullyQualifiedHostname returns the fully qualified DNS name for a service
-func GetServiceFullyQualifiedHostname(svc corev1.Service) string {
-	// TODO: cluster.local suffix should be configurable
-	return fmt.Sprintf("%s.%s.svc.cluster.local", svc.Name, svc.Namespace)
+// GetServiceDNSName returns the fully qualified DNS name for a service
+func GetServiceDNSName(svc corev1.Service) string {
+	return fmt.Sprintf("%s.%s.svc", svc.Name, svc.Namespace)
 }

--- a/operators/pkg/utils/k8s/k8sutils_test.go
+++ b/operators/pkg/utils/k8s/k8sutils_test.go
@@ -30,7 +30,7 @@ func TestExtractNamespacedName(t *testing.T) {
 	)
 }
 
-func TestGetServiceFullyQualifiedHostname(t *testing.T) {
+func TestGetServiceDNSName(t *testing.T) {
 	type args struct {
 		svc corev1.Service
 	}
@@ -44,13 +44,13 @@ func TestGetServiceFullyQualifiedHostname(t *testing.T) {
 			args: args{
 				svc: v1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-name"}},
 			},
-			want: "test-name.test-ns.svc.cluster.local",
+			want: "test-name.test-ns.svc",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetServiceFullyQualifiedHostname(tt.args.svc); got != tt.want {
-				t.Errorf("GetServiceFullyQualifiedHostname() = %v, want %v", got, tt.want)
+			if got := GetServiceDNSName(tt.args.svc); got != tt.want {
+				t.Errorf("GetServiceDNSName() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/operators/test/e2e/helpers/apm.go
+++ b/operators/test/e2e/helpers/apm.go
@@ -40,7 +40,7 @@ func NewApmServerClient(as apmtype.ApmServer, k *K8sHelper) (*ApmClient, error) 
 	}
 
 	inClusterURL := fmt.Sprintf(
-		"http://%s.%s.svc.cluster.local:%d", as.Status.ExternalService, as.Namespace, config.DefaultHTTPPort,
+		"http://%s.%s.svc:%d", as.Status.ExternalService, as.Namespace, config.DefaultHTTPPort,
 	)
 
 	client := NewHTTPClient()

--- a/operators/test/e2e/helpers/elasticsearch.go
+++ b/operators/test/e2e/helpers/elasticsearch.go
@@ -28,7 +28,7 @@ func NewElasticsearchClient(es v1alpha1.Elasticsearch, k *K8sHelper) (client.Cli
 	if err != nil {
 		return nil, err
 	}
-	inClusterURL := fmt.Sprintf("https://%s.%s.svc.cluster.local:9200", name.HTTPService(es.Name), es.Namespace)
+	inClusterURL := fmt.Sprintf("https://%s.%s.svc:9200", name.HTTPService(es.Name), es.Namespace)
 	var dialer net.Dialer
 	if params.AutoPortForward {
 		dialer = portforward.NewForwardingDialer()

--- a/operators/test/e2e/stack/checks_kb.go
+++ b/operators/test/e2e/stack/checks_kb.go
@@ -39,7 +39,7 @@ func (check *kbChecks) CheckKbLoginHealthy(kb kbtype.Kibana) helpers.TestStep {
 	return helpers.TestStep{
 		Name: "Kibana should be able to connect to Elasticsearch",
 		Test: helpers.Eventually(func() error {
-			resp, err := check.client.Get(fmt.Sprintf("http://%s.%s.svc.cluster.local:5601", name.HTTPService(kb.Name), kb.Namespace))
+			resp, err := check.client.Get(fmt.Sprintf("http://%s.%s.svc:5601", name.HTTPService(kb.Name), kb.Namespace))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Removes our internal use of .cluster.local suffixes where possible.