### PR TITLE
Rolling upgrade master nodes last

### DIFF
--- a/pkg/controller/elasticsearch/sset/list_test.go
+++ b/pkg/controller/elasticsearch/sset/list_test.go
@@ -263,3 +263,19 @@ func TestStatefulSetList_ToUpdate(t *testing.T) {
 		})
 	}
 }
+
+func TestStatefulSetList_Sort(t *testing.T) {
+	l := StatefulSetList{
+		TestSset{Name: "masterb", Master: true}.Build(),
+		TestSset{Name: "mastera", Master: true}.Build(),
+		TestSset{Name: "datab", Master: false}.Build(),
+		TestSset{Name: "dataa", Master: false}.Build(),
+	}
+	l.Sort()
+	require.Equal(t, StatefulSetList{
+		TestSset{Name: "dataa", Master: false}.Build(),
+		TestSset{Name: "datab", Master: false}.Build(),
+		TestSset{Name: "mastera", Master: true}.Build(),
+		TestSset{Name: "masterb", Master: true}.Build(),
+	}, l)
+}


### PR DESCRIPTION
During an upgrade for eg. v6 to v7, a cluster with a single master node
will form a v7 cluster that v6 data nodes won't be able to join.

As specified in ES doc:
> Similarly, if you run a testing/development environment with only one
master node, the master node should be upgraded last. Restarting a
single master node forces the cluster to be reformed. The new cluster
will initially only have the upgraded master node and will thus reject
the older nodes when they re-join the cluster. Nodes that have already
been upgraded will successfully re-join the upgraded master

An "easy" way to fix that is to upgrade wannabe master nodes last.

Relates https://github.com/elastic/cloud-on-k8s/issues/1642.