### PR TITLE
Ignore licence error during state update

### DIFF
--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -235,12 +235,13 @@ func (d *defaultDriver) Reconcile() *reconciler.Results {
 
 	// reconcile StatefulSets and nodes configuration
 	res = d.reconcileNodeSpecs(esReachable, esClient, d.ReconcileState, observedState, *resourcesState, keystoreResources, certificateResources)
-	if results.WithResults(res).HasError() {
+	results = results.WithResults(res)
+
+	if res.HasError() {
 		return results
 	}
 
 	d.ReconcileState.UpdateElasticsearchState(*resourcesState, observedState)
-
 	return results
 }
 


### PR DESCRIPTION
Fix to the case where a licence reconciliation error would have prevented the Elasticsearch cluster state from being updated. More information can be found in the issue.

Fixes #2244 
