### PR TITLE
Dump k8s data when e2e test fails

### DIFF
--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -73,6 +73,11 @@ pipeline {
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token'
                 }
+                googleStorageUpload bucket: "gs://devops-ci-artifacts/jobs/$JOB_NAME/$BUILD_NUMBER",
+                    credentialsId: "devops-ci-gcs-plugin",
+                    pattern: "*.tgz",
+                    sharedPublicly: true,
+                    showInline: true
             }
         }
         cleanup {

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -88,6 +88,11 @@ pipeline {
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token'
                 }
+                googleStorageUpload bucket: "gs://devops-ci-artifacts/jobs/$JOB_NAME/$BUILD_NUMBER",
+                    credentialsId: "devops-ci-gcs-plugin",
+                    pattern: "*.tgz",
+                    sharedPublicly: true,
+                    showInline: true
             }
         }
         cleanup {


### PR DESCRIPTION
Upload *.tgz using the `googleStorageUpload` Jenkins plugin for cloud-on-k8s-stack and cloud-on-k8s-versions-gke jobs, if the current stage’s run has not a "success" status.

Follow-up of #2027.