### PR TITLE
Remove undefine directive

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -43,7 +43,7 @@ TAG ?= $(shell git rev-parse --short --verify HEAD)
 
 ifeq ($(OPERATOR_IMAGE),)
 	# we never want this empty
-	undefine OPERATOR_IMAGE
+	OPERATOR_IMAGE := $(IMG):$(VERSION)-$(TAG)
 endif
 OPERATOR_IMAGE ?= $(IMG):$(VERSION)-$(TAG)
 


### PR DESCRIPTION
undefine is not supported by make 3.8.1 which is default on OSX.