### PR TITLE
Rename es,kb used by TestMutationResizeMemoryDown

### DIFF
--- a/operators/test/e2e/mutation_test.go
+++ b/operators/test/e2e/mutation_test.go
@@ -84,7 +84,7 @@ func TestMutationResizeMemoryUp(t *testing.T) {
 // then mutates it to a 1 node cluster with less RAM
 func TestMutationResizeMemoryDown(t *testing.T) {
 	// create a stack with a 4G node
-	initStack := stack.NewStackBuilder("test-mutation-resize-memory-up").
+	initStack := stack.NewStackBuilder("test-mutation-resize-memory-down").
 		WithESMasterDataNodes(1, corev1.ResourceRequirements{
 			Limits: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceMemory: resource.MustParse("4Gi"),


### PR DESCRIPTION
This commit fixes the name of the Elastisearch and the Kibana resources
used by the e2e test TestMutationResizeMemoryDown, that was already used
by the e2e test TestMutationResizeMemoryUp.