### PR TITLE
Increase rolling upgrade unavailabilty threshold

### DIFF
--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -21,8 +21,10 @@ import (
 const (
 	continuousHealthCheckTimeout = 5 * time.Second
 	// clusterUnavailabilityThreshold is the accepted duration for the cluster to temporarily not respond to requests
-	// (eg. during leader elections in the middle of a rolling upgrade)
-	clusterUnavailabilityThreshold = 60 * time.Second
+	// (eg. during leader elections in the middle of a rolling upgrade).
+	// The value is completely arbitrary and based on observations that killing the master node
+	// on Elasticsearch < 7.2 usually makes the cluster unavailable for about 50 sec in those tests.
+	clusterUnavailabilityThreshold = 120 * time.Second
 )
 
 func (b Builder) UpgradeTestSteps(k *test.K8sClient) test.StepList {


### PR DESCRIPTION
We used to have a 60sec threshold where we consider it's OK for a
cluster to be unavailable when the master node gets killed.
This test is very flaky, especially on 6.8.x and 7.1.x clusters where
the unavailability is usually around 50sec under good conditions.

I bumped the value to 120sec: this is really an arbitrary value, mostly
to avoid flakiness of the test while keeping it in its current form.

https://github.com/elastic/cloud-on-k8s/issues/2262 is still open so we
figure out a better way to deal with it.