### PR TITLE
Backport 0.9: change Kibana readiness endpoint to return a 200 OK

### DIFF
--- a/operators/pkg/controller/kibana/driver_test.go
+++ b/operators/pkg/controller/kibana/driver_test.go
@@ -116,7 +116,7 @@ func expectedDeploymentParams() *DeploymentParams {
 						Handler: corev1.Handler{
 							HTTPGet: &corev1.HTTPGetAction{
 								Port:   intstr.FromInt(5601),
-								Path:   "/",
+								Path:   "/login",
 								Scheme: corev1.URISchemeHTTPS,
 							},
 						},

--- a/operators/pkg/controller/kibana/pod/pod.go
+++ b/operators/pkg/controller/kibana/pod/pod.go
@@ -42,7 +42,7 @@ func readinessProbe(useTLS bool) corev1.Probe {
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Port:   intstr.FromInt(HTTPPort),
-				Path:   "/",
+				Path:   "/login",
 				Scheme: scheme,
 			},
 		},


### PR DESCRIPTION
Backport https://github.com/elastic/cloud-on-k8s/pull/1309 to 0.9.

I think it's a fairly safe fix to bring to 0.9? (@pebrc waiting for your approval here)