### PR TITLE
Add section about jvm heap size to Elasticsearch doc

### DIFF
--- a/docs/elasticsearch-spec.asciidoc
+++ b/docs/elasticsearch-spec.asciidoc
@@ -25,7 +25,7 @@ Advanced settings
 [id="{p}-jvm-heap-size"]
 === JVM heap size
 
-By default, the JVM heap used by Elasticsearch has minimum and maximum size set to 1Gi. Since it's not recommended for heap size to exceed 50% of RAM size, ECK will default to requesting 2Gi of memory for the Elasticsearch pod. You can change JVM heap size by using `ES_JAVA_OPTS` environment variable. You can adjust pod memory accordingly by setting resource requests and limits. Both changes are shown below. For more information on setting the heap size, see link:https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html[Setting the heap size].
+By default, the JVM heap used by Elasticsearch has minimum and maximum size set to 1Gi. As the heap size should not exceed 50% of RAM size, ECK requests by default 2Gi of memory for the Elasticsearch Pod. To change the JVM heap size, use the environment variable ES_JAVA_OPTS. It is also highly recommended to set the resource requests and limits to adjust the pod memory to not exceed 50% of the RAM size. Both changes are shown below. For more information, see link:https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html[Setting the heap size].
 
 [source,yaml]
 ----

--- a/docs/elasticsearch-spec.asciidoc
+++ b/docs/elasticsearch-spec.asciidoc
@@ -22,6 +22,24 @@ Advanced settings
 - Pod disruption budget
 - Change budget (maxUnavailable, maxSurge)
 
+[id="{p}-jvm-heap-size"]
+=== JVM heap size
+
+By default, JVM heap used by Elasticsearch has minimum and maximum size set to 1 GB. You can change that by using `ES_JAVA_OPTS` environment variable as shown below. For more information on setting the heap size, see link:https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html[Setting the heap size].
+
+[source,yaml]
+----
+spec:
+  nodes:
+  - podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          env:
+          - name: ES_JAVA_OPTS
+            value: -Xms2g -Xmx2g
+----
+
 [id="{p}-node-configuration"]
 === Node configuration
 

--- a/docs/elasticsearch-spec.asciidoc
+++ b/docs/elasticsearch-spec.asciidoc
@@ -25,7 +25,7 @@ Advanced settings
 [id="{p}-jvm-heap-size"]
 === JVM heap size
 
-By default, JVM heap used by Elasticsearch has minimum and maximum size set to 1 GB. Since it's not recommended for heap size to exceed 50% of RAM size, ECK will default to requesting 2Gi of memory. You can change JVM heap size by using `ES_JAVA_OPTS` environment variable. You can adjust pod memory accordingly by setting the resource requests. Both changes are shown below. For more information on setting the heap size, see link:https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html[Setting the heap size].
+By default, the JVM heap used by Elasticsearch has minimum and maximum size set to 1Gi. Since it's not recommended for heap size to exceed 50% of RAM size, ECK will default to requesting 2Gi of memory for the Elasticsearch pod. You can change JVM heap size by using `ES_JAVA_OPTS` environment variable. You can adjust pod memory accordingly by setting resource requests and limits. Both changes are shown below. For more information on setting the heap size, see link:https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html[Setting the heap size].
 
 [source,yaml]
 ----

--- a/docs/elasticsearch-spec.asciidoc
+++ b/docs/elasticsearch-spec.asciidoc
@@ -25,7 +25,7 @@ Advanced settings
 [id="{p}-jvm-heap-size"]
 === JVM heap size
 
-By default, JVM heap used by Elasticsearch has minimum and maximum size set to 1 GB. You can change that by using `ES_JAVA_OPTS` environment variable as shown below. For more information on setting the heap size, see link:https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html[Setting the heap size].
+By default, JVM heap used by Elasticsearch has minimum and maximum size set to 1 GB. Since it's not recommended for heap size to exceed 50% of RAM size, ECK will default to requesting 2Gi of memory. You can change JVM heap size by using `ES_JAVA_OPTS` environment variable. You can adjust pod memory accordingly by setting the resource requests. Both changes are shown below. For more information on setting the heap size, see link:https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html[Setting the heap size].
 
 [source,yaml]
 ----
@@ -38,6 +38,11 @@ spec:
           env:
           - name: ES_JAVA_OPTS
             value: -Xms2g -Xmx2g
+          resources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 4Gi
 ----
 
 [id="{p}-node-configuration"]


### PR DESCRIPTION
Part of work for #1031.