### PR TITLE
Return early on internal reconciliation error

### DIFF
--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -216,6 +216,12 @@ func (r *ReconcileElasticsearch) Reconcile(request reconcile.Request) (reconcile
 
 	state := esreconcile.NewState(es)
 	results := r.internalReconcile(es, state)
+	if results.HasError() {
+		res, err := results.Aggregate()
+		k8s.EmitErrorEvent(r.recorder, err, &es, events.EventReconciliationError, "Reconciliation error: %v", err)
+		return res, err
+	}
+
 	err = r.updateStatus(es, state)
 	if err != nil {
 		if apierrors.IsConflict(err) {


### PR DESCRIPTION
In the Elasticsearch operator, the state is updated without checking the error status of the preceding reconcile function which performs bulk of the reconciliation logic. Applying a partially updated state is probably not safe so we should report the error and return from the function.

Related to #1478 