### PR TITLE
Rename ownerName after logging the error

### DIFF
--- a/operators/pkg/controller/common/name/name.go
+++ b/operators/pkg/controller/common/name/name.go
@@ -63,9 +63,9 @@ func (n Namer) Suffix(ownerName string, suffixes ...string) string {
 	// Trim the ownerName and log an error as fallback.
 	maxPrefixLength := MaxNameLength - len(suffix)
 	if len(ownerName) > maxPrefixLength {
-		ownerName = ownerName[:maxPrefixLength]
 		log.Error(fmt.Errorf("ownerName should not exceed %d characters: got %s", maxPrefixLength, ownerName),
 			"Failed to suffix resource")
+		ownerName = ownerName[:maxPrefixLength]
 	}
 
 	return stringsutil.Concat(ownerName, suffix)


### PR DESCRIPTION
Small fix to rename the ownerName only after logging the error to log the initial name.

```
"msg":"Failed to suffix resource",
"error":"ownerName should not exceed 44 characters: got test-failure-kill-one-master-node-es-sj4cpg5"
```