### PR TITLE
Utility to dump info to diagnose problems

### DIFF
--- a/operators/hack/eck-dump.sh
+++ b/operators/hack/eck-dump.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# Support diagnostics utility for Elastic Cloud in Kubernetes (ECK)
+#
+set -eu
+
+help() {
+  echo 'Usage: ./eck-dump.sh [OPTIONS]
+
+Dumps Elastic Cloud in Kubernetes (ECK) info out suitable for debugging and diagnosing problems.
+
+By default, dumps everything to stdout. You can optionally specify a directory with --output-directory.
+By default only dumps things in the namespaces "elastic-system", "elastic-namespace-operators" and the 
+current, but you can switch to different namespaces with the --operator-namespaces and --elastic-namespaces
+flags.
+
+Options:
+  -N, --operator-namespaces     Namespace(s) in which operator(s) are running in (list separated by comma)
+  -n, --resources-namespaces    Namespace(s) in which resources are managed      (list separated by comma)
+  -d, --output-directory        Path to output dump files (default: .)
+  -v, --verbose                 Verbose mode
+
+Dependencies:
+  kubectl'
+  exit
+}
+
+OPERATOR_NS=elastic-system,elastic-namespace-operators
+ELASTIC_NS="default"
+OUTPUT_DIR=""
+VERBOSE=0
+
+parse_args() {
+  while :; do
+    local flag=${1:-""} value=${2:-""}
+    case $flag in
+    -h|--help)
+      help
+    ;;
+    -N|--operator-namespaces)
+      OPERATOR_NS=${value:-OPERATOR_NS}
+    ;;
+    -n|--elastic-namespaces)
+      ELASTIC_NS=${value:-${$(current_namespace):-ELASTIC_NS}}
+    ;;
+    -d|--output-directory)
+      OUTPUT_DIR=${value:-${OUTPUT_DIR:-"."}}
+    ;;
+    -v|--verbose)
+      VERBOSE=1
+    ;;
+    esac
+    shift || break
+  done
+}
+
+main() {
+  parse_args $@
+
+  IFS=, # use comma as field separator for iterations
+  
+  # start by checking the namespaces exist
+  local all_ns="$OPERATOR_NS,$ELASTIC_NS"
+  for ns in $all_ns; do
+    check_namespace $ns
+  done
+
+  # get global info
+  kubectl version   -o json | to_stdin_or_file version.json
+  kubectl get nodes -o json | to_stdin_or_file nodes.json
+
+  # get info from the namespaces in which operators are running in 
+  for ns in $OPERATOR_NS; do
+    get_resources $ns statefulsets
+    get_resources $ns pods
+    get_resources $ns services
+    get_resources $ns events
+    get_logs $ns
+  done
+
+  # get info from the namespaces in which resources are managed 
+  for ns in $ELASTIC_NS; do
+    get_resources $ns replicasets
+    get_resources $ns deployments
+    get_resources $ns pods
+    get_resources $ns services
+    get_resources $ns events
+    
+    local types="kibana,elasticsearch,apmserver"
+    for t in $types; do
+      get_resources $ns $t
+      get_logs $ns common.k8s.elastic.co/type=$t
+    done
+  done
+
+  if [[ "$OUTPUT_DIR" != "" ]]; then
+    echo "ECK info dumped to $OUTPUT_DIR"
+  fi
+}
+
+# get_resources lists resources in a speficied namespace in JSON output format
+get_resources() {
+  local ns=$1 resources=${2}
+  kubectl get -n $ns $resources -o json | to_stdin_or_file $ns/$resources.json
+}
+
+# get_logs retrieves logs for all pods in a specified namespace
+get_logs() {
+  local ns=$1 label=${2:-""} # optional label selector
+  while read name; do
+  (
+    echo "==== START logs for pod $ns/$name ===="
+    kubectl -n $ns logs $name --all-containers 
+    echo "==== END logs for pod $ns/$name ===="
+  ) | to_stdin_or_file $ns/$name/logs.txt
+  done \
+  < <(list_pods_names $ns $label)
+}
+
+# list_pods_names lists the names of the pods in a specified namespace
+list_pods_names() {
+  local ns=$1 label=${2:-}
+  [[ "$label" != "" ]] && label="-l $label"
+  kubectl get pods -n $ns $label --no-headers=true -o name 
+}
+
+# to_stdin_or_file redirects stdin to a file if OUTPUT_DIR is defined, else to stdout
+to_stdin_or_file() {
+  local filepath=$1
+  if [[ "$VERBOSE" == "1" ]]; then
+    >&2 echo "$OUTPUT_DIR/$filepath"
+  fi
+  if [[ $OUTPUT_DIR != "" ]]; then
+    mkdir -p $(dirname $OUTPUT_DIR/$filepath)
+    cat /dev/stdin > $OUTPUT_DIR/$filepath 
+  else
+    cat /dev/stdin
+  fi
+}
+
+# check_namespace fails and exits the program if the namespace does not exist
+check_namespace() {
+  local ns="$1"
+  kubectl get namespace $1 >/dev/null
+}
+
+# current_namespace returns the current namespace, empty if there is none
+current_namespace() {
+  kubectl config view --minify --output 'jsonpath={..namespace}' 2>/dev/null
+}
+
+main "$@"

--- a/operators/hack/eck-dump.sh
+++ b/operators/hack/eck-dump.sh
@@ -72,6 +72,8 @@ main() {
   kubectl version   -o json | to_stdin_or_file version.json
   kubectl get nodes -o json | to_stdin_or_file nodes.json
   kubectl get podsecuritypolicies -o json | to_stdin_or_file podsecuritypolicies.json
+  # describe matches by prefix
+  kubectl describe clusterroles elastic | to_stdin_or_file clusterroles.txt
 
   # get info from the namespaces in which operators are running in 
   for ns in $OPERATOR_NS; do

--- a/operators/hack/eck-dump.sh
+++ b/operators/hack/eck-dump.sh
@@ -29,7 +29,7 @@ Dependencies:
 }
 
 OPERATOR_NS=elastic-system
-ELASTIC_NS="default"
+RESOURCES_NS="default"
 OUTPUT_DIR=""
 VERBOSE=0
 
@@ -43,8 +43,8 @@ parse_args() {
     -N|--operator-namespaces)
       OPERATOR_NS=${value:-OPERATOR_NS}
     ;;
-    -n|--elastic-namespaces)
-      ELASTIC_NS=${value:-${$(current_namespace):-ELASTIC_NS}}
+    -n|--resources-namespaces)
+      RESOURCES_NS=${value:-${$(current_namespace):-RESOURCES_NS}}
     ;;
     -o|--output-directory)
       OUTPUT_DIR=${value:-${OUTPUT_DIR:-"."}}
@@ -62,8 +62,8 @@ main() {
 
   IFS=, # use comma as field separator for iterations
   
-  # start by checking the namespaces exist
-  local all_ns="$OPERATOR_NS,$ELASTIC_NS"
+  # start by checking if the namespaces exist
+  local all_ns="$OPERATOR_NS,$RESOURCES_NS"
   for ns in $all_ns; do
     check_namespace $ns
   done
@@ -82,7 +82,7 @@ main() {
   done
 
   # get info from the namespaces in which resources are managed 
-  for ns in $ELASTIC_NS; do
+  for ns in $RESOURCES_NS; do
     get_resources $ns replicasets
     get_resources $ns deployments
     get_resources $ns pods

--- a/operators/hack/eck-dump.sh
+++ b/operators/hack/eck-dump.sh
@@ -14,9 +14,8 @@ help() {
 Dumps Elastic Cloud in Kubernetes (ECK) info out suitable for debugging and diagnosing problems.
 
 By default, dumps everything to stdout. You can optionally specify a directory with --output-directory.
-By default only dumps things in the namespaces "elastic-system", "elastic-namespace-operators" and the 
-current, but you can switch to different namespaces with the --operator-namespaces and --elastic-namespaces
-flags.
+By default only dumps things in the namespaces "elastic-system" and the current, but you can switch to
+different namespaces with the --operator-namespaces and --elastic-namespaces flags.
 
 Options:
   -N, --operator-namespaces     Namespace(s) in which operator(s) are running in (list separated by comma)
@@ -29,7 +28,7 @@ Dependencies:
   exit
 }
 
-OPERATOR_NS=elastic-system,elastic-namespace-operators
+OPERATOR_NS=elastic-system
 ELASTIC_NS="default"
 OUTPUT_DIR=""
 VERBOSE=0

--- a/operators/hack/eck-dump.sh
+++ b/operators/hack/eck-dump.sh
@@ -4,14 +4,14 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
-# Diagnostics utility for Elastic Cloud in Kubernetes (ECK)
+# Diagnostics utility for Elastic Cloud on Kubernetes (ECK)
 
 set -eu
 
 help() {
   echo 'Usage: ./eck-dump.sh [OPTIONS]
 
-Dumps Elastic Cloud in Kubernetes (ECK) info out suitable for debugging and diagnosing problems.
+Dumps Elastic Cloud on Kubernetes (ECK) info out suitable for debugging and diagnosing problems.
 
 By default, dumps everything to stdout. You can optionally specify a directory with --output-directory.
 By default only dumps things in the namespaces "elastic-system" and the current, but you can switch to

--- a/operators/hack/eck-dump.sh
+++ b/operators/hack/eck-dump.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
-#
-# Support diagnostics utility for Elastic Cloud in Kubernetes (ECK)
-#
+
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+# Diagnostics utility for Elastic Cloud in Kubernetes (ECK)
+
 set -eu
 
 help() {

--- a/operators/hack/eck-dump.sh
+++ b/operators/hack/eck-dump.sh
@@ -77,6 +77,7 @@ main() {
     get_resources $ns statefulsets
     get_resources $ns pods
     get_resources $ns services
+    get_resources $ns configmaps
     get_resources $ns events
     get_logs $ns
   done
@@ -86,8 +87,12 @@ main() {
     get_resources $ns replicasets
     get_resources $ns deployments
     get_resources $ns pods
+    get_resources $ns persistentvolumes
+    get_resources $ns persistentvolumeclaims
     get_resources $ns services
+    get_resources $ns configmaps
     get_resources $ns events
+    list_resources $ns secrets
     
     local types="kibana,elasticsearch,apmserver"
     for t in $types; do
@@ -101,10 +106,17 @@ main() {
   fi
 }
 
-# get_resources lists resources in a speficied namespace in JSON output format
+# get_resources lists resources in a specified namespace in JSON output format
 get_resources() {
   local ns=$1 resources=${2}
   kubectl get -n $ns $resources -o json | to_stdin_or_file $ns/$resources.json
+}
+
+# list_resources lists resources in a specified namespace in human readable plain-text
+# Useful to list secrets without their content.
+list_resources() {
+  local ns=$1 resources=${2}
+  kubectl get -n $ns $resources | to_stdin_or_file $ns/$resources.txt
 }
 
 # get_logs retrieves logs for all pods in a specified namespace

--- a/operators/hack/eck-dump.sh
+++ b/operators/hack/eck-dump.sh
@@ -68,9 +68,10 @@ main() {
     check_namespace $ns
   done
 
-  # get global info
+  # get global info from cluster-level resources
   kubectl version   -o json | to_stdin_or_file version.json
   kubectl get nodes -o json | to_stdin_or_file nodes.json
+  kubectl get podsecuritypolicies -o json | to_stdin_or_file podsecuritypolicies.json
 
   # get info from the namespaces in which operators are running in 
   for ns in $OPERATOR_NS; do
@@ -79,6 +80,7 @@ main() {
     get_resources $ns services
     get_resources $ns configmaps
     get_resources $ns events
+    get_resources $ns networkpolicies
     get_logs $ns
   done
 
@@ -92,6 +94,7 @@ main() {
     get_resources $ns services
     get_resources $ns configmaps
     get_resources $ns events
+    get_resources $ns networkpolicies
     list_resources $ns secrets
     
     local types="kibana,elasticsearch,apmserver"

--- a/operators/hack/eck-dump.sh
+++ b/operators/hack/eck-dump.sh
@@ -21,6 +21,7 @@ Options:
   -N, --operator-namespaces     Namespace(s) in which operator(s) are running in (comma-separated list)
   -n, --resources-namespaces    Namespace(s) in which resources are managed      (comma-separated list)
   -o, --output-directory        Path to output dump files (default: .)
+  -z, --create-zip              Create an archive of the output directorty (implies --output-directory)
   -v, --verbose                 Verbose mode
 
 Dependencies:
@@ -31,6 +32,7 @@ Dependencies:
 OPERATOR_NS=elastic-system
 RESOURCES_NS="default"
 OUTPUT_DIR=""
+ZIP=""
 VERBOSE=0
 
 parse_args() {
@@ -53,6 +55,9 @@ parse_args() {
         exit 1
       fi
     ;;
+    -z|--create-zip)
+      ZIP=true
+    ;;
     -v|--verbose)
       VERBOSE=1
     ;;
@@ -63,6 +68,11 @@ parse_args() {
 
 main() {
   parse_args $@
+
+  if [[ -z $OUTPUT_DIR && ! -z $ZIP ]]; then
+    >&2 echo "flag needs to be defined : --output-directory"
+    exit 1
+  fi
 
   IFS=, # use comma as field separator for iterations
   
@@ -110,8 +120,13 @@ main() {
     done
   done
 
-  if [[ "$OUTPUT_DIR" != "" ]]; then
-    echo "ECK info dumped to $OUTPUT_DIR"
+  if [[ ! -z $OUTPUT_DIR ]]; then
+    local dest=$OUTPUT_DIR
+    if [[ ! -z $ZIP ]]; then
+      dest=$OUTPUT_DIR-$(date +%d_%b_%Y_%H_%M_%S).tgz
+      tar czf $dest $OUTPUT_DIR/*
+    fi
+    echo "ECK info dumped to $dest"
   fi
 }
 

--- a/operators/hack/eck-dump.sh
+++ b/operators/hack/eck-dump.sh
@@ -18,9 +18,9 @@ By default only dumps things in the namespaces "elastic-system" and the current,
 different namespaces with the --operator-namespaces and --elastic-namespaces flags.
 
 Options:
-  -N, --operator-namespaces     Namespace(s) in which operator(s) are running in (list separated by comma)
-  -n, --resources-namespaces    Namespace(s) in which resources are managed      (list separated by comma)
-  -d, --output-directory        Path to output dump files (default: .)
+  -N, --operator-namespaces     Namespace(s) in which operator(s) are running in (comma-separated list)
+  -n, --resources-namespaces    Namespace(s) in which resources are managed      (comma-separated list)
+  -o, --output-directory        Path to output dump files (default: .)
   -v, --verbose                 Verbose mode
 
 Dependencies:
@@ -46,7 +46,7 @@ parse_args() {
     -n|--elastic-namespaces)
       ELASTIC_NS=${value:-${$(current_namespace):-ELASTIC_NS}}
     ;;
-    -d|--output-directory)
+    -o|--output-directory)
       OUTPUT_DIR=${value:-${OUTPUT_DIR:-"."}}
     ;;
     -v|--verbose)

--- a/operators/hack/eck-dump.sh
+++ b/operators/hack/eck-dump.sh
@@ -41,13 +41,17 @@ parse_args() {
       help
     ;;
     -N|--operator-namespaces)
-      OPERATOR_NS=${value:-OPERATOR_NS}
+      OPERATOR_NS=${value:-$OPERATOR_NS}
     ;;
     -n|--resources-namespaces)
-      RESOURCES_NS=${value:-${$(current_namespace):-RESOURCES_NS}}
+      RESOURCES_NS=${value:-${$(current_namespace):-$RESOURCES_NS}}
     ;;
     -o|--output-directory)
-      OUTPUT_DIR=${value:-${OUTPUT_DIR:-"."}}
+      OUTPUT_DIR=${value:-$OUTPUT_DIR}
+      if [[ -z $OUTPUT_DIR ]]; then
+        >&2 echo "flag needs an argument: --output-directory"
+        exit 1
+      fi
     ;;
     -v|--verbose)
       VERBOSE=1
@@ -150,7 +154,7 @@ to_stdin_or_file() {
   if [[ "$VERBOSE" == "1" ]]; then
     >&2 echo "$OUTPUT_DIR/$filepath"
   fi
-  if [[ $OUTPUT_DIR != "" ]]; then
+  if [[ ! -z $OUTPUT_DIR ]]; then
     mkdir -p $(dirname $OUTPUT_DIR/$filepath)
     cat /dev/stdin > $OUTPUT_DIR/$filepath 
   else


### PR DESCRIPTION
Adds a utility script to dump info out suitable for debugging and diagnosing problems, heavily inspired by `kubectl cluster-info dump`.

```bash
> ./eck-dump.sh -h
Usage: ./eck-dump.sh [OPTIONS]

Dumps Elastic Cloud in Kubernetes (ECK) info out suitable for debugging and diagnosing problems.

By default, dumps everything to stdout. You can optionally specify a directory with --output-directory.
By default only dumps things in the namespaces "elastic-system", "elastic-namespace-operators" and the 
current, but you can switch to different namespaces with the --operator-namespaces and --elastic-namespaces
flags.

Options:
  -N, --operator-namespaces     Namespace(s) in which operator(s) are running in (list separated by comma)
  -n, --resources-namespaces    Namespace(s) in which resources are managed      (list separated by comma)
  -o, --output-directory        Path to output dump files (default: .)
  -v, --verbose                 Verbose mode

Dependencies:
  kubectl
```

Related to #46.