### PR TITLE
Remove commas from docker_images array declaration.

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -10,7 +10,7 @@ set -eou pipefail
 
 DOCKER_CI_IMAGE=$(cd build/ci/ && make show-image)
 
-declare -a docker_images=("$DOCKER_CI_IMAGE", "kindest/node:v1.14.3", "kindest/node:v1.15.0", "docker.elastic.co/elasticsearch/elasticsearch:7.3.0", "docker.elastic.co/kibana/kibana:7.3.0", "docker.elastic.co/apm/apm-server:7.3.0")
+declare -a docker_images=("$DOCKER_CI_IMAGE" "kindest/node:v1.14.3" "kindest/node:v1.15.0" "docker.elastic.co/elasticsearch/elasticsearch:7.3.0" "docker.elastic.co/kibana/kibana:7.3.0" "docker.elastic.co/apm/apm-server:7.3.0")
 
 # Pull all the required docker images
 for image in "${docker_images[@]}"


### PR DESCRIPTION
In #1680 a number of additional docker images were added, to be pulled during devops-ci image packing.

Unfortunately, bash "helpfully" includes the full strings as array members, including the commas. This resulted in [build failures](https://infra-ci.elastic.co/job/elastic+infra+master+packer-builder-devops-ci/BUILDER=gcp,BUILD_OS=ubuntu-1604-lts,label=linux%20&&%20immutable%20&&%20docker/106/console) due to `invalid reference format` errors, when packer_cache.sh was next run during packing.

In essence, it was trying to do this:

```
docker pull "kindest/node:v1.14.3,"
docker pull "kindest/node:v1.15.0,"
docker pull "docker.elastic.co/elasticsearch/elasticsearch:7.3.0,"
docker pull "docker.elastic.co/kibana/kibana:7.3.0,"
docker pull "docker.elastic.co/apm/apm-server:7.3.0"
```

This change just pops the commas out, so the strings are acceptable to docker again.

Just running `.ci/packer_cache.sh` should prove the change works :)