### PR TITLE
>=7.6.0: set allowed license upload types

### DIFF
--- a/pkg/apis/elasticsearch/v1/fields.go
+++ b/pkg/apis/elasticsearch/v1/fields.go
@@ -39,6 +39,8 @@ const (
 	XPackSecurityTransportSslEnabled                = "xpack.security.transport.ssl.enabled"
 	XPackSecurityTransportSslKey                    = "xpack.security.transport.ssl.key"
 	XPackSecurityTransportSslVerificationMode       = "xpack.security.transport.ssl.verification_mode"
+
+	XPackLicenseUploadTypes = "xpack.license.upload.types" // >= 7.6.0
 )
 
 var UnsupportedSettings = []string{

--- a/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/pkg/controller/elasticsearch/settings/merged_config.go
@@ -13,6 +13,7 @@ import (
 	common "github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	escerts "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
 )
 
@@ -111,6 +112,12 @@ func xpackConfig(ver version.Version, httpCfg commonv1.HTTPConfig, certResources
 		// 7.x syntax
 		cfg[esv1.XPackSecurityAuthcRealmsFileFile1Order] = -100
 		cfg[esv1.XPackSecurityAuthcRealmsNativeNative1Order] = -99
+	}
+
+	if ver.IsSameOrAfter(version.MustParse("7.6.0")) {
+		cfg[esv1.XPackLicenseUploadTypes] = []string{
+			string(client.ElasticsearchLicenseTypeTrial), string(client.ElasticsearchLicenseTypeEnterprise),
+		}
 	}
 
 	return &CanonicalConfig{common.MustCanonicalConfig(cfg)}

--- a/pkg/controller/elasticsearch/settings/merged_config_test.go
+++ b/pkg/controller/elasticsearch/settings/merged_config_test.go
@@ -126,6 +126,14 @@ func TestNewMergedESConfig(t *testing.T) {
 			},
 		},
 		{
+			name:    "prior to 7.6.0, we should not allowed license upload types",
+			version: "7.5.0",
+			cfgData: map[string]interface{}{},
+			assert: func(cfg CanonicalConfig) {
+				require.Equal(t, 0, len(cfg.HasKeys([]string{esv1.XPackLicenseUploadTypes})))
+			},
+		},
+		{
 			name:    "starting 7.6.0, we should set allowed license upload types",
 			version: "7.6.0",
 			cfgData: map[string]interface{}{},

--- a/pkg/controller/elasticsearch/settings/merged_config_test.go
+++ b/pkg/controller/elasticsearch/settings/merged_config_test.go
@@ -126,7 +126,7 @@ func TestNewMergedESConfig(t *testing.T) {
 			},
 		},
 		{
-			name:    "prior to 7.6.0, we should not allowed license upload types",
+			name:    "prior to 7.6.0, we should not set allowed license upload types",
 			version: "7.5.0",
 			cfgData: map[string]interface{}{},
 			assert: func(cfg CanonicalConfig) {

--- a/pkg/controller/elasticsearch/settings/merged_config_test.go
+++ b/pkg/controller/elasticsearch/settings/merged_config_test.go
@@ -125,6 +125,14 @@ func TestNewMergedESConfig(t *testing.T) {
 				require.Equal(t, 1, len(cfg.HasKeys([]string{esv1.DiscoverySeedProviders})))
 			},
 		},
+		{
+			name:    "starting 7.6.0, we should set allowed license upload types",
+			version: "7.6.0",
+			cfgData: map[string]interface{}{},
+			assert: func(cfg CanonicalConfig) {
+				require.Equal(t, 1, len(cfg.HasKeys([]string{esv1.XPackLicenseUploadTypes})))
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Adds support for https://github.com/elastic/elasticsearch/pull/49418 

~We may want to postpone merging until we have 7.6.0 snapshot to test with.~

Fixes #2197 