### PR TITLE
Use discovery.seed_providers instead of discovery.zen.hosts_provider starting 7.x

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -139,7 +139,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 			Labels: map[string]string{
 				"common.k8s.elastic.co/type":                    "elasticsearch",
 				"elasticsearch.k8s.elastic.co/cluster-name":     "name",
-				"elasticsearch.k8s.elastic.co/config-hash":      "593041036",
+				"elasticsearch.k8s.elastic.co/config-hash":      "1308765141",
 				"elasticsearch.k8s.elastic.co/http-scheme":      "https",
 				"elasticsearch.k8s.elastic.co/node-data":        "false",
 				"elasticsearch.k8s.elastic.co/node-ingest":      "true",

--- a/pkg/controller/elasticsearch/settings/fields.go
+++ b/pkg/controller/elasticsearch/settings/fields.go
@@ -9,7 +9,9 @@ const (
 
 	DiscoveryZenMinimumMasterNodes = "discovery.zen.minimum_master_nodes"
 	ClusterInitialMasterNodes      = "cluster.initial_master_nodes"
-	DiscoveryZenHostsProvider      = "discovery.zen.hosts_provider"
+
+	DiscoveryZenHostsProvider = "discovery.zen.hosts_provider" // ES < 7.X
+	DiscoverySeedProviders    = "discovery.seed_providers"     // ES >= 7.X
 
 	NetworkHost        = "network.host"
 	NetworkPublishHost = "network.publish_host"

--- a/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/pkg/controller/elasticsearch/settings/merged_config.go
@@ -54,10 +54,11 @@ func baseConfig(clusterName string, ver version.Version) *CanonicalConfig {
 	}
 
 	// seed hosts setting name changed starting ES 7.X
+	fileProvider := "file"
 	if ver.Major < 7 {
-		cfg[DiscoveryZenHostsProvider] = "file"
+		cfg[DiscoveryZenHostsProvider] = fileProvider
 	} else {
-		cfg[DiscoverySeedProviders] = "file"
+		cfg[DiscoverySeedProviders] = fileProvider
 	}
 
 	return &CanonicalConfig{common.MustCanonicalConfig(cfg)}

--- a/pkg/controller/elasticsearch/settings/merged_config_test.go
+++ b/pkg/controller/elasticsearch/settings/merged_config_test.go
@@ -96,6 +96,24 @@ func TestNewMergedESConfig(t *testing.T) {
 				require.Equal(t, 1, len(cfg.HasKeys([]string{xPackSecurityAuthcRealmsNativeNative1Order})))
 			},
 		},
+		{
+			name:    "in 6.x, seed hosts setting should be discovery.zen.hosts_provider",
+			version: "6.8.0",
+			cfgData: map[string]interface{}{},
+			assert: func(cfg CanonicalConfig) {
+				require.Equal(t, 1, len(cfg.HasKeys([]string{DiscoveryZenHostsProvider})))
+				require.Equal(t, 0, len(cfg.HasKeys([]string{DiscoverySeedProviders})))
+			},
+		},
+		{
+			name:    "starting 7.x, seed hosts settings should be discovery.seed_providers",
+			version: "7.0.0",
+			cfgData: map[string]interface{}{},
+			assert: func(cfg CanonicalConfig) {
+				require.Equal(t, 0, len(cfg.HasKeys([]string{DiscoveryZenHostsProvider})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{DiscoverySeedProviders})))
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
[Starting Elasticsearch 7.0](https://www.elastic.co/guide/en/elastic-stack/7.0/elasticsearch-breaking-changes.html#_discovery_configuration_is_required_in_production), `discovery.zen.hosts_provider` is deprecated
in favor of `discovery.seed_providers`.
The setting is removed in 8.0, preventing any 8.0 cluster to bootstrap.

This commit switches over the Elasticsearch version when building the
elasticsearch.yml configuration, to make sure versions lower than 7.0
use `discovery.zen.hosts_provider`, and other versions use the newer
`discovery.seed_providers`.

I did some manual testing, also covered by E2E tests:

* bootstrap a 6.8.0 cluster
* bootstrap a 7.2.0 cluster
* mutate a 6.8.0 cluster to 7.2.0
