### PR TITLE
Run license e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,7 +362,7 @@ e2e-run:
 		--operator-image=$(OPERATOR_IMAGE) \
 		--e2e-image=$(E2E_IMG) \
 		--test-regex=$(TESTS_MATCH) \
-		--test-licence=$(TEST_LICENSE) \
+		--test-license=$(TEST_LICENSE) \
 		--elastic-stack-version=$(STACK_VERSION) \
 		--log-verbosity=$(LOG_VERBOSITY) \
 		--crd-flavor=$(CRD_FLAVOR) \
@@ -384,7 +384,7 @@ e2e-local:
 	@go run test/e2e/cmd/main.go run \
 		--test-run-name=e2e \
 		--test-context-out=$(LOCAL_E2E_CTX) \
-		--test-licence=$(TEST_LICENSE) \
+		--test-license=$(TEST_LICENSE) \
 		--elastic-stack-version=$(STACK_VERSION) \
 		--auto-port-forwarding \
 		--local \

--- a/Makefile
+++ b/Makefile
@@ -348,7 +348,7 @@ E2E_JSON ?= false
 TEST_TIMEOUT ?= 5m
 
 # Run e2e tests as a k8s batch job
-e2e: build-operator-image e2e-docker-build e2e-docker-push e2e-run
+e2e: build-operator-image clean e2e-docker-build e2e-docker-push e2e-run
 
 e2e-docker-build:
 	docker build --build-arg E2E_JSON=$(E2E_JSON) -t $(E2E_IMG) -f test/e2e/Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -361,6 +361,7 @@ e2e-run:
 		--operator-image=$(OPERATOR_IMAGE) \
 		--e2e-image=$(E2E_IMG) \
 		--test-regex=$(TESTS_MATCH) \
+		--test-licence=$(TEST_LICENSE) \
 		--elastic-stack-version=$(STACK_VERSION) \
 		--log-verbosity=$(LOG_VERBOSITY) \
 		--crd-flavor=$(CRD_FLAVOR) \
@@ -382,6 +383,7 @@ e2e-local:
 	@go run test/e2e/cmd/main.go run \
 		--test-run-name=e2e \
 		--test-context-out=$(LOCAL_E2E_CTX) \
+		--test-licence=$(TEST_LICENSE) \
 		--elastic-stack-version=$(STACK_VERSION) \
 		--auto-port-forwarding \
 		--local \

--- a/Makefile
+++ b/Makefile
@@ -348,6 +348,7 @@ E2E_JSON ?= false
 TEST_TIMEOUT ?= 5m
 
 # Run e2e tests as a k8s batch job
+# clean between operator build and e2e build to remove irrelevant/build-breaking generated public keys
 e2e: build-operator-image clean e2e-docker-build e2e-docker-push e2e-run
 
 e2e-docker-build:

--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -67,5 +67,8 @@ yaml-upload:
 get-elastic-public-key:
 	@ VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=pubkey secret/release/license | base64 --decode > license.key
 
+get-test-license:
+	@ VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=enterprise  secret/devops-ci/cloud-on-k8s/test-licenses > test-license.json
+
 get-docker-creds:
 	@ echo "ELASTIC_DOCKER_PASSWORD = $(shell VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=value secret/devops-ci/cloud-on-k8s/eckadmin)" >> ../../.env

--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -105,6 +105,9 @@ REGISTRY = eu.gcr.io
 REPOSITORY = "$GCLOUD_PROJECT"
 SKIP_DOCKER_COMMAND = true
 E2E_JSON = true
+TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/build/ci/test-license.json
+GO_TAGS = release
+export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/build/ci/license.key
 EOF
         if [[ "${clusterVersion}" < "1.14" ]]; then
             echo "Setting CRD_FLAVOR to trivial-versions to support K8s < 1.14"
@@ -125,7 +128,7 @@ overrides:
 EOF
     """
     script {
-        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci TARGET=ci-e2e ci')
+        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci get-test-license get-elastic-public-key TARGET=ci-e2e ci')
 
         sh 'make -C build/ci TARGET=e2e-generate-xml ci'
         junit "e2e-tests.xml"

--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -55,6 +55,8 @@ REGISTRY = eu.gcr.io
 REPOSITORY = "$GCLOUD_PROJECT"
 SKIP_DOCKER_COMMAND = false
 TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/build/ci/test-license.json
+GO_TAGS = release
+export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/build/ci/license.key
 IMG_SUFFIX = -ci
 E2E_JSON = true
 EOF
@@ -71,7 +73,7 @@ overrides:
 EOF
                 """
                 script {
-                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci get-test-license TARGET=ci-e2e ci')
+                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci get-test-license get-elastic-public-key TARGET=ci-e2e ci')
 
                     sh 'make -C build/ci TARGET=e2e-generate-xml ci'
                     junit "e2e-tests.xml"

--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -54,6 +54,7 @@ GCLOUD_PROJECT = "$GCLOUD_PROJECT"
 REGISTRY = eu.gcr.io
 REPOSITORY = "$GCLOUD_PROJECT"
 SKIP_DOCKER_COMMAND = false
+TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/build/ci/test-license.json
 IMG_SUFFIX = -ci
 E2E_JSON = true
 EOF
@@ -70,7 +71,7 @@ overrides:
 EOF
                 """
                 script {
-                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci TARGET=ci-e2e ci')
+                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci get-test-license TARGET=ci-e2e ci')
 
                     sh 'make -C build/ci TARGET=e2e-generate-xml ci'
                     junit "e2e-tests.xml"

--- a/build/ci/e2e/Jenkinsfile-aks
+++ b/build/ci/e2e/Jenkinsfile-aks
@@ -34,6 +34,8 @@ REPOSITORY = operators
 IMG_SUFFIX = -ci
 CRD_FLAVOR = trivial-versions
 TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/build/ci/test-license.json
+GO_TAGS = release
+export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/build/ci/license.key
 E2E_JSON = true
 TEST_TIMEOUT = 10m
 EOF
@@ -48,7 +50,7 @@ overrides:
 EOF
                 """
                 script {
-                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci get-test-license TARGET=ci-e2e ci')
+                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci get-test-license get-elastic-public-key TARGET=ci-e2e ci')
 
                     sh 'make -C build/ci TARGET=e2e-generate-xml ci'
                     junit "e2e-tests.xml"

--- a/build/ci/e2e/Jenkinsfile-aks
+++ b/build/ci/e2e/Jenkinsfile-aks
@@ -33,6 +33,7 @@ REGISTRY = cloudonk8s.azurecr.io
 REPOSITORY = operators
 IMG_SUFFIX = -ci
 CRD_FLAVOR = trivial-versions
+TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/build/ci/test-license.json
 E2E_JSON = true
 TEST_TIMEOUT = 10m
 EOF
@@ -47,7 +48,7 @@ overrides:
 EOF
                 """
                 script {
-                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci TARGET=ci-e2e ci')
+                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci get-test-license TARGET=ci-e2e ci')
 
                     sh 'make -C build/ci TARGET=e2e-generate-xml ci'
                     junit "e2e-tests.xml"

--- a/build/ci/e2e/custom_operator_image.jenkinsfile
+++ b/build/ci/e2e/custom_operator_image.jenkinsfile
@@ -44,6 +44,9 @@ IMG_SUFFIX = -ci
 SKIP_DOCKER_COMMAND = true
 CRD_FLAVOR = trivial-versions
 E2E_JSON = true
+TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/build/ci/test-license.json
+GO_TAGS = release
+export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/build/ci/license.key
 EOF
                     cat >deployer-config.yml <<EOF
 id: gke-ci
@@ -58,7 +61,7 @@ overrides:
 EOF
                 """
                 script {
-                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci TARGET=ci-e2e ci')
+                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci get-test-license get-elastic-public-key TARGET=ci-e2e ci')
 
                     sh 'make -C build/ci TARGET=e2e-generate-xml ci'
                     junit "e2e-tests.xml"

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -121,6 +121,9 @@ SKIP_DOCKER_COMMAND = true
 REGISTRY = eu.gcr.io
 REPOSITORY = "$GCLOUD_PROJECT"
 E2E_JSON = true
+TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/build/ci/test-license.json
+GO_TAGS = release
+export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/build/ci/license.key
 EOF
         cat >deployer-config.yml <<EOF
 id: gke-ci
@@ -136,7 +139,7 @@ overrides:
 EOF
     """
     script {
-        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci TARGET=ci-e2e ci')
+        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci get-test-license get-elastic-public-key TARGET=ci-e2e ci')
 
         sh 'make -C build/ci TARGET=e2e-generate-xml ci'
         junit "e2e-tests.xml"

--- a/build/ci/e2e/vanilla_k8s.jenkinsfile
+++ b/build/ci/e2e/vanilla_k8s.jenkinsfile
@@ -90,10 +90,13 @@ REGISTRY = eu.gcr.io
 REPOSITORY = "$GCLOUD_PROJECT"
 E2E_JSON = true
 KIND_NODE_IMAGE = ${kindImage}
+TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/build/ci/test-license.json
+GO_TAGS = release
+export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/build/ci/license.key
 EOF
     """
     script {
-        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci TARGET=kind-e2e ci')
+        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci get-test-license get-elastic-public-key TARGET=kind-e2e ci')
 
         sh 'make -C build/ci TARGET=e2e-generate-xml ci'
         junit "e2e-tests.xml"

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -127,7 +127,7 @@ void createConfig() {
         cat >.env <<EOF
 REGISTRY = eu.gcr.io
 REPOSITORY = "$GCLOUD_PROJECT"
-TESTS_MATCH = TestSmoke
+TESTS_MATCH = TestEnterprise
 SKIP_DOCKER_COMMAND = false
 IMG_SUFFIX = -ci
 E2E_JSON = true

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
                             createConfig()
                             createDeployerConfig()
 
-                            env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci TARGET=ci-e2e ci')
+                            env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci get-test-license TARGET=ci-e2e ci')
 
                             sh 'make -C build/ci TARGET=e2e-generate-xml ci'
                             junit "e2e-tests.xml"
@@ -131,6 +131,7 @@ TESTS_MATCH = TestSmoke
 SKIP_DOCKER_COMMAND = false
 IMG_SUFFIX = -ci
 E2E_JSON = true
+TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/build/ci/test-license.json
 EOF
     """
 }

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -131,11 +131,7 @@ TESTS_MATCH = TestSmoke
 SKIP_DOCKER_COMMAND = false
 IMG_SUFFIX = -ci
 E2E_JSON = true
-GO_TAGS = release
-export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/build/ci/license.key
-TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/build/ci/test-license.json
 EOF
-       make -C build/ci get-elastic-public-key get-test-license
     """
 }
 

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -127,7 +127,7 @@ void createConfig() {
         cat >.env <<EOF
 REGISTRY = eu.gcr.io
 REPOSITORY = "$GCLOUD_PROJECT"
-TESTS_MATCH = TestEnterprise
+TESTS_MATCH = TestSmoke
 SKIP_DOCKER_COMMAND = false
 IMG_SUFFIX = -ci
 E2E_JSON = true

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
                             createConfig()
                             createDeployerConfig()
 
-                            env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci get-test-license TARGET=ci-e2e ci')
+                            env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci get-elastic-public-key get-test-license TARGET=ci-e2e ci')
 
                             sh 'make -C build/ci TARGET=e2e-generate-xml ci'
                             junit "e2e-tests.xml"
@@ -131,6 +131,8 @@ TESTS_MATCH = TestEnterprise
 SKIP_DOCKER_COMMAND = false
 IMG_SUFFIX = -ci
 E2E_JSON = true
+GO_TAGS = release
+export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/build/ci/license.key
 TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/build/ci/test-license.json
 EOF
     """

--- a/build/ci/pr/Jenkinsfile
+++ b/build/ci/pr/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
                             createConfig()
                             createDeployerConfig()
 
-                            env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci get-elastic-public-key get-test-license TARGET=ci-e2e ci')
+                            env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci TARGET=ci-e2e ci')
 
                             sh 'make -C build/ci TARGET=e2e-generate-xml ci'
                             junit "e2e-tests.xml"
@@ -135,6 +135,7 @@ GO_TAGS = release
 export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/build/ci/license.key
 TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/build/ci/test-license.json
 EOF
+       make -C build/ci get-elastic-public-key get-test-license
     """
 }
 

--- a/config/e2e/batch_job.yaml
+++ b/config/e2e/batch_job.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     test-run: {{ .Context.TestRun }}
 data:
-{{ range $key, $value := .Secrets.Data }}
+{{ range $key, $value := .Secrets }}
   {{ $key }}: |
     {{ $value | b64enc }}
 {{ end }}
@@ -53,7 +53,7 @@ spec:
             - name: test-config
               mountPath: /etc/e2e
             - name: test-secrets
-              mountPath: /etc/e2e-secrets
+              mountPath: {{ .Context.TestLicence | dir }}
           securityContext:
             allowPrivilegeEscalation: false
       volumes:

--- a/config/e2e/batch_job.yaml
+++ b/config/e2e/batch_job.yaml
@@ -1,48 +1,67 @@
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: "eck-{{ .Context.TestRun }}"
+  namespace: {{ .Context.E2ENamespace }}
+  labels:
+    test-run: {{ .Context.TestRun }}
+data:
+{{ range $key, $value := .Secrets.Data }}
+  {{ $key }}: |
+    {{ $value | b64enc }}
+{{ end }}
+
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "eck-{{ .TestRun }}"
-  namespace: {{ .E2ENamespace }}
+  name: "eck-{{ .Context.TestRun }}"
+  namespace: {{ .Context.E2ENamespace }}
   labels:
-    test-run: {{ .TestRun }}
+    test-run: {{ .Context.TestRun }}
 data:
   testcontext.json: |
-{{ . | toPrettyJson | indent 4 }}
+{{ .Context | toPrettyJson | indent 4 }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "eck-{{ .TestRun }}"
-  namespace: {{ .E2ENamespace }}
+  name: "eck-{{ .Context.TestRun }}"
+  namespace: {{ .Context.E2ENamespace }}
   labels:
-    test-run: {{ .TestRun }}
+    test-run: {{ .Context.TestRun }}
 spec:
   ttlSecondsAfterFinished: 360
   template:
     metadata:
       labels:
-        test-run: {{ .TestRun }}
+        test-run: {{ .Context.TestRun }}
     spec:
       securityContext:
         fsGroup: 101
         runAsNonRoot: true
         runAsUser: 101
         runAsGroup: 101
-      serviceAccountName: {{ .E2EServiceAccount }}
+      serviceAccountName: {{ .Context.E2EServiceAccount }}
       containers:
         - name: e2e
-          image: {{ .E2EImage }}
+          image: {{ .Context.E2EImage }}
           imagePullPolicy: IfNotPresent
-          args: [{{- if .TestRegex -}}"-run", "{{ .TestRegex }}",{{- end -}}"-args", "-testContextPath","/etc/e2e/testcontext.json"]
+          args: [{{- if .Context.TestRegex -}}"-run", "{{ .Context.TestRegex }}",{{- end -}}"-args", "-testContextPath","/etc/e2e/testcontext.json"]
           volumeMounts:
             - name: test-config
               mountPath: /etc/e2e
+            - name: test-secrets
+              mountPath: /etc/e2e-secrets
           securityContext:
             allowPrivilegeEscalation: false
       volumes:
         - name: test-config
           configMap:
-            name: "eck-{{ .TestRun }}"
+            name: "eck-{{ .Context.TestRun }}"
+        - name: test-secrets
+          secret:
+            secretName: "eck-{{ .Context.TestRun }}"
       restartPolicy: Never
   backoffLimit: 0 # don't retry a failed test

--- a/config/e2e/batch_job.yaml
+++ b/config/e2e/batch_job.yaml
@@ -53,7 +53,7 @@ spec:
             - name: test-config
               mountPath: /etc/e2e
             - name: test-secrets
-              mountPath: {{ .Context.TestLicense | dir }}
+              mountPath: /var/run/secrets/e2e
           securityContext:
             allowPrivilegeEscalation: false
       volumes:

--- a/config/e2e/batch_job.yaml
+++ b/config/e2e/batch_job.yaml
@@ -53,7 +53,7 @@ spec:
             - name: test-config
               mountPath: /etc/e2e
             - name: test-secrets
-              mountPath: {{ .Context.TestLicence | dir }}
+              mountPath: {{ .Context.TestLicense | dir }}
           securityContext:
             allowPrivilegeEscalation: false
       volumes:

--- a/test/e2e/cmd/run/command.go
+++ b/test/e2e/cmd/run/command.go
@@ -26,7 +26,7 @@ type runFlags struct {
 	kubeConfig          string
 	operatorImage       string
 	testContextOutPath  string
-	testLicence         string
+	testLicense         string
 	scratchDirRoot      string
 	testRegex           string
 	testRunName         string
@@ -73,7 +73,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&flags.operatorImage, "operator-image", "", "Operator image")
 	cmd.Flags().BoolVar(&flags.skipCleanup, "skip-cleanup", false, "Do not run cleanup actions after test run")
 	cmd.Flags().StringVar(&flags.testContextOutPath, "test-context-out", "", "Write the test context to the given path")
-	cmd.Flags().StringVar(&flags.testLicence, "test-licence", "", "Test licence to apply")
+	cmd.Flags().StringVar(&flags.testLicense, "test-license", "", "Test license to apply")
 	cmd.Flags().StringVar(&flags.scratchDirRoot, "scratch-dir", "/tmp/eck-e2e", "Path under which temporary files should be created")
 	cmd.Flags().StringVar(&flags.testRegex, "test-regex", "", "Regex to pass to the test runner")
 	cmd.Flags().StringVar(&flags.testRunName, "test-run-name", randomTestRunName(), "Name of this test run")

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -88,13 +88,9 @@ type helper struct {
 	eventLog       string
 	kubectlWrapper *command.Kubectl
 	testContext    test.Context
-	testSecrets    testSecrets
+	testSecrets    map[string]string
 	scratchDir     string
 	cleanupFuncs   []func()
-}
-
-type testSecrets struct {
-	Data map[string]string
 }
 
 func (h *helper) createScratchDir() error {
@@ -175,14 +171,14 @@ func (h *helper) initTestContext() error {
 }
 
 func (h *helper) initTestSecrets() error {
-	h.testSecrets = testSecrets{Data: map[string]string{}}
+	h.testSecrets = map[string]string{}
 	if h.testLicence != "" {
 		bytes, err := ioutil.ReadFile(h.testLicence)
 		if err != nil {
 			return err
 		}
-		h.testSecrets.Data["test-license.json"] = string(bytes)
-		h.testContext.TestLicence = "/etc/e2e-secrets/test-license.json"
+		h.testSecrets["test-license.json"] = string(bytes)
+		h.testContext.TestLicence = "/var/run/secrets/e2e/test-license.json"
 	}
 	return nil
 }
@@ -227,7 +223,7 @@ func (h *helper) deployTestJob() error {
 	log.Info("Deploying e2e test job")
 	return h.kubectlApplyTemplateWithCleanup("config/e2e/batch_job.yaml",
 		struct {
-			Secrets testSecrets
+			Secrets map[string]string
 			Context test.Context
 		}{
 			Secrets: h.testSecrets,

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -142,7 +142,7 @@ func (h *helper) initTestContext() error {
 			ManagedNamespaces: make([]string, len(h.managedNamespaces)),
 		},
 		OperatorImage: h.operatorImage,
-		TestLicence:   h.testLicence,
+		TestLicense:   h.testLicense,
 		TestRegex:     h.testRegex,
 		TestRun:       h.testRunName,
 		TestTimeout:   h.testTimeout,
@@ -172,13 +172,13 @@ func (h *helper) initTestContext() error {
 
 func (h *helper) initTestSecrets() error {
 	h.testSecrets = map[string]string{}
-	if h.testLicence != "" {
-		bytes, err := ioutil.ReadFile(h.testLicence)
+	if h.testLicense != "" {
+		bytes, err := ioutil.ReadFile(h.testLicense)
 		if err != nil {
 			return err
 		}
 		h.testSecrets["test-license.json"] = string(bytes)
-		h.testContext.TestLicence = "/var/run/secrets/e2e/test-license.json"
+		h.testContext.TestLicense = "/var/run/secrets/e2e/test-license.json"
 	}
 	return nil
 }

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -147,6 +148,14 @@ func (h *helper) initTestContext() error {
 
 	for i, ns := range h.managedNamespaces {
 		h.testContext.NamespaceOperator.ManagedNamespaces[i] = fmt.Sprintf("%s-%s", h.testRunName, ns)
+	}
+
+	if h.testLicence != "" {
+		bytes, err := ioutil.ReadFile(h.testLicence)
+		if err != nil {
+			return err
+		}
+		h.testContext.TestLicence = string(bytes)
 	}
 
 	// write the test context if required

--- a/test/e2e/es/license_test.go
+++ b/test/e2e/es/license_test.go
@@ -26,11 +26,11 @@ func TestEnterpriseLicenseSingle(t *testing.T) {
 
 	// create a single node cluster
 	esBuilder := elasticsearch.NewBuilder("test-es-license-provisioning").
-		WithESMasterNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	mutatedEsBuilder := esBuilder.
 		WithNoESTopology().
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	licenseTestContext := elasticsearch.NewLicenseTestContext(k, esBuilder.Elasticsearch)
 

--- a/test/e2e/es/license_test.go
+++ b/test/e2e/es/license_test.go
@@ -16,12 +16,12 @@ import (
 
 func TestEnterpriseLicenseSingle(t *testing.T) {
 	// only execute this test if we have a test license to work with
-	if test.Ctx().TestLicence == "" {
+	if test.Ctx().TestLicense == "" {
 		t.SkipNow()
 	}
 	k := test.NewK8sClientOrFatal()
 
-	licenseBytes, err := ioutil.ReadFile(test.Ctx().TestLicence)
+	licenseBytes, err := ioutil.ReadFile(test.Ctx().TestLicense)
 	require.NoError(t, err)
 
 	// create a single node cluster

--- a/test/e2e/es/license_test.go
+++ b/test/e2e/es/license_test.go
@@ -5,13 +5,11 @@
 package es
 
 import (
-	"io/ioutil"
 	"testing"
 
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/license"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
-	"github.com/stretchr/testify/require"
 )
 
 func TestEnterpriseLicenseSingle(t *testing.T) {
@@ -20,9 +18,6 @@ func TestEnterpriseLicenseSingle(t *testing.T) {
 		t.SkipNow()
 	}
 	k := test.NewK8sClientOrFatal()
-
-	licenseBytes, err := ioutil.ReadFile(test.Ctx().TestLicence)
-	require.NoError(t, err)
 
 	// create a single node cluster
 	esBuilder := elasticsearch.NewBuilder("test-es-license-provisioning").
@@ -43,7 +38,7 @@ func TestEnterpriseLicenseSingle(t *testing.T) {
 		WithStep(licenseTestContext.Init()).
 		WithSteps(test.StepList{
 			licenseTestContext.CheckElasticsearchLicense(license.ElasticsearchLicenseTypeBasic),
-			licenseTestContext.CreateEnterpriseLicenseSecret(licenseBytes),
+			licenseTestContext.CreateEnterpriseLicenseSecret([]byte(test.Ctx().TestLicence)),
 		}).
 		// Mutation shortcuts the license provisioning check...
 		WithSteps(mutatedEsBuilder.MutationTestSteps(k)).

--- a/test/e2e/es/license_test.go
+++ b/test/e2e/es/license_test.go
@@ -5,11 +5,13 @@
 package es
 
 import (
+	"io/ioutil"
 	"testing"
 
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/license"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEnterpriseLicenseSingle(t *testing.T) {
@@ -18,6 +20,9 @@ func TestEnterpriseLicenseSingle(t *testing.T) {
 		t.SkipNow()
 	}
 	k := test.NewK8sClientOrFatal()
+
+	licenseBytes, err := ioutil.ReadFile(test.Ctx().TestLicence)
+	require.NoError(t, err)
 
 	// create a single node cluster
 	esBuilder := elasticsearch.NewBuilder("test-es-license-provisioning").
@@ -38,7 +43,7 @@ func TestEnterpriseLicenseSingle(t *testing.T) {
 		WithStep(licenseTestContext.Init()).
 		WithSteps(test.StepList{
 			licenseTestContext.CheckElasticsearchLicense(license.ElasticsearchLicenseTypeBasic),
-			licenseTestContext.CreateEnterpriseLicenseSecret([]byte(test.Ctx().TestLicence)),
+			licenseTestContext.CreateEnterpriseLicenseSecret(licenseBytes),
 		}).
 		// Mutation shortcuts the license provisioning check...
 		WithSteps(mutatedEsBuilder.MutationTestSteps(k)).

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -88,7 +88,7 @@ type Context struct {
 	ElasticStackVersion string            `json:"elastic_stack_version"`
 	LogVerbosity        int               `json:"log_verbosity"`
 	OperatorImage       string            `json:"operator_image"`
-	TestLicence         string            `json:"test_licence"`
+	TestLicense         string            `json:"test_license"`
 	TestRegex           string            `json:"test_regex"`
 	TestRun             string            `json:"test_run"`
 	TestTimeout         time.Duration     `json:"test_timeout"`


### PR DESCRIPTION
This PR enables the license e2e test on CI. It introduces a Kubernetes secret to the test job and  some changes to the e2e run command to facilitate the mounting of (license) secrets into the e2e test job