### PR TITLE
Reuse APM Server suffixed name in E2E TestUpdateConfiguration

### DIFF
--- a/operators/test/e2e/apm/configuration_test.go
+++ b/operators/test/e2e/apm/configuration_test.go
@@ -94,7 +94,7 @@ func TestUpdateConfiguration(t *testing.T) {
 			{
 				Name: "Check the value of a parameter in the configuration",
 				Test: func(t *testing.T) {
-					config, err := partialAPMConfiguration(k, namespace, name)
+					config, err := partialAPMConfiguration(k, namespace, apmName)
 					require.NoError(t, err)
 
 					esHost := services.ExternalServiceURL(esBuilder.Elasticsearch)


### PR DESCRIPTION
Follow up of #1505.