### PR TITLE
Secure settings finalizer: do not rely on object.GetObjectKind()

### DIFF
--- a/operators/pkg/controller/apmserver/apmserver_controller.go
+++ b/operators/pkg/controller/apmserver/apmserver_controller.go
@@ -435,6 +435,6 @@ func (r *ReconcileApmServer) updateStatus(state State) (reconcile.Result, error)
 // finalizersFor returns the list of finalizers applying to a given APM deployment
 func (r *ReconcileApmServer) finalizersFor(as apmv1alpha1.ApmServer) []finalizer.Finalizer {
 	return []finalizer.Finalizer{
-		keystore.Finalizer(k8s.ExtractNamespacedName(&as), r.dynamicWatches, &as),
+		keystore.Finalizer(k8s.ExtractNamespacedName(&as), r.dynamicWatches, "apmserver"),
 	}
 }

--- a/operators/pkg/controller/common/keystore/user_secret.go
+++ b/operators/pkg/controller/common/keystore/user_secret.go
@@ -6,7 +6,6 @@ package keystore
 
 import (
 	"fmt"
-	"strings"
 
 	commonv1alpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/common/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/events"
@@ -16,7 +15,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 )
@@ -113,14 +111,10 @@ func watchSecureSettings(watched watches.DynamicWatches, secureSettingsRef *comm
 	})
 }
 
-func getKind(object runtime.Object) string {
-	return strings.ToLower(object.GetObjectKind().GroupVersionKind().Kind)
-}
-
 // Finalizer removes any dynamic watches on external user created secret.
-func Finalizer(namespacedName types.NamespacedName, watched watches.DynamicWatches, object runtime.Object) finalizer.Finalizer {
+func Finalizer(namespacedName types.NamespacedName, watched watches.DynamicWatches, kind string) finalizer.Finalizer {
 	return finalizer.Finalizer{
-		Name: "secure-settings.finalizers." + getKind(object) + ".k8s.elastic.co",
+		Name: "secure-settings.finalizers." + kind + ".k8s.elastic.co",
 		Execute: func() error {
 			watched.Secrets.RemoveHandlerForKey(secureSettingsWatchName(namespacedName))
 			return nil

--- a/operators/pkg/controller/common/keystore/user_secret.go
+++ b/operators/pkg/controller/common/keystore/user_secret.go
@@ -112,6 +112,8 @@ func watchSecureSettings(watched watches.DynamicWatches, secureSettingsRef *comm
 }
 
 // Finalizer removes any dynamic watches on external user created secret.
+// TODO: Kind of an object can be retrieved programmatically with object.GetObjectKind(), unfortunately it does not seem
+//  to be reliable with controller-runtime < v0.2.0-beta.4
 func Finalizer(namespacedName types.NamespacedName, watched watches.DynamicWatches, kind string) finalizer.Finalizer {
 	return finalizer.Finalizer{
 		Name: "secure-settings.finalizers." + kind + ".k8s.elastic.co",

--- a/operators/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/operators/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -274,7 +274,7 @@ func (r *ReconcileElasticsearch) finalizersFor(
 	return []finalizer.Finalizer{
 		reconciler.ExpectationsFinalizer(clusterName, r.podsExpectations),
 		r.esObservers.Finalizer(clusterName),
-		keystore.Finalizer(k8s.ExtractNamespacedName(&es), r.dynamicWatches, &es),
+		keystore.Finalizer(k8s.ExtractNamespacedName(&es), r.dynamicWatches, "elasticsearch"),
 		http.DynamicWatchesFinalizer(r.dynamicWatches, es.Name, esname.ESNamer),
 	}
 }

--- a/operators/pkg/controller/elasticsearch/settings/secure_settings.go
+++ b/operators/pkg/controller/elasticsearch/settings/secure_settings.go
@@ -8,21 +8,19 @@ import (
 	"fmt"
 	"reflect"
 
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-
 	commonv1alpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/common/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/events"
-	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/finalizer"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/name"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // ReconcileSecureSettings ensures a secret containing secure settings exists for the cluster.
@@ -117,15 +115,4 @@ func watchUserSecret(watched watches.DynamicWatches, userSecretRef *commonv1alph
 		},
 		Watcher: cluster,
 	})
-}
-
-// SecureSettingsFinalizer removes any dynamic watches on external user created secret.
-func SecureSettingsFinalizer(cluster types.NamespacedName, watched watches.DynamicWatches) finalizer.Finalizer {
-	return finalizer.Finalizer{
-		Name: "secure-settings.finalizers.elasticsearch.k8s.elastic.co",
-		Execute: func() error {
-			watched.Secrets.RemoveHandlerForKey(userSecretWatchName(cluster))
-			return nil
-		},
-	}
 }

--- a/operators/pkg/controller/kibana/kibana_controller.go
+++ b/operators/pkg/controller/kibana/kibana_controller.go
@@ -203,6 +203,6 @@ func (r *ReconcileKibana) updateStatus(state State) error {
 func (r *ReconcileKibana) finalizersFor(kb kibanav1alpha1.Kibana) []finalizer.Finalizer {
 	return []finalizer.Finalizer{
 		secretWatchFinalizer(kb, r.dynamicWatches),
-		keystore.Finalizer(k8s.ExtractNamespacedName(&kb), r.dynamicWatches, &kb),
+		keystore.Finalizer(k8s.ExtractNamespacedName(&kb), r.dynamicWatches, "kibana"),
 	}
 }


### PR DESCRIPTION
This is an attempt to fix #1275 as it seems that `object.GetObjectKind()` may return an empty string.
