### PR TITLE
Fix nightly build job definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,6 +326,7 @@ ifeq ($(KUBECTL_CLUSTER), minikube)
 	@ hack/registry.sh port-forward stop
 else
 ifeq ($(REGISTRY), docker.elastic.co)
+	@ docker tag $(OPERATOR_IMAGE) push.$(OPERATOR_IMAGE)
 	@ docker push push.$(OPERATOR_IMAGE)
 else
 	@ docker push $(OPERATOR_IMAGE)

--- a/build/ci/nightly/Jenkinsfile
+++ b/build/ci/nightly/Jenkinsfile
@@ -45,6 +45,7 @@ EOF
             steps {
                 sh """
                     export VERSION=\$(cat $WORKSPACE/VERSION)-\$(date +%F)-\$(git rev-parse --short --verify HEAD)
+                    export REGISTRY=${REGISTRY}
                     export OPERATOR_IMAGE=${REGISTRY}/${REPOSITORY}/${IMG_NAME}:\$VERSION
                     echo \$OPERATOR_IMAGE > eck_image.txt
                     cat >> .env <<EOF


### PR DESCRIPTION
- Propagate the `REGISTRY` env var to the `ci-release` make target.
- Tag the Docker image with the `push.` prefix

Fix a regression introduced by #1908.