### PR TITLE
Always enable native realm

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -139,7 +139,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 			Labels: map[string]string{
 				"common.k8s.elastic.co/type":                    "elasticsearch",
 				"elasticsearch.k8s.elastic.co/cluster-name":     "name",
-				"elasticsearch.k8s.elastic.co/config-hash":      "1308765141",
+				"elasticsearch.k8s.elastic.co/config-hash":      "2019720671",
 				"elasticsearch.k8s.elastic.co/http-scheme":      "https",
 				"elasticsearch.k8s.elastic.co/node-data":        "false",
 				"elasticsearch.k8s.elastic.co/node-ingest":      "true",

--- a/pkg/controller/elasticsearch/settings/fields.go
+++ b/pkg/controller/elasticsearch/settings/fields.go
@@ -21,9 +21,13 @@ const (
 	PathData = "path.data"
 	PathLogs = "path.logs"
 
-	XPackSecurityAuthcRealmsFileFile1Order          = "xpack.security.authc.realms.file.file1.order" // 7.x realm syntax
-	XPackSecurityAuthcRealmsFile1Order              = "xpack.security.authc.realms.file1.order"      // 6.x realm syntax
-	XPackSecurityAuthcRealmsFile1Type               = "xpack.security.authc.realms.file1.type"       // 6.x realm syntax
+	XPackSecurityAuthcRealmsFileFile1Order     = "xpack.security.authc.realms.file.file1.order"     // 7.x realm syntax
+	XPackSecurityAuthcRealmsFile1Order         = "xpack.security.authc.realms.file1.order"          // 6.x realm syntax
+	XPackSecurityAuthcRealmsFile1Type          = "xpack.security.authc.realms.file1.type"           // 6.x realm syntax
+	XPackSecurityAuthcRealmsNativeNative1Order = "xpack.security.authc.realms.native.native1.order" // 7.x realm syntax
+	XPackSecurityAuthcRealmsNative1Order       = "xpack.security.authc.realms.native1.order"        // 6.x realm syntax
+	XPackSecurityAuthcRealmsNative1Type        = "xpack.security.authc.realms.native1.type"         // 6.x realm syntax
+
 	XPackSecurityAuthcReservedRealmEnabled          = "xpack.security.authc.reserved_realm.enabled"
 	XPackSecurityEnabled                            = "xpack.security.enabled"
 	XPackSecurityHttpSslCertificate                 = "xpack.security.http.ssl.certificate"

--- a/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/pkg/controller/elasticsearch/settings/merged_config.go
@@ -99,14 +99,17 @@ func xpackConfig(ver version.Version, httpCfg v1beta1.HTTPConfig, certResources 
 		cfg[XPackSecurityHttpSslCertificateAuthorities] = path.Join(volume.HTTPCertificatesSecretVolumeMountPath, certificates.CAFileName)
 	}
 
-	// always enable the built-in file internal realm for user auth, ordered as first
+	// always enable the built-in file and native internal realms for user auth, ordered as first
 	if ver.Major < 7 {
 		// 6.x syntax
 		cfg[XPackSecurityAuthcRealmsFile1Type] = "file"
 		cfg[XPackSecurityAuthcRealmsFile1Order] = -100
+		cfg[XPackSecurityAuthcRealmsNative1Type] = "native"
+		cfg[XPackSecurityAuthcRealmsNative1Order] = -99
 	} else {
 		// 7.x syntax
 		cfg[XPackSecurityAuthcRealmsFileFile1Order] = -100
+		cfg[XPackSecurityAuthcRealmsNativeNative1Order] = -99
 	}
 
 	return &CanonicalConfig{common.MustCanonicalConfig(cfg)}

--- a/pkg/controller/elasticsearch/settings/merged_config_test.go
+++ b/pkg/controller/elasticsearch/settings/merged_config_test.go
@@ -15,9 +15,9 @@ import (
 
 func TestNewMergedESConfig(t *testing.T) {
 	nodeML := "node.ml"
-	xPackSecurityAuthcRealmsNativeNative1Order := "xpack.security.authc.realms.native.native1.order"
-	xPackSecurityAuthcRealmsNative1Type := "xpack.security.authc.realms.native1.type"
-	xPackSecurityAuthcRealmsNative1Order := "xpack.security.authc.realms.native1.order"
+	xPackSecurityAuthcRealmsActiveDirectoryAD1Order := "xpack.security.authc.realms.active_directory.ad1.order"
+	xPackSecurityAuthcRealmsAD1Type := "xpack.security.authc.realms.ad1.type"
+	xPackSecurityAuthcRealmsAD1Order := "xpack.security.authc.realms.ad1.order"
 
 	tests := []struct {
 		name    string
@@ -26,13 +26,15 @@ func TestNewMergedESConfig(t *testing.T) {
 		assert  func(cfg CanonicalConfig)
 	}{
 		{
-			name:    "in 6.x, empty config should have the default file realm settings configured",
+			name:    "in 6.x, empty config should have the default file and native realm settings configured",
 			version: "6.8.0",
 			cfgData: map[string]interface{}{},
 			assert: func(cfg CanonicalConfig) {
 				require.Equal(t, 0, len(cfg.HasKeys([]string{nodeML})))
 				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFile1Type})))
 				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFile1Order})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsNative1Type})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsNative1Order})))
 			},
 		},
 		{
@@ -45,35 +47,40 @@ func TestNewMergedESConfig(t *testing.T) {
 				require.Equal(t, 1, len(cfg.HasKeys([]string{nodeML})))
 				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFile1Type})))
 				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFile1Order})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsNative1Type})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsNative1Order})))
 			},
 		},
 		{
-			name:    "in 6.x, native realm settings should be merged with the default file realm settings",
+			name:    "in 6.x, active_directory realm settings should be merged with the default file and native realm settings",
 			version: "6.8.0",
 			cfgData: map[string]interface{}{
-				nodeML:                               true,
-				xPackSecurityAuthcRealmsNative1Type:  "native",
-				xPackSecurityAuthcRealmsNative1Order: 0,
+				nodeML:                           true,
+				xPackSecurityAuthcRealmsAD1Type:  "active_directory",
+				xPackSecurityAuthcRealmsAD1Order: 0,
 			},
 			assert: func(cfg CanonicalConfig) {
 				require.Equal(t, 1, len(cfg.HasKeys([]string{nodeML})))
 				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFile1Type})))
 				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFile1Order})))
-				require.Equal(t, 1, len(cfg.HasKeys([]string{xPackSecurityAuthcRealmsNative1Type})))
-				require.Equal(t, 1, len(cfg.HasKeys([]string{xPackSecurityAuthcRealmsNative1Order})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsNative1Type})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsNative1Order})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{xPackSecurityAuthcRealmsAD1Type})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{xPackSecurityAuthcRealmsAD1Order})))
 			},
 		},
 		{
-			name:    "in 7.x, empty config should have the default file realm settings configured",
+			name:    "in 7.x, empty config should have the default file and native realm settings configured",
 			version: "7.3.0",
 			cfgData: map[string]interface{}{},
 			assert: func(cfg CanonicalConfig) {
 				require.Equal(t, 0, len(cfg.HasKeys([]string{nodeML})))
 				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFileFile1Order})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsNativeNative1Order})))
 			},
 		},
 		{
-			name:    "in 7.x, sample config should have the default file realm settings configured",
+			name:    "in 7.x, sample config should have the default file and native realm settings configured",
 			version: "7.3.0",
 			cfgData: map[string]interface{}{
 				nodeML: true,
@@ -81,19 +88,21 @@ func TestNewMergedESConfig(t *testing.T) {
 			assert: func(cfg CanonicalConfig) {
 				require.Equal(t, 1, len(cfg.HasKeys([]string{nodeML})))
 				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFileFile1Order})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsNativeNative1Order})))
 			},
 		},
 		{
-			name:    "in 7.x, native realm settings should be merged with the default file realm settings",
+			name:    "in 7.x, active_directory realm settings should be merged with the default file and native realm settings",
 			version: "7.3.0",
 			cfgData: map[string]interface{}{
 				nodeML: true,
-				xPackSecurityAuthcRealmsNativeNative1Order: 0,
+				xPackSecurityAuthcRealmsActiveDirectoryAD1Order: 0,
 			},
 			assert: func(cfg CanonicalConfig) {
 				require.Equal(t, 1, len(cfg.HasKeys([]string{nodeML})))
 				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsFileFile1Order})))
-				require.Equal(t, 1, len(cfg.HasKeys([]string{xPackSecurityAuthcRealmsNativeNative1Order})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{XPackSecurityAuthcRealmsNativeNative1Order})))
+				require.Equal(t, 1, len(cfg.HasKeys([]string{xPackSecurityAuthcRealmsActiveDirectoryAD1Order})))
 			},
 		},
 		{


### PR DESCRIPTION
The native realm is only enabled by default if no other realms have
been defined. We explicitly enabled the file realm, which results in
the native realm getting disabled and preventing users from
authenticating using the credentials they create using the UI.

This commit ensures that the native realm is always enabled.

Resolves #2037.