### PR TITLE
Document secure settings breaking change

### DIFF
--- a/docs/release-notes/1.0.0-beta1.asciidoc
+++ b/docs/release-notes/1.0.0-beta1.asciidoc
@@ -10,7 +10,8 @@
 
 * Rename nodes to nodeSets, nodeCount to count {pull}1843[#1843]
 * Remove setVmMaxMapCount from Elasticsearch CRD {pull}1839[#1839] (issue: {issue}1712[#1712])
-* Bump CRD versions to v1betav1 {pull}1782[#1782]
+* Bump CRD versions to v1beta1 {pull}1782[#1782]
+* Allow for multiple user specified secure settings secrets {pull}1627[#1627]
 * Add webhook check for PVC modification {pull}1517[#1517] (issue: {issue}1293[#1293])
 * Refactor nodes orchestration to rely on StatefulSets {pull}1463[#1463] (issue: {issue}1299[#1299])
 * Orchestrate zen1 and zen2 settings for StatefulSets {pull}1262[#1262] (issue: {issue}1173[#1173])
@@ -43,7 +44,6 @@
 * Upgrade to Kubebuilder v2 {pull}1723[#1723] (issues: {issue}1188[#1188], {issue}1604[#1604])
 * Support more secret volume fields in secure settings {pull}1665[#1665]
 * Validate Elasticsearch resource names {pull}1647[#1647]
-* Allow for multiple user specified secure settings secrets {pull}1627[#1627]
 * Allow users to disable TLS for HTTP in the Elasticsearch spec {pull}1623[#1623]
 * Preserve labels and annotations on public cert secrets {pull}1580[#1580]
 * Generate events for reconcililation errors {pull}1578[#1578]

--- a/docs/upgrading-eck.asciidoc
+++ b/docs/upgrading-eck.asciidoc
@@ -47,6 +47,7 @@ CAUTION: These instructions are general guidelines only. You should have a thoro
 * Remove `setVmMaxMapCount`. See: <<{p}-virtual-memory>>.
 * Remove `groups` from `updateStrategy`. See: <<{p}-update-strategy>>.
 * Remove `featureFlags`
+* If you specify a `secureSettings`, convert the `secretName` to an array item
 
 [source,patch,subs="attributes"]
 ----
@@ -63,6 +64,9 @@ CAUTION: These instructions are general guidelines only. You should have a thoro
      changeBudget:
        maxUnavailable: 1
 -    groups: []
+   secureSettings:
+-    secretName: "gcs-credentials"
++  - secretName: "gcs-credentials"
 -  nodes:
 -  - nodeCount: 3
 +  nodeSets:
@@ -74,6 +78,7 @@ CAUTION: These instructions are general guidelines only. You should have a thoro
 .Kibana
 * Replace `v1alpha` in the `apiVersion` field with `v1beta1`
 * Rename `nodeCount` to `count`
+* If you specify a `secureSettings`, convert the `secretName` to an array item
 
 [source,patch,subs="attributes"]
 ----
@@ -88,12 +93,16 @@ CAUTION: These instructions are general guidelines only. You should have a thoro
 +  count: 1
    elasticsearchRef:
      name: "elasticsearch-sample"
+   secureSettings:
+-    secretName: "gcs-credentials"
++  - secretName: "gcs-credentials"
 ----
 
 
 .APM Server
 * Replace `v1alpha` in the `apiVersion` field with `v1beta1`
 * Rename `nodeCount` to `count`
+* If you specify a `secureSettings`, convert the `secretName` to an array item
 
 [source,patch,subs="attributes"]
 ----
@@ -108,4 +117,7 @@ CAUTION: These instructions are general guidelines only. You should have a thoro
 +  count: 1
    elasticsearchRef:
      name: "elasticsearch-sample"
+   secureSettings:
+-    secretName: "gcs-credentials"
++  - secretName: "gcs-credentials"
 ----

--- a/docs/upgrading-eck.asciidoc
+++ b/docs/upgrading-eck.asciidoc
@@ -47,7 +47,7 @@ CAUTION: These instructions are general guidelines only. You should have a thoro
 * Remove `setVmMaxMapCount`. See: <<{p}-virtual-memory>>.
 * Remove `groups` from `updateStrategy`. See: <<{p}-update-strategy>>.
 * Remove `featureFlags`
-* If you specify a `secureSettings`, convert the `secretName` to an array item
+* If you specified `secureSettings`, convert `secretName` into an array item by prefixing it with `-`
 
 [source,patch,subs="attributes"]
 ----
@@ -78,7 +78,7 @@ CAUTION: These instructions are general guidelines only. You should have a thoro
 .Kibana
 * Replace `v1alpha` in the `apiVersion` field with `v1beta1`
 * Rename `nodeCount` to `count`
-* If you specify a `secureSettings`, convert the `secretName` to an array item
+* If you specified `secureSettings`, convert `secretName` into an array item by prefixing it with `-`
 
 [source,patch,subs="attributes"]
 ----
@@ -102,7 +102,7 @@ CAUTION: These instructions are general guidelines only. You should have a thoro
 .APM Server
 * Replace `v1alpha` in the `apiVersion` field with `v1beta1`
 * Rename `nodeCount` to `count`
-* If you specify a `secureSettings`, convert the `secretName` to an array item
+* If you specified `secureSettings`, convert `secretName` into an array item by prefixing it with `-`
 
 [source,patch,subs="attributes"]
 ----


### PR DESCRIPTION
- Fix a typo in #1782 title (s|v1betav1|v1betav1|)
- Update #1627 label from enhancement to breaking
- Regenerate the release notes
- Add a note about the `secureSettings` conversion in the upgrading-eck doc