### PR TITLE
E2E tests: add a retry when getting the pod name

### DIFF
--- a/operators/hack/run-e2e.sh
+++ b/operators/hack/run-e2e.sh
@@ -17,6 +17,8 @@ TESTS_MATCH="$2" # Expression to match go test names (can be "")
 JOB_NAME="eck-e2e-tests-$(LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 6 | head -n 1)"
 NAMESPACE="e2e"
 
+# exit early if another job already exists
+set +e
 kubectl -n e2e get job $JOB_NAME && \
     echo "Job $JOB_NAME already exists, please delete it first. Exiting." && \
     exit 1

--- a/operators/hack/run-e2e.sh
+++ b/operators/hack/run-e2e.sh
@@ -9,7 +9,7 @@
 # Usage: ./hack/run-e2e.sh <e2e_docker_image_name> <go_tests_matcher>
 #
 
-set -eu
+set -eux
 
 IMG="$1" # Docker image name
 TESTS_MATCH="$2" # Expression to match go test names (can be "")

--- a/operators/hack/run-e2e.sh
+++ b/operators/hack/run-e2e.sh
@@ -36,6 +36,7 @@ sed \
 pod=""
 retry=0
 e2e_pod_creation_max_retries=30
+set +e # ignore error in the retry loop
 while true; do
     if [[ ${retry} -ge ${e2e_pod_creation_max_retries} ]]; then
         echo "failed to get the e2e pod name after ${e2e_pod_creation_max_retries} retries"
@@ -48,6 +49,7 @@ while true; do
     fi
     sleep 1;
 done
+set -e
 
 # wait until its container is started
 while kubectl -n $NAMESPACE get pod $pod | grep ContainerCreating; do

--- a/operators/hack/run-e2e.sh
+++ b/operators/hack/run-e2e.sh
@@ -35,10 +35,10 @@ sed \
 # retrieve pod responsible for running the job
 pod=""
 retry=0
-e2e_pod_creation_timeout=30
+e2e_pod_creation_max_retries=30
 while true; do
-    if [[ ${retry} -ge ${e2e_pod_creation_timeout} ]]; then
-        echo "failed to get the e2e pod name after ${e2e_pod_creation_timeout} seconds"
+    if [[ ${retry} -ge ${e2e_pod_creation_max_retries} ]]; then
+        echo "failed to get the e2e pod name after ${e2e_pod_creation_max_retries} retries"
         exit 1
     fi
     ((retry++))

--- a/operators/hack/run-e2e.sh
+++ b/operators/hack/run-e2e.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License;

--- a/operators/hack/run-e2e.sh
+++ b/operators/hack/run-e2e.sh
@@ -9,7 +9,7 @@
 # Usage: ./hack/run-e2e.sh <e2e_docker_image_name> <go_tests_matcher>
 #
 
-set -eux
+set -eu
 
 IMG="$1" # Docker image name
 TESTS_MATCH="$2" # Expression to match go test names (can be "")


### PR DESCRIPTION
When running the e2e job the pod might not be ready immediately.