### PR TITLE
Log validation errors

### DIFF
--- a/pkg/controller/common/validation/validation.go
+++ b/pkg/controller/common/validation/validation.go
@@ -6,9 +6,9 @@ package validation
 
 // Result contains validation results.
 type Result struct {
-	Error   error
+	Error   error `json:"error,omitempty"`
 	Allowed bool
-	Reason  string
+	Reason  string `json:"reason,omitempty"`
 }
 
 // OK is a successful validation result.

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -250,7 +250,8 @@ func (r *ReconcileElasticsearch) internalReconcile(
 	}
 	if len(violations) > 0 {
 		log.Error(
-			fmt.Errorf("manifest validation failed"), "Elasticsearch manifest validation failed",
+			fmt.Errorf("manifest validation failed"),
+			"Elasticsearch manifest validation failed",
 			"namespace", es.Namespace,
 			"es_name", es.Name,
 			"violations", violations,

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -249,6 +249,10 @@ func (r *ReconcileElasticsearch) internalReconcile(
 		return results.WithError(err)
 	}
 	if len(violations) > 0 {
+		log.Error(
+			fmt.Errorf("manifest validation failed"), "Elasticsearch manifest validation failed",
+			"violations", violations,
+		)
 		reconcileState.UpdateElasticsearchInvalid(violations)
 		return results
 	}

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -251,6 +251,8 @@ func (r *ReconcileElasticsearch) internalReconcile(
 	if len(violations) > 0 {
 		log.Error(
 			fmt.Errorf("manifest validation failed"), "Elasticsearch manifest validation failed",
+			"namespace", es.Namespace,
+			"es_name", es.Name,
 			"violations", violations,
 		)
 		reconcileState.UpdateElasticsearchInvalid(violations)


### PR DESCRIPTION
Fix #1939 

I have been tempted to add the `Stringer` interface to  `[]Result` in order to remove things like `"Error":null,` from the output but I'm not sure it is worth it...
Here is a sample result:

```
2019-10-09T11:07:34.933+0200	ERROR	elasticsearch-controller	Elasticsearch manifest validation failed	{"ver": "1.0.0-beta1-XXXX-00000000", "namespace": "elastic", "es_name": "elasticsearch-sample", "violations": [{"Error":null,"Allowed":false,"Reason":"Elasticsearch configuration would generate resources with invalid names: invalid nodeSet name '': [a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]"}], "error": "manifest validation failed"}
```