### PR TITLE
Don't run tests if only docs are changed

### DIFF
--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
                 stage("Run unit and integration tests") {
                     when {
                         expression {
+                            checkout scm
                             notOnlyDocs()
                         }
                     }
@@ -32,7 +33,6 @@ pipeline {
                         label 'linux'
                     }
                     steps {
-                        checkout scm
                         sh 'make -C build/ci ci-pr'
                     }
                 }
@@ -45,6 +45,7 @@ pipeline {
                 stage("Run smoke E2E tests") {
                     when {
                         expression {
+                            checkout scm
                             notOnlyDocs()
                         }
                     }
@@ -52,7 +53,6 @@ pipeline {
                         label 'linux'
                     }
                     steps {
-                        checkout scm
                         sh 'make -C build/ci ci-e2e'
                     }
                 }

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -70,12 +70,9 @@ pipeline {
 }
 
 def notOnlyDocs() {
-    sh 'git diff --name-status HEAD~1 HEAD > $WORKSPACE/changes.txt'
-    File file = new File(env.WORKSPACE + "/changes.txt")
-    def lines = file.readLines()
-    def counter = 0
-    for (line in lines) {
-        if (line.contains("docs/")) counter++
-    }
-    return counter != lines.size()
+    // grep succeeds if there is at least one line without docs/
+    return sh (
+        script: "git diff --name-status HEAD~1 HEAD | grep -v docs/",
+    	returnStatus: true
+    ) == 0
 }

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -23,6 +23,11 @@ pipeline {
         stage('Run tests in parallel') {
             parallel {
                 stage("Run unit and integration tests") {
+                    when {
+                        expression {
+                            notOnlyDocs()
+                        }
+                    }
                     agent {
                         label 'linux'
                     }
@@ -38,6 +43,11 @@ pipeline {
                     }
                 }
                 stage("Run smoke E2E tests") {
+                    when {
+                        expression {
+                            notOnlyDocs()
+                        }
+                    }
                     agent {
                         label 'linux'
                     }
@@ -57,4 +67,15 @@ pipeline {
         }
     }
 
+}
+
+def notOnlyDocs() {
+    sh 'git diff --name-status HEAD~1 HEAD > $WORKSPACE/changes.txt'
+    File file = new File(env.WORKSPACE + "/changes.txt")
+    def lines = file.readLines()
+    def counter = 0
+    for (line in lines) {
+        if (line.contains("docs/")) counter++
+    }
+    return counter != lines.size()
 }


### PR DESCRIPTION
This PR allows to skip running all the tests as part of PR job if in PR only docs were changed
close https://github.com/elastic/cloud-on-k8s/issues/936