### PR TITLE
Fix nil pointer in upgrade predicates

### DIFF
--- a/pkg/controller/elasticsearch/driver/upgrade.go
+++ b/pkg/controller/elasticsearch/driver/upgrade.go
@@ -131,6 +131,7 @@ func newRollingUpgrade(
 		ES:              d.ES,
 		statefulSets:    statefulSets,
 		esClient:        esClient,
+		shardLister:     esClient,
 		esState:         esState,
 		expectations:    d.Expectations,
 		reconcileState:  d.ReconcileState,

--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -194,8 +194,8 @@ func TestMutationAndReversal(t *testing.T) {
 
 }
 
-func TestMutationWithChangeBudget(t *testing.T) {
-	b := elasticsearch.NewBuilder("test-change-budget").
+func TestMutationNodeSetReplacementWithChangeBudget(t *testing.T) {
+	b := elasticsearch.NewBuilder("test-1-change-budget").
 		WithESMasterNodes(1, elasticsearch.DefaultResources).
 		WithNamedESDataNodes(5, "data1", elasticsearch.DefaultResources)
 
@@ -204,6 +204,25 @@ func TestMutationWithChangeBudget(t *testing.T) {
 		WithESMasterNodes(1, elasticsearch.DefaultResources).
 		WithNamedESDataNodes(5, "data2", elasticsearch.DefaultResources).
 		WithChangeBudget(1, 1)
+
+	RunESMutation(t, b, mutated)
+}
+
+func TestMutationWithLargerChangeBudget(t *testing.T) {
+	b := elasticsearch.NewBuilder("test-2-change-budget").
+		WithESMasterNodes(1, elasticsearch.DefaultResources).
+		WithNamedESDataNodes(2, "data1", elasticsearch.DefaultResources)
+
+	// trigger a mutation that will lead to a rolling upgrade
+	mutated := b.WithNoESTopology().
+		WithESMasterNodes(1, elasticsearch.DefaultResources).
+		WithNamedESDataNodes(2, "data1", elasticsearch.DefaultResources).
+		WithAdditionalConfig(map[string]map[string]interface{}{
+			"data1": {
+				"node.attr.value": "this-is-fine",
+			},
+		}).
+		WithChangeBudget(1, 2)
 
 	RunESMutation(t, b, mutated)
 }

--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -208,7 +208,7 @@ func TestMutationNodeSetReplacementWithChangeBudget(t *testing.T) {
 	RunESMutation(t, b, mutated)
 }
 
-func TestMutationWithLargerChangeBudget(t *testing.T) {
+func TestMutationWithLargerMaxUnavailable(t *testing.T) {
 	b := elasticsearch.NewBuilder("test-2-change-budget").
 		WithESMasterNodes(1, elasticsearch.DefaultResources).
 		WithNamedESDataNodes(2, "data1", elasticsearch.DefaultResources)


### PR DESCRIPTION
Fixes #2034 

* initialise `shardLister` in RollingUpgradeContext
* add e2e test that exercises the "do_not_delete_pods_with_same_shards" predicate