### PR TITLE
Increase E2E ES cluster size to fix APM test

### DIFF
--- a/operators/test/e2e/apm/association_test.go
+++ b/operators/test/e2e/apm/association_test.go
@@ -54,7 +54,7 @@ func TestAPMAssociationWithNonExistentES(t *testing.T) {
 func TestAPMAssociationWhenReferencedESDisappears(t *testing.T) {
 	name := "test-apm-del-referenced-es"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
 	apmBuilder := apmserver.NewBuilder(name).
 		WithNodeCount(1)
 


### PR DESCRIPTION
New E2E stack test step introduced in #1465 requires more than one ES node
available in the cluster to succeed (APM index template requires at least one replica). This caused a test introduced in #1469 to fail because it was creating an Elasticsearch cluster with just a single node.
