### PR TITLE
Add RBAC permission to E2E tests to access statefulsets

### DIFF
--- a/operators/config/e2e/rbac.yaml
+++ b/operators/config/e2e/rbac.yaml
@@ -99,6 +99,7 @@ rules:
       - "apps"
     resources:
       - deployments
+      - statefulsets
     verbs:
       - get
       - list


### PR DESCRIPTION
This should fix the current E2E test issue.