### PR TITLE
Refactor certificate rotation parameters 

### DIFF
--- a/operators/cmd/manager/main.go
+++ b/operators/cmd/manager/main.go
@@ -256,14 +256,18 @@ func execute() {
 
 	log.Info("Setting up controllers", "roles", roles)
 	if err := controller.AddToManager(mgr, roles, operator.Parameters{
-		Dialer:             dialer,
-		OperatorImage:      operatorImage,
-		OperatorNamespace:  operatorNamespace,
-		OperatorInfo:       operatorInfo,
-		CACertValidity:     caCertValidity,
-		CACertRotateBefore: caCertRotateBefore,
-		CertValidity:       certValidity,
-		CertRotateBefore:   certRotateBefore,
+		Dialer:            dialer,
+		OperatorImage:     operatorImage,
+		OperatorNamespace: operatorNamespace,
+		OperatorInfo:      operatorInfo,
+		CACertRotation: certificates.RotationParams{
+			Validity:     caCertValidity,
+			RotateBefore: caCertRotateBefore,
+		},
+		CertRotation: certificates.RotationParams{
+			Validity:     certValidity,
+			RotateBefore: certRotateBefore,
+		},
 	}); err != nil {
 		log.Error(err, "unable to register controllers to the manager")
 		os.Exit(1)

--- a/operators/pkg/controller/common/certificates/ca_reconcile_test.go
+++ b/operators/pkg/controller/common/certificates/ca_reconcile_test.go
@@ -289,7 +289,10 @@ func TestReconcileCAForCluster(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ca, err := ReconcileCAForOwner(
-				tt.cl, scheme.Scheme, testNamer, &testCluster, nil, TransportCAType, tt.caCertValidity, DefaultRotateBefore,
+				tt.cl, scheme.Scheme, testNamer, &testCluster, nil, TransportCAType, RotationParams{
+					Validity:     tt.caCertValidity,
+					RotateBefore: DefaultRotateBefore,
+				},
 			)
 			require.NoError(t, err)
 			require.NotNil(t, ca)

--- a/operators/pkg/controller/common/certificates/expiration.go
+++ b/operators/pkg/controller/common/certificates/expiration.go
@@ -13,3 +13,11 @@ const (
 	// should be re-issued
 	DefaultRotateBefore = 24 * time.Hour
 )
+
+// RotationParams defines validity and a safety margin for certificate rotation.
+type RotationParams struct {
+	// Validity is the validity duration of a newly created cert.
+	Validity time.Duration
+	// RotateBefore defines how long before expiration certificates should be rotated.
+	RotateBefore time.Duration
+}

--- a/operators/pkg/controller/common/operator/parameters.go
+++ b/operators/pkg/controller/common/operator/parameters.go
@@ -5,9 +5,8 @@
 package operator
 
 import (
-	"time"
-
 	"github.com/elastic/cloud-on-k8s/operators/pkg/about"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/net"
 )
 
@@ -21,12 +20,8 @@ type Parameters struct {
 	OperatorInfo about.OperatorInfo
 	// Dialer is used to create the Elasticsearch HTTP client.
 	Dialer net.Dialer
-	// CACertValidity is the validity duration of a newly created CA cert
-	CACertValidity time.Duration
-	// CACertRotateBefore defines how long before expiration CA certificates should be rotated
-	CACertRotateBefore time.Duration
-	// CertValidity is the validity duration of a newly created certificate
-	CertValidity time.Duration
-	// CertRotateBefore defines how long before expiration certificates should be rotated
-	CertRotateBefore time.Duration
+	// CACertRotation defines the rotation params for CA certificates.
+	CACertRotation certificates.RotationParams
+	// CertRotation defines the rotation params for non-CA certificates.
+	CertRotation certificates.RotationParams
 }

--- a/operators/pkg/controller/elasticsearch/certificates/http/reconcile_test.go
+++ b/operators/pkg/controller/elasticsearch/certificates/http/reconcile_test.go
@@ -167,7 +167,10 @@ func TestReconcileHTTPCertificates(t *testing.T) {
 
 			got, err := ReconcileHTTPCertificates(
 				tt.args.c, scheme.Scheme, w, tt.args.es, tt.args.ca, tt.args.services,
-				certificates.DefaultCertValidity, certificates.DefaultRotateBefore,
+				certificates.RotationParams{
+					Validity:     certificates.DefaultCertValidity,
+					RotateBefore: certificates.DefaultRotateBefore,
+				},
 			)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReconcileHTTPCertificates() error = %v, wantErr %v", err, tt.wantErr)

--- a/operators/pkg/controller/elasticsearch/certificates/transport/reconcile.go
+++ b/operators/pkg/controller/elasticsearch/certificates/transport/reconcile.go
@@ -36,8 +36,7 @@ func ReconcileTransportCertificateSecrets(
 	es v1alpha1.Elasticsearch,
 	services []corev1.Service,
 	trustRelationships []v1alpha1.TrustRelationship,
-	certValidity time.Duration,
-	certRotateBefore time.Duration,
+	rotationParams certificates.RotationParams,
 ) (reconcile.Result, error) {
 	log.Info("Reconciling transport certificate secrets")
 
@@ -66,7 +65,7 @@ func ReconcileTransportCertificateSecrets(
 		}
 
 		if res, err := doReconcileTransportCertificateSecret(
-			c, scheme, es, pod, services, ca, additionalCAs, certValidity, certRotateBefore,
+			c, scheme, es, pod, services, ca, additionalCAs, rotationParams,
 		); err != nil {
 			return res, err
 		}
@@ -84,8 +83,7 @@ func doReconcileTransportCertificateSecret(
 	svcs []corev1.Service,
 	ca *certificates.CA,
 	additionalTrustedCAsPemEncoded [][]byte,
-	certValidity time.Duration,
-	certReconcileBefore time.Duration,
+	rotationParams certificates.RotationParams,
 ) (reconcile.Result, error) {
 	secret, err := EnsureTransportCertificateSecretExists(c, scheme, es, pod)
 	if err != nil {
@@ -125,7 +123,7 @@ func doReconcileTransportCertificateSecret(
 	}
 
 	// check if the existing cert is correct
-	issueNewCertificate := shouldIssueNewCertificate(es, svcs, *secret, privateKey, ca, pod, certReconcileBefore)
+	issueNewCertificate := shouldIssueNewCertificate(es, svcs, *secret, privateKey, ca, pod, rotationParams.RotateBefore)
 
 	if issueNewCertificate {
 		log.Info(
@@ -145,7 +143,7 @@ func doReconcileTransportCertificateSecret(
 			return reconcile.Result{}, err
 		}
 
-		validatedCertificateTemplate, err := CreateValidatedCertificateTemplate(pod, es, svcs, parsedCSR, certValidity)
+		validatedCertificateTemplate, err := CreateValidatedCertificateTemplate(pod, es, svcs, parsedCSR, rotationParams.Validity)
 		if err != nil {
 			return reconcile.Result{}, err
 		}

--- a/operators/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
+++ b/operators/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
@@ -362,8 +362,10 @@ func Test_doReconcileTransportCertificateSecret(t *testing.T) {
 				tt.pod,
 				[]corev1.Service{testSvc},
 				testCA, tt.additionalTrustedCAsPemEncoded,
-				certificates.DefaultCertValidity,
-				certificates.DefaultRotateBefore,
+				certificates.RotationParams{
+					Validity:     certificates.DefaultCertValidity,
+					RotateBefore: certificates.DefaultRotateBefore,
+				},
 			)
 			if tt.wantErr != nil {
 				tt.wantErr(t, err)

--- a/operators/pkg/controller/elasticsearch/driver/default.go
+++ b/operators/pkg/controller/elasticsearch/driver/default.go
@@ -146,10 +146,8 @@ func (d *defaultDriver) Reconcile(
 		d.DynamicWatches,
 		es,
 		[]corev1.Service{genericResources.ExternalService},
-		d.Parameters.CACertValidity,
-		d.Parameters.CACertRotateBefore,
-		d.Parameters.CertValidity,
-		d.Parameters.CertRotateBefore,
+		d.Parameters.CACertRotation,
+		d.Parameters.CertRotation,
 	)
 	if results.WithResults(res).HasError() {
 		return results


### PR DESCRIPTION
While working on #90 :
a small refactoring to use a parameter struct instead of positional arguments for certificate rotation parameters