### PR TITLE
Set stack version in Makefile

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -289,7 +289,9 @@ purge-gcr-images:
 # can be overriden to eg. TESTS_MATCH=TestMutationMoreNodes to match a single test
 TESTS_MATCH ?= "^Test"
 E2E_IMG ?= $(IMG)-e2e-tests:$(TAG)
-STACK_VERSION ?= 7.3.0
+ifeq ($(STACK_VERSION),)
+	STACK_VERSION = 7.3.0
+endif
 
 # Run e2e tests as a k8s batch job
 e2e: docker-build docker-push e2e-docker-build e2e-docker-push e2e-run


### PR DESCRIPTION
We have issue similar to `OPERATOR_IMAGE` in the past. When `STACK_VERSION` might not be set. 
Solution is also similar to https://github.com/elastic/cloud-on-k8s/blob/master/operators/Makefile#L44