### PR TITLE
Set APM Server default memory requests and limits to 512MiB

### DIFF
--- a/pkg/controller/apmserver/apmserver_controller_test.go
+++ b/pkg/controller/apmserver/apmserver_controller_test.go
@@ -173,6 +173,7 @@ func expectedDeploymentParams() testParams {
 							},
 						},
 					},
+					Resources: DefaultResources,
 				}},
 				AutomountServiceAccountToken: &false,
 			},

--- a/pkg/controller/apmserver/pod.go
+++ b/pkg/controller/apmserver/pod.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -29,6 +30,15 @@ const (
 	DataVolumePath   = ApmBaseDir + "/data"
 	ConfigVolumePath = ApmBaseDir + "/config"
 )
+
+var DefaultResources = corev1.ResourceRequirements{
+	Requests: map[corev1.ResourceName]resource.Quantity{
+		corev1.ResourceMemory: resource.MustParse("512Mi"),
+	},
+	Limits: map[corev1.ResourceName]resource.Quantity{
+		corev1.ResourceMemory: resource.MustParse("512Mi"),
+	},
+}
 
 func readinessProbe(tls bool) corev1.Probe {
 	scheme := corev1.URISchemeHTTP
@@ -99,6 +109,7 @@ func newPodSpec(as *v1alpha1.ApmServer, p PodSpecParams) corev1.PodTemplateSpec 
 
 	builder := defaults.NewPodTemplateBuilder(
 		p.PodTemplate, v1alpha1.APMServerContainerName).
+		WithResources(DefaultResources).
 		WithDockerImage(p.CustomImageName, imageWithVersion(defaultImageRepositoryAndName, p.Version)).
 		WithReadinessProbe(readinessProbe(as.Spec.HTTP.TLS.Enabled())).
 		WithPorts(ports).

--- a/pkg/controller/apmserver/pod_test.go
+++ b/pkg/controller/apmserver/pod_test.go
@@ -94,6 +94,7 @@ func TestNewPodSpec(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{
 								configSecretVol.VolumeMount(), configVolume.VolumeMount(),
 							},
+							Resources: DefaultResources,
 						},
 					},
 				},


### PR DESCRIPTION
Similar to what we do with Elasticsearch, let's provide sane default
memory requirements that users are free to override.

Thanks @jalvz and @simitt for the help on picking 512.