### PR TITLE
Remove double quotes from docker address

### DIFF
--- a/build/ci/nightly/Jenkinsfile
+++ b/build/ci/nightly/Jenkinsfile
@@ -29,11 +29,11 @@ pipeline {
                 sh """
                     cat > .env <<EOF
 GCLOUD_PROJECT = $GCLOUD_PROJECT
-REGISTRY = "docker.elastic.co"
-REPOSITORY = "eck-snapshots"
-IMG_NAME = "eck-operator"
-SNAPSHOT = "true"
-LICENSE_PUBKEY = "/go/src/github.com/elastic/cloud-on-k8s/build/ci/license.key"
+REGISTRY = docker.elastic.co
+REPOSITORY = eck-snapshots
+IMG_NAME = eck-operator
+SNAPSHOT = true
+LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/build/ci/license.key
 IMG_SUFFIX = -ci
 ELASTIC_DOCKER_LOGIN = eckadmin
 EOF


### PR DESCRIPTION
An attempt to fix https://github.com/elastic/cloud-on-k8s/issues/2141.