### PR TITLE
Remove plugins from prepare-fs script in init container

### DIFF
--- a/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
@@ -59,7 +59,6 @@ var (
 )
 
 // NewPrepareFSInitContainer creates an init container to handle things such as:
-// - plugins installation
 // - configuration changes
 // Modified directories and files are meant to be persisted for reuse in the actual ES container.
 // This container does not need to be privileged.

--- a/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
@@ -76,7 +76,6 @@ func NewPrepareFSInitContainer(
 	certificatesVolumeMount.MountPath = "/mnt/elastic-internal/transport-certificates"
 
 	script, err := RenderScriptTemplate(TemplateParams{
-		Plugins:       defaultInstalledPlugins,
 		SharedVolumes: PrepareFsSharedVolumes,
 		LinkedFiles:   linkedFiles,
 		ChownToElasticsearch: []string{

--- a/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
@@ -40,17 +40,9 @@ var (
 		EsContainerMountPath:   "/usr/share/elasticsearch/config",
 	}
 
-	// EsPluginsSharedVolume contains the ES plugins/ directory
-	EsPluginsSharedVolume = SharedVolume{
-		Name:                   "elastic-internal-elasticsearch-plugins-local",
-		InitContainerMountPath: "/mnt/elastic-internal/elasticsearch-plugins-local",
-		EsContainerMountPath:   "/usr/share/elasticsearch/plugins",
-	}
-
 	PrepareFsSharedVolumes = SharedVolumeArray{
 		Array: []SharedVolume{
 			EsConfigSharedVolume,
-			EsPluginsSharedVolume,
 			EsBinSharedVolume,
 			DataSharedVolume,
 			LogsSharedVolume,

--- a/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
@@ -40,9 +40,17 @@ var (
 		EsContainerMountPath:   "/usr/share/elasticsearch/config",
 	}
 
+	// EsPluginsSharedVolume contains the ES plugins/ directory
+	EsPluginsSharedVolume = SharedVolume{
+		Name:                   "elastic-internal-elasticsearch-plugins-local",
+		InitContainerMountPath: "/mnt/elastic-internal/elasticsearch-plugins-local",
+		EsContainerMountPath:   "/usr/share/elasticsearch/plugins",
+	}
+
 	PrepareFsSharedVolumes = SharedVolumeArray{
 		Array: []SharedVolume{
 			EsConfigSharedVolume,
+			EsPluginsSharedVolume,
 			EsBinSharedVolume,
 			DataSharedVolume,
 			LogsSharedVolume,

--- a/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
@@ -34,12 +34,7 @@ func RenderScriptTemplate(params TemplateParams) (string, error) {
 // in the prepare-fs init container before ES starts
 var scriptTemplate = template.Must(template.New("").Parse(
 	`#!/usr/bin/env bash -eu
-
-	ES_DIR="/usr/share/elasticsearch"
-	CONFIG_DIR=$ES_DIR/config
-	PLUGIN_BIN=$ES_DIR/bin/elasticsearch-plugin
-	KEYSTORE_BIN=$ES_DIR/bin/elasticsearch-keystore 
-
+	
 	# compute time in seconds since the given start time
 	function duration() {
 		local start=$1

--- a/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
@@ -73,7 +73,7 @@ var scriptTemplate = template.Must(template.New("").Parse(
 	#  Files persistence #
 	######################
 
-	# Persist the content of bin/ and config/ 
+	# Persist the content of bin/, config/ and plugins/
 	# to a volume, to be used by the ES container
 	mv_start=$(date +%s)
 	{{range .SharedVolumes.Array}}

--- a/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
@@ -9,16 +9,8 @@ import (
 	"html/template"
 )
 
-// List of plugins to be installed on the ES instance
-var defaultInstalledPlugins = []string{
-	"repository-s3",  // S3 snapshots
-	"repository-gcs", // gcp snapshots
-}
-
 // TemplateParams are the parameters manipulated in the scriptTemplate
 type TemplateParams struct {
-	// Plugins is a list of plugins to install
-	Plugins []string
 	// SharedVolumes are directories to persist in shared volumes
 	SharedVolumes SharedVolumeArray
 	// LinkedFiles are files to link individually
@@ -62,23 +54,6 @@ var scriptTemplate = template.Must(template.New("").Parse(
 	script_start=$(date +%s)
 
 	echo "Starting init script"
-
-	######################
-	#       Plugins      #
-	######################
-
-	plugins_start=$(date +%s)
-	# Install extra plugins
-	{{range .Plugins}}
-		echo "Installing plugin {{.}}"
-		# Using --batch accepts any user prompt (y/n)
-		$PLUGIN_BIN install --batch {{.}}
-	{{end}}
-
-	echo "Installed plugins:"
-	$PLUGIN_BIN list
-
-	echo "Plugins installation duration: $(duration $plugins_start) sec."
 
 	######################
 	#  Config linking    #

--- a/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
@@ -73,7 +73,7 @@ var scriptTemplate = template.Must(template.New("").Parse(
 	#  Files persistence #
 	######################
 
-	# Persist the content of bin/, config/ and plugins/
+	# Persist the content of bin/ and config/ 
 	# to a volume, to be used by the ES container
 	mv_start=$(date +%s)
 	{{range .SharedVolumes.Array}}

--- a/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script_test.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script_test.go
@@ -30,6 +30,7 @@ func TestRenderScriptTemplate(t *testing.T) {
 			wantSubstr: []string{
 				"mv /usr/share/elasticsearch/config/* /mnt/elastic-internal/elasticsearch-config-local/",
 				"mv /usr/share/elasticsearch/bin/* /mnt/elastic-internal/elasticsearch-bin-local/",
+				"mv /usr/share/elasticsearch/plugins/* /mnt/elastic-internal/elasticsearch-plugins-local/",
 				"ln -sf /secrets/users /usr/share/elasticsearch/users",
 			},
 		},

--- a/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script_test.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script_test.go
@@ -30,7 +30,6 @@ func TestRenderScriptTemplate(t *testing.T) {
 			wantSubstr: []string{
 				"mv /usr/share/elasticsearch/config/* /mnt/elastic-internal/elasticsearch-config-local/",
 				"mv /usr/share/elasticsearch/bin/* /mnt/elastic-internal/elasticsearch-bin-local/",
-				"mv /usr/share/elasticsearch/plugins/* /mnt/elastic-internal/elasticsearch-plugins-local/",
 				"ln -sf /secrets/users /usr/share/elasticsearch/users",
 			},
 		},

--- a/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script_test.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script_test.go
@@ -20,7 +20,6 @@ func TestRenderScriptTemplate(t *testing.T) {
 		{
 			name: "Standard script rendering",
 			params: TemplateParams{
-				Plugins:       defaultInstalledPlugins,
 				SharedVolumes: PrepareFsSharedVolumes,
 				LinkedFiles: LinkedFilesArray{
 					Array: []LinkedFile{
@@ -29,8 +28,6 @@ func TestRenderScriptTemplate(t *testing.T) {
 							Target: "/usr/share/elasticsearch/users"}}},
 			},
 			wantSubstr: []string{
-				"$PLUGIN_BIN install --batch repository-s3",
-				"$PLUGIN_BIN install --batch repository-gcs",
 				"mv /usr/share/elasticsearch/config/* /mnt/elastic-internal/elasticsearch-config-local/",
 				"mv /usr/share/elasticsearch/bin/* /mnt/elastic-internal/elasticsearch-bin-local/",
 				"mv /usr/share/elasticsearch/plugins/* /mnt/elastic-internal/elasticsearch-plugins-local/",

--- a/operators/pkg/controller/elasticsearch/version/version6/podspecs_test.go
+++ b/operators/pkg/controller/elasticsearch/version/version6/podspecs_test.go
@@ -188,7 +188,7 @@ func TestCreateExpectedPodSpecsReturnsCorrectPodSpec(t *testing.T) {
 	esPodSpec := podSpec[0].PodSpec
 	assert.Equal(t, 1, len(esPodSpec.Containers))
 	assert.Equal(t, 3, len(esPodSpec.InitContainers))
-	assert.Equal(t, 13, len(esPodSpec.Volumes))
+	assert.Equal(t, 12, len(esPodSpec.Volumes))
 
 	esContainer := esPodSpec.Containers[0]
 	assert.NotEqual(t, 0, esContainer.Env)
@@ -198,6 +198,6 @@ func TestCreateExpectedPodSpecsReturnsCorrectPodSpec(t *testing.T) {
 	assert.ElementsMatch(t, pod.DefaultContainerPorts, esContainer.Ports)
 	// volume mounts is one less than volumes because we're not mounting the transport certs secret until pod creation
 	// time
-	assert.Equal(t, 14, len(esContainer.VolumeMounts))
+	assert.Equal(t, 13, len(esContainer.VolumeMounts))
 	assert.NotEmpty(t, esContainer.ReadinessProbe.Handler.Exec.Command)
 }

--- a/operators/pkg/controller/elasticsearch/version/version6/podspecs_test.go
+++ b/operators/pkg/controller/elasticsearch/version/version6/podspecs_test.go
@@ -188,7 +188,7 @@ func TestCreateExpectedPodSpecsReturnsCorrectPodSpec(t *testing.T) {
 	esPodSpec := podSpec[0].PodSpec
 	assert.Equal(t, 1, len(esPodSpec.Containers))
 	assert.Equal(t, 3, len(esPodSpec.InitContainers))
-	assert.Equal(t, 12, len(esPodSpec.Volumes))
+	assert.Equal(t, 13, len(esPodSpec.Volumes))
 
 	esContainer := esPodSpec.Containers[0]
 	assert.NotEqual(t, 0, esContainer.Env)
@@ -198,6 +198,6 @@ func TestCreateExpectedPodSpecsReturnsCorrectPodSpec(t *testing.T) {
 	assert.ElementsMatch(t, pod.DefaultContainerPorts, esContainer.Ports)
 	// volume mounts is one less than volumes because we're not mounting the transport certs secret until pod creation
 	// time
-	assert.Equal(t, 13, len(esContainer.VolumeMounts))
+	assert.Equal(t, 14, len(esContainer.VolumeMounts))
 	assert.NotEmpty(t, esContainer.ReadinessProbe.Handler.Exec.Command)
 }


### PR DESCRIPTION
Fixes #620 

* removes plugins from prepare-fs script in init container
* install plugins instead mechanism described in #1022 or via custom images
* trying to figure out whether we should remove the volume mount as well
     * Answer is no, we want to keep all the volume mounts to make it easier for users to actually leverage the new init container behaviour 
