### PR TITLE
E2E fix: Disable APM server ILM

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -320,6 +320,7 @@ e2e-local:
 	@go run test/e2e/cmd/main.go run \
 		--test-run-name=e2e \
 		--test-context-out=$(LOCAL_E2E_CTX) \
+		--elastic-stack-version=$(STACK_VERSION) \
 		--auto-port-forwarding \
 		--local
 	@test/e2e/run.sh -run "$(TESTS_MATCH)" -args -testContextPath $(LOCAL_E2E_CTX)

--- a/operators/test/e2e/test/apmserver/builder.go
+++ b/operators/test/e2e/test/apmserver/builder.go
@@ -30,6 +30,11 @@ func NewBuilder(name string) Builder {
 			Spec: apmtype.ApmServerSpec{
 				NodeCount: 1,
 				Version:   test.Ctx().ElasticStackVersion,
+				Config: &commonv1alpha1.Config{
+					Data: map[string]interface{}{
+						"apm-server.ilm.enabled": false,
+					},
+				},
 				PodTemplate: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						SecurityContext: test.DefaultSecurityContext(),


### PR DESCRIPTION
APM Server 7.3.0 defaults to having ILM enabled (https://github.com/elastic/apm-server/pull/2356) -- which breaks the assumptions about APM index names we currently have in our E2E tests (introduced in #1465). This PR explicitly disables ILM in APM tests so that the test suite will continue to work across different stack versions.

Fixes #1550 