### PR TITLE
Update Jenkins credentials ID

### DIFF
--- a/.ci/jobs/e2e-tests.yaml
+++ b/.ci/jobs/e2e-tests.yaml
@@ -17,7 +17,7 @@
             url: https://github.com/elastic/cloud-on-k8s
             branches:
               - master
-            credentials-id: 'f3af1bfb-d48e-48d1-82a2-acca009c1b23'
+            credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
       script-path: build/ci/e2e/Jenkinsfile
       lightweight-checkout: true
     wrappers:

--- a/.ci/jobs/pr.yml
+++ b/.ci/jobs/pr.yml
@@ -15,7 +15,7 @@
             url: https://github.com/elastic/cloud-on-k8s
             branches:
               - ${sha1}
-            credentials-id: 'f3af1bfb-d48e-48d1-82a2-acca009c1b23'
+            credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
             refspec: '+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*'
       script-path: build/ci/pr/Jenkinsfile
       lightweight-checkout: false


### PR DESCRIPTION
We are using credentials ID from `cloud-ci` in our `devops-ci` builds. It didn't fail so far because Jenkins is quite smart and replaced inexistent ID with one of available. But it definitely better to have a right one.