### PR TITLE
Do not set initial_master_nodes if cluster has been bootstrapped

### DIFF
--- a/operators/pkg/controller/elasticsearch/driver/default.go
+++ b/operators/pkg/controller/elasticsearch/driver/default.go
@@ -87,6 +87,9 @@ type defaultDriver struct {
 	// clusterInitialMasterNodesEnforcer enforces that cluster.initial_master_nodes is set where relevant
 	// this can safely be set to nil when it's not relevant (e.g for ES <= 6)
 	clusterInitialMasterNodesEnforcer func(
+		cluster v1alpha1.Elasticsearch,
+		clusterState observer.State,
+		c k8s.Client,
 		performableChanges mutation.PerformableChanges,
 		resourcesState reconcile.ResourcesState,
 	) (*mutation.PerformableChanges, error)
@@ -289,7 +292,13 @@ func (d *defaultDriver) Reconcile(
 	)
 
 	if d.clusterInitialMasterNodesEnforcer != nil {
-		performableChanges, err = d.clusterInitialMasterNodesEnforcer(*performableChanges, *resourcesState)
+		performableChanges, err = d.clusterInitialMasterNodesEnforcer(
+			es,
+			observedState,
+			d.Client,
+			*performableChanges,
+			*resourcesState,
+		)
 		if err != nil {
 			return results.WithError(err)
 		}

--- a/operators/pkg/controller/elasticsearch/version/version7/initial_master_nodes.go
+++ b/operators/pkg/controller/elasticsearch/version/version7/initial_master_nodes.go
@@ -70,7 +70,7 @@ func ClusterInitialMasterNodesEnforcer(
 	return &performableChanges, nil
 }
 
-// isBootstrapped checks if the cluster has already been bootstrapped once
+// isBootstrapped checks if the cluster has already been bootstrapped
 func isBootstrapped(cluster v1alpha1.Elasticsearch, clusterState observer.State, c k8s.Client) (bool, error) {
 	_, ok := cluster.Annotations[ClusterUUIDAnnotationName]
 	if ok {

--- a/operators/pkg/controller/elasticsearch/version/version7/initial_master_nodes.go
+++ b/operators/pkg/controller/elasticsearch/version/version7/initial_master_nodes.go
@@ -29,11 +29,11 @@ func ClusterInitialMasterNodesEnforcer(
 ) (*mutation.PerformableChanges, error) {
 
 	// Check if the cluster has an UUID, if not try to fetch it from the observer state and store it as an annotation.
-	hasBeenBootstrapped, err := hasBeenBootstrapped(cluster, clusterState, c)
+	isBootstrapped, err := isBootstrapped(cluster, clusterState, c)
 	if err != nil {
 		return nil, err
 	}
-	if hasBeenBootstrapped {
+	if isBootstrapped {
 		return &performableChanges, nil
 	}
 
@@ -70,8 +70,8 @@ func ClusterInitialMasterNodesEnforcer(
 	return &performableChanges, nil
 }
 
-// hasBeenBootstrapped checks if the cluster has already been bootstrapped once
-func hasBeenBootstrapped(cluster v1alpha1.Elasticsearch, clusterState observer.State, c k8s.Client) (bool, error) {
+// isBootstrapped checks if the cluster has already been bootstrapped once
+func isBootstrapped(cluster v1alpha1.Elasticsearch, clusterState observer.State, c k8s.Client) (bool, error) {
 	_, ok := cluster.Annotations[ClusterUUIDAnnotationName]
 	if ok {
 		// existence of the annotation shows that the cluster has been bootstrapped

--- a/operators/pkg/controller/elasticsearch/version/version7/initial_master_nodes.go
+++ b/operators/pkg/controller/elasticsearch/version/version7/initial_master_nodes.go
@@ -23,7 +23,7 @@ const (
 // It's also save the cluster UUID as an annotation to ensure that it's not set if the cluster has already been bootstrapped.
 func ClusterInitialMasterNodesEnforcer(
 	cluster v1alpha1.Elasticsearch,
-	clusterState observer.State,
+	observedState observer.State,
 	c k8s.Client,
 	performableChanges mutation.PerformableChanges,
 	resourcesState reconcile.ResourcesState,
@@ -37,12 +37,12 @@ func ClusterInitialMasterNodesEnforcer(
 	}
 
 	// no annotation, let see if the cluster has been bootstrapped by looking at it's UUID
-	if clusterState.ClusterState != nil && len(clusterState.ClusterState.ClusterUUID) > 0 {
+	if observedState.ClusterState != nil && len(observedState.ClusterState.ClusterUUID) > 0 {
 		// UUID is set, let's update the annotation on the Elasticsearch object
 		if cluster.Annotations == nil {
 			cluster.Annotations = make(map[string]string)
 		}
-		cluster.Annotations[ClusterUUIDAnnotationName] = clusterState.ClusterState.ClusterUUID
+		cluster.Annotations[ClusterUUIDAnnotationName] = observedState.ClusterState.ClusterUUID
 		if err := c.Update(&cluster); err != nil {
 			return nil, err
 		}

--- a/operators/pkg/controller/elasticsearch/version/version7/initial_master_nodes.go
+++ b/operators/pkg/controller/elasticsearch/version/version7/initial_master_nodes.go
@@ -5,27 +5,43 @@
 package version7
 
 import (
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/mutation"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/observer"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/reconcile"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/settings"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+)
+
+const (
+	// ClusterUUIDAnnotationName used to store the cluster UUID as an annotation when cluster has been bootstrapped.
+	ClusterUUIDAnnotationName = "elasticsearch.k8s.elastic.co/cluster-uuid"
 )
 
 // ClusterInitialMasterNodesEnforcer enforces that cluster.initial_master_nodes is set if the cluster is bootstrapping.
 func ClusterInitialMasterNodesEnforcer(
+	cluster v1alpha1.Elasticsearch,
+	clusterState observer.State,
+	c k8s.Client,
 	performableChanges mutation.PerformableChanges,
 	resourcesState reconcile.ResourcesState,
 ) (*mutation.PerformableChanges, error) {
+
+	// Check if the cluster has an UUID, if not try to fetch it from the observer state and store it as an annotation.
+	hasBeenBootstrapped, err := hasBeenBootstrapped(cluster, clusterState, c)
+	if err != nil {
+		return nil, err
+	}
+	if hasBeenBootstrapped {
+		return &performableChanges, nil
+	}
+
 	var masterEligibleNodeNames []string
 	for _, pod := range resourcesState.CurrentPods {
 		if label.IsMasterNode(pod.Pod) {
 			masterEligibleNodeNames = append(masterEligibleNodeNames, pod.Pod.Name)
 		}
-	}
-
-	// if we have masters in the cluster, we can relatively safely assume that it's already bootstrapped
-	if len(masterEligibleNodeNames) > 0 {
-		return &performableChanges, nil
 	}
 
 	// collect the master eligible node names from the pods we're about to create
@@ -52,4 +68,27 @@ func ClusterInitialMasterNodesEnforcer(
 	}
 
 	return &performableChanges, nil
+}
+
+// hasBeenBootstrapped checks if the cluster has already been bootstrapped once
+func hasBeenBootstrapped(cluster v1alpha1.Elasticsearch, clusterState observer.State, c k8s.Client) (bool, error) {
+	_, ok := cluster.Annotations[ClusterUUIDAnnotationName]
+	if ok {
+		// existence of the annotation shows that the cluster has been bootstrapped
+		return true, nil
+	}
+
+	// no annotation, let see if the cluster has been bootstrapped by looking at it's UUID
+	if clusterState.ClusterState != nil && len(clusterState.ClusterState.ClusterUUID) > 0 {
+		// UUID is set, let's update the annotation on the Elasticsearch object
+		if cluster.Annotations == nil {
+			cluster.Annotations = make(map[string]string)
+		}
+		cluster.Annotations[ClusterUUIDAnnotationName] = clusterState.ClusterState.ClusterUUID
+		if err := c.Update(&cluster); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	return false, nil
 }


### PR DESCRIPTION
This PR ensures that `initial_master_nodes` is not set once the cluster has been bootstrapped.

It is a partial fix for #1201 