### PR TITLE
Change CN and SAN naming

### DIFF
--- a/operators/pkg/controller/common/certificates/ca_reconcile.go
+++ b/operators/pkg/controller/common/certificates/ca_reconcile.go
@@ -17,7 +17,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 // CAType is a type of CA
@@ -100,7 +99,7 @@ func renewCA(
 ) (*CA, error) {
 	ca, err := NewSelfSignedCA(CABuilderOptions{
 		Subject: pkix.Name{
-			CommonName:         string(caType) + "-" + rand.String(16),
+			CommonName:         owner.GetName() + "-" + string(caType),
 			OrganizationalUnit: []string{owner.GetName()},
 		},
 		ExpireIn: &expireIn,

--- a/operators/pkg/controller/common/certificates/ca_reconcile_test.go
+++ b/operators/pkg/controller/common/certificates/ca_reconcile_test.go
@@ -219,6 +219,7 @@ func Test_renewCA(t *testing.T) {
 			ca, err := renewCA(tt.client, testNamer, &testCluster, nil, tt.expireIn, scheme.Scheme, TransportCAType)
 			require.NoError(t, err)
 			require.NotNil(t, ca)
+			assert.Equal(t, ca.Cert.Issuer.CommonName, testName+"-"+string(TransportCAType))
 			checkCASecrets(t, tt.client, testCluster, TransportCAType, ca, nil, tt.notExpected, tt.expireIn)
 		})
 	}

--- a/operators/pkg/controller/common/certificates/http/reconcile.go
+++ b/operators/pkg/controller/common/certificates/http/reconcile.go
@@ -331,8 +331,10 @@ func createValidatedHTTPCertificateTemplate(
 	certValidity time.Duration,
 ) (*certificates.ValidatedCertificateTemplate, error) {
 
+	defaultSuffixes := strings.Join(namer.DefaultSuffixes, "-")
+	shortName := owner.Name + "-" + defaultSuffixes + "-" + string(certificates.HTTPCAType)
 	cnNameParts := []string{
-		owner.Name,
+		shortName,
 		owner.Namespace,
 	}
 	cnNameParts = append(cnNameParts, namer.DefaultSuffixes...)
@@ -342,7 +344,8 @@ func createValidatedHTTPCertificateTemplate(
 	certCommonName := strings.Join(cnNameParts, ".")
 
 	dnsNames := []string{
-		certCommonName,
+		certCommonName, // eg. clusterName-es-http.default.es.local
+		shortName,      // eg. clusterName-es-http
 	}
 	var ipAddresses []net.IP
 

--- a/operators/pkg/controller/common/certificates/http/reconcile_test.go
+++ b/operators/pkg/controller/common/certificates/http/reconcile_test.go
@@ -240,7 +240,8 @@ func Test_createValidatedHTTPCertificateTemplate(t *testing.T) {
 				},
 			},
 			want: func(t *testing.T, cert *certificates.ValidatedCertificateTemplate) {
-				expectedCommonName := "test.test.es.local"
+				expectedCommonName := "test-es-http.test.es.local"
+				assert.Contains(t, cert.Subject.CommonName, expectedCommonName)
 				assert.Contains(t, cert.DNSNames, expectedCommonName)
 				assert.Contains(t, cert.DNSNames, "svc-name.svc-namespace.svc")
 				assert.Contains(t, cert.DNSNames, sanDNS1)

--- a/operators/test/e2e/test/elasticsearch/http_client.go
+++ b/operators/test/e2e/test/elasticsearch/http_client.go
@@ -28,7 +28,7 @@ func NewElasticsearchClient(es v1alpha1.Elasticsearch, k *test.K8sClient) (clien
 	if err != nil {
 		return nil, err
 	}
-	inClusterURL := fmt.Sprintf("https://%s.%s.svc:9200", name.HTTPService(es.Name), es.Namespace)
+	inClusterURL := fmt.Sprintf("https://%s:9200", name.HTTPService(es.Name))
 	var dialer net.Dialer
 	if test.AutoPortForward {
 		dialer = portforward.NewForwardingDialer()


### PR DESCRIPTION
Fixes #1217, changes:

Issuer CN for http: 
`http-randomString -> clusterName-http`

Issuer CN for transport: 
`transport-randomString -> clusterName-transport`

Cert CN: 
`clusterName.default.es.local -> clusterName-es-http.default.es.local`

Subject alt names:
`clusterName.default.es.local -> clusterName-es-http.default.es.local`
`clusterName.default.es.local -> clusterName-es-http.default.es.local`
`clusterName-es-http` (added)
`clusterName-es-http.default.svc` (same)
`clusterName-es-http.default` (same)

E.g.:
Before:
```
        Issuer: OU=quickstart, CN=http-jzsp87ln7hx9rssj
        Subject: OU=quickstart, CN=quickstart.default.es.local
        X509v3 extensions:
            X509v3 Subject Alternative Name:
                DNS:quickstart.default.es.local, DNS:quickstart-es-http.default.svc, DNS:quickstart-es-http.default
```

After:
```
       Issuer: OU=quickstart, CN=quickstart-http
       Subject: OU=quickstart, CN=quickstart-es-http.default.es.local
        X509v3 extensions:
            X509v3 Subject Alternative Name:
                DNS:quickstart-es-http.default.es.local, DNS:quickstart-es-http, DNS:quickstart-es-http.default.svc, DNS:quickstart-es-http.default
```