### PR TITLE
Optimize e2e tests CI jobs

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -299,7 +299,7 @@ ci: dep-vendor-only check-fmt generate check-local-changes unit integration e2e-
 # Run e2e tests in a dedicated gke cluster,
 # that we delete if everything went fine
 ci-e2e:
-	$(MAKE) bootstrap-gke dep-vendor-only docker-build docker-push deploy e2e delete-gke || ($(MAKE) delete-gke; exit 1)
+	$(MAKE) bootstrap-gke dep-vendor-only e2e delete-gke || ($(MAKE) delete-gke; exit 1)
 
 ci-release: export GO_TAGS = release
 ci-release: export LICENSE_PUBKEY = $(ROOT_DIR)/build/ci/license.key


### PR DESCRIPTION
With current target `ci-e2e` we are building the same Docker image 3 times: once explicitly during `docker-build` and 2 times implicitly during `deploy` and `e2e` targets. This change is reducing number of image builds to 1, it will mostly help PR job. 