### PR TITLE
Fix enable-debug-logs flag in the operator manifest

### DIFF
--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -146,8 +146,7 @@ and change the following lines from:
       - manager
       - --operator-roles
       - all
-      - --enable-debug-logs
-      - false
+      - --enable-debug-logs=false
 ----
 
 to
@@ -160,8 +159,7 @@ to
       - manager
       - --operator-roles
       - all
-      - --enable-debug-logs
-      - true
+      - --enable-debug-logs=true
 ----
 
 [float]

--- a/operators/config/operator/all-in-one/operator.template.yaml
+++ b/operators/config/operator/all-in-one/operator.template.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - image: <OPERATOR_IMAGE>
         name: manager
-        args: ["manager", "--operator-roles", "all", "--enable-debug-logs", "false"]
+        args: ["manager", "--operator-roles", "all", "--enable-debug-logs=false"]
         env:
           - name: OPERATOR_NAMESPACE
             valueFrom:


### PR DESCRIPTION
This flag was not taken into consideration, because it's a boolean
flag, and boolean flags don't use the <name><whitespace><value> syntax.

See https://golang.org/pkg/flag/#hdr-Command_line_flag_syntax for more
details.

Fixes https://github.com/elastic/cloud-on-k8s/issues/1371.