### PR TITLE
Refactor 'watching' checks to use test.Watcher

### DIFF
--- a/test/e2e/test/elasticsearch/checks_budget.go
+++ b/test/e2e/test/elasticsearch/checks_budget.go
@@ -5,151 +5,102 @@
 package elasticsearch
 
 import (
-	"fmt"
 	"math"
+	"testing"
 	"time"
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/reconcile"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/stretchr/testify/assert"
 )
 
-type MasterChangeBudgetCheck struct {
-	Observations []int
-	Errors       []error
-	stopChan     chan struct{}
-	es           v1beta1.Elasticsearch
-	interval     time.Duration
-	client       k8s.Client
-}
+// NewMasterChangeBudgetWatcher returns a watcher that checks whether at most one master pod at a time is added/removed.
+// Relies on the assumption that resolution of 1 second is high enough to observe all change steps.
+func NewMasterChangeBudgetWatcher(es v1beta1.Elasticsearch) test.Watcher {
+	var observations []int
 
-func NewMasterChangeBudgetCheck(es v1beta1.Elasticsearch, interval time.Duration, client k8s.Client) *MasterChangeBudgetCheck {
-	return &MasterChangeBudgetCheck{
-		es:       es,
-		interval: interval,
-		client:   client,
-		stopChan: make(chan struct{}),
-	}
-}
-
-func (mc *MasterChangeBudgetCheck) Start() {
-	go func() {
-		ticker := time.NewTicker(mc.interval)
-		for {
-			select {
-			case <-mc.stopChan:
+	return test.NewWatcher(
+		"master additions and removals: expect single master added/removed at a time",
+		1*time.Second,
+		func(k *test.K8sClient, t *testing.T) {
+			pods, err := sset.GetActualMastersForCluster(k.Client, es)
+			if err != nil {
+				t.Logf("got error listing masters: %v", err)
 				return
-			case <-ticker.C:
-				pods, err := sset.GetActualMastersForCluster(mc.client, mc.es)
-				if err != nil {
-					mc.Errors = append(mc.Errors, err)
-					continue
-				}
-				mc.Observations = append(mc.Observations, len(pods))
-				continue
 			}
-		}
-	}()
+			observations = append(observations, len(pods))
+		},
+		func(k *test.K8sClient, t *testing.T) {
+			for i := 1; i < len(observations); i++ {
+				prev := observations[i-1]
+				cur := observations[i]
+				abs := int(math.Abs(float64(cur - prev)))
+				// This is ofc potentially flaky if we miss an observation and see suddenly more than one master
+				// node popping up. This is due the fact that this check is depending on timing, the underlying
+				// assumption being that the observation interval is always shorter than the time an Elasticsearch
+				// node needs to boot.
+				assert.False(t, abs > 1, "%d master changes in one observation, expected max 1", abs)
+			}
+		})
 }
 
-func (mc *MasterChangeBudgetCheck) Stop() {
-	mc.stopChan <- struct{}{}
-}
+// NewChangeBudgetWatcher returns a watcher that checks whether the pod count stays within the given change budget.
+// Assumes that observations resolution of 1 second is high enough to observe all changes steps.
+func NewChangeBudgetWatcher(from v1beta1.ElasticsearchSpec, to v1beta1.Elasticsearch) test.Watcher {
+	var PodCounts []int32
+	var ReadyPodCounts []int32
 
-func (mc *MasterChangeBudgetCheck) Verify(maxRateOfChange int) error {
-	for i := 1; i < len(mc.Observations); i++ {
-		prev := mc.Observations[i-1]
-		cur := mc.Observations[i]
-		abs := int(math.Abs(float64(cur - prev)))
-		if abs > maxRateOfChange {
-			// This is ofc potentially flaky if we miss an observation and see suddenly more than one master
-			// node popping up. This is due the fact that this check is depending on timing, the underlying
-			// assumption being that the observation interval is always shorter than the time an Elasticsearch
-			// node needs to boot.
-			return fmt.Errorf("%d master changes in one observation, expected max %d", abs, maxRateOfChange)
-		}
-	}
-	return nil
-}
-
-type ChangeBudgetCheck struct {
-	PodCounts      []int32
-	ReadyPodCounts []int32
-	Errors         []error
-	stopChan       chan struct{}
-	es             v1beta1.Elasticsearch
-	client         k8s.Client
-}
-
-func NewChangeBudgetCheck(es v1beta1.Elasticsearch, client k8s.Client) *ChangeBudgetCheck {
-	return &ChangeBudgetCheck{
-		es:       es,
-		client:   client,
-		stopChan: make(chan struct{}),
-	}
-}
-
-func (c *ChangeBudgetCheck) Start() {
-	go func() {
-		ticker := time.NewTicker(1 * time.Second)
-		for {
-			select {
-			case <-c.stopChan:
+	es := to.Spec
+	return test.NewWatcher(
+		"pod count for change budget: expect to stay within the change budget",
+		1*time.Second,
+		func(k *test.K8sClient, t *testing.T) {
+			pods, err := sset.GetActualPodsForCluster(k.Client, to)
+			if err != nil {
+				t.Logf("got error listing pods: %v", err)
 				return
-			case <-ticker.C:
-				pods, err := sset.GetActualPodsForCluster(c.client, c.es)
-				if err != nil {
-					c.Errors = append(c.Errors, err)
-					continue
+			}
+			podsReady := reconcile.AvailableElasticsearchNodes(pods)
+
+			PodCounts = append(PodCounts, int32(len(pods)))
+			ReadyPodCounts = append(ReadyPodCounts, int32(len(podsReady)))
+		},
+		func(k *test.K8sClient, t *testing.T) {
+			desired := es.NodeCount()
+			budget := es.UpdateStrategy.ChangeBudget
+
+			// allowedMin, allowedMax bound observed values between the ones we expect to see given desired count and change budget.
+			// seenMin, seenMax allow for ramping up/down nodes when moving from spec outside of <allowedMin, allowedMax> node count.
+			// It's done by tracking lowest/highest values seen outside of bounds. This permits the values to only move monotonically
+			// until they are inside <allowedMin, allowedMax>.
+			maxSurge := budget.GetMaxSurgeOrDefault()
+			if maxSurge != nil {
+				allowedMax := desired + *maxSurge
+				seenMin := from.NodeCount()
+				for _, v := range PodCounts {
+					if v <= allowedMax || v <= seenMin {
+						seenMin = v
+						continue
+					}
+
+					assert.Fail(t, "change budget violated", "pod count %d when allowed max was %d", v, allowedMax)
 				}
-				podsReady := reconcile.AvailableElasticsearchNodes(pods)
-
-				c.PodCounts = append(c.PodCounts, int32(len(pods)))
-				c.ReadyPodCounts = append(c.ReadyPodCounts, int32(len(podsReady)))
-			}
-		}
-	}()
-}
-
-func (c *ChangeBudgetCheck) Stop() {
-	c.stopChan <- struct{}{}
-}
-
-func (c *ChangeBudgetCheck) Verify(from v1beta1.ElasticsearchSpec, to v1beta1.ElasticsearchSpec) error {
-	desired := to.NodeCount()
-	budget := to.UpdateStrategy.ChangeBudget
-
-	// allowedMin, allowedMax bound observed values between the ones we expect to see given desired count and change budget.
-	// seenMin, seenMax allow for ramping up/down nodes when moving from spec outside of <allowedMin, allowedMax> node count.
-	// It's done by tracking lowest/highest values seen outside of bounds. This permits the values to only move monotonically
-	// until they are inside <allowedMin, allowedMax>.
-	maxSurge := budget.GetMaxSurgeOrDefault()
-	if maxSurge != nil {
-		allowedMax := desired + *maxSurge
-		seenMin := from.NodeCount()
-		for _, v := range c.PodCounts {
-			if v <= allowedMax || v <= seenMin {
-				seenMin = v
-				continue
 			}
 
-			return fmt.Errorf("pod count %d when allowed max was %d", v, allowedMax)
-		}
-	}
+			maxUnavailable := budget.GetMaxUnavailableOrDefault()
+			if maxUnavailable != nil {
+				allowedMin := desired - *maxUnavailable
+				seenMax := from.NodeCount()
+				for _, v := range ReadyPodCounts {
+					if v >= allowedMin || v >= seenMax {
+						seenMax = v
+						continue
+					}
 
-	maxUnavailable := budget.GetMaxUnavailableOrDefault()
-	if maxUnavailable != nil {
-		allowedMin := desired - *maxUnavailable
-		seenMax := from.NodeCount()
-		for _, v := range c.ReadyPodCounts {
-			if v >= allowedMin || v >= seenMax {
-				seenMax = v
-				continue
+					assert.Fail(t, "change budget violated", "ready pod count %d when allowed min was %d", v, allowedMin)
+				}
 			}
-
-			return fmt.Errorf("ready pod count %d when allowed min was %d", v, allowedMin)
-		}
-	}
-	return nil
+		})
 }

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -43,14 +43,14 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 	var clusterIDBeforeMutation string
 	var continuousHealthChecks *ContinuousHealthCheck
 	var dataIntegrityCheck *DataIntegrityCheck
-	var masterChangeBudgetCheck *MasterChangeBudgetCheck
-	var changeBudgetCheck *ChangeBudgetCheck
-
 	mutatedFrom := b.MutatedFrom
 	if mutatedFrom == nil {
 		// cluster mutates to itself (same spec)
 		mutatedFrom = &b
 	}
+
+	masterChangeBudgetWatcher := NewMasterChangeBudgetWatcher(b.Elasticsearch)
+	changeBudgetWatcher := NewChangeBudgetWatcher(mutatedFrom.Elasticsearch.Spec, b.Elasticsearch)
 
 	return test.StepList{
 		test.Step{
@@ -75,20 +75,8 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 				continuousHealthChecks.Start()
 			},
 		},
-		test.Step{
-			Name: "Start tracking master additions and removals",
-			Test: func(t *testing.T) {
-				masterChangeBudgetCheck = NewMasterChangeBudgetCheck(b.Elasticsearch, 1*time.Second, k.Client)
-				masterChangeBudgetCheck.Start()
-			},
-		},
-		test.Step{
-			Name: "Start tracking pod count",
-			Test: func(t *testing.T) {
-				changeBudgetCheck = NewChangeBudgetCheck(b.Elasticsearch, k.Client)
-				changeBudgetCheck.Start()
-			},
-		},
+		masterChangeBudgetWatcher.StartStep(k),
+		changeBudgetWatcher.StartStep(k),
 		RetrieveClusterUUIDStep(b.Elasticsearch, k, &clusterIDBeforeMutation),
 	}.
 		WithSteps(AnnotatePodsWithBuilderHash(*mutatedFrom, k)).
@@ -97,20 +85,8 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 		WithSteps(b.CheckStackTestSteps(k)).
 		WithSteps(test.StepList{
 			CompareClusterUUIDStep(b.Elasticsearch, k, &clusterIDBeforeMutation),
-			test.Step{
-				Name: "Master change budget must not have been exceeded",
-				Test: func(t *testing.T) {
-					masterChangeBudgetCheck.Stop()
-					require.NoError(t, masterChangeBudgetCheck.Verify(1)) // fixed budget of 1 master node added/removed at a time
-				},
-			},
-			test.Step{
-				Name: "Pod count must not violate change budget",
-				Test: func(t *testing.T) {
-					changeBudgetCheck.Stop()
-					require.NoError(t, changeBudgetCheck.Verify(mutatedFrom.Elasticsearch.Spec, b.Elasticsearch.Spec))
-				},
-			},
+			masterChangeBudgetWatcher.StopStep(k),
+			changeBudgetWatcher.StopStep(k),
 			test.Step{
 				Name: "Elasticsearch cluster health should not have been red during mutation process",
 				Skip: func() bool {


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/2174.