### PR TITLE
Add an E2E test to cover Elasticsearch CRD validation

### DIFF
--- a/test/e2e/es/validation_test.go
+++ b/test/e2e/es/validation_test.go
@@ -1,0 +1,26 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package es
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// TestElasticsearchCRDOpenAPIValidation tests that the CRD OpenAPI validation is correctly setup.
+// It does not test every single validation, just checks validation exists.
+func TestElasticsearchCRDOpenAPIValidation(t *testing.T) {
+	// create an ES cluster with 0 NodeSet
+	b := elasticsearch.NewBuilder("es-crd-validation")
+	k := test.NewK8sClientOrFatal()
+	// creation should be rejected
+	err := k.Client.Create(&b.Elasticsearch)
+	require.True(t, apierrors.IsInvalid(err))
+}


### PR DESCRIPTION
Ensure there is validation set at the CRD level (OpenAPI).

The test does not aim at checking every single validation, it just
checks validation is correctly set up, to cover regressions in the CRD
generation.

Relates https://github.com/elastic/cloud-on-k8s/issues/2044 (make sure it doesn't happen again).