### PR TITLE
Add missing RBAC permissions for pod disruption budget to all-in-one

### DIFF
--- a/operators/config/operator/all-in-one/cluster_role.template.yaml
+++ b/operators/config/operator/all-in-one/cluster_role.template.yaml
@@ -50,6 +50,18 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - elasticsearch.k8s.elastic.co
   resources:
   - elasticsearches


### PR DESCRIPTION
Just what the title says