### PR TITLE
Remove Docker image publishing from devops-ci

### DIFF
--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -61,17 +61,6 @@ pipeline {
     }
 
     post {
-        success {
-            withEnv([
-                'REGISTRY=push.docker.elastic.co',
-                'REPOSITORY=eck-snapshots',
-                'IMG_SUFFIX=',
-                'SNAPSHOT_RELEASE=true',
-                'TAG_NAME=${ghprbPullId}'
-                ]) {
-                sh 'make -C build/ci ci-release'
-            }
-        }
         cleanup {
             script {
                 if (notOnlyDocs()) {


### PR DESCRIPTION
backport of https://github.com/elastic/cloud-on-k8s/pull/1339/
