### PR TITLE
Proper removing GKE cluster after e2e test job

### DIFF
--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -30,19 +30,8 @@ pipeline {
                     notOnlyDocs()
                 }
             }
-            stages {
-                stage('Run E2E tests') {
-                    steps {
-                        sh 'make -C build/ci ci-e2e'
-                    }
-                }
-                stage('Cleanup GKE') {
-                    steps {
-                        build job: 'cloud-on-k8s-e2e-cleanup',
-                            parameters: [string(name: 'GKE_CLUSTER', value: "${GKE_CLUSTER_NAME}")],
-                            wait: false
-                    }
-                }
+            steps {
+                sh 'make -C build/ci ci-e2e'
             }
         }
     }
@@ -59,6 +48,14 @@ pipeline {
             }
         }
         cleanup {
+            script {
+                if (notOnlyDocs()) {
+                    build job: 'cloud-on-k8s-e2e-cleanup',
+                        parameters: [string(name: 'GKE_CLUSTER', value: "${GKE_CLUSTER_NAME}")],
+                        wait: false
+                }
+            }
+
             cleanWs()
         }
     }


### PR DESCRIPTION
Currently, if e2e tests job fails, then GKE cluster cleanup will not happen. This PR fixes that by moving cluster cleanup into post build part (similar to PR job)