### PR TITLE
Change Kibana readiness endpoint to return a 200 OK

### DIFF
--- a/operators/pkg/controller/kibana/driver_test.go
+++ b/operators/pkg/controller/kibana/driver_test.go
@@ -116,7 +116,7 @@ func expectedDeploymentParams() *DeploymentParams {
 						Handler: corev1.Handler{
 							HTTPGet: &corev1.HTTPGetAction{
 								Port:   intstr.FromInt(5601),
-								Path:   "/",
+								Path:   "/login",
 								Scheme: corev1.URISchemeHTTPS,
 							},
 						},

--- a/operators/pkg/controller/kibana/pod/pod.go
+++ b/operators/pkg/controller/kibana/pod/pod.go
@@ -43,7 +43,7 @@ func readinessProbe(useTLS bool) corev1.Probe {
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Port:   intstr.FromInt(HTTPPort),
-				Path:   "/",
+				Path:   "/login",
 				Scheme: scheme,
 			},
 		},


### PR DESCRIPTION
The previous endpoint returned an http code 302. While this is fine for
Kubernetes, some derived systems like GCP LoadBalancers mimic the
container readiness check for their own readiness check. Except GCP
Loadbalancers only work with status 200.

It's not up to us to adapt GCP LoadBalancers to K8s, but this is a
fairly trivial fix for us.

Fixes https://github.com/elastic/cloud-on-k8s/issues/1308.