### PR TITLE
Clarify quickstart PV name

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -280,7 +280,7 @@ spec:
       node.ingest: true
     volumeClaimTemplates:
     - metadata:
-        name: elasticsearch-data # note: elasticsearch-data must be the name of the elasticsearch volume
+        name: elasticsearch-data # note: elasticsearch-data must be the name of the Elasticsearch volume
       spec:
         accessModes:
         - ReadWriteOnce

--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -280,7 +280,7 @@ spec:
       node.ingest: true
     volumeClaimTemplates:
     - metadata:
-        name: elasticsearch-data
+        name: elasticsearch-data # note: elasticsearch-data must be the name of the elasticsearch volume
       spec:
         accessModes:
         - ReadWriteOnce


### PR DESCRIPTION
Clarify that the ES volume name must be `elasticsearch-data` in the quickstart. In reference to issue raised in:
https://discuss.elastic.co/t/init-container-fails/193684/4

Will backport to 0.9 too.