### PR TITLE
Fix object deletion in association

### DIFF
--- a/operators/pkg/apis/common/v1alpha1/common.go
+++ b/operators/pkg/apis/common/v1alpha1/common.go
@@ -32,7 +32,7 @@ func (s ObjectSelector) NamespacedName() types.NamespacedName {
 	}
 }
 
-// IsDefined checks if the object selector is not nil and has both a name and a namespace.
+// IsDefined checks if the object selector is not nil and has a name.
 // Namespace is not mandatory as it may be inherited by the parent object.
 func (s *ObjectSelector) IsDefined() bool {
 	return s != nil && s.Name != ""

--- a/operators/pkg/apis/common/v1alpha1/common.go
+++ b/operators/pkg/apis/common/v1alpha1/common.go
@@ -33,8 +33,9 @@ func (s ObjectSelector) NamespacedName() types.NamespacedName {
 }
 
 // IsDefined checks if the object selector is not nil and has both a name and a namespace.
+// Namespace is not mandatory as it may be inherited by the parent object.
 func (s *ObjectSelector) IsDefined() bool {
-	return s != nil && s.Name != "" && s.Namespace != ""
+	return s != nil && s.Name != ""
 }
 
 // HTTPConfig configures a HTTP-based service.

--- a/operators/pkg/controller/kibanaassociation/association_controller_test.go
+++ b/operators/pkg/controller/kibanaassociation/association_controller_test.go
@@ -76,13 +76,7 @@ func Test_deleteOrphanedResources(t *testing.T) {
 				},
 			},
 			postCondition: func(c k8s.Client) {
-				assertExpectObjectsExist(t, c)
-				// user CR should be in ES namespace
-				/*assert.NoError(t, c.Get(types.NamespacedName{
-					Namespace: esFixture.Namespace,
-					Name:      userName,
-				}, &corev1.Secret{}),
-					"Elasticsearch should not be deleted")*/
+				assertExpectObjectsExist(t, c) // all objects must be exist
 			},
 			wantErr: false,
 		},

--- a/operators/pkg/controller/kibanaassociation/association_controller_test.go
+++ b/operators/pkg/controller/kibanaassociation/association_controller_test.go
@@ -7,9 +7,8 @@ package kibanaassociation
 import (
 	"testing"
 
-	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
-
 	commonv1alpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/common/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	kbtype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/kibana/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/user"
@@ -33,12 +32,64 @@ func Test_deleteOrphanedResources(t *testing.T) {
 		wantErr        bool
 	}{
 		{
+			name: "Do not delete if there's no namespace in the ref",
+			kibana: kbtype.Kibana{
+				ObjectMeta: kibanaFixtureObjectMeta,
+				Spec: kbtype.KibanaSpec{
+					ElasticsearchRef: commonv1alpha1.ObjectSelector{ // ElasticsearchRef without a namespace
+						Name: esFixture.Name,
+						//Namespace: esFixture.Namespace, No namespace on purpose
+					},
+				},
+			},
+			initialObjects: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      userSecretName,
+						Namespace: kibanaFixture.Namespace,
+						OwnerReferences: []metav1.OwnerReference{
+							ownerRefFixture,
+						},
+					},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      CACertSecretName(kibanaFixture.Name),
+						Namespace: kibanaFixture.Namespace,
+						OwnerReferences: []metav1.OwnerReference{
+							ownerRefFixture,
+						},
+					},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      userName,
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							esRefFixture,
+						},
+						Labels: map[string]string{
+							AssociationLabelName: kibanaFixture.Name,
+							common.TypeLabelName: user.UserType,
+						},
+					},
+				},
+			},
+			postCondition: func(c k8s.Client) {
+				assertExpectObjectsExist(t, c)
+				// user CR should be in ES namespace
+				/*assert.NoError(t, c.Get(types.NamespacedName{
+					Namespace: esFixture.Namespace,
+					Name:      userName,
+				}, &corev1.Secret{}),
+					"Elasticsearch should not be deleted")*/
+			},
+			wantErr: false,
+		},
+		{
 			name: "ES namespace has changed ",
 			kibana: kbtype.Kibana{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "kibana-foo",
-					Namespace: "default",
-				},
+				ObjectMeta: kibanaFixtureObjectMeta,
 				Spec: kbtype.KibanaSpec{
 					ElasticsearchRef: commonv1alpha1.ObjectSelector{
 						Name:      esFixture.Name,
@@ -70,11 +121,12 @@ func Test_deleteOrphanedResources(t *testing.T) {
 						Name:      userName,
 						Namespace: "default", // but we still have a user secret in default
 						OwnerReferences: []metav1.OwnerReference{
-							ownerRefFixture,
+							esRefFixture,
 						},
 						Labels: map[string]string{
-							AssociationLabelName: kibanaFixture.Name,
-							common.TypeLabelName: user.UserType,
+							AssociationLabelName:      kibanaFixture.Name,
+							AssociationLabelNamespace: kibanaFixture.Namespace,
+							common.TypeLabelName:      user.UserType,
 						},
 					},
 				},
@@ -122,7 +174,7 @@ func Test_deleteOrphanedResources(t *testing.T) {
 						Name:      userName,
 						Namespace: kibanaFixture.Namespace,
 						OwnerReferences: []metav1.OwnerReference{
-							ownerRefFixture,
+							esRefFixture,
 						},
 					},
 				},
@@ -135,10 +187,7 @@ func Test_deleteOrphanedResources(t *testing.T) {
 		{
 			name: "No more es ref in Kibana, orphan user & CA for previous es ref exist",
 			kibana: kbtype.Kibana{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "kibana-foo",
-					Namespace: "default",
-				},
+				ObjectMeta: kibanaFixtureObjectMeta,
 			},
 			es: esFixture,
 			initialObjects: []runtime.Object{
@@ -159,10 +208,11 @@ func Test_deleteOrphanedResources(t *testing.T) {
 						Name:      userName,
 						Namespace: kibanaFixture.Namespace,
 						Labels: map[string]string{
-							AssociationLabelName: kibanaFixture.Name,
+							AssociationLabelName:      kibanaFixture.Name,
+							AssociationLabelNamespace: kibanaFixture.Namespace,
 						},
 						OwnerReferences: []metav1.OwnerReference{
-							ownerRefFixture,
+							esRefFixture,
 						},
 					},
 				},

--- a/operators/pkg/controller/kibanaassociation/labels.go
+++ b/operators/pkg/controller/kibanaassociation/labels.go
@@ -28,11 +28,11 @@ func NewResourceSelector(name string) labels.Selector {
 }
 
 func hasBeenCreatedBy(object metav1.Object, kibana v1alpha1.Kibana) bool {
-	label := object.GetLabels()
-	if name, ok := label[AssociationLabelName]; !ok || name != kibana.Name {
+	labels := object.GetLabels()
+	if name, ok := labels[AssociationLabelName]; !ok || name != kibana.Name {
 		return false
 	}
-	if ns, ok := label[AssociationLabelNamespace]; !ok || ns != kibana.Namespace {
+	if ns, ok := labels[AssociationLabelNamespace]; !ok || ns != kibana.Namespace {
 		return false
 	}
 	return true

--- a/operators/pkg/controller/kibanaassociation/labels.go
+++ b/operators/pkg/controller/kibanaassociation/labels.go
@@ -5,6 +5,7 @@
 package kibanaassociation
 
 import (
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/kibana/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/user"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,6 +25,17 @@ func NewResourceSelector(name string) labels.Selector {
 	return labels.Set(map[string]string{
 		AssociationLabelName: name,
 	}).AsSelector()
+}
+
+func hasBeenCreatedBy(object metav1.Object, kibana v1alpha1.Kibana) bool {
+	label := object.GetLabels()
+	if name, ok := label[AssociationLabelName]; !ok || name != kibana.Name {
+		return false
+	}
+	if ns, ok := label[AssociationLabelNamespace]; !ok || ns != kibana.Namespace {
+		return false
+	}
+	return true
 }
 
 func NewUserLabelSelector(

--- a/operators/pkg/controller/kibanaassociation/user_test.go
+++ b/operators/pkg/controller/kibanaassociation/user_test.go
@@ -34,14 +34,28 @@ var esFixture = estype.Elasticsearch{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "es-foo",
 		Namespace: "default",
+		UID:       "f8d564d9-885e-11e9-896d-08002703f062",
 	},
+}
+var esRefFixture = metav1.OwnerReference{
+	APIVersion:         "elasticsearch.k8s.elastic.co/v1alpha1",
+	Kind:               "Elasticsearch",
+	Name:               "es-foo",
+	UID:                "f8d564d9-885e-11e9-896d-08002703f062",
+	Controller:         &t,
+	BlockOwnerDeletion: &t,
+}
+
+var kibanaFixtureUID types.UID = "82257b19-8862-11e9-896d-08002703f062"
+
+var kibanaFixtureObjectMeta = metav1.ObjectMeta{
+	Name:      "kibana-foo",
+	Namespace: "default",
+	UID:       kibanaFixtureUID,
 }
 
 var kibanaFixture = kbtype.Kibana{
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "kibana-foo",
-		Namespace: "default",
-	},
+	ObjectMeta: kibanaFixtureObjectMeta,
 	Spec: kbtype.KibanaSpec{
 		ElasticsearchRef: commonv1alpha1.ObjectSelector{
 			Name:      esFixture.Name,
@@ -55,7 +69,7 @@ var ownerRefFixture = metav1.OwnerReference{
 	APIVersion:         "kibana.k8s.elastic.co/v1alpha1",
 	Kind:               "Kibana",
 	Name:               "foo",
-	UID:                "",
+	UID:                kibanaFixtureUID,
 	Controller:         &t,
 	BlockOwnerDeletion: &t,
 }


### PR DESCRIPTION
This PR fixes a problem that occurs when the namespace of Elasticsearch is not set in the reference of an association.
It also adds and fixes the relevant unit tests.

It is worth to note that `metav1.IsControlledBy` only works properly if the objects used in unit tests have a `UID`