### PR TITLE
Disable mmap on all e2e tests relying on the Builder functions

### DIFF
--- a/test/e2e/es/naming_test.go
+++ b/test/e2e/es/naming_test.go
@@ -51,7 +51,7 @@ func testLongestPossibleName(t *testing.T) {
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
 		WithNamespace(test.Ctx().ManagedNamespace(0)).
 		WithVersion(test.Ctx().ElasticStackVersion).
-		WithNodeSpec(estype.NodeSet{
+		WithNodeSet(estype.NodeSet{
 			Name:  nodeSpecName,
 			Count: 1,
 		}).
@@ -88,7 +88,7 @@ func testRejectionOfLongName(t *testing.T) {
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
 		WithNamespace(test.Ctx().ManagedNamespace(0)).
 		WithVersion(test.Ctx().ElasticStackVersion).
-		WithNodeSpec(estype.NodeSet{
+		WithNodeSet(estype.NodeSet{
 			Name:  "default",
 			Count: 1,
 		}).

--- a/test/e2e/es/reversal_test.go
+++ b/test/e2e/es/reversal_test.go
@@ -49,7 +49,7 @@ func TestReversalStatefulSetRename(t *testing.T) {
 
 	copy := b.Elasticsearch.Spec.NodeSets[0]
 	copy.Name = "other"
-	renamed := b.WithNoESTopology().WithNodeSpec(copy)
+	renamed := b.WithNoESTopology().WithNodeSet(copy)
 
 	RunESMutationReversal(t, b, renamed)
 }
@@ -57,7 +57,7 @@ func TestReversalStatefulSetRename(t *testing.T) {
 func TestRiskyMasterReconfiguration(t *testing.T) {
 	b := elasticsearch.NewBuilder("test-sset-reconfig-reversal").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
-		WithNodeSpec(v1beta1.NodeSet{
+		WithNodeSet(v1beta1.NodeSet{
 			Name:  "other-master",
 			Count: 1,
 			Config: &common.Config{
@@ -71,7 +71,7 @@ func TestRiskyMasterReconfiguration(t *testing.T) {
 
 	// this currently breaks the cluster (something we might fix in the future at which point this just tests a temp downscale)
 	noMasterMaster := b.WithNoESTopology().WithESMasterDataNodes(1, elasticsearch.DefaultResources).
-		WithNodeSpec(v1beta1.NodeSet{
+		WithNodeSet(v1beta1.NodeSet{
 			Name:  "other-master",
 			Count: 1,
 			Config: &common.Config{

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -125,7 +125,7 @@ func (b Builder) WithNoESTopology() Builder {
 }
 
 func (b Builder) WithESMasterNodes(count int, resources corev1.ResourceRequirements) Builder {
-	return b.WithNodeSpec(estype.NodeSet{
+	return b.WithNodeSet(estype.NodeSet{
 		Name:  "master",
 		Count: int32(count),
 		Config: &commonv1beta1.Config{
@@ -138,7 +138,7 @@ func (b Builder) WithESMasterNodes(count int, resources corev1.ResourceRequireme
 }
 
 func (b Builder) WithESDataNodes(count int, resources corev1.ResourceRequirements) Builder {
-	return b.WithNodeSpec(estype.NodeSet{
+	return b.WithNodeSet(estype.NodeSet{
 		Name:  "data",
 		Count: int32(count),
 		Config: &commonv1beta1.Config{
@@ -151,7 +151,7 @@ func (b Builder) WithESDataNodes(count int, resources corev1.ResourceRequirement
 }
 
 func (b Builder) WithNamedESDataNodes(count int, name string, resources corev1.ResourceRequirements) Builder {
-	return b.WithNodeSpec(estype.NodeSet{
+	return b.WithNodeSet(estype.NodeSet{
 		Name:  name,
 		Count: int32(count),
 		Config: &commonv1beta1.Config{
@@ -164,21 +164,21 @@ func (b Builder) WithNamedESDataNodes(count int, name string, resources corev1.R
 }
 
 func (b Builder) WithESMasterDataNodes(count int, resources corev1.ResourceRequirements) Builder {
-	return b.WithNodeSpec(estype.NodeSet{
+	return b.WithNodeSet(estype.NodeSet{
 		Name:        "masterdata",
 		Count:       int32(count),
 		PodTemplate: ESPodTemplate(resources),
 	})
 }
 
-func (b Builder) WithNodeSpec(nodeSpec estype.NodeSet) Builder {
+func (b Builder) WithNodeSet(nodeSet estype.NodeSet) Builder {
 	// Make sure the config specifies "node.store.allow_mmap: false".
-	// We disable mmap to avoid having to set the vm.max_map_count sysctl on test nodes.
-	if nodeSpec.Config == nil {
-		nodeSpec.Config = &commonv1beta1.Config{Data: map[string]interface{}{}}
+	// We disable mmap to avoid having to set the vm.max_map_count sysctl on test k8s nodes.
+	if nodeSet.Config == nil {
+		nodeSet.Config = &commonv1beta1.Config{Data: map[string]interface{}{}}
 	}
-	nodeSpec.Config.Data["node.store.allow_mmap"] = false
-	b.Elasticsearch.Spec.NodeSets = append(b.Elasticsearch.Spec.NodeSets, nodeSpec)
+	nodeSet.Config.Data["node.store.allow_mmap"] = false
+	b.Elasticsearch.Spec.NodeSets = append(b.Elasticsearch.Spec.NodeSets, nodeSet)
 	return b
 }
 


### PR DESCRIPTION
Disable `node.store.allow_mmap` in `WithNodeSet()`, which is indirectly called by almost all E2E tests.
Also rename `WithNodeSpec()` to `WithNodeSet()`.