### PR TITLE
Add Overview section

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -6,6 +6,7 @@
 
 include::{asciidoc-dir}/../../shared/versions70.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+include::overview.asciidoc[]
 include::k8s-quickstart.asciidoc[]
 include::accessing-services.asciidoc[]
 include::advanced-node-scheduling.asciidoc[]

--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -8,8 +8,9 @@ With Elastic Cloud on Kubernetes you can streamline all those critical operation
 . Managing and monitoring multiple clusters
 . Scaling cluster capacity up and down
 . Changing cluster configuration
-. Dynamically scaling local storage (includes Elastic Local Volume, a local storage driver)
 . Scheduling backups
+. Securing clusters with TLS certificates
+. Setting up hot-warm-cold architectures with availability zone awareness
 
 Learn more about ECK:
 

--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -1,0 +1,19 @@
+[id="{p}-overview"]
+== Overview
+
+Built on the Kubernetes Operator pattern, Elastic Cloud on Kubernetes (ECK) extends the basic Kubernetes orchestration capabilities to support the setup and management of Elasticsearch and Kibana on Kubernetes.
+
+With Elastic Cloud on Kubernetes you can streamline all those critical operations, such as:
+
+. Managing and monitoring multiple clusters
+. Scaling cluster capacity up and down
+. Changing cluster configuration
+. Dynamically scaling local storage (includes Elastic Local Volume, a local storage driver)
+. Scheduling backups
+
+Learn more about ECK:
+
+- link:https://www.elastic.co/elasticsearch-kubernetes[Orchestrate Elasticsearch on Kubernetes]
+- link:https://www.elastic.co/blog/introducing-elastic-cloud-on-kubernetes-the-elasticsearch-operator-and-beyond?elektra=products&storm=sub1[ECK's Blog]
+
+


### PR DESCRIPTION
Closes #1073

- Drafted the Overview section
- Updated the index.asciidoc to include the new file

Once this PR is merged, I would remove the following text from the Quickstart. 

> With Elastic Cloud on Kubernetes (ECK) you can extend the basic Kubernetes orchestration capabilities to easily deploy, secure, upgrade your Elasticsearch cluster, and much more.

