### PR TITLE
Workaround controller-runtime webhook upsert bug

### DIFF
--- a/operators/pkg/webhook/server.go
+++ b/operators/pkg/webhook/server.go
@@ -5,11 +5,14 @@
 package webhook
 
 import (
+	"context"
+
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/webhook/elasticsearch"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/webhook/license"
 	admission "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -51,6 +54,17 @@ func RegisterValidations(mgr manager.Manager, params Parameters) error {
 	}
 
 	disabled := !params.AutoInstall
+	if params.AutoInstall {
+		// nasty side effect in register function
+		webhookSvc := corev1.Service{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      params.Bootstrap.Service.Name,
+				Namespace: params.Bootstrap.Service.Namespace,
+			},
+		}
+		// best effort deletion attempt to handle incompatible services from previous versions
+		_ = mgr.GetClient().Delete(context.Background(), &webhookSvc)
+	}
 	svr, err := webhook.NewServer(admissionServerName, mgr, webhook.ServerOptions{
 		Port:                          serverPort,
 		CertDir:                       "/tmp/cert",


### PR DESCRIPTION
Fixes #1335 

* deletes the webhook service on controller startup so that controller-runtime can recreate it correctly
* not v happy with this solution, side effect in registration function, pretty hacky
* alternatives:
    *  do it in `manager/main.go` which is cleaner but need to reconstruct a lot of context there: are we actually trying to install webhooks (autoinstall flag set, operator has the webhook role)?, 
    * don't fix it just document it?
