### PR TITLE
Enable linter for hack dir and fix all issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ run:
   deadline: 300s
   skip-dirs:
     - config
-    - hack
   skip-files:
     - utils/chrono/millis\.test\.go
 linters:

--- a/hack/deployer/cmd/create.go
+++ b/hack/deployer/cmd/create.go
@@ -19,7 +19,7 @@ overrides:
     gCloudProject: %s
 `
 
-func CreateCommand() *cobra.Command{
+func CreateCommand() *cobra.Command {
 	var path string
 
 	var createCommand = &cobra.Command{

--- a/hack/deployer/cmd/root.go
+++ b/hack/deployer/cmd/root.go
@@ -28,7 +28,7 @@ func Execute() {
 	}
 }
 
-func registerFileFlags(cmd *cobra.Command) (*string, *string){
+func registerFileFlags(cmd *cobra.Command) (*string, *string) {
 	var plansFile, configFile string
 	cmd.PersistentFlags().StringVar(&plansFile, "plans-file", "config/plans.yml", "File containing execution plans.")
 	cmd.PersistentFlags().StringVar(&configFile, "config-file", "config/deployer-config.yml", "File containing run config.")

--- a/hack/deployer/runner/aks.go
+++ b/hack/deployer/runner/aks.go
@@ -174,29 +174,29 @@ func (d *AksDriver) configureDocker() error {
 		return err
 	}
 
-	if !d.plan.ServiceAccount {
+	if d.plan.ServiceAccount {
 		// it's already set for the ServiceAccount
-		cmd := `az aks show --resource-group {{.ResourceGroup}} --name {{.ClusterName}} --query "servicePrincipalProfile.clientId" --output tsv`
-		clientIds, err := NewCommand(cmd).AsTemplate(d.ctx).StdoutOnly().OutputList()
-		if err != nil {
-			return err
-		}
-
-		cmd = `az acr show --resource-group {{.ResourceGroup}} --name {{.AcrName}} --query "id" --output tsv`
-		acrIds, err := NewCommand(cmd).AsTemplate(d.ctx).StdoutOnly().OutputList()
-		if err != nil {
-			return err
-		}
-
-		return NewCommand(`az role assignment create --assignee {{.ClientId}} --role acrpull --scope {{.AcrId}}`).
-			AsTemplate(map[string]interface{}{
-				"ClientId": clientIds[0],
-				"AcrId":    acrIds[0],
-			}).
-			Run()
+		return nil
 	}
 
-	return nil
+	cmd := `az aks show --resource-group {{.ResourceGroup}} --name {{.ClusterName}} --query "servicePrincipalProfile.clientId" --output tsv`
+	clientIds, err := NewCommand(cmd).AsTemplate(d.ctx).StdoutOnly().OutputList()
+	if err != nil {
+		return err
+	}
+
+	cmd = `az acr show --resource-group {{.ResourceGroup}} --name {{.AcrName}} --query "id" --output tsv`
+	acrIds, err := NewCommand(cmd).AsTemplate(d.ctx).StdoutOnly().OutputList()
+	if err != nil {
+		return err
+	}
+
+	return NewCommand(`az role assignment create --assignee {{.ClientId}} --role acrpull --scope {{.AcrId}}`).
+		AsTemplate(map[string]interface{}{
+			"ClientId": clientIds[0],
+			"AcrId":    acrIds[0],
+		}).
+		Run()
 }
 
 func (d *AksDriver) GetCredentials() error {

--- a/hack/deployer/runner/aks.go
+++ b/hack/deployer/runner/aks.go
@@ -10,11 +10,11 @@ import (
 )
 
 func init() {
-	drivers[AksDriverId] = &AksDriverFactory{}
+	drivers[AksDriverID] = &AksDriverFactory{}
 }
 
 const (
-	AksDriverId                    = "aks"
+	AksDriverID                    = "aks"
 	AksVaultPath                   = "secret/devops-ci/cloud-on-k8s/ci-azr-k8s-operator"
 	AksResourceGroupVaultFieldName = "resource-group"
 	AksAcrNameVaultFieldName       = "acr-name"
@@ -78,7 +78,9 @@ func (d *AksDriver) Execute() error {
 	switch d.plan.Operation {
 	case "delete":
 		if exists {
-			err = d.delete()
+			if err := d.delete(); err != nil {
+				return err
+			}
 		} else {
 			log.Printf("not deleting as cluster doesn't exist")
 		}
@@ -99,7 +101,7 @@ func (d *AksDriver) Execute() error {
 			return err
 		}
 	default:
-		err = fmt.Errorf("unknown operation %s", d.plan.Operation)
+		return fmt.Errorf("unknown operation %s", d.plan.Operation)
 	}
 
 	return nil
@@ -113,21 +115,21 @@ func (d *AksDriver) auth() error {
 		if err != nil {
 			return err
 		}
-		appId, tenantSecret, tenantId := secrets[0], secrets[1], secrets[2]
+		appID, tenantSecret, tenantID := secrets[0], secrets[1], secrets[2]
 
 		cmd := "az login --service-principal -u {{.AppId}} -p {{.TenantSecret}} --tenant {{.TenantId}}"
 		return NewCommand(cmd).
 			AsTemplate(map[string]interface{}{
-				"AppId":        appId,
+				"AppId":        appID,
 				"TenantSecret": tenantSecret,
-				"TenantId":     tenantId,
+				"TenantId":     tenantID,
 			}).
 			WithoutStreaming().
 			Run()
-	} else {
-		log.Print("Authenticating as user...")
-		return NewCommand("az login").Run()
 	}
+
+	log.Print("Authenticating as user...")
+	return NewCommand("az login").Run()
 }
 
 func (d *AksDriver) clusterExists() (bool, error) {

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -12,13 +12,13 @@ import (
 )
 
 const (
-	GkeDriverId                     = "gke"
+	GkeDriverID                     = "gke"
 	GkeVaultPath                    = "secret/devops-ci/cloud-on-k8s/ci-gcp-k8s-operator"
 	GkeServiceAccountVaultFieldName = "service-account"
 )
 
 func init() {
-	drivers[GkeDriverId] = &GkeDriverFactory{}
+	drivers[GkeDriverID] = &GkeDriverFactory{}
 }
 
 type GkeDriverFactory struct {
@@ -67,7 +67,7 @@ func (d *GkeDriver) Execute() error {
 		if exists {
 			log.Printf("not creating as cluster exists")
 		} else {
-			if err := d.configSsh(); err != nil {
+			if err := d.configSSH(); err != nil {
 				return err
 			}
 
@@ -120,19 +120,19 @@ func (d *GkeDriver) auth() error {
 		}
 
 		return NewCommand("gcloud auth activate-service-account --key-file=" + keyFileName).Run()
-	} else {
-		log.Println("Authenticating as user...")
-		accounts, err := NewCommand(`gcloud auth list "--format=value(account)"`).StdoutOnly().WithoutStreaming().Output()
-		if err != nil {
-			return err
-		}
-
-		if len(accounts) > 0 {
-			return nil
-		}
-
-		return NewCommand("gcloud auth login").Run()
 	}
+
+	log.Println("Authenticating as user...")
+	accounts, err := NewCommand(`gcloud auth list "--format=value(account)"`).StdoutOnly().WithoutStreaming().Output()
+	if err != nil {
+		return err
+	}
+
+	if len(accounts) > 0 {
+		return nil
+	}
+
+	return NewCommand("gcloud auth login").Run()
 }
 
 func (d *GkeDriver) clusterExists() (bool, error) {
@@ -147,7 +147,7 @@ func (d *GkeDriver) clusterExists() (bool, error) {
 	return err == nil, err
 }
 
-func (d *GkeDriver) configSsh() error {
+func (d *GkeDriver) configSSH() error {
 	log.Println("Configuring ssh...")
 	return NewCommand("gcloud --quiet --project {{.GCloudProject}} compute config-ssh").AsTemplate(d.ctx).Run()
 }

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -17,7 +17,7 @@ type Plans struct {
 
 // Plan encapsulates information needed to provision a cluster
 type Plan struct {
-	Id                string `yaml:"id"`
+	Id                string `yaml:"id"` //nolint
 	Operation         string `yaml:"operation"`
 	ClusterName       string `yaml:"clusterName"`
 	Provider          string `yaml:"provider"`
@@ -26,7 +26,7 @@ type Plan struct {
 	ServiceAccount    bool   `yaml:"serviceAccount"`
 
 	Psp      bool `yaml:"psp"`
-	VmMapMax bool `yaml:"vmMapMax"`
+	VmMapMax bool `yaml:"vmMapMax"` //nolint
 
 	Gke *GkeSettings `yaml:"gke,omitempty"`
 	Aks *AksSettings `yaml:"aks,omitempty"`
@@ -36,8 +36,8 @@ type Plan struct {
 
 type VaultInfo struct {
 	Address  string `yaml:"address"`
-	RoleId   string `yaml:"roleId"`
-	SecretId string `yaml:"secretId"`
+	RoleId   string `yaml:"roleId"`   //nolint
+	SecretId string `yaml:"secretId"` //nolint
 	Token    string `yaml:"token"`
 }
 
@@ -60,7 +60,7 @@ type AksSettings struct {
 
 // RunConfig encapsulates Id used to choose a plan and a map of overrides to apply to the plan, expected to map to a file
 type RunConfig struct {
-	Id        string                 `yaml:"id"`
+	Id        string                 `yaml:"id"` //nolint
 	Overrides map[string]interface{} `yaml:"overrides"`
 }
 

--- a/hack/deployer/runner/vault.go
+++ b/hack/deployer/runner/vault.go
@@ -13,8 +13,8 @@ import (
 
 type VaultClient struct {
 	client   *api.Client
-	roleId   string
-	secretId string
+	roleID   string
+	secretID string
 	token    string
 }
 
@@ -26,8 +26,8 @@ func NewClient(info VaultInfo) (*VaultClient, error) {
 
 	return &VaultClient{
 		client:   client,
-		roleId:   info.RoleId,
-		secretId: info.SecretId,
+		roleID:   info.RoleId,
+		secretID: info.SecretId,
 		token:    info.Token,
 	}, nil
 }
@@ -41,13 +41,14 @@ func (v *VaultClient) auth() error {
 	var data map[string]interface{}
 	var method string
 
-	if v.token != "" {
+	switch {
+	case v.token != "":
 		method = "github"
 		data = map[string]interface{}{"token": v.token}
-	} else if v.roleId != "" && v.secretId != "" {
+	case v.roleID != "" && v.secretID != "":
 		method = "approle"
-		data = map[string]interface{}{"role_id": v.roleId, "secret_id": v.secretId}
-	} else {
+		data = map[string]interface{}{"role_id": v.roleID, "secret_id": v.secretID}
+	default:
 		return fmt.Errorf("vault auth info not present")
 	}
 

--- a/hack/release_notes.go
+++ b/hack/release_notes.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"html/template"
 	"io"
@@ -96,7 +95,7 @@ type TemplateParams struct {
 }
 
 func fetch(url string, out interface{}) (string, error) {
-	resp, err := http.Get(url)
+	resp, err := http.Get(url) //#nosec
 	if err != nil {
 		return "", err
 	}
@@ -105,7 +104,7 @@ func fetch(url string, out interface{}) (string, error) {
 	nextLink := extractNextLink(resp.Header)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", errors.New(fmt.Sprintf("%s: %d %s ", url, resp.StatusCode, resp.Status))
+		return "", fmt.Errorf("%s: %d %s ", url, resp.StatusCode, resp.Status)
 	}
 
 	if err = json.NewDecoder(resp.Body).Decode(&out); err != nil {


### PR DESCRIPTION
I've noticed that hack/ is skipped in our config and since now we have somewhat important code there I've enabled it and fixed all issues. @pebrc, FYI, I've also fixed two nits in release_notes.go.