### PR TITLE
Always enable file based user auth

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -135,7 +135,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 			Labels: map[string]string{
 				"common.k8s.elastic.co/type":                        "elasticsearch",
 				"elasticsearch.k8s.elastic.co/cluster-name":         "name",
-				"elasticsearch.k8s.elastic.co/config-template-hash": "590139466",
+				"elasticsearch.k8s.elastic.co/config-template-hash": "2449560134",
 				"elasticsearch.k8s.elastic.co/http-scheme":          "https",
 				"elasticsearch.k8s.elastic.co/node-data":            "false",
 				"elasticsearch.k8s.elastic.co/node-ingest":          "true",

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -11,6 +11,7 @@ import (
 	commonv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/initcontainer"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
 	"github.com/go-test/deep"
@@ -87,7 +88,9 @@ var sampleES = v1alpha1.Elasticsearch{
 
 func TestBuildPodTemplateSpec(t *testing.T) {
 	nodeSpec := sampleES.Spec.Nodes[0]
-	cfg, err := settings.NewMergedESConfig(sampleES.Name, sampleES.Spec.HTTP, *nodeSpec.Config)
+	ver, err := version.Parse(sampleES.Spec.Version)
+	require.NoError(t, err)
+	cfg, err := settings.NewMergedESConfig(sampleES.Name, *ver, sampleES.Spec.HTTP, *nodeSpec.Config)
 	require.NoError(t, err)
 
 	actual, err := BuildPodTemplateSpec(sampleES, sampleES.Spec.Nodes[0], cfg, nil)

--- a/pkg/controller/elasticsearch/nodespec/resources.go
+++ b/pkg/controller/elasticsearch/nodespec/resources.go
@@ -5,6 +5,7 @@
 package nodespec
 
 import (
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
@@ -37,13 +38,18 @@ func (l ResourcesList) StatefulSets() sset.StatefulSetList {
 func BuildExpectedResources(es v1alpha1.Elasticsearch, keystoreResources *keystore.Resources) (ResourcesList, error) {
 	nodesResources := make(ResourcesList, 0, len(es.Spec.Nodes))
 
+	ver, err := version.Parse(es.Spec.Version)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, nodeSpec := range es.Spec.Nodes {
 		// build es config
 		userCfg := commonv1alpha1.Config{}
 		if nodeSpec.Config != nil {
 			userCfg = *nodeSpec.Config
 		}
-		cfg, err := settings.NewMergedESConfig(es.Name, es.Spec.HTTP, userCfg)
+		cfg, err := settings.NewMergedESConfig(es.Name, *ver, es.Spec.HTTP, userCfg)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/elasticsearch/settings/fields.go
+++ b/pkg/controller/elasticsearch/settings/fields.go
@@ -19,7 +19,9 @@ const (
 	PathData = "path.data"
 	PathLogs = "path.logs"
 
-	XPackSecurityAuthcRealmsFileFile1Order          = "xpack.security.authc.realms.file.file1.order"
+	XPackSecurityAuthcRealmsFileFile1Order          = "xpack.security.authc.realms.file.file1.order" // 7.x realm syntax
+	XPackSecurityAuthcRealmsFile1Order              = "xpack.security.authc.realms.file1.order"      // 6.x realm syntax
+	XPackSecurityAuthcRealmsFile1Type               = "xpack.security.authc.realms.file1.type"       // 6.x realm syntax
 	XPackSecurityAuthcReservedRealmEnabled          = "xpack.security.authc.reserved_realm.enabled"
 	XPackSecurityEnabled                            = "xpack.security.enabled"
 	XPackSecurityHttpSslCertificate                 = "xpack.security.http.ssl.certificate"

--- a/pkg/controller/elasticsearch/settings/fields.go
+++ b/pkg/controller/elasticsearch/settings/fields.go
@@ -19,6 +19,7 @@ const (
 	PathData = "path.data"
 	PathLogs = "path.logs"
 
+	XPackSecurityAuthcRealmsFileFile1Order          = "xpack.security.authc.realms.file.file1.order"
 	XPackSecurityAuthcReservedRealmEnabled          = "xpack.security.authc.reserved_realm.enabled"
 	XPackSecurityEnabled                            = "xpack.security.enabled"
 	XPackSecurityHttpSslCertificate                 = "xpack.security.http.ssl.certificate"

--- a/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/pkg/controller/elasticsearch/settings/merged_config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/apis/common/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	common "github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
 )
 
@@ -17,6 +18,7 @@ import (
 // parameters.
 func NewMergedESConfig(
 	clusterName string,
+	ver version.Version,
 	httpConfig v1alpha1.HTTPConfig,
 	userConfig v1alpha1.Config,
 ) (CanonicalConfig, error) {
@@ -26,7 +28,7 @@ func NewMergedESConfig(
 	}
 	err = config.MergeWith(
 		baseConfig(clusterName).CanonicalConfig,
-		xpackConfig(httpConfig).CanonicalConfig,
+		xpackConfig(ver, httpConfig).CanonicalConfig,
 	)
 	if err != nil {
 		return CanonicalConfig{}, err
@@ -54,16 +56,13 @@ func baseConfig(clusterName string) *CanonicalConfig {
 }
 
 // xpackConfig returns the configuration bit related to XPack settings
-func xpackConfig(httpCfg v1alpha1.HTTPConfig) *CanonicalConfig {
+func xpackConfig(ver version.Version, httpCfg v1alpha1.HTTPConfig) *CanonicalConfig {
 	// enable x-pack security, including TLS
 	cfg := map[string]interface{}{
 		// x-pack security general settings
 		XPackSecurityEnabled:                      "true",
 		XPackSecurityAuthcReservedRealmEnabled:    "false",
 		XPackSecurityTransportSslVerificationMode: "certificate",
-
-		// x-pack security file realm enabled first by default
-		XPackSecurityAuthcRealmsFileFile1Order: -100,
 
 		// x-pack security http settings
 		XPackSecurityHttpSslEnabled:     httpCfg.TLS.Enabled(),
@@ -86,5 +85,16 @@ func xpackConfig(httpCfg v1alpha1.HTTPConfig) *CanonicalConfig {
 			path.Join(volume.TransportCertificatesSecretVolumeMountPath, certificates.CAFileName),
 		},
 	}
+
+	// always enable the built-in file internal realm for user auth, ordered as first
+	if ver.Major < 7 {
+		// 6.x syntax
+		cfg[XPackSecurityAuthcRealmsFile1Type] = "file"
+		cfg[XPackSecurityAuthcRealmsFile1Order] = -100
+	} else {
+		// 7.x syntax
+		cfg[XPackSecurityAuthcRealmsFileFile1Order] = -100
+	}
+
 	return &CanonicalConfig{common.MustCanonicalConfig(cfg)}
 }

--- a/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/pkg/controller/elasticsearch/settings/merged_config.go
@@ -13,7 +13,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
 )
 
-// NewMergedESConfig merges user provided Elasticsearch configuration with configuration derived  from the given
+// NewMergedESConfig merges user provided Elasticsearch configuration with configuration derived from the given
 // parameters.
 func NewMergedESConfig(
 	clusterName string,
@@ -61,6 +61,9 @@ func xpackConfig(httpCfg v1alpha1.HTTPConfig) *CanonicalConfig {
 		XPackSecurityEnabled:                      "true",
 		XPackSecurityAuthcReservedRealmEnabled:    "false",
 		XPackSecurityTransportSslVerificationMode: "certificate",
+
+		// x-pack security file realm enabled first by default
+		XPackSecurityAuthcRealmsFileFile1Order: -100,
 
 		// x-pack security http settings
 		XPackSecurityHttpSslEnabled:     httpCfg.TLS.Enabled(),

--- a/pkg/controller/elasticsearch/settings/merged_config_test.go
+++ b/pkg/controller/elasticsearch/settings/merged_config_test.go
@@ -8,20 +8,63 @@ import (
 	"testing"
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/common/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewMergedESConfig(t *testing.T) {
 	nodeML := "node.ml"
 	xPackSecurityAuthcRealmsNativeNative1Order := "xpack.security.authc.realms.native.native1.order"
+	xPackSecurityAuthcRealmsNative1Type := "xpack.security.authc.realms.native1.type"
+	xPackSecurityAuthcRealmsNative1Order := "xpack.security.authc.realms.native1.order"
 
 	tests := []struct {
 		name    string
+		version string
 		cfgData map[string]interface{}
 		assert  func(cfg CanonicalConfig)
 	}{
 		{
-			name:    "empty config should have the default file realm settings configured",
+			name:    "in 6.x, empty config should have the default file realm settings configured",
+			version: "6.8.0",
+			cfgData: map[string]interface{}{},
+			assert: func(cfg CanonicalConfig) {
+				require.Equal(t, 0, len(cfg.HasKeys([]string{nodeML})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFile1Type})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFile1Order})))
+			},
+		},
+		{
+			name:    "in 6.x, sample config should have the default file realm settings configured",
+			version: "6.8.0",
+			cfgData: map[string]interface{}{
+				nodeML: true,
+			},
+			assert: func(cfg CanonicalConfig) {
+				require.Equal(t, 1, len(cfg.HasKeys([]string{nodeML})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFile1Type})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFile1Order})))
+			},
+		},
+		{
+			name:    "in 6.x, native realm settings should be merged with the default file realm settings",
+			version: "6.8.0",
+			cfgData: map[string]interface{}{
+				nodeML:                               true,
+				xPackSecurityAuthcRealmsNative1Type:  "native",
+				xPackSecurityAuthcRealmsNative1Order: 0,
+			},
+			assert: func(cfg CanonicalConfig) {
+				require.Equal(t, 1, len(cfg.HasKeys([]string{nodeML})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFile1Type})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFile1Order})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{xPackSecurityAuthcRealmsNative1Type})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{xPackSecurityAuthcRealmsNative1Order})))
+			},
+		},
+		{
+			name:    "in 7.x, empty config should have the default file realm settings configured",
+			version: "7.3.0",
 			cfgData: map[string]interface{}{},
 			assert: func(cfg CanonicalConfig) {
 				require.Equal(t, 0, len(cfg.HasKeys([]string{nodeML})))
@@ -29,7 +72,8 @@ func TestNewMergedESConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "sample config should have the default file realm settings configured",
+			name:    "in 7.x, sample config should have the default file realm settings configured",
+			version: "7.3.0",
 			cfgData: map[string]interface{}{
 				nodeML: true,
 			},
@@ -39,7 +83,8 @@ func TestNewMergedESConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "native realm settings should be merged with the default file realm settings",
+			name:    "in 7.x, native realm settings should be merged with the default file realm settings",
+			version: "7.3.0",
 			cfgData: map[string]interface{}{
 				nodeML: true,
 				xPackSecurityAuthcRealmsNativeNative1Order: 0,
@@ -53,7 +98,9 @@ func TestNewMergedESConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewMergedESConfig("clusterName", v1alpha1.HTTPConfig{}, v1alpha1.Config{
+			ver, err := version.Parse(tt.version)
+			require.NoError(t, err)
+			cfg, err := NewMergedESConfig("clusterName", *ver, v1alpha1.HTTPConfig{}, v1alpha1.Config{
 				Data: tt.cfgData,
 			})
 			require.NoError(t, err)

--- a/pkg/controller/elasticsearch/settings/merged_config_test.go
+++ b/pkg/controller/elasticsearch/settings/merged_config_test.go
@@ -1,0 +1,63 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package settings
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/pkg/apis/common/v1alpha1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMergedESConfig(t *testing.T) {
+	nodeML := "node.ml"
+	xPackSecurityAuthcRealmsNativeNative1Order := "xpack.security.authc.realms.native.native1.order"
+
+	tests := []struct {
+		name    string
+		cfgData map[string]interface{}
+		assert  func(cfg CanonicalConfig)
+	}{
+		{
+			name:    "empty config should have the default file realm settings configured",
+			cfgData: map[string]interface{}{},
+			assert: func(cfg CanonicalConfig) {
+				require.Equal(t, 0, len(cfg.HasKeys([]string{nodeML})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFileFile1Order})))
+			},
+		},
+		{
+			name: "sample config should have the default file realm settings configured",
+			cfgData: map[string]interface{}{
+				nodeML: true,
+			},
+			assert: func(cfg CanonicalConfig) {
+				require.Equal(t, 1, len(cfg.HasKeys([]string{nodeML})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFileFile1Order})))
+			},
+		},
+		{
+			name: "native realm settings should be merged with the default file realm settings",
+			cfgData: map[string]interface{}{
+				nodeML: true,
+				xPackSecurityAuthcRealmsNativeNative1Order: 0,
+			},
+			assert: func(cfg CanonicalConfig) {
+				require.Equal(t, 1, len(cfg.HasKeys([]string{nodeML})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFileFile1Order})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{xPackSecurityAuthcRealmsNativeNative1Order})))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := NewMergedESConfig("clusterName", v1alpha1.HTTPConfig{}, v1alpha1.Config{
+				Data: tt.cfgData,
+			})
+			require.NoError(t, err)
+			tt.assert(cfg)
+		})
+	}
+}


### PR DESCRIPTION
The operator relies on file realm for creating all the internal users
including the built-in elastic user. This commit makes sure the file
realm is always enabled in case a user wants to configure additional
realms.
The order of the file realm is set to -100 to favor the fact that it is
used first but there is no complete guarantee about that. The user can
still configure a realm with an order less than -100 but it is very
unlikely given this is not suggested in the documentation (order starts to 0).
The main known issue could be to configure a realm that relies on a
system (e.g. Active Directory) that has a temporary lock-out period
after several successive failed login attempts, as being checked first
(https://www.elastic.co/guide/en/elastic-stack-overview/current/trouble-shoot-active-directory.html).

Resolves #1629.