### PR TITLE
Fix E2E tests job definitions

### DIFF
--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -1,5 +1,5 @@
 def failedTests = []
-def testScript
+def lib
 
 pipeline {
 
@@ -22,7 +22,7 @@ pipeline {
         stage('Load common scripts') {
             steps {
                 script {
-                    testScript = load "build/ci/common/tests.groovy"
+                    lib = load "build/ci/common/tests.groovy"
                 }
             }
         }
@@ -35,7 +35,7 @@ pipeline {
                     steps {
                         checkout scm
                         script {
-                            runWith(failedTests, '1.12', "eck-gke12-${BUILD_NUMBER}-e2e")
+                            runWith(lib, failedTests, '1.12', "eck-gke12-${BUILD_NUMBER}-e2e")
                         }
                     }
                 }
@@ -46,7 +46,7 @@ pipeline {
                     steps {
                         checkout scm
                         script {
-                            runWith(failedTests, '1.13', "eck-gke13-${BUILD_NUMBER}-e2e")
+                            runWith(lib, failedTests, '1.13', "eck-gke13-${BUILD_NUMBER}-e2e")
                         }
                     }
                 }
@@ -57,7 +57,7 @@ pipeline {
                     steps {
                         checkout scm
                         script {
-                            runWith(failedTests, '1.14', "eck-gke14-${BUILD_NUMBER}-e2e")
+                            runWith(lib, failedTests, '1.14', "eck-gke14-${BUILD_NUMBER}-e2e")
                         }
                     }
                 }
@@ -71,7 +71,7 @@ pipeline {
                 if (params.SEND_NOTIFICATIONS) {
                     Set<String> filter = new HashSet<>()
                     filter.addAll(failedTests)
-                    def msg = testScript.generateSlackMessage("E2E tests for different k8s versions in GKE failed!", env.BUILD_URL, filter)
+                    def msg = lib.generateSlackMessage("E2E tests for different k8s versions in GKE failed!", env.BUILD_URL, filter)
 
                     slackSend botUser: true,
                         channel: '#cloud-k8s',
@@ -100,7 +100,7 @@ pipeline {
     }
 }
 
-def runWith(failedTests, clusterVersion, clusterName) {
+def runWith(lib, failedTests, clusterVersion, clusterName) {
     sh """#!/bin/bash
 
         cat >.env <<EOF
@@ -137,7 +137,7 @@ EOF
         junit "e2e-tests.xml"
 
         if (env.SHELL_EXIT_CODE != 0) {
-            failedTests.addAll(testScript.getListOfFailedTests())
+            failedTests.addAll(lib.getListOfFailedTests())
         }
 
         sh 'exit $SHELL_EXIT_CODE'

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -1,5 +1,5 @@
 def failedTests = []
-def testScript
+def lib
 
 pipeline {
 
@@ -22,7 +22,7 @@ pipeline {
         stage('Load common scripts') {
             steps {
                 script {
-                    testScript = load "build/ci/common/tests.groovy"
+                    lib = load "build/ci/common/tests.groovy"
                 }
             }
         }
@@ -32,7 +32,7 @@ pipeline {
                     steps {
                         checkout scm
                         script {
-                            runWith(failedTests, "eck-68-${BUILD_NUMBER}-e2e", "6.8.4")
+                            runWith(lib, failedTests, "eck-68-${BUILD_NUMBER}-e2e", "6.8.4")
                         }
                     }
                 }
@@ -43,7 +43,7 @@ pipeline {
                     steps {
                         checkout scm
                         script {
-                            runWith(failedTests, "eck-71-${BUILD_NUMBER}-e2e", "7.1.1")
+                            runWith(lib, failedTests, "eck-71-${BUILD_NUMBER}-e2e", "7.1.1")
                         }
                     }
                 }
@@ -54,7 +54,7 @@ pipeline {
                     steps {
                         checkout scm
                         script {
-                            runWith(failedTests, "eck-72-${BUILD_NUMBER}-e2e", "7.2.1")
+                            runWith(lib, failedTests, "eck-72-${BUILD_NUMBER}-e2e", "7.2.1")
                         }
                     }
                 }
@@ -65,7 +65,7 @@ pipeline {
                     steps {
                         checkout scm
                         script {
-                            runWith(failedTests, "eck-73-${BUILD_NUMBER}-e2e", "7.3.2")
+                            runWith(lib, failedTests, "eck-73-${BUILD_NUMBER}-e2e", "7.3.2")
                         }
                     }
                 }
@@ -76,7 +76,7 @@ pipeline {
                     steps {
                         checkout scm
                         script {
-                            runWith(failedTests, "eck-74-${BUILD_NUMBER}-e2e", "7.4.1")
+                            runWith(lib, failedTests, "eck-74-${BUILD_NUMBER}-e2e", "7.4.1")
                         }
                     }
                 }
@@ -90,7 +90,7 @@ pipeline {
                 if (params.SEND_NOTIFICATIONS) {
                     Set<String> filter = new HashSet<>()
                     filter.addAll(failedTests)
-                    def msg = testScript.generateSlackMessage("E2E tests for different Elastic stack versions failed!", env.BUILD_URL, filter)
+                    def msg = lib.generateSlackMessage("E2E tests for different Elastic stack versions failed!", env.BUILD_URL, filter)
 
                     slackSend botUser: true,
                         channel: '#cloud-k8s',
@@ -120,7 +120,7 @@ pipeline {
 
 }
 
-def runWith(failedTests, clusterName, stackVersion) {
+def runWith(lib, failedTests, clusterName, stackVersion) {
     sh """
         cat >.env <<EOF
 OPERATOR_IMAGE = "${IMAGE}"
@@ -152,7 +152,7 @@ EOF
         junit "e2e-tests.xml"
 
         if (env.SHELL_EXIT_CODE != 0) {
-            failedTests.addAll(testScript.getListOfFailedTests())
+            failedTests.addAll(lib.getListOfFailedTests())
         }
 
         sh 'exit $SHELL_EXIT_CODE'


### PR DESCRIPTION
Temporary workaround to fix the E2E tests job definitions:
- pass the loaded lib in parameter to runWith

Longer-term solution could be to move and factorize runWith method in the common library.

Follow-up #2114.