### PR TITLE
Add cert-manager example

### DIFF
--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -258,12 +258,46 @@ spec:
         secretName: my-cert
 ----
 
-This is an example on how to create a Kubernetes TLS secret with a self-signed certificate:
+[float]
+==== Custom self-signed certificate using OpenSSL
+
+This example illustrates how to create your own self-signed certificate for the <<{p}-deploy-elasticsearch,quickstart Elasticsearch cluster>> using the OpenSSL command line utility. Note the subject alternative name (SAN) entry for `quickstart-es-http.default.svc`.
 
 [source,sh]
 ----
 $ openssl req -x509 -sha256 -nodes -newkey rsa:4096 -days 365 -subj "/CN=quickstart-es-http" -addext "subjectAltName=DNS:quickstart-es-http.default.svc" -keyout tls.key -out tls.crt
-$ kubectl create secret generic my-cert --from-file=ca.crt=tls.crt --from-file=tls.crt=tls.crt --from-file=tls.key=tls.key
+$ kubectl create secret generic quickstart-es-cert --from-file=ca.crt=tls.crt --from-file=tls.crt=tls.crt --from-file=tls.key=tls.key
+----
+
+[float]
+==== Custom self-signed certificate using cert-manager
+
+This example illustrates how to issue a self-signed certificate for the <<{p}-deploy-elasticsearch,quickstart Elasticsearch cluster>> using a link:https://cert-manager.io[cert-manager] self-signed issuer.
+
+[source,yaml]
+----
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: quickstart-es-cert
+spec:
+  isCA: true
+  dnsNames:
+    - quickstart-es-http
+    - quickstart-es-http.default.svc
+    - quickstart-es-http.default.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: quickstart-es-cert
 ----
 
 

--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -255,7 +255,7 @@ spec:
   http:
     tls:
       certificate:
-        secretName: my-cert
+        secretName: quickstart-es-cert
 ----
 
 [float]


### PR DESCRIPTION
Adds an example section on how to create custom certificates for Elasticsearch using cert-manager. If users forget to set `isCA` in the certificate resource, Kibana refuses to connect to Elasticsearch with the unhelpful generic error message `No living connections` -- which is not easy to debug.

[Preview](http://cloud-on-k8s_2324.docs-preview.app.elstc.co/guide/en/cloud-on-k8s/master/k8s-custom-http-certificate.html)