### PR TITLE
Remove extra Kind() funcs for cr types

### DIFF
--- a/pkg/apis/apm/v1alpha1/apmserver_types.go
+++ b/pkg/apis/apm/v1alpha1/apmserver_types.go
@@ -10,10 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	APMServerContainerName = "apm-server"
-	Kind                   = "ApmServer"
-)
+const APMServerContainerName = "apm-server"
 
 // ApmServerSpec defines the desired state of ApmServer
 type ApmServerSpec struct {
@@ -121,12 +118,6 @@ func (as *ApmServer) ElasticsearchRef() commonv1alpha1.ObjectSelector {
 
 func (as *ApmServer) SecureSettings() []commonv1alpha1.SecretSource {
 	return as.Spec.SecureSettings
-}
-
-// Kind can technically be retrieved from metav1.Object, but there is a bug preventing us to retrieve it
-// see https://github.com/kubernetes-sigs/controller-runtime/issues/406
-func (as *ApmServer) Kind() string {
-	return Kind
 }
 
 func (as *ApmServer) AssociationConf() *commonv1alpha1.AssociationConf {

--- a/pkg/apis/apm/v1beta1/apmserver_types.go
+++ b/pkg/apis/apm/v1beta1/apmserver_types.go
@@ -10,10 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	APMServerContainerName = "apm-server"
-	Kind                   = "ApmServer"
-)
+const APMServerContainerName = "apm-server"
 
 // ApmServerSpec defines the desired state of ApmServer
 type ApmServerSpec struct {
@@ -122,12 +119,6 @@ func (as *ApmServer) ElasticsearchRef() commonv1beta1.ObjectSelector {
 
 func (as *ApmServer) SecureSettings() []commonv1beta1.SecretSource {
 	return as.Spec.SecureSettings
-}
-
-// Kind can technically be retrieved from metav1.Object, but there is a bug preventing us to retrieve it
-// see https://github.com/kubernetes-sigs/controller-runtime/issues/406
-func (as *ApmServer) Kind() string {
-	return Kind
 }
 
 func (as *ApmServer) AssociationConf() *commonv1beta1.AssociationConf {

--- a/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1alpha1/elasticsearch_types.go
@@ -10,10 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	ElasticsearchContainerName = "elasticsearch"
-	Kind                       = "Elasticsearch"
-)
+const ElasticsearchContainerName = "elasticsearch"
 
 // ElasticsearchSpec defines the desired state of Elasticsearch
 type ElasticsearchSpec struct {
@@ -240,12 +237,6 @@ func (e Elasticsearch) IsMarkedForDeletion() bool {
 
 func (e Elasticsearch) SecureSettings() []commonv1alpha1.SecretSource {
 	return e.Spec.SecureSettings
-}
-
-// Kind can technically be retrieved from metav1.Object, but there is a bug preventing us to retrieve it
-// see https://github.com/kubernetes-sigs/controller-runtime/issues/406
-func (e Elasticsearch) Kind() string {
-	return Kind
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/apis/elasticsearch/v1beta1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1beta1/elasticsearch_types.go
@@ -10,10 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	ElasticsearchContainerName = "elasticsearch"
-	Kind                       = "Elasticsearch"
-)
+const ElasticsearchContainerName = "elasticsearch"
 
 // ElasticsearchSpec defines the desired state of Elasticsearch
 type ElasticsearchSpec struct {
@@ -237,12 +234,6 @@ func (e Elasticsearch) IsMarkedForDeletion() bool {
 
 func (e Elasticsearch) SecureSettings() []commonv1beta1.SecretSource {
 	return e.Spec.SecureSettings
-}
-
-// Kind can technically be retrieved from metav1.Object, but there is a bug preventing us to retrieve it
-// see https://github.com/kubernetes-sigs/controller-runtime/issues/406
-func (e Elasticsearch) Kind() string {
-	return Kind
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/apis/kibana/v1alpha1/kibana_types.go
+++ b/pkg/apis/kibana/v1alpha1/kibana_types.go
@@ -11,10 +11,7 @@ import (
 	commonv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1alpha1"
 )
 
-const (
-	KibanaContainerName = "kibana"
-	Kind                = "Kibana"
-)
+const KibanaContainerName = "kibana"
 
 // KibanaSpec defines the desired state of Kibana
 type KibanaSpec struct {
@@ -86,12 +83,6 @@ func (k *Kibana) ElasticsearchRef() commonv1alpha1.ObjectSelector {
 
 func (k *Kibana) SecureSettings() []commonv1alpha1.SecretSource {
 	return k.Spec.SecureSettings
-}
-
-// Kind can technically be retrieved from metav1.Object, but there is a bug preventing us to retrieve it
-// see https://github.com/kubernetes-sigs/controller-runtime/issues/406
-func (k *Kibana) Kind() string {
-	return Kind
 }
 
 func (k *Kibana) AssociationConf() *commonv1alpha1.AssociationConf {

--- a/pkg/apis/kibana/v1beta1/kibana_types.go
+++ b/pkg/apis/kibana/v1beta1/kibana_types.go
@@ -11,10 +11,7 @@ import (
 	commonv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1beta1"
 )
 
-const (
-	KibanaContainerName = "kibana"
-	Kind                = "Kibana"
-)
+const KibanaContainerName = "kibana"
 
 // KibanaSpec defines the desired state of Kibana
 type KibanaSpec struct {
@@ -86,12 +83,6 @@ func (k *Kibana) ElasticsearchRef() commonv1beta1.ObjectSelector {
 
 func (k *Kibana) SecureSettings() []commonv1beta1.SecretSource {
 	return k.Spec.SecureSettings
-}
-
-// Kind can technically be retrieved from metav1.Object, but there is a bug preventing us to retrieve it
-// see https://github.com/kubernetes-sigs/controller-runtime/issues/406
-func (k *Kibana) Kind() string {
-	return Kind
 }
 
 func (k *Kibana) AssociationConf() *commonv1beta1.AssociationConf {

--- a/pkg/controller/apmserver/apmserver_controller.go
+++ b/pkg/controller/apmserver/apmserver_controller.go
@@ -462,6 +462,6 @@ func (r *ReconcileApmServer) updateStatus(state State) (reconcile.Result, error)
 // finalizersFor returns the list of finalizers applying to a given APM deployment
 func (r *ReconcileApmServer) finalizersFor(as apmv1beta1.ApmServer) []finalizer.Finalizer {
 	return []finalizer.Finalizer{
-		keystore.Finalizer(k8s.ExtractNamespacedName(&as), r.dynamicWatches, as.Kind()),
+		keystore.Finalizer(k8s.ExtractNamespacedName(&as), r.dynamicWatches, as.Kind),
 	}
 }

--- a/pkg/controller/apmserver/pod.go
+++ b/pkg/controller/apmserver/pod.go
@@ -120,7 +120,7 @@ func newPodSpec(as *v1beta1.ApmServer, p PodSpecParams) corev1.PodTemplateSpec {
 
 	if p.keystoreResources != nil {
 		dataVolume := keystore.DataVolume(
-			strings.ToLower(as.Kind()),
+			strings.ToLower(as.Kind),
 			DataVolumePath,
 		)
 		builder.WithInitContainers(p.keystoreResources.InitContainer).

--- a/pkg/controller/apmserverelasticsearchassociation/apmserverelasticsearchassociation_controller.go
+++ b/pkg/controller/apmserverelasticsearchassociation/apmserverelasticsearchassociation_controller.go
@@ -144,7 +144,7 @@ func (r *ReconcileApmServerElasticsearchAssociation) Reconcile(request reconcile
 	err := handler.Handle(
 		&apmServer,
 		watchFinalizer(apmName, r.watches),
-		user.UserFinalizer(r.Client, apmServer.Kind(), NewUserLabelSelector(apmName)),
+		user.UserFinalizer(r.Client, apmServer.Kind, NewUserLabelSelector(apmName)),
 	)
 	if err != nil {
 		// failed to prepare finalizer or run finalizer: retry

--- a/pkg/controller/common/keystore/resources.go
+++ b/pkg/controller/common/keystore/resources.go
@@ -34,9 +34,6 @@ type HasKeystore interface {
 	metav1.Object
 	runtime.Object
 	SecureSettings() []commonv1beta1.SecretSource
-	// Kind can technically be retrieved from metav1.Object, but there is a bug preventing us to retrieve it
-	// see https://github.com/kubernetes-sigs/controller-runtime/issues/406
-	Kind() string
 }
 
 // NewResources optionally returns a volume and init container to include in pods,
@@ -62,7 +59,7 @@ func NewResources(
 	// build an init container to create the keystore from the secure settings volume
 	initContainer, err := initContainer(
 		*secretVolume,
-		strings.ToLower(hasKeystore.Kind()),
+		strings.ToLower(hasKeystore.GetObjectKind().GroupVersionKind().Kind),
 		initContainerParams,
 	)
 	if err != nil {

--- a/pkg/controller/common/keystore/user_secret.go
+++ b/pkg/controller/common/keystore/user_secret.go
@@ -227,8 +227,6 @@ func watchSecureSettings(watched watches.DynamicWatches, secureSettingsRef []com
 }
 
 // Finalizer removes any dynamic watches on external user created secret.
-// TODO: Kind of an object can be retrieved programmatically with object.GetObjectKind(), unfortunately it does not seem
-//  to be reliable with controller-runtime < v0.2.0-beta.4
 func Finalizer(namespacedName types.NamespacedName, watched watches.DynamicWatches, kind string) finalizer.Finalizer {
 	return finalizer.Finalizer{
 		Name: "finalizer." + strings.ToLower(kind) + ".k8s.elastic.co/secure-settings-secret",

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -300,7 +300,7 @@ func (r *ReconcileElasticsearch) finalizersFor(
 	clusterName := k8s.ExtractNamespacedName(&es)
 	return []finalizer.Finalizer{
 		r.esObservers.Finalizer(clusterName),
-		keystore.Finalizer(k8s.ExtractNamespacedName(&es), r.dynamicWatches, es.Kind()),
-		http.DynamicWatchesFinalizer(r.dynamicWatches, es.Kind(), es.Name, esname.ESNamer),
+		keystore.Finalizer(k8s.ExtractNamespacedName(&es), r.dynamicWatches, es.Kind),
+		http.DynamicWatchesFinalizer(r.dynamicWatches, es.Kind, es.Name, esname.ESNamer),
 	}
 }

--- a/pkg/controller/kibana/kibana_controller.go
+++ b/pkg/controller/kibana/kibana_controller.go
@@ -226,6 +226,6 @@ func (r *ReconcileKibana) updateStatus(state State) error {
 func (r *ReconcileKibana) finalizersFor(kb *kibanav1beta1.Kibana) []finalizer.Finalizer {
 	return []finalizer.Finalizer{
 		secretWatchFinalizer(*kb, r.dynamicWatches),
-		keystore.Finalizer(k8s.ExtractNamespacedName(kb), r.dynamicWatches, kb.Kind()),
+		keystore.Finalizer(k8s.ExtractNamespacedName(kb), r.dynamicWatches, kb.Kind),
 	}
 }

--- a/pkg/controller/kibanaassociation/association_controller.go
+++ b/pkg/controller/kibanaassociation/association_controller.go
@@ -132,7 +132,7 @@ func (r *ReconcileAssociation) Reconcile(request reconcile.Request) (reconcile.R
 	err := h.Handle(
 		&kibana,
 		watchFinalizer(kbName, r.watches),
-		user.UserFinalizer(r.Client, kibana.Kind(), NewUserLabelSelector(kbName)),
+		user.UserFinalizer(r.Client, kibana.Kind, NewUserLabelSelector(kbName)),
 	)
 	if err != nil {
 		if apierrors.IsConflict(err) {


### PR DESCRIPTION
This PR removes a Kind() method used to workaround https://github.com/kubernetes-sigs/controller-runtime/issues/406. It is no longer needed.

Fixes #1831