### PR TITLE
Add relabel bot config for triaging issues

### DIFF
--- a/.github/relabel.yaml
+++ b/.github/relabel.yaml
@@ -1,0 +1,3 @@
+requiredLabels:
+  - missingLabel: triage
+    regex: >.*


### PR DESCRIPTION
Based on https://github.com/lswith/probot-require-label

Corresponding GH config is still pending.
