### PR TITLE
Relax Elasticsearch validation hook failure policy

### DIFF
--- a/operators/pkg/webhook/server.go
+++ b/operators/pkg/webhook/server.go
@@ -32,7 +32,7 @@ func RegisterValidations(mgr manager.Manager, params Parameters) error {
 	esWh, err := builder.NewWebhookBuilder().
 		Name("validation.elasticsearch.elastic.co").
 		Validating().
-		FailurePolicy(admission.Fail).
+		FailurePolicy(admission.Ignore).
 		ForType(&v1alpha1.Elasticsearch{}).
 		Handlers(&elasticsearch.ValidationHandler{}).
 		WithManager(mgr).


### PR DESCRIPTION
We relaxed the failure policy for the secret validation hook in #1305 but it occurred to me that it might make sense to do the same for Elasticsearch itself, so that users are not blocked in case of problems with the webhook service, which seem to occur more often than not. 

Validations still run in any case inside the reconciliation loop so there is no danger of circumventing validations.