### PR TITLE
Update the way to add settings in the ES keystore

### DIFF
--- a/operators/pkg/controller/common/keystore/initcontainer.go
+++ b/operators/pkg/controller/common/keystore/initcontainer.go
@@ -44,7 +44,7 @@ for filename in  {{ .SecureSettingsVolumeMountPath }}/*; do
 	[[ -e "$filename" ]] || continue # glob does not match
 	key=$(basename "$filename")
 	echo "Adding "$key" to the keystore."
-	{{ .KeystoreAddCommand }} "$key" --stdin < "$filename"
+	{{ .KeystoreAddCommand }} "$key" "$filename"
 done
 
 echo "Keystore initialization successful."

--- a/operators/pkg/controller/common/keystore/resources_test.go
+++ b/operators/pkg/controller/common/keystore/resources_test.go
@@ -97,7 +97,7 @@ for filename in  /foo/secret/*; do
 	[[ -e "$filename" ]] || continue # glob does not match
 	key=$(basename "$filename")
 	echo "Adding "$key" to the keystore."
-	/keystore/bin/keystore add "$key" --stdin < "$filename"
+	/keystore/bin/keystore add "$key" "$filename"
 done
 
 echo "Keystore initialization successful."

--- a/operators/pkg/controller/elasticsearch/driver/default.go
+++ b/operators/pkg/controller/elasticsearch/driver/default.go
@@ -46,7 +46,7 @@ import (
 // initContainerParams is used to generate the init container that will load the secure settings into a keystore
 var initContainerParams = keystore.InitContainerParameters{
 	KeystoreCreateCommand:         "/usr/share/elasticsearch/bin/elasticsearch-keystore create",
-	KeystoreAddCommand:            "/usr/share/elasticsearch/bin/elasticsearch-keystore add",
+	KeystoreAddCommand:            "/usr/share/elasticsearch/bin/elasticsearch-keystore add-file",
 	SecureSettingsVolumeMountPath: keystore.SecureSettingsVolumeMountPath,
 	DataVolumePath:                esvolume.ElasticsearchDataMountPath,
 }


### PR DESCRIPTION
This fixes an issue where the `repository-gcs` plugin fails if the
setting `gcs.client.default.credentials_file` is not a compacted JSON
and is added using `elasticsearch-keystore add key --stdin`.

Since the secure settings are now in a Secret and each key of a Secret is mounted in a container as files I think we can safely change the way `elasticsearch-keystore` is called to add settings.

Fixes #1349.