### PR TITLE
Disable build cancelation on PR update

### DIFF
--- a/.ci/jobs/pr.yml
+++ b/.ci/jobs/pr.yml
@@ -26,7 +26,7 @@
           allow-whitelist-orgs-as-admins: true
           github-hooks: true
           status-context: devops-ci
-          cancel-builds-on-update: true
+          cancel-builds-on-update: false
     properties:
       - github:
           url: https://github.com/elastic/cloud-on-k8s/


### PR DESCRIPTION
Currently we are using setting `cancel-builds-on-update: true` which cancel existing builds when a PR is updated. Unfortunately, when build is canceled it doesn't triggers post conditions. After adding e2e tests to PR build we are having situations when GKE clusters weren't removed after build cancelation.