### PR TITLE
Optimize PR job

### DIFF
--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -22,6 +22,11 @@ pipeline {
 
     stages {
         stage('Check if Docker image needs rebuilding') {
+            when {
+                expression {
+                    notOnlyDocs()
+                }
+            }
             steps {
                 sh 'make -C build/ci ci-build-image'
             }
@@ -78,25 +83,11 @@ EOF
         cleanup {
             script {
                 if (notOnlyDocs()) {
-                    sh """
-                        cat >operators/run-config.yml <<EOF
-id: gke-ci
-overrides:
-  operation: delete
-  kubernetesVersion: "$CLUSTER_VERSION"
-  clusterName: $CLUSTER_NAME
-  vaultInfo:
-    address: $VAULT_ADDR
-    roleId: $VAULT_ROLE_ID
-    secretId: $VAULT_SECRET_ID
-  gke:
-    gCloudProject: $GCLOUD_PROJECT
-EOF
-                        make -C build/ci ci-run-deployer
-                    """
+                    build job: 'cloud-on-k8s-e2e-cleanup',
+                        parameters: [string(name: 'GKE_CLUSTER', value: "${CLUSTER_NAME}")],
+                        wait: false
                 }
             }
-
             cleanWs()
         }
     }


### PR DESCRIPTION
This PR introduces 2 changes for PR job:
1) Checking Docker image only if changes not related to documentation
2) Doing GKE cluster cleanup in a separate job instead of PR job

Totally, it will speed up PR job from 4 min (for most PR's) to 7 min (for docs, in this case everything will be skipped)