### PR TITLE
Use the webhook server in e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,6 +384,7 @@ e2e-local:
 		--auto-port-forwarding \
 		--local \
 		--log-verbosity=$(LOG_VERBOSITY) \
+		--ignore-webhook-failures \
 		--test-timeout=$(TEST_TIMEOUT)
 	@E2E_JSON=$(E2E_JSON) test/e2e/run.sh -run "$(TESTS_MATCH)" -args -testContextPath $(LOCAL_E2E_CTX)
 

--- a/config/e2e/global_operator.yaml
+++ b/config/e2e/global_operator.yaml
@@ -185,6 +185,13 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        readinessProbe:
+          httpGet:
+            path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
+            port: webhook-server
+            scheme: HTTPS
+          failureThreshold: 3
+          periodSeconds: 5
         ports:
         - containerPort: 9443
           name: webhook-server
@@ -213,7 +220,7 @@ webhooks:
         namespace: {{ .GlobalOperator.Namespace }}
         # this is the path controller-runtime automatically generates
         path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
-    failurePolicy: Ignore
+    failurePolicy: {{ if .IgnoreWebhookFailures }}Ignore{{ else }}Fail{{ end }}
     name: elastic-es-validation.k8s.elastic.co
     rules:
       - apiGroups:
@@ -232,7 +239,7 @@ webhooks:
         namespace: {{ .GlobalOperator.Namespace }}
         # this is the path controller-runtime automatically generates
         path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
-    failurePolicy: Ignore
+    failurePolicy: {{ if .IgnoreWebhookFailures }}Ignore{{ else }}Fail{{ end }}
     name: elastic-es-validation.k8s.elastic.co
     rules:
       - apiGroups:
@@ -255,4 +262,4 @@ spec:
     - port: 443
       targetPort: 9443
   selector:
-    control-plane: elastic-operator
+    control-plane: {{ .GlobalOperator.Name }}

--- a/test/e2e/cmd/run/command.go
+++ b/test/e2e/cmd/run/command.go
@@ -20,23 +20,24 @@ import (
 )
 
 type runFlags struct {
-	managedNamespaces   []string
-	e2eImage            string
-	elasticStackVersion string
-	kubeConfig          string
-	operatorImage       string
-	testContextOutPath  string
-	testLicense         string
-	scratchDirRoot      string
-	testRegex           string
-	testRunName         string
-	commandTimeout      time.Duration
-	autoPortForwarding  bool
-	skipCleanup         bool
-	local               bool
-	logToFile           bool
-	logVerbosity        int
-	testTimeout         time.Duration
+	managedNamespaces     []string
+	e2eImage              string
+	elasticStackVersion   string
+	kubeConfig            string
+	operatorImage         string
+	testContextOutPath    string
+	testLicense           string
+	scratchDirRoot        string
+	testRegex             string
+	testRunName           string
+	commandTimeout        time.Duration
+	autoPortForwarding    bool
+	skipCleanup           bool
+	local                 bool
+	logToFile             bool
+	logVerbosity          int
+	testTimeout           time.Duration
+	ignoreWebhookFailures bool
 }
 
 var log logr.Logger
@@ -78,6 +79,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&flags.testRunName, "test-run-name", randomTestRunName(), "Name of this test run")
 	cmd.Flags().DurationVar(&flags.testTimeout, "test-timeout", 5*time.Minute, "Timeout before failing a test")
 	cmd.Flags().BoolVar(&flags.logToFile, "log-to-file", false, "Specifies if should log test output to file. Disabled by default.")
+	cmd.Flags().BoolVar(&flags.ignoreWebhookFailures, "ignore-webhook-failures", false, "Specifies if webhook errors should be ignored. Useful when running test locally. False by default")
 	logutil.BindFlags(cmd.PersistentFlags())
 
 	// enable setting flags via environment variables

--- a/test/e2e/cmd/run/command.go
+++ b/test/e2e/cmd/run/command.go
@@ -35,9 +35,9 @@ type runFlags struct {
 	skipCleanup           bool
 	local                 bool
 	logToFile             bool
+	ignoreWebhookFailures bool
 	logVerbosity          int
 	testTimeout           time.Duration
-	ignoreWebhookFailures bool
 }
 
 var log logr.Logger

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -141,11 +141,12 @@ func (h *helper) initTestContext() error {
 			},
 			ManagedNamespaces: make([]string, len(h.managedNamespaces)),
 		},
-		OperatorImage: h.operatorImage,
-		TestLicense:   h.testLicense,
-		TestRegex:     h.testRegex,
-		TestRun:       h.testRunName,
-		TestTimeout:   h.testTimeout,
+		OperatorImage:         h.operatorImage,
+		TestLicense:           h.testLicense,
+		TestRegex:             h.testRegex,
+		TestRun:               h.testRunName,
+		TestTimeout:           h.testTimeout,
+		IgnoreWebhookFailures: h.ignoreWebhookFailures,
 	}
 
 	for i, ns := range h.managedNamespaces {

--- a/test/e2e/es/naming_test.go
+++ b/test/e2e/es/naming_test.go
@@ -104,7 +104,7 @@ func testRejectionOfLongName(t *testing.T) {
 					err := k.Client.Create(obj)
 					if err != nil {
 						// validating webhook is active and rejected the request
-						require.Contains(t, err.Error(), `admission webhook "validation.elasticsearch.elastic.co" denied the request`)
+						require.Contains(t, err.Error(), `admission webhook "elastic-es-validation.k8s.elastic.co" denied the request`)
 						return
 					}
 

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -61,8 +61,9 @@ func initializeContext() {
 
 func defaultContext() Context {
 	return Context{
-		AutoPortForwarding:  false,
-		ElasticStackVersion: defaultElasticStackVersion,
+		AutoPortForwarding:    false,
+		ElasticStackVersion:   defaultElasticStackVersion,
+		IgnoreWebhookFailures: false,
 		GlobalOperator: ClusterResource{
 			Name:      "elastic-global-operator",
 			Namespace: "elastic-system",
@@ -80,20 +81,21 @@ func defaultContext() Context {
 
 // Context encapsulates data about a specific test run
 type Context struct {
-	GlobalOperator      ClusterResource   `json:"global_operator"`
-	NamespaceOperator   NamespaceOperator `json:"namespace_operator"`
-	E2EImage            string            `json:"e2e_image"`
-	E2ENamespace        string            `json:"e2e_namespace"`
-	E2EServiceAccount   string            `json:"e2e_service_account"`
-	ElasticStackVersion string            `json:"elastic_stack_version"`
-	LogVerbosity        int               `json:"log_verbosity"`
-	OperatorImage       string            `json:"operator_image"`
-	TestLicense         string            `json:"test_license"`
-	TestRegex           string            `json:"test_regex"`
-	TestRun             string            `json:"test_run"`
-	TestTimeout         time.Duration     `json:"test_timeout"`
-	AutoPortForwarding  bool              `json:"auto_port_forwarding"`
-	Local               bool              `json:"local"`
+	GlobalOperator        ClusterResource   `json:"global_operator"`
+	NamespaceOperator     NamespaceOperator `json:"namespace_operator"`
+	E2EImage              string            `json:"e2e_image"`
+	E2ENamespace          string            `json:"e2e_namespace"`
+	E2EServiceAccount     string            `json:"e2e_service_account"`
+	ElasticStackVersion   string            `json:"elastic_stack_version"`
+	LogVerbosity          int               `json:"log_verbosity"`
+	OperatorImage         string            `json:"operator_image"`
+	TestLicense           string            `json:"test_license"`
+	TestRegex             string            `json:"test_regex"`
+	TestRun               string            `json:"test_run"`
+	TestTimeout           time.Duration     `json:"test_timeout"`
+	AutoPortForwarding    bool              `json:"auto_port_forwarding"`
+	Local                 bool              `json:"local"`
+	IgnoreWebhookFailures bool              `json:"ignore_webhook_failures"`
 }
 
 // ManagedNamespace returns the nth managed namespace.


### PR DESCRIPTION
Fix #2153 

This PR sets the failure policy to `Fail` by default. You can change this behaviour by adding the following field `ignore_webhook_failures` to `true` in your e2e test context: 

```json
{
...
  "ignore_webhook_failures": true
}
```