### PR TITLE
Support 7.5

### DIFF
--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -80,6 +80,17 @@ pipeline {
                         }
                     }
                 }
+                stage("7.5.0") {
+                    agent {
+                        label 'linux'
+                    }
+                    steps {
+                        checkout scm
+                        script {
+                            runWith(lib, failedTests, "eck-75-${BUILD_NUMBER}-e2e", "7.5.0")
+                        }
+                    }
+                }
             }
         }
     }
@@ -107,7 +118,14 @@ pipeline {
         }
         cleanup {
             script {
-                clusters = ["eck-68-${BUILD_NUMBER}-e2e", "eck-71-${BUILD_NUMBER}-e2e", "eck-72-${BUILD_NUMBER}-e2e", "eck-73-${BUILD_NUMBER}-e2e", "eck-74-${BUILD_NUMBER}-e2e"]
+                clusters = [
+                    "eck-68-${BUILD_NUMBER}-e2e",
+                    "eck-71-${BUILD_NUMBER}-e2e",
+                    "eck-72-${BUILD_NUMBER}-e2e",
+                    "eck-73-${BUILD_NUMBER}-e2e",
+                    "eck-74-${BUILD_NUMBER}-e2e",
+                    "eck-75-${BUILD_NUMBER}-e2e"
+                ]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
                         parameters: [string(name: 'GKE_CLUSTER', value: clusters[i])],

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -28,11 +28,11 @@ pipeline {
         }
         stage('Run tests for different ELK stack versions in GKE') {
             parallel {
-                stage("6.8.4") {
+                stage("6.8.5") {
                     steps {
                         checkout scm
                         script {
-                            runWith(lib, failedTests, "eck-68-${BUILD_NUMBER}-e2e", "6.8.4")
+                            runWith(lib, failedTests, "eck-68-${BUILD_NUMBER}-e2e", "6.8.5")
                         }
                     }
                 }
@@ -69,14 +69,14 @@ pipeline {
                         }
                     }
                 }
-                stage("7.4.1") {
+                stage("7.4.2") {
                     agent {
                         label 'linux'
                     }
                     steps {
                         checkout scm
                         script {
-                            runWith(lib, failedTests, "eck-74-${BUILD_NUMBER}-e2e", "7.4.1")
+                            runWith(lib, failedTests, "eck-74-${BUILD_NUMBER}-e2e", "7.4.2")
                         }
                     }
                 }

--- a/test/e2e/es/version_upgrade_test.go
+++ b/test/e2e/es/version_upgrade_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestVersionUpgrade680To730(t *testing.T) {
-	initial := elasticsearch.NewBuilder("test-version-up-3-680-to-730").
-		WithVersion("6.8.0").
+	initial := elasticsearch.NewBuilder("test-version-up-3-685-to-730").
+		WithVersion("6.8.5").
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
@@ -23,31 +23,31 @@ func TestVersionUpgrade680To730(t *testing.T) {
 }
 
 func TestVersionUpgradeSingle680To730(t *testing.T) {
-	initial := elasticsearch.NewBuilder("test-version-up-1-680-to-730").
-		WithVersion("6.8.0").
+	initial := elasticsearch.NewBuilder("test-version-up-1-685-to-732").
+		WithVersion("6.8.5").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
-		WithVersion("7.3.0").
+		WithVersion("7.3.2").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	RunESMutation(t, initial, mutated)
 }
 
 func TestVersionUpgradeSingle710To730(t *testing.T) {
-	initial := elasticsearch.NewBuilder("test-version-up-1-710-to-730").
+	initial := elasticsearch.NewBuilder("test-version-up-1-710-to-732").
 		WithVersion("7.1.0").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
-		WithVersion("7.3.0").
+		WithVersion("7.3.2").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	RunESMutation(t, initial, mutated)
 }
 
 func TestVersionUpgradeSingle740To750(t *testing.T) {
-	initial := elasticsearch.NewBuilder("test-version-up-1-740-to-750").
+	initial := elasticsearch.NewBuilder("test-version-up-1-742-to-750").
 		WithVersion("7.4.2").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 

--- a/test/e2e/es/version_upgrade_test.go
+++ b/test/e2e/es/version_upgrade_test.go
@@ -45,3 +45,15 @@ func TestVersionUpgradeSingle710To730(t *testing.T) {
 
 	RunESMutation(t, initial, mutated)
 }
+
+func TestVersionUpgradeSingle740To750(t *testing.T) {
+	initial := elasticsearch.NewBuilder("test-version-up-1-740-to-750").
+		WithVersion("7.4.2").
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+
+	mutated := initial.WithNoESTopology().
+		WithVersion("7.5.0").
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+
+	RunESMutation(t, initial, mutated)
+}

--- a/test/e2e/es/version_upgrade_test.go
+++ b/test/e2e/es/version_upgrade_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
 )
 
-func TestVersionUpgrade680To720(t *testing.T) {
-	initial := elasticsearch.NewBuilder("test-version-up-3-680-to-720").
+func TestVersionUpgrade680To730(t *testing.T) {
+	initial := elasticsearch.NewBuilder("test-version-up-3-680-to-730").
 		WithVersion("6.8.0").
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
 
@@ -22,8 +22,8 @@ func TestVersionUpgrade680To720(t *testing.T) {
 	RunESMutation(t, initial, mutated)
 }
 
-func TestVersionUpgradeSingle680To720(t *testing.T) {
-	initial := elasticsearch.NewBuilder("test-version-up-1-680-to-720").
+func TestVersionUpgradeSingle680To730(t *testing.T) {
+	initial := elasticsearch.NewBuilder("test-version-up-1-680-to-730").
 		WithVersion("6.8.0").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
@@ -34,8 +34,8 @@ func TestVersionUpgradeSingle680To720(t *testing.T) {
 	RunESMutation(t, initial, mutated)
 }
 
-func TestVersionUpgradeSingle710To720(t *testing.T) {
-	initial := elasticsearch.NewBuilder("test-version-up-1-710-to-720").
+func TestVersionUpgradeSingle710To730(t *testing.T) {
+	initial := elasticsearch.NewBuilder("test-version-up-1-710-to-730").
 		WithVersion("7.1.0").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 

--- a/test/e2e/kb/version_upgrade_test.go
+++ b/test/e2e/kb/version_upgrade_test.go
@@ -23,7 +23,7 @@ func TestVersionUpgrade(t *testing.T) {
 	name := "test-version-upgrade"
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
-		WithVersion("7.4.1")
+		WithVersion("7.4.2")
 
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
@@ -45,7 +45,7 @@ func TestVersionUpgrade(t *testing.T) {
 	test.RunMutationsWhileWatching(
 		t,
 		[]test.Builder{esBuilder, kbBuilder},
-		[]test.Builder{esBuilder, kbBuilder.WithVersion("7.4.1").WithMutatedFrom(&kbBuilder)},
+		[]test.Builder{esBuilder, kbBuilder.WithVersion("7.4.2").WithMutatedFrom(&kbBuilder)},
 		[]test.Watcher{NewReadinessWatcher(opts...), NewVersionWatcher(opts...)},
 	)
 }
@@ -54,7 +54,7 @@ func TestVersionUpgradeAndRespec(t *testing.T) {
 	name := "test-upgrade-and-respec"
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
-		WithVersion("7.4.1")
+		WithVersion("7.4.2")
 
 	kbBuilder1 := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
@@ -64,7 +64,7 @@ func TestVersionUpgradeAndRespec(t *testing.T) {
 	// perform a Kibana version upgrade immediately followed by a Kibana configuration change.
 	// we want to make sure that the second upgrade will be done in rolling upgrade fashion instead of terminating
 	// and recreating all the pods at once.
-	kbBuilder2 := kbBuilder1.WithMutatedFrom(&kbBuilder1).WithVersion("7.4.1")
+	kbBuilder2 := kbBuilder1.WithMutatedFrom(&kbBuilder1).WithVersion("7.4.2")
 	kbBuilder3 := kbBuilder2.WithMutatedFrom(&kbBuilder2).WithLabel("some", "label")
 
 	opts := []client.ListOption{


### PR DESCRIPTION
- Add version `7.5.0` to the versions matrix of the stack-versions job
- Add an E2E test that upgrades from 7.4.2 to 7.5.0
- Bump the patch digit of old releases in the E2E test code and the stack-versions job

Resolves #2018.