### PR TITLE
Upload all CRDs flavors during the release

### DIFF
--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -56,6 +56,10 @@ yaml-upload:
 	@ $(MAKE) \
 		DOCKER_OPTS="-e AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) -e AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY)" \
 		DOCKER_CMD="aws s3 cp $(GO_MOUNT_PATH)/config/all-in-one-flavor-trivial-versions.yaml \
+		s3://download.elasticsearch.org/downloads/eck/$(TAG_NAME)/all-in-one-no-validation.yaml" ci-internal
+	@ $(MAKE) \
+		DOCKER_OPTS="-e AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) -e AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY)" \
+		DOCKER_CMD="aws s3 cp $(GO_MOUNT_PATH)/config/all-in-one-flavor-default.yaml \
 		s3://download.elasticsearch.org/downloads/eck/$(TAG_NAME)/all-in-one.yaml" ci-internal
 
 # reads Elastic public key from Vault into license.key


### PR DESCRIPTION
Upload the two different flavors of the CRDs to s3 during the release.

`config/all-in-one-flavor-default.yaml` is uploaded as `all-in-one.yaml` 
(and considered as the default all-in-one)
and 
`config/all-in-one-flavor-trivial-versions.yaml` is uploaded as `all-in-one-no-validation.yaml`.

Part of #1876. 