### PR TITLE
Improve YAML examples in the docs

### DIFF
--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -36,6 +36,10 @@ Pod templates are the same you know and love from stateful sets and deployments.
 
 [source,yaml]
 ----
+spec:
+  nodeSets:
+  - name: default
+    count: 1
     podTemplate:
       metadata:
         labels:
@@ -52,13 +56,16 @@ You might want to set environment variables to configure Elasticsearch. For exam
 [source,yaml]
 ----
 spec:
-  podTemplate:
-    spec:
-      containers:
-      - name: elasticsearch
-        env:
-        - name: ES_JAVA_OPTS
-          value: "-Xms2g -Xmx4g"
+  nodeSets:
+  - name: default
+    count: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          env:
+          - name: ES_JAVA_OPTS
+            value: "-Xms2g -Xmx4g"
 ----
 
 For more information on Pod templates, see the Kubernetes documentation:
@@ -140,7 +147,8 @@ If you are not concerned about data loss, you can use an `emptyDir` volume for E
 ----
 spec:
   nodeSets:
-  - config:
+  - name: data
+    count: 10
     podTemplate:
       spec:
         volumes:
@@ -196,9 +204,9 @@ metadata:
   name: quickstart
 spec:
   version: {version}
-  nodes:
+  nodeSets:
   - name: default
-    nodeCount: 1
+    count: 3
     config:
       node.master: true
       node.data: true
@@ -306,7 +314,9 @@ nodes start, use an init container to run the link:https://www.elastic.co/guide/
 ----
 spec:
   nodeSets:
-  - podTemplate:
+  - name: default
+    count: 3
+    podTemplate:
       spec:
         initContainers:
         - name: install-plugins
@@ -327,7 +337,9 @@ But you can use the same approach for any kind of file you want to mount into th
 ----
 spec:
   nodeSets:
-  - podTemplate:
+  - name: default
+    count: 3
+    podTemplate:
       spec:
         containers:
         - name: elasticsearch <1>
@@ -350,7 +362,11 @@ You can install custom plugins before the Elasticsearch container starts with an
 
 [source,yaml]
 ----
-  - podTemplate:
+spec:
+  nodeSets:
+  - name: default
+    count: 3
+    podTemplate:
       spec:
         initContainers:
         - name: install-plugins

--- a/docs/snapshots.asciidoc
+++ b/docs/snapshots.asciidoc
@@ -52,6 +52,7 @@ spec:
   version: {version}
   nodeSets:
   - name: default
+    count: 1
     podTemplate:
       spec:
         initContainers:
@@ -61,7 +62,6 @@ spec:
           - -c
           - |
             bin/elasticsearch-plugin install --batch repository-gcs
-    count: 1
 ----
 
 Assuming you stored this in a file called `elasticsearch.yaml` you can in both cases create the Elasticsearch cluster with:
@@ -108,12 +108,15 @@ kubectl create secret generic gcs-credentials --from-file=gcs.client.default.cre
 +
 [source,yaml]
 ----
+apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
 kind: Elasticsearch
+metadata:
+  name: elasticsearch-sample
 spec:
-    # ...
-    # Inject secure settings into Elasticsearch nodes from a k8s secret reference
-    secureSettings:
-    - secretName: gcs-credentials
+  version: {version}
+  # Inject secure settings into Elasticsearch nodes from a k8s secret reference
+  secureSettings:
+  - secretName: gcs-credentials
 ----
 If you did not follow the instructions above and named your GCS credentials file differently, you can still map it to the expected name now. See <<{p}-es-secure-settings,Secure Settings>> for details.
 . Apply the modifications:


### PR DESCRIPTION
Minor fixes on the sample YAML code snippets embedded in the docs.
I propose to always display the root `spec` to provide a reference from where we are in the yaml.
And also display the `name` and `count` fields when we document something under `nodeSets`.
```
spec:
  nodeSets:
  - name: default
    count: 3
    <XXXXXXXXXX>
```