### PR TITLE
Adjust sampling rate in e2e test to be able to observe downscales

### DIFF
--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -60,7 +60,7 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 		test.Step{
 			Name: "Start tracking master additions and removals",
 			Test: func(t *testing.T) {
-				masterChangeBudgetCheck = NewMasterChangeBudgetCheck(b.Elasticsearch, 10*time.Second, k.Client)
+				masterChangeBudgetCheck = NewMasterChangeBudgetCheck(b.Elasticsearch, 1*time.Second, k.Client)
 				masterChangeBudgetCheck.Start()
 			},
 		},


### PR DESCRIPTION
The previous rate of 10 secs was chosen with upscales in mind but given the small amounts of
data we use in the test clusters downscales happen much quicker than 10 secs.


