### PR TITLE
Define order of release notes sub-groups

### DIFF
--- a/operators/hack/release_notes.go
+++ b/operators/hack/release_notes.go
@@ -26,13 +26,15 @@ const (
 
 [[release-notes-{{.Version}}]]
 == {n} version {{.Version}}
-{{range $group, $prs := .Groups}}
+{{range $group := .GroupOrder -}}
+{{with (index $.Groups $group)}}
 [[{{- id $group -}}-{{$.Version}}]]
 [float]
 === {{index $.GroupLabels $group}}
-{{range $prs}}
+{{range .}}
 * {{.Title}} {pull}{{.Number}}[#{{.Number}}]{{with .RelatedIssues -}}
 {{$length := len .}} (issue{{if gt $length 1}}s{{end}}: {{range $idx, $el := .}}{{if $idx}}, {{end}}{issue}{{$el}}[#{{$el}}]{{end}})
+{{- end}}
 {{- end}}
 {{- end}}
 {{end}}
@@ -40,6 +42,15 @@ const (
 )
 
 var (
+	order = []string{
+		">breaking",
+		">deprecation",
+		">feature",
+		">enhancement",
+		">bug",
+		"nogroup",
+	}
+
 	groupLabels = map[string]string{
 		">breaking":    "Breaking changes",
 		">deprecation": "Deprecations",
@@ -81,6 +92,7 @@ type TemplateParams struct {
 	Repo        string
 	GroupLabels map[string]string
 	Groups      GroupedIssues
+	GroupOrder  []string
 }
 
 func fetch(url string, out interface{}) (string, error) {
@@ -251,6 +263,7 @@ func main() {
 		Repo:        repo,
 		GroupLabels: groupLabels,
 		Groups:      groupedIssues,
+		GroupOrder:  order,
 	}, os.Stdout)
 
 }

--- a/operators/hack/release_notes_test.go
+++ b/operators/hack/release_notes_test.go
@@ -29,6 +29,9 @@ func Test_dumpIssues(t *testing.T) {
 					GroupLabels: map[string]string{
 						">bugs": "Bug Fixes",
 					},
+					GroupOrder: []string{
+						">bugs",
+					},
 					Groups: GroupedIssues{
 						">bugs": []Issue{
 							{
@@ -75,6 +78,9 @@ func Test_dumpIssues(t *testing.T) {
 					GroupLabels: map[string]string{
 						">bugs": "Bug Fixes",
 					},
+					GroupOrder: []string{
+						">bugs",
+					},
 					Groups: GroupedIssues{
 						">bugs": []Issue{
 							{
@@ -112,6 +118,9 @@ func Test_dumpIssues(t *testing.T) {
 					GroupLabels: map[string]string{
 						">bugs": "Bug Fixes",
 					},
+					GroupOrder: []string{
+						">bugs",
+					},
 					Groups: GroupedIssues{
 						">bugs": []Issue{
 							{
@@ -137,6 +146,58 @@ func Test_dumpIssues(t *testing.T) {
 === Bug Fixes
 
 * title {pull}123[#123] (issues: {issue}456[#456], {issue}789[#789])
+
+`,
+		},
+		{
+			name: "multi issue--multi group",
+			args: args{
+				params: TemplateParams{
+					Version: "0.9.0",
+					Repo:    "me/my-repo/",
+					GroupLabels: map[string]string{
+						">bugs":    "Bug Fixes",
+						">feature": "New Features",
+					},
+					GroupOrder: []string{
+						">feature",
+						">bugs",
+					},
+					Groups: GroupedIssues{
+						">bugs": []Issue{
+							{
+								Body:   "body",
+								Title:  "title",
+								Number: 123,
+							},
+						},
+						">feature": []Issue{
+							{
+								Body:   "feature",
+								Title:  "feature",
+								Number: 987,
+							},
+						},
+					},
+				},
+			},
+			wantOut: `:issue: https://github.com/me/my-repo/issues/
+:pull: https://github.com/me/my-repo/pull/
+
+[[release-notes-0.9.0]]
+== {n} version 0.9.0
+
+[[feature-0.9.0]]
+[float]
+=== New Features
+
+* feature {pull}987[#987]
+
+[[bugs-0.9.0]]
+[float]
+=== Bug Fixes
+
+* title {pull}123[#123]
 
 `,
 		},


### PR DESCRIPTION
* Map iteration order is undefined in Go
* Adds an array or sub sections with a defined order and uses that in the asciidoc template