### PR TITLE
Don't return keystore errors for rolling upgrade errors in e2e tests

### DIFF
--- a/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/test/e2e/test/elasticsearch/checks_k8s.go
@@ -167,7 +167,7 @@ podsLoop:
 				continue podsLoop
 			}
 		}
-		return fmt.Errorf("pod %s is not ready yet", p.Name)
+		return fmt.Errorf("pod %s is not ready yet. Phase: %s. Reason: %s", p.Name, p.Status.Phase, p.Status.Reason)
 	}
 	return nil
 }

--- a/test/e2e/test/elasticsearch/checks_keystore.go
+++ b/test/e2e/test/elasticsearch/checks_keystore.go
@@ -24,6 +24,14 @@ func CheckESKeystoreEntries(k *test.K8sClient, b Builder, expectedKeys []string)
 			if err != nil {
 				return err
 			}
+			// wait for any ongoing rolling-upgrade to be over
+			if err := allPodsReady(b, k); err != nil {
+				return err
+			}
+			if err := clusterHealthGreen(b, k); err != nil {
+				return err
+			}
+			// check keystore entries on all Pods
 			if err := test.OnAllPods(pods, func(p corev1.Pod) error {
 				// exec into the pod to list keystore entries
 				stdout, stderr, err := k.Exec(k8s.ExtractNamespacedName(&p), []string{initcontainer.KeystoreBinPath, "list"})
@@ -50,14 +58,6 @@ func CheckESKeystoreEntries(k *test.K8sClient, b Builder, expectedKeys []string)
 				return err
 			}
 
-			// rolling upgrade leading to that correct keystore configuration should eventually be over,
-			// with cluster health green
-			if err := allPodsReady(b, k); err != nil {
-				return err
-			}
-			if err := clusterHealthGreen(b, k); err != nil {
-				return err
-			}
 			return nil
 		}),
 	}


### PR DESCRIPTION
We sometimes report keystore errors, where what's actually happening is
a rolling upgrade not making progress for some reasons (eg. cannot mount
PersistentVolume).
Let's reverse the order we check things to report any rolling upgrade
error before keystore errors.

The PR also adds more details in the error we return when a Pod is not "ready" as expected.

Should fix https://github.com/elastic/cloud-on-k8s/issues/1325#issuecomment-537435622 so E2E tests report the correct error (but not fix the underlying GCP volume mount problem).