### PR TITLE
Add webhook Secret and ValidatingWebhookConfiguration certificate management

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/webhook"
-
 	// allow gcp authentication
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
@@ -29,6 +27,7 @@ import (
 	kbassn "github.com/elastic/cloud-on-k8s/pkg/controller/kibanaassociation"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/license"
 	licensetrial "github.com/elastic/cloud-on-k8s/pkg/controller/license/trial"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/webhook"
 	"github.com/elastic/cloud-on-k8s/pkg/dev"
 	"github.com/elastic/cloud-on-k8s/pkg/dev/portforward"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/net"

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -125,7 +125,7 @@ func init() {
 	Cmd.Flags().Bool(
 		ManageWebhookCertsFlag,
 		true,
-		"enables automatic certificates management for the webhook, the Secret and the ValidatingWebhookConfiguration must be created before running the operator",
+		"enables automatic certificates management for the webhook. The Secret and the ValidatingWebhookConfiguration must be created before running the operator",
 	)
 	Cmd.Flags().String(
 		OperatorNamespaceFlag,

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -56,7 +56,7 @@ const (
 
 	OperatorNamespaceFlag = "operator-namespace"
 
-	SetupWebhookCertsFlag    = "setup-webhook-certs"
+	ManageWebhookCertsFlag   = "manage-webhook-certs"
 	WebhookSecretFlag        = "webhook-secret"
 	WebhookConfigurationName = "elastic-webhook.k8s.elastic.co"
 	WebhookPort              = 9443
@@ -123,7 +123,7 @@ func init() {
 		"Duration representing how long before expiration TLS certificates should be reissued",
 	)
 	Cmd.Flags().Bool(
-		SetupWebhookCertsFlag,
+		ManageWebhookCertsFlag,
 		true,
 		"enables automatic certificates management for the webhook, the Secret and the ValidatingWebhookConfiguration must be created before running the operator",
 	)
@@ -335,8 +335,8 @@ func ValidateCertExpirationFlags(validityFlag string, rotateBeforeFlag string) (
 }
 
 func setupWebhook(mgr manager.Manager, certRotation certificates.RotationParams, clientset kubernetes.Interface) {
-	setupWebhookCerts := viper.GetBool(SetupWebhookCertsFlag)
-	if setupWebhookCerts {
+	manageWebhookCerts := viper.GetBool(ManageWebhookCertsFlag)
+	if manageWebhookCerts {
 		log.Info("Automatic management of the webhook certificates enabled")
 		// Ensure that all the certificates needed by the webhook server are already created
 		webhookParams := webhook.Params{

--- a/config/operator/all-in-one/operator.template.yaml
+++ b/config/operator/all-in-one/operator.template.yaml
@@ -28,7 +28,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: WEBHOOK_SECRET
-            value: webhook-server-secret
+            value: elastic-webhook-server-cert
           - name: WEBHOOK_PODS_LABEL
             value: elastic-operator
           - name: OPERATOR_IMAGE
@@ -41,7 +41,16 @@ spec:
             cpu: 100m
             memory: 50Mi
         ports:
-        - containerPort: 9876
+        - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        volumeMounts:
+          - mountPath: /tmp/k8s-webhook-server/serving-certs
+            name: cert
+            readOnly: true
       terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: elastic-webhook-server-cert

--- a/config/operator/all-in-one/webhook.template.yaml
+++ b/config/operator/all-in-one/webhook.template.yaml
@@ -1,0 +1,1 @@
+../global/webhook.template.yaml

--- a/config/operator/global/operator.template.yaml
+++ b/config/operator/global/operator.template.yaml
@@ -28,7 +28,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: WEBHOOK_SECRET
-            value: webhook-server-secret
+            value: elastic-webhook-server-cert
           - name: WEBHOOK_PODS_LABEL
             value: elastic-global-operator
           - name: OPERATOR_IMAGE
@@ -41,8 +41,17 @@ spec:
             cpu: 100m
             memory: 20Mi
         ports:
-        - containerPort: 9876
+        - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        volumeMounts:
+          - mountPath: /tmp/k8s-webhook-server/serving-certs
+            name: cert
+            readOnly: true
       terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: elastic-webhook-server-cert
 

--- a/config/operator/global/webhook.template.yaml
+++ b/config/operator/global/webhook.template.yaml
@@ -1,0 +1,42 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: elastic-webhook.k8s.elastic.co
+webhooks:
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: elastic-webhook-server
+        namespace: <NAMESPACE>
+        # this is the path controller-runtime automatically generates
+        path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
+    failurePolicy: Ignore
+    name: elastic-es-validation.k8s.elastic.co
+    rules:
+      - apiGroups:
+          - elasticsearch.k8s.elastic.co
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - elasticsearches
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elastic-webhook-server
+  namespace: <NAMESPACE>
+spec:
+  ports:
+    - port: 443
+      targetPort: 9443
+  selector:
+    control-plane: elastic-operator
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: elastic-webhook-server-cert
+  namespace: <NAMESPACE>

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -13,7 +13,7 @@ webhooks:
       namespace: system
       path: /validate-elasticsearch
   failurePolicy: Ignore
-  name: elastic-es-validation
+  name: elastic-es-validation.k8s.elastic.co
   rules:
   - apiGroups:
     - elasticsearch.k8s.elastic.co

--- a/pkg/apis/elasticsearch/v1beta1/webhook.go
+++ b/pkg/apis/elasticsearch/v1beta1/webhook.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-// +kubebuilder:webhook:path=/validate-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1beta1,name=elastic-es-validation
+// +kubebuilder:webhook:path=/validate-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1beta1,name=elastic-es-validation.k8s.elastic.co
 
 func (r *Elasticsearch) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).

--- a/pkg/controller/common/certificates/ca_reconcile.go
+++ b/pkg/controller/common/certificates/ca_reconcile.go
@@ -70,14 +70,14 @@ func ReconcileCAForOwner(
 	}
 
 	// build CA
-	ca := buildCAFromSecret(caInternalSecret)
+	ca := BuildCAFromSecret(caInternalSecret)
 	if ca == nil {
 		log.Info("Cannot build CA from secret, creating a new one", "owner_namespace", owner.GetNamespace(), "owner_name", owner.GetName(), "ca_type", caType)
 		return renewCA(cl, namer, owner, labels, rotationParams.Validity, scheme, caType)
 	}
 
 	// renew if cannot reuse
-	if !canReuseCA(ca, rotationParams.RotateBefore) {
+	if !CanReuseCA(ca, rotationParams.RotateBefore) {
 		log.Info("Cannot reuse existing CA, creating a new one", "owner_namespace", owner.GetNamespace(), "owner_name", owner.GetName(), "ca_type", caType)
 		return renewCA(cl, namer, owner, labels, rotationParams.Validity, scheme, caType)
 	}
@@ -125,14 +125,14 @@ func renewCA(
 	return ca, nil
 }
 
-// canReuseCA returns true if the given CA is valid for reuse
-func canReuseCA(ca *CA, expirationSafetyMargin time.Duration) bool {
-	return PrivateMatchesPublicKey(ca.Cert.PublicKey, *ca.PrivateKey) && certIsValid(*ca.Cert, expirationSafetyMargin)
+// CanReuseCA returns true if the given CA is valid for reuse
+func CanReuseCA(ca *CA, expirationSafetyMargin time.Duration) bool {
+	return PrivateMatchesPublicKey(ca.Cert.PublicKey, *ca.PrivateKey) && CertIsValid(*ca.Cert, expirationSafetyMargin)
 }
 
-// certIsValid returns true if the given cert is valid,
+// CertIsValid returns true if the given cert is valid,
 // according to a safety time margin.
-func certIsValid(cert x509.Certificate, expirationSafetyMargin time.Duration) bool {
+func CertIsValid(cert x509.Certificate, expirationSafetyMargin time.Duration) bool {
 	now := time.Now()
 	if now.Before(cert.NotBefore) {
 		log.Info("CA cert is not valid yet", "subject", cert.Subject)
@@ -166,9 +166,9 @@ func internalSecretForCA(
 	}
 }
 
-// buildCAFromSecret parses the given secret into a CA.
+// BuildCAFromSecret parses the given secret into a CA.
 // It returns nil if the secrets could not be parsed into a CA.
-func buildCAFromSecret(caInternalSecret corev1.Secret) *CA {
+func BuildCAFromSecret(caInternalSecret corev1.Secret) *CA {
 	if caInternalSecret.Data == nil {
 		return nil
 	}

--- a/pkg/controller/common/certificates/ca_reconcile_test.go
+++ b/pkg/controller/common/certificates/ca_reconcile_test.go
@@ -87,8 +87,8 @@ func Test_certIsValid(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := certIsValid(tt.cert, tt.safetyMargin); got != tt.want {
-				t.Errorf("certIsValid() = %v, want %v", got, tt.want)
+			if got := CertIsValid(tt.cert, tt.safetyMargin); got != tt.want {
+				t.Errorf("CertIsValid() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -134,8 +134,8 @@ func Test_canReuseCA(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := canReuseCA(tt.ca(), DefaultRotateBefore); got != tt.want {
-				t.Errorf("canReuseCA() = %v, want %v", got, tt.want)
+			if got := CanReuseCA(tt.ca(), DefaultRotateBefore); got != tt.want {
+				t.Errorf("CanReuseCA() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -152,7 +152,7 @@ func checkCASecrets(
 	expectedExpiration time.Duration,
 ) {
 	// ca cert should be valid
-	require.True(t, certIsValid(*ca.Cert, DefaultRotateBefore))
+	require.True(t, CertIsValid(*ca.Cert, DefaultRotateBefore))
 
 	// expiration date should be correctly set
 	require.True(t, ca.Cert.NotBefore.After(time.Now().Add(-1*time.Hour)))
@@ -181,7 +181,7 @@ func checkCASecrets(
 	require.NotEmpty(t, internalCASecret.Data[KeyFileName])
 
 	// secret should be ok to parse as a CA
-	parsedCa := buildCAFromSecret(internalCASecret)
+	parsedCa := BuildCAFromSecret(internalCASecret)
 	require.NotNil(t, parsedCa)
 	// and return the ca
 	require.True(t, ca.Cert.Equal(parsedCa.Cert))
@@ -377,7 +377,7 @@ func Test_buildCAFromSecret(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ca := buildCAFromSecret(tt.internalSecret)
+			ca := BuildCAFromSecret(tt.internalSecret)
 			if !reflect.DeepEqual(ca, tt.wantCa) {
 				t.Errorf("CaFromSecrets() got = %v, want %v", ca, tt.wantCa)
 			}

--- a/pkg/controller/webhook/cert.go
+++ b/pkg/controller/webhook/cert.go
@@ -1,0 +1,126 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package webhook
+
+import (
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"time"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// WebhookCertificates holds the artifacts used by the webhook server and the webhook configuration.
+type WebhookCertificates struct {
+	caCert []byte
+
+	serverKey  []byte
+	serverCert []byte
+}
+
+func (w *Params) shouldRenewCertificates(serverCertificates *corev1.Secret, webhookConfiguration *v1beta1.ValidatingWebhookConfiguration) bool {
+	// Read the current certificate used by the server
+	serverCA := certificates.BuildCAFromSecret(*serverCertificates)
+	if serverCA == nil {
+		return true
+	}
+	if !certificates.CanReuseCA(serverCA, w.Rotation.RotateBefore) {
+		return true
+	}
+	// Read the certificate in the webhook configuration
+	for _, webhook := range webhookConfiguration.Webhooks {
+		caBytes := webhook.ClientConfig.CABundle
+		if len(caBytes) == 0 {
+			return true
+		}
+		// Parse the certificates
+		certs, err := certificates.ParsePEMCerts(caBytes)
+		if err != nil {
+			log.Error(err, "Cannot parse PEM cert from webhook configuration, will create a new one", "webhook_name", webhookConfiguration.Name)
+			return true
+		}
+		if len(certs) == 0 {
+			return true
+		}
+		for _, cert := range certs {
+			if !certificates.CertIsValid(*cert, w.Rotation.RotateBefore) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (w *Params) newCertificates() (WebhookCertificates, error) {
+	webhookCertificates := WebhookCertificates{}
+
+	// Create a new CA
+	ca, err := certificates.NewSelfSignedCA(certificates.CABuilderOptions{
+		Subject: pkix.Name{
+			CommonName:         "elastic-webhook-ca",
+			OrganizationalUnit: []string{"elastic-webhook"},
+		},
+		ExpireIn: &w.Rotation.Validity,
+	})
+	if err != nil {
+		return webhookCertificates, err
+	}
+	webhookCertificates.caCert = certificates.EncodePEMCert(ca.Cert.Raw)
+
+	// Create a new certificate for the webhook server
+	privateKey, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+	if err != nil {
+		return webhookCertificates, err
+	}
+	webhookCertificates.serverKey = certificates.EncodePEMPrivateKey(*privateKey)
+
+	csr, err := x509.CreateCertificateRequest(cryptorand.Reader, &x509.CertificateRequest{}, privateKey)
+	if err != nil {
+		return webhookCertificates, err
+	}
+	parsedCSR, err := x509.ParseCertificateRequest(csr)
+	if err != nil {
+		return webhookCertificates, err
+	}
+
+	certificateTemplate := certificates.ValidatedCertificateTemplate(x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:         "elastic-webhook",
+			OrganizationalUnit: []string{"elastic-webhook"},
+		},
+
+		DNSNames: k8s.GetServiceDNSName(corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: w.Namespace,
+				Name:      w.ServerDomainName,
+			},
+		}),
+
+		NotBefore: time.Now().Add(-10 * time.Minute),
+		NotAfter:  time.Now().Add(w.Rotation.Validity),
+
+		PublicKeyAlgorithm: parsedCSR.PublicKeyAlgorithm,
+		PublicKey:          parsedCSR.PublicKey,
+
+		Signature:          parsedCSR.Signature,
+		SignatureAlgorithm: parsedCSR.SignatureAlgorithm,
+
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	})
+
+	cert, err := ca.CreateCertificate(certificateTemplate)
+	if err != nil {
+		return webhookCertificates, err
+	}
+	webhookCertificates.serverCert = certificates.EncodePEMCert(cert)
+	return webhookCertificates, nil
+}

--- a/pkg/controller/webhook/reconcile.go
+++ b/pkg/controller/webhook/reconcile.go
@@ -14,7 +14,6 @@ import (
 type Params struct {
 	Namespace                string
 	SecretName               string
-	ServerDomainName         string
 	WebhookConfigurationName string
 
 	// Certificate options
@@ -40,6 +39,12 @@ func (w *Params) ReconcileResources(clientset kubernetes.Interface) error {
 
 	// check if we need to renew the certificates used in the resources
 	if w.shouldRenewCertificates(webhookServerSecret, webhookConfiguration) {
+		log.Info(
+			"Creating new webhook certificates",
+			"webhook", webhookConfiguration.Name,
+			"secret_namespace", webhookServerSecret.Namespace,
+			"secret_name", webhookServerSecret.Name,
+		)
 		newCertificates, err := w.newCertificates()
 		if err != nil {
 			return err

--- a/pkg/controller/webhook/reconcile.go
+++ b/pkg/controller/webhook/reconcile.go
@@ -1,0 +1,66 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package webhook
+
+import (
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Params are params to create and manage the webhook resources (Cert secret and ValidatingWebhookConfiguration)
+type Params struct {
+	Namespace                string
+	SecretName               string
+	ServerDomainName         string
+	WebhookConfigurationName string
+
+	// Certificate options
+	Rotation certificates.RotationParams
+}
+
+// ReconcileResources reconciles the certificates used by the webhook client and the webhook server.
+// It also returns the duration after which a certificate rotation should be scheduled.
+func (w *Params) ReconcileResources(clientset kubernetes.Interface) error {
+	// retrieve current webhook server cert secret
+	webhookServerSecret, err := clientset.CoreV1().Secrets(w.Namespace).Get(w.SecretName, metav1.GetOptions{})
+	if err != nil {
+		// 404 is still considered as an error, webhook secret is expected to be created before the operator is started
+		return err
+	}
+
+	// retrieve the current webhook configuration
+	webhookConfiguration, err := clientset.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(w.WebhookConfigurationName, metav1.GetOptions{})
+	if err != nil {
+		// 404 is also considered as an error, webhook configuration is expected to be created before the operator is started
+		return err
+	}
+
+	// check if we need to renew the certificates used in the resources
+	if w.shouldRenewCertificates(webhookServerSecret, webhookConfiguration) {
+		newCertificates, err := w.newCertificates()
+		if err != nil {
+			return err
+		}
+		// update the webhook configuration
+		for i := range webhookConfiguration.Webhooks {
+			webhookConfiguration.Webhooks[i].ClientConfig.CABundle = newCertificates.caCert
+		}
+		if _, err := clientset.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Update(webhookConfiguration); err != nil {
+			return err
+		}
+
+		// update server secret
+		webhookServerSecret.Data = map[string][]byte{
+			certificates.CertFileName: newCertificates.serverCert,
+			certificates.KeyFileName:  newCertificates.serverKey,
+		}
+		if _, err := clientset.CoreV1().Secrets(w.Namespace).Update(webhookServerSecret); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/webhook/reconcile_test.go
+++ b/pkg/controller/webhook/reconcile_test.go
@@ -17,16 +17,11 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-const (
-	sampleServiceName = "elastic-webhook-server"
-)
-
 func TestParams_ReconcileResources(t *testing.T) {
 
 	w := Params{
 		Namespace:                "elastic-system",
 		SecretName:               "elastic-webhook-server-cert",
-		ServerDomainName:         sampleServiceName,
 		WebhookConfigurationName: "elastic-webhook.k8s.elastic.co",
 		Rotation: certificates.RotationParams{
 			Validity:     certificates.DefaultCertValidity,

--- a/pkg/controller/webhook/reconcile_test.go
+++ b/pkg/controller/webhook/reconcile_test.go
@@ -24,9 +24,9 @@ const (
 func TestParams_ReconcileResources(t *testing.T) {
 
 	w := Params{
-		Namespace:  "elastic-system",
-		SecretName: "elastic-webhook-server-cert",
-		//ServerDomainName:              sampleServiceName,
+		Namespace:                "elastic-system",
+		SecretName:               "elastic-webhook-server-cert",
+		ServerDomainName:         sampleServiceName,
 		WebhookConfigurationName: "elastic-webhook.k8s.elastic.co",
 		Rotation: certificates.RotationParams{
 			Validity:     certificates.DefaultCertValidity,
@@ -108,7 +108,7 @@ func verifyCertificates(t *testing.T, rootCert []byte, serverCert []byte) {
 	cert, err := x509.ParseCertificate(block.Bytes)
 	assert.NoError(t, err)
 	opts := x509.VerifyOptions{
-		DNSName: ServerCertCommonName,
+		DNSName: "elastic-webhook-server.elastic-system.svc",
 		Roots:   ca,
 	}
 	_, err = cert.Verify(opts)

--- a/pkg/controller/webhook/reconcile_test.go
+++ b/pkg/controller/webhook/reconcile_test.go
@@ -1,0 +1,116 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package webhook
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	sampleServiceName = "elastic-webhook-server"
+)
+
+func TestParams_ReconcileResources(t *testing.T) {
+
+	w := Params{
+		Namespace:  "elastic-system",
+		SecretName: "elastic-webhook-server-cert",
+		//ServerDomainName:              sampleServiceName,
+		WebhookConfigurationName: "elastic-webhook.k8s.elastic.co",
+		Rotation: certificates.RotationParams{
+			Validity:     certificates.DefaultCertValidity,
+			RotateBefore: certificates.DefaultRotateBefore,
+		},
+	}
+
+	clientset :=
+		fake.NewSimpleClientset(
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "elastic-system",
+					Name:      "elastic-webhook-server-cert",
+				},
+			},
+			&v1beta1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "elastic-webhook.k8s.elastic.co",
+				},
+				Webhooks: []v1beta1.ValidatingWebhook{
+					{
+						Name:         "elastic-es-validation.k8s.elastic.co",
+						ClientConfig: v1beta1.WebhookClientConfig{},
+					},
+				},
+			},
+		)
+
+	if err := w.ReconcileResources(clientset); err != nil {
+		t.Errorf("Params.ReconcileResources() error = %v", err)
+	}
+
+	// Secret and ValidatingWebhookConfiguration must have been filled with the certificates
+	// retrieve current webhook server cert secret
+	webhookServerSecret, err := clientset.CoreV1().Secrets(w.Namespace).Get(w.SecretName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(webhookServerSecret.Data))
+
+	// retrieve the current webhook configuration
+	webhookConfiguration, err := clientset.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(w.WebhookConfigurationName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	caBundle := webhookConfiguration.Webhooks[0].ClientConfig.CABundle
+	assert.True(t, len(caBundle) > 0)
+
+	// Check that the cert in the secret has been signed by the caBundle
+	verifyCertificates(t, caBundle, webhookServerSecret.Data["tls.crt"])
+
+	// Delete the content of the secret, certificates should be recreated
+	webhookServerSecret.Data = map[string][]byte{}
+	_, err = clientset.CoreV1().Secrets(w.Namespace).Update(webhookServerSecret)
+	assert.NoError(t, err)
+	webhookServerSecret, err = clientset.CoreV1().Secrets(w.Namespace).Get(w.SecretName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(webhookServerSecret.Data))
+
+	if err := w.ReconcileResources(clientset); err != nil {
+		t.Errorf("Params.ReconcileResources() error = %v", err)
+	}
+
+	webhookServerSecret, err = clientset.CoreV1().Secrets(w.Namespace).Get(w.SecretName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(webhookServerSecret.Data))
+
+	// retrieve the new ca
+	webhookConfiguration, err = clientset.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(w.WebhookConfigurationName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	caBundle = webhookConfiguration.Webhooks[0].ClientConfig.CABundle
+	// Check again that the cert in the secret has been signed by the caBundle
+	verifyCertificates(t, caBundle, webhookServerSecret.Data["tls.crt"])
+
+}
+
+func verifyCertificates(t *testing.T, rootCert []byte, serverCert []byte) {
+	ca := x509.NewCertPool()
+	ok := ca.AppendCertsFromPEM(rootCert)
+	assert.True(t, ok)
+	block, _ := pem.Decode(serverCert)
+	assert.NotNil(t, block)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	assert.NoError(t, err)
+	opts := x509.VerifyOptions{
+		DNSName: ServerCertCommonName,
+		Roots:   ca,
+	}
+	_, err = cert.Verify(opts)
+	assert.NoError(t, err)
+}

--- a/pkg/controller/webhook/webhook_certificates_controller.go
+++ b/pkg/controller/webhook/webhook_certificates_controller.go
@@ -1,0 +1,114 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package webhook
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	ControllerName = "webhook-certificates-controller"
+)
+
+var log = logf.Log.WithName(ControllerName)
+
+var _ reconcile.Reconciler = &ReconcileWebhookResources{}
+
+// ReconcileWebhookResources reconciles the certificates used by the webhook server.
+type ReconcileWebhookResources struct {
+	// k8s.Client is used to watch resources
+	k8s.Client
+	// iteration is the number of times this controller has run its Reconcile method
+	iteration uint64
+
+	// webhook parameters
+	webhookParams Params
+	// resources are updated with a native Kubernetes client
+	clientset kubernetes.Interface
+}
+
+func (r *ReconcileWebhookResources) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	defer common.LogReconciliationRun(log, request, &r.iteration)()
+	if err := r.webhookParams.ReconcileResources(r.clientset); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Get the latest content of the webhook CA
+	webhookServerSecret, err := r.clientset.CoreV1().Secrets(r.webhookParams.Namespace).Get(r.webhookParams.SecretName, metav1.GetOptions{})
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	serverCA := certificates.BuildCAFromSecret(*webhookServerSecret)
+	if serverCA == nil {
+		return reconcile.Result{}, fmt.Errorf("cannot find CA in webhook secret %s/%s", r.webhookParams.Namespace, r.webhookParams.SecretName)
+	}
+
+	return reconcile.Result{
+		RequeueAfter: certificates.ShouldRotateIn(time.Now(), serverCA.Cert.NotAfter, r.webhookParams.Rotation.RotateBefore),
+	}, nil
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager, webhookParams Params, clientset kubernetes.Interface) *ReconcileWebhookResources {
+	c := k8s.WrapClient(mgr.GetClient())
+	return &ReconcileWebhookResources{
+		Client:        c,
+		webhookParams: webhookParams,
+		clientset:     clientset,
+	}
+}
+
+// Add adds a new Controller to mgr with r as the reconcile.Reconciler
+func Add(mgr manager.Manager, webhookParams Params, clientset kubernetes.Interface) error {
+	r := newReconciler(mgr, webhookParams, clientset)
+	// Create a new controller
+	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	secret := types.NamespacedName{
+		Namespace: webhookParams.Namespace,
+		Name:      webhookParams.SecretName,
+	}
+
+	if err := c.Watch(&source.Kind{Type: &corev1.Secret{}}, &watches.NamedWatch{
+		Name:    "webhook-server-cert",
+		Watched: []types.NamespacedName{secret},
+		Watcher: secret,
+	}); err != nil {
+		return err
+	}
+
+	webhookConfiguration := types.NamespacedName{
+		Name: webhookParams.WebhookConfigurationName,
+	}
+
+	if err := c.Watch(&source.Kind{Type: &v1beta1.ValidatingWebhookConfiguration{}}, &watches.NamedWatch{
+		Name:    "validatingwebhookconfiguration",
+		Watched: []types.NamespacedName{webhookConfiguration},
+		Watcher: webhookConfiguration,
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/controller/webhook/webhook_certificates_controller.go
+++ b/pkg/controller/webhook/webhook_certificates_controller.go
@@ -48,11 +48,11 @@ type ReconcileWebhookResources struct {
 
 func (r *ReconcileWebhookResources) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	defer common.LogReconciliationRun(log, request, &r.iteration)()
-	res := r.reconcileInternal(request)
+	res := r.reconcileInternal()
 	return res.Aggregate()
 }
 
-func (r *ReconcileWebhookResources) reconcileInternal(request reconcile.Request) *reconciler.Results {
+func (r *ReconcileWebhookResources) reconcileInternal() *reconciler.Results {
 	res := &reconciler.Results{}
 	if err := r.webhookParams.ReconcileResources(r.clientset); err != nil {
 		return res.WithError(err)


### PR DESCRIPTION
This pr automatically fills the Secret and the ValidatingWebhookConfiguration of the webhook with some certificates.

A few notes:
* since the Secret and the ValidatingWebhookConfiguration must be setup before the manager is started this code use a "native" K8S client.
* a controller is started to watch the content of the resources and trigger an update before the certificates expire.
* contrary to what I said a CA is setup and is used to sign the webhook server certificate. The secret key of the CA is not kept, a new one is created if needed.

TODO: 
- [X] still need to do some tests with the cert. manager - *it works, user can switch to a "self-managed" certificates to a "cert manager" scenario*
- [ ] update the already opened pr
- [ ] it needs follow-up pr is to add some documentations.