### PR TITLE
Fix panic in TestKibanaEsSample

### DIFF
--- a/test/e2e/test/elasticsearch/settings.go
+++ b/test/e2e/test/elasticsearch/settings.go
@@ -22,7 +22,7 @@ func MustNumDataNodes(es v1alpha1.Elasticsearch) int {
 
 func isDataNode(node v1alpha1.NodeSpec) bool {
 	if node.Config == nil {
-		return true // if not specified all node type fields are true
+		return v1alpha1.DefaultCfg.Node.Data // if not specified use the default
 	}
 	config, err := common.NewCanonicalConfigFrom(node.Config.Data)
 	if err != nil {

--- a/test/e2e/test/elasticsearch/settings.go
+++ b/test/e2e/test/elasticsearch/settings.go
@@ -13,19 +13,26 @@ import (
 func MustNumDataNodes(es v1alpha1.Elasticsearch) int {
 	var numNodes int
 	for _, n := range es.Spec.Nodes {
-		config, err := common.NewCanonicalConfigFrom(n.Config.Data)
-		if err != nil {
-			panic(err)
-		}
-		nodeCfg, err := settings.CanonicalConfig{
-			CanonicalConfig: config,
-		}.Unpack()
-		if err != nil {
-			panic(err)
-		}
-		if nodeCfg.Node.Data {
+		if isDataNode(n) {
 			numNodes += int(n.NodeCount)
 		}
 	}
 	return numNodes
+}
+
+func isDataNode(node v1alpha1.NodeSpec) bool {
+	if node.Config == nil {
+		return true // if not specified all node type fields are true
+	}
+	config, err := common.NewCanonicalConfigFrom(node.Config.Data)
+	if err != nil {
+		panic(err)
+	}
+	nodeCfg, err := settings.CanonicalConfig{
+		CanonicalConfig: config,
+	}.Unpack()
+	if err != nil {
+		panic(err)
+	}
+	return nodeCfg.Node.Data
 }


### PR DESCRIPTION
Fix the following e2e test:

```
12:02:11  === RUN   TestKibanaEsSample/Add_some_data_to_the_cluster_before_starting_the_mutation
12:02:11  panic: runtime error: invalid memory address or nil pointer dereference [recovered]
12:02:11      panic: runtime error: invalid memory address or nil pointer dereference
12:02:11  [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1075a2c]
12:02:11  
12:02:11  goroutine 4839 [running]:
12:02:11  testing.tRunner.func1(0xc000778500)
12:02:11      /usr/local/go/src/testing/testing.go:792 +0x387
12:02:11  panic(0x11a6740, 0x1f3a760)
12:02:11      /usr/local/go/src/runtime/panic.go:513 +0x1b9
12:02:11  github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch.MustNumDataNodes(0xc000722a00, 0xd, 0xc0007111d0, 0x25, 0xc0008b55e0, 0x19, 0x0, 0x0, 0xc0003fe3a0, 0x11, ...)
```
