### PR TITLE
Don't prefix logger names with "kubebuilder."

### DIFF
--- a/operators/cmd/main.go
+++ b/operators/cmd/main.go
@@ -12,7 +12,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-var log = logf.KBLog.WithName("main")
+var log = logf.Log.WithName("main")
 
 func main() {
 	var rootCmd = &cobra.Command{Use: "elastic-operator"}

--- a/operators/pkg/controller/elasticsearch/certificates/transport/reconcile.go
+++ b/operators/pkg/controller/elasticsearch/certificates/transport/reconcile.go
@@ -25,7 +25,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-var log = logf.KBLog.WithName("transport")
+var log = logf.Log.WithName("transport")
 
 // ReconcileTransportCertificateSecrets reconciles certificate secrets for nodes
 // of the given es cluster.

--- a/operators/pkg/controller/elasticsearch/reconcile/log.go
+++ b/operators/pkg/controller/elasticsearch/reconcile/log.go
@@ -6,4 +6,4 @@ package reconcile
 
 import logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
-var log = logf.KBLog.WithName("reconcile")
+var log = logf.Log.WithName("reconcile")

--- a/operators/pkg/dev/portforward/doc.go
+++ b/operators/pkg/dev/portforward/doc.go
@@ -16,5 +16,5 @@ import (
 )
 
 var (
-	log = logf.KBLog.WithName("portforward")
+	log = logf.Log.WithName("portforward")
 )


### PR DESCRIPTION
A very small subset of our loggers were relying on `KBLog`, which adds a
"kubebuilder." prefix to the logger name in logs output.

Let's remove that usage and rely on a normal (non-prefixed) logger, similar with what we do with the rest of the code.
