### PR TITLE
Fix KibanaAssociationWithNonExistentES E2E test

### DIFF
--- a/test/e2e/kb/association_test.go
+++ b/test/e2e/kb/association_test.go
@@ -42,6 +42,7 @@ func TestCrossNSAssociation(t *testing.T) {
 func TestKibanaAssociationWithNonExistentES(t *testing.T) {
 	name := "test-kb-assoc-non-existent-es"
 	kbBuilder := kibana.NewBuilder(name).
+		WithElasticsearchRef(commonv1beta1.ObjectSelector{Name: "some-es"}).
 		WithNodeCount(1)
 
 	k := test.NewK8sClientOrFatal()


### PR DESCRIPTION
Change introduced in #2021 requires the Elasticsearch reference to be explicitly defined in order for an association to be formed.

Fixes #2096 