### PR TITLE
Fix ECK image in all-in-one.yaml

### DIFF
--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -93,6 +93,7 @@ ci-release: vault-public-key vault-docker-creds
     	-e "ELASTIC_DOCKER_PASSWORD=$(shell cat $(DOCKER_CREDENTIALS_FILE))" \
     	-e "USE_ELASTIC_DOCKER_REGISTRY=true" \
     	-e "OPERATOR_IMAGE=$(OPERATOR_IMAGE)" \
+    	-e "LATEST_RELEASED_IMG=$(LATEST_RELEASED_IMG)" \
     	-e "VERSION=$(VERSION)" \
     	-e "SNAPSHOT=$(SNAPSHOT)" \
     	cloud-on-k8s-ci-release \

--- a/operators/Makefile
+++ b/operators/Makefile
@@ -334,7 +334,6 @@ ci-bootstrap-gke:
 
 ci-release: export GO_TAGS = release
 ci-release: export LICENSE_PUBKEY = $(ROOT_DIR)/build/ci/license.key
-ci-release: export LATEST_RELEASED_IMG = docker.elastic.co/$(REPOSITORY)/eck-operator:$(TAG)
 ci-release:
 	@ $(MAKE) dep-vendor-only generate docker-build docker-push
 	@ echo $(OPERATOR_IMAGE) was pushed!


### PR DESCRIPTION
Currently we are generating `all-in-one.yaml` for uploading during release with incorrect ECK image. This PR fixes that.
This change needs to be backported to `0.9`