### PR TITLE
Simplify license installation

### DIFF
--- a/pkg/controller/common/license/parser.go
+++ b/pkg/controller/common/license/parser.go
@@ -12,9 +12,30 @@ import (
 
 func ParseEnterpriseLicense(raw map[string][]byte) (EnterpriseLicense, error) {
 	var license EnterpriseLicense
-	err := json.Unmarshal(raw[FileName], &license)
+
+	bytes, err := FetchLicenseData(raw)
 	if err != nil {
-		return EnterpriseLicense{}, errors.Wrapf(err, "license cannot be unmarshalled")
+		return license, err
 	}
+
+	err = json.Unmarshal(bytes, &license)
+	if err != nil {
+		return license, errors.Wrapf(err, "license cannot be unmarshalled")
+	}
+
 	return license, nil
+}
+
+func FetchLicenseData(raw map[string][]byte) ([]byte, error) {
+	if len(raw) != 1 {
+		return nil, errors.New("Elasticsearch license secret needs to contain exactly one file with any name")
+	}
+
+	var result []byte
+	// will only loop once due to the check above
+	for _, bytes := range raw {
+		result = bytes
+	}
+
+	return result, nil
 }

--- a/pkg/controller/common/license/parser.go
+++ b/pkg/controller/common/license/parser.go
@@ -28,7 +28,7 @@ func ParseEnterpriseLicense(raw map[string][]byte) (EnterpriseLicense, error) {
 
 func FetchLicenseData(raw map[string][]byte) ([]byte, error) {
 	if len(raw) != 1 {
-		return nil, errors.New("Elasticsearch license secret needs to contain exactly one file with any name")
+		return nil, errors.New("license secret needs to contain exactly one file with any name")
 	}
 
 	var result []byte

--- a/pkg/controller/common/license/parser_test.go
+++ b/pkg/controller/common/license/parser_test.go
@@ -47,13 +47,14 @@ func TestParseEnterpriseLicenses(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "wrong key",
+			name: "different key",
 			args: args{
 				raw: map[string][]byte{
 					"_": good,
 				},
 			},
-			wantErr: true,
+			want:    expectedLicenseSpec,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/controller/elasticsearch/license/apply.go
+++ b/pkg/controller/elasticsearch/license/apply.go
@@ -43,13 +43,12 @@ func applyLinkedLicense(
 		}
 		return err
 	}
-	if len(license.Data) != 1 {
-		return fmt.Errorf(
-			"linked Elasticsearch license secret needs to contain exactly one file called %s",
-			common_license.FileName,
-		)
+
+	bytes, err := common_license.FetchLicenseData(license.Data)
+	if err != nil {
+		return err
 	}
-	bytes := license.Data[common_license.FileName]
+
 	var lic esclient.License
 	err = json.Unmarshal(bytes, &lic)
 	if err != nil {

--- a/pkg/controller/elasticsearch/license/apply_test.go
+++ b/pkg/controller/elasticsearch/license/apply_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/license"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	fixtures "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client/test_fixtures"
@@ -121,7 +120,7 @@ func Test_applyLinkedLicense(t *testing.T) {
 						Namespace: "default",
 					},
 					Data: map[string][]byte{
-						license.FileName: []byte(fixtures.LicenseSample),
+						"anything": []byte(fixtures.LicenseSample),
 					},
 				},
 			},
@@ -152,7 +151,7 @@ func Test_applyLinkedLicense(t *testing.T) {
 						Namespace: "default",
 					},
 					Data: map[string][]byte{
-						license.FileName: {},
+						"anything2": {},
 					},
 				},
 			},

--- a/pkg/controller/license/license_controller.go
+++ b/pkg/controller/license/license_controller.go
@@ -178,8 +178,9 @@ func reconcileSecret(
 			Name:      secretName,
 			Namespace: cluster.Namespace,
 			Labels: map[string]string{
+				common.TypeLabelName:     license.Type,
 				license.LicenseLabelName: parent,
-				common.TypeLabelName:     string(license.LicenseLabelElasticsearch),
+				license.LicenseLabelType: string(license.LicenseLabelElasticsearch),
 			},
 		},
 		Data: map[string][]byte{

--- a/pkg/controller/license/validation/validations_test.go
+++ b/pkg/controller/license/validation/validations_test.go
@@ -84,6 +84,24 @@ func Test_eulaAccepted(t *testing.T) {
 			},
 			want: validation.OK,
 		},
+		{
+			name: "Regular license secret with different file name OK",
+			args: args{
+				ctx: Context{
+					Proposed: v1.Secret{
+						ObjectMeta: v12.ObjectMeta{
+							Labels: map[string]string{
+								common.TypeLabelName: license.Type,
+							},
+						},
+						Data: map[string][]byte{
+							"this-should-work": []byte("some license "),
+						},
+					},
+				},
+			},
+			want: validation.OK,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR:
- allows to use any file name in license secret `Data` (previously we expected only`license`),
- fixes labels on the license from:
```
common.k8s.elastic.co/type: elasticsearch
license.k8s.elastic.co/name: parent_license_UID
```
to:
```
common.k8s.elastic.co/type: license
license.k8s.elastic.co/name: parent_license_UID
license.k8s.elastic.co/type: elasticsearch
```

Fixes #1965.