### PR TITLE
Pods upgrade: log a summary of failed predicates

### DIFF
--- a/pkg/controller/elasticsearch/driver/upgrade_pods_deletion.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_pods_deletion.go
@@ -34,6 +34,7 @@ func (ctx *rollingUpgradeCtx) Delete() ([]corev1.Pod, error) {
 
 	// Step 2: Apply predicates
 	predicateContext := NewPredicateContext(
+		ctx.ES,
 		ctx.esState,
 		ctx.shardLister,
 		ctx.healthyPods,
@@ -171,23 +172,24 @@ func deletePod(k8sClient k8s.Client, es v1beta1.Elasticsearch, pod corev1.Pod, e
 	return nil
 }
 
+// runPredicates runs all the predicates on a given Pod. Result is non nil if a predicate has failed.
+// The second error is non nil if one of the predicate encountered an internal error.
 func runPredicates(
 	ctx PredicateContext,
 	candidate corev1.Pod,
 	deletedPods []corev1.Pod,
 	maxUnavailableReached bool,
-) (bool, error) {
+) (*failedPredicate, error) {
 	for _, predicate := range predicates {
 		canDelete, err := predicate.fn(ctx, candidate, deletedPods, maxUnavailableReached)
 		if err != nil {
-			return false, err
+			return nil, err
 		}
 		if !canDelete {
-			log.Info("Predicate failed", "pod_name", candidate.Name, "predicate_name", predicate.name)
 			// Skip this Pod, it can't be deleted for the moment
-			return false, nil
+			return newFailedPredicate(candidate.Name, predicate.name), nil
 		}
 	}
 	// All predicates passed!
-	return true, nil
+	return nil, nil
 }

--- a/pkg/controller/elasticsearch/driver/upgrade_pods_deletion.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_pods_deletion.go
@@ -187,7 +187,10 @@ func runPredicates(
 		}
 		if !canDelete {
 			// Skip this Pod, it can't be deleted for the moment
-			return newFailedPredicate(candidate.Name, predicate.name), nil
+			return &failedPredicate{
+				pod:       candidate.Name,
+				predicate: predicate.name,
+			}, nil
 		}
 	}
 	// All predicates passed!

--- a/pkg/controller/elasticsearch/driver/upgrade_predicates.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_predicates.go
@@ -34,13 +34,6 @@ type failedPredicate struct {
 	predicate string
 }
 
-func newFailedPredicate(pod, predicate string) *failedPredicate {
-	return &failedPredicate{
-		pod:       pod,
-		predicate: predicate,
-	}
-}
-
 type failedPredicates []failedPredicate
 
 // groupByPredicates groups by predicates the pods that can't be upgraded.
@@ -106,10 +99,10 @@ Loop:
 	// the user to understand why.
 	if len(failedPredicates) > 0 {
 		log.Info(
-			"Nodes can't be upgraded",
+			"Cannot restart some nodes for upgrade at this time",
 			"namespace", ctx.es.Namespace,
 			"es_name", ctx.es.Name,
-			"failedPredicates", groupByPredicates(failedPredicates))
+			"failed_predicates", groupByPredicates(failedPredicates))
 	}
 	return deletedPods, nil
 }


### PR DESCRIPTION
Follow up of #2099 

This pr reduces the verbosity of the logs when nodes can't be restarted because of some failing predicates: 

before: 
```json
{"level":"info","@timestamp":"2019-11-18T13:36:45.996Z","logger":"elasticsearch-controller","message":"Starting reconciliation run","ver":"1.0.0-beta1-16b253de","iteration":7,"namespace":"default","name":"elasticsearch-sample"}
{"level":"info","@timestamp":"2019-11-18T13:36:46.282Z","logger":"kibana-association-controller","message":"Ending reconciliation run","ver":"1.0.0-beta1-16b253de","iteration":6,"namespace":"default","name":"kibana-sample","took":0.287476481}
{"level":"info","@timestamp":"2019-11-18T13:36:46.810Z","logger":"zen2","message":"Ensuring no voting exclusions are set","ver":"1.0.0-beta1-16b253de","namespace":"default","es_name":"elasticsearch-sample"}
{"level":"info","@timestamp":"2019-11-18T13:36:46.875Z","logger":"driver","message":"Predicate failed","ver":"1.0.0-beta1-16b253de","pod_name":"elasticsearch-sample-es-default-7","predicate_name":"do_not_restart_healthy_node_if_not_green"}
{"level":"info","@timestamp":"2019-11-18T13:36:46.875Z","logger":"driver","message":"Predicate failed","ver":"1.0.0-beta1-16b253de","pod_name":"elasticsearch-sample-es-default-6","predicate_name":"do_not_restart_healthy_node_if_not_green"}
{"level":"info","@timestamp":"2019-11-18T13:36:46.875Z","logger":"driver","message":"Predicate failed","ver":"1.0.0-beta1-16b253de","pod_name":"elasticsearch-sample-es-default-5","predicate_name":"do_not_restart_healthy_node_if_not_green"}
{"level":"info","@timestamp":"2019-11-18T13:36:46.875Z","logger":"driver","message":"Predicate failed","ver":"1.0.0-beta1-16b253de","pod_name":"elasticsearch-sample-es-default-4","predicate_name":"do_not_restart_healthy_node_if_not_green"}
{"level":"info","@timestamp":"2019-11-18T13:36:46.875Z","logger":"driver","message":"Predicate failed","ver":"1.0.0-beta1-16b253de","pod_name":"elasticsearch-sample-es-default-3","predicate_name":"do_not_restart_healthy_node_if_not_green"}
{"level":"info","@timestamp":"2019-11-18T13:36:46.875Z","logger":"driver","message":"Predicate failed","ver":"1.0.0-beta1-16b253de","pod_name":"elasticsearch-sample-es-default-2","predicate_name":"do_not_restart_healthy_node_if_not_green"}
{"level":"info","@timestamp":"2019-11-18T13:36:46.875Z","logger":"driver","message":"Predicate failed","ver":"1.0.0-beta1-16b253de","pod_name":"elasticsearch-sample-es-default-1","predicate_name":"do_not_restart_healthy_node_if_not_green"}
{"level":"info","@timestamp":"2019-11-18T13:36:46.875Z","logger":"driver","message":"Predicate failed","ver":"1.0.0-beta1-16b253de","pod_name":"elasticsearch-sample-es-default-0","predicate_name":"do_not_restart_healthy_node_if_not_green"}
{"level":"info","@timestamp":"2019-11-18T13:36:46.891Z","logger":"elasticsearch-controller","message":"Updating status","ver":"1.0.0-beta1-16b253de","iteration":7,"namespace":"default","es_name":"elasticsearch-sample"}
{"level":"info","@timestamp":"2019-11-18T13:36:46.891Z","logger":"elasticsearch-controller","message":"Ending reconciliation run","ver":"1.0.0-beta1-16b253de","iteration":7,"namespace":"default","name":"elasticsearch-sample","took":0.895109087}
```

with the pr:
```json
{"level":"info","@timestamp":"2019-11-18T13:46:14.841Z","logger":"elasticsearch-controller","message":"Starting reconciliation run","ver":"1.0.0-beta1-7c26b998","iteration":30,"namespace":"default","name":"elasticsearch-sample"}
{"level":"info","@timestamp":"2019-11-18T13:46:15.501Z","logger":"zen2","message":"Ensuring no voting exclusions are set","ver":"1.0.0-beta1-7c26b998","namespace":"default","es_name":"elasticsearch-sample"}
{"level":"info","@timestamp":"2019-11-18T13:46:15.549Z","logger":"driver","message":"Nodes can't be upgraded","ver":"1.0.0-beta1-7c26b998","namespace":"default","es_name":"elasticsearch-sample","failedPredicates":{"do_not_restart_healthy_node_if_not_green":["elasticsearch-sample-es-default-7","elasticsearch-sample-es-default-6","elasticsearch-sample-es-default-5","elasticsearch-sample-es-default-4","elasticsearch-sample-es-default-3","elasticsearch-sample-es-default-2","elasticsearch-sample-es-default-1","elasticsearch-sample-es-default-0"]}}
{"level":"info","@timestamp":"2019-11-18T13:46:15.552Z","logger":"elasticsearch-controller","message":"Updating status","ver":"1.0.0-beta1-7c26b998","iteration":30,"namespace":"default","es_name":"elasticsearch-sample"}
{"level":"info","@timestamp":"2019-11-18T13:46:15.552Z","logger":"elasticsearch-controller","message":"Ending reconciliation run","ver":"1.0.0-beta1-7c26b998","iteration":30,"namespace":"default","name":"elasticsearch-sample","took":0.711200508}
```