### PR TITLE
Restore v1alpha1 in the list of crds

### DIFF
--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -380,6 +380,9 @@ spec:
   - name: v1beta1
     served: true
     storage: true
+  - name: v1alpha1
+    served: false
+    storage: false
 status:
   acceptedNames:
     kind: ""
@@ -1086,6 +1089,9 @@ spec:
   - name: v1beta1
     served: true
     storage: true
+  - name: v1alpha1
+    served: false
+    storage: false
 status:
   acceptedNames:
     kind: ""
@@ -1464,6 +1470,9 @@ spec:
   - name: v1beta1
     served: true
     storage: true
+  - name: v1alpha1
+    served: false
+    storage: false
 status:
   acceptedNames:
     kind: ""

--- a/config/crds/patches/all-patches.yaml
+++ b/config/crds/patches/all-patches.yaml
@@ -4,3 +4,11 @@
 # TODO: remove when fixed in controller-tools
 - op: remove
   path: /spec/validation/openAPIV3Schema/type
+# Add v1alpha1 to the list of versions, to not break compatibility when upgrading from previous versions of the CRD
+# that list the v1alpha1 version in their status.storedVersions. We mark it as `served: false` so it cannot be used.
+- op: add
+  path: /spec/versions/-
+  value:
+    name: v1alpha1
+    served: false
+    storage: false

--- a/config/crds/patches/all-patches.yaml
+++ b/config/crds/patches/all-patches.yaml
@@ -1,0 +1,6 @@
+# Remove validation.Type that causes failures on k8s 1.11.
+# This should have been fixed with https://github.com/kubernetes-sigs/controller-tools/pull/72, but it looks like
+# this commit has been lost in history. See https://github.com/kubernetes-sigs/controller-tools/issues/296.
+# TODO: remove when fixed in controller-tools
+- op: remove
+  path: /spec/validation/openAPIV3Schema/type

--- a/config/crds/patches/apm-kibana-patches.yaml
+++ b/config/crds/patches/apm-kibana-patches.yaml
@@ -5,9 +5,3 @@
 # that would maybe not match the user's k8s version.
 - op: remove
   path: /spec/validation/openAPIV3Schema/properties/spec/properties/podTemplate/properties
-# Remove validation.Type that causes failures on k8s 1.11.
-# This should have been fixed with https://github.com/kubernetes-sigs/controller-tools/pull/72, but it looks like
-# this commit has been lost in history. See https://github.com/kubernetes-sigs/controller-tools/issues/296.
-# TODO: remove when fixed in controller-tools
-- op: remove
-  path: /spec/validation/openAPIV3Schema/type

--- a/config/crds/patches/elasticsearch-patches.yaml
+++ b/config/crds/patches/elasticsearch-patches.yaml
@@ -5,9 +5,3 @@
 # that would maybe not match the user's k8s version.
 - op: remove
   path: /spec/validation/openAPIV3Schema/properties/spec/properties/nodeSets/items/properties/podTemplate/properties
-# Remove validation.Type that causes failures on k8s 1.11.
-# This should have been fixed with https://github.com/kubernetes-sigs/controller-tools/pull/72, but it looks like
-# this commit has been lost in history. See https://github.com/kubernetes-sigs/controller-tools/issues/296.
-# TODO: remove when fixed in controller-tools
-- op: remove
-  path: /spec/validation/openAPIV3Schema/type

--- a/config/crds/patches/kustomization.yaml
+++ b/config/crds/patches/kustomization.yaml
@@ -2,21 +2,43 @@ bases:
   - ../bases
 
 patchesJson6902:
+  # patches that apply to all CRDS
   - target:
       group: apiextensions.k8s.io
       version: v1beta1
       kind: CustomResourceDefinition
       name: apmservers.apm.k8s.elastic.co
-    path: apm-and-kibana-podtemplate-patch.yaml
+    path: all-patches.yaml
   - target:
       group: apiextensions.k8s.io
       version: v1beta1
       kind: CustomResourceDefinition
       name: elasticsearches.elasticsearch.k8s.elastic.co
-    path: elasticsearch-podtemplate-patch.yaml
+    path: all-patches.yaml
   - target:
       group: apiextensions.k8s.io
       version: v1beta1
       kind: CustomResourceDefinition
       name: kibanas.kibana.k8s.elastic.co
-    path: apm-and-kibana-podtemplate-patch.yaml
+    path: all-patches.yaml
+  # custom patches for apm
+  - target:
+      group: apiextensions.k8s.io
+      version: v1beta1
+      kind: CustomResourceDefinition
+      name: apmservers.apm.k8s.elastic.co
+    path: apm-kibana-patches.yaml
+  # custom patches for Elasticsearch
+  - target:
+      group: apiextensions.k8s.io
+      version: v1beta1
+      kind: CustomResourceDefinition
+      name: elasticsearches.elasticsearch.k8s.elastic.co
+    path: elasticsearch-patches.yaml
+  # custom patches for Kibana
+  - target:
+      group: apiextensions.k8s.io
+      version: v1beta1
+      kind: CustomResourceDefinition
+      name: kibanas.kibana.k8s.elastic.co
+    path: apm-kibana-patches.yaml


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/2196.

Removing v1alpha1 from the list of version in the CRD prevents users to successfully upgrade
from alpha -> beta -> GA version of the operator. This is because in
their situation, the v1alpha1 version is listed in `status.storedVersion`.
We cannot easily patch the status only when using `kubectl apply` as
upgrade mechanism, and patching the entire CRD fails the validation
webhook that checks versions in the status.

This PR patches the output CRD to list the `v1alpha1` version, but
mark it with `served: false` so it cannot be used anymore.

See this issue for more details.

It also restructures a bit the CRD patches directory so we now have:
- patches that apply to all resources in `all-patches.yaml`
- patches that apply to specific resources in `elasticsearch-patches.yaml`, `apm-kibana-patches.yaml`
