### PR TITLE
Check resource version when deleting a Pod during force-upgrades

### DIFF
--- a/pkg/controller/elasticsearch/driver/upgrade_pods_deletion.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_pods_deletion.go
@@ -156,9 +156,11 @@ func deletePod(k8sClient k8s.Client, es v1beta1.Elasticsearch, pod corev1.Pod, e
 	log.Info("Deleting pod for rolling upgrade", "es_name", es.Name, "namespace", es.Namespace, "pod_name", pod.Name, "pod_uid", pod.UID)
 	// The name of the Pod we want to delete is not enough as it may have been already deleted/recreated.
 	// The uid of the Pod we want to delete is used as a precondition to check that we actually delete the right one.
-	// If not it means that we are running with a stale cache.
+	// We also check the version of the Pod resource, to make sure its status is the current one and we're not deleting
+	// eg. a Pending Pod that is not Pending anymore.
 	opt := client.Preconditions{
-		UID: &pod.UID,
+		UID:             &pod.UID,
+		ResourceVersion: &pod.ResourceVersion,
 	}
 	err := k8sClient.Delete(&pod, opt)
 	if err != nil {


### PR DESCRIPTION
This commit adds an additional precondition when we delete a Pod during
a force-upgrade: we require the Pod version in the apiserver to be the
same as the cached Pod version we want to delete.

This helps avoiding situations were we would, for example, delete a
Pending pod that is actually not Pending anymore.

Fixes https://github.com/elastic/cloud-on-k8s/issues/1916.