### PR TITLE
Fix links to custom images documentation page (#2110)

### DIFF
--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -305,7 +305,7 @@ NOTE: The first option has the advantage that you can verify the correctness of 
 maximum flexibility. But the second option also means you might catch any errors only at runtime. Plugin installation at runtime has another drawback in that it needs access to the Internet from your cluster
 and downloads each plugin multiple times, once for each Elasticsearch node.
 
-See link:custom-images.asciidoc[Creating custom images] for instructions on how to build custom Docker images based on the official Elastic images.
+See <<{p}-custom-images,Creating custom images>> for instructions on how to build custom Docker images based on the official Elastic images.
 
 The following example describes option 2, using a repository plugin. To install the plugin before the Elasticsearch
 nodes start, use an init container to run the link:https://www.elastic.co/guide/en/elasticsearch/plugins/current/installation.html[plugin installation tool].

--- a/docs/snapshots.asciidoc
+++ b/docs/snapshots.asciidoc
@@ -21,7 +21,7 @@ For more information on Elasticsearch snapshots, see https://www.elastic.co/guid
 [id="{p}-install-plugin"]
 ==== Install the storage repository plugin
 
-To install the storage repository plugin, you can either use a link:k8s-images.html[custom image] or link:k8s-init-containers-plugin-downloads.html[add your own init container] which
+To install the storage repository plugin, you can either use a <<{p}-custom-images,custom image>> or <<{p}-init-containers-plugin-downloads,add your own init container>> which
 installs the plugin when the Pod is created.
 
 To use your own custom image with all necessary plugins pre-installed, use an Elasticsearch resource like the following one:


### PR DESCRIPTION
Backports https://github.com/elastic/cloud-on-k8s/pull/2110 on the 1.0 branch.