### PR TITLE
Do not move files when preparing the fs, copy them instead

### DIFF
--- a/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
@@ -79,8 +79,8 @@ var scriptTemplate = template.Must(template.New("").Parse(
 		if [[ -z "$(ls -A {{.EsContainerMountPath}})" ]]; then
 			echo "Empty dir {{.EsContainerMountPath}}"
 		else
-			echo "Moving {{.EsContainerMountPath}}/* to {{.InitContainerMountPath}}/"
-			mv {{.EsContainerMountPath}}/* {{.InitContainerMountPath}}/
+			echo "Copying {{.EsContainerMountPath}}/* to {{.InitContainerMountPath}}/"
+			cp -av {{.EsContainerMountPath}}/* {{.InitContainerMountPath}}/
 		fi
 	{{end}}
 	echo "Files copy duration: $(duration $mv_start) sec."

--- a/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script_test.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs_script_test.go
@@ -28,9 +28,9 @@ func TestRenderScriptTemplate(t *testing.T) {
 							Target: "/usr/share/elasticsearch/users"}}},
 			},
 			wantSubstr: []string{
-				"mv /usr/share/elasticsearch/config/* /mnt/elastic-internal/elasticsearch-config-local/",
-				"mv /usr/share/elasticsearch/bin/* /mnt/elastic-internal/elasticsearch-bin-local/",
-				"mv /usr/share/elasticsearch/plugins/* /mnt/elastic-internal/elasticsearch-plugins-local/",
+				"cp -av /usr/share/elasticsearch/config/* /mnt/elastic-internal/elasticsearch-config-local/",
+				"cp -av /usr/share/elasticsearch/bin/* /mnt/elastic-internal/elasticsearch-bin-local/",
+				"cp -av /usr/share/elasticsearch/plugins/* /mnt/elastic-internal/elasticsearch-plugins-local/",
 				"ln -sf /secrets/users /usr/share/elasticsearch/users",
 			},
 		},


### PR DESCRIPTION
Directories in /usr/share/elasticsearch are owned by user 1000 (`elasticsearch`), they can only be moved by this user or by root.

If the pod is running as an other user it is not possible to move files, let's just copy them instead.