### PR TITLE
Inherit existing sset.volumeClaimTemplates ownerReferences

### DIFF
--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -48,7 +48,7 @@ func (d *defaultDriver) reconcileNodeSpecs(
 		return results.WithError(err)
 	}
 
-	expectedResources, err := nodespec.BuildExpectedResources(d.ES, keystoreResources, d.Scheme(), certResources)
+	expectedResources, err := nodespec.BuildExpectedResources(d.ES, keystoreResources, d.Scheme(), certResources, actualStatefulSets)
 	if err != nil {
 		return results.WithError(err)
 	}

--- a/pkg/controller/elasticsearch/nodespec/resources.go
+++ b/pkg/controller/elasticsearch/nodespec/resources.go
@@ -42,6 +42,7 @@ func BuildExpectedResources(
 	keystoreResources *keystore.Resources,
 	scheme *runtime.Scheme,
 	certResources *certificates.CertificateResources,
+	existingStatefulSets sset.StatefulSetList,
 ) (ResourcesList, error) {
 	nodesResources := make(ResourcesList, 0, len(es.Spec.NodeSets))
 
@@ -62,7 +63,7 @@ func BuildExpectedResources(
 		}
 
 		// build stateful set and associated headless service
-		statefulSet, err := BuildStatefulSet(es, nodeSpec, cfg, keystoreResources, scheme)
+		statefulSet, err := BuildStatefulSet(es, nodeSpec, cfg, keystoreResources, existingStatefulSets, scheme)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/elasticsearch/nodespec/resources_test.go
+++ b/pkg/controller/elasticsearch/nodespec/resources_test.go
@@ -8,13 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestResourcesList_MasterNodesNames(t *testing.T) {
@@ -45,71 +39,6 @@ func TestResourcesList_MasterNodesNames(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.l.MasterNodesNames(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ResourcesList.MasterNodesNames() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestSetVolumeClaimsControllerReference(t *testing.T) {
-	es := v1beta1.Elasticsearch{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "es1",
-			Namespace: "default",
-			UID:       "ABCDEF",
-		},
-	}
-	type args struct {
-		volumeClaims []corev1.PersistentVolumeClaim
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    []string
-		wantErr bool
-	}{
-		{
-			name: "Simple test case",
-			args: args{
-				volumeClaims: []corev1.PersistentVolumeClaim{
-					{ObjectMeta: v1.ObjectMeta{Name: "elasticsearch-data"}},
-				},
-			},
-			want: []string{"elasticsearch-data"},
-		},
-		{
-			name: "With a user volume",
-			args: args{
-				volumeClaims: []corev1.PersistentVolumeClaim{
-					{ObjectMeta: v1.ObjectMeta{Name: "elasticsearch-data"}},
-					{ObjectMeta: v1.ObjectMeta{Name: "user-volume"}},
-				},
-			},
-			want: []string{"elasticsearch-data", "user-volume"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := setVolumeClaimsControllerReference(tt.args.volumeClaims, es, k8s.Scheme())
-			if (err != nil) != tt.wantErr {
-				t.Errorf("BuildExpectedResources() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			assert.Equal(t, len(tt.want), len(got))
-
-			// Extract PVC names
-			actualPVCs := make([]string, len(got))
-			for i := range got {
-				actualPVCs[i] = got[i].Name
-			}
-			// Check the number of PVCs we got
-			assert.ElementsMatch(t, tt.want, actualPVCs)
-
-			// Check that VolumeClaimTemplates have an owner with the right settings
-			for _, pvc := range got {
-				assert.Equal(t, 1, len(pvc.OwnerReferences))
-				ownerRef := pvc.OwnerReferences[0]
-				require.False(t, *ownerRef.BlockOwnerDeletion)
-				assert.Equal(t, es.UID, ownerRef.UID)
 			}
 		})
 	}

--- a/pkg/controller/elasticsearch/nodespec/statefulset.go
+++ b/pkg/controller/elasticsearch/nodespec/statefulset.go
@@ -79,11 +79,11 @@ func BuildStatefulSet(
 	}
 
 	// maybe inherit volumeClaimTemplates ownerRefs from the existing StatefulSet
-	var inheritedClaims []corev1.PersistentVolumeClaim
+	var existingClaims []corev1.PersistentVolumeClaim
 	if existingSset, exists := existingStatefulSets.GetByName(statefulSetName); exists {
-		inheritedClaims = existingSset.Spec.VolumeClaimTemplates
+		existingClaims = existingSset.Spec.VolumeClaimTemplates
 	}
-	claims, err := setVolumeClaimsControllerReference(nodeSet.VolumeClaimTemplates, inheritedClaims, es, scheme)
+	claims, err := setVolumeClaimsControllerReference(nodeSet.VolumeClaimTemplates, existingClaims, es, scheme)
 	if err != nil {
 		return appsv1.StatefulSet{}, err
 	}
@@ -140,7 +140,7 @@ func setVolumeClaimsControllerReference(
 			// built with a prior version of the operator. If the Elasticsearch apiVersion has changed,
 			// from eg. `v1beta1` to `v1`, we want to keep the existing ownerRef (pointing to eg. a `v1beta1` owner).
 			// Having ownerReferences with a "deprecated" apiVersion is fine, and does not prevent resources
-			// to be garbage collected as expected.
+			// from being garbage collected as expected.
 			claim.OwnerReferences = existingClaim.OwnerReferences
 
 			claims = append(claims, claim)

--- a/pkg/controller/elasticsearch/nodespec/statefulset_test.go
+++ b/pkg/controller/elasticsearch/nodespec/statefulset_test.go
@@ -1,0 +1,223 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package nodespec
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+)
+
+func Test_setVolumeClaimsControllerReference(t *testing.T) {
+	varTrue := true
+	varFalse := false
+	es := v1beta1.Elasticsearch{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Elasticsearch",
+			APIVersion: "elasticsearch.k8s.elastic.co/v1beta1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "es1",
+			Namespace: "default",
+			UID:       "ABCDEF",
+		},
+	}
+	tests := []struct {
+		name                   string
+		persistentVolumeClaims []corev1.PersistentVolumeClaim
+		existingClaims         []corev1.PersistentVolumeClaim
+		wantClaims             []corev1.PersistentVolumeClaim
+	}{
+		{
+			name: "should set the ownerRef when building a new StatefulSet",
+			persistentVolumeClaims: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: v1.ObjectMeta{Name: "elasticsearch-data"}},
+			},
+			existingClaims: nil,
+			wantClaims: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "elasticsearch-data",
+						OwnerReferences: []v1.OwnerReference{
+							{
+								APIVersion:         es.APIVersion,
+								Kind:               es.Kind,
+								Name:               es.Name,
+								UID:                es.UID,
+								Controller:         &varTrue,
+								BlockOwnerDeletion: &varFalse,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should set the ownerRef on user-provided claims when building a new StatefulSet",
+			persistentVolumeClaims: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: v1.ObjectMeta{Name: "elasticsearch-data"}},
+				{ObjectMeta: v1.ObjectMeta{Name: "user-provided"}},
+			},
+			existingClaims: nil,
+			wantClaims: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "elasticsearch-data",
+						OwnerReferences: []v1.OwnerReference{
+							{
+								APIVersion:         es.APIVersion,
+								Kind:               es.Kind,
+								Name:               es.Name,
+								UID:                es.UID,
+								Controller:         &varTrue,
+								BlockOwnerDeletion: &varFalse,
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "user-provided",
+						OwnerReferences: []v1.OwnerReference{
+							{
+								APIVersion:         es.APIVersion,
+								Kind:               es.Kind,
+								Name:               es.Name,
+								UID:                es.UID,
+								Controller:         &varTrue,
+								BlockOwnerDeletion: &varFalse,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should inherit existing claim ownerRefs that may have a different apiVersion",
+			persistentVolumeClaims: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: v1.ObjectMeta{Name: "elasticsearch-data"}},
+				{ObjectMeta: v1.ObjectMeta{Name: "user-provided"}},
+			},
+			existingClaims: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "elasticsearch-data",
+						OwnerReferences: []v1.OwnerReference{
+							{
+								// claim already exists, with a different apiVersion
+								APIVersion:         "elasticsearch.k8s.elastic.co/v1alpha1",
+								Kind:               es.Kind,
+								Name:               es.Name,
+								UID:                es.UID,
+								Controller:         &varTrue,
+								BlockOwnerDeletion: &varFalse,
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "user-provided",
+						OwnerReferences: []v1.OwnerReference{
+							{
+								// claim already exists, with a different apiVersion
+								APIVersion:         "elasticsearch.k8s.elastic.co/v1alpha1",
+								Kind:               es.Kind,
+								Name:               es.Name,
+								UID:                es.UID,
+								Controller:         &varTrue,
+								BlockOwnerDeletion: &varFalse,
+							},
+						},
+					},
+				},
+			},
+			// existing claims should be preserved
+			wantClaims: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "elasticsearch-data",
+						OwnerReferences: []v1.OwnerReference{
+							{
+								APIVersion:         "elasticsearch.k8s.elastic.co/v1alpha1",
+								Kind:               es.Kind,
+								Name:               es.Name,
+								UID:                es.UID,
+								Controller:         &varTrue,
+								BlockOwnerDeletion: &varFalse,
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "user-provided",
+						OwnerReferences: []v1.OwnerReference{
+							{
+								APIVersion:         "elasticsearch.k8s.elastic.co/v1alpha1",
+								Kind:               es.Kind,
+								Name:               es.Name,
+								UID:                es.UID,
+								Controller:         &varTrue,
+								BlockOwnerDeletion: &varFalse,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := setVolumeClaimsControllerReference(tt.persistentVolumeClaims, tt.existingClaims, es, k8s.Scheme())
+			require.NoError(t, err)
+			require.Equal(t, tt.wantClaims, got)
+		})
+	}
+}
+
+func Test_getClaimMatchingName(t *testing.T) {
+	tests := []struct {
+		name      string
+		claims    []corev1.PersistentVolumeClaim
+		claimName string
+		want      *corev1.PersistentVolumeClaim
+	}{
+		{
+			name: "return matching claim",
+			claims: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: metav1.ObjectMeta{Name: "claim1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "claim2"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "claim3"}},
+			},
+			claimName: "claim2",
+			want:      &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "claim2"}},
+		},
+		{
+			name: "return nil if no match",
+			claims: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: metav1.ObjectMeta{Name: "claim1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "claim2"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "claim3"}},
+			},
+			claimName: "claim4",
+			want:      nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getClaimMatchingName(tt.claims, tt.claimName); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getMatchingClaim() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/2192.

When we update the Elasticsearch CRD to a new version, existing
ownerReferences in StatefulSets.volumeClaimTemplates still point to the
"old" Elasticsearch apiVersion (eg. `v1beta1` instead of `v1`).

Since the volumeClaimtemplate section is immutable, the ownerRef
apiVersion cannot be updated so the StatefulSet update is rejected.
In that situation, it is fine to just keep the existing ownerRef
targeting the deprecated Elasticsearch apiVersion. It does not prevent
resource garbage collection to happen as expected.

This commit also changes the way we recently set a Namespace to the
claim, to not error out in `SetControllerReference`. We don't need that
namespace (and it breaks backward compatibility), so we now just set it
temporarily for `SetControllerReference` to not return any error.