### PR TITLE
Add combined rolling update and scale down e2e test

### DIFF
--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -175,7 +175,7 @@ func TestMutationRollingDownscaleCombination(t *testing.T) {
 			"data-1": {
 				"node.attr.important": "attribute", // triggers the rolling update on data-1
 			},
-	})
+		})
 	RunESMutation(t, b, mutated)
 }
 

--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -163,14 +163,14 @@ func TestMutationSecondMasterSetDown(t *testing.T) {
 // TestMutationRollingDownscaleCombination combines a rolling update with scale down operation.
 func TestMutationRollingDownscaleCombination(t *testing.T) {
 	b := elasticsearch.NewBuilder("test-combined-upgrade-downscale").
-		WithESMasterNodes(3, elasticsearch.DefaultResources).
-		WithNamedESDataNodes(2, "data-1", elasticsearch.DefaultResources).
-		WithNamedESDataNodes(3, "data-2", elasticsearch.DefaultResources)
+		WithESMasterNodes(1, elasticsearch.DefaultResources).
+		WithNamedESDataNodes(1, "data-1", elasticsearch.DefaultResources).
+		WithNamedESDataNodes(2, "data-2", elasticsearch.DefaultResources)
 
 	mutated := b.WithNoESTopology().
-		WithESMasterNodes(3, elasticsearch.DefaultResources).
-		WithNamedESDataNodes(2, "data-1", elasticsearch.DefaultResources).
-		WithNamedESDataNodes(2, "data-2", elasticsearch.DefaultResources). // scaling down data-2
+		WithESMasterNodes(1, elasticsearch.DefaultResources).
+		WithNamedESDataNodes(1, "data-1", elasticsearch.DefaultResources).
+		WithNamedESDataNodes(1, "data-2", elasticsearch.DefaultResources). // scaling down data-2
 		WithAdditionalConfig(map[string]map[string]interface{}{
 			"data-1": {
 				"node.attr.important": "attribute", // triggers the rolling update on data-1

--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -160,6 +160,25 @@ func TestMutationSecondMasterSetDown(t *testing.T) {
 	RunESMutation(t, b, mutated)
 }
 
+// TestMutationRollingDownscaleCombination combines a rolling update with scale down operation.
+func TestMutationRollingDownscaleCombination(t *testing.T) {
+	b := elasticsearch.NewBuilder("test-combined-upgrade-downscale").
+		WithESMasterNodes(3, elasticsearch.DefaultResources).
+		WithNamedESDataNodes(2, "data-1", elasticsearch.DefaultResources).
+		WithNamedESDataNodes(3, "data-2", elasticsearch.DefaultResources)
+
+	mutated := b.WithNoESTopology().
+		WithESMasterNodes(3, elasticsearch.DefaultResources).
+		WithNamedESDataNodes(2, "data-1", elasticsearch.DefaultResources).
+		WithNamedESDataNodes(2, "data-2", elasticsearch.DefaultResources). // scaling down data-2
+		WithAdditionalConfig(map[string]map[string]interface{}{
+			"data-1": {
+				"node.attr.important": "attribute", // triggers the rolling update on data-1
+			},
+	})
+	RunESMutation(t, b, mutated)
+}
+
 func TestMutationAndReversal(t *testing.T) {
 	b := elasticsearch.NewBuilder("test-reverted-mutation").
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources)

--- a/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/test/e2e/test/elasticsearch/checks_k8s.go
@@ -367,8 +367,8 @@ func AnnotatePodsWithBuilderHash(b Builder, k *test.K8sClient) []test.Step {
 
 // nodeSetHash builds a hash of the nodeSet specification in the given ES resource.
 func nodeSetHash(es estype.Elasticsearch, nodeSet estype.NodeSet) string {
-	 // Normalize the count to zero to exclude it from the hash. Otherwise scaling up/down would affect the hash but
-	 // existing nodes not affected by the scaling will not be cycled and therefore be annotated with the previous hash.
+	// Normalize the count to zero to exclude it from the hash. Otherwise scaling up/down would affect the hash but
+	// existing nodes not affected by the scaling will not be cycled and therefore be annotated with the previous hash.
 	nodeSet.Count = 0
 	specHash := hash.HashObject(nodeSet)
 	esVersionHash := hash.HashObject(es.Spec.Version)

--- a/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/test/e2e/test/elasticsearch/checks_k8s.go
@@ -367,6 +367,9 @@ func AnnotatePodsWithBuilderHash(b Builder, k *test.K8sClient) []test.Step {
 
 // nodeSetHash builds a hash of the nodeSet specification in the given ES resource.
 func nodeSetHash(es estype.Elasticsearch, nodeSet estype.NodeSet) string {
+	 // Normalize the count to zero to exclude it from the hash. Otherwise scaling up/down would affect the hash but
+	 // existing nodes not affected by the scaling will not be cycled and therefore be annotated with the previous hash.
+	nodeSet.Count = 0
 	specHash := hash.HashObject(nodeSet)
 	esVersionHash := hash.HashObject(es.Spec.Version)
 	httpServiceHash := hash.HashObject(es.Spec.HTTP)


### PR DESCRIPTION
Part of #1156 

Combined rolling update with scale down of another node set to potentially test any interactions between delete logic and upgrade logic.

Also excludes `count` from the e2e builder hash calculation which became a problem when combining a rolling update with a downscale (because not all pods are replaced but the hash would change, see comment in code)