### PR TITLE
Fix cleanup CI job after moving operators directory

### DIFF
--- a/build/ci/support/cleanup.jenkinsfile
+++ b/build/ci/support/cleanup.jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
             }
             steps {
                 sh """
-                    cat >operators/run-config.yml <<EOF
+                    cat >run-config.yml <<EOF
 id: gke-ci
 overrides:
   operation: delete


### PR DESCRIPTION
Cleanup job breaks after https://github.com/elastic/cloud-on-k8s/pull/1616. This PR fixes that.