### PR TITLE
Replace deprecated NewFakeClient usages with NewFakeClientWithScheme

### DIFF
--- a/pkg/apis/elasticsearch/v1beta1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1beta1/elasticsearch_types.go
@@ -6,7 +6,7 @@ package v1beta1
 
 import (
 	commonv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1beta1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -118,7 +118,7 @@ type ChangeBudget struct {
 // most cases.
 var DefaultChangeBudget = ChangeBudget{
 	MaxSurge:       nil,
-	MaxUnavailable: common.Int32(1),
+	MaxUnavailable: pointer.Int32(1),
 }
 
 func (cb ChangeBudget) GetMaxSurgeOrDefault() *int32 {

--- a/pkg/apis/elasticsearch/v1beta1/elasticsearch_types_test.go
+++ b/pkg/apis/elasticsearch/v1beta1/elasticsearch_types_test.go
@@ -11,7 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -134,7 +135,7 @@ func Test_GetMaxSurgeOrDefault(t *testing.T) {
 	}{
 		{
 			name:     "negative in spec results in unbounded",
-			fromSpec: common.Int32(-1),
+			fromSpec: pointer.Int32(-1),
 			want:     nil,
 		},
 		{
@@ -149,13 +150,13 @@ func Test_GetMaxSurgeOrDefault(t *testing.T) {
 		},
 		{
 			name:     "0 in spec results in 0",
-			fromSpec: common.Int32(0),
-			want:     common.Int32(0),
+			fromSpec: pointer.Int32(0),
+			want:     pointer.Int32(0),
 		},
 		{
 			name:     "1 in spec results in 1",
-			fromSpec: common.Int32(1),
-			want:     common.Int32(1),
+			fromSpec: pointer.Int32(1),
+			want:     pointer.Int32(1),
 		},
 	}
 
@@ -177,7 +178,7 @@ func Test_GetMaxUnavailableOrDefault(t *testing.T) {
 	}{
 		{
 			name:     "negative in spec results in unbounded",
-			fromSpec: common.Int32(-1),
+			fromSpec: pointer.Int32(-1),
 			want:     nil,
 		},
 		{
@@ -188,17 +189,17 @@ func Test_GetMaxUnavailableOrDefault(t *testing.T) {
 		{
 			name:     "nil in spec results in default, currently 1",
 			fromSpec: nil,
-			want:     common.Int32(1),
+			want:     pointer.Int32(1),
 		},
 		{
 			name:     "0 in spec results in 0",
-			fromSpec: common.Int32(0),
-			want:     common.Int32(0),
+			fromSpec: pointer.Int32(0),
+			want:     pointer.Int32(0),
 		},
 		{
 			name:     "1 in spec results in 1",
-			fromSpec: common.Int32(1),
-			want:     common.Int32(1),
+			fromSpec: pointer.Int32(1),
+			want:     pointer.Int32(1),
 		},
 	}
 

--- a/pkg/controller/apmserver/config/config_test.go
+++ b/pkg/controller/apmserver/config/config_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestNewConfigFromSpec(t *testing.T) {
@@ -83,7 +82,7 @@ func TestNewConfigFromSpec(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			client := k8s.WrapClient(fake.NewFakeClient(mkAuthSecret()))
+			client := k8s.WrappedFakeClient(mkAuthSecret())
 			apmServer := mkAPMServer(tc.configOverrides, tc.assocConf)
 			gotConf, err := NewConfigFromSpec(client, apmServer)
 			if tc.wantErr {

--- a/pkg/controller/apmserverelasticsearchassociation/apmserverelasticsearchassociation_controller_test.go
+++ b/pkg/controller/apmserverelasticsearchassociation/apmserverelasticsearchassociation_controller_test.go
@@ -9,7 +9,6 @@ import (
 
 	apmtype "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1beta1"
 	commonv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1beta1"
-	estype "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,8 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const (
@@ -50,19 +47,7 @@ var apmFixture = apmtype.ApmServer{
 	},
 }
 
-func setupScheme(t *testing.T) *runtime.Scheme {
-	sc := scheme.Scheme
-	if err := apmtype.SchemeBuilder.AddToScheme(sc); err != nil {
-		assert.Fail(t, "failed to add apm types")
-	}
-	if err := estype.SchemeBuilder.AddToScheme(sc); err != nil {
-		assert.Fail(t, "failed to add Es types")
-	}
-	return sc
-}
-
 func Test_deleteOrphanedResources(t *testing.T) {
-	s := setupScheme(t)
 	tests := []struct {
 		name           string
 		args           apmtype.ApmServer
@@ -149,7 +134,7 @@ func Test_deleteOrphanedResources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := k8s.WrapClient(fake.NewFakeClientWithScheme(s, tt.initialObjects...))
+			c := k8s.WrappedFakeClient(tt.initialObjects...)
 			if err := deleteOrphanedResources(c, &tt.args); (err != nil) != tt.wantErr {
 				t.Errorf("deleteOrphanedResources() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/controller/common/annotation/controller_version_test.go
+++ b/pkg/controller/common/annotation/controller_version_test.go
@@ -7,22 +7,15 @@ package annotation
 import (
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	kibanav1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	apmtype "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1beta1"
-	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
-	estype "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
 // Test UpdateControllerVersion updates annotation if there is an older version
@@ -37,8 +30,7 @@ func TestAnnotationUpdated(t *testing.T) {
 		},
 	}
 	obj := kibana.DeepCopy()
-	sc := setupScheme(t)
-	client := k8s.WrapClient(fake.NewFakeClientWithScheme(sc, obj))
+	client := k8s.WrappedFakeClient(obj)
 	err := UpdateControllerVersion(client, obj, "newversion")
 	require.NoError(t, err)
 	require.Equal(t, obj.GetAnnotations()[ControllerVersionAnnotation], "newversion")
@@ -54,8 +46,7 @@ func TestAnnotationCreated(t *testing.T) {
 	}
 
 	obj := kibana.DeepCopy()
-	sc := setupScheme(t)
-	client := k8s.WrapClient(fake.NewFakeClientWithScheme(sc, obj))
+	client := k8s.WrappedFakeClient(obj)
 	err := UpdateControllerVersion(client, obj, "newversion")
 	require.NoError(t, err)
 	actualKibana := &kibanav1beta1.Kibana{}
@@ -87,8 +78,7 @@ func TestMissingAnnotationOldVersion(t *testing.T) {
 			},
 		},
 	}
-	sc := setupScheme(t)
-	client := k8s.WrapClient(fake.NewFakeClientWithScheme(sc, es, svc))
+	client := k8s.WrappedFakeClient(es, svc)
 	selector := getElasticsearchSelector(es)
 	compat, err := ReconcileCompatibility(client, es, selector, MinCompatibleControllerVersion)
 	require.NoError(t, err)
@@ -117,8 +107,7 @@ func TestMissingAnnotationNewObject(t *testing.T) {
 		},
 	}
 
-	sc := setupScheme(t)
-	client := k8s.WrapClient(fake.NewFakeClientWithScheme(sc, es, svc))
+	client := k8s.WrappedFakeClient(es, svc)
 	selector := getElasticsearchSelector(es)
 	compat, err := ReconcileCompatibility(client, es, selector, MinCompatibleControllerVersion)
 	require.NoError(t, err)
@@ -140,8 +129,7 @@ func TestSameAnnotation(t *testing.T) {
 			},
 		},
 	}
-	sc := setupScheme(t)
-	client := k8s.WrapClient(fake.NewFakeClientWithScheme(sc, es))
+	client := k8s.WrappedFakeClient(es)
 	selector := getElasticsearchSelector(es)
 	compat, err := ReconcileCompatibility(client, es, selector, MinCompatibleControllerVersion)
 	require.NoError(t, err)
@@ -159,8 +147,7 @@ func TestIncompatibleAnnotation(t *testing.T) {
 			},
 		},
 	}
-	sc := setupScheme(t)
-	client := k8s.WrapClient(fake.NewFakeClientWithScheme(sc, es))
+	client := k8s.WrappedFakeClient(es)
 	selector := getElasticsearchSelector(es)
 	compat, err := ReconcileCompatibility(client, es, selector, MinCompatibleControllerVersion)
 	require.NoError(t, err)
@@ -179,24 +166,11 @@ func TestNewerAnnotation(t *testing.T) {
 			},
 		},
 	}
-	sc := setupScheme(t)
-	client := k8s.WrapClient(fake.NewFakeClientWithScheme(sc, es))
+	client := k8s.WrappedFakeClient(es)
 	selector := getElasticsearchSelector(es)
 	compat, err := ReconcileCompatibility(client, es, selector, MinCompatibleControllerVersion)
 	assert.NoError(t, err)
 	assert.True(t, compat)
-}
-
-// setupScheme creates a scheme to use for our fake clients so they know about our custom resources
-func setupScheme(t *testing.T) *runtime.Scheme {
-	sc := scheme.Scheme
-	err := apmtype.AddToScheme(sc)
-	require.NoError(t, err)
-	err = estype.SchemeBuilder.AddToScheme(sc)
-	require.NoError(t, err)
-	err = kibanav1beta1.SchemeBuilder.AddToScheme(sc)
-	require.NoError(t, err)
-	return sc
 }
 
 func getElasticsearchSelector(es *v1beta1.Elasticsearch) map[string]string {

--- a/pkg/controller/common/annotation/pod_test.go
+++ b/pkg/controller/common/annotation/pod_test.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestMarkPodAsUpdated(t *testing.T) {
@@ -36,7 +35,7 @@ func TestMarkPodAsUpdated(t *testing.T) {
 	}{
 		{
 			args: args{
-				c:   k8s.WrapClient(fake.NewFakeClient(pod.DeepCopy())),
+				c:   k8s.WrappedFakeClient(pod.DeepCopy()),
 				pod: pod,
 			},
 		},

--- a/pkg/controller/common/association/association_test.go
+++ b/pkg/controller/common/association/association_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetCredentials(t *testing.T) {
@@ -38,13 +37,13 @@ func TestGetCredentials(t *testing.T) {
 	}{
 		{
 			name: "When auth details are defined",
-			client: k8s.WrapClient(fake.NewFakeClient(&corev1.Secret{
+			client: k8s.WrappedFakeClient(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "apmelasticsearchassociation-sample-elastic-internal-apm",
 					Namespace: "default",
 				},
 				Data: map[string][]byte{"elastic-internal-apm": []byte("a2s1Nmt0N3Nwdmg4cmpqdDlucWhsN3cy")},
-			})),
+			}),
 			assocConf: commonv1beta1.AssociationConf{
 				AuthSecretName: "apmelasticsearchassociation-sample-elastic-internal-apm",
 				AuthSecretKey:  "elastic-internal-apm",
@@ -56,13 +55,13 @@ func TestGetCredentials(t *testing.T) {
 		},
 		{
 			name: "When auth details are undefined",
-			client: k8s.WrapClient(fake.NewFakeClient(&corev1.Secret{
+			client: k8s.WrappedFakeClient(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "apmelasticsearchassociation-sample-elastic-internal-apm",
 					Namespace: "default",
 				},
 				Data: map[string][]byte{"elastic-internal-apm": []byte("a2s1Nmt0N3Nwdmg4cmpqdDlucWhsN3cy")},
-			})),
+			}),
 			assocConf: commonv1beta1.AssociationConf{
 				CASecretName: "ca-secret",
 				URL:          "https://elasticsearch-sample-es-http.default.svc:9200",
@@ -70,13 +69,13 @@ func TestGetCredentials(t *testing.T) {
 		},
 		{
 			name: "When the auth secret does not exist",
-			client: k8s.WrapClient(fake.NewFakeClient(&corev1.Secret{
+			client: k8s.WrappedFakeClient(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "some-secret",
 					Namespace: "default",
 				},
 				Data: map[string][]byte{"elastic-internal-apm": []byte("a2s1Nmt0N3Nwdmg4cmpqdDlucWhsN3cy")},
-			})),
+			}),
 			assocConf: commonv1beta1.AssociationConf{
 				AuthSecretName: "apmelasticsearchassociation-sample-elastic-internal-apm",
 				AuthSecretKey:  "elastic-internal-apm",

--- a/pkg/controller/common/association/ca_test.go
+++ b/pkg/controller/common/association/ca_test.go
@@ -18,15 +18,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const ElasticsearchCASecretSuffix = "xx-es-ca" // nolint
 
 func TestReconcileAssociation_reconcileCASecret(t *testing.T) {
-	// setup scheme and init watches
-	require.NoError(t, estype.AddToScheme(scheme.Scheme))
-	require.NoError(t, kbtype.AddToScheme(scheme.Scheme))
+	// init watches
 	w := watches.NewDynamicWatches()
 	require.NoError(t, w.Secrets.InjectScheme(scheme.Scheme))
 
@@ -89,7 +86,7 @@ func TestReconcileAssociation_reconcileCASecret(t *testing.T) {
 	}{
 		{
 			name:   "create new CA in kibana namespace",
-			client: k8s.WrapClient(fake.NewFakeClient(&es, &esCA)),
+			client: k8s.WrappedFakeClient(&es, &esCA),
 			kibana: kibanaFixture,
 			es:     esFixture,
 			want:   ElasticsearchCACertSecretName(&kibanaFixture, ElasticsearchCASecretSuffix),
@@ -97,7 +94,7 @@ func TestReconcileAssociation_reconcileCASecret(t *testing.T) {
 		},
 		{
 			name:   "update existing CA in kibana namespace",
-			client: k8s.WrapClient(fake.NewFakeClient(&es, &updatedEsCA, &kibanaEsCA)),
+			client: k8s.WrappedFakeClient(&es, &updatedEsCA, &kibanaEsCA),
 			kibana: kibanaFixture,
 			es:     esFixture,
 			want:   ElasticsearchCACertSecretName(&kibanaFixture, ElasticsearchCASecretSuffix),
@@ -105,7 +102,7 @@ func TestReconcileAssociation_reconcileCASecret(t *testing.T) {
 		},
 		{
 			name:   "ES CA secret does not exist (yet)",
-			client: k8s.WrapClient(fake.NewFakeClient(&es)),
+			client: k8s.WrappedFakeClient(&es),
 			kibana: kibanaFixture,
 			es:     esFixture,
 			want:   "",

--- a/pkg/controller/common/association/conf_test.go
+++ b/pkg/controller/common/association/conf_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -26,8 +24,6 @@ func TestFetchWithAssociation(t *testing.T) {
 }
 
 func testFetchAPMServer(t *testing.T) {
-	require.NoError(t, apmv1beta1.AddToScheme(scheme.Scheme))
-
 	testCases := []struct {
 		name          string
 		apmServer     *apmv1beta1.ApmServer
@@ -64,7 +60,7 @@ func testFetchAPMServer(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			client := k8s.WrapClient(fake.NewFakeClient(tc.apmServer))
+			client := k8s.WrappedFakeClient(tc.apmServer)
 
 			var got apmv1beta1.ApmServer
 			ok, err := FetchWithAssociation(client, tc.request, &got)
@@ -108,8 +104,6 @@ func mkAPMServer(withAnnotations bool) *apmv1beta1.ApmServer {
 }
 
 func testFetchKibana(t *testing.T) {
-	require.NoError(t, kbv1beta1.AddToScheme(scheme.Scheme))
-
 	testCases := []struct {
 		name          string
 		kibana        *kbv1beta1.Kibana
@@ -146,7 +140,7 @@ func testFetchKibana(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			client := k8s.WrapClient(fake.NewFakeClient(tc.kibana))
+			client := k8s.WrappedFakeClient(tc.kibana)
 
 			var got kbv1beta1.Kibana
 			ok, err := FetchWithAssociation(client, tc.request, &got)
@@ -190,10 +184,9 @@ func mkKibana(withAnnotations bool) *kbv1beta1.Kibana {
 }
 
 func TestUpdateAssociationConf(t *testing.T) {
-	require.NoError(t, kbv1beta1.AddToScheme(scheme.Scheme))
 	kb := mkKibana(true)
 	request := reconcile.Request{NamespacedName: types.NamespacedName{Name: "kb-test", Namespace: "kb-ns"}}
-	client := k8s.WrapClient(fake.NewFakeClient(kb))
+	client := k8s.WrappedFakeClient(kb)
 
 	assocConf := &commonv1beta1.AssociationConf{
 		AuthSecretName: "auth-secret",
@@ -233,10 +226,9 @@ func TestUpdateAssociationConf(t *testing.T) {
 }
 
 func TestRemoveAssociationConf(t *testing.T) {
-	require.NoError(t, kbv1beta1.AddToScheme(scheme.Scheme))
 	kb := mkKibana(true)
 	request := reconcile.Request{NamespacedName: types.NamespacedName{Name: "kb-test", Namespace: "kb-ns"}}
-	client := k8s.WrapClient(fake.NewFakeClient(kb))
+	client := k8s.WrappedFakeClient(kb)
 
 	assocConf := &commonv1beta1.AssociationConf{
 		AuthSecretName: "auth-secret",

--- a/pkg/controller/common/association/user_test.go
+++ b/pkg/controller/common/association/user_test.go
@@ -7,6 +7,8 @@ package association
 import (
 	"testing"
 
+	"k8s.io/client-go/kubernetes/scheme"
+
 	commonv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1beta1"
 	estype "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	kbtype "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1beta1"
@@ -23,8 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const (
@@ -60,20 +60,7 @@ var kibanaFixture = kbtype.Kibana{
 	},
 }
 
-func setupScheme(t *testing.T) *runtime.Scheme {
-	sc := scheme.Scheme
-	if err := kbtype.SchemeBuilder.AddToScheme(sc); err != nil {
-		assert.Fail(t, "failed to add Kibana types")
-	}
-	if err := estype.SchemeBuilder.AddToScheme(sc); err != nil {
-		assert.Fail(t, "failed to add Es types")
-	}
-	return sc
-}
-
 func Test_reconcileEsUser(t *testing.T) {
-	sc := setupScheme(t)
-
 	type args struct {
 		initialObjects []runtime.Object
 		kibana         kbtype.Kibana
@@ -263,11 +250,11 @@ func Test_reconcileEsUser(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		c := k8s.WrapClient(fake.NewFakeClient(tt.args.initialObjects...))
+		c := k8s.WrappedFakeClient(tt.args.initialObjects...)
 		t.Run(tt.name, func(t *testing.T) {
 			if err := ReconcileEsUser(
 				c,
-				sc,
+				scheme.Scheme,
 				&tt.args.kibana,
 				map[string]string{
 					associationLabelName:      tt.args.kibana.Name,

--- a/pkg/controller/common/certificates/ca_reconcile_test.go
+++ b/pkg/controller/common/certificates/ca_reconcile_test.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var testNamer = name.Namer{
@@ -195,9 +194,6 @@ func Test_renewCA(t *testing.T) {
 	require.NoError(t, err)
 	internalCASecret := internalSecretForCA(testCa, testNamer, &testCluster, nil, TransportCAType)
 
-	err = v1beta1.AddToScheme(scheme.Scheme)
-	require.NoError(t, err)
-
 	tests := []struct {
 		name        string
 		client      k8s.Client
@@ -206,12 +202,12 @@ func Test_renewCA(t *testing.T) {
 	}{
 		{
 			name:     "create new CA",
-			client:   k8s.WrapClient(fake.NewFakeClient()),
+			client:   k8s.WrappedFakeClient(),
 			expireIn: DefaultCertValidity,
 		},
 		{
 			name:        "replace existing CA",
-			client:      k8s.WrapClient(fake.NewFakeClient(&internalCASecret)),
+			client:      k8s.WrappedFakeClient(&internalCASecret),
 			expireIn:    DefaultCertValidity,
 			notExpected: testCa, // existing CA should be replaced
 		},
@@ -228,9 +224,6 @@ func Test_renewCA(t *testing.T) {
 }
 
 func TestReconcileCAForCluster(t *testing.T) {
-	err := v1beta1.AddToScheme(scheme.Scheme)
-	require.NoError(t, err)
-
 	validCa, err := NewSelfSignedCA(CABuilderOptions{})
 	require.NoError(t, err)
 	internalCASecret := internalSecretForCA(validCa, testNamer, &testCluster, nil, TransportCAType)
@@ -259,31 +252,31 @@ func TestReconcileCAForCluster(t *testing.T) {
 	}{
 		{
 			name:           "no existing CA cert nor private key",
-			cl:             k8s.WrapClient(fake.NewFakeClient()),
+			cl:             k8s.WrappedFakeClient(),
 			caCertValidity: DefaultCertValidity,
 			shouldReuseCa:  nil, // should create a new one
 		},
 		{
 			name:           "existing CA cert but no private key",
-			cl:             k8s.WrapClient(fake.NewFakeClient(internalCASecretWithoutPrivateKey)),
+			cl:             k8s.WrappedFakeClient(internalCASecretWithoutPrivateKey),
 			caCertValidity: DefaultCertValidity,
 			shouldReuseCa:  nil, // should create a new one
 		},
 		{
 			name:           "existing private key cert but no cert",
-			cl:             k8s.WrapClient(fake.NewFakeClient(internalCASecretWithoutCACert)),
+			cl:             k8s.WrappedFakeClient(internalCASecretWithoutCACert),
 			caCertValidity: DefaultCertValidity,
 			shouldReuseCa:  nil, // should create a new one
 		},
 		{
 			name:           "existing valid internal secret",
-			cl:             k8s.WrapClient(fake.NewFakeClient(&internalCASecret)),
+			cl:             k8s.WrappedFakeClient(&internalCASecret),
 			caCertValidity: DefaultCertValidity,
 			shouldReuseCa:  validCa, // should reuse existing one
 		},
 		{
 			name:             "existing internal cert is soon to expire",
-			cl:               k8s.WrapClient(fake.NewFakeClient(&soonToExpireInternalCASecret)),
+			cl:               k8s.WrappedFakeClient(&soonToExpireInternalCASecret),
 			caCertValidity:   DefaultCertValidity,
 			shouldReuseCa:    nil,            // should create a new one
 			shouldNotReuseCa: soonToExpireCa, // and not reuse existing one

--- a/pkg/controller/common/certificates/http/public_secret_test.go
+++ b/pkg/controller/common/certificates/http/public_secret_test.go
@@ -17,7 +17,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -42,7 +41,7 @@ func TestReconcileHTTPCertsPublicSecret(t *testing.T) {
 
 	mkClient := func(t *testing.T, objs ...runtime.Object) k8s.Client {
 		t.Helper()
-		return k8s.WrapClient(fake.NewFakeClient(objs...))
+		return k8s.WrappedFakeClient(objs...)
 	}
 
 	mkWantedSecret := func(t *testing.T) *corev1.Secret {

--- a/pkg/controller/common/certificates/http/reconcile_test.go
+++ b/pkg/controller/common/certificates/http/reconcile_test.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const (
@@ -67,10 +66,6 @@ var (
 )
 
 func init() {
-	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
-		panic(err)
-	}
-
 	var err error
 	block, _ := pem.Decode([]byte(testPemPrivateKey))
 	if testRSAPrivateKey, err = x509.ParsePKCS1PrivateKey(block.Bytes); err != nil {
@@ -121,7 +116,7 @@ func TestReconcileHTTPCertificates(t *testing.T) {
 		{
 			name: "should generate new certificates if none exists",
 			args: args{
-				c:  k8s.WrapClient(fake.NewFakeClient()),
+				c:  k8s.WrappedFakeClient(),
 				es: testES,
 				ca: testCA,
 			},
@@ -133,13 +128,13 @@ func TestReconcileHTTPCertificates(t *testing.T) {
 		{
 			name: "should use custom certificates if provided",
 			args: args{
-				c: k8s.WrapClient(fake.NewFakeClient(&corev1.Secret{
+				c: k8s.WrappedFakeClient(&corev1.Secret{
 					ObjectMeta: v1.ObjectMeta{Name: "my-cert", Namespace: "test-namespace"},
 					Data: map[string][]byte{
 						certificates.CertFileName: tls,
 						certificates.KeyFileName:  key,
 					},
-				})),
+				}),
 				es: v1beta1.Elasticsearch{
 					ObjectMeta: v1.ObjectMeta{Name: "test-es-name", Namespace: "test-namespace"},
 					Spec: v1beta1.ElasticsearchSpec{

--- a/pkg/controller/common/deployment/reconcile.go
+++ b/pkg/controller/common/deployment/reconcile.go
@@ -10,10 +10,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
 )
 
 var (
@@ -39,7 +39,7 @@ func New(params Params) appsv1.Deployment {
 			Labels:    params.Labels,
 		},
 		Spec: appsv1.DeploymentSpec{
-			RevisionHistoryLimit: common.Int32(defaultRevisionHistoryLimit),
+			RevisionHistoryLimit: pointer.Int32(defaultRevisionHistoryLimit),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: params.Selector,
 			},

--- a/pkg/controller/common/expectations/expectations_test.go
+++ b/pkg/controller/common/expectations/expectations_test.go
@@ -16,7 +16,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGenerationsExpectations(t *testing.T) {
@@ -107,7 +106,7 @@ func TestExpectations_ExpectDeletion(t *testing.T) {
 
 	// Create a fake client with new UID for the last remaining Pod in cluster1
 	cluster1Pod3 = newPod(testCluster1, "cluster1Pod3")
-	client := k8s.WrapClient(fake.NewFakeClient(&cluster1Pod3, &cluster2Pod1))
+	client := k8s.WrappedFakeClient(&cluster1Pod3, &cluster2Pod1)
 
 	// UID has changed for the last Pod of cluster1, expectation must be satisfied
 	satisfied, err := e.SatisfiedDeletions(client, testCluster1)

--- a/pkg/controller/common/finalizer/handler_test.go
+++ b/pkg/controller/common/finalizer/handler_test.go
@@ -9,10 +9,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -115,7 +113,7 @@ func TestHandler_Handle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// pretend resource already exists in api server
-			fakeClient := fake.NewFakeClient(&tt.resource)
+			fakeClient := k8s.FakeClient(&tt.resource)
 			handler := Handler{
 				client: k8s.WrapClient(fakeClient),
 			}

--- a/pkg/controller/common/keystore/resources_test.go
+++ b/pkg/controller/common/keystore/resources_test.go
@@ -19,7 +19,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var (
@@ -61,9 +60,6 @@ var (
 )
 
 func TestResources(t *testing.T) {
-	sc := scheme.Scheme
-	require.NoError(t, v1beta1.SchemeBuilder.AddToScheme(sc))
-
 	varFalse := false
 	tests := []struct {
 		name           string
@@ -75,7 +71,7 @@ func TestResources(t *testing.T) {
 	}{
 		{
 			name:           "no secure settings specified: no resources",
-			client:         k8s.WrapClient(fake.NewFakeClient()),
+			client:         k8s.WrappedFakeClient(),
 			kb:             testKibana,
 			wantContainers: nil,
 			wantVersion:    "",
@@ -83,7 +79,7 @@ func TestResources(t *testing.T) {
 		},
 		{
 			name:   "secure settings specified: return volume, init container and (empty) version",
-			client: k8s.WrapClient(fake.NewFakeClient(&testSecureSettingsSecret)),
+			client: k8s.WrappedFakeClient(&testSecureSettingsSecret),
 			kb:     testKibanaWithSecureSettings,
 			wantContainers: &corev1.Container{
 				Command: []string{
@@ -131,7 +127,7 @@ echo "Keystore initialization successful."
 		},
 		{
 			name:           "secure settings specified but secret not there: no resources",
-			client:         k8s.WrapClient(fake.NewFakeClient()),
+			client:         k8s.WrappedFakeClient(),
 			kb:             testKibanaWithSecureSettings,
 			wantContainers: nil,
 			wantVersion:    "",

--- a/pkg/controller/common/license/check_test.go
+++ b/pkg/controller/common/license/check_test.go
@@ -9,18 +9,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/chrono"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestChecker_EnterpriseFeaturesEnabled(t *testing.T) {
-	require.NoError(t, v1beta1.AddToScheme(scheme.Scheme))
-
 	privKey, err := x509.ParsePKCS1PrivateKey(privateKeyFixture)
 	require.NoError(t, err)
 
@@ -73,7 +68,7 @@ func TestChecker_EnterpriseFeaturesEnabled(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lc := &checker{
-				k8sClient:         k8s.WrapClient(fake.NewFakeClientWithScheme(scheme.Scheme, tt.fields.initialObjects...)),
+				k8sClient:         k8s.WrappedFakeClient(tt.fields.initialObjects...),
 				operatorNamespace: tt.fields.operatorNamespace,
 				publicKey:         tt.fields.publicKey,
 			}

--- a/pkg/controller/common/license/trial_test.go
+++ b/pkg/controller/common/license/trial_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	estype "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/pkg/errors"
@@ -18,9 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 type failingClient struct {
@@ -32,8 +29,6 @@ func (failingClient) Create(o runtime.Object, opts ...client.CreateOption) error
 }
 
 func TestInitTrial(t *testing.T) {
-	require.NoError(t, estype.AddToScheme(scheme.Scheme))
-
 	licenseFixture := EnterpriseLicense{
 		License: LicenseSpec{
 			Type: LicenseTypeEnterpriseTrial,
@@ -52,7 +47,7 @@ func TestInitTrial(t *testing.T) {
 		{
 			name: "nil license",
 			args: args{
-				c: k8s.WrapClient(fake.NewFakeClient()),
+				c: k8s.WrappedFakeClient(),
 				l: nil,
 			},
 			wantErr: true,
@@ -75,7 +70,7 @@ func TestInitTrial(t *testing.T) {
 		{
 			name: "not a trial license",
 			args: args{
-				c: k8s.WrapClient(fake.NewFakeClient()),
+				c: k8s.WrappedFakeClient(),
 				l: &EnterpriseLicense{},
 			},
 			want: func(l *EnterpriseLicense, k *rsa.PublicKey) {
@@ -87,12 +82,12 @@ func TestInitTrial(t *testing.T) {
 		{
 			name: "successful trial start",
 			args: args{
-				c: k8s.WrapClient(fake.NewFakeClient(&corev1.Secret{
+				c: k8s.WrappedFakeClient(&corev1.Secret{
 					ObjectMeta: v1.ObjectMeta{
 						Namespace: "elastic-system",
 						Name:      string(LicenseTypeEnterpriseTrial),
 					},
-				})),
+				}),
 				l: &licenseFixture,
 			},
 			want: func(l *EnterpriseLicense, k *rsa.PublicKey) {

--- a/pkg/controller/common/reconciler/reconciler_test.go
+++ b/pkg/controller/common/reconciler/reconciler_test.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func withoutControllerRef(obj runtime.Object) runtime.Object {
@@ -261,7 +260,7 @@ func TestReconcileResource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			client := k8s.WrapClient(fake.NewFakeClient(tt.initialObjects...))
+			client := k8s.WrappedFakeClient(tt.initialObjects...)
 			args := tt.args()
 			p := Params{
 				Client:           client,

--- a/pkg/controller/elasticsearch/certificates/transport/public_secret_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/public_secret_test.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -38,7 +37,7 @@ func TestReconcileTransportCertsPublicSecret(t *testing.T) {
 
 	mkClient := func(t *testing.T, objs ...runtime.Object) k8s.Client {
 		t.Helper()
-		return k8s.WrapClient(fake.NewFakeClient(objs...))
+		return k8s.WrappedFakeClient(objs...)
 	}
 
 	mkWantedSecret := func(t *testing.T) *corev1.Secret {

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func Test_ensureTransportCertificateSecretExists(t *testing.T) {
@@ -53,7 +52,7 @@ func Test_ensureTransportCertificateSecretExists(t *testing.T) {
 		{
 			name: "should create a secret if it does not already exist",
 			args: args{
-				c:     k8s.WrapClient(fake.NewFakeClient()),
+				c:     k8s.WrappedFakeClient(),
 				owner: testES,
 			},
 			want: func(t *testing.T, secret *corev1.Secret) {
@@ -67,9 +66,9 @@ func Test_ensureTransportCertificateSecretExists(t *testing.T) {
 		{
 			name: "should update an existing secret",
 			args: args{
-				c: k8s.WrapClient(fake.NewFakeClient(defaultSecretWith(func(secret *corev1.Secret) {
+				c: k8s.WrappedFakeClient(defaultSecretWith(func(secret *corev1.Secret) {
 					secret.ObjectMeta.UID = types.UID("42")
-				}))),
+				})),
 				owner: testES,
 			},
 			want: func(t *testing.T, secret *corev1.Secret) {
@@ -82,9 +81,9 @@ func Test_ensureTransportCertificateSecretExists(t *testing.T) {
 		{
 			name: "should allow additional labels in the secret",
 			args: args{
-				c: k8s.WrapClient(fake.NewFakeClient(defaultSecretWith(func(secret *corev1.Secret) {
+				c: k8s.WrappedFakeClient(defaultSecretWith(func(secret *corev1.Secret) {
 					secret.ObjectMeta.Labels["foo"] = "bar"
-				}))),
+				})),
 				owner: testES,
 			},
 			want: func(t *testing.T, secret *corev1.Secret) {

--- a/pkg/controller/elasticsearch/certificates/transport/transport_fixtures_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/transport_fixtures_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
 // fixtures
@@ -62,10 +61,6 @@ wg/HcAJWY60xZTJDFN+Qfx8ZQvBEin6c2/h+zZi5IVY=
 )
 
 func init() {
-	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
-		panic(err)
-	}
-
 	var err error
 	block, _ := pem.Decode([]byte(testPemPrivateKey))
 	if testRSAPrivateKey, err = x509.ParsePKCS1PrivateKey(block.Bytes); err != nil {

--- a/pkg/controller/elasticsearch/driver/bootstrap_test.go
+++ b/pkg/controller/elasticsearch/driver/bootstrap_test.go
@@ -7,18 +7,15 @@ package driver
 import (
 	"testing"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
-	"github.com/go-test/deep"
-	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/observer"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/go-test/deep"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
 func bootstrappedES() *v1beta1.Elasticsearch {
@@ -66,11 +63,9 @@ func TestAnnotatedForBootstrap(t *testing.T) {
 }
 
 func Test_annotateWithUUID(t *testing.T) {
-	require.NoError(t, v1beta1.AddToScheme(scheme.Scheme))
-
 	cluster := notBootstrappedES()
 	observedState := observer.State{ClusterInfo: &client.Info{ClusterUUID: "cluster-uuid"}}
-	k8sClient := k8s.WrapClient(fake.NewFakeClient(cluster))
+	k8sClient := k8s.WrappedFakeClient(cluster)
 
 	err := annotateWithUUID(cluster, observedState, k8sClient)
 	require.NoError(t, err)
@@ -118,7 +113,6 @@ func Test_clusterIsBootstrapped(t *testing.T) {
 }
 
 func TestReconcileClusterUUID(t *testing.T) {
-	require.NoError(t, v1beta1.AddToScheme(scheme.Scheme))
 	tests := []struct {
 		name          string
 		c             k8s.Client
@@ -128,54 +122,54 @@ func TestReconcileClusterUUID(t *testing.T) {
 	}{
 		{
 			name:        "already annotated",
-			c:           k8s.WrapClient(fake.NewFakeClient()),
+			c:           k8s.WrappedFakeClient(),
 			cluster:     bootstrappedES(),
 			wantCluster: bootstrappedES(),
 		},
 		{
 			name:          "not annotated, but not bootstrapped yet (cluster state empty)",
 			cluster:       notBootstrappedES(),
-			c:             k8s.WrapClient(fake.NewFakeClient()),
+			c:             k8s.WrappedFakeClient(),
 			observedState: observer.State{ClusterInfo: nil},
 			wantCluster:   notBootstrappedES(),
 		},
 		{
 			name:          "not annotated, but not bootstrapped yet (cluster UUID empty)",
 			cluster:       notBootstrappedES(),
-			c:             k8s.WrapClient(fake.NewFakeClient()),
+			c:             k8s.WrappedFakeClient(),
 			observedState: observer.State{ClusterInfo: &client.Info{ClusterUUID: ""}},
 			wantCluster:   notBootstrappedES(),
 		},
 		{
 			name:          "not annotated, but bootstrapped",
-			c:             k8s.WrapClient(fake.NewFakeClient(notBootstrappedES())),
+			c:             k8s.WrappedFakeClient(notBootstrappedES()),
 			cluster:       notBootstrappedES(),
 			observedState: observer.State{ClusterInfo: &client.Info{ClusterUUID: "uuid"}},
 			wantCluster:   bootstrappedES(),
 		},
 		{
 			name: "annotated, bootstrapped, but needs re-bootstrapping due to single node upgrade ",
-			c: k8s.WrapClient(fake.NewFakeClient(
+			c: k8s.WrappedFakeClient(
 				bootstrappedES(),
 				sset.TestPod{
 					ClusterName: "cluster",
 					Version:     "6.8.0",
 					Master:      true,
-				}.BuildPtr())),
+				}.BuildPtr()),
 			cluster:       bootstrappedES(),
 			observedState: observer.State{ClusterInfo: &client.Info{ClusterUUID: "uuid"}},
 			wantCluster:   reBootstrappingES(),
 		},
 		{
 			name: "not annotated, bootstrapped, but still on pre-upgrade version",
-			c: k8s.WrapClient(fake.NewFakeClient(
+			c: k8s.WrappedFakeClient(
 				reBootstrappingES(),
 				sset.TestPod{
 					ClusterName: "cluster",
 					Version:     "6.8.0",
 					Master:      true,
 				}.BuildPtr(),
-			)),
+			),
 			cluster:       reBootstrappingES(),
 			observedState: observer.State{ClusterInfo: &client.Info{ClusterUUID: "uuid"}},
 			wantCluster:   reBootstrappingES(),

--- a/pkg/controller/elasticsearch/driver/downscale_invariants_test.go
+++ b/pkg/controller/elasticsearch/driver/downscale_invariants_test.go
@@ -8,17 +8,15 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
 func Test_newDownscaleState(t *testing.T) {
@@ -35,7 +33,7 @@ func Test_newDownscaleState(t *testing.T) {
 		{
 			name:             "no resources in the apiserver",
 			initialResources: nil,
-			want:             &downscaleState{masterRemovalInProgress: false, runningMasters: 0, removalsAllowed: common.Int32(0)},
+			want:             &downscaleState{masterRemovalInProgress: false, runningMasters: 0, removalsAllowed: pointer.Int32(0)},
 		},
 		{
 			name: "3 masters running in the apiserver, 1 not running",
@@ -123,12 +121,12 @@ func Test_newDownscaleState(t *testing.T) {
 					},
 				},
 			},
-			want: &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: common.Int32(0)},
+			want: &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: pointer.Int32(0)},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			k8sClient := k8s.WrapClient(fake.NewFakeClient(tt.initialResources...))
+			k8sClient := k8s.WrappedFakeClient(tt.initialResources...)
 			got, err := newDownscaleState(k8sClient, es)
 			require.NoError(t, err)
 			if !reflect.DeepEqual(got, tt.want) {
@@ -157,15 +155,15 @@ func Test_calculateRemovalsAllowed(t *testing.T) {
 			name:           "scaling down, at least one node up",
 			nodesReady:     10,
 			desiredNodes:   3,
-			maxUnavailable: common.Int32(2),
-			want:           common.Int32(9),
+			maxUnavailable: pointer.Int32(2),
+			want:           pointer.Int32(9),
 		},
 		{
 			name:           "scaling up, can't remove anything",
 			nodesReady:     3,
 			desiredNodes:   5,
-			maxUnavailable: common.Int32(1),
-			want:           common.Int32(0),
+			maxUnavailable: pointer.Int32(1),
+			want:           pointer.Int32(0),
 		},
 	}
 	for _, tt := range tests {
@@ -188,40 +186,40 @@ func Test_checkDownscaleInvariants(t *testing.T) {
 	}{
 		{
 			name:             "should allow removing data node if maxUnavailable allows",
-			state:            &downscaleState{runningMasters: 1, masterRemovalInProgress: true, removalsAllowed: common.Int32(1)},
+			state:            &downscaleState{runningMasters: 1, masterRemovalInProgress: true, removalsAllowed: pointer.Int32(1)},
 			statefulSet:      ssetData4Replicas,
 			wantCanDownscale: true,
 		},
 		{
 			name:             "should not allow removing data nodes of maxUnavailable disallows",
-			state:            &downscaleState{runningMasters: 1, masterRemovalInProgress: true, removalsAllowed: common.Int32(0)},
+			state:            &downscaleState{runningMasters: 1, masterRemovalInProgress: true, removalsAllowed: pointer.Int32(0)},
 			statefulSet:      ssetData4Replicas,
 			wantCanDownscale: false,
 			wantReason:       RespectMaxUnavailableInvariant,
 		},
 		{
 			name:             "should allow removing one master if there is another one running",
-			state:            &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: common.Int32(1)},
+			state:            &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: pointer.Int32(1)},
 			statefulSet:      ssetMaster3Replicas,
 			wantCanDownscale: true,
 		},
 		{
 			name:             "should not allow removing the last master",
-			state:            &downscaleState{runningMasters: 1, masterRemovalInProgress: false, removalsAllowed: common.Int32(1)},
+			state:            &downscaleState{runningMasters: 1, masterRemovalInProgress: false, removalsAllowed: pointer.Int32(1)},
 			statefulSet:      ssetMaster3Replicas,
 			wantCanDownscale: false,
 			wantReason:       AtLeastOneRunningMasterInvariant,
 		},
 		{
 			name:             "should not allow removing a master if one is already being removed",
-			state:            &downscaleState{runningMasters: 2, masterRemovalInProgress: true, removalsAllowed: common.Int32(2)},
+			state:            &downscaleState{runningMasters: 2, masterRemovalInProgress: true, removalsAllowed: pointer.Int32(2)},
 			statefulSet:      ssetMaster3Replicas,
 			wantCanDownscale: false,
 			wantReason:       OneMasterAtATimeInvariant,
 		},
 		{
 			name:             "should not allow removing a master if maxUnavailable disallows",
-			state:            &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: common.Int32(0)},
+			state:            &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: pointer.Int32(0)},
 			statefulSet:      ssetMaster3Replicas,
 			wantCanDownscale: false,
 			wantReason:       RespectMaxUnavailableInvariant,
@@ -252,22 +250,22 @@ func Test_downscaleState_recordRemoval(t *testing.T) {
 			name:        "removing a data node should decrease nodes available for removal",
 			statefulSet: ssetData4Replicas,
 			removals:    1,
-			state:       &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: common.Int32(1)},
-			wantState:   &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: common.Int32(0)},
+			state:       &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: pointer.Int32(1)},
+			wantState:   &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: pointer.Int32(0)},
 		},
 		{
 			name:        "removing many data nodes should decrease nodes available for removal",
 			statefulSet: ssetData4Replicas,
 			removals:    3,
-			state:       &downscaleState{runningMasters: 1, masterRemovalInProgress: false, removalsAllowed: common.Int32(3)},
-			wantState:   &downscaleState{runningMasters: 1, masterRemovalInProgress: false, removalsAllowed: common.Int32(0)},
+			state:       &downscaleState{runningMasters: 1, masterRemovalInProgress: false, removalsAllowed: pointer.Int32(3)},
+			wantState:   &downscaleState{runningMasters: 1, masterRemovalInProgress: false, removalsAllowed: pointer.Int32(0)},
 		},
 		{
 			name:        "removing a master node should mutate the budget",
 			statefulSet: ssetMaster3Replicas,
 			removals:    1,
-			state:       &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: common.Int32(2)},
-			wantState:   &downscaleState{runningMasters: 1, masterRemovalInProgress: true, removalsAllowed: common.Int32(1)},
+			state:       &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: pointer.Int32(2)},
+			wantState:   &downscaleState{runningMasters: 1, masterRemovalInProgress: true, removalsAllowed: pointer.Int32(1)},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/expectations"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	commonscheme "github.com/elastic/cloud-on-k8s/pkg/controller/common/scheme"
@@ -22,14 +21,13 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // Sample StatefulSets to use in tests
@@ -135,7 +133,7 @@ func TestHandleDownscale(t *testing.T) {
 	// We want to downscale 2 StatefulSets (masters 3 -> 1 and data 4 -> 2) in version 7.X,
 	// but should only be allowed a partial downscale (3 -> 2 and 4 -> 3).
 
-	k8sClient := k8s.WrapClient(fake.NewFakeClient(runtimeObjs...))
+	k8sClient := k8s.WrappedFakeClient(runtimeObjs...)
 	esClient := &fakeESClient{}
 	actualStatefulSets := sset.StatefulSetList{ssetMaster3Replicas, ssetData4Replicas}
 	downscaleCtx := downscaleContext{
@@ -158,10 +156,10 @@ func TestHandleDownscale(t *testing.T) {
 
 	// request master nodes downscale from 3 to 1 replicas
 	ssetMaster3ReplicasDownscaled := *ssetMaster3Replicas.DeepCopy()
-	nodespec.UpdateReplicas(&ssetMaster3ReplicasDownscaled, common.Int32(1))
+	nodespec.UpdateReplicas(&ssetMaster3ReplicasDownscaled, pointer.Int32(1))
 	// request data nodes downscale from 4 to 2 replicas
 	ssetData4ReplicasDownscaled := *ssetData4Replicas.DeepCopy()
-	nodespec.UpdateReplicas(&ssetData4ReplicasDownscaled, common.Int32(2))
+	nodespec.UpdateReplicas(&ssetData4ReplicasDownscaled, pointer.Int32(2))
 	requestedStatefulSets := sset.StatefulSetList{ssetMaster3ReplicasDownscaled, ssetData4ReplicasDownscaled}
 
 	// do the downscale
@@ -175,11 +173,11 @@ func TestHandleDownscale(t *testing.T) {
 	// only part of the expected replicas of ssetMaster3Replicas should be updated,
 	// since we remove only one master at a time
 	ssetMaster3ReplicasExpectedAfterDownscale := *ssetMaster3Replicas.DeepCopy()
-	nodespec.UpdateReplicas(&ssetMaster3ReplicasExpectedAfterDownscale, common.Int32(2))
+	nodespec.UpdateReplicas(&ssetMaster3ReplicasExpectedAfterDownscale, pointer.Int32(2))
 	// only part of the expected replicas of ssetData4Replicas should be updated,
 	// since a node still needs to migrate data
 	ssetData4ReplicasExpectedAfterDownscale := *ssetData4Replicas.DeepCopy()
-	nodespec.UpdateReplicas(&ssetData4ReplicasExpectedAfterDownscale, common.Int32(3))
+	nodespec.UpdateReplicas(&ssetData4ReplicasExpectedAfterDownscale, pointer.Int32(3))
 
 	expectedAfterDownscale := []appsv1.StatefulSet{ssetMaster3ReplicasExpectedAfterDownscale, ssetData4ReplicasExpectedAfterDownscale}
 
@@ -208,7 +206,7 @@ func TestHandleDownscale(t *testing.T) {
 	require.Equal(t, requeueResults, results)
 
 	// one less master
-	nodespec.UpdateReplicas(&ssetMaster3ReplicasExpectedAfterDownscale, common.Int32(1))
+	nodespec.UpdateReplicas(&ssetMaster3ReplicasExpectedAfterDownscale, pointer.Int32(1))
 	expectedAfterDownscale = []appsv1.StatefulSet{ssetMaster3ReplicasExpectedAfterDownscale, ssetData4ReplicasExpectedAfterDownscale}
 	err = k8sClient.List(&actual)
 	require.NoError(t, err)
@@ -222,7 +220,7 @@ func TestHandleDownscale(t *testing.T) {
 			{Index: "index-1", Shard: "0", State: esclient.STARTED, NodeName: "ssetData4Replicas-1"},
 		},
 	)
-	nodespec.UpdateReplicas(&expectedAfterDownscale[1], common.Int32(2))
+	nodespec.UpdateReplicas(&expectedAfterDownscale[1], pointer.Int32(2))
 	results = HandleDownscale(downscaleCtx, requestedStatefulSets, actual.Items)
 	require.False(t, results.HasError())
 	require.Equal(t, emptyResults, results)
@@ -258,7 +256,7 @@ func Test_calculateDownscales(t *testing.T) {
 				Name:      "sset0",
 			},
 			Spec: appsv1.StatefulSetSpec{
-				Replicas: common.Int32(3),
+				Replicas: pointer.Int32(3),
 			},
 		},
 		{
@@ -267,7 +265,7 @@ func Test_calculateDownscales(t *testing.T) {
 				Name:      "sset1",
 			},
 			Spec: appsv1.StatefulSetSpec{
-				Replicas: common.Int32(3)},
+				Replicas: pointer.Int32(3)},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -275,7 +273,7 @@ func Test_calculateDownscales(t *testing.T) {
 				Name:      "sset2",
 			},
 			Spec: appsv1.StatefulSetSpec{
-				Replicas: common.Int32(3)},
+				Replicas: pointer.Int32(3)},
 		},
 	}
 
@@ -345,7 +343,7 @@ func Test_calculateDownscales(t *testing.T) {
 						Name:      "sset0",
 					},
 					Spec: appsv1.StatefulSetSpec{
-						Replicas: common.Int32(3),
+						Replicas: pointer.Int32(3),
 					},
 				},
 				{
@@ -354,7 +352,7 @@ func Test_calculateDownscales(t *testing.T) {
 						Name:      "sset1",
 					},
 					Spec: appsv1.StatefulSetSpec{
-						Replicas: common.Int32(2)},
+						Replicas: pointer.Int32(2)},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -362,7 +360,7 @@ func Test_calculateDownscales(t *testing.T) {
 						Name:      "sset2",
 					},
 					Spec: appsv1.StatefulSetSpec{
-						Replicas: common.Int32(1)},
+						Replicas: pointer.Int32(1)},
 				},
 			},
 			actualStatefulSets: ssets,
@@ -390,7 +388,7 @@ func Test_calculateDownscales(t *testing.T) {
 						Name:      "sset0",
 					},
 					Spec: appsv1.StatefulSetSpec{
-						Replicas: common.Int32(4),
+						Replicas: pointer.Int32(4),
 					},
 				},
 				{
@@ -399,7 +397,7 @@ func Test_calculateDownscales(t *testing.T) {
 						Name:      "sset1",
 					},
 					Spec: appsv1.StatefulSetSpec{
-						Replicas: common.Int32(5)},
+						Replicas: pointer.Int32(5)},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -407,7 +405,7 @@ func Test_calculateDownscales(t *testing.T) {
 						Name:      "sset2",
 					},
 					Spec: appsv1.StatefulSetSpec{
-						Replicas: common.Int32(3)},
+						Replicas: pointer.Int32(3)},
 				},
 			},
 			actualStatefulSets: ssets,
@@ -469,7 +467,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 					targetReplicas:  3,
 					finalReplicas:   3,
 				},
-				state:           &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: common.Int32(1)},
+				state:           &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: pointer.Int32(1)},
 				allLeavingNodes: []string{"node-1", "node-2"},
 			},
 			want: ssetDownscale{
@@ -489,7 +487,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 					targetReplicas:  2,
 					finalReplicas:   2,
 				},
-				state:           &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: common.Int32(1)},
+				state:           &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: pointer.Int32(1)},
 				allLeavingNodes: []string{"node-1", "node-2"},
 			},
 			want: ssetDownscale{
@@ -510,7 +508,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 					targetReplicas:  3,
 					finalReplicas:   2,
 				},
-				state:           &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: common.Int32(0)},
+				state:           &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: pointer.Int32(0)},
 				allLeavingNodes: []string{"node-1", "node-2"},
 			},
 			want: ssetDownscale{
@@ -532,7 +530,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 					finalReplicas:   2,
 				},
 				// a master node has already been removed
-				state:           &downscaleState{masterRemovalInProgress: true, runningMasters: 3, removalsAllowed: common.Int32(1)},
+				state:           &downscaleState{masterRemovalInProgress: true, runningMasters: 3, removalsAllowed: pointer.Int32(1)},
 				allLeavingNodes: []string{"node-1", "node-2"},
 			},
 			want: ssetDownscale{
@@ -555,7 +553,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 					finalReplicas:   1,
 				},
 				// invariants limits us to one master node downscale only
-				state:           &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: common.Int32(1)},
+				state:           &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: pointer.Int32(1)},
 				allLeavingNodes: []string{"node-1", "node-2"},
 			},
 			want: ssetDownscale{
@@ -578,7 +576,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 					finalReplicas:   0,
 				},
 				// only one master is running
-				state:           &downscaleState{masterRemovalInProgress: false, runningMasters: 1, removalsAllowed: common.Int32(1)},
+				state:           &downscaleState{masterRemovalInProgress: false, runningMasters: 1, removalsAllowed: pointer.Int32(1)},
 				allLeavingNodes: []string{"node-1", "node-2"},
 			},
 			want: ssetDownscale{
@@ -617,7 +615,7 @@ func Test_attemptDownscale(t *testing.T) {
 				initialReplicas: 0,
 				targetReplicas:  0,
 			},
-			state: &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: common.Int32(0)},
+			state: &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: pointer.Int32(0)},
 			statefulSets: sset.StatefulSetList{
 				sset.TestSset{Name: "should-be-removed", Version: "7.1.0", Replicas: 0, Master: true, Data: true}.Build(),
 				sset.TestSset{Name: "should-stay", Version: "7.1.0", Replicas: 2, Master: true, Data: true}.Build(),
@@ -633,7 +631,7 @@ func Test_attemptDownscale(t *testing.T) {
 				initialReplicas: 3,
 				targetReplicas:  3,
 			},
-			state: &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: common.Int32(1)},
+			state: &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: pointer.Int32(1)},
 			statefulSets: sset.StatefulSetList{
 				sset.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
 			},
@@ -648,7 +646,7 @@ func Test_attemptDownscale(t *testing.T) {
 				initialReplicas: 3,
 				targetReplicas:  4,
 			},
-			state: &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: common.Int32(1)},
+			state: &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: pointer.Int32(1)},
 			statefulSets: sset.StatefulSetList{
 				sset.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
 			},
@@ -663,7 +661,7 @@ func Test_attemptDownscale(t *testing.T) {
 				initialReplicas: 3,
 				targetReplicas:  2,
 			},
-			state: &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: common.Int32(1)},
+			state: &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: pointer.Int32(1)},
 			statefulSets: sset.StatefulSetList{
 				sset.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
 			},
@@ -679,7 +677,7 @@ func Test_attemptDownscale(t *testing.T) {
 				targetReplicas:  3,
 				finalReplicas:   2,
 			},
-			state: &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: common.Int32(0)},
+			state: &downscaleState{runningMasters: 2, masterRemovalInProgress: false, removalsAllowed: pointer.Int32(0)},
 			statefulSets: sset.StatefulSetList{
 				sset.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
 			},
@@ -694,7 +692,7 @@ func Test_attemptDownscale(t *testing.T) {
 			for i := range tt.statefulSets {
 				runtimeObjs = append(runtimeObjs, &tt.statefulSets[i])
 			}
-			k8sClient := k8s.WrapClient(fake.NewFakeClient(runtimeObjs...))
+			k8sClient := k8s.WrappedFakeClient(runtimeObjs...)
 			downscaleCtx := downscaleContext{
 				k8sClient:      k8sClient,
 				expectations:   expectations.NewExpectations(),
@@ -719,7 +717,7 @@ func Test_doDownscale_updateReplicasAndExpectations(t *testing.T) {
 	sset1.Generation = 1
 	sset2 := ssetData4Replicas
 	sset2.Generation = 1
-	k8sClient := k8s.WrapClient(fake.NewFakeClient(&sset1, &sset2))
+	k8sClient := k8s.WrappedFakeClient(&sset1, &sset2)
 	downscaleCtx := downscaleContext{
 		k8sClient:    k8sClient,
 		expectations: expectations.NewExpectations(),
@@ -824,7 +822,7 @@ func Test_doDownscale_zen2VotingConfigExclusions(t *testing.T) {
 					},
 				},
 			}
-			k8sClient := k8s.WrapClient(fake.NewFakeClient(&ssetMasters, &ssetData, &v7Pod))
+			k8sClient := k8s.WrappedFakeClient(&ssetMasters, &ssetData, &v7Pod)
 			esClient := &fakeESClient{}
 			downscaleCtx := downscaleContext{
 				k8sClient:      k8sClient,
@@ -922,7 +920,7 @@ func Test_doDownscale_zen1MinimumMasterNodes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			k8sClient := k8s.WrapClient(fake.NewFakeClient(tt.apiserverResources...))
+			k8sClient := k8s.WrappedFakeClient(tt.apiserverResources...)
 			esClient := &fakeESClient{}
 			downscaleCtx := downscaleContext{
 				k8sClient:      k8sClient,
@@ -949,7 +947,6 @@ func Test_removeStatefulSetResources(t *testing.T) {
 	cfg := settings.ConfigSecret(es, sset.Name, []byte("fake config data"))
 	svc := nodespec.HeadlessService(k8s.ExtractNamespacedName(&es), sset.Name)
 
-	require.NoError(t, v1beta1.AddToScheme(scheme.Scheme))
 	tests := []struct {
 		name      string
 		resources []runtime.Object
@@ -965,7 +962,7 @@ func Test_removeStatefulSetResources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			k8sClient := k8s.WrapClient(fake.NewFakeClient(tt.resources...))
+			k8sClient := k8s.WrappedFakeClient(tt.resources...)
 			err := removeStatefulSetResources(k8sClient, es, sset)
 			require.NoError(t, err)
 			// sset, cfg and headless services should not be there anymore

--- a/pkg/controller/elasticsearch/driver/expectations_test.go
+++ b/pkg/controller/elasticsearch/driver/expectations_test.go
@@ -7,18 +7,17 @@ package driver
 import (
 	"testing"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/expectations"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
 	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func Test_defaultDriver_expectationsMet(t *testing.T) {
 	d := &defaultDriver{DefaultDriverParameters{
 		Expectations: expectations.NewExpectations(),
-		Client:       k8s.WrapClient(fake.NewFakeClient()),
+		Client:       k8s.WrappedFakeClient(),
 	}}
 
 	// no expectations set
@@ -43,7 +42,7 @@ func Test_defaultDriver_expectationsMet(t *testing.T) {
 
 	// we expect some sset replicas to exist
 	// but corresponding pod does not exist
-	statefulSet.Spec.Replicas = common.Int32(1)
+	statefulSet.Spec.Replicas = pointer.Int32(1)
 	// expectations should not be met: we miss a pod
 	met, err = d.expectationsMet(sset.StatefulSetList{statefulSet})
 	require.NoError(t, err)
@@ -51,7 +50,7 @@ func Test_defaultDriver_expectationsMet(t *testing.T) {
 
 	// add the missing pod
 	pod := sset.TestPod{Name: "sset-0", StatefulSetName: statefulSet.Name}.Build()
-	d.Client = k8s.WrapClient(fake.NewFakeClient(&pod))
+	d.Client = k8s.WrappedFakeClient(&pod)
 	// expectations should be met
 	met, err = d.expectationsMet(sset.StatefulSetList{statefulSet})
 	require.NoError(t, err)

--- a/pkg/controller/elasticsearch/driver/fixtures.go
+++ b/pkg/controller/elasticsearch/driver/fixtures.go
@@ -6,10 +6,10 @@ package driver
 
 import (
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -113,7 +113,7 @@ func (u upgradeTestPods) toES(maxUnavailable int) v1beta1.Elasticsearch {
 		Spec: v1beta1.ElasticsearchSpec{
 			UpdateStrategy: v1beta1.UpdateStrategy{
 				ChangeBudget: v1beta1.ChangeBudget{
-					MaxUnavailable: common.Int32(int32(maxUnavailable)),
+					MaxUnavailable: pointer.Int32(int32(maxUnavailable)),
 				},
 			},
 		},

--- a/pkg/controller/elasticsearch/driver/pvc_test.go
+++ b/pkg/controller/elasticsearch/driver/pvc_test.go
@@ -8,17 +8,15 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
 func buildSsetWithClaims(name string, replicas int32, claims ...string) appsv1.StatefulSet {
@@ -141,7 +139,7 @@ func TestGarbageCollectPVCs(t *testing.T) {
 	}
 	actualSsets := sset.StatefulSetList{buildSsetWithClaims("sset1", 1, "claim1")}
 	expectedSsets := sset.StatefulSetList{buildSsetWithClaims("sset2", 1, "claim1")}
-	k8sClient := k8s.WrapClient(fake.NewFakeClient(existingPVCS...))
+	k8sClient := k8s.WrappedFakeClient(existingPVCS...)
 	err := GarbageCollectPVCs(k8sClient, es, actualSsets, expectedSsets)
 	require.NoError(t, err)
 

--- a/pkg/controller/elasticsearch/driver/upgrade_forced_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_forced_test.go
@@ -7,14 +7,11 @@ package driver
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/expectations"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
-
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -164,7 +161,7 @@ func Test_defaultDriver_maybeForceUpgrade(t *testing.T) {
 			for i := range tt.actualPods {
 				runtimeObjs = append(runtimeObjs, &tt.actualPods[i])
 			}
-			k8sClient := k8s.WrapClient(fake.NewFakeClient(runtimeObjs...))
+			k8sClient := k8s.WrappedFakeClient(runtimeObjs...)
 			d := &defaultDriver{
 				DefaultDriverParameters: DefaultDriverParameters{
 					Client:       k8sClient,

--- a/pkg/controller/elasticsearch/driver/upgrade_predicates_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_predicates_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/reconcile"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // These tests are focused on "type changes", i.e. when the type of a nodeSet is changed.
@@ -132,9 +131,7 @@ func TestUpgradePodsDeletion_WithNodeTypeMutations(t *testing.T) {
 		esClient := &fakeESClient{}
 		es := tt.fields.upgradeTestPods.toES(tt.fields.maxUnavailable)
 		ctx := rollingUpgradeCtx{
-			client: k8s.WrapClient(
-				fake.NewFakeClient(tt.fields.upgradeTestPods.toRuntimeObjects(tt.fields.maxUnavailable, nothing)...),
-			),
+			client:          k8s.WrappedFakeClient(tt.fields.upgradeTestPods.toRuntimeObjects(tt.fields.maxUnavailable, nothing)...),
 			ES:              es,
 			statefulSets:    tt.fields.upgradeTestPods.toStatefulSetList(),
 			esClient:        esClient,
@@ -392,9 +389,7 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 		}
 		esClient := &fakeESClient{}
 		ctx := rollingUpgradeCtx{
-			client: k8s.WrapClient(
-				fake.NewFakeClient(tt.fields.upgradeTestPods.toRuntimeObjects(tt.fields.maxUnavailable, tt.fields.podFilter)...),
-			),
+			client:          k8s.WrappedFakeClient(tt.fields.upgradeTestPods.toRuntimeObjects(tt.fields.maxUnavailable, tt.fields.podFilter)...),
 			ES:              tt.fields.upgradeTestPods.toES(tt.fields.maxUnavailable),
 			statefulSets:    tt.fields.upgradeTestPods.toStatefulSetList(),
 			esClient:        esClient,

--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -14,7 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const testNamespace = "ns"
@@ -106,7 +105,7 @@ func Test_podsToUpgrade(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := k8s.WrapClient(fake.NewFakeClient(tt.args.pods...))
+			client := k8s.WrappedFakeClient(tt.args.pods...)
 			got, err := podsToUpgrade(client, tt.args.statefulSets)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("podsToUpgrade() error = %v, wantErr %v", err, tt.wantErr)
@@ -167,7 +166,7 @@ func Test_healthyPods(t *testing.T) {
 			esState := &testESState{
 				inCluster: tt.args.pods.podsInCluster(),
 			}
-			client := k8s.WrapClient(fake.NewFakeClient(tt.args.pods.toRuntimeObjects(0, nothing)...))
+			client := k8s.WrappedFakeClient(tt.args.pods.toRuntimeObjects(0, nothing)...)
 			got, err := healthyPods(client, tt.args.statefulSets, esState)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("healthyPods() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/controller/elasticsearch/driver/upscale_state.go
+++ b/pkg/controller/elasticsearch/driver/upscale_state.go
@@ -7,14 +7,13 @@ package driver
 import (
 	"sync"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type upscaleState struct {
@@ -171,12 +170,12 @@ func (s *upscaleState) limitNodesCreation(
 	actualReplicas := sset.GetReplicas(actual)
 	targetReplicas := sset.GetReplicas(toApply)
 
-	nodespec.UpdateReplicas(&toApply, common.Int32(actualReplicas))
+	nodespec.UpdateReplicas(&toApply, pointer.Int32(actualReplicas))
 	replicasToCreate := targetReplicas - actualReplicas
 	replicasToCreate = s.getMaxNodesToCreate(replicasToCreate)
 
 	if replicasToCreate > 0 {
-		nodespec.UpdateReplicas(&toApply, common.Int32(actualReplicas+replicasToCreate))
+		nodespec.UpdateReplicas(&toApply, pointer.Int32(actualReplicas+replicasToCreate))
 		s.recordNodesCreation(replicasToCreate)
 		ssetLogger(toApply).Info(
 			"Creating nodes",
@@ -201,7 +200,7 @@ func (s *upscaleState) limitMasterNodesCreation(
 	actualReplicas := sset.GetReplicas(actual)
 	targetReplicas := sset.GetReplicas(toApply)
 
-	nodespec.UpdateReplicas(&toApply, common.Int32(actualReplicas))
+	nodespec.UpdateReplicas(&toApply, pointer.Int32(actualReplicas))
 	for rep := actualReplicas + 1; rep <= targetReplicas; rep++ {
 		if !s.canCreateMasterNode() {
 			ssetLogger(toApply).Info(
@@ -212,7 +211,7 @@ func (s *upscaleState) limitMasterNodesCreation(
 			break
 		}
 		// allow one more master node to be created
-		nodespec.UpdateReplicas(&toApply, common.Int32(rep))
+		nodespec.UpdateReplicas(&toApply, pointer.Int32(rep))
 		s.recordMasterNodeCreation()
 		ssetLogger(toApply).Info(
 			"Creating master node",

--- a/pkg/controller/elasticsearch/driver/upscale_state_test.go
+++ b/pkg/controller/elasticsearch/driver/upscale_state_test.go
@@ -8,13 +8,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -50,67 +48,67 @@ func Test_upscaleState_limitNodesCreation(t *testing.T) {
 		},
 		{
 			name:        "upscale data nodes from 1 to 3: should go through",
-			state:       &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: common.Int32(2)},
+			state:       &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: pointer.Int32(2)},
 			actual:      sset.TestSset{Name: "sset", Replicas: 1, Master: false}.Build(),
 			ssetToApply: sset.TestSset{Name: "sset", Replicas: 3, Master: false}.Build(),
 			wantSset:    sset.TestSset{Name: "sset", Replicas: 3, Master: false}.Build(),
-			wantState:   &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: common.Int32(2), recordedCreates: 2},
+			wantState:   &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: pointer.Int32(2), recordedCreates: 2},
 		},
 		{
 			name:        "upscale data nodes from 1 to 4: should limit to 3",
-			state:       &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: common.Int32(2)},
+			state:       &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: pointer.Int32(2)},
 			actual:      sset.TestSset{Name: "sset", Replicas: 1, Master: false}.Build(),
 			ssetToApply: sset.TestSset{Name: "sset", Replicas: 4, Master: false}.Build(),
 			wantSset:    sset.TestSset{Name: "sset", Replicas: 3, Master: false}.Build(),
-			wantState:   &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: common.Int32(2), recordedCreates: 2},
+			wantState:   &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: pointer.Int32(2), recordedCreates: 2},
 		},
 		{
 			name:        "upscale master nodes from 1 to 3: should limit to 2",
-			state:       &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: common.Int32(1)},
+			state:       &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: pointer.Int32(1)},
 			actual:      sset.TestSset{Name: "sset", Replicas: 1, Master: true}.Build(),
 			ssetToApply: sset.TestSset{Name: "sset", Replicas: 3, Master: true}.Build(),
 			wantSset:    sset.TestSset{Name: "sset", Replicas: 2, Master: true}.Build(),
-			wantState:   &upscaleState{allowMasterCreation: false, isBootstrapped: true, createsAllowed: common.Int32(1), recordedCreates: 1},
+			wantState:   &upscaleState{allowMasterCreation: false, isBootstrapped: true, createsAllowed: pointer.Int32(1), recordedCreates: 1},
 		},
 		{
 			name:        "upscale master nodes from 1 to 3 when cluster not yet bootstrapped: should go through",
-			state:       &upscaleState{allowMasterCreation: true, isBootstrapped: false, createsAllowed: common.Int32(2)},
+			state:       &upscaleState{allowMasterCreation: true, isBootstrapped: false, createsAllowed: pointer.Int32(2)},
 			actual:      sset.TestSset{Name: "sset", Replicas: 1, Master: true}.Build(),
 			ssetToApply: sset.TestSset{Name: "sset", Replicas: 3, Master: true}.Build(),
 			wantSset:    sset.TestSset{Name: "sset", Replicas: 3, Master: true}.Build(),
-			wantState:   &upscaleState{allowMasterCreation: true, isBootstrapped: false, createsAllowed: common.Int32(2), recordedCreates: 2},
+			wantState:   &upscaleState{allowMasterCreation: true, isBootstrapped: false, createsAllowed: pointer.Int32(2), recordedCreates: 2},
 		},
 		{
 			name:        "upscale masters from 3 to 4, but no creates allowed: should limit to 0",
-			state:       &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: common.Int32(0)},
+			state:       &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: pointer.Int32(0)},
 			actual:      sset.TestSset{Name: "sset", Replicas: 3, Master: true}.Build(),
 			ssetToApply: sset.TestSset{Name: "sset", Replicas: 4, Master: true}.Build(),
 			wantSset:    sset.TestSset{Name: "sset", Replicas: 3, Master: true}.Build(),
-			wantState:   &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: common.Int32(0), recordedCreates: 0},
+			wantState:   &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: pointer.Int32(0), recordedCreates: 0},
 		},
 		{
 			name:        "upscale data nodes from 3 to 4, but no creates allowed: should limit to 0",
-			state:       &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: common.Int32(0)},
+			state:       &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: pointer.Int32(0)},
 			actual:      sset.TestSset{Name: "sset", Replicas: 3, Master: false}.Build(),
 			ssetToApply: sset.TestSset{Name: "sset", Replicas: 4, Master: false}.Build(),
 			wantSset:    sset.TestSset{Name: "sset", Replicas: 3, Master: false}.Build(),
-			wantState:   &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: common.Int32(0), recordedCreates: 0},
+			wantState:   &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: pointer.Int32(0), recordedCreates: 0},
 		},
 		{
 			name:        "new StatefulSet with 5 master nodes, cluster isn't bootstrapped yet: should go through",
-			state:       &upscaleState{allowMasterCreation: true, isBootstrapped: false, createsAllowed: common.Int32(3)},
+			state:       &upscaleState{allowMasterCreation: true, isBootstrapped: false, createsAllowed: pointer.Int32(3)},
 			actual:      appsv1.StatefulSet{},
 			ssetToApply: sset.TestSset{Name: "sset", Replicas: 3, Master: true}.Build(),
 			wantSset:    sset.TestSset{Name: "sset", Replicas: 3, Master: true}.Build(),
-			wantState:   &upscaleState{allowMasterCreation: true, isBootstrapped: false, createsAllowed: common.Int32(3), recordedCreates: 3},
+			wantState:   &upscaleState{allowMasterCreation: true, isBootstrapped: false, createsAllowed: pointer.Int32(3), recordedCreates: 3},
 		},
 		{
 			name:        "new StatefulSet with 5 master nodes, cluster already bootstrapped: should limit to 1",
-			state:       &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: common.Int32(1)},
+			state:       &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: pointer.Int32(1)},
 			actual:      appsv1.StatefulSet{},
 			ssetToApply: sset.TestSset{Name: "sset", Replicas: 3, Master: true}.Build(),
 			wantSset:    sset.TestSset{Name: "sset", Replicas: 1, Master: true}.Build(),
-			wantState:   &upscaleState{allowMasterCreation: false, isBootstrapped: true, createsAllowed: common.Int32(1), recordedCreates: 1},
+			wantState:   &upscaleState{allowMasterCreation: false, isBootstrapped: true, createsAllowed: pointer.Int32(1), recordedCreates: 1},
 		},
 	}
 	for _, tt := range tests {
@@ -236,14 +234,14 @@ func Test_newUpscaleState(t *testing.T) {
 		},
 		{
 			name: "bootstrapped, no master node joining",
-			args: args{ctx: upscaleCtx{k8sClient: k8s.WrapClient(fake.NewFakeClient()), es: *bootstrappedES()}},
+			args: args{ctx: upscaleCtx{k8sClient: k8s.WrappedFakeClient(), es: *bootstrappedES()}},
 			want: &upscaleState{allowMasterCreation: true, isBootstrapped: true, createsAllowed: nil},
 		},
 		{
 			name: "bootstrapped, a master node is pending",
 			args: args{
 				ctx: upscaleCtx{
-					k8sClient: k8s.WrapClient(fake.NewFakeClient(sset.TestPod{ClusterName: "cluster", Master: true, Phase: corev1.PodPending}.BuildPtr())),
+					k8sClient: k8s.WrappedFakeClient(sset.TestPod{ClusterName: "cluster", Master: true, Phase: corev1.PodPending}.BuildPtr()),
 					es:        *bootstrappedES(),
 				},
 			},
@@ -253,7 +251,7 @@ func Test_newUpscaleState(t *testing.T) {
 			name: "bootstrapped, a data node is pending",
 			args: args{
 				ctx: upscaleCtx{
-					k8sClient: k8s.WrapClient(fake.NewFakeClient(sset.TestPod{ClusterName: "cluster", Master: false, Data: true, Phase: corev1.PodPending}.BuildPtr())),
+					k8sClient: k8s.WrappedFakeClient(sset.TestPod{ClusterName: "cluster", Master: false, Data: true, Phase: corev1.PodPending}.BuildPtr()),
 					es:        *bootstrappedES(),
 				},
 			},
@@ -304,8 +302,8 @@ func Test_newUpscaleStateWithChangeBudget(t *testing.T) {
 		return test{
 			name: args.name,
 			ctx: upscaleCtx{
-				k8sClient: k8s.WrapClient(fake.NewFakeClient()),
-				es:        *bootstrappedESWithChangeBudget(args.maxSurge, common.Int32(0)),
+				k8sClient: k8s.WrappedFakeClient(),
+				es:        *bootstrappedESWithChangeBudget(args.maxSurge, pointer.Int32(0)),
 			},
 			actual:   actualSsets,
 			expected: expectedResources,
@@ -316,11 +314,11 @@ func Test_newUpscaleStateWithChangeBudget(t *testing.T) {
 	defaultTest.ctx.es.Spec.UpdateStrategy = v1beta1.UpdateStrategy{}
 
 	tests := []test{
-		getTest(args{actual: []int{3}, expected: []int{3}, maxSurge: common.Int32(0), createsAllowed: common.Int32(0), name: "3 nodes present, 3 nodes target - no creates allowed"}),
-		getTest(args{actual: []int{3, 3}, expected: []int{3, 3}, maxSurge: common.Int32(0), createsAllowed: common.Int32(0), name: "2 ssets, 6 nodes present, 6 nodes target - no creates allowed"}),
-		getTest(args{actual: []int{2}, expected: []int{3}, maxSurge: common.Int32(0), createsAllowed: common.Int32(1), name: "2 nodes present, 3 nodes target - 1 create allowed"}),
-		getTest(args{actual: []int{}, expected: []int{5}, maxSurge: common.Int32(3), createsAllowed: common.Int32(8), name: "0 nodes present, 5 nodes target, 3 maxSurge - 8 creates allowed"}),
-		getTest(args{actual: []int{5}, expected: []int{3}, maxSurge: common.Int32(3), createsAllowed: common.Int32(1), name: "5 nodes present, 3 nodes target, 3 maxSurge - 1 create allowed"}),
+		getTest(args{actual: []int{3}, expected: []int{3}, maxSurge: pointer.Int32(0), createsAllowed: pointer.Int32(0), name: "3 nodes present, 3 nodes target - no creates allowed"}),
+		getTest(args{actual: []int{3, 3}, expected: []int{3, 3}, maxSurge: pointer.Int32(0), createsAllowed: pointer.Int32(0), name: "2 ssets, 6 nodes present, 6 nodes target - no creates allowed"}),
+		getTest(args{actual: []int{2}, expected: []int{3}, maxSurge: pointer.Int32(0), createsAllowed: pointer.Int32(1), name: "2 nodes present, 3 nodes target - 1 create allowed"}),
+		getTest(args{actual: []int{}, expected: []int{5}, maxSurge: pointer.Int32(3), createsAllowed: pointer.Int32(8), name: "0 nodes present, 5 nodes target, 3 maxSurge - 8 creates allowed"}),
+		getTest(args{actual: []int{5}, expected: []int{3}, maxSurge: pointer.Int32(3), createsAllowed: pointer.Int32(1), name: "5 nodes present, 3 nodes target, 3 maxSurge - 1 create allowed"}),
 		defaultTest,
 	}
 	for _, tt := range tests {
@@ -346,11 +344,11 @@ func Test_calculateCreatesAllowed(t *testing.T) {
 	}
 	tests := []args{
 		{name: "nil budget, 5->6, want max", maxSurge: nil, actual: 5, expected: 6, want: nil},
-		{name: "0 budget, 5->5, want 0", maxSurge: common.Int32(0), actual: 5, expected: 5, want: common.Int32(0)},
-		{name: "1 budget, 5->5, want 1", maxSurge: common.Int32(1), actual: 5, expected: 5, want: common.Int32(1)},
-		{name: "2 budget, 5->5, want 2", maxSurge: common.Int32(2), actual: 5, expected: 5, want: common.Int32(2)},
-		{name: "2 budget, 3->5, want 4", maxSurge: common.Int32(2), actual: 3, expected: 5, want: common.Int32(4)},
-		{name: "6 budget, 10->5, want 4", maxSurge: common.Int32(6), actual: 10, expected: 5, want: common.Int32(1)},
+		{name: "0 budget, 5->5, want 0", maxSurge: pointer.Int32(0), actual: 5, expected: 5, want: pointer.Int32(0)},
+		{name: "1 budget, 5->5, want 1", maxSurge: pointer.Int32(1), actual: 5, expected: 5, want: pointer.Int32(1)},
+		{name: "2 budget, 5->5, want 2", maxSurge: pointer.Int32(2), actual: 5, expected: 5, want: pointer.Int32(2)},
+		{name: "2 budget, 3->5, want 4", maxSurge: pointer.Int32(2), actual: 3, expected: 5, want: pointer.Int32(4)},
+		{name: "6 budget, 10->5, want 4", maxSurge: pointer.Int32(6), actual: 10, expected: 5, want: pointer.Int32(1)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/elasticsearch/license/apply_test.go
+++ b/pkg/controller/elasticsearch/license/apply_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/license"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
@@ -16,15 +15,12 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/name"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func Test_updateLicense(t *testing.T) {
@@ -175,7 +171,7 @@ func Test_applyLinkedLicense(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &fakeClient{
-				Client: k8s.WrapClient(fake.NewFakeClientWithScheme(registerScheme(t), tt.initialObjs...)),
+				Client: k8s.WrappedFakeClient(tt.initialObjs...),
 				errors: tt.errors,
 			}
 			if err := applyLinkedLicense(
@@ -206,11 +202,3 @@ func (f *fakeClient) Get(key client.ObjectKey, obj runtime.Object) error {
 }
 
 var _ k8s.Client = &fakeClient{}
-
-func registerScheme(t *testing.T) *runtime.Scheme {
-	sc := scheme.Scheme
-	if err := v1beta1.SchemeBuilder.AddToScheme(sc); err != nil {
-		assert.Fail(t, "failed to build custom scheme")
-	}
-	return sc
-}

--- a/pkg/controller/elasticsearch/nodespec/resources_test.go
+++ b/pkg/controller/elasticsearch/nodespec/resources_test.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
 func TestResourcesList_MasterNodesNames(t *testing.T) {
@@ -58,7 +58,6 @@ func TestSetVolumeClaimsControllerReference(t *testing.T) {
 			UID:       "ABCDEF",
 		},
 	}
-	require.NoError(t, v1beta1.AddToScheme(scheme.Scheme))
 	type args struct {
 		volumeClaims []corev1.PersistentVolumeClaim
 	}
@@ -90,7 +89,7 @@ func TestSetVolumeClaimsControllerReference(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := setVolumeClaimsControllerReference(tt.args.volumeClaims, es, scheme.Scheme)
+			got, err := setVolumeClaimsControllerReference(tt.args.volumeClaims, es, k8s.Scheme())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildExpectedResources() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/elasticsearch/settings/config_volume_test.go
+++ b/pkg/controller/elasticsearch/settings/config_volume_test.go
@@ -12,12 +12,9 @@ import (
 	common "github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestConfigSecretName(t *testing.T) {
@@ -55,7 +52,7 @@ func TestGetESConfigContent(t *testing.T) {
 	}{
 		{
 			name:      "valid config exists",
-			client:    k8s.WrapClient(fake.NewFakeClient(&secret)),
+			client:    k8s.WrappedFakeClient(&secret),
 			namespace: namespace,
 			ssetName:  ssetName,
 			want:      CanonicalConfig{common.MustCanonicalConfig(map[string]string{"a": "b", "c": "d"})},
@@ -63,7 +60,7 @@ func TestGetESConfigContent(t *testing.T) {
 		},
 		{
 			name:      "config does not exist",
-			client:    k8s.WrapClient(fake.NewFakeClient()),
+			client:    k8s.WrappedFakeClient(),
 			namespace: namespace,
 			ssetName:  ssetName,
 			want:      CanonicalConfig{},
@@ -71,7 +68,7 @@ func TestGetESConfigContent(t *testing.T) {
 		},
 		{
 			name:      "stored config is invalid",
-			client:    k8s.WrapClient(fake.NewFakeClient(&secretInvalid)),
+			client:    k8s.WrappedFakeClient(&secretInvalid),
 			namespace: namespace,
 			ssetName:  ssetName,
 			want:      CanonicalConfig{},
@@ -93,8 +90,6 @@ func TestGetESConfigContent(t *testing.T) {
 }
 
 func TestReconcileConfig(t *testing.T) {
-	err := v1beta1.AddToScheme(scheme.Scheme)
-	assert.NoError(t, err)
 	es := v1beta1.Elasticsearch{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "ns",
@@ -128,7 +123,7 @@ func TestReconcileConfig(t *testing.T) {
 	}{
 		{
 			name:     "config does not exist",
-			client:   k8s.WrapClient(fake.NewFakeClient()),
+			client:   k8s.WrappedFakeClient(),
 			es:       es,
 			ssetName: ssetName,
 			config:   config,
@@ -136,7 +131,7 @@ func TestReconcileConfig(t *testing.T) {
 		},
 		{
 			name:     "config already exists",
-			client:   k8s.WrapClient(fake.NewFakeClient(&configSecret)),
+			client:   k8s.WrappedFakeClient(&configSecret),
 			es:       es,
 			ssetName: ssetName,
 			config:   config,
@@ -144,7 +139,7 @@ func TestReconcileConfig(t *testing.T) {
 		},
 		{
 			name:     "config should be updated",
-			client:   k8s.WrapClient(fake.NewFakeClient(&configSecret)),
+			client:   k8s.WrappedFakeClient(&configSecret),
 			es:       es,
 			ssetName: ssetName,
 			config:   CanonicalConfig{common.MustCanonicalConfig(map[string]string{"a": "b", "c": "different"})},

--- a/pkg/controller/elasticsearch/settings/masters_test.go
+++ b/pkg/controller/elasticsearch/settings/masters_test.go
@@ -13,13 +13,11 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // newPodWithIP creates a new Pod potentially labeled as master with a given podIP
@@ -41,7 +39,6 @@ func newPodWithIP(name, ip string, master bool) corev1.Pod {
 }
 
 func TestUpdateSeedHostsConfigMap(t *testing.T) {
-	require.NoError(t, v1beta1.AddToScheme(scheme.Scheme))
 	es := v1beta1.Elasticsearch{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "es1",
@@ -70,7 +67,7 @@ func TestUpdateSeedHostsConfigMap(t *testing.T) {
 					newPodWithIP("node1", "", false),
 					newPodWithIP("node2", "10.0.2.8", false),
 				},
-				c:      k8s.WrapClient(fake.NewFakeClient()),
+				c:      k8s.WrappedFakeClient(),
 				es:     es,
 				scheme: scheme.Scheme,
 			},
@@ -84,7 +81,7 @@ func TestUpdateSeedHostsConfigMap(t *testing.T) {
 					newPodWithIP("node1", "", false),
 					newPodWithIP("node2", "10.0.2.8", false),
 				},
-				c:      k8s.WrapClient(fake.NewFakeClient()),
+				c:      k8s.WrappedFakeClient(),
 				es:     es,
 				scheme: scheme.Scheme,
 			},
@@ -101,7 +98,7 @@ func TestUpdateSeedHostsConfigMap(t *testing.T) {
 					newPodWithIP("node1", "10.0.9.3", false),
 					newPodWithIP("node2", "10.0.2.8", false),
 				},
-				c:      k8s.WrapClient(fake.NewFakeClient()),
+				c:      k8s.WrappedFakeClient(),
 				es:     es,
 				scheme: scheme.Scheme,
 			},
@@ -118,7 +115,7 @@ func TestUpdateSeedHostsConfigMap(t *testing.T) {
 					newPodWithIP("node1", "", false),
 					newPodWithIP("node2", "10.0.2.8", false),
 				},
-				c:      k8s.WrapClient(fake.NewFakeClient()),
+				c:      k8s.WrappedFakeClient(),
 				es:     es,
 				scheme: scheme.Scheme,
 			},

--- a/pkg/controller/elasticsearch/sset/list_test.go
+++ b/pkg/controller/elasticsearch/sset/list_test.go
@@ -8,16 +8,14 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
 var ssetv7 = appsv1.StatefulSet{
@@ -88,7 +86,7 @@ func TestStatefulSetList_GetExistingPods(t *testing.T) {
 			},
 		},
 	}
-	client := k8s.WrapClient(fake.NewFakeClient(&pod1, &pod2, &podNotInSset))
+	client := k8s.WrappedFakeClient(&pod1, &pod2, &podNotInSset)
 	pods, err := StatefulSetList{ssetv7}.GetActualPods(client)
 	require.NoError(t, err)
 	require.Equal(t, []corev1.Pod{pod1, pod2}, pods)
@@ -106,21 +104,21 @@ func TestStatefulSetList_PodReconciliationDone(t *testing.T) {
 		{
 			name: "no pods, no sset",
 			l:    nil,
-			c:    k8s.WrapClient(fake.NewFakeClient()),
+			c:    k8s.WrappedFakeClient(),
 			want: true,
 		},
 		{
 			name: "some pods, no sset",
 			l:    nil,
-			c: k8s.WrapClient(fake.NewFakeClient(
+			c: k8s.WrappedFakeClient(
 				TestPod{Namespace: "ns", Name: "sset-0", StatefulSetName: "sset", Revision: "current-rev"}.BuildPtr(),
-			)),
+			),
 			want: true,
 		},
 		{
 			name: "some statefulSets, no pod",
 			l:    StatefulSetList{TestSset{Name: "sset1", Replicas: 3}.Build()},
-			c:    k8s.WrapClient(fake.NewFakeClient(TestSset{Name: "sset1", Replicas: 3}.BuildPtr())),
+			c:    k8s.WrappedFakeClient(TestSset{Name: "sset1", Replicas: 3}.BuildPtr()),
 			want: false,
 		},
 		{
@@ -128,12 +126,12 @@ func TestStatefulSetList_PodReconciliationDone(t *testing.T) {
 			l: StatefulSetList{
 				TestSset{Name: "sset1", Namespace: "ns", Replicas: 2, Status: appsv1.StatefulSetStatus{CurrentRevision: "current-rev"}}.Build(),
 			},
-			c: k8s.WrapClient(fake.NewFakeClient(
+			c: k8s.WrappedFakeClient(
 				TestPod{Namespace: "ns", Name: "sset1-0", StatefulSetName: "sset1", Revision: "current-rev"}.BuildPtr(),
 				TestPod{Namespace: "ns", Name: "sset1-1", StatefulSetName: "sset1", Revision: "current-rev"}.BuildPtr(),
 				TestPod{Namespace: "ns", Name: "sset2-0", StatefulSetName: "sset2", Revision: "current-rev"}.BuildPtr(),
 				TestPod{Namespace: "ns0", Name: "sset1-0", StatefulSetName: "sset1", Revision: "current-rev"}.BuildPtr(),
-			)),
+			),
 			want: true,
 		},
 		{
@@ -141,9 +139,9 @@ func TestStatefulSetList_PodReconciliationDone(t *testing.T) {
 			l: StatefulSetList{
 				TestSset{Name: "sset1", Replicas: 2, Status: appsv1.StatefulSetStatus{CurrentRevision: "current-rev"}}.Build(),
 			},
-			c: k8s.WrapClient(fake.NewFakeClient(
+			c: k8s.WrappedFakeClient(
 				TestPod{Namespace: "ns", Name: "sset1-0", StatefulSetName: "sset2", Revision: "current-rev"}.BuildPtr(),
-			)),
+			),
 			want: false,
 		},
 		// TODO: test more than one StatefulSet once https://github.com/kubernetes-sigs/controller-runtime/pull/311 is available

--- a/pkg/controller/elasticsearch/sset/pod_test.go
+++ b/pkg/controller/elasticsearch/sset/pod_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -17,7 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestPodName(t *testing.T) {
@@ -33,7 +32,7 @@ func TestPodNames(t *testing.T) {
 				Name:      "sset",
 			},
 			Spec: appsv1.StatefulSetSpec{
-				Replicas: common.Int32(3),
+				Replicas: pointer.Int32(3),
 			},
 		}),
 	)
@@ -83,7 +82,7 @@ func TestGetActualPodsForStatefulSet(t *testing.T) {
 		getPodSample("pod2", "ns0", "sset1", "clus1", "0"),
 		getPodSample("pod3", "ns0", "sset1", "clus0", "0"),
 	}
-	c := k8s.WrapClient(fake.NewFakeClient(objs...))
+	c := k8s.WrappedFakeClient(objs...)
 	sset0 := getSsetSample("sset0", "ns0", "clus0")
 	pods, err := GetActualPodsForStatefulSet(c, k8s.ExtractNamespacedName(&sset0))
 	require.NoError(t, err)
@@ -107,7 +106,7 @@ func TestGetActualMastersForCluster(t *testing.T) {
 		getPodSample("pod3", "ns0", "sset1", "clus1", "0"),
 		getPodSample("pod4", "ns0", "sset1", "clus0", "0"),
 	}
-	c := k8s.WrapClient(fake.NewFakeClient(objs...))
+	c := k8s.WrappedFakeClient(objs...)
 
 	es := v1beta1.Elasticsearch{
 		ObjectMeta: v1.ObjectMeta{

--- a/pkg/controller/elasticsearch/sset/reconcile_test.go
+++ b/pkg/controller/elasticsearch/sset/reconcile_test.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
@@ -24,7 +23,6 @@ import (
 )
 
 func TestReconcileStatefulSet(t *testing.T) {
-	require.NoError(t, v1beta1.AddToScheme(scheme.Scheme))
 	es := v1beta1.Elasticsearch{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "ns",
@@ -57,19 +55,19 @@ func TestReconcileStatefulSet(t *testing.T) {
 	}{
 		{
 			name:                    "create new sset",
-			c:                       k8s.WrapClient(fake.NewFakeClient()),
+			c:                       k8s.WrappedFakeClient(),
 			expected:                ssetSample,
 			wantExpectationsUpdated: false,
 		},
 		{
 			name:                    "no update on existing sset",
-			c:                       k8s.WrapClient(fake.NewFakeClient(&ssetSample)),
+			c:                       k8s.WrappedFakeClient(&ssetSample),
 			expected:                ssetSample,
 			wantExpectationsUpdated: false,
 		},
 		{
 			name:                    "update on sset with different template hash",
-			c:                       k8s.WrapClient(fake.NewFakeClient(&ssetSample)),
+			c:                       k8s.WrappedFakeClient(&ssetSample),
 			expected:                updatedSset,
 			wantExpectationsUpdated: true,
 		},

--- a/pkg/controller/elasticsearch/validation/upgrade_checks_test.go
+++ b/pkg/controller/elasticsearch/validation/upgrade_checks_test.go
@@ -10,10 +10,8 @@ import (
 
 	estype "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/validation"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
 func es(v string) *estype.Elasticsearch {
@@ -27,7 +25,6 @@ func es(v string) *estype.Elasticsearch {
 }
 
 func TestValidation_noDowngrades(t *testing.T) {
-	assert.NoError(t, estype.SchemeBuilder.AddToScheme(scheme.Scheme))
 	type args struct {
 		toValidate estype.Elasticsearch
 	}

--- a/pkg/controller/elasticsearch/version/zen1/compatibility_test.go
+++ b/pkg/controller/elasticsearch/version/zen1/compatibility_test.go
@@ -15,7 +15,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func createStatefulSetWithVersion(version string) appsv1.StatefulSet {
@@ -97,31 +96,31 @@ func TestAtLeastOneNodeCompatibleWithZen1(t *testing.T) {
 		{
 			name:         "no sset",
 			statefulSets: nil,
-			client:       k8s.WrapClient(fake.NewFakeClient()),
+			client:       k8s.WrappedFakeClient(),
 			want:         false,
 		},
 		{
 			name:         "none compatible",
 			statefulSets: sset.StatefulSetList{createStatefulSetWithVersion("7.0.0"), createStatefulSetWithVersion("7.1.0")},
-			client:       k8s.WrapClient(fake.NewFakeClient()),
+			client:       k8s.WrappedFakeClient(),
 			want:         false,
 		},
 		{
 			name:         "one compatible",
 			statefulSets: sset.StatefulSetList{createStatefulSetWithVersion("6.8.0"), createStatefulSetWithVersion("7.1.0")},
-			client:       k8s.WrapClient(fake.NewFakeClient()),
+			client:       k8s.WrappedFakeClient(),
 			want:         true,
 		},
 		{
 			name:         "all compatible",
 			statefulSets: sset.StatefulSetList{createStatefulSetWithVersion("6.8.0"), createStatefulSetWithVersion("6.9.0")},
-			client:       k8s.WrapClient(fake.NewFakeClient()),
+			client:       k8s.WrappedFakeClient(),
 			want:         true,
 		},
 		{
 			name:         "Version in StatefulSet spec in 7.2.0 but there're still some 6.8.0 in flight",
 			statefulSets: sset.StatefulSetList{createStatefulSetWithVersion("7.2.0")},
-			client:       k8s.WrapClient(fake.NewFakeClient(createMasterPodsWithVersion("foo", "6.8.0", 5)...)),
+			client:       k8s.WrappedFakeClient(createMasterPodsWithVersion("foo", "6.8.0", 5)...),
 			want:         true,
 		},
 	}

--- a/pkg/controller/elasticsearch/version/zen1/minimum_masters_test.go
+++ b/pkg/controller/elasticsearch/version/zen1/minimum_masters_test.go
@@ -22,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestSetupMinimumMasterNodesConfig(t *testing.T) {
@@ -76,7 +75,7 @@ func TestSetupMinimumMasterNodesConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := k8s.WrapClient(fake.NewFakeClient(tt.pods...))
+			client := k8s.WrappedFakeClient(tt.pods...)
 			err := SetupMinimumMasterNodesConfig(client, testES, tt.nodeSpecResources)
 			require.NoError(t, err)
 			for i := 0; i < len(tt.nodeSpecResources); i++ {
@@ -159,11 +158,11 @@ func TestUpdateMinimumMasterNodes(t *testing.T) {
 			name:               "no v6 nodes",
 			actualStatefulSets: sset.StatefulSetList{sset.TestSset{Name: "nodes", Namespace: ns, Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build()},
 			wantCalled:         false,
-			c:                  k8s.WrapClient(fake.NewFakeClient(createMasterPodsWithVersion("nodes", "7.1.0", 3)...)),
+			c:                  k8s.WrappedFakeClient(createMasterPodsWithVersion("nodes", "7.1.0", 3)...),
 		},
 		{
 			name:               "correct mmn already set in ES annotation",
-			c:                  k8s.WrapClient(fake.NewFakeClient(&podsReady3[0], &podsReady3[1], &podsReady3[2])),
+			c:                  k8s.WrappedFakeClient(&podsReady3[0], &podsReady3[1], &podsReady3[2]),
 			actualStatefulSets: sset.StatefulSetList{ssetSample},
 			es: v1beta1.Elasticsearch{
 				ObjectMeta: metav1.ObjectMeta{
@@ -178,7 +177,7 @@ func TestUpdateMinimumMasterNodes(t *testing.T) {
 		},
 		{
 			name:               "mmn should be updated, it's different in the ES annotation",
-			c:                  k8s.WrapClient(fake.NewFakeClient(&podsReady3[0], &podsReady3[1], &podsReady3[2])),
+			c:                  k8s.WrappedFakeClient(&podsReady3[0], &podsReady3[1], &podsReady3[2]),
 			actualStatefulSets: sset.StatefulSetList{ssetSample},
 			es: v1beta1.Elasticsearch{
 				ObjectMeta: metav1.ObjectMeta{
@@ -194,7 +193,7 @@ func TestUpdateMinimumMasterNodes(t *testing.T) {
 		},
 		{
 			name:               "mmn should be updated, it isn't set in the ES annotation",
-			c:                  k8s.WrapClient(fake.NewFakeClient(&podsReady3[0], &podsReady3[1], &podsReady3[2])),
+			c:                  k8s.WrappedFakeClient(&podsReady3[0], &podsReady3[1], &podsReady3[2]),
 			actualStatefulSets: sset.StatefulSetList{ssetSample},
 			es:                 v1beta1.Elasticsearch{ObjectMeta: k8s.ToObjectMeta(nsn)},
 			wantCalled:         true,
@@ -202,7 +201,7 @@ func TestUpdateMinimumMasterNodes(t *testing.T) {
 		},
 		{
 			name:               "cannot update since not enough masters available",
-			c:                  k8s.WrapClient(fake.NewFakeClient(&podsReady1[0], &podsReady1[1], &podsReady1[2])),
+			c:                  k8s.WrappedFakeClient(&podsReady1[0], &podsReady1[1], &podsReady1[2]),
 			actualStatefulSets: sset.StatefulSetList{ssetSample},
 			es:                 v1beta1.Elasticsearch{ObjectMeta: k8s.ToObjectMeta(nsn)},
 			wantCalled:         false,

--- a/pkg/controller/elasticsearch/version/zen2/compatibility_test.go
+++ b/pkg/controller/elasticsearch/version/zen2/compatibility_test.go
@@ -7,17 +7,15 @@ package zen2
 import (
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
 func createStatefulSetWithESVersion(version string) appsv1.StatefulSet {
@@ -107,7 +105,7 @@ func TestAllMastersCompatibleWithZen2(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := AllMastersCompatibleWithZen2(k8s.WrapClient(fake.NewFakeClient(tt.pods...)), es)
+			got, err := AllMastersCompatibleWithZen2(k8s.WrappedFakeClient(tt.pods...), es)
 			require.NoError(t, err)
 			if got != tt.want {
 				t.Errorf("AllMastersCompatibleWithZen2() got = %v, want %v", got, tt.want)
@@ -130,7 +128,7 @@ func TestIsInitialZen2Upgrade(t *testing.T) {
 		{
 			name: "new 7.x",
 			args: args{
-				c:  k8s.WrapClient(fake.NewFakeClient()),
+				c:  k8s.WrappedFakeClient(),
 				es: v1beta1.Elasticsearch{Spec: v1beta1.ElasticsearchSpec{Version: "7.3.0"}},
 			},
 			want:    true,
@@ -139,14 +137,14 @@ func TestIsInitialZen2Upgrade(t *testing.T) {
 		{
 			name: "6.x to 7.x",
 			args: args{
-				c: k8s.WrapClient(fake.NewFakeClient(sset.TestPod{
+				c: k8s.WrappedFakeClient(sset.TestPod{
 					Namespace:       "default",
 					Name:            "pod-0",
 					ClusterName:     "es",
 					StatefulSetName: "masters",
 					Version:         "6.8.0",
 					Master:          true,
-				}.BuildPtr())),
+				}.BuildPtr()),
 				es: v1beta1.Elasticsearch{
 					Spec: v1beta1.ElasticsearchSpec{Version: "7.3.0"},
 				},
@@ -157,14 +155,14 @@ func TestIsInitialZen2Upgrade(t *testing.T) {
 		{
 			name: "7.x to 7.x",
 			args: args{
-				c: k8s.WrapClient(fake.NewFakeClient(sset.TestPod{
+				c: k8s.WrappedFakeClient(sset.TestPod{
 					Namespace:       "default",
 					Name:            "pod-0",
 					ClusterName:     "es",
 					StatefulSetName: "masters",
 					Version:         "7.1.0",
 					Master:          true,
-				}.BuildPtr())),
+				}.BuildPtr()),
 				es: v1beta1.Elasticsearch{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "es",
@@ -179,14 +177,14 @@ func TestIsInitialZen2Upgrade(t *testing.T) {
 		{
 			name: "6.x to 6.x",
 			args: args{
-				c: k8s.WrapClient(fake.NewFakeClient(sset.TestPod{
+				c: k8s.WrappedFakeClient(sset.TestPod{
 					Namespace:       "default",
 					Name:            "pod-0",
 					ClusterName:     "es",
 					StatefulSetName: "masters",
 					Version:         "6.8.0",
 					Master:          true,
-				}.BuildPtr())),
+				}.BuildPtr()),
 				es: v1beta1.Elasticsearch{
 					Spec: v1beta1.ElasticsearchSpec{Version: "6.8.1"},
 				},

--- a/pkg/controller/elasticsearch/version/zen2/voting_exclusions_test.go
+++ b/pkg/controller/elasticsearch/version/zen2/voting_exclusions_test.go
@@ -8,15 +8,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type fakeESClient struct {
@@ -55,7 +53,7 @@ func Test_ClearVotingConfigExclusions(t *testing.T) {
 	}{
 		{
 			name: "no v7 nodes",
-			c:    k8s.WrapClient(fake.NewFakeClient()),
+			c:    k8s.WrappedFakeClient(),
 			actualStatefulSets: sset.StatefulSetList{
 				createStatefulSetWithESVersion("6.8.0"),
 			},
@@ -64,21 +62,21 @@ func Test_ClearVotingConfigExclusions(t *testing.T) {
 		},
 		{
 			name:               "3/3 nodes there: can clear",
-			c:                  k8s.WrapClient(fake.NewFakeClient(&statefulSet3rep, &pods[0], &pods[1], &pods[2])),
+			c:                  k8s.WrappedFakeClient(&statefulSet3rep, &pods[0], &pods[1], &pods[2]),
 			actualStatefulSets: sset.StatefulSetList{statefulSet3rep},
 			wantCall:           true,
 			wantRequeue:        false,
 		},
 		{
 			name:               "2/3 nodes there: cannot clear, should requeue",
-			c:                  k8s.WrapClient(fake.NewFakeClient(&statefulSet3rep, &pods[0], &pods[1])),
+			c:                  k8s.WrappedFakeClient(&statefulSet3rep, &pods[0], &pods[1]),
 			actualStatefulSets: sset.StatefulSetList{statefulSet3rep},
 			wantCall:           false,
 			wantRequeue:        true,
 		},
 		{
 			name:               "3/2 nodes there: cannot clear, should requeue",
-			c:                  k8s.WrapClient(fake.NewFakeClient(&statefulSet2rep, &pods[0], &pods[1], &pods[2])),
+			c:                  k8s.WrappedFakeClient(&statefulSet2rep, &pods[0], &pods[1], &pods[2]),
 			actualStatefulSets: sset.StatefulSetList{statefulSet2rep},
 			wantCall:           false,
 			wantRequeue:        true,

--- a/pkg/controller/kibana/config/reconciler_test.go
+++ b/pkg/controller/kibana/config/reconciler_test.go
@@ -17,9 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var defaultKibana = v1beta1.Kibana{
@@ -104,11 +102,7 @@ func TestReconcileConfigSecret(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sc := scheme.Scheme
-			if err := v1beta1.SchemeBuilder.AddToScheme(sc); err != nil {
-				assert.Fail(t, "failed to build custom scheme")
-			}
-			k8sClient := k8s.WrapClient(fake.NewFakeClientWithScheme(sc, tt.args.initialObjects...))
+			k8sClient := k8s.WrappedFakeClient(tt.args.initialObjects...)
 
 			err := ReconcileConfigSecret(k8sClient, tt.args.kb, CanonicalConfig{settings.NewCanonicalConfig()}, about.OperatorInfo{})
 			assert.NoError(t, err)

--- a/pkg/controller/license/license_controller_test.go
+++ b/pkg/controller/license/license_controller_test.go
@@ -22,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -172,8 +171,7 @@ func TestReconcileLicenses_reconcileInternal(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.NoError(t, v1beta1.AddToScheme(scheme.Scheme))
-			client := k8s.WrapClient(fake.NewFakeClient(tt.k8sResources...))
+			client := k8s.WrappedFakeClient(tt.k8sResources...)
 			r := &ReconcileLicenses{
 				Client:  client,
 				scheme:  scheme.Scheme,

--- a/pkg/controller/license/list_test.go
+++ b/pkg/controller/license/list_test.go
@@ -8,18 +8,14 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/license"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -35,11 +31,6 @@ func (f *failingClient) List(list runtime.Object, opts ...client.ListOption) err
 var _ k8s.Client = &failingClient{}
 
 func Test_listAffectedLicenses(t *testing.T) {
-	s := scheme.Scheme
-	if err := v1beta1.SchemeBuilder.AddToScheme(s); err != nil {
-		assert.Fail(t, "failed to build custom scheme")
-	}
-
 	true := true
 
 	type args struct {
@@ -89,7 +80,7 @@ func Test_listAffectedLicenses(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := k8s.WrapClient(fake.NewFakeClient(tt.args.initialObjects...))
+			client := k8s.WrappedFakeClient(tt.args.initialObjects...)
 			if tt.injectedError != nil {
 				client = &failingClient{Client: client, Error: tt.injectedError}
 			}

--- a/pkg/dev/portforward/service_forwarder_test.go
+++ b/pkg/dev/portforward/service_forwarder_test.go
@@ -11,13 +11,13 @@ import (
 	"net"
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func Test_parseServiceAddr(t *testing.T) {
@@ -80,7 +80,7 @@ func Test_serviceForwarder_DialContext(t *testing.T) {
 			fields: fields{
 				network: "tcp",
 				addr:    "foo.bar.svc:9200",
-				client: fake.NewFakeClient(
+				client: k8s.FakeClient(
 					&corev1.Service{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "foo",
@@ -133,7 +133,7 @@ func Test_serviceForwarder_DialContext(t *testing.T) {
 			fields: fields{
 				network: "tcp",
 				addr:    "foo.bar.svc:1234",
-				client: fake.NewFakeClient(
+				client: k8s.FakeClient(
 					&corev1.Service{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "foo",

--- a/pkg/utils/k8s/fake.go
+++ b/pkg/utils/k8s/fake.go
@@ -1,0 +1,32 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package k8s
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/scheme"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func Scheme() *runtime.Scheme {
+	if err := scheme.SetupScheme(); err != nil {
+		fmt.Println("Cannot setup scheme for fake K8s client", err)
+		os.Exit(1)
+	}
+	return k8sscheme.Scheme
+}
+
+func FakeClient(initObjs ...runtime.Object) client.Client {
+	return fake.NewFakeClientWithScheme(Scheme(), initObjs...)
+}
+
+func WrappedFakeClient(initObjs ...runtime.Object) Client {
+	return WrapClient(FakeClient(initObjs...))
+}

--- a/pkg/utils/pointer/numeric.go
+++ b/pkg/utils/pointer/numeric.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package common
+package pointer
 
 // Int32 returns a pointer to an Int32
 func Int32(v int32) *int32 { return &v }

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -7,8 +7,8 @@ package elasticsearch
 import (
 	commonv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1beta1"
 	estype "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -266,8 +266,8 @@ func (b Builder) WithAdditionalConfig(nodeSetCfg map[string]map[string]interface
 
 func (b Builder) WithChangeBudget(maxSurge, maxUnavailable int32) Builder {
 	b.Elasticsearch.Spec.UpdateStrategy.ChangeBudget = estype.ChangeBudget{
-		MaxSurge:       common.Int32(maxSurge),
-		MaxUnavailable: common.Int32(maxUnavailable),
+		MaxSurge:       pointer.Int32(maxSurge),
+		MaxUnavailable: pointer.Int32(maxUnavailable),
 	}
 	return b
 }


### PR DESCRIPTION
Hi guys, `NewFakeClient` is now deprecated. This PR replaces it with `NewFakeClientWithScheme`. If there is any better approach, let me know.