### PR TITLE
Set a default memory limit of 2Gi for the ES Pod

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/defaults.go
+++ b/pkg/controller/elasticsearch/nodespec/defaults.go
@@ -38,8 +38,13 @@ var (
 	// DefaultResources for the Elasticsearch container. The JVM default heap size is 1Gi, so we
 	// request at least 2Gi for the container to make sure ES can work properly.
 	// Not applying this minimum default would make ES randomly crash (OOM) on small machines.
+	// Similarly, we apply a default memory limit of 2Gi, to ensure the Pod isn't the first one to get evicted.
+	// No CPU requirement is set by default.
 	DefaultResources = corev1.ResourceRequirements{
 		Requests: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+		Limits: map[corev1.ResourceName]resource.Quantity{
 			corev1.ResourceMemory: resource.MustParse("2Gi"),
 		},
 	}


### PR DESCRIPTION
Similar to how we set a default request of 2Gi to prevent the Pod from
being scheduled on a node without at least 2Gi memory, let's set a
default memory request of 2Gi. Which should prevent the Pod from being
the first one evicted on a node running out of memory.

Those defaults can be overridden by the user, or disabled entirely by
providing an empty (`{}`) memory requests or limits.
If either limits or requests is provided by the user (or both), we don't
apply our default resources requirements.

No default CPU is set.

Fixes the ES part of https://github.com/elastic/cloud-on-k8s/issues/1454.