### PR TITLE
Add statefulsets info in eck-dump tool

### DIFF
--- a/hack/eck-dump.sh
+++ b/hack/eck-dump.sh
@@ -102,6 +102,7 @@ main() {
 
   # get info from the namespaces in which resources are managed 
   for ns in $RESOURCES_NS; do
+    get_resources $ns statefulsets
     get_resources $ns replicasets
     get_resources $ns deployments
     get_resources $ns pods


### PR DESCRIPTION
This commit updates the `eck-dump` tool to get all the statefulsets info 
from the namespaces in which resources are managed.