### PR TITLE
Add an E2E test for ES v6 to v7 rolling upgrade

### DIFF
--- a/test/e2e/es/license_test.go
+++ b/test/e2e/es/license_test.go
@@ -46,7 +46,7 @@ func TestEnterpriseLicenseSingle(t *testing.T) {
 			licenseTestContext.CreateEnterpriseLicenseSecret(licenseBytes),
 		}).
 		// Mutation shortcuts the license provisioning check...
-		WithSteps(mutatedEsBuilder.MutationTestSteps(k)).
+		WithSteps(mutatedEsBuilder.MutationTestSteps(k, test.MutationOptions{})).
 		// enterprise license can contain all kinds of cluster licenses so we are a bit lenient here and expect either gold or platinum
 		WithStep(licenseTestContext.CheckElasticsearchLicense(
 			license.ElasticsearchLicenseTypeGold,

--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -26,7 +26,7 @@ func TestMutationMdiToDedicated(t *testing.T) {
 		WithESDataNodes(1, elasticsearch.DefaultResources).
 		WithESMasterNodes(1, elasticsearch.DefaultResources)
 
-	test.RunMutation(t, b, mutated)
+	test.RunMutation(t, b, mutated, test.MutationOptions{IncludesRollingUpgrade: false})
 }
 
 // TestMutationMoreNodes creates a 1 node cluster,
@@ -40,7 +40,7 @@ func TestMutationMoreNodes(t *testing.T) {
 		WithNoESTopology().
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
-	test.RunMutation(t, b, mutated)
+	test.RunMutation(t, b, mutated, test.MutationOptions{IncludesRollingUpgrade: false})
 }
 
 // TestMutationLessNodes creates a 3 node cluster,
@@ -55,7 +55,7 @@ func TestMutationLessNodes(t *testing.T) {
 		WithNoESTopology().
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
-	test.RunMutation(t, b, mutated)
+	test.RunMutation(t, b, mutated, test.MutationOptions{IncludesRollingUpgrade: false})
 }
 
 // TestMutationResizeMemoryUp creates a 1 node cluster,
@@ -79,7 +79,7 @@ func TestMutationResizeMemoryUp(t *testing.T) {
 			},
 		})
 
-	test.RunMutation(t, b, mutated)
+	test.RunMutation(t, b, mutated, test.MutationOptions{IncludesRollingUpgrade: true})
 }
 
 // TestMutationResizeMemoryDown creates a 1 node cluster,

--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -103,5 +103,20 @@ func TestMutationResizeMemoryDown(t *testing.T) {
 			},
 		})
 
-	test.RunMutation(t, b, mutated)
+	test.RunMutation(t, b, mutated, test.MutationOptions{IncludesRollingUpgrade: true})
+}
+
+// TestVersionUpgrade680To720 creates a cluster in version 6.8.0,
+// and upgrades it to 7.2.0.
+func TestVersionUpgrade680To720(t *testing.T) {
+	// create an ES cluster with 3 x 6.8.0 nodes
+	initial := elasticsearch.NewBuilder("test-version-up-680-to-720").
+		WithVersion("6.8.0").
+		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
+	// mutate it to 3 x 7.2.0 nodes
+	mutated := initial.WithNoESTopology().
+		WithVersion("7.2.0").
+		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
+
+	test.RunMutation(t, initial, mutated, test.MutationOptions{IncludesRollingUpgrade: true})
 }

--- a/test/e2e/es/reversal_test.go
+++ b/test/e2e/es/reversal_test.go
@@ -27,7 +27,7 @@ func TestReversalIllegalConfig(t *testing.T) {
 		},
 	})
 
-	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{bogus})
+	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{bogus}, test.MutationOptions{IncludesRollingUpgrade: true})
 }
 
 func TestReversalRiskyMasterDownscale(t *testing.T) {
@@ -40,7 +40,7 @@ func TestReversalRiskyMasterDownscale(t *testing.T) {
 	// TODO it might be necessary to accept some data loss for 6.x here
 	down := b.WithNoESTopology().WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
-	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{down})
+	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{down}, test.MutationOptions{IncludesRollingUpgrade: false})
 }
 
 func TestReversalStatefulSetRename(t *testing.T) {
@@ -51,7 +51,7 @@ func TestReversalStatefulSetRename(t *testing.T) {
 	copy.Name = "other"
 	renamed := b.WithNoESTopology().WithNodeSpec(copy)
 
-	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{renamed})
+	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{renamed}, test.MutationOptions{IncludesRollingUpgrade: false})
 }
 
 func TestRiskyMasterReconfiguration(t *testing.T) {
@@ -83,5 +83,5 @@ func TestRiskyMasterReconfiguration(t *testing.T) {
 			PodTemplate: elasticsearch.ESPodTemplate(elasticsearch.DefaultResources),
 		})
 
-	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{noMasterMaster})
+	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{noMasterMaster}, test.MutationOptions{IncludesRollingUpgrade: true})
 }

--- a/test/e2e/kb/association_test.go
+++ b/test/e2e/kb/association_test.go
@@ -43,7 +43,7 @@ func TestCrossNSAssociation(t *testing.T) {
 		WithRestrictedSecurityContext()
 
 	builders := []test.Builder{esBuilder, kbBuilder}
-	test.RunMutations(t, builders, builders)
+	test.RunMutations(t, builders, builders, test.MutationOptions{IncludesRollingUpgrade: false})
 }
 
 func TestKibanaAssociationWithNonExistentES(t *testing.T) {

--- a/test/e2e/kb/sample_test.go
+++ b/test/e2e/kb/sample_test.go
@@ -49,5 +49,5 @@ func TestKibanaEsSample(t *testing.T) {
 
 	builders := []test.Builder{esBuilder, kbBuilder}
 	// run, with mutation to the same resource (should work and do nothing)
-	test.RunMutations(t, builders, builders)
+	test.RunMutations(t, builders, builders, test.MutationOptions{IncludesRollingUpgrade: false})
 }

--- a/test/e2e/test/apmserver/steps_mutation.go
+++ b/test/e2e/test/apmserver/steps_mutation.go
@@ -6,7 +6,7 @@ package apmserver
 
 import "github.com/elastic/cloud-on-k8s/test/e2e/test"
 
-func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
+func (b Builder) MutationTestSteps(k *test.K8sClient, options test.MutationOptions) test.StepList {
 	panic("not implemented")
 }
 
@@ -14,6 +14,6 @@ func (b Builder) UpgradeTestSteps(k *test.K8sClient) test.StepList {
 	panic("not implemented")
 }
 
-func (b Builder) MutationReversalTestContext() test.ReversalTestContext {
+func (b Builder) MutationReversalTestContext(options test.MutationOptions) test.ReversalTestContext {
 	panic("not implemented")
 }

--- a/test/e2e/test/builder.go
+++ b/test/e2e/test/builder.go
@@ -20,9 +20,9 @@ type Builder interface {
 	// MutationTestSteps returns all test steps to test changes on a resource.
 	// We expect the resource to be already created and running.
 	// If the resource to mutate to is the same as the original resource, then all tests should still pass.
-	MutationTestSteps(k *K8sClient) StepList
+	MutationTestSteps(k *K8sClient, options MutationOptions) StepList
 	// MutationReversalTestContext returns a context struct to test changes on a resource that are immediately reverted.
 	// We assume the resource to be ready and running.
 	// We assume the resource to be the same as the original resource after reversion.
-	MutationReversalTestContext() ReversalTestContext
+	MutationReversalTestContext(options MutationOptions) ReversalTestContext
 }

--- a/test/e2e/test/elasticsearch/checks_reversal.go
+++ b/test/e2e/test/elasticsearch/checks_reversal.go
@@ -15,11 +15,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func (b Builder) MutationReversalTestContext() test.ReversalTestContext {
+func (b Builder) MutationReversalTestContext(mutationOptions test.MutationOptions) test.ReversalTestContext {
 	return &mutationReversalTestContext{
 		es:                     b.Elasticsearch,
 		initialRevisions:       make(map[string]string),
 		initialCurrentReplicas: make(map[string]int32),
+		mutationOptions:        mutationOptions,
 	}
 }
 
@@ -28,6 +29,7 @@ type mutationReversalTestContext struct {
 	initialCurrentReplicas map[string]int32
 	initialRevisions       map[string]string
 	dataIntegrity          *DataIntegrityCheck
+	mutationOptions        test.MutationOptions
 }
 
 func (s *mutationReversalTestContext) PreMutationSteps(k *test.K8sClient) test.StepList {
@@ -47,7 +49,7 @@ func (s *mutationReversalTestContext) PreMutationSteps(k *test.K8sClient) test.S
 			Name: "Add some data to the cluster before any mutation",
 			Test: func(t *testing.T) {
 				var err error
-				s.dataIntegrity, err = NewDataIntegrityCheck(s.es, k)
+				s.dataIntegrity, err = NewDataIntegrityCheck(s.es, k, s.mutationOptions.IncludesRollingUpgrade)
 				require.NoError(t, err)
 				require.NoError(t, s.dataIntegrity.Init())
 			},

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -34,7 +34,7 @@ func (b Builder) UpgradeTestSteps(k *test.K8sClient) test.StepList {
 	}
 }
 
-func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
+func (b Builder) MutationTestSteps(k *test.K8sClient, options test.MutationOptions) test.StepList {
 	var clusterIDBeforeMutation string
 	var continuousHealthChecks *ContinuousHealthCheck
 	var dataIntegrityCheck *DataIntegrityCheck
@@ -44,7 +44,7 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 			Name: "Add some data to the cluster before starting the mutation",
 			Test: func(t *testing.T) {
 				var err error
-				dataIntegrityCheck, err = NewDataIntegrityCheck(b.Elasticsearch, k)
+				dataIntegrityCheck, err = NewDataIntegrityCheck(b.Elasticsearch, k, options.IncludesRollingUpgrade)
 				require.NoError(t, err)
 				require.NoError(t, dataIntegrityCheck.Init())
 			},

--- a/test/e2e/test/kibana/steps_mutation.go
+++ b/test/e2e/test/kibana/steps_mutation.go
@@ -13,13 +13,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
+func (b Builder) MutationTestSteps(k *test.K8sClient, options test.MutationOptions) test.StepList {
 	return b.UpgradeTestSteps(k).
 		WithSteps(b.CheckK8sTestSteps(k)).
 		WithSteps(b.CheckStackTestSteps(k))
 }
 
-func (b Builder) MutationReversalTestContext() test.ReversalTestContext {
+func (b Builder) MutationReversalTestContext(options test.MutationOptions) test.ReversalTestContext {
 	panic("not implemented")
 }
 

--- a/test/e2e/test/run_mutation.go
+++ b/test/e2e/test/run_mutation.go
@@ -8,9 +8,15 @@ import (
 	"testing"
 )
 
+type MutationOptions struct {
+	// IncludesRollingUpgrade specifies if the mutation to perform includes some rolling upgrade,
+	// for which shards with 0 replicas are expected to become unavailable.
+	IncludesRollingUpgrade bool
+}
+
 // RunMutations tests resources changes on given resources.
 // If the resource to mutate to is the same as the original resource, then all tests should still pass.
-func RunMutations(t *testing.T, creationBuilders []Builder, mutationBuilders []Builder) {
+func RunMutations(t *testing.T, creationBuilders []Builder, mutationBuilders []Builder, opts MutationOptions) {
 	k := NewK8sClientOrFatal()
 	steps := StepList{}
 
@@ -26,7 +32,7 @@ func RunMutations(t *testing.T, creationBuilders []Builder, mutationBuilders []B
 
 	// Trigger some mutations
 	for _, mutateTo := range mutationBuilders {
-		steps = steps.WithSteps(mutateTo.MutationTestSteps(k))
+		steps = steps.WithSteps(mutateTo.MutationTestSteps(k, opts))
 	}
 
 	for _, mutateTo := range mutationBuilders {
@@ -37,6 +43,6 @@ func RunMutations(t *testing.T, creationBuilders []Builder, mutationBuilders []B
 }
 
 // RunMutations tests one resource change on a given resource.
-func RunMutation(t *testing.T, toCreate Builder, mutateTo Builder) {
-	RunMutations(t, []Builder{toCreate}, []Builder{mutateTo})
+func RunMutation(t *testing.T, toCreate Builder, mutateTo Builder, options MutationOptions) {
+	RunMutations(t, []Builder{toCreate}, []Builder{mutateTo}, options)
 }

--- a/test/e2e/test/run_reversal.go
+++ b/test/e2e/test/run_reversal.go
@@ -16,7 +16,7 @@ type ReversalTestContext interface {
 
 // RunMutationReversal tests mutations that are either invalid or aborted mid way leading to a configuration reversal of
 // the original configuration.
-func RunMutationReversal(t *testing.T, creationBuilders []Builder, mutationBuilders []Builder) {
+func RunMutationReversal(t *testing.T, creationBuilders []Builder, mutationBuilders []Builder, options MutationOptions) {
 	k := NewK8sClientOrFatal()
 	steps := StepList{}
 
@@ -32,7 +32,7 @@ func RunMutationReversal(t *testing.T, creationBuilders []Builder, mutationBuild
 
 	ctxs := make([]ReversalTestContext, 0, len(mutationBuilders))
 	for _, mutateTo := range mutationBuilders {
-		ctxs = append(ctxs, mutateTo.MutationReversalTestContext())
+		ctxs = append(ctxs, mutateTo.MutationReversalTestContext(options))
 	}
 
 	for _, ctx := range ctxs {


### PR DESCRIPTION
Add an additional E2E test to upgrade a cluster in version 6 to a cluster in version 7.

Note it ignores the version currently set in the context (a context with version 7.3.0 with still run the 6.8.0 to 7.2.0 test). Not great but it seems hard to do better with the current framework?
Fixes https://github.com/elastic/cloud-on-k8s/issues/822.

The above test fails if we don't also tweak our data integrity checks to expect a rolling upgrade to happen.
When a rolling update happens, a node goes down without triggering data migration first. It is expected that the cluster will become red if some shards have 0 replicas.
Let's specify it when running the test. If we expect rolling upgrades to happen, we should create shards with 1 replica. Else, if we expect data migration to happen, we should create shards with 0 replicas.
Fixes https://github.com/elastic/cloud-on-k8s/issues/1621.
