### PR TITLE
Document PreStop hook and it's env vars

### DIFF
--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -515,7 +515,7 @@ include::snapshots.asciidoc[]
 
 By default, the readiness probe checks that the pod can successfully respond to HTTP requests within a three second timeout. This is acceptable in most cases. In some cases (such as when the cluster is under heavy load), it may be helpful to increase the timeout. This allows the pod to stay in a `Ready` state and thus be part of the Elasticsearch service even if it is responding slowly. To adjust the timeout, set the `READINESS_PROBE_TIMEOUT` environment variable in the pod template. The readiness probe configuration also must be updated with the new timeout. For example, to increase the API call timeout to ten seconds and the overall check time to twelve seconds:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 spec:
   version: {version}
@@ -553,7 +553,7 @@ When an Elasticsearch `Pod` is terminated, its `Endpoint` is removed from the `S
 
 To address this issue and guarantee no downtime for new connections, ECK relies on a link:https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/[PreStop lifecycle hook]. This waits to terminate the Elasticsearch process until the `Service` DNS record does not contain the IP of the `Pod`. First, the PreStop lifecycle hook will keep querying DNS for `MAX_WAIT_SECONDS` (defaulting to 20) and then it will wait for `ADDITIONAL_WAIT_SECONDS` (defaulting to 1). Additional wait is used to give clients time to use an IP resolved just before DNS record was updated. The exact behavior is configurable using environment variables, for example:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 spec:
   version: {version}

--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -549,7 +549,7 @@ Note that this will require restarting the pods.
 [id="{p}-prestop"]
 === Pod PreStop hook
 
-When Elasticsearch `Pod` is terminated, its `Endpoint` is removed from the `Service` and the Elasticsearch process is terminated. As these two operations happen in parallel, a race condition exists. If the Elasticsearch process is already shut down, but the `Endpoint` is still a part of the `Service`, any new connection might fail. For more information, see link:https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods[Termination of pods].
+When an Elasticsearch `Pod` is terminated, its `Endpoint` is removed from the `Service` and the Elasticsearch process is terminated. As these two operations happen in parallel, a race condition exists. If the Elasticsearch process is already shut down, but the `Endpoint` is still a part of the `Service`, any new connection might fail. For more information, see link:https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods[Termination of pods].
 
 To address this issue and guarantee no downtime for new connections, ECK relies on PreStop lifecycle hook. This allows to delay Elasticsearch process termination until `Service` DNS record won't contain the IP of the `Pod`. First, PreStop lifecycle hook will keep querying DNS for `MAX_WAIT_SECONDS` (defaulting to 20) and then it will wait for `ADDITIONAL_WAIT_SECONDS` (defaulting to 1). Additional wait is needed to give clients time to use IP resolved just before DNS record was updated. The exact behavior is configurable using environment variables, for example:
 

--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -30,6 +30,7 @@ Before you deploy and run ECK, take some time to look at the basic and advanced 
 - <<{p}-orchestration>>
 - <<{p}-snapshots,Create automated snapshots>>
 - <<{p}-readiness>>
+- <<{p}-prestop>>
 
 [id="{p}-pod-template"]
 === Pod Template
@@ -517,7 +518,7 @@ By default, the readiness probe checks that the pod can successfully respond to 
 [source,yaml]
 ----
 spec:
-  version: 7.4.2
+  version: {version}
   nodeSets:
     - name: default
       count: 1
@@ -544,3 +545,27 @@ spec:
 ----
 
 Note that this will require restarting the pods.
+
+[id="{p}-prestop"]
+=== Pod PreStop hook
+
+When Elasticsearch `Pod` is terminated, it's `Endpoint` is being removed from the `Service` and the Elasticsearch process is terminated. As these two operations are happening in parallel, a race condition exists. If the Elasticsearch process is already shut down, but the `Endpoint` is still being a part of the `Service`, any new connection might fail. For more information, see link:https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods[Termination of pods].
+
+To address this issue and guarantee no downtime for new connections, ECK relies on PreStop lifecycle hook. This allows to delay Elasticsearch process termination until `Service` DNS record won't contain the IP of the `Pod`. First, PreStop lifecycle hook will keep querying DNS for `MAX_WAIT_SECONDS` (defaulting to 20) and then it will wait for `ADDITIONAL_WAIT_SECONDS` (defaulting to 1). Additional wait is needed to give clients time to use IP resolved just before DNS record was updated. The exact behavior is configurable using environment variables, for example:
+
+[source,yaml]
+----
+spec:
+  version: {version}
+  nodeSets:
+    - name: default
+      count: 1
+      podTemplate:
+        spec:
+          containers:
+          - name: elasticsearch
+            env:
+            - name: MAX_WAIT_SECONDS
+              value: "10"
+            - name: ADDITIONAL_WAIT_SECONDS
+              value: "5"

--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -549,7 +549,7 @@ Note that this will require restarting the pods.
 [id="{p}-prestop"]
 === Pod PreStop hook
 
-When Elasticsearch `Pod` is terminated, it's `Endpoint` is being removed from the `Service` and the Elasticsearch process is terminated. As these two operations are happening in parallel, a race condition exists. If the Elasticsearch process is already shut down, but the `Endpoint` is still being a part of the `Service`, any new connection might fail. For more information, see link:https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods[Termination of pods].
+When Elasticsearch `Pod` is terminated, its `Endpoint` is removed from the `Service` and the Elasticsearch process is terminated. As these two operations happen in parallel, a race condition exists. If the Elasticsearch process is already shut down, but the `Endpoint` is still a part of the `Service`, any new connection might fail. For more information, see link:https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods[Termination of pods].
 
 To address this issue and guarantee no downtime for new connections, ECK relies on PreStop lifecycle hook. This allows to delay Elasticsearch process termination until `Service` DNS record won't contain the IP of the `Pod`. First, PreStop lifecycle hook will keep querying DNS for `MAX_WAIT_SECONDS` (defaulting to 20) and then it will wait for `ADDITIONAL_WAIT_SECONDS` (defaulting to 1). Additional wait is needed to give clients time to use IP resolved just before DNS record was updated. The exact behavior is configurable using environment variables, for example:
 

--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -551,7 +551,7 @@ Note that this will require restarting the pods.
 
 When an Elasticsearch `Pod` is terminated, its `Endpoint` is removed from the `Service` and the Elasticsearch process is terminated. As these two operations happen in parallel, a race condition exists. If the Elasticsearch process is already shut down, but the `Endpoint` is still a part of the `Service`, any new connection might fail. For more information, see link:https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods[Termination of pods].
 
-To address this issue and guarantee no downtime for new connections, ECK relies on PreStop lifecycle hook. This allows to delay Elasticsearch process termination until `Service` DNS record won't contain the IP of the `Pod`. First, PreStop lifecycle hook will keep querying DNS for `MAX_WAIT_SECONDS` (defaulting to 20) and then it will wait for `ADDITIONAL_WAIT_SECONDS` (defaulting to 1). Additional wait is needed to give clients time to use IP resolved just before DNS record was updated. The exact behavior is configurable using environment variables, for example:
+To address this issue and guarantee no downtime for new connections, ECK relies on a link:https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/[PreStop lifecycle hook]. This waits to terminate the Elasticsearch process until the `Service` DNS record does not contain the IP of the `Pod`. First, the PreStop lifecycle hook will keep querying DNS for `MAX_WAIT_SECONDS` (defaulting to 20) and then it will wait for `ADDITIONAL_WAIT_SECONDS` (defaulting to 1). Additional wait is used to give clients time to use an IP resolved just before DNS record was updated. The exact behavior is configurable using environment variables, for example:
 
 [source,yaml]
 ----

--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -569,3 +569,4 @@ spec:
               value: "10"
             - name: ADDITIONAL_WAIT_SECONDS
               value: "5"
+----


### PR DESCRIPTION
Docs for https://github.com/elastic/cloud-on-k8s/pull/2233. Also, changing static version to `{version}` in readiness probe docs.