### PR TITLE
Bump default k8s version for E2E tests to 1.13

### DIFF
--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -49,7 +49,6 @@ EOF
                     cat >deployer-config.yml <<EOF
 id: gke-ci
 overrides:
-  kubernetesVersion: "1.12"
   clusterName: $BUILD_TAG
   vaultInfo:
     address: $VAULT_ADDR

--- a/build/ci/e2e/Jenkinsfile-aks
+++ b/build/ci/e2e/Jenkinsfile-aks
@@ -37,7 +37,6 @@ EOF
                     cat >deployer-config.yml <<EOF
 id: aks-ci
 overrides:
-  kubernetesVersion: "1.12.8"
   clusterName: $BUILD_TAG
   vaultInfo:
     address: $VAULT_ADDR

--- a/build/ci/e2e/custom_operator_image.jenkinsfile
+++ b/build/ci/e2e/custom_operator_image.jenkinsfile
@@ -37,7 +37,6 @@ EOF
                     cat >deployer-config.yml <<EOF
 id: gke-ci
 overrides:
-  kubernetesVersion: "1.12"
   clusterName: $BUILD_TAG
   vaultInfo:
     address: $VAULT_ADDR

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -18,7 +18,7 @@ plans:
   operation: create
   clusterName: dev
   provider: gke
-  kubernetesVersion: 1.12
+  kubernetesVersion: 1.13
   machineType: n1-standard-8
   serviceAccount: false
   psp: false
@@ -33,7 +33,7 @@ plans:
   operation: create
   clusterName: ci
   provider: aks
-  kubernetesVersion: 1.12.8
+  kubernetesVersion: 1.13.10
   machineType: Standard_D8s_v3
   serviceAccount: true
   psp: false


### PR DESCRIPTION
- Bump the k8s version in the plans.yml definition used by the deployer to `1.13`
- Remove `kubernetesVersion` from the CI job to use the default one provided 
by the deployer