### PR TITLE
Avoid test runner failure when namespace exists

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -305,17 +305,13 @@ e2e-compile:
 # that can reach ES services running in the k8s cluster through port-forwarding.
 LOCAL_E2E_CTX:=/tmp/e2e-local.json
 
-e2e-local: e2e-local-setup
-	@test/e2e/run.sh -run "$(TESTS_MATCH)" -args -testContextPath $(LOCAL_E2E_CTX)
-
-e2e-local-setup: $(LOCAL_E2E_CTX)
-
-$(LOCAL_E2E_CTX):
+e2e-local:
 	@go run test/e2e/cmd/main.go run \
 		--test-run-name=e2e \
 		--test-context-out=$(LOCAL_E2E_CTX) \
 		--auto-port-forwarding \
 		--local
+	@test/e2e/run.sh -run "$(TESTS_MATCH)" -args -testContextPath $(LOCAL_E2E_CTX)
 
 ##########################################
 ##  --    Continuous integration    --  ##

--- a/operators/config/e2e/local_namespace.yaml
+++ b/operators/config/e2e/local_namespace.yaml
@@ -1,0 +1,10 @@
+{{- $testRun := .TestRun -}}
+{{- range .NamespaceOperators }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .ManagedNamespace }}
+  labels:
+    test-run: {{ $testRun }}
+{{- end }}

--- a/operators/test/e2e/cmd/run/run.go
+++ b/operators/test/e2e/cmd/run/run.go
@@ -185,16 +185,8 @@ func (h *helper) installCRDs() error {
 }
 
 func (h *helper) createManagedNamespaces() error {
-	for _, ns := range h.managedNamespaces {
-		managedNS := fmt.Sprintf("%s-%s", h.testRunName, ns)
-		if err := h.kubectl("create", "ns", managedNS); err != nil {
-			log.Error(err, "Failed to create managed namespace", "namespace", managedNS)
-			return err
-		}
-		log.Info("Created managed namespace", "namespace", managedNS)
-	}
-
-	return nil
+	log.Info("Creating managed namespaces")
+	return h.kubectlApplyTemplate("config/e2e/local_namespace.yaml", h.testContext, false)
 }
 
 func (h *helper) deployGlobalOperator() error {


### PR DESCRIPTION
When running in local mode the test runner used to invoke `kubectl create <namespace>`  -- which fails if the namespace already exists. Furthermore, skipping the test runner execution when `/tmp/e2e-local.json` files exists could lead to surprising behaviour (eg. when the cluster is re-created).

This PR fixes the above problems by doing the following:

- Create the namespaces using `kubectl apply`
- Update the Makefile to skip checking for the existence of `/tmp/e2e-local.json`

Fixes #1449 


