### PR TITLE
Increase vault client timeout to 120s

### DIFF
--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -7,6 +7,9 @@
 ROOT_DIR = $(CURDIR)/../..
 GO_MOUNT_PATH ?= /go/src/github.com/elastic/cloud-on-k8s
 
+# This is set to avoid the issue described in https://github.com/hashicorp/vault/issues/6710
+VAULT_CLIENT_TIMEOUT = 120
+
 # BUILD_ID is present during run on Jenkins machine, but not on dev box, hence using it here to distinguish between those cases
 ifdef BUILD_ID
 VAULT_TOKEN = $(shell vault write -address=$(VAULT_ADDR) -field=token auth/approle/login role_id=$(VAULT_ROLE_ID) secret_id=$(VAULT_SECRET_ID))

--- a/hack/deployer/runner/vault.go
+++ b/hack/deployer/runner/vault.go
@@ -7,6 +7,7 @@ package runner
 import (
 	"fmt"
 	"io/ioutil"
+	"time"
 
 	"github.com/hashicorp/vault/api"
 )
@@ -19,7 +20,8 @@ type VaultClient struct {
 }
 
 func NewClient(info VaultInfo) (*VaultClient, error) {
-	client, err := api.NewClient(&api.Config{Address: info.Address})
+	// Timeout is set to avoid the issue described in https://github.com/hashicorp/vault/issues/6710
+	client, err := api.NewClient(&api.Config{Address: info.Address, Timeout: 120 * time.Second })
 	if err != nil {
 		return nil, err
 	}

--- a/hack/deployer/runner/vault.go
+++ b/hack/deployer/runner/vault.go
@@ -21,7 +21,7 @@ type VaultClient struct {
 
 func NewClient(info VaultInfo) (*VaultClient, error) {
 	// Timeout is set to avoid the issue described in https://github.com/hashicorp/vault/issues/6710
-	client, err := api.NewClient(&api.Config{Address: info.Address, Timeout: 120 * time.Second })
+	client, err := api.NewClient(&api.Config{Address: info.Address, Timeout: 120 * time.Second})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This should prevent the issue described in https://github.com/hashicorp/vault/issues/6710 from happening.

Example from https://devops-ci.elastic.co/job/cloud-on-k8s-e2e-tests-aks/10/:
```
[2019-08-28T11:19:52.655Z] Error: Put ****/v1/auth/approle/login: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```