### PR TITLE
Add e2e test for HTTP cert SAN update and verification

### DIFF
--- a/operators/test/e2e/es/certs_test.go
+++ b/operators/test/e2e/es/certs_test.go
@@ -1,0 +1,150 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package es
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/certificates"
+	esname "github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/name"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/elasticsearch"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestUpdateHTTPCertSAN(t *testing.T) {
+	name := "test-http-cert-san"
+	b := elasticsearch.NewBuilder(name).
+		WithESMasterNodes(1, elasticsearch.DefaultResources).
+		WithHTTPLoadBalancer()
+
+	var caCert []byte
+	var publicIP string
+
+	steps := func(k *test.K8sClient) test.StepList {
+		return test.StepList{
+			{
+				Name: "Retrieve ES certificate",
+				Test: func(t *testing.T) {
+					var err error
+					caCert, err = getCert(k, test.Namespace, name)
+					require.NoError(t, err)
+				},
+			},
+			{
+				Name: "Retrieve ES public IP",
+				Test: test.Eventually(func() error {
+					var err error
+					publicIP, err = getPublicIP(k, test.Namespace, name)
+					return err
+				}),
+			},
+			{
+				Name: "Check ES is not reachable with cert verification",
+				Test: func(t *testing.T) {
+					_, err := requestESWithCA(publicIP, caCert)
+					require.Error(t, err)
+					require.Contains(t, err.Error(), "x509: cannot validate certificate")
+				},
+			},
+			{
+				Name: "Add load balancer IP to the SAN",
+				Test: func(t *testing.T) {
+					var currentEs v1alpha1.Elasticsearch
+					err := k.Client.Get(k8s.ExtractNamespacedName(&b.Elasticsearch), &currentEs)
+					require.NoError(t, err)
+
+					b.Elasticsearch = currentEs
+					b = b.WithHTTPSAN(publicIP)
+					require.NoError(t, k.Client.Update(&b.Elasticsearch))
+				},
+			},
+			{
+				Name: "Check ES is reachable with cert verification",
+				Test: test.Eventually(func() error {
+					status, err := requestESWithCA(publicIP, caCert)
+					if err != nil {
+						return err
+					}
+					fmt.Println("s:", status)
+					if status != 401 {
+						return fmt.Errorf("invalid status code to reach ES: %d", status)
+					}
+					return nil
+				}),
+			},
+		}
+	}
+
+	test.Sequence(nil, steps, b).RunSequential(t)
+}
+
+func getCert(k *test.K8sClient, ns string, esName string) ([]byte, error) {
+	var secret corev1.Secret
+	key := types.NamespacedName{
+		Namespace: ns,
+		Name:      certificates.PublicSecretName(esname.ESNamer, esName, certificates.HTTPCAType),
+	}
+	if err := k.Client.Get(key, &secret); err != nil {
+		return nil, err
+	}
+	certBytes, exists := secret.Data[certificates.CertFileName]
+	if !exists || len(certBytes) == 0 {
+		return nil, fmt.Errorf("no value found for secret %s", certificates.CertFileName)
+	}
+
+	return certBytes, nil
+}
+
+func getPublicIP(k *test.K8sClient, ns string, esName string) (string, error) {
+	var svc corev1.Service
+	key := types.NamespacedName{
+		Namespace: ns,
+		Name:      esname.HTTPService(esName),
+	}
+	if err := k.Client.Get(key, &svc); err != nil {
+		return "", err
+	}
+
+	for _, ing := range svc.Status.LoadBalancer.Ingress {
+		if ing.IP != "" {
+			return ing.IP, nil
+		}
+	}
+
+	return "", errors.New("no external IP found")
+}
+
+func requestESWithCA(IP string, caCert []byte) (int, error) {
+	url := fmt.Sprintf("https://%s:9200", IP)
+
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	client := &http.Client{}
+	if caCert != nil {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: caCertPool,
+			},
+		}
+	}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return 0, err
+	}
+
+	return resp.StatusCode, nil
+}

--- a/operators/test/e2e/test/elasticsearch/builder.go
+++ b/operators/test/e2e/test/elasticsearch/builder.go
@@ -71,6 +71,18 @@ func (b Builder) WithVersion(version string) Builder {
 	return b
 }
 
+func (b Builder) WithHTTPLoadBalancer() Builder {
+	b.Elasticsearch.Spec.HTTP.Service.Spec.Type = corev1.ServiceTypeLoadBalancer
+	return b
+}
+
+func (b Builder) WithHTTPSAN(IP string) Builder {
+	b.Elasticsearch.Spec.HTTP.TLS.SelfSignedCertificate = &commonv1alpha1.SelfSignedCertificate{
+		SubjectAlternativeNames: []commonv1alpha1.SubjectAlternativeName{{IP: IP}},
+	}
+	return b
+}
+
 // -- ES Nodes
 
 func (b Builder) WithNoESTopology() Builder {


### PR DESCRIPTION
Add an e2e test to cover SAN usage and cert verification in 5 steps:
- Create an ES cluster with a load balancer HTTP service
- Retrieve the ES CA certificate
- **Eventually** retrieve the ES load balancer public IP
- Check that ES is not reachable with cert verification (error contains `x509: cannot validate certificate`)
- Add the load balancer IP to the SAN and update the ES definition
- Check that ES is reachable with cert verification (and returns 401)

```go
    --- PASS: TestUpdateHTTPCertSAN (238.56s)
    --- PASS: TestUpdateHTTPCertSAN/K8S_should_be_accessible (0.17s)
    --- PASS: TestUpdateHTTPCertSAN/Elasticsearch_CRDs_should_exist (0.07s)
    --- PASS: TestUpdateHTTPCertSAN/Remove_Elasticsearch_if_it_already_exists (0.17s)
    --- PASS: TestUpdateHTTPCertSAN/Creating_an_Elasticsearch_cluster_should_succeed (0.08s)
    --- PASS: TestUpdateHTTPCertSAN/Elasticsearch_cluster_should_be_created (0.05s)
    --- PASS: TestUpdateHTTPCertSAN/ES_certificate_authority_should_be_set_and_deployed (3.18s)
    --- PASS: TestUpdateHTTPCertSAN/ES_version_should_be_the_expected_one (0.06s)
    --- PASS: TestUpdateHTTPCertSAN/ES_pods_should_eventually_be_running (150.88s)
    --- PASS: TestUpdateHTTPCertSAN/ES_services_should_be_created (0.06s)
    --- PASS: TestUpdateHTTPCertSAN/ES_pods_should_eventually_be_ready (12.33s)
    --- PASS: TestUpdateHTTPCertSAN/ES_pods_should_eventually_have_a_certificate (0.12s)
    --- PASS: TestUpdateHTTPCertSAN/ES_services_should_have_endpoints (0.06s)
    --- PASS: TestUpdateHTTPCertSAN/ES_cluster_health_should_eventually_be_green (9.20s)
    --- PASS: TestUpdateHTTPCertSAN/ES_cluster_UUID_should_eventually_appear_in_the_ES_status (0.06s)
    --- PASS: TestUpdateHTTPCertSAN/Elastic_password_should_be_available (0.06s)
    --- PASS: TestUpdateHTTPCertSAN/Elasticsearch_data_volumes_should_be_of_the_specified_type (0.07s)
    --- PASS: TestUpdateHTTPCertSAN/Every_secret_should_be_set_so_that_we_can_build_an_ES_client (0.11s)
    --- PASS: TestUpdateHTTPCertSAN/ES_cluster_health_endpoint_should_eventually_be_reachable (2.89s)
    --- PASS: TestUpdateHTTPCertSAN/ES_version_should_be_the_expected_one#01 (0.06s)
    --- PASS: TestUpdateHTTPCertSAN/ES_endpoint_should_eventually_be_reachable (0.06s)
    --- PASS: TestUpdateHTTPCertSAN/ES_nodes_topology_should_eventually_be_the_expected_one (0.13s)
    --- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
    --- PASS: TestUpdateHTTPCertSAN/Retrieve_ES_certificate (0.10s)
    --- PASS: TestUpdateHTTPCertSAN/Retrieve_ES_public_IP (0.05s)
    --- PASS: TestUpdateHTTPCertSAN/Check_ES_is_not_reachable_with_cert_verification (0.12s)
    --- PASS: TestUpdateHTTPCertSAN/Add_load_balancer_IP_to_the_SAN (0.12s)
    --- PASS: TestUpdateHTTPCertSAN/Check_ES_is_reachable_with_cert_verification (50.07s)
    --- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
    --- PASS: TestUpdateHTTPCertSAN/Deleting_Elasticsearch_should_return_no_error (0.07s)
    --- PASS: TestUpdateHTTPCertSAN/Elasticsearch_should_not_be_there_anymore (3.11s)
    --- PASS: TestUpdateHTTPCertSAN/Elasticsearch_pods_should_be_eventually_be_removed (3.12s)
PASS
ok      github.com/elastic/cloud-on-k8s/operators/test/e2e/es   238.572s
```

Resolves #724.