### PR TITLE
Add link to kubectl page

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -14,7 +14,7 @@ Eager to get started? This fast guide shows you how to:
 
 **Requirements**
 
-This quickstart assumes you already have Kubernetes 1.11+.
+Make sure that you have link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl] version 1.11+ installed.
 
 [float]
 [id="{p}-deploy-eck"]


### PR DESCRIPTION
Closes #909

In the **Prerequisites** note, I added a link to the [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) page.