### PR TITLE
Fix pod count check and downscale bug

### DIFF
--- a/pkg/controller/elasticsearch/driver/downscale.go
+++ b/pkg/controller/elasticsearch/driver/downscale.go
@@ -83,8 +83,8 @@ func calculateDownscales(state downscaleState, expectedStatefulSets sset.Statefu
 			}
 
 			toDelete := actualReplicas - expectedReplicas
-			if label.IsMasterNodeSet(actualSset) {
-				toDelete = 1 // Only one removal allowed for masters
+			if label.IsMasterNodeSet(actualSset) && toDelete > 0 {
+				toDelete = 1 // Only one removal allowed for masters and if it's not already at 0
 			}
 			toDelete = state.getMaxNodesToRemove(toDelete)
 			downscales = append(downscales, ssetDownscale{

--- a/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -278,7 +278,26 @@ func Test_calculateDownscales(t *testing.T) {
 				Replicas: common.Int32(3)},
 		},
 	}
-	tests := []struct {
+
+	masterSset := sset.StatefulSetList{
+		sset.TestSset{
+			Name:      "masters",
+			Namespace: "ns",
+			Replicas:  0,
+			Master:    true,
+		}.Build(),
+	}
+
+	dataSset := sset.StatefulSetList{
+		sset.TestSset{
+			Name:      "masters",
+			Namespace: "ns",
+			Replicas:  0,
+			Master:    false,
+		}.Build(),
+	}
+
+	var tests = []struct {
 		name                 string
 		expectedStatefulSets sset.StatefulSetList
 		actualStatefulSets   sset.StatefulSetList
@@ -393,6 +412,30 @@ func Test_calculateDownscales(t *testing.T) {
 			},
 			actualStatefulSets: ssets,
 			want:               []ssetDownscale{},
+		},
+		{
+			name:               "master statefulset removal",
+			actualStatefulSets: masterSset,
+			want: []ssetDownscale{
+				{
+					statefulSet:     masterSset[0],
+					initialReplicas: 0,
+					targetReplicas:  0,
+					finalReplicas:   0,
+				},
+			},
+		},
+		{
+			name:               "data statefulset removal",
+			actualStatefulSets: dataSset,
+			want: []ssetDownscale{
+				{
+					statefulSet:     dataSset[0],
+					initialReplicas: 0,
+					targetReplicas:  0,
+					finalReplicas:   0,
+				},
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -101,7 +101,9 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 				Name: "Pod count must not violate change budget",
 				Test: func(t *testing.T) {
 					changeBudgetCheck.Stop()
-					require.NoError(t, changeBudgetCheck.Verify(b.Elasticsearch.Spec))
+					if b.MutatedFrom != nil {
+						require.NoError(t, changeBudgetCheck.Verify(b.MutatedFrom.Elasticsearch.Spec, b.Elasticsearch.Spec))
+					}
 				},
 			},
 			test.Step{


### PR DESCRIPTION
This PR fixes two issues:
1. when checking pod counts we didn't take into account the fact that we may be scaling up or down from spec that is outside of bounds of the new spec.
2. when dealing with master statefulset removal we requested 1 pod to be deleted even if set was already at 0, this caused targetReplicas to be -1 and statefulset never being removed due to the `downscale.isRemoval` expecting (rightfully) targetReplicas to be 0.