### PR TITLE
Add webhook troubleshooting section

### DIFF
--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -239,7 +239,7 @@ This can also be done for Kibana and APM Server.
 [id="{p}-webhook-troubleshooting"]
 === Webhook troubleshooting
 
-On startup, the operator deploys an https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/[admission webhook] that points to the operator's service. If this is inaccessible, you may see errors in your Kubernetes API server logs indicating that it cannot reach the service. A common cause may be that the operator pods are failing to start for some reason, or that the control plane is isolated from the operator pod by some mechanism (for instance via network policies or running the control plane externally as in https://github.com/elastic/cloud-on-k8s/issues/1369[issue #1369]).
+On startup, the operator deploys an https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/[admission webhook] that points to the operator's service. If this is inaccessible, you may see errors in your Kubernetes API server logs indicating that it cannot reach the service. A common cause may be that the operator pods are failing to start for some reason, or that the control plane is isolated from the operator pod by some mechanism (for instance via network policies or running the control plane externally as in https://github.com/elastic/cloud-on-k8s/issues/896#issuecomment-507224945[issue #869] and https://github.com/elastic/cloud-on-k8s/issues/1369[issue #1369]).
 
 [float]
 [id="{p}-ask-for-help"]

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -236,6 +236,12 @@ kubectl exec -ti elasticsearch-sample-es-p45nrjch29 bash
 This can also be done for Kibana and APM Server.
 
 [float]
+[id="{p}-webhook-troubleshooting"]
+=== Webhook troubleshooting
+
+On startup, the operator deploys an https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/[admission webhook] that points to the operator's service. If this is inaccessible, you may see errors in your Kubernetes API server logs indicating that it cannot reach the service. A common cause may be that the operator pods are failing to start for some reason, or that the control plane is isolated from the operator pod by some mechanism (for instance via network policies or running the control plane externally as in https://github.com/elastic/cloud-on-k8s/issues/1369[issue #1369]).
+
+[float]
 [id="{p}-ask-for-help"]
 === Ask for help
 


### PR DESCRIPTION
Related to https://github.com/elastic/cloud-on-k8s/issues/1369

Added a note about the webhook existing and possible issues. I'm not super happy with this, but it should be less of an issue with 0.9 since it will not hard fail.