### PR TITLE
Enable the E2E test TestUpdateSecureSettings for the Keystore

### DIFF
--- a/operators/test/e2e/keystore_test.go
+++ b/operators/test/e2e/keystore_test.go
@@ -2,21 +2,19 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-// +build flaky
-
 package e2e
 
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/helpers"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/params"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/stack"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestUpdateSecureSettings(t *testing.T) {
@@ -27,7 +25,7 @@ func TestUpdateSecureSettings(t *testing.T) {
 	secureSettings := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secureSettingsSecretName,
-			Namespace: helpers.DefaultNamespace,
+			Namespace: params.Namespace,
 		},
 		Data: map[string][]byte{
 			"key.without.prefix":        []byte("string value"),

--- a/operators/test/e2e/keystore_test.go
+++ b/operators/test/e2e/keystore_test.go
@@ -28,11 +28,11 @@ func TestUpdateSecureSettings(t *testing.T) {
 			Namespace: params.Namespace,
 		},
 		Data: map[string][]byte{
-			"key.without.prefix":        []byte("string value"),
-			"es.string.string.setting1": []byte("string value"),
-			"es.string.string.setting2": []byte("string value"),
-			"es.file.file.setting1":     []byte("file content"),
-			"es.file.file.setting2":     []byte("file content"),
+			"key.without.prefix": []byte("string value"),
+			"string.setting1":    []byte("string value"),
+			"string.setting2":    []byte("string value"),
+			"file.setting1":      []byte("file content"),
+			"file.setting2":      []byte("file content"),
 		},
 	}
 
@@ -69,9 +69,9 @@ func TestUpdateSecureSettings(t *testing.T) {
 				Test: func(t *testing.T) {
 					// remove some keys, add new ones
 					secureSettings.Data = map[string][]byte{
-						"es.string.string.setting1":     []byte("new string content"), // the actual value update cannot be checked :(
-						"es.string.new.string.setting2": []byte("string content"),
-						"es.file.new.file.setting":      []byte("file content"),
+						"string.setting1":     []byte("new string content"), // the actual value update cannot be checked :(
+						"new.string.setting2": []byte("string content"),
+						"new.file.setting":    []byte("file content"),
 					}
 					err := k.Client.Update(&secureSettings)
 					require.NoError(t, err)


### PR DESCRIPTION
This commit fixes and enables again the E2E test `TestUpdateSecureSettings`.

I couldn't reproduce the error after dozens of tries. I have a small doubt that the flakiness was due to the use of a previous version of the process manager.

Related to #733.