### PR TITLE
Replace in-job cluster removal with CI job call

### DIFF
--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        createRunConfig('create', '1.11', "${BUILD_TAG}-11")
+                        createRunConfig('1.11', "${BUILD_TAG}-11")
                         sh 'make -C build/ci ci-e2e'
                     }
                 }
@@ -38,7 +38,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        createRunConfig('create', '1.12', "${BUILD_TAG}-12")
+                        createRunConfig('1.12', "${BUILD_TAG}-12")
                         sh 'make -C build/ci ci-e2e'
                     }
                 }
@@ -48,7 +48,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        createRunConfig('create', '1.13', "${BUILD_TAG}-13")
+                        createRunConfig('1.13', "${BUILD_TAG}-13")
                         sh 'make -C build/ci ci-e2e'
                     }
                 }
@@ -60,10 +60,10 @@ pipeline {
         cleanup {
             script {
                 clusters = ["${BUILD_TAG}-11", "${BUILD_TAG}-12", "${BUILD_TAG}-13"]
-                versions = ["1.11", "1.12", "1.13"]
                 for (int i = 0; i < clusters.size(); i++) {
-                    createRunConfig('delete', versions[i], clusters[i])
-                    sh 'make -C build/ci ci-run-deployer'
+                    build job: 'cloud-on-k8s-e2e-cleanup',
+                        parameters: [string(name: 'GKE_CLUSTER', value: clusters[i])],
+                        wait: false
                 }
             }
             cleanWs()
@@ -71,12 +71,12 @@ pipeline {
     }
 }
 
-void createRunConfig(operation, clusterVersion, clusterName) {
+void createRunConfig(clusterVersion, clusterName) {
     sh """
-                    cat >operators/run-config.yml <<EOF
+        cat >operators/run-config.yml <<EOF
 id: gke-ci
 overrides:
-  operation: ${operation}
+  operation: create
   kubernetesVersion: "${clusterVersion}"
   clusterName: ${clusterName}
   vaultInfo:

--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -65,22 +65,9 @@ EOF
         cleanup {
             script {
                 if (notOnlyDocs()) {
-                    sh """
-                        cat >operators/run-config.yml <<EOF
-id: gke-ci
-overrides:
-  operation: delete
-  kubernetesVersion: "$CLUSTER_VERSION"
-  clusterName: $CLUSTER_NAME
-  vaultInfo:
-    address: $VAULT_ADDR
-    roleId: $VAULT_ROLE_ID
-    secretId: $VAULT_SECRET_ID
-  gke:
-    gCloudProject: $GCLOUD_PROJECT
-EOF
-                        make -C build/ci ci-run-deployer
-                    """
+                    build job: 'cloud-on-k8s-e2e-cleanup',
+                        parameters: [string(name: 'GKE_CLUSTER', value: "${CLUSTER_NAME}")],
+                        wait: false
                 }
             }
 

--- a/build/ci/e2e/custom_operator_image.jenkinsfile
+++ b/build/ci/e2e/custom_operator_image.jenkinsfile
@@ -60,24 +60,9 @@ EOF
             }
         }
         cleanup {
-            script {
-                sh """
-                    cat >operators/run-config.yml <<EOF
-id: gke-ci
-overrides:
-  operation: delete
-  kubernetesVersion: "$CLUSTER_VERSION"
-  clusterName: $CLUSTER_NAME
-  vaultInfo:
-    address: $VAULT_ADDR
-    roleId: $VAULT_ROLE_ID
-    secretId: $VAULT_SECRET_ID
-  gke:
-    gCloudProject: $GCLOUD_PROJECT
-EOF
-                    make -C build/ci ci-run-deployer
-                """
-            }
+            build job: 'cloud-on-k8s-e2e-cleanup',
+                parameters: [string(name: 'GKE_CLUSTER', value: "${CLUSTER_NAME}")],
+                wait: false
             cleanWs()
         }
     }

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        createRunConfig('create', "${BUILD_TAG}-680")
+                        createRunConfig("${BUILD_TAG}-680")
                         sh 'make -C build/ci ci-e2e'
                     }
                 }
@@ -41,7 +41,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        createRunConfig('create', "${BUILD_TAG}-710")
+                        createRunConfig("${BUILD_TAG}-710")
                         sh 'make -C build/ci ci-e2e'
                     }
                 }
@@ -54,7 +54,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        createRunConfig('create', "${BUILD_TAG}-720")
+                        createRunConfig("${BUILD_TAG}-720")
                         sh 'make -C build/ci ci-e2e'
                     }
                 }
@@ -67,7 +67,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        createRunConfig('create', "${BUILD_TAG}-730")
+                        createRunConfig("${BUILD_TAG}-730")
                         sh 'make -C build/ci ci-e2e'
                     }
                 }
@@ -80,8 +80,9 @@ pipeline {
             script {
                 clusters = ["${BUILD_TAG}-680", "${BUILD_TAG}-710", "${BUILD_TAG}-720", "${BUILD_TAG}-730"]
                 for (int i = 0; i < clusters.size(); i++) {
-                    createRunConfig('delete', clusters[i])
-                    sh 'make -C build/ci ci-run-deployer'
+                    build job: 'cloud-on-k8s-e2e-cleanup',
+                        parameters: [string(name: 'GKE_CLUSTER', value: clusters[i])],
+                        wait: false
                 }
             }
             cleanWs()
@@ -90,12 +91,12 @@ pipeline {
 
 }
 
-def createRunConfig(operation, clusterName) {
+def createRunConfig(clusterName) {
     sh """
-                    cat >operators/run-config.yml <<EOF
+        cat >operators/run-config.yml <<EOF
 id: gke-ci
 overrides:
-  operation: ${operation}
+  operation: create
   clusterName: ${clusterName}
   vaultInfo:
     address: $VAULT_ADDR


### PR DESCRIPTION
This PR replaces in-job call to `deployer` for cluster removal with CI job call for removing cluster. It will simplify CI jobs and speedup them a little bit (it takes 3-5 min to remove cluster)