### PR TITLE
Force upgrade all Pods if non-ready

### DIFF
--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -75,46 +75,45 @@ func (d *defaultDriver) reconcileNodeSpecs(
 		return results.WithError(err)
 	}
 
-	if !esReachable {
-		// Cannot perform next operations if we cannot request Elasticsearch.
-		log.Info("ES external service not ready yet for further reconciliation, re-queuing.", "namespace", d.ES.Namespace, "es_name", d.ES.Name)
+	if esReachable {
+		// Update Zen1 minimum master nodes through the API, corresponding to the current nodes we have.
+		requeue, err := zen1.UpdateMinimumMasterNodes(d.Client, d.ES, esClient, actualStatefulSets)
+		if err != nil {
+			return results.WithError(err)
+		}
+		if requeue {
+			results.WithResult(defaultRequeue)
+		}
+		// Maybe clear zen2 voting config exclusions.
+		requeue, err = zen2.ClearVotingConfigExclusions(d.ES, d.Client, esClient, actualStatefulSets)
+		if err != nil {
+			return results.WithError(err)
+		}
+		if requeue {
+			results.WithResult(defaultRequeue)
+		}
+
+		// Phase 2: handle sset scale down.
+		// We want to safely remove nodes from the cluster, either because the sset requires less replicas,
+		// or because it should be removed entirely.
+		downscaleCtx := newDownscaleContext(
+			d.Client,
+			esClient,
+			resourcesState,
+			observedState,
+			reconcileState,
+			d.Expectations,
+			d.ES,
+		)
+		downscaleRes := HandleDownscale(downscaleCtx, expectedResources.StatefulSets(), actualStatefulSets)
+		results.WithResults(downscaleRes)
+		if downscaleRes.HasError() {
+			return results
+		}
+	} else {
+		// ES cannot be reached right now, let's make sure we requeue.
 		reconcileState.UpdateElasticsearchApplyingChanges(resourcesState.CurrentPods)
-		return results.WithResult(defaultRequeue)
-	}
-
-	// Update Zen1 minimum master nodes through the API, corresponding to the current nodes we have.
-	requeue, err := zen1.UpdateMinimumMasterNodes(d.Client, d.ES, esClient, actualStatefulSets)
-	if err != nil {
-		return results.WithError(err)
-	}
-	if requeue {
 		results.WithResult(defaultRequeue)
-	}
-	// Maybe clear zen2 voting config exclusions.
-	requeue, err = zen2.ClearVotingConfigExclusions(d.ES, d.Client, esClient, actualStatefulSets)
-	if err != nil {
-		return results.WithError(err)
-	}
-	if requeue {
-		results.WithResult(defaultRequeue)
-	}
-
-	// Phase 2: handle sset scale down.
-	// We want to safely remove nodes from the cluster, either because the sset requires less replicas,
-	// or because it should be removed entirely.
-	downscaleCtx := newDownscaleContext(
-		d.Client,
-		esClient,
-		resourcesState,
-		observedState,
-		reconcileState,
-		d.Expectations,
-		d.ES,
-	)
-	downscaleRes := HandleDownscale(downscaleCtx, expectedResources.StatefulSets(), actualStatefulSets)
-	results.WithResults(downscaleRes)
-	if downscaleRes.HasError() {
-		return results
 	}
 
 	// Phase 3: handle rolling upgrades.

--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -117,7 +117,7 @@ func (d *defaultDriver) reconcileNodeSpecs(
 	}
 
 	// Phase 3: handle rolling upgrades.
-	rollingUpgradesRes := d.handleRollingUpgrades(esClient, esState, actualStatefulSets, expectedResources.MasterNodesNames())
+	rollingUpgradesRes := d.handleRollingUpgrades(esClient, esReachable, esState, actualStatefulSets, expectedResources.MasterNodesNames())
 	results.WithResults(rollingUpgradesRes)
 	if rollingUpgradesRes.HasError() {
 		return results

--- a/pkg/controller/elasticsearch/driver/upgrade_forced.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_forced.go
@@ -1,0 +1,52 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package driver
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+)
+
+// maybeForceUpgrade may attempt a forced upgrade of all podsToUpgrade if allowed to,
+// in order to unlock situations where the reconciliation may otherwise be stuck
+// (eg. no cluster formed, all nodes have a bad spec).
+func (d *defaultDriver) maybeForceUpgrade(actualPods []corev1.Pod, podsToUpgrade []corev1.Pod) (attempted bool, err error) {
+	attempted = false
+	if len(podsToUpgrade) == 0 {
+		return attempted, nil
+	}
+	if !shouldForceUpgrade(actualPods) {
+		return attempted, nil
+	}
+
+	attempted = true
+	log.Info("Performing a forced rolling upgrade since no Pod is ready",
+		"namespace", d.ES.Namespace, "es_name", d.ES.Name,
+		"pod_count", len(podsToUpgrade),
+	)
+	for _, pod := range podsToUpgrade {
+		if err := deletePod(d.Client, d.ES, pod, d.Expectations); err != nil {
+			return attempted, err
+		}
+	}
+	return attempted, nil
+}
+
+// shouldForceUpgrade returns true if all existing Pods can be safely upgraded,
+// without further safety checks.
+// In practice, we're OK to force-upgrade if all Pods are non-ready.
+// /!\ race condition: since the readiness is based on a cached value, we may allow
+// a forced rolling upgrade to go through based on out-of-date Pod data.
+func shouldForceUpgrade(pods []corev1.Pod) bool {
+	for _, p := range pods {
+		if k8s.IsPodReady(p) {
+			// at least one pod is ready
+			return false
+		}
+	}
+	// all pods are not ready
+	return true
+}

--- a/pkg/controller/elasticsearch/driver/upgrade_forced_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_forced_test.go
@@ -1,0 +1,112 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package driver
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/expectations"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_defaultDriver_maybeForceUpgrade(t *testing.T) {
+	tests := []struct {
+		name              string
+		actualPods        []corev1.Pod
+		podsToUpgrade     []corev1.Pod
+		wantAttempted     bool
+		wantRemainingPods []corev1.Pod
+	}{
+		{
+			name: "no pods to upgrade",
+			actualPods: []corev1.Pod{
+				sset.TestPod{Name: "pod1", Ready: false}.Build(),
+				sset.TestPod{Name: "pod2", Ready: true}.Build(),
+			},
+			podsToUpgrade: nil,
+			wantAttempted: false,
+			wantRemainingPods: []corev1.Pod{
+				sset.TestPod{Name: "pod1", Ready: false}.Build(),
+				sset.TestPod{Name: "pod2", Ready: true}.Build(),
+			},
+		},
+		{
+			name: "no pods ready, upgrade them all",
+			actualPods: []corev1.Pod{
+				sset.TestPod{Name: "pod1", Ready: false}.Build(),
+				sset.TestPod{Name: "pod2", Ready: false}.Build(),
+			},
+			podsToUpgrade: []corev1.Pod{
+				sset.TestPod{Name: "pod1", Ready: false}.Build(),
+				sset.TestPod{Name: "pod2", Ready: false}.Build(),
+			},
+			wantAttempted:     true,
+			wantRemainingPods: nil,
+		},
+		{
+			name: "1/2 pod to upgrade",
+			actualPods: []corev1.Pod{
+				sset.TestPod{Name: "pod1", Ready: false}.Build(),
+				sset.TestPod{Name: "pod2", Ready: false}.Build(),
+			},
+			podsToUpgrade: []corev1.Pod{
+				sset.TestPod{Name: "pod2", Ready: false}.Build(),
+			},
+			wantAttempted: true,
+			wantRemainingPods: []corev1.Pod{
+				sset.TestPod{Name: "pod1", Ready: false}.Build(),
+			},
+		},
+		{
+			name: "at least one pod ready, don't upgrade any",
+			actualPods: []corev1.Pod{
+				sset.TestPod{Name: "pod1", Ready: false}.Build(),
+				sset.TestPod{Name: "pod2", Ready: true}.Build(),
+				sset.TestPod{Name: "pod3", Ready: false}.Build(),
+			},
+			podsToUpgrade: []corev1.Pod{
+				sset.TestPod{Name: "pod1", Ready: false}.Build(),
+				sset.TestPod{Name: "pod2", Ready: true}.Build(),
+				sset.TestPod{Name: "pod3", Ready: false}.Build(),
+			},
+			wantAttempted: false,
+			wantRemainingPods: []corev1.Pod{
+				sset.TestPod{Name: "pod1", Ready: false}.Build(),
+				sset.TestPod{Name: "pod2", Ready: true}.Build(),
+				sset.TestPod{Name: "pod3", Ready: false}.Build(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtimeObjs := make([]runtime.Object, 0, len(tt.actualPods))
+			for i := range tt.actualPods {
+				runtimeObjs = append(runtimeObjs, &tt.actualPods[i])
+			}
+			k8sClient := k8s.WrapClient(fake.NewFakeClient(runtimeObjs...))
+			d := &defaultDriver{
+				DefaultDriverParameters: DefaultDriverParameters{
+					Client:       k8sClient,
+					Expectations: expectations.NewExpectations(),
+				},
+			}
+
+			attempted, err := d.maybeForceUpgrade(tt.actualPods, tt.podsToUpgrade)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantAttempted, attempted)
+			var pods corev1.PodList
+			require.NoError(t, k8sClient.List(&pods))
+			require.ElementsMatch(t, tt.wantRemainingPods, pods.Items)
+		})
+	}
+}

--- a/pkg/controller/elasticsearch/driver/upgrade_pods_deletion.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_pods_deletion.go
@@ -7,8 +7,11 @@ package driver
 import (
 	"sort"
 
+	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/expectations"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -66,9 +69,7 @@ func (ctx *rollingUpgradeCtx) Delete() ([]corev1.Pod, error) {
 		if err := ctx.handleMasterScaleChange(podToDelete); err != nil {
 			return deletedPods, err
 		}
-		ctx.expectations.ExpectDeletion(podToDelete)
-		if err := ctx.delete(&podToDelete); err != nil {
-			ctx.expectations.CancelExpectedDeletion(podToDelete)
+		if err := deletePod(ctx.client, ctx.ES, podToDelete, ctx.expectations); err != nil {
 			return deletedPods, err
 		}
 		deletedPods = append(deletedPods, podToDelete)
@@ -148,15 +149,22 @@ func (ctx *rollingUpgradeCtx) handleMasterScaleChange(pod corev1.Pod) error {
 	return nil
 }
 
-func (ctx *rollingUpgradeCtx) delete(pod *corev1.Pod) error {
-	log.Info("Deleting pod for rolling upgrade", "es_name", ctx.ES.Name, "namespace", ctx.ES.Namespace, "pod_name", pod.Name, "pod_uid", pod.UID)
+func deletePod(k8sClient k8s.Client, es v1alpha1.Elasticsearch, pod corev1.Pod, expectations *expectations.Expectations) error {
+	log.Info("Deleting pod for rolling upgrade", "es_name", es.Name, "namespace", es.Namespace, "pod_name", pod.Name, "pod_uid", pod.UID)
 	// The name of the Pod we want to delete is not enough as it may have been already deleted/recreated.
 	// The uid of the Pod we want to delete is used as a precondition to check that we actually delete the right one.
 	// If not it means that we are running with a stale cache.
 	opt := client.Preconditions{
 		UID: &pod.UID,
 	}
-	return ctx.client.Delete(pod, opt)
+	// expect the pod to not be there in the cache at next reconciliation
+	expectations.ExpectDeletion(pod)
+	err := k8sClient.Delete(&pod, opt)
+	if err != nil {
+		// cancel our expectation since the Pod may not be deleted
+		expectations.CancelExpectedDeletion(pod)
+	}
+	return err
 }
 
 func runPredicates(

--- a/pkg/controller/elasticsearch/driver/upscale_state_test.go
+++ b/pkg/controller/elasticsearch/driver/upscale_state_test.go
@@ -230,7 +230,7 @@ func Test_newUpscaleState(t *testing.T) {
 		{
 			name: "bootstrapped, a master node is pending",
 			args: args{
-				c:  k8s.WrapClient(fake.NewFakeClient(sset.TestPod{ClusterName: "cluster", Master: true, Status: corev1.PodStatus{Phase: corev1.PodPending}}.BuildPtr())),
+				c:  k8s.WrapClient(fake.NewFakeClient(sset.TestPod{ClusterName: "cluster", Master: true, Phase: corev1.PodPending}.BuildPtr())),
 				es: *bootstrappedES(),
 			},
 			want: &upscaleState{allowMasterCreation: false, isBootstrapped: true},
@@ -238,7 +238,7 @@ func Test_newUpscaleState(t *testing.T) {
 		{
 			name: "bootstrapped, a data node is pending",
 			args: args{
-				c:  k8s.WrapClient(fake.NewFakeClient(sset.TestPod{ClusterName: "cluster", Master: false, Data: true, Status: corev1.PodStatus{Phase: corev1.PodPending}}.BuildPtr())),
+				c:  k8s.WrapClient(fake.NewFakeClient(sset.TestPod{ClusterName: "cluster", Master: false, Data: true, Phase: corev1.PodPending}.BuildPtr())),
 				es: *bootstrappedES(),
 			},
 			want: &upscaleState{allowMasterCreation: true, isBootstrapped: true},

--- a/pkg/controller/elasticsearch/sset/fixtures.go
+++ b/pkg/controller/elasticsearch/sset/fixtures.go
@@ -88,8 +88,8 @@ type TestPod struct {
 	Master          bool
 	Data            bool
 	Ingest          bool
-	Status          corev1.PodStatus
 	Ready           bool
+	Status          corev1.PodStatus
 }
 
 func (t TestPod) Build() corev1.Pod {

--- a/pkg/controller/elasticsearch/sset/fixtures.go
+++ b/pkg/controller/elasticsearch/sset/fixtures.go
@@ -89,9 +89,9 @@ type TestPod struct {
 	Master          bool
 	Data            bool
 	Ingest          bool
-	Phase           corev1.PodPhase
 	Ready           bool
 	RestartCount    int32
+	Phase           corev1.PodPhase
 }
 
 func (t TestPod) Build() corev1.Pod {

--- a/pkg/controller/elasticsearch/sset/fixtures.go
+++ b/pkg/controller/elasticsearch/sset/fixtures.go
@@ -89,6 +89,7 @@ type TestPod struct {
 	Data            bool
 	Ingest          bool
 	Status          corev1.PodStatus
+	Ready           bool
 }
 
 func (t TestPod) Build() corev1.Pod {
@@ -101,6 +102,18 @@ func (t TestPod) Build() corev1.Pod {
 	label.NodeTypesMasterLabelName.Set(t.Master, labels)
 	label.NodeTypesDataLabelName.Set(t.Data, labels)
 	label.NodeTypesIngestLabelName.Set(t.Ingest, labels)
+	if t.Ready {
+		t.Status.Conditions = append(t.Status.Conditions,
+			corev1.PodCondition{
+				Status: corev1.ConditionTrue,
+				Type:   corev1.ContainersReady,
+			},
+			corev1.PodCondition{
+				Status: corev1.ConditionTrue,
+				Type:   corev1.PodReady,
+			},
+		)
+	}
 	return corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: t.Namespace,

--- a/test/e2e/es/forced_upgrade_test.go
+++ b/test/e2e/es/forced_upgrade_test.go
@@ -1,0 +1,78 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package es
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestForceUpgradePendingPods(t *testing.T) {
+	// create a cluster whose Pods will stay Pending forever
+	initial := elasticsearch.NewBuilder("force-upgrade-pending").
+		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
+	initial.Elasticsearch.Spec.Nodes[0].PodTemplate.Spec.NodeSelector = map[string]string{
+		"cannot": "be-scheduled",
+	}
+	// fix that cluster to remove the wrong NodeSelector
+	fixed := elasticsearch.Builder{}
+	fixed.Elasticsearch = *initial.Elasticsearch.DeepCopy()
+	fixed.Elasticsearch.Spec.Nodes[0].PodTemplate.Spec.NodeSelector = nil
+
+	k := test.NewK8sClientOrFatal()
+	elasticsearch.ForcedUpgradeTestSteps(
+		k,
+		initial,
+		// wait for all initial Pods to be Pending
+		elasticsearch.CheckESPodsPending(initial, k),
+		fixed,
+	).RunSequential(t)
+}
+
+func TestForceUpgradeBootloopingPods(t *testing.T) {
+	// create a cluster with a bad ES configuration that leads to Pods bootlooping
+	initial := elasticsearch.NewBuilder("force-upgrade-bootloop").
+		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
+		WithAdditionalConfig(map[string]map[string]interface{}{
+			"masterdata": {
+				"this leads": "to a bootlooping instance",
+			},
+		})
+
+	// fix that cluster to remove the wrong configuration
+	fixed := elasticsearch.Builder{}
+	fixed.Elasticsearch = *initial.Elasticsearch.DeepCopy()
+	fixed.Elasticsearch.Spec.Nodes[0].Config = nil
+
+	k := test.NewK8sClientOrFatal()
+	elasticsearch.ForcedUpgradeTestSteps(
+		k,
+		initial,
+		// wait for Pods to restart due to wrong config
+		elasticsearch.CheckPodsCondition(
+			initial,
+			k,
+			"Pods should have restarted at least once due to wrong ES config",
+			func(p corev1.Pod) error {
+				for _, containerStatus := range p.Status.ContainerStatuses {
+					if containerStatus.Name != v1alpha1.ElasticsearchContainerName {
+						continue
+					}
+					if containerStatus.RestartCount < 1 {
+						return fmt.Errorf("container not restarted yet")
+					}
+					return nil
+				}
+				return fmt.Errorf("container %s not found in pod %s", v1alpha1.ElasticsearchContainerName, p.Name)
+			},
+		),
+		fixed,
+	).RunSequential(t)
+}

--- a/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/test/e2e/test/elasticsearch/checks_k8s.go
@@ -75,19 +75,39 @@ func CheckPodCertificates(b Builder, k *test.K8sClient) test.Step {
 
 // CheckESPodsRunning checks that all ES pods for the given ES are running
 func CheckESPodsRunning(b Builder, k *test.K8sClient) test.Step {
+	return checkESPodsPhase(b, k, corev1.PodRunning)
+}
+
+// CheckESPodsRunning checks that all ES pods for the given ES are running
+func CheckESPodsPending(b Builder, k *test.K8sClient) test.Step {
+	return checkESPodsPhase(b, k, corev1.PodPending)
+}
+
+func checkESPodsPhase(b Builder, k *test.K8sClient, phase corev1.PodPhase) test.Step {
+	return CheckPodsCondition(b,
+		k,
+		fmt.Sprintf("Pods should eventually be %s", phase),
+		func(p corev1.Pod) error {
+			if p.Status.Phase != phase {
+				return fmt.Errorf("pod not %s", phase)
+			}
+			return nil
+		},
+	)
+}
+
+func CheckPodsCondition(b Builder, k *test.K8sClient, name string, condition func(p corev1.Pod) error) test.Step {
 	return test.Step{
-		Name: "ES pods should eventually be running",
+		Name: name,
 		Test: test.Eventually(func() error {
 			pods, err := k.GetPods(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name)...)
 			if err != nil {
 				return err
 			}
-			for _, p := range pods {
-				if p.Status.Phase != corev1.PodRunning {
-					return fmt.Errorf("pod not running yet")
-				}
+			if int32(len(pods)) != b.Elasticsearch.Spec.NodeCount() {
+				return fmt.Errorf("expected %d pods, got %d", len(pods), b.Elasticsearch.Spec.NodeCount())
 			}
-			return nil
+			return test.OnAllPods(pods, condition)
 		}),
 	}
 }

--- a/test/e2e/test/elasticsearch/steps_forced_upgrade.go
+++ b/test/e2e/test/elasticsearch/steps_forced_upgrade.go
@@ -1,0 +1,26 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package elasticsearch
+
+import (
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+)
+
+// ForcedUpgradeTestSteps creates the initial cluster that is not expected to run, wait for condition to be reached,
+// then mutates it to the fixed cluster, that is expected to become healthy.
+func ForcedUpgradeTestSteps(k *test.K8sClient, initial Builder, condition test.Step, fixed Builder) test.StepList {
+	return test.StepList{}.
+		// create the initial (failing) cluster
+		WithSteps(initial.InitTestSteps(k)).
+		WithSteps(initial.CreationTestSteps(k)).
+		// wait for condition to be met
+		WithStep(condition).
+		// apply the fixed Elasticsearch resource
+		WithSteps(fixed.UpgradeTestSteps(k)).
+		// ensure the cluster eventually becomes healthy
+		WithSteps(test.CheckTestSteps(fixed, k)).
+		// then remove it
+		WithSteps(fixed.DeletionTestSteps(k))
+}


### PR DESCRIPTION
Bypass any rolling upgrade check and budget if some pods need to be
upgraded, and none of the existing pod is ready.

This allows moving on with clusters where all pods as misconfigured
(eg. bootlooping due to wrong ES configuration, or all Pending due to
a wrong PodTemplate spec).

Side-effect: it's possible to quickly change the spec of a cluster while
it starting up for the first time, or if it's completely down.

Since the check is based on Pod readiness, there is a race condition
where the readiness we get does not match the actual one on the
apiserver. In which case we should normally not do the forced rolling
upgrade. This edge case is ignored here.

Fixes https://github.com/elastic/cloud-on-k8s/issues/1799.