### PR TITLE
Consider more defaulted values when comparing Services for reconciliation

### DIFF
--- a/operators/pkg/controller/common/service_control.go
+++ b/operators/pkg/controller/common/service_control.go
@@ -50,6 +50,17 @@ func needsUpdate(expected *corev1.Service, reconciled *corev1.Service) bool {
 	if expected.Spec.ClusterIP == "" {
 		expected.Spec.ClusterIP = reconciled.Spec.ClusterIP
 	}
+
+	// Type may be defaulted by the api server
+	if expected.Spec.Type == "" {
+		expected.Spec.Type = reconciled.Spec.Type
+	}
+
+	// SessionAffinity may be defaulted by the api server
+	if expected.Spec.SessionAffinity == "" {
+		expected.Spec.SessionAffinity = reconciled.Spec.SessionAffinity
+	}
+
 	// same for the target port and node port
 	if len(expected.Spec.Ports) == len(reconciled.Spec.Ports) {
 		for i := range expected.Spec.Ports {
@@ -62,6 +73,7 @@ func needsUpdate(expected *corev1.Service, reconciled *corev1.Service) bool {
 			}
 		}
 	}
+
 	return !reflect.DeepEqual(expected.Spec, reconciled.Spec)
 }
 

--- a/operators/pkg/controller/common/service_control_test.go
+++ b/operators/pkg/controller/common/service_control_test.go
@@ -23,31 +23,39 @@ func TestNeedsUpdate(t *testing.T) {
 		want corev1.Service
 	}{
 		{
-			name: "Reconciled clusterIP is used if expected clusterIP is empty",
+			name: "Reconciled ClusterIP/Type/SessionAffinity is used if expected ClusterIP/Type/SessionAffinity is empty",
 			args: args{
-				expected: corev1.Service{Spec: corev1.ServiceSpec{
-					Type: corev1.ServiceTypeClusterIP, ClusterIP: "",
-				}},
+				expected: corev1.Service{Spec: corev1.ServiceSpec{}},
 				reconciled: corev1.Service{Spec: corev1.ServiceSpec{
-					Type: corev1.ServiceTypeClusterIP, ClusterIP: "1.2.3.4",
+					Type:            corev1.ServiceTypeClusterIP,
+					ClusterIP:       "1.2.3.4",
+					SessionAffinity: corev1.ServiceAffinityClientIP,
 				}},
 			},
 			want: corev1.Service{Spec: corev1.ServiceSpec{
-				Type: corev1.ServiceTypeClusterIP, ClusterIP: "1.2.3.4",
+				Type:            corev1.ServiceTypeClusterIP,
+				ClusterIP:       "1.2.3.4",
+				SessionAffinity: corev1.ServiceAffinityClientIP,
 			}},
 		},
 		{
-			name: "Reconciled clusterIP is not used if expected clusterIP is set",
+			name: "Reconciled ClusterIP/Type/SessionAffinity is not used if expected ClusterIP/Type/SessionAffinity is set",
 			args: args{
 				expected: corev1.Service{Spec: corev1.ServiceSpec{
-					Type: corev1.ServiceTypeClusterIP, ClusterIP: "0.0.0.0",
+					Type:            corev1.ServiceTypeLoadBalancer,
+					ClusterIP:       "4.3.2.1",
+					SessionAffinity: corev1.ServiceAffinityNone,
 				}},
 				reconciled: corev1.Service{Spec: corev1.ServiceSpec{
-					Type: corev1.ServiceTypeClusterIP, ClusterIP: "1.2.3.4",
+					Type:            corev1.ServiceTypeClusterIP,
+					ClusterIP:       "1.2.3.4",
+					SessionAffinity: corev1.ServiceAffinityClientIP,
 				}},
 			},
 			want: corev1.Service{Spec: corev1.ServiceSpec{
-				Type: corev1.ServiceTypeClusterIP, ClusterIP: "0.0.0.0",
+				Type:            corev1.ServiceTypeLoadBalancer,
+				ClusterIP:       "4.3.2.1",
+				SessionAffinity: corev1.ServiceAffinityNone,
 			}},
 		},
 		{


### PR DESCRIPTION
Here's some more values that may be defaulted by the API server we should be aware of for comparison purposes.