### PR TITLE
Dump k8s data when e2e test fails

### DIFF
--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -90,6 +90,17 @@ pipeline {
     }
 
     post {
+        always {
+            script {
+                if (notOnlyDocs()) {
+                    googleStorageUpload bucket: "gs://devops-ci-artifacts/eck/data-dump",
+                        credentialsId: "devops-ci-gcs-plugin",
+                        pattern: "*.tgz",
+                        sharedPublicly: true,
+                        showInline: true
+                }
+            }
+        }
         cleanup {
             script {
                 if (notOnlyDocs()) {

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
         always {
             script {
                 if (notOnlyDocs()) {
-                    googleStorageUpload bucket: "gs://devops-ci-artifacts/eck/data-dump",
+                    googleStorageUpload bucket: "gs://devops-ci-artifacts/jobs/$JOB_NAME/$BUILD_NUMBER",
                         credentialsId: "devops-ci-gcs-plugin",
                         pattern: "*.tgz",
                         sharedPublicly: true,

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -224,6 +224,7 @@ func (h *helper) runTestJob() error {
 
 	if err != nil {
 		h.dumpEventLog()
+		h.dumpK8sData()
 		return errors.Wrap(err, "test run failed")
 	}
 
@@ -470,5 +471,15 @@ func (h *helper) dumpEventLog() {
 	var buffer [1024]byte
 	if _, err := io.CopyBuffer(os.Stdout, f, buffer[:]); err != nil {
 		log.Error(err, "Failed to output event log")
+	}
+}
+
+func (h *helper) dumpK8sData() {
+	operatorNs := h.testContext.GlobalOperator.Namespace + "," + h.testContext.NamespaceOperator.Namespace
+	managedNs := strings.Join(h.testContext.NamespaceOperator.ManagedNamespaces, ",")
+	cmd := exec.Command("hack/eck-dump.sh", "-N", operatorNs, "-n", managedNs, "-o", h.testContext.TestRun, "-z")
+	err := cmd.Run()
+	if err != nil {
+		log.Error(err, "Failed to run hack/eck-dump.sh")
 	}
 }

--- a/test/e2e/test/utils.go
+++ b/test/e2e/test/utils.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	DefaultRetryDelay = 3 * time.Second
-	defaultTimeout    = 5 * time.Minute
+	defaultTimeout    = 10 * time.Second
 )
 
 func CheckKeystoreEntries(k *K8sClient, keystoreCmd []string, expectedKeys []string, opts ...client.ListOption) Step {

--- a/test/e2e/test/utils.go
+++ b/test/e2e/test/utils.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	DefaultRetryDelay = 3 * time.Second
-	defaultTimeout    = 10 * time.Second
+	defaultTimeout    = 5 * time.Minute
 )
 
 func CheckKeystoreEntries(k *K8sClient, keystoreCmd []string, expectedKeys []string, opts ...client.ListOption) Step {


### PR DESCRIPTION
- Run `hack/eck-dump.sh -N $operatorNs -n $managedNs -o $name -z` when an E2E test fails
- Upload the generated archive by using the `googleStorageUpload` Jenkins plugin

Resolves #556.