### PR TITLE
Pass GO_TAGS to go run invocation

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -127,7 +127,9 @@ run: install-crds go-run
 go-run:
     # Run the operator locally with role All, with operator image set to latest and operator namespace as for a global operator
 	AUTO_PORT_FORWARD=true OPERATOR_IMAGE=$(OPERATOR_IMAGE_LATEST) \
-		go run -ldflags "$(GO_LDFLAGS)" \
+		go run \
+			-ldflags "$(GO_LDFLAGS)" \
+			-tags "$(GO_TAGS)" \
 			./cmd/main.go manager \
 				--development --operator-roles=global,namespace \
 				--ca-cert-validity=10h --ca-cert-rotate-before=1h \


### PR DESCRIPTION
We have a source code include for the license public key that is predicated on a build constraint named 'release'. Without propagating the build tag it is not possible to run locally with a license public key included.