### PR TITLE
Don't build and push operator image in bootstrap-gke

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -241,10 +241,6 @@ bootstrap-gke: require-gcloud-project
 ifeq ($(PSP), 1)
 	kubectl apply -f config/dev/elastic-psp.yaml
 endif
-ifeq ($(SKIP_DOCKER_COMMAND), false)
-	# push "latest" operator image to be used for init containers when running the operator locally
-	$(MAKE) docker-build docker-push
-endif
 
 delete-gke: require-gcloud-project
 	GKE_CLUSTER_VERSION=$(GKE_CLUSTER_VERSION) ./hack/gke-cluster.sh delete


### PR DESCRIPTION
We don't need to do that anymore, since we no longer use an init container
based on the operator image.