### PR TITLE
Add e2e test for custom config via pod template

### DIFF
--- a/operators/pkg/controller/elasticsearch/client/client.go
+++ b/operators/pkg/controller/elasticsearch/client/client.go
@@ -101,6 +101,8 @@ type Client interface {
 	//
 	// Introduced in: Elasticsearch 7.0.0
 	DeleteVotingConfigExclusions(ctx context.Context, waitForRemoval bool) error
+	// Request exposes a low level interface to the underlying HTTP client e.g. for testing purposes.
+	Request(ctx context.Context, r *http.Request) (*http.Response, error)
 }
 
 // NewElasticsearchClient creates a new client for the target cluster.

--- a/operators/pkg/controller/elasticsearch/client/client.go
+++ b/operators/pkg/controller/elasticsearch/client/client.go
@@ -102,6 +102,8 @@ type Client interface {
 	// Introduced in: Elasticsearch 7.0.0
 	DeleteVotingConfigExclusions(ctx context.Context, waitForRemoval bool) error
 	// Request exposes a low level interface to the underlying HTTP client e.g. for testing purposes.
+	// The Elasticsearch endpoint will be added automatically to the request URL which should therefore just be the path
+	// with a leading /
 	Request(ctx context.Context, r *http.Request) (*http.Response, error)
 }
 

--- a/operators/pkg/controller/elasticsearch/client/v6.go
+++ b/operators/pkg/controller/elasticsearch/client/v6.go
@@ -98,11 +98,11 @@ func (c *clientV6) DeleteVotingConfigExclusions(ctx context.Context, waitForRemo
 }
 
 func (c *clientV6) Request(ctx context.Context, r *http.Request) (*http.Response, error) {
-	newUrl, err := url.Parse(stringsutil.Concat(c.Endpoint, r.URL.String()))
+	newURL, err := url.Parse(stringsutil.Concat(c.Endpoint, r.URL.String()))
 	if err != nil {
 		return nil, err
 	}
-	r.URL = newUrl
+	r.URL = newURL
 	return c.doRequest(ctx, r)
 }
 

--- a/operators/pkg/controller/elasticsearch/client/v6.go
+++ b/operators/pkg/controller/elasticsearch/client/v6.go
@@ -6,7 +6,10 @@ package client
 
 import (
 	"context"
+	"net/http"
+	"net/url"
 
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/stringsutil"
 	"github.com/pkg/errors"
 )
 
@@ -92,6 +95,15 @@ func (c *clientV6) AddVotingConfigExclusions(ctx context.Context, nodeNames []st
 
 func (c *clientV6) DeleteVotingConfigExclusions(ctx context.Context, waitForRemoval bool) error {
 	return errors.New("Not supported in Elasticsearch 6.x")
+}
+
+func (c *clientV6) Request(ctx context.Context, r *http.Request) (*http.Response, error) {
+	newUrl, err := url.Parse(stringsutil.Concat(c.Endpoint, r.URL.String()))
+	if err != nil {
+		return nil, err
+	}
+	r.URL = newUrl
+	return c.doRequest(ctx, r)
 }
 
 // Equal returns true if c2 can be considered the same as c

--- a/operators/test/e2e/es/podtemplate_test.go
+++ b/operators/test/e2e/es/podtemplate_test.go
@@ -1,0 +1,144 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package es
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/client"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/elasticsearch"
+	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCustomConfiguration(t *testing.T) {
+	const synonyms = "synonyms"
+	synonymMap := corev1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      synonyms,
+			Namespace: test.Namespace,
+		},
+		Data: map[string]string{
+			"synonyms.txt": `ECK => Elastic Cloud on Kubernetes`,
+		},
+	}
+	es := elasticsearch.NewBuilder(synonyms).
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithPodTemplate(corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{
+						Name: synonyms,
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: synonyms,
+								},
+							},
+						},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name:      v1alpha1.ElasticsearchContainerName,
+						Resources: elasticsearch.DefaultResources,
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      synonyms,
+								MountPath: "/usr/share/elasticsearch/config/dictionaries",
+							},
+						},
+					},
+				},
+			},
+		})
+
+	init := func(c *test.K8sClient) test.StepList {
+		return test.StepList{
+			test.Step{
+				Name: "Create dictionary config map",
+				Test: func(t *testing.T) {
+					// delete left over data from previous runs
+					_ = c.Client.Delete(&synonymMap)
+					require.NoError(t, c.Client.Create(&synonymMap))
+				},
+			},
+		}
+	}
+	var esClient client.Client
+	runAnaylzer := func(c *test.K8sClient) test.StepList {
+		return test.StepList{
+			test.Step{
+				Name: "Create ES client",
+				Test: func(t *testing.T) {
+					var err error
+					esClient, err = elasticsearch.NewElasticsearchClient(es.Elasticsearch, c)
+					require.NoError(t, err)
+				},
+			},
+			test.Step{
+				Name: "Create index with synonym token filter",
+				Test: func(t *testing.T) {
+					settings := `
+{
+    "settings": {
+        "index" : {
+            "analysis" : {
+                "analyzer" : {
+                    "synonym" : {
+                        "tokenizer" : "whitespace",
+                        "filter" : ["synonym"]
+                    }
+                },
+                "filter" : {
+                    "synonym" : {
+                        "type" : "synonym",
+                        "synonyms_path" : "dictionaries/synonyms.txt"
+                    }
+                }
+            }
+        }
+    }
+}
+`
+					r, err := http.NewRequest(http.MethodPut, "/test-index", bytes.NewBufferString(settings))
+					require.NoError(t, err)
+					response, err := esClient.Request(context.Background(), r)
+					defer response.Body.Close()
+					require.NoError(t, err)
+				},
+			},
+			{
+				Name: "Analyse with synonyms",
+				Test: func(t *testing.T) {
+					body := `
+{
+  "analyzer": "synonym", 
+  "text" : "ECK runs Elasticsearch, Kibana and APM Server on Kubernetes"
+}
+`
+					r, err := http.NewRequest(http.MethodGet, "/test-index/_analyze", bytes.NewBufferString(body))
+					require.NoError(t, err)
+					response, err := esClient.Request(context.Background(), r)
+					defer response.Body.Close()
+					require.NoError(t, err)
+					actual, err := ioutil.ReadAll(response.Body)
+					require.NoError(t, err)
+					expected := `{"tokens":[{"token":"Elastic","start_offset":0,"end_offset":3,"type":"SYNONYM","position":0},{"token":"runs","start_offset":4,"end_offset":8,"type":"word","position":1},{"token":"Cloud","start_offset":4,"end_offset":8,"type":"SYNONYM","position":1},{"token":"Elasticsearch,","start_offset":9,"end_offset":23,"type":"word","position":2},{"token":"on","start_offset":9,"end_offset":23,"type":"SYNONYM","position":2},{"token":"Kibana","start_offset":24,"end_offset":30,"type":"word","position":3},{"token":"Kubernetes","start_offset":24,"end_offset":30,"type":"SYNONYM","position":3},{"token":"and","start_offset":31,"end_offset":34,"type":"word","position":4},{"token":"APM","start_offset":35,"end_offset":38,"type":"word","position":5},{"token":"Server","start_offset":39,"end_offset":45,"type":"word","position":6},{"token":"on","start_offset":46,"end_offset":48,"type":"word","position":7},{"token":"Kubernetes","start_offset":49,"end_offset":59,"type":"word","position":8}]}`
+					assert.Equal(t, string(actual), expected)
+				},
+			},
+		}
+	}
+	test.Sequence(init, runAnaylzer, es).RunSequential(t)
+}

--- a/operators/test/e2e/es/podtemplate_test.go
+++ b/operators/test/e2e/es/podtemplate_test.go
@@ -114,7 +114,7 @@ func TestCustomConfiguration(t *testing.T) {
 					r, err := http.NewRequest(http.MethodPut, "/test-index", bytes.NewBufferString(settings))
 					require.NoError(t, err)
 					response, err := esClient.Request(context.Background(), r)
-					defer response.Body.Close()
+					defer response.Body.Close() // nolint
 					require.NoError(t, err)
 				},
 			},
@@ -130,7 +130,7 @@ func TestCustomConfiguration(t *testing.T) {
 					r, err := http.NewRequest(http.MethodGet, "/test-index/_analyze", bytes.NewBufferString(body))
 					require.NoError(t, err)
 					response, err := esClient.Request(context.Background(), r)
-					defer response.Body.Close()
+					defer response.Body.Close() // nolint
 					require.NoError(t, err)
 					actual, err := ioutil.ReadAll(response.Body)
 					require.NoError(t, err)

--- a/operators/test/e2e/test/elasticsearch/builder.go
+++ b/operators/test/e2e/test/elasticsearch/builder.go
@@ -185,6 +185,13 @@ func (b Builder) WithPersistentVolumes(volumeName string, storageClassName *stri
 	return b
 }
 
+func (b Builder) WithPodTemplate(pt corev1.PodTemplateSpec) Builder {
+	for i := range b.Elasticsearch.Spec.Nodes {
+		b.Elasticsearch.Spec.Nodes[i].PodTemplate = pt
+	}
+	return b
+}
+
 // -- Helper functions
 
 func (b Builder) RuntimeObjects() []runtime.Object {


### PR DESCRIPTION
* adds a test to exercise the custom config mechanism via volume/volume mount 
* uses custom synonyms as the example
* adds a generic request method to the ES client (open to better suggestions here)