### PR TITLE
Generate an event on sset spec change failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,20 @@ go-run:
 				--operator-namespace=default --namespace= \
 				--auto-install-webhooks=false
 
+go-debug:
+	@(cd cmd &&	AUTO_PORT_FORWARD=true dlv debug \
+		--build-flags="-ldflags '$(GO_LDFLAGS)'" \
+		-- \
+		manager \
+		--development \
+		--operator-roles=global,namespace \
+		--log-verbosity=$(LOG_VERBOSITY) \
+		--ca-cert-validity=10h \
+		--ca-cert-rotate-before=1h \
+		--operator-namespace=default \
+		--namespace= \
+		--auto-install-webhooks=false)
+
 build-operator-image:
 ifeq ($(SKIP_DOCKER_COMMAND), false)
 	$(MAKE) docker-build docker-push

--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -5,6 +5,9 @@
 package driver
 
 import (
+	"fmt"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates"
@@ -17,6 +20,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/version/zen1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/version/zen2"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func (d *defaultDriver) reconcileNodeSpecs(
@@ -66,6 +70,7 @@ func (d *defaultDriver) reconcileNodeSpecs(
 	}
 	actualStatefulSets, err = HandleUpscaleAndSpecChanges(upscaleCtx, actualStatefulSets, expectedResources)
 	if err != nil {
+		reconcileState.AddEvent(corev1.EventTypeWarning, events.EventReconciliationError, fmt.Sprintf("Failed to apply spec change: %v", err))
 		return results.WithError(err)
 	}
 


### PR DESCRIPTION
Generates an event if a sset spec change cannot be applied (e.g., attempting to change the size of a volume claim template). Even though we have a validation check for PVC modification, it does not catch this issue because the manual validation check in the internal reconciliation loop always sets the `Current` spec to `nil` and the check requires both `Current` and `Proposed` to be non-nil in order to work.

```
 Type     Reason               Age                    From                      Message
  ----     ------               ----                   ----                      -------
  Warning  ReconciliationError  1s (x8 over 12s)       elasticsearch-controller  Failed to apply spec change: StatefulSet.apps "quickstart-es-default" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden
```

This is probably not the ideal way to handle this. It just avoids a large refactoring so close to a release. Long term, this should be revisited as part of #1811. 

Fixes #1871 