### PR TITLE
Move TestPod and TestSset into the sset package

### DIFF
--- a/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/observer"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/reconcile"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"

--- a/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -31,23 +31,23 @@ import (
 // Sample StatefulSets to use in tests
 var (
 	clusterName             = "cluster"
-	ssetMaster3Replicas     = nodespec.TestSset{Name: "ssetMaster3Replicas", Version: "7.2.0", Replicas: 3, Master: true, Data: false}.Build()
+	ssetMaster3Replicas     = sset.TestSset{Name: "ssetMaster3Replicas", Version: "7.2.0", Replicas: 3, Master: true, Data: false}.Build()
 	podsSsetMaster3Replicas = []corev1.Pod{
-		nodespec.TestPod{
+		sset.TestPod{
 			Namespace:   ssetMaster3Replicas.Namespace,
 			Name:        sset.PodName(ssetMaster3Replicas.Name, 0),
 			ClusterName: clusterName,
 			Version:     "7.2.0",
 			Master:      true,
 		}.Build(),
-		nodespec.TestPod{
+		sset.TestPod{
 			Namespace:   ssetMaster3Replicas.Namespace,
 			Name:        sset.PodName(ssetMaster3Replicas.Name, 1),
 			ClusterName: clusterName,
 			Version:     "7.2.0",
 			Master:      true,
 		}.Build(),
-		nodespec.TestPod{
+		sset.TestPod{
 			Namespace:   ssetMaster3Replicas.Namespace,
 			Name:        sset.PodName(ssetMaster3Replicas.Name, 2),
 			ClusterName: clusterName,
@@ -55,30 +55,30 @@ var (
 			Master:      true,
 		}.Build(),
 	}
-	ssetData4Replicas     = nodespec.TestSset{Name: "ssetData4Replicas", Version: "7.2.0", Replicas: 4, Master: false, Data: true}.Build()
+	ssetData4Replicas     = sset.TestSset{Name: "ssetData4Replicas", Version: "7.2.0", Replicas: 4, Master: false, Data: true}.Build()
 	podsSsetData4Replicas = []corev1.Pod{
-		nodespec.TestPod{
+		sset.TestPod{
 			Namespace:   ssetData4Replicas.Namespace,
 			Name:        sset.PodName(ssetData4Replicas.Name, 0),
 			ClusterName: clusterName,
 			Version:     "7.2.0",
 			Data:        true,
 		}.Build(),
-		nodespec.TestPod{
+		sset.TestPod{
 			Namespace:   ssetData4Replicas.Namespace,
 			Name:        sset.PodName(ssetData4Replicas.Name, 1),
 			ClusterName: clusterName,
 			Version:     "7.2.0",
 			Data:        true,
 		}.Build(),
-		nodespec.TestPod{
+		sset.TestPod{
 			Namespace:   ssetData4Replicas.Namespace,
 			Name:        sset.PodName(ssetData4Replicas.Name, 2),
 			ClusterName: clusterName,
 			Version:     "7.2.0",
 			Data:        true,
 		}.Build(),
-		nodespec.TestPod{
+		sset.TestPod{
 			Namespace:   ssetData4Replicas.Namespace,
 			Name:        sset.PodName(ssetData4Replicas.Name, 3),
 			ClusterName: clusterName,
@@ -567,62 +567,62 @@ func Test_attemptDownscale(t *testing.T) {
 		{
 			name: "1 statefulset should be removed",
 			downscale: ssetDownscale{
-				statefulSet:     nodespec.TestSset{Name: "should-be-removed", Version: "7.1.0", Replicas: 0, Master: true, Data: true}.Build(),
+				statefulSet:     sset.TestSset{Name: "should-be-removed", Version: "7.1.0", Replicas: 0, Master: true, Data: true}.Build(),
 				initialReplicas: 0,
 				targetReplicas:  0,
 			},
 			state: &downscaleState{runningMasters: 2, masterRemovalInProgress: false},
 			statefulSets: sset.StatefulSetList{
-				nodespec.TestSset{Name: "should-be-removed", Version: "7.1.0", Replicas: 0, Master: true, Data: true}.Build(),
-				nodespec.TestSset{Name: "should-stay", Version: "7.1.0", Replicas: 2, Master: true, Data: true}.Build(),
+				sset.TestSset{Name: "should-be-removed", Version: "7.1.0", Replicas: 0, Master: true, Data: true}.Build(),
+				sset.TestSset{Name: "should-stay", Version: "7.1.0", Replicas: 2, Master: true, Data: true}.Build(),
 			},
 			expectedStatefulSets: []appsv1.StatefulSet{
-				nodespec.TestSset{Name: "should-stay", Version: "7.1.0", Replicas: 2, Master: true, Data: true}.Build(),
+				sset.TestSset{Name: "should-stay", Version: "7.1.0", Replicas: 2, Master: true, Data: true}.Build(),
 			},
 		},
 		{
 			name: "target replicas == initial replicas",
 			downscale: ssetDownscale{
-				statefulSet:     nodespec.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
+				statefulSet:     sset.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
 				initialReplicas: 3,
 				targetReplicas:  3,
 			},
 			state: &downscaleState{runningMasters: 2, masterRemovalInProgress: false},
 			statefulSets: sset.StatefulSetList{
-				nodespec.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
+				sset.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
 			},
 			expectedStatefulSets: []appsv1.StatefulSet{
-				nodespec.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
+				sset.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
 			},
 		},
 		{
 			name: "upscale case",
 			downscale: ssetDownscale{
-				statefulSet:     nodespec.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
+				statefulSet:     sset.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
 				initialReplicas: 3,
 				targetReplicas:  4,
 			},
 			state: &downscaleState{runningMasters: 2, masterRemovalInProgress: false},
 			statefulSets: sset.StatefulSetList{
-				nodespec.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
+				sset.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
 			},
 			expectedStatefulSets: []appsv1.StatefulSet{
-				nodespec.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
+				sset.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
 			},
 		},
 		{
 			name: "perform 3 -> 2 downscale",
 			downscale: ssetDownscale{
-				statefulSet:     nodespec.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
+				statefulSet:     sset.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
 				initialReplicas: 3,
 				targetReplicas:  2,
 			},
 			state: &downscaleState{runningMasters: 2, masterRemovalInProgress: false},
 			statefulSets: sset.StatefulSetList{
-				nodespec.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
+				sset.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
 			},
 			expectedStatefulSets: []appsv1.StatefulSet{
-				nodespec.TestSset{Name: "default", Version: "7.1.0", Replicas: 2, Master: true, Data: true}.Build(),
+				sset.TestSset{Name: "default", Version: "7.1.0", Replicas: 2, Master: true, Data: true}.Build(),
 			},
 		},
 	}
@@ -702,8 +702,8 @@ func Test_doDownscale_updateReplicasAndExpectations(t *testing.T) {
 }
 
 func Test_doDownscale_zen2VotingConfigExclusions(t *testing.T) {
-	ssetMasters := nodespec.TestSset{Name: "masters", Version: "7.1.0", Replicas: 3, Master: true, Data: false}.Build()
-	ssetData := nodespec.TestSset{Name: "datas", Version: "7.1.0", Replicas: 3, Master: false, Data: true}.Build()
+	ssetMasters := sset.TestSset{Name: "masters", Version: "7.1.0", Replicas: 3, Master: true, Data: false}.Build()
+	ssetData := sset.TestSset{Name: "datas", Version: "7.1.0", Replicas: 3, Master: false, Data: true}.Build()
 	tests := []struct {
 		name               string
 		downscale          ssetDownscale
@@ -772,9 +772,9 @@ func Test_doDownscale_zen2VotingConfigExclusions(t *testing.T) {
 
 func Test_doDownscale_zen1MinimumMasterNodes(t *testing.T) {
 	es := v1alpha1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: ssetMaster3Replicas.Namespace, Name: "es"}}
-	ssetMasters := nodespec.TestSset{Name: "masters", Version: "6.8.0", Replicas: 3, Master: true, Data: false}.Build()
+	ssetMasters := sset.TestSset{Name: "masters", Version: "6.8.0", Replicas: 3, Master: true, Data: false}.Build()
 	masterPods := []corev1.Pod{
-		nodespec.TestPod{
+		sset.TestPod{
 			Namespace:       ssetMaster3Replicas.Namespace,
 			Name:            ssetMaster3Replicas.Name + "-0",
 			ClusterName:     es.Name,
@@ -782,7 +782,7 @@ func Test_doDownscale_zen1MinimumMasterNodes(t *testing.T) {
 			Version:         "6.8.0",
 			Master:          true,
 		}.Build(),
-		nodespec.TestPod{
+		sset.TestPod{
 			Namespace:       ssetMaster3Replicas.Namespace,
 			Name:            ssetMaster3Replicas.Name + "-1",
 			ClusterName:     es.Name,
@@ -790,7 +790,7 @@ func Test_doDownscale_zen1MinimumMasterNodes(t *testing.T) {
 			Version:         "6.8.0",
 			Master:          true,
 		}.Build(),
-		nodespec.TestPod{
+		sset.TestPod{
 			Namespace:       ssetMaster3Replicas.Namespace,
 			Name:            ssetMaster3Replicas.Name + "-2",
 			ClusterName:     es.Name,
@@ -799,7 +799,7 @@ func Test_doDownscale_zen1MinimumMasterNodes(t *testing.T) {
 			Master:          true,
 		}.Build(),
 	}
-	ssetData := nodespec.TestSset{Name: "datas", Version: "6.8.0", Replicas: 3, Master: false, Data: true}.Build()
+	ssetData := sset.TestSset{Name: "datas", Version: "6.8.0", Replicas: 3, Master: false, Data: true}.Build()
 	tests := []struct {
 		name               string
 		downscale          ssetDownscale

--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -9,12 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,6 +19,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
 )
 
 type mockESState struct {
@@ -89,7 +89,7 @@ func Test_defaultDriver_doRollingUpgrade(t *testing.T) {
 			name: "single sset upgrade",
 			args: args{
 				statefulSets: sset.StatefulSetList{
-					nodespec.TestSset{
+					sset.TestSset{
 						Name:      "default",
 						Replicas:  1,
 						Master:    true,
@@ -113,7 +113,7 @@ func Test_defaultDriver_doRollingUpgrade(t *testing.T) {
 			name: "just one (master) at a time",
 			args: args{
 				statefulSets: sset.StatefulSetList{
-					nodespec.TestSset{
+					sset.TestSset{
 						Name:      "default",
 						Replicas:  3,
 						Master:    true,
@@ -137,12 +137,12 @@ func Test_defaultDriver_doRollingUpgrade(t *testing.T) {
 			name: "multiple ssets, update correct sset",
 			args: args{
 				statefulSets: sset.StatefulSetList{
-					nodespec.TestSset{
+					sset.TestSset{
 						Name:     "master",
 						Replicas: 3,
 						Master:   true,
 					}.Build(),
-					nodespec.TestSset{
+					sset.TestSset{
 						Name:      "data",
 						Replicas:  1,
 						Data:      true,
@@ -165,7 +165,7 @@ func Test_defaultDriver_doRollingUpgrade(t *testing.T) {
 			name: "wait for healthy cluster",
 			args: args{
 				statefulSets: sset.StatefulSetList{
-					nodespec.TestSset{
+					sset.TestSset{
 						Name:      "default",
 						Replicas:  1,
 						Master:    true,
@@ -188,7 +188,7 @@ func Test_defaultDriver_doRollingUpgrade(t *testing.T) {
 			name: "partially rolled out upgrade",
 			args: args{
 				statefulSets: sset.StatefulSetList{
-					nodespec.TestSset{
+					sset.TestSset{
 						Name:      "default",
 						Replicas:  2,
 						Data:      true,
@@ -254,7 +254,7 @@ func Test_defaultDriver_MaybeEnableShardsAllocation(t *testing.T) {
 			name: "still update pending",
 			args: args{
 				statefulSets: sset.StatefulSetList{
-					nodespec.TestSset{
+					sset.TestSset{
 						Name:      "default",
 						Version:   "7.3.0",
 						Replicas:  1,
@@ -276,7 +276,7 @@ func Test_defaultDriver_MaybeEnableShardsAllocation(t *testing.T) {
 			name: "update done but node not in cluster",
 			args: args{
 				statefulSets: sset.StatefulSetList{
-					nodespec.TestSset{
+					sset.TestSset{
 						Name:      "default",
 						Replicas:  1,
 						Master:    true,
@@ -295,7 +295,7 @@ func Test_defaultDriver_MaybeEnableShardsAllocation(t *testing.T) {
 				},
 			},
 			runtimeObjects: []runtime.Object{
-				nodespec.TestPod{
+				sset.TestPod{
 					Name:     "default-0",
 					Revision: "b", // pod at latest revision
 					Master:   true,
@@ -308,7 +308,7 @@ func Test_defaultDriver_MaybeEnableShardsAllocation(t *testing.T) {
 			name: "should enable shard allocations",
 			args: args{
 				statefulSets: sset.StatefulSetList{
-					nodespec.TestSset{
+					sset.TestSset{
 						Name:      "default",
 						Replicas:  1,
 						Master:    true,
@@ -326,7 +326,7 @@ func Test_defaultDriver_MaybeEnableShardsAllocation(t *testing.T) {
 				},
 			},
 			runtimeObjects: []runtime.Object{
-				nodespec.TestPod{
+				sset.TestPod{
 					Name:     "default-0",
 					Revision: "b", // pod at latest revision
 					Master:   true,
@@ -407,7 +407,7 @@ func Test_podUpgradeDone(t *testing.T) {
 		{
 			name: "pod on incorrect rev: not done",
 			runtimeObjects: []runtime.Object{
-				nodespec.TestPod{
+				sset.TestPod{
 					Namespace: testNamespace,
 					Name:      testPod,
 					Revision:  "rev0",
@@ -419,7 +419,7 @@ func Test_podUpgradeDone(t *testing.T) {
 		{
 			name: "pod not ready: not done",
 			runtimeObjects: []runtime.Object{
-				nodespec.TestPod{
+				sset.TestPod{
 					Namespace: testNamespace,
 					Name:      testPod,
 					Revision:  upgradeRevision,

--- a/pkg/controller/elasticsearch/nodespec/resources_test.go
+++ b/pkg/controller/elasticsearch/nodespec/resources_test.go
@@ -7,6 +7,8 @@ package nodespec
 import (
 	"reflect"
 	"testing"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 )
 
 func TestResourcesList_MasterNodesNames(t *testing.T) {
@@ -23,9 +25,9 @@ func TestResourcesList_MasterNodesNames(t *testing.T) {
 		{
 			name: "3 master-only nodes, 3 master-data nodes, 3 data nodes",
 			l: ResourcesList{
-				{StatefulSet: TestSset{Name: "master-only", Version: "7.2.0", Replicas: 3, Master: true, Data: false}.Build()},
-				{StatefulSet: TestSset{Name: "master-data", Version: "7.2.0", Replicas: 3, Master: true, Data: true}.Build()},
-				{StatefulSet: TestSset{Name: "data-only", Version: "7.2.0", Replicas: 3, Master: false, Data: true}.Build()},
+				{StatefulSet: sset.TestSset{Name: "master-only", Version: "7.2.0", Replicas: 3, Master: true, Data: false}.Build()},
+				{StatefulSet: sset.TestSset{Name: "master-data", Version: "7.2.0", Replicas: 3, Master: true, Data: true}.Build()},
+				{StatefulSet: sset.TestSset{Name: "data-only", Version: "7.2.0", Replicas: 3, Master: false, Data: true}.Build()},
 			},
 			want: []string{
 				"master-only-0", "master-only-1", "master-only-2",

--- a/pkg/controller/elasticsearch/sset/fixtures.go
+++ b/pkg/controller/elasticsearch/sset/fixtures.go
@@ -5,11 +5,11 @@
 package sset
 
 import (
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 )
 
 type TestSset struct {
@@ -30,7 +30,7 @@ func (t TestSset) Build() appsv1.StatefulSet {
 	}
 	label.NodeTypesMasterLabelName.Set(t.Master, labels)
 	label.NodeTypesDataLabelName.Set(t.Data, labels)
-	statefulSet := appsv1.StatefulSet{
+	return appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: t.Name,
 		},
@@ -50,13 +50,6 @@ func (t TestSset) Build() appsv1.StatefulSet {
 		},
 		Status: t.Status,
 	}
-	statefulSet.Labels = hash.SetTemplateHashLabel(statefulSet.Labels, statefulSet.Spec)
-	return statefulSet
-}
-
-func (t TestSset) BuildPtr() *appsv1.StatefulSet {
-	built := t.Build()
-	return &built
 }
 
 type TestPod struct {

--- a/pkg/controller/elasticsearch/sset/fixtures.go
+++ b/pkg/controller/elasticsearch/sset/fixtures.go
@@ -2,9 +2,10 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package nodespec
+package sset
 
 import (
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,7 +30,7 @@ func (t TestSset) Build() appsv1.StatefulSet {
 	}
 	label.NodeTypesMasterLabelName.Set(t.Master, labels)
 	label.NodeTypesDataLabelName.Set(t.Data, labels)
-	return appsv1.StatefulSet{
+	statefulSet := appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: t.Name,
 		},
@@ -49,6 +50,13 @@ func (t TestSset) Build() appsv1.StatefulSet {
 		},
 		Status: t.Status,
 	}
+	statefulSet.Labels = hash.SetTemplateHashLabel(statefulSet.Labels, statefulSet.Spec)
+	return statefulSet
+}
+
+func (t TestSset) BuildPtr() *appsv1.StatefulSet {
+	built := t.Build()
+	return &built
 }
 
 type TestPod struct {

--- a/pkg/controller/elasticsearch/version/zen2/compatibility_test.go
+++ b/pkg/controller/elasticsearch/version/zen2/compatibility_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
@@ -76,26 +76,26 @@ func TestAllMastersCompatibleWithZen2(t *testing.T) {
 		{
 			name: "only v7 master nodes",
 			pods: []runtime.Object{
-				nodespec.TestPod{Namespace: es.Namespace, Name: "node0", ClusterName: es.Name, Version: "7.2.0", Master: true}.BuildPtr(),
-				nodespec.TestPod{Namespace: es.Namespace, Name: "node1", ClusterName: es.Name, Version: "7.2.0", Master: true}.BuildPtr(),
-				nodespec.TestPod{Namespace: es.Namespace, Name: "node2", ClusterName: es.Name, Version: "7.2.0", Data: true}.BuildPtr(),
+				sset.TestPod{Namespace: es.Namespace, Name: "node0", ClusterName: es.Name, Version: "7.2.0", Master: true}.BuildPtr(),
+				sset.TestPod{Namespace: es.Namespace, Name: "node1", ClusterName: es.Name, Version: "7.2.0", Master: true}.BuildPtr(),
+				sset.TestPod{Namespace: es.Namespace, Name: "node2", ClusterName: es.Name, Version: "7.2.0", Data: true}.BuildPtr(),
 			},
 			want: true,
 		},
 		{
 			name: "only v6 master nodes (with v7 data nodes)",
 			pods: []runtime.Object{
-				nodespec.TestPod{Namespace: es.Namespace, Name: "node0", ClusterName: es.Name, Version: "6.8.0", Master: true}.BuildPtr(),
-				nodespec.TestPod{Namespace: es.Namespace, Name: "node1", ClusterName: es.Name, Version: "6.8.0", Master: true}.BuildPtr(),
-				nodespec.TestPod{Namespace: es.Namespace, Name: "node2", ClusterName: es.Name, Version: "7.2.0", Data: true}.BuildPtr(),
+				sset.TestPod{Namespace: es.Namespace, Name: "node0", ClusterName: es.Name, Version: "6.8.0", Master: true}.BuildPtr(),
+				sset.TestPod{Namespace: es.Namespace, Name: "node1", ClusterName: es.Name, Version: "6.8.0", Master: true}.BuildPtr(),
+				sset.TestPod{Namespace: es.Namespace, Name: "node2", ClusterName: es.Name, Version: "7.2.0", Data: true}.BuildPtr(),
 			},
 			want: false,
 		},
 		{
 			name: "mixed v6/v7 masters",
 			pods: []runtime.Object{
-				nodespec.TestPod{Namespace: es.Namespace, Name: "node0", ClusterName: es.Name, Version: "7.2.0", Master: true}.BuildPtr(),
-				nodespec.TestPod{Namespace: es.Namespace, Name: "node1", ClusterName: es.Name, Version: "6.8.0", Master: true}.BuildPtr(),
+				sset.TestPod{Namespace: es.Namespace, Name: "node0", ClusterName: es.Name, Version: "7.2.0", Master: true}.BuildPtr(),
+				sset.TestPod{Namespace: es.Namespace, Name: "node1", ClusterName: es.Name, Version: "6.8.0", Master: true}.BuildPtr(),
 			},
 			want: false,
 		},

--- a/pkg/controller/elasticsearch/version/zen2/initial_master_nodes_test.go
+++ b/pkg/controller/elasticsearch/version/zen2/initial_master_nodes_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/observer"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
@@ -72,7 +73,7 @@ func TestSetupInitialMasterNodes_AlreadyBootstrapped(t *testing.T) {
 			name: "cluster already annotated for bootstrap: no changes",
 			es:   withAnnotation(newElasticsearch(), ClusterUUIDAnnotationName, defaultClusterUUID),
 			nodeSpecResources: nodespec.ResourcesList{
-				{StatefulSet: nodespec.TestSset{Name: "data", Version: "7.1.0", Replicas: 3, Master: false, Data: true}.Build(), Config: settings.NewCanonicalConfig()},
+				{StatefulSet: sset.TestSset{Name: "data", Version: "7.1.0", Replicas: 3, Master: false, Data: true}.Build(), Config: settings.NewCanonicalConfig()},
 			},
 			expected:   []settings.CanonicalConfig{settings.NewCanonicalConfig()},
 			expectedEs: withAnnotation(newElasticsearch(), ClusterUUIDAnnotationName, defaultClusterUUID),
@@ -82,7 +83,7 @@ func TestSetupInitialMasterNodes_AlreadyBootstrapped(t *testing.T) {
 			es:            newElasticsearch(),
 			observedState: observer.State{ClusterState: &client.ClusterState{ClusterUUID: defaultClusterUUID}},
 			nodeSpecResources: nodespec.ResourcesList{
-				{StatefulSet: nodespec.TestSset{Name: "data", Version: "7.1.0", Replicas: 3, Master: false, Data: true}.Build(), Config: settings.NewCanonicalConfig()},
+				{StatefulSet: sset.TestSset{Name: "data", Version: "7.1.0", Replicas: 3, Master: false, Data: true}.Build(), Config: settings.NewCanonicalConfig()},
 			},
 			expected:   []settings.CanonicalConfig{settings.NewCanonicalConfig()},
 			expectedEs: withAnnotation(newElasticsearch(), ClusterUUIDAnnotationName, defaultClusterUUID),
@@ -119,16 +120,16 @@ func TestSetupInitialMasterNodes_NotBootstrapped(t *testing.T) {
 		{
 			name: "no master nodes",
 			nodeSpecResources: nodespec.ResourcesList{
-				{StatefulSet: nodespec.TestSset{Name: "data", Version: "7.1.0", Replicas: 3, Master: false, Data: true}.Build(), Config: settings.NewCanonicalConfig()},
+				{StatefulSet: sset.TestSset{Name: "data", Version: "7.1.0", Replicas: 3, Master: false, Data: true}.Build(), Config: settings.NewCanonicalConfig()},
 			},
 			expected: []settings.CanonicalConfig{settings.NewCanonicalConfig()},
 		},
 		{
 			name: "3 masters, 3 master+data, 3 data",
 			nodeSpecResources: nodespec.ResourcesList{
-				{StatefulSet: nodespec.TestSset{Name: "master", Version: "7.1.0", Replicas: 3, Master: true, Data: false}.Build(), Config: settings.NewCanonicalConfig()},
-				{StatefulSet: nodespec.TestSset{Name: "masterdata", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(), Config: settings.NewCanonicalConfig()},
-				{StatefulSet: nodespec.TestSset{Name: "data", Version: "7.1.0", Replicas: 3, Master: false, Data: true}.Build(), Config: settings.NewCanonicalConfig()},
+				{StatefulSet: sset.TestSset{Name: "master", Version: "7.1.0", Replicas: 3, Master: true, Data: false}.Build(), Config: settings.NewCanonicalConfig()},
+				{StatefulSet: sset.TestSset{Name: "masterdata", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(), Config: settings.NewCanonicalConfig()},
+				{StatefulSet: sset.TestSset{Name: "data", Version: "7.1.0", Replicas: 3, Master: false, Data: true}.Build(), Config: settings.NewCanonicalConfig()},
 			},
 			expected: []settings.CanonicalConfig{
 				{CanonicalConfig: settings2.MustCanonicalConfig(map[string][]string{
@@ -144,15 +145,15 @@ func TestSetupInitialMasterNodes_NotBootstrapped(t *testing.T) {
 		{
 			name: "versionCompatibleWithZen2 <7: nothing should appear in the config",
 			nodeSpecResources: nodespec.ResourcesList{
-				{StatefulSet: nodespec.TestSset{Name: "master", Version: "6.8.0", Replicas: 3, Master: true, Data: false}.Build(), Config: settings.NewCanonicalConfig()},
+				{StatefulSet: sset.TestSset{Name: "master", Version: "6.8.0", Replicas: 3, Master: true, Data: false}.Build(), Config: settings.NewCanonicalConfig()},
 			},
 			expected: []settings.CanonicalConfig{settings.NewCanonicalConfig()},
 		},
 		{
 			name: "mixed v6 & v7: include all masters but only in v7 configs",
 			nodeSpecResources: nodespec.ResourcesList{
-				{StatefulSet: nodespec.TestSset{Name: "masterv6", Version: "6.8.0", Replicas: 3, Master: true, Data: false}.Build(), Config: settings.NewCanonicalConfig()},
-				{StatefulSet: nodespec.TestSset{Name: "masterv7", Version: "7.1.0", Replicas: 3, Master: true, Data: false}.Build(), Config: settings.NewCanonicalConfig()},
+				{StatefulSet: sset.TestSset{Name: "masterv6", Version: "6.8.0", Replicas: 3, Master: true, Data: false}.Build(), Config: settings.NewCanonicalConfig()},
+				{StatefulSet: sset.TestSset{Name: "masterv7", Version: "7.1.0", Replicas: 3, Master: true, Data: false}.Build(), Config: settings.NewCanonicalConfig()},
 			},
 			expected: []settings.CanonicalConfig{
 				settings.NewCanonicalConfig(),

--- a/pkg/controller/elasticsearch/version/zen2/voting_exclusions_test.go
+++ b/pkg/controller/elasticsearch/version/zen2/voting_exclusions_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
@@ -32,11 +31,11 @@ func (f *fakeESClient) DeleteVotingConfigExclusions(ctx context.Context, waitFor
 
 func Test_ClearVotingConfigExclusions(t *testing.T) {
 	// dummy statefulset with 3 pods
-	statefulSet3rep := nodespec.TestSset{Name: "nodes", Version: "7.2.0", Replicas: 3, Master: true, Data: true}.Build()
+	statefulSet3rep := sset.TestSset{Name: "nodes", Version: "7.2.0", Replicas: 3, Master: true, Data: true}.Build()
 	es := v1alpha1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Name: "es", Namespace: statefulSet3rep.Namespace}}
 	pods := make([]corev1.Pod, 0, *statefulSet3rep.Spec.Replicas)
 	for _, podName := range sset.PodNames(statefulSet3rep) {
-		pods = append(pods, nodespec.TestPod{
+		pods = append(pods, sset.TestPod{
 			Namespace:       statefulSet3rep.Namespace,
 			Name:            podName,
 			ClusterName:     es.Name,
@@ -46,7 +45,7 @@ func Test_ClearVotingConfigExclusions(t *testing.T) {
 		}.Build())
 	}
 	// simulate 2 pods out of the 3
-	statefulSet2rep := nodespec.TestSset{Name: "nodes", Version: "7.2.0", Replicas: 2, Master: true, Data: true}.Build()
+	statefulSet2rep := sset.TestSset{Name: "nodes", Version: "7.2.0", Replicas: 2, Master: true, Data: true}.Build()
 	tests := []struct {
 		name               string
 		c                  k8s.Client


### PR DESCRIPTION
I ran into a circular import problem by relying on those from the sset
package. Let's move them there directly, they belong to this lowerlevel
pkg, called by other packages such as nodespec.