### PR TITLE
Fix readiness script in case of operator upgrade

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/readiness_probe.go
+++ b/pkg/controller/elasticsearch/nodespec/readiness_probe.go
@@ -32,9 +32,16 @@ const ReadinessProbeScript string = `
 # Consider a node to be healthy if it responds to a simple GET on "/_cat/nodes?local"
 CURL_TIMEOUT=3
 
+# Check if PROBE_PASSWORD_PATH is set, otherwise fall back to its former name in 1.0.0.beta-1: PROBE_PASSWORD_FILE
+if [[ -z "${PROBE_PASSWORD_PATH}" ]]; then
+  probe_password_path="${PROBE_PASSWORD_FILE}"
+else
+  probe_password_path="${PROBE_PASSWORD_PATH}"
+fi
+
 # setup basic auth if credentials are available
-if [ -n "${PROBE_USERNAME}" ] && [ -f "${PROBE_PASSWORD_PATH}" ]; then
-  PROBE_PASSWORD=$(<$PROBE_PASSWORD_PATH)
+if [ -n "${PROBE_USERNAME}" ] && [ -f "${probe_password_path}" ]; then
+  PROBE_PASSWORD=$(<${probe_password_path})
   BASIC_AUTH="-u ${PROBE_USERNAME}:${PROBE_PASSWORD}"
 else
   BASIC_AUTH=''


### PR DESCRIPTION
If some Elasticsearch clusters have been deployed with 1.0.0-beta1 and the operator is upgraded then all pods suddenly became not ready: 

```
NAME                             READY   STATUS    RESTARTS   AGE   IP           NODE                                          NOMINATED NODE   READINESS GATES
pod/es-apm-sample-es-default-0   0/1     Running   0          19m   10.32.1.11   gke-michael-dev3-default-pool-4eb026fe-dt6p   <none>           <none>
pod/es-apm-sample-es-default-1   0/1     Running   0          19m   10.32.0.12   gke-michael-dev3-default-pool-84228e30-qgpl   <none>           <none>
pod/es-apm-sample-es-default-2   0/1     Running   0          19m   10.32.2.12   gke-michael-dev3-default-pool-de22c45a-wsx9  
```

The reason is that the readiness script has ben updated in #2180 and is propagated dynamically to all the Pods through a configmap, while for most of them `PROBE_PASSWORD_PATH` is unknown. 