### PR TITLE
Update existing ADRs with recent design decisions

### DIFF
--- a/docs/design/0001-no-stateful-sets.md
+++ b/docs/design/0001-no-stateful-sets.md
@@ -1,8 +1,10 @@
 # 1. Stateful set or custom controller
 
-* Status: accepted 
+**Update (2019-07-30):** we decided to refactor the code towards using StatefulSets in order to manage Elasticsearch pods. Mostly in order to get closer to Kubernetes standards, simplify PersistentVolumes management, and stay open to future improvements in the ecosystem. For more details, see [the StatefulSets discussion issue](https://github.com/elastic/cloud-on-k8s/issues/1173).
+
+* Status: ~~accepted~~ rejected, superseded by https://github.com/elastic/cloud-on-k8s/issues/1173
 * Deciders: @nkvoll
-* Date: 2019-02-12
+* Date: ~~~2019-02-12~~ 2019-07-30
 
 ## Context and Problem Statement
 

--- a/docs/design/0003-associations/0003-associations.md
+++ b/docs/design/0003-associations/0003-associations.md
@@ -1,8 +1,17 @@
 # 3. Associations and relations between resources
 
-* Status: accepted 
+**Update (2019-07-30)**:
+We decided to restrict the number of CRDs to a minimum, and avoid additional CRDs for:
+
+* ES/Kibana association (replaced by a reference to the ES cluster in the Kibana CRD)
+* ES/APM association (replaced by a reference to the ES cluster in the Kibana CRD)
+* Users (replaced by Kubernetes Secrets)
+
+These were judged as confusing for the end user, and indicative of over-engineering.
+
+* Status: ~~accepted~~ rejected
 * Deciders: k8s team
-* Date: 2019-02-12
+* Date: ~~2019-02-12~~ 2019-07-30
 
 
 ## Context and Problem Statement

--- a/docs/design/0006-certificate-management.md
+++ b/docs/design/0006-certificate-management.md
@@ -1,5 +1,8 @@
 # Elasticsearch nodes certificate management
 
+**Update (2019-07-30):**
+We decided to simplify the way we handle self-signed TLS certificates and nodes private keys. They are still managed by the operator, but signed by the operator then passed to ES pods through secrets directly. The main benefit is to remove the complexity of the CSR init container outlined in this proposal. We now also handle a set of certificates for the Transport protocol, and another set for the HTTP protocol. User-provided certificates are also supported.
+
 * Status: proposed
 * Deciders: k8s team
 * Date: 2019-02-22

--- a/docs/design/0006-sidecar-health.md
+++ b/docs/design/0006-sidecar-health.md
@@ -1,5 +1,8 @@
 # 6. Elasticsearch sidecar health
 
+**Update (2019-07-30):**
+There is no sidecar anymore. The process-manager has been removed for simplification, and the keystore updater now runs as an init-container. Hence, there is no need to monitor the sidecar health anymore.
+
 * Status: proposed
 * Deciders: cloud-on-k8s team
 * Date: 2019-03-05

--- a/docs/design/0008-volume-management.md
+++ b/docs/design/0008-volume-management.md
@@ -1,5 +1,8 @@
 # 8. Volume Management in case of disruption
 
+**Update (2019-07-30)**:
+We decided to rely on StatefulSets to manage PersistentVolumes. While this ADR remains valid, our range of action is now limited to what is supported by the StatefulSet controller, responsible for creating and reusing PVCs.
+
 * Status: proposed
 * Deciders: cloud-on-k8s team
 * Date: 2019-03-08


### PR DESCRIPTION
Some of our ADRs are now deprecated. Let's make sure this is clearly specified at the top of the file.

I'm wondering if we should go further with deprecated ADRs and:

* remove the files entirely?
* move them to an `archive` subfolder?

Fixes https://github.com/elastic/cloud-on-k8s/issues/1169.