### PR TITLE
Use release build constraint for nightly build

### DIFF
--- a/build/ci/nightly/Jenkinsfile
+++ b/build/ci/nightly/Jenkinsfile
@@ -33,6 +33,7 @@ REGISTRY = docker.elastic.co
 REPOSITORY = eck-snapshots
 IMG_NAME = eck-operator
 SNAPSHOT = true
+GO_TAGS = release
 LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/build/ci/license.key
 IMG_SUFFIX = -ci
 ELASTIC_DOCKER_LOGIN = eckadmin


### PR DESCRIPTION
Nightly build was missing the 'release' build tag which enables the inclusion of the correct public key. That subsequently leads to the dependent test runs failing when executing licensing related tests.

Fixes #2159 