### PR TITLE
Optimize checks stage for PR job

### DIFF
--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -29,12 +29,8 @@ pipeline {
         stage('Run checks') {
             when {
                 expression {
-                    checkout scm
                     notOnlyDocs()
                 }
-            }
-            agent {
-                label 'linux'
             }
             steps {
                 sh 'make -C build/ci TARGET=ci-check ci'


### PR DESCRIPTION
This PR optimizing stage `Run checks` for PR job.
- `agent`block means that new CI node will be created and stage will be executed on it. It's useful sometimes (we are using it in PR job to run several stages in parallel), but in this case it only adds delay to CI feedback to PR, cause all the checks can be executed on existed node
- `checkout scm` not needed because sources already have been checked out during previous step