### PR TITLE
Move e2e tests jobs to deployer

### DIFF
--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -112,26 +112,7 @@ yaml-upload: vault-aws-creds
 
 ## -- End-to-end tests job
 
-ci-e2e-new:
-	@ docker run --rm -t \
-		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
-		-w $(GO_MOUNT_PATH) \
-		-e "GCLOUD_PROJECT=$(GCLOUD_PROJECT)" \
-		$(IMAGE) \
-		bash -c "make -C operators ci-e2e-new"
-
-ci-deployer-new:
-	@ docker run --rm -t \
-		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
-		-w $(GO_MOUNT_PATH) \
-		-e "GCLOUD_PROJECT=$(GCLOUD_PROJECT)" \
-		$(IMAGE) \
-		bash -c "make -C operators deployer-new"
-
-# Spawn a k8s cluster, and run e2e tests against it
-ci-e2e: vault-gke-creds
+ci-e2e:
 	@ docker run --rm -t \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
@@ -140,56 +121,20 @@ ci-e2e: vault-gke-creds
 		-e "GCLOUD_PROJECT=$(GCLOUD_PROJECT)" \
 		-e "REGISTRY=$(REGISTRY)" \
 		-e "REPOSITORY=$(GCLOUD_PROJECT)" \
-		-e "GKE_CLUSTER_NAME=$(GKE_CLUSTER_NAME)" \
-		-e "GKE_SERVICE_ACCOUNT_KEY_FILE=$(GO_MOUNT_PATH)/build/ci/$(GKE_CREDS_FILE)" \
 		-e "TESTS_MATCH=$(TESTS_MATCH)" \
-		-e "GKE_CLUSTER_VERSION=$(GKE_CLUSTER_VERSION)" \
+		-e "SKIP_DOCKER_COMMAND=$(SKIP_DOCKER_COMMAND)" \
+		-e "OPERATOR_IMAGE=$(OPERATOR_IMAGE)" \
 		$(IMAGE) \
 		bash -c "make -C operators ci-e2e"
 
-# Run e2e tests in GKE against provided ECK image
-ci-e2e-rc: vault-gke-creds
+ci-deployer:
 	@ docker run --rm -t \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
 		-w $(GO_MOUNT_PATH) \
-		-e "IMG_SUFFIX=-ci" \
 		-e "GCLOUD_PROJECT=$(GCLOUD_PROJECT)" \
-		-e "REGISTRY=$(REGISTRY)" \
-		-e "REPOSITORY=$(GCLOUD_PROJECT)" \
-		-e "GKE_CLUSTER_NAME=$(GKE_CLUSTER_NAME)" \
-		-e "GKE_SERVICE_ACCOUNT_KEY_FILE=$(GO_MOUNT_PATH)/build/ci/$(GKE_CREDS_FILE)" \
-		-e "TESTS_MATCH=$(TESTS_MATCH)" \
-		-e "GKE_CLUSTER_VERSION=$(GKE_CLUSTER_VERSION)" \
-		-e "OPERATOR_IMAGE=$(OPERATOR_IMAGE)" \
 		$(IMAGE) \
-		bash -c "make -C operators ci-e2e-rc"
-
-## -- Support jobs
-
-# Remove k8s cluster
-ci-e2e-delete-cluster: vault-gke-creds
-	@ docker run --rm -t \
-    	-v /var/run/docker.sock:/var/run/docker.sock \
-    	-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
-    	-w $(GO_MOUNT_PATH) \
-    	-e "GCLOUD_PROJECT=$(GCLOUD_PROJECT)" \
-    	-e "GKE_CLUSTER_NAME=$(GKE_CLUSTER_NAME)" \
-    	-e "GKE_SERVICE_ACCOUNT_KEY_FILE=$(GO_MOUNT_PATH)/build/ci/$(GKE_CREDS_FILE)" \
-    	$(IMAGE) \
-    	bash -c "make -C operators set-context-gke delete-gke"
-
-# Remove all unused resources in GKE
-ci-gke-cleanup: ci-e2e-delete-cluster
-	@ docker run --rm -t \
-    	-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
-    	-w $(GO_MOUNT_PATH) \
-    	-e "GCLOUD_PROJECT=$(GCLOUD_PROJECT)" \
-    	-e "GKE_CLUSTER_NAME=$(GKE_CLUSTER_NAME)" \
-    	-e "GKE_SERVICE_ACCOUNT_KEY_FILE=$(GO_MOUNT_PATH)/build/ci/$(GKE_CREDS_FILE)" \
-    	$(IMAGE) \
-    	bash -c "GKE_CLUSTER_VERSION=1.11 $(GO_MOUNT_PATH)/operators/hack/gke-cluster.sh auth && \
-    	 	$(GO_MOUNT_PATH)/build/ci/delete_unused_disks.py"
+		bash -c "make -C operators deployer"
 
 # Check if Docker image exists by trying to pull it. If there is no image, then build and push it.
 ci-build-image: vault-docker-creds

--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -127,14 +127,14 @@ ci-e2e:
 		$(IMAGE) \
 		bash -c "make -C operators ci-e2e"
 
-ci-deployer:
+ci-run-deployer:
 	@ docker run --rm -t \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
 		-w $(GO_MOUNT_PATH) \
 		-e "GCLOUD_PROJECT=$(GCLOUD_PROJECT)" \
 		$(IMAGE) \
-		bash -c "make -C operators deployer"
+		bash -c "make -C operators run-deployer"
 
 # Check if Docker image exists by trying to pull it. If there is no image, then build and push it.
 ci-build-image: vault-docker-creds

--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                 versions = ["1.11", "1.12", "1.13"]
                 for (int i = 0; i < clusters.size(); i++) {
                     createRunConfig('delete', versions[i], clusters[i])
-                    make -C build/ci ci-deployer
+                    make -C build/ci ci-run-deployer
                 }
             }
             cleanWs()

--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -16,45 +16,37 @@ pipeline {
         GCLOUD_PROJECT = credentials('k8s-operators-gcloud-project')
         OPERATOR_IMAGE = "${IMAGE}"
         LATEST_RELEASED_IMG = "${IMAGE}"
+        SKIP_DOCKER_COMMAND = 'true'
     }
 
     stages {
         stage('Run tests for different k8s versions in GKE') {
             parallel {
                 stage("1.11") {
-                    environment {
-                        GKE_CLUSTER_VERSION = '1.11'
-                        GKE_CLUSTER_NAME = "${BUILD_TAG}-11"
-                    }
                     steps {
                         checkout scm
-                        sh 'make -C build/ci ci-e2e-rc'
+                        createRunConfig('create', '1.11', "${BUILD_TAG}-11")
+                        sh 'make -C build/ci ci-e2e'
                     }
                 }
                 stage("1.12") {
                     agent {
                         label 'linux'
                     }
-                    environment {
-                        GKE_CLUSTER_VERSION = '1.12'
-                        GKE_CLUSTER_NAME = "${BUILD_TAG}-12"
-                    }
                     steps {
                         checkout scm
-                        sh 'make -C build/ci ci-e2e-rc'
+                        createRunConfig('create', '1.12', "${BUILD_TAG}-12")
+                        sh 'make -C build/ci ci-e2e'
                     }
                 }
                 stage("1.13") {
                     agent {
                         label 'linux'
                     }
-                    environment {
-                        GKE_CLUSTER_VERSION = '1.13'
-                        GKE_CLUSTER_NAME = "${BUILD_TAG}-13"
-                    }
                     steps {
                         checkout scm
-                        sh 'make -C build/ci ci-e2e-rc'
+                        createRunConfig('create', '1.13', "${BUILD_TAG}-13")
+                        sh 'make -C build/ci ci-e2e'
                     }
                 }
             }
@@ -75,16 +67,31 @@ pipeline {
         cleanup {
             script {
                 clusters = ["${BUILD_TAG}-11", "${BUILD_TAG}-12", "${BUILD_TAG}-13"]
+                versions = ["1.11", "1.12", "1.13"]
                 for (int i = 0; i < clusters.size(); i++) {
-                        build job: 'cloud-on-k8s-e2e-cleanup',
-                              parameters: [string(name: 'GKE_CLUSTER', value: clusters[i])],
-                              wait: false
+                    createRunConfig('delete', versions[i], clusters[i])
+                    make -C build/ci ci-deployer
                 }
             }
             cleanWs()
         }
     }
-
 }
 
-
+void createRunConfig(operation, clusterVersion, clusterName) {
+    sh """
+                    cat >operators/run-config.yml <<EOF
+id: gke-ci
+overrides:
+  operation: ${operation}
+  kubernetesVersion: "${clusterVersion}"
+  clusterName: ${clusterName}
+  vaultInfo:
+    address: $VAULT_ADDR
+    roleId: $VAULT_ROLE_ID
+    secretId: $VAULT_SECRET_ID
+  gke:
+    gCloudProject: $GCLOUD_PROJECT
+EOF
+    """
+}

--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -31,7 +31,21 @@ pipeline {
                 }
             }
             steps {
-                sh 'make -C build/ci ci-e2e'
+                sh """
+                    cat >operators/run-config.yml <<EOF
+id: gke-ci
+overrides:
+  kubernetesVersion: "$CLUSTER_VERSION"
+  clusterName: $CLUSTER_NAME
+  vaultInfo:
+    address: $VAULT_ADDR
+    roleId: $VAULT_ROLE_ID
+    secretId: $VAULT_SECRET_ID
+  gke:
+    gCloudProject: $GCLOUD_PROJECT
+EOF
+                    make -C build/ci ci-e2e
+                """
             }
         }
     }
@@ -48,12 +62,28 @@ pipeline {
             }
         }
         cleanup {
-            script {
-                if (notOnlyDocs()) {
-                    build job: 'cloud-on-k8s-e2e-cleanup',
-                        parameters: [string(name: 'GKE_CLUSTER', value: "${GKE_CLUSTER_NAME}")],
-                        wait: false
+            when {
+                expression {
+                    notOnlyDocs()
                 }
+            }
+            steps {
+                sh """
+                    cat >operators/run-config.yml <<EOF
+id: gke-ci
+overrides:
+  operation: delete
+  kubernetesVersion: "$CLUSTER_VERSION"
+  clusterName: $CLUSTER_NAME
+  vaultInfo:
+    address: $VAULT_ADDR
+    roleId: $VAULT_ROLE_ID
+    secretId: $VAULT_SECRET_ID
+  gke:
+    gCloudProject: $GCLOUD_PROJECT
+EOF
+                    make -C build/ci ci-deployer
+                """
             }
 
             cleanWs()

--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -14,8 +14,8 @@ pipeline {
         VAULT_SECRET_ID = credentials('vault-secret-id')
         REGISTRY = "eu.gcr.io"
         GCLOUD_PROJECT = credentials('k8s-operators-gcloud-project')
-        GKE_CLUSTER_VERSION = '1.12'
-        GKE_CLUSTER_NAME = "${BUILD_TAG}"
+        CLUSTER_VERSION = '1.12'
+        CLUSTER_NAME = "${BUILD_TAG}"
     }
 
     stages {

--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -82,7 +82,7 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
-                    make -C build/ci ci-deployer
+                    make -C build/ci ci-run-deployer
                 """
             }
 

--- a/build/ci/e2e/Jenkinsfile-aks
+++ b/build/ci/e2e/Jenkinsfile-aks
@@ -56,7 +56,7 @@ overrides:
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
 EOF
-                    make -C build/ci ci-deployer
+                    make -C build/ci ci-run-deployer
                 """
             }
             cleanWs()

--- a/build/ci/e2e/Jenkinsfile-aks
+++ b/build/ci/e2e/Jenkinsfile-aks
@@ -35,7 +35,7 @@ overrides:
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
 EOF
-                    make -C build/ci ci-e2e-new
+                    make -C build/ci ci-e2e
                 """
             }
         }  
@@ -56,7 +56,7 @@ overrides:
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
 EOF
-                    make -C build/ci ci-deployer-new
+                    make -C build/ci ci-deployer
                 """
             }
             cleanWs()

--- a/build/ci/e2e/Jenkinsfile-new
+++ b/build/ci/e2e/Jenkinsfile-new
@@ -47,7 +47,7 @@ EOF
     post {
         unsuccessful {
             script {
-                def msg = "E2E tests with deployer failed!\r\n" + env.BUILD_URL
+                def msg = "E2E tests with failed!\r\n" + env.BUILD_URL
                 slackSend botUser: true,
                       channel: '#cloud-k8s',
                       color: 'danger',
@@ -71,7 +71,7 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
-                    make -C build/ci ci-deployer
+                    make -C build/ci ci-run-deployer
                 """
             }
             cleanWs()

--- a/build/ci/e2e/Jenkinsfile-new
+++ b/build/ci/e2e/Jenkinsfile-new
@@ -38,7 +38,7 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
-                    make -C build/ci ci-e2e-new
+                    make -C build/ci ci-e2e
                 """
             }
         }
@@ -71,7 +71,7 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
-                    make -C build/ci ci-deployer-new
+                    make -C build/ci ci-deployer
                 """
             }
             cleanWs()

--- a/build/ci/e2e/custom_operator_image.jenkinsfile
+++ b/build/ci/e2e/custom_operator_image.jenkinsfile
@@ -75,7 +75,7 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
-                    make -C build/ci ci-deployer
+                    make -C build/ci ci-run-deployer
                 """
             }
             cleanWs()

--- a/build/ci/e2e/custom_operator_image.jenkinsfile
+++ b/build/ci/e2e/custom_operator_image.jenkinsfile
@@ -14,8 +14,8 @@ pipeline {
         VAULT_SECRET_ID = credentials('vault-secret-id')
         REGISTRY = "eu.gcr.io"
         GCLOUD_PROJECT = credentials('k8s-operators-gcloud-project')
-        GKE_CLUSTER_VERSION = "${VERSION}"
-        GKE_CLUSTER_NAME = "${BUILD_TAG}"
+        CLUSTER_VERSION = "${VERSION}"
+        CLUSTER_NAME = "${BUILD_TAG}"
         OPERATOR_IMAGE = "${IMAGE}"
         LATEST_RELEASED_IMG = "${IMAGE}"
         SKIP_DOCKER_COMMAND = 'true'

--- a/build/ci/e2e/custom_operator_image.jenkinsfile
+++ b/build/ci/e2e/custom_operator_image.jenkinsfile
@@ -18,6 +18,7 @@ pipeline {
         GKE_CLUSTER_NAME = "${BUILD_TAG}"
         OPERATOR_IMAGE = "${IMAGE}"
         LATEST_RELEASED_IMG = "${IMAGE}"
+        SKIP_DOCKER_COMMAND = 'true'
     }
 
     stages {
@@ -28,7 +29,21 @@ pipeline {
         }
         stage("Run E2E tests") {
             steps {
-                sh 'make -C build/ci ci-e2e-rc'
+                sh """
+                    cat >operators/run-config.yml <<EOF
+id: gke-ci
+overrides:
+  kubernetesVersion: "$CLUSTER_VERSION"
+  clusterName: $CLUSTER_NAME
+  vaultInfo:
+    address: $VAULT_ADDR
+    roleId: $VAULT_ROLE_ID
+    secretId: $VAULT_SECRET_ID
+  gke:
+    gCloudProject: $GCLOUD_PROJECT
+EOF
+                    make -C build/ci ci-e2e
+                """
             }
         }
     }
@@ -45,10 +60,24 @@ pipeline {
             }
         }
         cleanup {
-            build job: 'cloud-on-k8s-e2e-cleanup',
-                  parameters: [string(name: 'GKE_CLUSTER', value: "${GKE_CLUSTER_NAME}")],
-                  wait: false
-
+            script {
+                sh """
+                    cat >operators/run-config.yml <<EOF
+id: gke-ci
+overrides:
+  operation: delete
+  kubernetesVersion: "$CLUSTER_VERSION"
+  clusterName: $CLUSTER_NAME
+  vaultInfo:
+    address: $VAULT_ADDR
+    roleId: $VAULT_ROLE_ID
+    secretId: $VAULT_SECRET_ID
+  gke:
+    gCloudProject: $GCLOUD_PROJECT
+EOF
+                    make -C build/ci ci-deployer
+                """
+            }
             cleanWs()
         }
     }

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -65,7 +65,21 @@ pipeline {
                         label 'linux'
                     }
                     steps {
-                        sh 'make -C build/ci ci-e2e'
+                        sh """
+                            cat >operators/run-config.yml <<EOF
+id: gke-ci
+overrides:
+  kubernetesVersion: "$CLUSTER_VERSION"
+  clusterName: $CLUSTER_NAME
+  vaultInfo:
+    address: $VAULT_ADDR
+    roleId: $VAULT_ROLE_ID
+    secretId: $VAULT_SECRET_ID
+  gke:
+    gCloudProject: $GCLOUD_PROJECT
+EOF
+                            make -C build/ci ci-e2e
+                        """
                     }
                 }
             }
@@ -74,12 +88,29 @@ pipeline {
 
     post {
         cleanup {
-            script {
-                if (notOnlyDocs()) {
-                    build job: 'cloud-on-k8s-e2e-cleanup',
-                          parameters: [string(name: 'GKE_CLUSTER', value: "${GKE_CLUSTER_NAME}")],
-                          wait: false
+           when {
+                expression {
+                    checkout scm
+                    notOnlyDocs()
                 }
+            }
+            steps {
+                sh """
+                    cat >operators/run-config.yml <<EOF
+id: gke-ci
+overrides:
+  operation: delete
+  kubernetesVersion: "$CLUSTER_VERSION"
+  clusterName: $CLUSTER_NAME
+  vaultInfo:
+    address: $VAULT_ADDR
+    roleId: $VAULT_ROLE_ID
+    secretId: $VAULT_SECRET_ID
+  gke:
+    gCloudProject: $GCLOUD_PROJECT
+EOF
+                    make -C build/ci ci-deployer
+                """
             }
             cleanWs()
         }

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -88,15 +88,11 @@ EOF
 
     post {
         cleanup {
-           when {
-                expression {
-                    checkout scm
-                    notOnlyDocs()
-                }
-            }
             steps {
-                sh """
-                    cat >operators/run-config.yml <<EOF
+                script {
+                    if (notOnlyDocs()) {
+                        sh """
+                            cat >operators/run-config.yml <<EOF
 id: gke-ci
 overrides:
   operation: delete
@@ -109,13 +105,15 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
-                    make -C build/ci ci-deployer
-                """
+                            make -C build/ci ci-deployer
+                        """
+                    }
+                }
+
+                cleanWs()
             }
-            cleanWs()
         }
     }
-
 }
 
 def notOnlyDocs() {

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -88,11 +88,10 @@ EOF
 
     post {
         cleanup {
-            steps {
-                script {
-                    if (notOnlyDocs()) {
-                        sh """
-                            cat >operators/run-config.yml <<EOF
+            script {
+                if (notOnlyDocs()) {
+                    sh """
+                        cat >operators/run-config.yml <<EOF
 id: gke-ci
 overrides:
   operation: delete
@@ -105,13 +104,12 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
-                            make -C build/ci ci-deployer
-                        """
-                    }
+                        make -C build/ci ci-deployer
+                    """
                 }
-
-                cleanWs()
             }
+
+            cleanWs()
         }
     }
 }

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -104,7 +104,7 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
-                        make -C build/ci ci-deployer
+                        make -C build/ci ci-run-deployer
                     """
                 }
             }

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -15,8 +15,8 @@ pipeline {
         REGISTRY = "eu.gcr.io"
         GCLOUD_PROJECT = credentials('k8s-operators-gcloud-project')
         TESTS_MATCH = 'TestSmoke'
-        GKE_CLUSTER_VERSION = '1.12'
-        GKE_CLUSTER_NAME = "${BUILD_TAG}"
+        CLUSTER_VERSION = '1.12'
+        CLUSTER_NAME = "${BUILD_TAG}"
     }
 
     stages {

--- a/operators/Makefile
+++ b/operators/Makefile
@@ -328,10 +328,10 @@ e2e-local:
 ci: dep-vendor-only check-fmt lint generate check-local-changes unit integration e2e-compile docker-build
 
 # Run e2e tests in a dedicated cluster.
-ci-e2e: deployer
+ci-e2e: run-deployer
 	$(MAKE) IMG_SUFFIX=-ci install-crds apply-psp e2e
 
-deployer: dep-vendor-only
+run-deployer: dep-vendor-only
 	@ go build -o hack/deployer/deployer ./hack/deployer/...
 	./hack/deployer/deployer --plans-file hack/deployer/config/plans.yml --run-config-file run-config.yml
 

--- a/operators/Makefile
+++ b/operators/Makefile
@@ -40,7 +40,13 @@ endif
 IMG_SUFFIX ?= -$(subst _,,$(USER))
 IMG ?= $(REGISTRY)/$(REPOSITORY)/$(NAME)$(IMG_SUFFIX)
 TAG ?= $(shell git rev-parse --short --verify HEAD)
+
+ifeq ($(OPERATOR_IMAGE),)
+	# we never want this empty
+	undefine OPERATOR_IMAGE
+endif
 OPERATOR_IMAGE ?= $(IMG):$(VERSION)-$(TAG)
+
 
 GO_LDFLAGS := -X github.com/elastic/cloud-on-k8s/operators/pkg/about.version=$(VERSION) \
 	-X github.com/elastic/cloud-on-k8s/operators/pkg/about.buildHash=$(TAG) \
@@ -321,30 +327,19 @@ e2e-local:
 
 ci: dep-vendor-only check-fmt lint generate check-local-changes unit integration e2e-compile docker-build
 
-# Run e2e tests in a dedicated gke cluster, that we delete if everything went fine.
-# Let's use n1-standard-8 machine to have enough room for multiple pods on a single node.
-ci-e2e: ci-bootstrap-gke e2e
+# Run e2e tests in a dedicated cluster.
+ci-e2e: deployer
+	$(MAKE) IMG_SUFFIX=-ci install-crds apply-psp e2e
 
-# Run e2e tests in gke using custom operator image
-ci-e2e-rc: export SKIP_DOCKER_COMMAND=true
-ci-e2e-rc: ci-bootstrap-gke e2e
-
-ci-bootstrap-gke:
-	PSP=1 GKE_MACHINE_TYPE=n1-standard-8 $(MAKE) bootstrap-gke
+deployer: dep-vendor-only
+	@ go build -o hack/deployer/deployer ./hack/deployer/...
+	./hack/deployer/deployer --plans-file hack/deployer/config/plans.yml --run-config-file run-config.yml
 
 ci-release: export GO_TAGS = release
 ci-release: export LICENSE_PUBKEY = $(ROOT_DIR)/build/ci/license.key
 ci-release:
 	@ $(MAKE) dep-vendor-only generate docker-build docker-push
 	@ echo $(OPERATOR_IMAGE) was pushed!
-
-ci-e2e-new: deployer-new
-	$(MAKE) IMG_SUFFIX=-ci install-crds apply-psp e2e
-
-deployer-new: dep-vendor-only
-	@ go build -o hack/deployer/deployer ./hack/deployer/...
-	./hack/deployer/deployer --plans-file hack/deployer/config/plans.yml --run-config-file run-config.yml
-
 
 ##########################
 ##  --   Helpers    --  ##

--- a/operators/hack/deployer/gke.go
+++ b/operators/hack/deployer/gke.go
@@ -214,5 +214,35 @@ func (d *GkeDriver) getCredentials() error {
 func (d *GkeDriver) delete() error {
 	log.Println("Deleting cluster...")
 	cmd := "gcloud beta --quiet --project {{.GCloudProject}} container clusters delete {{.ClusterName}} --region {{.Region}}"
-	return NewCommand(cmd).AsTemplate(d.ctx).Run()
+	if err := NewCommand(cmd).AsTemplate(d.ctx).Run(); err != nil {
+		return err
+	}
+
+	cmd = `gcloud compute disks list --filter="-users:*" --format="value[separator=','](name,zone)" --project {{.GCloudProject}}`
+	disks, err := NewCommand(cmd).AsTemplate(d.ctx).StdoutOnly().OutputList()
+	if err != nil {
+		return err
+	}
+
+	for _, disk := range disks {
+		nameZone := strings.Split(disk, ",")
+		if len(nameZone) != 2 {
+			return fmt.Errorf("disk name and zone contained unexpected number of fields")
+		}
+
+		name, zone := nameZone[0], nameZone[1]
+		cmd = `gcloud compute disks delete {{.Name}} --project {{.GCloudProject}} --zone {{.Zone}} --quiet`
+		err := NewCommand(cmd).
+			AsTemplate(map[string]interface{}{
+				"GCloudProject": d.plan.Gke.GCloudProject,
+				"Name":          name,
+				"Zone":          zone,
+			}).
+			Run()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/operators/hack/deployer/gke.go
+++ b/operators/hack/deployer/gke.go
@@ -218,6 +218,7 @@ func (d *GkeDriver) delete() error {
 		return err
 	}
 
+	// Deleting clusters in GKE does not delete associated disks, we have to delete them manually.
 	cmd = `gcloud compute disks list --filter="-users:*" --format="value[separator=','](name,zone)" --project {{.GCloudProject}}`
 	disks, err := NewCommand(cmd).AsTemplate(d.ctx).StdoutOnly().OutputList()
 	if err != nil {


### PR DESCRIPTION
This PR:
- removes temporary *-new targets,
- removes gke cleanup targets as the replacement is agnostic to the operation (create/delete) that is being driven,
- moves all create/delete gke operations in jenkinsfiles to use deployer,
- moves ci-e2e targets to use deployer,
- removes some ci-e2e-* targets.

build/ci/e2e/Jenkinsfile.* will be most likely merged from three to a single file soon, so run-config file creation won't be repeated so much.