### PR TITLE
e2e: use scope label when creating license secrets

### DIFF
--- a/test/e2e/test/elasticsearch/steps_license.go
+++ b/test/e2e/test/elasticsearch/steps_license.go
@@ -83,8 +83,8 @@ func (ltctx *LicenseTestContext) CreateEnterpriseLicenseSecret(secretName string
 					Namespace: test.Ctx().ManagedNamespace(0),
 					Name:      secretName,
 					Labels: map[string]string{
-						common.TypeLabelName:     license.Type,
-						license.LicenseLabelType: string(license.LicenseTypeEnterprise),
+						common.TypeLabelName:      license.Type,
+						license.LicenseLabelScope: string(license.LicenseScopeOperator),
 					},
 				},
 				Data: map[string][]byte{


### PR DESCRIPTION
#2198 introduced a new `scope` label to diffentiate licenses on the operator level and the cluster level. Unfortunately I missed to apply this label in the e2e tests when creating the license secret. This corrects this mistake.