### PR TITLE
Use the setvmmaxmapcount initcontainer by default in E2E tests

### DIFF
--- a/operators/test/e2e/test/elasticsearch/builder.go
+++ b/operators/test/e2e/test/elasticsearch/builder.go
@@ -44,8 +44,7 @@ func NewBuilder(name string) Builder {
 		Elasticsearch: estype.Elasticsearch{
 			ObjectMeta: meta,
 			Spec: estype.ElasticsearchSpec{
-				SetVMMaxMapCount: test.BoolPtr(false),
-				Version:          test.ElasticStackVersion,
+				Version: test.ElasticStackVersion,
 			},
 		},
 	}


### PR DESCRIPTION
Let's keep our default defaults :)

The setting is disabled explicitly for E2E tests where we enable a
restricted security context.