### PR TITLE
Handle StatefulSets scale up/down/replacement

### DIFF
--- a/operators/config/crds/elasticsearch_v1alpha1_elasticsearch.yaml
+++ b/operators/config/crds/elasticsearch_v1alpha1_elasticsearch.yaml
@@ -122,7 +122,7 @@ spec:
                   name:
                     description: Name is a logical name for this set of nodes. Used
                       as a part of the managed Elasticsearch node.name setting.
-                    maxLength: 12
+                    maxLength: 19
                     pattern: '[a-zA-Z0-9-]+'
                     type: string
                   nodeCount:

--- a/operators/config/samples/apm/apm_es_kibana.yaml
+++ b/operators/config/samples/apm/apm_es_kibana.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   version: "7.1.0"
   nodes:
-  - name: all
+  - name: default
     nodeCount: 3
 ---
 apiVersion: apm.k8s.elastic.co/v1alpha1

--- a/operators/config/samples/elasticsearch/elasticsearch.yaml
+++ b/operators/config/samples/elasticsearch/elasticsearch.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   version: "7.1.0"
   nodes:
-  - name: all
+  - name: default
     config:
       # most Elasticsearch configuration parameters are possible to set, e.g:
       node.attr.attr_name: attr_value

--- a/operators/config/samples/elasticsearch/elasticsearch_local_volume.yaml
+++ b/operators/config/samples/elasticsearch/elasticsearch_local_volume.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   version: "7.1.0"
   nodes:
-  - name: all
+  - name: default
     nodeCount: 3
     volumeClaimTemplates:
     - metadata:

--- a/operators/config/samples/kibana/kibana_es.yaml
+++ b/operators/config/samples/kibana/kibana_es.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   version: "7.1.0"
   nodes:
-  - name: all
+  - name: default
     nodeCount: 1
 ---
 apiVersion: kibana.k8s.elastic.co/v1alpha1

--- a/operators/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
+++ b/operators/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
@@ -66,7 +66,7 @@ func (es ElasticsearchSpec) NodeCount() int32 {
 type NodeSpec struct {
 	// Name is a logical name for this set of nodes. Used as a part of the managed Elasticsearch node.name setting.
 	// +kubebuilder:validation:Pattern=[a-zA-Z0-9-]+
-	// +kubebuilder:validation:MaxLength=12
+	// +kubebuilder:validation:MaxLength=19
 	Name string `json:"name"`
 
 	// Config represents Elasticsearch configuration.

--- a/operators/pkg/controller/elasticsearch/driver/default.go
+++ b/operators/pkg/controller/elasticsearch/driver/default.go
@@ -559,15 +559,15 @@ func (d *defaultDriver) reconcileNodeSpecs(
 	//    but do not rotate pods yet.
 	// 3. do **not** apply replicas scale down, otherwise nodes would be deleted before
 	//    we handle a clean deletion.
-	for _, nodeSpec := range nodeSpecResources {
+	for _, nodeSpecRes := range nodeSpecResources {
 		// always reconcile config (will apply to new & recreated pods)
-		if err := settings.ReconcileConfig(d.Client, es, nodeSpec.StatefulSet.Name, nodeSpec.Config); err != nil {
+		if err := settings.ReconcileConfig(d.Client, es, nodeSpecRes.StatefulSet.Name, nodeSpecRes.Config); err != nil {
 			return results.WithError(err)
 		}
-		if _, err := common.ReconcileService(d.Client, d.Scheme, &nodeSpec.HeadlessService, &es); err != nil {
+		if _, err := common.ReconcileService(d.Client, d.Scheme, &nodeSpecRes.HeadlessService, &es); err != nil {
 			return results.WithError(err)
 		}
-		ssetToApply := nodeSpec.StatefulSet.DeepCopy()
+		ssetToApply := nodeSpecRes.StatefulSet.DeepCopy()
 		actual, exists := actualStatefulSets.GetByName(ssetToApply.Name)
 		if exists && *ssetToApply.Spec.Replicas < *actual.Spec.Replicas {
 			// sset needs to be scaled down

--- a/operators/pkg/controller/elasticsearch/driver/default.go
+++ b/operators/pkg/controller/elasticsearch/driver/default.go
@@ -630,6 +630,7 @@ func (d *defaultDriver) scaleStatefulSetDown(
 	updatedReplicas := int32(*statefulSet.Spec.Replicas)
 
 	// leaving nodes names can be built from StatefulSet name and ordinals
+	// nodes are ordered by highest ordinal first
 	var leavingNodes []string
 	for i := int(*statefulSet.Spec.Replicas) - 1; i > targetReplicas-1; i-- {
 		leavingNodes = append(leavingNodes, sset.PodName(statefulSet.Name, i))

--- a/operators/pkg/controller/elasticsearch/migration/migrate_data.go
+++ b/operators/pkg/controller/elasticsearch/migration/migrate_data.go
@@ -8,8 +8,6 @@ import (
 	"context"
 	"strings"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/observer"
 )
@@ -66,16 +64,16 @@ func nodeIsMigratingData(nodeName string, shards []client.Shard, exclusions map[
 // IsMigratingData looks only at the presence of shards on a given node
 // and checks if there is at least one other copy of the shard in the cluster
 // that is started and not relocating.
-func IsMigratingData(state observer.State, pod corev1.Pod, exclusions []corev1.Pod) bool {
+func IsMigratingData(state observer.State, podName string, exclusions []string) bool {
 	clusterState := state.ClusterState
-	if clusterState.IsEmpty() {
+	if clusterState == nil || clusterState.IsEmpty() {
 		return true // we don't know if the request timed out or the cluster has not formed yet
 	}
 	excludedNodes := make(map[string]struct{}, len(exclusions))
-	for _, n := range exclusions {
-		excludedNodes[n.Name] = struct{}{}
+	for _, name := range exclusions {
+		excludedNodes[name] = struct{}{}
 	}
-	return nodeIsMigratingData(pod.Name, clusterState.GetShards(), excludedNodes)
+	return nodeIsMigratingData(podName, clusterState.GetShards(), excludedNodes)
 }
 
 // AllocationSettings captures Elasticsearch API calls around allocation filtering.

--- a/operators/pkg/controller/elasticsearch/migration/migrate_data_test.go
+++ b/operators/pkg/controller/elasticsearch/migration/migrate_data_test.go
@@ -158,6 +158,17 @@ func TestIsMigratingData(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "no data migration in progress",
+			args: args{
+				state: observer.State{ClusterState: &client.ClusterState{
+					ClusterName: "name",
+				}},
+				podName:    "pod",
+				exclusions: nil,
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/operators/pkg/controller/elasticsearch/nodespec/resources.go
+++ b/operators/pkg/controller/elasticsearch/nodespec/resources.go
@@ -21,7 +21,6 @@ type Resources struct {
 	StatefulSet     appsv1.StatefulSet
 	HeadlessService corev1.Service
 	Config          settings.CanonicalConfig
-	// TLS certs
 }
 
 type ResourcesList []Resources

--- a/operators/pkg/controller/elasticsearch/nodespec/resources.go
+++ b/operators/pkg/controller/elasticsearch/nodespec/resources.go
@@ -27,8 +27,8 @@ type ResourcesList []Resources
 
 func (l ResourcesList) StatefulSets() sset.StatefulSetList {
 	ssetList := make(sset.StatefulSetList, 0, len(l))
-	for _, nodeSpec := range l {
-		ssetList = append(ssetList, nodeSpec.StatefulSet)
+	for _, resource := range l {
+		ssetList = append(ssetList, resource.StatefulSet)
 	}
 	return ssetList
 }

--- a/operators/pkg/controller/elasticsearch/sset/getter.go
+++ b/operators/pkg/controller/elasticsearch/sset/getter.go
@@ -1,0 +1,17 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package sset
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// Replicas returns the replicas configured for this StatefulSet, or 0 if nil.
+func Replicas(statefulSet appsv1.StatefulSet) int32 {
+	if statefulSet.Spec.Replicas != nil {
+		return *statefulSet.Spec.Replicas
+	}
+	return 0
+}

--- a/operators/pkg/controller/elasticsearch/sset/pod.go
+++ b/operators/pkg/controller/elasticsearch/sset/pod.go
@@ -1,0 +1,11 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package sset
+
+import "fmt"
+
+func PodName(ssetName string, ordinal int) string {
+	return fmt.Sprintf("%s-%d", ssetName, ordinal)
+}


### PR DESCRIPTION
Based on https://github.com/elastic/cloud-on-k8s/pull/1205 which should be reviewed and merged first.

Only last 3 commits matter for this PR (119d9ac, c451042, fc12730).
___

Add support for scaling a StatefulSet up (just update sset replicas) or
down (migrate data away then remove nodes when ready). Which also adds
support for renaming a StatefulSet, by creating the new sset, then
slowly remove the existing one with data migration.

It ignores any zen1/zen2 consideration for now (works fine with zen2 in most
cases).
It ignores any change budget consideration for now.
Unit tests and E2E tests are missing, but a refactoring is to be
expected to handle zen2/zen2 and the changeBudget. I'd prefer waiting
for this refactoring to happen before dealing with large unit testing.
Consider this as still work in progress.

The PR also modifies the way pods and ssets are watched by the Elasticsearch controller.