### PR TITLE
Support all 7.x versions of Elasticsearch

### DIFF
--- a/operators/pkg/controller/elasticsearch/driver/driver.go
+++ b/operators/pkg/controller/elasticsearch/driver/driver.go
@@ -102,7 +102,7 @@ func SupportedVersions(v version.Version) *esversion.LowestHighestSupportedVersi
 			// Min. version is 6.7.0 for now. Will be 6.8.0 soon.
 			LowestSupportedVersion: version.MustParse("6.7.0"),
 			// higher may be possible, but not proven yet, lower may also be a requirement...
-			HighestSupportedVersion: version.MustParse("6.8.99"),
+			HighestSupportedVersion: version.MustParse("6.99.99"),
 		}
 	case 7:
 		res = &esversion.LowestHighestSupportedVersions{

--- a/operators/pkg/controller/elasticsearch/driver/driver.go
+++ b/operators/pkg/controller/elasticsearch/driver/driver.go
@@ -109,7 +109,7 @@ func SupportedVersions(v version.Version) *esversion.LowestHighestSupportedVersi
 			// 6.7.0 is the lowest wire compatibility version for 7.x
 			LowestSupportedVersion: version.MustParse("6.7.0"),
 			// higher may be possible, but not proven yet, lower may also be a requirement...
-			HighestSupportedVersion: version.MustParse("7.1.99"),
+			HighestSupportedVersion: version.MustParse("7.99.99"),
 		}
 	}
 	return res

--- a/operators/pkg/controller/elasticsearch/driver/driver_test.go
+++ b/operators/pkg/controller/elasticsearch/driver/driver_test.go
@@ -1,0 +1,66 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package driver
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSupportedVersions(t *testing.T) {
+	type args struct {
+		v version.Version
+	}
+	tests := []struct {
+		name        string
+		args        args
+		supported   []version.Version
+		unsupported []version.Version
+	}{
+		{
+			name: "6.x",
+			args: args{
+				v: version.MustParse("6.8.0"),
+			},
+			supported: []version.Version{
+				version.MustParse("6.7.0"),
+				version.MustParse("6.8.0"),
+				version.MustParse("6.99.99"),
+			},
+			unsupported: []version.Version{
+				version.MustParse("6.5.0"),
+				version.MustParse("7.0.0"),
+			},
+		},
+		{
+			name: "7.x",
+			args: args{
+				v: version.MustParse("7.1.0"),
+			},
+			supported: []version.Version{
+				version.MustParse("6.7.0"), //wire compat
+				version.MustParse("7.2.0"),
+				version.MustParse("7.99.99"),
+			},
+			unsupported: []version.Version{
+				version.MustParse("6.6.0"),
+				version.MustParse("8.0.0"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vs := SupportedVersions(tt.args.v)
+			for _, v := range tt.supported {
+				require.NoError(t, vs.Supports(v))
+			}
+			for _, v := range tt.unsupported {
+				require.Error(t, vs.Supports(v))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1065

* Removes the restriction to 7.1.x and replaces it with a restriction to 7.x
* Question: should we be even more lenient and allow all of 8.x?