### PR TITLE
Add a simple e2e test for license provisioning

### DIFF
--- a/operators/test/e2e/license_test.go
+++ b/operators/test/e2e/license_test.go
@@ -53,6 +53,7 @@ func TestEnterpriseLicenseSingle(t *testing.T) {
 			license.ElasticsearchLicenseTypeGold,
 			license.ElasticsearchLicenseTypePlatinum,
 		)).
+		WithSteps(stack.DeletionTestSteps(s, k)...).
 		RunSequential(t)
 
 }

--- a/operators/test/e2e/license_test.go
+++ b/operators/test/e2e/license_test.go
@@ -28,21 +28,31 @@ func TestEnterpriseLicenseSingle(t *testing.T) {
 	require.NoError(t, err)
 
 	// create a single node cluster
-	s := stack.NewStackBuilder("test-es-license-provisioning").
+	initStack := stack.NewStackBuilder("test-es-license-provisioning").
 		WithESMasterDataNodes(1, stack.DefaultResources)
 
-	testContext := stack.NewLicenseTestContext(k, s.Elasticsearch)
+	mutated := initStack.
+		WithNoESTopology().
+		WithESMasterDataNodes(1, stack.DefaultResources)
+
+	testContext := stack.NewLicenseTestContext(k, initStack.Elasticsearch)
 
 	helpers.TestStepList{}.
-		WithSteps(stack.InitTestSteps(s, k)...).
-		WithSteps(stack.CreationTestSteps(s, k)...).
+		WithSteps(stack.InitTestSteps(initStack, k)...).
+		// make sure no left over license is still around
+		WithSteps(testContext.DeleteEnterpriseLicenseSecret()).
+		WithSteps(stack.CreationTestSteps(initStack, k)...).
+		WithSteps(testContext.Init()).
 		WithSteps(
-			testContext.WrapSteps(
-				testContext.CheckElasticsearchLicense(license.ElasticsearchLicenseTypeBasic),
-				testContext.CreateEnterpriseLicenseSecret(licenseBytes),
-				// enterprise license can contain all kinds of cluster licenses so we are a bit lenient here and expect either gold or platinum
-				testContext.CheckElasticsearchLicense(license.ElasticsearchLicenseTypeGold, license.ElasticsearchLicenseTypePlatinum),
-			)...).
+			testContext.CheckElasticsearchLicense(license.ElasticsearchLicenseTypeBasic),
+			testContext.CreateEnterpriseLicenseSecret(licenseBytes)).
+		// Mutation shortcuts the license provisioning check...
+		WithSteps(stack.MutationTestSteps(mutated, k)...).
+		// enterprise license can contain all kinds of cluster licenses so we are a bit lenient here and expect either gold or platinum
+		WithSteps(testContext.CheckElasticsearchLicense(
+			license.ElasticsearchLicenseTypeGold,
+			license.ElasticsearchLicenseTypePlatinum,
+		)).
 		RunSequential(t)
 
 }

--- a/operators/test/e2e/license_test.go
+++ b/operators/test/e2e/license_test.go
@@ -29,7 +29,7 @@ func TestEnterpriseLicenseSingle(t *testing.T) {
 
 	// create a single node cluster
 	initStack := stack.NewStackBuilder("test-es-license-provisioning").
-		WithESMasterDataNodes(1, stack.DefaultResources)
+		WithESMasterNodes(1, stack.DefaultResources)
 
 	mutated := initStack.
 		WithNoESTopology().
@@ -53,7 +53,7 @@ func TestEnterpriseLicenseSingle(t *testing.T) {
 			license.ElasticsearchLicenseTypeGold,
 			license.ElasticsearchLicenseTypePlatinum,
 		)).
-		WithSteps(stack.DeletionTestSteps(s, k)...).
+		WithSteps(stack.DeletionTestSteps(mutated, k)...).
 		RunSequential(t)
 
 }

--- a/operators/test/e2e/license_test.go
+++ b/operators/test/e2e/license_test.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package e2e
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/license"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/helpers"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/params"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/stack"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnterpriseLicenseSingle(t *testing.T) {
+	// only execute this test if we have a test license to work with
+	if params.TestLicense == "" {
+		t.SkipNow()
+	}
+	k := helpers.NewK8sClientOrFatal()
+
+	licenseBytes, err := ioutil.ReadFile(params.TestLicense)
+	require.NoError(t, err)
+
+	// create a single node cluster
+	s := stack.NewStackBuilder("test-es-license-provisioning").
+		WithESMasterDataNodes(1, stack.DefaultResources)
+
+	testContext := stack.NewLicenseTestContext(k, s.Elasticsearch)
+
+	helpers.TestStepList{}.
+		WithSteps(stack.InitTestSteps(s, k)...).
+		WithSteps(stack.CreationTestSteps(s, k)...).
+		WithSteps(
+			testContext.WrapSteps(
+				testContext.CheckElasticsearchLicense(license.ElasticsearchLicenseTypeBasic),
+				testContext.CreateEnterpriseLicenseSecret(licenseBytes),
+				// enterprise license can contain all kinds of cluster licenses so we are a bit lenient here and expect either gold or platinum
+				testContext.CheckElasticsearchLicense(license.ElasticsearchLicenseTypeGold, license.ElasticsearchLicenseTypePlatinum),
+			)...).
+		RunSequential(t)
+
+}

--- a/operators/test/e2e/params/params.go
+++ b/operators/test/e2e/params/params.go
@@ -21,11 +21,13 @@ var (
 	ElasticStackVersion string
 	Namespace           string
 	AutoPortForward     bool
+	TestLicense         string
 )
 
 func init() {
 	flag.StringVar(&ElasticStackVersion, "version", defaultElasticStackVersion, "Elastic Stack version")
 	flag.StringVar(&Namespace, "namespace", defaultNamespace, "Namespace")
+	flag.StringVar(&TestLicense, "test-license", "", "path to Enterprise license to be used for testing")
 	flag.BoolVar(&AutoPortForward, "auto-port-forward", false, "enables automatic port-forwarding "+
 		"(for dev use only as it exposes k8s resources on ephemeral ports to localhost)")
 	flag.Parse()

--- a/operators/test/e2e/stack/checks_es.go
+++ b/operators/test/e2e/stack/checks_es.go
@@ -96,18 +96,28 @@ func (e *esClusterChecks) CheckESHealthGreen() helpers.TestStep {
 }
 func (e *esClusterChecks) CheckESNodesTopology(es estype.Elasticsearch) helpers.TestStep {
 	return helpers.TestStep{
-		Name: "Elasticsearch nodes topology should be the expected one",
-		Test: func(t *testing.T) {
+		Name: "Elasticsearch nodes topology should eventually be the expected one",
+		Test: helpers.Eventually(func() error {
 			ctx, cancel := context.WithTimeout(context.Background(), client.DefaultReqTimeout)
 			defer cancel()
 
 			nodes, err := e.client.GetNodes(ctx)
-			require.NoError(t, err)
-			require.Equal(t, int(es.Spec.NodeCount()), len(nodes.Nodes))
+			if err != nil {
+				return err
+			}
+			if int(es.Spec.NodeCount()) != len(nodes.Nodes) {
+				return fmt.Errorf("expected node count %d but was %d", es.Spec.NodeCount(), len(nodes.Nodes))
+			}
 
 			nodesStats, err := e.client.GetNodesStats(ctx)
-			require.NoError(t, err)
-			require.Equal(t, int(es.Spec.NodeCount()), len(nodesStats.Nodes))
+			if err != nil {
+				return err
+			}
+			if int(es.Spec.NodeCount()) != len(nodesStats.Nodes) {
+				return fmt.Errorf(
+					"expected node count %d but _nodes/stats returned %d", es.Spec.NodeCount(), len(nodesStats.Nodes),
+				)
+			}
 
 			// flatten the topology
 			var expectedTopology []estype.NodeSpec
@@ -120,12 +130,22 @@ func (e *esClusterChecks) CheckESNodesTopology(es estype.Elasticsearch) helpers.
 			for nodeId, node := range nodes.Nodes {
 				nodeRoles := rolesToConfig(node.Roles)
 
-				require.Contains(t, nodesStats.Nodes, nodeId)
-				nodeStats := nodesStats.Nodes[nodeId]
+				var found bool
+				for k, _ := range nodesStats.Nodes {
+					if k == nodeId {
+						found = true
+					}
+				}
+				if !found {
+					return fmt.Errorf("%s was not in %+v", nodeId, nodesStats.Nodes)
+				}
 
+				nodeStats := nodesStats.Nodes[nodeId]
 				for i, topoElem := range expectedTopology {
 					cfg, err := v1alpha1.UnpackConfig(topoElem.Config)
-					require.NoError(t, err)
+					if err != nil {
+						return err
+					}
 
 					podNameExample := name.NewPodName(es.Name, topoElem)
 
@@ -133,7 +153,9 @@ func (e *esClusterChecks) CheckESNodesTopology(es estype.Elasticsearch) helpers.
 					cgroupMemoryLimitsInBytes, err := strconv.ParseInt(
 						nodeStats.OS.CGroup.Memory.LimitInBytes, 10, 64,
 					)
-					require.NoError(t, err)
+					if err != nil {
+						return err
+					}
 
 					if cfg.Node == nodeRoles &&
 						compareMemoryLimit(topoElem, cgroupMemoryLimitsInBytes) &&
@@ -146,8 +168,11 @@ func (e *esClusterChecks) CheckESNodesTopology(es estype.Elasticsearch) helpers.
 				}
 			}
 			// expected topology should have matched all nodes
-			require.Empty(t, expectedTopology)
-		},
+			if len(expectedTopology) > 0 {
+				return fmt.Errorf("expected elements missing from cluster %+v", expectedTopology)
+			}
+			return nil
+		}),
 	}
 }
 

--- a/operators/test/e2e/stack/license.go
+++ b/operators/test/e2e/stack/license.go
@@ -39,15 +39,7 @@ func NewLicenseTestContext(k *helpers.K8sHelper, es estype.Elasticsearch) licens
 	}
 }
 
-func (ltctx *licenseTestContext) WrapSteps(steps ...helpers.TestStep) helpers.TestStepList {
-	testSteps := helpers.TestStepList{
-		ltctx.createESClient(),
-	}
-	testSteps = append(testSteps, steps...)
-	return testSteps
-}
-
-func (ltctx *licenseTestContext) createESClient() helpers.TestStep {
+func (ltctx *licenseTestContext) Init() helpers.TestStep {
 	return helpers.TestStep{
 		Name: "Creating Elasticsearch client",
 		Test: func(t *testing.T) {
@@ -97,9 +89,22 @@ func (ltctx *licenseTestContext) CreateEnterpriseLicenseSecret(licenseBytes []by
 					license.FileName: licenseBytes,
 				},
 			}
-			// delete if left over from previous run
-			_ = ltctx.k.Client.Delete(&sec)
 			require.NoError(t, ltctx.k.Client.Create(&sec))
+		},
+	}
+}
+
+func (ltctx *licenseTestContext) DeleteEnterpriseLicenseSecret() helpers.TestStep {
+	return helpers.TestStep{
+		Name: "Removing any test enterprise licenses",
+		Test: func(t *testing.T) {
+			sec := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: params.Namespace,
+					Name:      licenseSecretName,
+				},
+			}
+			_ = ltctx.k.Client.Delete(&sec)
 		},
 	}
 }

--- a/operators/test/e2e/stack/license.go
+++ b/operators/test/e2e/stack/license.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package stack
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	estype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/license"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/client"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/stringsutil"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/helpers"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/params"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	licenseSecretName = "e2e-enterprise-license"
+)
+
+type licenseTestContext struct {
+	esClient client.Client
+	k        *helpers.K8sHelper
+	es       estype.Elasticsearch
+}
+
+func NewLicenseTestContext(k *helpers.K8sHelper, es estype.Elasticsearch) licenseTestContext {
+	return licenseTestContext{
+		k:  k,
+		es: es,
+	}
+}
+
+func (ltctx *licenseTestContext) WrapSteps(steps ...helpers.TestStep) helpers.TestStepList {
+	testSteps := helpers.TestStepList{
+		ltctx.createESClient(),
+	}
+	testSteps = append(testSteps, steps...)
+	return testSteps
+}
+
+func (ltctx *licenseTestContext) createESClient() helpers.TestStep {
+	return helpers.TestStep{
+		Name: "Creating Elasticsearch client",
+		Test: func(t *testing.T) {
+			esclient, err := helpers.NewElasticsearchClient(ltctx.es, ltctx.k)
+			require.NoError(t, err)
+			ltctx.esClient = esclient
+		},
+	}
+}
+
+func (ltctx *licenseTestContext) CheckElasticsearchLicense(expectedTypes ...license.ElasticsearchLicenseType) helpers.TestStep {
+	return helpers.TestStep{
+		Name: fmt.Sprintf("Elasticsearch license should be %v", expectedTypes),
+		Test: helpers.Eventually(func() error {
+			ctx, cancel := context.WithTimeout(context.Background(), client.DefaultReqTimeout)
+			defer cancel()
+
+			l, err := ltctx.esClient.GetLicense(ctx)
+			if err != nil {
+				return err
+			}
+			var expectedStrings []string
+			for i := range expectedTypes {
+				expectedStrings = append(expectedStrings, string(expectedTypes[i]))
+			}
+			if !stringsutil.StringInSlice(l.Type, expectedStrings) {
+				return fmt.Errorf("expectedTypes license type %v got %s", expectedStrings, l.Type)
+			}
+			return nil
+		}),
+	}
+}
+
+func (ltctx *licenseTestContext) CreateEnterpriseLicenseSecret(licenseBytes []byte) helpers.TestStep {
+	return helpers.TestStep{
+		Name: "Creating enterprise license secret",
+		Test: func(t *testing.T) {
+			sec := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: params.Namespace,
+					Name:      licenseSecretName,
+					Labels: map[string]string{
+						license.LicenseLabelType: string(license.LicenseTypeEnterprise),
+					},
+				},
+				Data: map[string][]byte{
+					license.FileName: licenseBytes,
+				},
+			}
+			// delete if left over from previous run
+			_ = ltctx.k.Client.Delete(&sec)
+			require.NoError(t, ltctx.k.Client.Create(&sec))
+		},
+	}
+}


### PR DESCRIPTION
* tests license provisioning for a single cluster
* does not run by default unless the path to a test license is specified via `--test-license`
* Follow up work: find out how we can get a test license into the CI infrastructure and use that for testing.