### PR TITLE
Update GKE version to 1.12 on CI

### DIFF
--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
         VAULT_SECRET_ID = credentials('vault-secret-id')
         REGISTRY = "eu.gcr.io"
         GCLOUD_PROJECT = credentials('k8s-operators-gcloud-project')
-        GKE_CLUSTER_VERSION = '1.11'
+        GKE_CLUSTER_VERSION = '1.12'
         GKE_CLUSTER_NAME = "${BUILD_TAG}"
     }
 

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
         REGISTRY = "eu.gcr.io"
         GCLOUD_PROJECT = credentials('k8s-operators-gcloud-project')
         TESTS_MATCH = 'TestSmoke'
-        GKE_CLUSTER_VERSION = '1.11'
+        GKE_CLUSTER_VERSION = '1.12'
         GKE_CLUSTER_NAME = "${BUILD_TAG}"
     }
 


### PR DESCRIPTION
Updating CI jobs to use k8s version 1.12 after https://github.com/elastic/cloud-on-k8s/pull/1167