### PR TITLE
When using OnDelete strategy don't rely on current/updated revision

### DIFF
--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -45,8 +45,14 @@ func Test_podsToUpgrade(t *testing.T) {
 			name: "all pods need to be upgraded",
 			args: args{
 				statefulSets: sset.StatefulSetList{
-					sset.TestSset{Name: "masters", Replicas: 2, Master: true, Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-a", UpdateRevision: "rev-b"}}.Build(),
-					sset.TestSset{Name: "nodes", Replicas: 3, Master: true, Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-a", UpdateRevision: "rev-b"}}.Build(),
+					sset.TestSset{
+						Name: "masters", Replicas: 2, Master: true,
+						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-a", UpdateRevision: "rev-b", UpdatedReplicas: 0, Replicas: 2},
+					}.Build(),
+					sset.TestSset{
+						Name: "nodes", Replicas: 3, Master: true,
+						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-a", UpdateRevision: "rev-b", UpdatedReplicas: 0, Replicas: 3},
+					}.Build(),
 				},
 				pods: []runtime.Object{
 					podWithRevision("masters-0", "rev-a"),
@@ -62,8 +68,14 @@ func Test_podsToUpgrade(t *testing.T) {
 			name: "only a sset needs to be upgraded",
 			args: args{
 				statefulSets: sset.StatefulSetList{
-					sset.TestSset{Name: "masters", Replicas: 2, Master: true, Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-a", UpdateRevision: "rev-b"}}.Build(),
-					sset.TestSset{Name: "nodes", Replicas: 3, Master: true, Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-b", UpdateRevision: "rev-b"}}.Build(),
+					sset.TestSset{
+						Name: "masters", Replicas: 2, Master: true,
+						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-a", UpdateRevision: "rev-b", UpdatedReplicas: 0, Replicas: 2},
+					}.Build(),
+					sset.TestSset{
+						Name: "nodes", Replicas: 3, Master: true,
+						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-b", UpdateRevision: "rev-b", UpdatedReplicas: 3, Replicas: 3},
+					}.Build(),
 				},
 				pods: []runtime.Object{
 					podWithRevision("masters-0", "rev-a"),
@@ -76,8 +88,14 @@ func Test_podsToUpgrade(t *testing.T) {
 			name: "only 1 node need to be upgraded",
 			args: args{
 				statefulSets: sset.StatefulSetList{
-					sset.TestSset{Name: "masters", Replicas: 2, Master: true, Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-a", UpdateRevision: "rev-b"}}.Build(),
-					sset.TestSset{Name: "nodes", Replicas: 3, Master: true, Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-b", UpdateRevision: "rev-b"}}.Build(),
+					sset.TestSset{
+						Name: "masters", Replicas: 2, Master: true,
+						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-a", UpdateRevision: "rev-b", UpdatedReplicas: 1, Replicas: 2},
+					}.Build(),
+					sset.TestSset{
+						Name: "nodes", Replicas: 3, Master: true,
+						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-b", UpdateRevision: "rev-b", UpdatedReplicas: 3, Replicas: 3},
+					}.Build(),
 				},
 				pods: []runtime.Object{
 					podWithRevision("masters-0", "rev-b"),

--- a/pkg/controller/elasticsearch/sset/list.go
+++ b/pkg/controller/elasticsearch/sset/list.go
@@ -54,7 +54,12 @@ func (l StatefulSetList) ObjectMetas() []metav1.ObjectMeta {
 func (l StatefulSetList) ToUpdate() StatefulSetList {
 	toUpdate := StatefulSetList{}
 	for _, s := range l {
-		if s.Status.UpdateRevision != "" && (s.Status.UpdateRevision != s.Status.CurrentRevision) {
+		// When using on delete current revision is never reset to update revision
+		// just looking that the update/current revision therefore does not work when reverting
+		// to previous revision and gives constant false positives after an initial update.
+		// Either updated replicas != replicas expresses the fact that
+		// an update is still pending.
+		if s.Status.UpdatedReplicas != s.Status.Replicas {
 			toUpdate = append(toUpdate, s)
 		}
 	}

--- a/pkg/controller/elasticsearch/sset/list.go
+++ b/pkg/controller/elasticsearch/sset/list.go
@@ -54,11 +54,10 @@ func (l StatefulSetList) ObjectMetas() []metav1.ObjectMeta {
 func (l StatefulSetList) ToUpdate() StatefulSetList {
 	toUpdate := StatefulSetList{}
 	for _, s := range l {
-		// When using on delete current revision is never reset to update revision
-		// just looking that the update/current revision therefore does not work when reverting
-		// to previous revision and gives constant false positives after an initial update.
-		// Either updated replicas != replicas expresses the fact that
-		// an update is still pending.
+		// When using an OnDelete strategy current revision is never reset to update revision.
+		// Just looking that the revision to detect updates does therefore does not work when reverting
+		// to a previous revision and gives constant false positives after an initial update.
+		// Only updated replicas != replicas expresses the fact that an update is still pending.
 		if s.Status.UpdatedReplicas != s.Status.Replicas {
 			toUpdate = append(toUpdate, s)
 		}

--- a/pkg/controller/elasticsearch/sset/list_test.go
+++ b/pkg/controller/elasticsearch/sset/list_test.go
@@ -195,19 +195,15 @@ func TestStatefulSetList_GetByName(t *testing.T) {
 func TestStatefulSetList_ToUpdate(t *testing.T) {
 	toUpdate1 := appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "toUpdate1"},
-		Status:     appsv1.StatefulSetStatus{UpdateRevision: "update-rev", CurrentRevision: "current-rev"},
+		Status:     appsv1.StatefulSetStatus{UpdatedReplicas: 1, Replicas: 2},
 	}
 	toUpdate2 := appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "toUpdate2"},
-		Status:     appsv1.StatefulSetStatus{UpdateRevision: "update-rev", CurrentRevision: "current-rev"},
-	}
-	noUpdateRev := appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "noUpdateRev"},
-		Status:     appsv1.StatefulSetStatus{UpdateRevision: "", CurrentRevision: "current-rev"},
+		Status:     appsv1.StatefulSetStatus{UpdatedReplicas: 1, Replicas: 2},
 	}
 	updateMatchCurrent := appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "noUpdateRev"},
-		Status:     appsv1.StatefulSetStatus{UpdateRevision: "update-rev", CurrentRevision: "update-rev"},
+		ObjectMeta: metav1.ObjectMeta{Name: "updateMatchCurrent"},
+		Status:     appsv1.StatefulSetStatus{UpdatedReplicas: 1, Replicas: 1},
 	}
 	tests := []struct {
 		name string
@@ -220,8 +216,8 @@ func TestStatefulSetList_ToUpdate(t *testing.T) {
 			want: StatefulSetList{},
 		},
 		{
-			name: "2/4 StatefulSets to update",
-			l:    StatefulSetList{noUpdateRev, toUpdate1, updateMatchCurrent, toUpdate2},
+			name: "2/3 StatefulSets to update",
+			l:    StatefulSetList{toUpdate1, updateMatchCurrent, toUpdate2},
 			want: StatefulSetList{toUpdate1, toUpdate2},
 		},
 	}

--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -160,6 +160,21 @@ func TestMutationSecondMasterSetDown(t *testing.T) {
 	RunESMutation(t, b, mutated)
 }
 
+func TestMutationAndReversal(t *testing.T) {
+	b := elasticsearch.NewBuilder("test-reverted-mutation").
+		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
+
+	mutation := b.WithNoESTopology().WithESMasterDataNodes(3, elasticsearch.DefaultResources).
+		WithAdditionalConfig(map[string]map[string]interface{}{
+			"masterdata": map[string]interface{}{
+				"node.attr.box_type": "mixed",
+			},
+		})
+	mutation.MutatedFrom = &b
+	test.RunMutations(t, []test.Builder{b}, []test.Builder{mutation, b})
+
+}
+
 func RunESMutation(t *testing.T, toCreate elasticsearch.Builder, mutateTo elasticsearch.Builder) {
 	mutateTo.MutatedFrom = &toCreate
 	test.RunMutation(t, toCreate, mutateTo)

--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -166,7 +166,7 @@ func TestMutationAndReversal(t *testing.T) {
 
 	mutation := b.WithNoESTopology().WithESMasterDataNodes(3, elasticsearch.DefaultResources).
 		WithAdditionalConfig(map[string]map[string]interface{}{
-			"masterdata": map[string]interface{}{
+			"masterdata": {
 				"node.attr.box_type": "mixed",
 			},
 		})

--- a/test/e2e/test/elasticsearch/checks_data.go
+++ b/test/e2e/test/elasticsearch/checks_data.go
@@ -59,6 +59,18 @@ func (dc *DataIntegrityCheck) Init() error {
     }
 }
 `
+	// delete index if running check multiple times
+	indexDeletion, err := http.NewRequest(
+		http.MethodDelete,
+		fmt.Sprintf("/%s", dc.indexName),
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+	// delete the index but ignore errors (e.g. if it did not exist yet)
+	_, _ = esClient.Request(context.Background(), indexDeletion)
+
 	// create the index with controlled settings
 	indexCreation, err := http.NewRequest(
 		http.MethodPut,

--- a/test/e2e/test/elasticsearch/checks_data.go
+++ b/test/e2e/test/elasticsearch/checks_data.go
@@ -69,7 +69,10 @@ func (dc *DataIntegrityCheck) Init() error {
 		return err
 	}
 	// delete the index but ignore errors (e.g. if it did not exist yet)
-	_, _ = esClient.Request(context.Background(), indexDeletion)
+	resp, err := esClient.Request(context.Background(), indexDeletion)
+	if err == nil {
+		resp.Body.Close()
+	}
 
 	// create the index with controlled settings
 	indexCreation, err := http.NewRequest(
@@ -80,7 +83,7 @@ func (dc *DataIntegrityCheck) Init() error {
 	if err != nil {
 		return err
 	}
-	resp, err := esClient.Request(context.Background(), indexCreation)
+	resp, err = esClient.Request(context.Background(), indexCreation)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/test/run_mutation.go
+++ b/test/e2e/test/run_mutation.go
@@ -29,8 +29,9 @@ func RunMutations(t *testing.T, creationBuilders []Builder, mutationBuilders []B
 		steps = steps.WithSteps(mutateTo.MutationTestSteps(k))
 	}
 
-	for _, mutateTo := range mutationBuilders {
-		steps = steps.WithSteps(mutateTo.DeletionTestSteps(k))
+	// Delete using the original builder (so that we can use it as a mutation builder as well)
+	for _, toCreate := range creationBuilders {
+		steps = steps.WithSteps(toCreate.DeletionTestSteps(k))
 	}
 
 	steps.RunSequential(t)


### PR DESCRIPTION
When using on delete current revision is never reset to updated revision. Just looking at the update/current revision therefore does not work when reverting to previous a previous revision and gives constant false positives after an initial update. 

Consequences: when going back to a previous configuration the operator is simply stuck, when moving forward the operator constantly checks all pods. 

Only updated replicas != replicas expresses the fact that an update is still pending.

Another solution to this problem would be to remove the `ToUpdate` method completely and to always check all pods. I am open to that but kind of think that checking the status might be more efficient on larger clusters.

This was tested/observed on k8s 1.14