### PR TITLE
Allow license secret webhook to fail

### DIFF
--- a/operators/pkg/webhook/server.go
+++ b/operators/pkg/webhook/server.go
@@ -41,7 +41,7 @@ func RegisterValidations(mgr manager.Manager, params Parameters) error {
 	licWh, err := builder.NewWebhookBuilder().
 		Name("validation.license.elastic.co").
 		Validating().
-		FailurePolicy(admission.Fail).
+		FailurePolicy(admission.Ignore).
 		ForType(&corev1.Secret{}).
 		Handlers(&license.ValidationHandler{}).
 		WithManager(mgr).


### PR DESCRIPTION
Webhooks on core k8s objects are just too debilitating in case our
webhook service fails. This sets the failure policy for the secret
webhook to ignore to strike a balance between UX (immediate feedback)
and keeping the users k8s cluster in a working state. Also we have an
additional validation run on controller level so this does not allow
circumventing our validation logic.

