### PR TITLE
Remove default PVCs when setting emptyDirs in E2E tests

### DIFF
--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -199,6 +199,9 @@ func (b Builder) WithESSecureSettings(secretNames ...string) Builder {
 
 func (b Builder) WithEmptyDirVolumes() Builder {
 	for i := range b.Elasticsearch.Spec.NodeSets {
+		// remove any default claim
+		b.Elasticsearch.Spec.NodeSets[i].VolumeClaimTemplates = nil
+		// setup an EmptyDir for the data volume
 		b.Elasticsearch.Spec.NodeSets[i].PodTemplate.Spec.Volumes = []corev1.Volume{
 			{
 				Name: volume.ElasticsearchDataVolumeName,


### PR DESCRIPTION
We recently changed the way we handle default PVCs in all E2E tests. An
unfortunate consequence is that clusters configured for using EmptyDirs
also have a default PVC set (but not used), which makes the
`TestVolumeEmptyDir` fail.

This commit fixes it by removing any PVC when setting emptyDirs.
