### PR TITLE
Use gibibytes in e2e default memory resources

### DIFF
--- a/operators/test/e2e/stack/builder.go
+++ b/operators/test/e2e/stack/builder.go
@@ -18,7 +18,7 @@ import (
 
 var DefaultResources = corev1.ResourceRequirements{
 	Limits: map[corev1.ResourceName]resource.Quantity{
-		corev1.ResourceMemory: resource.MustParse("2G"),
+		corev1.ResourceMemory: resource.MustParse("2Gi"),
 		corev1.ResourceCPU:    resource.MustParse("2"),
 	},
 }


### PR DESCRIPTION
It avoids the need to make some approximation logic when comparing the memory limit defined in the topology spec and the real value read in the container by ES.

Fixes #1047.