### PR TITLE
Add e2e test for kibana resources changes

### DIFF
--- a/operators/test/e2e/kb/resource_test.go
+++ b/operators/test/e2e/kb/resource_test.go
@@ -1,0 +1,53 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kb
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/elasticsearch"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/kibana"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestUpdateKibanaResources(t *testing.T) {
+	resources := corev1.ResourceRequirements{
+		Requests: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+		},
+		Limits: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+		},
+	}
+	name := "test-kb-resources"
+	esBuilder := elasticsearch.NewBuilder(name).
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+	kbBuilder := kibana.NewBuilder(name).
+		WithNodeCount(1).
+		WithResources(resources)
+
+	stepsFn := func(k *test.K8sClient) test.StepList {
+		return test.StepList{
+			test.Step{
+				Name: "Check resources are propagated to the pod spec",
+				Test: func(t *testing.T) {
+					pods, err := k.GetPods(test.KibanaPodListOptions(name))
+					require.NoError(t, err)
+					for _, p := range pods {
+						require.Equal(t, resources, p.Spec.Containers[0].Resources)
+					}
+				},
+			},
+		}
+	}
+
+	test.Sequence(nil, stepsFn, esBuilder, kbBuilder).
+		RunSequential(t)
+}

--- a/operators/test/e2e/test/kibana/builder.go
+++ b/operators/test/e2e/test/kibana/builder.go
@@ -72,6 +72,21 @@ func (b Builder) WithKibanaSecureSettings(secretName string) Builder {
 	return b
 }
 
+func (b Builder) WithResources(resources corev1.ResourceRequirements) Builder {
+	if len(b.Kibana.Spec.PodTemplate.Spec.Containers) == 0 {
+		b.Kibana.Spec.PodTemplate.Spec.Containers = []corev1.Container{
+			{Name: kbtype.KibanaContainerName},
+		}
+	}
+	for i, c := range b.Kibana.Spec.PodTemplate.Spec.Containers {
+		if c.Name == kbtype.KibanaContainerName {
+			c.Resources = resources
+			b.Kibana.Spec.PodTemplate.Spec.Containers[i] = c
+		}
+	}
+	return b
+}
+
 // -- Helper functions
 
 func (b Builder) RuntimeObjects() []runtime.Object {


### PR DESCRIPTION
Add an E2E test to check that setting custom resources requests and
limits on the podTemplate of the Kibana resource is propagated to the
pods created by the operator.

Resolves #773.