### PR TITLE
Add e2e tests to for configuration reversal scenarios

### DIFF
--- a/operators/test/e2e/es/reversal_test.go
+++ b/operators/test/e2e/es/reversal_test.go
@@ -21,7 +21,7 @@ func TestReversalIllegalConfig(t *testing.T) {
 		WithESMasterNodes(1, elasticsearch.DefaultResources)
 
 	bogus := b.WithAdditionalConfig(map[string]map[string]interface{}{
-		"data": map[string]interface{}{
+		"data": {
 			"this leads": "to a bootlooping instance",
 		},
 	})

--- a/operators/test/e2e/es/reversal_test.go
+++ b/operators/test/e2e/es/reversal_test.go
@@ -1,0 +1,98 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package es
+
+import (
+	"testing"
+
+	common "github.com/elastic/cloud-on-k8s/operators/pkg/apis/common/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test/elasticsearch"
+)
+
+func TestReversalIllegalConfig(t *testing.T) {
+	// mutate to 1 m node + 1 d node
+	b := elasticsearch.NewBuilder("test-illegal-config").
+		WithNoESTopology().
+		WithESDataNodes(1, elasticsearch.DefaultResources).
+		WithESMasterNodes(1, elasticsearch.DefaultResources)
+
+	bogus := b.WithAdditionalConfig(map[string]map[string]interface{}{
+		"data": map[string]interface{}{
+			"this leads": "to a bootlooping instance",
+		},
+	})
+
+	state := elasticsearch.NewMutationReversalTestState(b.Elasticsearch)
+	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{bogus}, state)
+}
+
+func TestReversalRiskyMasterDownscale(t *testing.T) {
+	b := elasticsearch.NewBuilder("test-non-ha-downscale-reversal").
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
+	down := b.WithNoESTopology().WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+
+	state := elasticsearch.NewMutationReversalTestState(b.Elasticsearch)
+	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{down}, state)
+}
+
+// TODO we validate a full downscale
+func TestReversalSingleMasterDownscale(t *testing.T) {
+	t.Skip()
+	b := elasticsearch.NewBuilder("test-non-ha-downscale-reversal").
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+	down := b.WithNoESTopology().WithESMasterDataNodes(0, elasticsearch.DefaultResources)
+
+	state := elasticsearch.NewMutationReversalTestState(b.Elasticsearch)
+	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{down}, state)
+}
+
+func TestReversalStatefulSetRename(t *testing.T) {
+	b := elasticsearch.NewBuilder("test-sset-rename-reversal").
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+
+	copy := b.Elasticsearch.Spec.Nodes[0]
+	copy.Name = "other"
+	renamed := b.WithNoESTopology().WithNodeSpec(copy)
+
+	state := elasticsearch.NewMutationReversalTestState(b.Elasticsearch)
+	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{renamed}, state)
+}
+
+// TODO investigate why it does not apply the change here
+func TestRiskyMasterReconfiguration(t *testing.T) {
+	t.Skip()
+	b := elasticsearch.NewBuilder("test-sset-reconfig-reversal").
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithNodeSpec(v1alpha1.NodeSpec{
+			Name:      "other-master",
+			NodeCount: 1,
+			Config: &common.Config{
+				Data: map[string]interface{}{
+					v1alpha1.NodeMaster: true,
+					v1alpha1.NodeData:   true,
+				},
+			},
+			PodTemplate: elasticsearch.ESPodTemplate(elasticsearch.DefaultResources),
+		})
+
+	// this currently breaks the cluster (something we might fix in the future at which point this just tests a temp downscale)
+	noMasterMaster := b.WithNoESTopology().WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithNodeSpec(v1alpha1.NodeSpec{
+			Name:      "other-master",
+			NodeCount: 1,
+			Config: &common.Config{
+				Data: map[string]interface{}{
+					v1alpha1.NodeMaster: false,
+					v1alpha1.NodeData:   true,
+				},
+			},
+			PodTemplate: elasticsearch.ESPodTemplate(elasticsearch.DefaultResources),
+		})
+
+	state := elasticsearch.NewMutationReversalTestState(b.Elasticsearch)
+	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{noMasterMaster}, state)
+}

--- a/operators/test/e2e/es/reversal_test.go
+++ b/operators/test/e2e/es/reversal_test.go
@@ -27,8 +27,7 @@ func TestReversalIllegalConfig(t *testing.T) {
 		},
 	})
 
-	state := elasticsearch.NewMutationReversalTestState(b.Elasticsearch)
-	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{bogus}, state)
+	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{bogus})
 }
 
 func TestReversalRiskyMasterDownscale(t *testing.T) {
@@ -41,8 +40,7 @@ func TestReversalRiskyMasterDownscale(t *testing.T) {
 	// TODO it might be necessary to accept some data loss for 6.x here
 	down := b.WithNoESTopology().WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
-	state := elasticsearch.NewMutationReversalTestState(b.Elasticsearch)
-	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{down}, state)
+	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{down})
 }
 
 func TestReversalStatefulSetRename(t *testing.T) {
@@ -53,8 +51,7 @@ func TestReversalStatefulSetRename(t *testing.T) {
 	copy.Name = "other"
 	renamed := b.WithNoESTopology().WithNodeSpec(copy)
 
-	state := elasticsearch.NewMutationReversalTestState(b.Elasticsearch)
-	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{renamed}, state)
+	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{renamed})
 }
 
 func TestRiskyMasterReconfiguration(t *testing.T) {
@@ -86,6 +83,5 @@ func TestRiskyMasterReconfiguration(t *testing.T) {
 			PodTemplate: elasticsearch.ESPodTemplate(elasticsearch.DefaultResources),
 		})
 
-	state := elasticsearch.NewMutationReversalTestState(b.Elasticsearch)
-	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{noMasterMaster}, state)
+	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{noMasterMaster})
 }

--- a/operators/test/e2e/es/reversal_test.go
+++ b/operators/test/e2e/es/reversal_test.go
@@ -39,7 +39,7 @@ func TestReversalRiskyMasterDownscale(t *testing.T) {
 	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{down}, state)
 }
 
-// TODO we validate a full downscale
+// TODO we validate a downscale to replica=0 not sure if we should allow it
 func TestReversalSingleMasterDownscale(t *testing.T) {
 	t.Skip()
 	b := elasticsearch.NewBuilder("test-non-ha-downscale-reversal").
@@ -62,9 +62,7 @@ func TestReversalStatefulSetRename(t *testing.T) {
 	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{renamed}, state)
 }
 
-// TODO investigate why it does not apply the change here
 func TestRiskyMasterReconfiguration(t *testing.T) {
-	t.Skip()
 	b := elasticsearch.NewBuilder("test-sset-reconfig-reversal").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
 		WithNodeSpec(v1alpha1.NodeSpec{

--- a/operators/test/e2e/test/apmserver/builder.go
+++ b/operators/test/e2e/test/apmserver/builder.go
@@ -19,6 +19,8 @@ type Builder struct {
 	ApmServer apmtype.ApmServer
 }
 
+var _ test.Builder = Builder{}
+
 func NewBuilder(name string) Builder {
 	meta := metav1.ObjectMeta{
 		Name:      name,

--- a/operators/test/e2e/test/apmserver/steps_mutation.go
+++ b/operators/test/e2e/test/apmserver/steps_mutation.go
@@ -13,3 +13,7 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 func (b Builder) UpgradeTestSteps(k *test.K8sClient) test.StepList {
 	panic("not implemented")
 }
+
+func (b Builder) MutationReversalTestContext() test.ReversalTestContext {
+	panic("not implemented")
+}

--- a/operators/test/e2e/test/apmserver/steps_mutation.go
+++ b/operators/test/e2e/test/apmserver/steps_mutation.go
@@ -9,3 +9,7 @@ import "github.com/elastic/cloud-on-k8s/operators/test/e2e/test"
 func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 	panic("not implemented")
 }
+
+func (b Builder) UpgradeTestSteps(k *test.K8sClient) test.StepList {
+	panic("not implemented")
+}

--- a/operators/test/e2e/test/builder.go
+++ b/operators/test/e2e/test/builder.go
@@ -13,6 +13,8 @@ type Builder interface {
 	CheckK8sTestSteps(k *K8sClient) StepList
 	// CheckStackTestSteps returns all test steps to verify the given resource is running as expected
 	CheckStackTestSteps(k *K8sClient) StepList
+	// UpgradeTestSteps returns all the steps necessary to upgrade an existing resource to new configuration.
+	UpgradeTestSteps(k *K8sClient) StepList
 	// DeletionTestSteps returns all test step to delete a resource.
 	DeletionTestSteps(k *K8sClient) StepList
 	// MutationTestSteps returns all test steps to test changes on a resource.

--- a/operators/test/e2e/test/builder.go
+++ b/operators/test/e2e/test/builder.go
@@ -13,7 +13,7 @@ type Builder interface {
 	CheckK8sTestSteps(k *K8sClient) StepList
 	// CheckStackTestSteps returns all test steps to verify the given resource is running as expected
 	CheckStackTestSteps(k *K8sClient) StepList
-	// UpgradeTestSteps returns all the steps necessary to upgrade an existing resource to new configuration.
+	// UpgradeTestSteps returns all the steps necessary to upgrade an existing resource to new revision.
 	UpgradeTestSteps(k *K8sClient) StepList
 	// DeletionTestSteps returns all test step to delete a resource.
 	DeletionTestSteps(k *K8sClient) StepList
@@ -21,4 +21,8 @@ type Builder interface {
 	// We expect the resource to be already created and running.
 	// If the resource to mutate to is the same as the original resource, then all tests should still pass.
 	MutationTestSteps(k *K8sClient) StepList
+	// MutationReversalTestContext returns a context struct to test changes on a resource that are immediately reverted.
+	// We assume the resource to be ready and running.
+	// We assume the resource to be the same as the original resource after reversion.
+	MutationReversalTestContext() ReversalTestContext
 }

--- a/operators/test/e2e/test/elasticsearch/checks_reversal.go
+++ b/operators/test/e2e/test/elasticsearch/checks_reversal.go
@@ -1,0 +1,87 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package elasticsearch
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/operators/test/e2e/test"
+	"github.com/stretchr/testify/require"
+)
+
+type MutationReversalTestState struct {
+	es                     v1alpha1.Elasticsearch
+	initialCurrentReplicas map[string]int32
+	dataIntegrity          *DataIntegrityCheck
+}
+
+func NewMutationReversalTestState(es v1alpha1.Elasticsearch) *MutationReversalTestState {
+	return &MutationReversalTestState{
+		es:                     es,
+		initialCurrentReplicas: make(map[string]int32),
+	}
+}
+
+func (s *MutationReversalTestState) PreMutationSteps(k *test.K8sClient) test.StepList {
+	return test.StepList{
+		{
+			Name: "Remember the current config revisions",
+			Test: func(t *testing.T) {
+				statefulSets, err := sset.RetrieveActualStatefulSets(k.Client, k8s.ExtractNamespacedName(&s.es))
+				require.NoError(t, err)
+				for _, set := range statefulSets {
+					s.initialCurrentReplicas[set.Name] = set.Status.CurrentReplicas
+				}
+			},
+		},
+		{
+			Name: "Add some data to the cluster before any mutation",
+			Test: func(t *testing.T) {
+				var err error
+				s.dataIntegrity, err = NewDataIntegrityCheck(s.es, k)
+				require.NoError(t, err)
+				require.NoError(t, s.dataIntegrity.Init())
+			},
+		},
+	}
+}
+
+func (s *MutationReversalTestState) PostMutationSteps(k *test.K8sClient) test.StepList {
+	return test.StepList{
+		{
+			Name: "Verify that a config change is being applied",
+			Test: test.Eventually(func() error {
+				statefulSets, err := sset.RetrieveActualStatefulSets(k.Client, k8s.ExtractNamespacedName(&s.es))
+				if err != nil {
+					return err
+				}
+				// at least one sset should have started replacing pods
+				for _, set := range statefulSets {
+					if s.initialCurrentReplicas[set.Name] != set.Status.CurrentReplicas {
+						return nil
+					}
+				}
+				return errors.New("no upgrade in progress")
+			}),
+		},
+	}
+}
+
+func (s *MutationReversalTestState) VerificationSteps(k *test.K8sClient) test.StepList {
+	return test.StepList{
+		{
+			Name: "Verify no data loss has happened during the aborted upgrade",
+			Test: func(t *testing.T) {
+				require.NoError(t, s.dataIntegrity.Verify())
+			},
+		},
+	}
+}
+
+var _ test.ReversalTestState = &MutationReversalTestState{}

--- a/operators/test/e2e/test/elasticsearch/checks_reversal.go
+++ b/operators/test/e2e/test/elasticsearch/checks_reversal.go
@@ -15,22 +15,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type MutationReversalTestState struct {
+func (b Builder) MutationReversalTestContext() test.ReversalTestContext {
+	return &mutationReversalTestContext{
+		es:                     b.Elasticsearch,
+		initialRevisions:       make(map[string]string),
+		initialCurrentReplicas: make(map[string]int32),
+	}
+}
+
+type mutationReversalTestContext struct {
 	es                     v1alpha1.Elasticsearch
 	initialCurrentReplicas map[string]int32
 	initialRevisions       map[string]string
 	dataIntegrity          *DataIntegrityCheck
 }
 
-func NewMutationReversalTestState(es v1alpha1.Elasticsearch) *MutationReversalTestState {
-	return &MutationReversalTestState{
-		es:                     es,
-		initialRevisions:       make(map[string]string),
-		initialCurrentReplicas: make(map[string]int32),
-	}
-}
-
-func (s *MutationReversalTestState) PreMutationSteps(k *test.K8sClient) test.StepList {
+func (s *mutationReversalTestContext) PreMutationSteps(k *test.K8sClient) test.StepList {
 	return test.StepList{
 		{
 			Name: "Remember the current config revisions",
@@ -55,7 +55,7 @@ func (s *MutationReversalTestState) PreMutationSteps(k *test.K8sClient) test.Ste
 	}
 }
 
-func (s *MutationReversalTestState) PostMutationSteps(k *test.K8sClient) test.StepList {
+func (s *mutationReversalTestContext) PostMutationSteps(k *test.K8sClient) test.StepList {
 	return test.StepList{
 		{
 			Name: "Verify that a config change is being applied",
@@ -80,7 +80,7 @@ func (s *MutationReversalTestState) PostMutationSteps(k *test.K8sClient) test.St
 	}
 }
 
-func (s *MutationReversalTestState) VerificationSteps(k *test.K8sClient) test.StepList {
+func (s *mutationReversalTestContext) VerificationSteps(k *test.K8sClient) test.StepList {
 	return test.StepList{
 		{
 			Name: "Verify no data loss has happened during the aborted upgrade",
@@ -91,4 +91,4 @@ func (s *MutationReversalTestState) VerificationSteps(k *test.K8sClient) test.St
 	}
 }
 
-var _ test.ReversalTestState = &MutationReversalTestState{}
+var _ test.ReversalTestContext = &mutationReversalTestContext{}

--- a/operators/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/operators/test/e2e/test/elasticsearch/steps_mutation.go
@@ -6,7 +6,6 @@ package elasticsearch
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -29,8 +28,6 @@ func (b Builder) UpgradeTestSteps(k *test.K8sClient) test.StepList {
 				var curEs estype.Elasticsearch
 				require.NoError(t, k.Client.Get(k8s.ExtractNamespacedName(&b.Elasticsearch), &curEs))
 				curEs.Spec = b.Elasticsearch.Spec
-				bytes, _ := json.MarshalIndent(b.Elasticsearch.Spec, "", " ")
-				println(string(bytes))
 				require.NoError(t, k.Client.Update(&curEs))
 			},
 		},

--- a/operators/test/e2e/test/kibana/builder.go
+++ b/operators/test/e2e/test/kibana/builder.go
@@ -19,6 +19,8 @@ type Builder struct {
 	Kibana kbtype.Kibana
 }
 
+var _ test.Builder = Builder{}
+
 func NewBuilder(name string) Builder {
 	meta := metav1.ObjectMeta{
 		Name:      name,

--- a/operators/test/e2e/test/kibana/steps_mutation.go
+++ b/operators/test/e2e/test/kibana/steps_mutation.go
@@ -19,6 +19,10 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 		WithSteps(b.CheckStackTestSteps(k))
 }
 
+func (b Builder) MutationReversalTestContext() test.ReversalTestContext {
+	panic("not implemented")
+}
+
 func (b Builder) UpgradeTestSteps(k *test.K8sClient) test.StepList {
 	return test.StepList{
 		{

--- a/operators/test/e2e/test/kibana/steps_mutation.go
+++ b/operators/test/e2e/test/kibana/steps_mutation.go
@@ -14,6 +14,12 @@ import (
 )
 
 func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
+	return b.UpgradeTestSteps(k).
+		WithSteps(b.CheckK8sTestSteps(k)).
+		WithSteps(b.CheckStackTestSteps(k))
+}
+
+func (b Builder) UpgradeTestSteps(k *test.K8sClient) test.StepList {
 	return test.StepList{
 		{
 			Name: "Applying the Kibana mutation should succeed",
@@ -23,7 +29,5 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 				kb.Spec = b.Kibana.Spec
 				require.NoError(t, k.Client.Update(&kb))
 			},
-		}}.
-		WithSteps(b.CheckK8sTestSteps(k)).
-		WithSteps(b.CheckStackTestSteps(k))
+		}}
 }

--- a/operators/test/e2e/test/run_reversal.go
+++ b/operators/test/e2e/test/run_reversal.go
@@ -1,0 +1,62 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package test
+
+import (
+	"testing"
+)
+
+type ReversalTestState interface {
+	PreMutationSteps(k *K8sClient) StepList
+	PostMutationSteps(k *K8sClient) StepList
+	VerificationSteps(k *K8sClient) StepList
+}
+
+// RunMutationReversal tests mutations that are either invalid or aborted mid way leading to a configuration reversal of
+// the original configuration.
+func RunMutationReversal(t *testing.T, creationBuilders []Builder, mutationBuilders []Builder, state ReversalTestState) {
+	k := NewK8sClientOrFatal()
+	steps := StepList{}
+
+	for _, toCreate := range creationBuilders {
+		steps = steps.WithSteps(toCreate.InitTestSteps(k))
+	}
+	for _, toCreate := range creationBuilders {
+		steps = steps.WithSteps(toCreate.CreationTestSteps(k))
+	}
+	for _, toCreate := range creationBuilders {
+		steps = steps.WithSteps(CheckTestSteps(toCreate, k))
+	}
+	// set up the mutation test
+	steps = steps.WithSteps(state.PreMutationSteps(k))
+
+	// Trigger some mutations
+	for _, mutateTo := range mutationBuilders {
+		steps = steps.WithSteps(mutateTo.UpgradeTestSteps(k))
+	}
+
+	// ensure the desired progress has been made with the mutation
+	steps = steps.WithSteps(state.PostMutationSteps(k))
+
+	// now revert the mutation
+	for _, toRevertTo := range creationBuilders {
+		steps = steps.WithSteps(toRevertTo.UpgradeTestSteps(k))
+	}
+
+	// run the standard checks once more
+	for _, toCreate := range creationBuilders {
+		steps = steps.WithSteps(CheckTestSteps(toCreate, k))
+	}
+
+	// verify the specifics of the upgrade reversal
+	steps = steps.WithSteps(state.VerificationSteps(k))
+
+	// and delete the resources again
+	for _, mutateTo := range mutationBuilders {
+		steps = steps.WithSteps(mutateTo.DeletionTestSteps(k))
+	}
+
+	steps.RunSequential(t)
+}

--- a/operators/test/e2e/test/run_reversal.go
+++ b/operators/test/e2e/test/run_reversal.go
@@ -32,7 +32,7 @@ func RunMutationReversal(t *testing.T, creationBuilders []Builder, mutationBuild
 	// set up the mutation test
 	steps = steps.WithSteps(state.PreMutationSteps(k))
 
-	// Trigger some mutations
+	// trigger some mutations
 	for _, mutateTo := range mutationBuilders {
 		steps = steps.WithSteps(mutateTo.UpgradeTestSteps(k))
 	}
@@ -53,7 +53,7 @@ func RunMutationReversal(t *testing.T, creationBuilders []Builder, mutationBuild
 	// verify the specifics of the upgrade reversal
 	steps = steps.WithSteps(state.VerificationSteps(k))
 
-	// and delete the resources again
+	// and delete the resources
 	for _, mutateTo := range mutationBuilders {
 		steps = steps.WithSteps(mutateTo.DeletionTestSteps(k))
 	}

--- a/operators/test/e2e/test/run_reversal.go
+++ b/operators/test/e2e/test/run_reversal.go
@@ -30,7 +30,7 @@ func RunMutationReversal(t *testing.T, creationBuilders []Builder, mutationBuild
 		steps = steps.WithSteps(CheckTestSteps(toCreate, k))
 	}
 
-	var ctxs []ReversalTestContext
+	ctxs := make([]ReversalTestContext, len(mutationBuilders))
 	for _, mutateTo := range mutationBuilders {
 		ctxs = append(ctxs, mutateTo.MutationReversalTestContext())
 	}


### PR DESCRIPTION
Basic idea: create a cluster, apply a potential risky or invalid configuration
change and reverse it. No data loss should be observable and the cluster should
stay operational.

But it is acceptable that the cluster desintegrates during the configuration change
or dips temporarily into yellow/red.

Part of #1156 
