### PR TITLE
Set the restricted SecurityContext in E2E TestCustomConfiguration

### DIFF
--- a/operators/test/e2e/es/podtemplate_test.go
+++ b/operators/test/e2e/es/podtemplate_test.go
@@ -61,7 +61,8 @@ func TestCustomConfiguration(t *testing.T) {
 					},
 				},
 			},
-		})
+		}).
+		WithRestrictedSecurityContext()
 
 	init := func(c *test.K8sClient) test.StepList {
 		return test.StepList{


### PR DESCRIPTION
The E2E tests are run in a k8s cluster configured with a Pod Security
Policy. This forces to set up a Security Context in the Pod template
of any Elastic custom resources in the E2E tests.
Normally this Security Context is set through `WithESMasterDataNodes`
but in this test, a custom Pod template defined just after overrides and
cancels it.
Thus `WithRestrictedSecurityContext` is called at the end to restore
the cancelled definition of the Security Context.