### PR TITLE
Increase e2e test timeout

### DIFF
--- a/build/ci/e2e/Jenkinsfile-aks
+++ b/build/ci/e2e/Jenkinsfile-aks
@@ -5,7 +5,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 180, unit: 'MINUTES')
+        timeout(time: 240, unit: 'MINUTES')
     }
 
     environment {

--- a/build/ci/e2e/Jenkinsfile-aks
+++ b/build/ci/e2e/Jenkinsfile-aks
@@ -5,7 +5,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 240, unit: 'MINUTES')
+        timeout(time: 300, unit: 'MINUTES')
     }
 
     environment {

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -12,8 +12,8 @@ set -euo pipefail
 for PKG in $(go list github.com/elastic/cloud-on-k8s/test/e2e/...); do
     if [ "$E2E_JSON" == "true" ]
     then
-        go test -v -failfast -timeout=2h -tags=e2e -p=1 --json $PKG $@
+        go test -v -failfast -timeout=4h -tags=e2e -p=1 --json $PKG $@
     else
-        go test -v -failfast -timeout=2h -tags=e2e -p=1 $PKG $@
+        go test -v -failfast -timeout=4h -tags=e2e -p=1 $PKG $@
     fi
 done


### PR DESCRIPTION
We seem to be hitting 2h time limit of `go test` and we seem to be very close to hitting 3h limit of entire Jenkins pipeline for AKS. This PR raises both those limits.