### PR TITLE
PVC may be stolen by an other pod

### DIFF
--- a/operators/pkg/controller/elasticsearch/driver/default.go
+++ b/operators/pkg/controller/elasticsearch/driver/default.go
@@ -327,7 +327,7 @@ func (d *defaultDriver) Reconcile(
 		}
 	}
 
-	// List the orphaned PVC before the Pods are created.
+	// List the orphaned PVCs before the Pods are created.
 	// If there are some orphaned PVCs they will be adopted and remove sequentially from the list when Pods are created.
 	orphanedPVCs, err := pvc.FindOrphanedVolumeClaims(d.Client, es)
 	if err != nil {

--- a/operators/pkg/controller/elasticsearch/driver/default.go
+++ b/operators/pkg/controller/elasticsearch/driver/default.go
@@ -327,6 +327,8 @@ func (d *defaultDriver) Reconcile(
 		}
 	}
 
+	// List the orphaned PVC before the Pods are created.
+	// If there are some orphaned PVCs they will be adopted and remove sequentially from the list when Pods are created.
 	orphanedPVCs, err := pvc.FindOrphanedVolumeClaims(d.Client, es)
 	if err != nil {
 		return results.WithError(err)

--- a/operators/pkg/controller/elasticsearch/driver/pods.go
+++ b/operators/pkg/controller/elasticsearch/driver/pods.go
@@ -32,11 +32,8 @@ func createElasticsearchPod(
 	reconcileState *esreconcile.State,
 	pod corev1.Pod,
 	podSpecCtx pod.PodSpecContext,
+	orphanedPVCs *pvcutils.OrphanedPersistentVolumeClaims,
 ) error {
-	orphanedPVCs, err := pvcutils.FindOrphanedVolumeClaims(c, es)
-	if err != nil {
-		return err
-	}
 
 	// when can we re-use a metav1.PersistentVolumeClaim?
 	// - It is the same size, storageclass etc, or resizable as such


### PR DESCRIPTION
This PR fixes a situation where a PVC can be adopted/stolen if a Pod takes too long to be created.