### PR TITLE
Increase timeout for PR job

### DIFF
--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 45, unit: 'MINUTES')
     }
 
     environment {


### PR DESCRIPTION
Currently we have 30 min timeout for PR job. No fails because of timeout so far. 
With plans to introduce snapshot releases (https://github.com/elastic/cloud-on-k8s/pull/1184) or proper cleanup for GCP (https://github.com/elastic/cloud-on-k8s/pull/1163) job is starting to take more time. And both my PR fails because of timeout. 

I would suggest to increase timeout as short term solution and in the future offload snapshots, cleanup and other tasks to a separate job(s) which triggering after PR job finished.