### PR TITLE
E2E Tests: add GKE local SSD support

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -10,7 +10,7 @@ plans:
   gke:
     region: europe-west1
     adminUsername: admin
-    localSsdCount: 1
+    localSsdCount: 5
     nodeCountPerZone: 1
     gcpScopes: https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append
 - id: gke-dev
@@ -24,7 +24,7 @@ plans:
   gke:
     region: europe-west1
     adminUsername: admin
-    localSsdCount: 1
+    localSsdCount: 5
     nodeCountPerZone: 1
     gcpScopes: https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append
 - id: aks-ci

--- a/hack/deployer/runner/aks.go
+++ b/hack/deployer/runner/aks.go
@@ -105,7 +105,7 @@ func (d *AksDriver) Execute() error {
 			return err
 		}
 
-		if err := createStorageClass(); err != nil {
+		if err := createStorageClass(&DefaultStorageClass); err != nil {
 			return err
 		}
 	default:

--- a/hack/deployer/runner/gke_ssd_provisioner.go
+++ b/hack/deployer/runner/gke_ssd_provisioner.go
@@ -85,14 +85,14 @@ metadata:
   name: local-storage-provisioner-node-clusterrole
   namespace: default
 rules:
-  - apiGroups:
-      - extensions
-    resources:
-      - podsecuritypolicies
-    resourceNames:
-      - gce.privileged
-    verbs:
-      - use
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - gce.privileged
+  verbs:
+  - use
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get"]

--- a/hack/deployer/runner/gke_ssd_provisioner.go
+++ b/hack/deployer/runner/gke_ssd_provisioner.go
@@ -85,6 +85,14 @@ metadata:
   name: local-storage-provisioner-node-clusterrole
   namespace: default
 rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - gce.privileged
+    verbs:
+      - use
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get"]

--- a/hack/deployer/runner/gke_ssd_provisioner.go
+++ b/hack/deployer/runner/gke_ssd_provisioner.go
@@ -1,0 +1,105 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package runner
+
+const GkeSsdProvisioner = `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-provisioner-config 
+  namespace: default 
+data:
+  useNodeNameOnly: "true"
+  storageClassMap: |     
+    e2e-default:
+       hostDir: /mnt/disks
+       mountDir:  /mnt/disks  
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+  namespace: default
+  labels:
+    app: local-volume-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner 
+  template:
+    metadata:
+      labels:
+        app: local-volume-provisioner
+    spec:
+      serviceAccountName: local-storage-admin
+      containers:
+        - image: "quay.io/external_storage/local-volume-provisioner:v2.2.0"
+          imagePullPolicy: "Always"
+          name: provisioner 
+          securityContext:
+            privileged: true
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /etc/provisioner/config 
+              name: provisioner-config
+              readOnly: true             
+            - mountPath:  /mnt/disks 
+              name: e2e-default 
+      volumes:
+        - name: provisioner-config
+          configMap:
+            name: local-provisioner-config         
+        - name: e2e-default
+          hostPath:
+            path: /mnt/disks 
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-storage-admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-pv-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: system:persistent-volume-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-storage-provisioner-node-clusterrole
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-node-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: local-storage-provisioner-node-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+`

--- a/hack/deployer/runner/storage.go
+++ b/hack/deployer/runner/storage.go
@@ -7,11 +7,17 @@ package runner
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 )
 
+var (
+	StorageClassProvisionerRegExp = regexp.MustCompile(`provisioner:.+\n`)
+	DefaultStorageClass           = ""
+)
+
 // createStorageClass based on default storageclass, creates new, non-default class with "volumeBindingMode: WaitForFirstConsumer"
-func createStorageClass() error {
+func createStorageClass(provisioner *string) error {
 	log.Println("Creating storage class...")
 
 	if exists, err := NewCommand("kubectl get sc").OutputContainsAny("e2e-default"); err != nil {
@@ -48,6 +54,9 @@ func createStorageClass() error {
 
 	sc = strings.Replace(sc, fmt.Sprintf("name: %s", defaultName), "name: e2e-default", -1)
 	sc = strings.Replace(sc, "volumeBindingMode: Immediate", "volumeBindingMode: WaitForFirstConsumer", -1)
+	if provisioner != nil {
+		sc = StorageClassProvisionerRegExp.ReplaceAllString(sc, fmt.Sprintf("provisioner: %s\n", *provisioner))
+	}
 	// Some providers (AKS) don't allow changing the default. To avoid having two defaults, set newly created storage
 	// class to be non-default. Depending on k8s version, a different annotation is needed. To avoid parsing version
 	// string, both are set.


### PR DESCRIPTION
This PR improves the execution time of the e2e tests on GKE by using the local SSDs instead of some attached GCP persistent disks.

The primary motivations are:
* Do not rely on the external capacity of GKE to provision and attach a disk
* PV on SSD are pre-created and continuously recycled. Pods are _(almost)_ immediately scheduled without waiting for the dynamic provisioning to happen. 
* Pod startup should be slightly faster

I did a few tests, here are the worst cases:

With GCP Persistent Disk:
```
> time make ci-e2e STACK_VERSION=7.4.0  GCLOUD_PROJECT=elastic-cloud-dev REGISTRY=eu.gcr.io REPOSITORY=elastic-cloud-dev
...
2:19:12 elapsed
```

With SSDs:
```
time make ci-e2e STACK_VERSION=7.4.0  GCLOUD_PROJECT=elastic-cloud-dev REGISTRY=eu.gcr.io REPOSITORY=elastic-cloud-dev
...
{"level":"info","@timestamp":"2019-12-08T21:24:51.318Z","logger":"e2e-yhus0","message":"Tests completed successfully","ver":"0.0.0-00000000","name":"eck-e2e-yhus0-t27hf"}
{"level":"info","@timestamp":"2019-12-08T21:24:51.319Z","logger":"e2e-yhus0","message":"Skipping cleanup","ver":"0.0.0-00000000"}
 1:55:50 elapsed
```
_(I managed to run one in 1:48:00, it looks like some of the tests are randomly slow)_

Notes:
* It is only the time taken by the `make ci-e2e`, creation of the cluster is not accounted.
* Due to the setup of my experiment, event if it is closed to what happen in Jenkins, the e2e tests related to the license have not been run.

It roughly saves 25 minutes, it's not a silver bullet but it can help in the current situation and improve the stability of the tests.