### PR TITLE
Fix APM e2e test on 6.x stack

### DIFF
--- a/test/e2e/test/apmserver/checks_apm.go
+++ b/test/e2e/test/apmserver/checks_apm.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 
 	apmtype "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1alpha1"
@@ -164,9 +165,14 @@ func (c *apmClusterChecks) CheckEventsInElasticsearch(apm apmtype.ApmServer, k *
 			}
 
 			// Check that the metric has been stored
+			metricIndexPattern := "apm-%s-metric-2017.05.30"
+			if strings.HasPrefix(updatedApmServer.Spec.Version, "6") {
+				// Stacks 6.x and 7.x do not share the same index pattern
+				metricIndexPattern = "apm-%s-2017.05.30"
+			}
 			err := assertCountIndexEqual(
 				c.esClient,
-				fmt.Sprintf("apm-%s-metric-2017.05.30", updatedApmServer.Spec.Version),
+				fmt.Sprintf(metricIndexPattern, updatedApmServer.Spec.Version),
 				1,
 			)
 			if err != nil {
@@ -174,9 +180,14 @@ func (c *apmClusterChecks) CheckEventsInElasticsearch(apm apmtype.ApmServer, k *
 			}
 
 			// Check that the error has been stored
+			errorIndexPattern := "apm-%s-error-2018.08.09"
+			if strings.HasPrefix(updatedApmServer.Spec.Version, "6") {
+				// Same as above
+				errorIndexPattern = "apm-%s-2018.08.09"
+			}
 			err = assertCountIndexEqual(
 				c.esClient,
-				fmt.Sprintf("apm-%s-error-2018.08.09", updatedApmServer.Spec.Version),
+				fmt.Sprintf(errorIndexPattern, updatedApmServer.Spec.Version),
 				1,
 			)
 			if err != nil {


### PR DESCRIPTION
This PR fixes the following E2E test which is OK in 7.x but is failing with 6.x:

```
[2019-09-24T00:36:35.771Z]     --- FAIL: TestAPMAssociationWhenReferencedESDisappears/Events_should_eventually_show_up_in_Elasticsearch (300.00s)

[2019-09-24T00:36:35.771Z]         require.go:794: 
[2019-09-24T00:36:35.771Z]             	Error Trace:	utils.go:80
[2019-09-24T00:36:35.771Z]             	Error:      	Received unexpected error:
[2019-09-24T00:36:35.771Z]             	            	404 Not Found: no such index
[2019-09-24T00:36:35.771Z]             	Test:       	TestAPMAssociationWhenReferencedESDisappears/Events_should_eventually_show_up_in_Elasticsearch
```

The reason is that 6.x and 7.x do not have the same index pattern.