### PR TITLE
Update Quickstart to 0.9.0

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -28,7 +28,7 @@ NOTE: If you are using Amazon EKS, make sure the Kubernetes control plane is all
 +
 [source,sh]
 ----
-kubectl apply -f https://download.elastic.co/downloads/eck/0.8.0/all-in-one.yaml
+kubectl apply -f https://download.elastic.co/downloads/eck/0.9.0/all-in-one.yaml
 ----
 
 . Monitor the operator logs:


### PR DESCRIPTION
Update Quickstart to 0.9.0
backport of https://github.com/elastic/cloud-on-k8s/pull/1317