### PR TITLE
Reuse suffixed name in e2e tests

### DIFF
--- a/operators/test/e2e/apm/configuration_test.go
+++ b/operators/test/e2e/apm/configuration_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/elasticsearch"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -64,7 +64,12 @@ func TestUpdateConfiguration(t *testing.T) {
 		WithVersion(test.Ctx().ElasticStackVersion).
 		WithRestrictedSecurityContext()
 
-	var previousPodUID *types.UID
+	apmName := apmBuilder.ApmServer.Name
+	apmNamespacedName := types.NamespacedName{
+		Name:      apmName,
+		Namespace: namespace,
+	}
+	apmPodListOpts := test.ApmServerPodListOptions(namespace, apmName)
 
 	initStepsFn := func(k *test.K8sClient) test.StepList {
 		return test.StepList{
@@ -79,14 +84,11 @@ func TestUpdateConfiguration(t *testing.T) {
 				},
 			},
 			// Keystore should be empty
-			test.CheckKeystoreEntries(k, test.ApmServerPodListOptions(namespace, name), APMKeystoreCmd, nil),
+			test.CheckKeystoreEntries(k, apmPodListOpts, APMKeystoreCmd, nil),
 		}
 	}
-	apmNamespacedName := types.NamespacedName{
-		Name:      name,
-		Namespace: test.Ctx().ManagedNamespace(0),
-	}
 
+	var previousPodUID *types.UID
 	stepsFn := func(k *test.K8sClient) test.StepList {
 		return test.StepList{
 			{
@@ -94,6 +96,7 @@ func TestUpdateConfiguration(t *testing.T) {
 				Test: func(t *testing.T) {
 					config, err := partialAPMConfiguration(k, namespace, name)
 					require.NoError(t, err)
+
 					esHost := services.ExternalServiceURL(esBuilder.Elasticsearch)
 					require.Equal(t, config.Output.Elasticsearch.Hosts[0], esHost)
 					require.Equal(t, config.Output.Elasticsearch.CompressionLevel, 0) // CompressionLevel is not set by default
@@ -103,7 +106,7 @@ func TestUpdateConfiguration(t *testing.T) {
 				Name: "Add a Keystore to the APM server",
 				Test: func(t *testing.T) {
 					// get current pod id
-					pods, err := k.GetPods(test.ApmServerPodListOptions(namespace, name))
+					pods, err := k.GetPods(apmPodListOpts)
 					require.NoError(t, err)
 					require.True(t, len(pods) == 1)
 					previousPodUID = &pods[0].UID
@@ -120,7 +123,7 @@ func TestUpdateConfiguration(t *testing.T) {
 				Name: "APM Pod should be recreated",
 				Test: test.Eventually(func() error {
 					// get current pod id
-					pods, err := k.GetPods(test.ApmServerPodListOptions(namespace, name))
+					pods, err := k.GetPods(apmPodListOpts)
 					if err != nil {
 						return err
 					}
@@ -134,13 +137,13 @@ func TestUpdateConfiguration(t *testing.T) {
 				}),
 			},
 
-			test.CheckKeystoreEntries(k, test.ApmServerPodListOptions(namespace, name), APMKeystoreCmd, []string{"logging.verbose"}),
+			test.CheckKeystoreEntries(k, apmPodListOpts, APMKeystoreCmd, []string{"logging.verbose"}),
 
 			test.Step{
 				Name: "Customize configuration of the APM server",
 				Test: func(t *testing.T) {
 					// get current pod id
-					pods, err := k.GetPods(test.ApmServerPodListOptions(namespace, name))
+					pods, err := k.GetPods(apmPodListOpts)
 					require.NoError(t, err)
 					require.True(t, len(pods) == 1)
 					previousPodUID = &pods[0].UID
@@ -158,7 +161,7 @@ func TestUpdateConfiguration(t *testing.T) {
 				Name: "APM Pod should be recreated",
 				Test: test.Eventually(func() error {
 					// get current pod id
-					pods, err := k.GetPods(test.ApmServerPodListOptions(namespace, name))
+					pods, err := k.GetPods(apmPodListOpts)
 					if err != nil {
 						return err
 					}
@@ -175,7 +178,7 @@ func TestUpdateConfiguration(t *testing.T) {
 			test.Step{
 				Name: "Check the value of a parameter in the configuration",
 				Test: func(t *testing.T) {
-					config, err := partialAPMConfiguration(k, namespace, name)
+					config, err := partialAPMConfiguration(k, namespace, apmName)
 					require.NoError(t, err)
 					require.Equal(t, config.Output.Elasticsearch.CompressionLevel, 1) // value should be updated to 1
 				},
@@ -198,13 +201,18 @@ func TestUpdateConfiguration(t *testing.T) {
 
 func partialAPMConfiguration(k *test.K8sClient, namespace, name string) (PartialApmConfiguration, error) {
 	var config PartialApmConfiguration
-	// get current pod id
+	// get current pods
 	pods, err := k.GetPods(test.ApmServerPodListOptions(namespace, name))
 	if err != nil {
 		return config, err
 	}
+	if len(pods) == 0 {
+		return config, errors.New("no pods found")
+	}
+
 	// exec into the pod to list keystore entries
-	stdout, stderr, err := k.Exec(k8s.ExtractNamespacedName(&pods[0]), []string{"cat", "/usr/share/apm-server/config/config-secret/apm-server.yml"})
+	stdout, stderr, err := k.Exec(k8s.ExtractNamespacedName(&pods[0]),
+		[]string{"cat", "/usr/share/apm-server/config/config-secret/apm-server.yml"})
 	if err != nil {
 		return config, errors.Wrap(err, fmt.Sprintf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
 	}

--- a/operators/test/e2e/es/certs_test.go
+++ b/operators/test/e2e/es/certs_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestUpdateHTTPCertSAN(t *testing.T) {
-	name := "test-http-cert-san"
-	b := elasticsearch.NewBuilder(name).
+	b := elasticsearch.NewBuilder("test-http-cert-san").
 		WithESMasterNodes(1, elasticsearch.DefaultResources).
 		WithHTTPLoadBalancer()
 
@@ -38,7 +37,7 @@ func TestUpdateHTTPCertSAN(t *testing.T) {
 				Name: "Retrieve ES certificate",
 				Test: func(t *testing.T) {
 					var err error
-					caCert, err = getCert(k, test.Ctx().ManagedNamespace(0), name)
+					caCert, err = getCert(k, b.Elasticsearch.Namespace, b.Elasticsearch.Name)
 					require.NoError(t, err)
 				},
 			},
@@ -46,7 +45,7 @@ func TestUpdateHTTPCertSAN(t *testing.T) {
 				Name: "Retrieve ES public IP",
 				Test: test.Eventually(func() error {
 					var err error
-					publicIP, err = getPublicIP(k, test.Ctx().ManagedNamespace(0), name)
+					publicIP, err = getPublicIP(k, b.Elasticsearch.Namespace, b.Elasticsearch.Name)
 					return err
 				}),
 			},

--- a/operators/test/e2e/kb/keystore_test.go
+++ b/operators/test/e2e/kb/keystore_test.go
@@ -46,7 +46,7 @@ func TestUpdateKibanaSecureSettings(t *testing.T) {
 		WithNodeCount(1).
 		WithKibanaSecureSettings(secureSettings.Name)
 
-	namespace := kbBuilder.Kibana.Namespace
+	kbPodListOpts := test.KibanaPodListOptions(kbBuilder.Kibana.Namespace, kbBuilder.Kibana.Name)
 
 	initStepsFn := func(k *test.K8sClient) test.StepList {
 		return test.StepList{
@@ -62,9 +62,10 @@ func TestUpdateKibanaSecureSettings(t *testing.T) {
 			},
 		}
 	}
+
 	stepsFn := func(k *test.K8sClient) test.StepList {
 		return test.StepList{
-			test.CheckKeystoreEntries(k, test.KibanaPodListOptions(namespace, name), KibanaKeystoreCmd, []string{"logging.verbose"}),
+			test.CheckKeystoreEntries(k, kbPodListOpts, KibanaKeystoreCmd, []string{"logging.verbose"}),
 			// modify the secure settings secret
 			test.Step{
 				Name: "Modify secure settings secret",
@@ -80,7 +81,7 @@ func TestUpdateKibanaSecureSettings(t *testing.T) {
 			},
 
 			// keystore should be updated accordingly
-			test.CheckKeystoreEntries(k, test.KibanaPodListOptions(namespace, name), KibanaKeystoreCmd, []string{"logging.json", "logging.verbose"}),
+			test.CheckKeystoreEntries(k, kbPodListOpts, KibanaKeystoreCmd, []string{"logging.json", "logging.verbose"}),
 
 			// remove the secure settings reference
 			test.Step{
@@ -98,7 +99,7 @@ func TestUpdateKibanaSecureSettings(t *testing.T) {
 			},
 
 			// keystore should be updated accordingly
-			test.CheckKeystoreEntries(k, test.KibanaPodListOptions(namespace, name), KibanaKeystoreCmd, nil),
+			test.CheckKeystoreEntries(k, kbPodListOpts, KibanaKeystoreCmd, nil),
 
 			// cleanup extra resources
 			test.Step{

--- a/operators/test/e2e/kb/resource_test.go
+++ b/operators/test/e2e/kb/resource_test.go
@@ -39,7 +39,7 @@ func TestUpdateKibanaResources(t *testing.T) {
 			test.Step{
 				Name: "Check resources are propagated to the pod spec",
 				Test: func(t *testing.T) {
-					pods, err := k.GetPods(test.KibanaPodListOptions(kbBuilder.Kibana.Namespace, name))
+					pods, err := k.GetPods(test.KibanaPodListOptions(kbBuilder.Kibana.Namespace, kbBuilder.Kibana.Name))
 					require.NoError(t, err)
 					for _, p := range pods {
 						require.Equal(t, resources, p.Spec.Containers[0].Resources)

--- a/operators/test/e2e/test/apmserver/builder.go
+++ b/operators/test/e2e/test/apmserver/builder.go
@@ -52,7 +52,6 @@ func (b Builder) WithRestrictedSecurityContext() Builder {
 
 func (b Builder) WithNamespace(namespace string) Builder {
 	b.ApmServer.ObjectMeta.Namespace = namespace
-	b.ApmServer.Spec.ElasticsearchRef.Namespace = namespace
 	return b
 }
 

--- a/operators/test/e2e/test/kibana/builder.go
+++ b/operators/test/e2e/test/kibana/builder.go
@@ -57,7 +57,6 @@ func (b Builder) WithRestrictedSecurityContext() Builder {
 
 func (b Builder) WithNamespace(namespace string) Builder {
 	b.Kibana.ObjectMeta.Namespace = namespace
-	b.Kibana.Spec.ElasticsearchRef.Namespace = namespace
 	return b
 }
 


### PR DESCRIPTION
- Reuse APM Server suffixed name in E2E test TestUpdateConfiguration
- Reuse ES suffixed name in E2E test TestUpdateHTTPCertSAN
- Reuse Kibana suffixed name in Kibana E2E tests
- Stop to update esRef namespace in WithNamespace since WithElasticsearchRef is used 

Resolves #1498.