### PR TITLE
Run dump upload in every parallel build stage

### DIFF
--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -79,11 +79,6 @@ pipeline {
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token'
                 }
-                googleStorageUpload bucket: "gs://devops-ci-artifacts/jobs/$JOB_NAME/$BUILD_NUMBER",
-                    credentialsId: "devops-ci-gcs-plugin",
-                    pattern: "*.tgz",
-                    sharedPublicly: true,
-                    showInline: true
             }
         }
         cleanup {
@@ -140,6 +135,11 @@ EOF
 
         if (env.SHELL_EXIT_CODE != 0) {
             failedTests.addAll(lib.getListOfFailedTests())
+            googleStorageUpload bucket: "gs://devops-ci-artifacts/jobs/$JOB_NAME/$BUILD_NUMBER",
+                credentialsId: "devops-ci-gcs-plugin",
+                pattern: "*.tgz",
+                sharedPublicly: true,
+                showInline: true
         }
 
         sh 'exit $SHELL_EXIT_CODE'

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -155,6 +155,11 @@ EOF
 
         if (env.SHELL_EXIT_CODE != 0) {
             failedTests.addAll(lib.getListOfFailedTests())
+            googleStorageUpload bucket: "gs://devops-ci-artifacts/jobs/$JOB_NAME/$BUILD_NUMBER",
+                credentialsId: "devops-ci-gcs-plugin",
+                pattern: "*.tgz",
+                sharedPublicly: true,
+                showInline: true
         }
 
         sh 'exit $SHELL_EXIT_CODE'


### PR DESCRIPTION
Currently the eck-dump upload is configured to run after all parallel stages have completed. This does not work because each stage runs on a different worker and the result of the dumps is not available in the filesystem of the worker running the final post build steps.

This moves the GCS upload into the individual stages. 