### PR TITLE
Update location of Stack version attributes file

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -4,7 +4,7 @@
 :idprefix: k8s-
 :s: k8s
 
-include::{asciidoc-dir}/../../shared/versions70.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 include::overview.asciidoc[]
 include::k8s-quickstart.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -4,7 +4,7 @@
 :idprefix: k8s-
 :s: k8s
 
-include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/7.x.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 include::overview.asciidoc[]
 include::k8s-quickstart.asciidoc[]


### PR DESCRIPTION
Docs team have moved the stack version attributes file to a different location (see https://github.com/elastic/docs/pull/1172 for more information.)


 
