### PR TITLE
e2e data check: adjust size of search query

### DIFF
--- a/test/e2e/test/elasticsearch/checks_data.go
+++ b/test/e2e/test/elasticsearch/checks_data.go
@@ -115,7 +115,7 @@ func (dc *DataIntegrityCheck) Verify() error {
 	}
 
 	// retrieve the previously indexed documents
-	r, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/%s/_search", dc.indexName), nil)
+	r, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/%s/_search?size=%d", dc.indexName, dc.docCount), nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* make the search query return as many results as we created in the data integrity check.
* this is only a problem if you change the number of test documents created to be larger as 10 (which also happens to be the default number of results returned)
* why not just check `hits.total`? because we have two different formats of `hits.total`in 6.8 and 7.x. so this seemed a pragmatic quick fix for now