### PR TITLE
Drop single namespace assumption from E2E tests

### DIFF
--- a/operators/test/e2e/es/failure_test.go
+++ b/operators/test/e2e/es/failure_test.go
@@ -32,7 +32,7 @@ func TestKillOneDataNode(t *testing.T) {
 	}
 
 	test.RunFailure(t,
-		test.KillNodeSteps(test.ESPodListOptions(b.Elasticsearch.Name), matchDataNode),
+		test.KillNodeSteps(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name), matchDataNode),
 		b)
 }
 
@@ -47,7 +47,7 @@ func TestKillOneMasterNode(t *testing.T) {
 	}
 
 	test.RunFailure(t,
-		test.KillNodeSteps(test.ESPodListOptions(b.Elasticsearch.Name), matchMasterNode),
+		test.KillNodeSteps(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name), matchMasterNode),
 		b)
 }
 
@@ -60,7 +60,7 @@ func TestKillSingleNodeReusePV(t *testing.T) {
 	}
 
 	test.RunFailure(t,
-		test.KillNodeSteps(test.ESPodListOptions(b.Elasticsearch.Name), matchNode),
+		test.KillNodeSteps(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name), matchNode),
 		b)
 }
 
@@ -93,7 +93,7 @@ func TestKillCorrectPVReuse(t *testing.T) {
 			{
 				Name: "Kill a node",
 				Test: func(t *testing.T) {
-					pods, err := k.GetPods(test.ESPodListOptions(b.Elasticsearch.Name))
+					pods, err := k.GetPods(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name))
 					require.NoError(t, err)
 					require.True(t, len(pods) > 0, "need at least one pod to kill")
 					for i, pod := range pods {
@@ -108,7 +108,7 @@ func TestKillCorrectPVReuse(t *testing.T) {
 			{
 				Name: "Wait for pod to be deleted",
 				Test: test.Eventually(func() error {
-					pod, err := k.GetPod(killedPod.Name)
+					pod, err := k.GetPod(killedPod.Namespace, killedPod.Name)
 					if err != nil && !apierrors.IsNotFound(err) {
 						return err
 					}
@@ -150,7 +150,7 @@ func TestKillCorrectPVReuse(t *testing.T) {
 			Test: func(t *testing.T) {
 				// should be resurrected with same name due to second PVC still around and forcing the pods name
 				// back to the old one
-				pod, err := k.GetPod(killedPod.Name)
+				pod, err := k.GetPod(killedPod.Namespace, killedPod.Name)
 				require.NoError(t, err)
 				var checkedVolumes bool
 				for _, v := range pod.Spec.Volumes {
@@ -192,7 +192,7 @@ func TestDeleteServices(t *testing.T) {
 			{
 				Name: "Delete external service",
 				Test: func(t *testing.T) {
-					s, err := k.GetService(esname.HTTPService(b.Elasticsearch.Name))
+					s, err := k.GetService(b.Elasticsearch.Namespace, esname.HTTPService(b.Elasticsearch.Name))
 					require.NoError(t, err)
 					err = k.Client.Delete(s)
 					require.NoError(t, err)

--- a/operators/test/e2e/kb/association_test.go
+++ b/operators/test/e2e/kb/association_test.go
@@ -1,0 +1,41 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kb
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/elasticsearch"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/kibana"
+)
+
+// TestCrossNSAssociation tests associating ElasticSearch running in a different namespace.
+func TestCrossNSAssociation(t *testing.T) {
+	// This test currently does not work in the E2E environment because each namespace has a dedicated
+	// controller (see https://github.com/elastic/cloud-on-k8s/issues/1438)
+	if !test.Ctx().Local {
+		t.SkipNow()
+	}
+
+	esNamespace := test.Ctx().ManagedNamespace(0)
+	kbNamespace := test.Ctx().ManagedNamespace(1)
+	name := "test-cross-ns-assoc"
+
+	esBuilder := elasticsearch.NewBuilder(name).
+		WithNamespace(esNamespace).
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithRestrictedSecurityContext()
+
+	kbBuilder := kibana.NewBuilder(name).
+		WithNamespace(kbNamespace).
+		WithNodeCount(1).
+		WithRestrictedSecurityContext()
+	kbBuilder.Kibana.Spec.ElasticsearchRef.Name = name
+	kbBuilder.Kibana.Spec.ElasticsearchRef.Namespace = esNamespace
+
+	builders := []test.Builder{esBuilder, kbBuilder}
+	test.RunMutations(t, builders, builders)
+}

--- a/operators/test/e2e/kb/association_test.go
+++ b/operators/test/e2e/kb/association_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/kibana"
 )
 
-// TestCrossNSAssociation tests associating ElasticSearch running in a different namespace.
+// TestCrossNSAssociation tests associating Elasticsearch and Kibana running in different namespaces.
 func TestCrossNSAssociation(t *testing.T) {
 	// This test currently does not work in the E2E environment because each namespace has a dedicated
 	// controller (see https://github.com/elastic/cloud-on-k8s/issues/1438)

--- a/operators/test/e2e/kb/failure_test.go
+++ b/operators/test/e2e/kb/failure_test.go
@@ -28,7 +28,7 @@ func TestKillKibanaPod(t *testing.T) {
 		return true
 	}
 	test.RunFailure(t,
-		test.KillNodeSteps(test.KibanaPodListOptions(kbBuilder.Kibana.Name), matchFirst),
+		test.KillNodeSteps(test.KibanaPodListOptions(kbBuilder.Kibana.Namespace, kbBuilder.Kibana.Name), matchFirst),
 		esBuilder, kbBuilder)
 }
 

--- a/operators/test/e2e/kb/keystore_test.go
+++ b/operators/test/e2e/kb/keystore_test.go
@@ -45,6 +45,8 @@ func TestUpdateKibanaSecureSettings(t *testing.T) {
 		WithNodeCount(1).
 		WithKibanaSecureSettings(secureSettings.Name)
 
+	namespace := kbBuilder.Kibana.Namespace
+
 	initStepsFn := func(k *test.K8sClient) test.StepList {
 		return test.StepList{
 			{
@@ -61,7 +63,7 @@ func TestUpdateKibanaSecureSettings(t *testing.T) {
 	}
 	stepsFn := func(k *test.K8sClient) test.StepList {
 		return test.StepList{
-			test.CheckKeystoreEntries(k, test.KibanaPodListOptions(name), KibanaKeystoreCmd, []string{"logging.verbose"}),
+			test.CheckKeystoreEntries(k, test.KibanaPodListOptions(namespace, name), KibanaKeystoreCmd, []string{"logging.verbose"}),
 			// modify the secure settings secret
 			test.Step{
 				Name: "Modify secure settings secret",
@@ -77,7 +79,7 @@ func TestUpdateKibanaSecureSettings(t *testing.T) {
 			},
 
 			// keystore should be updated accordingly
-			test.CheckKeystoreEntries(k, test.KibanaPodListOptions(name), KibanaKeystoreCmd, []string{"logging.json", "logging.verbose"}),
+			test.CheckKeystoreEntries(k, test.KibanaPodListOptions(namespace, name), KibanaKeystoreCmd, []string{"logging.json", "logging.verbose"}),
 
 			// remove the secure settings reference
 			test.Step{
@@ -95,7 +97,7 @@ func TestUpdateKibanaSecureSettings(t *testing.T) {
 			},
 
 			// keystore should be updated accordingly
-			test.CheckKeystoreEntries(k, test.KibanaPodListOptions(name), KibanaKeystoreCmd, nil),
+			test.CheckKeystoreEntries(k, test.KibanaPodListOptions(namespace, name), KibanaKeystoreCmd, nil),
 
 			// cleanup extra resources
 			test.Step{

--- a/operators/test/e2e/kb/resource_test.go
+++ b/operators/test/e2e/kb/resource_test.go
@@ -38,7 +38,7 @@ func TestUpdateKibanaResources(t *testing.T) {
 			test.Step{
 				Name: "Check resources are propagated to the pod spec",
 				Test: func(t *testing.T) {
-					pods, err := k.GetPods(test.KibanaPodListOptions(name))
+					pods, err := k.GetPods(test.KibanaPodListOptions(kbBuilder.Kibana.Namespace, name))
 					require.NoError(t, err)
 					for _, p := range pods {
 						require.Equal(t, resources, p.Spec.Containers[0].Resources)

--- a/operators/test/e2e/test/apmserver/checks_k8s.go
+++ b/operators/test/e2e/test/apmserver/checks_k8s.go
@@ -53,7 +53,7 @@ func CheckApmServerPodsCount(b Builder, k *test.K8sClient) test.Step {
 	return test.Step{
 		Name: "ApmServer pods count should match the expected one",
 		Test: test.Eventually(func() error {
-			return k.CheckPodCount(test.ApmServerPodListOptions(b.ApmServer.Name), int(b.ApmServer.Spec.NodeCount))
+			return k.CheckPodCount(test.ApmServerPodListOptions(b.ApmServer.Namespace, b.ApmServer.Name), int(b.ApmServer.Spec.NodeCount))
 		}),
 	}
 }
@@ -63,7 +63,7 @@ func CheckApmServerPodsRunning(b Builder, k *test.K8sClient) test.Step {
 	return test.Step{
 		Name: "ApmServer pods should eventually be running",
 		Test: test.Eventually(func() error {
-			pods, err := k.GetPods(test.ApmServerPodListOptions(b.ApmServer.Name))
+			pods, err := k.GetPods(test.ApmServerPodListOptions(b.ApmServer.Namespace, b.ApmServer.Name))
 			if err != nil {
 				return err
 			}
@@ -85,7 +85,7 @@ func CheckServices(b Builder, k *test.K8sClient) test.Step {
 			for _, s := range []string{
 				b.ApmServer.Name + "-apm-http",
 			} {
-				if _, err := k.GetService(s); err != nil {
+				if _, err := k.GetService(b.ApmServer.Namespace, s); err != nil {
 					return err
 				}
 			}
@@ -102,7 +102,7 @@ func CheckServicesEndpoints(b Builder, k *test.K8sClient) test.Step {
 			for endpointName, addrCount := range map[string]int{
 				b.ApmServer.Name + "-apm-http": int(b.ApmServer.Spec.NodeCount),
 			} {
-				endpoints, err := k.GetEndpoints(endpointName)
+				endpoints, err := k.GetEndpoints(b.ApmServer.Namespace, endpointName)
 				if err != nil {
 					return err
 				}

--- a/operators/test/e2e/test/apmserver/http_client.go
+++ b/operators/test/e2e/test/apmserver/http_client.go
@@ -46,7 +46,7 @@ func NewApmServerClient(as apmtype.ApmServer, k *test.K8sClient) (*ApmClient, er
 	var caCerts []*x509.Certificate
 	if as.Spec.HTTP.TLS.Enabled() {
 		scheme = "https"
-		crts, err := k.GetHTTPCerts(name.APMNamer, as.Name)
+		crts, err := k.GetHTTPCerts(name.APMNamer, as.Namespace, as.Name)
 		if err != nil {
 			return nil, err
 		}

--- a/operators/test/e2e/test/apmserver/steps_deletion.go
+++ b/operators/test/e2e/test/apmserver/steps_deletion.go
@@ -50,7 +50,7 @@ func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
 		{
 			Name: "APM Server pods should be eventually be removed",
 			Test: test.Eventually(func() error {
-				return k.CheckPodCount(test.ApmServerPodListOptions(b.ApmServer.Name), 0)
+				return k.CheckPodCount(test.ApmServerPodListOptions(b.ApmServer.Namespace, b.ApmServer.Name), 0)
 			}),
 		},
 	}

--- a/operators/test/e2e/test/apmserver/steps_init.go
+++ b/operators/test/e2e/test/apmserver/steps_init.go
@@ -46,7 +46,7 @@ func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
 				}
 				// wait for ES pods to disappear
 				test.Eventually(func() error {
-					return k.CheckPodCount(test.ApmServerPodListOptions(b.ApmServer.Name), 0)
+					return k.CheckPodCount(test.ApmServerPodListOptions(b.ApmServer.Namespace, b.ApmServer.Name), 0)
 				})(t)
 			},
 		},

--- a/operators/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/operators/test/e2e/test/elasticsearch/checks_k8s.go
@@ -38,13 +38,13 @@ func CheckCertificateAuthority(b Builder, k *test.K8sClient) test.Step {
 		Name: "ES certificate authority should be set and deployed",
 		Test: test.Eventually(func() error {
 			// Check that the Transport CA may be loaded
-			_, err := k.GetCA(b.Elasticsearch.Name, certificates.TransportCAType)
+			_, err := k.GetCA(b.Elasticsearch.Namespace, b.Elasticsearch.Name, certificates.TransportCAType)
 			if err != nil {
 				return err
 			}
 
 			// Check that the HTTP CA may be loaded
-			_, err = k.GetCA(b.Elasticsearch.Name, certificates.HTTPCAType)
+			_, err = k.GetCA(b.Elasticsearch.Namespace, b.Elasticsearch.Name, certificates.HTTPCAType)
 			if err != nil {
 				return err
 			}
@@ -59,12 +59,12 @@ func CheckPodCertificates(b Builder, k *test.K8sClient) test.Step {
 	return test.Step{
 		Name: "ES pods should eventually have a certificate",
 		Test: test.Eventually(func() error {
-			pods, err := k.GetPods(test.ESPodListOptions(b.Elasticsearch.Name))
+			pods, err := k.GetPods(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name))
 			if err != nil {
 				return err
 			}
 			for _, pod := range pods {
-				_, _, err := k.GetTransportCert(pod.Name)
+				_, _, err := k.GetTransportCert(pod.Namespace, pod.Name)
 				if err != nil {
 					return err
 				}
@@ -79,7 +79,7 @@ func CheckESPodsRunning(b Builder, k *test.K8sClient) test.Step {
 	return test.Step{
 		Name: "ES pods should eventually be running",
 		Test: test.Eventually(func() error {
-			pods, err := k.GetPods(test.ESPodListOptions(b.Elasticsearch.Name))
+			pods, err := k.GetPods(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name))
 			if err != nil {
 				return err
 			}
@@ -99,7 +99,7 @@ func CheckESVersion(b Builder, k *test.K8sClient) test.Step {
 	return test.Step{
 		Name: "ES version should be the expected one",
 		Test: test.Eventually(func() error {
-			pods, err := k.GetPods(test.ESPodListOptions(b.Elasticsearch.Name))
+			pods, err := k.GetPods(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name))
 			if err != nil {
 				return err
 			}
@@ -125,7 +125,7 @@ func CheckESPodsReady(b Builder, k *test.K8sClient) test.Step {
 	return test.Step{
 		Name: "ES pods should eventually be ready",
 		Test: test.Eventually(func() error {
-			pods, err := k.GetPods(test.ESPodListOptions(b.Elasticsearch.Name))
+			pods, err := k.GetPods(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name))
 			if err != nil {
 				return err
 			}
@@ -175,7 +175,7 @@ func CheckServices(b Builder, k *test.K8sClient) test.Step {
 			for _, s := range []string{
 				esname.HTTPService(b.Elasticsearch.Name),
 			} {
-				if _, err := k.GetService(s); err != nil {
+				if _, err := k.GetService(b.Elasticsearch.Namespace, s); err != nil {
 					return err
 				}
 			}
@@ -195,7 +195,7 @@ func CheckServicesEndpoints(b Builder, k *test.K8sClient) test.Step {
 				if addrCount == 0 {
 					continue // maybe no Kibana
 				}
-				endpoints, err := k.GetEndpoints(endpointName)
+				endpoints, err := k.GetEndpoints(b.Elasticsearch.Namespace, endpointName)
 				if err != nil {
 					return err
 				}
@@ -234,7 +234,7 @@ func CheckESPassword(b Builder, k *test.K8sClient) test.Step {
 	return test.Step{
 		Name: "Elastic password should be available",
 		Test: test.Eventually(func() error {
-			password, err := k.GetElasticPassword(b.Elasticsearch.Name)
+			password, err := k.GetElasticPassword(b.Elasticsearch.Namespace, b.Elasticsearch.Name)
 			if err != nil {
 				return err
 			}

--- a/operators/test/e2e/test/elasticsearch/checks_keystore.go
+++ b/operators/test/e2e/test/elasticsearch/checks_keystore.go
@@ -21,7 +21,7 @@ func CheckESKeystoreEntries(k *test.K8sClient, es v1alpha1.Elasticsearch, expect
 	return test.Step{
 		Name: "Elasticsearch secure settings should eventually be set in all nodes keystore",
 		Test: test.Eventually(func() error {
-			pods, err := k.GetPods(test.ESPodListOptions(es.Name))
+			pods, err := k.GetPods(test.ESPodListOptions(es.Namespace, es.Name))
 			if err != nil {
 				return err
 			}

--- a/operators/test/e2e/test/elasticsearch/checks_volume.go
+++ b/operators/test/e2e/test/elasticsearch/checks_volume.go
@@ -30,7 +30,7 @@ func CheckESDataVolumeType(es estype.Elasticsearch, k *test.K8sClient) test.Step
 		Name: "Elasticsearch data volumes should be of the specified type",
 		Test: func(t *testing.T) {
 			checkForEmptyDir := usesEmptyDir(es)
-			pods, err := k.GetPods(test.ESPodListOptions(es.Name))
+			pods, err := k.GetPods(test.ESPodListOptions(es.Namespace, es.Name))
 			require.NoError(t, err)
 			for _, p := range pods {
 				for _, v := range p.Spec.Volumes {

--- a/operators/test/e2e/test/elasticsearch/http_client.go
+++ b/operators/test/e2e/test/elasticsearch/http_client.go
@@ -18,13 +18,13 @@ import (
 
 // NewElasticsearchClient returns an ES client for the given ES cluster
 func NewElasticsearchClient(es v1alpha1.Elasticsearch, k *test.K8sClient) (client.Client, error) {
-	password, err := k.GetElasticPassword(es.Name)
+	password, err := k.GetElasticPassword(es.Namespace, es.Name)
 	if err != nil {
 		return nil, err
 	}
 	esUser := client.UserAuth{Name: "elastic", Password: password}
 
-	caCert, err := k.GetHTTPCerts(name.ESNamer, es.Name)
+	caCert, err := k.GetHTTPCerts(name.ESNamer, es.Namespace, es.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/operators/test/e2e/test/elasticsearch/steps_deletion.go
+++ b/operators/test/e2e/test/elasticsearch/steps_deletion.go
@@ -51,7 +51,7 @@ func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
 		{
 			Name: "Elasticsearch pods should be eventually be removed",
 			Test: test.Eventually(func() error {
-				return k.CheckPodCount(test.ESPodListOptions(b.Elasticsearch.Name), 0)
+				return k.CheckPodCount(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name), 0)
 			}),
 		},
 	}

--- a/operators/test/e2e/test/elasticsearch/steps_init.go
+++ b/operators/test/e2e/test/elasticsearch/steps_init.go
@@ -56,7 +56,7 @@ func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
 				}
 				// wait for ES pods to disappear
 				test.Eventually(func() error {
-					return k.CheckPodCount(test.ESPodListOptions(b.Elasticsearch.Name), 0)
+					return k.CheckPodCount(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name), 0)
 				})(t)
 
 				// it may take some extra time for Elasticsearch to be fully deleted

--- a/operators/test/e2e/test/k8s_client.go
+++ b/operators/test/e2e/test/k8s_client.go
@@ -105,9 +105,9 @@ func (k *K8sClient) GetPods(listOpts k8sclient.ListOptions) ([]corev1.Pod, error
 	return podList.Items, nil
 }
 
-func (k *K8sClient) GetPod(name string) (corev1.Pod, error) {
+func (k *K8sClient) GetPod(namespace, name string) (corev1.Pod, error) {
 	var pod corev1.Pod
-	if err := k.Client.Get(types.NamespacedName{Namespace: Ctx().ManagedNamespace(0), Name: name}, &pod); err != nil {
+	if err := k.Client.Get(types.NamespacedName{Namespace: namespace, Name: name}, &pod); err != nil {
 		return corev1.Pod{}, err
 	}
 	return pod, nil
@@ -129,10 +129,10 @@ func (k *K8sClient) CheckPodCount(listOpts k8sclient.ListOptions, expectedCount 
 	return nil
 }
 
-func (k *K8sClient) GetService(name string) (*corev1.Service, error) {
+func (k *K8sClient) GetService(namespace, name string) (*corev1.Service, error) {
 	var service corev1.Service
 	key := types.NamespacedName{
-		Namespace: Ctx().ManagedNamespace(0),
+		Namespace: namespace,
 		Name:      name,
 	}
 	if err := k.Client.Get(key, &service); err != nil {
@@ -141,10 +141,10 @@ func (k *K8sClient) GetService(name string) (*corev1.Service, error) {
 	return &service, nil
 }
 
-func (k *K8sClient) GetEndpoints(name string) (*corev1.Endpoints, error) {
+func (k *K8sClient) GetEndpoints(namespace, name string) (*corev1.Endpoints, error) {
 	var endpoints corev1.Endpoints
 	key := types.NamespacedName{
-		Namespace: Ctx().ManagedNamespace(0),
+		Namespace: namespace,
 		Name:      name,
 	}
 	if err := k.Client.Get(key, &endpoints); err != nil {
@@ -153,12 +153,12 @@ func (k *K8sClient) GetEndpoints(name string) (*corev1.Endpoints, error) {
 	return &endpoints, nil
 }
 
-func (k *K8sClient) GetElasticPassword(esName string) (string, error) {
+func (k *K8sClient) GetElasticPassword(namespace, esName string) (string, error) {
 	secretName := esName + "-es-elastic-user"
 	elasticUserKey := "elastic"
 	var secret corev1.Secret
 	key := types.NamespacedName{
-		Namespace: Ctx().ManagedNamespace(0),
+		Namespace: namespace,
 		Name:      secretName,
 	}
 	if err := k.Client.Get(key, &secret); err != nil {
@@ -171,12 +171,12 @@ func (k *K8sClient) GetElasticPassword(esName string) (string, error) {
 	return string(password), nil
 }
 
-func (k *K8sClient) GetHTTPCerts(namer name.Namer, ownerName string) ([]*x509.Certificate, error) {
+func (k *K8sClient) GetHTTPCerts(namer name.Namer, ownerNamespace, ownerName string) ([]*x509.Certificate, error) {
 	var secret corev1.Secret
 	secretNSN := http.PublicCertsSecretRef(
 		namer,
 		types.NamespacedName{
-			Namespace: Ctx().ManagedNamespace(0),
+			Namespace: ownerNamespace,
 			Name:      ownerName,
 		},
 	)
@@ -196,10 +196,10 @@ func (k *K8sClient) GetHTTPCerts(namer name.Namer, ownerName string) ([]*x509.Ce
 }
 
 // GetCA returns the CA of the given owner name
-func (k *K8sClient) GetCA(ownerName string, caType certificates.CAType) (*certificates.CA, error) {
+func (k *K8sClient) GetCA(ownerNamespace, ownerName string, caType certificates.CAType) (*certificates.CA, error) {
 	var secret corev1.Secret
 	key := types.NamespacedName{
-		Namespace: Ctx().ManagedNamespace(0),
+		Namespace: ownerNamespace,
 		Name:      certificates.CAInternalSecretName(esname.ESNamer, ownerName, caType),
 	}
 	if err := k.Client.Get(key, &secret); err != nil {
@@ -232,10 +232,10 @@ func (k *K8sClient) GetCA(ownerName string, caType certificates.CAType) (*certif
 }
 
 // GetTransportCert retrieves the certificate of the CA and the transport certificate
-func (k *K8sClient) GetTransportCert(podName string) (caCert, transportCert []*x509.Certificate, err error) {
+func (k *K8sClient) GetTransportCert(podNamespace, podName string) (caCert, transportCert []*x509.Certificate, err error) {
 	var secret corev1.Secret
 	key := types.NamespacedName{
-		Namespace: Ctx().ManagedNamespace(0),
+		Namespace: podNamespace,
 		Name:      esname.TransportCertsSecret(podName),
 	}
 	if err = k.Client.Get(key, &secret); err != nil {
@@ -302,26 +302,26 @@ func (k *K8sClient) Exec(pod types.NamespacedName, cmd []string) (string, string
 	return stdout.String(), stderr.String(), err
 }
 
-func ESPodListOptions(esName string) k8sclient.ListOptions {
+func ESPodListOptions(esNamespace, esName string) k8sclient.ListOptions {
 	return k8sclient.ListOptions{
-		Namespace: Ctx().ManagedNamespace(0),
+		Namespace: esNamespace,
 		LabelSelector: labels.SelectorFromSet(labels.Set(map[string]string{
 			common.TypeLabelName:       label.Type,
 			label.ClusterNameLabelName: esName,
 		}))}
 }
 
-func KibanaPodListOptions(kbName string) k8sclient.ListOptions {
+func KibanaPodListOptions(kbNamespace, kbName string) k8sclient.ListOptions {
 	return k8sclient.ListOptions{
-		Namespace: Ctx().ManagedNamespace(0),
+		Namespace: kbNamespace,
 		LabelSelector: labels.SelectorFromSet(labels.Set(map[string]string{
 			kblabel.KibanaNameLabelName: kbName,
 		}))}
 }
 
-func ApmServerPodListOptions(apmName string) k8sclient.ListOptions {
+func ApmServerPodListOptions(apmNamespace, apmName string) k8sclient.ListOptions {
 	return k8sclient.ListOptions{
-		Namespace: Ctx().ManagedNamespace(0),
+		Namespace: apmNamespace,
 		LabelSelector: labels.SelectorFromSet(labels.Set(map[string]string{
 			common.TypeLabelName:             apmlabels.Type,
 			apmlabels.ApmServerNameLabelName: apmName,

--- a/operators/test/e2e/test/kibana/http_client.go
+++ b/operators/test/e2e/test/kibana/http_client.go
@@ -23,7 +23,7 @@ import (
 func NewKibanaClient(kb v1alpha1.Kibana, k *test.K8sClient) (*http.Client, error) {
 	var caCerts []*x509.Certificate
 	if kb.Spec.HTTP.TLS.Enabled() {
-		crts, err := k.GetHTTPCerts(name.KBNamer, kb.Name)
+		crts, err := k.GetHTTPCerts(name.KBNamer, kb.Namespace, kb.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -34,7 +34,7 @@ func NewKibanaClient(kb v1alpha1.Kibana, k *test.K8sClient) (*http.Client, error
 
 // DoKibanaReq executes an HTTP request against a Kibana instance.
 func DoKibanaReq(k *test.K8sClient, b Builder, method string, uri string, body []byte) ([]byte, error) {
-	password, err := k.GetElasticPassword(b.Kibana.Spec.ElasticsearchRef.Name)
+	password, err := k.GetElasticPassword(b.Kibana.Spec.ElasticsearchRef.Namespace, b.Kibana.Spec.ElasticsearchRef.Name)
 	if err != nil {
 		return nil, errors.Wrap(err, "while getting elastic password")
 	}

--- a/operators/test/e2e/test/kibana/steps_deletion.go
+++ b/operators/test/e2e/test/kibana/steps_deletion.go
@@ -51,7 +51,7 @@ func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
 		{
 			Name: "Kibana pods should be eventually be removed",
 			Test: test.Eventually(func() error {
-				return k.CheckPodCount(test.KibanaPodListOptions(b.Kibana.Name), 0)
+				return k.CheckPodCount(test.KibanaPodListOptions(b.Kibana.Namespace, b.Kibana.Name), 0)
 			}),
 		},
 	}

--- a/operators/test/e2e/test/kibana/steps_init.go
+++ b/operators/test/e2e/test/kibana/steps_init.go
@@ -50,7 +50,7 @@ func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
 				}
 				// wait for Kibana pods to disappear
 				test.Eventually(func() error {
-					return k.CheckPodCount(test.KibanaPodListOptions(b.Kibana.Name), 0)
+					return k.CheckPodCount(test.KibanaPodListOptions(b.Kibana.Namespace, b.Kibana.Name), 0)
 				})(t)
 			},
 		},

--- a/operators/test/e2e/test/run_failure.go
+++ b/operators/test/e2e/test/run_failure.go
@@ -64,7 +64,7 @@ func KillNodeSteps(listOptions client.ListOptions, podMatch func(p corev1.Pod) b
 			{
 				Name: "Wait for pod to be deleted",
 				Test: Eventually(func() error {
-					pod, err := k.GetPod(killedPod.Name)
+					pod, err := k.GetPod(killedPod.Namespace, killedPod.Name)
 					if err != nil && !apierrors.IsNotFound(err) {
 						return err
 					}


### PR DESCRIPTION
Currently the E2E test utilities assume that resources are all within a single namespace. This PR removes that assumption in order to support running tests across multiple namespaces.

Also adds a test for cross namespace ES-KB association that currently only
works in local mode due to reasons described in #1438.

Partially fixes #782 
