### PR TITLE
Delete GKE cluster in PR job only if changes were made not in docs

### DIFF
--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -73,7 +73,11 @@ pipeline {
             }
         }
         cleanup {
-            sh 'make -C build/ci ci-gke-cleanup'
+            script {
+                if (notOnlyDocs()) {
+                    sh 'make -C build/ci ci-gke-cleanup'
+                }
+            }
             cleanWs()
         }
     }


### PR DESCRIPTION
https://github.com/elastic/cloud-on-k8s/commit/ea836f656428b1e10ab44c1f1b1813ec500750ba added check to not run any tests if change was made to docs only. I missed a potential case when change was made to docs, but in cleanup it tries to delete unexisted GKE cluster for E2E tests andd fail PR job because of it, like in https://github.com/elastic/cloud-on-k8s/pull/1214. This PR fixes that.