### PR TITLE
Fix issue when nightly build triggering test jobs

### DIFF
--- a/build/ci/nightly/Jenkinsfile
+++ b/build/ci/nightly/Jenkinsfile
@@ -32,6 +32,7 @@ pipeline {
                     export VERSION=\$(cat $WORKSPACE/operators/VERSION)-\$(date +%F)-\$(git rev-parse --short --verify HEAD)
                     export OPERATOR_IMAGE=${REGISTRY}/${REPOSITORY}/${IMG_NAME}:\$VERSION
                     export LATEST_RELEASED_IMG=docker.elastic.co/${REPOSITORY}/${IMG_NAME}:\$VERSION
+                    echo \$LATEST_RELEASED_IMG > eck_image.txt
                     make -C build/ci ci-release
                 """
             }
@@ -41,10 +42,7 @@ pipeline {
     post {
         success {
             script {
-                def version = readFile("$WORKSPACE/operators/VERSION").trim()
-                def hash = sh(returnStdout: true, script: 'git rev-parse --short --verify HEAD')
-                def date = new Date()
-                def image = env.DOCKER_IMAGE_NO_TAG + ":" + version + "-" + date.format("yyyy-MM-dd") + "-" + hash
+                def image = readFile("$WORKSPACE/eck_image.txt").trim()
                 currentBuild.description = image
 
                 build job: 'cloud-on-k8s-versions-gke',


### PR DESCRIPTION
I figured out that issues with triggering build from nightly job happens because of incorrect Docker image name which assembled in post build section. I wasn't been able to figure it out that wrong with the name exactly but I did a workaround. Instead of assembling image name it will read it from file and this approach works on a local Jenkins.
Fixing https://github.com/elastic/cloud-on-k8s/issues/1545