### PR TITLE
Enable debug log level on the operator for E2E tests

### DIFF
--- a/config/e2e/global_operator.yaml
+++ b/config/e2e/global_operator.yaml
@@ -166,7 +166,7 @@ spec:
       - image: {{ .OperatorImage }}
         imagePullPolicy: IfNotPresent
         name: manager
-        args: ["manager", "--operator-roles", "global,webhook"]
+        args: ["manager", "--operator-roles", "global,webhook", "--log-verbosity=1"]
         env:
           - name: OPERATOR_NAMESPACE
             valueFrom:

--- a/config/e2e/namespace_operator.yaml
+++ b/config/e2e/namespace_operator.yaml
@@ -202,7 +202,7 @@ spec:
       - image: {{ $operatorImage }}
         imagePullPolicy: IfNotPresent
         name: manager
-        args: ["manager", "--namespaces", "{{ .NamespaceOperator.ManagedNamespaces | join "," }}", "--operator-roles", "namespace"]
+        args: ["manager", "--namespaces", "{{ .NamespaceOperator.ManagedNamespaces | join "," }}", "--operator-roles", "namespace", "--log-verbosity=1"]
         env:
           - name: OPERATOR_NAMESPACE
             valueFrom:


### PR DESCRIPTION
This should make it easier to debug failing E2E tests if the operator
gives us a bit more logs.
