### PR TITLE
Remove statefulset config secret and headless service

### DIFF
--- a/pkg/controller/elasticsearch/sset/fixtures.go
+++ b/pkg/controller/elasticsearch/sset/fixtures.go
@@ -13,6 +13,7 @@ import (
 )
 
 type TestSset struct {
+	Namespace   string
 	Name        string
 	ClusterName string
 	Version     string
@@ -31,7 +32,8 @@ func (t TestSset) Build() appsv1.StatefulSet {
 	label.NodeTypesDataLabelName.Set(t.Data, labels)
 	statefulSet := appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: t.Name,
+			Name:      t.Name,
+			Namespace: t.Namespace,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &t.Replicas,


### PR DESCRIPTION
When removing a StatefulSet, we should also remove the corresponding
Configuration Secret and headless service. Otherwise they end up staying
in the apiserver, useless, until the cluster is deleted.

Since the operator may crash at any time in between those 3 deletions,
we ignore any config or service not found error (already removed in the
past).

Fixes https://github.com/elastic/cloud-on-k8s/issues/1713.