### PR TITLE
Don't override user-provided labels from Kibana podTemplate

### DIFF
--- a/operators/pkg/controller/apmserver/pod.go
+++ b/operators/pkg/controller/apmserver/pod.go
@@ -5,12 +5,13 @@
 package apmserver
 
 import (
-	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/apmserver/config"
-	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/volume"
-	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/stringsutil"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/apmserver/config"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/volume"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/stringsutil"
 )
 
 const (

--- a/operators/pkg/controller/common/overrides/labels.go
+++ b/operators/pkg/controller/common/overrides/labels.go
@@ -1,0 +1,21 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package overrides
+
+// SetDefaultLabels append labels from defaults into existing. If a label already exists,
+// its value is not overridden from the one in defaults.
+// One use case here is to inherit user-provided labels, and append our own only if not already
+// set by the user.
+func SetDefaultLabels(existing map[string]string, defaults map[string]string) map[string]string {
+	if existing == nil {
+		existing = make(map[string]string, len(defaults))
+	}
+	for k, v := range defaults {
+		if _, exists := existing[k]; !exists {
+			existing[k] = v
+		}
+	}
+	return existing
+}

--- a/operators/pkg/controller/common/overrides/labels_test.go
+++ b/operators/pkg/controller/common/overrides/labels_test.go
@@ -1,0 +1,45 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package overrides
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSetDefaultLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing map[string]string
+		defaults map[string]string
+		want     map[string]string
+	}{
+		{
+			name:     "nil existing is correctly handled",
+			existing: nil,
+			defaults: map[string]string{"a": "b", "c": "d"},
+			want:     map[string]string{"a": "b", "c": "d"},
+		},
+		{
+			name:     "no conflict",
+			existing: map[string]string{"a": "b", "c": "d"},
+			defaults: map[string]string{"e": "f", "g": "h"},
+			want:     map[string]string{"a": "b", "c": "d", "e": "f", "g": "h"},
+		},
+		{
+			name:     "in case of conflict, keep existing value",
+			existing: map[string]string{"a": "b", "c": "d"},
+			defaults: map[string]string{"a": "conflicting", "e": "f"},
+			want:     map[string]string{"a": "b", "c": "d", "e": "f"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SetDefaultLabels(tt.existing, tt.defaults); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SetDefaultLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/operators/pkg/controller/elasticsearch/version/common.go
+++ b/operators/pkg/controller/elasticsearch/version/common.go
@@ -262,23 +262,12 @@ func NewPod(
 	objectMeta.Name = name.NewPodName(es.Name, podSpecCtx.NodeSpec)
 	objectMeta.Namespace = es.Namespace
 
-	// build labels on top of user-provided ones
-	if objectMeta.Labels == nil {
-		objectMeta.Labels = map[string]string{}
-	}
-
 	cfg, err := podSpecCtx.Config.Unpack()
 	if err != nil {
 		return corev1.Pod{}, err
 	}
-
-	for k, v := range label.NewPodLabels(es, version, cfg) {
-		// don't override user-provided labels
-		// this may lead to issues but we consider users know what they are doing at this point.
-		if _, exists := objectMeta.Labels[k]; !exists {
-			objectMeta.Labels[k] = v
-		}
-	}
+	// add labels on top of user-provided ones, but don't override them
+	objectMeta.Labels = overrides.SetDefaultLabels(objectMeta.Labels, label.NewPodLabels(es, version, cfg))
 
 	if podSpecCtx.PodSpec.Hostname == "" {
 		podSpecCtx.PodSpec.Hostname = objectMeta.Name

--- a/operators/pkg/controller/kibana/pod/pod.go
+++ b/operators/pkg/controller/kibana/pod/pod.go
@@ -36,12 +36,15 @@ func NewPodTemplateSpec(kb v1alpha1.Kibana) corev1.PodTemplateSpec {
 	objectMeta := kb.Spec.PodTemplate.ObjectMeta.DeepCopy()
 	spec := kb.Spec.PodTemplate.Spec.DeepCopy()
 
-	// add (or override) our labels on top of user-provided ones
 	if objectMeta.Labels == nil {
 		objectMeta.Labels = map[string]string{}
 	}
+	// add our labels on top of user-provided ones,
+	// only if not already specified by the user
 	for k, v := range label.NewLabels(kb.Name) {
-		objectMeta.Labels[k] = v
+		if _, exists := objectMeta.Labels[k]; !exists {
+			objectMeta.Labels[k] = v
+		}
 	}
 
 	// disable service account token automount unless enabled by the user

--- a/operators/pkg/controller/kibana/pod/pod.go
+++ b/operators/pkg/controller/kibana/pod/pod.go
@@ -6,6 +6,7 @@ package pod
 
 import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/kibana/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/overrides"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/kibana/label"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/stringsutil"
 
@@ -36,16 +37,11 @@ func NewPodTemplateSpec(kb v1alpha1.Kibana) corev1.PodTemplateSpec {
 	objectMeta := kb.Spec.PodTemplate.ObjectMeta.DeepCopy()
 	spec := kb.Spec.PodTemplate.Spec.DeepCopy()
 
+	// add our labels on top of user-provided ones (but don't override)
 	if objectMeta.Labels == nil {
 		objectMeta.Labels = map[string]string{}
 	}
-	// add our labels on top of user-provided ones,
-	// only if not already specified by the user
-	for k, v := range label.NewLabels(kb.Name) {
-		if _, exists := objectMeta.Labels[k]; !exists {
-			objectMeta.Labels[k] = v
-		}
-	}
+	objectMeta.Labels = overrides.SetDefaultLabels(objectMeta.Labels, label.NewLabels(kb.Name))
 
 	// disable service account token automount unless enabled by the user
 	varFalse := false


### PR DESCRIPTION
This allows users to override labels set by the operator, and potentially
shoot themselves in the foot; but it's consistent with the way we do
things for other podTemplate sections.