### PR TITLE
Perform StatefulSets deletions before replicas downscale

### DIFF
--- a/pkg/controller/elasticsearch/driver/downscale_invariants.go
+++ b/pkg/controller/elasticsearch/driver/downscale_invariants.go
@@ -95,8 +95,8 @@ func (s *downscaleState) getMaxNodesToRemove(noMoreThan int32) int32 {
 	return noMoreThan
 }
 
-// recordRemoval updates the state to consider n-replica downscale of the given statefulSet.
-func (s *downscaleState) recordRemoval(statefulSet appsv1.StatefulSet, accountedRemovals int32) {
+// recordNodeRemoval updates the state to consider n-replica downscale of the given statefulSet.
+func (s *downscaleState) recordNodeRemoval(statefulSet appsv1.StatefulSet, accountedRemovals int32) {
 	if accountedRemovals == 0 {
 		return
 	}

--- a/pkg/controller/elasticsearch/driver/downscale_invariants_test.go
+++ b/pkg/controller/elasticsearch/driver/downscale_invariants_test.go
@@ -270,7 +270,7 @@ func Test_downscaleState_recordRemoval(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.state.recordRemoval(tt.statefulSet, tt.removals)
+			tt.state.recordNodeRemoval(tt.statefulSet, tt.removals)
 			require.Equal(t, tt.wantState, tt.state)
 		})
 	}

--- a/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -1036,9 +1036,7 @@ func Test_deleteStatefulSets(t *testing.T) {
 			},
 			objs:          []runtime.Object{},
 			wantRemaining: nil,
-			wantErr: func(err error) bool {
-				return apierrors.IsNotFound(err)
-			},
+			wantErr:       apierrors.IsNotFound,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/controller/elasticsearch/driver/downscale_utils.go
+++ b/pkg/controller/elasticsearch/driver/downscale_utils.go
@@ -54,7 +54,6 @@ func newDownscaleContext(
 }
 
 // ssetDownscale helps with the downscale of a single StatefulSet.
-// A StatefulSet removal (going from 0 to 0 replicas) is also considered as a Downscale here.
 type ssetDownscale struct {
 	statefulSet     appsv1.StatefulSet
 	initialReplicas int32
@@ -73,17 +72,6 @@ func (d ssetDownscale) leavingNodeNames() []string {
 		leavingNodes = append(leavingNodes, sset.PodName(d.statefulSet.Name, i))
 	}
 	return leavingNodes
-}
-
-// isRemoval returns true if this downscale is a StatefulSet removal.
-func (d ssetDownscale) isRemoval() bool {
-	// StatefulSet does not have any replica, and should not have one
-	return d.initialReplicas == 0 && d.targetReplicas == 0
-}
-
-// isReplicaDecrease returns true if this downscale corresponds to decreasing replicas.
-func (d ssetDownscale) isReplicaDecrease() bool {
-	return d.targetReplicas < d.initialReplicas
 }
 
 // leavingNodeNames returns the names of all nodes that should leave the cluster (across StatefulSets).


### PR DESCRIPTION
We had a bug where a StatefulSet with 0 replicas could be kept forever
under particular conditions (eg. cannot be removed since there is a risk
to remove the last master node... even though there is 0 replicas).

This commit fixes it by decoupling StatefulSets deletions from
StatefulSet downscales.
A StatefulSet deletion is only performed when the actual StatefulSet has
0 replicas. Our expectations mechanism ensures there is no Pod still
alive for that StatefulSet (eg. if it was just downscaled from 1 to 0
replicas). So that StatefulSet can be safely garbage-collected.

StatefulSets deletions are now ran before handling downscales,
regardless of any downscale invariant constraint.
The downscale code is a bit simplified since it does not need to handle
StatefulSets deletions anymore.

Fixes #2009 and the TestMutationMdiToDedicated E2E test.