### PR TITLE
Generate notice file from dependency licences

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ run:
   deadline: 300s
   skip-dirs:
     - config
+    - hack/licence\-detector
   skip-files:
     - utils/chrono/millis\.test\.go
 linters:

--- a/hack/licence-detector/.gitignore
+++ b/hack/licence-detector/.gitignore
@@ -1,0 +1,2 @@
+notice.txt
+licence-detector

--- a/hack/licence-detector/NOTICE.txt.tmpl
+++ b/hack/licence-detector/NOTICE.txt.tmpl
@@ -1,0 +1,34 @@
+{{- define "depInfo" -}}
+{{- range $i, $dep := . }}
+{{ "-" | line }}
+{{ if $dep.Replace -}}
+Module  : {{ $dep.Path }} => {{ $dep.Replace.Path }}
+Version : {{ $dep.Replace.Version }}
+Time    : {{ $dep.Replace.Time }}
+{{- else -}}
+Module  : {{ $dep.Path }}
+Version : {{ $dep.Version }}
+Time    : {{ $dep.Time }}
+{{- end }}
+
+{{ $dep | licenceText }}
+{{ end }}
+{{- end -}}
+
+Copyright 2014-{{ currentYear }} Elasticsearch BV
+
+This product includes software developed by The Apache Software
+Foundation (http://www.apache.org/).
+
+{{ "=" | line }}
+Third party libraries used by the Elastic Cloud on Kubernetes project
+{{ "=" | line }}
+
+{{ template "depInfo" .Direct }}
+
+{{ if .Indirect }}
+{{ "=" | line }}
+Indirect dependencies
+
+{{ template "depInfo" .Indirect }}
+{{ end }}

--- a/hack/licence-detector/detector/detector.go
+++ b/hack/licence-detector/detector/detector.go
@@ -1,0 +1,145 @@
+package detector
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/karrick/godirwalk"
+)
+
+var errLicenceNotFound = errors.New("failed to detect licence")
+
+type Dependencies struct {
+	Direct   []LicenceInfo
+	Indirect []LicenceInfo
+}
+
+type LicenceInfo struct {
+	Module
+	LicenceFile string
+	Error       error
+}
+
+type Module struct {
+	Path     string     // module path
+	Version  string     // module version
+	Main     bool       // is this the main module?
+	Time     *time.Time // time version was created
+	Indirect bool       // is this module only an indirect dependency of main module?
+	Dir      string     // directory holding files for this module, if any
+	Replace  *Module    // replace directive
+}
+
+func Detect(data io.Reader, includeIndirect bool) (*Dependencies, error) {
+	dependencies, err := parseDependencies(data, includeIndirect)
+	if err != nil {
+		return nil, err
+	}
+
+	err = detectLicences(dependencies)
+	return dependencies, err
+}
+
+func parseDependencies(data io.Reader, includeIndirect bool) (*Dependencies, error) {
+	deps := &Dependencies{}
+	decoder := json.NewDecoder(data)
+	for {
+		var mod Module
+		if err := decoder.Decode(&mod); err != nil {
+			if err == io.EOF {
+				return deps, nil
+			}
+			return deps, fmt.Errorf("failed to parse dependencies: %w", err)
+		}
+
+		if !mod.Main && mod.Dir != "" {
+			if mod.Indirect {
+				if includeIndirect {
+					deps.Indirect = append(deps.Indirect, LicenceInfo{Module: mod})
+				}
+				continue
+			}
+			deps.Direct = append(deps.Direct, LicenceInfo{Module: mod})
+		}
+	}
+
+	sort.Slice(deps.Direct, func(i, j int) bool {
+		return deps.Direct[i].Path < deps.Direct[j].Path
+	})
+
+	sort.Slice(deps.Indirect, func(i, j int) bool {
+		return deps.Indirect[i].Path < deps.Indirect[j].Path
+	})
+
+	return deps, nil
+}
+
+func detectLicences(deps *Dependencies) error {
+	licenceRegex := buildLicenceRegex()
+	for _, depList := range [][]LicenceInfo{deps.Direct, deps.Indirect} {
+		for i, dep := range depList {
+			srcDir := dep.Dir
+			if dep.Replace != nil {
+				srcDir = dep.Replace.Dir
+			}
+
+			depList[i].LicenceFile, depList[i].Error = findLicenceFile(srcDir, licenceRegex)
+			if depList[i].Error != nil && depList[i].Error != errLicenceNotFound {
+				return fmt.Errorf("unexpected error while finding licence for %s in %s: %w", dep.Path, srcDir, depList[i].Error)
+			}
+		}
+	}
+
+	return nil
+}
+
+func buildLicenceRegex() *regexp.Regexp {
+	// inspired by https://github.com/src-d/go-license-detector/blob/7961dd6009019bc12778175ef7f074ede24bd128/licensedb/internal/investigation.go#L29
+	licenceFileNames := []string{
+		`li[cs]en[cs]es?`,
+		`legal`,
+		`copy(left|right|ing)`,
+		`unlicense`,
+		`l?gpl([-_ v]?)(\d\.?\d)?`,
+		`bsd`,
+		`mit`,
+		`apache`,
+	}
+
+	regexStr := fmt.Sprintf(`^(?i:(%s)(\.(txt|md|rst))?)$`, strings.Join(licenceFileNames, "|"))
+	return regexp.MustCompile(regexStr)
+}
+
+func findLicenceFile(root string, licenceRegex *regexp.Regexp) (string, error) {
+	errStopWalk := errors.New("stop walk")
+	var licenceFile string
+	err := godirwalk.Walk(root, &godirwalk.Options{
+		Callback: func(osPathName string, dirent *godirwalk.Dirent) error {
+			if licenceRegex.MatchString(dirent.Name()) {
+				if dirent.IsDir() {
+					return filepath.SkipDir
+				}
+				licenceFile = osPathName
+				return errStopWalk
+			}
+			return nil
+		},
+		Unsorted: true,
+	})
+
+	if err != nil {
+		if errors.Is(err, errStopWalk) {
+			return licenceFile, nil
+		}
+		return "", err
+	}
+
+	return "", errLicenceNotFound
+}

--- a/hack/licence-detector/detector/detector_test.go
+++ b/hack/licence-detector/detector/detector_test.go
@@ -1,0 +1,122 @@
+package detector
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetect(t *testing.T) {
+	testCases := []struct {
+		name             string
+		includeIndirect  bool
+		wantDependencies *Dependencies
+		wantErr          bool
+	}{
+		{
+			name:            "All",
+			includeIndirect: true,
+			wantDependencies: &Dependencies{
+				Indirect: mkIndirectDeps(),
+				Direct:   mkDirectDeps(),
+			},
+		},
+		{
+			name:            "DirectOnly",
+			includeIndirect: false,
+			wantDependencies: &Dependencies{
+				Direct: mkDirectDeps(),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := os.Open("testdata/deps.json")
+			require.NoError(t, err)
+			defer f.Close()
+
+			gotDependencies, err := Detect(f, tc.includeIndirect)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantDependencies, gotDependencies)
+		})
+	}
+}
+
+func mkIndirectDeps() []LicenceInfo {
+	return []LicenceInfo{
+		{
+			Module: Module{
+				Path:     "github.com/davecgh/go-spew",
+				Version:  "v1.1.0",
+				Time:     mustParseTime("2016-10-29T20:57:26Z"),
+				Indirect: true,
+				Dir:      "testdata/github.com/davecgh/go-spew@v1.1.0",
+			},
+			LicenceFile: "testdata/github.com/davecgh/go-spew@v1.1.0/LICENCE.txt",
+		},
+		{
+			Module: Module{
+				Path:     "github.com/dgryski/go-minhash",
+				Version:  "v0.0.0-20170608043002-7fe510aff544",
+				Time:     mustParseTime("2017-06-08T04:30:02Z"),
+				Indirect: true,
+				Dir:      "testdata/github.com/dgryski/go-minhash@v0.0.0-20170608043002-7fe510aff544",
+			},
+			LicenceFile: "testdata/github.com/dgryski/go-minhash@v0.0.0-20170608043002-7fe510aff544/licence",
+		},
+		{
+			Module: Module{
+				Path:     "github.com/dgryski/go-spooky",
+				Version:  "v0.0.0-20170606183049-ed3d087f40e2",
+				Time:     mustParseTime("2017-06-06T18:30:49Z"),
+				Indirect: true,
+				Dir:      "testdata/github.com/dgryski/go-spooky@v0.0.0-20170606183049-ed3d087f40e2",
+			},
+			LicenceFile: "testdata/github.com/dgryski/go-spooky@v0.0.0-20170606183049-ed3d087f40e2/COPYING",
+		},
+	}
+}
+
+func mkDirectDeps() []LicenceInfo {
+	return []LicenceInfo{
+		{
+			Module: Module{
+				Path:    "github.com/ekzhu/minhash-lsh",
+				Version: "v0.0.0-20171225071031-5c06ee8586a1",
+				Time:    mustParseTime("2017-12-25T07:10:31Z"),
+				Dir:     "testdata/github.com/ekzhu/minhash-lsh@v0.0.0-20171225071031-5c06ee8586a1",
+			},
+			Error: errLicenceNotFound,
+		},
+		{
+			Module: Module{
+				Path:    "gopkg.in/russross/blackfriday.v2",
+				Version: "v2.0.1",
+				Replace: &Module{
+					Path:    "github.com/russross/blackfriday/v2",
+					Version: "v2.0.1",
+					Time:    mustParseTime("2018-09-20T17:16:15Z"),
+					Dir:     "testdata/github.com/russross/blackfriday/v2@v2.0.1",
+				},
+				Dir: "testdata/github.com/russross/blackfriday/v2@v2.0.1",
+			},
+			LicenceFile: "testdata/github.com/russross/blackfriday/v2@v2.0.1/LICENSE.rst",
+		},
+	}
+}
+
+func mustParseTime(value string) *time.Time {
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return &t
+}

--- a/hack/licence-detector/detector/testdata/deps.json
+++ b/hack/licence-detector/detector/testdata/deps.json
@@ -1,0 +1,51 @@
+{
+	"Path": "github.com/charith-elastic/licence-detector",
+	"Main": true,
+	"Dir": "testdata/github.com/charith-elastic/license-detector",
+	"GoMod": "testdata/github.com/charith-elastic/license-detector/go.mod",
+	"GoVersion": "1.13"
+}
+{
+	"Path": "github.com/davecgh/go-spew",
+	"Version": "v1.1.0",
+	"Time": "2016-10-29T20:57:26Z",
+	"Indirect": true,
+	"Dir": "testdata/github.com/davecgh/go-spew@v1.1.0",
+	"GoMod": "testdata/cache/download/github.com/davecgh/go-spew/@v/v1.1.0.mod"
+}
+{
+	"Path": "github.com/dgryski/go-minhash",
+	"Version": "v0.0.0-20170608043002-7fe510aff544",
+	"Time": "2017-06-08T04:30:02Z",
+	"Indirect": true,
+	"Dir": "testdata/github.com/dgryski/go-minhash@v0.0.0-20170608043002-7fe510aff544",
+	"GoMod": "testdata/cache/download/github.com/dgryski/go-minhash/@v/v0.0.0-20170608043002-7fe510aff544.mod"
+}
+{
+	"Path": "github.com/dgryski/go-spooky",
+	"Version": "v0.0.0-20170606183049-ed3d087f40e2",
+	"Time": "2017-06-06T18:30:49Z",
+	"Indirect": true,
+	"Dir": "testdata/github.com/dgryski/go-spooky@v0.0.0-20170606183049-ed3d087f40e2",
+	"GoMod": "testdata/cache/download/github.com/dgryski/go-spooky/@v/v0.0.0-20170606183049-ed3d087f40e2.mod"
+}
+{
+	"Path": "github.com/ekzhu/minhash-lsh",
+	"Version": "v0.0.0-20171225071031-5c06ee8586a1",
+	"Time": "2017-12-25T07:10:31Z",
+	"Dir": "testdata/github.com/ekzhu/minhash-lsh@v0.0.0-20171225071031-5c06ee8586a1",
+	"GoMod": "testdata/cache/download/github.com/ekzhu/minhash-lsh/@v/v0.0.0-20171225071031-5c06ee8586a1.mod"
+}
+{
+	"Path": "gopkg.in/russross/blackfriday.v2",
+	"Version": "v2.0.1",
+	"Replace": {
+		"Path": "github.com/russross/blackfriday/v2",
+		"Version": "v2.0.1",
+		"Time": "2018-09-20T17:16:15Z",
+		"Dir": "testdata/github.com/russross/blackfriday/v2@v2.0.1",
+		"GoMod": "testdata/cache/download/github.com/russross/blackfriday/v2/@v/v2.0.1.mod"
+	},
+	"Dir": "testdata/github.com/russross/blackfriday/v2@v2.0.1",
+	"GoMod": "testdata/github.com/russross/blackfriday/v2@v2.0.1/go.mod"
+}

--- a/hack/licence-detector/detector/testdata/github.com/davecgh/go-spew@v1.1.0/LICENCE.txt
+++ b/hack/licence-detector/detector/testdata/github.com/davecgh/go-spew@v1.1.0/LICENCE.txt
@@ -1,0 +1,1 @@
+LICENCE

--- a/hack/licence-detector/detector/testdata/github.com/dgryski/go-minhash@v0.0.0-20170608043002-7fe510aff544/licence
+++ b/hack/licence-detector/detector/testdata/github.com/dgryski/go-minhash@v0.0.0-20170608043002-7fe510aff544/licence
@@ -1,0 +1,1 @@
+licence

--- a/hack/licence-detector/detector/testdata/github.com/dgryski/go-spooky@v0.0.0-20170606183049-ed3d087f40e2/COPYING
+++ b/hack/licence-detector/detector/testdata/github.com/dgryski/go-spooky@v0.0.0-20170606183049-ed3d087f40e2/COPYING
@@ -1,0 +1,1 @@
+licence

--- a/hack/licence-detector/generate-notice.sh
+++ b/hack/licence-detector/generate-notice.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+# Script to generate a NOTICE file containing licence information from dependencies.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR=${SCRIPT_DIR}/../..
+
+build_licence_detector() {
+    (
+        cd $SCRIPT_DIR
+        go build -v github.com/elastic/cloud-on-k8s/hack/licence-detector
+    )
+}
+
+generate_notice() {
+    (
+        cd $PROJECT_DIR
+        go list -m -json all | ${SCRIPT_DIR}/licence-detector -template=${SCRIPT_DIR}/NOTICE.txt.tmpl -out=${PROJECT_DIR}/NOTICE.txt
+    )
+}
+
+build_licence_detector
+generate_notice

--- a/hack/licence-detector/go.mod
+++ b/hack/licence-detector/go.mod
@@ -1,0 +1,8 @@
+module github.com/elastic/cloud-on-k8s/hack/licence-detector
+
+go 1.13
+
+require (
+	github.com/karrick/godirwalk v1.10.12
+	github.com/stretchr/testify v1.4.0
+)

--- a/hack/licence-detector/go.sum
+++ b/hack/licence-detector/go.sum
@@ -1,0 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/karrick/godirwalk v1.10.12 h1:BqUm+LuJcXjGv1d2mj3gBiQyrQ57a0rYoAmhvJQ7RDU=
+github.com/karrick/godirwalk v1.10.12/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/hack/licence-detector/main.go
+++ b/hack/licence-detector/main.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"go/build"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/elastic/cloud-on-k8s/hack/licence-detector/detector"
+)
+
+var (
+	inFlag              = flag.String("in", "-", "Dependency list (output from go list -m -json all)")
+	includeIndirectFlag = flag.Bool("includeIndirect", false, "Include indirect dependencies")
+	outFlag             = flag.String("out", "-", "Path to output the notice information")
+	templateFlag        = flag.String("template", "NOTICE.txt.tmpl", "Path to the template file")
+
+	goModCache = filepath.Join(build.Default.GOPATH, "pkg", "mod")
+)
+
+func main() {
+	flag.Parse()
+	depInput, err := mkReader(*inFlag)
+	if err != nil {
+		log.Fatalf("Failed to create reader for %s: %v", *inFlag, err)
+	}
+	defer depInput.Close()
+
+	dependencies, err := detector.Detect(depInput, *includeIndirectFlag)
+	if err != nil {
+		log.Fatalf("Failed to detect licences: %v", err)
+	}
+
+	if err := renderNotice(dependencies, *templateFlag, *outFlag); err != nil {
+		log.Fatalf("Failed to render notice: %v", err)
+	}
+}
+
+func mkReader(path string) (io.ReadCloser, error) {
+	if path == "-" {
+		return ioutil.NopCloser(os.Stdin), nil
+	}
+
+	return os.Open(path)
+}
+
+func renderNotice(dependencies *detector.Dependencies, templatePath, outputPath string) error {
+	funcMap := template.FuncMap{
+		"currentYear": CurrentYear,
+		"line":        Line,
+		"licenceText": LicenceText,
+	}
+	tmpl, err := template.New(filepath.Base(templatePath)).Funcs(funcMap).ParseFiles(templatePath)
+	if err != nil {
+		return fmt.Errorf("failed to parse template at %s: %w", templatePath, err)
+	}
+
+	w, cleanup, err := mkWriter(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create output file %s: %w", outputPath, err)
+	}
+	defer cleanup()
+
+	if err := tmpl.Execute(w, dependencies); err != nil {
+		return fmt.Errorf("failed to render template: %w", err)
+	}
+
+	return nil
+}
+
+func mkWriter(path string) (io.Writer, func(), error) {
+	if path == "-" {
+		return os.Stdout, func() {}, nil
+	}
+
+	f, err := os.Create(path)
+	return f, func() { f.Close() }, err
+}
+
+/* Template functions */
+
+func CurrentYear() string {
+	return strconv.Itoa(time.Now().Year())
+}
+
+func Line(ch string) string {
+	return strings.Repeat(ch, 80)
+}
+
+func LicenceText(licInfo detector.LicenceInfo) string {
+	if licInfo.Error != nil {
+		return licInfo.Error.Error()
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString("Contents of probable licence file ")
+	buf.WriteString(strings.Replace(licInfo.LicenceFile, goModCache, "$GOMODCACHE", -1))
+	buf.WriteString(":\n\n")
+
+	f, err := os.Open(licInfo.LicenceFile)
+	if err != nil {
+		log.Fatalf("Failed to open licence file %s: %v", licInfo.LicenceFile, err)
+	}
+	defer f.Close()
+
+	_, err = io.Copy(&buf, f)
+	if err != nil {
+		log.Fatalf("Failed to read licence file %s: %v", licInfo.LicenceFile, err)
+	}
+
+	return buf.String()
+}


### PR DESCRIPTION
An alternative implementation of #1689 that does not require generating the vendor directory.  This code parses the output of `go list -m -json all` to locate all dependencies and their paths on disk (taking replace directives into account). It then detects possible licence files in the path and builds a notice file.

Sample output generated using the output of `go list -m -json all` on [Kubebuilder v2 branch](/anyasabo/cloud-on-k8s/tree/kubebuilderv2): https://gist.github.com/charith-elastic/fa284284cfbcdfa479820f28d542fc48

