### PR TITLE
Backport: update stack version in docs and samples with a bash script (#1413)

### DIFF
--- a/docs/accessing-services.asciidoc
+++ b/docs/accessing-services.asciidoc
@@ -249,17 +249,7 @@ You can now reach Elasticsearch:
   "name" : "hulk-es-4qk62zd928",
   "cluster_name" : "hulk",
   "cluster_uuid" : "q6itjqFqRqW576FXF0uohg",
-  "version" : {
-    "number" : "7.2.0",
-    "build_flavor" : "default",
-    "build_type" : "docker",
-    "build_hash" : "508c38a",
-    "build_date" : "2019-06-20T15:54:18.811730Z",
-    "build_snapshot" : false,
-    "lucene_version" : "8.0.0",
-    "minimum_wire_compatibility_version" : "6.8.0",
-    "minimum_index_compatibility_version" : "6.0.0-beta1"
-  },
+  "version" : {...},
   "tagline" : "You Know, for Search"
 }
 ----

--- a/docs/advanced-node-scheduling.asciidoc
+++ b/docs/advanced-node-scheduling.asciidoc
@@ -24,7 +24,7 @@ kind: Elasticsearch
 metadata:
   name: quickstart
 spec:
-  version: 7.1.0
+  version: 7.2.0
   nodes:
   # 3 dedicated master nodes
   - nodeCount: 3
@@ -59,7 +59,7 @@ kind: Elasticsearch
 metadata:
   name: quickstart
 spec:
-  version: 7.1.0
+  version: 7.2.0
   nodes:
   - nodeCount: 3
     podTemplate:
@@ -86,7 +86,7 @@ kind: Elasticsearch
 metadata:
   name: quickstart
 spec:
-  version: 7.1.0
+  version: 7.2.0
   nodes:
   - nodeCount: 3
     podTemplate:
@@ -103,7 +103,7 @@ kind: Elasticsearch
 metadata:
   name: quickstart
 spec:
-  version: 7.1.0
+  version: 7.2.0
   nodes:
   - nodeCount: 3
     podTemplate:
@@ -149,7 +149,7 @@ kind: Elasticsearch
 metadata:
   name: quickstart
 spec:
-  version: 7.1.0
+  version: 7.2.0
   nodes:
   - nodeCount: 3
     podTemplate:
@@ -168,7 +168,7 @@ kind: Elasticsearch
 metadata:
   name: quickstart
 spec:
-  version: 7.1.0
+  version: 7.2.0
   nodes:
   - nodeCount: 3
     podTemplate:
@@ -208,7 +208,7 @@ kind: Elasticsearch
 metadata:
   name: quickstart
 spec:
-  version: 7.1.0
+  version: 7.2.0
   nodes:
   - nodeCount: 1
     config:
@@ -276,7 +276,7 @@ kind: Elasticsearch
 metadata:
   name: quickstart
 spec:
-  version: 7.1.0
+  version: 7.2.0
   nodes:
   # hot nodes, with high CPU and fast IO
   - nodeCount: 3

--- a/docs/apm.asciidoc
+++ b/docs/apm.asciidoc
@@ -32,7 +32,7 @@ metadata:
   name: apm-server-quickstart
   namespace: default
 spec:
-  version: "7.2.0"
+  version: 7.2.0
   nodeCount: 1
   elasticsearchRef:
     name: quickstart
@@ -52,8 +52,8 @@ kubectl get apmservers
 
 [source,sh]
 ----
-NAME                    HEALTH   NODES   VERSION   AGE
-apm-server-quickstart   green    1       7.2.0     8m
+NAME                     HEALTH    NODES    VERSION   AGE
+apm-server-quickstart    green     1         7.2.0     8m
 ----
 And you can list all the Pods belonging to a given deployment:
 
@@ -85,7 +85,7 @@ metadata:
   name: apm-server-quickstart
   namespace: default
 spec:
-  version: "7.2.0"
+  version: 7.2.0
   nodeCount: 1
   config:
     output:
@@ -120,7 +120,7 @@ metadata:
   name: apm-server-quickstart
   namespace: default
 spec:
-  version: "7.2.0"
+  version: 7.2.0
   nodeCount: 1
   secureSettings:
     secretName: apm-secret-settings
@@ -159,7 +159,7 @@ metadata:
   name: apm-server-quickstart
   namespace: default
 spec:
-  version: "7.2.0"
+  version: 7.2.0
   nodeCount: 1
   secureSettings:
     secretName: apm-secret-settings

--- a/docs/elasticsearch-spec.asciidoc
+++ b/docs/elasticsearch-spec.asciidoc
@@ -381,7 +381,7 @@ kind: Elasticsearch
 metadata:
   name: quickstart
 spec:
-  version: 7.1.0
+  version: 7.2.0
   nodes:
   - nodeCount: 3
     config:

--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -160,17 +160,7 @@ NOTE: For testing purposes only, you can specify the `-k` option to turn off cer
   "name" : "quickstart-es-r56c9dzzcr",
   "cluster_name" : "quickstart",
   "cluster_uuid" : "XqWg0xIiRmmEBg4NMhnYPg",
-  "version" : {
-    "number" : "7.2.0",
-    "build_flavor" : "default",
-    "build_type" : "docker",
-    "build_hash" : "04116c9",
-    "build_date" : "2019-05-08T06:20:03.781729Z",
-    "build_snapshot" : true,
-    "lucene_version" : "8.0.0",
-    "minimum_wire_compatibility_version" : "6.8.0",
-    "minimum_index_compatibility_version" : "6.0.0-beta1"
-  },
+  "version" : {...},
   "tagline" : "You Know, for Search"
 }
 ----

--- a/docs/snapshots.asciidoc
+++ b/docs/snapshots.asciidoc
@@ -28,8 +28,8 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 7.1.0
-  image: your/custom/image:7.1.0
+  version: 7.2.0
+  image: your/custom/image:tag
   nodes:
   - nodeCount: 1
 ----
@@ -43,7 +43,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 7.1.0
+  version: 7.2.0
   nodes:
   - podTemplate:
       spec:

--- a/operators/config/samples/apm/apm_es_kibana.yaml
+++ b/operators/config/samples/apm/apm_es_kibana.yaml
@@ -5,7 +5,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: "7.2.0"
+  version: 7.2.0
   nodes:
   - nodeCount: 3
 ---
@@ -14,7 +14,7 @@ kind: ApmServer
 metadata:
   name: apm-server-sample
 spec:
-  version: "7.2.0"
+  version: 7.2.0
   nodeCount: 1
   elasticsearchRef:
     name: "elasticsearch-sample"
@@ -24,7 +24,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: "7.2.0"
+  version: 7.2.0
   nodeCount: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/operators/config/samples/apm/apmserver.yaml
+++ b/operators/config/samples/apm/apmserver.yaml
@@ -3,7 +3,7 @@ kind: ApmServer
 metadata:
   name: apmserver-sample
 spec:
-  version: "7.2.0"
+  version: 7.2.0
   nodeCount: 1
   config:
     output.console:

--- a/operators/config/samples/elasticsearch/elasticsearch.yaml
+++ b/operators/config/samples/elasticsearch/elasticsearch.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: "7.2.0"
+  version: 7.2.0
   nodes:
   - config:
       # most Elasticsearch configuration parameters are possible to set, e.g:

--- a/operators/config/samples/kibana/kibana.yaml
+++ b/operators/config/samples/kibana/kibana.yaml
@@ -4,7 +4,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: "7.1.0"
+  version: 7.2.0
   elasticsearch:
     url: https://url.to.elasticsearch:9200
     auth:

--- a/operators/config/samples/kibana/kibana_es.yaml
+++ b/operators/config/samples/kibana/kibana_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: "7.1.0"
+  version: 7.2.0
   nodes:
   - nodeCount: 1
 ---
@@ -13,7 +13,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: "7.1.0"
+  version: 7.2.0
   nodeCount: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/operators/hack/update-doc-stack-version.sh
+++ b/operators/hack/update-doc-stack-version.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+#
+# Update the Elastic stack version in samples and documentation.
+# Usage: ./hack/update-doc-stack-version.sh <version>
+#
+
+set -eu
+
+# Elastic stack version
+VERSION="$1"
+
+# Directories containing version references to replace
+: "${DIRS:="config/samples ../docs"}"
+
+# For all yaml and asciidoc files in the directory trees, replace the existing version with sed.
+# We use the "-i.bak" trick to be compatible with both Linux and OSX.
+# We are replacing occurrences of:
+# - version: 1.2.3<EOL>
+# - version: "1.2.3"<EOL>
+# - quickstart    green     1         1.2.3    (special case for es & apm quickstart)
+LC_CTYPE=C LANG=C find ${DIRS} -type f \( -iname \*.asciidoc -o -iname \*.yaml \) \
+    -exec sed -i.bak -E "s|version: \"?[0-9]\.[0-9]\.[0-9]\"?$|version: $VERSION|g" "{}" \; \
+    -exec sed -i.bak -E "s|quickstart[[:space:]]+green[[:space:]]+1[[:space:]]+[0-9]\.[0-9]\.[0-9]  |quickstart    green     1         $VERSION  |g" "{}" \; \
+    -exec rm "{}.bak" \;


### PR DESCRIPTION
Backport https://github.com/elastic/cloud-on-k8s/pull/1413.

Add a bash script to automatically update all referenced stack versions in docs and samples.
The script was applied with 7.2.0 (7.2.1 should be available soon, but isn't yet).

I had to deal with sed tricks to make it compatible with both OSX sed and GNU sed.
To avoid dealing with curl responses from Elasticsearch (GET /), I chose to shortcut the version section of the response to a simple {...}.

Another way of doing this would be to templatize docs and samples entirely, and generate them from the template. Which would be a bit cleaner, but also many more files. I thought this first step would maybe be good enough (until we have too many special cases).


* Add a bash script to replace all stack versions in docs and samples

* Run the script with 7.2.0

* Remove the version section of ES API response

* Set a version independant custom image tag example

* Replace image by tag

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/master/CONTRIBUTING.md)?
- If you submit code, is your pull request against master? We recommend pull requests against master. We will backport them as needed.
