### PR TITLE
Change gke-ci plan to use europe-west2 region

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -8,7 +8,7 @@ plans:
   serviceAccount: true
   psp: true
   gke:
-    region: europe-west1
+    region: europe-west2
     adminUsername: admin
     localSsdCount: 1
     nodeCountPerZone: 1


### PR DESCRIPTION
Change the CI region for GKE to use separate quotas, other than our dev clusters.