### PR TITLE
Variabilize more the keystore settings addition

### DIFF
--- a/operators/pkg/controller/apmserver/apmserver_controller.go
+++ b/operators/pkg/controller/apmserver/apmserver_controller.go
@@ -65,7 +65,7 @@ var (
 
 	initContainerParameters = keystore.InitContainerParameters{
 		KeystoreCreateCommand:         ApmServerBin + " keystore create --force",
-		KeystoreAddCommand:            ApmServerBin + " keystore add",
+		KeystoreAddCommand:            ApmServerBin + ` keystore add "$key" --stdin < "$filename"`,
 		SecureSettingsVolumeMountPath: keystore.SecureSettingsVolumeMountPath,
 		DataVolumePath:                DataVolumePath,
 	}

--- a/operators/pkg/controller/common/keystore/initcontainer.go
+++ b/operators/pkg/controller/common/keystore/initcontainer.go
@@ -44,7 +44,7 @@ for filename in  {{ .SecureSettingsVolumeMountPath }}/*; do
 	[[ -e "$filename" ]] || continue # glob does not match
 	key=$(basename "$filename")
 	echo "Adding "$key" to the keystore."
-	{{ .KeystoreAddCommand }} "$key" "$filename"
+	{{ .KeystoreAddCommand }}
 done
 
 echo "Keystore initialization successful."

--- a/operators/pkg/controller/common/keystore/resources_test.go
+++ b/operators/pkg/controller/common/keystore/resources_test.go
@@ -23,7 +23,7 @@ import (
 var (
 	initContainersParameters = InitContainerParameters{
 		KeystoreCreateCommand:         "/keystore/bin/keystore create",
-		KeystoreAddCommand:            "/keystore/bin/keystore add",
+		KeystoreAddCommand:            `/keystore/bin/keystore add "$key" "$filename"`,
 		SecureSettingsVolumeMountPath: "/foo/secret",
 		DataVolumePath:                "/bar/data",
 	}

--- a/operators/pkg/controller/elasticsearch/driver/default.go
+++ b/operators/pkg/controller/elasticsearch/driver/default.go
@@ -46,7 +46,7 @@ import (
 // initContainerParams is used to generate the init container that will load the secure settings into a keystore
 var initContainerParams = keystore.InitContainerParameters{
 	KeystoreCreateCommand:         "/usr/share/elasticsearch/bin/elasticsearch-keystore create",
-	KeystoreAddCommand:            "/usr/share/elasticsearch/bin/elasticsearch-keystore add-file",
+	KeystoreAddCommand:            `/usr/share/elasticsearch/bin/elasticsearch-keystore add-file "$key" "$filename"`,
 	SecureSettingsVolumeMountPath: keystore.SecureSettingsVolumeMountPath,
 	DataVolumePath:                esvolume.ElasticsearchDataMountPath,
 }

--- a/operators/pkg/controller/kibana/driver.go
+++ b/operators/pkg/controller/kibana/driver.go
@@ -38,7 +38,7 @@ import (
 // initContainersParameters is used to generate the init container that will load the secure settings into a keystore
 var initContainersParameters = keystore.InitContainerParameters{
 	KeystoreCreateCommand:         "/usr/share/kibana/bin/kibana-keystore create",
-	KeystoreAddCommand:            "/usr/share/kibana/bin/kibana-keystore add",
+	KeystoreAddCommand:            `/usr/share/kibana/bin/kibana-keystore add "$key" --stdin < "$filename"`,
 	SecureSettingsVolumeMountPath: keystore.SecureSettingsVolumeMountPath,
 	DataVolumePath:                volume.DataVolumeMountPath,
 }


### PR DESCRIPTION
Given it's convenient to not use `--stdin` with the ES keystore to fix #1349,
this commit makes the keystore settings addition different for ES than
for Kibana and the APM Server.

Only the Elasticsearch keystore supports settings additions using a file
path. Kibana and APM Server supports only to pass the value through
stdin and use the --stdin flag.

Fixes #1399.