### PR TITLE
Fix scripts invocation

### DIFF
--- a/operators/pkg/controller/elasticsearch/initcontainer/inject_process_manager.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/inject_process_manager.go
@@ -11,8 +11,8 @@ import (
 
 const (
 	envBinDirectoryPath = "LOCAL_BIN"
-	script              = `
-		#!/usr/bin/env bash -eu
+	script              = `#!/usr/bin/env bash 
+		set -eu
 		cp process-manager $` + envBinDirectoryPath + `
 `
 )
@@ -30,7 +30,7 @@ func NewInjectProcessManagerInitContainer(imageName string) (corev1.Container, e
 			{Name: envBinDirectoryPath, Value: ProcessManagerVolume.InitContainerMountPath},
 		},
 		Name:         injectProcessManagerContainerName,
-		Command:      []string{"bash", "-c", script},
+		Command:      []string{"/usr/bin/env", "bash", "-c", script},
 		VolumeMounts: []corev1.VolumeMount{ProcessManagerVolume.InitContainerVolumeMount()},
 	}
 	return container, nil

--- a/operators/pkg/controller/kibana/securesettings/initcontainer.go
+++ b/operators/pkg/controller/kibana/securesettings/initcontainer.go
@@ -16,7 +16,9 @@ const (
 
 // script is a small bash script to create a Kibana keystore,
 // then add all entries from the secure settings secret volume into it.
-const script = `#!/usr/bin/env bash -eu
+const script = `#!/usr/bin/env bash
+
+set -eu
 
 echo "Initializing Kibana keystore."
 
@@ -45,7 +47,7 @@ func initContainer(secureSettingsSecret volume.SecretVolume) corev1.Container {
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: &privileged,
 		},
-		Command: []string{"bash", "-c", script},
+		Command: []string{"/usr/bin/env", "bash", "-c", script},
 		VolumeMounts: []corev1.VolumeMount{
 			// access secure settings
 			secureSettingsSecret.VolumeMount(),


### PR DESCRIPTION
Three issues being fixed here:
1. 'bash -c string' reads commands from string and interprets them. There is no call to execve as there is no file. This means that shebang gets ignored as a comment.
2. shebang contains path to env, bash and bash_arguments, but handling of the arguments differ. On OSX it will pass arguments correctly (and run '/usr/bin/env bash -eu'), but on centos it will try to call '/usr/bin/env "bash bash_arguments"' which will fail.
3. '#!' have to be first two characters.

Shebang is kept in the script body, so its runnable even if invoked differently. Current invocation of the script is changed to go via env directly.