### PR TITLE
Update k8s versions to run E2E tests on GKE

### DIFF
--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runWith('1.11', "${BUILD_TAG}-11")
+                        runWith('1.12', "${BUILD_TAG}-12")
                     }
                 }
                 stage("1.12") {
@@ -33,7 +33,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runWith('1.12', "${BUILD_TAG}-12")
+                        runWith('1.13', "${BUILD_TAG}-14")
                     }
                 }
                 stage("1.13") {
@@ -42,7 +42,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runWith('1.13', "${BUILD_TAG}-13")
+                        runWith('1.14', "${BUILD_TAG}-14")
                     }
                 }
             }
@@ -64,7 +64,7 @@ pipeline {
         }
         cleanup {
             script {
-                clusters = ["${BUILD_TAG}-11", "${BUILD_TAG}-12", "${BUILD_TAG}-13"]
+                clusters = ["${BUILD_TAG}-12", "${BUILD_TAG}-13", "${BUILD_TAG}-14"]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
                         parameters: [string(name: 'GKE_CLUSTER', value: clusters[i])],

--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     stages {
         stage('Run tests for different k8s versions in GKE') {
             parallel {
-                stage("1.11") {
+                stage("1.12") {
                     agent {
                         label 'linux'
                     }
@@ -27,16 +27,16 @@ pipeline {
                         runWith('1.12', "${BUILD_TAG}-12")
                     }
                 }
-                stage("1.12") {
+                stage("1.13") {
                     agent {
                         label 'linux'
                     }
                     steps {
                         checkout scm
-                        runWith('1.13', "${BUILD_TAG}-14")
+                        runWith('1.13', "${BUILD_TAG}-13")
                     }
                 }
-                stage("1.13") {
+                stage("1.14") {
                     agent {
                         label 'linux'
                     }


### PR DESCRIPTION
The version 1.11 of k8s is no longer supported on GKE but 1.14 is now available.
Let's replace 1.11 with 1.14.

Resolves #1739.