### PR TITLE
Retry cleanup job on CI

### DIFF
--- a/build/ci/support/cleanup.jenkinsfile
+++ b/build/ci/support/cleanup.jenkinsfile
@@ -18,6 +18,9 @@ pipeline {
 
     stages {
         stage('Cleanup GKE') {
+            options {
+                retry(3)
+            }
             steps {
                 sh 'make -C build/ci ci-gke-cleanup'
             }


### PR DESCRIPTION
Sometimes cleanup job fails because of known Vault issue, like https://devops-ci.elastic.co/view/cloud-on-k8s/job/cloud-on-k8s-e2e-cleanup/203/. This PR adds retry in case of fail which can help with proper GKE clusters cleanup.