### PR TITLE
Add flag for debug logs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,3 +21,37 @@ $ kubectl annotate stack stack-sample --overwrite common.k8s.elastic.co/pause=tr
 ```
 
 Please note that if the annotation is set on the Stack all the dependents *(kibana, elasticsearchcluster)* are also paused.
+
+### Debug logs
+
+To enable debug logs for the operator, restart it with the flag `--log-level=DEBUG`. For example:
+
+```shell
+kubectl edit statefulset.apps -n elastic-system elastic-operator
+```
+
+and change the following lines from:
+
+```yaml
+    spec:
+      containers:
+      - args:
+        - manager
+        - --operator-roles
+        - all
+        - --log-level
+        - INFO
+```
+
+to
+
+```yaml
+    spec:
+      containers:
+      - args:
+        - manager
+        - --operator-roles
+        - all
+        - --log-level
+        - DEBUG
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -24,7 +24,7 @@ Please note that if the annotation is set on the Stack all the dependents *(kiba
 
 ### Debug logs
 
-To enable debug logs for the operator, restart it with the flag `--log-level=DEBUG`. For example:
+To enable debug logs for the operator, restart it with the flag `--enable-debug-logs=true`. For example:
 
 ```shell
 kubectl edit statefulset.apps -n elastic-system elastic-operator
@@ -39,8 +39,8 @@ and change the following lines from:
         - manager
         - --operator-roles
         - all
-        - --log-level
-        - INFO
+        - --enable-debug-logs
+        - false
 ```
 
 to
@@ -52,6 +52,6 @@ to
         - manager
         - --operator-roles
         - all
-        - --log-level
-        - DEBUG
+        - --enable-debug-logs
+        - true
 ```

--- a/operators/Makefile
+++ b/operators/Makefile
@@ -132,7 +132,7 @@ go-run:
 			-tags "$(GO_TAGS)" \
 			./cmd/main.go manager \
 				--development --operator-roles=global,namespace \
-				--log-level=DEBUG \
+				--enable-debug-logs=true \
 				--ca-cert-validity=10h --ca-cert-rotate-before=1h \
 				--operator-namespace=default --namespace= \
 				--auto-install-webhooks=false

--- a/operators/Makefile
+++ b/operators/Makefile
@@ -125,7 +125,7 @@ install-crds: generate
 run: install-crds go-run
 
 go-run:
-    # Run the operator locally with role All, with operator image set to latest and operator namespace as for a global operator			
+    # Run the operator locally with role All, with debug logs, operator image set to latest and operator namespace for a global operator
 	AUTO_PORT_FORWARD=true OPERATOR_IMAGE=$(OPERATOR_IMAGE_LATEST) \
 		go run \
 			-ldflags "$(GO_LDFLAGS)" \

--- a/operators/Makefile
+++ b/operators/Makefile
@@ -125,13 +125,14 @@ install-crds: generate
 run: install-crds go-run
 
 go-run:
-    # Run the operator locally with role All, with operator image set to latest and operator namespace as for a global operator
+    # Run the operator locally with role All, with operator image set to latest and operator namespace as for a global operator			
 	AUTO_PORT_FORWARD=true OPERATOR_IMAGE=$(OPERATOR_IMAGE_LATEST) \
 		go run \
 			-ldflags "$(GO_LDFLAGS)" \
 			-tags "$(GO_TAGS)" \
 			./cmd/main.go manager \
 				--development --operator-roles=global,namespace \
+				--log-level=DEBUG \
 				--ca-cert-validity=10h --ca-cert-rotate-before=1h \
 				--operator-namespace=default --namespace= \
 				--auto-install-webhooks=false

--- a/operators/cmd/main.go
+++ b/operators/cmd/main.go
@@ -17,12 +17,18 @@ var log = logf.Log.WithName("main")
 func main() {
 	var rootCmd = &cobra.Command{Use: "elastic-operator"}
 	rootCmd.AddCommand(manager.Cmd)
-
+	logLevelFlag := "log-level"
 	// development mode is only available as a command line flag to avoid accidentally enabling it
 	rootCmd.PersistentFlags().BoolVar(&dev.Enabled, "development", false, "turns on development mode")
+	rootCmd.PersistentFlags().String(logLevelFlag, "INFO", "sets the log level. May be either INFO or DEBUG")
 
 	cobra.OnInitialize(func() {
-		logf.SetLogger(logf.ZapLogger(dev.Enabled))
+		level, _ := rootCmd.Flags().GetString(logLevelFlag)
+		logLevel := false
+		if level == "DEBUG" {
+			logLevel = true
+		}
+		logf.SetLogger(logf.ZapLogger(logLevel))
 	})
 
 	if err := rootCmd.Execute(); err != nil {

--- a/operators/cmd/main.go
+++ b/operators/cmd/main.go
@@ -16,19 +16,15 @@ var log = logf.Log.WithName("main")
 
 func main() {
 	var rootCmd = &cobra.Command{Use: "elastic-operator"}
+	logLevelFlag := "enable-debug-logs"
 	rootCmd.AddCommand(manager.Cmd)
-	logLevelFlag := "log-level"
 	// development mode is only available as a command line flag to avoid accidentally enabling it
 	rootCmd.PersistentFlags().BoolVar(&dev.Enabled, "development", false, "turns on development mode")
-	rootCmd.PersistentFlags().String(logLevelFlag, "INFO", "sets the log level. May be either INFO or DEBUG")
+	rootCmd.PersistentFlags().Bool(logLevelFlag, false, "If true, enables debug logs. Defaults to false")
 
 	cobra.OnInitialize(func() {
-		level, _ := rootCmd.Flags().GetString(logLevelFlag)
-		logLevel := false
-		if level == "DEBUG" {
-			logLevel = true
-		}
-		logf.SetLogger(logf.ZapLogger(logLevel))
+		debug, _ := rootCmd.Flags().GetBool(logLevelFlag)
+		logf.SetLogger(logf.ZapLogger(debug))
 	})
 
 	if err := rootCmd.Execute(); err != nil {

--- a/operators/config/operator/all-in-one/operator.template.yaml
+++ b/operators/config/operator/all-in-one/operator.template.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - image: <OPERATOR_IMAGE>
         name: manager
-        args: ["manager", "--operator-roles", "all", "--log-level", "INFO"]
+        args: ["manager", "--operator-roles", "all", "--enable-debug-logs", "false"]
         env:
           - name: OPERATOR_NAMESPACE
             valueFrom:

--- a/operators/config/operator/all-in-one/operator.template.yaml
+++ b/operators/config/operator/all-in-one/operator.template.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - image: <OPERATOR_IMAGE>
         name: manager
-        args: ["manager", "--operator-roles", "all"]
+        args: ["manager", "--operator-roles", "all", "--log-level", "INFO"]
         env:
           - name: OPERATOR_NAMESPACE
             valueFrom:


### PR DESCRIPTION
Adds a distinct log level flag to enable debug logs (rather than as part of the development flag), as part of https://github.com/elastic/cloud-on-k8s/issues/305

I wasn't sure if we wanted a flag or env var, so I followed how it was previously set up. Definitely open to changing it. Modifying env vars (or a env vars via a config map) feels slightly preferable but I don't feel strongly either way.