### PR TITLE
Do not support clusters with ES version <6.8

### DIFF
--- a/pkg/controller/elasticsearch/client/client_test.go
+++ b/pkg/controller/elasticsearch/client/client_test.go
@@ -134,7 +134,7 @@ func requestAssertion(test func(req *http.Request)) RoundTripFunc {
 func TestClientErrorHandling(t *testing.T) {
 	// 303 would lead to a redirect to another error response if we would also set the Location header
 	codes := []int{100, 303, 400, 404, 500}
-	testClient := NewMockClient(version.MustParse("6.7.0"), errorResponses(codes))
+	testClient := NewMockClient(version.MustParse("6.8.0"), errorResponses(codes))
 	requests := []func() (string, error){
 		func() (string, error) {
 			_, err := testClient.GetClusterState(context.Background())
@@ -155,7 +155,7 @@ func TestClientErrorHandling(t *testing.T) {
 }
 
 func TestClientUsesJsonContentType(t *testing.T) {
-	testClient := NewMockClient(version.MustParse("6.7.0"), requestAssertion(func(req *http.Request) {
+	testClient := NewMockClient(version.MustParse("6.8.0"), requestAssertion(func(req *http.Request) {
 		assert.Equal(t, []string{"application/json; charset=utf-8"}, req.Header["Content-Type"])
 	}))
 
@@ -196,7 +196,7 @@ func TestClientSupportsBasicAuth(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		testClient := NewMockClientWithUser(version.MustParse("6.7.0"),
+		testClient := NewMockClientWithUser(version.MustParse("6.8.0"),
 			tt.args,
 			requestAssertion(func(req *http.Request) {
 				username, password, ok := req.BasicAuth()
@@ -281,7 +281,7 @@ func TestAPIError_Error(t *testing.T) {
 
 func TestClientGetNodes(t *testing.T) {
 	expectedPath := "/_nodes/_all/jvm,settings"
-	testClient := NewMockClient(version.MustParse("6.7.0"), func(req *http.Request) *http.Response {
+	testClient := NewMockClient(version.MustParse("6.8.0"), func(req *http.Request) *http.Response {
 		require.Equal(t, expectedPath, req.URL.Path)
 		return &http.Response{
 			StatusCode: 200,
@@ -300,7 +300,7 @@ func TestClientGetNodes(t *testing.T) {
 
 func TestClientGetNodesStats(t *testing.T) {
 	expectedPath := "/_nodes/_all/stats/os"
-	testClient := NewMockClient(version.MustParse("6.7.0"), func(req *http.Request) *http.Response {
+	testClient := NewMockClient(version.MustParse("6.8.0"), func(req *http.Request) *http.Response {
 		require.Equal(t, expectedPath, req.URL.Path)
 		return &http.Response{
 			StatusCode: 200,
@@ -343,7 +343,7 @@ func TestClient_Equal(t *testing.T) {
 		return ca.Cert
 	}
 	dummyCACerts := []*x509.Certificate{createCert()}
-	v6 := version.MustParse("6.7.0")
+	v6 := version.MustParse("6.8.0")
 	v7 := version.MustParse("7.0.0")
 	x509.NewCertPool()
 	tests := []struct {
@@ -427,7 +427,7 @@ func TestClient_UpdateLicense(t *testing.T) {
 	}{
 		{
 			expectedPath: "/_xpack/license",
-			version:      version.MustParse("6.7.0"),
+			version:      version.MustParse("6.8.0"),
 		},
 		{
 			expectedPath: "/_license",
@@ -473,7 +473,7 @@ func TestClient_GetLicense(t *testing.T) {
 	}{
 		{
 			expectedPath: "/_xpack/license",
-			version:      version.MustParse("6.7.0"),
+			version:      version.MustParse("6.8.0"),
 		},
 		{
 			expectedPath: "/_license",
@@ -513,7 +513,7 @@ func TestClient_AddVotingConfigExclusions(t *testing.T) {
 	}{
 		{
 			expectedPath: "",
-			version:      version.MustParse("6.7.0"),
+			version:      version.MustParse("6.8.0"),
 			wantErr:      true,
 		},
 		{
@@ -546,7 +546,7 @@ func TestClient_DeleteVotingConfigExclusions(t *testing.T) {
 	}{
 		{
 			expectedPath: "",
-			version:      version.MustParse("6.7.0"),
+			version:      version.MustParse("6.8.0"),
 			wantErr:      true,
 		},
 		{
@@ -581,7 +581,7 @@ func TestClient_SetMinimumMasterNodes(t *testing.T) {
 		{
 			name:         "mininum master nodes is essential in v6",
 			expectedPath: "/_cluster/settings",
-			version:      version.MustParse("6.7.0"),
+			version:      version.MustParse("6.8.0"),
 			wantErr:      false,
 		},
 		{

--- a/pkg/controller/elasticsearch/license/apply_test.go
+++ b/pkg/controller/elasticsearch/license/apply_test.go
@@ -96,7 +96,7 @@ func Test_updateLicense(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			c := esclient.NewMockClient(version.MustParse("6.7.0"), tt.reqFn)
+			c := esclient.NewMockClient(version.MustParse("6.8.0"), tt.reqFn)
 			if err := updateLicense(c, tt.args.current, tt.args.desired); (err != nil) != tt.wantErr {
 				t.Errorf("updateLicense() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/controller/elasticsearch/observer/observer_test.go
+++ b/pkg/controller/elasticsearch/observer/observer_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func fakeEsClient200(user client.UserAuth) client.Client {
-	return client.NewMockClientWithUser(version.MustParse("6.7.0"),
+	return client.NewMockClientWithUser(version.MustParse("6.8.0"),
 		user,
 		func(req *http.Request) *http.Response {
 			return &http.Response{

--- a/pkg/controller/elasticsearch/observer/state_test.go
+++ b/pkg/controller/elasticsearch/observer/state_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func fakeEsClient(healthRespErr, stateRespErr, licenseRespErr bool) client.Client {
-	return client.NewMockClient(version.MustParse("6.7.0"), func(req *http.Request) *http.Response {
+	return client.NewMockClient(version.MustParse("6.8.0"), func(req *http.Request) *http.Response {
 		statusCode := 200
 		var respBody io.ReadCloser
 

--- a/pkg/controller/elasticsearch/validation/upgrade_checks_test.go
+++ b/pkg/controller/elasticsearch/validation/upgrade_checks_test.go
@@ -41,7 +41,7 @@ func TestValidation_noDowngrades(t *testing.T) {
 		{
 			name: "no validation on create",
 			args: args{
-				toValidate: *es("6.7.0"),
+				toValidate: *es("6.8.0"),
 			},
 			current: nil,
 			want:    validation.OK,

--- a/pkg/controller/elasticsearch/validation/validations_test.go
+++ b/pkg/controller/elasticsearch/validation/validations_test.go
@@ -37,7 +37,7 @@ func Test_hasMaster(t *testing.T) {
 		{
 			name: "no topology",
 			args: args{
-				esCluster: *es("6.7.0"),
+				esCluster: *es("6.8.0"),
 			},
 			want: failedValidation,
 		},
@@ -334,7 +334,7 @@ func TestValidNames(t *testing.T) {
 						Namespace: "default",
 						Name:      "that-is-a-very-long-name-with-37chars",
 					},
-					Spec: estype.ElasticsearchSpec{Version: "6.7.0"},
+					Spec: estype.ElasticsearchSpec{Version: "6.8.0"},
 				},
 			},
 			want: validation.Result{
@@ -350,7 +350,7 @@ func TestValidNames(t *testing.T) {
 						Namespace: "default",
 						Name:      "that-is-a-very-long-name-with-36char",
 					},
-					Spec: estype.ElasticsearchSpec{Version: "6.7.0"},
+					Spec: estype.ElasticsearchSpec{Version: "6.8.0"},
 				},
 			},
 			want: validation.OK,
@@ -380,7 +380,7 @@ func Test_validSanIP(t *testing.T) {
 		{
 			name: "no SAN IP: OK",
 			esCluster: estype.Elasticsearch{
-				Spec: estype.ElasticsearchSpec{Version: "6.7.0"},
+				Spec: estype.ElasticsearchSpec{Version: "6.8.0"},
 			},
 			want: validation.OK,
 		},
@@ -388,7 +388,7 @@ func Test_validSanIP(t *testing.T) {
 			name: "valid SAN IPs: OK",
 			esCluster: estype.Elasticsearch{
 				Spec: estype.ElasticsearchSpec{
-					Version: "6.7.0",
+					Version: "6.8.0",
 					HTTP: common.HTTPConfig{
 						TLS: common.TLSOptions{
 							SelfSignedCertificate: &common.SelfSignedCertificate{
@@ -414,7 +414,7 @@ func Test_validSanIP(t *testing.T) {
 			name: "invalid SAN IPs: NOT OK",
 			esCluster: estype.Elasticsearch{
 				Spec: estype.ElasticsearchSpec{
-					Version: "6.7.0",
+					Version: "6.8.0",
 					HTTP: common.HTTPConfig{
 						TLS: common.TLSOptions{
 							SelfSignedCertificate: &common.SelfSignedCertificate{

--- a/pkg/controller/elasticsearch/validation/validations_test.go
+++ b/pkg/controller/elasticsearch/validation/validations_test.go
@@ -159,7 +159,7 @@ func Test_supportedVersion(t *testing.T) {
 		{
 			name: "supported OK",
 			args: args{
-				esCluster: *es("6.7.0"),
+				esCluster: *es("6.8.0"),
 			},
 			want: validation.OK,
 		},

--- a/pkg/controller/elasticsearch/version/supported_versions.go
+++ b/pkg/controller/elasticsearch/version/supported_versions.go
@@ -24,15 +24,15 @@ func SupportedVersions(v version.Version) *LowestHighestSupportedVersions {
 	switch v.Major {
 	case 6:
 		return &LowestHighestSupportedVersions{
-			// Min. version is 6.7.0.
-			LowestSupportedVersion: version.MustParse("6.7.0"),
+			// Min. version is 6.8.0.
+			LowestSupportedVersion: version.MustParse("6.8.0"),
 			// higher may be possible, but not proven yet, lower may also be a requirement...
 			HighestSupportedVersion: version.MustParse("6.99.99"),
 		}
 	case 7:
 		return &LowestHighestSupportedVersions{
-			// 6.7.0 is the lowest wire compatibility version for 7.x
-			LowestSupportedVersion: version.MustParse("6.7.0"),
+			// 6.8.0 is the lowest wire compatibility version for 7.x
+			LowestSupportedVersion: version.MustParse("6.8.0"),
 			// higher may be possible, but not proven yet, lower may also be a requirement...
 			HighestSupportedVersion: version.MustParse("7.99.99"),
 		}

--- a/pkg/controller/elasticsearch/version/supported_versions_test.go
+++ b/pkg/controller/elasticsearch/version/supported_versions_test.go
@@ -31,12 +31,11 @@ func TestSupportedVersions(t *testing.T) {
 		unsupported []version.Version
 	}{
 		{
-			name: "6.x",
+			name: "6.X",
 			args: args{
 				v: version.MustParse("6.8.0"),
 			},
 			supported: []version.Version{
-				version.MustParse("6.7.0"),
 				version.MustParse("6.8.0"),
 				version.MustParse("6.99.99"),
 			},
@@ -51,7 +50,7 @@ func TestSupportedVersions(t *testing.T) {
 				v: version.MustParse("7.1.0"),
 			},
 			supported: []version.Version{
-				version.MustParse("6.7.0"), //wire compat
+				version.MustParse("6.8.0"), //wire compat
 				version.MustParse("7.2.0"),
 				version.MustParse("7.99.99"),
 			},

--- a/pkg/controller/elasticsearch/version/supported_versions_test.go
+++ b/pkg/controller/elasticsearch/version/supported_versions_test.go
@@ -31,7 +31,7 @@ func TestSupportedVersions(t *testing.T) {
 		unsupported []version.Version
 	}{
 		{
-			name: "6.X",
+			name: "6.x",
 			args: args{
 				v: version.MustParse("6.8.0"),
 			},


### PR DESCRIPTION
The version was set to 6.7.X, which is not supported due to TLS
constraints with the Basic license. Let's make this 6.8.0 explicitly.

This PR also fixes references to v6.7 in the code (unit tests mostly).

Relates https://github.com/elastic/cloud-on-k8s/issues/1727.
