### PR TITLE
Refactor license labels to be more consistent

### DIFF
--- a/docs/licensing.asciidoc
+++ b/docs/licensing.asciidoc
@@ -41,7 +41,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    license.k8s.elastic.co/type: enterprise <1>
+    license.k8s.elastic.co/scope: operator <1>
   name: eck-license
 type: Opaque
 data:
@@ -56,7 +56,7 @@ An easy way to create this secret is to rely on `kubectl` 's built-in support fo
 [source,shell script]
 ----
 kubectl create secret generic eck-license --from-file=my-license-file.json -n elastic-system
-kubectl label secret eck-license "license.k8s.elastic.co/type"=enterprise -n elastic-system
+kubectl label secret eck-license "license.k8s.elastic.co/scope"=operator -n elastic-system
 ----
 
 NOTE: Once you have installed a license into ECK new Elastic stack applications you manage with ECK will have all platinum and enterprise features enabled.

--- a/pkg/controller/common/license/crud_test.go
+++ b/pkg/controller/common/license/crud_test.go
@@ -1,0 +1,79 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package license
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestUpdateEnterpriseLicense(t *testing.T) {
+	type args struct {
+		c      k8s.Client
+		secret v1.Secret
+		l      EnterpriseLicense
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantErr   bool
+		assertion func(k8s.Client)
+	}{
+		{
+			name: "updates labels preserving existing ones",
+			args: args{
+				c: k8s.WrappedFakeClient(&v1.Secret{}),
+				secret: v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"my-label": "value",
+						},
+					},
+				},
+				l: licenseFixture,
+			},
+			wantErr: false,
+			assertion: func(client k8s.Client) {
+				var sec v1.Secret
+				err := client.Get(types.NamespacedName{}, &sec)
+				require.NoError(t, err)
+				require.Equal(t, sec.Labels["my-label"], "value")
+				require.Contains(t, sec.Labels, LicenseLabelScope)
+			},
+		},
+		{
+			name: "basic update",
+			args: args{
+				c:      k8s.WrappedFakeClient(&v1.Secret{}),
+				secret: v1.Secret{},
+				l:      licenseFixture,
+			},
+			wantErr: false,
+			assertion: func(client k8s.Client) {
+				var sec v1.Secret
+				err := client.Get(types.NamespacedName{}, &sec)
+				require.NoError(t, err)
+				require.Equal(t, string(licenseFixture.License.Type), sec.Labels[LicenseLabelType])
+				require.Equal(t, string(LicenseScopeOperator), sec.Labels[LicenseLabelScope])
+				require.Len(t, sec.Data, 1)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := UpdateEnterpriseLicense(tt.args.c, tt.args.secret, tt.args.l); (err != nil) != tt.wantErr {
+				t.Errorf("UpdateEnterpriseLicense() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.assertion != nil {
+				tt.assertion(tt.args.c)
+			}
+		})
+	}
+}

--- a/pkg/controller/common/license/detection.go
+++ b/pkg/controller/common/license/detection.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func isLicenseType(secret corev1.Secret, licenseType EnterpriseLicenseType) bool {
+func isLicenseType(secret corev1.Secret, licenseType OperatorLicenseType) bool {
 	// is it a license at all (but be lenient if user omitted label)?
 	baseType, hasLabel := secret.Labels[common.TypeLabelName]
 	if hasLabel && baseType != Type {
@@ -26,4 +26,9 @@ func IsEnterpriseTrial(secret corev1.Secret) bool {
 
 func IsEnterpriseLicense(secret corev1.Secret) bool {
 	return isLicenseType(secret, LicenseTypeEnterprise)
+}
+
+func IsOperatorLicense(secret corev1.Secret) bool {
+	scope, hasLabel := secret.Labels[LicenseLabelScope]
+	return hasLabel && scope == string(LicenseScopeOperator)
 }

--- a/pkg/controller/common/license/fixtures_test.go
+++ b/pkg/controller/common/license/fixtures_test.go
@@ -48,6 +48,7 @@ func asRuntimeObjects(l EnterpriseLicense, sig []byte) []runtime.Object {
 				Name:      "test-license",
 				Labels: map[string]string{
 					common.TypeLabelName: Type,
+					LicenseLabelScope:    string(LicenseScopeOperator),
 					LicenseLabelType:     string(l.License.Type),
 				},
 			},

--- a/pkg/controller/common/license/labels.go
+++ b/pkg/controller/common/license/labels.go
@@ -13,37 +13,31 @@ const (
 	// LicenseLabelName is a label pointing to the name of the source enterprise license.
 	LicenseLabelName         = "license.k8s.elastic.co/name"
 	LicenseLabelType         = "license.k8s.elastic.co/type"
+	LicenseLabelScope        = "license.k8s.elastic.co/scope"
 	Type                     = "license"
 	EULAAnnotation           = "elastic.co/eula"
 	EULAAcceptedValue        = "accepted"
 	LicenseInvalidAnnotation = "license.k8s.elastic.co/invalid"
 )
 
-// LicenseType is the type of license a resource is describing.
-type LicenseType string
+type LicenseScope string
 
 const (
-	LicenseLabelEnterprise    LicenseType = "enterprise"
-	LicenseLabelElasticsearch LicenseType = "elasticsearch"
+	LicenseScopeOperator      LicenseScope = "operator"
+	LicenseScopeElasticsearch LicenseScope = "elasticsearch"
 )
 
-// LabelsForType creates a map of labels for the given type of either enterprise or Elasticsearch license.
-func LabelsForType(licenseType LicenseType) map[string]string {
+// LabelsForOperatorScope creates a map of labels for the given scope of either operator or Elasticsearch scope.
+func LabelsForOperatorScope(t OperatorLicenseType) map[string]string {
 	return map[string]string{
 		common.TypeLabelName: Type,
-		LicenseLabelType:     string(licenseType),
+		LicenseLabelScope:    string(LicenseScopeOperator),
+		LicenseLabelType:     string(t),
 	}
 }
 
-// NewLicenseByNameSelector is a list selector to filter by a label containing the license name.
-func NewLicenseByNameSelector(licenseName string) client.MatchingLabels {
-	return client.MatchingLabels(map[string]string{
-		LicenseLabelName: licenseName,
-	})
-}
-
-func NewLicenseByTypeSelector(licenseType string) client.MatchingLabels {
-	return client.MatchingLabels(map[string]string{
-		LicenseLabelType: licenseType,
-	})
+func NewLicenseByScopeSelector(scope LicenseScope) client.MatchingLabels {
+	return map[string]string{
+		LicenseLabelScope: string(scope),
+	}
 }

--- a/pkg/controller/common/license/labels.go
+++ b/pkg/controller/common/license/labels.go
@@ -27,7 +27,7 @@ const (
 	LicenseScopeElasticsearch LicenseScope = "elasticsearch"
 )
 
-// LabelsForOperatorScope creates a map of labels for the given scope of either operator or Elasticsearch scope.
+// LabelsForOperatorScope creates a map of labels for operator scope with licence type set to the given value.
 func LabelsForOperatorScope(t OperatorLicenseType) map[string]string {
 	return map[string]string{
 		common.TypeLabelName: Type,

--- a/pkg/controller/common/license/model.go
+++ b/pkg/controller/common/license/model.go
@@ -11,12 +11,12 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 )
 
-// EnterpriseLicenseType is the type of enterprise license a resource is describing.
-type EnterpriseLicenseType string
+// OperatorLicenseType is the type of operator level license a resource is describing.
+type OperatorLicenseType string
 
 const (
-	LicenseTypeEnterprise      EnterpriseLicenseType = "enterprise"
-	LicenseTypeEnterpriseTrial EnterpriseLicenseType = "enterprise-trial"
+	LicenseTypeEnterprise      OperatorLicenseType = "enterprise"
+	LicenseTypeEnterpriseTrial OperatorLicenseType = "enterprise-trial"
 )
 
 type ElasticsearchLicense struct {
@@ -30,7 +30,7 @@ type EnterpriseLicense struct {
 type LicenseSpec struct {
 	Status             string                 `json:"status,omitempty"`
 	UID                string                 `json:"uid"`
-	Type               EnterpriseLicenseType  `json:"type"`
+	Type               OperatorLicenseType    `json:"type"`
 	IssueDate          *time.Time             `json:"issue_date,omitempty"`
 	IssueDateInMillis  int64                  `json:"issue_date_in_millis"`
 	ExpiryDate         *time.Time             `json:"expiry_date,omitempty"`
@@ -106,16 +106,18 @@ type ElasticsearchLicenseType string
 
 // Supported ElasticsearchLicenseTypes.
 const (
-	ElasticsearchLicenseTypeBasic    ElasticsearchLicenseType = "basic"
-	ElasticsearchLicenseTypeTrial    ElasticsearchLicenseType = "trial"
-	ElasticsearchLicenseTypeGold     ElasticsearchLicenseType = "gold"
-	ElasticsearchLicenseTypePlatinum ElasticsearchLicenseType = "platinum"
+	ElasticsearchLicenseTypeBasic      ElasticsearchLicenseType = "basic"
+	ElasticsearchLicenseTypeTrial      ElasticsearchLicenseType = "trial"
+	ElasticsearchLicenseTypeGold       ElasticsearchLicenseType = "gold"
+	ElasticsearchLicenseTypePlatinum   ElasticsearchLicenseType = "platinum"
+	ElasticsearchLicenseTypeEnterprise ElasticsearchLicenseType = "enterprise"
 )
 
 // ElasticsearchLicenseTypeOrder license types mapped to ints in increasing order of feature sets for sorting purposes.
 var ElasticsearchLicenseTypeOrder = map[ElasticsearchLicenseType]int{
-	ElasticsearchLicenseTypeBasic:    1,
-	ElasticsearchLicenseTypeTrial:    2,
-	ElasticsearchLicenseTypeGold:     3,
-	ElasticsearchLicenseTypePlatinum: 4,
+	ElasticsearchLicenseTypeBasic:      1,
+	ElasticsearchLicenseTypeTrial:      2,
+	ElasticsearchLicenseTypeGold:       3,
+	ElasticsearchLicenseTypePlatinum:   4,
+	ElasticsearchLicenseTypeEnterprise: 5,
 }

--- a/pkg/controller/license/license_controller_test.go
+++ b/pkg/controller/license/license_controller_test.go
@@ -104,7 +104,7 @@ func enterpriseLicense(t *testing.T, licenseType commonlicense.ElasticsearchLice
 	require.NoError(t, err)
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: commonlicense.LabelsForType(commonlicense.LicenseLabelEnterprise),
+			Labels: commonlicense.LabelsForOperatorScope(license.License.Type),
 		},
 		Data: map[string][]byte{
 			commonlicense.FileName: bytes,


### PR DESCRIPTION
Introduce scope label to distinguish between operator and Elasticsearch scope
as `enterprise` is no longer sufficient as differentiator. Make trial controller add the
operator scope after creating the trial license to hand over responsibility to the
license controller while preserving the original type label on the user created trial license.

The different license types and scopes after this PR are:

* `scope=operator`
   * `enterprise`
   * `enterprise-trial`
* `scope=elasticsearch`
   * (`basic`)
   * `trial`
   * `gold`
   * `platinum`
   * `enterprise`

Fixes #2198 