### PR TITLE
Store transport keys and certificates in a single shared secret. 

### DIFF
--- a/operators/pkg/controller/elasticsearch/certificates/ca_reconcile.go
+++ b/operators/pkg/controller/elasticsearch/certificates/ca_reconcile.go
@@ -107,7 +107,7 @@ func Reconcile(
 	}
 
 	// reconcile transport certificates
-	result, err := transport.ReconcileTransportCertificateSecrets(
+	result, err := transport.ReconcileTransportCertificatesSecrets(
 		c,
 		scheme,
 		transportCA,

--- a/operators/pkg/controller/elasticsearch/certificates/transport/csr.go
+++ b/operators/pkg/controller/elasticsearch/certificates/transport/csr.go
@@ -18,8 +18,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// CreateValidatedCertificateTemplate validates a CSR and creates a certificate template.
-func CreateValidatedCertificateTemplate(
+// createValidatedCertificateTemplate validates a CSR and creates a certificate template.
+func createValidatedCertificateTemplate(
 	pod corev1.Pod,
 	cluster v1alpha1.Elasticsearch,
 	svcs []corev1.Service,

--- a/operators/pkg/controller/elasticsearch/certificates/transport/csr_test.go
+++ b/operators/pkg/controller/elasticsearch/certificates/transport/csr_test.go
@@ -35,8 +35,8 @@ func Test_createValidatedCertificateTemplate(t *testing.T) {
 	// we expect this name to be used for both the common name as well as the es othername
 	cn := "test-pod-name.node.test-es-name.test-namespace.es.local"
 
-	validatedCert, err := CreateValidatedCertificateTemplate(
-		testPod, testCluster, []corev1.Service{testSvc}, testCSR, certificates.DefaultCertValidity,
+	validatedCert, err := createValidatedCertificateTemplate(
+		testPod, testES, []corev1.Service{testSvc}, testCSR, certificates.DefaultCertValidity,
 	)
 	require.NoError(t, err)
 
@@ -86,7 +86,7 @@ func Test_buildGeneralNames(t *testing.T) {
 		{
 			name: "no svcs and user-provided SANs",
 			args: args{
-				cluster: testCluster,
+				cluster: testES,
 				pod:     testPod,
 			},
 			want: []certificates.GeneralName{

--- a/operators/pkg/controller/elasticsearch/certificates/transport/pod_secret.go
+++ b/operators/pkg/controller/elasticsearch/certificates/transport/pod_secret.go
@@ -5,80 +5,216 @@
 package transport
 
 import (
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"fmt"
+	"reflect"
+	"time"
+
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
-	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/reconciler"
-	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
-	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/name"
-	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/certificates"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
-const (
-	// LabelCertificateType is a label key that specifies what type of certificates the secret contains
-	LabelCertificateType = "certificates.elasticsearch.k8s.elastic.co/type"
-	// LabelCertificateTypeTransport is the LabelCertificateType value used for transport certificates
-	LabelCertificateTypeTransport = "transport"
-)
+// PodKeyFileName returns the name of the private key entry for a specific pod in a transport certificates secret.
+func PodKeyFileName(podName string) string {
+	return fmt.Sprintf("%s.%s", podName, certificates.KeyFileName)
+}
 
-// EnsureTransportCertificateSecretExists ensures the existence and Labels of the corev1.Secret that at a later point
-// in time will contain the transport certificates.
-func EnsureTransportCertificateSecretExists(
-	c k8s.Client,
-	scheme *runtime.Scheme,
+// PodCertFileName returns the name of the certificates entry for a specific pod in a transport certificates secret.
+func PodCertFileName(podName string) string {
+	return fmt.Sprintf("%s.%s", podName, certificates.CertFileName)
+}
+
+// ensureTransportCertificatesSecretContentsForPod ensures that the transport certificates secret has the correct
+// content for a specific pod
+func ensureTransportCertificatesSecretContentsForPod(
 	es v1alpha1.Elasticsearch,
+	secret *corev1.Secret,
 	pod corev1.Pod,
-) (*corev1.Secret, error) {
-	expected := corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: pod.Namespace,
-			Name:      name.TransportCertsSecret(pod.Name),
-
-			Labels: map[string]string{
-				// a label that allows us to list secrets of this type
-				LabelCertificateType: LabelCertificateTypeTransport,
-				// a label referencing the related pod so we can look up the pod from this secret
-				label.PodNameLabelName: pod.Name,
-				// a label showing which cluster this pod belongs to
-				label.ClusterNameLabelName: es.Name,
-			},
-		},
+	svcs []corev1.Service,
+	ca *certificates.CA,
+	rotationParams certificates.RotationParams,
+) error {
+	// verify that the secret contains a parsable private key, create if it does not exist
+	var privateKey *rsa.PrivateKey
+	needsNewPrivateKey := true
+	if privateKeyData, ok := secret.Data[PodKeyFileName(pod.Name)]; ok {
+		storedPrivateKey, err := certificates.ParsePEMPrivateKey(privateKeyData)
+		if err != nil {
+			log.Error(err, "Unable to parse stored private key", "pod", pod.Name)
+		} else {
+			needsNewPrivateKey = false
+			privateKey = storedPrivateKey
+		}
 	}
 
-	// reconcile the secret resource
-	var reconciled corev1.Secret
-	if err := reconciler.ReconcileResource(reconciler.Params{
-		Client:     c,
-		Scheme:     scheme,
-		Owner:      &es,
-		Expected:   &expected,
-		Reconciled: &reconciled,
-		NeedsUpdate: func() bool {
-			// we only care about labels, not contents at this point, and we can allow additional labels
-			if reconciled.Labels == nil {
-				return true
-			}
+	// if we need a new private key, generate it
+	if needsNewPrivateKey {
+		generatedPrivateKey, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+		if err != nil {
+			return err
+		}
 
-			for k, v := range expected.Labels {
-				if rv, ok := reconciled.Labels[k]; !ok || rv != v {
-					return true
-				}
-			}
-			return false
-		},
-		UpdateReconciled: func() {
-			if reconciled.Labels == nil {
-				reconciled.Labels = expected.Labels
-			} else {
-				for k, v := range expected.Labels {
-					reconciled.Labels[k] = v
-				}
-			}
-		},
-	}); err != nil {
-		return nil, err
+		privateKey = generatedPrivateKey
+		secret.Data[PodKeyFileName(pod.Name)] = certificates.EncodePEMPrivateKey(*privateKey)
 	}
 
-	return &reconciled, nil
+	if shouldIssueNewCertificate(es, *secret, pod, privateKey, svcs, ca, rotationParams.RotateBefore) {
+		log.Info(
+			"Issuing new certificate",
+			"pod", pod.Name,
+		)
+
+		csr, err := x509.CreateCertificateRequest(cryptorand.Reader, &x509.CertificateRequest{}, privateKey)
+		if err != nil {
+			return err
+		}
+
+		// create a cert from the csr
+		parsedCSR, err := x509.ParseCertificateRequest(csr)
+		if err != nil {
+			return err
+		}
+
+		validatedCertificateTemplate, err := createValidatedCertificateTemplate(
+			pod, es, svcs, parsedCSR, rotationParams.Validity,
+		)
+		if err != nil {
+			return err
+		}
+		// sign the certificate
+		certData, err := ca.CreateCertificate(*validatedCertificateTemplate)
+		if err != nil {
+			return err
+		}
+
+		// store the issued certificate in a secret mounted into the pod
+		secret.Data[PodCertFileName(pod.Name)] = certificates.EncodePEMCert(certData, ca.Cert.Raw)
+	}
+
+	return nil
+}
+
+// shouldIssueNewCertificate returns true if we should issue a new certificate.
+//
+// Reasons for reissuing a certificate:
+// - no certificate yet
+// - certificate has the wrong format
+// - certificate is invalid or expired
+// - certificate SAN and IP does not match pod SAN and IP
+func shouldIssueNewCertificate(
+	es v1alpha1.Elasticsearch,
+	secret corev1.Secret,
+	pod corev1.Pod,
+	privateKey *rsa.PrivateKey,
+	svcs []corev1.Service,
+	ca *certificates.CA,
+	certReconcileBefore time.Duration,
+) bool {
+	certCommonName := buildCertificateCommonName(pod, es.Name, es.Namespace)
+
+	generalNames, err := buildGeneralNames(es, svcs, pod)
+	if err != nil {
+		log.Error(err, "Cannot create GeneralNames for the TLS certificate", "pod", pod.Name)
+		return true
+	}
+
+	cert := extractTransportCert(secret, pod, certCommonName)
+	if cert == nil {
+		return true
+	}
+
+	publicKey, publicKeyOk := cert.PublicKey.(*rsa.PublicKey)
+	if !publicKeyOk || publicKey.N.Cmp(privateKey.PublicKey.N) != 0 || publicKey.E != privateKey.PublicKey.E {
+		log.Info(
+			"Certificate belongs do a different public key, should issue new",
+			"subject", cert.Subject,
+			"issuer", cert.Issuer,
+			"current_ca_subject", ca.Cert.Subject,
+			"pod", pod.Name,
+		)
+		return true
+	}
+
+	pool := x509.NewCertPool()
+	pool.AddCert(ca.Cert)
+	verifyOpts := x509.VerifyOptions{
+		DNSName:       certCommonName,
+		Roots:         pool,
+		Intermediates: pool,
+	}
+	if _, err := cert.Verify(verifyOpts); err != nil {
+		log.Info(
+			fmt.Sprintf("Certificate was not valid, should issue new: %s", err),
+			"subject", cert.Subject,
+			"issuer", cert.Issuer,
+			"current_ca_subject", ca.Cert.Subject,
+			"pod", pod.Name,
+		)
+		return true
+	}
+
+	if time.Now().After(cert.NotAfter.Add(-certReconcileBefore)) {
+		log.Info("Certificate soon to expire, should issue new", "pod", pod.Name)
+		return true
+	}
+
+	// compare actual vs. expected SANs
+	expected, err := certificates.MarshalToSubjectAlternativeNamesData(generalNames)
+	if err != nil {
+		log.Error(err, "Cannot marshal subject alternative names", "pod", pod.Name)
+		return true
+	}
+	extraExtensionFound := false
+	for _, ext := range cert.Extensions {
+		if !ext.Id.Equal(certificates.SubjectAlternativeNamesObjectIdentifier) {
+			continue
+		}
+		extraExtensionFound = true
+		if !reflect.DeepEqual(ext.Value, expected) {
+			log.Info("Certificate SANs do not match expected one, should issue new", "pod", pod.Name)
+			return true
+		}
+	}
+	if !extraExtensionFound {
+		log.Info("SAN extra extension not found, should issue new certificate", "pod", pod.Name)
+		return true
+	}
+
+	return false
+}
+
+// extractTransportCert extracts the transport certificate for the pod with the commonName from the Secret
+func extractTransportCert(secret corev1.Secret, pod corev1.Pod, commonName string) *x509.Certificate {
+	certData, ok := secret.Data[PodCertFileName(pod.Name)]
+	if !ok {
+		log.Info("No tls certificate found in secret", "pod", pod.Name)
+		return nil
+	}
+
+	certs, err := certificates.ParsePEMCerts(certData)
+	if err != nil {
+		log.Error(err, "Invalid certificate data found, issuing new certificate", "pod", pod.Name)
+		return nil
+	}
+
+	// look for the certificate based on the CommonName
+	var names []string
+	for _, c := range certs {
+		if c.Subject.CommonName == commonName {
+			return c
+		}
+		names = append(names, c.Subject.CommonName)
+	}
+
+	log.Info(
+		"Did not find a certificate with the expected common name",
+		"pod", pod.Name,
+		"expected", commonName,
+		"found", names,
+	)
+
+	return nil
 }

--- a/operators/pkg/controller/elasticsearch/certificates/transport/pod_secret_test.go
+++ b/operators/pkg/controller/elasticsearch/certificates/transport/pod_secret_test.go
@@ -6,121 +6,219 @@ package transport
 
 import (
 	"testing"
+	"time"
 
-	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
-	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
-	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/certificates"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestEnsureTransportCertificateSecretExists(t *testing.T) {
-	es := v1alpha1.Elasticsearch{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-es",
-		},
-	}
-
-	pod := corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "pod",
-		},
-	}
-
-	defaultPodSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "pod-certs",
-			Labels: map[string]string{
-				LabelCertificateType:       LabelCertificateTypeTransport,
-				label.PodNameLabelName:     pod.Name,
-				label.ClusterNameLabelName: es.Name,
-			},
-		},
-	}
-
-	defaultPodSecretWith := func(setter func(secret *corev1.Secret)) *corev1.Secret {
-		secret := defaultPodSecret.DeepCopy()
-		setter(secret)
-		return secret
-	}
-
+func Test_shouldIssueNewCertificate(t *testing.T) {
 	type args struct {
-		c      k8s.Client
-		scheme *runtime.Scheme
-		owner  v1alpha1.Elasticsearch
-		pod    corev1.Pod
-		labels map[string]string
+		secret       corev1.Secret
+		pod          *corev1.Pod
+		rotateBefore time.Duration
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    func(*testing.T, *corev1.Secret)
-		wantErr bool
+		name string
+		args args
+		want bool
 	}{
 		{
-			name: "should create a secret if it does not already exist",
+			name: "missing cert in secret",
 			args: args{
-				c:     k8s.WrapClient(fake.NewFakeClient()),
-				owner: es,
-				pod:   pod,
+				secret:       corev1.Secret{},
+				rotateBefore: certificates.DefaultRotateBefore,
 			},
-			want: func(t *testing.T, secret *corev1.Secret) {
-				// owner references are set upon creation, so ignore for comparison
-				expected := defaultPodSecretWith(func(s *corev1.Secret) {
-					s.OwnerReferences = secret.OwnerReferences
-				})
-				assert.Equal(t, expected, secret)
+			want: true,
+		},
+		{
+			name: "invalid cert data",
+			args: args{
+				secret: corev1.Secret{
+					Data: map[string][]byte{
+						PodCertFileName(testPod.Name): []byte("invalid"),
+					},
+				},
+				rotateBefore: certificates.DefaultRotateBefore,
+			},
+			want: true,
+		},
+		{
+			name: "pod name mismatch",
+			args: args{
+				secret: corev1.Secret{
+					Data: map[string][]byte{
+						PodCertFileName(testPod.Name): pemCert,
+					},
+				},
+				pod:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "different"}},
+				rotateBefore: certificates.DefaultRotateBefore,
+			},
+			want: true,
+		},
+		{
+			name: "valid cert",
+			args: args{
+				secret: corev1.Secret{
+					Data: map[string][]byte{
+						PodCertFileName(testPod.Name): pemCert,
+					},
+				},
+				rotateBefore: certificates.DefaultRotateBefore,
+			},
+			want: false,
+		},
+		{
+			name: "should be rotated soon",
+			args: args{
+				secret: corev1.Secret{
+					Data: map[string][]byte{
+						PodCertFileName(testPod.Name): pemCert,
+					},
+				},
+				rotateBefore: certificates.DefaultCertValidity, // rotate before the same duration as total validity
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.args.pod == nil {
+				tt.args.pod = &testPod
+			}
+
+			if got := shouldIssueNewCertificate(
+				testES,
+				tt.args.secret,
+				*tt.args.pod,
+				testRSAPrivateKey,
+				[]corev1.Service{testSvc},
+				testCA,
+				tt.args.rotateBefore,
+			); got != tt.want {
+				t.Errorf("shouldIssueNewCertificate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_ensureTransportCertificatesSecretContentsForPod(t *testing.T) {
+	tests := []struct {
+		name       string
+		secret     *corev1.Secret
+		pod        *corev1.Pod
+		assertions func(t *testing.T, before corev1.Secret, after corev1.Secret)
+		wantErr    func(t *testing.T, err error)
+	}{
+		{
+			name: "no private key in the secret",
+			secret: &corev1.Secret{
+				Data: map[string][]byte{
+					PodCertFileName(testPod.Name): pemCert,
+				},
+			},
+			assertions: func(t *testing.T, before corev1.Secret, after corev1.Secret) {
+				assert.NotEmpty(t, after.Data[PodKeyFileName(testPod.Name)])
+				assert.NotEmpty(t, after.Data[PodCertFileName(testPod.Name)])
+
+				// cert should be re-generated
+				assert.NotEqual(t, after.Data[PodCertFileName(testPod.Name)], before.Data[PodCertFileName(testPod.Name)])
 			},
 		},
 		{
-			name: "should update an existing secret",
-			args: args{
-				c: k8s.WrapClient(fake.NewFakeClient(defaultPodSecretWith(func(secret *corev1.Secret) {
-					secret.ObjectMeta.UID = types.UID("42")
-				}))),
-				owner: es,
-				pod:   pod,
+			name: "no cert in the secret",
+			secret: &corev1.Secret{
+				Data: map[string][]byte{
+					PodKeyFileName(testPod.Name): certificates.EncodePEMPrivateKey(*testRSAPrivateKey),
+				},
 			},
-			want: func(t *testing.T, secret *corev1.Secret) {
-				// UID should be kept the same
-				assert.Equal(t, defaultPodSecretWith(func(secret *corev1.Secret) {
-					secret.ObjectMeta.UID = types.UID("42")
-				}), secret)
+			assertions: func(t *testing.T, before corev1.Secret, after corev1.Secret) {
+				assert.NotEmpty(t, after.Data[PodKeyFileName(testPod.Name)])
+				assert.NotEmpty(t, after.Data[PodCertFileName(testPod.Name)])
+
+				// key should be re-used
+				assert.Equal(t, before.Data[PodKeyFileName(testPod.Name)], after.Data[PodKeyFileName(testPod.Name)])
 			},
 		},
 		{
-			name: "should allow additional labels in the secret",
-			args: args{
-				c: k8s.WrapClient(fake.NewFakeClient(defaultPodSecretWith(func(secret *corev1.Secret) {
-					secret.ObjectMeta.Labels["foo"] = "bar"
-				}))),
-				owner: es,
-				pod:   pod,
+			name: "cert does not belong to the key in the secret",
+			secret: &corev1.Secret{
+				Data: map[string][]byte{
+					PodKeyFileName(testPod.Name):  certificates.EncodePEMPrivateKey(*testRSAPrivateKey),
+					PodCertFileName(testPod.Name): certificates.EncodePEMCert(testCA.Cert.Raw),
+				},
 			},
-			want: func(t *testing.T, secret *corev1.Secret) {
-				assert.Equal(t, defaultPodSecretWith(func(secret *corev1.Secret) {
-					secret.ObjectMeta.Labels["foo"] = "bar"
-				}), secret)
+			assertions: func(t *testing.T, before corev1.Secret, after corev1.Secret) {
+				assert.NotEmpty(t, after.Data[PodKeyFileName(testPod.Name)])
+				assert.NotEmpty(t, after.Data[PodCertFileName(testPod.Name)])
+
+				// key should be re-used
+				assert.Equal(t, before.Data[PodKeyFileName(testPod.Name)], after.Data[PodKeyFileName(testPod.Name)])
+				assert.NotEqual(t, after.Data[PodCertFileName(testPod.Name)], before.Data[PodCertFileName(testPod.Name)])
+			},
+		},
+		{
+			name: "invalid cert in the secret",
+			secret: &corev1.Secret{
+				Data: map[string][]byte{
+					PodKeyFileName(testPod.Name):  certificates.EncodePEMPrivateKey(*testRSAPrivateKey),
+					PodCertFileName(testPod.Name): []byte("invalid"),
+				},
+			},
+			assertions: func(t *testing.T, before corev1.Secret, after corev1.Secret) {
+				assert.NotEmpty(t, after.Data[PodKeyFileName(testPod.Name)])
+				assert.NotEmpty(t, after.Data[PodCertFileName(testPod.Name)])
+
+				// key should be re-used
+				assert.Equal(t, before.Data[PodKeyFileName(testPod.Name)], after.Data[PodKeyFileName(testPod.Name)])
+				assert.NotEqual(t, after.Data[PodCertFileName(testPod.Name)], before.Data[PodCertFileName(testPod.Name)])
+			},
+		},
+		{
+			name: "valid data should not require updating",
+			secret: &corev1.Secret{
+				Data: map[string][]byte{
+					PodKeyFileName(testPod.Name):  certificates.EncodePEMPrivateKey(*testRSAPrivateKey),
+					PodCertFileName(testPod.Name): pemCert,
+				},
+			},
+			assertions: func(t *testing.T, before corev1.Secret, after corev1.Secret) {
+				assert.Equal(t, before, after)
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.args.scheme == nil {
-				tt.args.scheme = scheme.Scheme
+			if tt.secret == nil {
+				tt.secret = &corev1.Secret{}
+			}
+			if tt.pod == nil {
+				tt.pod = testPod.DeepCopy()
 			}
 
-			got, err := EnsureTransportCertificateSecretExists(tt.args.c, tt.args.scheme, tt.args.owner, tt.args.pod)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("EnsureTransportCertificateSecretExists() error = %v, wantErr %v", err, tt.wantErr)
+			beforeSecret := tt.secret.DeepCopy()
+
+			err := ensureTransportCertificatesSecretContentsForPod(
+				testES,
+				tt.secret,
+				*tt.pod,
+				[]corev1.Service{testSvc},
+				testCA,
+				certificates.RotationParams{
+					Validity:     certificates.DefaultCertValidity,
+					RotateBefore: certificates.DefaultRotateBefore,
+				},
+			)
+			if tt.wantErr != nil {
+				tt.wantErr(t, err)
 				return
 			}
-			tt.want(t, got)
+			require.NoError(t, err)
+
+			tt.assertions(t, *beforeSecret, *tt.secret)
 		})
 	}
 }

--- a/operators/pkg/controller/elasticsearch/certificates/transport/reconcile.go
+++ b/operators/pkg/controller/elasticsearch/certificates/transport/reconcile.go
@@ -6,19 +6,19 @@ package transport
 
 import (
 	"bytes"
-	cryptorand "crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"fmt"
 	"reflect"
-	"time"
+	"strings"
 
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/name"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/pod"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -27,9 +27,9 @@ import (
 
 var log = logf.Log.WithName("transport")
 
-// ReconcileTransportCertificateSecrets reconciles certificate secrets for nodes
-// of the given es cluster.
-func ReconcileTransportCertificateSecrets(
+// ReconcileTransportCertificatesSecrets reconciles the secret containing transport certificates for all nodes in the
+// cluster.
+func ReconcileTransportCertificatesSecrets(
 	c k8s.Client,
 	scheme *runtime.Scheme,
 	ca *certificates.CA,
@@ -37,7 +37,7 @@ func ReconcileTransportCertificateSecrets(
 	services []corev1.Service,
 	rotationParams certificates.RotationParams,
 ) (reconcile.Result, error) {
-	log.Info("Reconciling transport certificate secrets")
+	log.Info("Reconciling transport certificates secrets")
 
 	var pods corev1.PodList
 	if err := c.List(&client.ListOptions{
@@ -47,235 +47,127 @@ func ReconcileTransportCertificateSecrets(
 		return reconcile.Result{}, err
 	}
 
+	secret, err := ensureTransportCertificatesSecretExists(c, scheme, es)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	// defensive copy of the current secret so we can check whether we need to update later on
+	currentTransportCertificatesSecret := secret.DeepCopy()
+
 	for _, pod := range pods.Items {
 		if pod.Status.PodIP == "" {
 			log.Info("Skipping pod because it has no IP yet", "pod", pod.Name)
 			continue
 		}
 
-		if res, err := doReconcileTransportCertificateSecret(
-			c, scheme, es, pod, services, ca, rotationParams,
+		if err := ensureTransportCertificatesSecretContentsForPod(
+			es, secret, pod, services, ca, rotationParams,
 		); err != nil {
-			return res, err
-		}
-	}
-
-	return reconcile.Result{}, nil
-}
-
-// doReconcileTransportCertificateSecret ensures that the transport certificate secret has the correct content.
-func doReconcileTransportCertificateSecret(
-	c k8s.Client,
-	scheme *runtime.Scheme,
-	es v1alpha1.Elasticsearch,
-	pod corev1.Pod,
-	svcs []corev1.Service,
-	ca *certificates.CA,
-	rotationParams certificates.RotationParams,
-) (reconcile.Result, error) {
-	secret, err := EnsureTransportCertificateSecretExists(c, scheme, es, pod)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	// a placeholder secret may have nil entries, create them if needed
-	if secret.Data == nil {
-		secret.Data = make(map[string][]byte)
-	}
-	if secret.Annotations == nil {
-		secret.Annotations = make(map[string]string)
-	}
-
-	// verify that the secret contains a parsable private key, create if it does not exist
-	var privateKey *rsa.PrivateKey
-	needsNewPrivateKey := true
-	if privateKeyData, ok := secret.Data[certificates.KeyFileName]; ok {
-		storedPrivateKey, err := certificates.ParsePEMPrivateKey(privateKeyData)
-		if err != nil {
-			log.Error(err, "Unable to parse stored private key", "secret", secret.Name)
-		} else {
-			needsNewPrivateKey = false
-			privateKey = storedPrivateKey
-		}
-	}
-
-	// if we need a new private key, generate it
-	if needsNewPrivateKey {
-		generatedPrivateKey, err := rsa.GenerateKey(cryptorand.Reader, 2048)
-		if err != nil {
 			return reconcile.Result{}, err
 		}
-
-		privateKey = generatedPrivateKey
-		secret.Data[certificates.KeyFileName] = certificates.EncodePEMPrivateKey(*privateKey)
 	}
 
-	// check if the existing cert is correct
-	issueNewCertificate := shouldIssueNewCertificate(es, svcs, *secret, privateKey, ca, pod, rotationParams.RotateBefore)
-
-	if issueNewCertificate {
-		log.Info(
-			"Issuing new certificate",
-			"pod", pod.Name,
-			"es", k8s.ExtractNamespacedName(&es),
-		)
-
-		csr, err := x509.CreateCertificateRequest(cryptorand.Reader, &x509.CertificateRequest{}, privateKey)
-		if err != nil {
-			return reconcile.Result{}, err
+	// remove certificates and keys for deleted pods
+	podsByName := pod.PodsByName(pods.Items)
+	keysToPrune := make([]string, 0)
+	for secretDataKey := range secret.Data {
+		if secretDataKey == certificates.CAFileName {
+			// never remove the CA file
+			continue
 		}
 
-		// create a cert from the csr
-		parsedCSR, err := x509.ParseCertificateRequest(csr)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
+		// get the pod name from the secret key name (the first segment before the ".")
+		podNameForKey := strings.SplitN(secretDataKey, ".", 2)[0]
 
-		validatedCertificateTemplate, err := CreateValidatedCertificateTemplate(pod, es, svcs, parsedCSR, rotationParams.Validity)
-		if err != nil {
-			return reconcile.Result{}, err
+		if _, ok := podsByName[podNameForKey]; !ok {
+			// pod no longer exists, so the element is safe to delete.
+			keysToPrune = append(keysToPrune, secretDataKey)
 		}
-		// sign the certificate
-		certData, err := ca.CreateCertificate(*validatedCertificateTemplate)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
+	}
+	if len(keysToPrune) > 0 {
+		log.Info("Pruning keys from certificates secret", "keys", keysToPrune)
 
-		// store the issued certificate in a secret mounted into the pod
-		secret.Data[certificates.CertFileName] = certificates.EncodePEMCert(certData, ca.Cert.Raw)
+		for _, keyToRemove := range keysToPrune {
+			delete(secret.Data, keyToRemove)
+		}
 	}
 
-	// prepare trusted CA certs: CA of this node
-	trusted := certificates.EncodePEMCert(ca.Cert.Raw)
+	caBytes := certificates.EncodePEMCert(ca.Cert.Raw)
 
 	// compare with current trusted CA certs.
-	updateTrustedCACerts := !bytes.Equal(trusted, secret.Data[certificates.CAFileName])
-	if updateTrustedCACerts {
-		secret.Data[certificates.CAFileName] = trusted
+	if !bytes.Equal(caBytes, secret.Data[certificates.CAFileName]) {
+		secret.Data[certificates.CAFileName] = caBytes
 	}
 
-	if needsNewPrivateKey || issueNewCertificate || updateTrustedCACerts {
-		log.Info("Updating transport certificate secret", "secret", secret.Name)
+	if !reflect.DeepEqual(secret, currentTransportCertificatesSecret) {
 		if err := c.Update(secret); err != nil {
 			return reconcile.Result{}, err
 		}
-		annotation.MarkPodAsUpdated(c, pod)
+		for _, pod := range pods.Items {
+			annotation.MarkPodAsUpdated(c, pod)
+		}
 	}
 
 	return reconcile.Result{}, nil
 }
 
-// extractTransportCert extracts the transport certificate with the commonName from the Secret
-func extractTransportCert(secret corev1.Secret, commonName string) *x509.Certificate {
-	certData, ok := secret.Data[certificates.CertFileName]
-	if !ok {
-		log.Info("No tls certificate found in secret", "secret", secret.Name)
-		return nil
+// ensureTransportCertificatesSecretExists ensures the existence and Labels of the Secret that at a later point
+// in time will contain the transport certificates.
+func ensureTransportCertificatesSecretExists(
+	c k8s.Client,
+	scheme *runtime.Scheme,
+	es v1alpha1.Elasticsearch,
+) (*corev1.Secret, error) {
+	expected := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: es.Namespace,
+			Name:      name.TransportCertificatesSecret(es.Name),
+
+			Labels: map[string]string{
+				// a label showing which es these certificates belongs to
+				label.ClusterNameLabelName: es.Name,
+			},
+		},
 	}
 
-	certs, err := certificates.ParsePEMCerts(certData)
-	if err != nil {
-		log.Error(err, "Invalid certificate data found, issuing new certificate", "secret", secret.Name)
-		return nil
+	// reconcile the secret resource
+	var reconciled corev1.Secret
+	if err := reconciler.ReconcileResource(reconciler.Params{
+		Client:     c,
+		Scheme:     scheme,
+		Owner:      &es,
+		Expected:   &expected,
+		Reconciled: &reconciled,
+		NeedsUpdate: func() bool {
+			// we only care about labels, not contents at this point, and we can allow additional labels
+			if reconciled.Labels == nil {
+				return true
+			}
+
+			for k, v := range expected.Labels {
+				if rv, ok := reconciled.Labels[k]; !ok || rv != v {
+					return true
+				}
+			}
+			return false
+		},
+		UpdateReconciled: func() {
+			if reconciled.Labels == nil {
+				reconciled.Labels = expected.Labels
+			} else {
+				for k, v := range expected.Labels {
+					reconciled.Labels[k] = v
+				}
+			}
+		},
+	}); err != nil {
+		return nil, err
 	}
 
-	// look for the certificate based on the CommonName
-	var names []string
-	for _, c := range certs {
-		if c.Subject.CommonName == commonName {
-			return c
-		}
-		names = append(names, c.Subject.CommonName)
+	// a placeholder secret may have nil entries, create them if needed
+	if reconciled.Data == nil {
+		reconciled.Data = make(map[string][]byte)
 	}
 
-	log.Info("Did not found a certificate with the expected common name", "secret", secret.Name, "expected", commonName, "found", names)
-
-	return nil
-}
-
-// shouldIssueNewCertificate returns true if we should issue a new certificate.
-//
-// Reasons for reissuing a certificate:
-// - no certificate yet
-// - certificate has the wrong format
-// - certificate is invalid or expired
-// - certificate SAN and IP does not match pod SAN and IP
-func shouldIssueNewCertificate(
-	cluster v1alpha1.Elasticsearch,
-	svcs []corev1.Service,
-	secret corev1.Secret,
-	privateKey *rsa.PrivateKey,
-	ca *certificates.CA,
-	pod corev1.Pod,
-	certReconcileBefore time.Duration,
-) bool {
-	certCommonName := buildCertificateCommonName(pod, cluster.Name, cluster.Namespace)
-
-	generalNames, err := buildGeneralNames(cluster, svcs, pod)
-	if err != nil {
-		log.Error(err, "Cannot create GeneralNames for the TLS certificate", "pod", pod.Name)
-		return true
-	}
-
-	cert := extractTransportCert(secret, certCommonName)
-	if cert == nil {
-		return true
-	}
-
-	publicKey, publicKeyOk := cert.PublicKey.(*rsa.PublicKey)
-	if !publicKeyOk || publicKey.N.Cmp(privateKey.PublicKey.N) != 0 || publicKey.E != privateKey.PublicKey.E {
-		log.Info(
-			"Certificate belongs do a different public key, should issue new",
-			"subject", cert.Subject,
-			"issuer", cert.Issuer,
-			"current_ca_subject", ca.Cert.Subject,
-		)
-		return true
-	}
-
-	pool := x509.NewCertPool()
-	pool.AddCert(ca.Cert)
-	verifyOpts := x509.VerifyOptions{
-		DNSName:       certCommonName,
-		Roots:         pool,
-		Intermediates: pool,
-	}
-	if _, err := cert.Verify(verifyOpts); err != nil {
-		log.Info(
-			fmt.Sprintf("Certificate was not valid, should issue new: %s", err),
-			"subject", cert.Subject,
-			"issuer", cert.Issuer,
-			"current_ca_subject", ca.Cert.Subject,
-		)
-		return true
-	}
-
-	if time.Now().After(cert.NotAfter.Add(-certReconcileBefore)) {
-		log.Info("Certificate soon to expire, should issue new", "secret", secret.Name)
-		return true
-	}
-
-	// compare actual vs. expected SANs
-	expected, err := certificates.MarshalToSubjectAlternativeNamesData(generalNames)
-	if err != nil {
-		log.Error(err, "Cannot marshal subject alternative names", "secret", secret.Name)
-		return true
-	}
-	extraExtensionFound := false
-	for _, ext := range cert.Extensions {
-		if !ext.Id.Equal(certificates.SubjectAlternativeNamesObjectIdentifier) {
-			continue
-		}
-		extraExtensionFound = true
-		if !reflect.DeepEqual(ext.Value, expected) {
-			log.Info("Certificate SANs do not match expected one, should issue new", "secret", secret.Name)
-			return true
-		}
-	}
-	if !extraExtensionFound {
-		log.Info("SAN extra extension not found, should issue new certificate", "secret", secret.Name)
-		return true
-	}
-
-	return false
+	return &reconciled, nil
 }

--- a/operators/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
+++ b/operators/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
@@ -5,397 +5,108 @@
 package transport
 
 import (
-	cryptorand "crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
-	"reflect"
 	"testing"
-	"time"
+
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/name"
 
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
-	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/annotation"
-	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
-	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/name"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-// fixtures
-var (
-	testCA                       *certificates.CA
-	testRSAPrivateKey            *rsa.PrivateKey
-	testCSRBytes                 []byte
-	testCSR                      *x509.CertificateRequest
-	validatedCertificateTemplate *certificates.ValidatedCertificateTemplate
-	certData                     []byte
-	pemCert                      []byte
-	testIP                       = "1.2.3.4"
-	testCluster                  = v1alpha1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Name: "test-es-name", Namespace: "test-namespace"}}
-	testPod                      = corev1.Pod{
+func Test_ensureTransportCertificateSecretExists(t *testing.T) {
+	defaultSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-pod-name",
+			Name:      name.TransportCertificatesSecret(testES.Name),
+			Namespace: testES.Namespace,
+			Labels: map[string]string{
+				label.ClusterNameLabelName: testES.Name,
+			},
 		},
-		Status: corev1.PodStatus{
-			PodIP: testIP,
-		},
-	}
-	testSvc = corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-service",
-			Namespace: "default",
-		},
-		Spec: corev1.ServiceSpec{
-			ClusterIP: "2.2.3.3",
-		},
-	}
-	additionalCA = [][]byte{[]byte(testAdditionalCA)}
-)
-
-const (
-	testPemPrivateKey = `
------BEGIN RSA PRIVATE KEY-----
-MIICXAIBAAKBgQCxoeCUW5KJxNPxMp+KmCxKLc1Zv9Ny+4CFqcUXVUYH69L3mQ7v
-IWrJ9GBfcaA7BPQqUlWxWM+OCEQZH1EZNIuqRMNQVuIGCbz5UQ8w6tS0gcgdeGX7
-J7jgCQ4RK3F/PuCM38QBLaHx988qG8NMc6VKErBjctCXFHQt14lerd5KpQIDAQAB
-AoGAYrf6Hbk+mT5AI33k2Jt1kcweodBP7UkExkPxeuQzRVe0KVJw0EkcFhywKpr1
-V5eLMrILWcJnpyHE5slWwtFHBG6a5fLaNtsBBtcAIfqTQ0Vfj5c6SzVaJv0Z5rOd
-7gQF6isy3t3w9IF3We9wXQKzT6q5ypPGdm6fciKQ8RnzREkCQQDZwppKATqQ41/R
-vhSj90fFifrGE6aVKC1hgSpxGQa4oIdsYYHwMzyhBmWW9Xv/R+fPyr8ZwPxp2c12
-33QwOLPLAkEA0NNUb+z4ebVVHyvSwF5jhfJxigim+s49KuzJ1+A2RaSApGyBZiwS
-rWvWkB471POAKUYt5ykIWVZ83zcceQiNTwJBAMJUFQZX5GDqWFc/zwGoKkeR49Yi
-MTXIvf7Wmv6E++eFcnT461FlGAUHRV+bQQXGsItR/opIG7mGogIkVXa3E1MCQARX
-AAA7eoZ9AEHflUeuLn9QJI/r0hyQQLEtrpwv6rDT1GCWaLII5HJ6NUFVf4TTcqxo
-6vdM4QGKTJoO+SaCyP0CQFdpcxSAuzpFcKv0IlJ8XzS/cy+mweCMwyJ1PFEc4FX6
-wg/HcAJWY60xZTJDFN+Qfx8ZQvBEin6c2/h+zZi5IVY=
------END RSA PRIVATE KEY-----
-`
-	testAdditionalCA = `-----BEGIN CERTIFICATE-----
-MIIDKzCCAhOgAwIBAgIRAK7i/u/wsh+i2G0yUygsJckwDQYJKoZIhvcNAQELBQAw
-LzEZMBcGA1UECxMQNG1jZnhjbnh0ZjZuNHA5bDESMBAGA1UEAxMJdHJ1c3Qtb25l
-MB4XDTE5MDMyMDIwNDg1NloXDTIwMDMxOTIwNDk1NlowLzEZMBcGA1UECxMQNG1j
-Znhjbnh0ZjZuNHA5bDESMBAGA1UEAxMJdHJ1c3Qtb25lMIIBIjANBgkqhkiG9w0B
-AQEFAAOCAQ8AMIIBCgKCAQEAu/Pws5FcyJw843pNow/Y95rApWAuGanU99DEmeOG
-ggtpc3qtDWWKwLZ6cU+av3u82tf0HYSpy0Z2hn3PS2dGGgHPTr/tTGYA5alu1dn5
-CgqQDBVLbkKA1lDcm8w98fRavRw6a0TX5DURqXs+smhdMztQjDNCl3kJ40JbXVAY
-x5vhD2pKPCK0VIr9uYK0E/9dvrU0SJGLUlB+CY/DU7c8t22oer2T6fjCZzh3Fhwi
-/aOKEwEUoE49orte0N9b1HSKlVePzIUuTTc3UU2ntWi96Uf2FesuAubU11WH4kIL
-wRlofty7ewBzVmGte1fKUMjHB3mgb+WYwkEFwjpQL4LhkQIDAQABo0IwQDAOBgNV
-HQ8BAf8EBAMCAoQwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA8GA1Ud
-EwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAI+qczKQgkb5L5dXzn+KW92J
-Sq1rrmaYUYLRTtPFH7t42REPYLs4UV0qR+6v/hJljQbAS+Vu3BioLWuxq85NsIjf
-OK1KO7D8lwVI9tAetE0tKILqljTjwZpqfZLZ8fFqwzd9IM/WfoI7Z05k8BSL6XdM
-FaRfSe/GJ+DR1dCwnWAVKGxAry4JSceVS9OXxYNRTcfQuT5s8h/6X5UaonTbhil7
-91fQFaX8LSuZj23/3kgDTnjPmvj2sz5nODymI4YeTHLjdlMmTufWSJj901ITp7Bw
-DMO3GhRADFpMz3vjHA2rHA4AQ6nC8N4lIYTw0AF1VAOC0SDntf6YEgrhRKRFAUY=
------END CERTIFICATE-----`
-)
-
-func init() {
-	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
-		panic(err)
+		Data: make(map[string][]byte),
 	}
 
-	var err error
-	block, _ := pem.Decode([]byte(testPemPrivateKey))
-	if testRSAPrivateKey, err = x509.ParsePKCS1PrivateKey(block.Bytes); err != nil {
-		panic("Failed to parse private key: " + err.Error())
+	defaultSecretWith := func(setter func(secret *corev1.Secret)) *corev1.Secret {
+		secret := defaultSecret.DeepCopy()
+		setter(secret)
+		return secret
 	}
 
-	if testCA, err = certificates.NewSelfSignedCA(certificates.CABuilderOptions{
-		Subject:    pkix.Name{CommonName: "test-common-name"},
-		PrivateKey: testRSAPrivateKey,
-	}); err != nil {
-		panic("Failed to create new self signed CA: " + err.Error())
-	}
-
-	testCSRBytes, err = x509.CreateCertificateRequest(cryptorand.Reader, &x509.CertificateRequest{}, testRSAPrivateKey)
-	if err != nil {
-		panic("Failed to create CSR:" + err.Error())
-	}
-	testCSR, err = x509.ParseCertificateRequest(testCSRBytes)
-
-	validatedCertificateTemplate, err = CreateValidatedCertificateTemplate(
-		testPod, testCluster, []corev1.Service{testSvc}, testCSR, certificates.DefaultCertValidity)
-	if err != nil {
-		panic("Failed to create validated cert template:" + err.Error())
-	}
-
-	certData, err = testCA.CreateCertificate(*validatedCertificateTemplate)
-	if err != nil {
-		panic("Failed to create cert data:" + err.Error())
-	}
-
-	pemCert = certificates.EncodePEMCert(certData, testCA.Cert.Raw)
-}
-
-func Test_shouldIssueNewCertificate(t *testing.T) {
 	type args struct {
-		secret       corev1.Secret
-		pod          corev1.Pod
-		cluster      v1alpha1.Elasticsearch
-		rotateBefore time.Duration
+		c      k8s.Client
+		scheme *runtime.Scheme
+		owner  v1alpha1.Elasticsearch
+		labels map[string]string
 	}
 	tests := []struct {
-		name string
-		args args
-		want bool
+		name    string
+		args    args
+		want    func(*testing.T, *corev1.Secret)
+		wantErr bool
 	}{
 		{
-			name: "missing cert in secret",
+			name: "should create a secret if it does not already exist",
 			args: args{
-				secret:       corev1.Secret{},
-				pod:          testPod,
-				cluster:      testCluster,
-				rotateBefore: certificates.DefaultRotateBefore,
+				c:     k8s.WrapClient(fake.NewFakeClient()),
+				owner: testES,
 			},
-			want: true,
+			want: func(t *testing.T, secret *corev1.Secret) {
+				// owner references are set upon creation, so ignore for comparison
+				expected := defaultSecretWith(func(s *corev1.Secret) {
+					s.OwnerReferences = secret.OwnerReferences
+				})
+				assert.Equal(t, expected, secret)
+			},
 		},
 		{
-			name: "invalid cert data",
+			name: "should update an existing secret",
 			args: args{
-				secret: corev1.Secret{
-					Data: map[string][]byte{
-						certificates.CertFileName: []byte("invalid"),
-					},
-				},
-				pod:          testPod,
-				cluster:      testCluster,
-				rotateBefore: certificates.DefaultRotateBefore,
+				c: k8s.WrapClient(fake.NewFakeClient(defaultSecretWith(func(secret *corev1.Secret) {
+					secret.ObjectMeta.UID = types.UID("42")
+				}))),
+				owner: testES,
 			},
-			want: true,
+			want: func(t *testing.T, secret *corev1.Secret) {
+				// UID should be kept the same
+				assert.Equal(t, defaultSecretWith(func(secret *corev1.Secret) {
+					secret.ObjectMeta.UID = types.UID("42")
+				}), secret)
+			},
 		},
 		{
-			name: "pod name mismatch",
+			name: "should allow additional labels in the secret",
 			args: args{
-				secret: corev1.Secret{
-					Data: map[string][]byte{
-						certificates.CertFileName: pemCert,
-					},
-				},
-				pod:          corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "different"}},
-				cluster:      testCluster,
-				rotateBefore: certificates.DefaultRotateBefore,
+				c: k8s.WrapClient(fake.NewFakeClient(defaultSecretWith(func(secret *corev1.Secret) {
+					secret.ObjectMeta.Labels["foo"] = "bar"
+				}))),
+				owner: testES,
 			},
-			want: true,
-		},
-		{
-			name: "pod name mismatch",
-			args: args{
-				secret: corev1.Secret{
-					Data: map[string][]byte{
-						certificates.CertFileName: pemCert,
-					},
-				},
-				pod:          corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "different"}},
-				cluster:      testCluster,
-				rotateBefore: certificates.DefaultRotateBefore,
+			want: func(t *testing.T, secret *corev1.Secret) {
+				assert.Equal(t, defaultSecretWith(func(secret *corev1.Secret) {
+					secret.ObjectMeta.Labels["foo"] = "bar"
+				}), secret)
 			},
-			want: true,
-		},
-		{
-			name: "valid cert",
-			args: args{
-				secret: corev1.Secret{
-					Data: map[string][]byte{
-						certificates.CertFileName: pemCert,
-					},
-				},
-				pod:          testPod,
-				cluster:      testCluster,
-				rotateBefore: certificates.DefaultRotateBefore,
-			},
-			want: false,
-		},
-		{
-			name: "should be rotated soon",
-			args: args{
-				secret: corev1.Secret{
-					Data: map[string][]byte{
-						certificates.CertFileName: pemCert,
-					},
-				},
-				pod:          testPod,
-				cluster:      testCluster,
-				rotateBefore: certificates.DefaultCertValidity, // rotate before the same duration as total validity
-			},
-			want: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldIssueNewCertificate(tt.args.cluster, []corev1.Service{testSvc}, tt.args.secret, testRSAPrivateKey, testCA, tt.args.pod, tt.args.rotateBefore); got != tt.want {
-				t.Errorf("shouldIssueNewCertificate() = %v, want %v", got, tt.want)
+			if tt.args.scheme == nil {
+				tt.args.scheme = scheme.Scheme
 			}
-		})
-	}
-}
 
-func Test_doReconcileTransportCertificateSecret(t *testing.T) {
-	objMeta := metav1.ObjectMeta{
-		Namespace: "namespace",
-		Name:      name.TransportCertsSecret(testPod.Name),
-		Labels: map[string]string{
-			LabelCertificateType:       LabelCertificateTypeTransport,
-			label.PodNameLabelName:     testPod.Name,
-			label.ClusterNameLabelName: testCluster.Name,
-		},
-	}
-
-	tests := []struct {
-		name                            string
-		secret                          corev1.Secret
-		pod                             corev1.Pod
-		additionalTrustedCAsPemEncoded  [][]byte
-		wantSecretUpdated               bool
-		wantCertUpdateAnnotationUpdated bool
-		wantErr                         func(t *testing.T, err error)
-	}{
-		{
-			name: "do not requeue without updating secret if there is an additional CA",
-			secret: corev1.Secret{
-				ObjectMeta: objMeta,
-				Data: map[string][]byte{
-					certificates.CertFileName: pemCert,
-					certificates.CAFileName:   certificates.EncodePEMCert(testCA.Cert.Raw),
-				},
-			},
-			additionalTrustedCAsPemEncoded:  additionalCA,
-			pod:                             testPod,
-			wantSecretUpdated:               true,
-			wantCertUpdateAnnotationUpdated: false,
-		},
-		{
-			name: "no private key in the secret",
-			secret: corev1.Secret{
-				ObjectMeta: objMeta,
-				Data: map[string][]byte{
-					certificates.CertFileName: pemCert,
-					certificates.CAFileName:   certificates.EncodePEMCert(testCA.Cert.Raw),
-				},
-			},
-			pod:                             testPod,
-			wantSecretUpdated:               true,
-			wantCertUpdateAnnotationUpdated: true,
-		},
-		{
-			name: "no cert in the secret",
-			secret: corev1.Secret{
-				ObjectMeta: objMeta,
-				Data: map[string][]byte{
-					certificates.KeyFileName: certificates.EncodePEMPrivateKey(*testRSAPrivateKey),
-					certificates.CAFileName:  certificates.EncodePEMCert(testCA.Cert.Raw),
-				},
-			},
-			pod:                             testPod,
-			wantSecretUpdated:               true,
-			wantCertUpdateAnnotationUpdated: true,
-		},
-		{
-			name: "cert does not belong to the key in the secret",
-			secret: corev1.Secret{
-				ObjectMeta: objMeta,
-				Data: map[string][]byte{
-					certificates.KeyFileName:  certificates.EncodePEMPrivateKey(*testRSAPrivateKey),
-					certificates.CertFileName: certificates.EncodePEMCert(testCA.Cert.Raw),
-					certificates.CAFileName:   certificates.EncodePEMCert(testCA.Cert.Raw),
-				},
-			},
-			pod:                             testPod,
-			wantSecretUpdated:               true,
-			wantCertUpdateAnnotationUpdated: true,
-		},
-		{
-			name: "invalid cert in the secret",
-			secret: corev1.Secret{
-				ObjectMeta: objMeta,
-				Data: map[string][]byte{
-					certificates.KeyFileName:  certificates.EncodePEMPrivateKey(*testRSAPrivateKey),
-					certificates.CertFileName: []byte("invalid"),
-					certificates.CAFileName:   certificates.EncodePEMCert(testCA.Cert.Raw),
-				},
-			},
-			pod:                             testPod,
-			wantSecretUpdated:               true,
-			wantCertUpdateAnnotationUpdated: true,
-		},
-		{
-			name:   "no cert generated, but pod has no IP yet: requeue",
-			secret: corev1.Secret{ObjectMeta: objMeta},
-			pod:    corev1.Pod{},
-			wantErr: func(t *testing.T, err error) {
-				assert.Contains(t, err.Error(), "pod currently has no valid IP")
-			},
-		},
-		{
-			name: "valid data should not require updating",
-			secret: corev1.Secret{
-				ObjectMeta: objMeta,
-				Data: map[string][]byte{
-					certificates.KeyFileName:  certificates.EncodePEMPrivateKey(*testRSAPrivateKey),
-					certificates.CertFileName: pemCert,
-					certificates.CAFileName:   certificates.EncodePEMCert(testCA.Cert.Raw),
-				},
-			},
-			pod:               testPod,
-			wantSecretUpdated: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			secret := tt.secret.DeepCopy()
-			fakeClient := k8s.WrapClient(fake.NewFakeClient(secret))
-			err := fakeClient.Create(&tt.pod)
-			require.NoError(t, err)
-
-			_, err = doReconcileTransportCertificateSecret(
-				fakeClient,
-				scheme.Scheme,
-				testCluster,
-				tt.pod,
-				[]corev1.Service{testSvc},
-				testCA,
-				certificates.RotationParams{
-					Validity:     certificates.DefaultCertValidity,
-					RotateBefore: certificates.DefaultRotateBefore,
-				},
-			)
-			if tt.wantErr != nil {
-				tt.wantErr(t, err)
+			got, err := ensureTransportCertificatesSecretExists(tt.args.c, tt.args.scheme, tt.args.owner)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("EnsureTransportCertificateSecretExists() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			require.NoError(t, err)
-
-			var updatedSecret corev1.Secret
-			err = fakeClient.Get(k8s.ExtractNamespacedName(&objMeta), &updatedSecret)
-			require.NoError(t, err)
-
-			var updatedPod corev1.Pod
-			err = fakeClient.Get(k8s.ExtractNamespacedName(&tt.pod), &updatedPod)
-
-			isUpdated := !reflect.DeepEqual(tt.secret, updatedSecret)
-			require.Equal(t, tt.wantSecretUpdated, isUpdated, "want secret updated")
-
-			if tt.wantSecretUpdated {
-				assert.NotEmpty(t, updatedSecret.Data[certificates.CAFileName])
-				assert.NotEmpty(t, updatedSecret.Data[certificates.CertFileName])
-				if tt.wantCertUpdateAnnotationUpdated {
-					// check that the pod annotation has been updated
-					assert.NotEmpty(t, updatedPod.Annotations[annotation.UpdateAnnotation])
-					lastPodUpdate, err := time.Parse(time.RFC3339Nano, updatedPod.Annotations[annotation.UpdateAnnotation])
-					require.NoError(t, err)
-					assert.True(t, lastPodUpdate.Add(-5*time.Minute).Before(time.Now()))
-				}
-			} else {
-				assert.Equal(t, tt.secret.Data, updatedSecret.Data)
-			}
+			tt.want(t, got)
 		})
 	}
 }

--- a/operators/pkg/controller/elasticsearch/certificates/transport/transport_fixtures_test.go
+++ b/operators/pkg/controller/elasticsearch/certificates/transport/transport_fixtures_test.go
@@ -1,0 +1,129 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package transport
+
+import (
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/certificates"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// fixtures
+var (
+	testCA                       *certificates.CA
+	testRSAPrivateKey            *rsa.PrivateKey
+	testCSRBytes                 []byte
+	testCSR                      *x509.CertificateRequest
+	validatedCertificateTemplate *certificates.ValidatedCertificateTemplate
+	certData                     []byte
+	pemCert                      []byte
+	testIP                       = "1.2.3.4"
+	testES                       = v1alpha1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-es-name", Namespace: "test-namespace"},
+	}
+	testPod = corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod-name",
+		},
+		Status: corev1.PodStatus{
+			PodIP: testIP,
+		},
+	}
+	testSvc = corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-service",
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "2.2.3.3",
+		},
+	}
+	additionalCA = [][]byte{[]byte(testAdditionalCA)}
+)
+
+const (
+	testPemPrivateKey = `
+-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQCxoeCUW5KJxNPxMp+KmCxKLc1Zv9Ny+4CFqcUXVUYH69L3mQ7v
+IWrJ9GBfcaA7BPQqUlWxWM+OCEQZH1EZNIuqRMNQVuIGCbz5UQ8w6tS0gcgdeGX7
+J7jgCQ4RK3F/PuCM38QBLaHx988qG8NMc6VKErBjctCXFHQt14lerd5KpQIDAQAB
+AoGAYrf6Hbk+mT5AI33k2Jt1kcweodBP7UkExkPxeuQzRVe0KVJw0EkcFhywKpr1
+V5eLMrILWcJnpyHE5slWwtFHBG6a5fLaNtsBBtcAIfqTQ0Vfj5c6SzVaJv0Z5rOd
+7gQF6isy3t3w9IF3We9wXQKzT6q5ypPGdm6fciKQ8RnzREkCQQDZwppKATqQ41/R
+vhSj90fFifrGE6aVKC1hgSpxGQa4oIdsYYHwMzyhBmWW9Xv/R+fPyr8ZwPxp2c12
+33QwOLPLAkEA0NNUb+z4ebVVHyvSwF5jhfJxigim+s49KuzJ1+A2RaSApGyBZiwS
+rWvWkB471POAKUYt5ykIWVZ83zcceQiNTwJBAMJUFQZX5GDqWFc/zwGoKkeR49Yi
+MTXIvf7Wmv6E++eFcnT461FlGAUHRV+bQQXGsItR/opIG7mGogIkVXa3E1MCQARX
+AAA7eoZ9AEHflUeuLn9QJI/r0hyQQLEtrpwv6rDT1GCWaLII5HJ6NUFVf4TTcqxo
+6vdM4QGKTJoO+SaCyP0CQFdpcxSAuzpFcKv0IlJ8XzS/cy+mweCMwyJ1PFEc4FX6
+wg/HcAJWY60xZTJDFN+Qfx8ZQvBEin6c2/h+zZi5IVY=
+-----END RSA PRIVATE KEY-----
+`
+	testAdditionalCA = `-----BEGIN CERTIFICATE-----
+MIIDKzCCAhOgAwIBAgIRAK7i/u/wsh+i2G0yUygsJckwDQYJKoZIhvcNAQELBQAw
+LzEZMBcGA1UECxMQNG1jZnhjbnh0ZjZuNHA5bDESMBAGA1UEAxMJdHJ1c3Qtb25l
+MB4XDTE5MDMyMDIwNDg1NloXDTIwMDMxOTIwNDk1NlowLzEZMBcGA1UECxMQNG1j
+Znhjbnh0ZjZuNHA5bDESMBAGA1UEAxMJdHJ1c3Qtb25lMIIBIjANBgkqhkiG9w0B
+AQEFAAOCAQ8AMIIBCgKCAQEAu/Pws5FcyJw843pNow/Y95rApWAuGanU99DEmeOG
+ggtpc3qtDWWKwLZ6cU+av3u82tf0HYSpy0Z2hn3PS2dGGgHPTr/tTGYA5alu1dn5
+CgqQDBVLbkKA1lDcm8w98fRavRw6a0TX5DURqXs+smhdMztQjDNCl3kJ40JbXVAY
+x5vhD2pKPCK0VIr9uYK0E/9dvrU0SJGLUlB+CY/DU7c8t22oer2T6fjCZzh3Fhwi
+/aOKEwEUoE49orte0N9b1HSKlVePzIUuTTc3UU2ntWi96Uf2FesuAubU11WH4kIL
+wRlofty7ewBzVmGte1fKUMjHB3mgb+WYwkEFwjpQL4LhkQIDAQABo0IwQDAOBgNV
+HQ8BAf8EBAMCAoQwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA8GA1Ud
+EwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAI+qczKQgkb5L5dXzn+KW92J
+Sq1rrmaYUYLRTtPFH7t42REPYLs4UV0qR+6v/hJljQbAS+Vu3BioLWuxq85NsIjf
+OK1KO7D8lwVI9tAetE0tKILqljTjwZpqfZLZ8fFqwzd9IM/WfoI7Z05k8BSL6XdM
+FaRfSe/GJ+DR1dCwnWAVKGxAry4JSceVS9OXxYNRTcfQuT5s8h/6X5UaonTbhil7
+91fQFaX8LSuZj23/3kgDTnjPmvj2sz5nODymI4YeTHLjdlMmTufWSJj901ITp7Bw
+DMO3GhRADFpMz3vjHA2rHA4AQ6nC8N4lIYTw0AF1VAOC0SDntf6YEgrhRKRFAUY=
+-----END CERTIFICATE-----`
+)
+
+func init() {
+	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		panic(err)
+	}
+
+	var err error
+	block, _ := pem.Decode([]byte(testPemPrivateKey))
+	if testRSAPrivateKey, err = x509.ParsePKCS1PrivateKey(block.Bytes); err != nil {
+		panic("Failed to parse private key: " + err.Error())
+	}
+
+	if testCA, err = certificates.NewSelfSignedCA(certificates.CABuilderOptions{
+		Subject:    pkix.Name{CommonName: "test-common-name"},
+		PrivateKey: testRSAPrivateKey,
+	}); err != nil {
+		panic("Failed to create new self signed CA: " + err.Error())
+	}
+
+	testCSRBytes, err = x509.CreateCertificateRequest(cryptorand.Reader, &x509.CertificateRequest{}, testRSAPrivateKey)
+	if err != nil {
+		panic("Failed to create CSR:" + err.Error())
+	}
+	testCSR, err = x509.ParseCertificateRequest(testCSRBytes)
+
+	validatedCertificateTemplate, err = createValidatedCertificateTemplate(
+		testPod, testES, []corev1.Service{testSvc}, testCSR, certificates.DefaultCertValidity)
+	if err != nil {
+		panic("Failed to create validated cert template:" + err.Error())
+	}
+
+	certData, err = testCA.CreateCertificate(*validatedCertificateTemplate)
+	if err != nil {
+		panic("Failed to create cert data:" + err.Error())
+	}
+
+	pemCert = certificates.EncodePEMCert(certData, testCA.Cert.Raw)
+}

--- a/operators/pkg/controller/elasticsearch/driver/pods_test.go
+++ b/operators/pkg/controller/elasticsearch/driver/pods_test.go
@@ -151,19 +151,11 @@ func Test_createElasticsearchPod(t *testing.T) {
 	err = client.Get(k8s.ExtractNamespacedName(&pod), &pod)
 	require.NoError(t, err)
 
-	// should have a volume for transport certs (existing one replaced)
-	found := false
-	for _, v := range pod.Spec.Volumes {
-		if v.Name == esvolume.TransportCertificatesSecretVolumeName {
-			require.NotEqual(t, "should-be-replaced", v.Secret.SecretName)
-			found = true
-		}
-	}
-	require.True(t, found)
 	// should have a volume for config (existing one replaced)
-	found = false
+	found := false
+	configSecretVolumeName := settings.ConfigSecretVolume(pod.Name).Name()
 	for _, v := range pod.Spec.Volumes {
-		if v.Name == esvolume.TransportCertificatesSecretVolumeName {
+		if v.Name == configSecretVolumeName {
 			require.NotEqual(t, "should-be-replaced", v.Secret.SecretName)
 			found = true
 		}

--- a/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
+++ b/operators/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
@@ -5,11 +5,9 @@
 package initcontainer
 
 import (
-	"fmt"
 	"path"
 
-	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/certificates"
-	volume "github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/volume"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/volume"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/name"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/settings"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/user"
@@ -19,7 +17,7 @@ import (
 )
 
 const (
-	transportCertificatesVolumeMountPath = "/mnt/elastic-internal/transport-certificates"
+	initContainerTransportCertificatesVolumeMountPath = "/mnt/elastic-internal/transport-certificates"
 )
 
 // Volumes that are shared between the prepare-fs init container and the ES container
@@ -35,7 +33,7 @@ var (
 	EsConfigSharedVolume = SharedVolume{
 		Name:                   "elastic-internal-elasticsearch-config-local",
 		InitContainerMountPath: "/mnt/elastic-internal/elasticsearch-config-local",
-		EsContainerMountPath:   "/usr/share/elasticsearch/config",
+		EsContainerMountPath:   esvolume.ConfigVolumeMountPath,
 	}
 
 	// EsPluginsSharedVolume contains the ES plugins/ directory
@@ -93,7 +91,7 @@ func NewPrepareFSInitContainer(
 	// will attempt to move all the files under the configuration directory to a different volume, and it should not
 	// be attempting to move files from this secret volume mount (any attempt to do so will be logged as errors).
 	certificatesVolumeMount := transportCertificatesVolume.VolumeMount()
-	certificatesVolumeMount.MountPath = transportCertificatesVolumeMountPath
+	certificatesVolumeMount.MountPath = initContainerTransportCertificatesVolumeMountPath
 
 	scriptsVolume := volume.NewConfigMapVolumeWithMode(
 		name.ScriptsConfigMap(clusterName),
@@ -108,6 +106,11 @@ func NewPrepareFSInitContainer(
 		Name:            prepareFilesystemContainerName,
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: &privileged,
+		},
+		Env: []corev1.EnvVar{
+			{Name: settings.EnvPodName, Value: "", ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "metadata.name"},
+			}},
 		},
 		Command: []string{"bash", "-c", path.Join(esvolume.ScriptsVolumeMountPath, PrepareFsScriptConfigKey)},
 		VolumeMounts: append(
@@ -130,9 +133,17 @@ func RenderPrepareFsScript() (string, error) {
 			esvolume.ElasticsearchDataMountPath,
 			esvolume.ElasticsearchLogsMountPath,
 		},
-		TransportCertificatesKeyPath: fmt.Sprintf(
-			"%s/%s",
-			transportCertificatesVolumeMountPath,
-			certificates.KeyFileName),
+		InitContainerTransportCertificatesSecretVolumeMountPath: initContainerTransportCertificatesVolumeMountPath,
+		InitContainerNodeTransportCertificatesKeyPath: path.Join(
+			EsConfigSharedVolume.InitContainerMountPath,
+			esvolume.NodeTransportCertificatePathSegment,
+			esvolume.NodeTransportCertificateKeyFile,
+		),
+		InitContainerNodeTransportCertificatesCertPath: path.Join(
+			EsConfigSharedVolume.InitContainerMountPath,
+			esvolume.NodeTransportCertificatePathSegment,
+			esvolume.NodeTransportCertificateCertFile,
+		),
+		TransportCertificatesSecretVolumeMountPath: esvolume.TransportCertificatesSecretVolumeMountPath,
 	})
 }

--- a/operators/pkg/controller/elasticsearch/name/name.go
+++ b/operators/pkg/controller/elasticsearch/name/name.go
@@ -22,17 +22,17 @@ const (
 	// podRandomSuffixLength represents the length of the random suffix that is appended in NewPodName.
 	podRandomSuffixLength = 10
 
-	configSecretSuffix          = "config"
-	secureSettingsSecretSuffix  = "secure-settings"
-	certsSecretSuffix           = "certs"
-	httpServiceSuffix           = "http"
-	elasticUserSecretSuffix     = "elastic-user"
-	xpackFileRealmSecretSuffix  = "xpack-file-realm"
-	internalUsersSecretSuffix   = "internal-users"
-	unicastHostsConfigMapSuffix = "unicast-hosts"
-	licenseSecretSuffix         = "license"
-	defaultPodDisruptionBudget  = "default"
-	scriptsConfigMapSuffix      = "scripts"
+	configSecretSuffix                = "config"
+	secureSettingsSecretSuffix        = "secure-settings"
+	httpServiceSuffix                 = "http"
+	elasticUserSecretSuffix           = "elastic-user"
+	xpackFileRealmSecretSuffix        = "xpack-file-realm"
+	internalUsersSecretSuffix         = "internal-users"
+	unicastHostsConfigMapSuffix       = "unicast-hosts"
+	licenseSecretSuffix               = "license"
+	defaultPodDisruptionBudget        = "default"
+	scriptsConfigMapSuffix            = "scripts"
+	transportCertificatesSecretSuffix = "transport-certificates"
 )
 
 // ESNamer is a Namer that is configured with the defaults for resources related to an ES cluster.
@@ -90,8 +90,8 @@ func SecureSettingsSecret(esName string) string {
 	return ESNamer.Suffix(esName, secureSettingsSecretSuffix)
 }
 
-func TransportCertsSecret(podName string) string {
-	return esNoDefaultSuffixesNamer.Suffix(podName, certsSecretSuffix)
+func TransportCertificatesSecret(esName string) string {
+	return ESNamer.Suffix(esName, transportCertificatesSecretSuffix)
 }
 
 func HTTPService(esName string) string {

--- a/operators/pkg/controller/elasticsearch/pod/pod.go
+++ b/operators/pkg/controller/elasticsearch/pod/pod.go
@@ -121,3 +121,12 @@ func PodMapToNames(pods map[string]corev1.Pod) []string {
 	}
 	return names
 }
+
+// PodsByName returns a map of pod names to pods
+func PodsByName(pods []corev1.Pod) map[string]corev1.Pod {
+	podMap := make(map[string]corev1.Pod, len(pods))
+	for _, pod := range pods {
+		podMap[pod.Name] = pod
+	}
+	return podMap
+}

--- a/operators/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/operators/pkg/controller/elasticsearch/settings/merged_config.go
@@ -67,10 +67,20 @@ func xpackConfig() *CanonicalConfig {
 		XPackSecurityHttpSslCertificate: path.Join(volume.HTTPCertificatesSecretVolumeMountPath, certificates.CertFileName),
 
 		// x-pack security transport settings
-		XPackSecurityTransportSslEnabled:                "true",
-		XPackSecurityTransportSslKey:                    path.Join(volume.TransportCertificatesSecretVolumeMountPath, certificates.KeyFileName),
-		XPackSecurityTransportSslCertificate:            path.Join(volume.TransportCertificatesSecretVolumeMountPath, certificates.CertFileName),
-		XPackSecurityTransportSslCertificateAuthorities: []string{path.Join(volume.TransportCertificatesSecretVolumeMountPath, certificates.CAFileName)},
+		XPackSecurityTransportSslEnabled: "true",
+		XPackSecurityTransportSslKey: path.Join(
+			volume.ConfigVolumeMountPath,
+			volume.NodeTransportCertificatePathSegment,
+			volume.NodeTransportCertificateKeyFile,
+		),
+		XPackSecurityTransportSslCertificate: path.Join(
+			volume.ConfigVolumeMountPath,
+			volume.NodeTransportCertificatePathSegment,
+			volume.NodeTransportCertificateCertFile,
+		),
+		XPackSecurityTransportSslCertificateAuthorities: []string{
+			path.Join(volume.TransportCertificatesSecretVolumeMountPath, certificates.CAFileName),
+		},
 	}
 	return &CanonicalConfig{common.MustCanonicalConfig(cfg)}
 }

--- a/operators/pkg/controller/elasticsearch/version/common.go
+++ b/operators/pkg/controller/elasticsearch/version/common.go
@@ -111,6 +111,11 @@ func podSpecContext(
 		esvolume.HTTPCertificatesSecretVolumeName,
 		esvolume.HTTPCertificatesSecretVolumeMountPath,
 	)
+	transportCertificatesVolume := volume.NewSecretVolumeWithMountPath(
+		name.TransportCertificatesSecret(p.Elasticsearch.Name),
+		esvolume.TransportCertificatesSecretVolumeName,
+		esvolume.TransportCertificatesSecretVolumeMountPath,
+	)
 
 	// A few secret volumes will be generated based on the pod name.
 	// At this point the (maybe future) pod does not have a name yet: we still want to
@@ -119,11 +124,6 @@ func podSpecContext(
 	// and secret refs in Volumes Mounts will be fixed right before pod creation,
 	// if this spec ends up leading to a new pod creation.
 	podNamePlaceholder := "pod-name-placeholder"
-	transportCertificatesVolume := volume.NewSecretVolumeWithMountPath(
-		name.TransportCertsSecret(podNamePlaceholder),
-		esvolume.TransportCertificatesSecretVolumeName,
-		esvolume.TransportCertificatesSecretVolumeMountPath,
-	)
 	configVolume := settings.ConfigSecretVolume(podNamePlaceholder)
 
 	// append future volumes from PVCs (not resolved to a claim yet)

--- a/operators/pkg/controller/elasticsearch/volume/names.go
+++ b/operators/pkg/controller/elasticsearch/volume/names.go
@@ -12,6 +12,11 @@ const (
 	KeystoreUserSecretMountPath = "/mnt/elastic-internal/keystore-user"
 	KeystoreUserVolumeName      = "elastic-internal-keystore-user"
 
+	ConfigVolumeMountPath               = "/usr/share/elasticsearch/config"
+	NodeTransportCertificatePathSegment = "node-transport-cert"
+	NodeTransportCertificateKeyFile     = "transport.tls.key"
+	NodeTransportCertificateCertFile    = "transport.tls.crt"
+
 	TransportCertificatesSecretVolumeName      = "elastic-internal-transport-certificates"
 	TransportCertificatesSecretVolumeMountPath = "/usr/share/elasticsearch/config/transport-certs"
 

--- a/operators/pkg/controller/kibana/config/settings_test.go
+++ b/operators/pkg/controller/kibana/config/settings_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/kibana/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
-	"github.com/elastic/go-ucfg"
+	ucfg "github.com/elastic/go-ucfg"
 	uyaml "github.com/elastic/go-ucfg/yaml"
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/require"

--- a/operators/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/operators/test/e2e/test/elasticsearch/checks_k8s.go
@@ -64,7 +64,7 @@ func CheckPodCertificates(b Builder, k *test.K8sClient) test.Step {
 				return err
 			}
 			for _, pod := range pods {
-				_, _, err := k.GetTransportCert(pod.Name)
+				_, _, err := k.GetTransportCert(b.Elasticsearch.Name, pod.Name)
 				if err != nil {
 					return err
 				}

--- a/operators/test/e2e/test/k8s_client.go
+++ b/operators/test/e2e/test/k8s_client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/certificates/http"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/name"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/certificates/transport"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
 	esname "github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/name"
 	kblabel "github.com/elastic/cloud-on-k8s/operators/pkg/controller/kibana/label"
@@ -232,11 +233,11 @@ func (k *K8sClient) GetCA(ownerName string, caType certificates.CAType) (*certif
 }
 
 // GetTransportCert retrieves the certificate of the CA and the transport certificate
-func (k *K8sClient) GetTransportCert(podName string) (caCert, transportCert []*x509.Certificate, err error) {
+func (k *K8sClient) GetTransportCert(esName, podName string) (caCert, transportCert []*x509.Certificate, err error) {
 	var secret corev1.Secret
 	key := types.NamespacedName{
 		Namespace: Namespace,
-		Name:      esname.TransportCertsSecret(podName),
+		Name:      esname.TransportCertificatesSecret(esName),
 	}
 	if err = k.Client.Get(key, &secret); err != nil {
 		return nil, nil, err
@@ -249,9 +250,9 @@ func (k *K8sClient) GetTransportCert(podName string) (caCert, transportCert []*x
 	if err != nil {
 		return nil, nil, err
 	}
-	transportCertBytes, exists := secret.Data[certificates.CertFileName]
+	transportCertBytes, exists := secret.Data[transport.PodCertFileName(podName)]
 	if !exists || len(transportCertBytes) == 0 {
-		return nil, nil, fmt.Errorf("no value found for secret %s", certificates.CertFileName)
+		return nil, nil, fmt.Errorf("no value found for secret %s", transport.PodCertFileName(podName))
 	}
 	transportCert, err = certificates.ParsePEMCerts(transportCertBytes)
 	if err != nil {


### PR DESCRIPTION
This facilitates a move to StatefulSets where the mounted secrets must be the same between all the Pods in the same StatefulSet.