### PR TITLE
Minimize Slack messages, show only test name and URL to details

### DIFF
--- a/build/ci/common/tests.groovy
+++ b/build/ci/common/tests.groovy
@@ -8,7 +8,7 @@ def getListOfFailedTests() {
     def failed = currentBuild.rawBuild.getAction(hudson.tasks.test.AbstractTestResultAction.class)?.getResult()?.getFailedTests()
     def result = []
     failed.each { ft ->
-        result.add(String.format("%s\r\n%s", ft.getDisplayName(), ft.getErrorStackTrace()))
+        result.add(ft.getDisplayName())
     }
     return result
 }
@@ -18,6 +18,7 @@ def generateSlackMessage(baseMsg, URL, failedTests) {
     sb.append(baseMsg)
     sb.append("\r\n")
     sb.append(URL)
+    sb.append("/testReport")
     if (failedTests.size() > 0) {
         sb.append("\r\n")
         sb.append("List of failed tests:")

--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
                 if (params.SEND_NOTIFICATIONS) {
                     Set<String> filter = new HashSet<>()
                     filter.addAll(failedTests)
-                    def msg = testScript.generateSlackMessage("E2E tests for different k8s versions in GKE failed!", env.RUN_DISPLAY_URL, filter)
+                    def msg = testScript.generateSlackMessage("E2E tests for different k8s versions in GKE failed!", env.BUILD_URL, filter)
 
                     slackSend botUser: true,
                         channel: '#cloud-k8s',

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -80,7 +80,7 @@ pipeline {
                 if (params.SEND_NOTIFICATIONS) {
                     Set<String> filter = new HashSet<>()
                     filter.addAll(failedTests)
-                    def msg = testScript.generateSlackMessage("E2E tests for different Elastic stack versions failed!", env.RUN_DISPLAY_URL, filter)
+                    def msg = testScript.generateSlackMessage("E2E tests for different Elastic stack versions failed!", env.BUILD_URL, filter)
 
                     slackSend botUser: true,
                         channel: '#cloud-k8s',


### PR DESCRIPTION
Current implementation is too verbose, because it shows the whole stacktrace. This PR minimizes message. Message will contain list of failed tests and link to test results in Jenkins, for example https://devops-ci.elastic.co/view/cloud-on-k8s/job/cloud-on-k8s-e2e-tests/502/testReport/