### PR TITLE
E2E tests: killed pod may be replaced by a pod with the same name

### DIFF
--- a/operators/config/e2e/rbac.yaml
+++ b/operators/config/e2e/rbac.yaml
@@ -40,6 +40,7 @@ rules:
       - watch
       - delete
       - create
+      - update
   - apiGroups:
       - "apps"
     resources:

--- a/operators/test/e2e/failure_test.go
+++ b/operators/test/e2e/failure_test.go
@@ -62,8 +62,8 @@ func killNodeTest(t *testing.T, s stack.Builder, listOptions client.ListOptions,
 			{
 				Name: "Wait for pod to be deleted",
 				Test: helpers.Eventually(func() error {
-					_, err := k.GetPod(killedPod.Name)
-					if apierrors.IsNotFound(err) {
+					pod, err := k.GetPod(killedPod.Name)
+					if apierrors.IsNotFound(err) || killedPod.UID != pod.UID {
 						return nil
 					}
 					if err != nil {

--- a/operators/test/e2e/failure_test.go
+++ b/operators/test/e2e/failure_test.go
@@ -63,11 +63,11 @@ func killNodeTest(t *testing.T, s stack.Builder, listOptions client.ListOptions,
 				Name: "Wait for pod to be deleted",
 				Test: helpers.Eventually(func() error {
 					pod, err := k.GetPod(killedPod.Name)
+					if err != nil && !apierrors.IsNotFound(err) {
+						return err
+					}
 					if apierrors.IsNotFound(err) || killedPod.UID != pod.UID {
 						return nil
-					}
-					if err != nil {
-						return err
 					}
 					return fmt.Errorf("Pod %s not deleted yet", killedPod.Name)
 				}),

--- a/operators/test/e2e/keystore_test.go
+++ b/operators/test/e2e/keystore_test.go
@@ -109,5 +109,6 @@ func TestUpdateSecureSettings(t *testing.T) {
 				},
 			},
 		).
+		WithSteps(stack.DeletionTestSteps(s, k)...).
 		RunSequential(t)
 }


### PR DESCRIPTION
This PR fixes a situation where a pod is not detected as killed because it is replaced with a pod that has the same name.
