### PR TITLE
Set the top-level validation field in a single all-in-one manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ vendor/
 license.key
 
 # generated from merging multiple files in the Makefile
-config/all-in-one-flavor-*.yaml
+config/all-in-one.yaml
 
 # ignore all generated docs HTML
 docs/html/*

--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -55,11 +55,7 @@ AWS_SECRET_ACCESS_KEY = $(shell VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$
 yaml-upload:
 	@ $(MAKE) \
 		DOCKER_OPTS="-e AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) -e AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY)" \
-		DOCKER_CMD="aws s3 cp $(GO_MOUNT_PATH)/config/all-in-one-flavor-trivial-versions.yaml \
-		s3://download.elasticsearch.org/downloads/eck/$(TAG_NAME)/all-in-one-no-validation.yaml" ci-internal
-	@ $(MAKE) \
-		DOCKER_OPTS="-e AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) -e AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY)" \
-		DOCKER_CMD="aws s3 cp $(GO_MOUNT_PATH)/config/all-in-one-flavor-default.yaml \
+		DOCKER_CMD="aws s3 cp $(GO_MOUNT_PATH)/config/all-in-one.yaml \
 		s3://download.elasticsearch.org/downloads/eck/$(TAG_NAME)/all-in-one.yaml" ci-internal
 
 # reads Elastic public key from Vault into license.key

--- a/config/crds-flavor-default/apm-and-kibana-podtemplate-patch.yaml
+++ b/config/crds-flavor-default/apm-and-kibana-podtemplate-patch.yaml
@@ -4,3 +4,9 @@
 # remove spec.podTemplate for v1beta1
 - op: remove
   path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/podTemplate
+- op: move
+  from: /spec/versions/1/schema
+  path: /spec/validation
+# remove v1alpha1 schema
+- op: remove
+  path: /spec/versions/0/schema

--- a/config/crds-flavor-default/elasticsearch-podtemplate-patch.yaml
+++ b/config/crds-flavor-default/elasticsearch-podtemplate-patch.yaml
@@ -4,3 +4,10 @@
 # remove spec.nodeSets[].podTemplate for v1beta1
 - op: remove
   path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/nodeSets/items/properties/podTemplate
+# replace per-version schema by top-level validation of v1beta1 version
+- op: move
+  from: /spec/versions/1/schema
+  path: /spec/validation
+# remove v1alpha1 schema
+- op: remove
+  path: /spec/versions/0/schema

--- a/config/crds/kustomization.yaml
+++ b/config/crds/kustomization.yaml
@@ -2,3 +2,23 @@ resources:
   - apm.k8s.elastic.co_apmservers.yaml
   - elasticsearch.k8s.elastic.co_elasticsearches.yaml
   - kibana.k8s.elastic.co_kibanas.yaml
+
+patchesJson6902:
+  - target:
+      group: apiextensions.k8s.io
+      version: v1beta1
+      kind: CustomResourceDefinition
+      name: apmservers.apm.k8s.elastic.co
+    path: patch-apm-kibana.yaml
+  - target:
+      group: apiextensions.k8s.io
+      version: v1beta1
+      kind: CustomResourceDefinition
+      name: elasticsearches.elasticsearch.k8s.elastic.co
+    path: patch-elasticsearch.yaml
+  - target:
+      group: apiextensions.k8s.io
+      version: v1beta1
+      kind: CustomResourceDefinition
+      name: kibanas.kibana.k8s.elastic.co
+    path: patch-apm-kibana.yaml

--- a/config/crds/patch-apm-kibana.yaml
+++ b/config/crds/patch-apm-kibana.yaml
@@ -1,0 +1,16 @@
+# Move v1beta1 schema into the top-level validation field,
+# since per-version schema is only officially supported starting Kubernetes 1.16.
+# All resources creation/update will be validated against the v1beta1 schema.
+- op: move
+  from: /spec/versions/1/schema
+  path: /spec/validation
+# Remove v1alpha1 schema, mutually exclusive with the top-level validation.
+- op: remove
+  path: /spec/versions/0/schema
+# Remove spec.podTemplate, since its verbosity may lead
+# to the CRD exceeding the maximum size limit.
+- op: remove
+  path: /spec/validation/openAPIV3Schema/properties/spec/properties/podTemplate
+# Remove the deprecated misleading 'version' field, replaced by 'versions'.
+- op: remove
+  path: /spec/version

--- a/config/crds/patch-elasticsearch.yaml
+++ b/config/crds/patch-elasticsearch.yaml
@@ -1,0 +1,16 @@
+# Move v1beta1 schema into the top-level validation field,
+# since per-version schema is only officially supported starting Kubernetes 1.16.
+# All resources creation/update will be validated against the v1beta1 schema.
+- op: move
+  from: /spec/versions/1/schema
+  path: /spec/validation
+# Remove v1alpha1 schema, mutually exclusive with the top-level validation.
+- op: remove
+  path: /spec/versions/0/schema
+# Remove spec.nodeSets[].podTemplate, since its verbosity may lead
+# to the CRD exceeding the maximum size limit.
+- op: remove
+  path: /spec/validation/openAPIV3Schema/properties/spec/properties/nodeSets/items/properties/podTemplate
+# Remove the deprecated misleading 'version' field, replaced by 'versions'.
+- op: remove
+  path: /spec/version

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -34,18 +34,9 @@ NOTE: If you are using Amazon EKS, make sure the Kubernetes control plane is all
 
 . Install link:https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/[custom resource definitions] and the operator with its RBAC rules:
 +
-For Kubernetes clusters running version 1.13 or higher:
-+
 [source,sh,subs="attributes"]
 ----
 kubectl apply -f https://download.elastic.co/downloads/eck/{eck_version}/all-in-one.yaml
-----
-+
-For Kubernetes clusters running version 1.12 or lower:
-+
-[source,sh,subs="attributes"]
-----
-kubectl apply -f https://download.elastic.co/downloads/eck/{eck_version}/all-in-one-no-validation.yaml
 ----
 
 . Monitor the operator logs:


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/2044.

Before this commit, the generated crds were derived into 2 flavours:

1. "default" with per-version schema
2. "trivial" with no schema at all

The "default" version validation only works starting Kubernetes 1.16,
earlier versions need a feature flag to be enabled.

This commit changes the behaviour to rely on the top-level 'validation'
field, and removes any version-specific schema. As a result, only the
v1beta1 schema applies for all resources.

It also removes the deprecated 'version' (singular) field from the
generated CRD. It was already deprecated in Kubernetes 1.11.

And updates release scripts and quickstart documentation.