### PR TITLE
Avoid lossy type conversion when parsing number of available replicas

### DIFF
--- a/config/crds/apm.k8s.elastic.co_apmservers.yaml
+++ b/config/crds/apm.k8s.elastic.co_apmservers.yaml
@@ -9285,6 +9285,7 @@ spec:
                   clusters.
                 type: string
               availableNodes:
+                format: int64
                 type: integer
               health:
                 description: ApmServerHealth expresses the status of the Apm Server

--- a/config/crds/apm.k8s.elastic.co_apmservers.yaml
+++ b/config/crds/apm.k8s.elastic.co_apmservers.yaml
@@ -9285,7 +9285,7 @@ spec:
                   clusters.
                 type: string
               availableNodes:
-                format: int64
+                format: int32
                 type: integer
               health:
                 description: ApmServerHealth expresses the status of the Apm Server

--- a/config/crds/elasticsearch.k8s.elastic.co_elasticsearches.yaml
+++ b/config/crds/elasticsearch.k8s.elastic.co_elasticsearches.yaml
@@ -10527,7 +10527,7 @@ spec:
             description: ElasticsearchStatus defines the observed state of Elasticsearch
             properties:
               availableNodes:
-                format: int64
+                format: int32
                 type: integer
               health:
                 description: ElasticsearchHealth is the health of the cluster as returned

--- a/config/crds/elasticsearch.k8s.elastic.co_elasticsearches.yaml
+++ b/config/crds/elasticsearch.k8s.elastic.co_elasticsearches.yaml
@@ -10527,6 +10527,7 @@ spec:
             description: ElasticsearchStatus defines the observed state of Elasticsearch
             properties:
               availableNodes:
+                format: int64
                 type: integer
               health:
                 description: ElasticsearchHealth is the health of the cluster as returned

--- a/config/crds/kibana.k8s.elastic.co_kibanas.yaml
+++ b/config/crds/kibana.k8s.elastic.co_kibanas.yaml
@@ -9272,6 +9272,7 @@ spec:
                 description: AssociationStatus is the status of an association resource.
                 type: string
               availableNodes:
+                format: int64
                 type: integer
               health:
                 description: KibanaHealth expresses the status of the Kibana instances.

--- a/config/crds/kibana.k8s.elastic.co_kibanas.yaml
+++ b/config/crds/kibana.k8s.elastic.co_kibanas.yaml
@@ -9272,7 +9272,7 @@ spec:
                 description: AssociationStatus is the status of an association resource.
                 type: string
               availableNodes:
-                format: int64
+                format: int32
                 type: integer
               health:
                 description: KibanaHealth expresses the status of the Kibana instances.

--- a/pkg/apis/common/v1beta1/common.go
+++ b/pkg/apis/common/v1beta1/common.go
@@ -16,7 +16,7 @@ import (
 
 // ReconcilerStatus represents status information about desired/available nodes.
 type ReconcilerStatus struct {
-	AvailableNodes int64 `json:"availableNodes,omitempty"`
+	AvailableNodes int32 `json:"availableNodes,omitempty"`
 }
 
 // SecretRef is a reference to a secret that exists in the same namespace.

--- a/pkg/apis/common/v1beta1/common.go
+++ b/pkg/apis/common/v1beta1/common.go
@@ -16,7 +16,7 @@ import (
 
 // ReconcilerStatus represents status information about desired/available nodes.
 type ReconcilerStatus struct {
-	AvailableNodes int `json:"availableNodes,omitempty"`
+	AvailableNodes int64 `json:"availableNodes,omitempty"`
 }
 
 // SecretRef is a reference to a secret that exists in the same namespace.

--- a/pkg/controller/apmserver/state.go
+++ b/pkg/controller/apmserver/state.go
@@ -30,7 +30,7 @@ func NewState(request reconcile.Request, as *v1beta1.ApmServer) State {
 // UpdateApmServerState updates the ApmServer status based on the given deployment.
 func (s State) UpdateApmServerState(deployment v1.Deployment, apmServerSecret corev1.Secret) {
 	s.ApmServer.Status.SecretTokenSecretName = apmServerSecret.Name
-	s.ApmServer.Status.AvailableNodes = int(deployment.Status.AvailableReplicas) // TODO lossy type conversion
+	s.ApmServer.Status.AvailableNodes = int64(deployment.Status.AvailableReplicas)
 	s.ApmServer.Status.Health = v1beta1.ApmServerRed
 	for _, c := range deployment.Status.Conditions {
 		if c.Type == v1.DeploymentAvailable && c.Status == corev1.ConditionTrue {

--- a/pkg/controller/apmserver/state.go
+++ b/pkg/controller/apmserver/state.go
@@ -30,7 +30,7 @@ func NewState(request reconcile.Request, as *v1beta1.ApmServer) State {
 // UpdateApmServerState updates the ApmServer status based on the given deployment.
 func (s State) UpdateApmServerState(deployment v1.Deployment, apmServerSecret corev1.Secret) {
 	s.ApmServer.Status.SecretTokenSecretName = apmServerSecret.Name
-	s.ApmServer.Status.AvailableNodes = int32(deployment.Status.AvailableReplicas)
+	s.ApmServer.Status.AvailableNodes = deployment.Status.AvailableReplicas
 	s.ApmServer.Status.Health = v1beta1.ApmServerRed
 	for _, c := range deployment.Status.Conditions {
 		if c.Type == v1.DeploymentAvailable && c.Status == corev1.ConditionTrue {

--- a/pkg/controller/apmserver/state.go
+++ b/pkg/controller/apmserver/state.go
@@ -30,7 +30,7 @@ func NewState(request reconcile.Request, as *v1beta1.ApmServer) State {
 // UpdateApmServerState updates the ApmServer status based on the given deployment.
 func (s State) UpdateApmServerState(deployment v1.Deployment, apmServerSecret corev1.Secret) {
 	s.ApmServer.Status.SecretTokenSecretName = apmServerSecret.Name
-	s.ApmServer.Status.AvailableNodes = int64(deployment.Status.AvailableReplicas)
+	s.ApmServer.Status.AvailableNodes = int32(deployment.Status.AvailableReplicas)
 	s.ApmServer.Status.Health = v1beta1.ApmServerRed
 	for _, c := range deployment.Status.Conditions {
 		if c.Type == v1.DeploymentAvailable && c.Status == corev1.ConditionTrue {

--- a/pkg/controller/elasticsearch/reconcile/state.go
+++ b/pkg/controller/elasticsearch/reconcile/state.go
@@ -43,7 +43,7 @@ func (s *State) updateWithPhase(
 	resourcesState ResourcesState,
 	observedState observer.State,
 ) *State {
-	s.status.AvailableNodes = len(AvailableElasticsearchNodes(resourcesState.CurrentPods))
+	s.status.AvailableNodes = int64(len(AvailableElasticsearchNodes(resourcesState.CurrentPods)))
 	s.status.Phase = phase
 
 	s.status.Health = v1beta1.ElasticsearchUnknownHealth
@@ -76,7 +76,7 @@ func (s *State) IsElasticsearchReady(observedState observer.State) bool {
 
 // UpdateElasticsearchApplyingChanges marks Elasticsearch as being the applying changes phase in the resource status.
 func (s *State) UpdateElasticsearchApplyingChanges(pods []corev1.Pod) *State {
-	s.status.AvailableNodes = len(AvailableElasticsearchNodes(pods))
+	s.status.AvailableNodes = int64(len(AvailableElasticsearchNodes(pods)))
 	s.status.Phase = v1beta1.ElasticsearchApplyingChangesPhase
 	s.status.Health = v1beta1.ElasticsearchRedHealth
 	return s

--- a/pkg/controller/elasticsearch/reconcile/state.go
+++ b/pkg/controller/elasticsearch/reconcile/state.go
@@ -43,7 +43,7 @@ func (s *State) updateWithPhase(
 	resourcesState ResourcesState,
 	observedState observer.State,
 ) *State {
-	s.status.AvailableNodes = int64(len(AvailableElasticsearchNodes(resourcesState.CurrentPods)))
+	s.status.AvailableNodes = int32(len(AvailableElasticsearchNodes(resourcesState.CurrentPods)))
 	s.status.Phase = phase
 
 	s.status.Health = v1beta1.ElasticsearchUnknownHealth
@@ -76,7 +76,7 @@ func (s *State) IsElasticsearchReady(observedState observer.State) bool {
 
 // UpdateElasticsearchApplyingChanges marks Elasticsearch as being the applying changes phase in the resource status.
 func (s *State) UpdateElasticsearchApplyingChanges(pods []corev1.Pod) *State {
-	s.status.AvailableNodes = int64(len(AvailableElasticsearchNodes(pods)))
+	s.status.AvailableNodes = int32(len(AvailableElasticsearchNodes(pods)))
 	s.status.Phase = v1beta1.ElasticsearchApplyingChangesPhase
 	s.status.Health = v1beta1.ElasticsearchRedHealth
 	return s

--- a/pkg/controller/kibana/state.go
+++ b/pkg/controller/kibana/state.go
@@ -28,7 +28,7 @@ func NewState(request reconcile.Request, kb *v1beta1.Kibana) State {
 
 // UpdateKibanaState updates the Kibana status based on the given deployment.
 func (s State) UpdateKibanaState(deployment v1.Deployment) {
-	s.Kibana.Status.AvailableNodes = int32(deployment.Status.AvailableReplicas)
+	s.Kibana.Status.AvailableNodes = deployment.Status.AvailableReplicas
 	s.Kibana.Status.Health = v1beta1.KibanaRed
 	for _, c := range deployment.Status.Conditions {
 		if c.Type == v1.DeploymentAvailable && c.Status == corev1.ConditionTrue {

--- a/pkg/controller/kibana/state.go
+++ b/pkg/controller/kibana/state.go
@@ -28,7 +28,7 @@ func NewState(request reconcile.Request, kb *v1beta1.Kibana) State {
 
 // UpdateKibanaState updates the Kibana status based on the given deployment.
 func (s State) UpdateKibanaState(deployment v1.Deployment) {
-	s.Kibana.Status.AvailableNodes = int64(deployment.Status.AvailableReplicas)
+	s.Kibana.Status.AvailableNodes = int32(deployment.Status.AvailableReplicas)
 	s.Kibana.Status.Health = v1beta1.KibanaRed
 	for _, c := range deployment.Status.Conditions {
 		if c.Type == v1.DeploymentAvailable && c.Status == corev1.ConditionTrue {

--- a/pkg/controller/kibana/state.go
+++ b/pkg/controller/kibana/state.go
@@ -28,7 +28,7 @@ func NewState(request reconcile.Request, kb *v1beta1.Kibana) State {
 
 // UpdateKibanaState updates the Kibana status based on the given deployment.
 func (s State) UpdateKibanaState(deployment v1.Deployment) {
-	s.Kibana.Status.AvailableNodes = int(deployment.Status.AvailableReplicas) // TODO lossy type conversion
+	s.Kibana.Status.AvailableNodes = int64(deployment.Status.AvailableReplicas)
 	s.Kibana.Status.Health = v1beta1.KibanaRed
 	for _, c := range deployment.Status.Conditions {
 		if c.Type == v1.DeploymentAvailable && c.Status == corev1.ConditionTrue {


### PR DESCRIPTION
There was a TODO on a lossy type conversion when reading the number of available replicas from k8s. This aims to fix it by using int64 instead of int on `ReconcilerStatus.AvailableNodes`