### PR TITLE
Refactor CI jobs and CI makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ hack/deployer/config/run-config.yml
 
 # ignore CI config files
 run-config.yml
-environment
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ docs/html/*
 # ignore deployer files
 hack/deployer/deployer
 hack/deployer/config/run-config.yml
+
+# ignore CI config files
+run-config.yml
+environment

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 90s
+  deadline: 300s
   skip-dirs:
     - config
     - hack

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@
 ##  --      Variables      --  ##
 #################################
 
+# reads file 'environment', ignores if it doesn't exist
+-include environment
 
 # make sure sub-commands don't use eg. fish shell
 export SHELL := /bin/bash
@@ -25,11 +27,8 @@ LATEST_RELEASED_IMG ?= "docker.elastic.co/eck/$(NAME):0.8.0"
 # on GKE, use GCR and GCLOUD_PROJECT
 ifneq ($(findstring gke_,$(KUBECTL_CLUSTER)),)
 	REGISTRY ?= eu.gcr.io
-	REPOSITORY = ${GCLOUD_PROJECT}
-else ifneq ($(findstring azmk8s.io:443,$(shell kubectl config view --minify -o=jsonpath={.clusters[*].cluster.server} 2> /dev/null)),)
-	REGISTRY ?= cloudonk8s.azurecr.io
-	REPOSITORY ?= operators
-else ifeq ($(REGISTRY),)
+	REPOSITORY ?= ${GCLOUD_PROJECT}
+else
 	# default to local registry
 	REGISTRY ?= localhost:5000
 endif
@@ -38,11 +37,6 @@ endif
 IMG_SUFFIX ?= -$(subst _,,$(USER))
 IMG ?= $(REGISTRY)/$(REPOSITORY)/$(NAME)$(IMG_SUFFIX)
 TAG ?= $(shell git rev-parse --short --verify HEAD)
-
-ifeq ($(OPERATOR_IMAGE),)
-	# we never want this empty
-	OPERATOR_IMAGE := $(IMG):$(VERSION)-$(TAG)
-endif
 OPERATOR_IMAGE ?= $(IMG):$(VERSION)-$(TAG)
 
 
@@ -300,9 +294,7 @@ purge-gcr-images:
 # can be overriden to eg. TESTS_MATCH=TestMutationMoreNodes to match a single test
 TESTS_MATCH ?= "^Test"
 E2E_IMG ?= $(IMG)-e2e-tests:$(TAG)
-ifeq ($(STACK_VERSION),)
-	STACK_VERSION = 7.3.0
-endif
+STACK_VERSION ?= 7.3.0
 
 # Run e2e tests as a k8s batch job
 e2e: build-operator-image e2e-docker-build e2e-docker-push e2e-run
@@ -341,20 +333,25 @@ e2e-local:
 ##  --    Continuous integration    --  ##
 ##########################################
 
-ci: dep-vendor-only check-fmt lint generate check-local-changes unit integration e2e-compile docker-build
+ci: check-fmt lint generate check-local-changes unit integration e2e-compile docker-build
 
 # Run e2e tests in a dedicated cluster.
-ci-e2e: run-deployer
-	$(MAKE) IMG_SUFFIX=-ci install-crds apply-psp e2e
+ci-e2e: run-deployer install-crds apply-psp e2e
 
-run-deployer: dep-vendor-only build-deployer
+run-deployer: build-deployer
 	./hack/deployer/deployer execute --plans-file hack/deployer/config/plans.yml --run-config-file run-config.yml
 
-ci-release: export GO_TAGS = release
-ci-release: export LICENSE_PUBKEY = $(CURDIR)/build/ci/license.key
-ci-release: clean
-	@ $(MAKE) dep-vendor-only generate docker-build docker-push
+ci-release: clean dep-vendor-only generate build-operator-image
 	@ echo $(OPERATOR_IMAGE) was pushed!
+
+VAULT_AWS_CREDS ?= secret/cloud-team/cloud-ci/eck-release
+# reads AWS creds for yaml upload
+# uploads to https://download.elastic.co/downloads/eck/$TAG_NAME/all-in-one.yaml
+yaml-upload:
+	@ AWS_ACCESS_KEY_ID=$(shell vault read -address=$(VAULT_ADDR) -field=access-key-id $(VAULT_AWS_CREDS)) \
+		AWS_SECRET_ACCESS_KEY=$(shell vault read -address=$(VAULT_ADDR) -field=secret-access-key $(VAULT_AWS_CREDS)) \
+		bash -c "aws s3 cp $(GO_MOUNT_PATH)/operators/config/all-in-one.yaml \
+		s3://download.elasticsearch.org/downloads/eck/$(TAG_NAME)/all-in-one.yaml"
 
 ##########################
 ##  --   Helpers    --  ##

--- a/Makefile
+++ b/Makefile
@@ -344,15 +344,6 @@ run-deployer: build-deployer
 ci-release: clean dep-vendor-only generate build-operator-image
 	@ echo $(OPERATOR_IMAGE) was pushed!
 
-VAULT_AWS_CREDS ?= secret/cloud-team/cloud-ci/eck-release
-# reads AWS creds for yaml upload
-# uploads to https://download.elastic.co/downloads/eck/$TAG_NAME/all-in-one.yaml
-yaml-upload:
-	@ AWS_ACCESS_KEY_ID=$(shell vault read -address=$(VAULT_ADDR) -field=access-key-id $(VAULT_AWS_CREDS)) \
-		AWS_SECRET_ACCESS_KEY=$(shell vault read -address=$(VAULT_ADDR) -field=secret-access-key $(VAULT_AWS_CREDS)) \
-		bash -c "aws s3 cp $(GO_MOUNT_PATH)/operators/config/all-in-one.yaml \
-		s3://download.elasticsearch.org/downloads/eck/$(TAG_NAME)/all-in-one.yaml"
-
 ##########################
 ##  --   Helpers    --  ##
 ##########################

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 #################################
 
 # reads file 'environment', ignores if it doesn't exist
--include environment
+-include .env
 
 # make sure sub-commands don't use eg. fish shell
 export SHELL := /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -333,12 +333,12 @@ e2e-local:
 ##  --    Continuous integration    --  ##
 ##########################################
 
-ci: check-fmt lint generate check-local-changes unit integration e2e-compile docker-build
+ci: dep-vendor-only check-fmt lint generate check-local-changes unit integration e2e-compile docker-build
 
 # Run e2e tests in a dedicated cluster.
-ci-e2e: run-deployer install-crds apply-psp e2e
+ci-e2e: dep-vendor-only run-deployer install-crds apply-psp e2e
 
-run-deployer: build-deployer
+run-deployer: dep-vendor-only build-deployer
 	./hack/deployer/deployer execute --plans-file hack/deployer/config/plans.yml --run-config-file run-config.yml
 
 ci-release: clean dep-vendor-only generate build-operator-image

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 ##  --      Variables      --  ##
 #################################
 
-# reads file 'environment', ignores if it doesn't exist
+# reads file '.env', ignores if it doesn't exist
 -include .env
 
 # make sure sub-commands don't use eg. fish shell

--- a/build/ci/Dockerfile
+++ b/build/ci/Dockerfile
@@ -6,7 +6,6 @@ ENV GCLOUD_VERSION=232.0.0
 ENV KUBECTL_VERSION=1.13.6
 ENV DOCKER_VERSION=18.03.1-ce
 ENV GOLANGCILINT_VERSION=1.17.1
-ENV VAULT_CLI_VERSION=1.2.2
 
 # Download required golang tools
 RUN go get github.com/golang/dep/cmd/dep golang.org/x/tools/cmd/goimports
@@ -50,12 +49,6 @@ RUN apt-get update && apt-get --no-install-recommends -y install \
 
 # Download Azure CLI
 RUN curl -sSL https://aka.ms/InstallAzureCLIDeb | bash
-
-# Download Vault CLI
-RUN apt-get install unzip && \
-    curl -fsSLO https://releases.hashicorp.com/vault/${VAULT_CLI_VERSION}/vault_${VAULT_CLI_VERSION}_linux_amd64.zip && \
-    unzip vault_${VAULT_CLI_VERSION}_linux_amd64.zip && \
-    mv vault /usr/local/bin/vault
 
 # Add Go dependencies to Docker image
 WORKDIR /go/src/github.com/elastic/cloud-on-k8s

--- a/build/ci/Dockerfile
+++ b/build/ci/Dockerfile
@@ -6,6 +6,7 @@ ENV GCLOUD_VERSION=232.0.0
 ENV KUBECTL_VERSION=1.13.6
 ENV DOCKER_VERSION=18.03.1-ce
 ENV GOLANGCILINT_VERSION=1.17.1
+ENV VAULT_CLI_VERSION=1.2.2
 
 # Download required golang tools
 RUN go get github.com/golang/dep/cmd/dep golang.org/x/tools/cmd/goimports
@@ -49,6 +50,12 @@ RUN apt-get update && apt-get --no-install-recommends -y install \
 
 # Download Azure CLI
 RUN curl -sSL https://aka.ms/InstallAzureCLIDeb | bash
+
+# Download Vault CLI
+RUN apt-get install unzip && \
+    curl -fsSLO https://releases.hashicorp.com/vault/${VAULT_CLI_VERSION}/vault_${VAULT_CLI_VERSION}_linux_amd64.zip && \
+    unzip vault_${VAULT_CLI_VERSION}_linux_amd64.zip && \
+    mv vault /usr/local/bin/vault
 
 # Add Go dependencies to Docker image
 WORKDIR /go/src/github.com/elastic/cloud-on-k8s

--- a/build/ci/Dockerfile
+++ b/build/ci/Dockerfile
@@ -54,7 +54,7 @@ RUN curl -sSL https://aka.ms/InstallAzureCLIDeb | bash
 WORKDIR /go/src/github.com/elastic/cloud-on-k8s
 COPY Gopkg.lock .
 COPY Gopkg.toml .
-RUN dep ensure --vendor-only -v
+RUN dep ensure --vendor-only -v && rm -rf vendor/
 
 # Cleanup
 RUN rm /go/src/github.com/elastic/cloud-on-k8s/Gopkg.lock && \

--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -9,12 +9,13 @@ GO_MOUNT_PATH ?= /go/src/github.com/elastic/cloud-on-k8s
 
 # BUILD_ID is present during run on Jenkins machine, but not on dev box, hence using it here to distinguish between those cases
 ifdef BUILD_ID
-VAULT_TOKEN = $(shell vault write -field=token auth/approle/login role_id=$(VAULT_ROLE_ID) secret_id=$(VAULT_SECRET_ID))
+VAULT_TOKEN = $(shell vault write -address=$(VAULT_ADDR) -field=token auth/approle/login role_id=$(VAULT_ROLE_ID) secret_id=$(VAULT_SECRET_ID))
 else
 VAULT_TOKEN = $(shell vault write -address=$(VAULT_ADDR) -field=token auth/github/login token=$(GITHUB_TOKEN))
 # we use roleId as a string that has to be there for authn/z for CI, but it's empty and not needed for local execution
 NOT_USED = $(shell test -e ../../run-config.yml && sed -i -e "s;roleId:;token: $(GITHUB_TOKEN);g" ../../run-config.yml)
 endif
+export VAULT_TOKEN
 
 CI_IMAGE ?= docker.elastic.co/eck/eck-ci:$(shell md5sum $(ROOT_DIR)/Gopkg.lock $(ROOT_DIR)/build/ci/Dockerfile | awk '{print $$1}' | md5sum | awk '{print $$1}')
 
@@ -33,7 +34,6 @@ ci-internal: ci-build-image
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
 		-w $(GO_MOUNT_PATH) \
-		-e "VAULT_TOKEN=$(VAULT_TOKEN)" \
 		$(CI_IMAGE) \
 		bash -c "$(DOCKER_CMD)"
 

--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -55,3 +55,6 @@ yaml-upload:
 		DOCKER_CMD="aws s3 cp $(GO_MOUNT_PATH)/config/all-in-one.yaml \
 		s3://download.elasticsearch.org/downloads/eck/$(TAG_NAME)/all-in-one.yaml" ci-internal
 
+# reads Elastic public key from Vault into license.key
+get-elastic-public-key:
+	@ VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=pubkey secret/release/license | base64 --decode > license.key

--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -21,7 +21,7 @@ CI_IMAGE ?= docker.elastic.co/eck/eck-ci:$(shell md5sum $(ROOT_DIR)/Gopkg.lock $
 show-image:
 	@ echo $(CI_IMAGE)
 
-# runs $COMMAND in context of CI container and dev makefile
+# runs $TARGET in context of CI container and dev makefile
 ci: ci-build-image
 	@ docker run --rm -t \
 		-v /var/run/docker.sock:/var/run/docker.sock \
@@ -29,7 +29,7 @@ ci: ci-build-image
 		-w $(GO_MOUNT_PATH) \
 		-e "VAULT_TOKEN=$(VAULT_TOKEN)" \
 		$(CI_IMAGE) \
-		bash -c "make $(COMMAND)"
+		bash -c "make $(TARGET)"
 
 ci-interactive: ci-build-image
 	@ docker run --rm -t -i \

--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -15,7 +15,6 @@ VAULT_TOKEN = $(shell vault write -address=$(VAULT_ADDR) -field=token auth/githu
 # we use roleId as a string that has to be there for authn/z for CI, but it's empty and not needed for local execution
 NOT_USED = $(shell test -e ../../run-config.yml && sed -i -e "s;roleId:;token: $(GITHUB_TOKEN);g" ../../run-config.yml)
 endif
-export VAULT_TOKEN
 
 CI_IMAGE ?= docker.elastic.co/eck/eck-ci:$(shell md5sum $(ROOT_DIR)/Gopkg.lock $(ROOT_DIR)/build/ci/Dockerfile | awk '{print $$1}' | md5sum | awk '{print $$1}')
 
@@ -43,12 +42,12 @@ ci-internal: ci-build-image
 ci-build-image:
 	@ docker pull $(CI_IMAGE) || (docker build -f $(ROOT_DIR)/build/ci/Dockerfile -t push.$(CI_IMAGE) \
 		--label "commit.hash=$(shell git rev-parse --short --verify HEAD)" $(ROOT_DIR) && docker login -u eckadmin \
-		-p $(shell vault read -address=$(VAULT_ADDR) -field=value secret/devops-ci/cloud-on-k8s/eckadmin) \
+		-p $(shell VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=value secret/devops-ci/cloud-on-k8s/eckadmin) \
 		push.docker.elastic.co && docker push push.$(CI_IMAGE))
 
 VAULT_AWS_CREDS = secret/cloud-team/cloud-ci/eck-release
-AWS_ACCESS_KEY_ID = $(shell vault read -address=$(VAULT_ADDR) -field=access-key-id $(VAULT_AWS_CREDS))
-AWS_SECRET_ACCESS_KEY = $(shell vault read -address=$(VAULT_ADDR) -field=secret-access-key $(VAULT_AWS_CREDS))
+AWS_ACCESS_KEY_ID = $(shell VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=access-key-id $(VAULT_AWS_CREDS))
+AWS_SECRET_ACCESS_KEY = $(shell VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=secret-access-key $(VAULT_AWS_CREDS))
 # reads AWS creds for yaml upload to https://download.elastic.co/downloads/eck/$TAG_NAME/all-in-one.yaml
 yaml-upload:
 	@ $(MAKE) \

--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -22,23 +22,21 @@ show-image:
 	@ echo $(CI_IMAGE)
 
 # runs $TARGET in context of CI container and dev makefile
-ci: ci-build-image
-	@ docker run --rm -t \
-		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
-		-w $(GO_MOUNT_PATH) \
-		-e "VAULT_TOKEN=$(VAULT_TOKEN)" \
-		$(CI_IMAGE) \
-		bash -c "make $(TARGET)"
+ci:
+	@ $(MAKE) DOCKER_CMD="make $(TARGET)" ci-internal
 
-ci-interactive: ci-build-image
-	@ docker run --rm -t -i \
+ci-interactive:
+	@ $(MAKE) DOCKER_OPTS=-i DOCKER_CMD=bash ci-internal
+
+ci-internal: ci-build-image
+	@ docker run --rm -t $(DOCKER_OPTS) \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
 		-w $(GO_MOUNT_PATH) \
 		-e "VAULT_TOKEN=$(VAULT_TOKEN)" \
 		$(CI_IMAGE) \
-		bash
+		bash -c "$(DOCKER_CMD)"
+
 
 # reads Docker password from Vault,
 # checks if Docker image exists by trying to pull it. If there is no image, then build and push it.
@@ -47,3 +45,14 @@ ci-build-image:
 		--label "commit.hash=$(shell git rev-parse --short --verify HEAD)" $(ROOT_DIR) && docker login -u eckadmin \
 		-p $(shell vault read -address=$(VAULT_ADDR) -field=value secret/devops-ci/cloud-on-k8s/eckadmin) \
 		push.docker.elastic.co && docker push push.$(CI_IMAGE))
+
+VAULT_AWS_CREDS = secret/cloud-team/cloud-ci/eck-release
+AWS_ACCESS_KEY_ID = $(shell vault read -address=$(VAULT_ADDR) -field=access-key-id $(VAULT_AWS_CREDS))
+AWS_SECRET_ACCESS_KEY = $(shell vault read -address=$(VAULT_ADDR) -field=secret-access-key $(VAULT_AWS_CREDS))
+# reads AWS creds for yaml upload to https://download.elastic.co/downloads/eck/$TAG_NAME/all-in-one.yaml
+yaml-upload:
+	@ $(MAKE) \
+		DOCKER_OPTS="-e AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) -e AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY)" \
+		DOCKER_CMD="aws s3 cp $(GO_MOUNT_PATH)/config/all-in-one.yaml \
+		s3://download.elasticsearch.org/downloads/eck/$(TAG_NAME)/all-in-one.yaml" ci-internal
+

--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -7,141 +7,43 @@
 ROOT_DIR = $(CURDIR)/../..
 GO_MOUNT_PATH ?= /go/src/github.com/elastic/cloud-on-k8s
 
-CI_IMAGE ?= docker.elastic.co/eck/eck-ci:$(shell md5sum $(ROOT_DIR)/Gopkg.lock $(ROOT_DIR)/build/ci/Dockerfile | awk '{print $$1}' | md5sum | awk '{print $$1}')
-
-VAULT_GKE_CREDS_SECRET ?= secret/cloud-team/cloud-ci/ci-gcp-k8s-operator
-GKE_CREDS_FILE ?= credentials.json
-VAULT_PUBLIC_KEY ?= secret/release/license
-PUBLIC_KEY_FILE ?= license.key
-VAULT_DOCKER_CREDENTIALS ?= secret/devops-ci/cloud-on-k8s/eckadmin
-DOCKER_LOGIN ?= eckadmin
-DOCKER_CREDENTIALS_FILE ?= docker_credentials.file
-VAULT_AWS_CREDS ?= secret/cloud-team/cloud-ci/eck-release
-VAULT_AWS_ACCESS_KEY_FILE ?= aws_access_key.file
-VAULT_AWS_SECRET_KEY_FILE ?= aws_secret_key.file
-
+# BUILD_ID is present during run on Jenkins machine, but not on dev box, hence using it here to distinguish between those cases
+ifdef BUILD_ID
 VAULT_TOKEN ?= $(shell vault write -field=token auth/approle/login role_id=$(VAULT_ROLE_ID) secret_id=$(VAULT_SECRET_ID))
+else
+VAULT_TOKEN = $(shell vault write -address=$(VAULT_ADDR) -field=token auth/github/login token=$(GITHUB_TOKEN))
+# we use roleId as a string that has to be there for authn/z for CI, but it's empty and not needed for local execution
+NOT_USED = $(shell test -e ../../run-config.yml && sed -i -e "s;roleId:;token: $(GITHUB_TOKEN);g" ../../run-config.yml)
+endif
 
-check-license-header:
-	./../check-license-header.sh
+CI_IMAGE ?= docker.elastic.co/eck/eck-ci:$(shell md5sum $(ROOT_DIR)/Gopkg.lock $(ROOT_DIR)/build/ci/Dockerfile | awk '{print $$1}' | md5sum | awk '{print $$1}')
 
 show-image:
 	@ echo $(CI_IMAGE)
 
-# login to vault and retrieve gke creds into $GKE_CREDS_FILE
-vault-gke-creds:
-	@ VAULT_TOKEN=$(VAULT_TOKEN) \
-		vault read \
-		-address=$(VAULT_ADDR) \
-		-field=service-account \
-		$(VAULT_GKE_CREDS_SECRET) \
-		> $(GKE_CREDS_FILE)
-
-# reads Elastic public key from Vault into $PUBLIC_KEY_FILE
-vault-public-key:
-	@ VAULT_TOKEN=$(VAULT_TOKEN) \
-	 	vault read \
-		-address=$(VAULT_ADDR) \
-		-field=pubkey \
-		$(VAULT_PUBLIC_KEY) \
-		| base64 --decode \
-		> $(PUBLIC_KEY_FILE)
-
-# reads Docker password from Vault
-vault-docker-creds:
-	@ VAULT_TOKEN=$(VAULT_TOKEN) \
-	 	vault read \
-		-address=$(VAULT_ADDR) \
-		-field=value \
-		$(VAULT_DOCKER_CREDENTIALS) \
-		> $(DOCKER_CREDENTIALS_FILE)
-
-# reads AWS creds for yaml upload
-vault-aws-creds:
-	@ VAULT_TOKEN=$(VAULT_TOKEN) \
-		vault read \
-		-address=$(VAULT_ADDR) \
-		-field=access-key-id \
-		$(VAULT_AWS_CREDS) \
-		> $(VAULT_AWS_ACCESS_KEY_FILE)
-	@ VAULT_TOKEN=$(VAULT_TOKEN) \
-		vault read \
-		-address=$(VAULT_ADDR) \
-		-field=secret-access-key \
-		$(VAULT_AWS_CREDS) \
-		> $(VAULT_AWS_SECRET_KEY_FILE)
-
-## -- Job executed on all PRs
-
-ci-pr: check-license-header
+# runs $COMMAND in context of CI container and dev makefile
+ci: ci-build-image
 	@ docker run --rm -t \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
 		-w $(GO_MOUNT_PATH) \
-		-e "IMG_SUFFIX=-ci" \
-		--net=host \
+		-e "VAULT_TOKEN=$(VAULT_TOKEN)" \
 		$(CI_IMAGE) \
-		bash -c \
-			"make ci"
+		bash -c "make $(COMMAND)"
 
-## -- Release job
-
-ci-release: vault-public-key vault-docker-creds
-	@ docker run --rm -t \
-    	-v /var/run/docker.sock:/var/run/docker.sock \
-    	-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
-    	-w $(GO_MOUNT_PATH) \
-    	-e "ELASTIC_DOCKER_LOGIN=$(DOCKER_LOGIN)" \
-    	-e "ELASTIC_DOCKER_PASSWORD=$(shell cat $(DOCKER_CREDENTIALS_FILE))" \
-    	-e "USE_ELASTIC_DOCKER_REGISTRY=true" \
-    	-e "OPERATOR_IMAGE=$(OPERATOR_IMAGE)" \
-    	-e "LATEST_RELEASED_IMG=$(LATEST_RELEASED_IMG)" \
-    	-e "VERSION=$(VERSION)" \
-    	-e "SNAPSHOT=$(SNAPSHOT)" \
-    	$(CI_IMAGE) \
-		bash -c "make ci-release"
-
-# Will be uploaded to https://download.elastic.co/downloads/eck/$TAG_NAME/all-in-one.yaml
-yaml-upload: vault-aws-creds
-	@ docker run --rm -t \
-        -v $(ROOT_DIR):$(GO_MOUNT_PATH) \
-        -w $(GO_MOUNT_PATH) \
-        -e "AWS_ACCESS_KEY_ID=$(shell cat $(VAULT_AWS_ACCESS_KEY_FILE))" \
-        -e "AWS_SECRET_ACCESS_KEY=$(shell cat $(VAULT_AWS_SECRET_KEY_FILE))" \
-        $(CI_IMAGE) \
-        bash -c "aws s3 cp $(GO_MOUNT_PATH)/config/all-in-one.yaml \
-		s3://download.elasticsearch.org/downloads/eck/$(TAG_NAME)/all-in-one.yaml"
-
-## -- End-to-end tests job
-
-ci-e2e:
-	@ docker run --rm -t \
+ci-interactive: ci-build-image
+	@ docker run --rm -t -i \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
 		-w $(GO_MOUNT_PATH) \
-		-e "IMG_SUFFIX=-ci" \
-		-e "GCLOUD_PROJECT=$(GCLOUD_PROJECT)" \
-		-e "REGISTRY=$(REGISTRY)" \
-		-e "REPOSITORY=$(GCLOUD_PROJECT)" \
-		-e "TESTS_MATCH=$(TESTS_MATCH)" \
-		-e "SKIP_DOCKER_COMMAND=$(SKIP_DOCKER_COMMAND)" \
-		-e "OPERATOR_IMAGE=$(OPERATOR_IMAGE)" \
-		-e "STACK_VERSION=$(STACK_VERSION)" \
+		-e "VAULT_TOKEN=$(VAULT_TOKEN)" \
 		$(CI_IMAGE) \
-		bash -c "make ci-e2e"
+		bash
 
-ci-run-deployer:
-	@ docker run --rm -t \
-		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
-		-w $(GO_MOUNT_PATH) \
-		-e "GCLOUD_PROJECT=$(GCLOUD_PROJECT)" \
-		$(CI_IMAGE) \
-		bash -c "make run-deployer"
-
-# Check if Docker image exists by trying to pull it. If there is no image, then build and push it.
-ci-build-image: vault-docker-creds
+# reads Docker password from Vault,
+# checks if Docker image exists by trying to pull it. If there is no image, then build and push it.
+ci-build-image:
 	@ docker pull $(CI_IMAGE) || (docker build -f $(ROOT_DIR)/build/ci/Dockerfile -t push.$(CI_IMAGE) \
-	--label "commit.hash=$(shell git rev-parse --short --verify HEAD)" $(ROOT_DIR) &&\
-	docker login -u $(DOCKER_LOGIN) -p $(shell cat $(DOCKER_CREDENTIALS_FILE)) push.docker.elastic.co &&\
-	docker push push.$(CI_IMAGE))
+		--label "commit.hash=$(shell git rev-parse --short --verify HEAD)" $(ROOT_DIR) && docker login -u eckadmin \
+		-p $(shell vault read -address=$(VAULT_ADDR) -field=value secret/devops-ci/cloud-on-k8s/eckadmin) \
+		push.docker.elastic.co && docker push push.$(CI_IMAGE))

--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -9,7 +9,7 @@ GO_MOUNT_PATH ?= /go/src/github.com/elastic/cloud-on-k8s
 
 # BUILD_ID is present during run on Jenkins machine, but not on dev box, hence using it here to distinguish between those cases
 ifdef BUILD_ID
-VAULT_TOKEN ?= $(shell vault write -field=token auth/approle/login role_id=$(VAULT_ROLE_ID) secret_id=$(VAULT_SECRET_ID))
+VAULT_TOKEN = $(shell vault write -field=token auth/approle/login role_id=$(VAULT_ROLE_ID) secret_id=$(VAULT_SECRET_ID))
 else
 VAULT_TOKEN = $(shell vault write -address=$(VAULT_ADDR) -field=token auth/github/login token=$(GITHUB_TOKEN))
 # we use roleId as a string that has to be there for authn/z for CI, but it's empty and not needed for local execution

--- a/build/ci/README.md
+++ b/build/ci/README.md
@@ -1,0 +1,71 @@
+# Continuous integration
+
+### Structure
+
+We are using Jenkins as CI runner and keep its configuration as code in the repo. The address of the instance we use is https://devops-ci.elastic.co/view/cloud-on-k8s/.
+
+There are few layers in most of our jobs:
+ 
+1. [Job definition](../../.ci/jobs) - description of the job.
+2. Jenkinsfile - loads vault credentials, sets up configuration. 
+3. [CI makefile](Makefile) - creates container to run CI in, consolidates dev and CI setups.
+4. [operators makefile](../../operators/Makefile) - contains logic, delegates to specific tools as needed.
+5. tools - e.g. for [e2e test running](../../operators/test/e2e) and [cluster provisioning](../../operators/hack/deployer).
+
+### Local repro
+
+For debugging and development purposes it's possible to run CI jobs from dev box. It requires minimal setup and it mirrors CI closely, starting at CI makefile layer.
+
+Once, run:
+```
+export BUILD_TAG=local-ci-$(USER//_)
+
+# fill out:
+export GCLOUD_PROJECT=YOUR_GCLOUD_PROJECT
+export VAULT_ADDR=YOUR_VAULT_INSTANCE_ADDRESS
+export GITHUB_TOKEN=YOUR_PERSONAL_ACCESS_TOKEN
+``` 
+
+Per repro, depending on the job, set up environment and run-config.yml files. E.g.: to repro e2e tests run, look at its [Jenkinsfile](e2e/Jenkinsfile) and rerun the script locally in repo root: 
+```
+cat >operators/environment <<EOF
+GCLOUD_PROJECT = "$GCLOUD_PROJECT"
+REGISTRY = eu.gcr.io
+REPOSITORY = "$GCLOUD_PROJECT"
+SKIP_DOCKER_COMMAND = false
+IMG_SUFFIX = -ci
+EOF
+
+cat >operators/run-config.yml <<EOF
+id: gke-ci
+overrides:
+  kubernetesVersion: "1.12"
+  clusterName: $BUILD_TAG
+  vaultInfo:
+    address: $VAULT_ADDR
+    roleId: $VAULT_ROLE_ID
+    secretId: $VAULT_SECRET_ID
+  gke:
+    gCloudProject: $GCLOUD_PROJECT
+EOF
+
+make -C build/ci COMMAND=ci-e2e ci
+```
+
+CI makefile will take care of setting up correct credentials in the environment and run-config.yml file.
+
+This will run e2e test using the same:
+1. container
+1. credentials
+1. settings
+1. call path
+
+as the CI job.
+
+### CI container
+
+You can build and run CI container interactively with:
+
+```
+make -C build/ci ci-interactive
+```

--- a/build/ci/README.md
+++ b/build/ci/README.md
@@ -7,7 +7,7 @@ We are using Jenkins as CI runner and keep its configuration as code in the repo
 There are few layers in most of our jobs:
  
 1. [Job definition](../../.ci/jobs) - description of the job.
-2. Jenkinsfile - loads vault credentials, sets up configuration. 
+2. Jenkinsfile (e.g.: [e2e/Jenkinsfile](e2e/Jenkinsfile)) - loads vault credentials, sets up configuration. 
 3. [CI makefile](Makefile) - creates container to run CI in, consolidates dev and CI setups.
 4. [operators makefile](../../operators/Makefile) - contains logic, delegates to specific tools as needed.
 5. tools - e.g. for [e2e test running](../../operators/test/e2e) and [cluster provisioning](../../operators/hack/deployer).

--- a/build/ci/README.md
+++ b/build/ci/README.md
@@ -26,7 +26,7 @@ export VAULT_ADDR=YOUR_VAULT_INSTANCE_ADDRESS
 export GITHUB_TOKEN=YOUR_PERSONAL_ACCESS_TOKEN
 ``` 
 
-Per repro, depending on the job, set up environment and run-config.yml files. E.g.: to repro e2e tests run, look at its [Jenkinsfile](e2e/Jenkinsfile) and rerun the script locally in repo root: 
+Per repro, depending on the job, set up .env and run-config.yml files. E.g.: to repro e2e tests run, look at its [Jenkinsfile](e2e/Jenkinsfile) and rerun the script locally in repo root: 
 ```
 cat >.env <<EOF
 GCLOUD_PROJECT = "$GCLOUD_PROJECT"
@@ -52,7 +52,7 @@ EOF
 make -C build/ci COMMAND=ci-e2e ci
 ```
 
-CI makefile will take care of setting up correct credentials in the environment and run-config.yml file.
+CI makefile will take care of setting up correct credentials in the .env and run-config.yml file.
 
 This will run e2e test using the same:
 1. container

--- a/build/ci/README.md
+++ b/build/ci/README.md
@@ -28,7 +28,7 @@ export GITHUB_TOKEN=YOUR_PERSONAL_ACCESS_TOKEN
 
 Per repro, depending on the job, set up environment and run-config.yml files. E.g.: to repro e2e tests run, look at its [Jenkinsfile](e2e/Jenkinsfile) and rerun the script locally in repo root: 
 ```
-cat >operators/environment <<EOF
+cat >operators/.env <<EOF
 GCLOUD_PROJECT = "$GCLOUD_PROJECT"
 REGISTRY = eu.gcr.io
 REPOSITORY = "$GCLOUD_PROJECT"

--- a/build/ci/README.md
+++ b/build/ci/README.md
@@ -9,8 +9,8 @@ There are few layers in most of our jobs:
 1. [Job definition](../../.ci/jobs) - description of the job.
 2. Jenkinsfile (e.g.: [e2e/Jenkinsfile](e2e/Jenkinsfile)) - loads vault credentials, sets up configuration. 
 3. [CI makefile](Makefile) - creates container to run CI in, consolidates dev and CI setups.
-4. [operators makefile](../../operators/Makefile) - contains logic, delegates to specific tools as needed.
-5. tools - e.g. for [e2e test running](../../operators/test/e2e) and [cluster provisioning](../../operators/hack/deployer).
+4. [dev makefile](../../Makefile) - contains logic, delegates to specific tools as needed.
+5. tools - e.g. for [e2e test running](../../test/e2e) and [cluster provisioning](../../hack/deployer).
 
 ### Local repro
 
@@ -28,7 +28,7 @@ export GITHUB_TOKEN=YOUR_PERSONAL_ACCESS_TOKEN
 
 Per repro, depending on the job, set up environment and run-config.yml files. E.g.: to repro e2e tests run, look at its [Jenkinsfile](e2e/Jenkinsfile) and rerun the script locally in repo root: 
 ```
-cat >operators/.env <<EOF
+cat >.env <<EOF
 GCLOUD_PROJECT = "$GCLOUD_PROJECT"
 REGISTRY = eu.gcr.io
 REPOSITORY = "$GCLOUD_PROJECT"
@@ -36,7 +36,7 @@ SKIP_DOCKER_COMMAND = false
 IMG_SUFFIX = -ci
 EOF
 
-cat >operators/run-config.yml <<EOF
+cat >run-config.yml <<EOF
 id: gke-ci
 overrides:
   kubernetesVersion: "1.12"

--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -97,6 +97,6 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
-        make -C build/ci COMMAND=ci-e2e ci
+        make -C build/ci TARGET=ci-e2e ci
     """
 }

--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -12,11 +12,7 @@ pipeline {
         VAULT_ADDR = credentials('vault-addr')
         VAULT_ROLE_ID = credentials('vault-role-id')
         VAULT_SECRET_ID = credentials('vault-secret-id')
-        REGISTRY = "eu.gcr.io"
         GCLOUD_PROJECT = credentials('k8s-operators-gcloud-project')
-        OPERATOR_IMAGE = "${IMAGE}"
-        LATEST_RELEASED_IMG = "${IMAGE}"
-        SKIP_DOCKER_COMMAND = 'true'
     }
 
     stages {
@@ -28,8 +24,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        createRunConfig('1.11', "${BUILD_TAG}-11")
-                        sh 'make -C build/ci ci-e2e'
+                        runWith('1.11', "${BUILD_TAG}-11")
                     }
                 }
                 stage("1.12") {
@@ -38,8 +33,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        createRunConfig('1.12', "${BUILD_TAG}-12")
-                        sh 'make -C build/ci ci-e2e'
+                        runWith('1.12', "${BUILD_TAG}-12")
                     }
                 }
                 stage("1.13") {
@@ -48,8 +42,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        createRunConfig('1.13', "${BUILD_TAG}-13")
-                        sh 'make -C build/ci ci-e2e'
+                        runWith('1.13', "${BUILD_TAG}-13")
                     }
                 }
             }
@@ -81,8 +74,16 @@ pipeline {
     }
 }
 
-void createRunConfig(clusterVersion, clusterName) {
+void runWith(clusterVersion, clusterName) {
     sh """
+        cat >environment <<EOF
+GCLOUD_PROJECT = "$GCLOUD_PROJECT"
+LATEST_RELEASED_IMG = "$IMAGE"
+OPERATOR_IMAGE = "$IMAGE"
+REGISTRY = eu.gcr.io
+REPOSITORY = "$GCLOUD_PROJECT"
+SKIP_DOCKER_COMMAND = true
+EOF
         cat >run-config.yml <<EOF
 id: gke-ci
 overrides:
@@ -96,5 +97,6 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
+        make -C build/ci COMMAND=ci-e2e ci
     """
 }

--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
 
 void runWith(clusterVersion, clusterName) {
     sh """
-        cat >environment <<EOF
+        cat >.env <<EOF
 GCLOUD_PROJECT = "$GCLOUD_PROJECT"
 LATEST_RELEASED_IMG = "$IMAGE"
 OPERATOR_IMAGE = "$IMAGE"

--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
             }
             steps {
                 sh """
-                    cat >environment <<EOF
+                    cat >.env <<EOF
 GCLOUD_PROJECT = "$GCLOUD_PROJECT"
 REGISTRY = eu.gcr.io
 REPOSITORY = "$GCLOUD_PROJECT"

--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -48,7 +48,7 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
-                    make -C build/ci COMMAND=ci-e2e ci
+                    make -C build/ci TARGET=ci-e2e ci
                 """
             }
         }

--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -69,7 +69,7 @@ EOF
             script {
                 if (notOnlyDocs()) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
-                        parameters: [string(name: 'GKE_CLUSTER', value: "${CLUSTER_NAME}")],
+                        parameters: [string(name: 'GKE_CLUSTER', value: "${BUILD_TAG}")],
                         wait: false
                 }
             }

--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -12,11 +12,7 @@ pipeline {
         VAULT_ADDR = credentials('vault-addr')
         VAULT_ROLE_ID = credentials('vault-role-id')
         VAULT_SECRET_ID = credentials('vault-secret-id')
-        REGISTRY = "eu.gcr.io"
         GCLOUD_PROJECT = credentials('k8s-operators-gcloud-project')
-        CLUSTER_VERSION = '1.12'
-        CLUSTER_NAME = "${BUILD_TAG}"
-        SKIP_DOCKER_COMMAND = "false"
     }
 
     stages {
@@ -33,11 +29,18 @@ pipeline {
             }
             steps {
                 sh """
+                    cat >environment <<EOF
+GCLOUD_PROJECT = "$GCLOUD_PROJECT"
+REGISTRY = eu.gcr.io
+REPOSITORY = "$GCLOUD_PROJECT"
+SKIP_DOCKER_COMMAND = false
+IMG_SUFFIX = -ci
+EOF
                     cat >run-config.yml <<EOF
 id: gke-ci
 overrides:
-  kubernetesVersion: "$CLUSTER_VERSION"
-  clusterName: $CLUSTER_NAME
+  kubernetesVersion: "1.12"
+  clusterName: $BUILD_TAG
   vaultInfo:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
@@ -45,7 +48,7 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
-                    make -C build/ci ci-e2e
+                    make -C build/ci COMMAND=ci-e2e ci
                 """
             }
         }
@@ -74,7 +77,6 @@ EOF
             cleanWs()
         }
     }
-
 }
 
 def notOnlyDocs() {

--- a/build/ci/e2e/Jenkinsfile-aks
+++ b/build/ci/e2e/Jenkinsfile-aks
@@ -23,7 +23,7 @@ pipeline {
         stage("Run E2E tests") {
             steps {
                 sh """
-                    cat >environment <<EOF
+                    cat >.env <<EOF
 REGISTRY = cloudonk8s.azurecr.io
 REPOSITORY = operators
 IMG_SUFFIX = -ci

--- a/build/ci/e2e/Jenkinsfile-aks
+++ b/build/ci/e2e/Jenkinsfile-aks
@@ -12,10 +12,6 @@ pipeline {
         VAULT_ADDR = credentials('vault-addr')
         VAULT_ROLE_ID = credentials('vault-role-id')
         VAULT_SECRET_ID = credentials('vault-secret-id')
-        CLUSTER_VERSION = '1.12.8'
-        CLUSTER_NAME = "${BUILD_TAG}"
-        REGISTRY = "cloudonk8s.azurecr.io"
-        REPOSITORY = "operators"
     }
 
     stages {
@@ -27,17 +23,22 @@ pipeline {
         stage("Run E2E tests") {
             steps {
                 sh """
+                    cat >environment <<EOF
+REGISTRY = cloudonk8s.azurecr.io
+REPOSITORY = operators
+IMG_SUFFIX = -ci
+EOF
                     cat >run-config.yml <<EOF
 id: aks-ci
 overrides:
-  kubernetesVersion: "$CLUSTER_VERSION"
-  clusterName: $CLUSTER_NAME
+  kubernetesVersion: "1.12.8"
+  clusterName: $BUILD_TAG
   vaultInfo:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
 EOF
-                    make -C build/ci ci-e2e
+                    make -C build/ci COMMAND=ci-e2e ci
                 """
             }
         }  
@@ -51,14 +52,14 @@ EOF
 id: aks-ci
 overrides:
   operation: delete
-  kubernetesVersion: "$CLUSTER_VERSION"
-  clusterName: $CLUSTER_NAME
+  kubernetesVersion: "1.12.8"
+  clusterName: $BUILD_TAG
   vaultInfo:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
 EOF
-                    make -C build/ci ci-run-deployer
+                    make -C build/ci COMMAND=run-deployer ci
                 """
             }
             cleanWs()

--- a/build/ci/e2e/Jenkinsfile-aks
+++ b/build/ci/e2e/Jenkinsfile-aks
@@ -38,7 +38,7 @@ overrides:
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
 EOF
-                    make -C build/ci COMMAND=ci-e2e ci
+                    make -C build/ci TARGET=ci-e2e ci
                 """
             }
         }  
@@ -59,7 +59,7 @@ overrides:
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
 EOF
-                    make -C build/ci COMMAND=run-deployer ci
+                    make -C build/ci TARGET=run-deployer ci
                 """
             }
             cleanWs()

--- a/build/ci/e2e/custom_operator_image.jenkinsfile
+++ b/build/ci/e2e/custom_operator_image.jenkinsfile
@@ -46,7 +46,7 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
-                    make -C build/ci COMMAND=ci-e2e ci
+                    make -C build/ci TARGET=ci-e2e ci
                 """
             }
         }

--- a/build/ci/e2e/custom_operator_image.jenkinsfile
+++ b/build/ci/e2e/custom_operator_image.jenkinsfile
@@ -25,7 +25,6 @@ pipeline {
             steps {
                 sh """
                     cat >.env <<EOF
-VAULT_ADDR = "$VAULT_ADDR"
 GCLOUD_PROJECT = "$GCLOUD_PROJECT"
 LATEST_RELEASED_IMG = "$IMAGE"
 OPERATOR_IMAGE = "$IMAGE"

--- a/build/ci/e2e/custom_operator_image.jenkinsfile
+++ b/build/ci/e2e/custom_operator_image.jenkinsfile
@@ -12,13 +12,7 @@ pipeline {
         VAULT_ADDR = credentials('vault-addr')
         VAULT_ROLE_ID = credentials('vault-role-id')
         VAULT_SECRET_ID = credentials('vault-secret-id')
-        REGISTRY = "eu.gcr.io"
         GCLOUD_PROJECT = credentials('k8s-operators-gcloud-project')
-        CLUSTER_VERSION = "${VERSION}"
-        CLUSTER_NAME = "${BUILD_TAG}"
-        OPERATOR_IMAGE = "${IMAGE}"
-        LATEST_RELEASED_IMG = "${IMAGE}"
-        SKIP_DOCKER_COMMAND = 'true'
     }
 
     stages {
@@ -30,11 +24,21 @@ pipeline {
         stage("Run E2E tests") {
             steps {
                 sh """
+                    cat >environment <<EOF
+VAULT_ADDR = "$VAULT_ADDR"
+GCLOUD_PROJECT = "$GCLOUD_PROJECT"
+LATEST_RELEASED_IMG = "$IMAGE"
+OPERATOR_IMAGE = "$IMAGE"
+REGISTRY = eu.gcr.io
+REPOSITORY = "$GCLOUD_PROJECT"
+IMG_SUFFIX = -ci
+SKIP_DOCKER_COMMAND = true
+EOF
                     cat >run-config.yml <<EOF
 id: gke-ci
 overrides:
-  kubernetesVersion: "$CLUSTER_VERSION"
-  clusterName: $CLUSTER_NAME
+  kubernetesVersion: "1.12"
+  clusterName: $BUILD_TAG
   vaultInfo:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
@@ -42,7 +46,7 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
-                    make -C build/ci ci-e2e
+                    make -C build/ci COMMAND=ci-e2e ci
                 """
             }
         }

--- a/build/ci/e2e/custom_operator_image.jenkinsfile
+++ b/build/ci/e2e/custom_operator_image.jenkinsfile
@@ -64,7 +64,7 @@ EOF
         }
         cleanup {
             build job: 'cloud-on-k8s-e2e-cleanup',
-                parameters: [string(name: 'GKE_CLUSTER', value: "${CLUSTER_NAME}")],
+                parameters: [string(name: 'GKE_CLUSTER', value: "${BUILD_TAG}")],
                 wait: false
             cleanWs()
         }

--- a/build/ci/e2e/custom_operator_image.jenkinsfile
+++ b/build/ci/e2e/custom_operator_image.jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
         stage("Run E2E tests") {
             steps {
                 sh """
-                    cat >environment <<EOF
+                    cat >.env <<EOF
 VAULT_ADDR = "$VAULT_ADDR"
 GCLOUD_PROJECT = "$GCLOUD_PROJECT"
 LATEST_RELEASED_IMG = "$IMAGE"

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -104,6 +104,6 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
-        make -C build/ci COMMAND=ci-e2e ci
+        make -C build/ci TARGET=ci-e2e ci
     """
 }

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -13,62 +13,42 @@ pipeline {
         VAULT_ROLE_ID = credentials('vault-role-id')
         VAULT_SECRET_ID = credentials('vault-secret-id')
         GCLOUD_PROJECT = credentials('k8s-operators-gcloud-project')
-        OPERATOR_IMAGE = "${IMAGE}"
-        LATEST_RELEASED_IMG = "${IMAGE}"
-        SKIP_DOCKER_COMMAND = 'true'
-        REGISTRY = "eu.gcr.io"
     }
 
     stages {
         stage('Run tests for different ELK stack versions in GKE') {
             parallel {
                 stage("6.8.2") {
-                    environment {
-                        STACK_VERSION = "6.8.2"
-                    }
                     steps {
                         checkout scm
-                        createRunConfig("${BUILD_TAG}-682")
-                        sh 'make -C build/ci ci-e2e'
+                        runWith("${BUILD_TAG}-682", "6.8.2")
                     }
                 }
                 stage("7.1.1") {
                     agent {
                         label 'linux'
                     }
-                    environment {
-                        STACK_VERSION = "7.1.1"
-                    }
                     steps {
                         checkout scm
-                        createRunConfig("${BUILD_TAG}-711")
-                        sh 'make -C build/ci ci-e2e'
+                        runWith("${BUILD_TAG}-711", "7.1.1")
                     }
                 }
                 stage("7.2.1") {
                     agent {
                         label 'linux'
                     }
-                    environment {
-                        STACK_VERSION = "7.2.1"
-                    }
                     steps {
                         checkout scm
-                        createRunConfig("${BUILD_TAG}-721")
-                        sh 'make -C build/ci ci-e2e'
+                        runWith("${BUILD_TAG}-721", "7.2.1")
                     }
                 }
                 stage("7.3.0") {
                     agent {
                         label 'linux'
                     }
-                    environment {
-                        STACK_VERSION = "7.3.0"
-                    }
                     steps {
                         checkout scm
-                        createRunConfig("${BUILD_TAG}-730")
-                        sh 'make -C build/ci ci-e2e'
+                        runWith("${BUILD_TAG}-730", "7.3.0")
                     }
                 }
             }
@@ -101,8 +81,17 @@ pipeline {
 
 }
 
-def createRunConfig(clusterName) {
+def runWith(clusterName, stackVersion) {
     sh """
+        cat >environment <<EOF
+OPERATOR_IMAGE = "${IMAGE}"
+LATEST_RELEASED_IMG = "${IMAGE}"
+GCLOUD_PROJECT = "$GCLOUD_PROJECT"
+STACK_VERSION = "${stackVersion}"
+SKIP_DOCKER_COMMAND = true
+REGISTRY = eu.gcr.io
+REPOSITORY = "$GCLOUD_PROJECT"
+EOF
         cat >run-config.yml <<EOF
 id: gke-ci
 overrides:
@@ -115,5 +104,6 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
+        make -C build/ci COMMAND=ci-e2e ci
     """
 }

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -83,7 +83,7 @@ pipeline {
 
 def runWith(clusterName, stackVersion) {
     sh """
-        cat >environment <<EOF
+        cat >.env <<EOF
 OPERATOR_IMAGE = "${IMAGE}"
 LATEST_RELEASED_IMG = "${IMAGE}"
 GCLOUD_PROJECT = "$GCLOUD_PROJECT"

--- a/build/ci/nightly/Jenkinsfile
+++ b/build/ci/nightly/Jenkinsfile
@@ -16,14 +16,21 @@ pipeline {
         REGISTRY = "push.docker.elastic.co"
         REPOSITORY = "eck-snapshots"
         IMG_NAME = "eck-operator"
-        SNAPSHOT = "true"
-        DOCKER_IMAGE_NO_TAG = "docker.elastic.co/${REPOSITORY}/${IMG_NAME}"
     }
 
     stages {
         stage('Run unit and integration tests') {
             steps {
-                sh 'make -C build/ci ci-pr'
+                sh """
+                    cat > operators/environment <<EOF
+GCLOUD_PROJECT = $GCLOUD_PROJECT
+REGISTRY = "push.docker.elastic.co"
+REPOSITORY = "eck-snapshots"
+IMG_NAME = "eck-operator"
+SNAPSHOT = "true"
+EOF
+                    make -C build/ci COMMAND=ci ci
+                """
             }
         }
         stage('Build and push Docker image') {
@@ -33,7 +40,11 @@ pipeline {
                     export OPERATOR_IMAGE=${REGISTRY}/${REPOSITORY}/${IMG_NAME}:\$VERSION
                     export LATEST_RELEASED_IMG=docker.elastic.co/${REPOSITORY}/${IMG_NAME}:\$VERSION
                     echo \$LATEST_RELEASED_IMG > eck_image.txt
-                    make -C build/ci ci-release
+                    cat >> operators/environment <<EOF
+OPERATOR_IMAGE = "$OPERATOR_IMAGE"
+LATEST_RELEASED_IMG = "$LATEST_RELEASED_IMG"
+EOF
+                    make -C build/ci COMMAND=ci-release ci
                 """
             }
         }
@@ -58,5 +69,4 @@ pipeline {
             cleanWs()
         }
     }
-
 }

--- a/build/ci/nightly/Jenkinsfile
+++ b/build/ci/nightly/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
         stage('Run unit and integration tests') {
             steps {
                 sh """
-                    cat > operators/.env <<EOF
+                    cat > .env <<EOF
 GCLOUD_PROJECT = $GCLOUD_PROJECT
 REGISTRY = "push.docker.elastic.co"
 REPOSITORY = "eck-snapshots"
@@ -40,7 +40,7 @@ EOF
                     export OPERATOR_IMAGE=${REGISTRY}/${REPOSITORY}/${IMG_NAME}:\$VERSION
                     export LATEST_RELEASED_IMG=docker.elastic.co/${REPOSITORY}/${IMG_NAME}:\$VERSION
                     echo \$LATEST_RELEASED_IMG > eck_image.txt
-                    cat >> operators/environment <<EOF
+                    cat >> .env <<EOF
 OPERATOR_IMAGE = "$OPERATOR_IMAGE"
 LATEST_RELEASED_IMG = "$LATEST_RELEASED_IMG"
 EOF

--- a/build/ci/nightly/Jenkinsfile
+++ b/build/ci/nightly/Jenkinsfile
@@ -28,6 +28,7 @@ REGISTRY = "push.docker.elastic.co"
 REPOSITORY = "eck-snapshots"
 IMG_NAME = "eck-operator"
 SNAPSHOT = "true"
+LICENSE_PUBKEY = "/go/src/github.com/elastic/cloud-on-k8s/build/ci/license.key"
 EOF
                     make -C build/ci TARGET=ci ci
                 """
@@ -44,7 +45,7 @@ EOF
 OPERATOR_IMAGE = "$OPERATOR_IMAGE"
 LATEST_RELEASED_IMG = "$LATEST_RELEASED_IMG"
 EOF
-                    make -C build/ci TARGET=ci-release ci
+                    make -C build/ci get-elastic-public-key TARGET=ci-release ci
                 """
             }
         }

--- a/build/ci/nightly/Jenkinsfile
+++ b/build/ci/nightly/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
         stage('Run unit and integration tests') {
             steps {
                 sh """
-                    cat > operators/environment <<EOF
+                    cat > operators/.env <<EOF
 GCLOUD_PROJECT = $GCLOUD_PROJECT
 REGISTRY = "push.docker.elastic.co"
 REPOSITORY = "eck-snapshots"

--- a/build/ci/nightly/Jenkinsfile
+++ b/build/ci/nightly/Jenkinsfile
@@ -29,7 +29,7 @@ REPOSITORY = "eck-snapshots"
 IMG_NAME = "eck-operator"
 SNAPSHOT = "true"
 EOF
-                    make -C build/ci COMMAND=ci ci
+                    make -C build/ci TARGET=ci ci
                 """
             }
         }
@@ -44,7 +44,7 @@ EOF
 OPERATOR_IMAGE = "$OPERATOR_IMAGE"
 LATEST_RELEASED_IMG = "$LATEST_RELEASED_IMG"
 EOF
-                    make -C build/ci COMMAND=ci-release ci
+                    make -C build/ci TARGET=ci-release ci
                 """
             }
         }

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
 id: gke-ci
 overrides:
   kubernetesVersion: "1.12"
-  clusterName: $CLUSTER_NAME
+  clusterName: $BUILD_TAG
   vaultInfo:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
@@ -81,7 +81,7 @@ EOF
             script {
                 if (notOnlyDocs()) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
-                        parameters: [string(name: 'GKE_CLUSTER', value: "${CLUSTER_NAME}")],
+                        parameters: [string(name: 'GKE_CLUSTER', value: "${BUILD_TAG}")],
                         wait: false
                 }
             }
@@ -101,7 +101,6 @@ def notOnlyDocs() {
 void createConfig() {
     sh """
         cat >.env <<EOF
-CLUSTER_NAME = "$BUILD_TAG"
 REGISTRY = eu.gcr.io
 REPOSITORY = "$GCLOUD_PROJECT"
 TESTS_MATCH = TestSmoke

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -12,12 +12,7 @@ pipeline {
         VAULT_ADDR = credentials('vault-addr')
         VAULT_ROLE_ID = credentials('vault-role-id')
         VAULT_SECRET_ID = credentials('vault-secret-id')
-        REGISTRY = "eu.gcr.io"
         GCLOUD_PROJECT = credentials('k8s-operators-gcloud-project')
-        TESTS_MATCH = 'TestSmoke'
-        CLUSTER_VERSION = '1.12'
-        CLUSTER_NAME = "${BUILD_TAG}"
-        SKIP_DOCKER_COMMAND = "false"
     }
 
     stages {
@@ -44,7 +39,8 @@ pipeline {
                         label 'linux'
                     }
                     steps {
-                        sh 'make -C build/ci ci-pr'
+                        createConfig()
+                        sh 'make -C build/ci COMMAND=ci ci'
                     }
                 }
                 stage("Run smoke E2E tests") {
@@ -58,11 +54,12 @@ pipeline {
                         label 'linux'
                     }
                     steps {
+                        createConfig()
                         sh """
                             cat >run-config.yml <<EOF
 id: gke-ci
 overrides:
-  kubernetesVersion: "$CLUSTER_VERSION"
+  kubernetesVersion: "1.12"
   clusterName: $CLUSTER_NAME
   vaultInfo:
     address: $VAULT_ADDR
@@ -71,7 +68,7 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
-                            make -C build/ci ci-e2e
+                            make -C build/ci COMMAND=ci-e2e ci
                         """
                     }
                 }
@@ -99,4 +96,17 @@ def notOnlyDocs() {
         script: "git diff --name-status HEAD~1 HEAD | grep -v docs/",
     	returnStatus: true
     ) == 0
+}
+
+void createConfig() {
+    sh """
+        cat >operators/environment <<EOF
+CLUSTER_NAME = "$BUILD_TAG"
+REGISTRY = eu.gcr.io
+REPOSITORY = "$GCLOUD_PROJECT"
+TESTS_MATCH = TestSmoke
+SKIP_DOCKER_COMMAND = false
+IMG_SUFFIX = -ci
+EOF
+    """
 }

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
                     }
                     steps {
                         createConfig()
-                        sh 'make -C build/ci COMMAND=ci ci'
+                        sh 'make -C build/ci TARGET=ci ci'
                     }
                 }
                 stage("Run smoke E2E tests") {
@@ -68,7 +68,7 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
-                            make -C build/ci COMMAND=ci-e2e ci
+                            make -C build/ci TARGET=ci-e2e ci
                         """
                     }
                 }

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -100,7 +100,7 @@ def notOnlyDocs() {
 
 void createConfig() {
     sh """
-        cat >operators/.env <<EOF
+        cat >.env <<EOF
 CLUSTER_NAME = "$BUILD_TAG"
 REGISTRY = eu.gcr.io
 REPOSITORY = "$GCLOUD_PROJECT"

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -100,7 +100,7 @@ def notOnlyDocs() {
 
 void createConfig() {
     sh """
-        cat >operators/environment <<EOF
+        cat >operators/.env <<EOF
 CLUSTER_NAME = "$BUILD_TAG"
 REGISTRY = eu.gcr.io
 REPOSITORY = "$GCLOUD_PROJECT"

--- a/build/ci/release/Jenkinsfile
+++ b/build/ci/release/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
                 stage('Build and push release image') {
                     steps {
                         sh """
-                            cat >operators/environment <<EOF
+                            cat >operators/.env <<EOF
 OPERATOR_IMAGE = "${REGISTRY}/${REPOSITORY}/${IMG_NAME}:${TAG_NAME}"
 LATEST_RELEASED_IMG = "docker.elastic.co/${REPOSITORY}/${IMG_NAME}:${TAG_NAME}"
 VERSION = "${TAG_NAME}"

--- a/build/ci/release/Jenkinsfile
+++ b/build/ci/release/Jenkinsfile
@@ -12,13 +12,6 @@ pipeline {
         VAULT_ADDR = credentials('vault-addr')
         VAULT_ROLE_ID = credentials('vault-role-id')
         VAULT_SECRET_ID = credentials('vault-secret-id')
-        REGISTRY = "push.docker.elastic.co"
-        REPOSITORY = "eck"
-        IMG_NAME = "eck-operator"
-        OPERATOR_IMAGE = "${REGISTRY}/${REPOSITORY}/${IMG_NAME}:${TAG_NAME}"
-        LATEST_RELEASED_IMG = "docker.elastic.co/${REPOSITORY}/${IMG_NAME}:${TAG_NAME}"
-        VERSION = "${TAG_NAME}"
-        SNAPSHOT = "false"
     }
 
     stages {
@@ -31,12 +24,25 @@ pipeline {
             stages {
                 stage('Build and push release image') {
                     steps {
-                        sh 'make -C build/ci ci-release'
+                        sh """
+                            cat >operators/environment <<EOF
+OPERATOR_IMAGE = "${REGISTRY}/${REPOSITORY}/${IMG_NAME}:${TAG_NAME}"
+LATEST_RELEASED_IMG = "docker.elastic.co/${REPOSITORY}/${IMG_NAME}:${TAG_NAME}"
+VERSION = "${TAG_NAME}"
+VAULT_ADDR = "$VAULT_ADDR"
+REGISTRY = push.docker.elastic.co
+REPOSITORY = eck
+IMG_NAME = eck-operator
+SNAPSHOT = false
+GO_TAGS = release
+EOF
+                            make -C build/ci COMMAND=ci-release ci
+                        """
                     }
                 }
                 stage('Upload yaml to S3') {
                     steps {
-                        sh 'make -C build/ci yaml-upload'
+                        sh 'make -C build/ci COMMAND=yaml-upload ci'
                     }
                 }
                 stage('Send message to Slack') {

--- a/build/ci/release/Jenkinsfile
+++ b/build/ci/release/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
                 stage('Build and push release image') {
                     steps {
                         sh """
-                            cat >operators/.env <<EOF
+                            cat >.env <<EOF
 OPERATOR_IMAGE = "${REGISTRY}/${REPOSITORY}/${IMG_NAME}:${TAG_NAME}"
 LATEST_RELEASED_IMG = "docker.elastic.co/${REPOSITORY}/${IMG_NAME}:${TAG_NAME}"
 VERSION = "${TAG_NAME}"

--- a/build/ci/release/Jenkinsfile
+++ b/build/ci/release/Jenkinsfile
@@ -29,7 +29,6 @@ pipeline {
 OPERATOR_IMAGE = "${REGISTRY}/${REPOSITORY}/${IMG_NAME}:${TAG_NAME}"
 LATEST_RELEASED_IMG = "docker.elastic.co/${REPOSITORY}/${IMG_NAME}:${TAG_NAME}"
 VERSION = "${TAG_NAME}"
-VAULT_ADDR = "$VAULT_ADDR"
 REGISTRY = push.docker.elastic.co
 REPOSITORY = eck
 IMG_NAME = eck-operator

--- a/build/ci/release/Jenkinsfile
+++ b/build/ci/release/Jenkinsfile
@@ -36,13 +36,13 @@ IMG_NAME = eck-operator
 SNAPSHOT = false
 GO_TAGS = release
 EOF
-                            make -C build/ci COMMAND=ci-release ci
+                            make -C build/ci TARGET=ci-release ci
                         """
                     }
                 }
                 stage('Upload yaml to S3') {
                     steps {
-                        sh 'make -C build/ci COMMAND=yaml-upload ci'
+                        sh 'make -C build/ci TARGET=yaml-upload ci'
                     }
                 }
                 stage('Send message to Slack') {

--- a/build/ci/release/Jenkinsfile
+++ b/build/ci/release/Jenkinsfile
@@ -34,8 +34,9 @@ REPOSITORY = eck
 IMG_NAME = eck-operator
 SNAPSHOT = false
 GO_TAGS = release
+LICENSE_PUBKEY = "/go/src/github.com/elastic/cloud-on-k8s/build/ci/license.key"
 EOF
-                            make -C build/ci TARGET=ci-release ci
+                            make -C build/ci get-elastic-public-key TARGET=ci-release ci
                         """
                     }
                 }

--- a/build/ci/support/cleanup.jenkinsfile
+++ b/build/ci/support/cleanup.jenkinsfile
@@ -34,8 +34,8 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
+                    make -C build/ci COMMAND=run-deployer ci
                 """
-                sh 'make -C build/ci ci-run-deployer'
             }
         }
     }

--- a/build/ci/support/cleanup.jenkinsfile
+++ b/build/ci/support/cleanup.jenkinsfile
@@ -34,7 +34,7 @@ overrides:
   gke:
     gCloudProject: $GCLOUD_PROJECT
 EOF
-                    make -C build/ci COMMAND=run-deployer ci
+                    make -C build/ci TARGET=run-deployer ci
                 """
             }
         }


### PR DESCRIPTION
This implements the [proposal](https://github.com/elastic/cloud-on-k8s/issues/1528#issuecomment-521146164) from #1528 I've written up last week. In short, this PR:
- moves config passing from being env var based to file based,
- moves logic away from ci makefile,
- makes ci makefile to be runnable from dev box.

Description of the CI setup is documented in README.md in this PR.