### PR TITLE
E2E tests: add a default fsgroup

### DIFF
--- a/operators/test/e2e/helpers/security.go
+++ b/operators/test/e2e/helpers/security.go
@@ -14,5 +14,6 @@ func DefaultSecurityContext() *corev1.PodSecurityContext {
 	return &corev1.PodSecurityContext{
 		RunAsNonRoot: BoolPtr(true),
 		RunAsUser:    &defaultUserId,
+		FSGroup:      &defaultUserId,
 	}
 }

--- a/operators/test/e2e/helpers/security.go
+++ b/operators/test/e2e/helpers/security.go
@@ -9,6 +9,8 @@ import (
 )
 
 // DefaultSecurityContext returns a minimalist, restricted, security context.
+// It provides some default so that pods have some descent values if they are
+// started by a developer.
 func DefaultSecurityContext() *corev1.PodSecurityContext {
 	defaultUserId := int64(1000)
 	return &corev1.PodSecurityContext{

--- a/operators/test/e2e/helpers/security.go
+++ b/operators/test/e2e/helpers/security.go
@@ -9,8 +9,8 @@ import (
 )
 
 // DefaultSecurityContext returns a minimalist, restricted, security context.
-// It provides some default so that pods have some descent values if they are
-// started by a developer.
+// Values should be inherited and checked against a PSP, but we provide some
+// default values if pods are started outside E2E tests, by a developer for example.
 func DefaultSecurityContext() *corev1.PodSecurityContext {
 	defaultUserId := int64(1000)
 	return &corev1.PodSecurityContext{


### PR DESCRIPTION
This PR adds a default `fsgroup` when running the e2e tests with the security context.
It should help developer to run the e2e tests from an IDE.
