### PR TITLE
Set a default memory resources request for Elasticsearch

### DIFF
--- a/operators/pkg/controller/common/defaults/pod_template.go
+++ b/operators/pkg/controller/common/defaults/pod_template.go
@@ -287,3 +287,14 @@ func (b *PodTemplateBuilder) WithInitContainers(initContainers ...corev1.Contain
 
 	return b
 }
+
+// WithResources sets up the given default resource requirements if both resources limits and requests
+// are nil in the main container.
+// If a zero-value (empty map) for at least one of limits or request is provided, the default resource requirements
+// are not applied: the user may want to use a LimitRange.
+func (b *PodTemplateBuilder) WithDefaultResources(defaultResources corev1.ResourceRequirements) *PodTemplateBuilder {
+	if b.Container.Resources.Requests == nil && b.Container.Resources.Limits == nil {
+		b.Container.Resources = defaultResources
+	}
+	return b
+}

--- a/operators/pkg/controller/common/defaults/pod_template.go
+++ b/operators/pkg/controller/common/defaults/pod_template.go
@@ -288,13 +288,13 @@ func (b *PodTemplateBuilder) WithInitContainers(initContainers ...corev1.Contain
 	return b
 }
 
-// WithResources sets up the given default resource requirements if both resources limits and requests
+// WithResources sets up the given resource requirements if both resources limits and requests
 // are nil in the main container.
-// If a zero-value (empty map) for at least one of limits or request is provided, the default resource requirements
+// If a zero-value (empty map) for at least one of limits or request is provided, the given resource requirements
 // are not applied: the user may want to use a LimitRange.
-func (b *PodTemplateBuilder) WithDefaultResources(defaultResources corev1.ResourceRequirements) *PodTemplateBuilder {
+func (b *PodTemplateBuilder) WithResources(resources corev1.ResourceRequirements) *PodTemplateBuilder {
 	if b.Container.Resources.Requests == nil && b.Container.Resources.Limits == nil {
-		b.Container.Resources = defaultResources
+		b.Container.Resources = resources
 	}
 	return b
 }

--- a/operators/pkg/controller/common/defaults/pod_template_test.go
+++ b/operators/pkg/controller/common/defaults/pod_template_test.go
@@ -1037,8 +1037,8 @@ func TestPodTemplateBuilder_WithDefaultResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := NewPodTemplateBuilder(tt.PodTemplate, containerName)
-			if got := b.WithDefaultResources(tt.defaultResources).Container.Resources; !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("PodTemplateBuilder.WithDefaultResources() = %v, want %v", got, tt.want)
+			if got := b.WithResources(tt.defaultResources).Container.Resources; !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PodTemplateBuilder.WithResources() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/operators/pkg/controller/common/defaults/pod_template_test.go
+++ b/operators/pkg/controller/common/defaults/pod_template_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -898,6 +899,147 @@ func TestPodTemplateBuilder_WithInitContainers(t *testing.T) {
 			got := b.WithInitContainers(tt.initContainers...).PodTemplate.Spec.InitContainers
 
 			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPodTemplateBuilder_WithDefaultResources(t *testing.T) {
+	containerName := "default-container"
+	tests := []struct {
+		name             string
+		PodTemplate      corev1.PodTemplateSpec
+		defaultResources corev1.ResourceRequirements
+		want             corev1.ResourceRequirements
+	}{
+		{
+			name: "no resource set (nil values): use defaults",
+			PodTemplate: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: containerName,
+						},
+					},
+				},
+			},
+			defaultResources: corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+			want: corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+		{
+			name: "resource limits set: don't use defaults",
+			PodTemplate: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: containerName,
+							Resources: corev1.ResourceRequirements{
+								Limits: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			defaultResources: corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+			want: corev1.ResourceRequirements{
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+		},
+		{
+			name: "resource requests set: don't use defaults",
+			PodTemplate: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: containerName,
+							Resources: corev1.ResourceRequirements{
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			defaultResources: corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+			want: corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+		},
+		{
+			name: "resource requests explicitly empty (not nil): don't use defaults",
+			PodTemplate: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: containerName,
+							Resources: corev1.ResourceRequirements{
+								Requests: map[corev1.ResourceName]resource.Quantity{},
+							},
+						},
+					},
+				},
+			},
+			defaultResources: corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+			want: corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]resource.Quantity{},
+			},
+		},
+		{
+			name: "resource limits explicitly empty (not nil): don't use defaults",
+			PodTemplate: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: containerName,
+							Resources: corev1.ResourceRequirements{
+								Limits: map[corev1.ResourceName]resource.Quantity{},
+							},
+						},
+					},
+				},
+			},
+			defaultResources: corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+			want: corev1.ResourceRequirements{
+				Limits: map[corev1.ResourceName]resource.Quantity{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewPodTemplateBuilder(tt.PodTemplate, containerName)
+			if got := b.WithDefaultResources(tt.defaultResources).Container.Resources; !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PodTemplateBuilder.WithDefaultResources() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/operators/pkg/controller/elasticsearch/driver/pods.go
+++ b/operators/pkg/controller/elasticsearch/driver/pods.go
@@ -5,6 +5,8 @@
 package driver
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -108,8 +110,7 @@ func createElasticsearchPod(
 		return err
 	}
 	if err := c.Create(&pod); err != nil {
-		reconcileState.AddEvent(corev1.EventTypeWarning, events.EventReasonUnexpected, stringsutil.Concat("Cannot create pod %s: %s", pod.Name, err.Error()))
-		log.Error(err, "Cannot create pod", "name", pod.Name, "namespace", pod.Namespace)
+		reconcileState.AddEvent(corev1.EventTypeWarning, events.EventReasonUnexpected, fmt.Sprintf("Cannot create pod %s: %s", pod.Name, err.Error()))
 		return err
 	}
 	reconcileState.AddEvent(corev1.EventTypeNormal, events.EventReasonCreated, stringsutil.Concat("Created pod ", pod.Name))

--- a/operators/pkg/controller/elasticsearch/driver/pods.go
+++ b/operators/pkg/controller/elasticsearch/driver/pods.go
@@ -108,6 +108,8 @@ func createElasticsearchPod(
 		return err
 	}
 	if err := c.Create(&pod); err != nil {
+		reconcileState.AddEvent(corev1.EventTypeWarning, events.EventReasonUnexpected, stringsutil.Concat("Cannot create pod %s: %s", pod.Name, err.Error()))
+		log.Error(err, "Cannot create pod", "name", pod.Name, "namespace", pod.Namespace)
 		return err
 	}
 	reconcileState.AddEvent(corev1.EventTypeNormal, events.EventReasonCreated, stringsutil.Concat("Created pod ", pod.Name))

--- a/operators/pkg/controller/elasticsearch/version/common.go
+++ b/operators/pkg/controller/elasticsearch/version/common.go
@@ -143,7 +143,7 @@ func podSpecContext(
 	// build on top of the user-provided pod template spec
 	builder := defaults.NewPodTemplateBuilder(p.NodeSpec.PodTemplate, v1alpha1.ElasticsearchContainerName).
 		WithDockerImage(p.Elasticsearch.Spec.Image, stringsutil.Concat(pod.DefaultImageRepository, ":", p.Elasticsearch.Spec.Version)).
-		WithDefaultResources(DefaultResources).
+		WithResources(DefaultResources).
 		WithTerminationGracePeriod(pod.DefaultTerminationGracePeriodSeconds).
 		WithPorts(pod.DefaultContainerPorts).
 		WithReadinessProbe(*pod.NewReadinessProbe()).

--- a/operators/pkg/controller/elasticsearch/version/common_test.go
+++ b/operators/pkg/controller/elasticsearch/version/common_test.go
@@ -188,7 +188,7 @@ func Test_podSpec(t *testing.T) {
 				esContainer := podSpec.Containers[0]
 				require.NotEmpty(t, esContainer.VolumeMounts)
 				require.Len(t, esContainer.Env, 2)
-				require.Nil(t, esContainer.Resources.Requests)
+				require.Equal(t, DefaultResources, esContainer.Resources)
 				require.Equal(t, pod.DefaultContainerPorts, esContainer.Ports)
 				require.Equal(t, pod.NewReadinessProbe(), esContainer.ReadinessProbe)
 				require.Equal(t, []string{processmanager.CommandPath}, esContainer.Command)


### PR DESCRIPTION
We recently disabled any default resources: as a result, it is possible
to deploy eg. 30 Elasticsearch nodes on a 1GB machine. They will all
randomly crash (OOM), which is quite confusing.

This commit enables a default memory resources request of 2Gi, matching
the default ES heap size of 1Gi, if the user does not provide their own
resource requirements.

For cases where the user wants to rely on the k8s cluster configured
LimitRanges, hence not provide resource requirements in the spec, it is
possible to explicitly pass empty resource requirements in the spec:

```
podTemplate:
  spec:
    containers:
    - name: elasticsearch
      resources:
        limits: {}
```

In this situation, the operator will not apply default resources.

Fixes https://github.com/elastic/cloud-on-k8s/issues/1097.