### PR TITLE
Increase timeout of E2E runner

### DIFF
--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	jobTimeout       = 120 * time.Minute // time to wait for the test job to finish
+	jobTimeout       = 200 * time.Minute // time to wait for the test job to finish
 	kubePollInterval = 10 * time.Second  // Kube API polling interval
 	logBufferSize    = 1024              // Size of the log buffer (1KiB)
 	testRunLabel     = "test-run"        // name of the label applied to resources


### PR DESCRIPTION
The E2E runner has an internal timeout that specifies how long it should wait for the test job to complete. Currently this is set to 120 minutes -- which is less than the Jenkins timeout of 150 minutes.

The timeout in the runner is to prevent a job from running forever (especially when it is run outside a CI environment that has no in-built timeout). 

New timeout value of 200 minutes was chosen because the current longest Jenkins timeout is 180 minutes. This should provide some room for future growth while ensuring that ad-hoc test jobs eventually terminate in a reasonable amount of time.