### PR TITLE
Disable metrics following changes in controller-runtime

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -222,6 +222,9 @@ func execute() {
 	if metricsPort != 0 {
 		log.Info("Exposing Prometheus metrics on /metrics", "port", metricsPort)
 		opts.MetricsBindAddress = fmt.Sprintf(":%d", metricsPort)
+	} else {
+		// disable metrics
+		opts.MetricsBindAddress = "0"
 	}
 
 	mgr, err := ctrl.NewManager(cfg, opts)


### PR DESCRIPTION
Controller-runtime metrics are now enabled by default since
https://github.com/kubernetes-sigs/controller-runtime/pull/510 was
merged.
To disable metrics, we must explicitly set the port to "0".