### PR TITLE
Remove default discovery service

### DIFF
--- a/operators/pkg/controller/elasticsearch/driver/default.go
+++ b/operators/pkg/controller/elasticsearch/driver/default.go
@@ -142,7 +142,7 @@ func (d *defaultDriver) Reconcile(
 		d.Scheme,
 		d.CSRClient,
 		es,
-		[]corev1.Service{genericResources.DiscoveryService, genericResources.ExternalService},
+		[]corev1.Service{genericResources.ExternalService},
 		d.Parameters.CACertValidity,
 		d.Parameters.CACertRotateBefore,
 		d.Parameters.CertValidity,

--- a/operators/pkg/controller/elasticsearch/driver/generic_resources.go
+++ b/operators/pkg/controller/elasticsearch/driver/generic_resources.go
@@ -18,8 +18,6 @@ import (
 type GenericResources struct {
 	// ExternalService is the user-facing service
 	ExternalService corev1.Service
-	// DiscoveryService is the service used by ES for discovery purposes
-	DiscoveryService corev1.Service
 }
 
 // reconcileGenericResources reconciles the expected generic resources of a cluster.
@@ -32,20 +30,13 @@ func reconcileGenericResources(
 	// TODO: consider removing the "res" bits of the ReconcileService signature?
 	results := &reconciler.Results{}
 
-	discoveryService := services.NewDiscoveryService(es)
-	_, err := common.ReconcileService(c, scheme, discoveryService, &es)
-	if err != nil {
-		return nil, results.WithError(err)
-	}
-
 	externalService := services.NewExternalService(es)
-	_, err = common.ReconcileService(c, scheme, externalService, &es)
+	_, err := common.ReconcileService(c, scheme, externalService, &es)
 	if err != nil {
 		return nil, results.WithError(err)
 	}
 
 	return &GenericResources{
-		DiscoveryService: *discoveryService,
-		ExternalService:  *externalService,
+		ExternalService: *externalService,
 	}, results
 }

--- a/operators/pkg/controller/elasticsearch/name/name.go
+++ b/operators/pkg/controller/elasticsearch/name/name.go
@@ -28,7 +28,6 @@ const (
 	secureSettingsSecretSuffix  = "secure-settings"
 	certsSecretSuffix           = "certs"
 	httpServiceSuffix           = "http"
-	discoveryServiceSuffix      = "discovery"
 	elasticUserSecretSuffix     = "elastic-user"
 	esRolesUsersSecretSuffix    = "roles-users"
 	clusterSecretsSecretSuffix  = "secrets"
@@ -100,10 +99,6 @@ func TransportCertsSecret(podName string) string {
 
 func HTTPService(esName string) string {
 	return ESNamer.Suffix(esName, httpServiceSuffix)
-}
-
-func DiscoveryService(esName string) string {
-	return ESNamer.Suffix(esName, discoveryServiceSuffix)
 }
 
 func ElasticUserSecret(esName string) string {

--- a/operators/pkg/controller/elasticsearch/pod/pod.go
+++ b/operators/pkg/controller/elasticsearch/pod/pod.go
@@ -58,8 +58,6 @@ type NewPodSpecParams struct {
 	CustomImageName string
 	// ClusterName is the name of the Elasticsearch cluster
 	ClusterName string
-	// DiscoveryServiceName is the name of the Service that should be used for discovery.
-	DiscoveryServiceName string
 	// DiscoveryZenMinimumMasterNodes is the setting for minimum master node in Zen Discovery
 	DiscoveryZenMinimumMasterNodes int
 

--- a/operators/pkg/controller/elasticsearch/version/common.go
+++ b/operators/pkg/controller/elasticsearch/version/common.go
@@ -15,7 +15,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/name"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/pod"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/processmanager"
-	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/services"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/settings"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/volume"
@@ -45,11 +44,10 @@ func NewExpectedPodSpecs(
 		for i := int32(0); i < node.NodeCount; i++ {
 			params := pod.NewPodSpecParams{
 				// cluster-wide params
-				Version:              es.Spec.Version,
-				CustomImageName:      es.Spec.Image,
-				ClusterName:          es.Name,
-				DiscoveryServiceName: services.DiscoveryServiceName(es.Name),
-				SetVMMaxMapCount:     es.Spec.SetVMMaxMapCount,
+				Version:          es.Spec.Version,
+				CustomImageName:  es.Spec.Image,
+				ClusterName:      es.Name,
+				SetVMMaxMapCount: es.Spec.SetVMMaxMapCount,
 				// volumes
 				UsersSecretVolume:  paramsTmpl.UsersSecretVolume,
 				ConfigMapVolume:    paramsTmpl.ConfigMapVolume,

--- a/operators/pkg/controller/remotecluster/driver_incluster.go
+++ b/operators/pkg/controller/remotecluster/driver_incluster.go
@@ -9,22 +9,29 @@ import (
 
 	commonv1alpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/common/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/finalizer"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
-	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/services"
+	esname "github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/name"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
 	LocalTrustRelationshipPrefix  = "rc"
 	RemoteTrustRelationshipPrefix = "rcr"
+
+	// remoteClusterSeedServiceSuffix is the suffix used for the remote cluster seed service
+	remoteClusterSeedServiceSuffix = "remote-cluster-seed"
 )
 
 func doReconcile(
 	r *ReconcileRemoteCluster,
 	remoteCluster v1alpha1.RemoteCluster,
 ) (v1alpha1.RemoteClusterStatus, error) {
-
 	// Get the previous remote associated cluster, if the remote namespace has been updated by the user we must
 	// delete the remote relationship from the old namespace and recreate it in the new namespace.
 	if len(remoteCluster.Status.K8SLocalStatus.RemoteSelector.Namespace) > 0 &&
@@ -71,8 +78,12 @@ func doReconcile(
 		remoteCluster,
 		localClusterSelector,
 		remoteCluster.Spec.Remote.K8sLocalRef,
-		r.watches)
-	err := h.Handle(&remoteCluster, watchFinalizer)
+		r.watches,
+	)
+
+	seedServiceFinalizer := seedServiceFinalizer(r.Client, remoteCluster)
+
+	err := h.Handle(&remoteCluster, watchFinalizer, seedServiceFinalizer)
 	if err != nil {
 		return updateStatusWithPhase(&remoteCluster, v1alpha1.RemoteClusterFailed), err
 	}
@@ -140,18 +151,65 @@ func doReconcile(
 		return updateStatusWithPhase(&remoteCluster, v1alpha1.RemoteClusterFailed), err
 	}
 
+	// Create remote service for seeding
+	svc, err := reconcileRemoteClusterSeedService(r.Client, r.scheme, remoteCluster)
+	if err != nil {
+		return updateStatusWithPhase(&remoteCluster, v1alpha1.RemoteClusterFailed), err
+	}
+
 	// Build status
 	status := v1alpha1.RemoteClusterStatus{
 		Phase:                  v1alpha1.RemoteClusterPropagated,
 		ClusterName:            localClusterSelector.Name,
 		LocalTrustRelationship: localRelationshipName,
-		SeedHosts:              []string{services.ExternalDiscoveryServiceHostname(remote.Selector.NamespacedName())},
+		SeedHosts:              seedHostsFromService(svc),
 		K8SLocalStatus: v1alpha1.LocalRefStatus{
 			RemoteSelector:          remote.Selector,
 			RemoteTrustRelationship: remoteRelationshipName,
 		},
 	}
 	return status, nil
+}
+
+// reconcileRemoteClusterSeedService reconciles a Service that we can use as the remote cluster seed hosts.
+//
+// This service is shared between all remote clusters configured this way, and is deleted whenever any of them are
+// deleted in a finalizer. There's a watch that re-creates it if it's still in use.
+func reconcileRemoteClusterSeedService(
+	c k8s.Client,
+	scheme *runtime.Scheme,
+	remoteCluster v1alpha1.RemoteCluster,
+) (*v1.Service, error) {
+	ns := remoteCluster.Spec.Remote.K8sLocalRef.Namespace
+	// if the remote has no namespace, assume it's in the same namespace as the RemoteCluster resource
+	if ns == "" {
+		ns = remoteCluster.Namespace
+	}
+	service := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      remoteClusterSeedServiceName(remoteCluster.Spec.Remote.K8sLocalRef.Name),
+			Labels: map[string]string{
+				RemoteClusterSeedServiceForLabelName: remoteCluster.Spec.Remote.K8sLocalRef.Name,
+			},
+		},
+		Spec: v1.ServiceSpec{
+			PublishNotReadyAddresses: true,
+			Ports: []v1.ServicePort{
+				{Protocol: v1.ProtocolTCP, Port: 9300, TargetPort: intstr.FromInt(9300)},
+			},
+			Selector: map[string]string{
+				common.TypeLabelName:       label.Type,
+				label.ClusterNameLabelName: remoteCluster.Spec.Remote.K8sLocalRef.Name,
+			},
+		},
+	}
+
+	if _, err := common.ReconcileService(c, scheme, &service, nil); err != nil {
+		return nil, err
+	}
+
+	return &service, nil
 }
 
 func caCertMissingError(location string, selector commonv1alpha1.ObjectSelector) string {
@@ -170,4 +228,14 @@ func updateStatusWithPhase(
 	status := remoteCluster.Status.DeepCopy()
 	status.Phase = phase
 	return *status
+}
+
+// remoteClusterSeedServiceName returns the name of the remote cluster seed service.
+func remoteClusterSeedServiceName(esName string) string {
+	return esname.ESNamer.Suffix(esName, remoteClusterSeedServiceSuffix)
+}
+
+// seedHostsFromService returns the seed hosts to use for a given service.
+func seedHostsFromService(svc *v1.Service) []string {
+	return []string{fmt.Sprintf("%s.%s.svc:9300", svc.Name, svc.Namespace)}
 }

--- a/operators/pkg/controller/remotecluster/driver_incluster_test.go
+++ b/operators/pkg/controller/remotecluster/driver_incluster_test.go
@@ -153,13 +153,18 @@ func Test_apply(t *testing.T) {
 					},
 					RemoteTrustRelationship: "rcr-remotecluster-sample-1-2-default",
 				},
-				SeedHosts: []string{"trust-two-es-es-discovery.default.svc.cluster.local:9300"},
+				SeedHosts: []string{"trust-two-es-es-remote-cluster-seed.default.svc:9300"},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.NoError(t, tt.args.rca.watches.InjectScheme(sc))
+			if tt.args.rca.scheme == nil {
+				tt.args.rca.scheme = sc
+			}
+
+			assert.NoError(t, tt.args.rca.watches.InjectScheme(tt.args.rca.scheme))
+
 			got, err := doReconcile(tt.args.rca, tt.args.remoteCluster)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("apply() error = %v, wantErr %v", err, tt.wantErr)

--- a/operators/pkg/controller/remotecluster/finalizers.go
+++ b/operators/pkg/controller/remotecluster/finalizers.go
@@ -9,6 +9,10 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/finalizer"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/watches"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // watchFinalizer ensure that we remove watches for Secrets  we are no longer interested in
@@ -22,6 +26,29 @@ func watchFinalizer(
 		Execute: func() error {
 			w.Secrets.RemoveHandlerForKey(watchName(clusterAssociation, local))
 			w.Secrets.RemoveHandlerForKey(watchName(clusterAssociation, remote))
+			return nil
+		},
+	}
+}
+
+// seedServiceFinalizer ensures that we remove the seed service if it's no longer required
+func seedServiceFinalizer(c k8s.Client, remoteCluster v1alpha1.RemoteCluster) finalizer.Finalizer {
+	return finalizer.Finalizer{
+		Name: RemoteClusterSeedServiceFinalizer,
+		Execute: func() error {
+			svc := v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: remoteCluster.Spec.Remote.K8sLocalRef.Namespace,
+					Name:      remoteClusterSeedServiceName(remoteCluster.Spec.Remote.K8sLocalRef.Name),
+				},
+			}
+			if svc.Namespace == "" {
+				svc.Namespace = remoteCluster.Namespace
+			}
+
+			if err := c.Delete(&svc); err != nil && errors.IsNotFound(err) {
+				return err
+			}
 			return nil
 		},
 	}

--- a/operators/pkg/controller/remotecluster/finalizers_test.go
+++ b/operators/pkg/controller/remotecluster/finalizers_test.go
@@ -1,0 +1,114 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package remotecluster
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+)
+
+import (
+	commonv1alpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/common/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/finalizer"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func Test_seedServiceFinalizer(t *testing.T) {
+	esName := "foo"
+	esNamespace := "bar"
+	rc := &v1alpha1.RemoteCluster{
+		Spec: v1alpha1.RemoteClusterSpec{
+			Remote: v1alpha1.RemoteClusterRef{
+				K8sLocalRef: commonv1alpha1.ObjectSelector{
+					Name:      esName,
+					Namespace: esNamespace,
+				},
+			},
+		},
+	}
+
+	// remote cluster whose remote cluster has no namespace defined
+	rcNoRemoteClusterNamespace := rc.DeepCopy()
+	rcNoRemoteClusterNamespace.Namespace = esNamespace
+	rcNoRemoteClusterNamespace.Spec.Remote.K8sLocalRef.Namespace = ""
+
+	rcSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      remoteClusterSeedServiceName(esName),
+			Namespace: esNamespace,
+		},
+	}
+
+	otherSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      remoteClusterSeedServiceName(esName) + "-other",
+			Namespace: esNamespace,
+		},
+	}
+
+	type args struct {
+		c             k8s.Client
+		remoteCluster v1alpha1.RemoteCluster
+	}
+	tests := []struct {
+		name string
+		args args
+		want func(t *testing.T, c k8s.Client, f finalizer.Finalizer)
+	}{
+		{
+			name: "should delete the related remote cluster seed service",
+			args: args{
+				c:             k8s.WrapClient(fake.NewFakeClient(rc, rcSvc, otherSvc)),
+				remoteCluster: *rc,
+			},
+			want: func(t *testing.T, c k8s.Client, f finalizer.Finalizer) {
+				require.NoError(t, f.Execute())
+
+				// the service should be deleted
+				var svc v1.Service
+				err := c.Get(k8s.ExtractNamespacedName(rcSvc), &svc)
+				assert.Error(t, err)
+				assert.True(t, errors.IsNotFound(err))
+
+				// the other service should not be deleted
+				err = c.Get(k8s.ExtractNamespacedName(otherSvc), &svc)
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name: "should default the namespace of the remote cluster to the namespace of the remote cluster resource",
+			args: args{
+				c:             k8s.WrapClient(fake.NewFakeClient(rc, rcSvc, otherSvc)),
+				remoteCluster: *rc,
+			},
+			want: func(t *testing.T, c k8s.Client, f finalizer.Finalizer) {
+				require.NoError(t, f.Execute())
+
+				// the service should be deleted
+				var svc v1.Service
+				err := c.Get(k8s.ExtractNamespacedName(rcSvc), &svc)
+				assert.Error(t, err)
+				assert.True(t, errors.IsNotFound(err))
+
+				// the other service should not be deleted
+				err = c.Get(k8s.ExtractNamespacedName(otherSvc), &svc)
+				assert.NoError(t, err)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := seedServiceFinalizer(tt.args.c, tt.args.remoteCluster)
+			tt.want(t, tt.args.c, got)
+		})
+	}
+}

--- a/operators/pkg/controller/remotecluster/labels.go
+++ b/operators/pkg/controller/remotecluster/labels.go
@@ -14,10 +14,14 @@ import (
 const (
 	// RemoteClusterDynamicWatchesFinalizer designates a finalizer to clean up unused watches.
 	RemoteClusterDynamicWatchesFinalizer = "dynamic-watches.remotecluster.k8s.elastic.co"
+	// RemoteClusterSeedServiceFinalizer designates a finalizer to clean up a seed Service.
+	RemoteClusterSeedServiceFinalizer = "seed-service.remotecluster.k8s.elastic.co"
 	// RemoteClusterNamespaceLabelName used to represent the namespace of the RemoteCluster in a TrustRelationship.
 	RemoteClusterNamespaceLabelName = "remotecluster.k8s.elastic.co/namespace"
 	// RemoteClusterNameLabelName used to represent the name of the RemoteCluster in a TrustRelationship.
 	RemoteClusterNameLabelName = "remotecluster.k8s.elastic.co/name"
+	// RemoteClusterSeedServiceForLabelName is used to mark a service as used as a seed service for remote clusters.
+	RemoteClusterSeedServiceForLabelName = "remotecluster.k8s.elastic.co/seed-service-for"
 )
 
 func trustRelationshipObjectMeta(

--- a/operators/pkg/controller/remotecluster/watches_test.go
+++ b/operators/pkg/controller/remotecluster/watches_test.go
@@ -1,0 +1,100 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package remotecluster
+
+import (
+	"testing"
+
+	v1alpha12 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/common/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func Test_allRemoteClustersWithMatchingSeedServiceMapper(t *testing.T) {
+	esName := "foo"
+	esNamespace := "bar"
+
+	rc := &v1alpha1.RemoteCluster{
+		ObjectMeta: v12.ObjectMeta{
+			Namespace: esNamespace,
+			Name:      "my-rc",
+		},
+		Spec: v1alpha1.RemoteClusterSpec{
+			Remote: v1alpha1.RemoteClusterRef{
+				K8sLocalRef: v1alpha12.ObjectSelector{
+					Name:      esName,
+					Namespace: esNamespace,
+				},
+			},
+		},
+	}
+
+	// another RC that uses the same remote as rc
+	rc2 := rc.DeepCopy()
+	rc2.ObjectMeta.Name = "my-rc-2"
+
+	otherRc := &v1alpha1.RemoteCluster{
+		ObjectMeta: v12.ObjectMeta{
+			Namespace: esNamespace,
+			Name:      "my-rc-3",
+		},
+		Spec: v1alpha1.RemoteClusterSpec{
+			Remote: v1alpha1.RemoteClusterRef{
+				K8sLocalRef: v1alpha12.ObjectSelector{
+					Name:      "not-" + esName,
+					Namespace: esNamespace,
+				},
+			},
+		},
+	}
+
+	svc := v1.Service{
+		ObjectMeta: v12.ObjectMeta{
+			Namespace: esNamespace,
+			Name:      remoteClusterSeedServiceName(esName),
+			Labels: map[string]string{
+				RemoteClusterSeedServiceForLabelName: esName,
+			},
+		},
+	}
+
+	type args struct {
+		c k8s.Client
+	}
+	tests := []struct {
+		name string
+		args args
+		want func(t *testing.T, c k8s.Client, mapper handler.Mapper)
+	}{
+		{
+			name: "should return requests for only relevant remote clusters",
+			args: args{
+				c: k8s.WrapClient(fake.NewFakeClient(rc, rc2, otherRc)),
+			},
+			want: func(t *testing.T, c k8s.Client, mapper handler.Mapper) {
+				requests := mapper.Map(handler.MapObject{Meta: &svc, Object: &svc})
+
+				assert.Len(t, requests, 2)
+				assert.Contains(t, requests, reconcile.Request{NamespacedName: k8s.ExtractNamespacedName(rc)})
+				assert.Contains(t, requests, reconcile.Request{NamespacedName: k8s.ExtractNamespacedName(rc2)})
+
+				// otherRc should not show up in the reconciled requests.
+				assert.NotContains(t, requests, reconcile.Request{NamespacedName: k8s.ExtractNamespacedName(otherRc)})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := allRemoteClustersWithMatchingSeedServiceMapper(tt.args.c)
+			tt.want(t, tt.args.c, got)
+		})
+	}
+}

--- a/operators/test/e2e/failure_test.go
+++ b/operators/test/e2e/failure_test.go
@@ -152,15 +152,6 @@ func TestDeleteServices(t *testing.T) {
 	RunFailureTest(t, s, func(k *helpers.K8sHelper) helpers.TestStepList {
 		return helpers.TestStepList{
 			{
-				Name: "Delete discovery service",
-				Test: func(t *testing.T) {
-					s, err := k.GetService(s.Elasticsearch.Name + "-es-discovery")
-					require.NoError(t, err)
-					err = k.Client.Delete(s)
-					require.NoError(t, err)
-				},
-			},
-			{
 				Name: "Delete external service",
 				Test: func(t *testing.T) {
 					s, err := k.GetService(name.HTTPService(s.Elasticsearch.Name))

--- a/operators/test/e2e/stack/checks_k8s.go
+++ b/operators/test/e2e/stack/checks_k8s.go
@@ -282,7 +282,6 @@ func CheckServices(stack Builder, k *helpers.K8sHelper) helpers.TestStep {
 		Name: "Services should be created",
 		Test: helpers.Eventually(func() error {
 			for _, s := range []string{
-				stack.Elasticsearch.Name + "-es-discovery",
 				esname.HTTPService(stack.Elasticsearch.Name),
 				kbname.HTTPService(stack.Kibana.Name),
 			} {
@@ -301,7 +300,6 @@ func CheckServicesEndpoints(stack Builder, k *helpers.K8sHelper) helpers.TestSte
 		Name: "Services should have endpoints",
 		Test: helpers.Eventually(func() error {
 			for endpointName, addrCount := range map[string]int{
-				stack.Elasticsearch.Name + "-es-discovery":   int(stack.Elasticsearch.Spec.NodeCount()),
 				kbname.HTTPService(stack.Kibana.Name):        int(stack.Kibana.Spec.NodeCount),
 				esname.HTTPService(stack.Elasticsearch.Name): int(stack.Elasticsearch.Spec.NodeCount()),
 			} {


### PR DESCRIPTION
Leaves remote clusters in a working state by reconciling a `{remote}-es-remote-cluster-seed` Service in the remote namespace so we have something to give to Elasticsearch through `seed_hosts`.

Since we cannot set owners across namespaces, and this same service could be used by multiple remote clusters, we have to deal with its lifecycle a bit differently:

1. All remote cluster resources reconcile this service to ensure it exists.
2. When a RemoteCluster resource is deleted, a finalizer deletes the Service to clean up.
3. The remote cluster controller watches services and reconciles all related remote cluster resources upon changes (including deletion) to the services. This causes the service to be deleted when it /might/ not be required anymore, and re-created immediately if it is still required.