### PR TITLE
Remove verbose flag from dep-vendor-only target

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -84,7 +84,7 @@ dep:
 
 dep-vendor-only:
 	# don't attempt to upgrade Gopkg.lock
-	dep ensure --vendor-only -v
+	dep ensure --vendor-only 
 
 # Generate API types code and manifests from annotations e.g. CRD, RBAC etc.
 generate:


### PR DESCRIPTION
The `dep-vendor-only` target is referenced several times during the E2E test run and having the verbose logging option enabled only adds noise to the logs.