### PR TITLE
Wait for webhook key to be present in fs

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -46,6 +47,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/dev"
 	"github.com/elastic/cloud-on-k8s/pkg/dev/portforward"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/net"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -322,7 +324,6 @@ func execute() {
 			os.Exit(1)
 		}
 	}
-
 	log.Info("Starting the manager", "uuid", operatorInfo.OperatorUUID,
 		"namespace", operatorNamespace, "version", operatorInfo.BuildInfo.Version,
 		"build_hash", operatorInfo.BuildInfo.Hash, "build_date", operatorInfo.BuildInfo.Date,
@@ -385,6 +386,28 @@ func setupWebhook(mgr manager.Manager, certRotation certificates.RotationParams,
 
 	if err := (&esv1.Elasticsearch{}).SetupWebhookWithManager(mgr); err != nil {
 		log.Error(err, "unable to create webhook", "webhook", "Elasticsearch")
+		os.Exit(1)
+	}
+
+	// wait for the secret to be populated in the local filesystem before returning
+	interval := time.Second * 1
+	timeout := time.Second * 30
+	keyPath := path.Join(mgr.GetWebhookServer().CertDir, "tls.crt")
+	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		_, err := os.Stat(keyPath)
+		// err could be that the file does not exist, but also that permission was denied or something else
+		if os.IsNotExist(err) {
+			log.V(1).Info("Webhook certificate file not present on filesystem yet", "path", keyPath)
+			return false, nil
+		} else if err != nil {
+			log.Error(err, "Error checking if webhook secret path exists", "path", keyPath)
+			return false, err
+		}
+		log.V(1).Info("Webhook certificate file present on filesystem", "path", keyPath)
+		return true, nil
+	})
+
+	if err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -392,7 +392,8 @@ func setupWebhook(mgr manager.Manager, certRotation certificates.RotationParams,
 	// wait for the secret to be populated in the local filesystem before returning
 	interval := time.Second * 1
 	timeout := time.Second * 30
-	keyPath := path.Join(mgr.GetWebhookServer().CertDir, "tls.crt")
+	keyPath := filepath.Join(mgr.GetWebhookServer().CertDir, certificates.CertFileName)
+	log.Info("Polling for the webhook certificate to be available", "path", keyPath)
 	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
 		_, err := os.Stat(keyPath)
 		// err could be that the file does not exist, but also that permission was denied or something else


### PR DESCRIPTION
@thbkrkr brought up out of band that he intermittently received this error starting the operator

```
{"level":"error","@timestamp":"2019-12-19T15:35:28.548Z","logger":"manager","message":"unable to run the manager","ver":"1.0.0-rc3-ae5f8e81","error":"open /tmp/k8s-webhook-server/serving-certs/tls.crt: no such file or directory","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error
	/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128
github.com/elastic/cloud-on-k8s/cmd/manager.execute
	/go/src/github.com/elastic/cloud-on-k8s/cmd/manager/main.go:331
github.com/elastic/cloud-on-k8s/cmd/manager.glob..func1
	/go/src/github.com/elastic/cloud-on-k8s/cmd/manager/main.go:81
github.com/spf13/cobra.(*Command).execute
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830
github.com/spf13/cobra.(*Command).ExecuteC
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914
github.com/spf13/cobra.(*Command).Execute
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main
	/go/src/github.com/elastic/cloud-on-k8s/cmd/main.go:27
runtime.main
	/usr/local/go/src/runtime/proc.go:203"}
```

I suspect that this is because we return `setupWebhook()` as soon as we update the secret with the generated key, but it may take more time for the kubelet to update the container's file system with the new contents of the secret. I'm not sure there's a simple way to write a test for this, but it worked in my testing. This is more of a proof of concept of checking for it, definitely open to alternate approaches if this is something we want to do.