### PR TITLE
Make sure we update sset template hash label before updating the sset

### DIFF
--- a/pkg/controller/common/reconciler/expectations.go
+++ b/pkg/controller/common/reconciler/expectations.go
@@ -32,3 +32,8 @@ func (e *Expectations) GenerationExpected(metaObjs ...metav1.ObjectMeta) bool {
 	}
 	return true
 }
+
+// GetGenerations returns the map of generations, for testing purpose mostly.
+func (e *Expectations) GetGenerations() map[types.UID]int64 {
+	return e.generations
+}

--- a/pkg/controller/elasticsearch/driver/downscale.go
+++ b/pkg/controller/elasticsearch/driver/downscale.go
@@ -12,6 +12,7 @@ import (
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/migration"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/version/zen1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/version/zen2"
@@ -187,7 +188,7 @@ func doDownscale(downscaleCtx downscaleContext, downscale ssetDownscale, actualS
 		return err
 	}
 
-	downscale.statefulSet.Spec.Replicas = &downscale.targetReplicas
+	nodespec.UpdateReplicas(&downscale.statefulSet, &downscale.targetReplicas)
 	if err := downscaleCtx.k8sClient.Update(&downscale.statefulSet); err != nil {
 		return err
 	}

--- a/pkg/controller/elasticsearch/driver/upgrade.go
+++ b/pkg/controller/elasticsearch/driver/upgrade.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
@@ -163,9 +164,8 @@ func (d *defaultDriver) upgradeStatefulSetPartition(
 		"from", statefulSet.Spec.UpdateStrategy.RollingUpdate.Partition,
 		"to", &newPartition,
 	)
-	statefulSet.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateStatefulSetStrategy{
-		Partition: &newPartition,
-	}
+
+	nodespec.UpdatePartition(statefulSet, &newPartition)
 	if err := d.Client.Update(statefulSet); err != nil {
 		return err
 	}

--- a/pkg/controller/elasticsearch/driver/upscale.go
+++ b/pkg/controller/elasticsearch/driver/upscale.go
@@ -61,13 +61,11 @@ func adaptForExistingStatefulSet(actualSset appsv1.StatefulSet, ssetToApply apps
 	if sset.GetReplicas(ssetToApply) < sset.GetReplicas(actualSset) {
 		// This is a downscale.
 		// We still want to update the sset spec to the newest one, but don't scale replicas down for now.
-		ssetToApply.Spec.Replicas = actualSset.Spec.Replicas
+		nodespec.UpdateReplicas(&ssetToApply, actualSset.Spec.Replicas)
 	}
 	// Make sure new pods (with ordinal>partition) get created with the newest revision,
 	// by setting the rollingUpdate partition to the actual StatefulSet replicas count.
 	// Any ongoing rolling upgrade may temporarily pause here, but will go through again.
-	ssetToApply.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateStatefulSetStrategy{
-		Partition: actualSset.Spec.Replicas,
-	}
+	nodespec.UpdatePartition(&ssetToApply, actualSset.Spec.Replicas)
 	return ssetToApply
 }

--- a/pkg/controller/elasticsearch/nodespec/statefulset.go
+++ b/pkg/controller/elasticsearch/nodespec/statefulset.go
@@ -107,3 +107,19 @@ func BuildStatefulSet(
 
 	return sset, nil
 }
+
+// UpdateReplicas updates the given StatefulSet with the given replicas,
+// and modifies the template hash label accordingly.
+func UpdateReplicas(statefulSet *appsv1.StatefulSet, replicas *int32) {
+	statefulSet.Spec.Replicas = replicas
+	statefulSet.Labels = hash.SetTemplateHashLabel(statefulSet.Labels, statefulSet.Spec)
+}
+
+// UpdateReplicas updates the given StatefulSet with the given rolling update partition,
+// and modifies the template hash label accordingly.
+func UpdatePartition(statefulSet *appsv1.StatefulSet, partition *int32) {
+	statefulSet.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateStatefulSetStrategy{
+		Partition: partition,
+	}
+	statefulSet.Labels = hash.SetTemplateHashLabel(statefulSet.Labels, statefulSet.Spec)
+}

--- a/pkg/controller/elasticsearch/sset/fixtures.go
+++ b/pkg/controller/elasticsearch/sset/fixtures.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 )
 
@@ -30,7 +31,7 @@ func (t TestSset) Build() appsv1.StatefulSet {
 	}
 	label.NodeTypesMasterLabelName.Set(t.Master, labels)
 	label.NodeTypesDataLabelName.Set(t.Data, labels)
-	return appsv1.StatefulSet{
+	statefulSet := appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: t.Name,
 		},
@@ -50,6 +51,8 @@ func (t TestSset) Build() appsv1.StatefulSet {
 		},
 		Status: t.Status,
 	}
+	statefulSet.Labels = hash.SetTemplateHashLabel(statefulSet.Labels, statefulSet.Spec)
+	return statefulSet
 }
 
 type TestPod struct {


### PR DESCRIPTION
We had a bug where the StatefulSet template hash that we use for
StatefulSet comparison purpose wasn't updated during downscales and
upgrades, where we change replicas and partitions.

This is not a problem with the current codebase, but starts becoming one
once we upscale only one master node at a time.

Let's make sure we update it.