### PR TITLE
Fix calling CI job after renaming

### DIFF
--- a/build/ci/nightly/Jenkinsfile
+++ b/build/ci/nightly/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
                       parameters: [string(name: 'IMAGE', value: image)],
                       wait: false
 
-                build job: 'cloud-on-k8s-stack-versions',
+                build job: 'cloud-on-k8s-stack',
                       parameters: [string(name: 'IMAGE', value: image)],
                       wait: false
             }


### PR DESCRIPTION
Renaming happened in https://github.com/elastic/cloud-on-k8s/pull/1548