### PR TITLE
Refactor downscales and add unit tests

### DIFF
--- a/operators/pkg/controller/elasticsearch/client/model.go
+++ b/operators/pkg/controller/elasticsearch/client/model.go
@@ -116,9 +116,11 @@ type ClusterState struct {
 	Version      int                         `json:"version"`
 	MasterNode   string                      `json:"master_node"`
 	Nodes        map[string]ClusterStateNode `json:"nodes"`
-	RoutingTable struct {
-		Indices map[string]Shards `json:"indices"`
-	} `json:"routing_table"`
+	RoutingTable RoutingTable                `json:"routing_table"`
+}
+
+type RoutingTable struct {
+	Indices map[string]Shards `json:"indices"`
 }
 
 // IsEmpty returns true if this is an empty struct without data.

--- a/operators/pkg/controller/elasticsearch/driver/downscale.go
+++ b/operators/pkg/controller/elasticsearch/driver/downscale.go
@@ -5,6 +5,7 @@
 package driver
 
 import (
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/reconciler"
 	esclient "github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
@@ -14,122 +15,221 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/version/zen1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/version/zen2"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
 	appsv1 "k8s.io/api/apps/v1"
 )
 
-func (d *defaultDriver) HandleDownscale(
+// downscaleContext holds the context of this downscale, including clients and states,
+// propagated from the main driver.
+type downscaleContext struct {
+	// clients
+	k8sClient k8s.Client
+	esClient  esclient.Client
+	// driver states
+	resourcesState reconcile.ResourcesState
+	observedState  observer.State
+	reconcileState *reconcile.State
+	expectations   *reconciler.Expectations
+	// ES cluster
+	es v1alpha1.Elasticsearch
+}
+
+// HandleDownscale attempts to downscale actual StatefulSets towards expected ones.
+func HandleDownscale(
+	downscaleCtx downscaleContext,
 	expectedStatefulSets sset.StatefulSetList,
 	actualStatefulSets sset.StatefulSetList,
-	esClient esclient.Client,
-	resourcesState reconcile.ResourcesState,
-	observedState observer.State,
-	reconcileState *reconcile.State,
 ) *reconciler.Results {
 	results := &reconciler.Results{}
 
-	// compute the list of nodes leaving the cluster, from which
-	// data should be migrated away
-	leavingNodes := []string{}
+	// compute the list of StatefulSet downscales to perform
+	downscales := calculateDownscales(expectedStatefulSets, actualStatefulSets)
+	leavingNodes := leavingNodeNames(downscales)
 
-	// process each statefulset for downscale
-	for i, actual := range actualStatefulSets {
-		expected, shouldExist := expectedStatefulSets.GetByName(actual.Name)
-		targetReplicas := int32(0) // sset removal
-		if shouldExist {           // sset downscale
-			targetReplicas = sset.Replicas(expected)
-		}
-		leaving, removalResult := d.scaleStatefulSetDown(actualStatefulSets, &actualStatefulSets[i], targetReplicas, esClient, resourcesState, observedState, reconcileState)
-		results.WithResults(removalResult)
-		if removalResult.HasError() {
-			return results
-		}
-		leavingNodes = append(leavingNodes, leaving...)
+	// migrate data away from nodes that should be removed
+	if err := scheduleDataMigrations(downscaleCtx.esClient, leavingNodes); err != nil {
+		return results.WithError(err)
 	}
 
-	// migrate data away from nodes leaving the cluster
-	log.V(1).Info("Migrating data away from nodes", "nodes", leavingNodes)
-	if err := migration.MigrateData(esClient, leavingNodes); err != nil {
-		return results.WithError(err)
+	for _, downscale := range downscales {
+		// attempt the StatefulSet downscale (may or may not remove nodes)
+		requeue, err := attemptDownscale(downscaleCtx, downscale, leavingNodes, actualStatefulSets)
+		if err != nil {
+			return results.WithError(err)
+		}
+		if requeue {
+			// retry downscaling this statefulset later
+			results.WithResult(defaultRequeue)
+		}
 	}
 
 	return results
 }
 
-// scaleStatefulSetDown scales the given StatefulSet down to targetReplicas, if possible.
-// It returns the names of the nodes that will leave the cluster.
-func (d *defaultDriver) scaleStatefulSetDown(
-	allStatefulSets sset.StatefulSetList,
-	ssetToScaleDown *appsv1.StatefulSet,
-	targetReplicas int32,
-	esClient esclient.Client,
-	resourcesState reconcile.ResourcesState,
-	observedState observer.State,
-	reconcileState *reconcile.State,
-) ([]string, *reconciler.Results) {
-	results := &reconciler.Results{}
-	logger := log.WithValues("namespace", ssetToScaleDown.Namespace, "statefulset", ssetToScaleDown.Name)
+// ssetDownscale helps with the downscale of a single StatefulSet.
+type ssetDownscale struct {
+	statefulSet     appsv1.StatefulSet
+	initialReplicas int32
+	targetReplicas  int32
+}
 
-	if sset.Replicas(*ssetToScaleDown) == 0 && targetReplicas == 0 {
-		// no replicas expected, StatefulSet can be safely deleted
-		logger.Info("Deleting statefulset", "namespace", ssetToScaleDown.Namespace, "name", ssetToScaleDown.Name)
-		if err := d.Client.Delete(ssetToScaleDown); err != nil {
-			return nil, results.WithError(err)
+// leavingNodeNames returns names of the nodes that are supposed to leave the Elasticsearch cluster
+// for this StatefulSet.
+func (d ssetDownscale) leavingNodeNames() []string {
+	if d.targetReplicas >= d.initialReplicas {
+		return nil
+	}
+	leavingNodes := make([]string, 0, d.initialReplicas-d.targetReplicas)
+	// nodes are ordered by highest ordinal first
+	for i := d.initialReplicas - 1; i >= d.targetReplicas; i-- {
+		leavingNodes = append(leavingNodes, sset.PodName(d.statefulSet.Name, i))
+	}
+	return leavingNodes
+}
+
+// canRemove returns true if the StatefulSet can be safely removed (no replicas).
+func (d ssetDownscale) canRemoveStatefulSet() bool {
+	// StatefulSet does not have any replica, and should not have one
+	return d.initialReplicas == 0 && d.targetReplicas == 0
+}
+
+// leavingNodeNames returns the names of all nodes that should leave the cluster (across StatefulSets).
+func leavingNodeNames(downscales []ssetDownscale) []string {
+	leavingNodes := []string{}
+	for _, d := range downscales {
+		leavingNodes = append(leavingNodes, d.leavingNodeNames()...)
+	}
+	return leavingNodes
+}
+
+// calculateDownscales compares expected and actual StatefulSets to return a list of ssetDownscale.
+func calculateDownscales(expectedStatefulSets sset.StatefulSetList, actualStatefulSets sset.StatefulSetList) []ssetDownscale {
+	downscales := []ssetDownscale{}
+	for _, actualSset := range actualStatefulSets {
+		actualReplicas := sset.Replicas(actualSset)
+		expectedSset, shouldExist := expectedStatefulSets.GetByName(actualSset.Name)
+		expectedReplicas := int32(0) // sset removal
+		if shouldExist {             // sset downscale
+			expectedReplicas = sset.Replicas(expectedSset)
+		}
+		if expectedReplicas == 0 || // removal
+			expectedReplicas < actualReplicas { // downscale
+			downscales = append(downscales, ssetDownscale{
+				statefulSet:     actualSset,
+				initialReplicas: actualReplicas,
+				targetReplicas:  expectedReplicas,
+			})
 		}
 	}
-	// copy the current replicas, to be decremented with nodes to remove
-	initialReplicas := sset.Replicas(*ssetToScaleDown)
-	updatedReplicas := initialReplicas
+	return downscales
+}
 
-	// leaving nodes names can be built from StatefulSet name and ordinals
-	// nodes are ordered by highest ordinal first
-	var leavingNodes []string
-	for i := initialReplicas - 1; i > targetReplicas-1; i-- {
-		leavingNodes = append(leavingNodes, sset.PodName(ssetToScaleDown.Name, i))
+// scheduleDataMigrations requests Elasticsearch to migrate data away from leavingNodes.
+func scheduleDataMigrations(esClient esclient.Client, leavingNodes []string) error {
+	if len(leavingNodes) == 0 {
+		return nil
+	}
+	log.V(1).Info("Migrating data away from nodes", "nodes", leavingNodes)
+	return migration.MigrateData(esClient, leavingNodes)
+}
+
+// attemptDownscale attempts to decrement the number of replicas of the given StatefulSet,
+// or deletes the StatefulSet entirely if it should not contain any replica.
+// Nodes whose data migration is not over will not be removed.
+// A boolean is returned to indicate if a requeue should be scheduled if the entire downscale could not be performed.
+func attemptDownscale(ctx downscaleContext, downscale ssetDownscale, allLeavingNodes []string, statefulSets sset.StatefulSetList) (bool, error) {
+	// TODO: only one master node downscale at a time
+	if downscale.canRemoveStatefulSet() {
+		ssetLogger(downscale.statefulSet).Info("Deleting statefulset")
+		if err := ctx.k8sClient.Delete(&downscale.statefulSet); err != nil {
+			return false, err
+		}
+		return false, nil
 	}
 
-	// TODO: don't remove last master/last data nodes?
-	// TODO: detect cases where data migration cannot happen since no nodes to host shards?
+	if downscale.targetReplicas >= downscale.initialReplicas {
+		// nothing to do
+		return false, nil
+	}
 
-	for _, node := range leavingNodes {
-		if migration.IsMigratingData(observedState, node, leavingNodes) {
-			// data migration not over yet: schedule a requeue
-			logger.V(1).Info("Data migration not over yet, skipping node deletion", "node", node)
-			reconcileState.UpdateElasticsearchMigrating(resourcesState, observedState)
-			results.WithResult(defaultRequeue)
+	// adjust the theoretical downscale to one we can safely perform
+	performable, shouldRequeue := calculatePerformableDownscale(ctx, downscale, allLeavingNodes)
+
+	// do the performable downscale
+	return shouldRequeue, doDownscale(ctx, performable, statefulSets)
+}
+
+// calculatePerformableDownscale updates the given downscale target replicas to account for nodes
+// which cannot be safely deleted yet.
+// It returns the updated downscale and a boolean indicating whether a requeue should be done.
+func calculatePerformableDownscale(
+	ctx downscaleContext,
+	downscale ssetDownscale,
+	allLeavingNodes []string,
+) (ssetDownscale, bool) {
+	// create another downscale based on the provided one, for which we'll slowly decrease target replicas
+	performableDownscale := ssetDownscale{
+		statefulSet:     downscale.statefulSet,
+		initialReplicas: downscale.initialReplicas,
+		targetReplicas:  downscale.initialReplicas, // target set to initial
+	}
+	// iterate on all leaving nodes (ordered by highest ordinal first)
+	for _, node := range downscale.leavingNodeNames() {
+		if migration.IsMigratingData(ctx.observedState, node, allLeavingNodes) {
+			ssetLogger(downscale.statefulSet).V(1).Info("Data migration not over yet, skipping node deletion", "node", node)
+			ctx.reconcileState.UpdateElasticsearchMigrating(ctx.resourcesState, ctx.observedState)
 			// no need to check other nodes since we remove them in order and this one isn't ready anyway
-			break
+			// make sure we requeue
+			return performableDownscale, true
 		}
 		// data migration over: allow pod to be removed
-		updatedReplicas--
+		performableDownscale.targetReplicas--
+	}
+	return performableDownscale, false
+}
+
+// doDownscale schedules nodes removal for the given downscale, and updates zen settings accordingly.
+func doDownscale(downscaleCtx downscaleContext, downscale ssetDownscale, actualStatefulSets sset.StatefulSetList) error {
+	ssetLogger(downscale.statefulSet).Info(
+		"Scaling replicas down",
+		"from", downscale.initialReplicas,
+		"to", downscale.targetReplicas,
+	)
+
+	if err := updateZenSettingsForDownscale(downscaleCtx, downscale, actualStatefulSets); err != nil {
+		return err
 	}
 
-	if updatedReplicas < initialReplicas {
-		// trigger deletion of nodes whose data migration is over
-		logger.Info("Scaling replicas down", "from", initialReplicas, "to", updatedReplicas)
-		ssetToScaleDown.Spec.Replicas = &updatedReplicas
-
-		if label.IsMasterNodeSet(*ssetToScaleDown) {
-			// Update Zen1 minimum master nodes API, accounting for the updated downscaled replicas.
-			_, err := zen1.UpdateMinimumMasterNodes(d.Client, d.ES, esClient, allStatefulSets, reconcileState)
-			if err != nil {
-				return nil, results.WithError(err)
-			}
-			// Update zen2 settings to exclude leaving master nodes from voting.
-			excludeNodes := make([]string, 0, initialReplicas-updatedReplicas)
-			for i := updatedReplicas; i < initialReplicas; i++ {
-				excludeNodes = append(excludeNodes, sset.PodName(ssetToScaleDown.Name, i))
-			}
-			if err := zen2.AddToVotingConfigExclusions(esClient, *ssetToScaleDown, excludeNodes); err != nil {
-				return nil, results.WithError(err)
-			}
-		}
-
-		if err := d.Client.Update(ssetToScaleDown); err != nil {
-			return nil, results.WithError(err)
-		}
-		// Expect the updated statefulset in the cache for next reconciliation.
-		d.Expectations.ExpectGeneration(ssetToScaleDown.ObjectMeta)
+	downscale.statefulSet.Spec.Replicas = &downscale.targetReplicas
+	if err := downscaleCtx.k8sClient.Update(&downscale.statefulSet); err != nil {
+		return err
 	}
 
-	return leavingNodes, results
+	// Expect the updated statefulset in the cache for next reconciliation.
+	downscaleCtx.expectations.ExpectGeneration(downscale.statefulSet.ObjectMeta)
+
+	return nil
+}
+
+// updateZenSettingsForDownscale makes sure zen1 and zen2 settings are updated to account for nodes
+// that will soon be removed.
+func updateZenSettingsForDownscale(ctx downscaleContext, downscale ssetDownscale, actualStatefulSets sset.StatefulSetList) error {
+	if !label.IsMasterNodeSet(downscale.statefulSet) {
+		// nothing to do
+		return nil
+	}
+
+	// TODO: only update in case 2->1 masters.
+	// Update Zen1 minimum master nodes API, accounting for the updated downscaled replicas.
+	_, err := zen1.UpdateMinimumMasterNodes(ctx.k8sClient, ctx.es, ctx.esClient, actualStatefulSets, ctx.reconcileState)
+	if err != nil {
+		return err
+	}
+
+	// Update zen2 settings to exclude leaving master nodes from voting.
+	if err := zen2.AddToVotingConfigExclusions(ctx.esClient, downscale.statefulSet, downscale.leavingNodeNames()); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/operators/pkg/controller/elasticsearch/driver/downscale.go
+++ b/operators/pkg/controller/elasticsearch/driver/downscale.go
@@ -132,11 +132,11 @@ func calculateDownscales(expectedStatefulSets sset.StatefulSetList, actualStatef
 }
 
 // scheduleDataMigrations requests Elasticsearch to migrate data away from leavingNodes.
+// If leavingNodes is empty, it clears any existing settings.
 func scheduleDataMigrations(esClient esclient.Client, leavingNodes []string) error {
-	if len(leavingNodes) == 0 {
-		return nil
+	if len(leavingNodes) != 0 {
+		log.V(1).Info("Migrating data away from nodes", "nodes", leavingNodes)
 	}
-	log.V(1).Info("Migrating data away from nodes", "nodes", leavingNodes)
 	return migration.MigrateData(esClient, leavingNodes)
 }
 

--- a/operators/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/operators/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -423,10 +423,9 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 		allLeavingNodes []string
 	}
 	tests := []struct {
-		name        string
-		args        args
-		want        ssetDownscale
-		wantRequeue bool
+		name string
+		args args
+		want ssetDownscale
 	}{
 		{
 			name: "no downscale planned",
@@ -442,7 +441,6 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 				initialReplicas: 3,
 				targetReplicas:  3,
 			},
-			wantRequeue: false,
 		},
 		{
 			name: "downscale possible from 3 to 1",
@@ -465,7 +463,6 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 				initialReplicas: 3,
 				targetReplicas:  1,
 			},
-			wantRequeue: false,
 		},
 		{
 			name: "downscale not possible: data migration not ready",
@@ -489,17 +486,13 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 				initialReplicas: 3,
 				targetReplicas:  3,
 			},
-			wantRequeue: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, gotRequeue := calculatePerformableDownscale(tt.args.ctx, tt.args.downscale, tt.args.allLeavingNodes)
+			got := calculatePerformableDownscale(tt.args.ctx, tt.args.downscale, tt.args.allLeavingNodes)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("calculatePerformableDownscale() got = %v, want %v", got, tt.want)
-			}
-			if gotRequeue != tt.wantRequeue {
-				t.Errorf("calculatePerformableDownscale() got1 = %v, want %v", gotRequeue, tt.wantRequeue)
 			}
 		})
 	}

--- a/operators/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/operators/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -23,9 +25,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/reconcile"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
-
-	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Sample StatefulSets to use in tests

--- a/operators/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/operators/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -1,0 +1,697 @@
+package driver
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/reconciler"
+	esclient "github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/client"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/nodespec"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/observer"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/reconcile"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Sample StatefulSets to use in tests
+var (
+	sset3Replicas = nodespec.CreateTestSset("sset3Replicas", "7.2.0", 3, true, true)
+	sset4Replicas = nodespec.CreateTestSset("sset4Replicas", "7.2.0", 4, true, true)
+)
+
+// fakeESClient mocks the ES client to register function calls that were made.
+type fakeESClient struct { //nolint:maligned
+	esclient.Client
+
+	SetMinimumMasterNodesCalled     bool
+	SetMinimumMasterNodesCalledWith int
+
+	AddVotingConfigExclusionsCalled     bool
+	AddVotingConfigExclusionsCalledWith []string
+
+	ExcludeFromShardAllocationCalled     bool
+	ExcludeFromShardAllocationCalledWith string
+}
+
+func (f *fakeESClient) SetMinimumMasterNodes(ctx context.Context, n int) error {
+	f.SetMinimumMasterNodesCalled = true
+	f.SetMinimumMasterNodesCalledWith = n
+	return nil
+}
+
+func (f *fakeESClient) AddVotingConfigExclusions(ctx context.Context, nodeNames []string, timeout string) error {
+	f.AddVotingConfigExclusionsCalled = true
+	f.AddVotingConfigExclusionsCalledWith = append(f.AddVotingConfigExclusionsCalledWith, nodeNames...)
+	return nil
+}
+
+func (f *fakeESClient) ExcludeFromShardAllocation(ctx context.Context, nodes string) error {
+	f.ExcludeFromShardAllocationCalled = true
+	f.ExcludeFromShardAllocationCalledWith = nodes
+	return nil
+}
+
+// -- Tests start here
+
+func TestHandleDownscale(t *testing.T) {
+	// This test focuses on one code path that visits most functions.
+	// Derived paths are individually tested in unit tests of the other functions.
+
+	// We want to downscale 2 StatefulSets (3 -> 1 and 4 -> 2) in version 7.X,
+	// but should only be allowed a partial downscale (3 -> 1 and 4 -> 3).
+
+	k8sClient := k8s.WrapClient(fake.NewFakeClient(&sset3Replicas, &sset4Replicas))
+	esClient := &fakeESClient{}
+	actualStatefulSets := sset.StatefulSetList{sset3Replicas, sset4Replicas}
+	downscaleCtx := downscaleContext{
+		k8sClient:      k8sClient,
+		expectations:   reconciler.NewExpectations(),
+		reconcileState: reconcile.NewState(v1alpha1.Elasticsearch{}),
+		observedState: observer.State{
+			ClusterState: &esclient.ClusterState{
+				ClusterName: "cluster-name",
+				Nodes: map[string]esclient.ClusterStateNode{
+					// nodes from 1st sset
+					"sset3Replicas-0": {Name: "sset3Replicas-0"},
+					"sset3Replicas-1": {Name: "sset3Replicas-1"},
+					"sset3Replicas-2": {Name: "sset3Replicas-2"},
+					// nodes from 2nd sset
+					"sset4Replicas-0": {Name: "sset4Replicas-0"},
+					"sset4Replicas-1": {Name: "sset4Replicas-1"},
+					"sset4Replicas-2": {Name: "sset4Replicas-2"},
+					"sset4Replicas-3": {Name: "sset4Replicas-3"},
+				},
+				RoutingTable: esclient.RoutingTable{
+					Indices: map[string]esclient.Shards{
+						"index-1": {
+							Shards: map[string][]esclient.Shard{
+								"0": {
+									// node sset4Replicas-2 cannot leave the cluster because of this shard
+									{Index: "index-1", Shard: 0, State: esclient.STARTED, Node: "sset4Replicas-2"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		esClient: esClient,
+	}
+
+	// request downscale from 3 to 1 replicas
+	sset3ReplicasDownscaled := *sset3Replicas.DeepCopy()
+	sset3ReplicasDownscaled.Spec.Replicas = common.Int32(1)
+	// request downscale from 4 to 2 replicas
+	sset4ReplicasDownscaled := *sset4Replicas.DeepCopy()
+	sset4ReplicasDownscaled.Spec.Replicas = common.Int32(2)
+	requestedStatefulSets := sset.StatefulSetList{sset3ReplicasDownscaled, sset4ReplicasDownscaled}
+
+	// do the downscale
+	results := HandleDownscale(downscaleCtx, requestedStatefulSets, actualStatefulSets)
+	require.False(t, results.HasError())
+
+	// data migration should have been requested for all nodes leaving the cluster
+	require.True(t, esClient.ExcludeFromShardAllocationCalled)
+	require.Equal(t, "sset3Replicas-2,sset3Replicas-1,sset4Replicas-3,sset4Replicas-2", esClient.ExcludeFromShardAllocationCalledWith)
+
+	// only part of the expected replicas of sset4Replicas should be updated,
+	// since a node still needs to migrate data
+	sset4ReplicasExpectedAfterDownscale := *sset4Replicas.DeepCopy()
+	sset4ReplicasExpectedAfterDownscale.Spec.Replicas = common.Int32(3)
+	expectedAfterDownscale := []appsv1.StatefulSet{sset3ReplicasDownscaled, sset4ReplicasExpectedAfterDownscale}
+
+	// voting config exclusion should have been added for leaving masters
+	require.True(t, esClient.AddVotingConfigExclusionsCalled)
+	require.Equal(t, []string{"sset3Replicas-2", "sset3Replicas-1", "sset4Replicas-3"}, esClient.AddVotingConfigExclusionsCalledWith)
+
+	// compare what has been updated in the apiserver with what we would expect
+	var actual appsv1.StatefulSetList
+	err := k8sClient.List(&client.ListOptions{}, &actual)
+	require.NoError(t, err)
+	require.Equal(t, expectedAfterDownscale, actual.Items)
+
+	// running the downscale again should give the same results
+	results = HandleDownscale(downscaleCtx, requestedStatefulSets, actualStatefulSets)
+	require.False(t, results.HasError())
+	err = k8sClient.List(&client.ListOptions{}, &actual)
+	require.NoError(t, err)
+	require.Equal(t, expectedAfterDownscale, actual.Items)
+
+	// once data migration is over the complete downscale should go through
+	downscaleCtx.observedState.ClusterState.RoutingTable = esclient.RoutingTable{}
+	expectedAfterDownscale[1].Spec.Replicas = common.Int32(2)
+	results = HandleDownscale(downscaleCtx, requestedStatefulSets, actualStatefulSets)
+	require.False(t, results.HasError())
+	err = k8sClient.List(&client.ListOptions{}, &actual)
+	require.NoError(t, err)
+	require.Equal(t, expectedAfterDownscale, actual.Items)
+}
+
+func Test_ssetDownscale_leavingNodeNames(t *testing.T) {
+	tests := []struct {
+		name            string
+		statefulSet     appsv1.StatefulSet
+		initialReplicas int32
+		targetReplicas  int32
+		want            []string
+	}{
+		{
+			name:            "no replicas",
+			statefulSet:     sset3Replicas,
+			initialReplicas: 0,
+			targetReplicas:  0,
+			want:            nil,
+		},
+		{
+			name:            "going from 2 to 0 replicas",
+			statefulSet:     sset3Replicas,
+			initialReplicas: 2,
+			targetReplicas:  0,
+			want:            []string{"sset3Replicas-1", "sset3Replicas-0"},
+		},
+		{
+			name:            "going from 2 to 1 replicas",
+			statefulSet:     sset3Replicas,
+			initialReplicas: 2,
+			targetReplicas:  1,
+			want:            []string{"sset3Replicas-1"},
+		},
+		{
+			name:            "going from 5 to 2 replicas",
+			statefulSet:     sset3Replicas,
+			initialReplicas: 5,
+			targetReplicas:  2,
+			want:            []string{"sset3Replicas-4", "sset3Replicas-3", "sset3Replicas-2"},
+		},
+		{
+			name:            "no replicas change",
+			statefulSet:     sset3Replicas,
+			initialReplicas: 2,
+			targetReplicas:  2,
+			want:            nil,
+		},
+		{
+			name:            "upscale",
+			statefulSet:     sset3Replicas,
+			initialReplicas: 2,
+			targetReplicas:  3,
+			want:            nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := ssetDownscale{
+				statefulSet:     tt.statefulSet,
+				initialReplicas: tt.initialReplicas,
+				targetReplicas:  tt.targetReplicas,
+			}
+			if got := d.leavingNodeNames(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("leavingNodeNames() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_leavingNodeNames(t *testing.T) {
+	tests := []struct {
+		name       string
+		downscales []ssetDownscale
+		want       []string
+	}{
+		{
+			name:       "no downscales",
+			downscales: nil,
+			want:       nil,
+		},
+		{
+			name: "2 downscales",
+			downscales: []ssetDownscale{
+				{
+					statefulSet:     sset3Replicas,
+					initialReplicas: 2,
+					targetReplicas:  1,
+				},
+				{
+					statefulSet:     sset4Replicas,
+					initialReplicas: 4,
+					targetReplicas:  3,
+				},
+			},
+			want: []string{"sset3Replicas-1", "sset4Replicas-3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := leavingNodeNames(tt.downscales); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("leavingNodeNames() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_calculateDownscales(t *testing.T) {
+	ssets := sset.StatefulSetList{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "sset0",
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: common.Int32(3),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "sset1",
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: common.Int32(3)},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "sset2",
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: common.Int32(3)},
+		},
+	}
+	tests := []struct {
+		name                 string
+		expectedStatefulSets sset.StatefulSetList
+		actualStatefulSets   sset.StatefulSetList
+		want                 []ssetDownscale
+	}{
+		{
+			name:               "no actual statefulset: no downscale",
+			actualStatefulSets: nil,
+			want:               []ssetDownscale{},
+		},
+		{
+			name:                 "expected == actual",
+			expectedStatefulSets: ssets,
+			actualStatefulSets:   ssets,
+			want:                 []ssetDownscale{},
+		},
+		{
+			name:                 "remove all ssets",
+			expectedStatefulSets: nil,
+			actualStatefulSets:   ssets,
+			want: []ssetDownscale{
+				{
+					statefulSet:     ssets[0],
+					initialReplicas: *ssets[0].Spec.Replicas,
+					targetReplicas:  0,
+				},
+				{
+					statefulSet:     ssets[1],
+					initialReplicas: *ssets[1].Spec.Replicas,
+					targetReplicas:  0,
+				},
+				{
+					statefulSet:     ssets[2],
+					initialReplicas: *ssets[2].Spec.Replicas,
+					targetReplicas:  0,
+				},
+			},
+		},
+		{
+			name: "downscale 2 out of 3 StatefulSets",
+			expectedStatefulSets: sset.StatefulSetList{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "sset0",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: common.Int32(3),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "sset1",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: common.Int32(2)},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "sset2",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: common.Int32(1)},
+				},
+			},
+			actualStatefulSets: ssets,
+			want: []ssetDownscale{
+				{
+					statefulSet:     ssets[1],
+					initialReplicas: *ssets[1].Spec.Replicas,
+					targetReplicas:  2,
+				},
+				{
+					statefulSet:     ssets[2],
+					initialReplicas: *ssets[2].Spec.Replicas,
+					targetReplicas:  1,
+				},
+			},
+		},
+		{
+			name: "upscale: no downscale",
+			expectedStatefulSets: sset.StatefulSetList{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "sset0",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: common.Int32(4),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "sset1",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: common.Int32(5)},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "sset2",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: common.Int32(3)},
+				},
+			},
+			actualStatefulSets: ssets,
+			want:               []ssetDownscale{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := calculateDownscales(tt.expectedStatefulSets, tt.actualStatefulSets); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("calculateDownscales() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_calculatePerformableDownscale(t *testing.T) {
+	type args struct {
+		ctx             downscaleContext
+		downscale       ssetDownscale
+		allLeavingNodes []string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		want        ssetDownscale
+		wantRequeue bool
+	}{
+		{
+			name: "no downscale planned",
+			args: args{
+				ctx: downscaleContext{},
+				downscale: ssetDownscale{
+					initialReplicas: 3,
+					targetReplicas:  3,
+				},
+				allLeavingNodes: []string{"node-1", "node-2"},
+			},
+			want: ssetDownscale{
+				initialReplicas: 3,
+				targetReplicas:  3,
+			},
+			wantRequeue: false,
+		},
+		{
+			name: "downscale possible from 3 to 1",
+			args: args{
+				ctx: downscaleContext{
+					observedState: observer.State{
+						// all migrations are over
+						ClusterState: &esclient.ClusterState{
+							ClusterName: "cluster-name",
+						},
+					},
+				},
+				downscale: ssetDownscale{
+					initialReplicas: 3,
+					targetReplicas:  1,
+				},
+				allLeavingNodes: []string{"node-1", "node-2"},
+			},
+			want: ssetDownscale{
+				initialReplicas: 3,
+				targetReplicas:  1,
+			},
+			wantRequeue: false,
+		},
+		{
+			name: "downscale not possible: data migration not ready",
+			args: args{
+				ctx: downscaleContext{
+					observedState: observer.State{
+						// cluster state is not populated
+						ClusterState: nil,
+					},
+					reconcileState: reconcile.NewState(v1alpha1.Elasticsearch{}),
+				},
+				downscale: ssetDownscale{
+					statefulSet:     sset3Replicas,
+					initialReplicas: 3,
+					targetReplicas:  1,
+				},
+				allLeavingNodes: []string{"node-1", "node-2"},
+			},
+			want: ssetDownscale{
+				statefulSet:     sset3Replicas,
+				initialReplicas: 3,
+				targetReplicas:  3,
+			},
+			wantRequeue: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotRequeue := calculatePerformableDownscale(tt.args.ctx, tt.args.downscale, tt.args.allLeavingNodes)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("calculatePerformableDownscale() got = %v, want %v", got, tt.want)
+			}
+			if gotRequeue != tt.wantRequeue {
+				t.Errorf("calculatePerformableDownscale() got1 = %v, want %v", gotRequeue, tt.wantRequeue)
+			}
+		})
+	}
+}
+
+func Test_doDownscale_updateReplicasAndExpectations(t *testing.T) {
+	sset1 := sset3Replicas
+	sset1.Generation = 1
+	sset2 := sset4Replicas
+	sset2.Generation = 1
+	k8sClient := k8s.WrapClient(fake.NewFakeClient(&sset1, &sset2))
+	downscaleCtx := downscaleContext{
+		k8sClient:    k8sClient,
+		expectations: reconciler.NewExpectations(),
+		esClient:     &fakeESClient{},
+	}
+
+	expectedSset1 := *sset1.DeepCopy()
+	// simulate sset generation updated during the downscale (not done by the fake client)
+	sset1.Generation = 2
+	expectedSset1.Generation = 2
+	// downscale a StatefulSet from 3 to 2 replicas
+	downscale := ssetDownscale{
+		statefulSet:     sset1,
+		initialReplicas: 3,
+		targetReplicas:  2,
+	}
+	expectedSset1.Spec.Replicas = &downscale.targetReplicas
+
+	// no expectation is currently set
+	require.True(t, downscaleCtx.expectations.GenerationExpected(sset1.ObjectMeta))
+
+	// do the downscale
+	err := doDownscale(downscaleCtx, downscale, sset.StatefulSetList{sset1, sset2})
+	require.NoError(t, err)
+
+	// sset resource should be updated
+	var ssets appsv1.StatefulSetList
+	err = k8sClient.List(&client.ListOptions{}, &ssets)
+	require.NoError(t, err)
+	require.Equal(t, []appsv1.StatefulSet{expectedSset1, sset2}, ssets.Items)
+
+	// expectations should have been be registered
+	require.True(t, downscaleCtx.expectations.GenerationExpected(sset1.ObjectMeta))
+	// not ok for a sset whose generation == 1
+	sset1.Generation = 1
+	require.False(t, downscaleCtx.expectations.GenerationExpected(sset1.ObjectMeta))
+}
+
+func Test_doDownscale_zen2VotingConfigExclusions(t *testing.T) {
+	ssetMasters := nodespec.CreateTestSset("masters", "7.1.0", 3, true, false)
+	ssetData := nodespec.CreateTestSset("datas", "7.1.0", 3, false, true)
+	tests := []struct {
+		name               string
+		downscale          ssetDownscale
+		wantZen2Called     bool
+		wantZen2CalledWith []string
+	}{
+		{
+			name: "3 -> 2 master nodes",
+			downscale: ssetDownscale{
+				statefulSet:     ssetMasters,
+				initialReplicas: 3,
+				targetReplicas:  2,
+			},
+			wantZen2Called:     true,
+			wantZen2CalledWith: []string{"masters-2"},
+		},
+		{
+			name: "3 -> 2 data nodes",
+			downscale: ssetDownscale{
+				statefulSet:     ssetData,
+				initialReplicas: 3,
+				targetReplicas:  2,
+			},
+			wantZen2Called:     false,
+			wantZen2CalledWith: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient := k8s.WrapClient(fake.NewFakeClient(&ssetMasters, &ssetData))
+			esClient := &fakeESClient{}
+			downscaleCtx := downscaleContext{
+				k8sClient:      k8sClient,
+				expectations:   reconciler.NewExpectations(),
+				reconcileState: reconcile.NewState(v1alpha1.Elasticsearch{}),
+				esClient:       esClient,
+			}
+			// do the downscale
+			err := doDownscale(downscaleCtx, tt.downscale, sset.StatefulSetList{ssetMasters, ssetData})
+			require.NoError(t, err)
+			// check call to zen2 is the expected one
+			require.Equal(t, tt.wantZen2Called, esClient.AddVotingConfigExclusionsCalled)
+			require.Equal(t, tt.wantZen2CalledWith, esClient.AddVotingConfigExclusionsCalledWith)
+		})
+	}
+}
+
+func Test_doDownscale_callsZen1ForMasterNodes(t *testing.T) {
+	// TODO: implement with https://github.com/elastic/cloud-on-k8s/issues/1281
+	//  to handle the 2->1 masters case
+}
+
+func Test_attemptDownscale(t *testing.T) {
+	tests := []struct {
+		name                 string
+		downscale            ssetDownscale
+		statefulSets         sset.StatefulSetList
+		expectedStatefulSets []appsv1.StatefulSet
+	}{
+		{
+			name: "1 statefulset should be removed",
+			downscale: ssetDownscale{
+				statefulSet:     nodespec.CreateTestSset("should-be-removed", "7.1.0", 0, true, true),
+				initialReplicas: 0,
+				targetReplicas:  0,
+			},
+			statefulSets: sset.StatefulSetList{
+				nodespec.CreateTestSset("should-be-removed", "7.1.0", 0, true, true),
+				nodespec.CreateTestSset("should-stay", "7.1.0", 2, true, true),
+			},
+			expectedStatefulSets: []appsv1.StatefulSet{
+				nodespec.CreateTestSset("should-stay", "7.1.0", 2, true, true),
+			},
+		},
+		{
+			name: "target replicas == initial replicas",
+			downscale: ssetDownscale{
+				statefulSet:     nodespec.CreateTestSset("default", "7.1.0", 3, true, true),
+				initialReplicas: 3,
+				targetReplicas:  3,
+			},
+			statefulSets: sset.StatefulSetList{
+				nodespec.CreateTestSset("default", "7.1.0", 3, true, true),
+			},
+			expectedStatefulSets: []appsv1.StatefulSet{
+				nodespec.CreateTestSset("default", "7.1.0", 3, true, true),
+			},
+		},
+		{
+			name: "upscale case",
+			downscale: ssetDownscale{
+				statefulSet:     nodespec.CreateTestSset("default", "7.1.0", 3, true, true),
+				initialReplicas: 3,
+				targetReplicas:  4,
+			},
+			statefulSets: sset.StatefulSetList{
+				nodespec.CreateTestSset("default", "7.1.0", 3, true, true),
+			},
+			expectedStatefulSets: []appsv1.StatefulSet{
+				nodespec.CreateTestSset("default", "7.1.0", 3, true, true),
+			},
+		},
+		{
+			name: "perform 3 -> 2 downscale",
+			downscale: ssetDownscale{
+				statefulSet:     nodespec.CreateTestSset("default", "7.1.0", 3, true, true),
+				initialReplicas: 3,
+				targetReplicas:  2,
+			},
+			statefulSets: sset.StatefulSetList{
+				nodespec.CreateTestSset("default", "7.1.0", 3, true, true),
+			},
+			expectedStatefulSets: []appsv1.StatefulSet{
+				nodespec.CreateTestSset("default", "7.1.0", 2, true, true),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var runtimeObjs []runtime.Object
+			for i := range tt.statefulSets {
+				runtimeObjs = append(runtimeObjs, &tt.statefulSets[i])
+			}
+			k8sClient := k8s.WrapClient(fake.NewFakeClient(runtimeObjs...))
+			downscaleCtx := downscaleContext{
+				k8sClient:      k8sClient,
+				expectations:   reconciler.NewExpectations(),
+				reconcileState: reconcile.NewState(v1alpha1.Elasticsearch{}),
+				observedState: observer.State{
+					// all migrations are over
+					ClusterState: &esclient.ClusterState{
+						ClusterName: "cluster-name",
+					},
+				},
+				esClient: &fakeESClient{},
+			}
+			// do the downscale
+			_, err := attemptDownscale(downscaleCtx, tt.downscale, nil, tt.statefulSets)
+			require.NoError(t, err)
+			// retrieve statefulsets
+			var ssets appsv1.StatefulSetList
+			err = k8sClient.List(&client.ListOptions{}, &ssets)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedStatefulSets, ssets.Items)
+		})
+	}
+}

--- a/operators/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/operators/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -236,7 +236,7 @@ func Test_leavingNodeNames(t *testing.T) {
 		{
 			name:       "no downscales",
 			downscales: nil,
-			want:       nil,
+			want:       []string{},
 		},
 		{
 			name: "2 downscales",

--- a/operators/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/operators/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -152,7 +152,7 @@ func TestHandleDownscale(t *testing.T) {
 	require.Equal(t, expectedAfterDownscale, actual.Items)
 
 	// once data migration is over the complete downscale should go through
-	downscaleCtx.observedState.ClusterState.RoutingTable = esclient.RoutingTable{}
+	downscaleCtx.observedState.ClusterState.RoutingTable.Indices["index-1"].Shards["0"][0].Node = "sset4Replicas-1"
 	expectedAfterDownscale[1].Spec.Replicas = common.Int32(2)
 	results = HandleDownscale(downscaleCtx, requestedStatefulSets, actual.Items)
 	require.False(t, results.HasError())

--- a/operators/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/operators/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -1,5 +1,9 @@
 package driver
 
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 import (
 	"context"
 	"reflect"

--- a/operators/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/operators/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -161,7 +161,7 @@ func TestHandleDownscale(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedAfterDownscale, actual.Items)
 
-	// data migration should have been requested for the master node leaving the cluster
+	// data migration should have been requested for the data node leaving the cluster
 	require.True(t, esClient.ExcludeFromShardAllocationCalled)
 	require.Equal(t, "sset4Replicas-2", esClient.ExcludeFromShardAllocationCalledWith)
 

--- a/operators/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/operators/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -1,8 +1,8 @@
-package driver
-
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
+
+package driver
 
 import (
 	"context"

--- a/operators/pkg/controller/elasticsearch/driver/driver.go
+++ b/operators/pkg/controller/elasticsearch/driver/driver.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	controller "sigs.k8s.io/controller-runtime/pkg/reconcile"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common"
@@ -41,7 +40,6 @@ import (
 )
 
 var (
-	log            = logf.Log.WithName("driver")
 	defaultRequeue = controller.Result{Requeue: true, RequeueAfter: 10 * time.Second}
 )
 

--- a/operators/pkg/controller/elasticsearch/driver/log.go
+++ b/operators/pkg/controller/elasticsearch/driver/log.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package driver
 
 import (

--- a/operators/pkg/controller/elasticsearch/driver/log.go
+++ b/operators/pkg/controller/elasticsearch/driver/log.go
@@ -1,0 +1,16 @@
+package driver
+
+import (
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var log = logf.Log.WithName("driver")
+
+func ssetLogger(statefulSet appsv1.StatefulSet) logr.Logger {
+	return log.WithValues(
+		"namespace", statefulSet.Namespace,
+		"statefulset_name", statefulSet.Name,
+	)
+}

--- a/operators/pkg/controller/elasticsearch/driver/nodes.go
+++ b/operators/pkg/controller/elasticsearch/driver/nodes.go
@@ -115,7 +115,16 @@ func (d *defaultDriver) reconcileNodeSpecs(
 	// Phase 2: handle sset scale down.
 	// We want to safely remove nodes from the cluster, either because the sset requires less replicas,
 	// or because it should be removed entirely.
-	downscaleRes := d.HandleDownscale(nodeSpecResources.StatefulSets(), actualStatefulSets, esClient, resourcesState, observedState, reconcileState)
+	downscaleCtx := downscaleContext{
+		k8sClient:      d.Client,
+		esClient:       esClient,
+		resourcesState: resourcesState,
+		observedState:  observedState,
+		reconcileState: reconcileState,
+		es:             d.ES,
+		expectations:   d.Expectations,
+	}
+	downscaleRes := HandleDownscale(downscaleCtx, nodeSpecResources.StatefulSets(), actualStatefulSets)
 	results.WithResults(downscaleRes)
 	if downscaleRes.HasError() {
 		return results

--- a/operators/pkg/controller/elasticsearch/sset/list.go
+++ b/operators/pkg/controller/elasticsearch/sset/list.go
@@ -81,6 +81,15 @@ func (l StatefulSetList) GetActualPods(c k8s.Client) ([]corev1.Pod, error) {
 	return allPods, nil
 }
 
+// DeepCopy returns a copy of the StatefulSetList with no reference to the original StatefulSetList.
+func (l StatefulSetList) DeepCopy() StatefulSetList {
+	result := make(StatefulSetList, 0, len(l))
+	for _, s := range l {
+		result = append(result, *s.DeepCopy())
+	}
+	return result
+}
+
 // GetUpdatePartition returns the updateStrategy.Partition index, or falls back to the number of replicas if not set.
 func GetUpdatePartition(statefulSet appsv1.StatefulSet) int32 {
 	if statefulSet.Spec.UpdateStrategy.RollingUpdate.Partition != nil {


### PR DESCRIPTION
This refactors the StatefulSets downscale code into multiple smaller
functions, easier to test.
It also adds unit tests for most of those functions, and generally covers
the entire downscale codebase with unit tests.

Relates #1287.