### PR TITLE
Add webhook with cert-manager recipe

### DIFF
--- a/config/recipes/cert-manager/webhook.asciidoc
+++ b/config/recipes/cert-manager/webhook.asciidoc
@@ -1,0 +1,168 @@
+[id="{p}-webhook"]
+== Validating webhook
+
+A validating webhook provides additional validation of Elasticsearch resources beyond what can be specified in OpenAPI specs. This allows advanced validation to help prevent Elasticsearch resources that are invalid and will not function correctly from being admitted by the Kubernetes API server, which can aid troubleshooting. To enable the validating webhook, you must first install cert-manager v0.11+ as described in their instructions link:from being admitted by the Kubernetes API server[here].
+
+Once that is complete, you can apply this yaml to create all of the resources necessary for the validating webhook to function. This same yaml is also available in `cloud-on-k8s/config/recipes/cert-manager/webhook.yaml`:
+
+[source,yaml]
+----
+cat $$<<$$EOF | kubectl apply -f -
+---
+# this configures
+# - a self signed cert-manager issuer
+# - a service to point to the webhook
+# - a self signed certificate for the webhook service
+# - a validating webhook configuration
+# - updates the ECK operator statefulset to enable the webhook
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: elastic-system
+spec:
+  selfSigned: {}
+...
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: elastic-webhook
+  namespace: elastic-system
+spec:
+  commonName: elastic-webhook.elastic-system.svc
+  dnsNames:
+  - elastic-webhook.elastic-system.svc.cluster.local
+  - elastic-webhook.elastic-system.svc
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: elastic-webhook-server-cert
+...
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elastic-webhook
+  namespace: elastic-system
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: elastic-operator
+  sessionAffinity: None
+  type: ClusterIP
+...
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: elastic-webhook.k8s.elastic.co
+  annotations:
+    cert-manager.io/inject-ca-from: elastic-system/elastic-webhook
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: elastic-webhook
+      namespace: elastic-system
+      # this is the path controller-runtime automatically generates
+      path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
+  failurePolicy: Ignore
+  name: elastic-es-validation.k8s.elastic.co
+  timeoutSeconds: 5
+  sideEffects: None
+  rules:
+  - apiGroups:
+    - elasticsearch.k8s.elastic.co
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - elasticsearches
+...
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    control-plane: elastic-operator
+  name: elastic-operator
+  namespace: elastic-system
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      control-plane: elastic-operator
+  serviceName: elastic-operator
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        control-plane: elastic-operator
+    spec:
+      containers:
+      - args:
+        - manager
+        - --operator-roles
+        - all
+        - --enable-debug-logs=true
+        - --enable-webhooks=true
+        env:
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: OPERATOR_IMAGE
+          value: docker.elastic.co/eck/eck-operator:1.0.0-beta1
+        # this may need to be updated to a snapshot build
+        image: docker.elastic.co/eck/eck-operator:1.0.0-beta1
+        imagePullPolicy: Always
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        # this is the path controller-runtime looks for certs and should not be changed
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        resources:
+          limits:
+            cpu: "1"
+            memory: 150Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: elastic-webhook-server-cert 
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: elastic-operator
+      serviceAccountName: elastic-operator
+      terminationGracePeriodSeconds: 10
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+...
+EOF
+----
+
+
+=== Troubleshooting
+
+You can change the `failurePolicy` of the webhook configuration to `Fail`, which will cause creations to error out if there is an error contacting the webhook.

--- a/config/recipes/cert-manager/webhook.yaml
+++ b/config/recipes/cert-manager/webhook.yaml
@@ -1,0 +1,149 @@
+---
+# this configures
+# - a self signed cert-manager issuer
+# - a service to point to the webhook
+# - a self signed certificate for the webhook service
+# - a validating webhook configuration
+# - updates the ECK operator statefulset to enable the webhook
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  # do these go in the cert manager namespace or wherever?
+  namespace: elastic-system
+spec:
+  selfSigned: {}
+...
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: elastic-webhook
+  namespace: elastic-system
+spec:
+  commonName: elastic-webhook.elastic-system.svc
+  dnsNames:
+  - elastic-webhook.elastic-system.svc.cluster.local
+  - elastic-webhook.elastic-system.svc
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: elastic-webhook-server-cert
+...
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elastic-webhook
+  namespace: elastic-system
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: elastic-operator
+  sessionAffinity: None
+  type: ClusterIP
+...
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: elastic-webhook.k8s.elastic.co
+  annotations:
+    cert-manager.io/inject-ca-from: elastic-system/elastic-webhook
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: elastic-webhook
+      namespace: elastic-system
+      path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
+  failurePolicy: Fail
+  name: elastic-es-validation.k8s.elastic.co
+  timeoutSeconds: 5
+  sideEffects: None
+  rules:
+  - apiGroups:
+    - elasticsearch.k8s.elastic.co
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - elasticsearches
+...
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    control-plane: elastic-operator
+  name: elastic-operator
+  namespace: elastic-system
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      control-plane: elastic-operator
+  serviceName: elastic-operator
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        control-plane: elastic-operator
+    spec:
+      containers:
+      - args:
+        - manager
+        - --operator-roles
+        - all
+        - --enable-debug-logs=true
+        - --enable-webhooks=true
+        env:
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: OPERATOR_IMAGE
+          value: eu.gcr.io/elastic-cloud-dev/eck-operator-sabo:1.0.0-beta1-50c7de0d
+        image: eu.gcr.io/elastic-cloud-dev/eck-operator-sabo:1.0.0-beta1-50c7de0d
+        imagePullPolicy: Always
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        resources:
+          limits:
+            cpu: "1"
+            memory: 150Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: elastic-webhook-server-cert 
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: elastic-operator
+      serviceAccountName: elastic-operator
+      terminationGracePeriodSeconds: 10
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+...

--- a/config/recipes/cert-manager/webhook.yaml
+++ b/config/recipes/cert-manager/webhook.yaml
@@ -9,7 +9,6 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: selfsigned-issuer
-  # do these go in the cert manager namespace or wherever?
   namespace: elastic-system
 spec:
   selfSigned: {}
@@ -59,8 +58,9 @@ webhooks:
     service:
       name: elastic-webhook
       namespace: elastic-system
+      # this is the path controller-runtime automatically generates
       path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: elastic-es-validation.k8s.elastic.co
   timeoutSeconds: 5
   sideEffects: None
@@ -111,8 +111,9 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         - name: OPERATOR_IMAGE
-          value: eu.gcr.io/elastic-cloud-dev/eck-operator-sabo:1.0.0-beta1-50c7de0d
-        image: eu.gcr.io/elastic-cloud-dev/eck-operator-sabo:1.0.0-beta1-50c7de0d
+          value: docker.elastic.co/eck/eck-operator:1.0.0-beta1
+        # this may need to be updated to a snapshot build
+        image: docker.elastic.co/eck/eck-operator:1.0.0-beta1
         imagePullPolicy: Always
         name: manager
         ports:
@@ -120,6 +121,7 @@ spec:
           name: webhook-server
           protocol: TCP
         volumeMounts:
+        # this is the path controller-runtime looks for certs and should not be changed
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -13,7 +13,7 @@ webhooks:
       namespace: system
       path: /validate-elasticsearch
   failurePolicy: Ignore
-  name: elastic-es-validation
+  name: elastic-es-validation.k8s.elastic.co
   rules:
   - apiGroups:
     - elasticsearch.k8s.elastic.co

--- a/docs/operator-config.asciidoc
+++ b/docs/operator-config.asciidoc
@@ -15,6 +15,7 @@ You can use several options to configure ECK. Unless otherwise noted, these opti
 
 |`log-verbosity` |int |0 |Verbosity level of logs. -2=Error, -1=Warn, 0=Info, >0=Debug
 |`enable-debug-logs` |bool |false |Enables debug logs. Equivalent to `log-verbosity=1`
+|`enable-webhooks` |bool |false |Enables the webhook server. Requires a `ValidatingWebhookConfiguration` to be used by the cluster
 |`metrics-port` |int |0 |Port to use for exposing metrics in the Prometheus format. Set 0 to disable
 |`operator-roles` |[]string |all |Roles this operator should assume. Valid values are namespace, global, webhook or all. Accepts multiple comma separated values. See <<{p}-ns-config>> for more information
 |`namespaces` |[]string |`""` |Namespaces in which this operator should manage resources. Accepts multiple comma-separated values. Defaults to all namespaces. See <<{p}-ns-config>> for more information

--- a/pkg/apis/elasticsearch/v1beta1/validations.go
+++ b/pkg/apis/elasticsearch/v1beta1/validations.go
@@ -86,7 +86,7 @@ func hasMaster(es *Elasticsearch) field.ErrorList {
 		hasMaster = hasMaster || (cfg.Node.Master && t.Count > 0)
 	}
 	if !hasMaster {
-		errs = append(errs, field.Invalid(field.NewPath("spec").Child("nodeSets"), es.Spec.NodeSets, masterRequiredMsg))
+		errs = append(errs, field.Required(field.NewPath("spec").Child("nodeSets"), masterRequiredMsg))
 	}
 	return errs
 }

--- a/pkg/apis/elasticsearch/v1beta1/webhook.go
+++ b/pkg/apis/elasticsearch/v1beta1/webhook.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-// +kubebuilder:webhook:path=/validate-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1beta1,name=elastic-es-validation
+// +kubebuilder:webhook:path=/validate-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1beta1,name=elastic-es-validation.k8s.elastic.co
 
 func (r *Elasticsearch) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).


### PR DESCRIPTION
Related to https://github.com/elastic/cloud-on-k8s/issues/1769

- Enables the webhook server if it's toggled in the config. It is not on by default because it looks for certificates in a specific location, so if they're not there it will be sad.
- Adds docs on how to install the webhook with cert-manager
- Updates the hasMaster validator to use a more specific error message

The update to use cert-manager v0.11 was only [merged a week ago](https://github.com/kubernetes-sigs/kubebuilder/issues/1093) in kubebuilder so a lot of the docs there still need some work. I also added comments in the yaml of some of the weird things I noticed in Kubebuilder about how it expects webhooks to function.

The other unfortunate part is that kubebuilder docs very much expect you to be working with their deployments + kustomize configuration, which we have not migrated to yet.

To test this you may need to run `make operator-image` and then update the `image` field with the newly built image. Once this is in master I think we can update the example to a snapshot build.