### PR TITLE
Update quickstart

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -54,7 +54,7 @@ kind: Elasticsearch
 metadata:
   name: quickstart
 spec:
-  version: 7.1.0
+  version: 7.2.0
   nodes:
   - nodeCount: 1
     config:
@@ -79,7 +79,7 @@ kubectl get elasticsearch
 [source,sh]
 ----
 NAME          HEALTH    NODES     VERSION   PHASE         AGE
-quickstart    green     1         7.1.0     Operational   1m
+quickstart    green     1         7.2.0     Operational   1m
 ----
 
 When you create the cluster, there is no `HEALTH` status and the `PHASE` is `Pending`. After a while, the `PHASE` turns into `Operational`, and `HEALTH` becomes `green`.
@@ -161,7 +161,7 @@ NOTE: For testing purposes only, you can specify the `-k` option to turn off cer
   "cluster_name" : "quickstart",
   "cluster_uuid" : "XqWg0xIiRmmEBg4NMhnYPg",
   "version" : {
-    "number" : "7.1.0",
+    "number" : "7.2.0",
     "build_flavor" : "default",
     "build_type" : "docker",
     "build_hash" : "04116c9",
@@ -191,7 +191,7 @@ kind: Kibana
 metadata:
   name: quickstart
 spec:
-  version: 7.1.0
+  version: 7.2.0
   nodeCount: 1
   elasticsearchRef:
     name: quickstart
@@ -255,7 +255,7 @@ kind: Elasticsearch
 metadata:
   name: quickstart
 spec:
-  version: 7.1.0
+  version: 7.2.0
   nodes:
   - nodeCount: 3
     config:
@@ -281,7 +281,7 @@ kind: Elasticsearch
 metadata:
   name: quickstart
 spec:
-  version: 7.1.0
+  version: 7.2.0
   nodes:
   - nodeCount: 3
     config:

--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -126,7 +126,7 @@ A default user named `elastic` is automatically created. Its password is stored 
 +
 [source,sh]
 ----
-PASSWORD=$(kubectl get secret quickstart-elastic-user -o=jsonpath='{.data.elastic}' | base64 --decode)
+PASSWORD=$(kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | base64 --decode)
 ----
 
 . Request the Elasticsearch endpoint.
@@ -236,7 +236,7 @@ Login with the `elastic` user. Retrieve its password with:
 +
 [source,sh]
 ----
-echo $(kubectl get secret quickstart-elastic-user -o=jsonpath='{.data.elastic}' | base64 --decode)
+echo $(kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | base64 --decode)
 ----
 
 [float]


### PR DESCRIPTION
This commit brings small updates for the quickstart:
- update the name of the secret for the elastic user
- bump the Elastic Stack version from 7.1.0 to 7.2.0