### PR TITLE
Add random prefix to e2e elastic stack name

### DIFF
--- a/operators/test/e2e/apm/association_test.go
+++ b/operators/test/e2e/apm/association_test.go
@@ -23,6 +23,9 @@ import (
 func TestAPMAssociationWithNonExistentES(t *testing.T) {
 	name := "test-apm-assoc-non-existent-es"
 	apmBuilder := apmserver.NewBuilder(name).
+		WithElasticsearchRef(commonv1alpha1.ObjectSelector{
+			Name: "non-existent-es",
+		}).
 		WithNodeCount(1)
 
 	k := test.NewK8sClientOrFatal()
@@ -56,6 +59,7 @@ func TestAPMAssociationWhenReferencedESDisappears(t *testing.T) {
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
 	apmBuilder := apmserver.NewBuilder(name).
+		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)
 
 	failureSteps := func(k *test.K8sClient) test.StepList {

--- a/operators/test/e2e/apm/configuration_test.go
+++ b/operators/test/e2e/apm/configuration_test.go
@@ -60,6 +60,7 @@ func TestUpdateConfiguration(t *testing.T) {
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
 	apmBuilder := apmserver.NewBuilder(name).
 		WithNamespace(namespace).
+		WithElasticsearchRef(esBuilder.Ref()).
 		WithVersion(test.Ctx().ElasticStackVersion).
 		WithRestrictedSecurityContext()
 

--- a/operators/test/e2e/apm/sample_test.go
+++ b/operators/test/e2e/apm/sample_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/apmserver"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/elasticsearch"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/kibana"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -37,19 +38,20 @@ func TestApmEsKibanaSample(t *testing.T) {
 
 	// set namespace and version
 	ns := test.Ctx().ManagedNamespace(0)
+	randSuffix := rand.String(4)
 	esBuilder = esBuilder.
-		WithRandomSuffix().
+		WithSuffix(randSuffix).
 		WithNamespace(ns).
 		WithVersion(test.Ctx().ElasticStackVersion).
 		WithRestrictedSecurityContext()
 	kbBuilder = kbBuilder.
-		WithRandomSuffix().
+		WithSuffix(randSuffix).
 		WithNamespace(ns).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithVersion(test.Ctx().ElasticStackVersion).
 		WithRestrictedSecurityContext()
 	apmBuilder = apmBuilder.
-		WithRandomSuffix().
+		WithSuffix(randSuffix).
 		WithNamespace(ns).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithVersion(test.Ctx().ElasticStackVersion).

--- a/operators/test/e2e/apm/sample_test.go
+++ b/operators/test/e2e/apm/sample_test.go
@@ -38,18 +38,18 @@ func TestApmEsKibanaSample(t *testing.T) {
 	// set namespace and version
 	ns := test.Ctx().ManagedNamespace(0)
 	esBuilder = esBuilder.
-		WithRandomPrefixName().
+		WithRandomSuffix().
 		WithNamespace(ns).
 		WithVersion(test.Ctx().ElasticStackVersion).
 		WithRestrictedSecurityContext()
 	kbBuilder = kbBuilder.
-		WithRandomPrefixName().
+		WithRandomSuffix().
 		WithNamespace(ns).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithVersion(test.Ctx().ElasticStackVersion).
 		WithRestrictedSecurityContext()
 	apmBuilder = apmBuilder.
-		WithRandomPrefixName().
+		WithRandomSuffix().
 		WithNamespace(ns).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithVersion(test.Ctx().ElasticStackVersion).

--- a/operators/test/e2e/apm/sample_test.go
+++ b/operators/test/e2e/apm/sample_test.go
@@ -36,16 +36,22 @@ func TestApmEsKibanaSample(t *testing.T) {
 	test.ExitOnErr(decoder.Decode(&kbBuilder.Kibana))
 
 	// set namespace and version
+	ns := test.Ctx().ManagedNamespace(0)
 	esBuilder = esBuilder.
-		WithNamespace(test.Ctx().ManagedNamespace(0)).
+		WithRandomPrefixName().
+		WithNamespace(ns).
 		WithVersion(test.Ctx().ElasticStackVersion).
 		WithRestrictedSecurityContext()
 	kbBuilder = kbBuilder.
-		WithNamespace(test.Ctx().ManagedNamespace(0)).
+		WithRandomPrefixName().
+		WithNamespace(ns).
+		WithElasticsearchRef(esBuilder.Ref()).
 		WithVersion(test.Ctx().ElasticStackVersion).
 		WithRestrictedSecurityContext()
 	apmBuilder = apmBuilder.
-		WithNamespace(test.Ctx().ManagedNamespace(0)).
+		WithRandomPrefixName().
+		WithNamespace(ns).
+		WithElasticsearchRef(esBuilder.Ref()).
 		WithVersion(test.Ctx().ElasticStackVersion).
 		WithRestrictedSecurityContext()
 

--- a/operators/test/e2e/apm/standalone_test.go
+++ b/operators/test/e2e/apm/standalone_test.go
@@ -15,7 +15,6 @@ import (
 // TestApmStandalone runs a test suite on an APM server that is not outputting to Elasticsearch
 func TestApmStandalone(t *testing.T) {
 	apmBuilder := apmserver.NewBuilder("standalone").
-		WithElasticsearchRef(v1alpha1.ObjectSelector{}).
 		WithConfig(map[string]interface{}{
 			"output.console": map[string]interface{}{
 				"pretty": true,
@@ -28,7 +27,6 @@ func TestApmStandalone(t *testing.T) {
 
 func TestApmStandaloneNoTLS(t *testing.T) {
 	apmBuilder := apmserver.NewBuilder("standalone-no-tls").
-		WithElasticsearchRef(v1alpha1.ObjectSelector{}).
 		WithConfig(map[string]interface{}{
 			"output.console": map[string]interface{}{
 				"pretty": true,

--- a/operators/test/e2e/kb/association_test.go
+++ b/operators/test/e2e/kb/association_test.go
@@ -36,13 +36,11 @@ func TestCrossNSAssociation(t *testing.T) {
 		WithNamespace(esNamespace).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
 		WithRestrictedSecurityContext()
-
 	kbBuilder := kibana.NewBuilder(name).
 		WithNamespace(kbNamespace).
+		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1).
 		WithRestrictedSecurityContext()
-	kbBuilder.Kibana.Spec.ElasticsearchRef.Name = name
-	kbBuilder.Kibana.Spec.ElasticsearchRef.Namespace = esNamespace
 
 	builders := []test.Builder{esBuilder, kbBuilder}
 	test.RunMutations(t, builders, builders)
@@ -84,6 +82,7 @@ func TestKibanaAssociationWhenReferencedESDisappears(t *testing.T) {
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
+		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)
 
 	failureSteps := func(k *test.K8sClient) test.StepList {

--- a/operators/test/e2e/kb/failure_test.go
+++ b/operators/test/e2e/kb/failure_test.go
@@ -22,6 +22,7 @@ func TestKillKibanaPod(t *testing.T) {
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
+		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)
 
 	matchFirst := func(p corev1.Pod) bool {
@@ -37,6 +38,7 @@ func TestKillKibanaDeployment(t *testing.T) {
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
+		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)
 
 	test.RunRecoverableFailureScenario(t, func(k *test.K8sClient) test.StepList {

--- a/operators/test/e2e/kb/keystore_test.go
+++ b/operators/test/e2e/kb/keystore_test.go
@@ -42,6 +42,7 @@ func TestUpdateKibanaSecureSettings(t *testing.T) {
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
+		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1).
 		WithKibanaSecureSettings(secureSettings.Name)
 

--- a/operators/test/e2e/kb/resource_test.go
+++ b/operators/test/e2e/kb/resource_test.go
@@ -30,6 +30,7 @@ func TestUpdateKibanaResources(t *testing.T) {
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
+		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1).
 		WithResources(resources)
 

--- a/operators/test/e2e/kb/sample_test.go
+++ b/operators/test/e2e/kb/sample_test.go
@@ -32,12 +32,16 @@ func TestKibanaEsSample(t *testing.T) {
 	test.ExitOnErr(decoder.Decode(&esBuilder.Elasticsearch))
 	test.ExitOnErr(decoder.Decode(&kbBuilder.Kibana))
 
+	ns := test.Ctx().ManagedNamespace(0)
 	esBuilder = esBuilder.
-		WithNamespace(test.Ctx().ManagedNamespace(0)).
+		WithRandomPrefixName().
+		WithNamespace(ns).
 		WithVersion(test.Ctx().ElasticStackVersion).
 		WithRestrictedSecurityContext()
 	kbBuilder = kbBuilder.
-		WithNamespace(test.Ctx().ManagedNamespace(0)).
+		WithRandomPrefixName().
+		WithNamespace(ns).
+		WithElasticsearchRef(esBuilder.Ref()).
 		WithVersion(test.Ctx().ElasticStackVersion).
 		WithRestrictedSecurityContext()
 

--- a/operators/test/e2e/kb/sample_test.go
+++ b/operators/test/e2e/kb/sample_test.go
@@ -34,12 +34,12 @@ func TestKibanaEsSample(t *testing.T) {
 
 	ns := test.Ctx().ManagedNamespace(0)
 	esBuilder = esBuilder.
-		WithRandomPrefixName().
+		WithRandomSuffix().
 		WithNamespace(ns).
 		WithVersion(test.Ctx().ElasticStackVersion).
 		WithRestrictedSecurityContext()
 	kbBuilder = kbBuilder.
-		WithRandomPrefixName().
+		WithRandomSuffix().
 		WithNamespace(ns).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithVersion(test.Ctx().ElasticStackVersion).

--- a/operators/test/e2e/kb/sample_test.go
+++ b/operators/test/e2e/kb/sample_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/elasticsearch"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/kibana"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -33,13 +34,14 @@ func TestKibanaEsSample(t *testing.T) {
 	test.ExitOnErr(decoder.Decode(&kbBuilder.Kibana))
 
 	ns := test.Ctx().ManagedNamespace(0)
+	randSuffix := rand.String(4)
 	esBuilder = esBuilder.
-		WithRandomSuffix().
+		WithSuffix(randSuffix).
 		WithNamespace(ns).
 		WithVersion(test.Ctx().ElasticStackVersion).
 		WithRestrictedSecurityContext()
 	kbBuilder = kbBuilder.
-		WithRandomSuffix().
+		WithSuffix(randSuffix).
 		WithNamespace(ns).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithVersion(test.Ctx().ElasticStackVersion).

--- a/operators/test/e2e/kb/telemetry_test.go
+++ b/operators/test/e2e/kb/telemetry_test.go
@@ -20,6 +20,7 @@ func TestTelemetry(t *testing.T) {
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
+		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)
 
 	stepsFn := func(k *test.K8sClient) test.StepList {

--- a/operators/test/e2e/smoke_test.go
+++ b/operators/test/e2e/smoke_test.go
@@ -33,16 +33,16 @@ func TestSmoke(t *testing.T) {
 
 	ns := test.Ctx().ManagedNamespace(0)
 	esBuilder = esBuilder.
-		WithRandomPrefixName().
+		WithRandomSuffix().
 		WithNamespace(ns).
 		WithRestrictedSecurityContext()
 	kbBuilder = kbBuilder.
-		WithRandomPrefixName().
+		WithRandomSuffix().
 		WithNamespace(ns).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithRestrictedSecurityContext()
 	apmBuilder = apmBuilder.
-		WithRandomPrefixName().
+		WithRandomSuffix().
 		WithNamespace(ns).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithRestrictedSecurityContext()

--- a/operators/test/e2e/smoke_test.go
+++ b/operators/test/e2e/smoke_test.go
@@ -31,14 +31,20 @@ func TestSmoke(t *testing.T) {
 	test.ExitOnErr(decoder.Decode(&apmBuilder.ApmServer))
 	test.ExitOnErr(decoder.Decode(&kbBuilder.Kibana))
 
+	ns := test.Ctx().ManagedNamespace(0)
 	esBuilder = esBuilder.
-		WithNamespace(test.Ctx().ManagedNamespace(0)).
+		WithRandomPrefixName().
+		WithNamespace(ns).
 		WithRestrictedSecurityContext()
 	kbBuilder = kbBuilder.
-		WithNamespace(test.Ctx().ManagedNamespace(0)).
+		WithRandomPrefixName().
+		WithNamespace(ns).
+		WithElasticsearchRef(esBuilder.Ref()).
 		WithRestrictedSecurityContext()
 	apmBuilder = apmBuilder.
-		WithNamespace(test.Ctx().ManagedNamespace(0)).
+		WithRandomPrefixName().
+		WithNamespace(ns).
+		WithElasticsearchRef(esBuilder.Ref()).
 		WithRestrictedSecurityContext()
 
 	test.Sequence(nil, test.EmptySteps, esBuilder, kbBuilder, apmBuilder).

--- a/operators/test/e2e/smoke_test.go
+++ b/operators/test/e2e/smoke_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/apmserver"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/elasticsearch"
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/kibana"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -32,17 +33,18 @@ func TestSmoke(t *testing.T) {
 	test.ExitOnErr(decoder.Decode(&kbBuilder.Kibana))
 
 	ns := test.Ctx().ManagedNamespace(0)
+	randSuffix := rand.String(4)
 	esBuilder = esBuilder.
-		WithRandomSuffix().
+		WithSuffix(randSuffix).
 		WithNamespace(ns).
 		WithRestrictedSecurityContext()
 	kbBuilder = kbBuilder.
-		WithRandomSuffix().
+		WithSuffix(randSuffix).
 		WithNamespace(ns).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithRestrictedSecurityContext()
 	apmBuilder = apmBuilder.
-		WithRandomSuffix().
+		WithSuffix(randSuffix).
 		WithNamespace(ns).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithRestrictedSecurityContext()

--- a/operators/test/e2e/test/apmserver/builder.go
+++ b/operators/test/e2e/test/apmserver/builder.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 // Builder to create APM Servers
@@ -36,11 +37,11 @@ func NewBuilder(name string) Builder {
 				},
 			},
 		},
-	}.WithRandomSuffix()
+	}.WithSuffix(rand.String(4))
 }
 
-func (b Builder) WithRandomSuffix() Builder {
-	b.ApmServer.ObjectMeta.Name = test.WithRandomPrefix(b.ApmServer.ObjectMeta.Name)
+func (b Builder) WithSuffix(suffix string) Builder {
+	b.ApmServer.ObjectMeta.Name = b.ApmServer.ObjectMeta.Name + "-" + suffix
 	return b
 }
 

--- a/operators/test/e2e/test/apmserver/builder.go
+++ b/operators/test/e2e/test/apmserver/builder.go
@@ -29,10 +29,6 @@ func NewBuilder(name string) Builder {
 			Spec: apmtype.ApmServerSpec{
 				NodeCount: 1,
 				Version:   test.Ctx().ElasticStackVersion,
-				ElasticsearchRef: commonv1alpha1.ObjectSelector{
-					Name:      name,
-					Namespace: test.Ctx().ManagedNamespace(0),
-				},
 				PodTemplate: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						SecurityContext: test.DefaultSecurityContext(),
@@ -40,7 +36,12 @@ func NewBuilder(name string) Builder {
 				},
 			},
 		},
-	}
+	}.WithRandomPrefixName()
+}
+
+func (b Builder) WithRandomPrefixName() Builder {
+	b.ApmServer.ObjectMeta.Name = test.WithRandomPrefix(b.ApmServer.ObjectMeta.Name)
+	return b
 }
 
 func (b Builder) WithRestrictedSecurityContext() Builder {

--- a/operators/test/e2e/test/apmserver/builder.go
+++ b/operators/test/e2e/test/apmserver/builder.go
@@ -36,10 +36,10 @@ func NewBuilder(name string) Builder {
 				},
 			},
 		},
-	}.WithRandomPrefixName()
+	}.WithRandomSuffix()
 }
 
-func (b Builder) WithRandomPrefixName() Builder {
+func (b Builder) WithRandomSuffix() Builder {
 	b.ApmServer.ObjectMeta.Name = test.WithRandomPrefix(b.ApmServer.ObjectMeta.Name)
 	return b
 }

--- a/operators/test/e2e/test/builder.go
+++ b/operators/test/e2e/test/builder.go
@@ -4,8 +4,6 @@
 
 package test
 
-import "k8s.io/apimachinery/pkg/util/rand"
-
 type Builder interface {
 	// InitTestSteps includes pre-requisite tests (eg. is k8s accessible) and cleanup from previous tests.
 	InitTestSteps(k *K8sClient) StepList
@@ -21,8 +19,4 @@ type Builder interface {
 	// We expect the resource to be already created and running.
 	// If the resource to mutate to is the same as the original resource, then all tests should still pass.
 	MutationTestSteps(k *K8sClient) StepList
-}
-
-func WithRandomPrefix(name string) string {
-	return name + "-" + rand.String(4)
 }

--- a/operators/test/e2e/test/builder.go
+++ b/operators/test/e2e/test/builder.go
@@ -4,6 +4,8 @@
 
 package test
 
+import "k8s.io/apimachinery/pkg/util/rand"
+
 type Builder interface {
 	// InitTestSteps includes pre-requisite tests (eg. is k8s accessible) and cleanup from previous tests.
 	InitTestSteps(k *K8sClient) StepList
@@ -19,4 +21,8 @@ type Builder interface {
 	// We expect the resource to be already created and running.
 	// If the resource to mutate to is the same as the original resource, then all tests should still pass.
 	MutationTestSteps(k *K8sClient) StepList
+}
+
+func WithRandomPrefix(name string) string {
+	return name + "-" + rand.String(4)
 }

--- a/operators/test/e2e/test/elasticsearch/builder.go
+++ b/operators/test/e2e/test/elasticsearch/builder.go
@@ -48,6 +48,18 @@ func NewBuilder(name string) Builder {
 				Version:          test.Ctx().ElasticStackVersion,
 			},
 		},
+	}.WithRandomPrefixName()
+}
+
+func (b Builder) WithRandomPrefixName() Builder {
+	b.Elasticsearch.ObjectMeta.Name = test.WithRandomPrefix(b.Elasticsearch.ObjectMeta.Name)
+	return b
+}
+
+func (b Builder) Ref() commonv1alpha1.ObjectSelector {
+	return commonv1alpha1.ObjectSelector{
+		Name:      b.Elasticsearch.Name,
+		Namespace: b.Elasticsearch.Namespace,
 	}
 }
 

--- a/operators/test/e2e/test/elasticsearch/builder.go
+++ b/operators/test/e2e/test/elasticsearch/builder.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 func ESPodTemplate(resources corev1.ResourceRequirements) corev1.PodTemplateSpec {
@@ -48,11 +49,11 @@ func NewBuilder(name string) Builder {
 				Version:          test.Ctx().ElasticStackVersion,
 			},
 		},
-	}.WithRandomSuffix()
+	}.WithSuffix(rand.String(4))
 }
 
-func (b Builder) WithRandomSuffix() Builder {
-	b.Elasticsearch.ObjectMeta.Name = test.WithRandomPrefix(b.Elasticsearch.ObjectMeta.Name)
+func (b Builder) WithSuffix(suffix string) Builder {
+	b.Elasticsearch.ObjectMeta.Name = b.Elasticsearch.ObjectMeta.Name + "-" + suffix
 	return b
 }
 

--- a/operators/test/e2e/test/elasticsearch/builder.go
+++ b/operators/test/e2e/test/elasticsearch/builder.go
@@ -48,10 +48,10 @@ func NewBuilder(name string) Builder {
 				Version:          test.Ctx().ElasticStackVersion,
 			},
 		},
-	}.WithRandomPrefixName()
+	}.WithRandomSuffix()
 }
 
-func (b Builder) WithRandomPrefixName() Builder {
+func (b Builder) WithRandomSuffix() Builder {
 	b.Elasticsearch.ObjectMeta.Name = test.WithRandomPrefix(b.Elasticsearch.ObjectMeta.Name)
 	return b
 }

--- a/operators/test/e2e/test/kibana/builder.go
+++ b/operators/test/e2e/test/kibana/builder.go
@@ -28,11 +28,6 @@ func NewBuilder(name string) Builder {
 			ObjectMeta: meta,
 			Spec: kbtype.KibanaSpec{
 				Version: test.Ctx().ElasticStackVersion,
-				// Create an ElasticsearchRef by default with the same name
-				ElasticsearchRef: commonv1alpha1.ObjectSelector{
-					Name:      name,
-					Namespace: test.Ctx().ManagedNamespace(0),
-				},
 				PodTemplate: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						SecurityContext: test.DefaultSecurityContext(),
@@ -40,7 +35,17 @@ func NewBuilder(name string) Builder {
 				},
 			},
 		},
-	}
+	}.WithRandomPrefixName()
+}
+
+func (b Builder) WithRandomPrefixName() Builder {
+	b.Kibana.ObjectMeta.Name = test.WithRandomPrefix(b.Kibana.ObjectMeta.Name)
+	return b
+}
+
+func (b Builder) WithElasticsearchRef(ref commonv1alpha1.ObjectSelector) Builder {
+	b.Kibana.Spec.ElasticsearchRef = ref
+	return b
 }
 
 // WithRestrictedSecurityContext helps to enforce a restricted security context on the objects.

--- a/operators/test/e2e/test/kibana/builder.go
+++ b/operators/test/e2e/test/kibana/builder.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 // Builder to create Kibana instances
@@ -35,11 +36,11 @@ func NewBuilder(name string) Builder {
 				},
 			},
 		},
-	}.WithRandomSuffix()
+	}.WithSuffix(rand.String(4))
 }
 
-func (b Builder) WithRandomSuffix() Builder {
-	b.Kibana.ObjectMeta.Name = test.WithRandomPrefix(b.Kibana.ObjectMeta.Name)
+func (b Builder) WithSuffix(suffix string) Builder {
+	b.Kibana.ObjectMeta.Name = b.Kibana.ObjectMeta.Name + "-" + suffix
 	return b
 }
 

--- a/operators/test/e2e/test/kibana/builder.go
+++ b/operators/test/e2e/test/kibana/builder.go
@@ -35,10 +35,10 @@ func NewBuilder(name string) Builder {
 				},
 			},
 		},
-	}.WithRandomPrefixName()
+	}.WithRandomSuffix()
 }
 
-func (b Builder) WithRandomPrefixName() Builder {
+func (b Builder) WithRandomSuffix() Builder {
 	b.Kibana.ObjectMeta.Name = test.WithRandomPrefix(b.Kibana.ObjectMeta.Name)
 	return b
 }


### PR DESCRIPTION
- Add implicitly a random prefix to the name of the elastic stack in the builder constructors
- Set explicitly the Elastisearch ref in the Kibana and APM Server builders
- Add explicitly a random prefix name and set an Elasticsearch ref in E2E tests using YAML samples

Resolves #1461.