### PR TITLE
Fix APM association E2E test failure

### DIFF
--- a/operators/config/e2e/rbac.yaml
+++ b/operators/config/e2e/rbac.yaml
@@ -87,6 +87,7 @@ rules:
       - secrets
       - persistentvolumeclaims
       - configmaps
+      - events
     verbs:
       - get
       - list

--- a/operators/test/e2e/test/k8s_client.go
+++ b/operators/test/e2e/test/k8s_client.go
@@ -339,6 +339,7 @@ func ApmServerPodListOptions(apmNamespace, apmName string) k8sclient.ListOptions
 
 func EventListOptions(namespace, name string) k8sclient.ListOptions {
 	return k8sclient.ListOptions{
+		Namespace: namespace,
 		FieldSelector: fields.SelectorFromSet(fields.Set(map[string]string{
 			"involvedObject.name":      name,
 			"involvedObject.namespace": namespace,


### PR DESCRIPTION
After merging  #1469, APM association tests started failing with the message `events is forbidden: User "system:serviceaccount:e2e-cq02n:e2e-cq02n" cannot list resource "events" in API group "" at the cluster scope`. It is unclear why the tests didn't fail during the PR process but this change should allow the tests to pass again.