### PR TITLE
Display events of non-running pods on E2E tests failure

### DIFF
--- a/operators/hack/run-e2e.sh
+++ b/operators/hack/run-e2e.sh
@@ -81,6 +81,14 @@ else
     echo "--"
     kubectl -n $NAMESPACE get elastic,pods,rs,deploy,svc,cm,secrets,pvc,pv
     echo "--"
+    echo "# events for non-running pods"
+    for pod in $(kubectl get pods -n $NAMESPACE | tail -n +2 | grep -v Running | awk '{print $1}')
+    do
+        echo "--"
+        echo "> kubectl -n $NAMESPACE describe pod $pod | grep -A30 Events"
+        kubectl -n $NAMESPACE describe pod $pod | grep -A30 Events
+        echo "--"
+    done
 fi
 
 # delete job

--- a/operators/hack/run-e2e.sh
+++ b/operators/hack/run-e2e.sh
@@ -82,11 +82,11 @@ else
     kubectl -n $NAMESPACE get elastic,pods,rs,deploy,svc,cm,secrets,pvc,pv
     echo "--"
     echo "# events for non-running pods"
-    for pod in $(kubectl get pods -n $NAMESPACE | tail -n +2 | grep -v Running | awk '{print $1}')
+    for pod in $(kubectl -n $NAMESPACE get pods --no-headers --field-selector=status.phase!=Running -o custom-columns=:metadata.name)
     do
         echo "--"
-        echo "> kubectl -n $NAMESPACE describe pod $pod | grep -A30 Events"
-        kubectl -n $NAMESPACE describe pod $pod | grep -A30 Events
+        echo "> kubectl -n $NAMESPACE get event --field-selector involvedObject.name=$pod"
+        kubectl -n $NAMESPACE get event --field-selector involvedObject.name=$pod
         echo "--"
     done
 fi


### PR DESCRIPTION
This should help tracking problems with Pods that stay Pending in e2e
tests (lack of CPU, unbound PVs, etc.).

Get the list of pods that are not running: for each one grep the `Events` section of the `kubectl describe pod $pod` output.