### PR TITLE
Fix handling of HTTP CA

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
   enable-all: true
   disable:
     - dupl
+    - funlen
     - gochecknoglobals
     - gochecknoinits
     - interfacer

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,6 @@ linters:
   enable-all: true
   disable:
     - dupl
-    - funlen
     - gochecknoglobals
     - gochecknoinits
     - interfacer

--- a/docs/accessing-services.asciidoc
+++ b/docs/accessing-services.asciidoc
@@ -144,7 +144,7 @@ You can bring your own certificate to configure TLS to ensure that communication
 
 Create a Kubernetes secret with:
 
-- `ca.crt`: CA certificate (optional if `tls.crt` was issued by a well-known CA)
+- `ca.crt`: CA certificate (optional if `tls.crt` was issued by a well-known CA).
 - `tls.crt`: the certificate.
 - `tls.key`: the private key to the first certificate in the certificate chain.
 

--- a/docs/accessing-services.asciidoc
+++ b/docs/accessing-services.asciidoc
@@ -144,12 +144,13 @@ You can bring your own certificate to configure TLS to ensure that communication
 
 Create a Kubernetes secret with:
 
-- `tls.crt`: the certificate (or a chain).
+- `ca.crt`: CA certificate (optional if `tls.crt` was issued by a well-known CA)
+- `tls.crt`: the certificate.
 - `tls.key`: the private key to the first certificate in the certificate chain.
 
 [source,sh]
 ----
-kubectl create secret tls my-cert --cert tls.crt --key tls.key
+kubectl create secret generic my-cert --from-file=ca.crt=tls.crt --from-file=tls.crt=tls.crt --from-file=tls.key=tls.key
 ----
 
 Then you just have to reference the secret name in the `http.tls.certificate` section of the resource manifest.

--- a/docs/api-docs.asciidoc
+++ b/docs/api-docs.asciidoc
@@ -220,6 +220,10 @@ _string_
 _string_
 |
 ---
+| *`caCertProvided`* +
+_bool_
+|
+---
 | *`caSecretName`* +
 _string_
 |

--- a/docs/elasticsearch-spec.asciidoc
+++ b/docs/elasticsearch-spec.asciidoc
@@ -215,8 +215,9 @@ spec:
 === Custom HTTP certificate
 
 You can provide your own CA and certificates instead of the self-signed certificate to connect to Elasticsearch via HTTPS using a Kubernetes secret.
+The certificate must be stored under `tls.crt` and the private key must be stored under `tls.key`. If your certificate was not issued by a well-known CA, you must include the trust chain under `ca.crt` as well.
 
-You need to reference the name of a secret that contains a TLS private key and a certificate (or a chain), in the `spec.http.tls.certificate` section.
+You need to reference the name of a secret that contains a TLS private key and a certificate (and optionally, a trust chain), in the `spec.http.tls.certificate` section.
 
 [source,yaml]
 ----
@@ -231,8 +232,8 @@ This is an example on how create a Kubernetes TLS secret with a self-signed cert
 
 [source,sh]
 ----
-$ openssl req -x509 -newkey rsa:4096 -keyout tls.key -out tls.crt -days 365 -nodes
-$ kubectl create secret tls my-cert --cert tls.crt --key tls.key
+$ openssl req -x509 -sha256 -nodes -newkey rsa:4096 -days 365 -subj "/CN=quickstart-es-http" -addext "subjectAltName=DNS:quickstart-es-http.default.svc" -keyout tls.key -out tls.crt
+$ kubectl create secret generic my-cert --from-file=ca.crt=tls.crt --from-file=tls.crt=tls.crt --from-file=tls.key=tls.key
 ----
 
 [id="{p}-es-secure-settings"]

--- a/pkg/apis/common/v1alpha1/association.go
+++ b/pkg/apis/common/v1alpha1/association.go
@@ -41,63 +41,71 @@ type Associator interface {
 type AssociationConf struct {
 	AuthSecretName string `json:"authSecretName"`
 	AuthSecretKey  string `json:"authSecretKey"`
+	CACertProvided bool   `json:"caCertProvided"`
 	CASecretName   string `json:"caSecretName"`
 	URL            string `json:"url"`
 }
 
 // IsConfigured returns true if all the fields are set.
-func (esac *AssociationConf) IsConfigured() bool {
-	return esac.AuthIsConfigured() && esac.CAIsConfigured() && esac.URLIsConfigured()
+func (ac *AssociationConf) IsConfigured() bool {
+	return ac.AuthIsConfigured() && ac.CAIsConfigured() && ac.URLIsConfigured()
 }
 
 // AuthIsConfigured returns true if all the auth fields are set.
-func (esac *AssociationConf) AuthIsConfigured() bool {
-	if esac == nil {
+func (ac *AssociationConf) AuthIsConfigured() bool {
+	if ac == nil {
 		return false
 	}
-	return esac.AuthSecretName != "" && esac.AuthSecretKey != ""
+	return ac.AuthSecretName != "" && ac.AuthSecretKey != ""
 }
 
 // CAIsConfigured returns true if the CA field is set.
-func (esac *AssociationConf) CAIsConfigured() bool {
-	if esac == nil {
+func (ac *AssociationConf) CAIsConfigured() bool {
+	if ac == nil {
 		return false
 	}
-	return esac.CASecretName != ""
+	return ac.CASecretName != ""
 }
 
 // URLIsConfigured returns true if the URL field is set.
-func (esac *AssociationConf) URLIsConfigured() bool {
-	if esac == nil {
+func (ac *AssociationConf) URLIsConfigured() bool {
+	if ac == nil {
 		return false
 	}
-	return esac.URL != ""
+	return ac.URL != ""
 }
 
-func (esac *AssociationConf) GetAuthSecretName() string {
-	if esac == nil {
+func (ac *AssociationConf) GetAuthSecretName() string {
+	if ac == nil {
 		return ""
 	}
-	return esac.AuthSecretName
+	return ac.AuthSecretName
 }
 
-func (esac *AssociationConf) GetAuthSecretKey() string {
-	if esac == nil {
+func (ac *AssociationConf) GetAuthSecretKey() string {
+	if ac == nil {
 		return ""
 	}
-	return esac.AuthSecretKey
+	return ac.AuthSecretKey
 }
 
-func (esac *AssociationConf) GetCASecretName() string {
-	if esac == nil {
-		return ""
+func (ac *AssociationConf) GetCACertProvided() bool {
+	if ac == nil {
+		return false
 	}
-	return esac.CASecretName
+	return ac.CACertProvided
 }
 
-func (esac *AssociationConf) GetURL() string {
-	if esac == nil {
+func (ac *AssociationConf) GetCASecretName() string {
+	if ac == nil {
 		return ""
 	}
-	return esac.URL
+	return ac.CASecretName
+}
+
+func (ac *AssociationConf) GetURL() string {
+	if ac == nil {
+		return ""
+	}
+	return ac.URL
 }

--- a/pkg/controller/apmserver/config/config.go
+++ b/pkg/controller/apmserver/config/config.go
@@ -51,15 +51,17 @@ func NewConfigFromSpec(c k8s.Client, as *v1alpha1.ApmServer) (*settings.Canonica
 		if err != nil {
 			return nil, err
 		}
-		outputCfg = settings.MustCanonicalConfig(
-			map[string]interface{}{
-				"output.elasticsearch.hosts":                       []string{as.AssociationConf().GetURL()},
-				"output.elasticsearch.username":                    username,
-				"output.elasticsearch.password":                    password,
-				"output.elasticsearch.ssl.certificate_authorities": []string{filepath.Join(CertificatesDir, certificates.CertFileName)},
-			},
-		)
 
+		tmpOutputCfg := map[string]interface{}{
+			"output.elasticsearch.hosts":    []string{as.AssociationConf().GetURL()},
+			"output.elasticsearch.username": username,
+			"output.elasticsearch.password": password,
+		}
+		if as.AssociationConf().GetCACertProvided() {
+			tmpOutputCfg["output.elasticsearch.ssl.certificate_authorities"] = []string{filepath.Join(CertificatesDir, certificates.CAFileName)}
+		}
+
+		outputCfg = settings.MustCanonicalConfig(tmpOutputCfg)
 	}
 
 	// Create a base configuration.

--- a/pkg/controller/apmserver/config/config_test.go
+++ b/pkg/controller/apmserver/config/config_test.go
@@ -1,0 +1,144 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1alpha1"
+	commonv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestNewConfigFromSpec(t *testing.T) {
+	testCases := []struct {
+		name            string
+		configOverrides map[string]interface{}
+		assocConf       *commonv1alpha1.AssociationConf
+		wantConf        map[string]interface{}
+		wantErr         bool
+	}{
+		{
+			name: "default config",
+		},
+		{
+			name: "with overridden config",
+			configOverrides: map[string]interface{}{
+				"apm-server.secret_token": "MYSECRET",
+			},
+			wantConf: map[string]interface{}{
+				"apm-server.secret_token": "MYSECRET",
+			},
+		},
+		{
+			name: "without Elasticsearch CA cert",
+			assocConf: &commonv1alpha1.AssociationConf{
+				AuthSecretName: "test-es-elastic-user",
+				AuthSecretKey:  "elastic",
+				CASecretName:   "test-es-http-ca-public",
+				CACertProvided: false,
+				URL:            "https://test-es-http.default.svc:9200",
+			},
+			wantConf: map[string]interface{}{
+				"output.elasticsearch.hosts":    []string{"https://test-es-http.default.svc:9200"},
+				"output.elasticsearch.username": "elastic",
+				"output.elasticsearch.password": "password",
+			},
+		},
+		{
+			name: "with Elasticsearch CA cert",
+			assocConf: &commonv1alpha1.AssociationConf{
+				AuthSecretName: "test-es-elastic-user",
+				AuthSecretKey:  "elastic",
+				CASecretName:   "test-es-http-ca-public",
+				CACertProvided: true,
+				URL:            "https://test-es-http.default.svc:9200",
+			},
+			wantConf: map[string]interface{}{
+				"output.elasticsearch.hosts":                       []string{"https://test-es-http.default.svc:9200"},
+				"output.elasticsearch.username":                    "elastic",
+				"output.elasticsearch.password":                    "password",
+				"output.elasticsearch.ssl.certificate_authorities": []string{"config/elasticsearch-certs/ca.crt"},
+			},
+		},
+		{
+			name: "missing auth secret",
+			assocConf: &commonv1alpha1.AssociationConf{
+				AuthSecretName: "wrong-secret",
+				AuthSecretKey:  "elastic",
+				CASecretName:   "test-es-http-ca-public",
+				CACertProvided: true,
+				URL:            "https://test-es-http.default.svc:9200",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := k8s.WrapClient(fake.NewFakeClient(mkAuthSecret()))
+			apmServer := mkAPMServer(tc.configOverrides, tc.assocConf)
+			gotConf, err := NewConfigFromSpec(client, apmServer)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			wantConf := mkConf(t, tc.wantConf)
+			diff := wantConf.Diff(gotConf, nil)
+			require.Len(t, diff, 0)
+		})
+	}
+}
+
+func mkAPMServer(config map[string]interface{}, assocConf *commonv1alpha1.AssociationConf) *v1alpha1.ApmServer {
+	apmServer := &v1alpha1.ApmServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "apm-server",
+		},
+		Spec: v1alpha1.ApmServerSpec{
+			Config: &commonv1alpha1.Config{Data: config},
+		},
+	}
+
+	apmServer.SetAssociationConf(assocConf)
+	return apmServer
+}
+
+func mkAuthSecret() *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-es-elastic-user",
+		},
+		Data: map[string][]byte{
+			"elastic": []byte("password"),
+		},
+	}
+}
+
+func mkConf(t *testing.T, overrides map[string]interface{}) *settings.CanonicalConfig {
+	t.Helper()
+	cfg, err := settings.NewCanonicalConfigFrom(map[string]interface{}{
+		"apm-server.host":            ":8200",
+		"apm-server.secret_token":    "${SECRET_TOKEN}",
+		"apm-server.ssl.certificate": "/mnt/elastic-internal/http-certs/tls.crt",
+		"apm-server.ssl.enabled":     true,
+		"apm-server.ssl.key":         "/mnt/elastic-internal/http-certs/tls.key",
+	})
+	require.NoError(t, err)
+
+	overriddenCfg, err := settings.NewCanonicalConfigFrom(overrides)
+	require.NoError(t, err)
+
+	require.NoError(t, cfg.MergeWith(overriddenCfg))
+	return cfg
+}

--- a/pkg/controller/common/association/ca_test.go
+++ b/pkg/controller/common/association/ca_test.go
@@ -44,7 +44,8 @@ func TestReconcileAssociation_reconcileCASecret(t *testing.T) {
 			Name:      certificates.PublicSecretName(esname.ESNamer, es.Name, certificates.HTTPCAType),
 		},
 		Data: map[string][]byte{
-			certificates.CertFileName: []byte("fake-ca-cert"),
+			certificates.CertFileName: []byte("fake-cert"),
+			certificates.CAFileName:   []byte("fake-ca-cert"),
 		},
 	}
 	updatedEsCA := corev1.Secret{
@@ -53,7 +54,8 @@ func TestReconcileAssociation_reconcileCASecret(t *testing.T) {
 			Name:      certificates.PublicSecretName(esname.ESNamer, es.Name, certificates.HTTPCAType),
 		},
 		Data: map[string][]byte{
-			certificates.CertFileName: []byte("updated-fake-ca-cert"),
+			certificates.CertFileName: []byte("updated-fake-cert"),
+			certificates.CAFileName:   []byte("updated-fake-ca-cert"),
 		},
 	}
 	// mock existing ES CA secret for Kibana
@@ -63,7 +65,8 @@ func TestReconcileAssociation_reconcileCASecret(t *testing.T) {
 			Name:      ElasticsearchCACertSecretName(&kibanaFixture, ElasticsearchCASecretSuffix),
 		},
 		Data: map[string][]byte{
-			certificates.CertFileName: []byte("fake-ca-cert"),
+			certificates.CertFileName: []byte("fake-cert"),
+			certificates.CAFileName:   []byte("fake-ca-cert"),
 		},
 	}
 	updatedKibanaEsCA := corev1.Secret{
@@ -72,7 +75,8 @@ func TestReconcileAssociation_reconcileCASecret(t *testing.T) {
 			Name:      ElasticsearchCACertSecretName(&kibanaFixture, ElasticsearchCASecretSuffix),
 		},
 		Data: map[string][]byte{
-			certificates.CertFileName: []byte("updated-fake-ca-cert"),
+			certificates.CertFileName: []byte("updated-fake-cert"),
+			certificates.CAFileName:   []byte("updated-fake-ca-cert"),
 		},
 	}
 	tests := []struct {
@@ -120,7 +124,7 @@ func TestReconcileAssociation_reconcileCASecret(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.want, got.Name)
 
 			if tt.wantCA != nil {
 				var updatedKibanaCA corev1.Secret

--- a/pkg/controller/common/certificates/http/certificates_secret.go
+++ b/pkg/controller/common/certificates/http/certificates_secret.go
@@ -18,10 +18,7 @@ type CertificatesSecret v1.Secret
 
 // CAPem returns the certificate of the certificate authority.
 func (s CertificatesSecret) CAPem() []byte {
-	if ca, exist := s.Data[certificates.CAFileName]; exist {
-		return ca
-	}
-	return nil
+	return s.Data[certificates.CAFileName]
 }
 
 // CertChain combines the certificate of the CA and the host certificate.

--- a/pkg/controller/common/certificates/http/public_secret.go
+++ b/pkg/controller/common/certificates/http/public_secret.go
@@ -33,6 +33,9 @@ func ReconcileHTTPCertsPublicSecret(
 			certificates.CertFileName: httpCertificates.CertPem(),
 		},
 	}
+	if caPem := httpCertificates.CAPem(); caPem != nil {
+		expected.Data[certificates.CAFileName] = caPem
+	}
 
 	reconciled := &corev1.Secret{}
 

--- a/pkg/controller/common/certificates/http/public_secret_test.go
+++ b/pkg/controller/common/certificates/http/public_secret_test.go
@@ -51,6 +51,7 @@ func TestReconcileHTTPCertsPublicSecret(t *testing.T) {
 			ObjectMeta: k8s.ToObjectMeta(namespacedSecretName),
 			Data: map[string][]byte{
 				certificates.CertFileName: tls,
+				certificates.CAFileName:   ca,
 			},
 		}
 

--- a/pkg/controller/common/certificates/http/reconcile.go
+++ b/pkg/controller/common/certificates/http/reconcile.go
@@ -120,8 +120,11 @@ func reconcileHTTPInternalCertificatesSecret(
 			return nil, err
 		}
 		expectedSecretData := make(map[string][]byte)
-		expectedSecretData[certificates.CertFileName] = customCertificates.CertChain()
+		expectedSecretData[certificates.CertFileName] = customCertificates.CertPem()
 		expectedSecretData[certificates.KeyFileName] = customCertificates.KeyPem()
+		if caPem := customCertificates.CAPem(); caPem != nil {
+			expectedSecretData[certificates.CAFileName] = caPem
+		}
 
 		if !reflect.DeepEqual(secret.Data, expectedSecretData) {
 			needsUpdate = true
@@ -228,6 +231,7 @@ func ensureInternalSelfSignedCertificateSecretContents(
 
 		secretWasChanged = true
 		// store certificate and signed certificate in a secret mounted into the pod
+		secret.Data[certificates.CAFileName] = certificates.EncodePEMCert(ca.Cert.Raw)
 		secret.Data[certificates.CertFileName] = certificates.EncodePEMCert(certData, ca.Cert.Raw)
 	}
 

--- a/pkg/controller/elasticsearch/certificates/ca_reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/ca_reconcile.go
@@ -27,6 +27,9 @@ type CertificateResources struct {
 
 	// TransportCA is the CA used for Transport certificates
 	TransportCA *certificates.CA
+
+	// HTTPCACertProvided indicates whether ca.crt key is defined in the certificate secret.
+	HTTPCACertProvided bool
 }
 
 // reconcileGenericResources reconciles the expected generic resources of a cluster.
@@ -118,8 +121,10 @@ func Reconcile(
 		return nil, results.WithError(err)
 	}
 
+	_, httpCACertProvided := httpCertificates.Data[certificates.CAFileName]
 	return &CertificateResources{
 		TrustedHTTPCertificates: trustedHTTPCertificates,
 		TransportCA:             transportCA,
+		HTTPCACertProvided:      httpCACertProvided,
 	}, results
 }

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -236,7 +236,7 @@ func (d *defaultDriver) Reconcile() *reconciler.Results {
 	}
 
 	// reconcile StatefulSets and nodes configuration
-	res = d.reconcileNodeSpecs(esReachable, esClient, d.ReconcileState, observedState, *resourcesState, keystoreResources)
+	res = d.reconcileNodeSpecs(esReachable, esClient, d.ReconcileState, observedState, *resourcesState, keystoreResources, certificateResources)
 	if results.WithResults(res).HasError() {
 		return results
 	}

--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -7,6 +7,7 @@ package driver
 import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/observer"
@@ -24,6 +25,7 @@ func (d *defaultDriver) reconcileNodeSpecs(
 	observedState observer.State,
 	resourcesState reconcile.ResourcesState,
 	keystoreResources *keystore.Resources,
+	certResources *certificates.CertificateResources,
 ) *reconciler.Results {
 	results := &reconciler.Results{}
 
@@ -41,7 +43,7 @@ func (d *defaultDriver) reconcileNodeSpecs(
 		return results.WithResult(defaultRequeue)
 	}
 
-	expectedResources, err := nodespec.BuildExpectedResources(d.ES, keystoreResources, d.Scheme())
+	expectedResources, err := nodespec.BuildExpectedResources(d.ES, keystoreResources, d.Scheme(), certResources)
 	if err != nil {
 		return results.WithError(err)
 	}

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/initcontainer"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
 	"github.com/go-test/deep"
@@ -87,10 +88,11 @@ var sampleES = v1alpha1.Elasticsearch{
 }
 
 func TestBuildPodTemplateSpec(t *testing.T) {
+	certResources := certificates.CertificateResources{HTTPCACertProvided: true}
 	nodeSpec := sampleES.Spec.Nodes[0]
 	ver, err := version.Parse(sampleES.Spec.Version)
 	require.NoError(t, err)
-	cfg, err := settings.NewMergedESConfig(sampleES.Name, *ver, sampleES.Spec.HTTP, *nodeSpec.Config)
+	cfg, err := settings.NewMergedESConfig(sampleES.Name, *ver, sampleES.Spec.HTTP, *nodeSpec.Config, &certResources)
 	require.NoError(t, err)
 
 	actual, err := BuildPodTemplateSpec(sampleES, sampleES.Spec.Nodes[0], cfg, nil)
@@ -138,7 +140,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 			Labels: map[string]string{
 				"common.k8s.elastic.co/type":                        "elasticsearch",
 				"elasticsearch.k8s.elastic.co/cluster-name":         "name",
-				"elasticsearch.k8s.elastic.co/config-template-hash": "2449560134",
+				"elasticsearch.k8s.elastic.co/config-template-hash": "593041036",
 				"elasticsearch.k8s.elastic.co/http-scheme":          "https",
 				"elasticsearch.k8s.elastic.co/node-data":            "false",
 				"elasticsearch.k8s.elastic.co/node-ingest":          "true",

--- a/pkg/controller/elasticsearch/nodespec/resources.go
+++ b/pkg/controller/elasticsearch/nodespec/resources.go
@@ -5,7 +5,6 @@
 package nodespec
 
 import (
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -13,6 +12,8 @@ import (
 	commonv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
@@ -36,7 +37,7 @@ func (l ResourcesList) StatefulSets() sset.StatefulSetList {
 	return ssetList
 }
 
-func BuildExpectedResources(es v1alpha1.Elasticsearch, keystoreResources *keystore.Resources, scheme *runtime.Scheme) (ResourcesList, error) {
+func BuildExpectedResources(es v1alpha1.Elasticsearch, keystoreResources *keystore.Resources, scheme *runtime.Scheme, certResources *certificates.CertificateResources) (ResourcesList, error) {
 	nodesResources := make(ResourcesList, 0, len(es.Spec.Nodes))
 
 	ver, err := version.Parse(es.Spec.Version)
@@ -50,7 +51,7 @@ func BuildExpectedResources(es v1alpha1.Elasticsearch, keystoreResources *keysto
 		if nodeSpec.Config != nil {
 			userCfg = *nodeSpec.Config
 		}
-		cfg, err := settings.NewMergedESConfig(es.Name, *ver, es.Spec.HTTP, userCfg)
+		cfg, err := settings.NewMergedESConfig(es.Name, *ver, es.Spec.HTTP, userCfg, certResources)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/elasticsearch/settings/merged_config_test.go
+++ b/pkg/controller/elasticsearch/settings/merged_config_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/common/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates"
 	"github.com/stretchr/testify/require"
 )
 
@@ -100,9 +101,13 @@ func TestNewMergedESConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ver, err := version.Parse(tt.version)
 			require.NoError(t, err)
-			cfg, err := NewMergedESConfig("clusterName", *ver, v1alpha1.HTTPConfig{}, v1alpha1.Config{
-				Data: tt.cfgData,
-			})
+			cfg, err := NewMergedESConfig(
+				"clusterName",
+				*ver,
+				v1alpha1.HTTPConfig{},
+				v1alpha1.Config{Data: tt.cfgData},
+				&certificates.CertificateResources{},
+			)
 			require.NoError(t, err)
 			tt.assert(cfg)
 		})

--- a/pkg/controller/kibana/config/settings.go
+++ b/pkg/controller/kibana/config/settings.go
@@ -85,9 +85,14 @@ func kibanaTLSSettings(kb v1alpha1.Kibana) map[string]interface{} {
 }
 
 func elasticsearchTLSSettings(kb v1alpha1.Kibana) map[string]interface{} {
-	esCertsVolumeMountPath := es.CaCertSecretVolume(kb).VolumeMount().MountPath
-	return map[string]interface{}{
-		ElasticsearchSslCertificateAuthorities: path.Join(esCertsVolumeMountPath, certificates.CertFileName),
-		ElasticsearchSslVerificationMode:       "certificate",
+	cfg := map[string]interface{}{
+		ElasticsearchSslVerificationMode: "certificate",
 	}
+
+	if kb.AssociationConf().GetCACertProvided() {
+		esCertsVolumeMountPath := es.CaCertSecretVolume(kb).VolumeMount().MountPath
+		cfg[ElasticsearchSslCertificateAuthorities] = path.Join(esCertsVolumeMountPath, certificates.CAFileName)
+	}
+
+	return cfg
 }

--- a/pkg/controller/kibanaassociation/association_controller.go
+++ b/pkg/controller/kibanaassociation/association_controller.go
@@ -282,7 +282,7 @@ func (r *ReconcileAssociation) reconcileInternal(kibana *kbtype.Kibana) (commonv
 		return commonv1alpha1.AssociationPending, err
 	}
 
-	caSecretName, err := r.reconcileElasticsearchCA(kibana, esRefKey)
+	caSecret, err := r.reconcileElasticsearchCA(kibana, esRefKey)
 	if err != nil {
 		return commonv1alpha1.AssociationPending, err
 	}
@@ -292,7 +292,8 @@ func (r *ReconcileAssociation) reconcileInternal(kibana *kbtype.Kibana) (commonv
 	expectedESAssoc := &commonv1alpha1.AssociationConf{
 		AuthSecretName: authSecret.Name,
 		AuthSecretKey:  authSecret.Key,
-		CASecretName:   caSecretName,
+		CACertProvided: caSecret.CACertProvided,
+		CASecretName:   caSecret.Name,
 		URL:            services.ExternalServiceURL(es),
 	}
 
@@ -312,7 +313,7 @@ func (r *ReconcileAssociation) reconcileInternal(kibana *kbtype.Kibana) (commonv
 	return commonv1alpha1.AssociationEstablished, nil
 }
 
-func (r *ReconcileAssociation) reconcileElasticsearchCA(kibana *kbtype.Kibana, es types.NamespacedName) (string, error) {
+func (r *ReconcileAssociation) reconcileElasticsearchCA(kibana *kbtype.Kibana, es types.NamespacedName) (association.CASecret, error) {
 	kibanaKey := k8s.ExtractNamespacedName(kibana)
 	// watch ES CA secret to reconcile on any change
 	if err := r.watches.Secrets.AddHandler(watches.NamedWatch{
@@ -320,7 +321,7 @@ func (r *ReconcileAssociation) reconcileElasticsearchCA(kibana *kbtype.Kibana, e
 		Watched: []types.NamespacedName{http.PublicCertsSecretRef(esname.ESNamer, es)},
 		Watcher: kibanaKey,
 	}); err != nil {
-		return "", err
+		return association.CASecret{}, err
 	}
 	// Build the labels applied on the secret
 	labels := kblabel.NewLabels(kibana.Name)


### PR DESCRIPTION
More details can be found in #1614.
Briefly, this PR does the following:
- Treat the presence of `ca.crt` key in the secret as a signal to override the appropriate `*.certificate_authorities` setting of the associated stack application. 
- Add support for PKCS#8 encoded private keys.
- Update the documentation to clarify how custom certificates can be used.
- Update/add unit tests

Fixes #1614


