### PR TITLE
Clarify node type in docs

### DIFF
--- a/docs/accessing-elastic-services.asciidoc
+++ b/docs/accessing-elastic-services.asciidoc
@@ -92,7 +92,7 @@ hulk-kb-http        LoadBalancer   10.19.247.151   35.242.197.228   5601:31380/T
 [id="{p}-tls-certificates"]
 === TLS Certificates
 
-This section only covers TLS certificates for the HTTP layer. Those for the transport layer used for Elasticsearch internal communication between nodes in a cluster are managed by ECK and are not configurable.
+This section only covers TLS certificates for the HTTP layer. Those for the transport layer used for Elasticsearch internal communication between Elasticsearch nodes in a cluster are managed by ECK and are not configurable.
 
 [float]
 [id="{p}-default-self-signed-certificate"]

--- a/docs/advanced-node-scheduling.asciidoc
+++ b/docs/advanced-node-scheduling.asciidoc
@@ -258,7 +258,7 @@ spec:
 This example relies on:
 
 - Kubernetes nodes in each zone being labeled accordingly. `failure-domain.beta.kubernetes.io/zone` link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#interlude-built-in-node-labels[is standard], but any label can be used.
-- node affinity for each group of nodes set to match the Kubernetes node's zone.
+- node affinity for each group of nodes set to match the Kubernetes nodes' zone.
 - Elasticsearch configured to link:https://www.elastic.co/guide/en/elasticsearch/reference/current/allocation-awareness.html#allocation-awareness[allocate shards based on node attributes]. Here we specified `node.attr.zone`, but any attribute name can be used. `node.attr.rack_id` is another common example.
 
 [float]

--- a/docs/advanced-node-scheduling.asciidoc
+++ b/docs/advanced-node-scheduling.asciidoc
@@ -7,7 +7,7 @@ endif::[]
 
 === Advanced Elasticsearch node scheduling
 
-Elastic Cloud on Kubernetes (ECK) offers full control over cluster nodes scheduling by combining Elasticsearch configuration with Kubernetes scheduling options:
+Elastic Cloud on Kubernetes (ECK) offers full control over Elasticsearch cluster nodes scheduling by combining Elasticsearch configuration with Kubernetes scheduling options:
 
 * <<{p}-define-elasticsearch-nodes-roles,Define Elasticsearch nodes roles>>
 * <<{p}-affinity-options,Pod affinity and anti-affinity>>
@@ -103,7 +103,7 @@ spec:
         affinity: {}
 ----
 
-The default affinity is using `preferredDuringSchedulingIgnoredDuringExecution`, which acts as best effort and won't prevent a node to be scheduled on a host if there are no other hosts available. Scheduling a 4-nodes Elasticsearch cluster on a 3-hosts Kubernetes cluster would then successfully schedule 2 nodes on the same host. To enforce a strict single node per host, specify `requiredDuringSchedulingIgnoredDuringExecution` instead:
+The default affinity is using `preferredDuringSchedulingIgnoredDuringExecution`, which acts as best effort and won't prevent an Elasticsearch node from being scheduled on a host if there are no other hosts available. Scheduling a 4-nodes Elasticsearch cluster on a 3-host Kubernetes cluster would then successfully schedule 2 Elasticsearch nodes on the same host. To enforce a strict single node per host, specify `requiredDuringSchedulingIgnoredDuringExecution` instead:
 
 [source,yaml,subs="attributes"]
 ----
@@ -131,7 +131,7 @@ spec:
 [float]
 ===== Local Persistent Volume constraints
 
-By default, volumes can be bound to a pod before the pod gets scheduled to a particular node. This can be a problem if the PersistentVolume can only be accessed from a particular host or set of hosts. Local persistent volumes are a good example: they are accessible from a single host. If the pod gets scheduled to a different host based on any affinity or anti-affinity rule, the volume may not be available.
+By default, volumes can be bound to a pod before the pod gets scheduled to a particular Kubernetes node. This can be a problem if the PersistentVolume can only be accessed from a particular host or set of hosts. Local persistent volumes are a good example: they are accessible from a single host. If the pod gets scheduled to a different host based on any affinity or anti-affinity rule, the volume may not be available.
 
 To solve this problem, you can link:https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode[set the Volume Binding Mode] of the `StorageClass` you are using. Make sure  `volumeBindingMode: WaitForFirstConsumer` is set, link:https://kubernetes.io/docs/concepts/storage/volumes/#local[especially if you are using local persistent volumes].
 
@@ -148,7 +148,7 @@ volumeBindingMode: WaitForFirstConsumer
 [float]
 ===== Node affinity
 
-To restrict the scheduling to a particular set of nodes based on labels, use a link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector[NodeSelector].
+To restrict the scheduling to a particular set of Kubernetes nodes based on labels, use a link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector[NodeSelector].
 The following example schedules Elasticsearch pods on Kubernetes nodes tagged with both labels `diskType: ssd` and `environment: production`.
 
 [source,yaml,subs="attributes"]
@@ -204,7 +204,7 @@ spec:
                     - ssd
 ----
 
-This example restricts Elasticsearch nodes to be scheduled on Kubernetes hosts tagged with `environment: e2e` or `environment: production`. It favors nodes tagged with `diskType: ssd`.
+This example restricts Elasticsearch nodes from being scheduled on Kubernetes hosts tagged with `environment: e2e` or `environment: production`. It favors nodes tagged with `diskType: ssd`.
 
 [float]
 [id="{p}-availability-zone-awareness"]
@@ -257,8 +257,8 @@ spec:
 
 This example relies on:
 
-- nodes from each zone being labeled accordingly. `failure-domain.beta.kubernetes.io/zone` link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#interlude-built-in-node-labels[is standard], but any label can be used.
-- node affinity for each group of nodes set to match the Kubernetes nodes zone.
+- Kubernetes nodes in each zone being labeled accordingly. `failure-domain.beta.kubernetes.io/zone` link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#interlude-built-in-node-labels[is standard], but any label can be used.
+- node affinity for each group of nodes set to match the Kubernetes node's zone.
 - Elasticsearch configured to link:https://www.elastic.co/guide/en/elasticsearch/reference/current/allocation-awareness.html#allocation-awareness[allocate shards based on node attributes]. Here we specified `node.attr.zone`, but any attribute name can be used. `node.attr.rack_id` is another common example.
 
 [float]
@@ -342,11 +342,11 @@ spec:
         storageClassName: local-storage
 ----
 
-In this example, we configure two groups of nodes:
+In this example, we configure two groups of Elasticsearch nodes:
 
-- the first group has the `data` attribute set to `hot`. It is intended to run on hosts with high CPU resources and fast IO (SSD). Here we restrict pods to be scheduled on Kubernetes nodes labeled with `beta.kubernetes.io/instance-type: highio` (to adapt to your Kubernetes nodes labels).
-- the second group has the `data` attribute set to `warm`. It is intended to run on hosts with larger but maybe slower storage. Pods are restricted to be scheduled on nodes labeled with `beta.kubernetes.io/instance-type: highstorage`.
+- the first group has the `data` attribute set to `hot`. It is intended to run on hosts with high CPU resources and fast IO (SSD). Here we restrict pods to be scheduled on Kubernetes nodes labeled with `beta.kubernetes.io/instance-type: highio` (to adapt to your Kubernetes nodes' labels).
+- the second group has the `data` attribute set to `warm`. It is intended to run on hosts with larger but maybe slower storage. Pods are only able to be scheduled on nodes labeled with `beta.kubernetes.io/instance-type: highstorage`.
 
-NOTE: this example uses link:https://kubernetes.io/docs/concepts/storage/volumes/#local[Local Persistent Volumes] for both groups, but can be adapted to use high-performance volumes for `hot` nodes and high-storage volumes for `warm` nodes.
+NOTE: this example uses link:https://kubernetes.io/docs/concepts/storage/volumes/#local[Local Persistent Volumes] for both groups, but can be adapted to use high-performance volumes for `hot` Elasticsearch nodes and high-storage volumes for `warm` Elasticsearch nodes.
 
 Finally, setup link:https://www.elastic.co/guide/en/elasticsearch/reference/current/index-lifecycle-management.html[Index Lifecycle Management] policies on your indices, link:https://www.elastic.co/blog/implementing-hot-warm-cold-in-elasticsearch-with-index-lifecycle-management[optimizing for hot-warm architectures].

--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -425,7 +425,6 @@ Even if a `changeBudget` is specified, ECK makes sure that some invariants are m
 
 So under certain circumstances ECK ignores the change budget. For example, a safe migration from a 1-node cluster to another 1-node cluster can only be done by temporarily setting up a 2-node cluster.
 
-// TODO(sabo): update this
 It is possible to configure the `changeBudget` to optimize the reuse of persistent volumes, instead of migrating data across nodes. This feature is not supported yet, more details to come in the next release.
 
 [id="{p}-pod-disruption-budget"]

--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -80,7 +80,7 @@ See also: link:https://www.elastic.co/guide/en/elasticsearch/reference/current/h
 [id="{p}-node-configuration"]
 === Node configuration
 
-Any setting defined in the `elasticsearch.yml` configuration file can also be defined for each topology of nodes in the `spec.nodeSets[?].config` section.
+Any setting defined in the `elasticsearch.yml` configuration file can also be defined for set of Elasticsearch nodes in the `spec.nodeSets[?].config` section.
 
 [source,yaml]
 ----
@@ -260,8 +260,7 @@ $ kubectl create secret generic my-cert --from-file=ca.crt=tls.crt --from-file=t
 === Secure settings
 
 You can specify link:https://www.elastic.co/guide/en/elasticsearch/reference/current/secure-settings.html[secure settings] with Kubernetes secrets.
-The secrets should contain a key-value pair for each secure setting you want to add. Reference that secrets in the Elasticsearch
-resource specification for ECK to automatically inject those settings into the keystore on each node before it starts Elasticsearch.
+The secrets should contain a key-value pair for each secure setting you want to add. ECK automatically injects these settings into the keystore on each Elasticsearch node before it starts Elasticsearch.
 
 [source,yaml]
 ----
@@ -381,17 +380,17 @@ On any change, ECK reconciles Kubernetes resources towards the desired cluster d
 [id="{p}-change-budget"]
 ==== Change budget
 
-No downtime should be expected when the cluster topology changes. Shards on deprecated nodes are migrated away so the node can be safely removed.
+No downtime should be expected when the cluster topology changes. Shards on deprecated Elasticsearch nodes are migrated away so that the node can be safely removed.
 
-For example, to mutate a 3-nodes cluster with 16GB memory limit on each node to a 3-nodes cluster with 32GB memory limit on each node, ECK will:
+For example, to mutate a 3-node cluster with 16GB memory limit on each node to a 3-node cluster with 32GB memory limit on each node, ECK will:
 
-1. Add a new 32GB node: the cluster temporarily has 4 nodes
+1. Add a new 32GB Elasticsearch node: the cluster temporarily has 4 nodes
 2. Migrate data away from the first 16GB node
 3. Once data is migrated, remove the first 16GB node
 4. Follow the same steps for the 2 other 16GB nodes
 
 The cluster health stays green during the entire process.
-By default, only one extra node can be added on top of the expected ones. In the example above, a 3-nodes cluster may temporarily be composed of 4 nodes while data migration is in progress.
+By default, only one extra node can be added on top of the expected ones. In the example above, a 3-node cluster may temporarily be composed of 4 nodes while data migration is in progress.
 
 This behaviour can be controlled through the `changeBudget` section of the cluster specification `updateStrategy`. If not specified, it defaults to the following:
 
@@ -424,14 +423,15 @@ Even if a `changeBudget` is specified, ECK makes sure that some invariants are m
 * One master node alive
 * One data node alive
 
-So under certain circumstances ECK ignores the change budget. For example, a safe migration from a 1-node cluster to another 1-node cluster can only be done by temporarily setting up a 2-nodes cluster.
+So under certain circumstances ECK ignores the change budget. For example, a safe migration from a 1-node cluster to another 1-node cluster can only be done by temporarily setting up a 2-node cluster.
 
+// TODO(sabo): update this
 It is possible to configure the `changeBudget` to optimize the reuse of persistent volumes, instead of migrating data across nodes. This feature is not supported yet, more details to come in the next release.
 
 [id="{p}-pod-disruption-budget"]
 === Pod disruption budget
 
-A link:https://kubernetes.io/docs/tasks/run-application/configure-pdb/[Pod Disruption Budget] allows limiting disruptions on an existing set of Pods while the Kubernetes cluster administrator manages cluster nodes.
+A link:https://kubernetes.io/docs/tasks/run-application/configure-pdb/[Pod Disruption Budget] allows limiting disruptions on an existing set of Pods while the Kubernetes cluster administrator manages Kubernetes nodes.
 Elasticsearch makes sure some indices don't become unavailable.
 
 A default PDB of 1 `maxUnavailable` Pod on the entire cluster is enforced by default.

--- a/docs/managing-compute-resources.asciidoc
+++ b/docs/managing-compute-resources.asciidoc
@@ -6,7 +6,7 @@ endif::[]
 [id="{p}-managing-compute-resources"]
 == Managing compute resources
 
-In order to help the Kubernetes scheduler make better decisions about how to place pods in available nodes and ensure quality of service (QoS), it is recommended to specify the CPU and memory requirements for objects managed by the operator (Elasticsearch, Kibana or APM Server). In Kubernetes parlance, `requests` defines the minimum amount of resources that must be available for a pod to start and `limits` defines the maximum amount of resources that a pod is allowed to consume. For more information about how Kubernetes uses these hints, see: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/[Managing Compute Resources for Containers].
+In order to help the Kubernetes scheduler make better decisions about how to place pods in available Kubernetes nodes and ensure quality of service (QoS), it is recommended to specify the CPU and memory requirements for objects managed by the operator (Elasticsearch, Kibana or APM Server). In Kubernetes parlance, `requests` defines the minimum amount of resources that must be available for a pod to be scheduled and `limits` defines the maximum amount of resources that a pod is allowed to consume. For more information about how Kubernetes uses these hints, see: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/[Managing Compute Resources for Containers].
 
 [float]
 [id="{p}-compute-resources"]

--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -21,8 +21,8 @@ NOTE: Only Elasticsearch and Kibana are compatible with the `restricted` https:/
 === Before you begin
 
 . To run the instructions on this page, you must be a `system:admin` user or a user with the privileges to create Projects, CRDs, and RBAC resources at the cluster level.
-
-. Set virtual memory settings on the nodes.
+// TODO(sabo): update this with mmap example
+. Set virtual memory settings on the Kubernetes nodes.
 +
 Before deploying an Elasticsearch cluster with ECK, make sure you correctly applied the `vm.max_map_count` setting on all the nodes of your cluster. Pods created by ECK are likely to run with the `restricted` https://docs.openshift.com/container-platform/4.1/authentication/managing-security-context-constraints.html[Security Context Constraint] (SCC): they run with a limited set of privileges and cannot change this setting on the nodes that host them. For more details, see the Elasticsearch documentation on https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html[Virtual memory].
 

--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -21,7 +21,7 @@ NOTE: Only Elasticsearch and Kibana are compatible with the `restricted` https:/
 === Before you begin
 
 . To run the instructions on this page, you must be a `system:admin` user or a user with the privileges to create Projects, CRDs, and RBAC resources at the cluster level.
-// TODO(sabo): update this with mmap example
+
 . Set virtual memory settings on the Kubernetes nodes.
 +
 Before deploying an Elasticsearch cluster with ECK, make sure you correctly applied the `vm.max_map_count` setting on all the nodes of your cluster. Pods created by ECK are likely to run with the `restricted` https://docs.openshift.com/container-platform/4.1/authentication/managing-security-context-constraints.html[Security Context Constraint] (SCC): they run with a limited set of privileges and cannot change this setting on the nodes that host them. For more details, see the Elasticsearch documentation on https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html[Virtual memory].

--- a/docs/orchestration.asciidoc
+++ b/docs/orchestration.asciidoc
@@ -61,7 +61,7 @@ ECK handles smooth upgrades from one cluster specification to another. You can a
 
 Here are a few examples based on the Elasticsearch specification above:
 
-- To add five additional data nodes: change `count: 10` to `count: 15` in the `data-nodes` `NodeSet`.
+- To add five additional Elasticsearch data nodes: change `count: 10` to `count: 15` in the `data-nodes` `NodeSet`.
 - To increase the RAM memory limit of data nodes to 32Gi: link:k8s-managing-compute-resources.html[set a different resources limits] in the existing `data-nodes` `NodeSet` PodTemplate.
 - To replace dedicated master and dedicated data nodes by nodes having both master and data roles: replace the 2 existing `NodeSets` by a single one with a different name and the corresponding Elasticsearch configuration settings.
 - To upgrade Elasticsearch from version `7.2.0` to `7.3.0`: change the value in the `version` field.
@@ -117,7 +117,7 @@ If an Elasticsearch node holds the only copy of a shard, this shard becomes unav
 * Elasticsearch `Pods` may stay `Pending` during a rolling upgrade if the Kubernetes scheduler cannot re-schedule them back. This is especially important when using local `PersistentVolumes`. If the Kubernetes node bound to a local `PersistentVolume` does not have enough capacity to host an upgraded `Pod` which was temporarily removed, that `Pod` will stay Pending.
 
 * Rolling upgrades can only make progress if the Elasticsearch cluster health is green. It is risky to attempt upgrading a cluster in the yellow state as some shards could become completely unavailable and degrade the cluster health to red. ECK takes the cautionary approach of waiting for green health before progressing but advanced users may force an upgrade by manually deleting `Pods` themselves. The deleted `Pods` will be automatically recreated at the latest revision. There are two exceptions to this rule:
-** If all the nodes of a `NodeSet` are unavailable, probably caused by a misconfiguration, the operator ignores the cluster health and upgrades nodes of the `NodeSet`.
+** If all the Elasticsearch nodes of a `NodeSet` are unavailable, probably caused by a misconfiguration, the operator ignores the cluster health and upgrades nodes of the `NodeSet`.
 ** If an Elasticsearch node to upgrade is not healthy, and not part of the Elasticsearch cluster, the operator ignores the cluster health and upgrades the Elasticsearch node.
 
 * Elasticsearch versions cannot be downgraded. For example it is impossible to downgrade an existing cluster from version 7.3.0 to 7.2.0. This is not supported by Elasticsearch.

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -27,7 +27,7 @@ Make sure that you have link:https://kubernetes.io/docs/tasks/tools/install-kube
 
 NOTE: If you are using GKE, make sure your user has `cluster-admin` permissions. For more information, see link:https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#iam-rolebinding-bootstrap[Prerequisites for using Kubernetes RBAC on GKE].
 
-NOTE: If you are using Amazon EKS, make sure the Kubernetes control plane is allowed to communicate with nodes port 443. This is required for communication with the Validating Webhook. For more information, see link:https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html[Recommended inbound traffic].
+NOTE: If you are using Amazon EKS, make sure the Kubernetes control plane is allowed to communicate with the Kubernetes nodes on port 443. This is required for communication with the Validating Webhook. For more information, see link:https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html[Recommended inbound traffic].
 
 . Install link:https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/[custom resource definitions] and the operator with its RBAC rules:
 +
@@ -47,9 +47,9 @@ kubectl -n elastic-system logs -f statefulset.apps/elastic-operator
 [id="{p}-deploy-elasticsearch"]
 === Deploy an Elasticsearch cluster
 
-Apply a simple link:{ref}/getting-started.html[Elasticsearch] cluster specification, with one node:
+Apply a simple link:{ref}/getting-started.html[Elasticsearch] cluster specification, with one Elasticsearchnode:
 
-NOTE: If your Kubernetes cluster does not have any nodes with at least 2GiB of free memory, the pod will be stuck in `Pending` state. See <<{p}-managing-compute-resources>> for more information about resource requirements and how to configure them.
+NOTE: If your Kubernetes cluster does not have any Kubernetes nodes with at least 2GiB of free memory, the pod will be stuck in `Pending` state. See <<{p}-managing-compute-resources>> for more information about resource requirements and how to configure them.
 
 [source,yaml,subs="attributes,+macros"]
 ----
@@ -244,7 +244,7 @@ kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | ba
 
 You can add and modify most elements of the original cluster specification provided that they translate to valid transformations of the underlying Kubernetes resources (e.g., existing volume claims cannot be resized). The operator will attempt to apply your changes with minimal disruption to the existing cluster. You should ensure that the Kubernetes cluster has sufficient resources to accommodate the changes (extra storage space, sufficient memory and CPU resources to temporarily spin up new pods etc.).
 
-For example, you can grow the cluster to three nodes:
+For example, you can grow the cluster to three Elasticsearch nodes:
 
 [source,yaml,subs="attributes,+macros"]
 ----

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -47,7 +47,7 @@ kubectl -n elastic-system logs -f statefulset.apps/elastic-operator
 [id="{p}-deploy-elasticsearch"]
 === Deploy an Elasticsearch cluster
 
-Apply a simple link:{ref}/getting-started.html[Elasticsearch] cluster specification, with one Elasticsearchnode:
+Apply a simple link:{ref}/getting-started.html[Elasticsearch] cluster specification, with one Elasticsearch node:
 
 NOTE: If your Kubernetes cluster does not have any Kubernetes nodes with at least 2GiB of free memory, the pod will be stuck in `Pending` state. See <<{p}-managing-compute-resources>> for more information about resource requirements and how to configure them.
 

--- a/docs/snapshots.asciidoc
+++ b/docs/snapshots.asciidoc
@@ -123,13 +123,13 @@ If you did not follow the instructions above and named your GCS credentials file
 kubectl apply -f elasticsearch.yml
 ----
 
-GCS credentials are automatically propagated into each node's keystore. It can take up to a few minutes, depending on the number of secrets in the keystore. You don't have to restart the nodes.
+GCS credentials are automatically propagated into each Elasticsearch node's keystore. It can take up to a few minutes, depending on the number of secrets in the keystore. You don't have to restart the nodes.
 
 [float]
 [id="{p}-create-repository"]
 ==== Register the repository in Elasticsearch
 
-. Create the GCS snapshot repository in Elasticsearch. You can either use the https://www.elastic.co/guide/en/kibana/current/snapshot-repositories.html[Snapshot and Restore UI] in Kibana added[7.4.0] or follow the procedure described in https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html[Snapshot and Restore]:
+. Create the GCS snapshot repository in Elasticsearch. You can either use the https://www.elastic.co/guide/en/kibana/current/snapshot-repositories.html[Snapshot and Restore UI] in Kibana (in version >= 7.4.0) or follow the procedure described in https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html[Snapshot and Restore]:
 
 +
 [source,sh]
@@ -155,9 +155,7 @@ PUT /_snapshot/my_gcs_repository/test-snapshot
 [id="{p}-setup-cronjob"]
 ==== Periodic snapshots with Snapshot Lifecycle Management
 
-added[7.4.0]
-
-You can use the https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshot-lifecycle-management-api.html[snapshot lifecycle management APIs] to manage policies for the time and frequency of automatic snapshots.
+You can use the https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshot-lifecycle-management-api.html[snapshot lifecycle management APIs] to manage policies for the time and frequency of automatic snapshots (in versions >= 7.4.0).
 
 The https://www.elastic.co/guide/en/kibana/current/snapshot-repositories.html[Snapshot and Restore UI] allows you to manage these policies directly in Kibana as well.
 

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -102,7 +102,7 @@ If you see an error with unbound persistent volume claims (PVCs), it means there
 === Get Elasticsearch logs
 
 Each Elasticsearch node name is mapped to the corresponding Pod name.
-To get the logs of a particular node, just fetch the Pod logs:
+To get the logs of a particular Elasticsearch node, just fetch the Pod logs:
 
 [source,sh]
 ----


### PR DESCRIPTION
Fix https://github.com/elastic/cloud-on-k8s/issues/1851

Clarifies if we mean K8s or ES nodes in the docs. Sometimes it leads to a little extra verbosity but overall seems worthwhile