### PR TITLE
Fix the default e2e volume claim template to be named elasticsearch-data

### DIFF
--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -21,7 +21,6 @@ const (
 	// we setup our own storageClass with "volumeBindingMode: waitForFirstConsumer" that we
 	// reference in the VolumeClaimTemplates section of the Elasticsearch spec
 	defaultStorageClass = "e2e-default"
-	defaultVolumeName   = "e2e-default-volume"
 )
 
 func ESPodTemplate(resources corev1.ResourceRequirements) corev1.PodTemplateSpec {
@@ -216,15 +215,17 @@ func (b Builder) WithDefaultPersistentVolumes() Builder {
 	storageClass := defaultStorageClass
 	for i := range b.Elasticsearch.Spec.NodeSets {
 		for _, existing := range b.Elasticsearch.Spec.NodeSets[i].VolumeClaimTemplates {
-			if existing.Name == defaultVolumeName {
+			if existing.Name == volume.ElasticsearchDataVolumeName {
+				// already defined, don't set our defaults
 				goto next
 			}
 		}
 
+		// setup default claim with the custom storage class
 		b.Elasticsearch.Spec.NodeSets[i].VolumeClaimTemplates = append(b.Elasticsearch.Spec.NodeSets[i].VolumeClaimTemplates,
 			corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: defaultVolumeName,
+					Name: volume.ElasticsearchDataVolumeName,
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					AccessModes: []corev1.PersistentVolumeAccessMode{
@@ -238,17 +239,6 @@ func (b Builder) WithDefaultPersistentVolumes() Builder {
 					StorageClassName: &storageClass,
 				},
 			})
-		b.Elasticsearch.Spec.NodeSets[i].PodTemplate.Spec.Volumes = []corev1.Volume{
-			{
-				Name: defaultVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: defaultVolumeName,
-						ReadOnly:  false,
-					},
-				},
-			},
-		}
 
 	next:
 	}


### PR DESCRIPTION
In commit 7cd9c7f we introduced a new default storage class for E2E
tests, and patched E2E tests volume claim templates to use it.

Since its name was not the default "elasticsearch-data", we appended it
to the regular volume claim templates; then the operator appends its own
"elasticsearch-data" volume used for ES data.
So we ended up with 2 PVCs per Pod, the "elasticsearch-data" one managed
by ECK, using the default storage class, and the "e2e-default" one
managed by E2E tests, which was not even mounted in the pod:

```
⟩ k get pvc -n e2e-mercury
NAME
STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS          AGE
e2e-default-volume-force-upgrade-pending-sset-rzqk-es-data-0
Pending                                      e2e-default           16s
e2e-default-volume-force-upgrade-pending-sset-rzqk-es-data-1
Pending                                      e2e-default           16s
e2e-default-volume-force-upgrade-pending-sset-rzqk-es-masterdata-0
Pending                                      e2e-default           16s
elasticsearch-data-force-upgrade-pending-sset-rzqk-es-data-0
Pending                                      standard-customized   16s
elasticsearch-data-force-upgrade-pending-sset-rzqk-es-data-1
Pending                                      standard-customized   16s
elasticsearch-data-force-upgrade-pending-sset-rzqk-es-masterdata-0
Pending                                      standard-customized   16s
```

This commit fixes it by making sure the E2E default PVC uses the
"elasticsearch-data" name. In which case we don't need to also
specify the podTemplate volume.