### PR TITLE
Update OpenShift doc with info about mmap

### DIFF
--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -29,7 +29,7 @@ Before deploying an Elasticsearch cluster with ECK, make sure that the Kubernete
 +
 Alternatively, you can opt for setting `node.store.allow_mmap: false` at the <<{p}-node-configuration,Elasticsearch node configuration>> level, but note that this has performance implications and is not recommended for production workloads.
 +
-For more details, see the ECK documentation on link:k8s-virtual-memory.html[Virtual memory].
+For more information, see: <<{p}-virtual-memory>>.
 
 [float]
 [id="{p}-openshift-deploy-the-operator"]

--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -25,7 +25,11 @@ NOTE: Only Elasticsearch and Kibana are compatible with the `restricted` https:/
 
 . Set virtual memory settings on the Kubernetes nodes.
 +
-Before deploying an Elasticsearch cluster with ECK, make sure you correctly applied the `vm.max_map_count` setting on all the nodes of your cluster. Pods created by ECK are likely to run with the `restricted` https://docs.openshift.com/container-platform/4.1/authentication/managing-security-context-constraints.html[Security Context Constraint] (SCC): they run with a limited set of privileges and cannot change this setting on the nodes that host them. For more details, see the Elasticsearch documentation on https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html[Virtual memory].
+Before deploying an Elasticsearch cluster with ECK, make sure you correctly applied the `vm.max_map_count` sysctl setting on all the nodes of your cluster. Pods created by ECK are likely to run with the `restricted` https://docs.openshift.com/container-platform/4.1/authentication/managing-security-context-constraints.html[Security Context Constraint] (SCC): they run with a limited set of privileges and cannot change this setting on the nodes that host them.
++
+Alternatively, you can opt for setting `node.store.allow_mmap: false` at the link:k8s-node-configuration.html[Elasticsearch node configuration] level, but note that this has performance implications and is not recommended for production workloads.
++
+For more details, see the ECK documentation on link:k8s-virtual-memory.html[Virtual memory].
 
 [float]
 [id="{p}-openshift-deploy-the-operator"]

--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -25,7 +25,7 @@ NOTE: Only Elasticsearch and Kibana are compatible with the `restricted` https:/
 
 . Set virtual memory settings on the Kubernetes nodes.
 +
-Before deploying an Elasticsearch cluster with ECK, make sure you correctly applied the `vm.max_map_count` sysctl setting on all the nodes of your cluster. Pods created by ECK are likely to run with the `restricted` https://docs.openshift.com/container-platform/4.1/authentication/managing-security-context-constraints.html[Security Context Constraint] (SCC): they run with a limited set of privileges and cannot change this setting on the nodes that host them.
+Before deploying an Elasticsearch cluster with ECK, make sure that the Kubernetes nodes in your cluster have the correct `vm.max_map_count` sysctl setting applied. By default, Pods created by ECK are likely to run with the `restricted` https://docs.openshift.com/container-platform/4.1/authentication/managing-security-context-constraints.html[Security Context Constraint] (SCC) which restricts privileged access required to change this setting in the underlying Kubernetes nodes. 
 +
 Alternatively, you can opt for setting `node.store.allow_mmap: false` at the link:k8s-node-configuration.html[Elasticsearch node configuration] level, but note that this has performance implications and is not recommended for production workloads.
 +

--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -27,7 +27,7 @@ NOTE: Only Elasticsearch and Kibana are compatible with the `restricted` https:/
 +
 Before deploying an Elasticsearch cluster with ECK, make sure that the Kubernetes nodes in your cluster have the correct `vm.max_map_count` sysctl setting applied. By default, Pods created by ECK are likely to run with the `restricted` https://docs.openshift.com/container-platform/4.1/authentication/managing-security-context-constraints.html[Security Context Constraint] (SCC) which restricts privileged access required to change this setting in the underlying Kubernetes nodes. 
 +
-Alternatively, you can opt for setting `node.store.allow_mmap: false` at the link:k8s-node-configuration.html[Elasticsearch node configuration] level, but note that this has performance implications and is not recommended for production workloads.
+Alternatively, you can opt for setting `node.store.allow_mmap: false` at the <<{p}-node-configuration,Elasticsearch node configuration>> level, but note that this has performance implications and is not recommended for production workloads.
 +
 For more details, see the ECK documentation on link:k8s-virtual-memory.html[Virtual memory].
 


### PR DESCRIPTION
With the change to recommend mmap be disabled for the quickstart it
makes sense to also add a note about it in the OpenShift doc.

I also propose to reference k8s-virtual-memory.html instead of https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html (which is pointed in k8s-virtual-memory.html) that gives a bit more context about virtual memory.

Resolves #1934.