### PR TITLE
Add operator version to resources

### DIFF
--- a/operators/config/crds/apm_v1alpha1_apmserver.yaml
+++ b/operators/config/crds/apm_v1alpha1_apmserver.yaml
@@ -195,6 +195,10 @@ spec:
           type: object
         status:
           properties:
+            controllerVersion:
+              description: ControllerVersion is the version of the controller that
+                last updated the ApmServer instance
+              type: string
             health:
               type: string
             secretTokenSecret:

--- a/operators/config/crds/elasticsearch_v1alpha1_elasticsearch.yaml
+++ b/operators/config/crds/elasticsearch_v1alpha1_elasticsearch.yaml
@@ -244,6 +244,10 @@ spec:
           properties:
             clusterUUID:
               type: string
+            controllerVersion:
+              description: ControllerVersion is the version of the controller that
+                last updated the Elasticsearch cluster
+              type: string
             health:
               type: string
             masterNode:

--- a/operators/config/crds/kibana_v1alpha1_kibana.yaml
+++ b/operators/config/crds/kibana_v1alpha1_kibana.yaml
@@ -189,6 +189,10 @@ spec:
           properties:
             associationStatus:
               type: string
+            controllerVersion:
+              description: ControllerVersion is the version of the controller that
+                last updated the Kibana instance
+              type: string
             health:
               type: string
           type: object

--- a/operators/pkg/apis/apm/v1alpha1/apmserver_types.go
+++ b/operators/pkg/apis/apm/v1alpha1/apmserver_types.go
@@ -98,6 +98,8 @@ type ApmServerStatus struct {
 	SecretTokenSecretName string `json:"secretTokenSecret,omitempty"`
 	// Association is the status of any auto-linking to Elasticsearch clusters.
 	Association commonv1alpha1.AssociationStatus
+	// ControllerVersion is the version of the controller that last updated the ApmServer instance
+	ControllerVersion string `json:"controllerVersion,omitempty"`
 }
 
 // IsDegraded returns true if the current status is worse than the previous.

--- a/operators/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
+++ b/operators/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
@@ -219,6 +219,8 @@ type ElasticsearchStatus struct {
 	MasterNode      string                          `json:"masterNode,omitempty"`
 	ExternalService string                          `json:"service,omitempty"`
 	ZenDiscovery    ZenDiscoveryStatus              `json:"zenDiscovery,omitempty"`
+	// ControllerVersion is the version of the controller that last updated the Elasticsearch cluster
+	ControllerVersion string `json:"controllerVersion,omitempty"`
 }
 
 type ZenDiscoveryStatus struct {

--- a/operators/pkg/apis/kibana/v1alpha1/kibana_types.go
+++ b/operators/pkg/apis/kibana/v1alpha1/kibana_types.go
@@ -87,6 +87,8 @@ type KibanaStatus struct {
 	commonv1alpha1.ReconcilerStatus
 	Health            KibanaHealth                     `json:"health,omitempty"`
 	AssociationStatus commonv1alpha1.AssociationStatus `json:"associationStatus,omitempty"`
+	// ControllerVersion is the version of the controller that last updated the Kibana instance
+	ControllerVersion string `json"controllerVersion.omitempty"`
 }
 
 // IsDegraded returns true if the current status is worse than the previous.

--- a/operators/pkg/apis/kibana/v1alpha1/kibana_types.go
+++ b/operators/pkg/apis/kibana/v1alpha1/kibana_types.go
@@ -88,7 +88,7 @@ type KibanaStatus struct {
 	Health            KibanaHealth                     `json:"health,omitempty"`
 	AssociationStatus commonv1alpha1.AssociationStatus `json:"associationStatus,omitempty"`
 	// ControllerVersion is the version of the controller that last updated the Kibana instance
-	ControllerVersion string `json"controllerVersion.omitempty"`
+	ControllerVersion string `json:"controllerVersion,omitempty"`
 }
 
 // IsDegraded returns true if the current status is worse than the previous.

--- a/operators/pkg/controller/apmserver/state.go
+++ b/operators/pkg/controller/apmserver/state.go
@@ -43,3 +43,11 @@ func (s State) UpdateApmServerState(deployment v1.Deployment, apmServerSecret co
 func (s State) UpdateApmServerExternalService(svc corev1.Service) {
 	s.ApmServer.Status.ExternalService = svc.Name
 }
+
+func (s *State) UpdateApmServerControllerVersion(version string) {
+	s.ApmServer.Status.ControllerVersion = version
+}
+
+func (s *State) GetApmServerControllerVersion() string {
+	return s.ApmServer.Status.ControllerVersion
+}

--- a/operators/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/operators/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -194,6 +194,7 @@ func (r *ReconcileElasticsearch) Reconcile(request reconcile.Request) (reconcile
 	}
 
 	state := esreconcile.NewState(es)
+	state.UpdateElasticsearchControllerVersion(r.OperatorInfo.BuildInfo.Version)
 	results := r.internalReconcile(es, state)
 	err = r.updateStatus(es, state)
 	if err != nil && apierrors.IsConflict(err) {

--- a/operators/pkg/controller/elasticsearch/reconcile/state.go
+++ b/operators/pkg/controller/elasticsearch/reconcile/state.go
@@ -157,3 +157,13 @@ func (s *State) UpdateElasticsearchInvalid(results []validation.Result) {
 		s.AddEvent(corev1.EventTypeWarning, events.EventReasonValidation, r.Reason)
 	}
 }
+
+// UpdateElasticsearchControllerVersion sets the elasticsearch operator version that last updated the ES cluster
+func (s *State) UpdateElasticsearchControllerVersion(version string) {
+	s.status.ControllerVersion = version
+}
+
+// GetElasticsearchControllerVersion returns the elasticsearch operator version that last updated the ES cluster
+func (s *State) GetElasticsearchControllerVersion() string {
+	return s.status.ControllerVersion
+}

--- a/operators/pkg/controller/elasticsearch/reconcile/state.go
+++ b/operators/pkg/controller/elasticsearch/reconcile/state.go
@@ -158,7 +158,7 @@ func (s *State) UpdateElasticsearchInvalid(results []validation.Result) {
 	}
 }
 
-// UpdateElasticsearchControllerVersion sets the elasticsearch operator version that last updated the ES cluster
+// UpdateElasticsearchControllerVersion sets the elasticsearch controller version that last updated the ES cluster
 func (s *State) UpdateElasticsearchControllerVersion(version string) {
 	s.status.ControllerVersion = version
 }

--- a/operators/pkg/controller/elasticsearch/reconcile/state.go
+++ b/operators/pkg/controller/elasticsearch/reconcile/state.go
@@ -163,7 +163,7 @@ func (s *State) UpdateElasticsearchControllerVersion(version string) {
 	s.status.ControllerVersion = version
 }
 
-// GetElasticsearchControllerVersion returns the elasticsearch operator version that last updated the ES cluster
+// GetElasticsearchControllerVersion returns the elasticsearch controller version that last updated the ES cluster
 func (s *State) GetElasticsearchControllerVersion() string {
 	return s.status.ControllerVersion
 }

--- a/operators/pkg/controller/kibana/kibana_controller.go
+++ b/operators/pkg/controller/kibana/kibana_controller.go
@@ -171,6 +171,7 @@ func (r *ReconcileKibana) Reconcile(request reconcile.Request) (reconcile.Result
 		return reconcile.Result{}, err
 	}
 	state := NewState(request, kb)
+	state.UpdateKibanaControllerVersion(r.params.OperatorInfo.BuildInfo.Version)
 	driver, err := newDriver(r, r.scheme, *ver, r.dynamicWatches, r.recorder)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/operators/pkg/controller/kibana/state.go
+++ b/operators/pkg/controller/kibana/state.go
@@ -36,3 +36,13 @@ func (s State) UpdateKibanaState(deployment v1.Deployment) {
 		}
 	}
 }
+
+// UpdateKibanaControllerVersion updates the Kibana status with the controller version that last updated the Kibana instance
+func (s *State) UpdateKibanaControllerVersion(version string) {
+	s.Kibana.Status.ControllerVersion = version
+}
+
+// GetKibanaControllerVersion returns the controller version that last updated the Kibana instance
+func (s *State) GetKibanaControllerVersion() string {
+	return s.Kibana.Status.ControllerVersion
+}


### PR DESCRIPTION
Resolves https://github.com/elastic/cloud-on-k8s/issues/1137

Adds the version of the controller to the status of the CR to be used for debugging or potentially for control flow in the future.

Since the use case wasn't very defined yet there was some uncertainty over how to implement this -- should it be a label or annotation, should it be on all child resources or just the CR, but this seemed to be a good starting place at least.