### PR TITLE
Run ci job definition script with bash interpreter

### DIFF
--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -77,7 +77,8 @@ pipeline {
 }
 
 void runWith(clusterVersion, clusterName) {
-    sh """
+    sh """#!/bin/bash
+
         cat >.env <<EOF
 GCLOUD_PROJECT = "$GCLOUD_PROJECT"
 LATEST_RELEASED_IMG = "$IMAGE"


### PR DESCRIPTION
The GKE_k8s_versions job uses a bash snippet to choose how to generate
CRDs depending on the k8s cluster version.
In a Jenkins groovy pipeline script, by default, the system default
shell will be run.
Therefore, this commit specifies the bash interpreter selector in the pipeline
script to benefit from the richer syntax offered by bash compared to sh.

https://support.cloudbees.com/hc/en-us/articles/215171038-How-do-I-run-a-different-Shell-interpreter-in-a-Pipeline-Script