### PR TITLE
CI: Run checks before tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ PSP ?= 0
 ##  --       Development       --  ##
 #####################################
 
-all: dependencies lint check-license-header unit integration e2e-compile elastic-operator 
+all: dependencies lint check-license-header unit integration e2e-compile elastic-operator
 
 ## -- build
 
@@ -118,20 +118,18 @@ clean:
 ## -- tests
 
 unit: clean
-	go test ./pkg/... ./cmd/... -coverprofile cover.out
+	go test ./pkg/... ./cmd/... -cover
 
 unit_xml: clean
-	go test --json ./pkg/... ./cmd/... -coverprofile cover.out > unit-tests.json
-	gotestsum --junitfile unit-tests.xml --raw-command cat unit-tests.json
+	gotestsum --junitfile unit-tests.xml -- -cover ./pkg/... ./cmd/...
 
 integration: GO_TAGS += integration
 integration: clean generate
-	go test -tags='$(GO_TAGS)' ./pkg/... ./cmd/... -coverprofile cover.out
+	go test -tags='$(GO_TAGS)' ./pkg/... ./cmd/... -cover
 
 integration_xml: GO_TAGS += integration
 integration_xml: clean generate
-	go test -tags='$(GO_TAGS)' --json ./pkg/... ./cmd/... -coverprofile cover.out > integration-tests.json
-	gotestsum --junitfile integration-tests.xml --raw-command cat integration-tests.json
+	gotestsum --junitfile integration-tests.xml -- -tags='$(GO_TAGS)' -cover ./pkg/... ./cmd/...
 
 lint:
 	golangci-lint run
@@ -358,16 +356,17 @@ e2e-local:
 ##########################################
 ##  --    Continuous integration    --  ##
 ##########################################
+ci-check: check-license-header lint generate check-local-changes
 
-ci: lint check-license-header generate check-local-changes unit_xml integration_xml e2e-compile docker-build
+ci: unit_xml integration_xml docker-build
 
 # Run e2e tests in a dedicated cluster.
-ci-e2e: run-deployer install-crds apply-psp e2e
+ci-e2e: e2e-compile run-deployer install-crds apply-psp e2e
 
 run-deployer: build-deployer
 	./hack/deployer/deployer execute --plans-file hack/deployer/config/plans.yml --config-file deployer-config.yml
 
-ci-release: clean generate build-operator-image
+ci-release: clean ci-check build-operator-image
 	@ echo $(OPERATOR_IMAGE) was pushed!
 
 ##########################

--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -21,6 +21,16 @@ pipeline {
                 checkout scm
             }
         }
+        stage('Run Checks') {
+            when {
+                expression {
+                    notOnlyDocs()
+                }
+            }
+            steps {
+                sh 'make -C build/ci TARGET=ci-check ci'
+            }
+        }
         stage("E2E tests") {
             when {
                 expression {

--- a/build/ci/e2e/Jenkinsfile-aks
+++ b/build/ci/e2e/Jenkinsfile-aks
@@ -20,6 +20,11 @@ pipeline {
                 checkout scm
             }
         }
+        stage('Run Checks') {
+            steps {
+                sh 'make -C build/ci TARGET=ci-check ci'
+            }
+        }
         stage("Run E2E tests") {
             steps {
                 sh """
@@ -41,7 +46,7 @@ EOF
                     make -C build/ci TARGET=ci-e2e ci
                 """
             }
-        }  
+        }
     }
 
     post {

--- a/build/ci/nightly/Jenkinsfile
+++ b/build/ci/nightly/Jenkinsfile
@@ -19,6 +19,11 @@ pipeline {
     }
 
     stages {
+        stage('Run checks') {
+            steps {
+                sh 'make -C build/ci TARGET=ci-check ci'
+            }
+        }
         stage('Run unit and integration tests') {
             steps {
                 sh """

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -26,6 +26,20 @@ pipeline {
                 sh 'make -C build/ci ci-build-image'
             }
         }
+        stage('Run checks') {
+            when {
+                expression {
+                    checkout scm
+                    notOnlyDocs()
+                }
+            }
+            agent {
+                label 'linux'
+            }
+            steps {
+                sh 'make -C build/ci TARGET=ci-check ci'
+            }
+        }
         stage('Run tests in parallel') {
             parallel {
                 stage("Run unit and integration tests") {


### PR DESCRIPTION
This change introduces:
-  A check stage to fail fast if the basic sanity checks fail (currently E2E tests run regardless of whether these basic checks fail).
- Display test output even when the tests fail (currently the redirection of output makes it impossible to see which tests failed and the JUnit XML file does not get generated because the test command fails and the call to `gotestsum` never gets invoked)