### PR TITLE
Sort seed hosts to avoid unecessary configmap updates

### DIFF
--- a/pkg/controller/elasticsearch/settings/masters.go
+++ b/pkg/controller/elasticsearch/settings/masters.go
@@ -7,6 +7,7 @@ package settings
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
@@ -59,6 +60,8 @@ func UpdateSeedHostsConfigMap(
 
 	var hosts string
 	if seedHosts != nil {
+		// avoid unnecessary pod cycles due to changing order of seed hosts
+		sort.Strings(seedHosts)
 		hosts = strings.Join(seedHosts, "\n")
 	}
 	expected := corev1.ConfigMap{

--- a/pkg/controller/elasticsearch/settings/masters.go
+++ b/pkg/controller/elasticsearch/settings/masters.go
@@ -60,7 +60,7 @@ func UpdateSeedHostsConfigMap(
 
 	var hosts string
 	if seedHosts != nil {
-		// avoid unnecessary pod cycles due to changing order of seed hosts
+		// avoid unnecessary secret updates due to changing order of seed hosts
 		sort.Strings(seedHosts)
 		hosts = strings.Join(seedHosts, "\n")
 	}

--- a/pkg/controller/elasticsearch/settings/masters.go
+++ b/pkg/controller/elasticsearch/settings/masters.go
@@ -60,7 +60,7 @@ func UpdateSeedHostsConfigMap(
 
 	var hosts string
 	if seedHosts != nil {
-		// avoid unnecessary secret updates due to changing order of seed hosts
+		// avoid unnecessary config map updates due to changing order of seed hosts
 		sort.Strings(seedHosts)
 		hosts = strings.Join(seedHosts, "\n")
 	}

--- a/pkg/controller/elasticsearch/settings/masters_test.go
+++ b/pkg/controller/elasticsearch/settings/masters_test.go
@@ -102,7 +102,7 @@ func TestUpdateSeedHostsConfigMap(t *testing.T) {
 				scheme: scheme.Scheme,
 			},
 			wantErr:         false,
-			expectedContent: "10.0.9.2:9300\n10.0.3.3:9300",
+			expectedContent: "10.0.3.3:9300\n10.0.9.2:9300",
 		},
 		{
 			name: "All masters have IPs, some nodes don't",
@@ -119,7 +119,22 @@ func TestUpdateSeedHostsConfigMap(t *testing.T) {
 				scheme: scheme.Scheme,
 			},
 			wantErr:         false,
-			expectedContent: "10.0.9.2:9300\n10.0.6.5:9300\n10.0.3.3:9300",
+			expectedContent: "10.0.3.3:9300\n10.0.6.5:9300\n10.0.9.2:9300",
+		},
+		{
+			name: "Ordering of pods should not matter",
+			args: args{
+				pods: []corev1.Pod{ //
+					newPodWithIP("master2", "10.0.6.5", true),
+					newPodWithIP("master3", "10.0.3.3", true),
+					newPodWithIP("master1", "10.0.9.2", true),
+				},
+				c:      k8s.WrappedFakeClient(),
+				es:     es,
+				scheme: scheme.Scheme,
+			},
+			wantErr:         false,
+			expectedContent: "10.0.3.3:9300\n10.0.6.5:9300\n10.0.9.2:9300",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
```
{"level":"info","@timestamp":"2019-11-25T01:27:00.726Z","logger":"settings","message":"Seed hosts updated","ver":"1.0.0-beta1-b559ec38","namespace":"e2e-m9cld-mercury","es_name":"test-es-keystore-drf6","hosts":["10.72.2.38:9300","10.72.1.31:9300","10.72.0.25:9300"]}
{"level":"info","@timestamp":"2019-11-25T01:27:00.781Z","logger":"zen2","message":"Ensuring no voting exclusions are set","ver":"1.0.0-beta1-b559ec38","namespace":"e2e-m9cld-mercury","es_name":"test-es-keystore-drf6"}
{"level":"info","@timestamp":"2019-11-25T01:27:00.849Z","logger":"elasticsearch-controller","message":"Updating status","ver":"1.0.0-beta1-b559ec38","iteration":1232,"namespace":"e2e-m9cld-mercury","es_name":"test-es-keystore-drf6"}
{"level":"info","@timestamp":"2019-11-25T01:27:00.849Z","logger":"elasticsearch-controller","message":"Ending reconciliation run","ver":"1.0.0-beta1-b559ec38","iteration":1232,"namespace":"e2e-m9cld-mercury","name":"test-es-keystore-drf6","took":0.8772917}
{"level":"info","@timestamp":"2019-11-25T01:27:00.849Z","logger":"elasticsearch-controller","message":"Starting reconciliation run","ver":"1.0.0-beta1-b559ec38","iteration":1233,"namespace":"e2e-m9cld-mercury","name":"test-es-keystore-drf6"}
{"level":"info","@timestamp":"2019-11-25T01:27:01.587Z","logger":"generic-reconciler","message":"Updating resource","ver":"1.0.0-beta1-b559ec38","kind":"ConfigMap","namespace":"e2e-m9cld-mercury","name":"test-es-keystore-drf6-es-unicast-hosts"}
{"level":"info","@timestamp":"2019-11-25T01:27:01.595Z","logger":"settings","message":"Seed hosts updated","ver":"1.0.0-beta1-b559ec38","namespace":"e2e-m9cld-mercury","es_name":"test-es-keystore-drf6","hosts":["10.72.1.31:9300","10.72.0.25:9300","10.72.2.38:9300"]}
{"level":"info","@timestamp":"2019-11-25T01:27:01.671Z","logger":"zen2","message":"Ensuring no voting exclusions are set","ver":"1.0.0-beta1-b559ec38","namespace":"e2e-m9cld-mercury","es_name":"test-es-keystore-drf6"}
{"level":"info","@timestamp":"2019-11-25T01:27:01.736Z","logger":"elasticsearch-controller","message":"Updating status","ver":"1.0.0-beta1-b559ec38","iteration":1233,"namespace":"e2e-m9cld-mercury","es_name":"test-es-keystore-drf6"}
{"level":"info","@timestamp":"2019-11-25T01:27:01.736Z","logger":"elasticsearch-controller","message":"Ending reconciliation run","ver":"1.0.0-beta1-b559ec38","iteration":1233,"namespace":"e2e-m9cld-mercury","name":"test-es-keystore-drf6","took":0.886652754}
{"level":"info","@timestamp":"2019-11-25T01:27:01.736Z","logger":"elasticsearch-controller","message":"Starting reconciliation run","ver":"1.0.0-beta1-b559ec38","iteration":1234,"namespace":"e2e-m9cld-mercury","name":"test-es-keystore-drf6"}
{"level":"info","@timestamp":"2019-11-25T01:27:02.466Z","logger":"generic-reconciler","message":"Updating resource","ver":"1.0.0-beta1-b559ec38","kind":"ConfigMap","namespace":"e2e-m9cld-mercury","name":"test-es-keystore-drf6-es-unicast-hosts"}
{"level":"info","@timestamp":"2019-11-25T01:27:02.475Z","logger":"settings","message":"Seed hosts updated","ver":"1.0.0-beta1-b559ec38","namespace":"e2e-m9cld-mercury","es_name":"test-es-keystore-drf6","hosts":["10.72.0.25:9300","10.72.2.38:9300","10.72.1.31:9300"]}
```
While trying to understand why our e2e tests fail I noticed a lot of seed host updates going on that seemed purely caused by non-deterministic pod order and consequently updates of the configmap we use for the unicast hosts file.  

This PR sorts the seed nodes to avoid these configmap updates and adjusts the relevant unit test accordingly.
