### PR TITLE
Use more than 1 node on rolling upgrade E2E tests

### DIFF
--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -85,21 +85,21 @@ func TestMutationLessNodes(t *testing.T) {
 	RunESMutation(t, b, mutated)
 }
 
-// TestMutationResizeMemoryUp creates a 1 node cluster,
-// then mutates it to a 1 node cluster with more RAM
+// TestMutationResizeMemoryUp creates a 3 node cluster,
+// then mutates it to a 3 nodes cluster with more RAM.
 func TestMutationResizeMemoryUp(t *testing.T) {
-	// create an ES cluster with a 2G node
+	// create an ES cluster with 3 x 2G nodes
 	b := elasticsearch.NewBuilder("test-mutation-resize-memory-up").
-		WithESMasterDataNodes(1, corev1.ResourceRequirements{
+		WithESMasterDataNodes(3, corev1.ResourceRequirements{
 			Limits: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
 				corev1.ResourceCPU:    resource.MustParse("2"),
 			},
 		})
-	// mutate it to 1 node with 4G memory
+	// mutate it to 3 x 4GB nodes
 	mutated := b.
 		WithNoESTopology().
-		WithESMasterDataNodes(1, corev1.ResourceRequirements{
+		WithESMasterDataNodes(3, corev1.ResourceRequirements{
 			Limits: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
 				corev1.ResourceCPU:    resource.MustParse("2"),
@@ -109,21 +109,21 @@ func TestMutationResizeMemoryUp(t *testing.T) {
 	RunESMutation(t, b, mutated)
 }
 
-// TestMutationResizeMemoryDown creates a 1 node cluster,
-// then mutates it to a 1 node cluster with less RAM
+// TestMutationResizeMemoryDown creates a 3 nodes cluster,
+// then mutates it to a 3 nodes cluster with less RAM.
 func TestMutationResizeMemoryDown(t *testing.T) {
-	// create an ES cluster with a 4G node
+	// create an ES cluster with 3 x 4G nodes
 	b := elasticsearch.NewBuilder("test-mutation-resize-mem-down").
-		WithESMasterDataNodes(1, corev1.ResourceRequirements{
+		WithESMasterDataNodes(3, corev1.ResourceRequirements{
 			Limits: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
 				corev1.ResourceCPU:    resource.MustParse("2"),
 			},
 		})
-	// mutate it to 1 node with 2G memory
+	// mutate it to 3 x 2GB nodes
 	mutated := b.
 		WithNoESTopology().
-		WithESMasterDataNodes(1, corev1.ResourceRequirements{
+		WithESMasterDataNodes(3, corev1.ResourceRequirements{
 			Limits: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
 				corev1.ResourceCPU:    resource.MustParse("2"),


### PR DESCRIPTION
Doing a rolling upgrade of a 1-node cluster gives a short period of time
where the cluster becomes red, while shards are initializing after the
upgrade.

This is something we could consider in the cluster health check test, but I
think it makes more sense to do the cluster RAM increase/decrease tests
with a 3-nodes cluster, to ensure the cluster is not disrupted during
the rolling upgrade.

Fixes https://github.com/elastic/cloud-on-k8s/issues/1752.