### PR TITLE
Workaround subresources status update error

### DIFF
--- a/pkg/controller/apmserver/apmserver_controller.go
+++ b/pkg/controller/apmserver/apmserver_controller.go
@@ -468,5 +468,5 @@ func (r *ReconcileApmServer) updateStatus(state State) error {
 		r.recorder.Event(current, corev1.EventTypeWarning, events.EventReasonUnhealthy, "Apm Server health degraded")
 	}
 	log.Info("Updating status", "namespace", state.ApmServer.Namespace, "as_name", state.ApmServer.Name, "iteration", atomic.LoadUint64(&r.iteration))
-	return r.Status().Update(state.ApmServer)
+	return common.UpdateStatus(r.Client, state.ApmServer)
 }

--- a/pkg/controller/common/status.go
+++ b/pkg/controller/common/status.go
@@ -1,0 +1,41 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package common
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// UpdateStatus updates the status sub-resource of the given object.
+func UpdateStatus(client k8s.Client, obj runtime.Object) error {
+	err := client.Status().Update(obj)
+	return workaroundStatusUpdateError(err, client, obj)
+}
+
+// workaroundStatusUpdateError handles a bug on k8s < 1.15 that prevents status subresources updates
+// to be performed if the target resource storedVersion does not match the given resource version
+// (eg. storedVersion=v1beta1 vs. resource version=v1).
+// This is fixed by https://github.com/kubernetes/kubernetes/pull/78713 in k8s 1.15.
+// In case that happens here, let's retry the update on the full resource instead of the status subresource.
+func workaroundStatusUpdateError(err error, client k8s.Client, obj runtime.Object) error {
+	if !apierrors.IsInvalid(err) {
+		// not the case we're looking for here
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	log.Info(
+		"Status sub-resource update failed, attempting to update the entire resource instead",
+		"namespace", accessor.GetNamespace(),
+		"name", accessor.GetName(),
+	)
+	return client.Update(obj)
+}

--- a/pkg/controller/common/status_test.go
+++ b/pkg/controller/common/status_test.go
@@ -1,0 +1,59 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package common
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+)
+
+func Test_workaroundStatusUpdateError(t *testing.T) {
+	initialPod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "name"}}
+	updatedPod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "name"}, Status: corev1.PodStatus{Message: "updated"}}
+	tests := []struct {
+		name       string
+		err        error
+		wantErr    error
+		wantUpdate bool
+	}{
+		{
+			name:       "no error",
+			err:        nil,
+			wantErr:    nil,
+			wantUpdate: false,
+		},
+		{
+			name:       "different error",
+			err:        errors.New("something else"),
+			wantErr:    errors.New("something else"),
+			wantUpdate: false,
+		},
+		{
+			name:       "validation error",
+			err:        apierrors.NewInvalid(initialPod.GroupVersionKind().GroupKind(), initialPod.Name, field.ErrorList{}),
+			wantErr:    nil,
+			wantUpdate: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := k8s.WrappedFakeClient(&initialPod)
+			err := workaroundStatusUpdateError(tt.err, client, &updatedPod)
+			require.Equal(t, tt.wantErr, err)
+			// get back the pod to check if it was updated
+			var pod corev1.Pod
+			require.NoError(t, client.Get(k8s.ExtractNamespacedName(&initialPod), &pod))
+			require.Equal(t, tt.wantUpdate, pod.Status.Message == "updated")
+		})
+	}
+}

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -304,7 +304,7 @@ func (r *ReconcileElasticsearch) updateStatus(
 	if cluster == nil {
 		return nil
 	}
-	return r.Status().Update(cluster)
+	return common.UpdateStatus(r.Client, cluster)
 }
 
 // onDelete garbage collect resources when a Elasticsearch cluster is deleted

--- a/pkg/controller/kibana/kibana_controller.go
+++ b/pkg/controller/kibana/kibana_controller.go
@@ -221,7 +221,7 @@ func (r *ReconcileKibana) updateStatus(state State) error {
 		r.recorder.Event(current, corev1.EventTypeWarning, events.EventReasonUnhealthy, "Kibana health degraded")
 	}
 	log.Info("Updating status", "iteration", atomic.LoadUint64(&r.iteration), "namespace", state.Kibana.Namespace, "kibana_name", state.Kibana.Name)
-	return r.Status().Update(state.Kibana)
+	return common.UpdateStatus(r.Client, state.Kibana)
 }
 
 func (r *ReconcileKibana) onDelete(obj types.NamespacedName) {


### PR DESCRIPTION
A bug in K8s < 1.15 prevents status subresource updates to be successful
if the resource to update has a different storedVersion in etcd.

This commit works around the bug by catching the error (HTTP 422 -
resource invalid), and attempt an update of the entire resource instead
of the status sub-resource only.

Fixes https://github.com/elastic/cloud-on-k8s/issues/2226.
I manually tested it fixes the problem in https://github.com/elastic/cloud-on-k8s/pull/2184#issuecomment-562518887.