### PR TITLE
Add caching of Docker images for CI

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -13,5 +13,5 @@ declare -a docker_images=("docker.elastic.co/eck/eck-ci:57e169ff162c2ea351a1956e
 # Pull all the required docker images
 for image in "${docker_images[@]}"
 do
-  docker pull $image
+  docker pull "$image"
 done

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -1,0 +1,17 @@
+#! /usr/bin/env bash
+
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+# This script takes responsibility to create a minikube cluster. It has all
+# of the necessary default settings so that no environment variable has to
+# be specified.
+
+declare -a docker_images=("docker.elastic.co/eck/eck-ci:57e169ff162c2ea351a1956e1ad355b9")
+
+# Pull all the required docker images
+for image in "${docker_images[@]}"
+do
+  docker pull $image
+done

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -8,7 +8,9 @@
 
 set -eou pipefail
 
-declare -a docker_images=("docker.elastic.co/eck/eck-ci:57e169ff162c2ea351a1956e1ad355b9")
+DOCKER_CI_IMAGE=$(cd ../build/ci/ && make show-image)
+
+declare -a docker_images=("$DOCKER_CI_IMAGE")
 
 # Pull all the required docker images
 for image in "${docker_images[@]}"

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -6,6 +6,8 @@
 
 # This script used to "bake" Docker images into base image for Jenkins nodes.
 
+set -eou pipefail
+
 declare -a docker_images=("docker.elastic.co/eck/eck-ci:57e169ff162c2ea351a1956e1ad355b9")
 
 # Pull all the required docker images

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -4,9 +4,7 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
-# This script takes responsibility to create a minikube cluster. It has all
-# of the necessary default settings so that no environment variable has to
-# be specified.
+# This script used to "bake" Docker images into base image for Jenkins nodes.
 
 declare -a docker_images=("docker.elastic.co/eck/eck-ci:57e169ff162c2ea351a1956e1ad355b9")
 

--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -25,6 +25,9 @@ VAULT_TOKEN ?= $(shell vault write -field=token auth/approle/login role_id=$(VAU
 check-license-header:
 	./../check-license-header.sh
 
+show-image:
+	@ echo $(CI_IMAGE)
+
 # login to vault and retrieve gke creds into $GKE_CREDS_FILE
 vault-gke-creds:
 	@ VAULT_TOKEN=$(VAULT_TOKEN) \


### PR DESCRIPTION
At the moment, only Docker image for CI was added. In the future we can add more images, like from https://github.com/elastic/cloud-on-k8s/issues/1096