### PR TITLE
Only delete disk relevant to a cluster

### DIFF
--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
         }
         cleanup {
             script {
-                clusters = ["${BUILD_TAG}-12", "${BUILD_TAG}-13", "${BUILD_TAG}-14"]
+                clusters = ["eck-gke12-${BUILD_NUMBER}-e2e", "eck-gke13-${BUILD_NUMBER}-e2e", "eck-gke14-${BUILD_NUMBER}-e2e"]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
                         parameters: [string(name: 'GKE_CLUSTER', value: clusters[i])],

--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runWith('1.12', "${BUILD_TAG}-12")
+                        runWith('1.12', "eck-gke12-${BUILD_NUMBER}-e2e")
                     }
                 }
                 stage("1.13") {
@@ -33,7 +33,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runWith('1.13', "${BUILD_TAG}-13")
+                        runWith('1.13', "eck-gke13-${BUILD_NUMBER}-e2e")
                     }
                 }
                 stage("1.14") {
@@ -42,7 +42,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runWith('1.14', "${BUILD_TAG}-14")
+                        runWith('1.14', "eck-gke14-${BUILD_NUMBER}-e2e")
                     }
                 }
             }

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
         }
         cleanup {
             script {
-                clusters = ["${BUILD_TAG}-682", "${BUILD_TAG}-711", "${BUILD_TAG}-721", "${BUILD_TAG}-731", "${BUILD_TAG}-740"]
+                clusters = ["eck-682-${BUILD_NUMBER}-e2e", "eck-711-${BUILD_NUMBER}-e2e", "eck-721-${BUILD_NUMBER}-e2e", "eck-731-${BUILD_NUMBER}-e2e", "eck-740-${BUILD_NUMBER}-e2e"]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
                         parameters: [string(name: 'GKE_CLUSTER', value: clusters[i])],

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
                 stage("6.8.2") {
                     steps {
                         checkout scm
-                        runWith("${BUILD_TAG}-682", "6.8.2")
+                        runWith("eck-682-${BUILD_NUMBER}-e2e", "6.8.2")
                     }
                 }
                 stage("7.1.1") {
@@ -30,7 +30,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runWith("${BUILD_TAG}-711", "7.1.1")
+                        runWith("eck-711-${BUILD_NUMBER}-e2e", "7.1.1")
                     }
                 }
                 stage("7.2.1") {
@@ -39,7 +39,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runWith("${BUILD_TAG}-721", "7.2.1")
+                        runWith("eck-721-${BUILD_NUMBER}-e2e", "7.2.1")
                     }
                 }
                 stage("7.3.1") {
@@ -48,7 +48,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runWith("${BUILD_TAG}-731", "7.3.1")
+                        runWith("eck-731-${BUILD_NUMBER}-e2e", "7.3.1")
                     }
                 }
                 stage("7.4.0") {
@@ -57,7 +57,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runWith("${BUILD_TAG}-740", "7.4.0")
+                        runWith("eck-740-${BUILD_NUMBER}-e2e", "7.4.0")
                     }
                 }
             }

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -97,7 +97,7 @@ EOF
             script {
                 if (notOnlyDocs()) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
-                        parameters: [string(name: 'GKE_CLUSTER', value: "${BUILD_TAG}")],
+                        parameters: [string(name: 'GKE_CLUSTER', value: "eck-pr-${BUILD_NUMBER}")],
                         wait: false
                 }
             }

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
 id: gke-ci
 overrides:
   kubernetesVersion: "1.12"
-  clusterName: $BUILD_TAG
+  clusterName: eck-pr-$BUILD_NUMBER
   vaultInfo:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -19,7 +19,7 @@ const (
 
 var (
 	// GKE uses 18 chars to prefix the pvc created by a cluster
-	PvcPrefixMaxLength = 18
+	pvcPrefixMaxLength = 18
 )
 
 func init() {
@@ -36,8 +36,8 @@ type GkeDriver struct {
 
 func (gdf *GkeDriverFactory) Create(plan Plan) (Driver, error) {
 	pvcPrefix := plan.ClusterName
-	if len(pvcPrefix) > PvcPrefixMaxLength {
-		pvcPrefix = pvcPrefix[0:PvcPrefixMaxLength]
+	if len(pvcPrefix) > pvcPrefixMaxLength {
+		pvcPrefix = pvcPrefix[0:pvcPrefixMaxLength]
 	}
 	return &GkeDriver{
 		plan: plan,


### PR DESCRIPTION
This is an attempt to fix #1722 

Only the first 18 characters of a cluster name are used in the disk names. This PR helps keep the meaningful information at the beginning of the cluster name. 

I have not been able to test everything, hope it will not introduce some other issues.
