### PR TITLE
Remove remaining v1alpha1 references

### DIFF
--- a/pkg/controller/elasticsearch/driver/upgrade_forced.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_forced.go
@@ -9,7 +9,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
@@ -91,7 +91,7 @@ func allPodsBootlooping(pods []corev1.Pod) bool {
 			return false
 		}
 		for _, containerStatus := range p.Status.ContainerStatuses {
-			if containerStatus.Name == v1alpha1.ElasticsearchContainerName &&
+			if containerStatus.Name == v1beta1.ElasticsearchContainerName &&
 				containerStatus.RestartCount == 0 {
 				// the Pod may not be healthy, but it has not restarted (yet)
 				return false

--- a/test/e2e/es/forced_upgrade_test.go
+++ b/test/e2e/es/forced_upgrade_test.go
@@ -8,7 +8,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
+
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/name"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
@@ -110,7 +111,7 @@ func TestForceUpgradeBootloopingPods(t *testing.T) {
 			"Pods should have restarted at least once due to wrong ES config",
 			func(p corev1.Pod) error {
 				for _, containerStatus := range p.Status.ContainerStatuses {
-					if containerStatus.Name != v1alpha1.ElasticsearchContainerName {
+					if containerStatus.Name != v1beta1.ElasticsearchContainerName {
 						continue
 					}
 					if containerStatus.RestartCount < 1 {
@@ -118,7 +119,7 @@ func TestForceUpgradeBootloopingPods(t *testing.T) {
 					}
 					return nil
 				}
-				return fmt.Errorf("container %s not found in pod %s", v1alpha1.ElasticsearchContainerName, p.Name)
+				return fmt.Errorf("container %s not found in pod %s", v1beta1.ElasticsearchContainerName, p.Name)
 			},
 		),
 		fixed,


### PR DESCRIPTION
This PR removes remaining `v1alpha1` references from the project in favor of `v1beta1`. They were only using `ElasticsearchContainerName`, which has not changed, so there should be no problem. Related to #1783