### PR TITLE
For parameterized CI jobs add parameter to control Slack notifications

### DIFF
--- a/.ci/jobs/e2e-custom.yml
+++ b/.ci/jobs/e2e-custom.yml
@@ -11,6 +11,10 @@
           name: VERSION
           default: 1.12
           description: "Kubernetes version, default is 1.12"
+      - bool:
+          name: SEND_NOTIFICATIONS
+          default: true
+          description: "Specified if job should send notifications to Slack. Enabled by default."
     concurrent: true
     pipeline-scm:
       scm:

--- a/.ci/jobs/e2e-stack-versions.yml
+++ b/.ci/jobs/e2e-stack-versions.yml
@@ -7,6 +7,10 @@
       - string:
           name: IMAGE
           description: "Docker image with ECK"
+      - bool:
+          name: SEND_NOTIFICATIONS
+          default: true
+          description: "Specified if job should send notifications to Slack. Enabled by default."
     pipeline-scm:
       scm:
         - git:

--- a/.ci/jobs/gke-e2e-versions.yml
+++ b/.ci/jobs/gke-e2e-versions.yml
@@ -7,6 +7,10 @@
       - string:
           name: IMAGE
           description: "Docker image with ECK"
+      - bool:
+          name: SEND_NOTIFICATIONS
+          default: true
+          description: "Specified if job should send notifications to Slack. Enabled by default."
     pipeline-scm:
       scm:
         - git:

--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -52,12 +52,14 @@ pipeline {
     post {
         unsuccessful {
             script {
-                def msg = "E2E tests for different k8s versions in GKE failed!\r\n" + env.BUILD_URL
-                slackSend botUser: true,
-                    channel: '#cloud-k8s',
-                    color: 'danger',
-                    message: msg,
-                    tokenCredentialId: 'cloud-ci-slack-integration-token'
+                if (params.SEND_NOTIFICATIONS) {
+                    def msg = "E2E tests for different k8s versions in GKE failed!\r\n" + env.BUILD_URL
+                    slackSend botUser: true,
+                        channel: '#cloud-k8s',
+                        color: 'danger',
+                        message: msg,
+                        tokenCredentialId: 'cloud-ci-slack-integration-token'
+                }
             }
         }
         cleanup {

--- a/build/ci/e2e/custom_operator_image.jenkinsfile
+++ b/build/ci/e2e/custom_operator_image.jenkinsfile
@@ -54,12 +54,14 @@ EOF
     post {
         unsuccessful {
             script {
-                def msg = "E2E tests failed!\r\n" + env.BUILD_URL
-                slackSend botUser: true,
-                      channel: '#cloud-k8s',
-                      color: 'danger',
-                      message: msg,
-                      tokenCredentialId: 'cloud-ci-slack-integration-token'
+                if (params.SEND_NOTIFICATIONS) {
+                    def msg = "E2E tests failed!\r\n" + env.BUILD_URL
+                    slackSend botUser: true,
+                        channel: '#cloud-k8s',
+                        color: 'danger',
+                        message: msg,
+                        tokenCredentialId: 'cloud-ci-slack-integration-token'
+                }
             }
         }
         cleanup {

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -58,12 +58,14 @@ pipeline {
     post {
         unsuccessful {
             script {
-                def msg = "E2E tests for different Elastic stack versions failed!\r\n" + env.BUILD_URL
-                slackSend botUser: true,
-                      channel: '#cloud-k8s',
-                      color: 'danger',
-                      message: msg,
-                      tokenCredentialId: 'cloud-ci-slack-integration-token'
+                if (params.SEND_NOTIFICATIONS) {
+                    def msg = "E2E tests for different Elastic stack versions failed!\r\n" + env.BUILD_URL
+                    slackSend botUser: true,
+                        channel: '#cloud-k8s',
+                        color: 'danger',
+                        message: msg,
+                        tokenCredentialId: 'cloud-ci-slack-integration-token'
+                }
             }
         }
         cleanup {


### PR DESCRIPTION
This PR adds parameter to enable or disable Slack notifications for parameterized jobs. It can be helpful to control level of noise in Slack and/or to "debug" CI jobs without bothering others.