### PR TITLE
ES readiness: set success threshold to 1 and increase freq. of test

### DIFF
--- a/operators/pkg/controller/elasticsearch/mutation/calculate_test.go
+++ b/operators/pkg/controller/elasticsearch/mutation/calculate_test.go
@@ -60,8 +60,8 @@ func ESPodSpecContext(image string, cpuLimit string) pod.PodSpecContext {
 				ReadinessProbe: &corev1.Probe{
 					FailureThreshold:    3,
 					InitialDelaySeconds: 10,
-					PeriodSeconds:       10,
-					SuccessThreshold:    3,
+					PeriodSeconds:       5,
+					SuccessThreshold:    1,
 					TimeoutSeconds:      5,
 					Handler: corev1.Handler{
 						Exec: &corev1.ExecAction{

--- a/operators/pkg/controller/elasticsearch/pod/readiness_probe.go
+++ b/operators/pkg/controller/elasticsearch/pod/readiness_probe.go
@@ -12,8 +12,8 @@ func NewReadinessProbe() *corev1.Probe {
 	return &corev1.Probe{
 		FailureThreshold:    3,
 		InitialDelaySeconds: 10,
-		PeriodSeconds:       10,
-		SuccessThreshold:    3,
+		PeriodSeconds:       5,
+		SuccessThreshold:    1,
 		TimeoutSeconds:      5,
 		Handler: corev1.Handler{
 			Exec: &corev1.ExecAction{


### PR DESCRIPTION
This PR sets the SuccessThreshold of the Elasticsearch readiness probe to 1.
It also increases a little bit the freq. of the test with a test every 5 seconds.