### PR TITLE
Don't run E2E tests if change was in docs only

### DIFF
--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -19,10 +19,14 @@ pipeline {
     }
 
     stages {
+        stage('Git checkout') {
+            steps {
+                checkout scm
+            }
+        }
         stage("E2E tests") {
             when {
                 expression {
-                    checkout scm
                     notOnlyDocs()
                 }
             }

--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
     }
 
     stages {
-        stage('Git checkout') {
+        stage('Checkout from GitHub') {
             steps {
                 checkout scm
             }

--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -19,14 +19,26 @@ pipeline {
     }
 
     stages {
-        stage('Checkout from GitHub') {
-            steps {
-                checkout scm
+        stage("E2E tests") {
+            when {
+                expression {
+                    checkout scm
+                    notOnlyDocs()
+                }
             }
-        }
-        stage("Run E2E tests") {
-            steps {
-                sh 'make -C build/ci ci-e2e'
+            stages {
+                stage('Run E2E tests') {
+                    steps {
+                        sh 'make -C build/ci ci-e2e'
+                    }
+                }
+                stage('Cleanup GKE') {
+                    steps {
+                        build job: 'cloud-on-k8s-e2e-cleanup',
+                            parameters: [string(name: 'GKE_CLUSTER', value: "${GKE_CLUSTER_NAME}")],
+                            wait: false
+                    }
+                }
             }
         }
     }
@@ -43,12 +55,16 @@ pipeline {
             }
         }
         cleanup {
-            build job: 'cloud-on-k8s-e2e-cleanup',
-                  parameters: [string(name: 'GKE_CLUSTER', value: "${GKE_CLUSTER_NAME}")],
-                  wait: false
-
             cleanWs()
         }
     }
 
+}
+
+def notOnlyDocs() {
+    // grep succeeds if there is at least one line without docs/
+    return sh (
+        script: "git diff --name-status HEAD~1 HEAD | grep -v docs/",
+    	returnStatus: true
+    ) == 0
 }


### PR DESCRIPTION
Right now we are running E2E tests on every commit to `master`. Even if it was commit only to documentation. 
This change will skip E2E tests for documentation only changes.