### PR TITLE
Remove some debug logs

### DIFF
--- a/operators/pkg/controller/common/annotation/controller_version.go
+++ b/operators/pkg/controller/common/annotation/controller_version.go
@@ -42,7 +42,6 @@ func UpdateControllerVersion(client k8s.Client, obj runtime.Object, version stri
 
 	// do not send unnecessary update if the value would not change
 	if annotations[ControllerVersionAnnotation] == version {
-		log.V(1).Info("Skipping controller version annotation update, version already matches", "namespace", namespace, "name", name, "kind", obj.GetObjectKind())
 		return nil
 	}
 
@@ -112,8 +111,6 @@ func ReconcileCompatibility(client k8s.Client, obj runtime.Object, selector labe
 
 	// if the current version is gte the minimum version then they are compatible
 	if currentVersion.IsSameOrAfter(*minVersion) {
-		log.V(1).Info("Current controller version on resource is compatible with running controller version", "controller_version", ctrlVersion,
-			"resource_controller_version", currentVersion, "namespace", namespace, "name", name)
 		return true, nil
 	}
 

--- a/operators/pkg/controller/common/certificates/ca_reconcile.go
+++ b/operators/pkg/controller/common/certificates/ca_reconcile.go
@@ -83,7 +83,6 @@ func ReconcileCAForOwner(
 	}
 
 	// reuse existing CA
-	log.V(1).Info("Reusing existing CA", "owner_namespace", owner.GetNamespace(), "owner_name", owner.GetName(), "ca_type", caType)
 	return ca, nil
 }
 

--- a/operators/pkg/controller/common/reconciler/results.go
+++ b/operators/pkg/controller/common/reconciler/results.go
@@ -63,7 +63,6 @@ func (r *Results) Aggregate() (reconcile.Result, error) {
 			current = next
 		}
 	}
-	log.Info("Aggregated reconciliation results complete", "result", current)
 	return current, k8serrors.NewAggregate(r.errors)
 }
 

--- a/operators/pkg/controller/common/watches/handler.go
+++ b/operators/pkg/controller/common/watches/handler.go
@@ -65,8 +65,11 @@ func (d *DynamicEnqueueRequest) AddHandler(handler HandlerRegistration) error {
 		log.Error(err, "Failed to add handler to dynamic enqueue request")
 		return err
 	}
+	_, exists := d.registrations[handler.Key()]
+	if !exists {
+		log.V(1).Info("Adding new handler registration", "key", handler.Key(), "current_registrations", d.registrations)
+	}
 	d.registrations[handler.Key()] = handler
-	log.V(1).Info("Added new handler registration", "current_registrations", d.registrations)
 	return nil
 }
 
@@ -80,7 +83,6 @@ func (d *DynamicEnqueueRequest) RemoveHandlerForKey(key string) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 	delete(d.registrations, key)
-	log.V(1).Info("Removed handler registration", "removed", key, "current_registrations", d.registrations)
 }
 
 // Registrations returns the list of registered handler names.

--- a/operators/pkg/controller/common/watches/named_watch.go
+++ b/operators/pkg/controller/common/watches/named_watch.go
@@ -28,32 +28,27 @@ var _ handler.EventHandler = &NamedWatch{}
 
 func (w NamedWatch) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
 	for _, req := range w.toReconcileRequest(evt.Meta) {
-		log.V(1).Info("Create event transformed", "key", w.Key())
 		q.Add(req)
 	}
 }
 
 func (w NamedWatch) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
 	for _, req := range w.toReconcileRequest(evt.MetaOld) {
-		log.V(1).Info("Update event transformed (old)", "key", w.Key())
 		q.Add(req)
 	}
 	for _, req := range w.toReconcileRequest(evt.MetaNew) {
-		log.V(1).Info("Update event transformed (new)", "key", w.Key())
 		q.Add(req)
 	}
 }
 
 func (w NamedWatch) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
 	for _, req := range w.toReconcileRequest(evt.Meta) {
-		log.V(1).Info("Delete event transformed", "key", w.Key())
 		q.Add(req)
 	}
 }
 
 func (w NamedWatch) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
 	for _, req := range w.toReconcileRequest(evt.Meta) {
-		log.V(1).Info("Generic event transformed", "key", w.Key())
 		q.Add(req)
 	}
 }

--- a/operators/pkg/controller/elasticsearch/certificates/transport/reconcile.go
+++ b/operators/pkg/controller/elasticsearch/certificates/transport/reconcile.go
@@ -35,8 +35,6 @@ func ReconcileTransportCertificatesSecrets(
 	es v1alpha1.Elasticsearch,
 	rotationParams certificates.RotationParams,
 ) (reconcile.Result, error) {
-	log.Info("Reconciling transport certificate secrets", "namespace", es.Namespace, "es_name", es.Name)
-
 	var pods corev1.PodList
 	if err := c.List(&client.ListOptions{
 		LabelSelector: label.NewLabelSelectorForElasticsearch(es),

--- a/operators/pkg/controller/license/license_controller.go
+++ b/operators/pkg/controller/license/license_controller.go
@@ -55,14 +55,7 @@ func (r *ReconcileLicenses) Reconcile(request reconcile.Request) (reconcile.Resu
 	defer func() {
 		log.Info("End reconcile iteration", "iteration", currentIteration, "took", time.Since(iterationStartTime), "namespace", request.Namespace, "es_name", request.Name)
 	}()
-	result, err := r.reconcileInternal(request)
-	if result.Requeue {
-		log.Info("Re-queuing new license check immediately (rate-limited)", "namespace", request.Namespace, "es_name", request.Name)
-	}
-	if result.RequeueAfter > 0 {
-		log.Info("Re-queuing new license check", "namespace", request.Namespace, "es_name", request.Name, "RequeueAfter", result.RequeueAfter)
-	}
-	return result, err
+	return r.reconcileInternal(request)
 }
 
 // Add creates a new EnterpriseLicense Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller

--- a/operators/pkg/dev/portforward/pod_forwarder.go
+++ b/operators/pkg/dev/portforward/pod_forwarder.go
@@ -177,7 +177,7 @@ func (f *PodForwarder) DialContext(ctx context.Context) (net.Conn, error) {
 		return nil, f.viaErr
 	}
 
-	log.Info("Redirecting dial call", "addr", f.addr, "via", f.viaAddr)
+	log.V(1).Info("Redirecting dial call", "addr", f.addr, "via", f.viaAddr)
 	return f.dialerFunc(ctx, f.network, f.viaAddr)
 }
 
@@ -201,7 +201,7 @@ func (f *PodForwarder) Run(ctx context.Context) error {
 	defer runCtxCancel()
 
 	if f.clientset != nil {
-		log.Info("Watching pod for changes", "namespace", f.podNSN.Namespace, "pod_name", f.podNSN.Name)
+		log.V(1).Info("Watching pod for changes", "namespace", f.podNSN.Namespace, "pod_name", f.podNSN.Name)
 		w, err := f.clientset.CoreV1().Pods(f.podNSN.Namespace).Watch(metav1.ListOptions{
 			FieldSelector: fields.OneTermEqualSelector("metadata.name", f.podNSN.Name).String(),
 		})
@@ -215,7 +215,7 @@ func (f *PodForwarder) Run(ctx context.Context) error {
 				select {
 				case evt := <-w.ResultChan():
 					if evt.Type == watch.Deleted || evt.Type == watch.Error || evt.Type == "" {
-						log.Info(
+						log.V(1).Info(
 							"Pod is deleted or watch failed/closed, closing pod forwarder",
 							"namespace", f.podNSN.Namespace,
 							"pod_name", f.podNSN.Name,


### PR DESCRIPTION
I think those logs are quite verbose when running the operator locally
in dev mode, and don't help much understanding what's going on.

In most cases they are probably just fine to remove, especially when
they log at every single reconciliation with not much value added.

Happy to revert some of those if folks think the logs are useful.
