### PR TITLE
Increase e2e test timeout for AKS

### DIFF
--- a/build/ci/e2e/Jenkinsfile-aks
+++ b/build/ci/e2e/Jenkinsfile-aks
@@ -5,7 +5,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 150, unit: 'MINUTES')
+        timeout(time: 180, unit: 'MINUTES')
     }
 
     environment {


### PR DESCRIPTION
Last two runs (https://devops-ci.elastic.co/job/cloud-on-k8s-e2e-tests-aks/32, https://devops-ci.elastic.co/job/cloud-on-k8s-e2e-tests-aks/33) timed out on this timeout, hence increasing it here.

I filed #2081 separately to track whether we want to do some e2e tests refactoring or just keep pushing the timeouts.