### PR TITLE
Reorganize the Deep Dive section

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -267,7 +267,7 @@ EOF
 [id="{p}-persistent-storage"]
 === Use persistent storage
 
-Now that you have completed the quickstart, you can try out more features like using persistent storage. The cluster that you deployed in this quickstart uses an link:https://kubernetes.io/docs/concepts/storage/volumes/#emptydir[emptyDir volume], which might not qualify for production workloads.
+Now that you have completed the quickstart, you can try out more features like using persistent storage. The cluster that you deployed in this quickstart uses a default persistent volume claim of 1GiB, without a storage class set. This means that the default storage class defined in the Kubernetes cluster is the one that will be provisioned.
 
 You can request a `PersistentVolumeClaim` in the cluster specification, to target any `PersistentVolume` class available in your Kubernetes cluster:
 

--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -9,7 +9,8 @@ Eager to get started? This fast guide shows you how to:
 * <<{p}-deploy-elasticsearch,Deploy the Elasticsearch cluster>>
 * <<{p}-deploy-kibana,Deploy the Kibana instance>>
 * <<{p}-upgrade-deployment,Upgrade your deployment>>
-* <<{p}-deep-dive,Deep dive>>
+* <<{p}-persistent-storage,Use persistent storage>>
+* <<{p}-check-samples,Check out the samples>>
 
 **Requirements**
 
@@ -263,15 +264,10 @@ EOF
 ----
 
 [float]
-[id="{p}-deep-dive"]
-=== Deep dive
+[id="{p}-persistent-storage"]
+=== Use persistent storage
 
-Now that you have completed the quickstart, you can try out more features like using persistent storage.
-
-[float]
-==== Use persistent storage
-
-The cluster that you deployed in this quickstart uses an link:https://kubernetes.io/docs/concepts/storage/volumes/#emptydir[emptyDir volume], which might not qualify for production workloads.
+Now that you have completed the quickstart, you can try out more features like using persistent storage. The cluster that you deployed in this quickstart uses an link:https://kubernetes.io/docs/concepts/storage/volumes/#emptydir[emptyDir volume], which might not qualify for production workloads.
 
 You can request a `PersistentVolumeClaim` in the cluster specification, to target any `PersistentVolume` class available in your Kubernetes cluster:
 
@@ -310,7 +306,8 @@ To aim for the best performance, the operator supports persistent volumes local 
  * link:https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner[kubernetes-sigs local volume static provisioner] to setup static local volumes.
 
 [float]
-==== Check out the samples
+[id="{p}-check-samples"]
+=== Check out the samples
 
 You can find a set of sample resources link:https://github.com/elastic/cloud-on-k8s/tree/master/operators/config/samples[in the project repository].
 To customize the Elasticsearch resource, check the link:https://github.com/elastic/cloud-on-k8s/blob/master/operators/config/samples/elasticsearch/elasticsearch.yaml[Elasticsearch sample].


### PR DESCRIPTION
Suggested reorg for the following reasons:

- the **Deep Dive** section was originally meant to contain more advanced features. Now, it only contains `Use persistent storage`  and `Check out the samples`.
- a _deep dive_ section is not really coherent with a _quickstart_ approach

Alternatively, we can rename it something like "Want to discover more?", "Eager to know more?"