### PR TITLE
Don't upgrade pods if empty StatefulSet UpdateRevision

### DIFF
--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -83,6 +83,26 @@ func Test_podsToUpgrade(t *testing.T) {
 			want: []string{"masters-0", "masters-1"},
 		},
 		{
+			name: "no pods to upgrade if the StatefulSet UpdateRevision is empty",
+			args: args{
+				statefulSets: sset.StatefulSetList{
+					sset.TestSset{
+						Name: "masters", Replicas: 2, Master: true,
+						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-a", UpdateRevision: "", UpdatedReplicas: 0, Replicas: 2},
+					}.Build(),
+					sset.TestSset{
+						Name: "nodes", Replicas: 3, Master: true,
+						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-b", UpdateRevision: "", UpdatedReplicas: 3, Replicas: 3},
+					}.Build(),
+				},
+				pods: []runtime.Object{
+					podWithRevision("masters-0", "rev-a"),
+					podWithRevision("masters-1", "rev-a"),
+				},
+			},
+			want: []string{},
+		},
+		{
 			name: "only 1 node need to be upgraded",
 			args: args{
 				statefulSets: sset.StatefulSetList{


### PR DESCRIPTION
We had a bug were some Pods of a newly created StatefulSet would be
force upgraded because they are Pending, and we consider they need to be
upgraded because their revision does not match the StatefulSet update
revision.
That's because the StatefulSet updateRevision is empty on initial
StatefulSet creation.

This commit fixes it by not considering empty StatefulSet
updateRevisions when looking for Pods to upgrade.

Fixes https://github.com/elastic/cloud-on-k8s/issues/2320.