### PR TITLE
Update quick-start doc

### DIFF
--- a/docs/elasticsearch-spec.asciidoc
+++ b/docs/elasticsearch-spec.asciidoc
@@ -104,9 +104,7 @@ For more information on Elasticsearch settings, see https://www.elastic.co/guide
 [id="{p}-volume-claim-templates"]
 === Volume claim templates
 
-By default the operator creates a https://kubernetes.io/docs/concepts/storage/persistent-volumes/[`PersistentVolumeClaim`] with a capacity of 1Gi for every Pod in an Elasticsearch cluster. This is to ensure that there is no data loss if a Pod is deleted.
-
-You can customize the volume claim templates used by Elasticsearch to adjust the storage to your needs. The name in the template must be `elasticsearch-data`:
+By default, the operator creates a https://kubernetes.io/docs/concepts/storage/persistent-volumes/[`PersistentVolumeClaim`] with a capacity of 1Gi for each pod in an Elasticsearch cluster to prevent data loss in case of accidental pod deletion. For production workloads, you should define your own volume claim template with the desired storage capacity and (optionally) the Kubernetes link:https://kubernetes.io/docs/concepts/storage/storage-classes/[storage class] to associate with the persistent volume. The name of the volume claim must always be `elasticsearch-data`.
 
 [source,yaml]
 ----
@@ -124,7 +122,9 @@ spec:
         storageClassName: standard
 ----
 
-If you want to use an `emptyDir` volume, specify the `elasticsearch-data` volume in the `podTemplate`:
+IMPORTANT: Depending on the Kubernetes configuration and the underlying file system, some persistent volumes cannot be resized after they are created. You should consider future storage requirements when defining volume claims to ensure that you have plenty of space available to sustain the expected growth.
+
+If you are not concerned about data loss, you can use an `emptyDir` volume for Elasticsearch data as well:
 
 [source,yaml]
 ----
@@ -138,7 +138,8 @@ spec:
           emptyDir: {}
 ----
 
-IMPORTANT: Using `emptyDir` might result in data loss and is not recommended.
+CAUTION: Using `emptyDir` is not recommended due to the high likelihood of permanent data loss.
+
 
 [id="{p}-http-settings-tls-sans"]
 === HTTP settings & TLS SANs

--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -265,7 +265,7 @@ EOF
 [id="{p}-persistent-storage"]
 === Use persistent storage
 
-The cluster that you deployed in this quickstart guide only allocates a persistent volume of 1GiB for storage using the default link:https://kubernetes.io/docs/concepts/storage/storage-classes/[storage class] defined for the Kubernetes cluster. You will most likely want to have more control over this for any serious work. Refer to <<{p}-volume-claim-templates>> for more information.
+The cluster that you deployed in this quickstart guide only allocates a persistent volume of 1GiB for storage using the default link:https://kubernetes.io/docs/concepts/storage/storage-classes/[storage class] defined for the Kubernetes cluster. You will most likely want to have more control over this for production workloads. Refer to <<{p}-volume-claim-templates>> for more information.
 
 
 [float]

--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -40,7 +40,7 @@ kubectl -n elastic-system logs -f statefulset.apps/elastic-operator
 
 [float]
 [id="{p}-deploy-elasticsearch"]
-=== Deploy the Elasticsearch cluster
+=== Deploy an Elasticsearch cluster
 
 Apply a simple link:{ref}/getting-started.html[Elasticsearch] cluster specification, with one node:
 
@@ -66,9 +66,9 @@ spec:
 EOF
 ----
 
-The operator automatically manages Pods and resources corresponding to the desired cluster. It may take up to a few minutes until the cluster is ready.
+The operator automatically creates and manages Kubernetes resources to achieve the desired state of the Elasticsearch cluster. It may take up to a few minutes until all the resources are created and the cluster is ready for use.
 
-NOTE: Setting `node.store.allow_mmap: false` has performance implications and should be tuned for production workloads as described in the <<{p}-virtual-memory>> section.
+CAUTION: Setting `node.store.allow_mmap: false` has performance implications and should be tuned for production workloads as described in the <<{p}-virtual-memory>> section.
 
 [float]
 ==== Monitor cluster health and creation progress
@@ -171,7 +171,7 @@ NOTE: Disabling certificate verification using the `-k` flag is not recommended 
 
 [float]
 [id="{p}-deploy-kibana"]
-=== Deploy the Kibana instance
+=== Deploy a Kibana instance
 
 To deploy your link:{kibana-ref}/introduction.html#introduction[Kibana] instance go through the following steps.
 

--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -237,7 +237,7 @@ kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | ba
 [id="{p}-upgrade-deployment"]
 === Upgrade your deployment
 
-You can apply any modifications to the original cluster specification. The operator ensures that your changes are applied to the existing cluster with no disruption.
+You can add and modify most elements of the original cluster specification provided that they translate to valid transformations of the underlying Kubernetes resources (e.g., existing volume claims cannot be resized). The operator will attempt to apply your changes with minimal disruption to the existing cluster but it might not be possible to apply some changes gracefully. For complex topology changes, you should break your changes down to smaller incremental steps that the operatator can apply safely. You should also ensure that the Kubernetes cluster has sufficient resources to accommodate the changes (extra storage space, sufficient memory and CPU resources to temporarily spin up new pods etc.).
 
 For example, you can grow the cluster to three nodes:
 

--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -263,13 +263,11 @@ EOF
 
 [float]
 [id="{p}-persistent-storage"]
-=== Update persistent storage
+=== Use persistent storage
 
-Now that you have completed the quickstart, you can try out more features like tweaking persistent storage. The cluster that you deployed in this quickstart uses a default persistent volume claim of 1GiB without a storage class set. This means that the default storage class defined in the Kubernetes cluster is the one that will be provisioned.
+The cluster that you deployed in this quickstart guide only allocates a persistent volume of 1GiB for storage using the default link:https://kubernetes.io/docs/concepts/storage/storage-classes/[storage class] defined for the Kubernetes cluster. You will most likely want to have more control over this for any serious workloads.
 
-You can request a `PersistentVolumeClaim` with a larger size in the Elasticsearch specification or target any `PersistentVolume` class available in your Kubernetes cluster:
-
-NOTE: Depending on the Kubernetes configuration and the underlying file system, some persistent volumes cannot be resized after they are created. You should consider future storage requirements when defining volume claims to ensure that you have plenty of space available to sustain the projected growth.
+You can request a `PersistentVolumeClaim` with a larger size in the Elasticsearch specification and target any `StorageClass` available in your Kubernetes cluster:
 
 [source,yaml,subs="attributes"]
 ----
@@ -300,6 +298,8 @@ spec:
         #storageClassName: standard # can be any available storage class
 EOF
 ----
+
+NOTE: Depending on the Kubernetes configuration and the underlying file system, some persistent volumes cannot be resized after they are created. You should consider future storage requirements when defining volume claims to ensure that you have plenty of space available to sustain the expected growth.
 
 To aim for the best performance, the operator supports persistent volumes local to each node. For more details, see:
 

--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -265,46 +265,8 @@ EOF
 [id="{p}-persistent-storage"]
 === Use persistent storage
 
-The cluster that you deployed in this quickstart guide only allocates a persistent volume of 1GiB for storage using the default link:https://kubernetes.io/docs/concepts/storage/storage-classes/[storage class] defined for the Kubernetes cluster. You will most likely want to have more control over this for any serious workloads.
+The cluster that you deployed in this quickstart guide only allocates a persistent volume of 1GiB for storage using the default link:https://kubernetes.io/docs/concepts/storage/storage-classes/[storage class] defined for the Kubernetes cluster. You will most likely want to have more control over this for any serious work. Refer to <<{p}-volume-claim-templates>> for more information.
 
-You can request a `PersistentVolumeClaim` with a larger size in the Elasticsearch specification and target any `StorageClass` available in your Kubernetes cluster:
-
-[source,yaml,subs="attributes"]
-----
-cat <<EOF | kubectl apply -f -
-apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
-kind: Elasticsearch
-metadata:
-  name: quickstart
-spec:
-  version: {version}
-  nodeSets:
-  - name: default
-    count: 3
-    config:
-      node.master: true
-      node.data: true
-      node.ingest: true
-      node.store.allow_mmap: false
-    volumeClaimTemplates:
-    - metadata:
-        name: elasticsearch-data # note: elasticsearch-data must be the name of the Elasticsearch volume
-      spec:
-        accessModes:
-        - ReadWriteOnce
-        resources:
-          requests:
-            storage: 10Gi
-        #storageClassName: standard # can be any available storage class
-EOF
-----
-
-NOTE: Depending on the Kubernetes configuration and the underlying file system, some persistent volumes cannot be resized after they are created. You should consider future storage requirements when defining volume claims to ensure that you have plenty of space available to sustain the expected growth.
-
-To aim for the best performance, the operator supports persistent volumes local to each node. For more details, see:
-
- * link:https://kubernetes.io/docs/concepts/storage/storage-classes[persistent volumes storage classes]
- * link:https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner[kubernetes-sigs local volume static provisioner] to setup static local volumes.
 
 [float]
 [id="{p}-check-samples"]

--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -3,11 +3,11 @@
 
 With Elastic Cloud on Kubernetes (ECK) you can extend the basic Kubernetes orchestration capabilities to easily deploy, secure, upgrade your Elasticsearch cluster, and much more.
 
-Eager to get started? This fast guide shows you how to:
+Eager to get started? This quick guide shows you how to:
 
 * <<{p}-deploy-eck,Deploy ECK in your Kubernetes cluster>>
-* <<{p}-deploy-elasticsearch,Deploy the Elasticsearch cluster>>
-* <<{p}-deploy-kibana,Deploy the Kibana instance>>
+* <<{p}-deploy-elasticsearch,Deploy an Elasticsearch cluster>>
+* <<{p}-deploy-kibana,Deploy a Kibana instance>>
 * <<{p}-upgrade-deployment,Upgrade your deployment>>
 * <<{p}-persistent-storage,Use persistent storage>>
 * <<{p}-check-samples,Check out the samples>>
@@ -44,7 +44,7 @@ kubectl -n elastic-system logs -f statefulset.apps/elastic-operator
 
 Apply a simple link:{ref}/getting-started.html[Elasticsearch] cluster specification, with one node:
 
-NOTE: The default resource request is 2gb memory and 100m cpu, and your pod will be `Pending` if your cluster does not have enough resources.
+NOTE: If your Kubernetes cluster does not have any nodes with at least 2GiB of free memory, the pod will be stuck in `Pending` state. See <<{p}-managing-compute-resources>> for more information about resource requirements and how to configure them.
 
 [source,yaml,subs="attributes"]
 ----
@@ -68,7 +68,7 @@ EOF
 
 The operator automatically manages Pods and resources corresponding to the desired cluster. It may take up to a few minutes until the cluster is ready.
 
-Note that `node.store.allow_mmap: false` has performance implications and should be tuned for production workloads as described link:k8s-elasticsearch-spec.html#virtual-memory[here].
+NOTE: Setting `node.store.allow_mmap: false` has performance implications and should be tuned for production workloads as described in the <<{p}-virtual-memory>> section.
 
 [float]
 ==== Monitor cluster health and creation progress
@@ -97,15 +97,15 @@ kubectl get pods --selector='elasticsearch.k8s.elastic.co/cluster-name=quickstar
 
 [source,sh]
 ----
-NAME                       READY     STATUS    RESTARTS   AGE
-quickstart-es-5zctxpn8nd   1/1       Running   0          1m
+NAME                      READY   STATUS    RESTARTS   AGE
+quickstart-es-default-0   1/1     Running   0          79s
 ----
 
 Access the logs for that Pod:
 
 [source,sh]
 ----
-kubectl logs -f quickstart-es-5zctxpn8nd
+kubectl logs -f quickstart-es-default-0
 ----
 
 [float]
@@ -126,7 +126,7 @@ quickstart-es-http   ClusterIP   10.15.251.145   <none>        9200/TCP   34m
 
 . Get the credentials.
 +
-A default user named `elastic` is automatically created. Its password is stored as a Kubernetes secret:
+A default user named `elastic` is automatically created with the password stored in a Kubernetes secret:
 +
 [source,sh]
 ----
@@ -156,12 +156,12 @@ Then request `localhost`:
 curl -u "elastic:$PASSWORD" -k "https://localhost:9200"
 ----
 
-NOTE: For testing purposes only, you can specify the `-k` option to turn off certificate verification.
+NOTE: Disabling certificate verification using the `-k` flag is not recommended and should be used for testing purposes only. See: <<{p}-setting-up-your-own-certificate>>
 
 [source,json]
 ----
 {
-  "name" : "quickstart-es-r56c9dzzcr",
+  "name" : "quickstart-es-default-0",
   "cluster_name" : "quickstart",
   "cluster_uuid" : "XqWg0xIiRmmEBg4NMhnYPg",
   "version" : {...},
@@ -194,7 +194,7 @@ EOF
 
 . Monitor Kibana health and creation progress.
 +
-Similarly to Elasticsearch, you can retrieve details about Kibana instances:
+Similar to Elasticsearch, you can retrieve details about Kibana instances:
 +
 [source,sh]
 ----
@@ -224,20 +224,20 @@ Use `kubectl port-forward` to access Kibana from your local workstation:
 kubectl port-forward service/quickstart-kb-http 5601
 ----
 +
-Open `https://localhost:5601` in your browser. Your browser will show a warning because the self-signed certificate configured by default is not verified by a third party certificate authority and not trusted by your browser. You can either configure a link:k8s-accessing-elastic-services.html#k8s-setting-up-your-own-certificate[valid certificate] or acknowledge the warning for the purposes of this quick start.
+Open `https://localhost:5601` in your browser. Your browser will show a warning because the self-signed certificate configured by default is not verified by a third party certificate authority and not trusted by your browser. You can temporarily acknowledge the warning for the purposes of this quick start but it is highly recommended that you <<{p}-setting-up-your-own-certificate,configure valid certificates>> for any production deployments.
 +
-Login with the `elastic` user. Retrieve its password with:
+Login as the `elastic` user. The password can be obtained with the following command:
 +
 [source,sh]
 ----
-echo $(kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | base64 --decode)
+kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | base64 --decode; echo
 ----
 
 [float]
 [id="{p}-upgrade-deployment"]
 === Upgrade your deployment
 
-You can apply any modification to the original cluster specification. The operator makes sure that your changes are applied to the existing cluster, while avoiding downtime.
+You can apply any modifications to the original cluster specification. The operator ensures that your changes are applied to the existing cluster with no disruption.
 
 For example, you can grow the cluster to three nodes:
 
@@ -257,6 +257,7 @@ spec:
       node.master: true
       node.data: true
       node.ingest: true
+      node.store.allow_mmap: false
 EOF
 ----
 
@@ -264,9 +265,11 @@ EOF
 [id="{p}-persistent-storage"]
 === Update persistent storage
 
-Now that you have completed the quickstart, you can try out more features like tweaking persistent storage. The cluster that you deployed in this quickstart uses a default persistent volume claim of 1GiB, without a storage class set. This means that the default storage class defined in the Kubernetes cluster is the one that will be provisioned.
+Now that you have completed the quickstart, you can try out more features like tweaking persistent storage. The cluster that you deployed in this quickstart uses a default persistent volume claim of 1GiB without a storage class set. This means that the default storage class defined in the Kubernetes cluster is the one that will be provisioned.
 
 You can request a `PersistentVolumeClaim` with a larger size in the Elasticsearch specification or target any `PersistentVolume` class available in your Kubernetes cluster:
+
+NOTE: Depending on the Kubernetes configuration and the underlying file system, some persistent volumes cannot be resized after they are created. You should consider future storage requirements when defining volume claims to ensure that you have plenty of space available to sustain the projected growth.
 
 [source,yaml,subs="attributes"]
 ----
@@ -284,6 +287,7 @@ spec:
       node.master: true
       node.data: true
       node.ingest: true
+      node.store.allow_mmap: false
     volumeClaimTemplates:
     - metadata:
         name: elasticsearch-data # note: elasticsearch-data must be the name of the Elasticsearch volume

--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -237,7 +237,7 @@ kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | ba
 [id="{p}-upgrade-deployment"]
 === Upgrade your deployment
 
-You can add and modify most elements of the original cluster specification provided that they translate to valid transformations of the underlying Kubernetes resources (e.g., existing volume claims cannot be resized). The operator will attempt to apply your changes with minimal disruption to the existing cluster but it might not be possible to apply some changes gracefully. For complex topology changes, you should break your changes down to smaller incremental steps that the operatator can apply safely. You should also ensure that the Kubernetes cluster has sufficient resources to accommodate the changes (extra storage space, sufficient memory and CPU resources to temporarily spin up new pods etc.).
+You can add and modify most elements of the original cluster specification provided that they translate to valid transformations of the underlying Kubernetes resources (e.g., existing volume claims cannot be resized). The operator will attempt to apply your changes with minimal disruption to the existing cluster. You should ensure that the Kubernetes cluster has sufficient resources to accommodate the changes (extra storage space, sufficient memory and CPU resources to temporarily spin up new pods etc.).
 
 For example, you can grow the cluster to three nodes:
 


### PR DESCRIPTION
- Update outputs that have changed due to the use of ssets
- Use `node.store.allow_mmap: false` in all examples
- Fix hard-coded links
- Fix minor prose issues

Since webhooks are disabled in this release, we can probably remove the note about opening ports in EKS as well.