### PR TITLE
Standardize finalizers with fully qualified names

### DIFF
--- a/pkg/controller/apmserverelasticsearchassociation/apmserverelasticsearchassociation_controller.go
+++ b/pkg/controller/apmserverelasticsearchassociation/apmserverelasticsearchassociation_controller.go
@@ -145,7 +145,7 @@ func (r *ReconcileApmServerElasticsearchAssociation) Reconcile(request reconcile
 	err := handler.Handle(
 		&apmServer,
 		watchFinalizer(apmName, r.watches),
-		user.UserFinalizer(r.Client, NewUserLabelSelector(apmName)),
+		user.UserFinalizer(r.Client, NewUserLabelSelector(apmName), apmServer.Kind()),
 	)
 	if err != nil {
 		// failed to prepare finalizer or run finalizer: retry
@@ -196,7 +196,7 @@ func esCAWatchName(apm types.NamespacedName) string {
 // because the association to the APM server has been deleted.
 func watchFinalizer(assocKey types.NamespacedName, w watches.DynamicWatches) finalizer.Finalizer {
 	return finalizer.Finalizer{
-		Name: "dynamic-watches.finalizers.apm.k8s.elastic.co",
+		Name: "finalizer.association.apmserver.k8s.elastic.co/elasticsearch",
 		Execute: func() error {
 			w.ElasticsearchClusters.RemoveHandlerForKey(elasticsearchWatchName(assocKey))
 			w.Secrets.RemoveHandlerForKey(esCAWatchName(assocKey))

--- a/pkg/controller/common/certificates/http/dynamic_watches.go
+++ b/pkg/controller/common/certificates/http/dynamic_watches.go
@@ -5,6 +5,8 @@
 package http
 
 import (
+	"strings"
+
 	"github.com/elastic/cloud-on-k8s/pkg/apis/common/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/finalizer"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/name"
@@ -43,9 +45,9 @@ func reconcileDynamicWatches(dynamicWatches watches.DynamicWatches, owner types.
 }
 
 // DynamicWatchesFinalizer returns a Finalizer for dynamic watches related to http certificates
-func DynamicWatchesFinalizer(dynamicWatches watches.DynamicWatches, ownerName string, namer name.Namer) finalizer.Finalizer {
+func DynamicWatchesFinalizer(dynamicWatches watches.DynamicWatches, kind string, ownerName string, namer name.Namer) finalizer.Finalizer {
 	return finalizer.Finalizer{
-		Name: "dynamic-watches.finalizers.k8s.elastic.co/http-certificates",
+		Name: "finalizer." + strings.ToLower(kind) + ".k8s.elastic.co/http-certificates-secret",
 		Execute: func() error {
 			// es resource is being finalized, so we no longer need the dynamic watch
 			dynamicWatches.Secrets.RemoveHandlerForKey(httpCertificateWatchKey(namer, ownerName))

--- a/pkg/controller/common/keystore/user_secret.go
+++ b/pkg/controller/common/keystore/user_secret.go
@@ -231,7 +231,7 @@ func watchSecureSettings(watched watches.DynamicWatches, secureSettingsRef []com
 //  to be reliable with controller-runtime < v0.2.0-beta.4
 func Finalizer(namespacedName types.NamespacedName, watched watches.DynamicWatches, kind string) finalizer.Finalizer {
 	return finalizer.Finalizer{
-		Name: "secure-settings.finalizers." + strings.ToLower(kind) + ".k8s.elastic.co",
+		Name: "finalizer." + strings.ToLower(kind) + ".k8s.elastic.co/secure-settings-secret",
 		Execute: func() error {
 			watched.Secrets.RemoveHandlerForKey(secureSettingsWatchName(namespacedName))
 			return nil

--- a/pkg/controller/common/user/finalizer.go
+++ b/pkg/controller/common/user/finalizer.go
@@ -5,6 +5,8 @@
 package user
 
 import (
+	"strings"
+
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/finalizer"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
@@ -14,9 +16,9 @@ import (
 )
 
 // UserFinalizer ensures that any external user created for an associated object is removed.
-func UserFinalizer(c k8s.Client, selector labels.Selector) finalizer.Finalizer {
+func UserFinalizer(c k8s.Client, selector labels.Selector, kind string) finalizer.Finalizer {
 	return finalizer.Finalizer{
-		Name: "users.finalizers.associations.k8s.elastic.co",
+		Name: "finalizer.association." + strings.ToLower(kind) + ".k8s.elastic.co/external-user",
 		Execute: func() error {
 			var secrets corev1.SecretList
 			if err := c.List(&client.ListOptions{LabelSelector: selector}, &secrets); err != nil {

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -300,6 +300,6 @@ func (r *ReconcileElasticsearch) finalizersFor(
 	return []finalizer.Finalizer{
 		r.esObservers.Finalizer(clusterName),
 		keystore.Finalizer(k8s.ExtractNamespacedName(&es), r.dynamicWatches, es.Kind()),
-		http.DynamicWatchesFinalizer(r.dynamicWatches, es.Name, esname.ESNamer),
+		http.DynamicWatchesFinalizer(r.dynamicWatches, es.Kind(), es.Name, esname.ESNamer),
 	}
 }

--- a/pkg/controller/elasticsearch/observer/finalizer.go
+++ b/pkg/controller/elasticsearch/observer/finalizer.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// FinalizerName registered for each elasticsearch resource
-	FinalizerName = "observer.finalizers.elasticsearch.k8s.elastic.co"
+	FinalizerName = "finalizer.elasticsearch.k8s.elastic.co/observer"
 )
 
 // Finalizer returns a finalizer to be executed upon deletion of the given cluster,

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -77,7 +77,7 @@ func secretWatchKey(kibana kbtype.Kibana) string {
 
 func secretWatchFinalizer(kibana kbtype.Kibana, watches watches.DynamicWatches) finalizer.Finalizer {
 	return finalizer.Finalizer{
-		Name: "es-auth-secret.finalizers.kibana.k8s.elastic.co",
+		Name: "finalizer.kibana.k8s.elastic.co/es-auth-secret",
 		Execute: func() error {
 			watches.Secrets.RemoveHandlerForKey(secretWatchKey(kibana))
 			return nil

--- a/pkg/controller/kibanaassociation/association_controller.go
+++ b/pkg/controller/kibanaassociation/association_controller.go
@@ -133,7 +133,7 @@ func (r *ReconcileAssociation) Reconcile(request reconcile.Request) (reconcile.R
 	err := h.Handle(
 		&kibana,
 		watchFinalizer(kbName, r.watches),
-		user.UserFinalizer(r.Client, NewUserLabelSelector(kbName)),
+		user.UserFinalizer(r.Client, NewUserLabelSelector(kbName), kibana.Kind()),
 	)
 	if err != nil {
 		if apierrors.IsConflict(err) {

--- a/pkg/controller/kibanaassociation/watch.go
+++ b/pkg/controller/kibanaassociation/watch.go
@@ -58,7 +58,7 @@ func esCAWatchName(kibana types.NamespacedName) string {
 // because not referenced by any Kibana resource.
 func watchFinalizer(kibanaKey types.NamespacedName, w watches.DynamicWatches) finalizer.Finalizer {
 	return finalizer.Finalizer{
-		Name: "dynamic-watches.finalizers.associations.k8s.elastic.co",
+		Name: "finalizer.association.kibana.k8s.elastic.co/elasticsearch",
 		Execute: func() error {
 			w.ElasticsearchClusters.RemoveHandlerForKey(elasticsearchWatchName(kibanaKey))
 			w.Secrets.RemoveHandlerForKey(esCAWatchName(kibanaKey))


### PR DESCRIPTION
Core object finalizers might require a / to be fully qualified.
Attaching non-fully qualified finalizers to CRDs are generally fine, but
we prefer standardize nevertheless.
The new pattern to name a finalizer is:
`finalizer(.association)?.<resource_kind>.k8s.elastic.co/<object>`.

Before:
```ruby
> k get es,kb,apmserver -o yaml | grep finalizer
finalizers:
- observer.finalizers.elasticsearch.k8s.elastic.co
- secure-settings.finalizers.elasticsearch.k8s.elastic.co
- dynamic-watches.finalizers.k8s.elastic.co/http-certificates
finalizers:
- dynamic-watches.finalizers.associations.k8s.elastic.co
- users.finalizers.associations.k8s.elastic.co
- es-auth-secret.finalizers.kibana.k8s.elastic.co
- secure-settings.finalizers.kibana.k8s.elastic.co
finalizers:
- secure-settings.finalizers.apmserver.k8s.elastic.co
- dynamic-watches.finalizers.apm.k8s.elastic.co
- users.finalizers.associations.k8s.elastic.co
```
After:
```ruby
finalizers:
- finalizer.elasticsearch.k8s.elastic.co/observer
- finalizer.elasticsearch.k8s.elastic.co/secure-settings-secret
- finalizer.elasticsearch.k8s.elastic.co/http-certificates-secret
finalizers:
- finalizer.association.kibana.k8s.elastic.co/elasticsearch
- finalizer.association.kibana.k8s.elastic.co/external-user
- finalizer.kibana.k8s.elastic.co/es-auth-secret
- finalizer.kibana.k8s.elastic.co/secure-settings-secret
finalizers:
- finalizer.association.apmserver.k8s.elastic.co/elasticsearch
- finalizer.association.apmserver.k8s.elastic.co/external-user
- finalizer.apmserver.k8s.elastic.co/secure-settings-secret
```

Resolves #996