### PR TITLE
Set e2e webhook to fail

### DIFF
--- a/config/e2e/global_operator.yaml
+++ b/config/e2e/global_operator.yaml
@@ -213,7 +213,7 @@ webhooks:
         namespace: {{ .GlobalOperator.Namespace }}
         # this is the path controller-runtime automatically generates
         path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
-    failurePolicy: Ignore
+    failurePolicy: Fail
     name: elastic-es-validation.k8s.elastic.co
     rules:
       - apiGroups:


### PR DESCRIPTION
Changes the webhook configuration to fail so that we can be sure we are exercising the webhook in e2e tests