### PR TITLE
Calculate Docker image tag without paths

### DIFF
--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -7,7 +7,7 @@
 ROOT_DIR = $(CURDIR)/../..
 GO_MOUNT_PATH ?= /go/src/github.com/elastic/cloud-on-k8s
 
-IMAGE ?= docker.elastic.co/eck/eck-ci:$(shell md5sum $(ROOT_DIR)/operators/Gopkg.lock $(ROOT_DIR)/build/ci/Dockerfile $(ROOT_DIR)/local-volume/Gopkg.lock | md5sum | awk '{print $$1}')
+IMAGE ?= docker.elastic.co/eck/eck-ci:$(shell md5sum $(ROOT_DIR)/operators/Gopkg.lock $(ROOT_DIR)/build/ci/Dockerfile $(ROOT_DIR)/local-volume/Gopkg.lock | awk '{print $$1}' | md5sum | awk '{print $$1}')
 
 VAULT_GKE_CREDS_SECRET ?= secret/cloud-team/cloud-ci/ci-gcp-k8s-operator
 GKE_CREDS_FILE ?= credentials.json


### PR DESCRIPTION
Fixing issue after https://github.com/elastic/cloud-on-k8s/pull/1404

Original way of calculation a tag for Docker image considering also paths. Problem is that paths can be different in different CI jobs. This PR fixes that.