### PR TITLE
Fix Docker issue in job for test different stack versions

### DIFF
--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
         OPERATOR_IMAGE = "${IMAGE}"
         LATEST_RELEASED_IMG = "${IMAGE}"
         SKIP_DOCKER_COMMAND = 'true'
+        REGISTRY = "eu.gcr.io"
     }
 
     stages {

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -77,7 +77,7 @@ pipeline {
     post {
         unsuccessful {
             script {
-                def msg = "E2E tests for ELK stack versions failed!\r\n" + env.BUILD_URL
+                def msg = "E2E tests for Elastic stack versions failed!\r\n" + env.BUILD_URL
                 slackSend botUser: true,
                       channel: '#cloud-k8s',
                       color: 'danger',


### PR DESCRIPTION
https://devops-ci.elastic.co/view/cloud-on-k8s/job/cloud-on-k8s-stack/ fails because we didn't provide `REGISTRY` while it's expected in `build/ci/Makefile` https://github.com/elastic/cloud-on-k8s/blob/master/build/ci/Makefile#L122