### PR TITLE
Recreate Elasticsearch client in ContinuousHealthCheck

### DIFF
--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -31,7 +31,7 @@ func TestMutationHTTPToHTTPS(t *testing.T) {
 // then mutates it to a 3 node cluster running without TLS on the HTTP layer.
 func TestMutationHTTPSToHTTP(t *testing.T) {
 	// create a 3 md node cluster
-	b := elasticsearch.NewBuilder("test-mutation-http-to-https").
+	b := elasticsearch.NewBuilder("test-mutation-https-to-http").
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
 
 	// mutate to http

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -191,6 +191,7 @@ func (hc *ContinuousHealthCheck) Start() {
 				return
 			case <-ticker.C:
 				ctx, cancel := context.WithTimeout(context.Background(), continuousHealthCheckTimeout)
+				// recreate the Elasticsearch client at each iteration, since we may have switched protocol from http to https during the mutation
 				client, err := hc.esClientFactory()
 				if err != nil {
 					// treat client creation failure same as unavailable cluster

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -152,24 +152,22 @@ type ContinuousHealthCheckFailure struct {
 // ContinuousHealthCheck continuously runs health checks against Elasticsearch
 // during the whole mutation process
 type ContinuousHealthCheck struct {
-	b            Builder
-	SuccessCount int
-	FailureCount int
-	Failures     []ContinuousHealthCheckFailure
-	stopChan     chan struct{}
-	esClient     esclient.Client
+	b               Builder
+	SuccessCount    int
+	FailureCount    int
+	Failures        []ContinuousHealthCheckFailure
+	stopChan        chan struct{}
+	esClientFactory func() (esclient.Client, error)
 }
 
 // NewContinuousHealthCheck sets up a ContinuousHealthCheck struct
 func NewContinuousHealthCheck(b Builder, k *test.K8sClient) (*ContinuousHealthCheck, error) {
-	esClient, err := NewElasticsearchClient(b.Elasticsearch, k)
-	if err != nil {
-		return nil, err
-	}
 	return &ContinuousHealthCheck{
 		b:        b,
 		stopChan: make(chan struct{}),
-		esClient: esClient,
+		esClientFactory: func() (esclient.Client, error) {
+			return NewElasticsearchClient(b.Elasticsearch, k)
+		},
 	}, nil
 }
 
@@ -193,8 +191,13 @@ func (hc *ContinuousHealthCheck) Start() {
 				return
 			case <-ticker.C:
 				ctx, cancel := context.WithTimeout(context.Background(), continuousHealthCheckTimeout)
+				client, err := hc.esClientFactory()
+				if err != nil {
+					// treat client creation failure same as unavailable cluster
+					hc.AppendErr(err)
+				}
 				defer cancel()
-				health, err := hc.esClient.GetClusterHealth(ctx)
+				health, err := client.GetClusterHealth(ctx)
 				if err != nil {
 					// Could not retrieve cluster health, can happen when the master node is killed
 					// during a rolling upgrade. We allow it, unless it lasts for too long.


### PR DESCRIPTION
During tests that change the scheme from HTTPS to HTTP and vice versa, we ran into test errors because the client running the continuous health check was using the incorrect scheme. 

This changes the client to  be recreated on each iteration to auto-detect the correct scheme based on the Pods in the cluster. 

There is a small window where we still would use the wrong scheme while the go-client cache is not reflecting the current Pods. Initially I had:

```go
if err.Error() == "http: server gave HTTP response to HTTPS client" {
						// When switching scheme we might see intermittent TLS level errors like this one. While we derive
						// the scheme to use from the Pods in the cluster, a scheme change might go unnoticed initially due
						// to lag introduced by the go-client cache.
						continue
					}
```
to catch that but I opted to remove it again. This way we can 
* see how often we actually run into that error
* given that we allow for brief unavailability intervals we should be able handle the cache inconsistency without failure

If this turns out to be a problem we could add it in again and drop these errors but then we would need some logging to surface the fact that we are seeing these which I think is a a bit of  anti-pattern in test code (who looks at logs unless the test fails?) 