### PR TITLE
Generate XML test output for e2e tests and enable it for PR job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ integration-tests.json
 integration-tests.xml
 unit-tests.json
 unit-tests.xml
+e2e-tests.json
+e2e-tests.xml
 
 # ignore files fo release job
 eck_image.txt

--- a/Makefile
+++ b/Makefile
@@ -345,14 +345,13 @@ purge-gcr-images:
 TESTS_MATCH ?= "^Test"
 E2E_IMG ?= $(IMG)-e2e-tests:$(TAG)
 STACK_VERSION ?= 7.4.0
+E2E_JSON ?= false
 
 # Run e2e tests as a k8s batch job
 e2e: build-operator-image e2e-docker-build e2e-docker-push e2e-run
 
-e2e-local-run: build-operator-image e2e-docker-build e2e-docker-push e2e-local
-
 e2e-docker-build:
-	docker build -t $(E2E_IMG) -f test/e2e/Dockerfile .
+	docker build --build-arg E2E_JSON=$(E2E_JSON) -t $(E2E_IMG) -f test/e2e/Dockerfile .
 
 e2e-docker-push:
 	docker push $(E2E_IMG)
@@ -364,7 +363,8 @@ e2e-run:
 		--test-regex=$(TESTS_MATCH) \
 		--elastic-stack-version=$(STACK_VERSION) \
 		--log-verbosity=$(LOG_VERBOSITY) \
-		--crd-flavor=$(CRD_FLAVOR)
+		--crd-flavor=$(CRD_FLAVOR) \
+		--log-to-file=$(E2E_JSON)
 
 # Verify e2e tests compile with no errors, don't run them
 e2e-compile:

--- a/Makefile
+++ b/Makefile
@@ -349,6 +349,8 @@ STACK_VERSION ?= 7.4.0
 # Run e2e tests as a k8s batch job
 e2e: build-operator-image e2e-docker-build e2e-docker-push e2e-run
 
+e2e-local-run: build-operator-image e2e-docker-build e2e-docker-push e2e-local
+
 e2e-docker-build:
 	docker build -t $(E2E_IMG) -f test/e2e/Dockerfile .
 

--- a/Makefile
+++ b/Makefile
@@ -366,6 +366,9 @@ e2e-run:
 		--crd-flavor=$(CRD_FLAVOR) \
 		--log-to-file=$(E2E_JSON)
 
+e2e-generate-xml:
+	@ gotestsum --junitfile e2e-tests.xml --raw-command cat e2e-tests.json
+
 # Verify e2e tests compile with no errors, don't run them
 e2e-compile:
 	go test ./test/e2e/... -run=dryrun > /dev/null

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -72,24 +72,21 @@ pipeline {
                         }
                     }
                     steps {
-                        createConfig()
-                        sh """
-                            cat >deployer-config.yml <<EOF
-id: gke-ci
-overrides:
-  kubernetesVersion: "1.12"
-  clusterName: $BUILD_TAG
-  vaultInfo:
-    address: $VAULT_ADDR
-    roleId: $VAULT_ROLE_ID
-    secretId: $VAULT_SECRET_ID
-  gke:
-    gCloudProject: $GCLOUD_PROJECT
-EOF
-                            echo "Setting CRD_FLAVOR to trivial-versions to support K8s < 1.14"
-                            echo "CRD_FLAVOR = trivial-versions" >> .env
-                            make -C build/ci TARGET=ci-e2e ci
-                        """
+                        script {
+                            createConfig()
+                            createDeployerConfig()
+                            sh """
+                                echo "Setting CRD_FLAVOR to trivial-versions to support K8s < 1.14"
+                                echo "CRD_FLAVOR = trivial-versions" >> .env
+                            """
+
+                            env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci TARGET=ci-e2e ci')
+
+                            sh 'make -C build/ci TARGET=e2e-generate-xml ci'
+                            junit "e2e-tests.xml"
+
+                            sh 'exit $SHELL_EXIT_CODE'
+                        }
                     }
                 }
             }
@@ -126,6 +123,24 @@ REPOSITORY = "$GCLOUD_PROJECT"
 TESTS_MATCH = TestSmoke
 SKIP_DOCKER_COMMAND = false
 IMG_SUFFIX = -ci
+E2E_JSON = true
+EOF
+    """
+}
+
+def createDeployerConfig() {
+    sh """
+        cat >deployer-config.yml <<EOF
+id: gke-ci
+overrides:
+  kubernetesVersion: "1.12"
+  clusterName: $BUILD_TAG
+  vaultInfo:
+    address: $VAULT_ADDR
+    roleId: $VAULT_ROLE_ID
+    secretId: $VAULT_SECRET_ID
+  gke:
+    gCloudProject: $GCLOUD_PROJECT
 EOF
     """
 }

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,6 +1,9 @@
 # Run e2e tests
 FROM golang:1.13
 
+ARG E2E_JSON
+ENV E2E_JSON $E2E_JSON
+
 WORKDIR /go/src/github.com/elastic/cloud-on-k8s
 
 # Create the go test cache directory

--- a/test/e2e/cmd/run/command.go
+++ b/test/e2e/cmd/run/command.go
@@ -77,7 +77,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&flags.testRegex, "test-regex", "", "Regex to pass to the test runner")
 	cmd.Flags().StringVar(&flags.testRunName, "test-run-name", randomTestRunName(), "Name of this test run")
 	cmd.Flags().StringVar(&flags.crdFlavor, "crd-flavor", "default", "CRD flavor to install")
-	cmd.Flags().BoolVar(&flags.logToFile, "log-to-file", false, "Specifies if shoudl log test output to file. Disabled by default.")
+	cmd.Flags().BoolVar(&flags.logToFile, "log-to-file", false, "Specifies if should log test output to file. Disabled by default.")
 	logutil.BindFlags(cmd.PersistentFlags())
 
 	// enable setting flags via environment variables

--- a/test/e2e/cmd/run/command.go
+++ b/test/e2e/cmd/run/command.go
@@ -34,6 +34,7 @@ type runFlags struct {
 	autoPortForwarding  bool
 	skipCleanup         bool
 	local               bool
+	logToFile           bool
 	logVerbosity        int
 	crdFlavor           string
 }
@@ -76,6 +77,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&flags.testRegex, "test-regex", "", "Regex to pass to the test runner")
 	cmd.Flags().StringVar(&flags.testRunName, "test-run-name", randomTestRunName(), "Name of this test run")
 	cmd.Flags().StringVar(&flags.crdFlavor, "crd-flavor", "default", "CRD flavor to install")
+	cmd.Flags().BoolVar(&flags.logToFile, "log-to-file", false, "Specifies if shoudl log test output to file. Disabled by default.")
 	logutil.BindFlags(cmd.PersistentFlags())
 
 	// enable setting flags via environment variables

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -5,7 +5,6 @@
 package run
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -35,6 +34,7 @@ const (
 	kubePollInterval = 10 * time.Second  // Kube API polling interval
 	logBufferSize    = 1024              // Size of the log buffer (1KiB)
 	testRunLabel     = "test-run"        // name of the label applied to resources
+	testsLogFile     = "e2e-tests.json"  // name of file to keep all test logs in JSON format
 )
 
 type stepFunc func() error
@@ -341,28 +341,16 @@ func (h *helper) streamTestJobOutput(streamStatus chan<- error, client *kubernet
 	}
 	defer stream.Close()
 
-	vars := os.Environ()
-	for _, v := range vars {
-		fmt.Println(v)
-	}
-
-	fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-	fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-	fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-	fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-	fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-	fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-	fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-
 	//if h.logToFile
-	f, err := os.Create("/Users/artemnikitin/go/src/github.com/artemnikitin/cloud-on-k8s/test_output.txt")
+	f, err := os.Create(testsLogFile)
 	if err != nil {
 		return
 	}
-	//defer f.Close()
+	defer f.Close()
 
 	var buffer [logBufferSize]byte
-	if _, err := io.CopyBuffer(io.MultiWriter(os.Stdout, bufio.NewWriter(f)), stream, buffer[:]); err != nil {
+	if _, err := io.CopyBuffer(io.MultiWriter(os.Stdout, f), stream, buffer[:]); err != nil {
+		//if _, err := io.CopyBuffer(os.Stdout, stream, buffer[:]); err != nil {
 		if err == io.EOF {
 			log.Info("Log stream ended")
 			return

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -5,6 +5,7 @@
 package run
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -340,8 +341,28 @@ func (h *helper) streamTestJobOutput(streamStatus chan<- error, client *kubernet
 	}
 	defer stream.Close()
 
+	vars := os.Environ()
+	for _, v := range vars {
+		fmt.Println(v)
+	}
+
+	fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+	fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+	fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+	fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+	fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+	fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+	fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+
+	//if h.logToFile
+	f, err := os.Create("/Users/artemnikitin/go/src/github.com/artemnikitin/cloud-on-k8s/test_output.txt")
+	if err != nil {
+		return
+	}
+	//defer f.Close()
+
 	var buffer [logBufferSize]byte
-	if _, err := io.CopyBuffer(os.Stdout, stream, buffer[:]); err != nil {
+	if _, err := io.CopyBuffer(io.MultiWriter(os.Stdout, bufio.NewWriter(f)), stream, buffer[:]); err != nil {
 		if err == io.EOF {
 			log.Info("Log stream ended")
 			return

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -10,6 +10,10 @@
 set -euo pipefail
 
 for PKG in $(go list github.com/elastic/cloud-on-k8s/test/e2e/...); do
-    echo ">>> Running tests in package $PKG"
-    go test -v -failfast -timeout=2h -tags=e2e -p=1 $PKG $@
+    if [ "$E2E_JSON" == "true" ]
+    then
+        go test -v -failfast -timeout=2h -tags=e2e -p=1 --json $PKG $@
+    else
+        go test -v -failfast -timeout=2h -tags=e2e -p=1 $PKG $@
+    fi
 done

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -27,6 +27,7 @@ var (
 
 func init() {
 	logutil.InitLogger()
+	logutil.ChangeVerbosity(1)
 	log = logf.Log.WithName("e2e")
 }
 

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -102,6 +102,7 @@ type Context struct {
 	TestRun             string              `json:"test_run"`
 	AutoPortForwarding  bool                `json:"auto_port_forwarding"`
 	Local               bool                `json:"local"`
+	LogToFile           bool                `json:"log_to_file"`
 }
 
 // ManagedNamespace returns the nth managed namespace.

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -27,7 +27,6 @@ var (
 
 func init() {
 	logutil.InitLogger()
-	logutil.ChangeVerbosity(1)
 	log = logf.Log.WithName("e2e")
 }
 


### PR DESCRIPTION
This PR added option for generating xUnit compatible test output. For doing that:
- It adds parameter `log-to-file` for test runner, if it's enabled, then it will also capture test output to file. Disabled by default.
- It adds make target `e2e-generate-xml` which using `gotestsum` to generate XML from test output in JSON

This PR adds support only for PR job at the moment. Main reason for that is to check that everything properly works and prevent any disruptions. After successful merge of this PR I will add it to all jobs which runs e2e tests in a separate PR.