### PR TITLE
Allow users to specify transport certificate authorities

### DIFF
--- a/operators/pkg/controller/common/settings/canonical_config.go
+++ b/operators/pkg/controller/common/settings/canonical_config.go
@@ -23,7 +23,7 @@ import (
 type CanonicalConfig ucfg.Config
 
 // Options are config options for the YAML file. Currently contains only support for dotted keys.
-var Options = []ucfg.Option{ucfg.PathSep(".")}
+var Options = []ucfg.Option{ucfg.PathSep("."), ucfg.AppendValues}
 
 // NewCanonicalConfig creates a new empty config.
 func NewCanonicalConfig() *CanonicalConfig {
@@ -112,16 +112,13 @@ func (c *CanonicalConfig) MergeWith(cfgs ...*CanonicalConfig) error {
 	return nil
 }
 
-// HasPrefixes returns all keys in c that have one of the given prefix keys.
-// Keys are expected in dotted form.
-func (c *CanonicalConfig) HasPrefixes(keys []string) []string {
+// HasKeys returns all keys in c that are also in keys
+func (c *CanonicalConfig) HasKeys(keys []string) []string {
 	var has []string
-	flatKeys := c.asUCfg().FlattenedKeys(Options...)
 	for _, s := range keys {
-		for _, k := range flatKeys {
-			if strings.HasPrefix(k, s) {
-				has = append(has, s)
-			}
+		hasKey, err := c.asUCfg().Has(s, 0, Options...)
+		if err != nil || hasKey {
+			has = append(has, s)
 		}
 	}
 	return has

--- a/operators/pkg/controller/common/settings/canonical_config_test.go
+++ b/operators/pkg/controller/common/settings/canonical_config_test.go
@@ -62,6 +62,12 @@ func TestCanonicalConfig_MergeWith(t *testing.T) {
 			want: MustCanonicalConfig(map[string]string{"a": "b", "c": "d"}),
 		},
 		{
+			name: "merge arrays",
+			c:    MustCanonicalConfig(map[string][]string{"a": {"x"}}),
+			c2:   MustCanonicalConfig(map[string][]string{"a": {"y"}}),
+			want: MustCanonicalConfig(map[string][]string{"a": {"x", "y"}}),
+		},
+		{
 			name: "conflict: c2 has precedence",
 			c:    MustNewSingleValue("a", "b"),
 			c2:   MustCanonicalConfig(map[string]string{"c": "d", "a": "e"}),
@@ -73,7 +79,11 @@ func TestCanonicalConfig_MergeWith(t *testing.T) {
 			// Merge mutates c
 			require.NoError(t, tt.c.MergeWith(tt.c2))
 			if diff := tt.c.Diff(tt.want, nil); diff != nil {
-				t.Errorf("CanonicalConfig.MergeWith() = %v, want %v", diff, tt.want)
+				var wantMap map[string]interface{}
+				require.NoError(t, tt.want.Unpack(&wantMap))
+				var gotMap map[string]interface{}
+				require.NoError(t, tt.c.Unpack(&gotMap))
+				t.Errorf("CanonicalConfig.MergeWith() = %v, want %+v, got %+v ", diff, wantMap, gotMap)
 			}
 		})
 	}

--- a/operators/pkg/controller/elasticsearch/settings/fields.go
+++ b/operators/pkg/controller/elasticsearch/settings/fields.go
@@ -48,7 +48,6 @@ var Blacklist = []string{
 	XPackSecurityHttpSslEnabled,
 	XPackSecurityHttpSslKey,
 	XPackSecurityTransportSslCertificate,
-	XPackSecurityTransportSslCertificateAuthorities,
 	XPackSecurityTransportSslEnabled,
 	XPackSecurityTransportSslKey,
 	XPackSecurityTransportSslVerificationMode,

--- a/operators/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/operators/pkg/controller/elasticsearch/settings/merged_config.go
@@ -70,7 +70,7 @@ func xpackConfig() *CanonicalConfig {
 		XPackSecurityTransportSslEnabled:                "true",
 		XPackSecurityTransportSslKey:                    path.Join(volume.TransportCertificatesSecretVolumeMountPath, certificates.KeyFileName),
 		XPackSecurityTransportSslCertificate:            path.Join(volume.TransportCertificatesSecretVolumeMountPath, certificates.CertFileName),
-		XPackSecurityTransportSslCertificateAuthorities: path.Join(volume.TransportCertificatesSecretVolumeMountPath, certificates.CAFileName),
+		XPackSecurityTransportSslCertificateAuthorities: []string{path.Join(volume.TransportCertificatesSecretVolumeMountPath, certificates.CAFileName)},
 	}
 	return &CanonicalConfig{common.MustCanonicalConfig(cfg)}
 }

--- a/operators/pkg/controller/elasticsearch/validation/validations.go
+++ b/operators/pkg/controller/elasticsearch/validation/validations.go
@@ -77,7 +77,7 @@ func noBlacklistedSettings(ctx Context) validation.Result {
 			}
 			continue
 		}
-		forbidden := config.HasPrefixes(settings.Blacklist)
+		forbidden := config.HasKeys(settings.Blacklist)
 		// remove duplicates
 		set := set.Make(forbidden...)
 		if set.Count() > 0 {

--- a/operators/pkg/controller/elasticsearch/validation/validations_test.go
+++ b/operators/pkg/controller/elasticsearch/validation/validations_test.go
@@ -247,7 +247,26 @@ func Test_noBlacklistedSettings(t *testing.T) {
 			},
 			want: validation.OK,
 		},
-
+		{
+			name: "non blacklisted settings with blacklisted string prefix OK",
+			args: args{
+				es: estype.Elasticsearch{
+					Spec: estype.ElasticsearchSpec{
+						Version: "7.0.0",
+						Nodes: []estype.NodeSpec{
+							{
+								Config: &common.Config{
+									Data: map[string]interface{}{
+										settings.XPackSecurityTransportSslCertificateAuthorities: "foo",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: validation.OK,
+		},
 		{
 			name: "settings are canonicalized before validation",
 			args: args{


### PR DESCRIPTION
Fixes #962

* remove blacklisting for transport CAs (should we allow it for HTTP as well?)
* changes default behaviour when merging config to append on conflict instead of replacing in order to allow user provided CAs to be merged with our internal CA 
* changes the validation checks to no longer rely on a naive prefix check but use ucfg's APIs instead.

With this in place we can configure mutual trust without relying on our TrustRelationship CRDs like so:

Consider this modified quickstart cluster:
```
apiVersion: elasticsearch.k8s.elastic.co/v1alpha1
kind: Elasticsearch
metadata:
  name: quickstart
spec:
  version: 7.1.0
  nodes:
  - nodeCount: 3
    config:
      node.attr.server_name: ${POD_NAME}.node.quickstart.default.es.cluster.local
      xpack.security.transport.ssl.certificate_authorities:
      - /usr/share/elasticsearch/config/other/ca.crt
    podTemplate:
      spec:
        containers:
        - name: elasticsearch
          volumeMounts:
          - name: testing-certs
            mountPath: /usr/share/elasticsearch/config/other
        volumes:
        - name: testing-certs
          secret:
            secretName: testing-es-transport-certs-public 
```

and a second cluster: 

```
apiVersion: elasticsearch.k8s.elastic.co/v1alpha1
kind: Elasticsearch
metadata:
  name: testing
spec:
  version: 7.1.0
  nodes:
  - nodeCount: 1
    config:
      node.attr.server_name: ${POD_NAME}.node.testing.default.es.cluster.local
      xpack.security.transport.ssl.certificate_authorities:
      - /usr/share/elasticsearch/config/other/ca.crt
    podTemplate:
      spec:
        containers:
        - name: elasticsearch
          volumeMounts:
          - name: quickstart-certs
            mountPath: /usr/share/elasticsearch/config/other
        volumes:
        - name: quickstart-certs
          secret:
            secretName: quickstart-es-transport-certs-public
```

This would be the prerequisite to configure CCR/CCS w/o CRDs