### PR TITLE
Provide a default Affinity for ES Pods.

### DIFF
--- a/operators/pkg/controller/common/defaults/pod_template.go
+++ b/operators/pkg/controller/common/defaults/pod_template.go
@@ -107,6 +107,15 @@ func (b *PodTemplateBuilder) WithMemoryLimit(limit resource.Quantity) *PodTempla
 	return b
 }
 
+// WithAffinity sets a default affinity, unless already provided in the template.
+// An empty affinity in the spec is not overridden.
+func (b *PodTemplateBuilder) WithAffinity(affinity *corev1.Affinity) *PodTemplateBuilder {
+	if b.PodTemplate.Spec.Affinity == nil {
+		b.PodTemplate.Spec.Affinity = affinity
+	}
+	return b
+}
+
 // portExists checks if a port with the given name already exists in the Container.
 func (b *PodTemplateBuilder) portExists(name string) bool {
 	for _, p := range b.Container.Ports {

--- a/operators/pkg/controller/common/defaults/pod_template_test.go
+++ b/operators/pkg/controller/common/defaults/pod_template_test.go
@@ -325,6 +325,45 @@ func TestPodTemplateBuilder_WithResources(t *testing.T) {
 	}
 }
 
+func TestPodTemplateBuilder_WithAffinity(t *testing.T) {
+	defaultAffinity := &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{},
+	}
+
+	containerName := "mycontainer"
+	tests := []struct {
+		name        string
+		PodTemplate corev1.PodTemplateSpec
+		affinity    *corev1.Affinity
+		want        *corev1.Affinity
+	}{
+		{
+			name:        "set default affinity",
+			PodTemplate: corev1.PodTemplateSpec{},
+			affinity:    defaultAffinity,
+			want:        defaultAffinity,
+		},
+		{
+			name: "don't override user-provided affinity",
+			PodTemplate: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{},
+				},
+			},
+			affinity: defaultAffinity,
+			want:     &corev1.Affinity{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewPodTemplateBuilder(tt.PodTemplate, containerName)
+			if got := b.WithAffinity(tt.affinity).PodTemplate.Spec.Affinity; !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PodTemplateBuilder.WithAffinity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPodTemplateBuilder_WithPorts(t *testing.T) {
 	containerName := "mycontainer"
 	tests := []struct {

--- a/operators/pkg/controller/elasticsearch/version/common.go
+++ b/operators/pkg/controller/elasticsearch/version/common.go
@@ -115,7 +115,8 @@ func podSpec(
 		// enforce a memory resource limits if not provided by the user, since we need to compute JVM heap size
 		// we do not set resource Requests here in order to end up in the qosClass of Guaranteed by default
 		// see https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/ for more details
-		WithMemoryLimit(DefaultMemoryLimits)
+		WithMemoryLimit(DefaultMemoryLimits).
+		WithAffinity(pod.DefaultAffinity(p.ClusterName))
 
 	// setup heap size based on memory limits
 	heapSize := MemoryLimitsToHeapSize(*builder.Container.Resources.Limits.Memory())

--- a/operators/pkg/controller/elasticsearch/version/common_test.go
+++ b/operators/pkg/controller/elasticsearch/version/common_test.go
@@ -484,6 +484,31 @@ func Test_podSpec(t *testing.T) {
 				}, podSpec.Containers[0].Env)
 			},
 		},
+		{
+			name: "default affinity",
+			params: pod.NewPodSpecParams{
+				ClusterName: "my-cluster",
+			},
+			assertions: func(t *testing.T, podSpec corev1.PodSpec) {
+				require.Equal(t, pod.DefaultAffinity("my-cluster"), podSpec.Affinity)
+			},
+		},
+		{
+			name: "custom affinity",
+			params: pod.NewPodSpecParams{
+				ClusterName: "my-cluster",
+				NodeSpec: v1alpha1.NodeSpec{
+					PodTemplate: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Affinity: &corev1.Affinity{},
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, podSpec corev1.PodSpec) {
+				require.Equal(t, &corev1.Affinity{}, podSpec.Affinity)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The default affinity is a weighted preference to attempt to avoid co-locating two cluster nodes
to the same host.

To opt out of the default affinity, set an affinity in the pod template (empty is allowed):

```yaml
apiVersion: elasticsearch.k8s.elastic.co/v1alpha1
kind: Elasticsearch
metadata:
  name: elasticsearch-sample
spec:
  version: "7.1.0"
  nodes:
  - nodeCount: 1
    podTemplate:
      spec:
        affinity: {}
```

Closes: https://github.com/elastic/cloud-on-k8s/issues/915