### PR TITLE
Remove deprecated TODO about masters removal

### DIFF
--- a/pkg/controller/elasticsearch/driver/downscale.go
+++ b/pkg/controller/elasticsearch/driver/downscale.go
@@ -150,8 +150,6 @@ func calculatePerformableDownscale(
 	downscale ssetDownscale,
 	allLeavingNodes []string,
 ) ssetDownscale {
-	// TODO: only one master node downscale at a time
-
 	// create another downscale based on the provided one, for which we'll slowly decrease target replicas
 	performableDownscale := ssetDownscale{
 		statefulSet:     downscale.statefulSet,


### PR DESCRIPTION
Should have been removed with https://github.com/elastic/cloud-on-k8s/pull/1549.