### PR TITLE
Ignore synced flush conflict during rolling upgrades

### DIFF
--- a/pkg/controller/elasticsearch/client/client.go
+++ b/pkg/controller/elasticsearch/client/client.go
@@ -183,3 +183,13 @@ func IsNotFound(err error) bool {
 		return false
 	}
 }
+
+// IsConflict checks whether the error was an HTTP 409 error.
+func IsConflict(err error) bool {
+	switch err := err.(type) {
+	case *APIError:
+		return err.response.StatusCode == http.StatusConflict
+	default:
+		return false
+	}
+}

--- a/pkg/controller/elasticsearch/client/client_test.go
+++ b/pkg/controller/elasticsearch/client/client_test.go
@@ -606,3 +606,36 @@ func TestClient_SetMinimumMasterNodes(t *testing.T) {
 		}
 	}
 }
+
+func TestIsConflict(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "200 is not a conflict",
+			args: args{
+				err: &APIError{response: NewMockResponse(200, nil, "")},
+			},
+			want: false,
+		},
+		{
+			name: "409 is a conflict",
+			args: args{
+				err: &APIError{response: NewMockResponse(409, nil, "")},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsConflict(tt.args.err); got != tt.want {
+				t.Errorf("IsConflict() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/elasticsearch/client/client_test.go
+++ b/pkg/controller/elasticsearch/client/client_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -619,16 +620,23 @@ func TestIsConflict(t *testing.T) {
 		{
 			name: "200 is not a conflict",
 			args: args{
-				err: &APIError{response: NewMockResponse(200, nil, "")},
+				err: &APIError{response: NewMockResponse(200, nil, "")}, // nolint
 			},
 			want: false,
 		},
 		{
 			name: "409 is a conflict",
 			args: args{
-				err: &APIError{response: NewMockResponse(409, nil, "")},
+				err: &APIError{response: NewMockResponse(409, nil, "")}, // nolint
 			},
 			want: true,
+		},
+		{
+			name: "no api error",
+			args: args{
+				err: errors.New("not an api error"),
+			},
+			want: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Elasticsearch returns 409 CONFLICT if synced flush fails due to concurrent indexing operations. If a cluster under load is
upgraded this can block the operator for a long time. This changes ignores synced flush errors and considers synced flush
before rolling upgrades as a best effort operation.

Labeled as enhancement but I would say it's borderline bug 🤷‍♂ 

