### PR TITLE
Trigger ELK stack tests after building release

### DIFF
--- a/build/ci/release/Jenkinsfile
+++ b/build/ci/release/Jenkinsfile
@@ -74,6 +74,10 @@ EOF
             build job: 'cloud-on-k8s-e2e-tests-custom',
                 parameters: [string(name: 'IMAGE', value: "${LATEST_RELEASED_IMG}")],
                 wait: false
+
+            build job: 'cloud-on-k8s-stack',
+                parameters: [string(name: 'IMAGE', value: "${LATEST_RELEASED_IMG}")],
+                wait: false
         }
         unsuccessful {
             script {

--- a/build/ci/release/Jenkinsfile
+++ b/build/ci/release/Jenkinsfile
@@ -78,6 +78,10 @@ EOF
             build job: 'cloud-on-k8s-stack',
                 parameters: [string(name: 'IMAGE', value: "${LATEST_RELEASED_IMG}")],
                 wait: false
+                
+            build job: 'cloud-on-k8s-versions-gke',
+                parameters: [string(name: 'IMAGE', value: "${LATEST_RELEASED_IMG}")],
+                wait: false
         }
         unsuccessful {
             script {


### PR DESCRIPTION
Currently we automatically triggers e2e tests after successful build of release ECK image. This PR adds trigger for running tests against all supported ELK stack versions for newly builded ECK image.