### PR TITLE
Backport: Ignore resources reconciled by older controllers (#1286)

### DIFF
--- a/operators/pkg/controller/apmserver/apmserver_controller.go
+++ b/operators/pkg/controller/apmserver/apmserver_controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/apmserver/labels"
 	apmname "github.com/elastic/cloud-on-k8s/operators/pkg/controller/apmserver/name"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/certificates/http"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/defaults"
@@ -34,6 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -193,6 +195,21 @@ func (r *ReconcileApmServer) Reconcile(request reconcile.Request) (reconcile.Res
 	if as.IsMarkedForDeletion() {
 		// APM server will be deleted nothing to do other than run finalizers
 		return reconcile.Result{}, nil
+	}
+
+	selector := k8slabels.Set(map[string]string{labels.ApmServerNameLabelName: as.Name}).AsSelector()
+	compat, err := annotation.ReconcileCompatibility(r.Client, as, selector, r.OperatorInfo.BuildInfo.Version)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if !compat {
+		// this resource is not able to be reconciled by this version of the controller, so we will skip it and not requeue
+		return reconcile.Result{}, nil
+	}
+
+	err = annotation.UpdateControllerVersion(r.Client, as, r.OperatorInfo.BuildInfo.Version)
+	if err != nil {
+		return reconcile.Result{}, err
 	}
 
 	state := NewState(request, as)

--- a/operators/pkg/controller/common/annotation/controller_version.go
+++ b/operators/pkg/controller/common/annotation/controller_version.go
@@ -1,0 +1,147 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package annotation
+
+import (
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ControllerVersionAnnotation is the annotation name that indicates the last controller version to update a resource
+const ControllerVersionAnnotation = "common.k8s.elastic.co/controller-version"
+
+// UpdateControllerVersion updates the controller version annotation to the current version if necessary
+func UpdateControllerVersion(client k8s.Client, obj runtime.Object, version string) error {
+	accessor := meta.NewAccessor()
+	namespace, err := accessor.Namespace(obj)
+	if err != nil {
+		log.Error(err, "error getting namespace", "kind", obj.GetObjectKind().GroupVersionKind().Kind)
+		return err
+	}
+	name, err := accessor.Name(obj)
+	if err != nil {
+		log.Error(err, "error getting name", "namespace", namespace, "kind", obj.GetObjectKind().GroupVersionKind().Kind)
+		return err
+	}
+	annotations, err := accessor.Annotations(obj)
+	if err != nil {
+		log.Error(err, "error getting annotations", "namespace", namespace, "name", name, "kind", obj.GetObjectKind().GroupVersionKind().Kind)
+		return err
+	}
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	// do not send unnecessary update if the value would not change
+	if annotations[ControllerVersionAnnotation] == version {
+		log.V(1).Info("Skipping controller version annotation update, version already matches", "namespace", namespace, "name", name, "kind", obj.GetObjectKind())
+		return nil
+	}
+
+	annotations[ControllerVersionAnnotation] = version
+	err = accessor.SetAnnotations(obj, annotations)
+	if err != nil {
+		log.Error(err, "error updating controller version annotation", "namespace", namespace, "name", name, "kind", obj.GetObjectKind())
+		return err
+	}
+	log.V(1).Info("updating controller version annotation", "namespace", namespace, "name", name, "kind", obj.GetObjectKind())
+	return client.Update(obj)
+}
+
+// ReconcileCompatibility determines if this controller is compatible with a given resource by examining the controller version annotation
+// controller versions 0.9.0+ cannot reconcile resources created with earlier controllers, so this lets our controller skip those resources until they can be manually recreated
+// if an object does not have an annotation, it will determine if it is a new object or if it has been previously reconciled by an older controller version, as this annotation
+// was not applied by earlier controller versions. it will update the object's annotations indicating it is incompatible if so
+func ReconcileCompatibility(client k8s.Client, obj runtime.Object, selector labels.Selector, controllerVersion string) (bool, error) {
+	accessor := meta.NewAccessor()
+	namespace, err := accessor.Namespace(obj)
+	if err != nil {
+		log.Error(err, "error getting namespace", "kind", obj.GetObjectKind().GroupVersionKind().Kind)
+		return false, err
+	}
+	name, err := accessor.Name(obj)
+	if err != nil {
+		log.Error(err, "error getting name", "namespace", namespace, "kind", obj.GetObjectKind().GroupVersionKind().Kind)
+		return false, err
+	}
+	annotations, err := accessor.Annotations(obj)
+	if err != nil {
+		log.Error(err, "error getting annotations", "namespace", namespace, "name", name, "kind", obj.GetObjectKind().GroupVersionKind().Kind)
+		return false, err
+	}
+
+	annExists := annotations != nil && annotations[ControllerVersionAnnotation] != ""
+
+	// if the annotation does not exist, it might indicate it was reconciled by an older controller version that did not add the version annotation,
+	// in which case it is incompatible with the current controller, or it is a brand new resource that has not been reconciled by any controller yet
+	if !annExists {
+		exist, err := checkExistingResources(client, obj, selector)
+		if err != nil {
+			return false, err
+		}
+		if exist {
+			log.Info("Resource was previously reconciled by incompatible controller version and missing annotation, adding annotation", "controller_version", controllerVersion, "namespace", namespace, "name", name, "kind", obj.GetObjectKind().GroupVersionKind().Kind)
+			err = UpdateControllerVersion(client, obj, "0.8.0-UNKNOWN")
+			return false, err
+		}
+		// no annotation exists and there are no existing resources, so this has not previously been reconciled
+		err = UpdateControllerVersion(client, obj, controllerVersion)
+		return true, err
+	}
+
+	currentVersion, err := version.Parse(annotations[ControllerVersionAnnotation])
+	if err != nil {
+		return false, errors.Wrap(err, "Error parsing current version on resource")
+	}
+	minVersion, err := version.Parse("0.9.0-ALPHA")
+	if err != nil {
+		return false, errors.Wrap(err, "Error parsing minimum compatible version")
+	}
+	ctrlVersion, err := version.Parse(controllerVersion)
+	if err != nil {
+		return false, errors.Wrap(err, "Error parsing controller version")
+	}
+
+	// if the current version is gte the minimum version then they are compatible
+	if currentVersion.IsSameOrAfter(*minVersion) {
+		log.V(1).Info("Current controller version on resource is compatible with running controller version", "controller_version", ctrlVersion,
+			"resource_controller_version", currentVersion, "namespace", namespace, "name", name)
+		return true, nil
+	}
+
+	log.Info("Resource was created with older version of operator, will not take action", "controller_version", ctrlVersion,
+		"resource_controller_version", currentVersion, "namespace", namespace, "name", name)
+	return false, nil
+}
+
+// checkExistingResources returns a bool indicating if there are existing resources created for a given resource
+func checkExistingResources(client k8s.Client, obj runtime.Object, selector labels.Selector) (bool, error) {
+
+	accessor := meta.NewAccessor()
+	namespace, err := accessor.Namespace(obj)
+	if err != nil {
+		log.Error(err, "error getting namespace", "kind", obj.GetObjectKind().GroupVersionKind().Kind)
+		return false, err
+	}
+	// if there's no controller version annotation on the object, then we need to see maybe the object has been reconciled by an older, incompatible controller version
+	opts := ctrlclient.ListOptions{
+		LabelSelector: selector,
+		Namespace:     namespace,
+	}
+	var svcs corev1.ServiceList
+	err = client.List(&opts, &svcs)
+	if err != nil {
+		return false, err
+	}
+	// if we listed any services successfully, then we know this cluster was reconciled by an old version since any objects reconciled by a 0.9.0+ operator would have a label
+	return len(svcs.Items) != 0, nil
+
+}

--- a/operators/pkg/controller/common/annotation/controller_version_test.go
+++ b/operators/pkg/controller/common/annotation/controller_version_test.go
@@ -1,0 +1,214 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package annotation
+
+import (
+	"testing"
+
+	kibanav1alpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/kibana/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apmtype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/apm/v1alpha1"
+	assoctype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/associations/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	estype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// Test UpdateControllerVersion updates annotation if there is an older version
+func TestAnnotationUpdated(t *testing.T) {
+	kibana := kibanav1alpha1.Kibana{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "kibana",
+			Annotations: map[string]string{
+				ControllerVersionAnnotation: "oldversion",
+			},
+		},
+	}
+	obj := kibana.DeepCopy()
+	sc := setupScheme(t)
+	client := k8s.WrapClient(fake.NewFakeClientWithScheme(sc, obj))
+	err := UpdateControllerVersion(client, obj, "newversion")
+	require.NoError(t, err)
+	require.Equal(t, obj.GetAnnotations()[ControllerVersionAnnotation], "newversion")
+}
+
+// Test UpdateControllerVersion creates an annotation even if there are no current annotations
+func TestAnnotationCreated(t *testing.T) {
+	kibana := kibanav1alpha1.Kibana{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "kibana",
+		},
+	}
+
+	obj := kibana.DeepCopy()
+	sc := setupScheme(t)
+	client := k8s.WrapClient(fake.NewFakeClientWithScheme(sc, obj))
+	err := UpdateControllerVersion(client, obj, "newversion")
+	require.NoError(t, err)
+	actualKibana := &kibanav1alpha1.Kibana{}
+	err = client.Get(types.NamespacedName{
+		Namespace: obj.Namespace,
+		Name:      obj.Name,
+	}, actualKibana)
+	require.NoError(t, err)
+	require.NotNil(t, actualKibana.GetAnnotations())
+	assert.Equal(t, actualKibana.GetAnnotations()[ControllerVersionAnnotation], "newversion")
+}
+
+// TestMissingAnnotationOldVersion tests that we skip reconciling an object missing annotations that has already been reconciled by
+// a previous operator version, and add an annotation indicating an old controller version
+func TestMissingAnnotationOldVersion(t *testing.T) {
+
+	es := &v1alpha1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "es",
+		},
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "svc",
+			Labels: map[string]string{
+				label.ClusterNameLabelName: "es",
+			},
+		},
+	}
+	sc := setupScheme(t)
+	client := k8s.WrapClient(fake.NewFakeClientWithScheme(sc, es, svc))
+	selector := getElasticsearchSelector(es)
+	compat, err := ReconcileCompatibility(client, es, selector, "0.9.0-SNAPSHOT")
+	require.NoError(t, err)
+	assert.False(t, compat)
+
+	// check old version annotation was added
+	require.NotNil(t, es.Annotations)
+	assert.Equal(t, "0.8.0-UNKNOWN", es.Annotations[ControllerVersionAnnotation])
+}
+
+// TestMissingAnnotationNewObject tests that we add an annotation for new objects
+func TestMissingAnnotationNewObject(t *testing.T) {
+	es := &v1alpha1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "es",
+		},
+	}
+	// TODO this is currently broken due to an upstream bug in the fake client. when we upgrade controller runtime
+	// to a version that contains this PR we can uncomment this and add the service to the client
+
+	// add existing svc that is not part of cluster to make sure we have label selectors correct
+	// https://github.com/kubernetes-sigs/controller-runtime/pull/311
+	// svc := &corev1.Service{
+	// 	ObjectMeta: metav1.ObjectMeta{
+	// 		Namespace: "ns",
+	// 		Name:      "svc",
+	// 		Labels: map[string]string{
+	// 			label.ClusterNameLabelName: "literallyanything",
+	// 		},
+	// 	},
+	// }
+
+	sc := setupScheme(t)
+	// client := k8s.WrapClient(fake.NewFakeClientWithScheme(sc, es, svc))
+	client := k8s.WrapClient(fake.NewFakeClientWithScheme(sc, es))
+	selector := getElasticsearchSelector(es)
+	compat, err := ReconcileCompatibility(client, es, selector, "0.9.0-SNAPSHOT")
+	require.NoError(t, err)
+	assert.True(t, compat)
+
+	// check version annotation was added
+	require.NotNil(t, es.Annotations)
+	assert.Equal(t, "0.9.0-SNAPSHOT", es.Annotations[ControllerVersionAnnotation])
+}
+
+//
+func TestSameAnnotation(t *testing.T) {
+	es := &v1alpha1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "es",
+			Annotations: map[string]string{
+				ControllerVersionAnnotation: "0.9.0-SNAPSHOT",
+			},
+		},
+	}
+	sc := setupScheme(t)
+	client := k8s.WrapClient(fake.NewFakeClientWithScheme(sc, es))
+	selector := getElasticsearchSelector(es)
+	compat, err := ReconcileCompatibility(client, es, selector, "0.9.0-SNAPSHOT")
+	require.NoError(t, err)
+	assert.True(t, compat)
+	assert.Equal(t, "0.9.0-SNAPSHOT", es.Annotations[ControllerVersionAnnotation])
+}
+
+func TestIncompatibleAnnotation(t *testing.T) {
+	es := &v1alpha1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "es",
+			Annotations: map[string]string{
+				ControllerVersionAnnotation: "0.8.0-FOOBAR",
+			},
+		},
+	}
+	sc := setupScheme(t)
+	client := k8s.WrapClient(fake.NewFakeClientWithScheme(sc, es))
+	selector := getElasticsearchSelector(es)
+	compat, err := ReconcileCompatibility(client, es, selector, "0.9.0-SNAPSHOT")
+	require.NoError(t, err)
+	assert.False(t, compat)
+	// check we did not update the annotation
+	assert.Equal(t, "0.8.0-FOOBAR", es.Annotations[ControllerVersionAnnotation])
+}
+
+func TestNewerAnnotation(t *testing.T) {
+	es := &v1alpha1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "es",
+			Annotations: map[string]string{
+				ControllerVersionAnnotation: "2.0.0",
+			},
+		},
+	}
+	sc := setupScheme(t)
+	client := k8s.WrapClient(fake.NewFakeClientWithScheme(sc, es))
+	selector := getElasticsearchSelector(es)
+	compat, err := ReconcileCompatibility(client, es, selector, "0.9.0-SNAPSHOT")
+	assert.NoError(t, err)
+	assert.True(t, compat)
+}
+
+// setupScheme creates a scheme to use for our fake clients so they know about our custom resources
+func setupScheme(t *testing.T) *runtime.Scheme {
+	sc := scheme.Scheme
+	err := assoctype.SchemeBuilder.AddToScheme(sc)
+	require.NoError(t, err)
+	err = apmtype.SchemeBuilder.AddToScheme(sc)
+	require.NoError(t, err)
+	err = estype.SchemeBuilder.AddToScheme(sc)
+	require.NoError(t, err)
+	err = kibanav1alpha1.SchemeBuilder.AddToScheme(sc)
+	require.NoError(t, err)
+	return sc
+}
+
+func getElasticsearchSelector(es *v1alpha1.Elasticsearch) labels.Selector {
+	return labels.Set(map[string]string{label.ClusterNameLabelName: es.Name}).AsSelector()
+}

--- a/operators/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/operators/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -10,6 +10,7 @@ import (
 
 	elasticsearchv1alpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/certificates/http"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/finalizer"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/keystore"
@@ -26,6 +27,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -191,6 +193,21 @@ func (r *ReconcileElasticsearch) Reconcile(request reconcile.Request) (reconcile
 	if common.IsPaused(es.ObjectMeta) {
 		log.Info("Object is paused. Skipping reconciliation", "namespace", es.Namespace, "es_name", es.Name, "iteration", currentIteration)
 		return common.PauseRequeue, nil
+	}
+
+	selector := labels.Set(map[string]string{label.ClusterNameLabelName: es.Name}).AsSelector()
+	compat, err := annotation.ReconcileCompatibility(r.Client, &es, selector, r.OperatorInfo.BuildInfo.Version)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if !compat {
+		// this resource is not able to be reconciled by this version of the controller, so we will skip it and not requeue
+		return reconcile.Result{}, nil
+	}
+
+	err = annotation.UpdateControllerVersion(r.Client, &es, r.OperatorInfo.BuildInfo.Version)
+	if err != nil {
+		return reconcile.Result{}, err
 	}
 
 	state := esreconcile.NewState(es)

--- a/operators/pkg/controller/kibana/kibana_controller.go
+++ b/operators/pkg/controller/kibana/kibana_controller.go
@@ -11,16 +11,19 @@ import (
 
 	kibanav1alpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/kibana/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/finalizer"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/watches"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/kibana/label"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -150,6 +153,16 @@ func (r *ReconcileKibana) Reconcile(request reconcile.Request) (reconcile.Result
 	if common.IsPaused(kb.ObjectMeta) {
 		log.Info("Object is paused. Skipping reconciliation", "namespace", kb.Namespace, "kibana_name", kb.Name, "iteration", currentIteration)
 		return common.PauseRequeue, nil
+	}
+
+	selector := labels.Set(map[string]string{label.KibanaNameLabelName: kb.Name}).AsSelector()
+	compat, err := annotation.ReconcileCompatibility(r.Client, kb, selector, r.params.OperatorInfo.BuildInfo.Version)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if !compat {
+		// this resource is not able to be reconciled by this version of the controller, so we will skip it and not requeue
+		return reconcile.Result{}, nil
 	}
 
 	if err := r.finalizers.Handle(kb, r.finalizersFor(*kb)...); err != nil {

--- a/operators/pkg/controller/kibanaassociation/association_controller.go
+++ b/operators/pkg/controller/kibanaassociation/association_controller.go
@@ -13,15 +13,18 @@ import (
 	estype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	kbtype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/kibana/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/finalizer"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/user"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/services"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/kibana/label"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,11 +60,8 @@ var (
 
 // Add creates a new Association Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, _ operator.Parameters) error {
-	r, err := newReconciler(mgr)
-	if err != nil {
-		return err
-	}
+func Add(mgr manager.Manager, params operator.Parameters) error {
+	r := newReconciler(mgr, params)
 	c, err := add(mgr, r)
 	if err != nil {
 		return err
@@ -70,14 +70,15 @@ func Add(mgr manager.Manager, _ operator.Parameters) error {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager) (*ReconcileAssociation, error) {
+func newReconciler(mgr manager.Manager, params operator.Parameters) *ReconcileAssociation {
 	client := k8s.WrapClient(mgr.GetClient())
 	return &ReconcileAssociation{
-		Client:   client,
-		scheme:   mgr.GetScheme(),
-		watches:  watches.NewDynamicWatches(),
-		recorder: mgr.GetRecorder(name),
-	}, nil
+		Client:     client,
+		scheme:     mgr.GetScheme(),
+		watches:    watches.NewDynamicWatches(),
+		recorder:   mgr.GetRecorder(name),
+		Parameters: params,
+	}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -98,7 +99,7 @@ type ReconcileAssociation struct {
 	scheme   *runtime.Scheme
 	recorder record.EventRecorder
 	watches  watches.DynamicWatches
-
+	operator.Parameters
 	// iteration is the number of times this controller has run its Reconcile method
 	iteration int64
 }
@@ -150,6 +151,16 @@ func (r *ReconcileAssociation) Reconcile(request reconcile.Request) (reconcile.R
 	if common.IsPaused(kibana.ObjectMeta) {
 		log.Info("Object is paused. Skipping reconciliation", "namespace", kibana.Namespace, "kibana_name", kibana.Name, "iteration", currentIteration)
 		return common.PauseRequeue, nil
+	}
+
+	selector := labels.Set(map[string]string{label.KibanaNameLabelName: kibana.Name}).AsSelector()
+	compat, err := annotation.ReconcileCompatibility(r.Client, &kibana, selector, r.OperatorInfo.BuildInfo.Version)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if !compat {
+		// this resource is not able to be reconciled by this version of the controller, so we will skip it and not requeue
+		return reconcile.Result{}, nil
 	}
 
 	newStatus, err := r.reconcileInternal(kibana)


### PR DESCRIPTION
Ignore resources reconciled by older controllers

Backport of https://github.com/elastic/cloud-on-k8s/pull/1286 on 0.9.