### PR TITLE
Update Deployment config to point to kube-state-metrics.kube-system

### DIFF
--- a/config/recipes/beats/3_metricbeat-kubernetes.yaml
+++ b/config/recipes/beats/3_metricbeat-kubernetes.yaml
@@ -245,7 +245,7 @@ data:
         #- event
       period: 10s
       host: ${NODE_NAME}
-      hosts: ["kube-state-metrics:8080"]
+      hosts: ["kube-state-metrics.kube-system:8080"]
 ---
 # Deploy singleton instance in the whole cluster for some unique data sources, like kube-state-metrics
 apiVersion: apps/v1


### PR DESCRIPTION
Currently most of the users should be deploying `kube-state-metrics` under
`kube-system` namespace. Consequently, since Metricbeat is being deployed in
`beats` namespace we should make it work for the most generic case and make
it able to collect metrics from `kube-state-metrics` in `kube-system` namespace.

cc: @pebrc 