### PR TITLE
Fix incorrect data node count in e2e tests

### DIFF
--- a/test/e2e/test/elasticsearch/settings.go
+++ b/test/e2e/test/elasticsearch/settings.go
@@ -24,7 +24,7 @@ func MustNumDataNodes(es v1alpha1.Elasticsearch) int {
 			panic(err)
 		}
 		if nodeCfg.Node.Data {
-			numNodes++
+			numNodes = numNodes + int(n.NodeCount)
 		}
 	}
 	return numNodes

--- a/test/e2e/test/elasticsearch/settings.go
+++ b/test/e2e/test/elasticsearch/settings.go
@@ -24,7 +24,7 @@ func MustNumDataNodes(es v1alpha1.Elasticsearch) int {
 			panic(err)
 		}
 		if nodeCfg.Node.Data {
-			numNodes = numNodes + int(n.NodeCount)
+			numNodes += int(n.NodeCount)
 		}
 	}
 	return numNodes


### PR DESCRIPTION
Fixes an issue where data nodes where calculated incorrectly which we use to guestimate the number of replicas to use in e2e data integrity tests.