### PR TITLE
Mitigate memory leaks from long RequeueAfter periods

### DIFF
--- a/pkg/controller/common/reconciler/results.go
+++ b/pkg/controller/common/reconciler/results.go
@@ -5,9 +5,14 @@
 package reconciler
 
 import (
+	"time"
+
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+// MaximumRequeueAfter is the maximum period of time in which we requeue a reconciliation.
+const MaximumRequeueAfter = 10 * time.Hour
 
 // Results collects intermediate results of a reconciliation run and any errors that occurred.
 type Results struct {
@@ -56,12 +61,20 @@ func (r *Results) Apply(step string, recoverableStep func() (reconcile.Result, e
 // Aggregate compares the collected results with each other and returns the most specific one.
 // Where specific means requeue at a given time is more specific then generic requeue which is more specific
 // than no requeue. It also returns any errors recorded.
+// The aggregated `result.RequeueAfter` period will not be larger than MaximumRequeueAfter.
 func (r *Results) Aggregate() (reconcile.Result, error) {
 	var current reconcile.Result
 	for _, next := range r.results {
 		if nextResultTakesPrecedence(current, next) {
 			current = next
 		}
+	}
+	if current.RequeueAfter > MaximumRequeueAfter {
+		// A client-go leaky timer issue will cause memory leaks for long requeue periods,
+		// see https://github.com/elastic/cloud-on-k8s/issues/1984.
+		// To prevent this from happening, let's restrict the requeue to a fixed short-term value.
+		// TODO: remove once https://github.com/kubernetes/client-go/issues/701 is fixed.
+		current.RequeueAfter = MaximumRequeueAfter
 	}
 	return current, k8serrors.NewAggregate(r.errors)
 }

--- a/pkg/controller/common/reconciler/results_test.go
+++ b/pkg/controller/common/reconciler/results_test.go
@@ -62,7 +62,7 @@ func Test_nextTakesPrecedence(t *testing.T) {
 	}
 }
 
-func TestResults(t *testing.T) {
+func TestResults_Aggregate(t *testing.T) {
 	tests := []struct {
 		name string
 		args []reconcile.Result
@@ -82,6 +82,11 @@ func TestResults(t *testing.T) {
 			name: "multiple",
 			args: []reconcile.Result{{}, {Requeue: true}, {RequeueAfter: 1 * time.Second}},
 			want: reconcile.Result{RequeueAfter: 1 * time.Second},
+		},
+		{
+			name: "multiple with large RequeueAfter: reduced to the maximum value",
+			args: []reconcile.Result{{}, {Requeue: true}, {RequeueAfter: 100 * time.Hour}},
+			want: reconcile.Result{RequeueAfter: MaximumRequeueAfter},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/controller/license/license_controller_test.go
+++ b/pkg/controller/license/license_controller_test.go
@@ -180,7 +180,7 @@ func TestReconcileLicenses_reconcileInternal(t *testing.T) {
 				checker: commonlicense.MockChecker{},
 			}
 			nsn := k8s.ExtractNamespacedName(tt.cluster)
-			res, err := r.reconcileInternal(reconcile.Request{NamespacedName: nsn})
+			res, err := r.reconcileInternal(reconcile.Request{NamespacedName: nsn}).Aggregate()
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)
 				return


### PR DESCRIPTION
Fixes #1984.

We have an issue where the underlying timer used by client-go worker
queue implementation stays in memory until it expires.
Since one gets created at every reconciliation attempt, we end up with a
big bunch of timers in memory that will expire in 365 days by default.

To mitigate the memory leak, let's wait for no more than 10 hours to
reconcile. This does not prevent timers to leak, but restricts it to the next
10 hours.

This is done at the level of the aggregated results, to decouple this
workaround from any business logic like certs expiration. As opposed
to https://github.com/elastic/cloud-on-k8s/pull/1988 (closed).

The PR also refactors slightly the license controller to rely on the aggregated
Results structure. Hence benefit from the max 10 hour restriction.