### PR TITLE
Filter non-JSON lines from E2E log file

### DIFF
--- a/test/e2e/cmd/run/jsonlog.go
+++ b/test/e2e/cmd/run/jsonlog.go
@@ -1,0 +1,91 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package run
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+const newLine = byte('\n')
+
+// jsonLog implements a Writer that only emits valid JSON to output.
+type jsonLog struct {
+	out    io.WriteCloser
+	writer *bufio.Writer
+	buf    *bytes.Buffer
+}
+
+func newJSONLogToFile(outFile string) (*jsonLog, error) {
+	f, err := os.Create(outFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JSON log file %s: %w", outFile, err)
+	}
+
+	return newJSONLog(f), nil
+}
+
+func newJSONLog(out io.WriteCloser) *jsonLog {
+	return &jsonLog{
+		out:    out,
+		writer: bufio.NewWriter(out),
+		buf:    new(bytes.Buffer),
+	}
+}
+
+func (jl *jsonLog) Write(p []byte) (int, error) {
+	for i, b := range p {
+		if b == newLine {
+			if err := jl.writeLine(); err != nil {
+				return 0, err
+			}
+			continue
+		}
+		if err := jl.buf.WriteByte(b); err != nil {
+			return i, err
+		}
+	}
+	return len(p), nil
+}
+
+func (jl *jsonLog) writeLine() error {
+	line := jl.buf.Bytes()
+	if json.Valid(line) {
+		if _, err := jl.writer.Write(line); err != nil {
+			return err
+		}
+		if _, err := jl.writer.Write([]byte{newLine}); err != nil {
+			return err
+		}
+	}
+
+	jl.buf.Reset()
+	return nil
+}
+
+func (jl *jsonLog) Close() (err error) {
+	defer func() {
+		e := jl.out.Close()
+		if err == nil {
+			err = e
+		}
+	}()
+
+	// flush internal buffer
+	if err = jl.writeLine(); err != nil {
+		return
+	}
+
+	// flush the writer
+	if err = jl.writer.Flush(); err != nil {
+		return
+	}
+
+	return nil
+}

--- a/test/e2e/cmd/run/jsonlog_test.go
+++ b/test/e2e/cmd/run/jsonlog_test.go
@@ -1,0 +1,45 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package run
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeWriteCloser fakes an io.WriteCloser. (https://github.com/golang/go/issues/22823)
+type fakeWriteCloser struct {
+	io.Writer
+}
+
+func (f *fakeWriteCloser) Close() error {
+	return nil
+}
+
+func TestJSONLog(t *testing.T) {
+	buf := new(bytes.Buffer)
+	jl := newJSONLog(&fakeWriteCloser{Writer: buf})
+
+	w := bufio.NewWriter(jl)
+	_, err := w.WriteString(`
+gibberish
+{"key1": "value1", "key2": "value2"}
+garbage
+{"Time":"2019-10-30T10:52:39.933604025Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/test/e2e/es","Test":"TestVolumeEmptyDir/Creating_an_Elasticsearch_cluster_should_succeed","Output":"=== RUN   TestVolumeEmptyDir/Creating_an_Elasticsearch_cluster_should_succeed\n"}`)
+
+	require.NoError(t, err)
+	require.NoError(t, w.Flush())
+	require.NoError(t, jl.Close())
+
+	want := `{"key1": "value1", "key2": "value2"}
+{"Time":"2019-10-30T10:52:39.933604025Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/test/e2e/es","Test":"TestVolumeEmptyDir/Creating_an_Elasticsearch_cluster_should_succeed","Output":"=== RUN   TestVolumeEmptyDir/Creating_an_Elasticsearch_cluster_should_succeed\n"}
+`
+
+	require.Equal(t, want, buf.String())
+}


### PR DESCRIPTION
Prevents non-JSON lines from being written to the E2E test result log.  If this log file contains any lines that are not valid JSON, the JUnit XML test report generation step in Jenkins fails.

Fixes #1967 