### PR TITLE
Reintroduce link to webhook documentation

### DIFF
--- a/docs/operator-config.asciidoc
+++ b/docs/operator-config.asciidoc
@@ -64,3 +64,5 @@ to:
       - all
       - --enable-debug-logs=true
 ----
+
+include::webhook.asciidoc[]


### PR DESCRIPTION
Link to the webhook documentation has been involuntarily removed in #2258 