### PR TITLE
Enqueue reconciliations for no more than 10 hours

### DIFF
--- a/pkg/controller/apmserver/certificates/reconcile.go
+++ b/pkg/controller/apmserver/certificates/reconcile.go
@@ -48,7 +48,7 @@ func Reconcile(
 
 	// handle CA expiry via requeue
 	results.WithResult(reconcile.Result{
-		RequeueAfter: certificates.ShouldRotateIn(time.Now(), httpCa.Cert.NotAfter, rotation.RotateBefore),
+		RequeueAfter: certificates.ShouldReconcileIn(time.Now(), httpCa.Cert.NotAfter, rotation.RotateBefore),
 	})
 
 	// discover and maybe reconcile for the http certificates to use

--- a/pkg/controller/elasticsearch/certificates/ca_reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/ca_reconcile.go
@@ -59,7 +59,7 @@ func Reconcile(
 
 	// make sure to requeue before the CA cert expires
 	results.WithResult(reconcile.Result{
-		RequeueAfter: certificates.ShouldRotateIn(time.Now(), httpCA.Cert.NotAfter, caRotation.RotateBefore),
+		RequeueAfter: certificates.ShouldReconcileIn(time.Now(), httpCA.Cert.NotAfter, caRotation.RotateBefore),
 	})
 
 	// discover and maybe reconcile for the http certificates to use
@@ -96,7 +96,7 @@ func Reconcile(
 	}
 	// make sure to requeue before the CA cert expires
 	results.WithResult(reconcile.Result{
-		RequeueAfter: certificates.ShouldRotateIn(time.Now(), transportCA.Cert.NotAfter, caRotation.RotateBefore),
+		RequeueAfter: certificates.ShouldReconcileIn(time.Now(), transportCA.Cert.NotAfter, caRotation.RotateBefore),
 	})
 
 	// reconcile transport public certs secret:

--- a/pkg/controller/kibana/certificates/reconcile.go
+++ b/pkg/controller/kibana/certificates/reconcile.go
@@ -48,7 +48,7 @@ func Reconcile(
 
 	// handle CA expiry via requeue
 	results.WithResult(reconcile.Result{
-		RequeueAfter: certificates.ShouldRotateIn(time.Now(), httpCa.Cert.NotAfter, rotation.RotateBefore),
+		RequeueAfter: certificates.ShouldReconcileIn(time.Now(), httpCa.Cert.NotAfter, rotation.RotateBefore),
 	})
 
 	// discover and maybe reconcile for the http certificates to use

--- a/pkg/controller/license/license_controller_test.go
+++ b/pkg/controller/license/license_controller_test.go
@@ -56,12 +56,20 @@ func Test_nextReconcileRelativeTo(t *testing.T) {
 			want: reconcile.Result{Requeue: true},
 		},
 		{
-			name: "default: requeue after expiry - safety/2 ",
+			name: "default: requeue every 10 hour ",
 			args: args{
 				expiry: chrono.MustParseTime("2019-02-03"),
-				safety: 48 * time.Hour,
+				safety: 24 * time.Hour,
 			},
-			want: reconcile.Result{RequeueAfter: 24 * time.Hour},
+			want: reconcile.Result{RequeueAfter: 10 * time.Hour},
+		},
+		{
+			name: "requeue after expiry - safety/2 ",
+			args: args{
+				expiry: chrono.MustParseTime("2019-02-02"),
+				safety: 30 * time.Hour,
+			},
+			want: reconcile.Result{RequeueAfter: 9 * time.Hour}, // 24-(30/2)
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/1984.

Make sure we don't enqueue reconciliations in more than 10 hours, to mitigate memory leaks in the underlying go-client Timers usage.