### PR TITLE
Decrease ES name size in e2e tests

### DIFF
--- a/operators/test/e2e/es/failure_test.go
+++ b/operators/test/e2e/es/failure_test.go
@@ -79,7 +79,7 @@ func TestDeleteServices(t *testing.T) {
 }
 
 func TestDeleteElasticUserSecret(t *testing.T) {
-	b := elasticsearch.NewBuilder("test-delete-es-elastic-user-secret").
+	b := elasticsearch.NewBuilder("test-delete-elastic-user-secret").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	test.RunRecoverableFailureScenario(t, func(k *test.K8sClient) test.StepList {

--- a/operators/test/e2e/es/mutation_test.go
+++ b/operators/test/e2e/es/mutation_test.go
@@ -85,7 +85,7 @@ func TestMutationResizeMemoryUp(t *testing.T) {
 // then mutates it to a 1 node cluster with less RAM
 func TestMutationResizeMemoryDown(t *testing.T) {
 	// create an ES cluster with a 4G node
-	b := elasticsearch.NewBuilder("test-mutation-resize-memory-down").
+	b := elasticsearch.NewBuilder("test-mutation-resize-mem-down").
 		WithESMasterDataNodes(1, corev1.ResourceRequirements{
 			Limits: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceMemory: resource.MustParse("4Gi"),


### PR DESCRIPTION
By adding a random suffix, the limit of 36 characters is reached.

Quickfix before #1474 to Make E2E Tests Green Again.
