### PR TITLE
Allow user to override readiness timeout

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/readiness_probe.go
+++ b/pkg/controller/elasticsearch/nodespec/readiness_probe.go
@@ -30,7 +30,7 @@ const ReadinessProbeScriptConfigKey = "readiness-probe-script.sh"
 const ReadinessProbeScript string = `
 #!/usr/bin/env bash
 # Consider a node to be healthy if it responds to a simple GET on "/_cat/nodes?local"
-${CURL_TIMEOUT:=3}
+CURL_TIMEOUT=${CURL_TIMEOUT:=3}
 
 # Check if PROBE_PASSWORD_PATH is set, otherwise fall back to its former name in 1.0.0.beta-1: PROBE_PASSWORD_FILE
 if [[ -z "${PROBE_PASSWORD_PATH}" ]]; then

--- a/pkg/controller/elasticsearch/nodespec/readiness_probe.go
+++ b/pkg/controller/elasticsearch/nodespec/readiness_probe.go
@@ -30,7 +30,7 @@ const ReadinessProbeScriptConfigKey = "readiness-probe-script.sh"
 const ReadinessProbeScript string = `
 #!/usr/bin/env bash
 # Consider a node to be healthy if it responds to a simple GET on "/_cat/nodes?local"
-CURL_TIMEOUT=3
+${CURL_TIMEOUT:=3}
 
 # Check if PROBE_PASSWORD_PATH is set, otherwise fall back to its former name in 1.0.0.beta-1: PROBE_PASSWORD_FILE
 if [[ -z "${PROBE_PASSWORD_PATH}" ]]; then


### PR DESCRIPTION
Relates to https://github.com/elastic/cloud-on-k8s/issues/2259

Default the readiness timeout 3s, but allow the user to set an env var to override the timeout for clusters that are under load. Currently it is hardcoded so changing the timeout means you need to change the whole readiness probe