### PR TITLE
Nightly: use release build tag only in Docker image build step

### DIFF
--- a/build/ci/nightly/Jenkinsfile
+++ b/build/ci/nightly/Jenkinsfile
@@ -33,8 +33,6 @@ REGISTRY = docker.elastic.co
 REPOSITORY = eck-snapshots
 IMG_NAME = eck-operator
 SNAPSHOT = true
-GO_TAGS = release
-export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/build/ci/license.key
 IMG_SUFFIX = -ci
 ELASTIC_DOCKER_LOGIN = eckadmin
 EOF
@@ -50,6 +48,8 @@ EOF
                     export OPERATOR_IMAGE=${REGISTRY}/${REPOSITORY}/${IMG_NAME}:\$VERSION
                     echo \$OPERATOR_IMAGE > eck_image.txt
                     cat >> .env <<EOF
+GO_TAGS = release
+export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/build/ci/license.key
 OPERATOR_IMAGE = "\$OPERATOR_IMAGE"
 EOF
                     make -C build/ci get-docker-creds get-elastic-public-key TARGET=ci-release ci


### PR DESCRIPTION
We don't need the release build tag for the unit and integration test step but for the actual image build. 