### PR TITLE
Specify service principal during aks cluster creation

### DIFF
--- a/operators/hack/deployer/aks.go
+++ b/operators/hack/deployer/aks.go
@@ -148,9 +148,20 @@ func (d *AksDriver) clusterExists() (bool, error) {
 func (d *AksDriver) create() error {
 	log.Print("Creating cluster...")
 
+	servicePrincipal := ""
+	if d.plan.ServiceAccount {
+		// our service principal doesn't have permissions to create a service principal for aks cluster
+		// instead, we reuse the current service principal as the one for aks cluster
+		secrets, err := d.vaultClient.GetMany(AksVaultPath, "appId", "password")
+		if err != nil {
+			return err
+		}
+		servicePrincipal = fmt.Sprintf(" --service-principal %s --client-secret %s", secrets[0], secrets[1])
+	}
+
 	cmd := `az aks create --resource-group {{.ResourceGroup}} --name {{.ClusterName}} ` +
 		`--node-count {{.NodeCount}} --node-vm-size {{.MachineType}} --kubernetes-version {{.KubernetesVersion}} ` +
-		`--node-osdisk-size 30 --enable-addons http_application_routing,monitoring --generate-ssh-keys`
+		`--node-osdisk-size 30 --enable-addons http_application_routing,monitoring --generate-ssh-keys` + servicePrincipal
 	if err := NewCommand(cmd).AsTemplate(d.ctx).Run(); err != nil {
 		return err
 	}


### PR DESCRIPTION
AKS cluster needs to have service principal. When logged in as user, we have permissions to create service principal for aks cluster, but when ci is logged in as service princiapal it doesn't.

This PR reuses currently used service principal as the one for aks cluster.

Tested locally as ci.