### PR TITLE
Use short name for all e2e jobs

### DIFF
--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -49,7 +49,7 @@ EOF
                     cat >deployer-config.yml <<EOF
 id: gke-ci
 overrides:
-  clusterName: $BUILD_TAG
+  clusterName: eck-e2e-$BUILD_NUMBER
   vaultInfo:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
@@ -78,7 +78,7 @@ EOF
             script {
                 if (notOnlyDocs()) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
-                        parameters: [string(name: 'GKE_CLUSTER', value: "${BUILD_TAG}")],
+                        parameters: [string(name: 'GKE_CLUSTER', value: "eck-e2e-${BUILD_NUMBER}")],
                         wait: false
                 }
             }


### PR DESCRIPTION
Sorry for the noise :( 
This is the last use of `BUILD_TAG` in a GKE Jenkins files