### PR TITLE
Use meta version attribute file in docs

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -4,7 +4,7 @@
 :idprefix: k8s-
 :s: k8s
 
-include::{asciidoc-dir}/../../shared/versions/stack/7.3.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 include::eck-attributes.asciidoc[]
 include::overview.asciidoc[]


### PR DESCRIPTION
The docs repo now contains an attribute file that points to the latest released versions of the stack. It should help keep our documentation in sync with each stack release.

Related to #1747 
Docs repo PR: https://github.com/elastic/docs/pull/1198
Subsequent patch by Nik: https://github.com/elastic/docs/commit/45d3bdf6e13240c7ab299e82fd970def0d5bbdfe