### PR TITLE
Remove global operator webhook cert secret

### DIFF
--- a/config/operator/all-in-one/operator.template.yaml
+++ b/config/operator/all-in-one/operator.template.yaml
@@ -44,19 +44,4 @@ spec:
         - containerPort: 9876
           name: webhook-server
           protocol: TCP
-        volumeMounts:
-        - mountPath: /tmp/cert
-          name: cert
-          readOnly: true
       terminationGracePeriodSeconds: 10
-      volumes:
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: webhook-server-secret
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: webhook-server-secret
-  namespace: <NAMESPACE>

--- a/config/operator/global/operator.template.yaml
+++ b/config/operator/global/operator.template.yaml
@@ -44,19 +44,5 @@ spec:
         - containerPort: 9876
           name: webhook-server
           protocol: TCP
-        volumeMounts:
-        - mountPath: /tmp/cert
-          name: cert
-          readOnly: true
       terminationGracePeriodSeconds: 10
-      volumes:
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: webhook-server-secret
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: webhook-server-secret
-  namespace: <NAMESPACE>
+


### PR DESCRIPTION
We don't need it anymore. it's already removed from the namespace
operator config.