### PR TITLE
Reorder E2E tests checks

### DIFF
--- a/test/e2e/test/elasticsearch/checks_es.go
+++ b/test/e2e/test/elasticsearch/checks_es.go
@@ -30,7 +30,6 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 	return test.StepList{
 		e.CheckESNodesTopology(b.Elasticsearch),
 		e.CheckESVersion(b.Elasticsearch),
-		e.CheckESReachable(),
 		e.CheckESHealthGreen(),
 	}
 }
@@ -38,24 +37,6 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 func (e *esClusterChecks) newESClient() (client.Client, error) {
 	// recreate ES client for tests that switch between TlS/no TLS
 	return NewElasticsearchClient(e.es, e.k)
-}
-
-func (e *esClusterChecks) CheckESReachable() test.Step {
-	return test.Step{
-		Name: "ES cluster health endpoint should eventually be reachable",
-		Test: test.Eventually(func() error {
-			ctx, cancel := context.WithTimeout(context.Background(), client.DefaultReqTimeout)
-			defer cancel()
-			esClient, err := e.newESClient()
-			if err != nil {
-				return err
-			}
-			if _, err := esClient.GetClusterHealth(ctx); err != nil {
-				return err
-			}
-			return nil
-		}),
-	}
 }
 
 func (e *esClusterChecks) CheckESVersion(es estype.Elasticsearch) test.Step {

--- a/test/e2e/test/elasticsearch/checks_es.go
+++ b/test/e2e/test/elasticsearch/checks_es.go
@@ -28,10 +28,10 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 		k:  k,
 	}
 	return test.StepList{
-		e.CheckESReachable(),
-		e.CheckESVersion(b.Elasticsearch),
-		e.CheckESHealthGreen(),
 		e.CheckESNodesTopology(b.Elasticsearch),
+		e.CheckESVersion(b.Elasticsearch),
+		e.CheckESReachable(),
+		e.CheckESHealthGreen(),
 	}
 }
 


### PR DESCRIPTION
Run `CheckESNodesTopology` and `CheckESVersion` 
before `CheckESHealthGreen` and `CheckESReachable`
to avoid a race condition between these checks and
the operator when running mutation tests.
The race condition can cause these checks to be run against an old
(unmutated) cluster which is not intended. The topology and the version
can be validated whether expected pods are actually there.

Part of #1825.