### PR TITLE
Do not fail if annotations file does not exist

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/readiness_probe.go
+++ b/pkg/controller/elasticsearch/nodespec/readiness_probe.go
@@ -39,14 +39,13 @@ function fail {
 
 labels="` + volume.DownwardAPIMountPath + "/" + volume.LabelsFile + `"
 
-if [[ ! -f "${labels}" ]]; then
-  fail "\"reason\": \"${labels} does not exist\""
+version=""
+if [[ -f "${labels}" ]]; then
+  # get Elasticsearch version from the downward API
+  version=$(grep "` + label.VersionLabelName + `" ${labels} | cut -d '=' -f 2)
+  # remove quotes
+  version=$(echo "${version}" | tr -d '"')
 fi
-
-# get Elasticsearch version from the downward API
-version=$(grep "` + label.VersionLabelName + `" ${labels} | cut -d '=' -f 2)
-# remove quotes
-version=$(echo "${version}" | tr -d '"')
 
 READINESS_PROBE_TIMEOUT=${READINESS_PROBE_TIMEOUT:=3}
 


### PR DESCRIPTION
Fixing my own mistake: when upgrading the operator the file that contains the labels does not exist. Readiness script should not fail in that situation.