### PR TITLE
Apply pod security policy to naming test

### DIFF
--- a/test/e2e/es/naming_test.go
+++ b/test/e2e/es/naming_test.go
@@ -51,11 +51,11 @@ func testLongestPossibleName(t *testing.T) {
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
 		WithNamespace(test.Ctx().ManagedNamespace(0)).
 		WithVersion(test.Ctx().ElasticStackVersion).
-		WithRestrictedSecurityContext().
 		WithNodeSpec(estype.NodeSet{
 			Name:  nodeSpecName,
 			Count: 1,
-		})
+		}).
+		WithRestrictedSecurityContext()
 
 	kbNamePrefix := strings.Join([]string{esNamePrefix, "kb"}, "-")
 	kbName := strings.Join([]string{kbNamePrefix, strings.Repeat("x", name.MaxResourceNameLength-len(kbNamePrefix)-1)}, "-")
@@ -88,11 +88,11 @@ func testRejectionOfLongName(t *testing.T) {
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
 		WithNamespace(test.Ctx().ManagedNamespace(0)).
 		WithVersion(test.Ctx().ElasticStackVersion).
-		WithRestrictedSecurityContext().
 		WithNodeSpec(estype.NodeSet{
 			Name:  "default",
 			Count: 1,
-		})
+		}).
+		WithRestrictedSecurityContext()
 
 	objectCreated := false
 


### PR DESCRIPTION
Switches the order of methods called on the builder so that the default pod security policy gets applied to all node sets.

Fixes #1902 