### PR TITLE
Bump k8s version to 1.15.5 for AKS

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -31,7 +31,7 @@ plans:
   operation: create
   clusterName: ci
   provider: aks
-  kubernetesVersion: 1.13.12
+  kubernetesVersion: 1.15.5
   machineType: Standard_D8s_v3
   serviceAccount: true
   psp: false
@@ -41,7 +41,7 @@ plans:
   operation: create
   clusterName: dev
   provider: aks
-  kubernetesVersion: 1.13.12
+  kubernetesVersion: 1.15.5
   machineType: Standard_D8s_v3
   serviceAccount: false
   psp: false


### PR DESCRIPTION
According to https://github.com/kubernetes/kubernetes/issues/69262#issuecomment-562582528:
> In brief, pls upgrade to latest version 1.15.5, 1.15.x won't have this issue, thanks.

 it's going to solve https://github.com/elastic/cloud-on-k8s/issues/2132. Alternative would be bumping timeouts to ~20 minutes which I rather not do.

