### PR TITLE
Add list of supported versions to the docs

### DIFF
--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -15,7 +15,7 @@ With Elastic Cloud on Kubernetes you can streamline all those critical operation
 Supported versions:
 
 . Kubernetes: 1.11+
-. Elasticsearch: 6.8, 7.1+
+. Elasticsearch: 6.8.x, 7.1+
 
 Learn more about ECK:
 

--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -12,6 +12,11 @@ With Elastic Cloud on Kubernetes you can streamline all those critical operation
 . Securing clusters with TLS certificates
 . Setting up hot-warm-cold architectures with availability zone awareness
 
+Supported versions:
+
+. Kubernetes: 1.11+
+. Elasticsearch: 6.8, 7.1+
+
 Learn more about ECK:
 
 - link:https://www.elastic.co/elasticsearch-kubernetes[Orchestrate Elasticsearch on Kubernetes]


### PR DESCRIPTION
Looks like we have a list of supported k8s and stack versions only in https://github.com/elastic/cloud-on-k8s/blob/master/README.md but not in the docs. 