### PR TITLE
Add CI job to run e2e tests in vanilla K8s with Kind

### DIFF
--- a/.ci/jobs/e2e-vanilla.yml
+++ b/.ci/jobs/e2e-vanilla.yml
@@ -1,0 +1,22 @@
+---
+- job:
+    description: Job that runs ECK e2e tests against different versions of vanilla k8s with Kind. This Job is managed by JJB.
+    name: cloud-on-k8s-versions-vanilla
+    project-type: pipeline
+    parameters:
+      - string:
+          name: IMAGE
+          description: "Docker image with ECK"
+      - bool:
+          name: SEND_NOTIFICATIONS
+          default: true
+          description: "Specified if job should send notifications to Slack. Enabled by default."
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/elastic/cloud-on-k8s
+            branches:
+              - master
+            credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
+      script-path: build/ci/e2e/vanilla_k8s.jenkinsfile
+      lightweight-checkout: true

--- a/Makefile
+++ b/Makefile
@@ -468,6 +468,7 @@ ifneq ($(ECK_IMAGE),)
 else
 	$(MAKE) docker-build
 endif
+
 kind-e2e: export KUBECONFIG = ${HOME}/.kube/kind-config-eck-e2e
 kind-e2e: export NODE_IMAGE = ${KIND_NODE_IMAGE}
 kind-e2e: kind-node-variable-check set-kind-e2e-image e2e-docker-build

--- a/Makefile
+++ b/Makefile
@@ -427,7 +427,7 @@ validate-jenkins-pipelines:
 # Kind specific targets #
 #########################
 KIND_NODES ?= 0
-KIND_NODE_IMAGE ?= kindest/node:v1.15.0
+KIND_NODE_IMAGE ?= kindest/node:v1.15.3
 KIND_CLUSTER_NAME ?= eck
 
 kind-node-variable-check:

--- a/build/ci/Dockerfile
+++ b/build/ci/Dockerfile
@@ -56,7 +56,7 @@ RUN curl -fsSLO https://github.com/gotestyourself/gotestsum/releases/download/v$
     rm gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz
 
 # Install Kind to run k8s cluster locally in Docker
-RUN curl -fsSLO https://github.com/kubernetes-sigs/kind/releases/download/v{KIND_VERSION}/kind-linux-amd64 && \
+RUN curl -fsSLO https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64 && \
     mv kind-linux-amd64 /usr/local/bin/kind && chmod +x /usr/local/bin/kind
 
 # Add Go dependencies to Docker image

--- a/build/ci/Dockerfile
+++ b/build/ci/Dockerfile
@@ -7,6 +7,7 @@ ENV KUBECTL_VERSION=1.14.7
 ENV DOCKER_VERSION=18.03.1-ce
 ENV GOLANGCILINT_VERSION=1.21.0
 ENV GOTESTSUM_VERSION=0.3.5
+ENV KIND_VERSION=0.5.1
 
 # Install golangci-lint
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh \
@@ -53,6 +54,10 @@ RUN curl -fsSLO https://github.com/gotestyourself/gotestsum/releases/download/v$
     tar xzf gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz && \
     mv gotestsum /usr/local/bin/gotestsum && chmod +x /usr/local/bin/gotestsum && \
     rm gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz
+
+# Install Kind to run k8s cluster locally in Docker
+RUN curl -fsSLO https://github.com/kubernetes-sigs/kind/releases/download/v{KIND_VERSION}/kind-linux-amd64 && \
+    mv kind-linux-amd64 /usr/local/bin/kind && chmod +x /usr/local/bin/kind
 
 # Add Go dependencies to Docker image
 WORKDIR /go/src/github.com/elastic/cloud-on-k8s

--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -36,7 +36,7 @@ ci-internal: ci-build-image
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
 		-w $(GO_MOUNT_PATH) \
-		--network=host \
+		--network="host" \
 		$(CI_IMAGE) \
 		bash -c "$(DOCKER_CMD)"
 

--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -36,6 +36,7 @@ ci-internal: ci-build-image
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
 		-w $(GO_MOUNT_PATH) \
+		--network=host \
 		$(CI_IMAGE) \
 		bash -c "$(DOCKER_CMD)"
 

--- a/build/ci/e2e/vanilla_k8s.jenkinsfile
+++ b/build/ci/e2e/vanilla_k8s.jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
                 stage("1.11.10") {
                     steps {
                         checkout scm
-                        run("kindest/node:v1.11.10")
+                        runTests("kindest/node:v1.11.10")
                     }
                 }
                 stage("1.15.3") {
@@ -40,7 +40,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        run("kindest/node:v1.15.3")
+                        runTests("kindest/node:v1.15.3")
                     }
                 }
                 stage("1.16.2") {
@@ -49,7 +49,7 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        run("kindest/node:v1.16.2")
+                        runTests("kindest/node:v1.16.2")
                     }
                 }
             }
@@ -79,7 +79,7 @@ pipeline {
 
 }
 
-def run(image) {
+def runTests(kindImage) {
     sh """
         cat >.env <<EOF
 OPERATOR_IMAGE = "${IMAGE}"
@@ -89,7 +89,7 @@ SKIP_DOCKER_COMMAND = true
 REGISTRY = eu.gcr.io
 REPOSITORY = "$GCLOUD_PROJECT"
 E2E_JSON = true
-KIND_NODE_IMAGE = "${image}"
+KIND_NODE_IMAGE = "${kindImage}"
 EOF
     """
     script {

--- a/build/ci/e2e/vanilla_k8s.jenkinsfile
+++ b/build/ci/e2e/vanilla_k8s.jenkinsfile
@@ -89,7 +89,7 @@ SKIP_DOCKER_COMMAND = true
 REGISTRY = eu.gcr.io
 REPOSITORY = "$GCLOUD_PROJECT"
 E2E_JSON = true
-KIND_NODE_IMAGE = "${kindImage}"
+KIND_NODE_IMAGE = ${kindImage}
 EOF
     """
     script {

--- a/build/ci/e2e/vanilla_k8s.jenkinsfile
+++ b/build/ci/e2e/vanilla_k8s.jenkinsfile
@@ -1,0 +1,107 @@
+def failedTests = []
+def testScript
+
+pipeline {
+
+    agent {
+        label 'eck'
+    }
+
+    options {
+        timeout(time: 150, unit: 'MINUTES')
+    }
+
+    environment {
+        VAULT_ADDR = credentials('vault-addr')
+        VAULT_ROLE_ID = credentials('vault-role-id')
+        VAULT_SECRET_ID = credentials('vault-secret-id')
+        GCLOUD_PROJECT = credentials('k8s-operators-gcloud-project')
+    }
+
+    stages {
+        stage('Load common scripts') {
+            steps {
+                script {
+                    testScript = load "build/ci/common/tests.groovy"
+                }
+            }
+        }
+        stage('Run tests on different versions of vanilla K8s') {
+            parallel {
+                stage("1.11.10") {
+                    steps {
+                        checkout scm
+                        run("kindest/node:v1.11.10")
+                    }
+                }
+                stage("1.15.3") {
+                    agent {
+                        label 'eck'
+                    }
+                    steps {
+                        checkout scm
+                        run("kindest/node:v1.15.3")
+                    }
+                }
+                stage("1.16.2") {
+                    agent {
+                        label 'eck'
+                    }
+                    steps {
+                        checkout scm
+                        run("kindest/node:v1.16.2")
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        unsuccessful {
+            script {
+                if (params.SEND_NOTIFICATIONS) {
+                    Set<String> filter = new HashSet<>()
+                    filter.addAll(failedTests)
+                    def msg = testScript.generateSlackMessage("E2E tests for different versions of vanilla K8s failed!", env.BUILD_URL, filter)
+
+                    slackSend botUser: true,
+                        channel: '#cloud-k8s',
+                        color: 'danger',
+                        message: msg,
+                        tokenCredentialId: 'cloud-ci-slack-integration-token'
+                }
+            }
+        }
+        cleanup {
+            cleanWs()
+        }
+    }
+
+}
+
+def run(image) {
+    sh """
+        cat >.env <<EOF
+OPERATOR_IMAGE = "${IMAGE}"
+LATEST_RELEASED_IMG = "${IMAGE}"
+GCLOUD_PROJECT = "$GCLOUD_PROJECT"
+SKIP_DOCKER_COMMAND = true
+REGISTRY = eu.gcr.io
+REPOSITORY = "$GCLOUD_PROJECT"
+E2E_JSON = true
+KIND_NODE_IMAGE = "${image}"
+EOF
+    """
+    script {
+        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci TARGET=kind-e2e ci')
+
+        sh 'make -C build/ci TARGET=e2e-generate-xml ci'
+        junit "e2e-tests.xml"
+
+        if (env.SHELL_EXIT_CODE != 0) {
+            failedTests.addAll(testScript.getListOfFailedTests())
+        }
+
+        sh 'exit $SHELL_EXIT_CODE'
+    }
+}

--- a/config/e2e/batch_job.yaml
+++ b/config/e2e/batch_job.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: e2e
           image: {{ .E2EImage }}
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           args: [{{- if .TestRegex -}}"-run", "{{ .TestRegex }}",{{- end -}}"-args", "-testContextPath","/etc/e2e/testcontext.json"]
           volumeMounts:
             - name: test-config


### PR DESCRIPTION
This PR introduces new CI job which will run e2e tests on different versions of vanilla K8s using Kind.

Job will run tests on 1.11, 1.15 and 1.16. Why these versions?
We don't test on 1.11 in GKE anymore but still support it. 1.15 and 1.16 are not available in cloud services. Probably it doesn't make sense to test on 1.12, 1.13 or 1.14 because we are already testing on them in GKE.