### PR TITLE
Update service when labels and annotations are modified

### DIFF
--- a/pkg/controller/common/defaults/service.go
+++ b/pkg/controller/common/defaults/service.go
@@ -5,6 +5,7 @@
 package defaults
 
 import (
+	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -15,16 +16,7 @@ func SetServiceDefaults(
 	defaultSelector map[string]string,
 	defaultPorts []v1.ServicePort,
 ) *v1.Service {
-	if svc.ObjectMeta.Labels == nil {
-		svc.ObjectMeta.Labels = defaultLabels
-	} else {
-		// add our labels, but don't overwrite user labels
-		for k, v := range defaultLabels {
-			if _, ok := svc.ObjectMeta.Labels[k]; !ok {
-				svc.ObjectMeta.Labels[k] = v
-			}
-		}
-	}
+	svc.Labels = maps.MergePreservingExistingKeys(svc.Labels, defaultLabels)
 
 	if svc.Spec.Selector == nil {
 		svc.Spec.Selector = defaultSelector

--- a/pkg/controller/common/service_control.go
+++ b/pkg/controller/common/service_control.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -76,6 +77,9 @@ func needsUpdate(expected *corev1.Service, reconciled *corev1.Service) bool {
 	if expected.Spec.HealthCheckNodePort == 0 {
 		expected.Spec.HealthCheckNodePort = reconciled.Spec.HealthCheckNodePort
 	}
+
+	expected.Annotations = maps.MergePreservingExistingKeys(expected.Annotations, reconciled.Annotations)
+	expected.Labels = maps.MergePreservingExistingKeys(expected.Labels, reconciled.Labels)
 
 	return !reflect.DeepEqual(expected.Spec, reconciled.Spec)
 }

--- a/pkg/controller/kibana/services_test.go
+++ b/pkg/controller/kibana/services_test.go
@@ -68,6 +68,24 @@ func TestNewService(t *testing.T) {
 				return svc
 			},
 		},
+		{
+			name: "service template",
+			httpConf: commonv1beta1.HTTPConfig{
+				Service: commonv1beta1.ServiceTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels:      map[string]string{"foo": "bar"},
+						Annotations: map[string]string{"bar": "baz"},
+					},
+				},
+			},
+			wantSvc: func() corev1.Service {
+				svc := mkService()
+				svc.Labels["foo"] = "bar"
+				svc.Annotations = map[string]string{"bar": "baz"}
+				svc.Spec.Ports[0].Name = "https"
+				return svc
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/utils/compare/objects.go
+++ b/pkg/utils/compare/objects.go
@@ -1,0 +1,16 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package compare
+
+import (
+	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// LabelsAndAnnotationsAreEqual compares just the labels and annotations for equality from two ObjectMeta instances.
+func LabelsAndAnnotationsAreEqual(a, b metav1.ObjectMeta) bool {
+	return reflect.DeepEqual(a.Labels, b.Labels) && reflect.DeepEqual(a.Annotations, b.Annotations)
+}

--- a/pkg/utils/maps/maps.go
+++ b/pkg/utils/maps/maps.go
@@ -34,3 +34,21 @@ func Merge(dest, src map[string]string) map[string]string {
 
 	return dest
 }
+
+// MergePreservingExistingKeys merges source into destination while skipping any keys that exist in the destination.
+func MergePreservingExistingKeys(dest, src map[string]string) map[string]string {
+	if dest == nil {
+		if src == nil {
+			return nil
+		}
+		dest = make(map[string]string, len(src))
+	}
+
+	for k, v := range src {
+		if _, exists := dest[k]; !exists {
+			dest[k] = v
+		}
+	}
+
+	return dest
+}

--- a/pkg/utils/maps/maps_test.go
+++ b/pkg/utils/maps/maps_test.go
@@ -156,3 +156,76 @@ func TestMerge(t *testing.T) {
 		})
 	}
 }
+
+func TestMergePreservingExistingKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		dest map[string]string
+		src  map[string]string
+		want map[string]string
+	}{
+		{
+			name: "when dest is nil",
+			src:  map[string]string{"x": "y"},
+			want: map[string]string{"x": "y"},
+		},
+		{
+			name: "when src is nil",
+			dest: map[string]string{"x": "y"},
+			want: map[string]string{"x": "y"},
+		},
+		{
+			name: "when both maps are nil",
+		},
+		{
+			name: "when dest is empty",
+			dest: map[string]string{},
+			src:  map[string]string{"x": "y"},
+			want: map[string]string{"x": "y"},
+		},
+		{
+			name: "when src is empty",
+			dest: map[string]string{"x": "y"},
+			src:  map[string]string{},
+			want: map[string]string{"x": "y"},
+		},
+		{
+			name: "when both maps are empty",
+			dest: map[string]string{},
+			src:  map[string]string{},
+			want: map[string]string{},
+		},
+		{
+			name: "when both maps contain the same items",
+			dest: map[string]string{"x": "y", "a": "b"},
+			src:  map[string]string{"x": "y", "a": "b"},
+			want: map[string]string{"x": "y", "a": "b"},
+		},
+		{
+			name: "when keys are the same but value are different",
+			dest: map[string]string{"x": "p", "a": "q"},
+			src:  map[string]string{"x": "y", "a": "b"},
+			want: map[string]string{"x": "p", "a": "q"},
+		},
+
+		{
+			name: "when dest has fewer items than src",
+			dest: map[string]string{"x": "y"},
+			src:  map[string]string{"x": "z", "a": "b"},
+			want: map[string]string{"x": "y", "a": "b"},
+		},
+		{
+			name: "when dest has more items than src",
+			dest: map[string]string{"x": "y", "a": "b"},
+			src:  map[string]string{"x": "z"},
+			want: map[string]string{"x": "y", "a": "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			have := MergePreservingExistingKeys(tt.dest, tt.src)
+			require.Equal(t, tt.want, have)
+		})
+	}
+}


### PR DESCRIPTION
Currently, if a user edits a resource and changes the labels and/or annotations of the service template, those changes don't get applied to the existing service. 

This PR fixes the above problem and adds a few more unit tests to verify the behaviour. Additionally, any labels/annotations added manually (i.e. not through the service template) will be preserved as long as they don't conflict with the defaults or the service template.

Fixes #2175 