### PR TITLE
Warn about all-in-one-no-validation.yaml for k8s prior to 1.13

### DIFF
--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -29,19 +29,9 @@ Before deploying an Elasticsearch cluster with ECK, make sure you correctly appl
 [float]
 [id="{p}-openshift-deploy-the-operator"]
 === Deploy the operator
-
 . Apply the all-in-one template, as described in the link:k8s-quickstart.html[quickstart].
 +
-If you are using a Kubernetes cluster in version 1.12 or below, use:
-+
-[source,sh,subs="attributes"]
-----
-oc apply -f https://download.elastic.co/downloads/eck/{eck_version}/all-in-one-no-validation.yaml
-----
-+
-If you are using a Kubernetes cluster from version 1.13, use:
-+
-[source,sh,subs="attributes"]
+[source,shell,subs="attributes"]
 ----
 oc apply -f https://download.elastic.co/downloads/eck/{eck_version}/all-in-one.yaml
 ----

--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -29,9 +29,19 @@ Before deploying an Elasticsearch cluster with ECK, make sure you correctly appl
 [float]
 [id="{p}-openshift-deploy-the-operator"]
 === Deploy the operator
+
 . Apply the all-in-one template, as described in the link:k8s-quickstart.html[quickstart].
 +
-[source,shell,subs="attributes"]
+If you are using a Kubernetes cluster in version 1.12 or below, use:
++
+[source,sh,subs="attributes"]
+----
+oc apply -f https://download.elastic.co/downloads/eck/{eck_version}/all-in-one-no-validation.yaml
+----
++
+If you are using a Kubernetes cluster from version 1.13, use:
++
+[source,sh,subs="attributes"]
 ----
 oc apply -f https://download.elastic.co/downloads/eck/{eck_version}/all-in-one.yaml
 ----

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -35,18 +35,18 @@ NOTE: If you are using Amazon EKS, make sure the Kubernetes control plane is all
 
 . Install link:https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/[custom resource definitions] and the operator with its RBAC rules:
 +
-If you are using a Kubernetes cluster in version 1.12 or below, use:
-+
-[source,sh,subs="attributes"]
-----
-kubectl apply -f https://download.elastic.co/downloads/eck/{eck_version}/all-in-one-no-validation.yaml
-----
-+
-If you are using a Kubernetes cluster from version 1.13, use:
+For Kubernetes clusters running version 1.13 or higher:
 +
 [source,sh,subs="attributes"]
 ----
 kubectl apply -f https://download.elastic.co/downloads/eck/{eck_version}/all-in-one.yaml
+----
++
+For Kubernetes clusters running version 1.12 or lower:
++
+[source,sh,subs="attributes"]
+----
+kubectl apply -f https://download.elastic.co/downloads/eck/{eck_version}/all-in-one-no-validation.yaml
 ----
 
 . Monitor the operator logs:

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -40,6 +40,8 @@ NOTE: If you are using Amazon EKS, make sure the Kubernetes control plane is all
 kubectl apply -f https://download.elastic.co/downloads/eck/{eck_version}/all-in-one.yaml
 ----
 
+NOTE: If you are using a Kubernetes cluster prior to version 1.13, you have to use https://download.elastic.co/downloads/eck/{eck_version}/all-in-one-no-validation.yaml.
+
 . Monitor the operator logs:
 +
 [source,sh]

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -35,12 +35,19 @@ NOTE: If you are using Amazon EKS, make sure the Kubernetes control plane is all
 
 . Install link:https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/[custom resource definitions] and the operator with its RBAC rules:
 +
+If you are using a Kubernetes cluster in version 1.12 or below, use:
++
+[source,sh,subs="attributes"]
+----
+kubectl apply -f https://download.elastic.co/downloads/eck/{eck_version}/all-in-one-no-validation.yaml
+----
++
+If you are using a Kubernetes cluster from version 1.13, use:
++
 [source,sh,subs="attributes"]
 ----
 kubectl apply -f https://download.elastic.co/downloads/eck/{eck_version}/all-in-one.yaml
 ----
-
-NOTE: If you are using a Kubernetes cluster prior to version 1.13, you have to use https://download.elastic.co/downloads/eck/{eck_version}/all-in-one-no-validation.yaml.
 
 . Monitor the operator logs:
 +


### PR DESCRIPTION
Document which all-in-one.yaml to use according to the Kubernetes cluster version,
in the quickstart and the OpenShift docs.

Part of #1852.