### PR TITLE
Update documented command to delete all elastic resources

### DIFF
--- a/docs/uninstall.asciidoc
+++ b/docs/uninstall.asciidoc
@@ -1,11 +1,12 @@
 [id="{p}-uninstall"]
 == Uninstall ECK
 
-Before uninstalling the operator, remove all Elastic resources:
+Before uninstalling the operator, remove all Elastic resources in all namespaces:
 
 [source,shell]
 ----
-kubectl delete elastic --all --all-namespaces
+kubectl get namespaces --no-headers -o custom-columns=:metadata.name \
+  | xargs -n1 kubectl delete elastic --all -n
 ----
 
 This deletes all underlying Elasticsearch, Kibana, and APM Server resources (pods, secrets, services, etc.).


### PR DESCRIPTION
The `--all-namespaces` flag is available only from the version 1.14 of
kubectl. Let's propose another command without this flag to delete
all elastic resources.

Resolves #1670.

Will be backported to the 0.9 branch.