### PR TITLE
Compute number of replicas in E2E tests based on mutation topology

### DIFF
--- a/test/e2e/es/license_test.go
+++ b/test/e2e/es/license_test.go
@@ -46,7 +46,7 @@ func TestEnterpriseLicenseSingle(t *testing.T) {
 			licenseTestContext.CreateEnterpriseLicenseSecret(licenseBytes),
 		}).
 		// Mutation shortcuts the license provisioning check...
-		WithSteps(mutatedEsBuilder.MutationTestSteps(k, test.MutationOptions{})).
+		WithSteps(mutatedEsBuilder.MutationTestSteps(k)).
 		// enterprise license can contain all kinds of cluster licenses so we are a bit lenient here and expect either gold or platinum
 		WithStep(licenseTestContext.CheckElasticsearchLicense(
 			license.ElasticsearchLicenseTypeGold,
@@ -54,5 +54,4 @@ func TestEnterpriseLicenseSingle(t *testing.T) {
 		)).
 		WithSteps(mutatedEsBuilder.DeletionTestSteps(k)).
 		RunSequential(t)
-
 }

--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -26,7 +26,7 @@ func TestMutationMdiToDedicated(t *testing.T) {
 		WithESDataNodes(1, elasticsearch.DefaultResources).
 		WithESMasterNodes(1, elasticsearch.DefaultResources)
 
-	test.RunMutation(t, b, mutated, test.MutationOptions{IncludesRollingUpgrade: false})
+	RunESMutation(t, b, mutated)
 }
 
 // TestMutationMoreNodes creates a 1 node cluster,
@@ -40,7 +40,7 @@ func TestMutationMoreNodes(t *testing.T) {
 		WithNoESTopology().
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
-	test.RunMutation(t, b, mutated, test.MutationOptions{IncludesRollingUpgrade: false})
+	RunESMutation(t, b, mutated)
 }
 
 // TestMutationLessNodes creates a 3 node cluster,
@@ -55,7 +55,7 @@ func TestMutationLessNodes(t *testing.T) {
 		WithNoESTopology().
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
-	test.RunMutation(t, b, mutated, test.MutationOptions{IncludesRollingUpgrade: false})
+	RunESMutation(t, b, mutated)
 }
 
 // TestMutationResizeMemoryUp creates a 1 node cluster,
@@ -79,7 +79,7 @@ func TestMutationResizeMemoryUp(t *testing.T) {
 			},
 		})
 
-	test.RunMutation(t, b, mutated, test.MutationOptions{IncludesRollingUpgrade: true})
+	RunESMutation(t, b, mutated)
 }
 
 // TestMutationResizeMemoryDown creates a 1 node cluster,
@@ -103,7 +103,7 @@ func TestMutationResizeMemoryDown(t *testing.T) {
 			},
 		})
 
-	test.RunMutation(t, b, mutated, test.MutationOptions{IncludesRollingUpgrade: true})
+	RunESMutation(t, b, mutated)
 }
 
 // TestVersionUpgrade680To720 creates a cluster in version 6.8.0,
@@ -118,5 +118,10 @@ func TestVersionUpgrade680To720(t *testing.T) {
 		WithVersion("7.2.0").
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
 
-	test.RunMutation(t, initial, mutated, test.MutationOptions{IncludesRollingUpgrade: true})
+	RunESMutation(t, initial, mutated)
+}
+
+func RunESMutation(t *testing.T, toCreate elasticsearch.Builder, mutateTo elasticsearch.Builder) {
+	mutateTo.MutatedFrom = &toCreate
+	test.RunMutation(t, toCreate, mutateTo)
 }

--- a/test/e2e/es/reversal_test.go
+++ b/test/e2e/es/reversal_test.go
@@ -27,7 +27,7 @@ func TestReversalIllegalConfig(t *testing.T) {
 		},
 	})
 
-	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{bogus}, test.MutationOptions{IncludesRollingUpgrade: true})
+	RunESMutationReversal(t, b, bogus)
 }
 
 func TestReversalRiskyMasterDownscale(t *testing.T) {
@@ -40,7 +40,7 @@ func TestReversalRiskyMasterDownscale(t *testing.T) {
 	// TODO it might be necessary to accept some data loss for 6.x here
 	down := b.WithNoESTopology().WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
-	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{down}, test.MutationOptions{IncludesRollingUpgrade: false})
+	RunESMutationReversal(t, b, down)
 }
 
 func TestReversalStatefulSetRename(t *testing.T) {
@@ -51,7 +51,7 @@ func TestReversalStatefulSetRename(t *testing.T) {
 	copy.Name = "other"
 	renamed := b.WithNoESTopology().WithNodeSpec(copy)
 
-	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{renamed}, test.MutationOptions{IncludesRollingUpgrade: false})
+	RunESMutationReversal(t, b, renamed)
 }
 
 func TestRiskyMasterReconfiguration(t *testing.T) {
@@ -83,5 +83,11 @@ func TestRiskyMasterReconfiguration(t *testing.T) {
 			PodTemplate: elasticsearch.ESPodTemplate(elasticsearch.DefaultResources),
 		})
 
-	test.RunMutationReversal(t, []test.Builder{b}, []test.Builder{noMasterMaster}, test.MutationOptions{IncludesRollingUpgrade: true})
+	RunESMutationReversal(t, b, noMasterMaster)
+}
+
+func RunESMutationReversal(t *testing.T, toCreate elasticsearch.Builder, mutateTo elasticsearch.Builder) {
+	mutateTo.MutatedFrom = &toCreate
+	test.RunMutationReversal(t, []test.Builder{toCreate}, []test.Builder{mutateTo})
+
 }

--- a/test/e2e/kb/association_test.go
+++ b/test/e2e/kb/association_test.go
@@ -43,7 +43,7 @@ func TestCrossNSAssociation(t *testing.T) {
 		WithRestrictedSecurityContext()
 
 	builders := []test.Builder{esBuilder, kbBuilder}
-	test.RunMutations(t, builders, builders, test.MutationOptions{IncludesRollingUpgrade: false})
+	test.RunMutations(t, builders, builders)
 }
 
 func TestKibanaAssociationWithNonExistentES(t *testing.T) {

--- a/test/e2e/kb/sample_test.go
+++ b/test/e2e/kb/sample_test.go
@@ -49,5 +49,5 @@ func TestKibanaEsSample(t *testing.T) {
 
 	builders := []test.Builder{esBuilder, kbBuilder}
 	// run, with mutation to the same resource (should work and do nothing)
-	test.RunMutations(t, builders, builders, test.MutationOptions{IncludesRollingUpgrade: false})
+	test.RunMutations(t, builders, builders)
 }

--- a/test/e2e/test/apmserver/steps_mutation.go
+++ b/test/e2e/test/apmserver/steps_mutation.go
@@ -6,7 +6,7 @@ package apmserver
 
 import "github.com/elastic/cloud-on-k8s/test/e2e/test"
 
-func (b Builder) MutationTestSteps(k *test.K8sClient, options test.MutationOptions) test.StepList {
+func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 	panic("not implemented")
 }
 
@@ -14,6 +14,6 @@ func (b Builder) UpgradeTestSteps(k *test.K8sClient) test.StepList {
 	panic("not implemented")
 }
 
-func (b Builder) MutationReversalTestContext(options test.MutationOptions) test.ReversalTestContext {
+func (b Builder) MutationReversalTestContext() test.ReversalTestContext {
 	panic("not implemented")
 }

--- a/test/e2e/test/builder.go
+++ b/test/e2e/test/builder.go
@@ -20,9 +20,9 @@ type Builder interface {
 	// MutationTestSteps returns all test steps to test changes on a resource.
 	// We expect the resource to be already created and running.
 	// If the resource to mutate to is the same as the original resource, then all tests should still pass.
-	MutationTestSteps(k *K8sClient, options MutationOptions) StepList
+	MutationTestSteps(k *K8sClient) StepList
 	// MutationReversalTestContext returns a context struct to test changes on a resource that are immediately reverted.
 	// We assume the resource to be ready and running.
 	// We assume the resource to be the same as the original resource after reversion.
-	MutationReversalTestContext(options MutationOptions) ReversalTestContext
+	MutationReversalTestContext() ReversalTestContext
 }

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -34,6 +34,7 @@ func ESPodTemplate(resources corev1.ResourceRequirements) corev1.PodTemplateSpec
 // Builder to create Elasticsearch clusters
 type Builder struct {
 	Elasticsearch estype.Elasticsearch
+	MutatedFrom   *Builder
 }
 
 var _ test.Builder = Builder{}

--- a/test/e2e/test/elasticsearch/checks_data.go
+++ b/test/e2e/test/elasticsearch/checks_data.go
@@ -138,8 +138,10 @@ func dataIntegrityReplicas(b Builder) int {
 		return 0
 	}
 
+	// attempt do detect a rolling upgrade scenario
+	// Important: this only checks ES version and spec, other changes such as secure settings update
+	// are tricky to capture and ignored here.
 	isVersionUpgrade := initial.Elasticsearch.Spec.Version != b.Elasticsearch.Spec.Version
-
 	for _, initialNs := range initial.Elasticsearch.Spec.Nodes {
 		for _, mutatedNs := range b.Elasticsearch.Spec.Nodes {
 			if initialNs.Name == mutatedNs.Name &&

--- a/test/e2e/test/elasticsearch/checks_data.go
+++ b/test/e2e/test/elasticsearch/checks_data.go
@@ -12,35 +12,27 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"strings"
 
-	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/go-test/deep"
 )
 
 type DataIntegrityCheck struct {
-	client     client.Client
-	indexName  string
-	numShards  int
-	replicas   int
-	sampleData map[string]interface{}
-	docCount   int
+	client      client.Client
+	indexName   string
+	numShards   int
+	numReplicas int
+	sampleData  map[string]interface{}
+	docCount    int
 }
 
-func NewDataIntegrityCheck(es v1alpha1.Elasticsearch, k *test.K8sClient, rollingUpgradeExpected bool) (*DataIntegrityCheck, error) {
-	elasticsearchClient, err := NewElasticsearchClient(es, k)
+func NewDataIntegrityCheck(k *test.K8sClient, b Builder) (*DataIntegrityCheck, error) {
+	elasticsearchClient, err := NewElasticsearchClient(b.Elasticsearch, k)
 	if err != nil {
 		return nil, err
-	}
-
-	// default to 0 replicas to ensure we test data migration works: shards should always be available
-	replicas := 0
-	if rollingUpgradeExpected {
-		// we expect a rolling upgrade to happen: the cluster health will become red
-		// if we don't have at least one replica
-		replicas = 1
 	}
 
 	return &DataIntegrityCheck{
@@ -49,9 +41,9 @@ func NewDataIntegrityCheck(es v1alpha1.Elasticsearch, k *test.K8sClient, rolling
 		sampleData: map[string]interface{}{
 			"foo": "bar",
 		},
-		docCount:  5,
-		numShards: 3,
-		replicas:  replicas,
+		docCount:    5,
+		numShards:   3,
+		numReplicas: dataIntegrityReplicas(b),
 	}, nil
 }
 
@@ -70,7 +62,7 @@ func (dc *DataIntegrityCheck) Init() error {
 	indexCreation, err := http.NewRequest(
 		http.MethodPut,
 		fmt.Sprintf("/%s", dc.indexName),
-		bytes.NewBufferString(fmt.Sprintf(indexSettings, dc.numShards, dc.replicas)),
+		bytes.NewBufferString(fmt.Sprintf(indexSettings, dc.numShards, dc.numReplicas)),
 	)
 	if err != nil {
 		return err
@@ -131,4 +123,34 @@ func (dc *DataIntegrityCheck) Verify() error {
 		}
 	}
 	return nil
+}
+
+// dataIntegrityReplicas returns the number of replicas to use for the data integrity check,
+// according to the cluster topology, since it affects the cluster health during the mutation.
+func dataIntegrityReplicas(b Builder) int {
+	initial := b.MutatedFrom
+	if initial == nil {
+		initial = &b // consider mutated == initial
+	}
+
+	if initial.Elasticsearch.Spec.NodeCount() == 1 || b.Elasticsearch.Spec.NodeCount() == 1 {
+		// a 1 node cluster can only be green if shards have no replicas
+		return 0
+	}
+
+	isVersionUpgrade := initial.Elasticsearch.Spec.Version != b.Elasticsearch.Spec.Version
+
+	for _, initialNs := range initial.Elasticsearch.Spec.Nodes {
+		for _, mutatedNs := range b.Elasticsearch.Spec.Nodes {
+			if initialNs.Name == mutatedNs.Name &&
+				(isVersionUpgrade || !reflect.DeepEqual(initialNs, mutatedNs)) {
+				// a rolling upgrade is scheduled for that NodeSpec
+				// we need at least 1 replica per shard for the cluster to remain green during the operation
+				return 1
+			}
+		}
+	}
+
+	// default to 0 replicas, to ensure proper data migration happens during the mutation
+	return 0
 }

--- a/test/e2e/test/elasticsearch/checks_reversal.go
+++ b/test/e2e/test/elasticsearch/checks_reversal.go
@@ -8,28 +8,25 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/stretchr/testify/require"
 )
 
-func (b Builder) MutationReversalTestContext(mutationOptions test.MutationOptions) test.ReversalTestContext {
+func (b Builder) MutationReversalTestContext() test.ReversalTestContext {
 	return &mutationReversalTestContext{
-		es:                     b.Elasticsearch,
+		esBuilder:              b,
 		initialRevisions:       make(map[string]string),
 		initialCurrentReplicas: make(map[string]int32),
-		mutationOptions:        mutationOptions,
 	}
 }
 
 type mutationReversalTestContext struct {
-	es                     v1alpha1.Elasticsearch
+	esBuilder              Builder
 	initialCurrentReplicas map[string]int32
 	initialRevisions       map[string]string
 	dataIntegrity          *DataIntegrityCheck
-	mutationOptions        test.MutationOptions
 }
 
 func (s *mutationReversalTestContext) PreMutationSteps(k *test.K8sClient) test.StepList {
@@ -37,7 +34,7 @@ func (s *mutationReversalTestContext) PreMutationSteps(k *test.K8sClient) test.S
 		{
 			Name: "Remember the current config revisions",
 			Test: func(t *testing.T) {
-				statefulSets, err := sset.RetrieveActualStatefulSets(k.Client, k8s.ExtractNamespacedName(&s.es))
+				statefulSets, err := sset.RetrieveActualStatefulSets(k.Client, k8s.ExtractNamespacedName(&s.esBuilder.Elasticsearch))
 				require.NoError(t, err)
 				for _, set := range statefulSets {
 					s.initialRevisions[set.Name] = set.Status.CurrentRevision
@@ -49,7 +46,7 @@ func (s *mutationReversalTestContext) PreMutationSteps(k *test.K8sClient) test.S
 			Name: "Add some data to the cluster before any mutation",
 			Test: func(t *testing.T) {
 				var err error
-				s.dataIntegrity, err = NewDataIntegrityCheck(s.es, k, s.mutationOptions.IncludesRollingUpgrade)
+				s.dataIntegrity, err = NewDataIntegrityCheck(k, s.esBuilder)
 				require.NoError(t, err)
 				require.NoError(t, s.dataIntegrity.Init())
 			},
@@ -62,7 +59,7 @@ func (s *mutationReversalTestContext) PostMutationSteps(k *test.K8sClient) test.
 		{
 			Name: "Verify that a config change is being applied",
 			Test: test.Eventually(func() error {
-				statefulSets, err := sset.RetrieveActualStatefulSets(k.Client, k8s.ExtractNamespacedName(&s.es))
+				statefulSets, err := sset.RetrieveActualStatefulSets(k.Client, k8s.ExtractNamespacedName(&s.esBuilder.Elasticsearch))
 				if err != nil {
 					return err
 				}

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -34,7 +34,7 @@ func (b Builder) UpgradeTestSteps(k *test.K8sClient) test.StepList {
 	}
 }
 
-func (b Builder) MutationTestSteps(k *test.K8sClient, options test.MutationOptions) test.StepList {
+func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 	var clusterIDBeforeMutation string
 	var continuousHealthChecks *ContinuousHealthCheck
 	var dataIntegrityCheck *DataIntegrityCheck
@@ -44,7 +44,7 @@ func (b Builder) MutationTestSteps(k *test.K8sClient, options test.MutationOptio
 			Name: "Add some data to the cluster before starting the mutation",
 			Test: func(t *testing.T) {
 				var err error
-				dataIntegrityCheck, err = NewDataIntegrityCheck(b.Elasticsearch, k, options.IncludesRollingUpgrade)
+				dataIntegrityCheck, err = NewDataIntegrityCheck(k, b)
 				require.NoError(t, err)
 				require.NoError(t, dataIntegrityCheck.Init())
 			},

--- a/test/e2e/test/kibana/steps_mutation.go
+++ b/test/e2e/test/kibana/steps_mutation.go
@@ -13,13 +13,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func (b Builder) MutationTestSteps(k *test.K8sClient, options test.MutationOptions) test.StepList {
+func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 	return b.UpgradeTestSteps(k).
 		WithSteps(b.CheckK8sTestSteps(k)).
 		WithSteps(b.CheckStackTestSteps(k))
 }
 
-func (b Builder) MutationReversalTestContext(options test.MutationOptions) test.ReversalTestContext {
+func (b Builder) MutationReversalTestContext() test.ReversalTestContext {
 	panic("not implemented")
 }
 

--- a/test/e2e/test/run_mutation.go
+++ b/test/e2e/test/run_mutation.go
@@ -8,15 +8,9 @@ import (
 	"testing"
 )
 
-type MutationOptions struct {
-	// IncludesRollingUpgrade specifies if the mutation to perform includes some rolling upgrade,
-	// for which shards with 0 replicas are expected to become unavailable.
-	IncludesRollingUpgrade bool
-}
-
 // RunMutations tests resources changes on given resources.
 // If the resource to mutate to is the same as the original resource, then all tests should still pass.
-func RunMutations(t *testing.T, creationBuilders []Builder, mutationBuilders []Builder, opts MutationOptions) {
+func RunMutations(t *testing.T, creationBuilders []Builder, mutationBuilders []Builder) {
 	k := NewK8sClientOrFatal()
 	steps := StepList{}
 
@@ -32,7 +26,7 @@ func RunMutations(t *testing.T, creationBuilders []Builder, mutationBuilders []B
 
 	// Trigger some mutations
 	for _, mutateTo := range mutationBuilders {
-		steps = steps.WithSteps(mutateTo.MutationTestSteps(k, opts))
+		steps = steps.WithSteps(mutateTo.MutationTestSteps(k))
 	}
 
 	for _, mutateTo := range mutationBuilders {
@@ -43,6 +37,6 @@ func RunMutations(t *testing.T, creationBuilders []Builder, mutationBuilders []B
 }
 
 // RunMutations tests one resource change on a given resource.
-func RunMutation(t *testing.T, toCreate Builder, mutateTo Builder, options MutationOptions) {
-	RunMutations(t, []Builder{toCreate}, []Builder{mutateTo}, options)
+func RunMutation(t *testing.T, toCreate Builder, mutateTo Builder) {
+	RunMutations(t, []Builder{toCreate}, []Builder{mutateTo})
 }

--- a/test/e2e/test/run_reversal.go
+++ b/test/e2e/test/run_reversal.go
@@ -16,7 +16,7 @@ type ReversalTestContext interface {
 
 // RunMutationReversal tests mutations that are either invalid or aborted mid way leading to a configuration reversal of
 // the original configuration.
-func RunMutationReversal(t *testing.T, creationBuilders []Builder, mutationBuilders []Builder, options MutationOptions) {
+func RunMutationReversal(t *testing.T, creationBuilders []Builder, mutationBuilders []Builder) {
 	k := NewK8sClientOrFatal()
 	steps := StepList{}
 
@@ -32,7 +32,7 @@ func RunMutationReversal(t *testing.T, creationBuilders []Builder, mutationBuild
 
 	ctxs := make([]ReversalTestContext, 0, len(mutationBuilders))
 	for _, mutateTo := range mutationBuilders {
-		ctxs = append(ctxs, mutateTo.MutationReversalTestContext(options))
+		ctxs = append(ctxs, mutateTo.MutationReversalTestContext())
 	}
 
 	for _, ctx := range ctxs {


### PR DESCRIPTION
Automatically compute the data integrity index number of replicas, based
on the cluster topology (initial and mutated).
If single-node cluster, use 0 replicas (otherwise the cluster cannot be
green).
If a rolling upgrade should happen, use 1 replica (for the cluster to
stay green during the mutation).
Otherwise, use 0 replicas, to ensure the cluster goes red if a data
migration does not happen.

It removes MutationOptions that were added as part of https://github.com/elastic/cloud-on-k8s/pull/1625.