### PR TITLE
Don't use env variables ending in _FILE with Elasticsearch

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/defaults.go
+++ b/pkg/controller/elasticsearch/nodespec/defaults.go
@@ -55,7 +55,7 @@ func DefaultEnvVars(httpCfg v1beta1.HTTPConfig) []corev1.EnvVar {
 	return append(
 		defaults.PodDownwardEnvVars,
 		[]corev1.EnvVar{
-			{Name: settings.EnvProbePasswordFile, Value: path.Join(esvolume.ProbeUserSecretMountPath, user.InternalProbeUserName)},
+			{Name: settings.EnvProbePasswordPath, Value: path.Join(esvolume.ProbeUserSecretMountPath, user.InternalProbeUserName)},
 			{Name: settings.EnvProbeUsername, Value: user.InternalProbeUserName},
 			{Name: settings.EnvReadinessProbeProtocol, Value: httpCfg.Protocol()},
 

--- a/pkg/controller/elasticsearch/nodespec/readiness_probe.go
+++ b/pkg/controller/elasticsearch/nodespec/readiness_probe.go
@@ -33,8 +33,8 @@ const ReadinessProbeScript string = `
 CURL_TIMEOUT=3
 
 # setup basic auth if credentials are available
-if [ -n "${PROBE_USERNAME}" ] && [ -f "${PROBE_PASSWORD_FILE}" ]; then
-  PROBE_PASSWORD=$(<$PROBE_PASSWORD_FILE)
+if [ -n "${PROBE_USERNAME}" ] && [ -f "${PROBE_PASSWORD_PATH}" ]; then
+  PROBE_PASSWORD=$(<$PROBE_PASSWORD_PATH)
   BASIC_AUTH="-u ${PROBE_USERNAME}:${PROBE_PASSWORD}"
 else
   BASIC_AUTH=''

--- a/pkg/controller/elasticsearch/settings/environment.go
+++ b/pkg/controller/elasticsearch/settings/environment.go
@@ -8,7 +8,7 @@ package settings
 const (
 	EnvEsJavaOpts = "ES_JAVA_OPTS"
 
-	EnvProbePasswordFile      = "PROBE_PASSWORD_FILE"
+	EnvProbePasswordPath      = "PROBE_PASSWORD_PATH"
 	EnvProbeUsername          = "PROBE_USERNAME"
 	EnvReadinessProbeProtocol = "READINESS_PROBE_PROTOCOL"
 


### PR DESCRIPTION
*_FILE variables will interpreted as file paths and be read by
Elasticsearch as of v8.0 and are required to have strict read-only permissions.

Fixes #2177 (or rather works around it) 

Will raise an [issue](https://github.com/elastic/elasticsearch/issues/49653) against the Elasticsearch repo as well because on k8s even when using restricted `SecretVolume` permissions the file the variable points to is a symlink with 0777 permissions and only the file it is pointing to has the requested restricted permisssions with 0600 or 0400.

```
[root@cluster1-es-default-0 elasticsearch]# ls -l /mnt/elastic-internal/probe-user/
total 0
lrwxrwxrwx 1 root root 29 Nov 27 15:55 elastic-internal-probe -> ..data/elastic-internal-probe
[root@cluster1-es-default-0 elasticsearch]# ls -l /mnt/elastic-internal/probe-user/..data/elastic-internal-probe 
-rw------- 1 root root 24 Nov 27 15:55 /mnt/elastic-internal/probe-user/..data/elastic-internal-probe
```