### PR TITLE
Change readiness timeout var

### DIFF
--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -29,6 +29,7 @@ Before you deploy and run ECK, take some time to look at the basic and advanced 
 - <<{p}-advanced-node-scheduling,Advanced Elasticsearch node scheduling>>
 - <<{p}-orchestration>>
 - <<{p}-snapshots,Create automated snapshots>>
+- <<{p}-readiness>>
 
 [id="{p}-pod-template"]
 === Pod Template
@@ -506,3 +507,26 @@ spec:
 include::orchestration.asciidoc[]
 include::advanced-node-scheduling.asciidoc[]
 include::snapshots.asciidoc[]
+
+
+[id="{p}-readiness"]
+=== Readiness probe
+
+By default, the readiness probe checks that the pod can successfully respond to HTTP requests within a three second timeout. This is acceptable in most cases. In some cases (such as when the cluster is under heavy load), it may be helpful to increase the timeout. This allows the pod to stay in a `Ready` state and thus be part of the Elasticsearch service even if it is responding slowly. To adjust the timeout, set the `READINESS_PROBE_TIMEOUT` environment variable in the pod template. For example, to increase it to ten seconds:
+
+[source,yaml]
+----
+spec:
+  nodeSets:
+  - name: default
+    count: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          env:
+          - name: READINESS_PROBE_TIMEOUT
+            value: 10
+----
+
+Note that this will require restarting the pods.

--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -512,21 +512,35 @@ include::snapshots.asciidoc[]
 [id="{p}-readiness"]
 === Readiness probe
 
-By default, the readiness probe checks that the pod can successfully respond to HTTP requests within a three second timeout. This is acceptable in most cases. In some cases (such as when the cluster is under heavy load), it may be helpful to increase the timeout. This allows the pod to stay in a `Ready` state and thus be part of the Elasticsearch service even if it is responding slowly. To adjust the timeout, set the `READINESS_PROBE_TIMEOUT` environment variable in the pod template. For example, to increase it to ten seconds:
+By default, the readiness probe checks that the pod can successfully respond to HTTP requests within a three second timeout. This is acceptable in most cases. In some cases (such as when the cluster is under heavy load), it may be helpful to increase the timeout. This allows the pod to stay in a `Ready` state and thus be part of the Elasticsearch service even if it is responding slowly. To adjust the timeout, set the `READINESS_PROBE_TIMEOUT` environment variable in the pod template. The readiness probe configuration also must be updated with the new timeout. For example, to increase the API call timeout to ten seconds and the overall check time to twelve seconds:
 
 [source,yaml]
 ----
 spec:
+  version: 7.4.2
   nodeSets:
-  - name: default
-    count: 1
-    podTemplate:
-      spec:
-        containers:
-        - name: elasticsearch
-          env:
-          - name: READINESS_PROBE_TIMEOUT
-            value: 10
+    - name: default
+      count: 1
+      podTemplate:
+        spec:
+          containers:
+          - name: elasticsearch
+            readinessProbe:
+              exec:
+                command:
+                - bash
+                - -c
+                - /mnt/elastic-internal/scripts/readiness-probe-script.sh
+              failureThreshold: 3
+              initialDelaySeconds: 10
+              periodSeconds: 12
+              successThreshold: 1
+              timeoutSeconds: 12
+            env:
+            - name: READINESS_PROBE_TIMEOUT
+              value: "10"
+
+
 ----
 
 Note that this will require restarting the pods.

--- a/pkg/controller/elasticsearch/nodespec/readiness_probe.go
+++ b/pkg/controller/elasticsearch/nodespec/readiness_probe.go
@@ -29,7 +29,7 @@ func NewReadinessProbe() *corev1.Probe {
 const ReadinessProbeScriptConfigKey = "readiness-probe-script.sh"
 const ReadinessProbeScript = `#!/usr/bin/env bash
 # Consider a node to be healthy if it responds to a simple GET on "/_cat/nodes?local"
-CURL_TIMEOUT=${CURL_TIMEOUT:=3}
+READINESS_PROBE_TIMEOUT=${READINESS_PROBE_TIMEOUT:=3}
 
 # Check if PROBE_PASSWORD_PATH is set, otherwise fall back to its former name in 1.0.0.beta-1: PROBE_PASSWORD_FILE
 if [[ -z "${PROBE_PASSWORD_PATH}" ]]; then
@@ -48,7 +48,7 @@ fi
 
 # request Elasticsearch
 ENDPOINT="${READINESS_PROBE_PROTOCOL:-https}://127.0.0.1:9200/_cat/nodes?local"
-status=$(curl -o /dev/null -w "%{http_code}" --max-time $CURL_TIMEOUT -XGET -s -k ${BASIC_AUTH} $ENDPOINT)
+status=$(curl -o /dev/null -w "%{http_code}" --max-time $READINESS_PROBE_TIMEOUT -XGET -s -k ${BASIC_AUTH} $ENDPOINT)
 
 # ready if status code 200
 if [[ $status == "200" ]]; then


### PR DESCRIPTION
Follow up to https://github.com/elastic/cloud-on-k8s/pull/2260

Changing the name of the env var and adding some docs