### PR TITLE
Remove APM server defaults and allow standalone operation

### DIFF
--- a/operators/pkg/controller/apmserver/apmserver_controller.go
+++ b/operators/pkg/controller/apmserver/apmserver_controller.go
@@ -216,18 +216,7 @@ func (r *ReconcileApmServer) Reconcile(request reconcile.Request) (reconcile.Res
 	return r.updateStatus(state)
 }
 
-func (r *ReconcileApmServer) reconcileApmServerDeployment(
-	state State,
-	as *apmv1alpha1.ApmServer,
-) (State, error) {
-	if !as.Spec.Output.Elasticsearch.IsConfigured() {
-		log.Info("Aborting ApmServer deployment reconciliation as no Elasticsearch output is configured",
-			"namespace", as.Namespace, "as_name", as.Name)
-		return state, nil
-	}
-
-	// TODO: move server secret into separate method
-
+func (r *ReconcileApmServer) reconcileApmServerSecret(as *apmv1alpha1.ApmServer) (*corev1.Secret, error) {
 	expectedApmServerSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: as.Namespace,
@@ -239,7 +228,7 @@ func (r *ReconcileApmServer) reconcileApmServerDeployment(
 		},
 	}
 	reconciledApmServerSecret := &corev1.Secret{}
-	if err := reconciler.ReconcileResource(
+	return reconciledApmServerSecret, reconciler.ReconcileResource(
 		reconciler.Params{
 			Client: r.Client,
 			Scheme: r.scheme,
@@ -280,10 +269,18 @@ func (r *ReconcileApmServer) reconcileApmServerDeployment(
 				log.Info("Updating apm server secret", "namespace", expectedApmServerSecret.Namespace, "secret_name", expectedApmServerSecret.Name, "as_name", as.Name)
 			},
 		},
-	); err != nil {
+	)
+}
+
+func (r *ReconcileApmServer) reconcileApmServerDeployment(
+	state State,
+	as *apmv1alpha1.ApmServer,
+) (State, error) {
+
+	reconciledApmServerSecret, err := r.reconcileApmServerSecret(as)
+	if err != nil {
 		return state, err
 	}
-
 	reconciledConfigSecret, err := config.Reconcile(r.Client, r.scheme, as)
 	if err != nil {
 		return state, err
@@ -379,7 +376,7 @@ func (r *ReconcileApmServer) reconcileApmServerDeployment(
 	if err != nil {
 		return state, err
 	}
-	state.UpdateApmServerState(result, *expectedApmServerSecret)
+	state.UpdateApmServerState(result, *reconciledApmServerSecret)
 	return state, nil
 }
 

--- a/operators/pkg/controller/apmserver/apmserver_controller.go
+++ b/operators/pkg/controller/apmserver/apmserver_controller.go
@@ -276,7 +276,6 @@ func (r *ReconcileApmServer) reconcileApmServerDeployment(
 	state State,
 	as *apmv1alpha1.ApmServer,
 ) (State, error) {
-
 	reconciledApmServerSecret, err := r.reconcileApmServerSecret(as)
 	if err != nil {
 		return state, err

--- a/operators/test/e2e/apm/standalone_test.go
+++ b/operators/test/e2e/apm/standalone_test.go
@@ -28,5 +28,4 @@ func TestApmStandalone(t *testing.T) {
 
 	test.Sequence(nil, test.EmptySteps, apmBuilder).
 		RunSequential(t)
-	// TODO: is it possible to verify that it would also show up properly in Kibana?
 }

--- a/operators/test/e2e/apm/standalone_test.go
+++ b/operators/test/e2e/apm/standalone_test.go
@@ -12,9 +12,8 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/apmserver"
 )
 
-// TestApmStandalone runs a test suite using the sample ApmServer + ES + Kibana
+// TestApmStandalone runs a test suite on an APM server that is not outputting to Elasticsearch
 func TestApmStandalone(t *testing.T) {
-
 	apmBuilder := apmserver.NewBuilder("standalone").
 		WithNamespace(test.Namespace).
 		WithVersion(test.ElasticStackVersion).

--- a/operators/test/e2e/apm/standalone_test.go
+++ b/operators/test/e2e/apm/standalone_test.go
@@ -1,0 +1,32 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package apm
+
+import (
+	"testing"
+
+	apmtype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/apm/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/apmserver"
+)
+
+// TestApmStandalone runs a test suite using the sample ApmServer + ES + Kibana
+func TestApmStandalone(t *testing.T) {
+
+	apmBuilder := apmserver.NewBuilder("standalone").
+		WithNamespace(test.Namespace).
+		WithVersion(test.ElasticStackVersion).
+		WithRestrictedSecurityContext().
+		WithOutput(apmtype.Output{}).
+		WithConfig(map[string]interface{}{
+			"output.console": map[string]interface{}{
+				"pretty": true,
+			},
+		})
+
+	test.Sequence(nil, test.EmptySteps, apmBuilder).
+		RunSequential(t)
+	// TODO: is it possible to verify that it would also show up properly in Kibana?
+}

--- a/operators/test/e2e/test/apmserver/builder.go
+++ b/operators/test/e2e/test/apmserver/builder.go
@@ -74,6 +74,18 @@ func (b Builder) WithNodeCount(count int) Builder {
 	return b
 }
 
+func (b Builder) WithOutput(out apmtype.Output) Builder {
+	b.ApmServer.Spec.Output = out
+	return b
+}
+
+func (b Builder) WithConfig(cfg map[string]interface{}) Builder {
+	b.ApmServer.Spec.Config = &commonv1alpha1.Config{
+		Data: cfg,
+	}
+	return b
+}
+
 // -- Helper functions
 
 func (b Builder) RuntimeObjects() []runtime.Object {


### PR DESCRIPTION
* removes APM server config defaults (feedback from the APM team)
* allows standalone operation without Elasticsearch output (e.g. using console, kafka, logstash etc. output)
* why combine the two changes in one PR? Because we were hard-coding Elasticsearch output in the config defaults
* adds an e2e test for standalone operation
* why no unit test? because reconcile loop is still hard to test 