### PR TITLE
Add some documentation to help people easy understand where is the position of podTemplate

### DIFF
--- a/docs/managing-compute-resources.asciidoc
+++ b/docs/managing-compute-resources.asciidoc
@@ -25,7 +25,14 @@ For Elasticsearch objects, make sure to consider the heap size when you set reso
 ----
 spec:
   nodeSets:
-  - podTemplate:
+  - name: elasticsearch
+    count: 1
+    config:
+      node.master: true
+      node.data: true
+      node.ingest: true
+      node.store.allow_mmap: false
+    podTemplate:
       spec:
         containers:
         - name: elasticsearch


### PR DESCRIPTION
Since podTemplate is a field of nodeSets. So the original document makes people confused about the position of podTemplate.