### PR TITLE
Fix E2E tests job definitions

### DIFF
--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -95,7 +95,7 @@ pipeline {
     }
 }
 
-void runWith(clusterVersion, clusterName) {
+def runWith(failedTests, clusterVersion, clusterName) {
     sh """#!/bin/bash
 
         cat >.env <<EOF

--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -34,7 +34,9 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runWith('1.12', "eck-gke12-${BUILD_NUMBER}-e2e")
+                        script {
+                            runWith(failedTests, '1.12', "eck-gke12-${BUILD_NUMBER}-e2e")
+                        }
                     }
                 }
                 stage("1.13") {
@@ -43,7 +45,9 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runWith('1.13', "eck-gke13-${BUILD_NUMBER}-e2e")
+                        script {
+                            runWith(failedTests, '1.13', "eck-gke13-${BUILD_NUMBER}-e2e")
+                        }
                     }
                 }
                 stage("1.14") {
@@ -52,7 +56,9 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runWith('1.14', "eck-gke14-${BUILD_NUMBER}-e2e")
+                        script {
+                            runWith(failedTests, '1.14', "eck-gke14-${BUILD_NUMBER}-e2e")
+                        }
                     }
                 }
             }

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -115,7 +115,7 @@ pipeline {
 
 }
 
-def runWith(clusterName, stackVersion) {
+def runWith(failedTests, clusterName, stackVersion) {
     sh """
         cat >.env <<EOF
 OPERATOR_IMAGE = "${IMAGE}"

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -31,7 +31,9 @@ pipeline {
                 stage("6.8.4") {
                     steps {
                         checkout scm
-                        runWith("eck-68-${BUILD_NUMBER}-e2e", "6.8.4")
+                        script {
+                            runWith(failedTests, "eck-68-${BUILD_NUMBER}-e2e", "6.8.4")
+                        }
                     }
                 }
                 stage("7.1.1") {
@@ -40,7 +42,9 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runWith("eck-71-${BUILD_NUMBER}-e2e", "7.1.1")
+                        script {
+                            runWith(failedTests, "eck-71-${BUILD_NUMBER}-e2e", "7.1.1")
+                        }
                     }
                 }
                 stage("7.2.1") {
@@ -49,7 +53,9 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runWith("eck-72-${BUILD_NUMBER}-e2e", "7.2.1")
+                        script {
+                            runWith(failedTests, "eck-72-${BUILD_NUMBER}-e2e", "7.2.1")
+                        }
                     }
                 }
                 stage("7.3.2") {
@@ -58,7 +64,9 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runWith("eck-73-${BUILD_NUMBER}-e2e", "7.3.2")
+                        script {
+                            runWith(failedTests, "eck-73-${BUILD_NUMBER}-e2e", "7.3.2")
+                        }
                     }
                 }
                 stage("7.4.1") {
@@ -67,7 +75,9 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runWith("eck-74-${BUILD_NUMBER}-e2e", "7.4.1")
+                        script {
+                            runWith(failedTests, "eck-74-${BUILD_NUMBER}-e2e", "7.4.1")
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- Call `runWith` method in a `script` block
- Pass the `failedTests` variable in parameter

Resolves #2107. 