### PR TITLE
Try increasing default e2e test timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,6 +345,7 @@ TESTS_MATCH ?= "^Test"
 E2E_IMG ?= $(IMG)-e2e-tests:$(TAG)
 STACK_VERSION ?= 7.4.0
 E2E_JSON ?= false
+TEST_TIMEOUT ?= 5m
 
 # Run e2e tests as a k8s batch job
 e2e: build-operator-image e2e-docker-build e2e-docker-push e2e-run
@@ -363,7 +364,8 @@ e2e-run:
 		--elastic-stack-version=$(STACK_VERSION) \
 		--log-verbosity=$(LOG_VERBOSITY) \
 		--crd-flavor=$(CRD_FLAVOR) \
-		--log-to-file=$(E2E_JSON)
+		--log-to-file=$(E2E_JSON) \
+		--test-timeout=$(TEST_TIMEOUT)
 
 e2e-generate-xml:
 	@ gotestsum --junitfile e2e-tests.xml --raw-command cat e2e-tests.json
@@ -384,7 +386,8 @@ e2e-local:
 		--auto-port-forwarding \
 		--local \
 		--log-verbosity=$(LOG_VERBOSITY) \
-		--crd-flavor=$(CRD_FLAVOR)
+		--crd-flavor=$(CRD_FLAVOR) \
+		--test-timeout=$(TEST_TIMEOUT)
 	@E2E_JSON=$(E2E_JSON) test/e2e/run.sh -run "$(TESTS_MATCH)" -args -testContextPath $(LOCAL_E2E_CTX)
 
 ##########################################

--- a/build/ci/e2e/Jenkinsfile-aks
+++ b/build/ci/e2e/Jenkinsfile-aks
@@ -34,6 +34,7 @@ REPOSITORY = operators
 IMG_SUFFIX = -ci
 CRD_FLAVOR = trivial-versions
 E2E_JSON = true
+TEST_TIMEOUT = 10m
 EOF
                     cat >deployer-config.yml <<EOF
 id: aks-ci

--- a/test/e2e/cmd/run/command.go
+++ b/test/e2e/cmd/run/command.go
@@ -37,6 +37,7 @@ type runFlags struct {
 	logToFile           bool
 	logVerbosity        int
 	crdFlavor           string
+	testTimeout         time.Duration
 }
 
 var log logr.Logger
@@ -77,6 +78,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&flags.testRegex, "test-regex", "", "Regex to pass to the test runner")
 	cmd.Flags().StringVar(&flags.testRunName, "test-run-name", randomTestRunName(), "Name of this test run")
 	cmd.Flags().StringVar(&flags.crdFlavor, "crd-flavor", "default", "CRD flavor to install")
+	cmd.Flags().DurationVar(&flags.testTimeout, "test-timeout", 5*time.Minute, "Timeout before failing a test")
 	cmd.Flags().BoolVar(&flags.logToFile, "log-to-file", false, "Specifies if should log test output to file. Disabled by default.")
 	logutil.BindFlags(cmd.PersistentFlags())
 

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -142,6 +142,7 @@ func (h *helper) initTestContext() error {
 		TestLicence:   h.testLicence,
 		TestRegex:     h.testRegex,
 		TestRun:       h.testRunName,
+		TestTimeout:   h.testTimeout,
 	}
 
 	for i, ns := range h.managedNamespaces {

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	logutil "github.com/elastic/cloud-on-k8s/pkg/utils/log"
 	"github.com/go-logr/logr"
@@ -90,6 +91,7 @@ type Context struct {
 	TestLicence         string            `json:"test_licence"`
 	TestRegex           string            `json:"test_regex"`
 	TestRun             string            `json:"test_run"`
+	TestTimeout         time.Duration     `json:"test_timeout"`
 	AutoPortForwarding  bool              `json:"auto_port_forwarding"`
 	Local               bool              `json:"local"`
 }

--- a/test/e2e/test/utils.go
+++ b/test/e2e/test/utils.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	DefaultRetryDelay = 3 * time.Second
-	defaultTimeout    = 10 * time.Minute
 )
 
 func CheckKeystoreEntries(k *K8sClient, keystoreCmd []string, expectedKeys []string, opts ...client.ListOption) Step {
@@ -71,6 +70,7 @@ func ExitOnErr(err error) {
 // with a default timeout
 func Eventually(f func() error) func(*testing.T) {
 	return func(t *testing.T) {
+		defaultTimeout := Ctx().TestTimeout
 		fmt.Printf("Retries (%s timeout): ", defaultTimeout)
 		err := retry.UntilSuccess(func() error {
 			fmt.Print(".") // super modern progress bar 2.0!

--- a/test/e2e/test/utils.go
+++ b/test/e2e/test/utils.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	DefaultRetryDelay = 3 * time.Second
-	defaultTimeout    = 5 * time.Minute
+	defaultTimeout    = 10 * time.Minute
 )
 
 func CheckKeystoreEntries(k *K8sClient, keystoreCmd []string, expectedKeys []string, opts ...client.ListOption) Step {


### PR DESCRIPTION
While investigating AKS e2e test failures, I've noticed that tests often time out. Looking closer at recent runs (https://devops-ci.elastic.co/view/cloud-on-k8s/job/cloud-on-k8s-e2e-tests-aks/29/consoleText, https://devops-ci.elastic.co/view/cloud-on-k8s/job/cloud-on-k8s-e2e-tests-aks/30/consoleText, https://devops-ci.elastic.co/view/cloud-on-k8s/job/cloud-on-k8s-e2e-tests-aks/31/consoleText) it seems that AKS is not able to start pods quickly enough, ie. before our 5 minute timeout is hit. For example in run 31:

```
test started at:             "14:39:08"
pod scheduled at:            "14:39:19"
init container finished at:  "14:43:47"
es container started at:     "14:43:50"
test fails at:               "14:44:08"
```

Which means that ES had only 18 seconds between starting up and failing. While the fact that we need to wait that long is depressing, I don't see any other way than just increasing the timeout. To avoid waiting 10 minutes for each failed test every time, we could optimize for evident, non-recoverable failures if we can detect them (non-goal here).