### PR TITLE
Add version awareness to TestKibanaStandalone E2E test

### DIFF
--- a/test/e2e/kb/testdata/kibana_standalone_6x.yaml
+++ b/test/e2e/kb/testdata/kibana_standalone_6x.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: test-kibana-standalone-es-{{ .Suffix }}
+spec:
+  version: 6.8.5
+  nodeSets:
+  - count: 1
+    name: mdi
+    config:
+      node.master: true
+      node.data: true
+      node.store.allow_mmap: false
+---
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: test-kibana-standalone-{{ .Suffix }}
+spec:
+  version: 6.8.5
+  count: 1
+  config:
+    elasticsearch.url:
+      - https://test-kibana-standalone-es-{{ .Suffix }}-es-http:9200
+    elasticsearch.username: elastic
+    elasticsearch.ssl.verificationMode: none
+  podTemplate:
+    spec:
+      containers:
+        - name: kibana
+          env:
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: test-kibana-standalone-es-{{ .Suffix }}-es-elastic-user
+                  key: elastic


### PR DESCRIPTION
`TestKibanaStandalone` E2E test fails on 6.x stack versions because the configuration setting for specifying the Elasticsearch URL should be `elasticsearch.url` instead of `elasticsearch.hosts`. This PR changes the test to pick the correct manifest based on the stack version being tested.

Fixes #2325 