### PR TITLE
Simplifying JJBB job descriptions

### DIFF
--- a/.ci/jobs/cleanup.yml
+++ b/.ci/jobs/cleanup.yml
@@ -1,11 +1,6 @@
 ---
 - job:
     description: Job that cleanup resources in cloud services. This Job is managed by JJB.
-    logrotate:
-      daysToKeep: 7
-      numToKeep: 100
-      artifactDaysToKeep: 5
-      artifactNumToKeep: 10
     name: cloud-on-k8s-e2e-cleanup
     project-type: pipeline
     parameters:

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -8,4 +8,8 @@
 ##### JOB DEFAULTS
 
 - job:
-      foo: bar
+    logrotate:
+      daysToKeep: 7
+      numToKeep: 100
+      artifactDaysToKeep: 5
+      artifactNumToKeep: 10

--- a/.ci/jobs/e2e-custom.yml
+++ b/.ci/jobs/e2e-custom.yml
@@ -1,11 +1,6 @@
 ---
 - job:
     description: Job that runs e2e tests against custom ECK image running in a dedicated k8s cluster in GKE. This Job is managed by JJB.
-    logrotate:
-      daysToKeep: 7
-      numToKeep: 100
-      artifactDaysToKeep: 5
-      artifactNumToKeep: 10
     name: cloud-on-k8s-e2e-tests-custom
     project-type: pipeline
     parameters:
@@ -26,5 +21,3 @@
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
       script-path: build/ci/e2e/custom_operator_image.jenkinsfile
       lightweight-checkout: true
-    wrappers:
-      - ansicolor

--- a/.ci/jobs/e2e-tests-aks.yaml
+++ b/.ci/jobs/e2e-tests-aks.yaml
@@ -1,11 +1,6 @@
 ---
 - job:
     description: Job that runs e2e tests against Elastic Cloud on Kubernetes running in a dedicated k8s cluster in AKS. This Job is managed by JJB.
-    logrotate:
-      daysToKeep: 7
-      numToKeep: 100
-      artifactDaysToKeep: 5
-      artifactNumToKeep: 10
     name: cloud-on-k8s-e2e-tests-aks
     project-type: pipeline
     concurrent: true
@@ -18,5 +13,3 @@
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
       script-path: build/ci/e2e/Jenkinsfile-aks
       lightweight-checkout: true
-    wrappers:
-      - ansicolor

--- a/.ci/jobs/e2e-tests-new.yaml
+++ b/.ci/jobs/e2e-tests-new.yaml
@@ -1,11 +1,6 @@
 ---
 - job:
     description: Job that runs e2e tests-new against Elastic Cloud on Kubernetes running in a dedicated k8s cluster. This Job is managed by JJB.
-    logrotate:
-      daysToKeep: 7
-      numToKeep: 100
-      artifactDaysToKeep: 5
-      artifactNumToKeep: 10
     name: cloud-on-k8s-e2e-tests-new
     project-type: pipeline
     concurrent: true
@@ -18,5 +13,3 @@
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
       script-path: build/ci/e2e/Jenkinsfile-new
       lightweight-checkout: true
-    wrappers:
-      - ansicolor

--- a/.ci/jobs/e2e-tests.yaml
+++ b/.ci/jobs/e2e-tests.yaml
@@ -1,11 +1,6 @@
 ---
 - job:
     description: Job that runs e2e tests against Elastic Cloud on Kubernetes running in a dedicated k8s cluster. This Job is managed by JJB.
-    logrotate:
-      daysToKeep: 7
-      numToKeep: 100
-      artifactDaysToKeep: 5
-      artifactNumToKeep: 10
     name: cloud-on-k8s-e2e-tests
     project-type: pipeline
     triggers:
@@ -20,5 +15,3 @@
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
       script-path: build/ci/e2e/Jenkinsfile
       lightweight-checkout: true
-    wrappers:
-      - ansicolor

--- a/.ci/jobs/gke-e2e-versions.yml
+++ b/.ci/jobs/gke-e2e-versions.yml
@@ -1,11 +1,6 @@
 ---
 - job:
     description: Job that runs ECK e2e tests against different versions of k8s clusters in GKE. This Job is managed by JJB.
-    logrotate:
-      daysToKeep: 7
-      numToKeep: 100
-      artifactDaysToKeep: 5
-      artifactNumToKeep: 10
     name: cloud-on-k8s-versions-gke
     project-type: pipeline
     parameters:

--- a/.ci/jobs/nightly.yml
+++ b/.ci/jobs/nightly.yml
@@ -1,11 +1,6 @@
 ---
 - job:
     description: Job that build nightly images of ECK. This Job is managed by JJB.
-    logrotate:
-      daysToKeep: 7
-      numToKeep: 100
-      artifactDaysToKeep: 5
-      artifactNumToKeep: 10
     name: cloud-on-k8s-nightly
     project-type: pipeline
     triggers:

--- a/.ci/jobs/pr.yml
+++ b/.ci/jobs/pr.yml
@@ -1,11 +1,6 @@
 ---
 - job:
     description: Job that runs the pr Jenkinsfile on any PR of the Elastic Cloud on Kubernetes project. This Job is managed by JJB.
-    logrotate:
-      daysToKeep: 7
-      numToKeep: 100
-      artifactDaysToKeep: 5
-      artifactNumToKeep: 10
     name: cloud-on-k8s-pr
     project-type: pipeline
     concurrent: true

--- a/.ci/jobs/release.yml
+++ b/.ci/jobs/release.yml
@@ -1,11 +1,6 @@
 ---
 - job:
     description: Job that builds release version of ECK. This Job is managed by JJB.
-    logrotate:
-      daysToKeep: 7
-      numToKeep: 100
-      artifactDaysToKeep: 5
-      artifactNumToKeep: 10
     name: cloud-on-k8s-release
     project-type: multibranch
     prune-dead-branches: true


### PR DESCRIPTION
This PR simplifies our CI jobs descriptions a little bit.

1) Moving out `logrotate` options to `defaults.yml`
2) Removing unused `wrappers` section