### PR TITLE
Adds missing Namespace to some client.ListOptions structs

### DIFF
--- a/operators/pkg/controller/elasticsearch/user/reconciler.go
+++ b/operators/pkg/controller/elasticsearch/user/reconciler.go
@@ -96,6 +96,7 @@ func ReconcileUsers(
 	var customUsers corev1.SecretList
 	if err := c.List(&client.ListOptions{
 		LabelSelector: user.NewLabelSelectorForElasticsearch(es),
+		Namespace:     es.Namespace,
 	}, &customUsers); err != nil {
 		return nil, err
 	}

--- a/operators/pkg/controller/kibanaassociation/association_controller.go
+++ b/operators/pkg/controller/kibanaassociation/association_controller.go
@@ -271,7 +271,7 @@ func (r *ReconcileAssociation) reconcileInternal(kibana kbtype.Kibana) (commonv1
 func deleteOrphanedResources(c k8s.Client, kibana kbtype.Kibana) error {
 	var secrets corev1.SecretList
 	selector := NewResourceSelector(kibana.Name)
-	if err := c.List(&client.ListOptions{LabelSelector: selector}, &secrets); err != nil {
+	if err := c.List(&client.ListOptions{LabelSelector: selector, Namespace: kibana.Namespace}, &secrets); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Found two cases where it's evident that a Namespace should be set.