### PR TITLE
Update Packer cache for Docker images for newer Kind version

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -10,7 +10,7 @@ set -eou pipefail
 
 DOCKER_CI_IMAGE=$(cd build/ci/ && make show-image)
 
-declare -a docker_images=("$DOCKER_CI_IMAGE" "kindest/node:v1.14.3" "kindest/node:v1.15.0" "docker.elastic.co/elasticsearch/elasticsearch:7.3.0" "docker.elastic.co/kibana/kibana:7.3.0" "docker.elastic.co/apm/apm-server:7.3.0")
+declare -a docker_images=("$DOCKER_CI_IMAGE" "kindest/node:v1.14.6" "kindest/node:v1.15.3" "docker.elastic.co/elasticsearch/elasticsearch:7.3.0" "docker.elastic.co/kibana/kibana:7.3.0" "docker.elastic.co/apm/apm-server:7.3.0")
 
 # Pull all the required docker images
 for image in "${docker_images[@]}"


### PR DESCRIPTION
This PR updates cached images for Packer for latest version of `kind` in https://github.com/elastic/infra/pull/14393