### PR TITLE
Remove GKE_CLUSTER_VERSION from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@
 export SHELL := /bin/bash
 
 KUBECTL_CLUSTER := $(shell kubectl config current-context 2> /dev/null)
-GKE_CLUSTER_VERSION ?= 1.12
 
 REPOSITORY 	?= eck
 NAME       	?= eck-operator


### PR DESCRIPTION
Remove `GKE_CLUSTER_VERSION` as one could wrongly assume that it is used to control the version of the GKE cluster when doing `make bootstrap-gke GCLOUD_PROJECT=...`