### PR TITLE
Downscale one master at a time & don't remove last running master

### DIFF
--- a/operators/pkg/controller/elasticsearch/driver/downscale_invariants.go
+++ b/operators/pkg/controller/elasticsearch/driver/downscale_invariants.go
@@ -1,0 +1,70 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package driver
+
+import (
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/reconcile"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+const (
+	OneMasterAtATimeInvariant        = "A master node is already in the process of being removed"
+	AtLeastOneRunningMasterInvariant = "Cannot remove the last running master node"
+)
+
+// DownscaleInvariants restricts downscales to perform in a single reconciliation attempt:
+// - remove a single master at once
+// - don't remove the last living master node
+type DownscaleInvariants struct {
+	// masterRemoved indicates whether a master node is in the process of being removed already.
+	masterRemoved bool
+	// runningMasters indicates how many masters are currently running in the cluster.
+	runningMasters int
+}
+
+// NewDownscaleInvariants creates a new DownscaleInvariants.
+func NewDownscaleInvariants(c k8s.Client, es v1alpha1.Elasticsearch) (*DownscaleInvariants, error) {
+	// retrieve the number of masters running ready
+	actualPods, err := sset.GetActualPodsForCluster(c, es)
+	if err != nil {
+		return nil, err
+	}
+	mastersReady := reconcile.AvailableElasticsearchNodes(label.FilterMasterNodePods(actualPods))
+
+	return &DownscaleInvariants{
+		masterRemoved:  false,
+		runningMasters: len(mastersReady),
+	}, nil
+}
+
+// canDownscale returns true if the current state allows downscaling the given StatefulSet.
+// If not, it also returns the reason why.
+func (d *DownscaleInvariants) canDownscale(statefulSet appsv1.StatefulSet) (bool, string) {
+	if !label.IsMasterNodeSet(statefulSet) {
+		// only care about master nodes
+		return true, ""
+	}
+	if d.masterRemoved {
+		return false, OneMasterAtATimeInvariant
+	}
+	if d.runningMasters == 1 {
+		return false, AtLeastOneRunningMasterInvariant
+	}
+	return true, ""
+}
+
+// accountDownscale updates the current invariants state to consider a 1-replica downscale of the given statefulSet.
+func (d *DownscaleInvariants) accountOneRemoval(statefulSet appsv1.StatefulSet) {
+	if !label.IsMasterNodeSet(statefulSet) {
+		// only care about master nodes
+		return
+	}
+	d.masterRemoved = true
+	d.runningMasters--
+}

--- a/operators/pkg/controller/elasticsearch/driver/downscale_invariants.go
+++ b/operators/pkg/controller/elasticsearch/driver/downscale_invariants.go
@@ -18,18 +18,32 @@ const (
 	AtLeastOneRunningMasterInvariant = "Cannot remove the last running master node"
 )
 
-// DownscaleInvariants restricts downscales to perform in a single reconciliation attempt:
-// - remove a single master at once
-// - don't remove the last living master node
-type DownscaleInvariants struct {
-	// masterRemoved indicates whether a master node is in the process of being removed already.
-	masterRemoved bool
+// checkDownscaleInvariants returns true if the given state state allows downscaling the given StatefulSet.
+// If not, it also returns the reason why.
+func checkDownscaleInvariants(state downscaleState, statefulSet appsv1.StatefulSet) (bool, string) {
+	if !label.IsMasterNodeSet(statefulSet) {
+		// only care about master nodes
+		return true, ""
+	}
+	if state.masterRemovalInProgress {
+		return false, OneMasterAtATimeInvariant
+	}
+	if state.runningMasters == 1 {
+		return false, AtLeastOneRunningMasterInvariant
+	}
+	return true, ""
+}
+
+// downscaleState tracks the state of a downscale to be checked against invariants
+type downscaleState struct {
+	// masterRemovalInProgress indicates whether a master node is in the process of being removed already.
+	masterRemovalInProgress bool
 	// runningMasters indicates how many masters are currently running in the cluster.
 	runningMasters int
 }
 
-// NewDownscaleInvariants creates a new DownscaleInvariants.
-func NewDownscaleInvariants(c k8s.Client, es v1alpha1.Elasticsearch) (*DownscaleInvariants, error) {
+// newDownscaleState creates a new downscaleState.
+func newDownscaleState(c k8s.Client, es v1alpha1.Elasticsearch) (*downscaleState, error) {
 	// retrieve the number of masters running ready
 	actualPods, err := sset.GetActualPodsForCluster(c, es)
 	if err != nil {
@@ -37,34 +51,18 @@ func NewDownscaleInvariants(c k8s.Client, es v1alpha1.Elasticsearch) (*Downscale
 	}
 	mastersReady := reconcile.AvailableElasticsearchNodes(label.FilterMasterNodePods(actualPods))
 
-	return &DownscaleInvariants{
-		masterRemoved:  false,
-		runningMasters: len(mastersReady),
+	return &downscaleState{
+		masterRemovalInProgress: false,
+		runningMasters:          len(mastersReady),
 	}, nil
 }
 
-// canDownscale returns true if the current state allows downscaling the given StatefulSet.
-// If not, it also returns the reason why.
-func (d *DownscaleInvariants) canDownscale(statefulSet appsv1.StatefulSet) (bool, string) {
-	if !label.IsMasterNodeSet(statefulSet) {
-		// only care about master nodes
-		return true, ""
-	}
-	if d.masterRemoved {
-		return false, OneMasterAtATimeInvariant
-	}
-	if d.runningMasters == 1 {
-		return false, AtLeastOneRunningMasterInvariant
-	}
-	return true, ""
-}
-
-// accountDownscale updates the current invariants state to consider a 1-replica downscale of the given statefulSet.
-func (d *DownscaleInvariants) accountOneRemoval(statefulSet appsv1.StatefulSet) {
+// recordOneRemoval updates the state to consider a 1-replica downscale of the given statefulSet.
+func (s *downscaleState) recordOneRemoval(statefulSet appsv1.StatefulSet) {
 	if !label.IsMasterNodeSet(statefulSet) {
 		// only care about master nodes
 		return
 	}
-	d.masterRemoved = true
-	d.runningMasters--
+	s.masterRemovalInProgress = true
+	s.runningMasters--
 }

--- a/operators/pkg/controller/elasticsearch/driver/downscale_invariants_test.go
+++ b/operators/pkg/controller/elasticsearch/driver/downscale_invariants_test.go
@@ -1,0 +1,210 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package driver
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+)
+
+func TestNewDownscaleInvariants(t *testing.T) {
+	es := v1alpha1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: ssetMaster3Replicas.Namespace, Name: "name"}}
+	tests := []struct {
+		name             string
+		initialResources []runtime.Object
+		want             *DownscaleInvariants
+	}{
+		{
+			name:             "no resources in the apiserver",
+			initialResources: nil,
+			want:             &DownscaleInvariants{masterRemoved: false, runningMasters: 0},
+		},
+		{
+			name: "3 masters running in the apiserver, 1 not running",
+			initialResources: []runtime.Object{
+				// 3 masters running
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: ssetMaster3Replicas.Namespace,
+						Name:      ssetMaster3Replicas.Name + "-0",
+						Labels: map[string]string{
+							label.StatefulSetNameLabelName:         ssetMaster3Replicas.Name,
+							string(label.NodeTypesMasterLabelName): "true",
+							label.ClusterNameLabelName:             es.Name,
+						},
+					},
+					Status: corev1.PodStatus{
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: ssetMaster3Replicas.Namespace,
+						Name:      ssetMaster3Replicas.Name + "-1",
+						Labels: map[string]string{
+							label.StatefulSetNameLabelName:         ssetMaster3Replicas.Name,
+							string(label.NodeTypesMasterLabelName): "true",
+							label.ClusterNameLabelName:             es.Name,
+						},
+					},
+					Status: corev1.PodStatus{
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: ssetMaster3Replicas.Namespace,
+						Name:      ssetMaster3Replicas.Name + "-2",
+						Labels: map[string]string{
+							label.StatefulSetNameLabelName:         ssetMaster3Replicas.Name,
+							string(label.NodeTypesMasterLabelName): "true",
+							label.ClusterNameLabelName:             es.Name,
+						},
+					},
+					Status: corev1.PodStatus{
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				// 1 master not ready yet
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: ssetMaster3Replicas.Namespace,
+						Name:      ssetMaster3Replicas.Name + "-3",
+						Labels: map[string]string{
+							label.StatefulSetNameLabelName:         ssetMaster3Replicas.Name,
+							string(label.NodeTypesMasterLabelName): "true",
+							label.ClusterNameLabelName:             es.Name,
+						},
+					},
+				},
+			},
+			want: &DownscaleInvariants{masterRemoved: false, runningMasters: 3},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient := k8s.WrapClient(fake.NewFakeClient(tt.initialResources...))
+			got, err := NewDownscaleInvariants(k8sClient, es)
+			require.NoError(t, err)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewDownscaleInvariants() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_DownscaleInvariants_canDownscale(t *testing.T) {
+	tests := []struct {
+		name             string
+		budget           *DownscaleInvariants
+		statefulSet      appsv1.StatefulSet
+		wantCanDownscale bool
+		wantReason       string
+	}{
+		{
+			name:             "should always allow removing data nodes",
+			budget:           &DownscaleInvariants{runningMasters: 1, masterRemoved: true},
+			statefulSet:      ssetData4Replicas,
+			wantCanDownscale: true,
+		},
+		{
+			name:             "should allow removing one master if there is another one running",
+			budget:           &DownscaleInvariants{runningMasters: 2, masterRemoved: false},
+			statefulSet:      ssetMaster3Replicas,
+			wantCanDownscale: true,
+		},
+		{
+			name:             "should not allow removing the last master",
+			budget:           &DownscaleInvariants{runningMasters: 1, masterRemoved: false},
+			statefulSet:      ssetMaster3Replicas,
+			wantCanDownscale: false,
+			wantReason:       AtLeastOneRunningMasterInvariant,
+		},
+		{
+			name:             "should not allow removing a master if one is already being removed",
+			budget:           &DownscaleInvariants{runningMasters: 2, masterRemoved: true},
+			statefulSet:      ssetMaster3Replicas,
+			wantCanDownscale: false,
+			wantReason:       OneMasterAtATimeInvariant,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			canDownscale, reason := tt.budget.canDownscale(tt.statefulSet)
+			if canDownscale != tt.wantCanDownscale {
+				t.Errorf("canDownscale() canDownscale = %v, want %v", canDownscale, tt.wantCanDownscale)
+			}
+			if reason != tt.wantReason {
+				t.Errorf("canDownscale() reason = %v, want %v", reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+func Test_DownscaleInvariants_accountOneRemoval(t *testing.T) {
+	tests := []struct {
+		name           string
+		statefulSet    appsv1.StatefulSet
+		budget         *DownscaleInvariants
+		wantInvariants *DownscaleInvariants
+	}{
+		{
+			name:           "removing a data node should be a no-op",
+			statefulSet:    ssetData4Replicas,
+			budget:         &DownscaleInvariants{runningMasters: 2, masterRemoved: false},
+			wantInvariants: &DownscaleInvariants{runningMasters: 2, masterRemoved: false},
+		},
+		{
+			name:           "removing a master node should mutate the budget",
+			statefulSet:    ssetMaster3Replicas,
+			budget:         &DownscaleInvariants{runningMasters: 2, masterRemoved: false},
+			wantInvariants: &DownscaleInvariants{runningMasters: 1, masterRemoved: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.budget.accountOneRemoval(tt.statefulSet)
+			require.Equal(t, tt.wantInvariants, tt.budget)
+		})
+	}
+}

--- a/operators/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/operators/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/reconciler"
 	esclient "github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/client"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/nodespec"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/observer"
 	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/reconcile"
@@ -30,57 +31,57 @@ import (
 
 // Sample StatefulSets to use in tests
 var (
-	sset3Replicas     = nodespec.CreateTestSset("sset3Replicas", "7.2.0", 3, true, true)
-	podsSset3Replicas = []corev1.Pod{
+	ssetMaster3Replicas     = nodespec.CreateTestSset("ssetMaster3Replicas", "7.2.0", 3, true, false)
+	podsSsetMaster3Replicas = []corev1.Pod{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: sset3Replicas.Namespace,
-				Name:      sset.PodName(sset3Replicas.Name, 0),
+				Namespace: ssetMaster3Replicas.Namespace,
+				Name:      sset.PodName(ssetMaster3Replicas.Name, 0),
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: sset3Replicas.Namespace,
-				Name:      sset.PodName(sset3Replicas.Name, 1),
+				Namespace: ssetMaster3Replicas.Namespace,
+				Name:      sset.PodName(ssetMaster3Replicas.Name, 1),
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: sset3Replicas.Namespace,
-				Name:      sset.PodName(sset3Replicas.Name, 2),
-			},
-		},
-	}
-	sset4Replicas     = nodespec.CreateTestSset("sset4Replicas", "7.2.0", 4, true, true)
-	podsSset4Replicas = []corev1.Pod{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: sset3Replicas.Namespace,
-				Name:      sset.PodName(sset4Replicas.Name, 0),
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: sset3Replicas.Namespace,
-				Name:      sset.PodName(sset4Replicas.Name, 1),
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: sset3Replicas.Namespace,
-				Name:      sset.PodName(sset4Replicas.Name, 2),
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: sset3Replicas.Namespace,
-				Name:      sset.PodName(sset4Replicas.Name, 3),
+				Namespace: ssetMaster3Replicas.Namespace,
+				Name:      sset.PodName(ssetMaster3Replicas.Name, 2),
 			},
 		},
 	}
-	runtimeObjs = []runtime.Object{&sset3Replicas, &sset4Replicas,
-		&podsSset3Replicas[0], &podsSset3Replicas[1], &podsSset3Replicas[2],
-		&podsSset4Replicas[0], &podsSset4Replicas[1], &podsSset4Replicas[2], &podsSset4Replicas[3],
+	ssetData4Replicas     = nodespec.CreateTestSset("ssetData4Replicas", "7.2.0", 4, false, true)
+	podsSsetData4Replicas = []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ssetMaster3Replicas.Namespace,
+				Name:      sset.PodName(ssetData4Replicas.Name, 0),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ssetMaster3Replicas.Namespace,
+				Name:      sset.PodName(ssetData4Replicas.Name, 1),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ssetMaster3Replicas.Namespace,
+				Name:      sset.PodName(ssetData4Replicas.Name, 2),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ssetMaster3Replicas.Namespace,
+				Name:      sset.PodName(ssetData4Replicas.Name, 3),
+			},
+		},
+	}
+	runtimeObjs = []runtime.Object{&ssetMaster3Replicas, &ssetData4Replicas,
+		&podsSsetMaster3Replicas[0], &podsSsetMaster3Replicas[1], &podsSsetMaster3Replicas[2],
+		&podsSsetData4Replicas[0], &podsSsetData4Replicas[1], &podsSsetData4Replicas[2], &podsSsetData4Replicas[3],
 	}
 	requeueResults = (&reconciler.Results{}).WithResult(defaultRequeue)
 	emptyResults   = &reconciler.Results{}
@@ -124,12 +125,12 @@ func TestHandleDownscale(t *testing.T) {
 	// This test focuses on one code path that visits most functions.
 	// Derived paths are individually tested in unit tests of the other functions.
 
-	// We want to downscale 2 StatefulSets (3 -> 1 and 4 -> 2) in version 7.X,
-	// but should only be allowed a partial downscale (3 -> 1 and 4 -> 3).
+	// We want to downscale 2 StatefulSets (masters 3 -> 1 and data 4 -> 2) in version 7.X,
+	// but should only be allowed a partial downscale (3 -> 2 and 4 -> 3).
 
 	k8sClient := k8s.WrapClient(fake.NewFakeClient(runtimeObjs...))
 	esClient := &fakeESClient{}
-	actualStatefulSets := sset.StatefulSetList{sset3Replicas, sset4Replicas}
+	actualStatefulSets := sset.StatefulSetList{ssetMaster3Replicas, ssetData4Replicas}
 	downscaleCtx := downscaleContext{
 		k8sClient:      k8sClient,
 		expectations:   reconciler.NewExpectations(),
@@ -139,22 +140,22 @@ func TestHandleDownscale(t *testing.T) {
 				ClusterName: "cluster-name",
 				Nodes: map[string]esclient.ClusterStateNode{
 					// nodes from 1st sset
-					"sset3Replicas-0": {Name: "sset3Replicas-0"},
-					"sset3Replicas-1": {Name: "sset3Replicas-1"},
-					"sset3Replicas-2": {Name: "sset3Replicas-2"},
+					"ssetMaster3Replicas-0": {Name: "ssetMaster3Replicas-0"},
+					"ssetMaster3Replicas-1": {Name: "ssetMaster3Replicas-1"},
+					"ssetMaster3Replicas-2": {Name: "ssetMaster3Replicas-2"},
 					// nodes from 2nd sset
-					"sset4Replicas-0": {Name: "sset4Replicas-0"},
-					"sset4Replicas-1": {Name: "sset4Replicas-1"},
-					"sset4Replicas-2": {Name: "sset4Replicas-2"},
-					"sset4Replicas-3": {Name: "sset4Replicas-3"},
+					"ssetData4Replicas-0": {Name: "ssetData4Replicas-0"},
+					"ssetData4Replicas-1": {Name: "ssetData4Replicas-1"},
+					"ssetData4Replicas-2": {Name: "ssetData4Replicas-2"},
+					"ssetData4Replicas-3": {Name: "ssetData4Replicas-3"},
 				},
 				RoutingTable: esclient.RoutingTable{
 					Indices: map[string]esclient.Shards{
 						"index-1": {
 							Shards: map[string][]esclient.Shard{
 								"0": {
-									// node sset4Replicas-2 cannot leave the cluster because of this shard
-									{Index: "index-1", Shard: 0, State: esclient.STARTED, Node: "sset4Replicas-2"},
+									// node ssetData4Replicas-2 cannot leave the cluster because of this shard
+									{Index: "index-1", Shard: 0, State: esclient.STARTED, Node: "ssetData4Replicas-2"},
 								},
 							},
 						},
@@ -165,13 +166,13 @@ func TestHandleDownscale(t *testing.T) {
 		esClient: esClient,
 	}
 
-	// request downscale from 3 to 1 replicas
-	sset3ReplicasDownscaled := *sset3Replicas.DeepCopy()
-	sset3ReplicasDownscaled.Spec.Replicas = common.Int32(1)
-	// request downscale from 4 to 2 replicas
-	sset4ReplicasDownscaled := *sset4Replicas.DeepCopy()
-	sset4ReplicasDownscaled.Spec.Replicas = common.Int32(2)
-	requestedStatefulSets := sset.StatefulSetList{sset3ReplicasDownscaled, sset4ReplicasDownscaled}
+	// request master nodes downscale from 3 to 1 replicas
+	ssetMaster3ReplicasDownscaled := *ssetMaster3Replicas.DeepCopy()
+	ssetMaster3ReplicasDownscaled.Spec.Replicas = common.Int32(1)
+	// request data nodes downscale from 4 to 2 replicas
+	ssetData4ReplicasDownscaled := *ssetData4Replicas.DeepCopy()
+	ssetData4ReplicasDownscaled.Spec.Replicas = common.Int32(2)
+	requestedStatefulSets := sset.StatefulSetList{ssetMaster3ReplicasDownscaled, ssetData4ReplicasDownscaled}
 
 	// do the downscale
 	results := HandleDownscale(downscaleCtx, requestedStatefulSets, actualStatefulSets)
@@ -179,20 +180,26 @@ func TestHandleDownscale(t *testing.T) {
 
 	// data migration should have been requested for all nodes leaving the cluster
 	require.True(t, esClient.ExcludeFromShardAllocationCalled)
-	require.Equal(t, "sset3Replicas-2,sset3Replicas-1,sset4Replicas-3,sset4Replicas-2", esClient.ExcludeFromShardAllocationCalledWith)
+	require.Equal(t, "ssetMaster3Replicas-2,ssetMaster3Replicas-1,ssetData4Replicas-3,ssetData4Replicas-2", esClient.ExcludeFromShardAllocationCalledWith)
 
-	// only part of the expected replicas of sset4Replicas should be updated,
+	// only part of the expected replicas of ssetMaster3Replicas should be updated,
+	// since we remove only one master at a time
+	ssetMaster3ReplicasExpectedAfterDownscale := *ssetMaster3Replicas.DeepCopy()
+	ssetMaster3ReplicasExpectedAfterDownscale.Spec.Replicas = common.Int32(2)
+	// only part of the expected replicas of ssetData4Replicas should be updated,
 	// since a node still needs to migrate data
-	sset4ReplicasExpectedAfterDownscale := *sset4Replicas.DeepCopy()
-	sset4ReplicasExpectedAfterDownscale.Spec.Replicas = common.Int32(3)
-	expectedAfterDownscale := []appsv1.StatefulSet{sset3ReplicasDownscaled, sset4ReplicasExpectedAfterDownscale}
+	ssetData4ReplicasExpectedAfterDownscale := *ssetData4Replicas.DeepCopy()
+	ssetData4ReplicasExpectedAfterDownscale.Spec.Replicas = common.Int32(3)
+
+	expectedAfterDownscale := []appsv1.StatefulSet{ssetMaster3ReplicasExpectedAfterDownscale, ssetData4ReplicasExpectedAfterDownscale}
 
 	// a requeue should be requested since all nodes were not downscaled
-	require.Equal(t, requeueResults, results)
+	// (2 requeues actually: for data migration & master nodes)
+	require.Equal(t, (&reconciler.Results{}).WithResult(defaultRequeue).WithResult(defaultRequeue), results)
 
 	// voting config exclusion should have been added for leaving masters
 	require.True(t, esClient.AddVotingConfigExclusionsCalled)
-	require.Equal(t, []string{"sset3Replicas-2", "sset3Replicas-1", "sset4Replicas-3"}, esClient.AddVotingConfigExclusionsCalledWith)
+	require.Equal(t, []string{"ssetMaster3Replicas-2"}, esClient.AddVotingConfigExclusionsCalledWith)
 
 	// compare what has been updated in the apiserver with what we would expect
 	var actual appsv1.StatefulSetList
@@ -210,21 +217,26 @@ func TestHandleDownscale(t *testing.T) {
 	require.Equal(t, expectedAfterDownscale, actual.Items)
 
 	// simulate pods deletion that would be done by the StatefulSet controller
-	require.NoError(t, k8sClient.Delete(&podsSset3Replicas[2]))
-	require.NoError(t, k8sClient.Delete(&podsSset3Replicas[1]))
-	require.NoError(t, k8sClient.Delete(&podsSset4Replicas[3]))
+	require.NoError(t, k8sClient.Delete(&podsSsetMaster3Replicas[2]))
+	require.NoError(t, k8sClient.Delete(&podsSsetData4Replicas[3]))
 
-	// running the downscale again should requeue since data migration is still not over
+	// running the downscale again should remove the next master,
+	// and also requeue since data migration is still not over for data nodes
 	results = HandleDownscale(downscaleCtx, requestedStatefulSets, actual.Items)
 	require.False(t, results.HasError())
 	require.Equal(t, requeueResults, results)
-	// no StatefulSet should have been updated
+
+	// one less master
+	ssetMaster3ReplicasExpectedAfterDownscale.Spec.Replicas = common.Int32(1)
+	expectedAfterDownscale = []appsv1.StatefulSet{ssetMaster3ReplicasExpectedAfterDownscale, ssetData4ReplicasExpectedAfterDownscale}
 	err = k8sClient.List(&client.ListOptions{}, &actual)
 	require.NoError(t, err)
 	require.Equal(t, expectedAfterDownscale, actual.Items)
+	// simulate master pod deletion
+	require.NoError(t, k8sClient.Delete(&podsSsetMaster3Replicas[1]))
 
-	// once data migration is over the downscale should continue
-	downscaleCtx.observedState.ClusterState.RoutingTable.Indices["index-1"].Shards["0"][0].Node = "sset4Replicas-1"
+	// once data migration is over the downscale should continue for next data nodes
+	downscaleCtx.observedState.ClusterState.RoutingTable.Indices["index-1"].Shards["0"][0].Node = "ssetData4Replicas-1"
 	expectedAfterDownscale[1].Spec.Replicas = common.Int32(2)
 	results = HandleDownscale(downscaleCtx, requestedStatefulSets, actual.Items)
 	require.False(t, results.HasError())
@@ -235,10 +247,10 @@ func TestHandleDownscale(t *testing.T) {
 
 	// data migration should have been requested for the data node leaving the cluster
 	require.True(t, esClient.ExcludeFromShardAllocationCalled)
-	require.Equal(t, "sset4Replicas-2", esClient.ExcludeFromShardAllocationCalledWith)
+	require.Equal(t, "ssetData4Replicas-2", esClient.ExcludeFromShardAllocationCalledWith)
 
 	// simulate pod deletion
-	require.NoError(t, k8sClient.Delete(&podsSset4Replicas[2]))
+	require.NoError(t, k8sClient.Delete(&podsSsetData4Replicas[2]))
 
 	// running the downscale again should not remove any new node
 	results = HandleDownscale(downscaleCtx, requestedStatefulSets, actual.Items)
@@ -253,6 +265,195 @@ func TestHandleDownscale(t *testing.T) {
 	require.Equal(t, "none_excluded", esClient.ExcludeFromShardAllocationCalledWith)
 }
 
+func TestNewDownscaleInvariants(t *testing.T) {
+	es := v1alpha1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: ssetMaster3Replicas.Namespace, Name: "name"}}
+	tests := []struct {
+		name             string
+		initialResources []runtime.Object
+		want             *DownscaleInvariants
+	}{
+		{
+			name:             "no resources in the apiserver",
+			initialResources: nil,
+			want:             &DownscaleInvariants{masterRemoved: false, runningMasters: 0},
+		},
+		{
+			name: "3 masters running in the apiserver, 1 not running",
+			initialResources: []runtime.Object{
+				// 3 masters running
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: ssetMaster3Replicas.Namespace,
+						Name:      ssetMaster3Replicas.Name + "-0",
+						Labels: map[string]string{
+							label.StatefulSetNameLabelName:         ssetMaster3Replicas.Name,
+							string(label.NodeTypesMasterLabelName): "true",
+							label.ClusterNameLabelName:             es.Name,
+						},
+					},
+					Status: corev1.PodStatus{
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: ssetMaster3Replicas.Namespace,
+						Name:      ssetMaster3Replicas.Name + "-1",
+						Labels: map[string]string{
+							label.StatefulSetNameLabelName:         ssetMaster3Replicas.Name,
+							string(label.NodeTypesMasterLabelName): "true",
+							label.ClusterNameLabelName:             es.Name,
+						},
+					},
+					Status: corev1.PodStatus{
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: ssetMaster3Replicas.Namespace,
+						Name:      ssetMaster3Replicas.Name + "-2",
+						Labels: map[string]string{
+							label.StatefulSetNameLabelName:         ssetMaster3Replicas.Name,
+							string(label.NodeTypesMasterLabelName): "true",
+							label.ClusterNameLabelName:             es.Name,
+						},
+					},
+					Status: corev1.PodStatus{
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				// 1 master not ready yet
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: ssetMaster3Replicas.Namespace,
+						Name:      ssetMaster3Replicas.Name + "-3",
+						Labels: map[string]string{
+							label.StatefulSetNameLabelName:         ssetMaster3Replicas.Name,
+							string(label.NodeTypesMasterLabelName): "true",
+							label.ClusterNameLabelName:             es.Name,
+						},
+					},
+				},
+			},
+			want: &DownscaleInvariants{masterRemoved: false, runningMasters: 3},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient := k8s.WrapClient(fake.NewFakeClient(tt.initialResources...))
+			got, err := NewDownscaleInvariants(k8sClient, es)
+			require.NoError(t, err)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewDownscaleInvariants() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_DownscaleInvariants_canDownscale(t *testing.T) {
+	tests := []struct {
+		name             string
+		budget           *DownscaleInvariants
+		statefulSet      appsv1.StatefulSet
+		wantCanDownscale bool
+		wantReason       string
+	}{
+		{
+			name:             "should always allow removing data nodes",
+			budget:           &DownscaleInvariants{runningMasters: 1, masterRemoved: true},
+			statefulSet:      ssetData4Replicas,
+			wantCanDownscale: true,
+		},
+		{
+			name:             "should allow removing one master if there is another one running",
+			budget:           &DownscaleInvariants{runningMasters: 2, masterRemoved: false},
+			statefulSet:      ssetMaster3Replicas,
+			wantCanDownscale: true,
+		},
+		{
+			name:             "should not allow removing the last master",
+			budget:           &DownscaleInvariants{runningMasters: 1, masterRemoved: false},
+			statefulSet:      ssetMaster3Replicas,
+			wantCanDownscale: false,
+			wantReason:       AtLeastOneRunningMasterInvariant,
+		},
+		{
+			name:             "should not allow removing a master if one is already being removed",
+			budget:           &DownscaleInvariants{runningMasters: 2, masterRemoved: true},
+			statefulSet:      ssetMaster3Replicas,
+			wantCanDownscale: false,
+			wantReason:       OneMasterAtATimeInvariant,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			canDownscale, reason := tt.budget.canDownscale(tt.statefulSet)
+			if canDownscale != tt.wantCanDownscale {
+				t.Errorf("canDownscale() canDownscale = %v, want %v", canDownscale, tt.wantCanDownscale)
+			}
+			if reason != tt.wantReason {
+				t.Errorf("canDownscale() reason = %v, want %v", reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+func Test_DownscaleInvariants_accountOneRemoval(t *testing.T) {
+	tests := []struct {
+		name           string
+		statefulSet    appsv1.StatefulSet
+		budget         *DownscaleInvariants
+		wantInvariants *DownscaleInvariants
+	}{
+		{
+			name:           "removing a data node should be a no-op",
+			statefulSet:    ssetData4Replicas,
+			budget:         &DownscaleInvariants{runningMasters: 2, masterRemoved: false},
+			wantInvariants: &DownscaleInvariants{runningMasters: 2, masterRemoved: false},
+		},
+		{
+			name:           "removing a master node should mutate the budget",
+			statefulSet:    ssetMaster3Replicas,
+			budget:         &DownscaleInvariants{runningMasters: 2, masterRemoved: false},
+			wantInvariants: &DownscaleInvariants{runningMasters: 1, masterRemoved: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.budget.accountOneRemoval(tt.statefulSet)
+			require.Equal(t, tt.wantInvariants, tt.budget)
+		})
+	}
+}
+
 func Test_ssetDownscale_leavingNodeNames(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -263,42 +464,42 @@ func Test_ssetDownscale_leavingNodeNames(t *testing.T) {
 	}{
 		{
 			name:            "no replicas",
-			statefulSet:     sset3Replicas,
+			statefulSet:     ssetMaster3Replicas,
 			initialReplicas: 0,
 			targetReplicas:  0,
 			want:            nil,
 		},
 		{
 			name:            "going from 2 to 0 replicas",
-			statefulSet:     sset3Replicas,
+			statefulSet:     ssetMaster3Replicas,
 			initialReplicas: 2,
 			targetReplicas:  0,
-			want:            []string{"sset3Replicas-1", "sset3Replicas-0"},
+			want:            []string{"ssetMaster3Replicas-1", "ssetMaster3Replicas-0"},
 		},
 		{
 			name:            "going from 2 to 1 replicas",
-			statefulSet:     sset3Replicas,
+			statefulSet:     ssetMaster3Replicas,
 			initialReplicas: 2,
 			targetReplicas:  1,
-			want:            []string{"sset3Replicas-1"},
+			want:            []string{"ssetMaster3Replicas-1"},
 		},
 		{
 			name:            "going from 5 to 2 replicas",
-			statefulSet:     sset3Replicas,
+			statefulSet:     ssetMaster3Replicas,
 			initialReplicas: 5,
 			targetReplicas:  2,
-			want:            []string{"sset3Replicas-4", "sset3Replicas-3", "sset3Replicas-2"},
+			want:            []string{"ssetMaster3Replicas-4", "ssetMaster3Replicas-3", "ssetMaster3Replicas-2"},
 		},
 		{
 			name:            "no replicas change",
-			statefulSet:     sset3Replicas,
+			statefulSet:     ssetMaster3Replicas,
 			initialReplicas: 2,
 			targetReplicas:  2,
 			want:            nil,
 		},
 		{
 			name:            "upscale",
-			statefulSet:     sset3Replicas,
+			statefulSet:     ssetMaster3Replicas,
 			initialReplicas: 2,
 			targetReplicas:  3,
 			want:            nil,
@@ -333,17 +534,17 @@ func Test_leavingNodeNames(t *testing.T) {
 			name: "2 downscales",
 			downscales: []ssetDownscale{
 				{
-					statefulSet:     sset3Replicas,
+					statefulSet:     ssetMaster3Replicas,
 					initialReplicas: 2,
 					targetReplicas:  1,
 				},
 				{
-					statefulSet:     sset4Replicas,
+					statefulSet:     ssetData4Replicas,
 					initialReplicas: 4,
 					targetReplicas:  3,
 				},
 			},
-			want: []string{"sset3Replicas-1", "sset4Replicas-3"},
+			want: []string{"ssetMaster3Replicas-1", "ssetData4Replicas-3"},
 		},
 	}
 	for _, tt := range tests {
@@ -511,6 +712,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 	type args struct {
 		ctx             downscaleContext
 		downscale       ssetDownscale
+		invariants      *DownscaleInvariants
 		allLeavingNodes []string
 	}
 	tests := []struct {
@@ -526,6 +728,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 					initialReplicas: 3,
 					targetReplicas:  3,
 				},
+				invariants:      &DownscaleInvariants{masterRemoved: false, runningMasters: 3},
 				allLeavingNodes: []string{"node-1", "node-2"},
 			},
 			want: ssetDownscale{
@@ -534,7 +737,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 			},
 		},
 		{
-			name: "downscale possible from 3 to 1",
+			name: "downscale possible from 3 to 2",
 			args: args{
 				ctx: downscaleContext{
 					observedState: observer.State{
@@ -546,12 +749,91 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 				},
 				downscale: ssetDownscale{
 					initialReplicas: 3,
-					targetReplicas:  1,
+					targetReplicas:  2,
 				},
+				invariants:      &DownscaleInvariants{masterRemoved: false, runningMasters: 3},
 				allLeavingNodes: []string{"node-1", "node-2"},
 			},
 			want: ssetDownscale{
 				initialReplicas: 3,
+				targetReplicas:  2,
+			},
+		},
+		{
+			name: "downscale not possible: one master already removed",
+			args: args{
+				ctx: downscaleContext{
+					observedState: observer.State{
+						// all migrations are over
+						ClusterState: &esclient.ClusterState{
+							ClusterName: "cluster-name",
+						},
+					},
+				},
+				downscale: ssetDownscale{
+					statefulSet:     ssetMaster3Replicas,
+					initialReplicas: 3,
+					targetReplicas:  2,
+				},
+				// a master node has already been removed
+				invariants:      &DownscaleInvariants{masterRemoved: true, runningMasters: 3},
+				allLeavingNodes: []string{"node-1", "node-2"},
+			},
+			want: ssetDownscale{
+				statefulSet:     ssetMaster3Replicas,
+				initialReplicas: 3,
+				targetReplicas:  3,
+			},
+		},
+		{
+			name: "downscale only possible from 3 to 2 instead of 3 to 1 (1 master at a time)",
+			args: args{
+				ctx: downscaleContext{
+					observedState: observer.State{
+						// all migrations are over
+						ClusterState: &esclient.ClusterState{
+							ClusterName: "cluster-name",
+						},
+					},
+				},
+				downscale: ssetDownscale{
+					statefulSet:     ssetMaster3Replicas,
+					initialReplicas: 3,
+					targetReplicas:  1,
+				},
+				// invariants limits us to one master node downscale only
+				invariants:      &DownscaleInvariants{masterRemoved: false, runningMasters: 3},
+				allLeavingNodes: []string{"node-1", "node-2"},
+			},
+			want: ssetDownscale{
+				statefulSet:     ssetMaster3Replicas,
+				initialReplicas: 3,
+				targetReplicas:  2,
+			},
+		},
+		{
+			name: "downscale not possible: cannot remove the last master",
+			args: args{
+				ctx: downscaleContext{
+					observedState: observer.State{
+						// all migrations are over
+						ClusterState: &esclient.ClusterState{
+							ClusterName: "cluster-name",
+						},
+					},
+				},
+				downscale: ssetDownscale{
+					statefulSet:     ssetMaster3Replicas,
+					initialReplicas: 1,
+					targetReplicas:  0,
+				},
+				// only one master is running
+				invariants:      &DownscaleInvariants{masterRemoved: false, runningMasters: 1},
+				allLeavingNodes: []string{"node-1", "node-2"},
+			},
+			want: ssetDownscale{
+				statefulSet:     ssetMaster3Replicas,
+				initialReplicas: 1,
 				targetReplicas:  1,
 			},
 		},
@@ -566,14 +848,15 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 					reconcileState: reconcile.NewState(v1alpha1.Elasticsearch{}),
 				},
 				downscale: ssetDownscale{
-					statefulSet:     sset3Replicas,
+					statefulSet:     ssetMaster3Replicas,
 					initialReplicas: 3,
 					targetReplicas:  1,
 				},
+				invariants:      &DownscaleInvariants{masterRemoved: false, runningMasters: 3},
 				allLeavingNodes: []string{"node-1", "node-2"},
 			},
 			want: ssetDownscale{
-				statefulSet:     sset3Replicas,
+				statefulSet:     ssetMaster3Replicas,
 				initialReplicas: 3,
 				targetReplicas:  3,
 			},
@@ -581,7 +864,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := calculatePerformableDownscale(tt.args.ctx, tt.args.downscale, tt.args.allLeavingNodes)
+			got := calculatePerformableDownscale(tt.args.ctx, tt.args.invariants, tt.args.downscale, tt.args.allLeavingNodes)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("calculatePerformableDownscale() got = %v, want %v", got, tt.want)
 			}
@@ -590,9 +873,9 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 }
 
 func Test_doDownscale_updateReplicasAndExpectations(t *testing.T) {
-	sset1 := sset3Replicas
+	sset1 := ssetMaster3Replicas
 	sset1.Generation = 1
-	sset2 := sset4Replicas
+	sset2 := ssetData4Replicas
 	sset2.Generation = 1
 	k8sClient := k8s.WrapClient(fake.NewFakeClient(&sset1, &sset2))
 	downscaleCtx := downscaleContext{
@@ -692,6 +975,7 @@ func Test_attemptDownscale(t *testing.T) {
 	tests := []struct {
 		name                 string
 		downscale            ssetDownscale
+		invariants           *DownscaleInvariants
 		statefulSets         sset.StatefulSetList
 		expectedStatefulSets []appsv1.StatefulSet
 	}{
@@ -702,6 +986,7 @@ func Test_attemptDownscale(t *testing.T) {
 				initialReplicas: 0,
 				targetReplicas:  0,
 			},
+			invariants: &DownscaleInvariants{runningMasters: 2, masterRemoved: false},
 			statefulSets: sset.StatefulSetList{
 				nodespec.CreateTestSset("should-be-removed", "7.1.0", 0, true, true),
 				nodespec.CreateTestSset("should-stay", "7.1.0", 2, true, true),
@@ -717,6 +1002,7 @@ func Test_attemptDownscale(t *testing.T) {
 				initialReplicas: 3,
 				targetReplicas:  3,
 			},
+			invariants: &DownscaleInvariants{runningMasters: 2, masterRemoved: false},
 			statefulSets: sset.StatefulSetList{
 				nodespec.CreateTestSset("default", "7.1.0", 3, true, true),
 			},
@@ -731,6 +1017,7 @@ func Test_attemptDownscale(t *testing.T) {
 				initialReplicas: 3,
 				targetReplicas:  4,
 			},
+			invariants: &DownscaleInvariants{runningMasters: 2, masterRemoved: false},
 			statefulSets: sset.StatefulSetList{
 				nodespec.CreateTestSset("default", "7.1.0", 3, true, true),
 			},
@@ -745,6 +1032,7 @@ func Test_attemptDownscale(t *testing.T) {
 				initialReplicas: 3,
 				targetReplicas:  2,
 			},
+			invariants: &DownscaleInvariants{runningMasters: 2, masterRemoved: false},
 			statefulSets: sset.StatefulSetList{
 				nodespec.CreateTestSset("default", "7.1.0", 3, true, true),
 			},
@@ -773,7 +1061,7 @@ func Test_attemptDownscale(t *testing.T) {
 				esClient: &fakeESClient{},
 			}
 			// do the downscale
-			_, err := attemptDownscale(downscaleCtx, tt.downscale, nil, tt.statefulSets)
+			_, err := attemptDownscale(downscaleCtx, tt.downscale, tt.invariants, nil, tt.statefulSets)
 			require.NoError(t, err)
 			// retrieve statefulsets
 			var ssets appsv1.StatefulSetList

--- a/operators/pkg/controller/elasticsearch/driver/downscale_utils.go
+++ b/operators/pkg/controller/elasticsearch/driver/downscale_utils.go
@@ -1,0 +1,72 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package driver
+
+import (
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common/reconciler"
+	esclient "github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/client"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/observer"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/reconcile"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// downscaleContext holds the context of this downscale, including clients and states,
+// propagated from the main driver.
+type downscaleContext struct {
+	// clients
+	k8sClient k8s.Client
+	esClient  esclient.Client
+	// driver states
+	resourcesState reconcile.ResourcesState
+	observedState  observer.State
+	reconcileState *reconcile.State
+	expectations   *reconciler.Expectations
+	// ES cluster
+	es v1alpha1.Elasticsearch
+}
+
+// ssetDownscale helps with the downscale of a single StatefulSet.
+// A StatefulSet removal (going from 0 to 0 replicas) is also considered as a Downscale here.
+type ssetDownscale struct {
+	statefulSet     appsv1.StatefulSet
+	initialReplicas int32
+	targetReplicas  int32
+}
+
+// leavingNodeNames returns names of the nodes that are supposed to leave the Elasticsearch cluster
+// for this StatefulSet. They are ordered by highest ordinal first;
+func (d ssetDownscale) leavingNodeNames() []string {
+	if d.targetReplicas >= d.initialReplicas {
+		return nil
+	}
+	leavingNodes := make([]string, 0, d.initialReplicas-d.targetReplicas)
+	for i := d.initialReplicas - 1; i >= d.targetReplicas; i-- {
+		leavingNodes = append(leavingNodes, sset.PodName(d.statefulSet.Name, i))
+	}
+	return leavingNodes
+}
+
+// isRemoval returns true if this downscale is a StatefulSet removal.
+func (d ssetDownscale) isRemoval() bool {
+	// StatefulSet does not have any replica, and should not have one
+	return d.initialReplicas == 0 && d.targetReplicas == 0
+}
+
+// isReplicaDecrease returns true if this downscale corresponds to decreasing replicas.
+func (d ssetDownscale) isReplicaDecrease() bool {
+	return d.targetReplicas < d.initialReplicas
+}
+
+// leavingNodeNames returns the names of all nodes that should leave the cluster (across StatefulSets).
+func leavingNodeNames(downscales []ssetDownscale) []string {
+	leavingNodes := []string{}
+	for _, d := range downscales {
+		leavingNodes = append(leavingNodes, d.leavingNodeNames()...)
+	}
+	return leavingNodes
+}

--- a/operators/pkg/controller/elasticsearch/driver/downscale_utils_test.go
+++ b/operators/pkg/controller/elasticsearch/driver/downscale_utils_test.go
@@ -1,0 +1,114 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package driver
+
+import (
+	"reflect"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func Test_ssetDownscale_leavingNodeNames(t *testing.T) {
+	tests := []struct {
+		name            string
+		statefulSet     appsv1.StatefulSet
+		initialReplicas int32
+		targetReplicas  int32
+		want            []string
+	}{
+		{
+			name:            "no replicas",
+			statefulSet:     ssetMaster3Replicas,
+			initialReplicas: 0,
+			targetReplicas:  0,
+			want:            nil,
+		},
+		{
+			name:            "going from 2 to 0 replicas",
+			statefulSet:     ssetMaster3Replicas,
+			initialReplicas: 2,
+			targetReplicas:  0,
+			want:            []string{"ssetMaster3Replicas-1", "ssetMaster3Replicas-0"},
+		},
+		{
+			name:            "going from 2 to 1 replicas",
+			statefulSet:     ssetMaster3Replicas,
+			initialReplicas: 2,
+			targetReplicas:  1,
+			want:            []string{"ssetMaster3Replicas-1"},
+		},
+		{
+			name:            "going from 5 to 2 replicas",
+			statefulSet:     ssetMaster3Replicas,
+			initialReplicas: 5,
+			targetReplicas:  2,
+			want:            []string{"ssetMaster3Replicas-4", "ssetMaster3Replicas-3", "ssetMaster3Replicas-2"},
+		},
+		{
+			name:            "no replicas change",
+			statefulSet:     ssetMaster3Replicas,
+			initialReplicas: 2,
+			targetReplicas:  2,
+			want:            nil,
+		},
+		{
+			name:            "upscale",
+			statefulSet:     ssetMaster3Replicas,
+			initialReplicas: 2,
+			targetReplicas:  3,
+			want:            nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := ssetDownscale{
+				statefulSet:     tt.statefulSet,
+				initialReplicas: tt.initialReplicas,
+				targetReplicas:  tt.targetReplicas,
+			}
+			if got := d.leavingNodeNames(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("leavingNodeNames() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_leavingNodeNames(t *testing.T) {
+	tests := []struct {
+		name       string
+		downscales []ssetDownscale
+		want       []string
+	}{
+		{
+			name:       "no downscales",
+			downscales: nil,
+			want:       []string{},
+		},
+		{
+			name: "2 downscales",
+			downscales: []ssetDownscale{
+				{
+					statefulSet:     ssetMaster3Replicas,
+					initialReplicas: 2,
+					targetReplicas:  1,
+				},
+				{
+					statefulSet:     ssetData4Replicas,
+					initialReplicas: 4,
+					targetReplicas:  3,
+				},
+			},
+			want: []string{"ssetMaster3Replicas-1", "ssetData4Replicas-3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := leavingNodeNames(tt.downscales); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("leavingNodeNames() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/operators/pkg/controller/elasticsearch/label/label.go
+++ b/operators/pkg/controller/elasticsearch/label/label.go
@@ -59,6 +59,16 @@ func IsMasterNodeSet(statefulSet appsv1.StatefulSet) bool {
 	return NodeTypesMasterLabelName.HasValue(true, statefulSet.Spec.Template.Labels)
 }
 
+func FilterMasterNodePods(pods []corev1.Pod) []corev1.Pod {
+	masters := []corev1.Pod{}
+	for _, pod := range pods {
+		if IsMasterNode(pod) {
+			masters = append(masters, pod)
+		}
+	}
+	return masters
+}
+
 // IsDataNode returns true if the pod has the data node label
 func IsDataNode(pod corev1.Pod) bool {
 	return NodeTypesDataLabelName.HasValue(true, pod.Labels)


### PR DESCRIPTION
Add safety measures to StatefulSets downscales:

* Make sure we remove one master node at a time
    This plays nicely with zen settings in general (especially zen1).

* Don't remove a master if it's the last master running in the cluster
   This prevents situation where we can accidentally remove the last
running master, loosing cluster_state, while waiting for other masters
to be running during a sset mutation (eg. sset renamed).

Both are implemented as "invariants" in an "invariants" struct we use
through the downscale process.

Relates https://github.com/elastic/cloud-on-k8s/issues/1281.