### PR TITLE
Make association optional for Kibana

### DIFF
--- a/docs/kibana.asciidoc
+++ b/docs/kibana.asciidoc
@@ -5,6 +5,7 @@ The <<{p}-deploy-kibana,quickstart>> is a good starting point to quickly setup a
 The following sections describe how to customize a Kibana deployment to suit your requirements.
 
 * <<{p}-kibana-eck-managed-es,Use an Elasticsearch cluster managed by ECK>>
+* <<{p}-kibana-external-es,Connect to an Elasticsearch cluster not managed by ECK>>
 * <<{p}-kibana-advanced-configuration,Advanced configuration>>
 ** <<{p}-kibana-pod-configuration,Pod Configuration>>
 ** <<{p}-kibana-configuration,Kibana Configuration>>
@@ -38,6 +39,70 @@ spec:
 NOTE: `namespace` is optional if the Elasticsearch cluster is running in the same namespace as Kibana.
 
 The Kibana configuration file is automatically setup by ECK to establish a secure connection to Elasticsearch.
+
+[float]
+[id="{p}-kibana-external-es"]
+=== Connect to an Elasticsearch cluster not managed by ECK
+
+It is also possible to configure Kibana to connect to an Elasticsearch cluster that is being managed by a different installation of ECK or running outside the Kubernetes cluster. In this case, you need to know the IP address or URL of the Elasticsearch cluster and a valid username and password pair to access the cluster.
+
+Use the <<{p}-kibana-secure-settings,secure settings>> mechanism to securely store the credentials of the external Elasticsearch cluster:
+
+[source,shell]
+----
+kubectl create secret generic kibana-elasticsearch-credentials --from-literal=elasticsearch.password=$PASSWORD
+----
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: kibana.k8s.elastic.co/{eck_crd_version}
+kind: Kibana
+metadata:
+  name: kibana-sample
+spec:
+  version: {version}
+  count: 1
+  config:
+    elasticsearch.hosts:
+      - https://elasticsearch.example.com:9200
+    elasticsearch.username: elastic
+  secureSettings:
+    - secretName: kibana-elasticsearch-credentials
+----
+
+
+If the external Elasticsearch cluster is using a self-signed certificate, create a Kubernetes secret containing the CA certificate and mount it to the Kibana container as follows:
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: kibana.k8s.elastic.co/{eck_crd_version}
+kind: Kibana
+metadata:
+  name: kibana-sample
+spec:
+  version: {version}
+  count: 1
+  config:
+    elasticsearch.hosts:
+      - https://elasticsearch-sample-es-http:9200
+    elasticsearch.username: elastic
+    elasticsearch.ssl.certificateAuthorities: /etc/certs/ca.crt
+  secureSettings:
+    - secretName: kibana-elasticsearch-credentials
+  podTemplate:
+    spec:
+      volumes:
+        - name: elasticsearch-certs
+          secret:
+            secretName: elasticsearch-certs-secret
+      containers:
+        - name: kibana
+          volumeMounts:
+            - name: elasticsearch-certs
+              mountPath: /etc/certs
+              readOnly: true
+----
+
 
 [float]
 [id="{p}-kibana-advanced-configuration"]

--- a/pkg/apis/kibana/v1beta1/kibana_types.go
+++ b/pkg/apis/kibana/v1beta1/kibana_types.go
@@ -93,6 +93,11 @@ func (k *Kibana) SetAssociationConf(assocConf *commonv1beta1.AssociationConf) {
 	k.assocConf = assocConf
 }
 
+// RequiresAssociation returns true if the spec specifies an Elasticsearch reference.
+func (k *Kibana) RequiresAssociation() bool {
+	return k.Spec.ElasticsearchRef.Name != ""
+}
+
 // +kubebuilder:object:root=true
 
 // Kibana is the Schema for the kibanas API

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -21,6 +21,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	commonvolume "github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	kbcerts "github.com/elastic/cloud-on-k8s/pkg/controller/kibana/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana/config"
@@ -128,6 +129,8 @@ func (d *driver) deploymentParams(kb *kbtype.Kibana) (deployment.Params, error) 
 		d.dynamicWatches.Secrets.RemoveHandlerForKey(secretWatchKey(*kb))
 	}
 
+	volumes := []commonvolume.SecretVolume{config.SecretVolume(*kb)}
+
 	if kb.AssociationConf().CAIsConfigured() {
 		var esPublicCASecret corev1.Secret
 		key := types.NamespacedName{Namespace: kb.Namespace, Name: kb.AssociationConf().GetCASecretName()}
@@ -149,19 +152,12 @@ func (d *driver) deploymentParams(kb *kbtype.Kibana) (deployment.Params, error) 
 
 		// TODO: this is a little ugly as it reaches into the ES controller bits
 		esCertsVolume := es.CaCertSecretVolume(*kb)
-		configVolume := config.SecretVolume(*kb)
-
-		kibanaPodSpec.Spec.Volumes = append(kibanaPodSpec.Spec.Volumes,
-			esCertsVolume.Volume(), configVolume.Volume())
-
+		volumes = append(volumes, esCertsVolume)
 		for i := range kibanaPodSpec.Spec.InitContainers {
 			kibanaPodSpec.Spec.InitContainers[i].VolumeMounts = append(kibanaPodSpec.Spec.InitContainers[i].VolumeMounts,
 				esCertsVolume.VolumeMount())
 		}
 
-		kibanaContainer := pod.GetKibanaContainer(kibanaPodSpec.Spec)
-		kibanaContainer.VolumeMounts = append(kibanaContainer.VolumeMounts,
-			esCertsVolume.VolumeMount(), configVolume.VolumeMount())
 	}
 
 	if kb.Spec.HTTP.TLS.Enabled() {
@@ -178,12 +174,15 @@ func (d *driver) deploymentParams(kb *kbtype.Kibana) (deployment.Params, error) 
 			_, _ = configChecksum.Write(httpCert)
 		}
 
-		// add volume/mount for http certs to pod spec
 		httpCertsVolume := http.HTTPCertSecretVolume(kbname.KBNamer, kb.Name)
-		kibanaPodSpec.Spec.Volumes = append(kibanaPodSpec.Spec.Volumes, httpCertsVolume.Volume())
-		kibanaContainer := pod.GetKibanaContainer(kibanaPodSpec.Spec)
-		kibanaContainer.VolumeMounts = append(kibanaContainer.VolumeMounts, httpCertsVolume.VolumeMount())
+		volumes = append(volumes, httpCertsVolume)
+	}
 
+	// attach volumes
+	kibanaContainer := pod.GetKibanaContainer(kibanaPodSpec.Spec)
+	for _, volume := range volumes {
+		kibanaPodSpec.Spec.Volumes = append(kibanaPodSpec.Spec.Volumes, volume.Volume())
+		kibanaContainer.VolumeMounts = append(kibanaContainer.VolumeMounts, volume.VolumeMount())
 	}
 
 	// get config secret to add its content to the config checksum
@@ -214,9 +213,9 @@ func (d *driver) Reconcile(
 	params operator.Parameters,
 ) *reconciler.Results {
 	results := reconciler.Results{}
-	if !kb.AssociationConf().IsConfigured() {
+	if kb.RequiresAssociation() && !kb.AssociationConf().IsConfigured() {
 		d.recorder.Event(kb, corev1.EventTypeWarning, events.EventAssociationError, "Elasticsearch backend is not configured")
-		log.Info("Aborting Kibana deployment reconciliation as no Elasticsearch backend is configured", "namespace", kb.Namespace, "kibana_name", kb.Name)
+		log.Info("Elasticsearch association not established: skipping Kibana deployment reconciliation", "namespace", kb.Namespace, "kibana_name", kb.Name)
 		return &results
 	}
 
@@ -231,16 +230,12 @@ func (d *driver) Reconcile(
 		return &results
 	}
 
-	kbSettings, err := config.NewConfigSettings(d.client, *kb)
+	versionSpecificCfg := settings.MustCanonicalConfig(d.settingsFactory(*kb))
+	kbSettings, err := config.NewConfigSettings(d.client, *kb, versionSpecificCfg)
 	if err != nil {
 		return results.WithError(err)
 	}
-	err = kbSettings.MergeWith(
-		settings.MustCanonicalConfig(d.settingsFactory(*kb)),
-	)
-	if err != nil {
-		return results.WithError(err)
-	}
+
 	err = config.ReconcileConfigSecret(d.client, *kb, kbSettings, params.OperatorInfo)
 	if err != nil {
 		return results.WithError(err)

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -244,19 +244,19 @@ func expectedDeploymentParams() deployment.Params {
 						},
 					},
 					{
-						Name: "elasticsearch-certs",
+						Name: "config",
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
-								SecretName: "es-ca-secret",
+								SecretName: "test-kb-config",
 								Optional:   &false,
 							},
 						},
 					},
 					{
-						Name: "config",
+						Name: "elasticsearch-certs",
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
-								SecretName: "test-kb-config",
+								SecretName: "es-ca-secret",
 								Optional:   &false,
 							},
 						},
@@ -279,14 +279,14 @@ func expectedDeploymentParams() deployment.Params {
 							MountPath: volume.DataVolumeMountPath,
 						},
 						{
-							Name:      "elasticsearch-certs",
-							ReadOnly:  true,
-							MountPath: "/usr/share/kibana/config/elasticsearch-certs",
-						},
-						{
 							Name:      "config",
 							ReadOnly:  true,
 							MountPath: "/usr/share/kibana/config",
+						},
+						{
+							Name:      "elasticsearch-certs",
+							ReadOnly:  true,
+							MountPath: "/usr/share/kibana/config/elasticsearch-certs",
 						},
 						{
 							Name:      http.HTTPCertificatesSecretVolumeName,

--- a/test/e2e/kb/standalone_test.go
+++ b/test/e2e/kb/standalone_test.go
@@ -1,0 +1,59 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kb
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+	"text/template"
+
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/helper"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/kibana"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+// TestKibanaStandalone tests running Kibana without an automatic association to Elasticsearch.
+func TestKibanaStandalone(t *testing.T) {
+	builders := mkKibanaStandaloneBuilders(t)
+	test.Sequence(nil, test.EmptySteps, builders...).RunSequential(t)
+}
+
+func mkKibanaStandaloneBuilders(t *testing.T) []test.Builder {
+	t.Helper()
+
+	tmpl, err := template.ParseFiles("testdata/kibana_standalone.yaml")
+	require.NoError(t, err, "Failed to parse template")
+
+	buf := new(bytes.Buffer)
+	require.NoError(t, tmpl.Execute(buf, map[string]string{"Suffix": rand.String(4)}))
+
+	namespace := test.Ctx().ManagedNamespace(0)
+	stackVersion := test.Ctx().ElasticStackVersion
+
+	transform := func(builder test.Builder) test.Builder {
+		switch b := builder.(type) {
+		case elasticsearch.Builder:
+			return b.WithNamespace(namespace).
+				WithVersion(stackVersion).
+				WithRestrictedSecurityContext()
+		case kibana.Builder:
+			return b.WithNamespace(namespace).
+				WithVersion(stackVersion).
+				WithRestrictedSecurityContext()
+		default:
+			return b
+		}
+	}
+
+	decoder := helper.NewYAMLDecoder()
+	builders, err := decoder.ToBuilders(bufio.NewReader(buf), transform)
+	require.NoError(t, err, "Failed to create builders")
+
+	return builders
+}

--- a/test/e2e/kb/testdata/kibana_standalone.yaml
+++ b/test/e2e/kb/testdata/kibana_standalone.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: elasticsearch.k8s.elastic.co/v1beta1
+kind: Elasticsearch
+metadata:
+  name: test-kibana-standalone-es-{{ .Suffix }}
+spec:
+  version: 7.4.0
+  nodeSets:
+  - count: 1
+    name: mdi
+    config:
+      node.master: true
+      node.data: true
+      node.store.allow_mmap: false
+---
+apiVersion: kibana.k8s.elastic.co/v1beta1
+kind: Kibana
+metadata:
+  name: test-kibana-standalone-{{ .Suffix }}
+spec:
+  version: 7.4.0
+  count: 1
+  config:
+    elasticsearch.hosts:
+      - https://test-kibana-standalone-es-{{ .Suffix }}-es-http:9200
+    elasticsearch.username: elastic
+    elasticsearch.ssl.verificationMode: none
+  podTemplate:
+    spec:
+      containers:
+        - name: kibana
+          env:
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: test-kibana-standalone-es-{{ .Suffix }}-es-elastic-user
+                  key: elastic

--- a/test/e2e/test/helper/yaml.go
+++ b/test/e2e/test/helper/yaml.go
@@ -1,0 +1,81 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package helper
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+
+	apmtype "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1beta1"
+	estype "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
+	kbtype "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1beta1"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/apmserver"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/kibana"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+type BuilderTransform func(test.Builder) test.Builder
+
+// YAMLDecoder converts YAML bytes into test.Builder instances.
+type YAMLDecoder struct {
+	decoder runtime.Decoder
+}
+
+func NewYAMLDecoder() *YAMLDecoder {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(estype.GroupVersion, &estype.Elasticsearch{}, &estype.ElasticsearchList{})
+	scheme.AddKnownTypes(kbtype.GroupVersion, &kbtype.Kibana{}, &kbtype.KibanaList{})
+	scheme.AddKnownTypes(apmtype.GroupVersion, &apmtype.ApmServer{}, &apmtype.ApmServerList{})
+	decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
+
+	return &YAMLDecoder{decoder: decoder}
+}
+
+func (yd *YAMLDecoder) ToBuilders(reader *bufio.Reader, transform BuilderTransform) ([]test.Builder, error) {
+	var builders []test.Builder
+
+	yamlReader := yaml.NewYAMLReader(reader)
+	for {
+		yamlBytes, err := yamlReader.Read()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("failed to read YAML: %w", err)
+		}
+		obj, _, err := yd.decoder.Decode(yamlBytes, nil, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode YAML: %w", err)
+		}
+
+		var builder test.Builder
+
+		switch decodedObj := obj.(type) {
+		case *estype.Elasticsearch:
+			b := elasticsearch.NewBuilderWithoutSuffix(decodedObj.Name)
+			b.Elasticsearch = *decodedObj
+			builder = transform(b)
+		case *kbtype.Kibana:
+			b := kibana.NewBuilderWithoutSuffix(decodedObj.Name)
+			b.Kibana = *decodedObj
+			builder = transform(b)
+		case *apmtype.ApmServer:
+			b := apmserver.NewBuilderWithoutSuffix(decodedObj.Name)
+			b.ApmServer = *decodedObj
+			builder = transform(b)
+		default:
+			return builders, fmt.Errorf("unexpected object type: %t", decodedObj)
+		}
+
+		builders = append(builders, builder)
+	}
+
+	return builders, nil
+}


### PR DESCRIPTION
Allows Kibana to be deployed without an association and adds an E2E test to verify the behaviour.

Also adds documentation about connecting Kibana to external Elasticsearch clusters.

Fixes #1875, #2001 
