### PR TITLE
Updated podanitaffinity setting

### DIFF
--- a/docs/advanced-node-scheduling.asciidoc
+++ b/docs/advanced-node-scheduling.asciidoc
@@ -116,7 +116,7 @@ spec:
                 labelSelector:
                   matchLabels:
                     elasticsearch.k8s.elastic.co/cluster-name: quickstart
-                topologyKey: kubernetes.io/hostname
+              topologyKey: kubernetes.io/hostname
 ----
 
 [float]


### PR DESCRIPTION
The topologyKey should be in requiredDuringSchedulingIgnoredDuringExecution settings. The error in logs

error":"Pod \"escluster-es-master-4tbbwcms8n\" is invalid: [spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey: Required value: can not be empty, spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey: Invalid value:

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/master/CONTRIBUTING.md)?
- If you submit code, is your pull request against master? We recommend pull requests against master. We will backport them as needed.
