### PR TITLE
Fix Packer cache

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -8,7 +8,7 @@
 
 set -eou pipefail
 
-DOCKER_CI_IMAGE=$(cd ../build/ci/ && make show-image)
+DOCKER_CI_IMAGE=$(cd build/ci/ && make show-image)
 
 declare -a docker_images=("$DOCKER_CI_IMAGE")
 


### PR DESCRIPTION
Fix for caching Docker images with Packer. Related to https://github.com/elastic/infra/pull/14024