### PR TITLE
Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Elastic Cloud on Kubernetes automates the deployment, provisioning, management, and orchestration of Elasticsearch and Kibana on Kubernetes based on the operator pattern.
 
-This is an alpha version.
+This is a beta version.
 
 Current features:
 

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ Check the [Quickstart](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-
 
 If you want to contribute to the project, check our [contributing guide](CONTRIBUTING.md) and see [how to setup a local development environment](dev-setup.md).
 
-For general questions, please see Elastic [forums](https://discuss.elastic.co/c/eck).
+For general questions, please see the Elastic [forums](https://discuss.elastic.co/c/eck).

--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ Supported versions:
 Check the [Quickstart](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-quickstart.html) if you want to deploy you first cluster with ECK.
 
 If you want to contribute to the project, check our [contributing guide](CONTRIBUTING.md) and see [how to setup a local development environment](dev-setup.md).
+
+For general questions, please see Elastic [forums](https://discuss.elastic.co/c/eck).


### PR DESCRIPTION
Two changes:
- bump alpha to beta in readme,
- add link to Elastic forums (we have that in issue template, but this will be more visible and could get people to the right place quicker, see https://github.com/elastic/cloud-on-k8s/issues/1835).