### PR TITLE
Move readiness probe script to configmap

### DIFF
--- a/operators/pkg/controller/elasticsearch/configmap/configmap.go
+++ b/operators/pkg/controller/elasticsearch/configmap/configmap.go
@@ -1,0 +1,24 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package configmap
+
+import (
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// NewConfigMapWithData constructs a new config map with the given data
+func NewConfigMapWithData(es types.NamespacedName, data map[string]string) corev1.ConfigMap {
+	return corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      es.Name,
+			Namespace: es.Namespace,
+			Labels:    label.NewLabels(es),
+		},
+		Data: data,
+	}
+}

--- a/operators/pkg/controller/elasticsearch/configmap/configmap_control.go
+++ b/operators/pkg/controller/elasticsearch/configmap/configmap_control.go
@@ -1,0 +1,46 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package configmap
+
+import (
+	"reflect"
+
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var (
+	log = logf.Log.WithName("configmap")
+)
+
+// ReconcileConfigMap checks for an existing config map and updates it or creates one if it does not exist.
+func ReconcileConfigMap(
+	c k8s.Client,
+	scheme *runtime.Scheme,
+	es v1alpha1.Elasticsearch,
+	expected corev1.ConfigMap,
+) error {
+	reconciled := &corev1.ConfigMap{}
+	return reconciler.ReconcileResource(
+		reconciler.Params{
+			Client:     c,
+			Scheme:     scheme,
+			Owner:      &es,
+			Expected:   &expected,
+			Reconciled: reconciled,
+			NeedsUpdate: func() bool {
+				return !reflect.DeepEqual(expected.Data, reconciled.Data)
+			},
+			UpdateReconciled: func() {
+				reconciled.Data = expected.Data
+			},
+		},
+	)
+}

--- a/operators/pkg/controller/elasticsearch/configmap/configmap_control.go
+++ b/operators/pkg/controller/elasticsearch/configmap/configmap_control.go
@@ -10,7 +10,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"

--- a/operators/pkg/controller/elasticsearch/name/name.go
+++ b/operators/pkg/controller/elasticsearch/name/name.go
@@ -33,6 +33,7 @@ const (
 	unicastHostsConfigMapSuffix = "unicast-hosts"
 	licenseSecretSuffix         = "license"
 	defaultPodDisruptionBudget  = "default"
+	scriptsConfigMapSuffix      = "scripts"
 
 	certsPublicSecretName   = "certs-public"
 	certsInternalSecretName = "certs-internal"
@@ -116,6 +117,10 @@ func InternalUsersSecret(esName string) string {
 // UnicastHostsConfigMap returns the name of the ConfigMap that holds the list of seed nodes for a given cluster.
 func UnicastHostsConfigMap(esName string) string {
 	return ESNamer.Suffix(esName, unicastHostsConfigMapSuffix)
+}
+
+func ScriptsConfigMap(esName string) string {
+	return ESNamer.Suffix(esName, scriptsConfigMapSuffix)
 }
 
 func HTTPCertsInternalSecretName(esName string) string {

--- a/operators/pkg/controller/elasticsearch/pod/readiness_probe.go
+++ b/operators/pkg/controller/elasticsearch/pod/readiness_probe.go
@@ -5,6 +5,9 @@
 package pod
 
 import (
+	"path"
+
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/volume"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -17,12 +20,13 @@ func NewReadinessProbe() *corev1.Probe {
 		TimeoutSeconds:      5,
 		Handler: corev1.Handler{
 			Exec: &corev1.ExecAction{
-				Command: []string{"bash", "-c", ReadinessProbeScript},
+				Command: []string{"bash", "-c", path.Join(volume.ScriptsVolumeMountPath, ReadinessProbeScriptConfigKey)},
 			},
 		},
 	}
 }
 
+const ReadinessProbeScriptConfigKey = "readiness-probe-script.sh"
 const ReadinessProbeScript string = `
 #!/usr/bin/env bash
 # Consider a node to be healthy if it responds to a simple GET on "/"

--- a/operators/pkg/controller/elasticsearch/version/common.go
+++ b/operators/pkg/controller/elasticsearch/version/common.go
@@ -124,6 +124,12 @@ func podSpec(
 		return corev1.PodSpec{}, settings.CanonicalConfig{}, err
 	}
 
+	scriptsVolume := volume.NewConfigMapVolumeWithMode(
+		name.ScriptsConfigMap(p.ClusterName),
+		volume.ScriptsVolumeName,
+		volume.ScriptsVolumeMountPath,
+		0744)
+
 	builder = builder.
 		WithVolumes(
 			append(initcontainer.PrepareFsSharedVolumes.Volumes(),
@@ -134,6 +140,7 @@ func podSpec(
 				keystoreUserSecret.Volume(),
 				secureSettingsVolume.Volume(),
 				httpCertificatesVolume.Volume(),
+				scriptsVolume.Volume(),
 			)...).
 		WithVolumeMounts(
 			append(initcontainer.PrepareFsSharedVolumes.EsContainerVolumeMounts(),
@@ -145,6 +152,7 @@ func podSpec(
 				keystoreUserSecret.VolumeMount(),
 				secureSettingsVolume.VolumeMount(),
 				httpCertificatesVolume.VolumeMount(),
+				scriptsVolume.VolumeMount(),
 			)...).
 		WithInitContainerDefaults().
 		WithInitContainers(initContainers...)

--- a/operators/pkg/controller/elasticsearch/version/version6/podspecs_test.go
+++ b/operators/pkg/controller/elasticsearch/version/version6/podspecs_test.go
@@ -188,7 +188,7 @@ func TestCreateExpectedPodSpecsReturnsCorrectPodSpec(t *testing.T) {
 	esPodSpec := podSpec[0].PodSpec
 	assert.Equal(t, 1, len(esPodSpec.Containers))
 	assert.Equal(t, 3, len(esPodSpec.InitContainers))
-	assert.Equal(t, 12, len(esPodSpec.Volumes))
+	assert.Equal(t, 13, len(esPodSpec.Volumes))
 
 	esContainer := esPodSpec.Containers[0]
 	assert.NotEqual(t, 0, esContainer.Env)
@@ -198,6 +198,6 @@ func TestCreateExpectedPodSpecsReturnsCorrectPodSpec(t *testing.T) {
 	assert.ElementsMatch(t, pod.DefaultContainerPorts, esContainer.Ports)
 	// volume mounts is one less than volumes because we're not mounting the transport certs secret until pod creation
 	// time
-	assert.Equal(t, 13, len(esContainer.VolumeMounts))
+	assert.Equal(t, 14, len(esContainer.VolumeMounts))
 	assert.NotEmpty(t, esContainer.ReadinessProbe.Handler.Exec.Command)
 }

--- a/operators/pkg/controller/elasticsearch/volume/configmap.go
+++ b/operators/pkg/controller/elasticsearch/volume/configmap.go
@@ -10,10 +10,16 @@ import (
 
 // NewConfigMapVolume creates a new ConfigMapVolume struct
 func NewConfigMapVolume(configMapName, name, mountPath string) ConfigMapVolume {
+	return NewConfigMapVolumeWithMode(configMapName, name, mountPath, corev1.ConfigMapVolumeSourceDefaultMode)
+}
+
+// NewConfigMapVolume creates a new ConfigMapVolume struct with default mode
+func NewConfigMapVolumeWithMode(configMapName, name, mountPath string, defaultMode int32) ConfigMapVolume {
 	return ConfigMapVolume{
 		configMapName: configMapName,
 		name:          name,
 		mountPath:     mountPath,
+		defaultMode:   defaultMode,
 	}
 }
 
@@ -23,6 +29,7 @@ type ConfigMapVolume struct {
 	name          string
 	mountPath     string
 	items         []corev1.KeyToPath
+	defaultMode   int32
 }
 
 // VolumeMount returns the k8s volume mount.
@@ -43,8 +50,9 @@ func (cm ConfigMapVolume) Volume() corev1.Volume {
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: cm.configMapName,
 				},
-				Items:    cm.items,
-				Optional: &defaultOptional,
+				Items:       cm.items,
+				Optional:    &defaultOptional,
+				DefaultMode: &cm.defaultMode,
 			},
 		},
 	}

--- a/operators/pkg/controller/elasticsearch/volume/configmap.go
+++ b/operators/pkg/controller/elasticsearch/volume/configmap.go
@@ -13,7 +13,7 @@ func NewConfigMapVolume(configMapName, name, mountPath string) ConfigMapVolume {
 	return NewConfigMapVolumeWithMode(configMapName, name, mountPath, corev1.ConfigMapVolumeSourceDefaultMode)
 }
 
-// NewConfigMapVolume creates a new ConfigMapVolume struct with default mode
+// NewConfigMapVolumeWithMode creates a new ConfigMapVolume struct with default mode
 func NewConfigMapVolumeWithMode(configMapName, name, mountPath string, defaultMode int32) ConfigMapVolume {
 	return ConfigMapVolume{
 		configMapName: configMapName,

--- a/operators/pkg/controller/elasticsearch/volume/volume.go
+++ b/operators/pkg/controller/elasticsearch/volume/volume.go
@@ -38,7 +38,7 @@ const (
 	ElasticsearchLogsVolumeName = "elasticsearch-logs"
 
 	ScriptsVolumeName      = "elastic-internal-scripts"
-	ScriptsVolumeMountPath = "/mnt/elastic/scripts"
+	ScriptsVolumeMountPath = "/mnt/elastic-internal/scripts"
 )
 
 var (

--- a/operators/pkg/controller/elasticsearch/volume/volume.go
+++ b/operators/pkg/controller/elasticsearch/volume/volume.go
@@ -36,6 +36,9 @@ const (
 
 	ElasticsearchDataVolumeName = "elasticsearch-data"
 	ElasticsearchLogsVolumeName = "elasticsearch-logs"
+
+	ScriptsVolumeName      = "elastic-internal-scripts"
+	ScriptsVolumeMountPath = "/mnt/elastic/scripts"
 )
 
 var (


### PR DESCRIPTION
Moving readiness probe script from an inline script to config map. Part of the work for #932.
1. configmap gets created. This happens in Reconcile function, as configmap is shared between pods.
1. volume with scripts is added to pod spec.

configmap/configmap.go, configmap_control.go were revived since they are helpful here (@nkvoll you removed them previously, so let me know if I should move that code somewhere else).

