### PR TITLE
Upload dump from k8s cluster on e2e tests failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,6 +362,9 @@ run-deployer: dep-vendor-only build-deployer
 ci-release: clean dep-vendor-only generate build-operator-image
 	@ echo $(OPERATOR_IMAGE) was pushed!
 
+eck-dump: run-deployer
+	@ hack/eck-dump.sh -z -o $(CLUSTER_NAME)
+
 ##########################
 ##  --   Helpers    --  ##
 ##########################

--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,8 @@ e2e-run:
 		--e2e-image=$(E2E_IMG) \
 		--test-regex=$(TESTS_MATCH) \
 		--elastic-stack-version=$(STACK_VERSION) \
-		--log-verbosity=$(LOG_VERBOSITY)
+		--log-verbosity=$(LOG_VERBOSITY) \
+		--skip-cleanup=false
 
 # Verify e2e tests compile with no errors, don't run them
 e2e-compile:

--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,7 @@ e2e-run:
 		--test-regex=$(TESTS_MATCH) \
 		--elastic-stack-version=$(STACK_VERSION) \
 		--log-verbosity=$(LOG_VERBOSITY) \
-		--skip-cleanup=false
+		--skip-cleanup=true
 
 # Verify e2e tests compile with no errors, don't run them
 e2e-compile:

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -67,7 +67,6 @@ pipeline {
         always {
             script {
                 if (notOnlyDocs()) {
-                    createConfig()
                     deployerConfig("auth")
                     sh 'make -C build/ci TARGET=eck-dump ci'
 

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -13,6 +13,7 @@ pipeline {
         VAULT_ROLE_ID = credentials('vault-role-id')
         VAULT_SECRET_ID = credentials('vault-secret-id')
         GCLOUD_PROJECT = credentials('k8s-operators-gcloud-project')
+        GCS_BUCKET = credentials('gcs-bucket')
     }
 
     stages {
@@ -52,26 +53,10 @@ pipeline {
                             notOnlyDocs()
                         }
                     }
-                    agent {
-                        label 'linux'
-                    }
                     steps {
                         createConfig()
-                        sh """
-                            cat >deployer-config.yml <<EOF
-id: gke-ci
-overrides:
-  kubernetesVersion: "1.12"
-  clusterName: $BUILD_TAG
-  vaultInfo:
-    address: $VAULT_ADDR
-    roleId: $VAULT_ROLE_ID
-    secretId: $VAULT_SECRET_ID
-  gke:
-    gCloudProject: $GCLOUD_PROJECT
-EOF
-                            make -C build/ci TARGET=ci-e2e ci
-                        """
+                        deployerConfig()
+                        sh 'make -C build/ci TARGET=ci-e2e ci'
                     }
                 }
             }
@@ -79,6 +64,21 @@ EOF
     }
 
     post {
+        always {
+            script {
+                if (notOnlyDocs()) {
+                    createConfig()
+                    deployerConfig("auth")
+                    sh 'make -C build/ci TARGET=eck-dump ci'
+
+                    googleStorageUpload bucket: "gs://${GCS_BUCKET}/eck/data-dump",
+                        credentialsId: "devops-ci-gcs-plugin",
+                        pattern: "*.tgz",
+                        sharedPublicly: true,
+                        showInline: true
+                }
+            }
+        }
         cleanup {
             script {
                 if (notOnlyDocs()) {
@@ -108,6 +108,25 @@ REPOSITORY = "$GCLOUD_PROJECT"
 TESTS_MATCH = TestSmoke
 SKIP_DOCKER_COMMAND = false
 IMG_SUFFIX = -ci
+CLUSTER_NAME = "$BUILD_TAG"
 EOF
     """
+}
+
+def deployerConfig(def operation = "create") {
+    sh """
+        cat >deployer-config.yml <<EOF
+id: gke-ci
+overrides:
+  operation: ${operation}
+  kubernetesVersion: "1.12"
+  clusterName: $BUILD_TAG
+  vaultInfo:
+    address: $VAULT_ADDR
+    roleId: $VAULT_ROLE_ID
+    secretId: $VAULT_SECRET_ID
+  gke:
+    gCloudProject: $GCLOUD_PROJECT
+EOF
+   """
 }

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -13,7 +13,6 @@ pipeline {
         VAULT_ROLE_ID = credentials('vault-role-id')
         VAULT_SECRET_ID = credentials('vault-secret-id')
         GCLOUD_PROJECT = credentials('k8s-operators-gcloud-project')
-        GCS_BUCKET = credentials('gcs-bucket')
     }
 
     stages {
@@ -70,7 +69,7 @@ pipeline {
                     deployerConfig("auth")
                     sh 'make -C build/ci TARGET=eck-dump ci'
 
-                    googleStorageUpload bucket: "gs://${GCS_BUCKET}/eck/data-dump",
+                    googleStorageUpload bucket: "gs://devops-ci-artifacts/eck/data-dump",
                         credentialsId: "devops-ci-gcs-plugin",
                         pattern: "*.tgz",
                         sharedPublicly: true,

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -7,6 +7,7 @@ package runner
 import (
 	"fmt"
 	"log"
+	"os"
 	"strings"
 )
 
@@ -114,16 +115,15 @@ func (d *GkeDriver) auth() error {
 		log.Println("Authenticating as service account...")
 
 		client, err := NewClient(*d.plan.VaultInfo)
-		_ = client
 		if err != nil {
 			return err
 		}
 
 		keyFileName := "gke_service_account_key.json"
-		//defer os.Remove(keyFileName)
-		//if err := client.ReadIntoFile(keyFileName, GkeVaultPath, GkeServiceAccountVaultFieldName); err != nil {
-		//	return err
-		//}
+		defer os.Remove(keyFileName)
+		if err := client.ReadIntoFile(keyFileName, GkeVaultPath, GkeServiceAccountVaultFieldName); err != nil {
+			return err
+		}
 
 		return NewCommand("gcloud auth activate-service-account --key-file=" + keyFileName).Run()
 	}

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -7,7 +7,6 @@ package runner
 import (
 	"fmt"
 	"log"
-	"os"
 	"strings"
 )
 
@@ -57,6 +56,12 @@ func (d *GkeDriver) Execute() error {
 	}
 
 	switch d.plan.Operation {
+	case "auth":
+		log.Printf("Authorizing GKE access...")
+		if err := d.GetCredentials(); err != nil {
+			return err
+		}
+		log.Printf("GKE access granted!")
 	case "delete":
 		if exists {
 			err = d.delete()
@@ -109,15 +114,16 @@ func (d *GkeDriver) auth() error {
 		log.Println("Authenticating as service account...")
 
 		client, err := NewClient(*d.plan.VaultInfo)
+		_ = client
 		if err != nil {
 			return err
 		}
 
 		keyFileName := "gke_service_account_key.json"
-		defer os.Remove(keyFileName)
-		if err := client.ReadIntoFile(keyFileName, GkeVaultPath, GkeServiceAccountVaultFieldName); err != nil {
-			return err
-		}
+		//defer os.Remove(keyFileName)
+		//if err := client.ReadIntoFile(keyFileName, GkeVaultPath, GkeServiceAccountVaultFieldName); err != nil {
+		//	return err
+		//}
 
 		return NewCommand("gcloud auth activate-service-account --key-file=" + keyFileName).Run()
 	}


### PR DESCRIPTION
This PR adding support for `eck-dump.sh` script for e2e tests. On e2e tests failures it will run script and upload data to further investigation.

Close https://github.com/elastic/cloud-on-k8s/issues/556