### PR TITLE
Fix Kibana to terminate all pods before restarting during version change

### DIFF
--- a/docs/kibana.asciidoc
+++ b/docs/kibana.asciidoc
@@ -185,6 +185,8 @@ In this case all the instances must share the same encryption key.
 
 This can be done by setting the `xpack.security.encryptionKey` property using a secure setting as described in the next section.
 
+Note that while most reconfigurations of your Kibana instances will be carried out in rolling upgrade fashion, all version upgrades will cause Kibana downtime. This is due to the link:https://www.elastic.co/guide/en/kibana/current/upgrade.html[requirement] to run only a single version of Kibana at any given time.
+
 [float]
 [id="{p}-kibana-secure-settings"]
 === Secure Settings

--- a/pkg/controller/apmserver/apmserver_controller.go
+++ b/pkg/controller/apmserver/apmserver_controller.go
@@ -397,6 +397,7 @@ func (r *ReconcileApmServer) deploymentParams(
 		Selector:        labels.NewLabels(as.Name),
 		Labels:          labels.NewLabels(as.Name),
 		PodTemplateSpec: podSpec,
+		Type:            appsv1.RollingUpdateDeploymentStrategyType,
 	}, nil
 }
 

--- a/pkg/controller/apmserver/apmserver_controller.go
+++ b/pkg/controller/apmserver/apmserver_controller.go
@@ -397,7 +397,7 @@ func (r *ReconcileApmServer) deploymentParams(
 		Selector:        labels.NewLabels(as.Name),
 		Labels:          labels.NewLabels(as.Name),
 		PodTemplateSpec: podSpec,
-		Type:            appsv1.RollingUpdateDeploymentStrategyType,
+		Strategy:        appsv1.RollingUpdateDeploymentStrategyType,
 	}, nil
 }
 

--- a/pkg/controller/apmserver/apmserver_controller_test.go
+++ b/pkg/controller/apmserver/apmserver_controller_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,6 +89,7 @@ func expectedDeploymentParams() testParams {
 			Namespace: "",
 			Selector:  map[string]string{"apm.k8s.elastic.co/name": "test-apm-server", "common.k8s.elastic.co/type": "apm-server"},
 			Labels:    map[string]string{"apm.k8s.elastic.co/name": "test-apm-server", "common.k8s.elastic.co/type": "apm-server"},
+			Type:      appsv1.RollingUpdateDeploymentStrategyType,
 			PodTemplateSpec: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/pkg/controller/apmserver/apmserver_controller_test.go
+++ b/pkg/controller/apmserver/apmserver_controller_test.go
@@ -89,7 +89,7 @@ func expectedDeploymentParams() testParams {
 			Namespace: "",
 			Selector:  map[string]string{"apm.k8s.elastic.co/name": "test-apm-server", "common.k8s.elastic.co/type": "apm-server"},
 			Labels:    map[string]string{"apm.k8s.elastic.co/name": "test-apm-server", "common.k8s.elastic.co/type": "apm-server"},
-			Type:      appsv1.RollingUpdateDeploymentStrategyType,
+			Strategy:  appsv1.RollingUpdateDeploymentStrategyType,
 			PodTemplateSpec: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/pkg/controller/common/deployment/reconcile.go
+++ b/pkg/controller/common/deployment/reconcile.go
@@ -28,7 +28,7 @@ type Params struct {
 	Labels          map[string]string
 	PodTemplateSpec corev1.PodTemplateSpec
 	Replicas        int32
-	Type            appsv1.DeploymentStrategyType
+	Strategy        appsv1.DeploymentStrategyType
 }
 
 // New creates a Deployment from the given params.
@@ -47,7 +47,7 @@ func New(params Params) appsv1.Deployment {
 			Template: params.PodTemplateSpec,
 			Replicas: &params.Replicas,
 			Strategy: appsv1.DeploymentStrategy{
-				Type: params.Type,
+				Type: params.Strategy,
 			},
 		},
 	}

--- a/pkg/controller/common/deployment/reconcile.go
+++ b/pkg/controller/common/deployment/reconcile.go
@@ -28,6 +28,7 @@ type Params struct {
 	Labels          map[string]string
 	PodTemplateSpec corev1.PodTemplateSpec
 	Replicas        int32
+	Type            appsv1.DeploymentStrategyType
 }
 
 // New creates a Deployment from the given params.
@@ -45,6 +46,9 @@ func New(params Params) appsv1.Deployment {
 			},
 			Template: params.PodTemplateSpec,
 			Replicas: &params.Replicas,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: params.Type,
+			},
 		},
 	}
 }

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -90,7 +90,8 @@ func secretWatchFinalizer(kibana kbtype.Kibana, watches watches.DynamicWatches) 
 }
 
 // getStrategyType decides which deployment strategy (RollingUpdate or Recreate) to use based on whether the version
-// upgrade is in progress.
+// upgrade is in progress. Kibana does not support a smooth rolling upgrade from one version to another:
+// running multiple versions simultaneously may lead to concurrency bugs and data corruption.
 func (d *driver) getStrategyType(kb *kbtype.Kibana) (appsv1.DeploymentStrategyType, error) {
 	var pods corev1.PodList
 	var labels client.MatchingLabels = map[string]string{label.KibanaNameLabelName: kb.Name}
@@ -233,7 +234,7 @@ func (d *driver) deploymentParams(kb *kbtype.Kibana) (deployment.Params, error) 
 		Selector:        label.NewLabels(kb.Name),
 		Labels:          label.NewLabels(kb.Name),
 		PodTemplateSpec: kibanaPodSpec,
-		Type:            strategyType,
+		Strategy:        strategyType,
 	}, nil
 }
 

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -7,6 +7,7 @@ package kibana
 import (
 	"crypto/sha256"
 	"fmt"
+	"time"
 
 	kbtype "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
@@ -292,7 +293,7 @@ func (d *driver) Reconcile(
 	if err != nil {
 		return results.WithError(err)
 	} else if requeue {
-		return results.WithResult(reconcile.Result{Requeue: true})
+		return results.WithResult(reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second})
 	}
 
 	expectedDp := deployment.New(deploymentParams)

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -7,7 +7,6 @@ package kibana
 import (
 	"crypto/sha256"
 	"fmt"
-	"time"
 
 	kbtype "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
@@ -40,7 +39,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // initContainersParameters is used to generate the init container that will load the secure settings into a keystore
@@ -91,45 +89,29 @@ func secretWatchFinalizer(kibana kbtype.Kibana, watches watches.DynamicWatches) 
 	}
 }
 
-func (d *driver) getStrategyType(kb *kbtype.Kibana) (appsv1.DeploymentStrategyType, bool, error) {
+// getStrategyType decides which deployment strategy (RollingUpdate or Recreate) to use based on whether the version
+// upgrade is in progress.
+func (d *driver) getStrategyType(kb *kbtype.Kibana) (appsv1.DeploymentStrategyType, error) {
 	var pods corev1.PodList
 	var labels client.MatchingLabels = map[string]string{label.KibanaNameLabelName: kb.Name}
 	if err := d.client.List(&pods, client.InNamespace(kb.Namespace), labels); err != nil {
-		return "", false, err
+		return "", err
 	}
 
-	baselineVersion := kb.Spec.Version
-	differentVersionsDetected := false
-	owners := make(map[string]struct{})
 	for _, pod := range pods.Items {
-		if len(pod.OwnerReferences) != 1 {
-			return "", false, fmt.Errorf("pod %s has %d owners while expecting 1", pod.Name, len(pod.OwnerReferences))
-		}
-		owners[pod.OwnerReferences[0].Name] = struct{}{}
-
 		ver, ok := pod.Labels[label.KibanaVersionLabelName]
-		// if label is missing, we assume this is first pass of reconciliation that will populate
-		// the label. To be safe, assume the Kibana version has changed when operator was offline and use Recreate,
+		// if label is missing we assume that the last reconciliation was done by previous version of the operator
+		// to be safe, we assume the Kibana version has changed when operator was offline and use Recreate,
 		// otherwise we may run into data corruption/data loss.
-		if !ok || ver != baselineVersion {
-			differentVersionsDetected = true
+		if !ok || ver != kb.Spec.Version {
+			return appsv1.RecreateDeploymentStrategyType, nil
 		}
 	}
 
-	if differentVersionsDetected {
-		if len(owners) != 1 {
-			// if there are multiple owners (multiple replicasets with active pods) and multiple versions
-			// we keep requeuing until deployment is rolled out, ie. only a single replicaset has pods
-			return "", true, nil
-		}
-
-		return appsv1.RecreateDeploymentStrategyType, false, nil
-	}
-
-	return appsv1.RollingUpdateDeploymentStrategyType, false, nil
+	return appsv1.RollingUpdateDeploymentStrategyType, nil
 }
 
-func (d *driver) deploymentParams(kb *kbtype.Kibana) (deployment.Params, bool, error) {
+func (d *driver) deploymentParams(kb *kbtype.Kibana) (deployment.Params, error) {
 	// setup a keystore with secure settings in an init container, if specified by the user
 	keystoreResources, err := keystore.NewResources(
 		d,
@@ -139,7 +121,7 @@ func (d *driver) deploymentParams(kb *kbtype.Kibana) (deployment.Params, bool, e
 		initContainersParameters,
 	)
 	if err != nil {
-		return deployment.Params{}, false, err
+		return deployment.Params{}, err
 	}
 
 	kibanaPodSpec := pod.NewPodTemplateSpec(*kb, keystoreResources)
@@ -160,11 +142,11 @@ func (d *driver) deploymentParams(kb *kbtype.Kibana) (deployment.Params, bool, e
 			Watched: []types.NamespacedName{esAuthSecret},
 			Watcher: k8s.ExtractNamespacedName(kb),
 		}); err != nil {
-			return deployment.Params{}, false, err
+			return deployment.Params{}, err
 		}
 		sec := corev1.Secret{}
 		if err := d.client.Get(esAuthSecret, &sec); err != nil {
-			return deployment.Params{}, false, err
+			return deployment.Params{}, err
 		}
 		_, _ = configChecksum.Write(sec.Data[kb.AssociationConf().GetAuthSecretKey()])
 	} else {
@@ -182,11 +164,11 @@ func (d *driver) deploymentParams(kb *kbtype.Kibana) (deployment.Params, bool, e
 			Watched: []types.NamespacedName{key},
 			Watcher: k8s.ExtractNamespacedName(kb),
 		}); err != nil {
-			return deployment.Params{}, false, err
+			return deployment.Params{}, err
 		}
 
 		if err := d.client.Get(key, &esPublicCASecret); err != nil {
-			return deployment.Params{}, false, err
+			return deployment.Params{}, err
 		}
 		if certPem, ok := esPublicCASecret.Data[certificates.CertFileName]; ok {
 			_, _ = configChecksum.Write(certPem)
@@ -209,7 +191,7 @@ func (d *driver) deploymentParams(kb *kbtype.Kibana) (deployment.Params, bool, e
 			Name:      certificates.HTTPCertsInternalSecretName(kbname.KBNamer, kb.Name),
 		}, &httpCerts)
 		if err != nil {
-			return deployment.Params{}, false, err
+			return deployment.Params{}, err
 		}
 		if httpCert, ok := httpCerts.Data[certificates.CertFileName]; ok {
 			_, _ = configChecksum.Write(httpCert)
@@ -230,7 +212,7 @@ func (d *driver) deploymentParams(kb *kbtype.Kibana) (deployment.Params, bool, e
 	configSecret := corev1.Secret{}
 	err = d.client.Get(types.NamespacedName{Name: config.SecretName(*kb), Namespace: kb.Namespace}, &configSecret)
 	if err != nil {
-		return deployment.Params{}, false, err
+		return deployment.Params{}, err
 	}
 	_, _ = configChecksum.Write(configSecret.Data[config.SettingsFilename])
 
@@ -239,9 +221,9 @@ func (d *driver) deploymentParams(kb *kbtype.Kibana) (deployment.Params, bool, e
 	kibanaPodSpec.Labels[configChecksumLabel] = fmt.Sprintf("%x", configChecksum.Sum(nil))
 
 	// decide the strategy type
-	strategyType, requeue, err := d.getStrategyType(kb)
-	if err != nil || requeue {
-		return deployment.Params{}, requeue, err
+	strategyType, err := d.getStrategyType(kb)
+	if err != nil {
+		return deployment.Params{}, err
 	}
 
 	return deployment.Params{
@@ -252,7 +234,7 @@ func (d *driver) deploymentParams(kb *kbtype.Kibana) (deployment.Params, bool, e
 		Labels:          label.NewLabels(kb.Name),
 		PodTemplateSpec: kibanaPodSpec,
 		Type:            strategyType,
-	}, false, nil
+	}, nil
 }
 
 func (d *driver) Reconcile(
@@ -289,11 +271,9 @@ func (d *driver) Reconcile(
 		return results.WithError(err)
 	}
 
-	deploymentParams, requeue, err := d.deploymentParams(kb)
+	deploymentParams, err := d.deploymentParams(kb)
 	if err != nil {
 		return results.WithError(err)
-	} else if requeue {
-		return results.WithResult(reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second})
 	}
 
 	expectedDp := deployment.New(deploymentParams)

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -397,7 +397,7 @@ func expectedDeploymentParams() deployment.Params {
 		Selector:  map[string]string{"common.k8s.elastic.co/type": "kibana", "kibana.k8s.elastic.co/name": "test"},
 		Labels:    map[string]string{"common.k8s.elastic.co/type": "kibana", "kibana.k8s.elastic.co/name": "test"},
 		Replicas:  1,
-		Type:      appsv1.RollingUpdateDeploymentStrategyType,
+		Strategy:  appsv1.RollingUpdateDeploymentStrategyType,
 		PodTemplateSpec: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -5,6 +5,8 @@
 package kibana
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/common/v1beta1"
@@ -14,11 +16,13 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/deployment"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana/pod"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana/volume"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,10 +30,205 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var customResourceLimits = corev1.ResourceRequirements{
 	Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("2Gi")},
+}
+
+type failingClient struct {
+	k8s.Client
+}
+
+func (f *failingClient) List(list runtime.Object, opts ...client.ListOption) error {
+	return errors.New("client error")
+}
+
+func Test_getStrategyType(t *testing.T) {
+	// creates `count` of pods belonging to `kbName` Kibana and to `rs-kbName-version` ReplicaSet
+	getPods := func(kbName string, podCount int, version string) []runtime.Object {
+		var result []runtime.Object
+		for i := 0; i < podCount; i++ {
+			result = append(result, &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{Name: fmt.Sprintf("rs-%v-%v", kbName, version)},
+					},
+					Name:      fmt.Sprintf("pod-%v-%v-%v", kbName, version, i),
+					Namespace: "default",
+					Labels: map[string]string{
+						label.KibanaNameLabelName:    kbName,
+						label.KibanaVersionLabelName: version,
+					},
+				},
+			})
+		}
+		return result
+	}
+
+	clearVersionLabels := func(objects []runtime.Object) []runtime.Object {
+		for _, object := range objects {
+			pod, ok := object.(*corev1.Pod)
+			if !ok {
+				t.FailNow()
+			}
+
+			delete(pod.Labels, label.KibanaVersionLabelName)
+		}
+
+		return objects
+	}
+
+	tests := []struct {
+		name            string
+		expectedKbName  string
+		expectedVersion string
+		initialObjects  []runtime.Object
+		clientError     bool
+		wantErr         bool
+		wantRequeue     bool
+		wantStrategy    appsv1.DeploymentStrategyType
+	}{
+		{
+			name:            "Pods not created yet",
+			expectedVersion: "7.4.0",
+			expectedKbName:  "test",
+			initialObjects:  []runtime.Object{},
+			clientError:     false,
+			wantErr:         false,
+			wantRequeue:     false,
+			wantStrategy:    appsv1.RollingUpdateDeploymentStrategyType,
+		},
+		{
+			name:            "Versions match",
+			expectedVersion: "7.4.0",
+			expectedKbName:  "test",
+			initialObjects:  getPods("test", 3, "7.4.0"),
+			clientError:     false,
+			wantErr:         false,
+			wantRequeue:     false,
+			wantStrategy:    appsv1.RollingUpdateDeploymentStrategyType,
+		},
+		{
+			name:            "Versions match - multiple kibana deployments",
+			expectedVersion: "7.5.0",
+			expectedKbName:  "test2",
+			initialObjects:  append(getPods("test", 3, "7.4.0"), getPods("test2", 3, "7.5.0")...),
+			clientError:     false,
+			wantErr:         false,
+			wantRequeue:     false,
+			wantStrategy:    appsv1.RollingUpdateDeploymentStrategyType,
+		},
+		{
+			name:            "Version mismatch - single kibana deployment",
+			expectedVersion: "7.5.0",
+			expectedKbName:  "test",
+			initialObjects:  getPods("test", 3, "7.4.0"),
+			clientError:     false,
+			wantErr:         false,
+			wantRequeue:     false,
+			wantStrategy:    appsv1.RecreateDeploymentStrategyType,
+		},
+		{
+			name:            "Version mismatch - pods partially behind",
+			expectedVersion: "7.5.0",
+			expectedKbName:  "test",
+			initialObjects:  append(getPods("test", 2, "7.5.0"), getPods("test", 1, "7.4.0")...),
+			clientError:     false,
+			wantErr:         false,
+			wantRequeue:     true,
+			wantStrategy:    "",
+		},
+		{
+			name:            "Version mismatch - multiple kibana deployments",
+			expectedVersion: "7.5.0",
+			expectedKbName:  "test2",
+			initialObjects:  append(getPods("test", 3, "7.5.0"), getPods("test2", 3, "7.4.0")...),
+			clientError:     false,
+			wantErr:         false,
+			wantRequeue:     false,
+			wantStrategy:    appsv1.RecreateDeploymentStrategyType,
+		},
+		{
+			name:            "Version mismatch - multiple versions in flight",
+			expectedVersion: "7.5.0",
+			expectedKbName:  "test",
+			initialObjects: append(
+				getPods("test", 1, "7.5.0"),
+				append(
+					getPods("test", 1, "7.4.0"),
+					getPods("test", 1, "7.3.0")...)...),
+			clientError:  false,
+			wantErr:      false,
+			wantRequeue:  true,
+			wantStrategy: "",
+		},
+		{
+			name:            "Version label missing (operator upgrade case), should assume spec changed",
+			expectedVersion: "7.5.0",
+			expectedKbName:  "test",
+			initialObjects:  clearVersionLabels(getPods("test", 3, "7.5.0")),
+			clientError:     false,
+			wantErr:         false,
+			wantRequeue:     false,
+			wantStrategy:    appsv1.RecreateDeploymentStrategyType,
+		},
+		{
+			name:            "Client error",
+			expectedVersion: "7.4.0",
+			expectedKbName:  "test",
+			initialObjects:  getPods("test", 2, "7.4.0"),
+			clientError:     true,
+			wantErr:         true,
+			wantRequeue:     false,
+			wantStrategy:    "",
+		},
+		{
+			name:            "Owner reference missing",
+			expectedVersion: "7.4.0",
+			expectedKbName:  "test",
+			initialObjects: []runtime.Object{&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Labels:    map[string]string{label.KibanaNameLabelName: "test"},
+			}}},
+			clientError:  false,
+			wantErr:      true,
+			wantRequeue:  false,
+			wantStrategy: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := watches.NewDynamicWatches()
+			err := w.Secrets.InjectScheme(scheme.Scheme)
+			assert.NoError(t, err)
+
+			kb := kibanaFixture()
+			kb.Name = tt.expectedKbName
+			kb.Spec.Version = tt.expectedVersion
+			kbVersion, err := version.Parse(kb.Spec.Version)
+			assert.NoError(t, err)
+
+			client := k8s.WrappedFakeClient(tt.initialObjects...)
+			if tt.clientError {
+				client = &failingClient{}
+			}
+
+			d, err := newDriver(client, scheme.Scheme, *kbVersion, w, record.NewFakeRecorder(100))
+			assert.NoError(t, err)
+
+			strategy, requeue, err := d.getStrategyType(kb)
+			if tt.wantErr {
+				assert.Empty(t, strategy)
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, tt.wantRequeue, requeue)
+				assert.Equal(t, tt.wantStrategy, strategy)
+			}
+		})
+	}
 }
 
 func TestDriverDeploymentParams(t *testing.T) {
@@ -148,11 +347,7 @@ func TestDriverDeploymentParams(t *testing.T) {
 			},
 			want: func() deployment.Params {
 				p := expectedDeploymentParams()
-				p.PodTemplateSpec.Labels = map[string]string{
-					"common.k8s.elastic.co/type":            "kibana",
-					"kibana.k8s.elastic.co/name":            "test",
-					"kibana.k8s.elastic.co/config-checksum": "c5496152d789682387b90ea9b94efcd82a2c6f572f40c016fb86c0d7",
-				}
+				p.PodTemplateSpec.Labels["kibana.k8s.elastic.co/config-checksum"] = "c5496152d789682387b90ea9b94efcd82a2c6f572f40c016fb86c0d7"
 				return p
 			}(),
 			wantErr: false,
@@ -169,6 +364,7 @@ func TestDriverDeploymentParams(t *testing.T) {
 			},
 			want: func() deployment.Params {
 				p := expectedDeploymentParams()
+				p.PodTemplateSpec.Labels["kibana.k8s.elastic.co/version"] = "6.5.0"
 				return p
 			}(),
 			wantErr: false,
@@ -183,7 +379,11 @@ func TestDriverDeploymentParams(t *testing.T) {
 				},
 				initialObjects: defaultInitialObjects,
 			},
-			want:    expectedDeploymentParams(),
+			want: func() deployment.Params {
+				p := expectedDeploymentParams()
+				p.PodTemplateSpec.Labels["kibana.k8s.elastic.co/version"] = "6.6.0"
+				return p
+			}(),
 			wantErr: false,
 		},
 	}
@@ -202,13 +402,14 @@ func TestDriverDeploymentParams(t *testing.T) {
 			d, err := newDriver(client, scheme.Scheme, *kbVersion, w, record.NewFakeRecorder(100))
 			assert.NoError(t, err)
 
-			got, err := d.deploymentParams(kb)
+			got, requeue, err := d.deploymentParams(kb)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.Equal(t, tt.want, got)
+			require.False(t, requeue)
 		})
 	}
 }
@@ -221,12 +422,14 @@ func expectedDeploymentParams() deployment.Params {
 		Selector:  map[string]string{"common.k8s.elastic.co/type": "kibana", "kibana.k8s.elastic.co/name": "test"},
 		Labels:    map[string]string{"common.k8s.elastic.co/type": "kibana", "kibana.k8s.elastic.co/name": "test"},
 		Replicas:  1,
+		Type:      appsv1.RollingUpdateDeploymentStrategyType,
 		PodTemplateSpec: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					"common.k8s.elastic.co/type":            "kibana",
 					"kibana.k8s.elastic.co/name":            "test",
 					"kibana.k8s.elastic.co/config-checksum": "c530a02188193a560326ce91e34fc62dcbd5722b45534a3f60957663",
+					"kibana.k8s.elastic.co/version":         "7.0.0",
 				},
 			},
 			Spec: corev1.PodSpec{

--- a/pkg/controller/kibana/label/labels.go
+++ b/pkg/controller/kibana/label/labels.go
@@ -10,6 +10,9 @@ const (
 	// KibanaNameLabelName used to represent a Kibana in k8s resources
 	KibanaNameLabelName = "kibana.k8s.elastic.co/name"
 
+	// KibanaVersionLabelName used to propagate Kibana version from the spec to the pods
+	KibanaVersionLabelName = "kibana.k8s.elastic.co/version"
+
 	// Type represents the Kibana type
 	Type = "kibana"
 )

--- a/pkg/controller/kibana/pod/pod.go
+++ b/pkg/controller/kibana/pod/pod.go
@@ -66,9 +66,12 @@ func imageWithVersion(image string, version string) string {
 }
 
 func NewPodTemplateSpec(kb v1beta1.Kibana, keystore *keystore.Resources) corev1.PodTemplateSpec {
+	labels := label.NewLabels(kb.Name)
+	labels[label.KibanaVersionLabelName] = kb.Spec.Version
+
 	builder := defaults.NewPodTemplateBuilder(kb.Spec.PodTemplate, v1beta1.KibanaContainerName).
 		WithResources(DefaultResources).
-		WithLabels(label.NewLabels(kb.Name)).
+		WithLabels(labels).
 		WithDockerImage(kb.Spec.Image, imageWithVersion(defaultImageRepositoryAndName, kb.Spec.Version)).
 		WithReadinessProbe(readinessProbe(kb.Spec.HTTP.TLS.Enabled())).
 		WithPorts(ports).

--- a/pkg/controller/kibana/pod/pod_test.go
+++ b/pkg/controller/kibana/pod/pod_test.go
@@ -172,9 +172,11 @@ func TestNewPodTemplateSpec(t *testing.T) {
 							},
 						},
 					},
+					Version: "7.4.0",
 				}},
 			assertions: func(pod corev1.PodTemplateSpec) {
 				labels := label.NewLabels("kibana-name")
+				labels[label.KibanaVersionLabelName] = "7.4.0"
 				labels["label1"] = "value1"
 				labels["label2"] = "value2"
 				labels[label.KibanaNameLabelName] = "overridden-kibana-name"

--- a/pkg/utils/k8s/k8sutils.go
+++ b/pkg/utils/k8s/k8sutils.go
@@ -42,16 +42,6 @@ func IsPodReady(pod corev1.Pod) bool {
 	return conditionsTrue == 2
 }
 
-func ReadyPodsCount(pods []corev1.Pod) int {
-	ready := 0
-	for _, pod := range pods {
-		if IsPodReady(pod) {
-			ready++
-		}
-	}
-	return ready
-}
-
 // PodsByName returns a map of pod names to pods
 func PodsByName(pods []corev1.Pod) map[string]corev1.Pod {
 	podMap := make(map[string]corev1.Pod, len(pods))

--- a/pkg/utils/k8s/k8sutils.go
+++ b/pkg/utils/k8s/k8sutils.go
@@ -42,6 +42,16 @@ func IsPodReady(pod corev1.Pod) bool {
 	return conditionsTrue == 2
 }
 
+func ReadyPodsCount(pods []corev1.Pod) int {
+	ready := 0
+	for _, pod := range pods {
+		if IsPodReady(pod) {
+			ready++
+		}
+	}
+	return ready
+}
+
 // PodsByName returns a map of pod names to pods
 func PodsByName(pods []corev1.Pod) map[string]corev1.Pod {
 	podMap := make(map[string]corev1.Pod, len(pods))

--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -188,8 +188,8 @@ func TestMutationAndReversal(t *testing.T) {
 			"masterdata": {
 				"node.attr.box_type": "mixed",
 			},
-		})
-	mutation.MutatedFrom = &b
+		}).
+		WithMutatedFrom(&b)
 	test.RunMutations(t, []test.Builder{b}, []test.Builder{mutation, b})
 
 }
@@ -228,6 +228,5 @@ func TestMutationWithLargerMaxUnavailable(t *testing.T) {
 }
 
 func RunESMutation(t *testing.T, toCreate elasticsearch.Builder, mutateTo elasticsearch.Builder) {
-	mutateTo.MutatedFrom = &toCreate
-	test.RunMutation(t, toCreate, mutateTo)
+	test.RunMutation(t, toCreate, mutateTo.WithMutatedFrom(&toCreate))
 }

--- a/test/e2e/es/reversal_test.go
+++ b/test/e2e/es/reversal_test.go
@@ -87,7 +87,6 @@ func TestRiskyMasterReconfiguration(t *testing.T) {
 }
 
 func RunESMutationReversal(t *testing.T, toCreate elasticsearch.Builder, mutateTo elasticsearch.Builder) {
-	mutateTo.MutatedFrom = &toCreate
-	test.RunMutationReversal(t, []test.Builder{toCreate}, []test.Builder{mutateTo})
+	test.RunMutationReversal(t, []test.Builder{toCreate}, []test.Builder{mutateTo.WithMutatedFrom(&toCreate)})
 
 }

--- a/test/e2e/kb/version_upgrade_test.go
+++ b/test/e2e/kb/version_upgrade_test.go
@@ -1,0 +1,65 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana/label"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/kibana"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestVersionUpgrade(t *testing.T) {
+	name := "test-version-upgrade"
+	esBuilder := elasticsearch.NewBuilder(name).
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithVersion("7.4.1")
+
+	kbBuilder := kibana.NewBuilder(name).
+		WithElasticsearchRef(esBuilder.Ref()).
+		WithNodeCount(3).
+		WithVersion("7.4.0")
+
+	ns := client.InNamespace(kbBuilder.Kibana.Namespace)
+	matchLabels := client.MatchingLabels(map[string]string{
+		common.TypeLabelName:      label.Type,
+		label.KibanaNameLabelName: kbBuilder.Kibana.Name,
+	})
+
+	var observations []int
+	var errors []error
+	w := test.NewWatcher("watch pods readiness", 1*time.Second,
+		func(k *test.K8sClient, t *testing.T) {
+			if pods, err := k.GetPods(ns, matchLabels); err != nil {
+				errors = append(errors, err)
+				t.Logf("got error: %v", err)
+			} else {
+				ready := 0
+				for _, pod := range pods {
+					if k8s.IsPodReady(pod) {
+						ready++
+					}
+				}
+				observations = append(observations, ready)
+			}
+		},
+		func(k *test.K8sClient, t *testing.T) {
+			assert.Contains(t, observations, 0)
+		})
+
+	test.RunMutationsWhileWatching(
+		t,
+		[]test.Builder{esBuilder, kbBuilder},
+		[]test.Builder{esBuilder, kbBuilder.WithVersion("7.4.1").WithMutatedFrom(&kbBuilder)},
+		[]test.Watcher{w},
+	)
+}

--- a/test/e2e/kb/version_upgrade_test.go
+++ b/test/e2e/kb/version_upgrade_test.go
@@ -36,11 +36,9 @@ func TestVersionUpgrade(t *testing.T) {
 	})
 
 	var observations []int
-	var errors []error
 	w := test.NewWatcher("watch pods readiness", 1*time.Second,
 		func(k *test.K8sClient, t *testing.T) {
 			if pods, err := k.GetPods(ns, matchLabels); err != nil {
-				errors = append(errors, err)
 				t.Logf("got error: %v", err)
 			} else {
 				ready := 0
@@ -60,6 +58,63 @@ func TestVersionUpgrade(t *testing.T) {
 		t,
 		[]test.Builder{esBuilder, kbBuilder},
 		[]test.Builder{esBuilder, kbBuilder.WithVersion("7.4.1").WithMutatedFrom(&kbBuilder)},
+		[]test.Watcher{w},
+	)
+}
+
+func TestRespecAndVersionUpgrade(t *testing.T) {
+	name := "test-upgrade-and-respec"
+	esBuilder := elasticsearch.NewBuilder(name).
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithVersion("7.4.1")
+
+	kbBuilder1 := kibana.NewBuilder(name).
+		WithElasticsearchRef(esBuilder.Ref()).
+		WithNodeCount(3).
+		WithVersion("7.4.0")
+
+	kbBuilder2 := kbBuilder1.WithMutatedFrom(&kbBuilder1).WithVersion("7.4.1")
+	kbBuilder3 := kbBuilder2.WithMutatedFrom(&kbBuilder2).WithLabel("some", "label")
+
+	ns := client.InNamespace(kbBuilder1.Kibana.Namespace)
+	matchLabels := client.MatchingLabels(map[string]string{
+		common.TypeLabelName:      label.Type,
+		label.KibanaNameLabelName: kbBuilder1.Kibana.Name,
+	})
+
+	// checks whether after temporary downtime kibana will be available the rest of the time
+	var hadZero, shouldHaveNonZero, failed bool
+	w := test.NewWatcher("watch pods readiness", 1*time.Second,
+		func(k *test.K8sClient, t *testing.T) {
+			pods, err := k.GetPods(ns, matchLabels)
+			if err != nil {
+				t.Logf("got error: %v", err)
+			}
+
+			ready := 0
+			for _, pod := range pods {
+				if k8s.IsPodReady(pod) {
+					ready++
+				}
+			}
+
+			hadZero = hadZero || ready == 0
+			if hadZero && ready > 0 {
+				shouldHaveNonZero = true
+			}
+
+			if shouldHaveNonZero && ready == 0 {
+				failed = true
+			}
+		},
+		func(k *test.K8sClient, t *testing.T) {
+			assert.False(t, failed)
+		})
+
+	test.RunMutationsWhileWatching(
+		t,
+		[]test.Builder{esBuilder, kbBuilder1},
+		[]test.Builder{esBuilder, kbBuilder2, kbBuilder3},
 		[]test.Watcher{w},
 	)
 }

--- a/test/e2e/kb/version_upgrade_test.go
+++ b/test/e2e/kb/version_upgrade_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/reconcile"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana/label"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/kibana"
@@ -38,6 +38,10 @@ func TestVersionUpgrade(t *testing.T) {
 		}),
 	}
 
+	// perform a Kibana version upgrade and assert that:
+	// - there was a time were no Kibana pods were ready (when all old version pods were termintated,
+	//   but before new version pods were started), and
+	// - at all times all pods had the same Kibana version.
 	test.RunMutationsWhileWatching(
 		t,
 		[]test.Builder{esBuilder, kbBuilder},
@@ -57,8 +61,8 @@ func TestVersionUpgradeAndRespec(t *testing.T) {
 		WithNodeCount(3).
 		WithVersion("7.4.0")
 
-	// Perform a Kibana version upgrade immediately followed by a Kibana configuration change.
-	// We want to make sure that the second upgrade will be done in rolling upgrade fashion instead of terminating
+	// perform a Kibana version upgrade immediately followed by a Kibana configuration change.
+	// we want to make sure that the second upgrade will be done in rolling upgrade fashion instead of terminating
 	// and recreating all the pods at once.
 	kbBuilder2 := kbBuilder1.WithMutatedFrom(&kbBuilder1).WithVersion("7.4.1")
 	kbBuilder3 := kbBuilder2.WithMutatedFrom(&kbBuilder2).WithLabel("some", "label")
@@ -73,14 +77,16 @@ func TestVersionUpgradeAndRespec(t *testing.T) {
 
 	// checks whether after temporary downtime kibana will be available the rest of the time
 	var hadZero, shouldHaveNonZero, failed bool
-	w := test.NewWatcher("watch pods readiness", 1*time.Second,
+	w := test.NewWatcher(
+		"watch pods readiness: expect some downtime once and then no downtime",
+		1*time.Second,
 		func(k *test.K8sClient, t *testing.T) {
 			pods, err := k.GetPods(opts...)
 			if err != nil {
 				t.Logf("got error: %v", err)
 			}
 
-			ready := k8s.ReadyPodsCount(pods)
+			ready := len(reconcile.AvailableElasticsearchNodes(pods))
 			hadZero = hadZero || ready == 0
 			if hadZero && ready > 0 {
 				shouldHaveNonZero = true
@@ -102,14 +108,19 @@ func TestVersionUpgradeAndRespec(t *testing.T) {
 	)
 }
 
+// NewReadinessWatcher returns a watcher that asserts that there was at least one observation where no matching pods
+// were ready, ie. there was a period of unavailability. It relies on the assumption that pod termination and
+// initialization take more than 1 second (observations resolution), so the said observation can't be missed.
 func NewReadinessWatcher(opts ...client.ListOption) test.Watcher {
 	var readinessObservations []int
-	return test.NewWatcher("watch pods versions", 1*time.Second,
+	return test.NewWatcher(
+		"watch pods readiness: expect some downtime",
+		1*time.Second,
 		func(k *test.K8sClient, t *testing.T) {
 			if pods, err := k.GetPods(opts...); err != nil {
-				t.Logf("got error: %v", err)
+				t.Logf("failed to list pods: %v", err)
 			} else {
-				readinessObservations = append(readinessObservations, k8s.ReadyPodsCount(pods))
+				readinessObservations = append(readinessObservations, len(reconcile.AvailableElasticsearchNodes(pods)))
 			}
 		},
 		func(k *test.K8sClient, t *testing.T) {
@@ -117,12 +128,17 @@ func NewReadinessWatcher(opts ...client.ListOption) test.Watcher {
 		})
 }
 
+// NewVersionWatcher returns a watcher that asserts that in all observations all Kibana pods were running the same
+// Kibana version. It relies on the assumption that pod initialization and termination take more than 1 second
+// (observations resolution), so different versions running at the same time could always be caught.
 func NewVersionWatcher(opts ...client.ListOption) test.Watcher {
 	var podObservations [][]v1.Pod
-	return test.NewWatcher("watch pods versions", 1*time.Second,
+	return test.NewWatcher(
+		"watch pods versions: should not observe multiples versions running at once",
+		1*time.Second,
 		func(k *test.K8sClient, t *testing.T) {
 			if pods, err := k.GetPods(opts...); err != nil {
-				t.Logf("got error: %v", err)
+				t.Logf("failed to list pods: %v", err)
 			} else {
 				podObservations = append(podObservations, pods)
 			}

--- a/test/e2e/test/builder.go
+++ b/test/e2e/test/builder.go
@@ -4,6 +4,10 @@
 
 package test
 
+// BuilderHashAnnotation is the name of an annotation set by the E2E tests on Kibana resources
+// containing the hash of their Builder, for comparison purposes (pre/post rolling upgrade).
+const BuilderHashAnnotation = "k8s.elastic.co/e2e-builder-hash"
+
 type Builder interface {
 	// InitTestSteps includes pre-requisite tests (eg. is k8s accessible) and cleanup from previous tests.
 	InitTestSteps(k *K8sClient) StepList

--- a/test/e2e/test/builder.go
+++ b/test/e2e/test/builder.go
@@ -4,8 +4,8 @@
 
 package test
 
-// BuilderHashAnnotation is the name of an annotation set by the E2E tests on Kibana resources
-// containing the hash of their Builder, for comparison purposes (pre/post rolling upgrade).
+// BuilderHashAnnotation is the name of an annotation set by the E2E tests on resources containing the hash of their
+// Builder for comparison purposes (pre/post rolling upgrade).
 const BuilderHashAnnotation = "k8s.elastic.co/e2e-builder-hash"
 
 type Builder interface {

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -281,6 +281,11 @@ func (b Builder) WithChangeBudget(maxSurge, maxUnavailable int32) Builder {
 	return b
 }
 
+func (b Builder) WithMutatedFrom(builder *Builder) Builder {
+	b.MutatedFrom = builder
+	return b
+}
+
 // -- Helper functions
 
 func (b Builder) RuntimeObjects() []runtime.Object {

--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -112,6 +112,16 @@ func (b Builder) WithMutatedFrom(mutatedFrom *Builder) Builder {
 	return b
 }
 
+func (b Builder) WithLabel(key, value string) Builder {
+	labels := b.Kibana.Spec.PodTemplate.Labels
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[key] = value
+	b.Kibana.Spec.PodTemplate.Labels = labels
+	return b
+}
+
 // -- Helper functions
 
 func (b Builder) RuntimeObjects() []runtime.Object {

--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -16,7 +16,8 @@ import (
 
 // Builder to create Kibana instances
 type Builder struct {
-	Kibana kbtype.Kibana
+	Kibana      kbtype.Kibana
+	MutatedFrom *Builder
 }
 
 var _ test.Builder = Builder{}
@@ -103,6 +104,11 @@ func (b Builder) WithResources(resources corev1.ResourceRequirements) Builder {
 			b.Kibana.Spec.PodTemplate.Spec.Containers[i] = c
 		}
 	}
+	return b
+}
+
+func (b Builder) WithMutatedFrom(mutatedFrom *Builder) Builder {
+	b.MutatedFrom = mutatedFrom
 	return b
 }
 

--- a/test/e2e/test/kibana/steps_mutation.go
+++ b/test/e2e/test/kibana/steps_mutation.go
@@ -5,7 +5,6 @@
 package kibana
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1beta1"
@@ -28,41 +27,15 @@ func (b Builder) AnnotatePodsWithBuilderHash(k *test.K8sClient) test.StepList {
 		{
 			Name: "Annotate Pods with a hash of their Builder spec",
 			Test: test.Eventually(func() error {
-				if b.MutatedFrom == nil {
-					panic("builder has to have MutatedFrom set if it's a mutation builder")
-				}
-
 				var pods corev1.PodList
 				if err := k.Client.List(&pods, test.KibanaPodListOptions(b.Kibana.Namespace, b.Kibana.Name)...); err != nil {
 					return err
 				}
 
+				expectedHash := hash.HashObject(b.MutatedFrom.Kibana.Spec)
 				for _, pod := range pods.Items {
-					if pod.Annotations == nil {
-						pod.Annotations = make(map[string]string)
-					}
-					pod.Annotations[BuilderHashAnnotation] = hash.HashObject(b.MutatedFrom.Kibana.Spec)
-					if err := k.Client.Update(&pod); err != nil {
-						// may error out with a conflict if concurrently updated by the operator,
-						// which is why we retry with `test.Eventually`
+					if err := test.AnnotatePodWithBuilderHash(k, pod, expectedHash); err != nil {
 						return err
-					}
-				}
-				return nil
-			}),
-		},
-		// make sure this is propagated to the local cache so next test steps can expect annotated pods
-		{
-			Name: "Wait for annotated Pods to appear in the cache",
-			Test: test.Eventually(func() error {
-				var pods corev1.PodList
-				if err := k.Client.List(&pods, test.KibanaPodListOptions(b.Kibana.Namespace, b.Kibana.Name)...); err != nil {
-					return err
-				}
-
-				for _, pod := range pods.Items {
-					if pod.Annotations[BuilderHashAnnotation] == "" {
-						return fmt.Errorf("pod %s is not annotated with %s yet", pod.Name, BuilderHashAnnotation)
 					}
 				}
 				return nil

--- a/test/e2e/test/kibana/steps_mutation.go
+++ b/test/e2e/test/kibana/steps_mutation.go
@@ -47,7 +47,6 @@ func (b Builder) AnnotatePodsWithBuilderHash(k *test.K8sClient) test.StepList {
 						// which is why we retry with `test.Eventually`
 						return err
 					}
-					fmt.Printf("pod %s has builder hash set to %s\n", pod.Name, pod.Annotations[BuilderHashAnnotation])
 				}
 				return nil
 			}),

--- a/test/e2e/test/kibana/steps_mutation.go
+++ b/test/e2e/test/kibana/steps_mutation.go
@@ -5,18 +5,71 @@
 package kibana
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1beta1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
-	return b.UpgradeTestSteps(k).
+	return b.AnnotatePodsWithBuilderHash(k).
+		WithSteps(b.UpgradeTestSteps(k)).
 		WithSteps(b.CheckK8sTestSteps(k)).
 		WithSteps(b.CheckStackTestSteps(k))
+}
+
+func (b Builder) AnnotatePodsWithBuilderHash(k *test.K8sClient) test.StepList {
+	return []test.Step{
+		{
+			Name: "Annotate Pods with a hash of their Builder spec",
+			Test: test.Eventually(func() error {
+				if b.MutatedFrom == nil {
+					panic("builder has to have MutatedFrom set if it's a mutation builder")
+				}
+
+				var pods corev1.PodList
+				if err := k.Client.List(&pods, test.KibanaPodListOptions(b.Kibana.Namespace, b.Kibana.Name)...); err != nil {
+					return err
+				}
+
+				for _, pod := range pods.Items {
+					if pod.Annotations == nil {
+						pod.Annotations = make(map[string]string)
+					}
+					pod.Annotations[BuilderHashAnnotation] = hash.HashObject(b.MutatedFrom.Kibana.Spec)
+					if err := k.Client.Update(&pod); err != nil {
+						// may error out with a conflict if concurrently updated by the operator,
+						// which is why we retry with `test.Eventually`
+						return err
+					}
+					fmt.Printf("pod %s has builder hash set to %s\n", pod.Name, pod.Annotations[BuilderHashAnnotation])
+				}
+				return nil
+			}),
+		},
+		// make sure this is propagated to the local cache so next test steps can expect annotated pods
+		{
+			Name: "Wait for annotated Pods to appear in the cache",
+			Test: test.Eventually(func() error {
+				var pods corev1.PodList
+				if err := k.Client.List(&pods, test.KibanaPodListOptions(b.Kibana.Namespace, b.Kibana.Name)...); err != nil {
+					return err
+				}
+
+				for _, pod := range pods.Items {
+					if pod.Annotations[BuilderHashAnnotation] == "" {
+						return fmt.Errorf("pod %s is not annotated with %s yet", pod.Name, BuilderHashAnnotation)
+					}
+				}
+				return nil
+			}),
+		},
+	}
 }
 
 func (b Builder) MutationReversalTestContext() test.ReversalTestContext {

--- a/test/e2e/test/watcher.go
+++ b/test/e2e/test/watcher.go
@@ -1,0 +1,63 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+type Watcher struct {
+	name     string
+	interval time.Duration
+	watchFn  func(k *K8sClient, t *testing.T)
+	checkFn  func(k *K8sClient, t *testing.T)
+	stopChan chan struct{}
+}
+
+func NewWatcher(name string, interval time.Duration, watchFn func(k *K8sClient, t *testing.T), checkFn func(k *K8sClient, t *testing.T)) Watcher {
+	return Watcher{
+		name:     name,
+		interval: interval,
+		watchFn:  watchFn,
+		checkFn:  checkFn,
+		stopChan: make(chan struct{}),
+	}
+}
+
+func (w *Watcher) StartStep(k *K8sClient) Step {
+	return Step{
+		Name: fmt.Sprintf("Starting to %s", w.name),
+		Test: func(t *testing.T) {
+			go func() {
+				ticker := time.NewTicker(w.interval)
+				for {
+					select {
+					case <-w.stopChan:
+						return
+					case <-ticker.C:
+						w.watchFn(k, t)
+					}
+				}
+			}()
+		},
+		Skip: nil,
+	}
+}
+
+func (w *Watcher) StopStep(k *K8sClient) Step {
+	return Step{
+		Name: fmt.Sprintf("Stopping to %s", w.name),
+		Test: func(t *testing.T) {
+			w.stop()
+			w.checkFn(k, t)
+		},
+	}
+}
+
+func (w *Watcher) stop() {
+	w.stopChan <- struct{}{}
+}


### PR DESCRIPTION
### Description
This PR fixes #2049. 
During version upgrade, all Kibana instances with old version have to be stopped before starting any instance with the new version. To do that, the operator will supply Recreate strategy to Kibana deployment when it detects that version upgrade is in progress. To avoid Kibana downtime for all other spec changes, RollingUpdate strategy will be used when version doesn't change. 

### Detection
Operator needs to be consistent throughout the entire upgrade process even if reconciliation loop is ran multiple times. To do that, operator looks at current spec and all the versions in existing Kibana pods. If the version is the same everywhere, the RollingUpdate strategy is used, otherwise Recreate strategy is used.

### Pod version
New label is introduced on Kibana pods. It contains the Kibana version that the pod is running. The need for a new label comes from the fact that there is no other source of truth available:
- Kibana spec has a version, but Pods will outlive any particular version of that spec, so it's not possible to trace back if the spec was updated
- Deployment has the same "outliving" issue as Kibana spec
- Both ReplicaSet and Pod currently have config checksum and container image. The former changes on every config change and as we care only about version changes it's not useful. The latter can be user provided and might not indicate the version in the name.

Given the above, `kibana.k8s.elastic.co/version` label was introduced. Both ReplicaSets and Pods have it, but it's being read from Pods.

### Upgrade case
When the operator version containing new label will be deployed in k8s cluster with already existing Kibana deployment, the version label will not be present. This means that the operator can't reason about the deployment strategy to use. Given that, we have two options for default behavior:
- use RollingUpdate strategy - better experience for users, but slight risk of data corruption/loss (when Kibana spec is updated while operator is not running),
- use Recreate strategy - Kibana will have downtime on operator upgrade, but there is no risk of data corruption/loss.

It seems to me we should aim for safety first hence I went with Recreate strategy by default. 

### Stale cache considerations
If our client cache is stale, the operator might not see the actual state, but outdated one. I think there is just one case where we won't get the expected behavior.

Actual version (version in cache):
```
spec  | pods
A (A) | A (A), A (A), A (A)
-> version upgrade from A to B
B (A) | A (A), A (A), A (A)
B (B) | A (A), A (A), A (A)
B (B) | B (A), B (A), B (A)
B (B) | B (B), B (B), B (A)
-> non-version config change
```

- spec version gets updated from A to B
- all pods get updated to B, but cache still contains a stale entry with Pod at version A
- another change to spec comes in. It's not related to version, but as we read the stale cache we consider that version upgrade is still in progress and we use Recreate strategy
- Kibana has downtime when it wasn't necessary

To avoid the issue above we inspect the number of replicasets for given deployment. If there is more then one and they have multiple versions we requeue and wait until it stabilizes, ie. all pods are owned by a single replicaset.