### PR TITLE
Add docs on 0.8 -> 0.9 compatibility

### DIFF
--- a/docs/release-notes/highlights-0.9.0.asciidoc
+++ b/docs/release-notes/highlights-0.9.0.asciidoc
@@ -39,7 +39,8 @@ Existing resources (Elasticsearch and Kibana) that were created with a 0.8.x ver
 
 Resources created with a 0.8.X version will be stuck on the delete operation if ECK 0.9.X is running. To unlock the deletion, remove any registered finalizer:
 
-```
+[source,sh]
+----
 kubectl patch elasticsearch quickstart-0-8 --patch '{"metadata": {"finalizers": []}}' --type=merge
 kubectl patch kibana quickstart-0-8 --patch '{"metadata": {"finalizers": []}}' --type=merge
-```
+----

--- a/docs/release-notes/highlights-0.9.0.asciidoc
+++ b/docs/release-notes/highlights-0.9.0.asciidoc
@@ -32,4 +32,7 @@ or to specify `imagePullSecrets` for your private Docker registry.
 [float]
 === Breaking Changes
 
-Existing resources (Elasticsearch and Kibana) that were created with a 0.8.x version of the operator are *not* compatible with this release. They will automatically have an annotation added to them indicating the controller version, and then skipped. They will continue to function, but any changes made to them will not be processed by the 0.9.x version of the operator. To upgrade existing clusters, please https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html[perform a snapshot] of the existing cluster and restore them into a new cluster created by the 0.9.x version of the operator.
+Existing resources (Elasticsearch and Kibana) that were created with a 0.8.x version of the operator are *not* compatible with this release. They will automatically have an annotation added to them indicating the controller version, and then skipped. They will continue to function, but any changes made to them will not be processed by the 0.9.x version of the operator. To upgrade existing clusters, you can either:
+
+- https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html[Perform a snapshot] of the existing cluster and restore them into a new cluster created by the 0.9.x version of the operator, or
+- Create a new cluster, and https://www.elastic.co/guide/en/elasticsearch/reference/current/reindex-upgrade-remote.html[reindex from remote] to reindex your data to the new cluster.

--- a/docs/release-notes/highlights-0.9.0.asciidoc
+++ b/docs/release-notes/highlights-0.9.0.asciidoc
@@ -29,4 +29,7 @@ this allows you to configure your own init containers to run code before Elastic
 Or you can use the Pod template to mount additional volumes with configuration files, for example to configure SAML or synonym files,
 or to specify `imagePullSecrets` for your private Docker registry.
 
+[float]
+=== Breaking Changes
 
+Existing resources (Elasticsearch and Kibana) that were created with a 0.8.x version of the operator are *not* compatible with this release. They will automatically have an annotation added to them indicating the controller version, and then skipped. They will continue to function, but any changes made to them will not be processed by the 0.9.x version of the operator. To upgrade existing clusters, please https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html[perform a snapshot] of the existing cluster and restore them into a new cluster created by the 0.9.x version of the operator.

--- a/docs/release-notes/highlights-0.9.0.asciidoc
+++ b/docs/release-notes/highlights-0.9.0.asciidoc
@@ -36,3 +36,10 @@ Existing resources (Elasticsearch and Kibana) that were created with a 0.8.x ver
 
 - https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html[Perform a snapshot] of the existing cluster and restore them into a new cluster created by the 0.9.x version of the operator, or
 - Create a new cluster, and https://www.elastic.co/guide/en/elasticsearch/reference/current/reindex-upgrade-remote.html[reindex from remote] to reindex your data to the new cluster.
+
+Resources created with a 0.8.X version will be stuck on the delete operation if ECK 0.9.X is running. To unlock the deletion, remove any registered finalizer:
+
+```
+kubectl patch elasticsearch quickstart-0-8 --patch '{"metadata": {"finalizers": []}}' --type=merge
+kubectl patch kibana quickstart-0-8 --patch '{"metadata": {"finalizers": []}}' --type=merge
+```

--- a/docs/release-notes/highlights-0.9.0.asciidoc
+++ b/docs/release-notes/highlights-0.9.0.asciidoc
@@ -37,7 +37,7 @@ Existing resources (Elasticsearch and Kibana) that were created with a 0.8.x ver
 - https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html[Perform a snapshot] of the existing cluster and restore them into a new cluster created by the 0.9.x version of the operator, or
 - Create a new cluster, and https://www.elastic.co/guide/en/elasticsearch/reference/current/reindex-upgrade-remote.html[reindex from remote] to reindex your data to the new cluster.
 
-Resources created with a 0.8.X version will be stuck on the delete operation if ECK 0.9.X is running. To unlock the deletion, remove any registered finalizer:
+Attempting to delete resources created with a 0.8.x version will hang if ECK 0.9.x is running. To unblock the deletion, remove any registered finalizer from the resource:
 
 [source,sh]
 ----


### PR DESCRIPTION
Relates to https://github.com/elastic/cloud-on-k8s/issues/1242

I wasn't sure if there was a different place we also wanted to add these. Maybe also in `release-notes/0.9.0.asciidoc`?