### PR TITLE
Set the operator-namespace to default when running locally

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -129,7 +129,7 @@ run: install-crds
 			./cmd/main.go manager \
 				--development --operator-roles=global,namespace \
 				--ca-cert-validity=10h --ca-cert-rotate-before=1h \
-				--operator-namespace=elastic-system --namespace= \
+				--operator-namespace=default --namespace= \
 				--auto-install-webhooks=false
 
 # if the current k8s cluster is on GKE, GCLOUD_PROJECT must be set


### PR DESCRIPTION
The operator creates a configmap in its own namespace. When running
locally for development with `make run`, this namespace probably doesn't
exist, which makes the operator fail at startup.
Let's use the default namespace instead of "elastic-system", it seems
simpler than creating the "elastic-system" namespace on dev
environments.
