### PR TITLE
Improve resource statuses logging

### DIFF
--- a/pkg/controller/apmserver/apmserver_controller.go
+++ b/pkg/controller/apmserver/apmserver_controller.go
@@ -471,6 +471,11 @@ func (r *ReconcileApmServer) updateStatus(state State) error {
 	if state.ApmServer.Status.IsDegraded(current.Status) {
 		r.recorder.Event(current, corev1.EventTypeWarning, events.EventReasonUnhealthy, "Apm Server health degraded")
 	}
-	log.Info("Updating status", "namespace", state.ApmServer.Namespace, "as_name", state.ApmServer.Name, "iteration", atomic.LoadUint64(&r.iteration))
+	log.Info("Updating status",
+		"iteration", atomic.LoadUint64(&r.iteration),
+		"namespace", state.ApmServer.Namespace,
+		"as_name", state.ApmServer.Name,
+		"status", state.ApmServer.Status,
+	)
 	return common.UpdateStatus(r.Client, state.ApmServer)
 }

--- a/pkg/controller/apmserver/apmserver_controller.go
+++ b/pkg/controller/apmserver/apmserver_controller.go
@@ -471,7 +471,7 @@ func (r *ReconcileApmServer) updateStatus(state State) error {
 	if state.ApmServer.Status.IsDegraded(current.Status) {
 		r.recorder.Event(current, corev1.EventTypeWarning, events.EventReasonUnhealthy, "Apm Server health degraded")
 	}
-	log.Info("Updating status",
+	log.V(1).Info("Updating status",
 		"iteration", atomic.LoadUint64(&r.iteration),
 		"namespace", state.ApmServer.Namespace,
 		"as_name", state.ApmServer.Name,

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -307,6 +307,7 @@ func (r *ReconcileElasticsearch) updateStatus(
 		"iteration", atomic.LoadUint64(&r.iteration),
 		"namespace", es.Namespace,
 		"es_name", es.Name,
+		"status", cluster.Status,
 	)
 	return common.UpdateStatus(r.Client, cluster)
 }

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -303,7 +303,7 @@ func (r *ReconcileElasticsearch) updateStatus(
 	if cluster == nil {
 		return nil
 	}
-	log.Info("Updating status",
+	log.V(1).Info("Updating status",
 		"iteration", atomic.LoadUint64(&r.iteration),
 		"namespace", es.Namespace,
 		"es_name", es.Name,

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -295,7 +295,6 @@ func (r *ReconcileElasticsearch) updateStatus(
 	es esv1.Elasticsearch,
 	reconcileState *esreconcile.State,
 ) error {
-	log.Info("Updating status", "iteration", atomic.LoadUint64(&r.iteration), "namespace", es.Namespace, "es_name", es.Name)
 	events, cluster := reconcileState.Apply()
 	for _, evt := range events {
 		log.V(1).Info("Recording event", "event", evt)
@@ -304,6 +303,11 @@ func (r *ReconcileElasticsearch) updateStatus(
 	if cluster == nil {
 		return nil
 	}
+	log.Info("Updating status",
+		"iteration", atomic.LoadUint64(&r.iteration),
+		"namespace", es.Namespace,
+		"es_name", es.Name,
+	)
 	return common.UpdateStatus(r.Client, cluster)
 }
 

--- a/pkg/controller/kibana/kibana_controller.go
+++ b/pkg/controller/kibana/kibana_controller.go
@@ -220,7 +220,7 @@ func (r *ReconcileKibana) updateStatus(state State) error {
 	if state.Kibana.Status.IsDegraded(current.Status) {
 		r.recorder.Event(current, corev1.EventTypeWarning, events.EventReasonUnhealthy, "Kibana health degraded")
 	}
-	log.Info("Updating status",
+	log.V(1).Info("Updating status",
 		"iteration", atomic.LoadUint64(&r.iteration),
 		"namespace", state.Kibana.Namespace,
 		"kibana_name", state.Kibana.Name,

--- a/pkg/controller/kibana/kibana_controller.go
+++ b/pkg/controller/kibana/kibana_controller.go
@@ -220,7 +220,12 @@ func (r *ReconcileKibana) updateStatus(state State) error {
 	if state.Kibana.Status.IsDegraded(current.Status) {
 		r.recorder.Event(current, corev1.EventTypeWarning, events.EventReasonUnhealthy, "Kibana health degraded")
 	}
-	log.Info("Updating status", "iteration", atomic.LoadUint64(&r.iteration), "namespace", state.Kibana.Namespace, "kibana_name", state.Kibana.Name)
+	log.Info("Updating status",
+		"iteration", atomic.LoadUint64(&r.iteration),
+		"namespace", state.Kibana.Namespace,
+		"kibana_name", state.Kibana.Name,
+		"status", state.Kibana.Status,
+	)
 	return common.UpdateStatus(r.Client, state.Kibana)
 }
 


### PR DESCRIPTION
This PR brings 3 minor improvements to status logging:

1. Only log Elasticsearch status update when we call the status update function
2. Log the actual status in the log message. The Status object automatically gets nicely formatted:
```
 INFO    kibana-controller       Updating status {"ver":1.0.0-832a3230", "iteration": 15, "namespace": "default", "kibana_name": "kibana-sample", "status": {"health":"red","associationStatus":"Established"}}
```
3. Use the `Debug` log-level since this happens at almost every reconciliation and is not very useful to know about.