### PR TITLE
Fix github links in quickstart 0.9

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -310,10 +310,10 @@ To aim for the best performance, the operator supports persistent volumes local 
 [id="{p}-check-samples"]
 === Check out the samples
 
-You can find a set of sample resources link:https://github.com/elastic/cloud-on-k8s/tree/master/operators/config/samples[in the project repository].
-To customize the Elasticsearch resource, check the link:https://github.com/elastic/cloud-on-k8s/blob/master/operators/config/samples/elasticsearch/elasticsearch.yaml[Elasticsearch sample].
+You can find a set of sample resources link:https://github.com/elastic/cloud-on-k8s/tree/0.9/operators/config/samples[in the project repository].
+To customize the Elasticsearch resource, check the link:https://github.com/elastic/cloud-on-k8s/blob/0.9/operators/config/samples/elasticsearch/elasticsearch.yaml[Elasticsearch sample].
 
-For a full description of each `CustomResourceDefinition`, go to link:https://github.com/elastic/cloud-on-k8s/tree/master/operators/config/crds[the project repository].
+For a full description of each `CustomResourceDefinition`, go to link:https://github.com/elastic/cloud-on-k8s/tree/0.9/operators/config/crds[the project repository].
 You can also retrieve it from the cluster. For example, describe the Elasticsearch CRD specification with:
 
 [source,sh]


### PR DESCRIPTION
We should link to the 0.9 branch in the github repository, in case those
samples in master are incompatible with 0.9