### PR TITLE
Add Kind images with K8s versions to Packer cache

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -10,7 +10,7 @@ set -eou pipefail
 
 DOCKER_CI_IMAGE=$(cd build/ci/ && make show-image)
 
-declare -a docker_images=("$DOCKER_CI_IMAGE" "kindest/node:v1.14.6" "kindest/node:v1.15.3" "docker.elastic.co/elasticsearch/elasticsearch:7.4.0" "docker.elastic.co/kibana/kibana:7.4.0" "docker.elastic.co/apm/apm-server:7.4.0")
+declare -a docker_images=("$DOCKER_CI_IMAGE" "kindest/node:v1.11.10" "kindest/node:v1.15.3" "kindest/node:v1.16.2" "docker.elastic.co/elasticsearch/elasticsearch:7.4.0" "docker.elastic.co/kibana/kibana:7.4.0" "docker.elastic.co/apm/apm-server:7.4.0")
 
 # Pull all the required docker images
 for image in "${docker_images[@]}"


### PR DESCRIPTION
This PR adds images with k8s versions 1.11, 1.15 and 1.16 to CI nodes.

Why these versions?
We don't test on 1.11 in GKE anymore but still support it. 1.15 and 1.16 are not available in cloud services. Probably it doesn't make sense to test on 1.12, 1.13 or 1.14 because we are already testing on them in GKE.