### PR TITLE
Update dev setup doc + fix GKE bootstrap script

### DIFF
--- a/operators/dev-setup.md
+++ b/operators/dev-setup.md
@@ -30,7 +30,9 @@ Run `make check-requisites` to check that all dependencies are installed.
 
 ## Development
 
-1. Get a working development Kubernetes cluster. You can either use:
+1. Run `make dep-vendor-only` to download extra Go libraries needed to compile the project and store them in the vendor directory.
+
+2. Get a working development Kubernetes cluster. You can either use:
 
     [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/#install-minikube)
 
@@ -41,15 +43,16 @@ Run `make check-requisites` to check that all dependencies are installed.
 
       or [GKE](https://cloud.google.com/kubernetes-engine/)
 
+      Make sure that the Docker credential helper is configured as described [here](https://cloud.google.com/container-registry/docs/advanced-authentication#standalone_docker_credential_helper)
+
       ```bash
       export GCLOUD_PROJECT=my-project-id
       make bootstrap-gke
       # Sets up GKE cluster with required resources
       ```
 
-2. Deploy the operator.
+3. Deploy the operator.
 
-   * `make dep-vendor-only` to download extra Go libraries needed to compile the project and stores them in the vendor directory.
    * `make run` to run the operator locally, or `make deploy` to deploy the operators into the configured k8s cluster.
    * `make samples` to apply a sample stack resource.
 

--- a/operators/dev-setup.md
+++ b/operators/dev-setup.md
@@ -43,7 +43,7 @@ Run `make check-requisites` to check that all dependencies are installed.
 
       or [GKE](https://cloud.google.com/kubernetes-engine/)
 
-      Make sure that the Docker credential helper is configured as described [here](https://cloud.google.com/container-registry/docs/advanced-authentication#standalone_docker_credential_helper)
+      Make sure that container registry authentication is correctly configured as described [here](https://cloud.google.com/container-registry/docs/advanced-authentication).
 
       ```bash
       export GCLOUD_PROJECT=my-project-id

--- a/operators/hack/gke-cluster.sh
+++ b/operators/hack/gke-cluster.sh
@@ -58,7 +58,7 @@ create_cluster() {
         exit 0
     fi
 
-    local PSP_OPTION
+    local PSP_OPTION=""
     if [ "$PSP" == "1" ]; then
         PSP_OPTION="--enable-pod-security-policy"
     fi


### PR DESCRIPTION
- Update the dev setup document with extra information that might be useful for a new starter
- Initialize the `PSP_OPTIONS` variable in the GKE bootstrap script to prevent Bash from complaining about unset variables