### PR TITLE
Fix nightly release job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ integration-tests.json
 integration-tests.xml
 unit-tests.json
 unit-tests.xml
+
+# ignore files fo release job
+eck_image.txt

--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,7 @@ ci-e2e: e2e-compile run-deployer install-crds apply-psp e2e
 run-deployer: build-deployer
 	./hack/deployer/deployer execute --plans-file hack/deployer/config/plans.yml --config-file deployer-config.yml
 
-ci-release: clean check-license-header generate build-operator-image
+ci-release: clean ci-check build-operator-image
 	@ echo $(OPERATOR_IMAGE) was pushed!
 
 ##########################

--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,7 @@ ci-e2e: e2e-compile run-deployer install-crds apply-psp e2e
 run-deployer: build-deployer
 	./hack/deployer/deployer execute --plans-file hack/deployer/config/plans.yml --config-file deployer-config.yml
 
-ci-release: clean ci-check build-operator-image
+ci-release: clean check-license-header generate build-operator-image
 	@ echo $(OPERATOR_IMAGE) was pushed!
 
 ##########################


### PR DESCRIPTION
PR https://github.com/elastic/cloud-on-k8s/pull/1806 brokes nightly build by adding `ci-check` make target to it. As part of `ci-check` executed `check-local-changes` which check for uncommitted changes. It fails for release build on CI because in the process of release some temporary txt files created.