### PR TITLE
Update heap size and compute resources documentation

### DIFF
--- a/docs/elasticsearch-spec.asciidoc
+++ b/docs/elasticsearch-spec.asciidoc
@@ -64,7 +64,7 @@ For more information on Pod templates, see the Kubernetes documentation:
 [id="{p}-jvm-heap-size"]
 === JVM heap size
 
-To change the heap size of Elasticsearch, set the `ES_JAVA_OPTS` environment variable in the `podTemplate`. It is also highly recommended to set the resource `requests` and `limits` at the same time to ensure that the pod gets enough resources allocated within the Kubernetes cluster. See <<{p}-managing-compute-resources>> for an example and more information.
+To change the heap size of Elasticsearch, set the `ES_JAVA_OPTS` environment variable in the `podTemplate`. It is also highly recommended to set the resource `requests` and `limits` at the same time to ensure that the pod gets enough resources allocated within the Kubernetes cluster. See <<{p}-compute-resources-elasticsearch>> for an example and more information.
 
 If `ES_JAVA_OPTS` is not defined, the Elasticsearch default heap size of 1Gi will be in effect.
 

--- a/docs/elasticsearch-spec.asciidoc
+++ b/docs/elasticsearch-spec.asciidoc
@@ -125,9 +125,9 @@ spec:
             limits: {}
 ----
 
-See also:
-- link:https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html[Elasticsearch documentation on setting the heap size].
-- <<{p}-managing-compute-resources>>
+.See also:
+* link:https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html[Elasticsearch documentation on setting the heap size]
+* <<{p}-managing-compute-resources>>
 
 
 [id="{p}-node-configuration"]

--- a/docs/elasticsearch-spec.asciidoc
+++ b/docs/elasticsearch-spec.asciidoc
@@ -64,7 +64,7 @@ For more information on Pod templates, see the Kubernetes documentation:
 [id="{p}-jvm-heap-size"]
 === JVM heap size
 
-By default, the JVM heap used by Elasticsearch has minimum and maximum size set to 1Gi. As the heap size should not exceed 50% of RAM size, ECK requests by default 2Gi of memory for the Elasticsearch Pod. To change the JVM heap size, use the `ES_JAVA_OPTS` environment variable. It is also highly recommended to set the resource requests and limits to adjust the Pod memory to not exceed 50% of the RAM size. Both changes are shown below:
+To change the heap size of Elasticsearch, set the `ES_JAVA_OPTS` environment variable in the `podTemplate`. It is also highly recommended to set the resource `requests` and `limits` at the same time to ensure that the pod gets enough resources allocated within the cluster. The recommendation for heap size is that it should be half the size of RAM allocated to the pod.
 
 [source,yaml]
 ----
@@ -84,7 +84,51 @@ spec:
               memory: 4Gi
 ----
 
-For more information, see the Elasticsearch documentation on link:https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html[Setting the heap size].
+
+If no resource constraints are defined in the object specification, the operator applies a default memory `request` of 2Gi based on the assumption that Elasticsearch heap size is set to the default of 1Gi. If the Kubernetes cluster is configured with https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/[LimitRanges] that enforce a minimum memory constraint, they could interfere with the operator default and cause object creation to fail.
+
+For example, you might have a LimitRange that enforces a default and minimum memory limit on containers as follows:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-mem-per-container
+spec:
+  limits:
+  - min:
+      memory: "3Gi"
+    defaultRequest:
+      memory: "3Gi"
+    type: Container
+----
+
+With the above restriction in place, if you attempt to create an object without the `resources` declaration, it will fail to start with an error similar to the following:
+
+...................................
+Cannot create pod elasticsearch-sample-es-ldbgj48c7r: pods "elasticsearch-sample-es-ldbgj48c7r" is forbidden: minimum memory usage per Container is 3Gi, but request is 2Gi
+...................................
+
+This error can be avoided by defining an empty `limits` section in the specification to hint to the operator that it should not apply the default limits to the object:
+
+[source,yaml]
+----
+spec:
+  nodeSets:
+  - podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            # specify empty limits
+            limits: {}
+----
+
+See also:
+- link:https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html[Elasticsearch documentation on setting the heap size].
+- <<{p}-managing-compute-resources>>
+
 
 [id="{p}-node-configuration"]
 === Node configuration

--- a/docs/elasticsearch-spec.asciidoc
+++ b/docs/elasticsearch-spec.asciidoc
@@ -64,70 +64,11 @@ For more information on Pod templates, see the Kubernetes documentation:
 [id="{p}-jvm-heap-size"]
 === JVM heap size
 
-To change the heap size of Elasticsearch, set the `ES_JAVA_OPTS` environment variable in the `podTemplate`. It is also highly recommended to set the resource `requests` and `limits` at the same time to ensure that the pod gets enough resources allocated within the cluster. The recommendation for heap size is that it should be half the size of RAM allocated to the pod.
+To change the heap size of Elasticsearch, set the `ES_JAVA_OPTS` environment variable in the `podTemplate`. It is also highly recommended to set the resource `requests` and `limits` at the same time to ensure that the pod gets enough resources allocated within the Kubernetes cluster. See <<{p}-managing-compute-resources>> for an example and more information.
 
-[source,yaml]
-----
-spec:
-  nodes:
-  - podTemplate:
-      spec:
-        containers:
-        - name: elasticsearch
-          env:
-          - name: ES_JAVA_OPTS
-            value: -Xms2g -Xmx2g
-          resources:
-            requests:
-              memory: 4Gi
-            limits:
-              memory: 4Gi
-----
+If `ES_JAVA_OPTS` is not defined, the Elasticsearch default heap size of 1Gi will be in effect.
 
-
-If no resource constraints are defined in the object specification, the operator applies a default memory `request` of 2Gi based on the assumption that Elasticsearch heap size is set to the default of 1Gi. If the Kubernetes cluster is configured with https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/[LimitRanges] that enforce a minimum memory constraint, they could interfere with the operator default and cause object creation to fail.
-
-For example, you might have a LimitRange that enforces a default and minimum memory limit on containers as follows:
-
-[source,yaml]
-----
-apiVersion: v1
-kind: LimitRange
-metadata:
-  name: default-mem-per-container
-spec:
-  limits:
-  - min:
-      memory: "3Gi"
-    defaultRequest:
-      memory: "3Gi"
-    type: Container
-----
-
-With the above restriction in place, if you attempt to create an object without the `resources` declaration, it will fail to start with an error similar to the following:
-
-...................................
-Cannot create pod elasticsearch-sample-es-ldbgj48c7r: pods "elasticsearch-sample-es-ldbgj48c7r" is forbidden: minimum memory usage per Container is 3Gi, but request is 2Gi
-...................................
-
-This error can be avoided by defining an empty `limits` section in the specification to hint to the operator that it should not apply the default limits to the object:
-
-[source,yaml]
-----
-spec:
-  nodeSets:
-  - podTemplate:
-      spec:
-        containers:
-        - name: elasticsearch
-          resources:
-            # specify empty limits
-            limits: {}
-----
-
-.See also:
-* link:https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html[Elasticsearch documentation on setting the heap size]
-* <<{p}-managing-compute-resources>>
+See also: link:https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html[Elasticsearch documentation on setting the heap size]
 
 
 [id="{p}-node-configuration"]

--- a/docs/managing-compute-resources.asciidoc
+++ b/docs/managing-compute-resources.asciidoc
@@ -67,7 +67,7 @@ spec:
 
 If `resources` is not defined in the specification of an object, then the operator applies a default memory limit to ensure that pods have enough resources to start correctly. As the operator cannot make assumptions about the available CPU resources in the cluster, no CPU limits will be set -- resulting in the pods having the "Burstable" QoS class. You should consider whether this is acceptable for your use case and follow the instructions in the <<{p}-compute-resources>> section to configure appropriate limits.
 
-.Defaults
+.Default limits applied by the operator
 [cols="h,m,m", options="header"]
 |===
 |Type | Requests | Limits

--- a/docs/managing-compute-resources.asciidoc
+++ b/docs/managing-compute-resources.asciidoc
@@ -4,12 +4,14 @@
 In order to help the Kubernetes scheduler make better decisions about how to place pods in available nodes and ensure quality of service (QoS), it is recommended to specify the CPU and memory requirements for objects managed by the operator (Elasticsearch, Kibana or APM Server). In Kubernetes parlance, `requests` defines the minimum amount of resources that must be available for a pod to start and `limits` defines the maximum amount of resources that a pod is allowed to consume. For more information about how Kubernetes uses these hints, see: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/[Managing Compute Resources for Containers].
 
 [float]
-[id="{p}-custom-resources"]
-=== Set custom resources
+[id="{p}-compute-resources"]
+=== Set compute resources
 
-Resource limits can be set in the `podTemplate` of objects managed by the operator.
+Compute resource constraints can be set in the `podTemplate` of objects managed by the operator.
 
-==== Elasticsearch
+[float]
+[id="{p}-compute-resources-elasticsearch"]
+==== Set compute resources for Elasticsearch
 
 For Elasticsearch objects, it is important to consider the heap size when setting resource requirements. The recommendation for heap size is that it should be half the size of RAM allocated to the pod. To minimize disruption caused by pod evictions due to resource contention, it is highly recommended to run Elasticsearch pods at the "Guaranteed" QoS level by setting both `requests` and `limits` to appropriate values. It is also worth bearing in mind that Kubernetes throttles containers exceeding the CPU limit defined in the `limits` section. Do not set this value too low or it would affect the performance of Elasticsearch even if you have enough resources available in the Kubernetes cluster.
 
@@ -34,7 +36,10 @@ spec:
               cpu: 2
 ----
 
-==== Kibana and APM Server
+
+[float]
+[id="{p}-compute-resources-kibana-and-apm"]
+==== Set compute resources for Kibana and APM Server
 
 For Kibana or APM Server objects, the `podTemplate` can be configured as follows:
 
@@ -60,7 +65,7 @@ spec:
 [id="{p}-default-behavior"]
 === Default behavior
 
-If `resources` is not defined in the specification of an object, then the operator applies a default memory limit to ensure that pods have enough resources to start correctly. As the operator cannot make assumptions about the available CPU resources in the cluster, no CPU limits will be set -- resulting in the pods having the "Burstable" QoS class. You should consider whether this is acceptable for your use case and follow the instructions in the <<{p}-custom-resources>> section to configure apropriate limits.
+If `resources` is not defined in the specification of an object, then the operator applies a default memory limit to ensure that pods have enough resources to start correctly. As the operator cannot make assumptions about the available CPU resources in the cluster, no CPU limits will be set -- resulting in the pods having the "Burstable" QoS class. You should consider whether this is acceptable for your use case and follow the instructions in the <<{p}-compute-resources>> section to configure appropriate limits.
 
 .Defaults
 [cols="h,m,m", options="header"]

--- a/docs/managing-compute-resources.asciidoc
+++ b/docs/managing-compute-resources.asciidoc
@@ -1,39 +1,17 @@
 [id="{p}-managing-compute-resources"]
 == Managing compute resources
 
-When a Pod is created it may request CPU and RAM resources. This is the minimum amount required for the Pod to run. It may also specify the maximum resources that the containers are allowed to consume. Both Pod `limits` and `requests` can be set in the specification of any object managed by the operator (Elasticsearch, Kibana or the APM server). For more information on how this is used by Kubernetes, see https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/[Managing Compute Resources for Containers].
+In order to help the Kubernetes scheduler make better decisions about how to place pods in available nodes and ensure quality of service (QoS), it is recommended to specify the CPU and memory requirements for objects managed by the operator (Elasticsearch, Kibana or APM Server). In Kubernetes parlance, `requests` defines the minimum amount of resources that must be available for a pod to start and `limits` defines the maximum amount of resources that a pod is allowed to consume. For more information about how Kubernetes uses these hints, see: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/[Managing Compute Resources for Containers].
 
 [float]
 [id="{p}-custom-resources"]
 === Set custom resources
 
-The `resources` can be customized in the `podTemplate` of an object.
+Resource limits can be set in the `podTemplate` of objects managed by the operator.
 
-Here is an example for Elasticsearch:
+For Elasticsearch objects, it is important to consider the heap size when setting resource requirements. An example can be found in the <<{p}-jvm-heap-size>> page.
 
-[source,yaml]
-----
-spec:
-  nodes:
-  - podTemplate:
-      spec:
-        containers:
-        - name: elasticsearch
-          env:
-          - name: ES_JAVA_OPTS
-            value: -Xms2048M -Xmx2048M
-          resources:
-            requests:
-              memory: 2Gi
-              cpu: 1
-            limits:
-              memory: 4Gi
-              cpu: 2
-----
-
-This example also demonstrates how to set the JVM memory options accordingly, by using the `ES_JAVA_OPTS` environment variable.
-
-The same applies for every custom resource type managed by the operator. Use this code to customize resource requests and limits for Kibana:
+For Kibana or APM Server objects, the `podTemplate` can be configured as follows:
 
 [source,yaml]
 ----
@@ -41,7 +19,7 @@ spec:
   podTemplate:
     spec:
       containers:
-      - name: kibana
+      - name: kibana <1>
         resources:
           requests:
             memory: 1Gi
@@ -51,69 +29,11 @@ spec:
             cpu: 2
 ----
 
-Use this code to customize resource requests and limits on the APM server:
-
-[source,yaml]
-----
-spec:
-  podTemplate:
-    spec:
-      containers:
-      - name: apm-server
-        resources:
-          requests:
-            memory: 1Gi
-            cpu: 1
-          limits:
-            memory: 2Gi
-            cpu: 2
-----
+<1> Replace with `kibana` or `apm-server` as appropriate.
 
 [float]
 [id="{p}-default-behavior"]
 === Default behavior
 
-If there's no `resources` set in the specification of an object, then no `requests` or `limits` are applied on the containers, with the notable exception of Elasticsearch.
-For Elasticsearch, if no memory request is set in the `podTemplate` spec, the operator applies a default memory request of 2Gi. This is because Elasticsearch must have a minimum amount of memory to perform correctly.
-
-There can be conflicts if resources are https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/[managed with some LimitRanges at the namespace level] and if a minimum memory constraint is imposed.
-
-For example, you may want to apply a default request of 3Gi and enforce it as a minimum with a constraint:
-
-[source,yaml]
-----
-apiVersion: v1
-kind: LimitRange
-metadata:
-  name: default-mem-per-container
-spec:
-  limits:
-  - min:
-      memory: "3Gi"
-    defaultRequest:
-      memory: "3Gi"
-    type: Container
-----
-
-But if there is no `resources` declared in the specification, then the Pod can't be created and the following event is generated:
-
-...................................
-default     0s          Warning   Unexpected              elasticsearch/elasticsearch-sample                                            Cannot create pod elasticsearch-sample-es-ldbgj48c7r: pods "elasticsearch-sample-es-ldbgj48c7r" is forbidden: minimum memory usage per Container is 3Gi, but request is 2Gi
-...................................
-
-To solve this situation, you can define an empty `limits` section in the specification:
-
-[source,yaml]
-----
-spec:
-  nodes:
-  - podTemplate:
-      spec:
-        containers:
-        - name: elasticsearch
-          resources:
-            # specify empty limits
-            limits: {}
-----
-
-The default `requests` is not set by the operator and the Pod is created.
+If `resources` is not defined in the specification of an object, then no `requests` or `limits` will be applied to the containers except in the case of Elasticsearch.
+For Elasticsearch, if no memory request is set in the `podTemplate` spec, the operator applies a default memory request as described in the <<{p}-jvm-heap-size>> section. If your Kubernetes cluster is configured to enforce default resource limits using a `LimitRange` object, it could interfere with the operator default and cause object creation to fail. See <<{p}-jvm-heap-size>> for information on how to address this problem.

--- a/docs/managing-compute-resources.asciidoc
+++ b/docs/managing-compute-resources.asciidoc
@@ -9,7 +9,32 @@ In order to help the Kubernetes scheduler make better decisions about how to pla
 
 Resource limits can be set in the `podTemplate` of objects managed by the operator.
 
-For Elasticsearch objects, it is important to consider the heap size when setting resource requirements. An example can be found in the <<{p}-jvm-heap-size>> page.
+==== Elasticsearch
+
+For Elasticsearch objects, it is important to consider the heap size when setting resource requirements. The recommendation for heap size is that it should be half the size of RAM allocated to the pod. To minimize disruption caused by pod evictions due to resource contention, it is highly recommended to run Elasticsearch pods at the "Guaranteed" QoS level by setting both `requests` and `limits` to appropriate values. It is also worth bearing in mind that Kubernetes throttles containers exceeding the CPU limit defined in the `limits` section. Do not set this value too low or it would affect the performance of Elasticsearch even if you have enough resources available in the Kubernetes cluster.
+
+
+[source,yaml]
+----
+spec:
+  nodeSets:
+  - podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          env:
+          - name: ES_JAVA_OPTS
+            value: -Xms2g -Xmx2g
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 0.5
+            limits:
+              memory: 4Gi
+              cpu: 2
+----
+
+==== Kibana and APM Server
 
 For Kibana or APM Server objects, the `podTemplate` can be configured as follows:
 
@@ -23,7 +48,7 @@ spec:
         resources:
           requests:
             memory: 1Gi
-            cpu: 1
+            cpu: 0.5
           limits:
             memory: 2Gi
             cpu: 2
@@ -35,5 +60,53 @@ spec:
 [id="{p}-default-behavior"]
 === Default behavior
 
-If `resources` is not defined in the specification of an object, then no `requests` or `limits` will be applied to the containers except in the case of Elasticsearch.
-For Elasticsearch, if no memory request is set in the `podTemplate` spec, the operator applies a default memory request as described in the <<{p}-jvm-heap-size>> section. If your Kubernetes cluster is configured to enforce default resource limits using a `LimitRange` object, it could interfere with the operator default and cause object creation to fail. See <<{p}-jvm-heap-size>> for information on how to address this problem.
+If `resources` is not defined in the specification of an object, then the operator applies a default memory limit to ensure that pods have enough resources to start correctly. As the operator cannot make assumptions about the available CPU resources in the cluster, no CPU limits will be set -- resulting in the pods having the "Burstable" QoS class. You should consider whether this is acceptable for your use case and follow the instructions in the <<{p}-custom-resources>> section to configure apropriate limits.
+
+.Defaults
+[cols="h,m,m", options="header"]
+|===
+|Type | Requests | Limits
+|APM Server |512Mi |512Mi
+|Elasticsearch |2Gi |2Gi
+|Kibana |1Gi |1Gi
+|===
+
+If the Kubernetes cluster is configured with https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/[LimitRanges] that enforce a minimum memory constraint, they could interfere with the operator defaults and cause object creation to fail.
+
+For example, you might have a LimitRange that enforces a default and minimum memory limit on containers as follows:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-mem-per-container
+spec:
+  limits:
+  - min:
+      memory: "3Gi"
+    defaultRequest:
+      memory: "3Gi"
+    type: Container
+----
+
+With the above restriction in place, if you attempt to create an Elasticsearch object without defining the `resources` section, it will fail to start with an error similar to the following:
+
+...................................
+Cannot create pod elasticsearch-sample-es-ldbgj48c7r: pods "elasticsearch-sample-es-ldbgj48c7r" is forbidden: minimum memory usage per Container is 3Gi, but request is 2Gi
+...................................
+
+This error can be avoided by defining an empty `limits` section in the specification to hint to the operator that it should not apply the default limits to the object:
+
+[source,yaml]
+----
+spec:
+  nodeSets:
+  - podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            # specify empty limits
+            limits: {}
+----


### PR DESCRIPTION
Removes information duplicated between the two sections and emphasises the need to set resource constraints.

Implementation of #1454 will necessitate a few more minor updates to these sections but this change covers the important points.

Part of #1734 
