### PR TITLE
Create new pods with latest revision

### DIFF
--- a/pkg/controller/elasticsearch/driver/upscale.go
+++ b/pkg/controller/elasticsearch/driver/upscale.go
@@ -65,7 +65,7 @@ func adaptForExistingStatefulSet(actualSset appsv1.StatefulSet, ssetToApply apps
 	}
 	// Make sure new pods (with ordinal>partition) get created with the newest revision,
 	// by setting the rollingUpdate partition to the actual StatefulSet replicas count.
-	// Any ongoing rolling upgraded may temporarily pause here, but will go through again.
+	// Any ongoing rolling upgrade may temporarily pause here, but will go through again.
 	ssetToApply.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateStatefulSetStrategy{
 		Partition: actualSset.Spec.Replicas,
 	}

--- a/pkg/controller/elasticsearch/driver/upscale.go
+++ b/pkg/controller/elasticsearch/driver/upscale.go
@@ -5,6 +5,7 @@
 package driver
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
@@ -43,15 +44,30 @@ func HandleUpscaleAndSpecChanges(
 			return err
 		}
 		ssetToApply := *nodeSpecRes.StatefulSet.DeepCopy()
-		actual, exists := actualStatefulSets.GetByName(ssetToApply.Name)
-		if exists && sset.GetReplicas(ssetToApply) < sset.GetReplicas(actual) {
-			// sset needs to be scaled down
-			// update the sset to use the new spec but don't scale replicas down for now
-			ssetToApply.Spec.Replicas = actual.Spec.Replicas
+		actual, alreadyExists := actualStatefulSets.GetByName(ssetToApply.Name)
+		if alreadyExists {
+			ssetToApply = adaptForExistingStatefulSet(actual, ssetToApply)
 		}
 		if err := sset.ReconcileStatefulSet(k8sClient, scheme, es, ssetToApply); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// adaptForExistingStatefulSet modifies ssetToApply to account for the existing StatefulSet.
+// It avoids triggering downscales (done later), and makes sure new pods are created with the newest revision.
+func adaptForExistingStatefulSet(actualSset appsv1.StatefulSet, ssetToApply appsv1.StatefulSet) appsv1.StatefulSet {
+	if sset.GetReplicas(ssetToApply) < sset.GetReplicas(actualSset) {
+		// This is a downscale.
+		// We still want to update the sset spec to the newest one, but don't scale replicas down for now.
+		ssetToApply.Spec.Replicas = actualSset.Spec.Replicas
+	}
+	// Make sure new pods (with ordinal>partition) get created with the newest revision,
+	// by setting the rollingUpdate partition to the actual StatefulSet replicas count.
+	// Any ongoing rolling upgraded may temporarily pause here, but will go through again.
+	ssetToApply.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateStatefulSetStrategy{
+		Partition: actualSset.Spec.Replicas,
+	}
+	return ssetToApply
 }


### PR DESCRIPTION
When we upscale a cluster from eg. 3 to 5 nodes, and change the spec at
the same time, the 2 new nodes were created with the old spec.
It makes sense to create new nodes with the new spec directly.

In order to do so, we also update the rolling update partition to the
value of the StatefulSet replicas (before the upscale).
In the above example, the partition will be updated to 3: the 2 new
nodes will be created with the newest revision, while the previous 3
nodes will stay at their current revision, until handled with the
rolling upgrade.

In case a rolling upgrade was already in progress (ie. partition equals
1), we still update it to 3. The rolling upgrade is temporarily "paused"
but will go through again.

If we were to use `OnDelete` (https://github.com/elastic/cloud-on-k8s/issues/1442), we would get the expected behaviour directly.

Fixes https://github.com/elastic/cloud-on-k8s/issues/1619.