### PR TITLE
Make ECK requirements more explicit

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -14,7 +14,7 @@ Eager to get started? This quick guide shows you how to:
 
 **Supported versions**
 
-* link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl] version 1.11+
+* link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl] 1.11+
 * Kubernetes: 1.11+
 * Elasticsearch: 6.8+, 7.1+
 

--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -14,7 +14,6 @@ Eager to get started? This quick guide shows you how to:
 
 **Supported versions**
 
-Before you start, make sure that you have the following versions installed:
 * link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl] version 1.11+ installed
 * Kubernetes: 1.11+
 * Elasticsearch: 6.8+, 7.1+

--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -12,9 +12,12 @@ Eager to get started? This quick guide shows you how to:
 * <<{p}-persistent-storage,Use persistent storage>>
 * <<{p}-check-samples,Check out the samples>>
 
-**Requirements**
+**Supported versions**
 
-Make sure that you have link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl] version 1.11+ installed.
+Before you start, make sure that you have:
+* link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl] version 1.11+ installed
+* Kubernetes: 1.11+
+* Elasticsearch: 6.8+, 7.1+
 
 [float]
 [id="{p}-deploy-eck"]

--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -14,7 +14,7 @@ Eager to get started? This quick guide shows you how to:
 
 **Supported versions**
 
-Before you start, make sure that you have:
+Before you start, make sure that you have the following versions installed:
 * link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl] version 1.11+ installed
 * Kubernetes: 1.11+
 * Elasticsearch: 6.8+, 7.1+

--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -14,7 +14,7 @@ Eager to get started? This quick guide shows you how to:
 
 **Supported versions**
 
-* link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl] version 1.11+ installed
+* link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl] version 1.11+
 * Kubernetes: 1.11+
 * Elasticsearch: 6.8+, 7.1+
 


### PR DESCRIPTION
Rationale:
Considering the different places from where the Quickstart is already referenced as starting point for ECK, I would recommend to keep the requirements-related info in the Quickstart.

- Copied the supported stack versions + supported k8s versions from the Readme to the QuickStart.
- It doesn't hurt to leave this info in the repo Readme as well

Fixes #1858
Relates to #1846