### PR TITLE
Remove ineffective initialisation of REPOSITORY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,6 @@ endif
 # on GKE, use GCR and GCLOUD_PROJECT
 ifneq ($(findstring gke_,$(KUBECTL_CLUSTER)),)
 	REGISTRY ?= eu.gcr.io
-	ifeq ($(REGISTRY),eu.gcr.io)
-	REPOSITORY = $(GCLOUD_PROJECT)
-	endif
 else
 	# default to local registry
 	REGISTRY ?= localhost:5000

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ endif
 # on GKE, use GCR and GCLOUD_PROJECT
 ifneq ($(findstring gke_,$(KUBECTL_CLUSTER)),)
 	REGISTRY ?= eu.gcr.io
-	REPOSITORY ?= $(GCLOUD_PROJECT)
+	REPOSITORY = $(GCLOUD_PROJECT)
 else
 	# default to local registry
 	REGISTRY ?= localhost:5000

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,9 @@ endif
 # on GKE, use GCR and GCLOUD_PROJECT
 ifneq ($(findstring gke_,$(KUBECTL_CLUSTER)),)
 	REGISTRY ?= eu.gcr.io
+	ifeq ($(REGISTRY),eu.gcr.io)
 	REPOSITORY = $(GCLOUD_PROJECT)
+	endif
 else
 	# default to local registry
 	REGISTRY ?= localhost:5000


### PR DESCRIPTION
This was conditionally initialised if REPOSITORY was not set, but it is always set at the beginning of the Makefile and I think we always want the GCLOUD_PROJECT when using eu.gcr.io