### PR TITLE
E2E fix: Timing issue in data integrity check

### DIFF
--- a/operators/test/e2e/test/elasticsearch/checks_data.go
+++ b/operators/test/e2e/test/elasticsearch/checks_data.go
@@ -50,8 +50,8 @@ func (dc *DataIntegrityCheck) Init() error {
 {
     "settings" : {
         "index" : {
-            "number_of_shards" : %d, 
-            "number_of_replicas" : 0 
+            "number_of_shards" : %d,
+            "number_of_replicas" : 0
         }
     }
 }
@@ -77,7 +77,7 @@ func (dc *DataIntegrityCheck) Init() error {
 		return err
 	}
 	for i := 0; i < dc.docCount; i++ {
-		r, err := http.NewRequest(http.MethodPut, fmt.Sprintf("/%s/_doc/%d", dc.indexName, i), bytes.NewReader(payload))
+		r, err := http.NewRequest(http.MethodPut, fmt.Sprintf("/%s/_doc/%d?refresh=true", dc.indexName, i), bytes.NewReader(payload))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
In the data integrity check added in #1582, the time between indexing documents into the index and querying them can be less than the index refresh interval -- which causes the tests to fail with a false positive. This change adds `refresh=true` to the indexing request to make all documents visible immediately.