### PR TITLE
Clarify location of podTemplate in doc example

### DIFF
--- a/docs/managing-compute-resources.asciidoc
+++ b/docs/managing-compute-resources.asciidoc
@@ -25,7 +25,9 @@ For Elasticsearch objects, make sure to consider the heap size when you set reso
 ----
 spec:
   nodeSets:
-  - podTemplate:
+  - name: default
+    count: 1
+    podTemplate:
       spec:
         containers:
         - name: elasticsearch


### PR DESCRIPTION
Updates the resource limits example in the documentation to make it clear to users where the `podTemplate` section should go.

Replaces #2193 since it seems to be abandoned. 