### PR TITLE
Enable AKS github trigger, up AKS cluster version to 1.13.12

### DIFF
--- a/.ci/jobs/e2e-tests-aks.yaml
+++ b/.ci/jobs/e2e-tests-aks.yaml
@@ -3,6 +3,8 @@
     description: Job that runs e2e tests against Elastic Cloud on Kubernetes running in a dedicated k8s cluster in AKS. This Job is managed by JJB.
     name: cloud-on-k8s-e2e-tests-aks
     project-type: pipeline
+    triggers:
+      - github
     concurrent: true
     pipeline-scm:
       scm:

--- a/build/ci/e2e/Jenkinsfile-aks
+++ b/build/ci/e2e/Jenkinsfile-aks
@@ -66,7 +66,6 @@ EOF
 id: aks-ci
 overrides:
   operation: delete
-  kubernetesVersion: "1.12.8"
   clusterName: $BUILD_TAG
   vaultInfo:
     address: $VAULT_ADDR

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -31,7 +31,7 @@ plans:
   operation: create
   clusterName: ci
   provider: aks
-  kubernetesVersion: 1.13.10
+  kubernetesVersion: 1.13.12
   machineType: Standard_D8s_v3
   serviceAccount: true
   psp: false
@@ -41,7 +41,7 @@ plans:
   operation: create
   clusterName: dev
   provider: aks
-  kubernetesVersion: 1.13.10
+  kubernetesVersion: 1.13.12
   machineType: Standard_D8s_v3
   serviceAccount: false
   psp: false


### PR DESCRIPTION
This will cause:
- AKS test run on changes at master instead of on demand,
- AKS use 1.13.12 as 1.13.10 is deprecated.