### PR TITLE
Check expected Pods in E2E tests

### DIFF
--- a/pkg/controller/elasticsearch/name/name.go
+++ b/pkg/controller/elasticsearch/name/name.go
@@ -91,8 +91,8 @@ func Validate(es v1beta1.Elasticsearch) error {
 }
 
 // StatefulSet returns the name of the StatefulSet corresponding to the given NodeSet.
-func StatefulSet(esName string, nodeSpecName string) string {
-	return ESNamer.Suffix(esName, nodeSpecName)
+func StatefulSet(esName string, nodeSetName string) string {
+	return ESNamer.Suffix(esName, nodeSetName)
 }
 
 func ConfigSecret(ssetName string) string {

--- a/pkg/controller/elasticsearch/sset/list.go
+++ b/pkg/controller/elasticsearch/sset/list.go
@@ -135,7 +135,7 @@ func (l StatefulSetList) PVCNames() []string {
 func (l StatefulSetList) GetActualPods(c k8s.Client) ([]corev1.Pod, error) {
 	allPods := []corev1.Pod{}
 	for _, statefulSet := range l {
-		pods, err := GetActualPodsForStatefulSet(c, statefulSet)
+		pods, err := GetActualPodsForStatefulSet(c, k8s.ExtractNamespacedName(&statefulSet))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/elasticsearch/sset/pod.go
+++ b/pkg/controller/elasticsearch/sset/pod.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -39,7 +40,7 @@ func PodRevision(pod corev1.Pod) string {
 
 // GetActualPodsForStatefulSet returns the existing pods associated to this StatefulSet.
 // The returned pods may not match the expected StatefulSet replicas in a transient situation.
-func GetActualPodsForStatefulSet(c k8s.Client, sset appsv1.StatefulSet) ([]corev1.Pod, error) {
+func GetActualPodsForStatefulSet(c k8s.Client, sset types.NamespacedName) ([]corev1.Pod, error) {
 	var pods corev1.PodList
 	ns := client.InNamespace(sset.Namespace)
 	matchLabels := client.MatchingLabels(map[string]string{
@@ -82,7 +83,7 @@ func GetActualMastersForCluster(c k8s.Client, es v1beta1.Elasticsearch) ([]corev
 
 func PodReconciliationDoneForSset(c k8s.Client, statefulSet appsv1.StatefulSet) (bool, error) {
 	// check all expected pods are there: no more, no less
-	actualPods, err := GetActualPodsForStatefulSet(c, statefulSet)
+	actualPods, err := GetActualPodsForStatefulSet(c, k8s.ExtractNamespacedName(&statefulSet))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/elasticsearch/sset/pod_test.go
+++ b/pkg/controller/elasticsearch/sset/pod_test.go
@@ -85,7 +85,7 @@ func TestGetActualPodsForStatefulSet(t *testing.T) {
 	}
 	c := k8s.WrapClient(fake.NewFakeClient(objs...))
 	sset0 := getSsetSample("sset0", "ns0", "clus0")
-	pods, err := GetActualPodsForStatefulSet(c, sset0)
+	pods, err := GetActualPodsForStatefulSet(c, k8s.ExtractNamespacedName(&sset0))
 	require.NoError(t, err)
 	// only one pod is in the same stateful set and namespace
 	assert.Equal(t, 1, len(pods))

--- a/pkg/controller/elasticsearch/version/zen1/minimum_masters.go
+++ b/pkg/controller/elasticsearch/version/zen1/minimum_masters.go
@@ -56,7 +56,7 @@ func SetupMinimumMasterNodesConfig(
 			masters += int(sset.GetReplicas(resource.StatefulSet))
 		} else {
 			// Second situation: not a sset of masters, but we check if there are some of them waiting for a rolling upgrade
-			actualPods, err := sset.GetActualPodsForStatefulSet(c, resource.StatefulSet)
+			actualPods, err := sset.GetActualPodsForStatefulSet(c, k8s.ExtractNamespacedName(&resource.StatefulSet))
 			if err != nil {
 				return err
 			}

--- a/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/test/e2e/test/elasticsearch/checks_k8s.go
@@ -5,24 +5,37 @@
 package elasticsearch
 
 import (
+	"encoding/json"
 	"fmt"
+	"reflect"
+	"sort"
+	"testing"
 
 	estype "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	esname "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/name"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 )
+
+// BuilderHashAnnotation is the name of an annotation set by the E2E tests on Elasticsearch resources
+// containing the hash of their Builder, for comparison purposes (pre/post rolling upgrade).
+const BuilderHashAnnotation = "elasticsearch.k8s.elastic.co/e2e-builder-hash"
 
 func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
 	return test.StepList{
 		CheckCertificateAuthority(b, k),
+		CheckExpectedPodsEventuallyReady(b, k),
 		CheckESVersion(b, k),
-		CheckESPodsRunning(b, k),
 		CheckServices(b, k),
-		CheckESPodsReady(b, k),
 		CheckPodCertificates(b, k),
 		CheckServicesEndpoints(b, k),
 		CheckClusterHealth(b, k),
@@ -74,11 +87,6 @@ func CheckPodCertificates(b Builder, k *test.K8sClient) test.Step {
 }
 
 // CheckESPodsRunning checks that all ES pods for the given ES are running
-func CheckESPodsRunning(b Builder, k *test.K8sClient) test.Step {
-	return checkESPodsPhase(b, k, corev1.PodRunning)
-}
-
-// CheckESPodsRunning checks that all ES pods for the given ES are running
 func CheckESPodsPending(b Builder, k *test.K8sClient) test.Step {
 	return checkESPodsPhase(b, k, corev1.PodPending)
 }
@@ -113,7 +121,6 @@ func CheckPodsCondition(b Builder, k *test.K8sClient, name string, condition fun
 }
 
 // CheckESVersion checks that the running ES version is the expected one
-// TODO: request ES endpoint instead, not the k8s implementation detail
 func CheckESVersion(b Builder, k *test.K8sClient) test.Step {
 	return test.Step{
 		Name: "ES version should be the expected one",
@@ -136,40 +143,6 @@ func CheckESVersion(b Builder, k *test.K8sClient) test.Step {
 			return nil
 		}),
 	}
-}
-
-// CheckESPodsReady retrieves ES pods from the given ES,
-// and check they are in status ready, until success
-func CheckESPodsReady(b Builder, k *test.K8sClient) test.Step {
-	return test.Step{
-		Name: "ES pods should eventually be ready",
-		Test: test.Eventually(func() error {
-			return allPodsReady(b, k)
-		}),
-	}
-}
-
-func allPodsReady(b Builder, k *test.K8sClient) error {
-	pods, err := k.GetPods(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name)...)
-	if err != nil {
-		return err
-	}
-	// check number of pods
-	if len(pods) != int(b.Elasticsearch.Spec.NodeCount()) {
-		return fmt.Errorf("expected %d pods, got %d", b.Elasticsearch.Spec.NodeCount(), len(pods))
-	}
-	// check pod statuses
-podsLoop:
-	for _, p := range pods {
-		for _, c := range p.Status.Conditions {
-			if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
-				// pod is ready, move on to next pod
-				continue podsLoop
-			}
-		}
-		return fmt.Errorf("pod %s is not ready yet. Phase: %s. Reason: %s", p.Name, p.Status.Phase, p.Status.Reason)
-	}
-	return nil
 }
 
 // CheckClusterHealth checks that the given ES status reports a green ES health
@@ -253,4 +226,155 @@ func CheckESPassword(b Builder, k *test.K8sClient) test.Step {
 			return nil
 		}),
 	}
+}
+
+func CheckExpectedPodsEventuallyReady(b Builder, k *test.K8sClient) test.Step {
+	return test.Step{
+		Name: "All expected Pods should eventually be ready",
+		Test: test.Eventually(func() error {
+			return checkExpectedPodsReady(b, k)
+		}),
+	}
+}
+
+// checkExpectedPodsReady checks that all expected Pods (no more, no less) are there, ready,
+// and that any rolling upgrade is over.
+// It does not check the entire spec of the Pods.
+func checkExpectedPodsReady(b Builder, k *test.K8sClient) error {
+	// check StatefulSets are expected
+	if err := checkStatefulSetsReplicas(b, k); err != nil {
+		return err
+	}
+	// for each StatefulSet, make sure all Pods are there and Ready
+	for _, nodeSet := range b.Elasticsearch.Spec.NodeSets {
+		// retrieve the corresponding StatefulSet
+		var statefulSet appsv1.StatefulSet
+		if err := k.Client.Get(
+			types.NamespacedName{
+				Namespace: b.Elasticsearch.Namespace,
+				Name:      esname.StatefulSet(b.Elasticsearch.Name, nodeSet.Name),
+			},
+			&statefulSet,
+		); err != nil {
+			return err
+		}
+		// the exact expected list of Pods (no more, no less) should exist
+		expectedPodNames := sset.PodNames(statefulSet)
+		actualPods, err := sset.GetActualPodsForStatefulSet(k.Client, k8s.ExtractNamespacedName(&statefulSet))
+		if err != nil {
+			return err
+		}
+		actualPodNames := make([]string, 0, len(actualPods))
+		for _, p := range actualPods {
+			actualPodNames = append(actualPodNames, p.Name)
+		}
+		// sort alphabetically for comparison purposes
+		sort.Strings(expectedPodNames)
+		sort.Strings(actualPodNames)
+		if !reflect.DeepEqual(expectedPodNames, actualPodNames) {
+			return fmt.Errorf("invalid Pods for StatefulSet %s: expected %v, got %v", statefulSet.Name, expectedPodNames, actualPodNames)
+		}
+
+		// all Pods should be running and ready
+		for _, p := range actualPods {
+			if !k8s.IsPodReady(p) {
+				// pretty-print status JSON
+				statusJSON, err := json.MarshalIndent(p.Status, "", "    ")
+				if err != nil {
+					return err
+				}
+				return fmt.Errorf("pod %s is not Ready.\nStatus:%s\n", p.Name, statusJSON)
+			}
+			// Pod should either:
+			// - be annotated with the hash of the current ES spec from previous E2E steps
+			// - not be annotated at all (if recreated/upgraded, or not a mutation)
+			// But **not** be annotated with the hash of a different ES spec, meaning
+			// it probably still matches the spec of the pre-mutation builder (rolling upgrade not over).
+			//
+			// Important: this does not catch rolling upgrades due to a keystore change, where the Builder hash
+			// would stay the same.
+			expectedHash := nodeSetHash(b.Elasticsearch, nodeSet)
+			if p.Annotations[BuilderHashAnnotation] != "" && p.Annotations[BuilderHashAnnotation] != expectedHash {
+				return fmt.Errorf("pod %s was not upgraded (yet?) to match the expected Elasticsearch specification", p.Name)
+			}
+		}
+	}
+	return nil
+}
+
+func checkStatefulSetsReplicas(b Builder, k *test.K8sClient) error {
+	// build names and replicas count of expected StatefulSets
+	expected := make(map[string]int32, len(b.Elasticsearch.Spec.NodeSets)) // map[StatefulSetName]Replicas
+	for _, nodeSet := range b.Elasticsearch.Spec.NodeSets {
+		expected[esname.StatefulSet(b.Elasticsearch.Name, nodeSet.Name)] = nodeSet.Count
+	}
+	statefulSets, err := k.GetESStatefulSets(b.Elasticsearch.Namespace, b.Elasticsearch.Name)
+	if err != nil {
+		return err
+	}
+	// compare with actual StatefulSets
+	actual := make(map[string]int32, len(statefulSets)) // map[StatefulSetName]Replicas
+	for _, statefulSet := range statefulSets {
+		actual[statefulSet.Name] = *statefulSet.Spec.Replicas // should not be nil
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		return fmt.Errorf("invalid StatefulSets: expected %v, got %v", expected, actual)
+	}
+	return nil
+}
+
+func AnnotatePodsWithBuilderHash(b Builder, k *test.K8sClient) []test.Step {
+	return []test.Step{
+		{
+			Name: "Annotate Pods with a hash of their Builder spec",
+			Test: func(t *testing.T) {
+				annotateWithRetries(b, k, t)
+			},
+		},
+		// make sure this is propagated to the local cache so next test steps can expect annotated pods
+		{
+			Name: "Wait for annotated Pods to appear in the cache",
+			Test: test.Eventually(func() error {
+				pods, err := sset.GetActualPodsForCluster(k.Client, b.Elasticsearch)
+				if err != nil {
+					return err
+				}
+				for _, p := range pods {
+					if p.Annotations[BuilderHashAnnotation] == "" {
+						return fmt.Errorf("pod %s is not annotated with %s yet", p.Name, BuilderHashAnnotation)
+					}
+				}
+				return nil
+			}),
+		},
+	}
+}
+
+func annotateWithRetries(b Builder, k *test.K8sClient, t *testing.T) {
+	es := b.Elasticsearch
+	for _, nodeSet := range b.Elasticsearch.Spec.NodeSets {
+		pods, err := sset.GetActualPodsForStatefulSet(k.Client, types.NamespacedName{
+			Namespace: es.Namespace,
+			Name:      esname.StatefulSet(es.Name, nodeSet.Name),
+		})
+		require.NoError(t, err)
+		for i := range pods {
+			pods[i].Annotations[BuilderHashAnnotation] = nodeSetHash(es, nodeSet)
+			err := k.Client.Update(&pods[i])
+			if err != nil && apierrors.IsConflict(err) {
+				// pod was updated concurrently, retry
+				annotateWithRetries(b, k, t)
+			} else {
+				require.NoError(t, err)
+			}
+		}
+	}
+}
+
+// nodeSetHash builds a hash of the nodeSet specification in the given ES resource.
+func nodeSetHash(es estype.Elasticsearch, nodeSet estype.NodeSet) string {
+	specHash := hash.HashObject(nodeSet)
+	esVersionHash := hash.HashObject(es.Spec.Version)
+	httpServiceHash := hash.HashObject(es.Spec.HTTP)
+	return hash.HashObject(specHash + esVersionHash + httpServiceHash)
 }

--- a/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/test/e2e/test/elasticsearch/checks_k8s.go
@@ -283,7 +283,7 @@ func checkExpectedPodsReady(b Builder, k *test.K8sClient) error {
 				if err != nil {
 					return err
 				}
-				return fmt.Errorf("pod %s is not Ready.\nStatus:%s\n", p.Name, statusJSON)
+				return fmt.Errorf("pod %s is not Ready.\nStatus:%s", p.Name, statusJSON)
 			}
 			// Pod should either:
 			// - be annotated with the hash of the current ES spec from previous E2E steps

--- a/test/e2e/test/elasticsearch/checks_keystore.go
+++ b/test/e2e/test/elasticsearch/checks_keystore.go
@@ -25,7 +25,7 @@ func CheckESKeystoreEntries(k *test.K8sClient, b Builder, expectedKeys []string)
 				return err
 			}
 			// wait for any ongoing rolling-upgrade to be over
-			if err := allPodsReady(b, k); err != nil {
+			if err := checkExpectedPodsReady(b, k); err != nil {
 				return err
 			}
 			if err := clusterHealthGreen(b, k); err != nil {

--- a/test/e2e/test/k8s_client.go
+++ b/test/e2e/test/k8s_client.go
@@ -24,6 +24,7 @@ import (
 	kblabel "github.com/elastic/cloud-on-k8s/pkg/controller/kibana/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -107,6 +108,18 @@ func (k *K8sClient) GetPod(namespace, name string) (corev1.Pod, error) {
 		return corev1.Pod{}, err
 	}
 	return pod, nil
+}
+
+func (k *K8sClient) GetESStatefulSets(namespace string, esName string) ([]appsv1.StatefulSet, error) {
+	var ssetList appsv1.StatefulSetList
+	if err := k.Client.List(&ssetList,
+		k8sclient.InNamespace(namespace),
+		k8sclient.MatchingLabels{
+			label.ClusterNameLabelName: esName,
+		}); err != nil {
+		return nil, err
+	}
+	return ssetList.Items, nil
 }
 
 func (k *K8sClient) DeletePod(pod corev1.Pod) error {


### PR DESCRIPTION
Add a function that looks at all StatefulSets and Pods in the k8s
cluster, and returns an error if:
* some pods are missing
* there are extra pods around
* pods are not ready yet
* pods that should have been upgraded are not upgraded (yet)

If some pods are not ready yet (eg. still Pending because they cannot
mount a PersistentVolume), we output a pretty-printed pod Status in the
error message, for easier human parsing.

This check runs before any other mutation check, so we ensure other
checks happen **after** the cluster has been mutated.

To check if the mutation correctly happened, the approach in this commit
is to:
* annotate pods before mutation with a "builder" hash of the corresponding ES
Version + HTTP Service spec + NodeSet spec
* make sure the hash of all existing ready Pods either matches the
expected builder hash (no mutation should happen), or is empty (pod was upgraded hence recreated with no annotation)

This does not catch upgrades due to keystore changes, but this test
has its own logic.

Fixes https://github.com/elastic/cloud-on-k8s/issues/1825 by waiting for upgraded Pods to be ready before doing any other mutation test.
Fixes https://github.com/elastic/cloud-on-k8s/issues/1925 by adding more context to the error returned for non-ready Pods.

Some sample errors returned that should help debugging failing E2E tests:

* When a Pod is Pending because its PersistentVolume cannot be mounted:

```
    Error:          Received unexpected error:
                                pod es-apm-sample-dvss-es-default-0 is not Ready.
                                Status:{
                                    "phase": "Pending",
                                    "conditions": [
                                        {
                                            "type": "PodScheduled",
                                            "status": "False",
                                            "lastProbeTime": "2019-10-09T12:28:16Z",
                                            "lastTransitionTime": "2019-10-09T12:26:51Z",
                                            "reason": "Unschedulable",
                                            "message": "pod has unbound immediate PersistentVolumeClaims (repeated 3 times)"
                                        }
                                    ],
                                    "qosClass": "Burstable"
                                }
```
* When a Pod is Pending because it cannot be scheduled (node mismatch):
```
Error:          Received unexpected error:
                                pod es-apm-sample-zq7z-es-default-0 is not Ready.
                                Status:{
                                    "phase": "Pending",
                                    "conditions": [
                                        {
                                            "type": "PodScheduled",
                                            "status": "False",
                                            "lastProbeTime": "2019-10-09T12:37:23Z",
                                            "lastTransitionTime": "2019-10-09T12:36:56Z",
                                            "reason": "Unschedulable",
                                            "message": "0/3 nodes are available: 3 node(s) didn't match node selector."
                                        }
                                    ],
                                    "qosClass": "Burstable"
                                }
```
* When a Pod is Pending because it cannot be scheduled (not enough resources available):
```

Error:          Received unexpected error:
                                pod es-apm-sample-zwmx-es-default-0 is not Ready.
                                Status:{
                                    "phase": "Pending",
                                    "conditions": [
                                        {
                                            "type": "PodScheduled",
                                            "status": "False",
                                            "lastProbeTime": "2019-10-09T12:39:23Z",
                                            "lastTransitionTime": "2019-10-09T12:39:03Z",
                                            "reason": "Unschedulable",
                                            "message": "0/3 nodes are available: 3 Insufficient cpu, 3 Insufficient memory."
                                        }
                                    ],
                                    "qosClass": "Guaranteed"
                                }
```
* When a rolling upgrade does not complete soon enough:
```
Error:          Received unexpected error:
                                pod test-mutation-resize-memory-up-qpk2-es-masterdata-0 was not upgraded (yet?) to match the expected Elasticsearch specification
                Test:           TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready#01
```