### PR TITLE
Use xpack.license_management.ui.disabled setting in Kibana as of 7.6.0

### DIFF
--- a/pkg/controller/kibana/config/fields.go
+++ b/pkg/controller/kibana/config/fields.go
@@ -10,6 +10,7 @@ const (
 	ServerHost                                     = "server.host"
 	ElasticSearchHosts                             = "elasticsearch.hosts"
 	XpackMonitoringUiContainerElasticsearchEnabled = "xpack.monitoring.ui.container.elasticsearch.enabled"
+	XpackLicenseManagementUIEnabled                = "xpack.license_management.ui.enabled" // >= 7.6
 
 	ElasticsearchSslCertificateAuthorities = "elasticsearch.ssl.certificateAuthorities"
 	ElasticsearchSslVerificationMode       = "elasticsearch.ssl.verificationMode"

--- a/pkg/controller/kibana/version/version6/settings.go
+++ b/pkg/controller/kibana/version/version6/settings.go
@@ -6,11 +6,12 @@ package version6
 
 import (
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana/config"
 )
 
 // SettingsFactory returns Kibana settings for a 6.x Kibana.
-func SettingsFactory(kb kbv1.Kibana) map[string]interface{} {
+func SettingsFactory(kb kbv1.Kibana, _ version.Version) map[string]interface{} {
 	return map[string]interface{}{
 		config.ElasticsearchURL: kb.AssociationConf().GetURL(),
 	}

--- a/pkg/controller/kibana/version/version7/settings.go
+++ b/pkg/controller/kibana/version/version7/settings.go
@@ -6,12 +6,18 @@ package version7
 
 import (
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana/config"
 )
 
 // SettingsFactory returns Kibana settings for a 7.x Kibana.
-func SettingsFactory(kb kbv1.Kibana) map[string]interface{} {
-	return map[string]interface{}{
+func SettingsFactory(kb kbv1.Kibana, v version.Version) map[string]interface{} {
+	settings := map[string]interface{}{
 		config.ElasticsearchHosts: kb.AssociationConf().GetURL(),
 	}
+	if v.IsSameOrAfter(version.MustParse("7.6.0")) {
+		// setting exists only as of 7.6.0
+		settings[config.XpackLicenseManagementUIEnabled] = false
+	}
+	return settings
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/2252

Implements https://github.com/elastic/kibana/issues/52709 when orchestrating Kibana `>=7.6.0`