### PR TITLE
Remove building docs from PR job

### DIFF
--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -36,19 +36,6 @@ pipeline {
                         sh 'make -C build/ci ci-pr'
                     }
                 }
-                stage("Run docs build") {
-                    steps {
-                        checkout scm
-                        sh 'git clone git@github.com:elastic/docs.git docs-repo'
-                        sh """
-                            $WORKSPACE/docs-repo/build_docs \
-                            --doc $WORKSPACE/docs/index.asciidoc \
-                            --out $WORKSPACE/docs/html \
-                            --chunk 1
-                        """
-                        sh 'test -e $WORKSPACE/docs/html/index.html'
-                    }
-                }
                 stage("Run smoke E2E tests") {
                     when {
                         expression {


### PR DESCRIPTION
In https://github.com/elastic/cloud-on-k8s/issues/1470 we are evaluating `infra` job for building docs. If it will work as we want, then this PR should be merged to remove this check on our side.
close https://github.com/elastic/cloud-on-k8s/issues/1470