### PR TITLE
Use a bugfixed version of controllerutil.SetControllerReference

### DIFF
--- a/pkg/controller/common/certificates/http/public_secret_test.go
+++ b/pkg/controller/common/certificates/http/public_secret_test.go
@@ -10,13 +10,13 @@ import (
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func TestReconcileHTTPCertsPublicSecret(t *testing.T) {
@@ -53,7 +53,7 @@ func TestReconcileHTTPCertsPublicSecret(t *testing.T) {
 			},
 		}
 
-		if err := controllerutil.SetControllerReference(owner, wantSecret, scheme.Scheme); err != nil {
+		if err := reconciler.SetControllerReference(owner, wantSecret, scheme.Scheme); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/controller/common/certificates/http/reconcile.go
+++ b/pkg/controller/common/certificates/http/reconcile.go
@@ -18,6 +18,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/driver"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/name"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	netutil "github.com/elastic/cloud-on-k8s/pkg/utils/net"
 	corev1 "k8s.io/api/core/v1"
@@ -25,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -106,7 +106,7 @@ func reconcileHTTPInternalCertificatesSecret(
 		}
 	}
 
-	if err := controllerutil.SetControllerReference(owner, &secret, scheme); err != nil {
+	if err := reconciler.SetControllerReference(owner, &secret, scheme); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/common/reconciler/reconciler.go
+++ b/pkg/controller/common/reconciler/reconciler.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -16,8 +15,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
 var (
@@ -85,7 +85,7 @@ func ReconcileResource(params Params) error {
 	kind := gvk.Kind
 
 	if params.Owner != nil {
-		if err := controllerutil.SetControllerReference(params.Owner, metaObj, params.Scheme); err != nil {
+		if err := SetControllerReference(params.Owner, metaObj, params.Scheme); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/common/reconciler/tmp_controller_ref.go
+++ b/pkg/controller/common/reconciler/tmp_controller_ref.go
@@ -1,0 +1,103 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package reconciler
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// This entire file is copied over from a bugfix (https://github.com/kubernetes-sigs/controller-runtime/pull/707/files)
+// in controller-runtime that has not landed in a released version yet.
+// TODO: remove and rely on controllerutil.SetControllerReference once a controller-runtime release includes
+//  commit https://github.com/kubernetes-sigs/controller-runtime/commit/ce6bd3907b8993a6a27a4f43a84043ebcbc3d999.
+
+// AlreadyOwnedError is an error returned if the object you are trying to assign
+// a controller reference is already owned by another controller Object is the
+// subject and Owner is the reference for the current owner
+type AlreadyOwnedError struct {
+	Object metav1.Object
+	Owner  metav1.OwnerReference
+}
+
+func (e *AlreadyOwnedError) Error() string {
+	return fmt.Sprintf("Object %s/%s is already owned by another %s controller %s", e.Object.GetNamespace(), e.Object.GetName(), e.Owner.Kind, e.Owner.Name)
+}
+
+func newAlreadyOwnedError(Object metav1.Object, Owner metav1.OwnerReference) *AlreadyOwnedError {
+	return &AlreadyOwnedError{
+		Object: Object,
+		Owner:  Owner,
+	}
+}
+
+// SetControllerReference sets owner as a Controller OwnerReference on owned.
+// This is used for garbage collection of the owned object and for
+// reconciling the owner object on changes to owned (with a Watch + EnqueueRequestForOwner).
+// Since only one OwnerReference can be a controller, it returns an error if
+// there is another OwnerReference with Controller flag set.
+func SetControllerReference(owner, object metav1.Object, scheme *runtime.Scheme) error {
+	ro, ok := owner.(runtime.Object)
+	if !ok {
+		return fmt.Errorf("%T is not a runtime.Object, cannot call SetControllerReference", owner)
+	}
+
+	ownerNs := owner.GetNamespace()
+	if ownerNs != "" {
+		objNs := object.GetNamespace()
+		if objNs == "" {
+			return fmt.Errorf("cluster-scoped resource must not have a namespace-scoped owner, owner's namespace %s", ownerNs)
+		}
+		if ownerNs != objNs {
+			return fmt.Errorf("cross-namespace owner references are disallowed, owner's namespace %s, obj's namespace %s", owner.GetNamespace(), object.GetNamespace())
+		}
+	}
+
+	gvk, err := apiutil.GVKForObject(ro, scheme)
+	if err != nil {
+		return err
+	}
+
+	// Create a new ref
+	ref := *metav1.NewControllerRef(owner, schema.GroupVersionKind{Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind})
+
+	existingRefs := object.GetOwnerReferences()
+	fi := -1
+	for i, r := range existingRefs {
+		if referSameObject(ref, r) {
+			fi = i
+		} else if r.Controller != nil && *r.Controller {
+			return newAlreadyOwnedError(object, r)
+		}
+	}
+	if fi == -1 {
+		existingRefs = append(existingRefs, ref)
+	} else {
+		existingRefs[fi] = ref
+	}
+
+	// Update owner references
+	object.SetOwnerReferences(existingRefs)
+	return nil
+}
+
+// Returns true if a and b point to the same object
+func referSameObject(a, b metav1.OwnerReference) bool {
+	aGV, err := schema.ParseGroupVersion(a.APIVersion)
+	if err != nil {
+		return false
+	}
+
+	bGV, err := schema.ParseGroupVersion(b.APIVersion)
+	if err != nil {
+		return false
+	}
+
+	return aGV.Group == bGV.Group && a.Kind == b.Kind && a.Name == b.Name
+}

--- a/pkg/controller/common/reconciler/tmp_controller_ref.go
+++ b/pkg/controller/common/reconciler/tmp_controller_ref.go
@@ -30,10 +30,10 @@ func (e *AlreadyOwnedError) Error() string {
 	return fmt.Sprintf("Object %s/%s is already owned by another %s controller %s", e.Object.GetNamespace(), e.Object.GetName(), e.Owner.Kind, e.Owner.Name)
 }
 
-func newAlreadyOwnedError(Object metav1.Object, Owner metav1.OwnerReference) *AlreadyOwnedError {
+func newAlreadyOwnedError(object metav1.Object, owner metav1.OwnerReference) *AlreadyOwnedError {
 	return &AlreadyOwnedError{
-		Object: Object,
-		Owner:  Owner,
+		Object: object,
+		Owner:  owner,
 	}
 }
 

--- a/pkg/controller/common/watches/handler_test.go
+++ b/pkg/controller/common/watches/handler_test.go
@@ -7,6 +7,7 @@ package watches
 import (
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,7 +18,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/util/workqueue"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -309,7 +309,7 @@ func TestDynamicEnqueueRequest_EventHandler(t *testing.T) {
 	}))
 
 	// let's make object 1 the owner of object 2
-	require.NoError(t, controllerutil.SetControllerReference(testObject1, testObject2, scheme.Scheme))
+	require.NoError(t, reconciler.SetControllerReference(testObject1, testObject2, scheme.Scheme))
 	// an update on object 2 should enqueue a request for object 1 (the owner)
 	d.Update(event.UpdateEvent{
 		MetaOld:   testObject2.GetObjectMeta(),
@@ -408,7 +408,7 @@ func TestDynamicEnqueueRequest_OwnerWatch(t *testing.T) {
 	}))
 	// END FIXTURES
 
-	require.NoError(t, controllerutil.SetControllerReference(testObject1, testObject2, scheme.Scheme))
+	require.NoError(t, reconciler.SetControllerReference(testObject1, testObject2, scheme.Scheme))
 
 	d.Create(event.CreateEvent{
 		Meta:   testObject1.GetObjectMeta(),

--- a/pkg/controller/elasticsearch/certificates/transport/public_secret_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/public_secret_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/require"
@@ -23,7 +24,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func TestReconcileTransportCertsPublicSecret(t *testing.T) {
@@ -52,7 +52,7 @@ func TestReconcileTransportCertsPublicSecret(t *testing.T) {
 			},
 		}
 
-		if err := controllerutil.SetControllerReference(owner, wantSecret, scheme.Scheme); err != nil {
+		if err := reconciler.SetControllerReference(owner, wantSecret, scheme.Scheme); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/controller/elasticsearch/nodespec/statefulset.go
+++ b/pkg/controller/elasticsearch/nodespec/statefulset.go
@@ -123,6 +123,11 @@ func setVolumeClaimsControllerReference(
 	// so PVC get deleted automatically upon Elasticsearch resource deletion
 	claims := make([]corev1.PersistentVolumeClaim, 0, len(persistentVolumeClaims))
 	for _, claim := range persistentVolumeClaims {
+		// Set the claim namespace to match the ES namespace.
+		// This is technically not required, but `SetControllerReference` does a safety check on
+		// object vs. owner namespace mismatch. We know the PVC will end up in ES namespace anyway,
+		// so it's safe to include it.
+		claim.Namespace = es.Namespace
 		if err := reconciler.SetControllerReference(&es, &claim, scheme); err != nil {
 			return nil, err
 		}

--- a/pkg/controller/elasticsearch/nodespec/statefulset.go
+++ b/pkg/controller/elasticsearch/nodespec/statefulset.go
@@ -5,12 +5,11 @@
 package nodespec
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
 	esvolume "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
@@ -124,7 +123,7 @@ func setVolumeClaimsControllerReference(
 	// so PVC get deleted automatically upon Elasticsearch resource deletion
 	claims := make([]corev1.PersistentVolumeClaim, 0, len(persistentVolumeClaims))
 	for _, claim := range persistentVolumeClaims {
-		if err := controllerutil.SetControllerReference(&es, &claim, scheme); err != nil {
+		if err := reconciler.SetControllerReference(&es, &claim, scheme); err != nil {
 			return nil, err
 		}
 		// Set block owner deletion to false as the statefulset controller might not be able to do that if it cannot

--- a/pkg/controller/elasticsearch/pdb/reconcile.go
+++ b/pkg/controller/elasticsearch/pdb/reconcile.go
@@ -9,6 +9,7 @@ import (
 	esv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -18,7 +19,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // Reconcile ensures that a PodDisruptionBudget exists for this cluster, inheriting the spec content.
@@ -100,7 +100,7 @@ func expectedPDB(es esv1beta1.Elasticsearch, statefulSets sset.StatefulSetList, 
 	// and append our labels
 	expected.Labels = defaults.SetDefaultLabels(expected.Labels, label.NewLabels(k8s.ExtractNamespacedName(&es)))
 	// set owner reference for deletion upon ES resource deletion
-	if err := controllerutil.SetControllerReference(&es, &expected, scheme); err != nil {
+	if err := reconciler.SetControllerReference(&es, &expected, scheme); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/elasticsearch/pdb/reconcile_test.go
+++ b/pkg/controller/elasticsearch/pdb/reconcile_test.go
@@ -12,6 +12,7 @@ import (
 	esv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -22,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func TestReconcile(t *testing.T) {
@@ -135,7 +135,7 @@ func withHashLabel(pdb *v1beta1.PodDisruptionBudget) *v1beta1.PodDisruptionBudge
 }
 
 func withOwnerRef(pdb *v1beta1.PodDisruptionBudget, es esv1beta1.Elasticsearch) *v1beta1.PodDisruptionBudget {
-	if err := controllerutil.SetControllerReference(&es, pdb, scheme.Scheme); err != nil {
+	if err := reconciler.SetControllerReference(&es, pdb, scheme.Scheme); err != nil {
 		panic(err)
 	}
 	return pdb

--- a/pkg/controller/elasticsearch/sset/reconcile_test.go
+++ b/pkg/controller/elasticsearch/sset/reconcile_test.go
@@ -14,11 +14,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/expectations"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
@@ -41,7 +41,7 @@ func TestReconcileStatefulSet(t *testing.T) {
 	}
 	metaObj, err := meta.Accessor(&ssetSample)
 	require.NoError(t, err)
-	err = controllerutil.SetControllerReference(&es, metaObj, scheme.Scheme)
+	err = reconciler.SetControllerReference(&es, metaObj, scheme.Scheme)
 	require.NoError(t, err)
 
 	updatedSset := *ssetSample.DeepCopy()
@@ -81,7 +81,7 @@ func TestReconcileStatefulSet(t *testing.T) {
 			// expect owner ref to be set to the es resource
 			metaObj, err := meta.Accessor(&tt.expected)
 			require.NoError(t, err)
-			err = controllerutil.SetControllerReference(&es, metaObj, scheme.Scheme)
+			err = reconciler.SetControllerReference(&es, metaObj, scheme.Scheme)
 			require.NoError(t, err)
 
 			// check expectations were updated


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/2191.

## Goal

Temporarily duplicate the fixed version of
`controllerutil.SetControllerReference` in our own code, until we get a
proper release of controller-runtime with the fix.

At which point we can safely remove this file and rely on
`controllerutil.SetControllerReference` again.

controller-runtime PR including the fix:
kubernetes-sigs/controller-runtime#707

## Tweaks

The latest version of `controllerutil.SetControllerReference` does a
safety check on owner vs. object namespace mismatches.
We technically don't need to include a namespace in the
VolumeClaimtemplates of a StatefulSet, but since we know in which
namespace the PVC will be created anyway, it's safe to include the
namespace so we pass the function safety check.