### PR TITLE
[sset] (very) small optimization

### DIFF
--- a/operators/pkg/controller/elasticsearch/sset/list.go
+++ b/operators/pkg/controller/elasticsearch/sset/list.go
@@ -36,8 +36,8 @@ func (l StatefulSetList) GetByName(ssetName string) (appsv1.StatefulSet, bool) {
 
 func (l StatefulSetList) ObjectMetas() []metav1.ObjectMeta {
 	objs := make([]metav1.ObjectMeta, len(l))
-	for _, sset := range l {
-		objs = append(objs, sset.ObjectMeta)
+	for i, sset := range l {
+		objs[i] = sset.ObjectMeta
 	}
 	return objs
 }


### PR DESCRIPTION
Tiny optimization spotted while reviewing the statefulset implementation: we don't need to append items since the slice is created with the "right" `len`. 