### PR TITLE
Use PodTemplate that contains correct SecurityContext

### DIFF
--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -287,6 +287,25 @@ func (b Builder) WithMutatedFrom(builder *Builder) Builder {
 	return b
 }
 
+func (b Builder) WithEnvironmentVariable(name, value string) Builder {
+	for _, nodeSet := range b.Elasticsearch.Spec.NodeSets {
+		for _, container := range nodeSet.PodTemplate.Spec.Containers {
+			container.Env = append(container.Env, corev1.EnvVar{Name: name, Value: value})
+		}
+	}
+	return b
+}
+
+func (b Builder) WithPodLabel(key, value string) Builder {
+	for _, nodeSet := range b.Elasticsearch.Spec.NodeSets {
+		if nodeSet.PodTemplate.Labels == nil {
+			nodeSet.PodTemplate.Labels = make(map[string]string)
+		}
+		nodeSet.PodTemplate.Labels[key] = value
+	}
+	return b
+}
+
 // -- Helper functions
 
 func (b Builder) RuntimeObjects() []runtime.Object {

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -288,20 +288,21 @@ func (b Builder) WithMutatedFrom(builder *Builder) Builder {
 }
 
 func (b Builder) WithEnvironmentVariable(name, value string) Builder {
-	for _, nodeSet := range b.Elasticsearch.Spec.NodeSets {
-		for _, container := range nodeSet.PodTemplate.Spec.Containers {
+	for i, nodeSet := range b.Elasticsearch.Spec.NodeSets {
+		for j, container := range nodeSet.PodTemplate.Spec.Containers {
 			container.Env = append(container.Env, corev1.EnvVar{Name: name, Value: value})
+			b.Elasticsearch.Spec.NodeSets[i].PodTemplate.Spec.Containers[j].Env = container.Env
 		}
 	}
 	return b
 }
 
 func (b Builder) WithPodLabel(key, value string) Builder {
-	for _, nodeSet := range b.Elasticsearch.Spec.NodeSets {
-		if nodeSet.PodTemplate.Labels == nil {
-			nodeSet.PodTemplate.Labels = make(map[string]string)
+	for i := range b.Elasticsearch.Spec.NodeSets {
+		if b.Elasticsearch.Spec.NodeSets[i].PodTemplate.Labels == nil {
+			b.Elasticsearch.Spec.NodeSets[i].PodTemplate.Labels = make(map[string]string)
 		}
-		nodeSet.PodTemplate.Labels[key] = value
+		b.Elasticsearch.Spec.NodeSets[i].PodTemplate.Labels[key] = value
 	}
 	return b
 }


### PR DESCRIPTION
Fixes the fail reason of https://devops-ci.elastic.co/job/cloud-on-k8s-e2e-tests/603/ introduced in #2233.

When using `.WithPodTemplate()` one has to provide correct `SecurityContext`. To avoid that and use the default pod template, label and env var were set using new `With.*()` funcs.