### PR TITLE
Set expectations when upscaling a StatefulSet

### DIFF
--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -63,6 +63,7 @@ func (d *defaultDriver) reconcileNodeSpecs(
 		observedState:       observedState,
 		esState:             esState,
 		upscaleStateBuilder: &upscaleStateBuilder{},
+		expectations:        d.Expectations,
 	}
 	actualStatefulSets, err = HandleUpscaleAndSpecChanges(upscaleCtx, actualStatefulSets, expectedResources)
 	if err != nil {

--- a/pkg/controller/elasticsearch/driver/upscale.go
+++ b/pkg/controller/elasticsearch/driver/upscale.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/expectations"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/observer"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
@@ -26,6 +27,7 @@ type upscaleCtx struct {
 	observedState       observer.State
 	esState             ESState
 	upscaleStateBuilder *upscaleStateBuilder
+	expectations        *expectations.Expectations
 }
 
 // HandleUpscaleAndSpecChanges reconciles expected NodeSpec resources.
@@ -55,7 +57,7 @@ func HandleUpscaleAndSpecChanges(
 		if _, err := common.ReconcileService(ctx.k8sClient, ctx.scheme, &res.HeadlessService, &ctx.es); err != nil {
 			return nil, err
 		}
-		reconciled, err := sset.ReconcileStatefulSet(ctx.k8sClient, ctx.scheme, ctx.es, res.StatefulSet)
+		reconciled, err := sset.ReconcileStatefulSet(ctx.k8sClient, ctx.scheme, ctx.es, res.StatefulSet, ctx.expectations)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/elasticsearch/driver/upscale_test.go
+++ b/pkg/controller/elasticsearch/driver/upscale_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/expectations"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/name"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/observer"
@@ -44,6 +45,7 @@ func TestHandleUpscaleAndSpecChanges(t *testing.T) {
 		observedState:       observer.State{},
 		esState:             nil,
 		upscaleStateBuilder: &upscaleStateBuilder{},
+		expectations:        expectations.NewExpectations(),
 	}
 	expectedResources := nodespec.ResourcesList{
 		{
@@ -124,6 +126,8 @@ func TestHandleUpscaleAndSpecChanges(t *testing.T) {
 	require.NoError(t, k8sClient.Get(types.NamespacedName{Namespace: "ns", Name: "sset2"}, &sset2))
 	require.Equal(t, common.Int32(10), sset2.Spec.Replicas)
 	require.Equal(t, updatedStatefulSets[1], sset2)
+	// expectations should have been set
+	require.NotEmpty(t, ctx.expectations.GetGenerations())
 
 	// apply a spec change
 	actualStatefulSets = sset.StatefulSetList{sset1, sset2}

--- a/pkg/controller/elasticsearch/sset/reconcile.go
+++ b/pkg/controller/elasticsearch/sset/reconcile.go
@@ -6,6 +6,7 @@ package sset
 
 import (
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/expectations"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -14,7 +15,7 @@ import (
 )
 
 // ReconcileStatefulSet creates or updates the expected StatefulSet.
-func ReconcileStatefulSet(c k8s.Client, scheme *runtime.Scheme, es v1alpha1.Elasticsearch, expected appsv1.StatefulSet) (appsv1.StatefulSet, error) {
+func ReconcileStatefulSet(c k8s.Client, scheme *runtime.Scheme, es v1alpha1.Elasticsearch, expected appsv1.StatefulSet, expectations *expectations.Expectations) (appsv1.StatefulSet, error) {
 	var reconciled appsv1.StatefulSet
 	err := reconciler.ReconcileResource(reconciler.Params{
 		Client:     c,
@@ -30,6 +31,13 @@ func ReconcileStatefulSet(c k8s.Client, scheme *runtime.Scheme, es v1alpha1.Elas
 		},
 		UpdateReconciled: func() {
 			expected.DeepCopyInto(&reconciled)
+		},
+		PostUpdate: func() {
+			if expectations != nil {
+				// expect the reconciled StatefulSet to be there in the cache for next reconciliations,
+				// to prevent assumptions based on the wrong replica count
+				expectations.ExpectGeneration(reconciled.ObjectMeta)
+			}
 		},
 	})
 	return reconciled, err

--- a/pkg/controller/elasticsearch/sset/reconcile_test.go
+++ b/pkg/controller/elasticsearch/sset/reconcile_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/expectations"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
@@ -49,29 +50,34 @@ func TestReconcileStatefulSet(t *testing.T) {
 	updatedSset.Labels[hash.TemplateHashLabelName] = "updated"
 
 	tests := []struct {
-		name     string
-		c        k8s.Client
-		expected v1.StatefulSet
+		name                    string
+		c                       k8s.Client
+		expected                v1.StatefulSet
+		wantExpectationsUpdated bool
 	}{
 		{
-			name:     "create new sset",
-			c:        k8s.WrapClient(fake.NewFakeClient()),
-			expected: ssetSample,
+			name:                    "create new sset",
+			c:                       k8s.WrapClient(fake.NewFakeClient()),
+			expected:                ssetSample,
+			wantExpectationsUpdated: false,
 		},
 		{
-			name:     "no update on existing sset",
-			c:        k8s.WrapClient(fake.NewFakeClient(&ssetSample)),
-			expected: ssetSample,
+			name:                    "no update on existing sset",
+			c:                       k8s.WrapClient(fake.NewFakeClient(&ssetSample)),
+			expected:                ssetSample,
+			wantExpectationsUpdated: false,
 		},
 		{
-			name:     "update on sset with different template hash",
-			c:        k8s.WrapClient(fake.NewFakeClient(&ssetSample)),
-			expected: updatedSset,
+			name:                    "update on sset with different template hash",
+			c:                       k8s.WrapClient(fake.NewFakeClient(&ssetSample)),
+			expected:                updatedSset,
+			wantExpectationsUpdated: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			returned, err := ReconcileStatefulSet(tt.c, scheme.Scheme, es, tt.expected)
+			exp := expectations.NewExpectations()
+			returned, err := ReconcileStatefulSet(tt.c, scheme.Scheme, es, tt.expected, exp)
 			require.NoError(t, err)
 
 			// expect owner ref to be set to the es resource
@@ -79,6 +85,9 @@ func TestReconcileStatefulSet(t *testing.T) {
 			require.NoError(t, err)
 			err = controllerutil.SetControllerReference(&es, metaObj, scheme.Scheme)
 			require.NoError(t, err)
+
+			// check expectations were updated
+			require.Equal(t, tt.wantExpectationsUpdated, len(exp.GetGenerations()) != 0)
 
 			// returned sset should match the expected one
 			require.Equal(t, tt.expected, returned)


### PR DESCRIPTION
We had a race condition where some master nodes could be created at
reconciliation #1, then reconciliation #2 would create another set of
master nodes, ignoring the ones from #1 that were created. As a result,
master nodes from #2 would start with the wrong zen1/zen2 settings.

To prevent that from happening, let's reuse our existing expectations
mechanism. When we apply an update, make sure we wait for that update to
appear in the StatefulSets cache.

This goes beyond simply updating replicas and generally slows down the
reconciliation if fields other than replicas were updated.
For the sake of simplicity, I think it's fine.

Fixes https://github.com/elastic/cloud-on-k8s/issues/1678.

Kudos to @pebrc and @barkbay for finding this bug in https://github.com/elastic/cloud-on-k8s/pull/1654#discussion_r319818259.
