### PR TITLE
Fix webhook flag in Makefile and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ go-run:
 				--ca-cert-validity=10h --ca-cert-rotate-before=1h \
 				--operator-namespace=default \
 				--namespaces=$(MANAGED_NAMESPACES) \
-				--auto-install-webhooks=false
+				--manage-webhook-certs=false
 
 go-debug:
 	@(cd cmd &&	AUTO_PORT_FORWARD=true dlv debug \
@@ -183,7 +183,7 @@ go-debug:
 		--ca-cert-rotate-before=1h \
 		--operator-namespace=default \
 		--namespaces=$(MANAGED_NAMESPACES) \
-		--auto-install-webhooks=false)
+		--manage-webhook-certs=false)
 
 build-operator-image:
 ifeq ($(SKIP_DOCKER_COMMAND), false)

--- a/docs/operator-config.asciidoc
+++ b/docs/operator-config.asciidoc
@@ -22,7 +22,7 @@ You can use several options to configure ECK. Unless otherwise noted, these opti
 |`ca-cert-rotate-before` |duration (string) |1d |Duration representing how long before expiration CA certificates should be reissued
 |`cert-validity` |duration (string) |1y |Duration representing how long before a newly created TLS certificate expires
 |`cert-rotate-before` |duration (string) |1d |Duration representing how long before expiration TLS certificates should be reissued
-|`auto-install-webhooks` |bool |true |Enables automatic webhook installation
+|`manage-webhook-certs` |bool |true |Enables automatic webhook certificate management
 |`operator-namespace` |string |`""` |K8s namespace the operator runs in
 |`webhook-secret` |string |`""` |K8s secret name mounted into /tmp/cert to be used for webhook certificates
 |`webhook-pods-label` |string |`""` |K8s label to select pods running the operator


### PR DESCRIPTION
The Makefile and the docs still contained the now removed `auto-install-webhooks` flag. This PR fixes both occurences and replaces them with `mange-webhook-certs`