### PR TITLE
Use the same, non-default storage class for e2e tests

### DIFF
--- a/hack/deployer/runner/aks.go
+++ b/hack/deployer/runner/aks.go
@@ -104,6 +104,10 @@ func (d *AksDriver) Execute() error {
 		if err := d.GetCredentials(); err != nil {
 			return err
 		}
+
+		if err := createStorageClass(); err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("unknown operation %s", d.plan.Operation)
 	}
@@ -205,7 +209,7 @@ func (d *AksDriver) configureDocker() error {
 
 func (d *AksDriver) GetCredentials() error {
 	log.Print("Getting credentials...")
-	cmd := `az aks get-credentials --resource-group {{.ResourceGroup}} --name {{.ClusterName}}`
+	cmd := `az aks get-credentials --overwrite-existing --resource-group {{.ResourceGroup}} --name {{.ClusterName}}`
 	return NewCommand(cmd).AsTemplate(d.ctx).Run()
 }
 

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -94,7 +94,7 @@ func (d *GkeDriver) Execute() error {
 			return err
 		}
 
-		if err := d.patchStorageClass(); err != nil {
+		if err := createStorageClass(); err != nil {
 			return err
 		}
 	default:
@@ -184,57 +184,6 @@ func (d *GkeDriver) GetCredentials() error {
 	log.Println("Getting credentials...")
 	cmd := "gcloud container clusters --project {{.GCloudProject}} get-credentials {{.ClusterName}} --region {{.Region}}"
 	return NewCommand(cmd).AsTemplate(d.ctx).Run()
-}
-
-// patchStorageClass based on standard storageclass, creates new default with "volumeBindingMode: WaitForFirstConsumer"
-func (d *GkeDriver) patchStorageClass() error {
-	log.Println("Patching storage class...")
-
-	if exists, err := NewCommand("kubectl get sc").OutputContainsAny("standard-customized"); err != nil {
-		return err
-	} else if exists {
-		return nil
-	}
-
-	defaultName := ""
-	for _, annotation := range []string{
-		`storageclass\.kubernetes\.io/is-default-class`,
-		`storageclass\.beta\.kubernetes\.io/is-default-class`,
-	} {
-		template := `kubectl get sc -o=jsonpath="{$.items[?(@.metadata.annotations.%s=='true')].metadata.name}"`
-		baseScs, err := NewCommand(fmt.Sprintf(template, annotation)).OutputList()
-		if err != nil {
-			return err
-		}
-
-		if len(baseScs) != 0 {
-			defaultName = baseScs[0]
-			break
-		}
-	}
-
-	if defaultName == "" {
-		return fmt.Errorf("default storageclass not found")
-	}
-
-	sc, err := NewCommand(fmt.Sprintf("kubectl get sc %s -o yaml", defaultName)).Output()
-	if err != nil {
-		return err
-	}
-
-	sc = strings.Replace(sc, fmt.Sprintf("name: %s", defaultName), "name: standard-customized", -1)
-	sc = strings.Replace(sc, "volumeBindingMode: Immediate", "volumeBindingMode: WaitForFirstConsumer", -1)
-	err = NewCommand(fmt.Sprintf(`cat <<EOF | kubectl apply -f -
-%s
-EOF`, sc)).Run()
-	if err != nil {
-		return err
-	}
-
-	// Depending on K8s version, a different annotation is needed. To avoid parsing version string, both are set.
-	patch := `'{ "metadata": { "annotations": { "storageclass.kubernetes.io/is-default-class":"false", "storageclass.beta.kubernetes.io/is-default-class":"false"} } }'`
-	cmd := fmt.Sprintf(`kubectl patch storageclass %s -p %s`, defaultName, patch)
-	return NewCommand(cmd).Run()
 }
 
 func (d *GkeDriver) delete() error {

--- a/hack/deployer/runner/storage.go
+++ b/hack/deployer/runner/storage.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package runner
 
 import (

--- a/hack/deployer/runner/storage.go
+++ b/hack/deployer/runner/storage.go
@@ -1,0 +1,60 @@
+package runner
+
+import (
+	"fmt"
+	"log"
+	"strings"
+)
+
+// createStorageClass based on default storageclass, creates new, non-default class with "volumeBindingMode: WaitForFirstConsumer"
+func createStorageClass() error {
+	log.Println("Creating storage class...")
+
+	if exists, err := NewCommand("kubectl get sc").OutputContainsAny("e2e-default"); err != nil {
+		return err
+	} else if exists {
+		return nil
+	}
+
+	defaultName := ""
+	for _, annotation := range []string{
+		`storageclass\.kubernetes\.io/is-default-class`,
+		`storageclass\.beta\.kubernetes\.io/is-default-class`,
+	} {
+		template := `kubectl get sc -o=jsonpath="{$.items[?(@.metadata.annotations.%s=='true')].metadata.name}"`
+		baseScs, err := NewCommand(fmt.Sprintf(template, annotation)).OutputList()
+		if err != nil {
+			return err
+		}
+
+		if len(baseScs) != 0 {
+			defaultName = baseScs[0]
+			break
+		}
+	}
+
+	if defaultName == "" {
+		return fmt.Errorf("default storageclass not found")
+	}
+
+	sc, err := NewCommand(fmt.Sprintf("kubectl get sc %s -o yaml", defaultName)).Output()
+	if err != nil {
+		return err
+	}
+
+	sc = strings.Replace(sc, fmt.Sprintf("name: %s", defaultName), "name: e2e-default", -1)
+	sc = strings.Replace(sc, "volumeBindingMode: Immediate", "volumeBindingMode: WaitForFirstConsumer", -1)
+	err = NewCommand(fmt.Sprintf(`cat <<EOF | kubectl apply -f -
+%s
+EOF`, sc)).Run()
+	if err != nil {
+		return err
+	}
+
+	// Some providers (AKS) don't allow changing the default. To avoid having two defaults, set newly created storage
+	// class to be non-default. Depending on k8s version, a different annotation is needed. To avoid parsing version
+	// string, both are set.
+	patch := `'{ "metadata": { "annotations": { "storageclass.kubernetes.io/is-default-class":"false", "storageclass.beta.kubernetes.io/is-default-class":"false"} } }'`
+	cmd := fmt.Sprintf(`kubectl patch storageclass e2e-default -p %s`, patch)
+	return NewCommand(cmd).Run()
+}

--- a/hack/deployer/runner/storage.go
+++ b/hack/deployer/runner/storage.go
@@ -48,17 +48,12 @@ func createStorageClass() error {
 
 	sc = strings.Replace(sc, fmt.Sprintf("name: %s", defaultName), "name: e2e-default", -1)
 	sc = strings.Replace(sc, "volumeBindingMode: Immediate", "volumeBindingMode: WaitForFirstConsumer", -1)
-	err = NewCommand(fmt.Sprintf(`cat <<EOF | kubectl apply -f -
-%s
-EOF`, sc)).Run()
-	if err != nil {
-		return err
-	}
-
 	// Some providers (AKS) don't allow changing the default. To avoid having two defaults, set newly created storage
 	// class to be non-default. Depending on k8s version, a different annotation is needed. To avoid parsing version
 	// string, both are set.
-	patch := `'{ "metadata": { "annotations": { "storageclass.kubernetes.io/is-default-class":"false", "storageclass.beta.kubernetes.io/is-default-class":"false"} } }'`
-	cmd := fmt.Sprintf(`kubectl patch storageclass e2e-default -p %s`, patch)
-	return NewCommand(cmd).Run()
+	sc = strings.Replace(sc, `storageclass.kubernetes.io/is-default-class: "true"`, `storageclass.kubernetes.io/is-default-class: "false"`, -1)
+	sc = strings.Replace(sc, `storageclass.beta.kubernetes.io/is-default-class: "true"`, `storageclass.beta.kubernetes.io/is-default-class: "false"`, -1)
+	return NewCommand(fmt.Sprintf(`cat <<EOF | kubectl apply -f -
+%s
+EOF`, sc)).Run()
 }

--- a/test/e2e/apm/sample_test.go
+++ b/test/e2e/apm/sample_test.go
@@ -43,7 +43,8 @@ func TestApmEsKibanaSample(t *testing.T) {
 		WithSuffix(randSuffix).
 		WithNamespace(ns).
 		WithVersion(test.Ctx().ElasticStackVersion).
-		WithRestrictedSecurityContext()
+		WithRestrictedSecurityContext().
+		WithDefaultPersistentVolumes()
 	kbBuilder = kbBuilder.
 		WithSuffix(randSuffix).
 		WithNamespace(ns).

--- a/test/e2e/kb/sample_test.go
+++ b/test/e2e/kb/sample_test.go
@@ -39,7 +39,8 @@ func TestKibanaEsSample(t *testing.T) {
 		WithSuffix(randSuffix).
 		WithNamespace(ns).
 		WithVersion(test.Ctx().ElasticStackVersion).
-		WithRestrictedSecurityContext()
+		WithRestrictedSecurityContext().
+		WithDefaultPersistentVolumes()
 	kbBuilder = kbBuilder.
 		WithSuffix(randSuffix).
 		WithNamespace(ns).

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -37,7 +37,8 @@ func TestSmoke(t *testing.T) {
 	esBuilder = esBuilder.
 		WithSuffix(randSuffix).
 		WithNamespace(ns).
-		WithRestrictedSecurityContext()
+		WithRestrictedSecurityContext().
+		WithDefaultPersistentVolumes()
 	kbBuilder = kbBuilder.
 		WithSuffix(randSuffix).
 		WithNamespace(ns).

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -18,6 +18,8 @@ import (
 )
 
 const (
+	// we setup our own storageClass with "volumeBindingMode: waitForFirstConsumer" that we
+	// reference in the VolumeClaimTemplates section of the Elasticsearch spec
 	defaultStorageClass = "e2e-default"
 	defaultVolumeName   = "e2e-default-volume"
 )


### PR DESCRIPTION
As noted in #1948, AKS doesn't allow to change the default storage class. We could:
1. special case AKS and try:
a. to communicate between deployer and e2e test suite that AKS is being targetted,
b. to detect which provider we target from within e2e test suite,
2. assume a different storage class for all providers.

Due to simplicity, approach 2. was chosen. This PR implements it and fixes #1948. 