### PR TITLE
Bump min k8s version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 # Elastic Cloud on Kubernetes (ECK)
 
-Elastic Cloud on Kubernetes automates the deployment, provisioning, management, and orchestration of Elasticsearch and Kibana on Kubernetes based on the operator pattern.
+Elastic Cloud on Kubernetes automates the deployment, provisioning, management, and orchestration of Elasticsearch, Kibana and APM Server on Kubernetes based on the operator pattern.
 
 This is a beta version.
 
 Current features:
 
-*  Elasticsearch and Kibana deployments
+*  Elasticsearch, Kibana and APM Server deployments
 *  TLS Certificates management
 *  Safe Elasticsearch cluster configuration & topology changes
 *  Persistent volumes usage

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Current features:
 Supported versions:
 
 *  Kubernetes 1.12+ or OpenShift 3.11+
-*  Elasticsearch: 6.8+, 7.1+
+*  Elastic Stack: 6.8+, 7.1+
 
 Check the [Quickstart](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-quickstart.html) if you want to deploy you first cluster with ECK.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Current features:
 
 Supported versions:
 
-*  Kubernetes: 1.11+
+*  Kubernetes: 1.12+
 *  Elasticsearch: 6.8+, 7.1+
 
 Check the [Quickstart](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-quickstart.html) if you want to deploy you first cluster with ECK.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Current features:
 
 Supported versions:
 
-*  Kubernetes: 1.12+
+*  Kubernetes 1.12+ or OpenShift 3.11+
 *  Elasticsearch: 6.8+, 7.1+
 
 Check the [Quickstart](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-quickstart.html) if you want to deploy you first cluster with ECK.

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -1,3 +1,3 @@
 * link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl] 1.11+
-* Kubernetes: 1.11+
+* Kubernetes: 1.12+
 * Elasticsearch: 6.8+, 7.1+

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -1,3 +1,3 @@
 * link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl] 1.11+
 * Kubernetes 1.12+ or OpenShift 3.11+
-* Elasticsearch: 6.8+, 7.1+
+* Elastic Stack: 6.8+, 7.1+

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -1,3 +1,3 @@
 * link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl] 1.11+
-* Kubernetes: 1.12+
+* Kubernetes 1.12+ or OpenShift 3.11+
 * Elasticsearch: 6.8+, 7.1+


### PR DESCRIPTION
- Bump the minimal Kubernetes version supported by the operator (1.11+ -> 1.12+)
- Add the minimal OpenShift version supported (3.11+)

in the README.md and the `docs/supported-versions.asciidoc` files.

Relates to #1739.