### PR TITLE
Extract and unit test StatefulSets upscale

### DIFF
--- a/operators/pkg/controller/elasticsearch/driver/nodes_test.go
+++ b/operators/pkg/controller/elasticsearch/driver/nodes_test.go
@@ -1,0 +1,82 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package driver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/observer"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/settings"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+)
+
+func Test_expectedResources_zen2(t *testing.T) {
+	es := v1alpha1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "cluster",
+		},
+		Spec: v1alpha1.ElasticsearchSpec{
+			Version: "7.2.0",
+			Nodes: []v1alpha1.NodeSpec{
+				{
+					Name:      "masters",
+					NodeCount: 3,
+				},
+				{
+					Name:      "data",
+					NodeCount: 3,
+				},
+			},
+		},
+	}
+
+	resources, err := expectedResources(k8s.WrapClient(fake.NewFakeClient()), es, observer.State{}, nil)
+	require.NoError(t, err)
+
+	// 3 StatefulSets should be created
+	require.Equal(t, 2, len(resources.StatefulSets()))
+	// master nodes config should be patched to account for zen2 initial master nodes
+	require.NotEmpty(t, resources[0].Config.HasKeys([]string{settings.ClusterInitialMasterNodes}))
+	// zen1 m_m_n specific config should not be set
+	require.Empty(t, resources[0].Config.HasKeys([]string{settings.DiscoveryZenMinimumMasterNodes}))
+}
+
+func Test_expectedResources_zen1(t *testing.T) {
+	es := v1alpha1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "cluster",
+		},
+		Spec: v1alpha1.ElasticsearchSpec{
+			Version: "6.8.0",
+			Nodes: []v1alpha1.NodeSpec{
+				{
+					Name:      "masters",
+					NodeCount: 3,
+				},
+				{
+					Name:      "data",
+					NodeCount: 3,
+				},
+			},
+		},
+	}
+
+	resources, err := expectedResources(k8s.WrapClient(fake.NewFakeClient()), es, observer.State{}, nil)
+	require.NoError(t, err)
+
+	// 3 StatefulSets should be created
+	require.Equal(t, 2, len(resources.StatefulSets()))
+	// master nodes config should be patched to account for zen1 minimum_master_nodes
+	require.NotEmpty(t, resources[0].Config.HasKeys([]string{settings.DiscoveryZenMinimumMasterNodes}))
+	// zen2 config should not be set
+	require.Empty(t, resources[0].Config.HasKeys([]string{settings.ClusterInitialMasterNodes}))
+}

--- a/operators/pkg/controller/elasticsearch/driver/nodes_test.go
+++ b/operators/pkg/controller/elasticsearch/driver/nodes_test.go
@@ -41,7 +41,7 @@ func Test_expectedResources_zen2(t *testing.T) {
 	resources, err := expectedResources(k8s.WrapClient(fake.NewFakeClient()), es, observer.State{}, nil)
 	require.NoError(t, err)
 
-	// 3 StatefulSets should be created
+	// 2 StatefulSets should be created
 	require.Equal(t, 2, len(resources.StatefulSets()))
 	// master nodes config should be patched to account for zen2 initial master nodes
 	require.NotEmpty(t, resources[0].Config.HasKeys([]string{settings.ClusterInitialMasterNodes}))
@@ -73,7 +73,7 @@ func Test_expectedResources_zen1(t *testing.T) {
 	resources, err := expectedResources(k8s.WrapClient(fake.NewFakeClient()), es, observer.State{}, nil)
 	require.NoError(t, err)
 
-	// 3 StatefulSets should be created
+	// 2 StatefulSets should be created
 	require.Equal(t, 2, len(resources.StatefulSets()))
 	// master nodes config should be patched to account for zen1 minimum_master_nodes
 	require.NotEmpty(t, resources[0].Config.HasKeys([]string{settings.DiscoveryZenMinimumMasterNodes}))

--- a/operators/pkg/controller/elasticsearch/driver/upscale.go
+++ b/operators/pkg/controller/elasticsearch/driver/upscale.go
@@ -1,0 +1,57 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package driver
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/nodespec"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/settings"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+)
+
+// HandleUpscaleAndSpecChanges reconciles expected NodeSpec resources.
+// It does:
+// - create any new StatefulSets
+// - update existing StatefulSets specification, to be used for future pods rotation
+// - upscale StatefulSet for which we expect more replicas
+// It does not:
+// - perform any StatefulSet downscale (left for downscale phase)
+// - perform any pod upgrade (left for rolling upgrade phase)
+func HandleUpscaleAndSpecChanges(
+	k8sClient k8s.Client,
+	es v1alpha1.Elasticsearch,
+	scheme *runtime.Scheme,
+	expectedResources nodespec.ResourcesList,
+	actualStatefulSets sset.StatefulSetList,
+) error {
+	// TODO: there is a split brain possibility here if going from 1 to 3 masters or 3 to 7.
+	//  We should add only one master node at a time for safety.
+	//  See https://github.com/elastic/cloud-on-k8s/issues/1281.
+
+	for _, nodeSpecRes := range expectedResources {
+		// always reconcile config (will apply to new & recreated pods)
+		if err := settings.ReconcileConfig(k8sClient, es, nodeSpecRes.StatefulSet.Name, nodeSpecRes.Config); err != nil {
+			return err
+		}
+		if _, err := common.ReconcileService(k8sClient, scheme, &nodeSpecRes.HeadlessService, &es); err != nil {
+			return err
+		}
+		ssetToApply := *nodeSpecRes.StatefulSet.DeepCopy()
+		actual, exists := actualStatefulSets.GetByName(ssetToApply.Name)
+		if exists && sset.Replicas(ssetToApply) < sset.Replicas(actual) {
+			// sset needs to be scaled down
+			// update the sset to use the new spec but don't scale replicas down for now
+			ssetToApply.Spec.Replicas = actual.Spec.Replicas
+		}
+		if err := sset.ReconcileStatefulSet(k8sClient, scheme, es, ssetToApply); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/operators/pkg/controller/elasticsearch/driver/upscale_test.go
+++ b/operators/pkg/controller/elasticsearch/driver/upscale_test.go
@@ -1,0 +1,115 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package driver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/name"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/nodespec"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/settings"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/k8s"
+)
+
+func TestHandleUpscaleAndSpecChanges(t *testing.T) {
+	require.NoError(t, v1alpha1.AddToScheme(scheme.Scheme))
+	k8sClient := k8s.WrapClient(fake.NewFakeClient())
+	es := v1alpha1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es"}}
+	expectedResources := nodespec.ResourcesList{
+		{
+			StatefulSet: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "sset1",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: common.Int32(3),
+				},
+			},
+			HeadlessService: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "sset1",
+				},
+			},
+			Config: settings.CanonicalConfig{},
+		},
+		{
+			StatefulSet: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "sset2",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: common.Int32(4),
+				},
+			},
+			HeadlessService: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "sset2",
+				},
+			},
+			Config: settings.CanonicalConfig{},
+		},
+	}
+
+	// when no StatefulSets already exists
+	actualStatefulSets := sset.StatefulSetList{}
+	err := HandleUpscaleAndSpecChanges(k8sClient, es, scheme.Scheme, expectedResources, actualStatefulSets)
+	require.NoError(t, err)
+	// StatefulSets should be created with their expected replicas
+	var sset1 appsv1.StatefulSet
+	require.NoError(t, k8sClient.Get(types.NamespacedName{Namespace: "ns", Name: "sset1"}, &sset1))
+	require.Equal(t, common.Int32(3), sset1.Spec.Replicas)
+	var sset2 appsv1.StatefulSet
+	require.NoError(t, k8sClient.Get(types.NamespacedName{Namespace: "ns", Name: "sset2"}, &sset2))
+	require.Equal(t, common.Int32(4), sset2.Spec.Replicas)
+	// headless services should be created for both
+	require.NoError(t, k8sClient.Get(types.NamespacedName{Namespace: "ns", Name: nodespec.HeadlessServiceName("sset1")}, &corev1.Service{}))
+	require.NoError(t, k8sClient.Get(types.NamespacedName{Namespace: "ns", Name: nodespec.HeadlessServiceName("sset2")}, &corev1.Service{}))
+	// config should be created for both
+	require.NoError(t, k8sClient.Get(types.NamespacedName{Namespace: "ns", Name: name.ConfigSecret("sset1")}, &corev1.Secret{}))
+	require.NoError(t, k8sClient.Get(types.NamespacedName{Namespace: "ns", Name: name.ConfigSecret("sset2")}, &corev1.Secret{}))
+
+	// upscale data nodes
+	actualStatefulSets = sset.StatefulSetList{sset1, sset2}
+	expectedResources[1].StatefulSet.Spec.Replicas = common.Int32(10)
+	err = HandleUpscaleAndSpecChanges(k8sClient, es, scheme.Scheme, expectedResources, actualStatefulSets)
+	require.NoError(t, err)
+	require.NoError(t, k8sClient.Get(types.NamespacedName{Namespace: "ns", Name: "sset2"}, &sset2))
+	require.Equal(t, common.Int32(10), sset2.Spec.Replicas)
+
+	// apply a spec change
+	actualStatefulSets = sset.StatefulSetList{sset1, sset2}
+	expectedResources[1].StatefulSet.Spec.Template.Labels = map[string]string{"a": "b"}
+	err = HandleUpscaleAndSpecChanges(k8sClient, es, scheme.Scheme, expectedResources, actualStatefulSets)
+	require.NoError(t, err)
+	require.NoError(t, k8sClient.Get(types.NamespacedName{Namespace: "ns", Name: "sset2"}, &sset2))
+	require.Equal(t, "b", sset2.Spec.Template.Labels["a"])
+
+	// apply a spec change and a downscale from 10 to 2
+	actualStatefulSets = sset.StatefulSetList{sset1, sset2}
+	expectedResources[1].StatefulSet.Spec.Replicas = common.Int32(2)
+	expectedResources[1].StatefulSet.Spec.Template.Labels = map[string]string{"a": "c"}
+	err = HandleUpscaleAndSpecChanges(k8sClient, es, scheme.Scheme, expectedResources, actualStatefulSets)
+	require.NoError(t, err)
+	require.NoError(t, k8sClient.Get(types.NamespacedName{Namespace: "ns", Name: "sset2"}, &sset2))
+	// spec should be updated
+	require.Equal(t, "c", sset2.Spec.Template.Labels["a"])
+	// but StatefulSet should not be downscaled
+	require.Equal(t, common.Int32(10), sset2.Spec.Replicas)
+}


### PR DESCRIPTION
Extract smaller functions to build expected resources and upscale/apply
StatefulSets configuration, and add unit tests for both.