### PR TITLE
Wait for the rolling upgrade to be over after keystore e2e check

### DIFF
--- a/test/e2e/es/keystore_test.go
+++ b/test/e2e/es/keystore_test.go
@@ -73,7 +73,7 @@ func TestUpdateESSecureSettings(t *testing.T) {
 		WithSteps(test.CheckTestSteps(b, k)).
 		WithSteps(test.StepList{
 			// initial secure settings should be there in all nodes keystore
-			elasticsearch.CheckESKeystoreEntries(k, b.Elasticsearch, []string{
+			elasticsearch.CheckESKeystoreEntries(k, b, []string{
 				securePasswordSettingKey,
 				secureBarUserSettingKey}),
 
@@ -90,13 +90,10 @@ func TestUpdateESSecureSettings(t *testing.T) {
 				},
 			},
 			// keystore should be updated accordingly
-			elasticsearch.CheckESKeystoreEntries(k, b.Elasticsearch, []string{
+			elasticsearch.CheckESKeystoreEntries(k, b, []string{
 				securePasswordSettingKey,
 				secureBazUserSettingKey,
 			}),
-			// wait for the rolling upgrade to be fully over
-			elasticsearch.CheckESPodsReady(b, k),
-			elasticsearch.CheckClusterHealth(b, k),
 			// remove one secret
 			test.Step{
 				Name: "Remove one of the source secrets",
@@ -104,12 +101,10 @@ func TestUpdateESSecureSettings(t *testing.T) {
 					require.NoError(t, k.Client.Delete(&secureSettings2))
 				},
 			},
-			elasticsearch.CheckESKeystoreEntries(k, b.Elasticsearch, []string{
+			// keystore should be updated accordingly
+			elasticsearch.CheckESKeystoreEntries(k, b, []string{
 				securePasswordSettingKey,
 			}),
-			// wait for the rolling upgrade to be fully over
-			elasticsearch.CheckESPodsReady(b, k),
-			elasticsearch.CheckClusterHealth(b, k),
 			// remove the secure settings reference
 			test.Step{
 				Name: "Remove secure settings from the spec",
@@ -126,10 +121,7 @@ func TestUpdateESSecureSettings(t *testing.T) {
 			},
 
 			// keystore should be updated accordingly
-			elasticsearch.CheckESKeystoreEntries(k, b.Elasticsearch, nil),
-			// wait for the rolling upgrade to be fully over
-			elasticsearch.CheckESPodsReady(b, k),
-			elasticsearch.CheckClusterHealth(b, k),
+			elasticsearch.CheckESKeystoreEntries(k, b, nil),
 
 			// cleanup extra resources
 			test.Step{

--- a/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/test/e2e/test/elasticsearch/checks_k8s.go
@@ -125,28 +125,32 @@ func CheckESPodsReady(b Builder, k *test.K8sClient) test.Step {
 	return test.Step{
 		Name: "ES pods should eventually be ready",
 		Test: test.Eventually(func() error {
-			pods, err := k.GetPods(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name)...)
-			if err != nil {
-				return err
-			}
-			// check number of pods
-			if len(pods) != int(b.Elasticsearch.Spec.NodeCount()) {
-				return fmt.Errorf("expected %d pods, got %d", b.Elasticsearch.Spec.NodeCount(), len(pods))
-			}
-			// check pod statuses
-		podsLoop:
-			for _, p := range pods {
-				for _, c := range p.Status.Conditions {
-					if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
-						// pod is ready, move on to next pod
-						continue podsLoop
-					}
-				}
-				return fmt.Errorf("pod %s is not ready yet", p.Name)
-			}
-			return nil
+			return allPodsReady(b, k)
 		}),
 	}
+}
+
+func allPodsReady(b Builder, k *test.K8sClient) error {
+	pods, err := k.GetPods(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name)...)
+	if err != nil {
+		return err
+	}
+	// check number of pods
+	if len(pods) != int(b.Elasticsearch.Spec.NodeCount()) {
+		return fmt.Errorf("expected %d pods, got %d", b.Elasticsearch.Spec.NodeCount(), len(pods))
+	}
+	// check pod statuses
+podsLoop:
+	for _, p := range pods {
+		for _, c := range p.Status.Conditions {
+			if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+				// pod is ready, move on to next pod
+				continue podsLoop
+			}
+		}
+		return fmt.Errorf("pod %s is not ready yet", p.Name)
+	}
+	return nil
 }
 
 // CheckClusterHealth checks that the given ES status reports a green ES health
@@ -154,17 +158,21 @@ func CheckClusterHealth(b Builder, k *test.K8sClient) test.Step {
 	return test.Step{
 		Name: "ES cluster health should eventually be green",
 		Test: test.Eventually(func() error {
-			var es estype.Elasticsearch
-			err := k.Client.Get(k8s.ExtractNamespacedName(&b.Elasticsearch), &es)
-			if err != nil {
-				return err
-			}
-			if es.Status.Health != estype.ElasticsearchGreenHealth {
-				return fmt.Errorf("health is %s", es.Status.Health)
-			}
-			return nil
+			return clusterHealthGreen(b, k)
 		}),
 	}
+}
+
+func clusterHealthGreen(b Builder, k *test.K8sClient) error {
+	var es estype.Elasticsearch
+	err := k.Client.Get(k8s.ExtractNamespacedName(&b.Elasticsearch), &es)
+	if err != nil {
+		return err
+	}
+	if es.Status.Health != estype.ElasticsearchGreenHealth {
+		return fmt.Errorf("health is %s", es.Status.Health)
+	}
+	return nil
 }
 
 // CheckServices checks that all ES services are created

--- a/test/e2e/test/elasticsearch/checks_keystore.go
+++ b/test/e2e/test/elasticsearch/checks_keystore.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/initcontainer"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
@@ -17,15 +16,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func CheckESKeystoreEntries(k *test.K8sClient, es v1alpha1.Elasticsearch, expectedKeys []string) test.Step {
+func CheckESKeystoreEntries(k *test.K8sClient, b Builder, expectedKeys []string) test.Step {
 	return test.Step{
 		Name: "Elasticsearch secure settings should eventually be set in all nodes keystore",
 		Test: test.Eventually(func() error {
-			pods, err := k.GetPods(test.ESPodListOptions(es.Namespace, es.Name)...)
+			pods, err := k.GetPods(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name)...)
 			if err != nil {
 				return err
 			}
-			return test.OnAllPods(pods, func(p corev1.Pod) error {
+			if err := test.OnAllPods(pods, func(p corev1.Pod) error {
 				// exec into the pod to list keystore entries
 				stdout, stderr, err := k.Exec(k8s.ExtractNamespacedName(&p), []string{initcontainer.KeystoreBinPath, "list"})
 				if err != nil {
@@ -47,7 +46,19 @@ func CheckESKeystoreEntries(k *test.K8sClient, es v1alpha1.Elasticsearch, expect
 					return fmt.Errorf("invalid keystore entries. Expected: %s. Actual: %s", expectedKeys, entries)
 				}
 				return nil
-			})
+			}); err != nil {
+				return err
+			}
+
+			// rolling upgrade leading to that correct keystore configuration should eventually be over,
+			// with cluster health green
+			if err := allPodsReady(b, k); err != nil {
+				return err
+			}
+			if err := clusterHealthGreen(b, k); err != nil {
+				return err
+			}
+			return nil
 		}),
 	}
 }


### PR DESCRIPTION
When running the kesytore E2E tests, we chain several rolling upgrades,
in between which we check keystore entries on each node. It turns out
this test is a bit flaky since we sometimes fail, waiting for more than
5 minutes.

Since we don't wait for the rolling upgrade to be fully over before
going into the next secure settings change test, the 2nds test needs to
account for the 1st test rolling upgrade to be done. Which obviously
makes it longer to run.

Let's wait for rolling upgrades to be over before moving on with the
next keystore check.

Should help with (maybe fix?)
https://github.com/elastic/cloud-on-k8s/issues/1325.