### PR TITLE
Accept JSon content in apm e2e tests

### DIFF
--- a/test/e2e/test/apmserver/http_client.go
+++ b/test/e2e/test/apmserver/http_client.go
@@ -83,6 +83,9 @@ func (c *ApmClient) doRequest(context context.Context, request *http.Request) (*
 	// inject the authorization (secret token)
 	request.Header.Set("Authorization", c.authorizationHeaderValue)
 
+	// allow json content
+	request.Header.Set("Accept", "application/json")
+
 	return c.client.Do(withContext)
 }
 


### PR DESCRIPTION
Old versions of the APM Server seem to return plain text response by default.

This PR tells the server that we want some Json.

Fix #2302