### PR TITLE
Normalize the raw config when creating canonical configs

### DIFF
--- a/operators/pkg/controller/common/settings/canonical_config.go
+++ b/operators/pkg/controller/common/settings/canonical_config.go
@@ -30,9 +30,19 @@ func NewCanonicalConfig() *CanonicalConfig {
 	return fromConfig(ucfg.New())
 }
 
-// NewCanonicalConfigFrom creates a new config from the API type.
+// NewCanonicalConfigFrom creates a new config from the API type after normalizing the data.
 func NewCanonicalConfigFrom(data untypedDict) (*CanonicalConfig, error) {
-	config, err := ucfg.NewFrom(data, Options...)
+	// not great: round trip through yaml to normalize untyped dict before creating config
+	// to avoid  numeric differences in configs due to JSON marshalling/deep copies being restricted to float
+	bytes, err := yaml.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	var normalized untypedDict
+	if err := yaml.Unmarshal(bytes, &normalized); err != nil {
+		return nil, err
+	}
+	config, err := ucfg.NewFrom(normalized, Options...)
 	if err != nil {
 		return nil, err
 	}

--- a/operators/pkg/controller/common/settings/canonical_config_test.go
+++ b/operators/pkg/controller/common/settings/canonical_config_test.go
@@ -409,3 +409,42 @@ func TestCanonicalConfig_SetStrings(t *testing.T) {
 		})
 	}
 }
+
+func TestNewCanonicalConfigFrom(t *testing.T) {
+	type args struct {
+		data untypedDict
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *CanonicalConfig
+		wantErr bool
+	}{
+		{
+			name: "should normalize numeric types",
+			args: args{
+				data: map[string]interface{}{
+					"a": float64(1), // after json round trip or deep copy typically a float
+					"b": 1.2,
+				},
+			},
+			want: MustCanonicalConfig(map[string]interface{}{
+				"a": 1,
+				"b": 1.2,
+			}),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewCanonicalConfigFrom(tt.args.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewCanonicalConfigFrom() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := got.Diff(tt.want, nil); len(diff) > 0 {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This aims at counteracting the difference between JSON centric serialization and the use of YAML as the serialization format in canonical config. 
It does this by normalizing the raw config map by round tripping it through YAML before creating the canonical config object. 
 
If not normalizing integer values like `1` will differ when comparing configs as JSON deserializes integer numbers to float64 and YAML to uint64.

Alternatives considered: modifying the `Diff` function to consider `uint64(1)== float64(1)` which seems less ideal as it would hide the type difference instead of permanently eliminating it?

Fixes #1190 

