### PR TITLE
Take master change budget into account when adding new stateful sets

### DIFF
--- a/pkg/controller/elasticsearch/driver/upscale.go
+++ b/pkg/controller/elasticsearch/driver/upscale.go
@@ -106,13 +106,11 @@ func adjustStatefulSetReplicas(
 	if alreadyExists {
 		expected = adaptForExistingStatefulSet(actual, expected)
 	}
-	if alreadyExists && isReplicaIncrease(actual, expected) {
-		upscaleState, err := ctx.upscaleStateBuilder.InitOnce(ctx.k8sClient, ctx.es, ctx.esState)
-		if err != nil {
-			return appsv1.StatefulSet{}, err
-		}
-		expected = upscaleState.limitMasterNodesCreation(actualStatefulSets, expected)
+	upscaleState, err := ctx.upscaleStateBuilder.InitOnce(ctx.k8sClient, ctx.es, ctx.esState)
+	if err != nil {
+		return appsv1.StatefulSet{}, err
 	}
+	expected = upscaleState.limitMasterNodesCreation(actualStatefulSets, expected)
 	return expected, nil
 }
 

--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -133,6 +133,33 @@ func TestMutationResizeMemoryDown(t *testing.T) {
 	RunESMutation(t, b, mutated)
 }
 
+// TestMutationSecondMasterSet add a separate set of dedicated masters
+// to an existing cluster.
+func TestMutationSecondMasterSet(t *testing.T) {
+	b := elasticsearch.NewBuilder("test-mutation-2nd-master-set").
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
+
+	// add a second master sset
+	mutated := b.WithNoESTopology().
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources).
+		WithESMasterNodes(3, elasticsearch.DefaultResources)
+
+	RunESMutation(t, b, mutated)
+}
+
+// TestMutationSecondMasterSetDown test a downscale of a separate set of dedicated masters.
+func TestMutationSecondMasterSetDown(t *testing.T) {
+	b := elasticsearch.NewBuilder("test-mutation-2nd-master-set").
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources).
+		WithESMasterNodes(3, elasticsearch.DefaultResources)
+
+	// scale down to single node
+	mutated := b.WithNoESTopology().
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+
+	RunESMutation(t, b, mutated)
+}
+
 // TestVersionUpgrade680To720 creates a cluster in version 6.8.0,
 // and upgrades it to 7.2.0.
 func TestVersionUpgrade680To720(t *testing.T) {

--- a/test/e2e/test/elasticsearch/checks_limiting.go
+++ b/test/e2e/test/elasticsearch/checks_limiting.go
@@ -62,6 +62,10 @@ func (mc *MasterChangeBudgetCheck) Verify(maxRateOfChange int) error {
 		cur := mc.Observations[i]
 		abs := int(math.Abs(float64(cur - prev)))
 		if abs > maxRateOfChange {
+			// This is ofc potentially flaky if we miss an observation and see suddenly more than one master
+			// node popping up. This is due the fact that this check is depending on timing, the underlying
+			// assumption being that the observation interval is always shorter than the time an Elasticsearch
+			// node needs to boot.
 			return fmt.Errorf("%d master changes in one observation, expected max %d", abs, maxRateOfChange)
 		}
 	}

--- a/test/e2e/test/elasticsearch/checks_limiting.go
+++ b/test/e2e/test/elasticsearch/checks_limiting.go
@@ -1,0 +1,69 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package elasticsearch
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+)
+
+type MasterChangeBudgetCheck struct {
+	Observations []int
+	Errors       []error
+	stopChan     chan struct{}
+	es           v1alpha1.Elasticsearch
+	interval     time.Duration
+	client       k8s.Client
+}
+
+func NewMasterChangeBudgetCheck(es v1alpha1.Elasticsearch, interval time.Duration, client k8s.Client) *MasterChangeBudgetCheck {
+	return &MasterChangeBudgetCheck{
+		es:       es,
+		interval: interval,
+		client:   client,
+		stopChan: make(chan struct{}),
+	}
+}
+
+func (mc *MasterChangeBudgetCheck) Start() {
+	go func() {
+		ticker := time.NewTicker(mc.interval)
+		for {
+			select {
+			case <-mc.stopChan:
+				return
+			case <-ticker.C:
+				pods, err := sset.GetActualMastersForCluster(mc.client, mc.es)
+				if err != nil {
+					mc.Errors = append(mc.Errors, err)
+					continue
+				}
+				mc.Observations = append(mc.Observations, len(pods))
+				continue
+			}
+		}
+	}()
+}
+
+func (mc *MasterChangeBudgetCheck) Stop() {
+	mc.stopChan <- struct{}{}
+}
+
+func (mc *MasterChangeBudgetCheck) Verify(maxRateOfChange int) error {
+	for i := 1; i < len(mc.Observations); i++ {
+		prev := mc.Observations[i-1]
+		cur := mc.Observations[i]
+		abs := int(math.Abs(float64(cur - prev)))
+		if abs > maxRateOfChange {
+			return fmt.Errorf("%d master changes in one observation, expected max %d", abs, maxRateOfChange)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This addresses an issue where we would limit the amount of master nodes added
during rolling upgrades unless a user would add a whole new stateful set in which
case we would spin up all master nodes at once.

Fixes #1679 

