### PR TITLE
Simplify labeling of transport certificate secrets

### DIFF
--- a/operators/pkg/controller/elasticsearch/certificates/ca_reconcile.go
+++ b/operators/pkg/controller/elasticsearch/certificates/ca_reconcile.go
@@ -110,6 +110,7 @@ func Reconcile(
 	// reconcile transport certificates
 	result, err := transport.ReconcileTransportCertificateSecrets(
 		c,
+		scheme,
 		transportCA,
 		csrClient,
 		es,

--- a/operators/pkg/controller/elasticsearch/certificates/transport/csr.go
+++ b/operators/pkg/controller/elasticsearch/certificates/transport/csr.go
@@ -12,13 +12,12 @@ import (
 	"net"
 	"time"
 
-	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/initcontainer"
 	netutil "github.com/elastic/cloud-on-k8s/operators/pkg/utils/net"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // CSRRequestDelay limits the number of CSR requests we do in consecutive reconciliations

--- a/operators/pkg/controller/elasticsearch/certificates/transport/pod_secret.go
+++ b/operators/pkg/controller/elasticsearch/certificates/transport/pod_secret.go
@@ -5,81 +5,77 @@
 package transport
 
 import (
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/name"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"reflect"
 )
 
 const (
-	// LabelAssociatedPod is a label key that indicates the resource is supposed to have a named associated pod
-	LabelAssociatedPod = "transport.certificates.elasticsearch.k8s.elastic.co/associated-pod"
-
-	// LabelSecretUsage is a label key that specifies what the secret is used for
-	LabelSecretUsage = "transport.certificates.elasticsearch.k8s.elastic.co/secret-usage"
-	// LabelSecretUsageTransportCertificates is the LabelSecretUsage value used for transport certificates
-	LabelSecretUsageTransportCertificates = "transport-certificates"
-
-	// LabelTransportCertificateType is a label key indicating what the transport-certificates secret is used for
-	LabelTransportCertificateType = "transport.certificates.elasticsearch.k8s.elastic.co/certificate-type"
-	// LabelTransportCertificateTypeElasticsearchAll is the LabelTransportCertificateType value used for Elasticsearch
-	LabelTransportCertificateTypeElasticsearchAll = "elasticsearch.all"
+	// LabelCertificateType is a label key that specifies what type of certificates the secret contains
+	LabelCertificateType = "certificates.elasticsearch.k8s.elastic.co/type"
+	// LabelCertificateTypeTransport is the LabelCertificateType value used for transport certificates
+	LabelCertificateTypeTransport = "transport"
 
 	// LastCSRUpdateAnnotation is an annotation key to indicate the last time this secret's CSR was updated
 	LastCSRUpdateAnnotation = "transport.certificates.elasticsearch.k8s.elastic.co/last-csr-update"
 )
 
-// EnsureTransportCertificateSecretExists ensures the existence of the corev1.Secret that at a later point in time will
-// contain the transport certificates.
+// EnsureTransportCertificateSecretExists ensures the existence and Labels of the corev1.Secret that at a later point
+// in time will contain the transport certificates.
 func EnsureTransportCertificateSecretExists(
 	c k8s.Client,
 	scheme *runtime.Scheme,
 	owner metav1.Object,
 	pod corev1.Pod,
-	certificateType string,
 	labels map[string]string,
 ) (*corev1.Secret, error) {
-	secretRef := types.NamespacedName{
-		Namespace: pod.Namespace,
-		Name:      name.TransportCertsSecret(pod.Name),
-	}
+	expected := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: pod.Namespace,
+			Name:      name.TransportCertsSecret(pod.Name),
 
-	var secret corev1.Secret
-	if err := c.Get(secretRef, &secret); err != nil && !apierrors.IsNotFound(err) {
-		return nil, err
-	} else if apierrors.IsNotFound(err) {
-		secret = corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretRef.Name,
-				Namespace: secretRef.Namespace,
-
-				Labels: map[string]string{
-					// store the pod that this Secret will be mounted to so we can traverse from secret -> pod
-					LabelAssociatedPod:            pod.Name,
-					LabelSecretUsage:              LabelSecretUsageTransportCertificates,
-					LabelTransportCertificateType: certificateType,
-				},
+			Labels: map[string]string{
+				// a label that allows us to list secrets of this type
+				LabelCertificateType: LabelCertificateTypeTransport,
+				// a label that references the pod so we can look up the pod from this secret
+				label.PodNameLabelName: pod.Name,
 			},
-		}
-
-		// apply any provided labels
-		for key, value := range labels {
-			secret.Labels[key] = value
-		}
-
-		if err := controllerutil.SetControllerReference(owner, &secret, scheme); err != nil {
-			return nil, err
-		}
-
-		if err := c.Create(&secret); err != nil {
-			return nil, err
-		}
+		},
+	}
+	// apply any provided labels
+	for key, value := range labels {
+		expected.Labels[key] = value
 	}
 
-	// TODO: in the future we should consider reconciling the existing secret as well instead of leaving it untouched.
-	return &secret, nil
+	// reconcile the secret resource
+	var reconciled corev1.Secret
+	if err := reconciler.ReconcileResource(reconciler.Params{
+		Client:     c,
+		Scheme:     scheme,
+		Owner:      owner,
+		Expected:   &expected,
+		Reconciled: &reconciled,
+		NeedsUpdate: func() bool {
+			// we only care about labels, not contents
+			return reflect.DeepEqual(expected.Labels, reconciled.Labels)
+		},
+		UpdateReconciled: func() {
+			if reconciled.Labels == nil {
+				reconciled.Labels = expected.Labels
+			} else {
+				for k, v := range expected.Labels {
+					reconciled.Labels[k] = v
+				}
+			}
+		},
+	}); err != nil {
+		return nil, err
+	}
+
+	return &reconciled, nil
 }

--- a/operators/pkg/controller/elasticsearch/certificates/transport/pod_secret_test.go
+++ b/operators/pkg/controller/elasticsearch/certificates/transport/pod_secret_test.go
@@ -7,6 +7,7 @@ package transport
 import (
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -27,13 +28,18 @@ func TestEnsureTransportCertificateSecretExists(t *testing.T) {
 			Name: "pod-certs",
 		},
 	}
+	es := v1alpha1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-es",
+		},
+	}
 
 	type args struct {
-		c               k8s.Client
-		scheme          *runtime.Scheme
-		owner           metav1.Object
-		pod             corev1.Pod
-		labels          map[string]string
+		c      k8s.Client
+		scheme *runtime.Scheme
+		owner  v1alpha1.Elasticsearch
+		pod    corev1.Pod
+		labels map[string]string
 	}
 	tests := []struct {
 		name    string
@@ -44,8 +50,9 @@ func TestEnsureTransportCertificateSecretExists(t *testing.T) {
 		{
 			name: "should create a secret if it does not already exist",
 			args: args{
-				c:               k8s.WrapClient(fake.NewFakeClient()),
-				pod:             pod,
+				c:     k8s.WrapClient(fake.NewFakeClient()),
+				owner: es,
+				pod:   pod,
 			},
 			want: func(t *testing.T, secret *corev1.Secret) {
 				if assert.Contains(t, secret.Labels, LabelCertificateType) {
@@ -57,8 +64,9 @@ func TestEnsureTransportCertificateSecretExists(t *testing.T) {
 		{
 			name: "should not create a new secret if it already exists",
 			args: args{
-				c:   k8s.WrapClient(fake.NewFakeClient(preExistingSecret)),
-				pod: pod,
+				c:     k8s.WrapClient(fake.NewFakeClient(preExistingSecret)),
+				owner: es,
+				pod:   pod,
 			},
 			want: func(t *testing.T, secret *corev1.Secret) {
 				assert.Equal(t, preExistingSecret, secret)
@@ -71,11 +79,7 @@ func TestEnsureTransportCertificateSecretExists(t *testing.T) {
 				tt.args.scheme = scheme.Scheme
 			}
 
-			if tt.args.owner == nil {
-				tt.args.owner = &pod
-			}
-
-			got, err := EnsureTransportCertificateSecretExists(tt.args.c, tt.args.scheme, tt.args.owner, tt.args.pod, tt.args.labels)
+			got, err := EnsureTransportCertificateSecretExists(tt.args.c, tt.args.scheme, tt.args.owner, tt.args.pod)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("EnsureTransportCertificateSecretExists() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/operators/pkg/controller/elasticsearch/certificates/transport/pod_secret_test.go
+++ b/operators/pkg/controller/elasticsearch/certificates/transport/pod_secret_test.go
@@ -33,7 +33,6 @@ func TestEnsureTransportCertificateSecretExists(t *testing.T) {
 		scheme          *runtime.Scheme
 		owner           metav1.Object
 		pod             corev1.Pod
-		certificateType string
 		labels          map[string]string
 	}
 	tests := []struct {
@@ -46,12 +45,12 @@ func TestEnsureTransportCertificateSecretExists(t *testing.T) {
 			name: "should create a secret if it does not already exist",
 			args: args{
 				c:               k8s.WrapClient(fake.NewFakeClient()),
-				certificateType: LabelTransportCertificateTypeElasticsearchAll,
 				pod:             pod,
 			},
 			want: func(t *testing.T, secret *corev1.Secret) {
-				assert.Contains(t, secret.Labels, LabelTransportCertificateType)
-				assert.Equal(t, secret.Labels[LabelTransportCertificateType], LabelTransportCertificateTypeElasticsearchAll)
+				if assert.Contains(t, secret.Labels, LabelCertificateType) {
+					assert.Equal(t, secret.Labels[LabelCertificateType], LabelCertificateTypeTransport)
+				}
 				assert.Equal(t, "pod-certs", secret.Name)
 			},
 		},
@@ -76,7 +75,7 @@ func TestEnsureTransportCertificateSecretExists(t *testing.T) {
 				tt.args.owner = &pod
 			}
 
-			got, err := EnsureTransportCertificateSecretExists(tt.args.c, tt.args.scheme, tt.args.owner, tt.args.pod, tt.args.certificateType, tt.args.labels)
+			got, err := EnsureTransportCertificateSecretExists(tt.args.c, tt.args.scheme, tt.args.owner, tt.args.pod, tt.args.labels)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("EnsureTransportCertificateSecretExists() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/operators/pkg/controller/elasticsearch/certificates/transport/reconcile.go
+++ b/operators/pkg/controller/elasticsearch/certificates/transport/reconcile.go
@@ -17,9 +17,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -31,6 +29,7 @@ var log = logf.KBLog.WithName("transport")
 // of the given es cluster.
 func ReconcileTransportCertificateSecrets(
 	c k8s.Client,
+	scheme *runtime.Scheme,
 	ca *certificates.CA,
 	csrClient certificates.CSRClient,
 	es v1alpha1.Elasticsearch,
@@ -51,37 +50,21 @@ func ReconcileTransportCertificateSecrets(
 		additionalCAs = append(additionalCAs, []byte(trustRelationship.Spec.CaCert))
 	}
 
-	// get all existing transport certificate secrets for this cluster
-	certificateSecrets, err := findTransportCertificateSecrets(c, es)
-	if err != nil {
+	var pods corev1.PodList
+	if err := c.List(&client.ListOptions{
+		LabelSelector: label.NewLabelSelectorForElasticsearch(es),
+	}, &pods); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	for _, secret := range certificateSecrets {
-		// retrieve pod associated to this secret
-		podName, ok := secret.Labels[label.PodNameLabelName]
-		if !ok {
-			return reconcile.Result{}, fmt.Errorf("cannot find pod name in labels of secret %s", secret.Name)
-		}
-
-		var pod corev1.Pod
-		if err := c.Get(types.NamespacedName{Namespace: secret.Namespace, Name: podName}, &pod); err != nil {
-			if !apierrors.IsNotFound(err) {
-				return reconcile.Result{}, err
-			}
-
-			// pod does not exist yet, or has been deleted and this secret will be garbage collected by the cleanup
-			// package
-			continue
-		}
-
+	for _, pod := range pods.Items {
 		if pod.Status.PodIP == "" {
-			log.Info("Skipping secret because associated pod has no pod ip", "secret", secret.Name)
+			log.Info("Skipping pod because it has no IP yet", "pod", pod.Name)
 			continue
 		}
 
 		if res, err := doReconcileTransportCertificateSecret(
-			c, secret, pod, csrClient, es, services, ca, additionalCAs, certValidity, certRotateBefore,
+			c, scheme, es, pod, csrClient, services, ca, additionalCAs, certValidity, certRotateBefore,
 		); err != nil {
 			return res, err
 		}
@@ -90,40 +73,24 @@ func ReconcileTransportCertificateSecrets(
 	return reconcile.Result{}, nil
 }
 
-// findTransportCertificateSecrets returns all Secrets containing transport certificates.
-func findTransportCertificateSecrets(
-	c k8s.Client,
-	es v1alpha1.Elasticsearch,
-) ([]corev1.Secret, error) {
-	var certificateSecrets corev1.SecretList
-
-	listOptions := client.ListOptions{
-		Namespace: es.Namespace,
-		LabelSelector: labels.Set(map[string]string{
-			label.ClusterNameLabelName: es.Name,
-			LabelCertificateType:       LabelCertificateTypeTransport,
-		}).AsSelector(),
-	}
-	if err := c.List(&listOptions, &certificateSecrets); err != nil {
-		return nil, err
-	}
-
-	return certificateSecrets.Items, nil
-}
-
 // doReconcileTransportCertificateSecret ensures that the transport certificate secret has the correct content.
 func doReconcileTransportCertificateSecret(
 	c k8s.Client,
-	secret corev1.Secret,
+	scheme *runtime.Scheme,
+	es v1alpha1.Elasticsearch,
 	pod corev1.Pod,
 	csrClient certificates.CSRClient,
-	cluster v1alpha1.Elasticsearch,
 	svcs []corev1.Service,
 	ca *certificates.CA,
 	additionalTrustedCAsPemEncoded [][]byte,
 	certValidity time.Duration,
 	certReconcileBefore time.Duration,
 ) (reconcile.Result, error) {
+	secret, err := EnsureTransportCertificateSecretExists(c, scheme, es, pod)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// a placeholder secret may have nil entries, create them if needed
 	if secret.Data == nil {
 		secret.Data = make(map[string][]byte)
@@ -136,7 +103,7 @@ func doReconcileTransportCertificateSecret(
 	lastCSRUpdate := secret.Annotations[LastCSRUpdateAnnotation] // may be empty
 
 	// check if the existing cert is correct
-	issueNewCertificate := shouldIssueNewCertificate(cluster, svcs, secret, ca, pod, certReconcileBefore)
+	issueNewCertificate := shouldIssueNewCertificate(es, svcs, *secret, ca, pod, certReconcileBefore)
 
 	// if needed, replace the CSR by a fresh one
 	newCSR, err := maybeRequestCSR(pod, csrClient, lastCSRUpdate)
@@ -159,9 +126,8 @@ func doReconcileTransportCertificateSecret(
 	if issueNewCertificate {
 		log.Info(
 			"Issuing new certificate",
-			"secret", secret.Name,
-			"clusterName", cluster.Name,
-			"namespace", cluster.Namespace,
+			"pod", pod.Name,
+			"cluster", k8s.ExtractNamespacedName(&es),
 		)
 
 		// create a cert from the csr
@@ -169,7 +135,7 @@ func doReconcileTransportCertificateSecret(
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		validatedCertificateTemplate, err := CreateValidatedCertificateTemplate(pod, cluster, svcs, parsedCSR, certValidity)
+		validatedCertificateTemplate, err := CreateValidatedCertificateTemplate(pod, es, svcs, parsedCSR, certValidity)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -200,7 +166,7 @@ func doReconcileTransportCertificateSecret(
 
 	if issueNewCertificate || updateTrustedCACerts {
 		log.Info("Updating transport certificate secret", "secret", secret.Name)
-		if err := c.Update(&secret); err != nil {
+		if err := c.Update(secret); err != nil {
 			return reconcile.Result{}, err
 		}
 		annotation.MarkPodAsUpdated(c, pod)

--- a/operators/pkg/controller/elasticsearch/driver/pods.go
+++ b/operators/pkg/controller/elasticsearch/driver/pods.go
@@ -95,10 +95,8 @@ func createElasticsearchPod(
 	transportCertificatesSecret, err := transport.EnsureTransportCertificateSecretExists(
 		c,
 		scheme,
-		&es,
+		es,
 		pod,
-		// add the cluster name label so we select all the transport certificates secrets associated with a cluster easily
-		map[string]string{label.ClusterNameLabelName: es.Name},
 	)
 	if err != nil {
 		return err

--- a/operators/pkg/controller/elasticsearch/driver/pods.go
+++ b/operators/pkg/controller/elasticsearch/driver/pods.go
@@ -97,7 +97,6 @@ func createElasticsearchPod(
 		scheme,
 		&es,
 		pod,
-		transport.LabelTransportCertificateTypeElasticsearchAll,
 		// add the cluster name label so we select all the transport certificates secrets associated with a cluster easily
 		map[string]string{label.ClusterNameLabelName: es.Name},
 	)


### PR DESCRIPTION
Removes a bunch of superfluous labels from the transport certificate secrets.

Also reconciles transport certificate secrets by starting with the current Pods, which is foundational to being able to re-create {pod.name}-certs secrets if they are deleted from the API.

The remaining reason for not being able to re-create is that it's not possible to re-request the CSR from the pod (it can only be retrieved once during initialization).