### PR TITLE
Update partition of correct stateful set on rolling update

### DIFF
--- a/operators/pkg/controller/elasticsearch/driver/upgrade.go
+++ b/operators/pkg/controller/elasticsearch/driver/upgrade.go
@@ -62,7 +62,7 @@ func (d *defaultDriver) doRollingUpgrade(
 	maxMasterNodeUpgrades := 1
 	scheduledMasterNodeUpgrades := 0
 
-	for i, statefulSet := range statefulSets.ToUpdate() {
+	for _, statefulSet := range statefulSets.ToUpdate() {
 		// Inspect each pod, starting from the highest ordinal, and decrement the partition to allow
 		// pod upgrades to go through, controlled by the StatefulSet controller.
 		for partition := sset.GetUpdatePartition(statefulSet); partition >= 0; partition-- {
@@ -121,7 +121,7 @@ func (d *defaultDriver) doRollingUpgrade(
 			}
 
 			// Upgrade the pod.
-			if err := d.upgradeStatefulSetPartition(&statefulSets[i], partition); err != nil {
+			if err := d.upgradeStatefulSetPartition(statefulSet, partition); err != nil {
 				return results.WithError(err)
 			}
 		}

--- a/operators/pkg/controller/elasticsearch/driver/upgrade.go
+++ b/operators/pkg/controller/elasticsearch/driver/upgrade.go
@@ -121,7 +121,7 @@ func (d *defaultDriver) doRollingUpgrade(
 			}
 
 			// Upgrade the pod.
-			if err := d.upgradeStatefulSetPartition(statefulSet, partition); err != nil {
+			if err := d.upgradeStatefulSetPartition(&statefulSet, partition); err != nil {
 				return results.WithError(err)
 			}
 		}


### PR DESCRIPTION
TODO needs some tests just wanted to capture the bug not sure if tests are in progress as part of #1287 

We were updating the partition of the wrong sset when multiple ssets exist and you want to update not the first one, but any other one

Found during #1588 