### PR TITLE
Add tool for cluster provisioning

### DIFF
--- a/.ci/jobs/e2e-tests-new.yaml
+++ b/.ci/jobs/e2e-tests-new.yaml
@@ -8,15 +8,13 @@
       artifactNumToKeep: 10
     name: cloud-on-k8s-e2e-tests-new
     project-type: pipeline
-    triggers:
-      - github
     concurrent: true
     pipeline-scm:
       scm:
         - git:
             url: https://github.com/elastic/cloud-on-k8s
             branches:
-              - e2e-testing
+              - master
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
       script-path: build/ci/e2e/Jenkinsfile-new
       lightweight-checkout: true

--- a/.ci/jobs/e2e-tests-new.yaml
+++ b/.ci/jobs/e2e-tests-new.yaml
@@ -1,0 +1,24 @@
+---
+- job:
+    description: Job that runs e2e tests-new against Elastic Cloud on Kubernetes running in a dedicated k8s cluster. This Job is managed by JJB.
+    logrotate:
+      daysToKeep: 7
+      numToKeep: 100
+      artifactDaysToKeep: 5
+      artifactNumToKeep: 10
+    name: cloud-on-k8s-e2e-tests-new
+    project-type: pipeline
+    triggers:
+      - github
+    concurrent: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/elastic/cloud-on-k8s
+            branches:
+              - e2e-testing
+            credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
+      script-path: build/ci/e2e/Jenkinsfile-new
+      lightweight-checkout: true
+    wrappers:
+      - ansicolor

--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -113,6 +113,24 @@ yaml-upload: vault-aws-creds
 
 ## -- End-to-end tests job
 
+ci-e2e-new:
+	docker build -f Dockerfile -t cloud-on-k8s-ci-e2e .
+	docker run --rm -t \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
+		-w $(GO_MOUNT_PATH) \
+		cloud-on-k8s-ci-e2e \
+		bash -c "make -C operators ci-e2e-new"
+
+ci-deployer-new:
+	docker build -f Dockerfile -t cloud-on-k8s-ci-e2e .
+	docker run --rm -t \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
+		-w $(GO_MOUNT_PATH) \
+		cloud-on-k8s-ci-e2e \
+		bash -c "make -C operators deployer-new"
+
 # Spawn a k8s cluster, and run e2e tests against it
 ci-e2e: vault-gke-creds
 	docker build -f Dockerfile -t cloud-on-k8s-ci-e2e .

--- a/build/ci/e2e/Jenkinsfile-new
+++ b/build/ci/e2e/Jenkinsfile-new
@@ -35,7 +35,7 @@ overrides:
   vaultRoleId: $VAULT_ROLE_ID
   vaultSecretId: $VAULT_SECRET_ID
   gke:
-    gcloudProject: $GCLOUD_PROJECT
+    gCloudProject: $GCLOUD_PROJECT
 EOF
                     make -C build/ci ci-e2e-new
                 """
@@ -67,7 +67,7 @@ overrides:
   vaultRoleId: $VAULT_ROLE_ID
   vaultSecretId: $VAULT_SECRET_ID
   gke:
-    gcloudProject: $GCLOUD_PROJECT
+    gCloudProject: $GCLOUD_PROJECT
 EOF
                     make -C build/ci ci-deployer-new
                 """

--- a/build/ci/e2e/Jenkinsfile-new
+++ b/build/ci/e2e/Jenkinsfile-new
@@ -37,7 +37,7 @@ overrides:
   gke:
     gcloudProject: $GCLOUD_PROJECT
 EOF
-                    sh 'make -C build/ci ci-e2e-new'
+                    make -C build/ci ci-e2e-new
                 """
             }
         }
@@ -75,5 +75,4 @@ EOF
             cleanWs()
         }
     }
-
 }

--- a/build/ci/e2e/Jenkinsfile-new
+++ b/build/ci/e2e/Jenkinsfile-new
@@ -1,0 +1,72 @@
+pipeline {
+
+    agent {
+        label 'linux'
+    }
+
+    options {
+        timeout(time: 150, unit: 'MINUTES')
+    }
+
+    environment {
+        VAULT_ADDR = credentials('vault-addr')
+        VAULT_ROLE_ID = credentials('vault-role-id')
+        VAULT_SECRET_ID = credentials('vault-secret-id')
+        CLUSTER_VERSION = '1.12'
+        CLUSTER_NAME = "${BUILD_TAG}"
+    }
+
+    stages {
+        stage('Checkout from GitHub') {
+            steps {
+                checkout scm
+            }
+        }
+        stage("Run E2E tests") {
+            steps {
+                cat >operators/run-config.yml <<EOF
+id: gke
+overrides:
+  kubernetesVersion: $CLUSTER_VERSION
+  clusterName: $CLUSTER_NAME
+  vaultAddress: $VAULT_ADDR
+  vaultRoleId: $VAULT_ROLE_ID
+  vaultSecretId: $VAULT_SECRET_ID
+EOF
+                sh 'make -C build/ci ci-e2e-new'
+            }
+        }
+    }
+
+    post {
+        unsuccessful {
+            script {
+                def msg = "E2E tests with deployer failed!\r\n" + env.BUILD_URL
+                slackSend botUser: true,
+                      channel: '#cloud-k8s',
+                      color: 'danger',
+                      message: msg,
+                      tokenCredentialId: 'cloud-ci-slack-integration-token'
+            }
+        }
+        cleanup {
+            script {
+                sh """
+                    cat >operators/run-config.yml <<EOF
+id: gke
+overrides:
+  operation: delete
+  kubernetesVersion: $CLUSTER_VERSION
+  clusterName: $CLUSTER_NAME
+  vaultAddress: $VAULT_ADDR
+  vaultRoleId: $VAULT_ROLE_ID
+  vaultSecretId: $VAULT_SECRET_ID
+EOF
+                    make -C build/ci ci-deployer-new
+                """
+            }
+            cleanWs()
+        }
+    }
+
+}

--- a/build/ci/e2e/Jenkinsfile-new
+++ b/build/ci/e2e/Jenkinsfile-new
@@ -24,7 +24,8 @@ pipeline {
         }
         stage("Run E2E tests") {
             steps {
-                cat >operators/run-config.yml <<EOF
+                sh """
+                    cat >operators/run-config.yml <<EOF
 id: gke
 overrides:
   kubernetesVersion: $CLUSTER_VERSION
@@ -33,7 +34,8 @@ overrides:
   vaultRoleId: $VAULT_ROLE_ID
   vaultSecretId: $VAULT_SECRET_ID
 EOF
-                sh 'make -C build/ci ci-e2e-new'
+                    sh 'make -C build/ci ci-e2e-new'
+                """
             }
         }
     }

--- a/build/ci/e2e/Jenkinsfile-new
+++ b/build/ci/e2e/Jenkinsfile-new
@@ -12,6 +12,7 @@ pipeline {
         VAULT_ADDR = credentials('vault-addr')
         VAULT_ROLE_ID = credentials('vault-role-id')
         VAULT_SECRET_ID = credentials('vault-secret-id')
+        GCLOUD_PROJECT = credentials('k8s-operators-gcloud-project')
         CLUSTER_VERSION = '1.12'
         CLUSTER_NAME = "${BUILD_TAG}"
     }
@@ -26,13 +27,15 @@ pipeline {
             steps {
                 sh """
                     cat >operators/run-config.yml <<EOF
-id: gke
+id: gke-ci
 overrides:
   kubernetesVersion: $CLUSTER_VERSION
   clusterName: $CLUSTER_NAME
   vaultAddress: $VAULT_ADDR
   vaultRoleId: $VAULT_ROLE_ID
   vaultSecretId: $VAULT_SECRET_ID
+  gke:
+    gcloudProject: $GCLOUD_PROJECT
 EOF
                     sh 'make -C build/ci ci-e2e-new'
                 """
@@ -55,7 +58,7 @@ EOF
             script {
                 sh """
                     cat >operators/run-config.yml <<EOF
-id: gke
+id: gke-ci
 overrides:
   operation: delete
   kubernetesVersion: $CLUSTER_VERSION
@@ -63,6 +66,8 @@ overrides:
   vaultAddress: $VAULT_ADDR
   vaultRoleId: $VAULT_ROLE_ID
   vaultSecretId: $VAULT_SECRET_ID
+  gke:
+    gcloudProject: $GCLOUD_PROJECT
 EOF
                     make -C build/ci ci-deployer-new
                 """

--- a/operators/Makefile
+++ b/operators/Makefile
@@ -160,6 +160,9 @@ apply-operators:
 	MANAGED_NAMESPACE=$(MANAGED_NAMESPACE) \
 		$(MAKE) --no-print-directory -sC config/operator generate-namespace | kubectl apply -f -
 
+apply-psp:
+	kubectl apply -f config/dev/elastic-psp.yaml
+
 generate-crds:
 	for yaml in $$(ls config/crds/*); do \
 		cat $$yaml && echo -e "\n---\n" ; \
@@ -236,7 +239,7 @@ bootstrap-gke: require-gcloud-project
 	PSP=$(PSP) GKE_CLUSTER_VERSION=$(GKE_CLUSTER_VERSION) ./hack/gke-cluster.sh create
 	$(MAKE) set-context-gke cluster-bootstrap
 ifeq ($(PSP), 1)
-	kubectl apply -f config/dev/elastic-psp.yaml
+	$(MAKE) apply-psp
 endif
 
 delete-gke: require-gcloud-project
@@ -337,6 +340,13 @@ ci-release: export LICENSE_PUBKEY = $(ROOT_DIR)/build/ci/license.key
 ci-release:
 	@ $(MAKE) dep-vendor-only generate docker-build docker-push
 	@ echo $(OPERATOR_IMAGE) was pushed!
+
+ci-e2e-new: deployer-new
+	$(MAKE) IMG_SUFFIX=-ci cluster-bootstrap apply-psp e2e
+
+deployer-new:
+	@ go build -o hack/deployer/deployer ./hack/deployer/...
+	./hack/deployer/deployer --plans-file hack/deployer/config/plans.yml --run-config-file run-config.yml
 
 
 ##########################

--- a/operators/hack/deployer/command.go
+++ b/operators/hack/deployer/command.go
@@ -1,0 +1,74 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"text/template"
+)
+
+// Command allows building commands to execute using fluent-style api
+type Command struct {
+	command   string
+	params    map[string]interface{}
+	variables []string
+	stream    bool
+}
+
+func NewCommand(command string) *Command {
+	return &Command{command: command, stream: true}
+}
+
+func (c *Command) AsTemplate(params map[string]interface{}) *Command {
+	c.params = params
+	return c
+}
+
+func (c *Command) WithVariable(name, value string) *Command {
+	c.variables = append(c.variables, name+"="+value)
+	return c
+}
+
+func (c *Command) WithoutStreaming() *Command {
+	c.stream = false
+	return c
+}
+
+func (c *Command) Run() error {
+	_, err := c.output()
+	return err
+}
+
+func (c *Command) Output() (string, error) {
+	return c.output()
+}
+
+func (c *Command) output() (string, error) {
+	if c.params != nil {
+		var b bytes.Buffer
+		if err := template.Must(template.New("").Parse(c.command)).Execute(&b, c.params); err != nil {
+			return "", err
+		}
+		c.command = b.String()
+	}
+
+	cmd := exec.Command("/usr/bin/env", "bash", "-c", c.command)
+	cmd.Env = append(os.Environ(), c.variables...)
+
+	b := bytes.Buffer{}
+	if c.stream {
+		cmd.Stdout = io.MultiWriter(os.Stdout, &b)
+		cmd.Stderr = io.MultiWriter(os.Stderr, &b)
+	} else {
+		cmd.Stdout = &b
+		cmd.Stderr = &b
+	}
+
+	err := cmd.Run()
+	return b.String(), err
+}

--- a/operators/hack/deployer/config/plans.yml
+++ b/operators/hack/deployer/config/plans.yml
@@ -9,7 +9,6 @@ plans:
   psp: true
   vmMapMax: true
   gke:
-    gcloudProject: elastic-cloud-dev
     region: europe-west1
     adminUsername: admin
     localSsdCount: 1

--- a/operators/hack/deployer/config/plans.yml
+++ b/operators/hack/deployer/config/plans.yml
@@ -1,0 +1,17 @@
+plans:
+- id: gke-ci
+  operation: create
+  clusterName: ci
+  provider: gke
+  kubernetesVersion: 1.13
+  machineType: n1-standard-8
+  serviceAccount: true
+  psp: true
+  vmMapMax: true
+  gke:
+    gcloudProject: elastic-cloud-dev
+    region: europe-west1
+    adminUsername: admin
+    localSsdCount: 1
+    nodeCountPerZone: 1
+    gcpScopes: https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append

--- a/operators/hack/deployer/driver.go
+++ b/operators/hack/deployer/driver.go
@@ -1,0 +1,87 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/imdario/mergo"
+)
+
+var (
+	drivers = make(map[string]DriverFactory)
+)
+
+// DriverFactory allows creating a driver
+type DriverFactory interface {
+	Create(Plan) (Driver, error)
+}
+
+// Driver allows executing a plan
+type Driver interface {
+	Execute() error
+}
+
+// GetDriver picks plan based on the run config and returns the appropriate driver
+func GetDriver(plans []Plan, config RunConfig) (Driver, error) {
+	plan, err := choosePlan(plans, config.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	plan, err = merge(plan, config.Overrides)
+	if err != nil {
+		return nil, err
+	}
+
+	driverFactory, err := chooseFactory(plan.Provider)
+	if err != nil {
+		return nil, err
+	}
+
+	return driverFactory.Create(plan)
+}
+
+func choosePlan(plans []Plan, id string) (Plan, error) {
+	for _, p := range plans {
+		if p.Id == id {
+			return p, nil
+		}
+	}
+
+	return Plan{}, fmt.Errorf("no plan with id %s found", id)
+}
+
+func merge(base Plan, overrides map[string]interface{}) (Plan, error) {
+	// mergo will not override with empty values which is inconvenient for booleans, hence custom transformer
+	err := mergo.Map(&base, overrides, mergo.WithOverride, mergo.WithTransformers(boolTransformer{}))
+	return base, err
+}
+
+type boolTransformer struct {
+}
+
+func (bt boolTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	var b bool
+	if typ == reflect.TypeOf(b) {
+		return func(dst, src reflect.Value) error {
+			if dst.CanSet() {
+				dst.SetBool(src.Interface().(bool))
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+func chooseFactory(provider string) (DriverFactory, error) {
+	driverFactory, ok := drivers[provider]
+	if !ok {
+		return nil, fmt.Errorf("no driver for provider with id %s found", provider)
+	}
+
+	return driverFactory, nil
+}

--- a/operators/hack/deployer/gke.go
+++ b/operators/hack/deployer/gke.go
@@ -1,0 +1,263 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+)
+
+const (
+	GkeDriverId                   = "gke"
+	GkeServiceAccountKeyVaultName = "secret/cloud-team/cloud-ci/ci-gcp-k8s-operator"
+)
+
+func init() {
+	drivers[GkeDriverId] = &GkeDriverFactory{}
+}
+
+type GkeDriverFactory struct {
+}
+
+type GkeDriver struct {
+	plan Plan
+}
+
+func (gdf *GkeDriverFactory) Create(plan Plan) (Driver, error) {
+	return &GkeDriver{plan: plan}, nil
+}
+
+func (d *GkeDriver) Execute() error {
+	if err := d.auth(); err != nil {
+		return err
+	}
+
+	exists, err := d.clusterExists()
+	if err != nil {
+		return err
+	}
+
+	switch d.plan.Operation {
+	case "delete":
+		if exists {
+			err = d.delete()
+		} else {
+			log.Printf("not deleting as cluster doesn't exist")
+		}
+	case "create":
+		if exists {
+			log.Printf("not creating as cluster exists")
+		} else {
+			if err := d.configSsh(); err != nil {
+				return err
+			}
+
+			if err := d.create(); err != nil {
+				return err
+			}
+
+			if err := d.bindRoles(); err != nil {
+				return err
+			}
+		}
+
+		if err := d.getCredentials(); err != nil {
+			return err
+		}
+
+		if d.plan.VmMapMax {
+			if err := d.setMaxMapCount(); err != nil {
+				return err
+			}
+		}
+
+		if err := d.configureDocker(); err != nil {
+			return err
+		}
+	default:
+		err = fmt.Errorf("unknown operation %s", d.plan.Operation)
+	}
+
+	return err
+}
+
+func (d *GkeDriver) auth() error {
+	if d.plan.ServiceAccount {
+		return d.serviceAuth()
+	} else {
+		return d.userAuth()
+	}
+}
+
+func (d *GkeDriver) serviceAuth() error {
+	log.Println("Authenticating as service account...")
+
+	serviceAccountKey, err := ReadVault(d.plan.VaultAddress, d.plan.VaultRoleId, d.plan.VaultSecretId, GkeServiceAccountKeyVaultName)
+	if err != nil {
+		return err
+	}
+
+	file, err := ioutil.TempFile(".", "gke_service_account_key-")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(file.Name())
+
+	if err := ioutil.WriteFile(file.Name(), []byte(serviceAccountKey), 0644); err != nil {
+		return err
+	}
+
+	return NewCommand("gcloud auth activate-service-account --key-file={{.FileName}}").
+		AsTemplate(map[string]interface{}{
+			"FileName": file.Name(),
+		}).
+		Run()
+}
+
+func (d *GkeDriver) userAuth() error {
+	log.Println("Authenticating as user...")
+	return NewCommand("gcloud auth login").Run()
+}
+
+func (d *GkeDriver) clusterExists() (bool, error) {
+	log.Println("Checking if cluster exists...")
+	out, err := NewCommand("gcloud beta container clusters --project {{.GCloudProject}} describe {{.ClusterName}} --region {{.Region}}").
+		AsTemplate(map[string]interface{}{
+			"GCloudProject": d.plan.Gke.GCloudProject,
+			"ClusterName":   d.plan.ClusterName,
+			"Region":        d.plan.Gke.Region,
+		}).
+		WithoutStreaming().
+		Output()
+
+	if strings.Contains(out, "Not found") {
+		return false, nil
+	}
+
+	return err == nil, err
+}
+
+func (d *GkeDriver) configSsh() error {
+	log.Println("Configuring ssh...")
+	return NewCommand("gcloud --quiet --project {{.GCloudProject}} compute config-ssh").
+		AsTemplate(map[string]interface{}{
+			"GCloudProject": d.plan.Gke.GCloudProject,
+		}).
+		Run()
+}
+
+func (d *GkeDriver) create() error {
+	log.Println("Creating cluster...")
+	pspOption := ""
+	if d.plan.Psp {
+		pspOption = "--enable-pod-security-policy"
+	}
+
+	return NewCommand(`gcloud beta container --project {{.GCloudProject}} clusters create {{.ClusterName}} ` +
+		`--region {{.Region}} --username {{.AdminUsername}} --cluster-version {{.KubernetesVersion}} ` +
+		`--machine-type {{.MachineType}} --image-type COS --disk-type pd-ssd --disk-size 30 ` +
+		`--local-ssd-count {{.LocalSsdCount}} --scopes {{.GcpScopes}} --num-nodes {{.NodeCountPerZone}} ` +
+		`--enable-cloud-logging --enable-cloud-monitoring --addons HorizontalPodAutoscaling,HttpLoadBalancing ` +
+		`--no-enable-autoupgrade --no-enable-autorepair --network projects/{{.GCloudProject}}/global/networks/default ` +
+		`--subnetwork projects/{{.GCloudProject}}/regions/{{.Region}}/subnetworks/default {{.PspOption}}`).
+		AsTemplate(map[string]interface{}{
+			"GCloudProject":     d.plan.Gke.GCloudProject,
+			"ClusterName":       d.plan.ClusterName,
+			"Region":            d.plan.Gke.Region,
+			"AdminUsername":     d.plan.Gke.AdminUsername,
+			"KubernetesVersion": d.plan.KubernetesVersion,
+			"MachineType":       d.plan.MachineType,
+			"LocalSsdCount":     d.plan.Gke.LocalSsdCount,
+			"GcpScopes":         d.plan.Gke.GcpScopes,
+			"NodeCountPerZone":  d.plan.Gke.NodeCountPerZone,
+			"PspOption":         pspOption,
+		}).
+		Run()
+}
+
+func (d *GkeDriver) bindRoles() error {
+	log.Println("Binding roles...")
+	user, err := NewCommand(`gcloud auth list --filter=status:ACTIVE --format="value(account)"`).Output()
+	if err != nil {
+		return err
+	}
+
+	return NewCommand("kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user={{.User}}").
+		AsTemplate(map[string]interface{}{
+			"User": user,
+		}).
+		Run()
+}
+
+func (d *GkeDriver) setMaxMapCount() error {
+	log.Println("Setting max map count...")
+	out, err := NewCommand(`gcloud compute instances list ` +
+		`--project={{.GCloudProject}} ` +
+		`--filter="metadata.items.key['cluster-name']['value']='{{.ClusterName}}' AND metadata.items.key['cluster-name']['value']!='' " ` +
+		`--format="value[separator=','](name,zone)" --verbosity=error`).
+		AsTemplate(map[string]interface{}{
+			"GCloudProject": d.plan.Gke.GCloudProject,
+			"ClusterName":   d.plan.ClusterName,
+		}).
+		Output()
+	if err != nil {
+		return err
+	}
+
+	for _, instance := range strings.Split(out, "\n") {
+		if instance == "" {
+			continue
+		}
+
+		nameZone := strings.Split(instance, ",")
+		if len(nameZone) != 2 {
+			return fmt.Errorf("instance %s could not be parsed", instance)
+		}
+
+		name, zone := nameZone[0], nameZone[1]
+		err := NewCommand(`gcloud -q compute ssh jenkins@{{.Name}} --project={{.GCloudProject}} --zone={{.Zone}} --command="sudo sysctl -w vm.max_map_count=262144"`).
+			AsTemplate(map[string]interface{}{
+				"GCloudProject": d.plan.Gke.GCloudProject,
+				"Name":          name,
+				"Zone":          zone,
+			}).
+			Run()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *GkeDriver) configureDocker() error {
+	log.Println("Configuring Docker...")
+	return NewCommand("gcloud auth configure-docker --quiet").Run()
+}
+
+func (d *GkeDriver) getCredentials() error {
+	log.Println("Getting credentials...")
+	return NewCommand("gcloud beta --project {{.GCloudProject}} container clusters get-credentials {{.ClusterName}} --region {{.Region}}").
+		AsTemplate(map[string]interface{}{
+			"GCloudProject": d.plan.Gke.GCloudProject,
+			"ClusterName":   d.plan.ClusterName,
+			"Region":        d.plan.Gke.Region,
+		}).
+		Run()
+}
+
+func (d *GkeDriver) delete() error {
+	log.Println("Deleting cluster...")
+	return NewCommand("gcloud beta --quiet --project {{.GCloudProject}} container clusters delete {{.ClusterName}} --region {{.Region}}").
+		AsTemplate(map[string]interface{}{
+			"GCloudProject": d.plan.Gke.GCloudProject,
+			"ClusterName":   d.plan.ClusterName,
+			"Region":        d.plan.Gke.Region,
+		}).
+		Run()
+}

--- a/operators/hack/deployer/main.go
+++ b/operators/hack/deployer/main.go
@@ -1,0 +1,65 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/ghodss/yaml"
+)
+
+func main() {
+	plansFile := flag.String("plans-file", "config/plans.yml", "File containing execution plans.")
+	configFile := flag.String("run-config-file", "config/run-config.yml", "File containing run config.")
+	flag.Parse()
+
+	plans, err := parsePlans(*plansFile)
+	if err != nil {
+		log.Printf("error %s while trying to parse plans file at %s", err, *plansFile)
+		os.Exit(1)
+	}
+
+	runConfig, err := parseRunConfig(*configFile)
+	if err != nil {
+		log.Printf("error %s while trying to parse runConfig file at %s", err, *configFile)
+		os.Exit(1)
+	}
+
+	err = run(plans, runConfig)
+	if err != nil {
+		log.Printf("error %s while running plans at %s with runConfig at %s", err, *plansFile, *configFile)
+		os.Exit(1)
+	}
+}
+
+func run(plans Plans, runConfig RunConfig) error {
+	driver, err := GetDriver(plans.Plans, runConfig)
+	if err != nil {
+		return err
+	}
+
+	return driver.Execute()
+}
+
+func parsePlans(path string) (plans Plans, err error) {
+	yml, err := ioutil.ReadFile(path)
+	if err == nil {
+		err = yaml.Unmarshal(yml, &plans)
+	}
+
+	return
+}
+
+func parseRunConfig(path string) (runConfig RunConfig, err error) {
+	yml, err := ioutil.ReadFile(path)
+	if err == nil {
+		err = yaml.Unmarshal(yml, &runConfig)
+	}
+
+	return
+}

--- a/operators/hack/deployer/settings.go
+++ b/operators/hack/deployer/settings.go
@@ -1,0 +1,46 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+// Plans encapsulates list of plans, expected to map to a file
+type Plans struct {
+	Plans []Plan
+}
+
+// Plan encapsulates information needed to provision a cluster
+type Plan struct {
+	Id                string `yaml:"id"`
+	Operation         string `yaml:"operation"`
+	ClusterName       string `yaml:"clusterName"`
+	Provider          string `yaml:"provider"`
+	KubernetesVersion string `yaml:"kubernetesVersion"`
+	MachineType       string `yaml:"machineType"`
+	ServiceAccount    bool   `yaml:"serviceAccount"`
+
+	Psp      bool `yaml:"psp"`
+	VmMapMax bool `yaml:"vmMapMax"`
+
+	Gke *GkeSettings `yaml:"gke,omitempty"`
+
+	VaultAddress  string `yaml:"vaultAddress"`
+	VaultRoleId   string `yaml:"vaultRoleId"`
+	VaultSecretId string `yaml:"vaultSecretId"`
+}
+
+// GkeSettings encapculates settings specific to GKE
+type GkeSettings struct {
+	GCloudProject    string `yaml:"gcloudProject"`
+	Region           string `yaml:"region"`
+	AdminUsername    string `yaml:"adminUsername"`
+	LocalSsdCount    int64  `yaml:"localSsdCount"`
+	NodeCountPerZone int64  `yaml:"nodeCountPerZone"`
+	GcpScopes        string `yaml:"gcpScopes"`
+}
+
+// RunConfig encapsulates Id used to choose a plan and a map of overrides to apply to the plan, expected to map to a file
+type RunConfig struct {
+	Id        string                 `yaml:"id"`
+	Overrides map[string]interface{} `yaml:"overrides"`
+}

--- a/operators/hack/deployer/settings.go
+++ b/operators/hack/deployer/settings.go
@@ -29,9 +29,9 @@ type Plan struct {
 	VaultSecretId string `yaml:"vaultSecretId"`
 }
 
-// GkeSettings encapculates settings specific to GKE
+// GkeSettings encapsulates settings specific to GKE
 type GkeSettings struct {
-	GCloudProject    string `yaml:"gcloudProject"`
+	GCloudProject    string `yaml:"gCloudProject"`
 	Region           string `yaml:"region"`
 	AdminUsername    string `yaml:"adminUsername"`
 	LocalSsdCount    int64  `yaml:"localSsdCount"`

--- a/operators/hack/deployer/vault.go
+++ b/operators/hack/deployer/vault.go
@@ -32,6 +32,9 @@ func ReadVaultIntoFile(fileName, address, roleId, secretId, name string) error {
 		WithVariable(vaultTokenName, vaultToken).
 		WithoutStreaming().
 		Output()
+	if err != nil {
+		return err
+	}
 
 	return ioutil.WriteFile(fileName, []byte(serviceAccountKey), 0644)
 }

--- a/operators/hack/deployer/vault.go
+++ b/operators/hack/deployer/vault.go
@@ -1,0 +1,33 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+const (
+	vaultTokenName = "VAULT_TOKEN"
+)
+
+// ReadVault is a helper function used to read from Hashicorp Vault
+func ReadVault(address, roleId, secretId, name string) (string, error) {
+	vaultToken, err := NewCommand("vault write -address={{.Address}} -field=token auth/approle/login role_id={{.RoleId}} secret_id={{.SecretId}}").
+		AsTemplate(map[string]interface{}{
+			"Address":  address,
+			"RoleId":   roleId,
+			"SecretId": secretId,
+		}).
+		WithoutStreaming().
+		Output()
+	if err != nil {
+		return "", err
+	}
+
+	return NewCommand("vault read -address={{.Address}} -field=service-account {{.Name}}").
+		AsTemplate(map[string]interface{}{
+			"Address": address,
+			"Name":    name,
+		}).
+		WithVariable(vaultTokenName, vaultToken).
+		WithoutStreaming().
+		Output()
+}


### PR DESCRIPTION
Part of the work for #1257.

This PR introduces:
1. new tool (deployer) to provision k8s cluster through different providers,
1. support for GKE,
1. Jenkins job and targets for running e2e tests with setup done by deployer.


The general idea is to delegate everything we can to the deployer and its file config. This way, when introducing new settings, new k8s providers or when paramaterizing runs in new dimensions we need to work only with the top layer (Jenkinsfile) and deployer itself. We avoid touching anything in between.


Deployer works with two files: plans and run-config. The idea is that a single plans file captures sane defaults for all providers/use cases that we have (ci on gke, ci on aks, dev cluster on gke, dev cluster on aks, etc.). run-config file is used to choose the specific plan and override its settings if needed. File based approach was choosen so that the config is opaque to middle layers that it is passing through. We might add overrides as deployer arguments if we find that's needed.

After this is merged it will work in parallel with current e2e test job. Next steps include moving all ci jobs and dev bootstrap to deployer, deprecating gke-cluster.sh, deprecating provider-specific Makefile targets and adding support for other providers. This will be tracked under #1257.