### PR TITLE
Emit events when association status changes

### DIFF
--- a/operators/pkg/apis/common/v1alpha1/association.go
+++ b/operators/pkg/apis/common/v1alpha1/association.go
@@ -13,6 +13,7 @@ import (
 type AssociationStatus string
 
 const (
+	AssociationUnknown     AssociationStatus = ""
 	AssociationPending     AssociationStatus = "Pending"
 	AssociationEstablished AssociationStatus = "Established"
 	AssociationFailed      AssociationStatus = "Failed"

--- a/operators/pkg/controller/common/annotation/association_status.go
+++ b/operators/pkg/controller/common/annotation/association_status.go
@@ -1,0 +1,36 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package annotation
+
+import (
+	commonv1alpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/common/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// CurrAssocStatusAnnotation describes the currently observed association status of an object.
+	CurrAssocStatusAnnotation = "association.k8s.elastic.co/current-status"
+	// PrevAssocStatusAnnotation describes the previously observed association status of an object.
+	PrevAssocStatusAnnotation = "association.k8s.elastic.co/previous-status"
+)
+
+// ForAssociationStatusChange constructs the annotation map for an association status change event.
+func ForAssociationStatusChange(prevStatus, currStatus commonv1alpha1.AssociationStatus) map[string]string {
+	return map[string]string{
+		CurrAssocStatusAnnotation: string(currStatus),
+		PrevAssocStatusAnnotation: string(prevStatus),
+	}
+}
+
+// ExtractAssociationStatus extracts the association status values from the provided meta object.
+func ExtractAssociationStatus(obj metav1.ObjectMeta) (prevStatus, currStatus commonv1alpha1.AssociationStatus) {
+	if obj.Annotations == nil {
+		return commonv1alpha1.AssociationUnknown, commonv1alpha1.AssociationUnknown
+	}
+
+	prevStatus = commonv1alpha1.AssociationStatus(obj.Annotations[PrevAssocStatusAnnotation])
+	currStatus = commonv1alpha1.AssociationStatus(obj.Annotations[CurrAssocStatusAnnotation])
+	return
+}

--- a/operators/pkg/controller/common/events/events.go
+++ b/operators/pkg/controller/common/events/events.go
@@ -24,6 +24,14 @@ const (
 	EventReasonRestart = "Restart"
 )
 
+// Event reasons for Association controllers
+const (
+	// EventAssociationError describes an event fired when an association fails.
+	EventAssociationError = "AssociationError"
+	// EventAssociationStatusChange describes association status change events.
+	EventAssociationStatusChange = "AssociationStatusChange"
+)
+
 // Event is a k8s event that can be recorded via an event recorder.
 type Event struct {
 	EventType string

--- a/operators/pkg/controller/kibana/driver.go
+++ b/operators/pkg/controller/kibana/driver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/certificates/http"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/finalizer"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/operator"
@@ -196,6 +197,7 @@ func (d *driver) Reconcile(
 ) *reconciler.Results {
 	results := reconciler.Results{}
 	if !kb.Spec.Elasticsearch.IsConfigured() {
+		d.recorder.Event(kb, corev1.EventTypeWarning, events.EventAssociationError, "Elasticsearch backend is not configured")
 		log.Info("Aborting Kibana deployment reconciliation as no Elasticsearch backend is configured", "namespace", kb.Namespace, "kibana_name", kb.Name)
 		return &results
 	}

--- a/operators/pkg/controller/kibanaassociation/association_controller.go
+++ b/operators/pkg/controller/kibanaassociation/association_controller.go
@@ -190,11 +190,9 @@ func (r *ReconcileAssociation) Reconcile(request reconcile.Request) (reconcile.R
 func resultFromStatus(status commonv1alpha1.AssociationStatus) reconcile.Result {
 	switch status {
 	case commonv1alpha1.AssociationPending:
-		return defaultRequeue // retry again
-	case commonv1alpha1.AssociationEstablished, commonv1alpha1.AssociationFailed:
-		return reconcile.Result{} // we are done or there is not much we can do
+		return defaultRequeue // retry
 	default:
-		return reconcile.Result{} // make the compiler happy
+		return reconcile.Result{} // we are done or there is not much we can do
 	}
 }
 
@@ -210,7 +208,7 @@ func (r *ReconcileAssociation) reconcileInternal(kibana kbtype.Kibana) (commonv1
 		// stop watching any ES cluster previously referenced for this Kibana resource
 		r.watches.ElasticsearchClusters.RemoveHandlerForKey(elasticsearchWatchName(kibanaKey))
 		// other leftover resources are already garbage-collected
-		return "", nil
+		return commonv1alpha1.AssociationUnknown, nil
 	}
 
 	// this Kibana instance references an Elasticsearch cluster

--- a/operators/pkg/controller/kibanaassociation/association_controller.go
+++ b/operators/pkg/controller/kibanaassociation/association_controller.go
@@ -14,6 +14,7 @@ import (
 	kbtype "github.com/elastic/cloud-on-k8s/operators/pkg/apis/kibana/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/annotation"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/finalizer"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/user"
@@ -166,6 +167,7 @@ func (r *ReconcileAssociation) Reconcile(request reconcile.Request) (reconcile.R
 	newStatus, err := r.reconcileInternal(kibana)
 	// maybe update status
 	if !reflect.DeepEqual(kibana.Status.AssociationStatus, newStatus) {
+		oldStatus := kibana.Status.AssociationStatus
 		kibana.Status.AssociationStatus = newStatus
 		if err := r.Status().Update(&kibana); err != nil {
 			if apierrors.IsConflict(err) {
@@ -176,6 +178,11 @@ func (r *ReconcileAssociation) Reconcile(request reconcile.Request) (reconcile.R
 
 			return defaultRequeue, err
 		}
+		r.recorder.AnnotatedEventf(&kibana,
+			annotation.ForAssociationStatusChange(oldStatus, newStatus),
+			corev1.EventTypeNormal,
+			events.EventAssociationStatusChange,
+			"Association status changed from [%s] to [%s]", oldStatus, newStatus)
 	}
 	return resultFromStatus(newStatus), err
 }
@@ -235,6 +242,7 @@ func (r *ReconcileAssociation) reconcileInternal(kibana kbtype.Kibana) (commonv1
 
 	var es estype.Elasticsearch
 	if err := r.Get(esRefKey, &es); err != nil {
+		r.recorder.Eventf(&kibana, corev1.EventTypeWarning, events.EventAssociationError, "Failed to find referenced backend %s: %v", esRefKey, err)
 		if apierrors.IsNotFound(err) {
 			// ES not found. 2 options:
 			// - not created yet: that's ok, we'll reconcile on creation event

--- a/operators/test/e2e/apm/association_test.go
+++ b/operators/test/e2e/apm/association_test.go
@@ -2,65 +2,37 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package kb
+package apm
 
 import (
 	"fmt"
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/apm/v1alpha1"
 	commonv1alpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/common/v1alpha1"
-	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/kibana/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/apmserver"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/elasticsearch"
-	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/kibana"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
 
-// TestCrossNSAssociation tests associating Elasticsearch and Kibana running in different namespaces.
-func TestCrossNSAssociation(t *testing.T) {
-	// This test currently does not work in the E2E environment because each namespace has a dedicated
-	// controller (see https://github.com/elastic/cloud-on-k8s/issues/1438)
-	if !test.Ctx().Local {
-		t.SkipNow()
-	}
-
-	esNamespace := test.Ctx().ManagedNamespace(0)
-	kbNamespace := test.Ctx().ManagedNamespace(1)
-	name := "test-cross-ns-assoc"
-
-	esBuilder := elasticsearch.NewBuilder(name).
-		WithNamespace(esNamespace).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
-		WithRestrictedSecurityContext()
-
-	kbBuilder := kibana.NewBuilder(name).
-		WithNamespace(kbNamespace).
-		WithNodeCount(1).
-		WithRestrictedSecurityContext()
-	kbBuilder.Kibana.Spec.ElasticsearchRef.Name = name
-	kbBuilder.Kibana.Spec.ElasticsearchRef.Namespace = esNamespace
-
-	builders := []test.Builder{esBuilder, kbBuilder}
-	test.RunMutations(t, builders, builders)
-}
-
-func TestKibanaAssociationWithNonExistentES(t *testing.T) {
-	name := "test-kb-assoc-non-existent-es"
-	kbBuilder := kibana.NewBuilder(name).
+func TestAPMAssociationWithNonExistentES(t *testing.T) {
+	name := "test-apm-assoc-non-existent-es"
+	apmBuilder := apmserver.NewBuilder(name).
 		WithNodeCount(1)
 
 	k := test.NewK8sClientOrFatal()
 	steps := test.StepList{}
-	steps = steps.WithSteps(kbBuilder.InitTestSteps(k))
-	steps = steps.WithSteps(kbBuilder.CreationTestSteps(k))
+	steps = steps.WithSteps(apmBuilder.InitTestSteps(k))
+	steps = steps.WithSteps(apmBuilder.CreationTestSteps(k))
 	steps = steps.WithStep(test.Step{
 		Name: "Non existent backend should generate event",
 		Test: test.Eventually(func() error {
-			eventList, err := k.GetEvents(test.EventListOptions(kbBuilder.Kibana.Namespace, kbBuilder.Kibana.Name))
+			eventList, err := k.GetEvents(test.EventListOptions(apmBuilder.ApmServer.Namespace, apmBuilder.ApmServer.Name))
 			if err != nil {
 				return err
 			}
@@ -74,16 +46,16 @@ func TestKibanaAssociationWithNonExistentES(t *testing.T) {
 			return fmt.Errorf("event did not fire: %s", events.EventAssociationError)
 		}),
 	})
-	steps = steps.WithSteps(kbBuilder.DeletionTestSteps(k))
+	steps = steps.WithSteps(apmBuilder.DeletionTestSteps(k))
 
 	steps.RunSequential(t)
 }
 
-func TestKibanaAssociationWhenReferencedESDisappears(t *testing.T) {
-	name := "test-kb-del-referenced-es"
+func TestAPMAssociationWhenReferencedESDisappears(t *testing.T) {
+	name := "test-apm-del-referenced-es"
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
-	kbBuilder := kibana.NewBuilder(name).
+	apmBuilder := apmserver.NewBuilder(name).
 		WithNodeCount(1)
 
 	failureSteps := func(k *test.K8sClient) test.StepList {
@@ -91,16 +63,16 @@ func TestKibanaAssociationWhenReferencedESDisappears(t *testing.T) {
 			test.Step{
 				Name: "Updating to invalid Elasticsearch reference should succeed",
 				Test: func(t *testing.T) {
-					var kb v1alpha1.Kibana
-					require.NoError(t, k.Client.Get(k8s.ExtractNamespacedName(&kbBuilder.Kibana), &kb))
-					kb.Spec.ElasticsearchRef.Namespace = "xxxx"
-					require.NoError(t, k.Client.Update(&kb))
+					var apm v1alpha1.ApmServer
+					require.NoError(t, k.Client.Get(k8s.ExtractNamespacedName(&apmBuilder.ApmServer), &apm))
+					apm.Spec.ElasticsearchRef.Namespace = "xxxx"
+					require.NoError(t, k.Client.Update(&apm))
 				},
 			},
 			test.Step{
 				Name: "Lost Elasticsearch association should generate events",
 				Test: test.Eventually(func() error {
-					eventList, err := k.GetEvents(test.EventListOptions(kbBuilder.Kibana.Namespace, kbBuilder.Kibana.Name))
+					eventList, err := k.GetEvents(test.EventListOptions(apmBuilder.ApmServer.Namespace, apmBuilder.ApmServer.Name))
 					if err != nil {
 						return err
 					}
@@ -136,5 +108,5 @@ func TestKibanaAssociationWhenReferencedESDisappears(t *testing.T) {
 		}
 	}
 
-	test.RunUnrecoverableFailureScenario(t, failureSteps, kbBuilder, esBuilder)
+	test.RunUnrecoverableFailureScenario(t, failureSteps, apmBuilder, esBuilder)
 }

--- a/operators/test/e2e/es/failure_test.go
+++ b/operators/test/e2e/es/failure_test.go
@@ -31,7 +31,7 @@ func TestKillOneDataNode(t *testing.T) {
 		return label.IsDataNode(p) && !label.IsMasterNode(p)
 	}
 
-	test.RunFailure(t,
+	test.RunRecoverableFailureScenario(t,
 		test.KillNodeSteps(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name), matchDataNode),
 		b)
 }
@@ -46,7 +46,7 @@ func TestKillOneMasterNode(t *testing.T) {
 		return !label.IsDataNode(p) && label.IsMasterNode(p)
 	}
 
-	test.RunFailure(t,
+	test.RunRecoverableFailureScenario(t,
 		test.KillNodeSteps(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name), matchMasterNode),
 		b)
 }
@@ -59,7 +59,7 @@ func TestKillSingleNodeReusePV(t *testing.T) {
 		return true // match first node we find
 	}
 
-	test.RunFailure(t,
+	test.RunRecoverableFailureScenario(t,
 		test.KillNodeSteps(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name), matchNode),
 		b)
 }
@@ -187,7 +187,7 @@ func TestDeleteServices(t *testing.T) {
 	b := elasticsearch.NewBuilder("test-failure-delete-services").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
-	test.RunFailure(t, func(k *test.K8sClient) test.StepList {
+	test.RunRecoverableFailureScenario(t, func(k *test.K8sClient) test.StepList {
 		return test.StepList{
 			{
 				Name: "Delete external service",
@@ -206,7 +206,7 @@ func TestDeleteElasticUserSecret(t *testing.T) {
 	b := elasticsearch.NewBuilder("test-delete-es-elastic-user-secret").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
-	test.RunFailure(t, func(k *test.K8sClient) test.StepList {
+	test.RunRecoverableFailureScenario(t, func(k *test.K8sClient) test.StepList {
 		return test.StepList{
 			{
 				Name: "Delete elastic user secret",
@@ -229,7 +229,7 @@ func TestDeleteCACert(t *testing.T) {
 	b := elasticsearch.NewBuilder("test-failure-delete-ca-cert").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
-	test.RunFailure(t, func(k *test.K8sClient) test.StepList {
+	test.RunRecoverableFailureScenario(t, func(k *test.K8sClient) test.StepList {
 		return test.StepList{
 			{
 				Name: "Delete CA cert",

--- a/operators/test/e2e/kb/failure_test.go
+++ b/operators/test/e2e/kb/failure_test.go
@@ -27,7 +27,7 @@ func TestKillKibanaPod(t *testing.T) {
 	matchFirst := func(p corev1.Pod) bool {
 		return true
 	}
-	test.RunFailure(t,
+	test.RunRecoverableFailureScenario(t,
 		test.KillNodeSteps(test.KibanaPodListOptions(kbBuilder.Kibana.Namespace, kbBuilder.Kibana.Name), matchFirst),
 		esBuilder, kbBuilder)
 }
@@ -39,7 +39,7 @@ func TestKillKibanaDeployment(t *testing.T) {
 	kbBuilder := kibana.NewBuilder(name).
 		WithNodeCount(1)
 
-	test.RunFailure(t, func(k *test.K8sClient) test.StepList {
+	test.RunRecoverableFailureScenario(t, func(k *test.K8sClient) test.StepList {
 		return test.StepList{
 			{
 				Name: "Delete Kibana deployment",


### PR DESCRIPTION
Emit events when the Kibana or APM association status changes. This should help troubleshoot problems with associations.

Fixes #1187 