### PR TITLE
Fix storage class example

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -292,7 +292,7 @@ spec:
         resources:
           requests:
             storage: 10Gi
-        storageClassName: gcePersistentDisk # can be any available storage class
+        storageClassName: standard # can be any available storage class
 EOF
 ----
 

--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -292,7 +292,7 @@ spec:
         resources:
           requests:
             storage: 10Gi
-        storageClassName: standard # can be any available storage class
+        #storageClassName: standard # can be any available storage class
 EOF
 ----
 

--- a/operators/config/samples/elasticsearch/elasticsearch.yaml
+++ b/operators/config/samples/elasticsearch/elasticsearch.yaml
@@ -34,7 +34,7 @@ spec:
     #    resources:
     #      requests:
     #        storage: 2Gi
-    #    storageClassName: elastic-local # or eg. gcePersistentDisk
+    #    storageClassName: elastic-local # or eg. standard
   ## Inject secure settings into Elasticsearch nodes from a k8s secret reference
   # secureSettings:
   #   secretName: "ref-to-secret"

--- a/operators/config/samples/elasticsearch/elasticsearch_local_volume.yaml
+++ b/operators/config/samples/elasticsearch/elasticsearch_local_volume.yaml
@@ -17,4 +17,4 @@ spec:
         resources:
           requests:
             storage: 10M
-        storageClassName: elastic-local # or eg. gcePersistentDisk
+        storageClassName: elastic-local


### PR DESCRIPTION
This PR fixes the storage class example in the quickstart.
A storage class name must consist of lower case alphanumeric characters.