### PR TITLE
Disable mmap in E2E tests

### DIFF
--- a/config/samples/apm/apm_es_kibana.yaml
+++ b/config/samples/apm/apm_es_kibana.yaml
@@ -10,6 +10,8 @@ spec:
   - name: default
     count: 3
     config:
+      # This setting could have performance implications for production clusters.
+      # See: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
       node.store.allow_mmap: false
 ---
 apiVersion: apm.k8s.elastic.co/v1beta1

--- a/config/samples/apm/apm_es_kibana.yaml
+++ b/config/samples/apm/apm_es_kibana.yaml
@@ -9,6 +9,8 @@ spec:
   nodeSets:
   - name: default
     count: 3
+    config:
+      node.store.allow_mmap: false
 ---
 apiVersion: apm.k8s.elastic.co/v1beta1
 kind: ApmServer

--- a/config/samples/kibana/kibana_es.yaml
+++ b/config/samples/kibana/kibana_es.yaml
@@ -8,6 +8,8 @@ spec:
   nodeSets:
   - name: default
     count: 1
+    config:
+      node.store.allow_mmap: false
 ---
 apiVersion: kibana.k8s.elastic.co/v1beta1
 kind: Kibana

--- a/config/samples/kibana/kibana_es.yaml
+++ b/config/samples/kibana/kibana_es.yaml
@@ -9,6 +9,8 @@ spec:
   - name: default
     count: 1
     config:
+      # This setting could have performance implications for production clusters.
+      # See: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
       node.store.allow_mmap: false
 ---
 apiVersion: kibana.k8s.elastic.co/v1beta1

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -130,7 +130,8 @@ func (b Builder) WithESMasterNodes(count int, resources corev1.ResourceRequireme
 		Count: int32(count),
 		Config: &commonv1beta1.Config{
 			Data: map[string]interface{}{
-				estype.NodeData: "false",
+				estype.NodeData:         "false",
+				"node.store.allow_mmap": false,
 			},
 		},
 		PodTemplate: ESPodTemplate(resources),
@@ -143,7 +144,8 @@ func (b Builder) WithESDataNodes(count int, resources corev1.ResourceRequirement
 		Count: int32(count),
 		Config: &commonv1beta1.Config{
 			Data: map[string]interface{}{
-				estype.NodeMaster: "false",
+				estype.NodeMaster:       "false",
+				"node.store.allow_mmap": false,
 			},
 		},
 		PodTemplate: ESPodTemplate(resources),
@@ -168,7 +170,9 @@ func (b Builder) WithESMasterDataNodes(count int, resources corev1.ResourceRequi
 		Name:  "masterdata",
 		Count: int32(count),
 		Config: &commonv1beta1.Config{
-			Data: map[string]interface{}{},
+			Data: map[string]interface{}{
+				"node.store.allow_mmap": false,
+			},
 		},
 		PodTemplate: ESPodTemplate(resources),
 	})

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -39,6 +39,8 @@ type Builder struct {
 
 var _ test.Builder = Builder{}
 
+// nodeStoreAllowMMap is the configuration key to disable mmap.
+// We disable mmap to avoid having to set the vm.max_map_count sysctl on test nodes.
 const nodeStoreAllowMMap = "node.store.allow_mmap"
 
 func NewBuilder(name string) Builder {

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -39,6 +39,8 @@ type Builder struct {
 
 var _ test.Builder = Builder{}
 
+const nodeStoreAllowMMap = "node.store.allow_mmap"
+
 func NewBuilder(name string) Builder {
 	return newBuilder(name, rand.String(4))
 }
@@ -130,8 +132,8 @@ func (b Builder) WithESMasterNodes(count int, resources corev1.ResourceRequireme
 		Count: int32(count),
 		Config: &commonv1beta1.Config{
 			Data: map[string]interface{}{
-				estype.NodeData:         "false",
-				"node.store.allow_mmap": false,
+				estype.NodeData:    "false",
+				nodeStoreAllowMMap: false,
 			},
 		},
 		PodTemplate: ESPodTemplate(resources),
@@ -144,8 +146,8 @@ func (b Builder) WithESDataNodes(count int, resources corev1.ResourceRequirement
 		Count: int32(count),
 		Config: &commonv1beta1.Config{
 			Data: map[string]interface{}{
-				estype.NodeMaster:       "false",
-				"node.store.allow_mmap": false,
+				estype.NodeMaster:  "false",
+				nodeStoreAllowMMap: false,
 			},
 		},
 		PodTemplate: ESPodTemplate(resources),
@@ -158,7 +160,8 @@ func (b Builder) WithNamedESDataNodes(count int, name string, resources corev1.R
 		Count: int32(count),
 		Config: &commonv1beta1.Config{
 			Data: map[string]interface{}{
-				estype.NodeMaster: "false",
+				estype.NodeMaster:  "false",
+				nodeStoreAllowMMap: false,
 			},
 		},
 		PodTemplate: ESPodTemplate(resources),
@@ -171,7 +174,7 @@ func (b Builder) WithESMasterDataNodes(count int, resources corev1.ResourceRequi
 		Count: int32(count),
 		Config: &commonv1beta1.Config{
 			Data: map[string]interface{}{
-				"node.store.allow_mmap": false,
+				nodeStoreAllowMMap: false,
 			},
 		},
 		PodTemplate: ESPodTemplate(resources),


### PR DESCRIPTION
Some E2E test failures are linked to readiness probe failures caused by Elasticsearch boot checks. This PR disables mmap by default for E2E Elasticsearch objects.