### PR TITLE
Revert "Use the setvmmaxmapcount initcontainer by default in E2E test…

### DIFF
--- a/operators/test/e2e/test/elasticsearch/builder.go
+++ b/operators/test/e2e/test/elasticsearch/builder.go
@@ -44,7 +44,8 @@ func NewBuilder(name string) Builder {
 		Elasticsearch: estype.Elasticsearch{
 			ObjectMeta: meta,
 			Spec: estype.ElasticsearchSpec{
-				Version: test.ElasticStackVersion,
+				SetVMMaxMapCount: test.BoolPtr(false),
+				Version:          test.ElasticStackVersion,
 			},
 		},
 	}


### PR DESCRIPTION
This reverts commit fff15269be1c431121fdefd8ca8c6ad93db8c9df.
This commit is breaking our E2E tests chain, which deploys a
PodSecurityPolicy by default. Any privileged init container will not
work.

I'll open an issue for a longer-term fix to properly handle this.