### PR TITLE
Fix E2E tests to work with StatefulSets

### DIFF
--- a/operators/config/samples/apm/apm_es_kibana.yaml
+++ b/operators/config/samples/apm/apm_es_kibana.yaml
@@ -3,7 +3,7 @@
 apiVersion: elasticsearch.k8s.elastic.co/v1alpha1
 kind: Elasticsearch
 metadata:
-  name: elasticsearch-sample
+  name: es-apm-sample
 spec:
   version: 7.2.0
   nodes:
@@ -13,19 +13,19 @@ spec:
 apiVersion: apm.k8s.elastic.co/v1alpha1
 kind: ApmServer
 metadata:
-  name: apm-server-sample
+  name: apm-apm-sample
 spec:
   version: 7.2.0
   nodeCount: 1
   elasticsearchRef:
-    name: "elasticsearch-sample"
+    name: "es-apm-sample"
 ---
 apiVersion: kibana.k8s.elastic.co/v1alpha1
 kind: Kibana
 metadata:
-  name: kibana-sample
+  name: kb-apm-sample
 spec:
   version: 7.2.0
   nodeCount: 1
   elasticsearchRef:
-    name: "elasticsearch-sample"
+    name: "es-apm-sample"

--- a/operators/test/e2e/test/elasticsearch/builder.go
+++ b/operators/test/e2e/test/elasticsearch/builder.go
@@ -92,6 +92,7 @@ func (b Builder) WithNoESTopology() Builder {
 
 func (b Builder) WithESMasterNodes(count int, resources corev1.ResourceRequirements) Builder {
 	return b.withESTopologyElement(estype.NodeSpec{
+		Name:      "master",
 		NodeCount: int32(count),
 		Config: &commonv1alpha1.Config{
 			Data: map[string]interface{}{
@@ -104,6 +105,7 @@ func (b Builder) WithESMasterNodes(count int, resources corev1.ResourceRequireme
 
 func (b Builder) WithESDataNodes(count int, resources corev1.ResourceRequirements) Builder {
 	return b.withESTopologyElement(estype.NodeSpec{
+		Name:      "data",
 		NodeCount: int32(count),
 		Config: &commonv1alpha1.Config{
 			Data: map[string]interface{}{
@@ -116,6 +118,7 @@ func (b Builder) WithESDataNodes(count int, resources corev1.ResourceRequirement
 
 func (b Builder) WithESMasterDataNodes(count int, resources corev1.ResourceRequirements) Builder {
 	return b.withESTopologyElement(estype.NodeSpec{
+		Name:      "masterdata",
 		NodeCount: int32(count),
 		Config: &commonv1alpha1.Config{
 			Data: map[string]interface{}{},


### PR DESCRIPTION
* We now need to provide nodeSpec names (mandatory)
* Since we don't automatically delete PVCs yet (see https://github.com/elastic/cloud-on-k8s/issues/1288), there are possible conflicts between multiple E2E tests creating an ES cluster with the same name, where volumes from the previous E2E test (potentially a different ES version) would be reused. I renamed `apm_es_kibana` samples to not have the same name as `es_kibana` sample.