### PR TITLE
Fix spaces in quickstart doc

### DIFF
--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -101,7 +101,7 @@ kubectl get elasticsearch
 [source,sh,subs="attributes"]
 ----
 NAME          HEALTH    NODES     VERSION   PHASE         AGE
-quickstart    green     1         {version}     Ready   1m
+quickstart    green     1         {version}     Ready         1m
 ----
 
 When you create the cluster, there is no `HEALTH` status and the `PHASE` is empty. After a while, the `PHASE` turns into `Ready`, and `HEALTH` becomes `green`.


### PR DESCRIPTION
Fixes the alignment for the column `AGE` in a sample output in the quickstart.

![2019-10-11-121236_1159x128_scrot](https://user-images.githubusercontent.com/582883/66644192-9ab25d80-ec20-11e9-9a94-4594b64b5a93.png)
