### PR TITLE
Add scheduler to handle long-running requeues

### DIFF
--- a/pkg/controller/common/driver/interface.go
+++ b/pkg/controller/common/driver/interface.go
@@ -5,6 +5,7 @@
 package driver
 
 import (
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/scheduler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,15 +17,21 @@ type Interface interface {
 	K8sClient() k8s.Client
 	Scheme() *runtime.Scheme
 	DynamicWatches() watches.DynamicWatches
+	Scheduler() scheduler.Scheduler
 	Recorder() record.EventRecorder
 }
 
 // TestDriver is a struct implementing the common driver interface for testing purposes.
 type TestDriver struct {
-	Client        k8s.Client
-	RuntimeScheme *runtime.Scheme
-	Watches       watches.DynamicWatches
-	FakeRecorder  *record.FakeRecorder
+	Client         k8s.Client
+	RuntimeScheme  *runtime.Scheme
+	Watches        watches.DynamicWatches
+	FakeRecorder   *record.FakeRecorder
+	EventScheduler scheduler.Scheduler
+}
+
+func (t TestDriver) Scheduler() scheduler.Scheduler {
+	return t.EventScheduler
 }
 
 func (t TestDriver) K8sClient() k8s.Client {

--- a/pkg/controller/common/scheduler/mock.go
+++ b/pkg/controller/common/scheduler/mock.go
@@ -1,0 +1,32 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package scheduler
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+// MockScheduler implements the Scheduler interface for testing purposes.
+// Events() will be nil and no timers will be created.
+// To inspect scheduled events see Scheduled
+type MockScheduler struct {
+	Scheduled map[types.NamespacedName]time.Duration
+}
+
+func (m *MockScheduler) Events() chan event.GenericEvent {
+	return nil
+}
+
+func (m *MockScheduler) Schedule(nsn types.NamespacedName, after time.Duration) {
+	if m.Scheduled == nil {
+		m.Scheduled = make(map[types.NamespacedName]time.Duration)
+	}
+	m.Scheduled[nsn] = after
+}
+
+var _ Scheduler = &MockScheduler{}

--- a/pkg/controller/common/scheduler/scheduler.go
+++ b/pkg/controller/common/scheduler/scheduler.go
@@ -1,0 +1,51 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package scheduler
+
+import (
+	"sync"
+	"time"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+type Scheduler struct {
+	timers map[types.NamespacedName]*time.Timer
+	mutex  sync.Mutex
+	out    chan event.GenericEvent
+}
+
+func NewScheduler() *Scheduler {
+	return &Scheduler{
+		timers: map[types.NamespacedName]*time.Timer{},
+		out: make(chan event.GenericEvent),
+	}
+}
+
+func (s *Scheduler) Schedule(nsn types.NamespacedName, after time.Duration) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	timer, exists := s.timers[nsn]
+	if exists {
+		timer.Stop() // I think we don't need to drain the channel
+	}
+	s.timers[nsn] = time.AfterFunc(after, func() {
+		s.out <- event.GenericEvent{
+			Meta: &v1.ObjectMeta{
+				Name:      nsn.Name,
+				Namespace: nsn.Namespace,
+			},
+		}
+	})
+}
+
+func Events(m *Scheduler) *source.Channel {
+	return &source.Channel{
+		Source: m.out,
+	}
+}

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -17,6 +17,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/scheduler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates"
@@ -82,11 +83,17 @@ type DefaultDriverParameters struct {
 	// Expectations control some expectations set on resources in the cache, in order to
 	// avoid doing certain operations if the cache hasn't seen an up-to-date resource yet.
 	Expectations *expectations.Expectations
+	// EventScheduler allows scheduling reconciliation events with significant delay.
+	EventScheduler scheduler.Scheduler
 }
 
 // defaultDriver is the default Driver implementation
 type defaultDriver struct {
 	DefaultDriverParameters
+}
+
+func (d *defaultDriver) Scheduler() scheduler.Scheduler {
+	return d.EventScheduler
 }
 
 func (d *defaultDriver) K8sClient() k8s.Client {

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -289,6 +289,7 @@ func (r *ReconcileElasticsearch) internalReconcile(
 		Observers:          r.esObservers,
 		DynamicWatches:     r.dynamicWatches,
 		SupportedVersions:  *supported,
+		EventScheduler:     r.scheduler,
 	}).Reconcile()
 }
 

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/scheduler"
 	commonversion "github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/driver"
@@ -72,6 +73,7 @@ func newReconciler(mgr manager.Manager, params operator.Parameters) *ReconcileEl
 		finalizers:     finalizer.NewHandler(client),
 		dynamicWatches: watches.NewDynamicWatches(),
 		expectations:   expectations.NewExpectations(),
+		scheduler:      scheduler.NewScheduler(),
 
 		Parameters: params,
 	}
@@ -150,6 +152,10 @@ func addWatches(c controller.Controller, r *ReconcileElasticsearch) error {
 		return err
 	}
 
+	if err := c.Watch(scheduler.Events(r.scheduler), reconciler.GenericEventHandler()); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -167,6 +173,8 @@ type ReconcileElasticsearch struct {
 	finalizers finalizer.Handler
 
 	dynamicWatches watches.DynamicWatches
+
+	scheduler scheduler.Scheduler
 
 	// expectations help dealing with inconsistencies in our client cache,
 	// by marking resources updates as expected, and skipping some operations if the cache is not up-to-date.

--- a/pkg/controller/kibana/certificates/reconcile.go
+++ b/pkg/controller/kibana/certificates/reconcile.go
@@ -14,8 +14,8 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana/name"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	coverv1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func Reconcile(
@@ -46,10 +46,8 @@ func Reconcile(
 		return results.WithError(err)
 	}
 
-	// handle CA expiry via requeue
-	results.WithResult(reconcile.Result{
-		RequeueAfter: certificates.ShouldRotateIn(time.Now(), httpCa.Cert.NotAfter, rotation.RotateBefore),
-	})
+	// handle CA expiry via custom scheduler as it may be far in the future
+	d.Scheduler().Schedule(k8s.ExtractNamespacedName(&kb), certificates.ShouldRotateIn(time.Now(), httpCa.Cert.NotAfter, rotation.RotateBefore))
 
 	// discover and maybe reconcile for the http certificates to use
 	httpCertificates, err := http.ReconcileHTTPCertificates(

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/scheduler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
@@ -52,6 +53,7 @@ type driver struct {
 	settingsFactory func(kb kbtype.Kibana) map[string]interface{}
 	dynamicWatches  watches.DynamicWatches
 	recorder        record.EventRecorder
+	scheduler       scheduler.Scheduler
 }
 
 func (d *driver) DynamicWatches() watches.DynamicWatches {
@@ -68,6 +70,10 @@ func (d *driver) Recorder() record.EventRecorder {
 
 func (d *driver) Scheme() *runtime.Scheme {
 	return d.scheme
+}
+
+func (d *driver) Scheduler() scheduler.Scheduler {
+	return d.scheduler
 }
 
 var _ driver2.Interface = &driver{}

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -271,12 +271,14 @@ func newDriver(
 	version version.Version,
 	watches watches.DynamicWatches,
 	recorder record.EventRecorder,
+	scheduler scheduler.Scheduler,
 ) (*driver, error) {
 	d := driver{
 		client:         client,
 		scheme:         scheme,
 		dynamicWatches: watches,
 		recorder:       recorder,
+		scheduler:      scheduler,
 	}
 	switch version.Major {
 	case 6:

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates/http"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/deployment"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/scheduler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana/pod"
@@ -205,7 +206,7 @@ func TestDriverDeploymentParams(t *testing.T) {
 
 			kbVersion, err := version.Parse(kb.Spec.Version)
 			assert.NoError(t, err)
-			d, err := newDriver(client, s, *kbVersion, w, record.NewFakeRecorder(100))
+			d, err := newDriver(client, s, *kbVersion, w, record.NewFakeRecorder(100), &scheduler.MockScheduler{})
 			assert.NoError(t, err)
 
 			got, err := d.deploymentParams(kb)

--- a/pkg/controller/license/license_controller.go
+++ b/pkg/controller/license/license_controller.go
@@ -152,7 +152,7 @@ type ReconcileLicenses struct {
 	scheme *runtime.Scheme
 	// iteration is the number of times this controller has run its Reconcile method
 	iteration uint64
-	scheduler *scheduler.Scheduler
+	scheduler scheduler.Scheduler
 	checker   license.Checker
 }
 

--- a/pkg/controller/license/license_controller_integration_test.go
+++ b/pkg/controller/license/license_controller_integration_test.go
@@ -40,9 +40,9 @@ func TestMain(m *testing.M) {
 func TestReconcile(t *testing.T) {
 	c, stop := test.StartManager(t, func(mgr manager.Manager, p operator.Parameters) error {
 		return add(mgr, &ReconcileLicenses{
-			Client:  k8s.WrapClient(mgr.GetClient()),
-			scheme:  mgr.GetScheme(),
-			checker: license.MockChecker{},
+			Client:    k8s.WrapClient(mgr.GetClient()),
+			scheme:    mgr.GetScheme(),
+			checker:   license.MockChecker{},
 			scheduler: scheduler.NewScheduler(),
 		})
 	}, operator.Parameters{})

--- a/pkg/controller/license/license_controller_integration_test.go
+++ b/pkg/controller/license/license_controller_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/license"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/scheduler"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	esname "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/name"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/chrono"
@@ -42,6 +43,7 @@ func TestReconcile(t *testing.T) {
 			Client:  k8s.WrapClient(mgr.GetClient()),
 			scheme:  mgr.GetScheme(),
 			checker: license.MockChecker{},
+			scheduler: scheduler.NewScheduler(),
 		})
 	}, operator.Parameters{})
 	defer stop()


### PR DESCRIPTION
Draft of an idea of how to avoid timer leaks due to long-running requeues that we currently use to handle certificate rotation and license expiry.

Fixes #1984  