### PR TITLE
Update operator information

### DIFF
--- a/operators/cmd/manager/main.go
+++ b/operators/cmd/manager/main.go
@@ -275,7 +275,7 @@ func execute() {
 		os.Exit(1)
 	}
 
-	log.Info("Starting the manager", "uuid", operatorInfo.UUID,
+	log.Info("Starting the manager", "uuid", operatorInfo.OperatorUUID,
 		"namespace", operatorNamespace, "version", operatorInfo.BuildInfo.Version,
 		"build_hash", operatorInfo.BuildInfo.Hash, "build_date", operatorInfo.BuildInfo.Date,
 		"build_snapshot", operatorInfo.BuildInfo.Snapshot)

--- a/operators/cmd/manager/main.go
+++ b/operators/cmd/manager/main.go
@@ -276,7 +276,7 @@ func execute() {
 	}
 
 	log.Info("Starting the manager", "uuid", operatorInfo.UUID,
-		"namespace", operatorInfo.Namespace, "version", operatorInfo.BuildInfo.Version,
+		"namespace", operatorNamespace, "version", operatorInfo.BuildInfo.Version,
 		"build_hash", operatorInfo.BuildInfo.Hash, "build_date", operatorInfo.BuildInfo.Date,
 		"build_snapshot", operatorInfo.BuildInfo.Snapshot)
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {

--- a/operators/cmd/manager/main.go
+++ b/operators/cmd/manager/main.go
@@ -248,7 +248,7 @@ func execute() {
 		os.Exit(1)
 	}
 
-	operatorInfo, err := about.GetOperatorInfo(clientset, operatorNamespace)
+	operatorInfo, err := about.GetOperatorInfo(clientset, operatorNamespace, roles)
 	if err != nil {
 		log.Error(err, "unable to get operator info")
 		os.Exit(1)

--- a/operators/pkg/about/info.go
+++ b/operators/pkg/about/info.go
@@ -26,9 +26,10 @@ var defaultOperatorNamespaces = []string{"elastic-system", "elastic-namespace-op
 // OperatorInfo contains information about the operator.
 type OperatorInfo struct {
 	OperatorUUID            types.UID `json:"operator_uuid"`
+	OperatorRoles           []string  `json:"operator_roles"`
+	CustomOperatorNamespace bool      `json:"custom_operator_namespace"`
 	Distribution            string    `json:"distribution"`
 	BuildInfo               BuildInfo `json:"build"`
-	CustomOperatorNamespace bool      `json:"custom_operator_namespace"`
 }
 
 // BuildInfo contains build metadata information.
@@ -48,8 +49,9 @@ func (i OperatorInfo) IsDefined() bool {
 		i.BuildInfo.Date != "1970-01-01T00:00:00Z"
 }
 
-// GetOperatorInfo returns an OperatorInfo given an operator client, a Kubernetes client config and an operator namespace.
-func GetOperatorInfo(clientset kubernetes.Interface, operatorNs string) (OperatorInfo, error) {
+// GetOperatorInfo returns an OperatorInfo given an operator client, a Kubernetes client config, an operator namespace
+// and operator roles.
+func GetOperatorInfo(clientset kubernetes.Interface, operatorNs string, operatorRoles []string) (OperatorInfo, error) {
 	operatorUUID, err := getOperatorUUID(clientset, operatorNs)
 	if err != nil {
 		return OperatorInfo{}, err
@@ -68,15 +70,16 @@ func GetOperatorInfo(clientset kubernetes.Interface, operatorNs string) (Operato
 	}
 
 	return OperatorInfo{
-		OperatorUUID: operatorUUID,
-		Distribution: distribution,
+		OperatorUUID:            operatorUUID,
+		OperatorRoles:           operatorRoles,
+		CustomOperatorNamespace: customOperatorNs,
+		Distribution:            distribution,
 		BuildInfo: BuildInfo{
 			version,
 			buildHash,
 			buildDate,
 			buildSnapshot,
 		},
-		CustomOperatorNamespace: customOperatorNs,
 	}, nil
 }
 

--- a/operators/pkg/about/info.go
+++ b/operators/pkg/about/info.go
@@ -21,7 +21,7 @@ const (
 	UUIDCfgMapKey = "uuid"
 )
 
-var defaultOperatorNamespaces = []string{"elastic-namespace", "elastic-namespace-operators"}
+var defaultOperatorNamespaces = []string{"elastic-system", "elastic-namespace-operators"}
 
 // OperatorInfo contains information about the operator.
 type OperatorInfo struct {

--- a/operators/pkg/about/info.go
+++ b/operators/pkg/about/info.go
@@ -21,11 +21,14 @@ const (
 	UUIDCfgMapKey = "uuid"
 )
 
+var defaultOperatorNamespaces = []string{"elastic-namespace", "elastic-namespace-operators"}
+
 // OperatorInfo contains information about the operator.
 type OperatorInfo struct {
-	OperatorUUID types.UID `json:"operator_uuid"`
-	Distribution string    `json:"distribution"`
-	BuildInfo    BuildInfo `json:"build"`
+	OperatorUUID            types.UID `json:"operator_uuid"`
+	Distribution            string    `json:"distribution"`
+	BuildInfo               BuildInfo `json:"build"`
+	CustomOperatorNamespace bool      `json:"custom_operator_namespace"`
 }
 
 // BuildInfo contains build metadata information.
@@ -57,6 +60,13 @@ func GetOperatorInfo(clientset kubernetes.Interface, operatorNs string) (Operato
 		return OperatorInfo{}, err
 	}
 
+	customOperatorNs := true
+	for _, ns := range defaultOperatorNamespaces {
+		if operatorNs == ns {
+			customOperatorNs = false
+		}
+	}
+
 	return OperatorInfo{
 		OperatorUUID: operatorUUID,
 		Distribution: distribution,
@@ -66,6 +76,7 @@ func GetOperatorInfo(clientset kubernetes.Interface, operatorNs string) (Operato
 			buildDate,
 			buildSnapshot,
 		},
+		CustomOperatorNamespace: customOperatorNs,
 	}, nil
 }
 

--- a/operators/pkg/about/info.go
+++ b/operators/pkg/about/info.go
@@ -23,7 +23,7 @@ const (
 
 // OperatorInfo contains information about the operator.
 type OperatorInfo struct {
-	UUID         types.UID `json:"uuid"`
+	OperatorUUID types.UID `json:"operator_uuid"`
 	Distribution string    `json:"distribution"`
 	BuildInfo    BuildInfo `json:"build"`
 }
@@ -38,7 +38,7 @@ type BuildInfo struct {
 
 // IsDefined returns true if the info's default values have been replaced.
 func (i OperatorInfo) IsDefined() bool {
-	return i.UUID != "" &&
+	return i.OperatorUUID != "" &&
 		i.Distribution != "" &&
 		i.BuildInfo.Version != "0.0.0" &&
 		i.BuildInfo.Hash != "00000000" &&
@@ -58,7 +58,7 @@ func GetOperatorInfo(clientset kubernetes.Interface, operatorNs string) (Operato
 	}
 
 	return OperatorInfo{
-		UUID:         operatorUUID,
+		OperatorUUID: operatorUUID,
 		Distribution: distribution,
 		BuildInfo: BuildInfo{
 			version,

--- a/operators/pkg/about/info.go
+++ b/operators/pkg/about/info.go
@@ -24,7 +24,6 @@ const (
 // OperatorInfo contains information about the operator.
 type OperatorInfo struct {
 	UUID         types.UID `json:"uuid"`
-	Namespace    string    `json:"namespace"`
 	Distribution string    `json:"distribution"`
 	BuildInfo    BuildInfo `json:"build"`
 }
@@ -40,7 +39,6 @@ type BuildInfo struct {
 // IsDefined returns true if the info's default values have been replaced.
 func (i OperatorInfo) IsDefined() bool {
 	return i.UUID != "" &&
-		i.Namespace != "" &&
 		i.Distribution != "" &&
 		i.BuildInfo.Version != "0.0.0" &&
 		i.BuildInfo.Hash != "00000000" &&
@@ -61,7 +59,6 @@ func GetOperatorInfo(clientset kubernetes.Interface, operatorNs string) (Operato
 
 	return OperatorInfo{
 		UUID:         operatorUUID,
-		Namespace:    operatorNs,
 		Distribution: distribution,
 		BuildInfo: BuildInfo{
 			version,

--- a/operators/pkg/about/info_test.go
+++ b/operators/pkg/about/info_test.go
@@ -72,7 +72,7 @@ func TestGetOperatorInfo(t *testing.T) {
 			require.NoError(t, err)
 
 			// the operator uuid should be defined
-			uuid := operatorInfo.UUID
+			uuid := operatorInfo.OperatorUUID
 			test.assert(uuid)
 
 			// retrieve operator info a second time
@@ -80,7 +80,7 @@ func TestGetOperatorInfo(t *testing.T) {
 			require.NoError(t, err)
 
 			// the operator uuid should be the same than the first time
-			assert.Equal(t, uuid, operatorInfo.UUID)
+			assert.Equal(t, uuid, operatorInfo.OperatorUUID)
 		})
 	}
 }

--- a/operators/pkg/about/info_test.go
+++ b/operators/pkg/about/info_test.go
@@ -68,7 +68,7 @@ func TestGetOperatorInfo(t *testing.T) {
 			fakeClientset := k8sfake.NewSimpleClientset(test.initObjs...)
 
 			// retrieve operator info a first time
-			operatorInfo, err := GetOperatorInfo(fakeClientset, fakeOperatorNs)
+			operatorInfo, err := GetOperatorInfo(fakeClientset, fakeOperatorNs, []string{"all"})
 			require.NoError(t, err)
 
 			// the operator uuid should be defined
@@ -76,7 +76,7 @@ func TestGetOperatorInfo(t *testing.T) {
 			test.assert(uuid)
 
 			// retrieve operator info a second time
-			operatorInfo, err = GetOperatorInfo(fakeClientset, fakeOperatorNs)
+			operatorInfo, err = GetOperatorInfo(fakeClientset, fakeOperatorNs, []string{"all"})
 			require.NoError(t, err)
 
 			// the operator uuid should be the same than the first time


### PR DESCRIPTION
This commit:
- removes the operator namespace in the operator information because it may be seen as private
- rename the uuid field in operator_uuid
- add a boolean field for the use of a custom operator namespace 
- add operator roles