### PR TITLE
Split Makefile generate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,9 @@ dependencies:
 
 # Generate code, CRDs and documentation
 ALL_CRDS=config/crds/all-crds.yaml
-generate: controller-gen
+generate: generate-crds generate-api-docs generate-notice-file
+
+generate-crds: controller-gen
 	# we use this in pkg/controller/common/license
 	go generate -tags='$(GO_TAGS)' ./pkg/... ./cmd/...
 	$(CONTROLLER_GEN) webhook object:headerFile=./hack/boilerplate.go.txt paths=./pkg/apis/...
@@ -105,8 +107,6 @@ generate: controller-gen
 	kubectl kustomize config/crds/patches > $(ALL_CRDS)
 	# generate an all-in-one version including the operator manifests
 	$(MAKE) --no-print-directory generate-all-in-one
-	$(MAKE) --no-print-directory generate-api-docs
-	$(MAKE) --no-print-directory generate-notice-file
 
 generate-api-docs:
 	@hack/api-docs/build.sh
@@ -129,11 +129,11 @@ unit_xml: clean
 	gotestsum --junitfile unit-tests.xml -- -cover ./pkg/... ./cmd/...
 
 integration: GO_TAGS += integration
-integration: clean generate
+integration: clean generate-crds
 	go test -tags='$(GO_TAGS)' ./pkg/... ./cmd/... -cover
 
 integration_xml: GO_TAGS += integration
-integration_xml: clean generate
+integration_xml: clean generate-crds
 	gotestsum --junitfile integration-tests.xml -- -tags='$(GO_TAGS)' -cover ./pkg/... ./cmd/...
 
 lint:
@@ -143,7 +143,7 @@ lint:
 ##  --       Run       --  ##
 #############################
 
-install-crds: generate
+install-crds: generate-crds
 	kubectl apply -f $(ALL_CRDS)
 
 # Run locally against the configured Kubernetes cluster, with port-forwarding enabled so that


### PR DESCRIPTION
Splits the `generate` target in the Makefile so that API docs and licence notice does not get generated multiple times during an E2E test run in CI.