### PR TITLE
Restore notifications for fixed CI jobs

### DIFF
--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -57,6 +57,16 @@ pipeline {
     }
 
     post {
+        unsuccessful {
+            script {
+                def msg = "E2E tests for different k8s versions in GKE failed!\r\n" + env.BUILD_URL
+                slackSend botUser: true,
+                    channel: '#cloud-k8s',
+                    color: 'danger',
+                    message: msg,
+                    tokenCredentialId: 'cloud-ci-slack-integration-token'
+            }
+        }
         cleanup {
             script {
                 clusters = ["${BUILD_TAG}-11", "${BUILD_TAG}-12", "${BUILD_TAG}-13"]

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -24,11 +24,11 @@ pipeline {
             parallel {
                 stage("6.8.0") {
                     environment {
-                        STACK_VERSION = "6.8.0"
+                        STACK_VERSION = "6.8.2"
                     }
                     steps {
                         checkout scm
-                        createRunConfig("${BUILD_TAG}-680")
+                        createRunConfig("${BUILD_TAG}-682")
                         sh 'make -C build/ci ci-e2e'
                     }
                 }
@@ -37,11 +37,11 @@ pipeline {
                         label 'linux'
                     }
                     environment {
-                        STACK_VERSION = "7.1.0"
+                        STACK_VERSION = "7.1.1"
                     }
                     steps {
                         checkout scm
-                        createRunConfig("${BUILD_TAG}-710")
+                        createRunConfig("${BUILD_TAG}-711")
                         sh 'make -C build/ci ci-e2e'
                     }
                 }
@@ -50,11 +50,11 @@ pipeline {
                         label 'linux'
                     }
                     environment {
-                        STACK_VERSION = "7.2.0"
+                        STACK_VERSION = "7.2.1"
                     }
                     steps {
                         checkout scm
-                        createRunConfig("${BUILD_TAG}-720")
+                        createRunConfig("${BUILD_TAG}-721")
                         sh 'make -C build/ci ci-e2e'
                     }
                 }
@@ -76,9 +76,19 @@ pipeline {
     }
 
     post {
+        unsuccessful {
+            script {
+                def msg = "E2E tests for different Elastic stack versions failed!\r\n" + env.BUILD_URL
+                slackSend botUser: true,
+                      channel: '#cloud-k8s',
+                      color: 'danger',
+                      message: msg,
+                      tokenCredentialId: 'cloud-ci-slack-integration-token'
+            }
+        }
         cleanup {
             script {
-                clusters = ["${BUILD_TAG}-680", "${BUILD_TAG}-710", "${BUILD_TAG}-720", "${BUILD_TAG}-730"]
+                clusters = ["${BUILD_TAG}-682", "${BUILD_TAG}-711", "${BUILD_TAG}-721", "${BUILD_TAG}-730"]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
                         parameters: [string(name: 'GKE_CLUSTER', value: clusters[i])],

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
     stages {
         stage('Run tests for different ELK stack versions in GKE') {
             parallel {
-                stage("6.8.0") {
+                stage("6.8.2") {
                     environment {
                         STACK_VERSION = "6.8.2"
                     }
@@ -32,7 +32,7 @@ pipeline {
                         sh 'make -C build/ci ci-e2e'
                     }
                 }
-                stage("7.1.0") {
+                stage("7.1.1") {
                     agent {
                         label 'linux'
                     }
@@ -45,7 +45,7 @@ pipeline {
                         sh 'make -C build/ci ci-e2e'
                     }
                 }
-                stage("7.2.0") {
+                stage("7.2.1") {
                     agent {
                         label 'linux'
                     }


### PR DESCRIPTION
Restoring notifications disabled in https://github.com/elastic/cloud-on-k8s/pull/1568. Should be merged after https://github.com/elastic/cloud-on-k8s/issues/1545 is fixed.

Also updating stack versions to latest patches.