### PR TITLE
Fix APM e2e test (backport of #1284)

### DIFF
--- a/operators/test/e2e/apm/configuration_test.go
+++ b/operators/test/e2e/apm/configuration_test.go
@@ -56,7 +56,7 @@ func TestUpdateConfiguration(t *testing.T) {
 
 	name := "test-apm-configuration"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
 	apmBuilder := apmserver.NewBuilder(name).
 		WithNamespace(test.Namespace).
 		WithVersion(test.ElasticStackVersion).


### PR DESCRIPTION
Backport of #1284 on 0.9