### PR TITLE
Disable serving prometheus metrics by default

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -45,7 +45,7 @@ import (
 
 const (
 	MetricsPortFlag   = "metrics-port"
-	DefaultMetricPort = 8080
+	DefaultMetricPort = 0 // disabled
 
 	AutoPortForwardFlagName = "auto-port-forward"
 	NamespaceFlagName       = "namespace"
@@ -217,15 +217,12 @@ func execute() {
 		Namespace: viper.GetString(NamespaceFlagName),
 	}
 
-	// only expose prometheus metrics if provided a specific port
+	// only expose prometheus metrics if provided a non-zero port
 	metricsPort := viper.GetInt(MetricsPortFlag)
 	if metricsPort != 0 {
 		log.Info("Exposing Prometheus metrics on /metrics", "port", metricsPort)
-		opts.MetricsBindAddress = fmt.Sprintf(":%d", metricsPort)
-	} else {
-		// disable metrics
-		opts.MetricsBindAddress = "0"
 	}
+	opts.MetricsBindAddress = fmt.Sprintf(":%d", metricsPort) // 0 to disable
 
 	mgr, err := ctrl.NewManager(cfg, opts)
 	if err != nil {

--- a/docs/operator-config.asciidoc
+++ b/docs/operator-config.asciidoc
@@ -10,7 +10,7 @@ The operator exposes several configuration options. Unless otherwise noted, they
 
 |log-verbosity |int |0 |Verbosity level of logs. -2=Error, -1=Warn, 0=Info, >0=Debug
 |enable-debug-logs |bool |false |Enables debug logs. Equivalent to `log-verbosity=1`
-|metrics-port |int |8080 |Port to use for exposing metrics in the Prometheus format. Set 0 to disable
+|metrics-port |int |0 |Port to use for exposing metrics in the Prometheus format. Set 0 to disable
 |operator-roles |[]string |all |Roles this operator should assume. Valid values are namespace, global, webhook or all. Accepts multiple comma separated values. See <<{p}-ns-config>> for more information
 |namespace |string |`""` |Namespace in which this operator should manage resources. Defaults to all namespaces. See <<{p}-ns-config>> for more information
 |ca-cert-validity |duration (string) |1y |Duration representing how long before a newly created CA cert expires


### PR DESCRIPTION
We recently fixed how the metrics flag passed with "0" disables prometheus metrics.
But kept the default value of 8080, which means metrics are enabled by
default.
I think this should be opt-in. The port is not set in the operator pod
resource anyway.