### PR TITLE
Don't set a nil config that doesn't disable mmap in e2e tests

### DIFF
--- a/test/e2e/es/forced_upgrade_test.go
+++ b/test/e2e/es/forced_upgrade_test.go
@@ -96,9 +96,7 @@ func TestForceUpgradeBootloopingPods(t *testing.T) {
 		})
 
 	// fix that cluster to remove the wrong configuration
-	fixed := elasticsearch.Builder{}
-	fixed.Elasticsearch = *initial.Elasticsearch.DeepCopy()
-	fixed.Elasticsearch.Spec.NodeSets[0].Config = nil
+	fixed := initial.WithNoESTopology().WithESMasterDataNodes(3, elasticsearch.DefaultResources)
 
 	k := test.NewK8sClientOrFatal()
 	elasticsearch.ForcedUpgradeTestSteps(


### PR DESCRIPTION
The forced upgrade test resets the config to nil, which does not set the
disabled mmap setting. Resulting Pods of the mutated cluster do not
start, which fails the test.

Fix it by not manually setting the configuration, but rely on the
Builder functions instead.