### PR TITLE
Refactor logging configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ SNAPSHOT   	?= true
 
 LATEST_RELEASED_IMG ?= "docker.elastic.co/eck/$(NAME):0.8.0"
 
+# Default to debug logging
+LOG_VERBOSITY ?= 1
+
 ## -- Docker image
 
 # on GKE, use GCR and GCLOUD_PROJECT
@@ -76,7 +79,7 @@ dep:
 
 dep-vendor-only:
 	# don't attempt to upgrade Gopkg.lock
-	dep ensure --vendor-only 
+	dep ensure --vendor-only
 
 # Generate API types code and manifests from annotations e.g. CRD, RBAC etc.
 generate:
@@ -131,7 +134,7 @@ go-run:
 			-tags "$(GO_TAGS)" \
 			./cmd/main.go manager \
 				--development --operator-roles=global,namespace \
-				--enable-debug-logs=true \
+				--log-verbosity=$(LOG_VERBOSITY) \
 				--ca-cert-validity=10h --ca-cert-rotate-before=1h \
 				--operator-namespace=default --namespace= \
 				--auto-install-webhooks=false
@@ -310,7 +313,8 @@ e2e-run:
 		--operator-image=$(OPERATOR_IMAGE) \
 		--e2e-image=$(E2E_IMG) \
 		--test-regex=$(TESTS_MATCH) \
-		--elastic-stack-version=$(STACK_VERSION)
+		--elastic-stack-version=$(STACK_VERSION) \
+		--log-verbosity=$(LOG_VERBOSITY)
 
 # Verify e2e tests compile with no errors, don't run them
 e2e-compile:
@@ -326,7 +330,8 @@ e2e-local:
 		--test-context-out=$(LOCAL_E2E_CTX) \
 		--elastic-stack-version=$(STACK_VERSION) \
 		--auto-port-forwarding \
-		--local
+		--local \
+		--log-verbosity=$(LOG_VERBOSITY)
 	@test/e2e/run.sh -run "$(TESTS_MATCH)" -args -testContextPath $(LOCAL_E2E_CTX)
 
 ##########################################

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,27 +7,24 @@ package main
 import (
 	"github.com/elastic/cloud-on-k8s/cmd/manager"
 	"github.com/elastic/cloud-on-k8s/pkg/dev"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/log"
 	"github.com/spf13/cobra"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-var log = logf.Log.WithName("main")
-
 func main() {
 	var rootCmd = &cobra.Command{Use: "elastic-operator"}
-	logLevelFlag := "enable-debug-logs"
 	rootCmd.AddCommand(manager.Cmd)
 	// development mode is only available as a command line flag to avoid accidentally enabling it
 	rootCmd.PersistentFlags().BoolVar(&dev.Enabled, "development", false, "turns on development mode")
-	rootCmd.PersistentFlags().Bool(logLevelFlag, false, "If true, enables debug logs. Defaults to false")
+	log.BindFlags(rootCmd.PersistentFlags())
 
 	cobra.OnInitialize(func() {
-		debug, _ := rootCmd.Flags().GetBool(logLevelFlag)
-		logf.SetLogger(logf.ZapLogger(debug))
+		log.InitLogger()
 	})
 
 	if err := rootCmd.Execute(); err != nil {
-		log.Error(err, "Unexpected error while executing command")
+		logf.Log.WithName("main").Error(err, "Unexpected error while executing command")
 	}
 }

--- a/pkg/about/info.go
+++ b/pkg/about/info.go
@@ -74,12 +74,7 @@ func GetOperatorInfo(clientset kubernetes.Interface, operatorNs string, operator
 		OperatorRoles:           operatorRoles,
 		CustomOperatorNamespace: customOperatorNs,
 		Distribution:            distribution,
-		BuildInfo: BuildInfo{
-			version,
-			buildHash,
-			buildDate,
-			buildSnapshot,
-		},
+		BuildInfo:               GetBuildInfo(),
 	}, nil
 }
 
@@ -140,4 +135,14 @@ func getDistribution(clientset kubernetes.Interface) (string, error) {
 	}
 
 	return version.GitVersion, nil
+}
+
+// GetBuildInfo returns information about the current build.
+func GetBuildInfo() BuildInfo {
+	return BuildInfo{
+		version,
+		buildHash,
+		buildDate,
+		buildSnapshot,
+	}
 }

--- a/pkg/utils/log/log.go
+++ b/pkg/utils/log/log.go
@@ -1,0 +1,118 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package log
+
+import (
+	"flag"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/elastic/cloud-on-k8s/pkg/about"
+	"github.com/elastic/cloud-on-k8s/pkg/dev"
+	"github.com/go-logr/zapr"
+	pflag "github.com/spf13/pflag"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"k8s.io/klog"
+	crlog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var (
+	verbosity       = flag.Int("log-verbosity", 0, "Verbosity level of logs (-2=Error, -1=Warn, 0=Info, >0=Debug)")
+	enableDebugLogs = flag.Bool("enable-debug-logs", false, "Enable debug logs")
+)
+
+// BindFlags attaches logging flags to the given flag set.
+func BindFlags(flags *pflag.FlagSet) {
+	flags.AddGoFlag(flag.Lookup("log-verbosity"))
+	flags.AddGoFlag(flag.Lookup("enable-debug-logs"))
+}
+
+// InitLogger initializes the global logger informed by the values of log-verbosity and enable-debug-logs flags.
+func InitLogger() {
+	setLogger(verbosity, enableDebugLogs)
+}
+
+// ChangeVerbosity replaces the global logger with a new logger set to the sepcified verbosity level.
+// Verbosity levels from 2 are custom levels that increase the verbosity as the value increases.
+// Standard levels are as follows:
+// level | Zap level | name
+// -------------------------
+//  1    | -1        | Debug
+//  0    |  0        | Info
+// -1    |  1        | Warn
+// -2    |  2        | Error
+func ChangeVerbosity(v int) {
+	debugLogs := false
+	setLogger(&v, &debugLogs)
+}
+
+func setLogger(v *int, debug *bool) {
+	level := determineLogLevel(v, debug)
+
+	// if the level is higher than 1 set the klog level to the same level
+	if level.Level() < zap.DebugLevel {
+		flagset := flag.NewFlagSet("", flag.ContinueOnError)
+		klog.InitFlags(flagset)
+		_ = flagset.Set("v", strconv.Itoa(int(level.Level())*-1))
+	}
+
+	var encoder zapcore.Encoder
+	var opts []zap.Option
+	if dev.Enabled {
+		encoderConf := zap.NewDevelopmentEncoderConfig()
+		encoderConf.EncodeLevel = zapcore.CapitalColorLevelEncoder
+		encoder = zapcore.NewConsoleEncoder(encoderConf)
+
+		opts = append(opts, zap.Development(), zap.AddStacktrace(zap.ErrorLevel))
+	} else {
+		encoderConf := zap.NewProductionEncoderConfig()
+		encoderConf.MessageKey = "message"
+		encoderConf.TimeKey = "@timestamp"
+		encoderConf.EncodeTime = zapcore.ISO8601TimeEncoder
+		encoder = zapcore.NewJSONEncoder(encoderConf)
+
+		opts = append(opts, zap.AddStacktrace(zap.WarnLevel))
+		if level.Level() > zap.DebugLevel {
+			opts = append(opts, zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+				return zapcore.NewSampler(core, time.Second, 100, 100)
+			}))
+		}
+	}
+
+	sink := zapcore.AddSync(os.Stderr)
+	opts = append(opts, zap.AddCallerSkip(1), zap.ErrorOutput(sink))
+	log := zap.New(zapcore.NewCore(&crlog.KubeAwareEncoder{Encoder: encoder, Verbose: dev.Enabled}, sink, level))
+	log = log.WithOptions(opts...)
+	log = log.With(zap.String("ver", getVersionString()))
+
+	crlog.SetLogger(zapr.NewLogger(log))
+}
+
+func determineLogLevel(v *int, debug *bool) zap.AtomicLevel {
+	switch {
+	case v != nil && *v > -3:
+		return zap.NewAtomicLevelAt(zapcore.Level(*v * -1))
+	case debug != nil && *debug:
+		return zap.NewAtomicLevelAt(zapcore.DebugLevel)
+	case dev.Enabled:
+		return zap.NewAtomicLevelAt(zapcore.DebugLevel)
+	default:
+		return zap.NewAtomicLevelAt(zapcore.InfoLevel)
+	}
+}
+
+func getVersionString() string {
+	var version strings.Builder
+	buildInfo := about.GetBuildInfo()
+
+	version.WriteString(buildInfo.Version)
+	version.WriteString("-")
+	version.WriteString(buildInfo.Hash)
+
+	return version.String()
+}

--- a/pkg/utils/log/log.go
+++ b/pkg/utils/log/log.go
@@ -76,7 +76,7 @@ func setLogger(v *int, debug *bool) {
 		encoderConf.EncodeTime = zapcore.ISO8601TimeEncoder
 		encoder = zapcore.NewJSONEncoder(encoderConf)
 
-		opts = append(opts, zap.AddStacktrace(zap.WarnLevel))
+		opts = append(opts, zap.AddStacktrace(zap.ErrorLevel))
 		if zapLevel.Level() > zap.DebugLevel {
 			opts = append(opts, zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 				return zapcore.NewSampler(core, time.Second, 100, 100)

--- a/test/e2e/cmd/main.go
+++ b/test/e2e/cmd/main.go
@@ -7,10 +7,10 @@ package main
 import (
 	"os"
 
+	"github.com/elastic/cloud-on-k8s/pkg/utils/log"
 	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 func main() {
@@ -19,7 +19,7 @@ func main() {
 		Short:        "E2E testing utilities",
 		SilenceUsage: true,
 		PersistentPreRun: func(_ *cobra.Command, _ []string) {
-			logf.SetLogger(logf.ZapLogger(false))
+			log.InitLogger()
 		},
 	}
 

--- a/test/e2e/cmd/run/command.go
+++ b/test/e2e/cmd/run/command.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	logutil "github.com/elastic/cloud-on-k8s/pkg/utils/log"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -33,6 +34,7 @@ type runFlags struct {
 	autoPortForwarding  bool
 	skipCleanup         bool
 	local               bool
+	logVerbosity        int
 }
 
 var log logr.Logger
@@ -52,7 +54,8 @@ func Command() *cobra.Command {
 
 			return nil
 		},
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			flags.logVerbosity, _ = cmd.PersistentFlags().GetInt("log-verbosity")
 			return doRun(flags)
 		},
 	}
@@ -71,6 +74,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&flags.scratchDirRoot, "scratch-dir", "/tmp/eck-e2e", "Path under which temporary files should be created")
 	cmd.Flags().StringVar(&flags.testRegex, "test-regex", "", "Regex to pass to the test runner")
 	cmd.Flags().StringVar(&flags.testRunName, "test-run-name", randomTestRunName(), "Name of this test run")
+	logutil.BindFlags(cmd.PersistentFlags())
 
 	// enable setting flags via environment variables
 	_ = viper.BindPFlags(cmd.Flags())

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -129,6 +129,7 @@ func (h *helper) initTestContext() error {
 			Namespace: fmt.Sprintf("%s-elastic-system", h.testRunName),
 		},
 		Local:              h.local,
+		LogVerbosity:       h.logVerbosity,
 		NamespaceOperators: make([]test.NamespaceOperator, len(h.managedNamespaces)),
 		OperatorImage:      h.operatorImage,
 		TestLicence:        h.testLicence,

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"sync"
 
+	logutil "github.com/elastic/cloud-on-k8s/pkg/utils/log"
+	"github.com/go-logr/logr"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
@@ -20,11 +22,12 @@ var (
 	testContextPath = flag.String("testContextPath", "", "Path to the test context file")
 	ctxInit         sync.Once
 	ctx             Context
-	log             = logf.Log.WithName("e2e")
+	log             logr.Logger
 )
 
 func init() {
-	logf.SetLogger(logf.ZapLogger(true))
+	logutil.InitLogger()
+	log = logf.Log.WithName("e2e")
 }
 
 // Ctx returns the current test context.
@@ -51,6 +54,7 @@ func initializeContext() {
 		panic(fmt.Errorf("failed to decode test context: %v", err))
 	}
 
+	logutil.ChangeVerbosity(ctx.LogVerbosity)
 	log.Info("Test context initialized", "context", ctx)
 }
 
@@ -90,6 +94,7 @@ type Context struct {
 	E2ENamespace        string              `json:"e2e_namespace"`
 	E2EServiceAccount   string              `json:"e2e_service_account"`
 	ElasticStackVersion string              `json:"elastic_stack_version"`
+	LogVerbosity        int                 `json:"log_verbosity"`
 	OperatorImage       string              `json:"operator_image"`
 	TestLicence         string              `json:"test_licence"`
 	TestRegex           string              `json:"test_regex"`


### PR DESCRIPTION
This change does the following:
- Allow logging verbosity levels to be configured from the command-line (`log.V(2)` etc. should actually work as intended now) 
- Output the timestamp in ISO8601 format (#1587)
- Change log message key to `message` (StackDriver logging can render logs nicely if this key exists)
- Change timestamp key to `@timestamp`
- Add the `ver` key to report operator version in log lines
- Propagate log verbosity to E2E tests

As we are currently on controller-runtime v0.1, `log.InitLogger` is much more complicated than it needs to be. When we migrate to controller-runtime v0.2 it can be simplified.

The suggestion in #1587 to be compatible with ECS logging format by renaming `logger` to `log.level` and `level` to `log.level` didn't seem to add much benefit at this point so I have left the shorter keys in place to aid readability.

Fixes #1587 
