### PR TITLE
Fix quickstart phase

### DIFF
--- a/docs/k8s-quickstart.asciidoc
+++ b/docs/k8s-quickstart.asciidoc
@@ -83,10 +83,10 @@ kubectl get elasticsearch
 [source,sh,subs="attributes"]
 ----
 NAME          HEALTH    NODES     VERSION   PHASE         AGE
-quickstart    green     1         {version}     Operational   1m
+quickstart    green     1         {version}     Ready   1m
 ----
 
-When you create the cluster, there is no `HEALTH` status and the `PHASE` is `Pending`. After a while, the `PHASE` turns into `Operational`, and `HEALTH` becomes `green`.
+When you create the cluster, there is no `HEALTH` status and the `PHASE` is empty. After a while, the `PHASE` turns into `Ready`, and `HEALTH` becomes `green`.
 
 You can see that one Pod is in the process of being started:
 


### PR DESCRIPTION
We now use Phase "Ready" instead of "Operational".
When the cluster is initially created, its phase is empty.