### PR TITLE
Allow node restart even if cluster health is yellow

### DIFF
--- a/pkg/controller/elasticsearch/client/client_test.go
+++ b/pkg/controller/elasticsearch/client/client_test.go
@@ -99,8 +99,8 @@ func TestShardsByNode(t *testing.T) {
 			name: "Can parse populated routing table",
 			args: fixtures.SampleShards,
 			want: map[string][]Shard{
-				"stack-sample-es-lkrjf7224s": {{Index: "sample-data-2", Shard: "0", State: STARTED, NodeName: "stack-sample-es-lkrjf7224s"}},
-				"stack-sample-es-4fxm76vnwj": {{Index: "sample-data-2", Shard: "1", State: STARTED, NodeName: "stack-sample-es-4fxm76vnwj"}},
+				"stack-sample-es-lkrjf7224s": {{Index: "sample-data-2", Shard: "0", State: STARTED, NodeName: "stack-sample-es-lkrjf7224s", Type: Primary}},
+				"stack-sample-es-4fxm76vnwj": {{Index: "sample-data-2", Shard: "1", State: STARTED, NodeName: "stack-sample-es-4fxm76vnwj", Type: Replica}},
 			},
 		},
 	}

--- a/pkg/controller/elasticsearch/client/model.go
+++ b/pkg/controller/elasticsearch/client/model.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
 )
@@ -24,21 +25,21 @@ type Info struct {
 
 // Health represents the response from _cluster/health
 type Health struct {
-	ClusterName                 string  `json:"cluster_name"`
-	Status                      string  `json:"status"`
-	TimedOut                    bool    `json:"timed_out"`
-	NumberOfNodes               int     `json:"number_of_nodes"`
-	NumberOfDataNodes           int     `json:"number_of_data_nodes"`
-	ActivePrimaryShards         int     `json:"active_primary_shards"`
-	ActiveShards                int     `json:"active_shards"`
-	RelocatingShards            int     `json:"relocating_shards"`
-	InitializingShards          int     `json:"initializing_shards"`
-	UnassignedShards            int     `json:"unassigned_shards"`
-	DelayedUnassignedShards     int     `json:"delayed_unassigned_shards"`
-	NumberOfPendingTasks        int     `json:"number_of_pending_tasks"`
-	NumberOfInFlightFetch       int     `json:"number_of_in_flight_fetch"`
-	TaskMaxWaitingInQueueMillis int     `json:"task_max_waiting_in_queue_millis"`
-	ActiveShardsPercentAsNumber float32 `json:"active_shards_percent_as_number"`
+	ClusterName                 string                   `json:"cluster_name"`
+	Status                      esv1.ElasticsearchHealth `json:"status"`
+	TimedOut                    bool                     `json:"timed_out"`
+	NumberOfNodes               int                      `json:"number_of_nodes"`
+	NumberOfDataNodes           int                      `json:"number_of_data_nodes"`
+	ActivePrimaryShards         int                      `json:"active_primary_shards"`
+	ActiveShards                int                      `json:"active_shards"`
+	RelocatingShards            int                      `json:"relocating_shards"`
+	InitializingShards          int                      `json:"initializing_shards"`
+	UnassignedShards            int                      `json:"unassigned_shards"`
+	DelayedUnassignedShards     int                      `json:"delayed_unassigned_shards"`
+	NumberOfPendingTasks        int                      `json:"number_of_pending_tasks"`
+	NumberOfInFlightFetch       int                      `json:"number_of_in_flight_fetch"`
+	TaskMaxWaitingInQueueMillis int                      `json:"task_max_waiting_in_queue_millis"`
+	ActiveShardsPercentAsNumber float32                  `json:"active_shards_percent_as_number"`
 }
 
 type ShardState string
@@ -49,6 +50,13 @@ const (
 	INITIALIZING ShardState = "INITIALIZING"
 	RELOCATING   ShardState = "RELOCATING"
 	UNASSIGNED   ShardState = "UNASSIGNED"
+)
+
+type ShardType string
+
+const (
+	Primary ShardType = "p"
+	Replica ShardType = "r"
 )
 
 // Nodes partially models the response from a request to /_nodes
@@ -116,6 +124,7 @@ type Shard struct {
 	Shard    string     `json:"shard"`
 	State    ShardState `json:"state"`
 	NodeName string     `json:"node"`
+	Type     ShardType  `json:"prirep"`
 }
 
 type RoutingTable struct {
@@ -165,6 +174,16 @@ func (s Shard) IsStarted() bool {
 // IsInitializing is true if the shard is currently initializing on the node.
 func (s Shard) IsInitializing() bool {
 	return s.State == INITIALIZING
+}
+
+// IsReplica is true if the shard is a replica.
+func (s Shard) IsReplica() bool {
+	return s.Type == Replica
+}
+
+// IsPrimary is true if the shard is a primary shard.
+func (s Shard) IsPrimary() bool {
+	return s.Type == Primary
 }
 
 // Key is a composite key of index name and shard number that identifies all

--- a/pkg/controller/elasticsearch/driver/esstate_test.go
+++ b/pkg/controller/elasticsearch/driver/esstate_test.go
@@ -153,34 +153,34 @@ func Test_memoizingShardsAllocationEnabled_ShardAllocationsEnabled(t *testing.T)
 }
 
 func Test_memoizingGreenHealth_GreenHealth(t *testing.T) {
-	esClient := &fakeESClient{health: esclient.Health{Status: string(esv1.ElasticsearchGreenHealth)}}
-	h := &memoizingGreenHealth{esClient: esClient}
+	esClient := &fakeESClient{health: esclient.Health{Status: esv1.ElasticsearchGreenHealth}}
+	h := &memoizingHealth{esClient: esClient}
 
-	green, err := h.GreenHealth()
+	health, err := h.Health()
 	require.NoError(t, err)
 	// es should be requested on first call
 	require.Equal(t, 1, esClient.GetClusterHealthCalledCount)
-	require.True(t, green)
+	require.Equal(t, esv1.ElasticsearchGreenHealth, health)
 	// ES should not be requested again on subsequent calls
-	green, err = h.GreenHealth()
+	health, err = h.Health()
 	require.NoError(t, err)
 	require.Equal(t, 1, esClient.GetClusterHealthCalledCount)
-	require.True(t, green)
+	require.Equal(t, esv1.ElasticsearchGreenHealth, health)
 
 	// simulate yellow health
-	esClient = &fakeESClient{health: esclient.Health{Status: string(esv1.ElasticsearchYellowHealth)}}
-	h = &memoizingGreenHealth{esClient: esClient}
-	green, err = h.GreenHealth()
+	esClient = &fakeESClient{health: esclient.Health{Status: esv1.ElasticsearchYellowHealth}}
+	h = &memoizingHealth{esClient: esClient}
+	health, err = h.Health()
 	require.NoError(t, err)
 	require.Equal(t, 1, esClient.GetClusterHealthCalledCount)
-	require.False(t, green)
+	require.NotEqual(t, esv1.ElasticsearchGreenHealth, health)
 }
 
 func TestNewMemoizingESState(t *testing.T) {
 	esClient := &fakeESClient{}
 	// just make sure everything is initialized correctly (no panic for nil pointers)
 	s := NewMemoizingESState(esClient)
-	_, err := s.GreenHealth()
+	_, err := s.Health()
 	require.NoError(t, err)
 	_, err = s.ShardAllocationsEnabled()
 	require.NoError(t, err)

--- a/pkg/controller/elasticsearch/driver/upgrade_predicates.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_predicates.go
@@ -240,9 +240,9 @@ var predicates = [...]Predicate{
 					continue
 				}
 				shardKey := shard.Key()
-				replicas[shardKey] += 1
+				replicas[shardKey]++
 				if shard.State == client.STARTED {
-					startedReplicas[shardKey] += 1
+					startedReplicas[shardKey]++
 				}
 			}
 

--- a/pkg/controller/elasticsearch/driver/upgrade_predicates.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_predicates.go
@@ -142,23 +142,23 @@ var predicates = [...]Predicate{
 		},
 	},
 	{
-		// In Yellow or Red status only allow unhealthy Pods to be restarted.
+		// If health is not Green or Yellow only allow unhealthy Pods to be restarted.
 		// This is intended to unlock some situations where the cluster is not green and
 		// a Pod has to be restarted a second time.
-		name: "do_not_restart_healthy_node_if_not_green",
+		name: "only_restart_healthy_node_if_green_or_yellow",
 		fn: func(
 			context PredicateContext,
 			candidate corev1.Pod,
 			deletedPods []corev1.Pod,
 			maxUnavailableReached bool,
 		) (b bool, e error) {
-			// Green health is retrieved only once from the cluster.
+			// Cluster health is retrieved only once from the cluster.
 			// We rely on "shard conflict" predicate to avoid to delete two ES nodes that share some shards.
-			green, err := context.esState.GreenHealth()
+			health, err := context.esState.Health()
 			if err != nil {
 				return false, err
 			}
-			if green {
+			if health == esv1.ElasticsearchGreenHealth || health == esv1.ElasticsearchYellowHealth {
 				return true, nil
 			}
 			_, healthy := context.healthyPods[candidate.Name]
@@ -166,6 +166,102 @@ var predicates = [...]Predicate{
 				return true, nil
 			}
 			return false, nil
+		},
+	},
+	{
+		// During a rolling upgrade, primary shards assigned to a node running a new version cannot have their
+		// replicas assigned to a node with the old version. Therefore we must allow some Pods to be restarted
+		// even if cluster health is Yellow so the replicas can be assigned.
+		// This predicate checks that the following conditions are met for a candidate:
+		// * A cluster upgrade is in progress and the candidate version is not up to date
+		// * All primaries are assigned, only replicas are actually not assigned
+		// * There are no initializing or relocating shards
+		// See https://github.com/elastic/cloud-on-k8s/issues/1643
+		name: "if_yellow_only_restart_upgrading_nodes_with_unassigned_replicas",
+		fn: func(
+			context PredicateContext,
+			candidate corev1.Pod,
+			deletedPods []corev1.Pod,
+			maxUnavailableReached bool,
+		) (b bool, e error) {
+			health, err := context.esState.Health()
+			if err != nil {
+				return false, err
+			}
+			_, healthyNode := context.healthyPods[candidate.Name]
+			if health != esv1.ElasticsearchYellowHealth || !healthyNode {
+				// This predicate is only relevant on healthy node if cluster health is yellow
+				return true, nil
+			}
+			version := candidate.Labels[label.VersionLabelName]
+			if version == context.es.Spec.Version {
+				// Restart in yellow state is only allowed during version upgrade
+				return false, nil
+			}
+			// This candidate needs a version upgrade, check if the Shards are in a compatible state.
+			shards, err := context.shardLister.GetShards()
+			if err != nil {
+				return false, err
+			}
+			for _, shard := range shards {
+				switch shard.State {
+				case client.INITIALIZING, client.RELOCATING:
+					return false, nil
+				case client.UNASSIGNED:
+					if !shard.IsReplica() {
+						return false, nil
+					}
+				}
+			}
+			return true, nil
+		},
+	},
+	{
+		name: "do_not_delete_last_started_shard",
+		fn: func(
+			context PredicateContext,
+			candidate corev1.Pod,
+			deletedPods []corev1.Pod,
+			maxUnavailableReached bool,
+		) (b bool, e error) {
+			allShards, err := context.shardLister.GetShards()
+			if err != nil {
+				return false, err
+			}
+			// We maintain two data structures to record:
+			// * The total number of replicas for a shard
+			// * How many of them are STARTED
+			startedReplicas := make(map[string]int)
+			replicas := make(map[string]int)
+			for _, shard := range allShards {
+				if shard.NodeName == candidate.Name {
+					continue
+				}
+				shardKey := shard.Key()
+				shardReplica := replicas[shardKey]
+				replicas[shardKey] = shardReplica + 1
+				if shard.State == client.STARTED {
+					assignedReplica := startedReplicas[shardKey]
+					startedReplicas[shardKey] = assignedReplica + 1
+				}
+			}
+
+			// Do not delete a node with a Primary if at least one replica is not STARTED
+			shardsByNode := allShards.GetShardsByNode()
+			shardsOnCandidate := shardsByNode[candidate.Name]
+			for _, shard := range shardsOnCandidate {
+				if !shard.IsPrimary() {
+					continue
+				}
+				shardKey := shard.Key()
+				replicas := replicas[shardKey]
+				assignedReplica := startedReplicas[shardKey]
+				if replicas > 0 && assignedReplica == 0 {
+					// If this node is deleted there will be no more shards available
+					return false, nil
+				}
+			}
+			return true, nil
 		},
 	},
 	{

--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -166,7 +166,7 @@ func Test_healthyPods(t *testing.T) {
 			esState := &testESState{
 				inCluster: tt.args.pods.podsInCluster(),
 			}
-			client := k8s.WrappedFakeClient(tt.args.pods.toRuntimeObjects(0, nothing)...)
+			client := k8s.WrappedFakeClient(tt.args.pods.toRuntimeObjects("7.5.0", 0, nothing)...)
 			got, err := healthyPods(client, tt.args.statefulSets, esState)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("healthyPods() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/controller/elasticsearch/reconcile/state.go
+++ b/pkg/controller/elasticsearch/reconcile/state.go
@@ -49,7 +49,7 @@ func (s *State) updateWithPhase(
 
 	s.status.Health = esv1.ElasticsearchUnknownHealth
 	if observedState.ClusterHealth != nil && observedState.ClusterHealth.Status != "" {
-		s.status.Health = esv1.ElasticsearchHealth(observedState.ClusterHealth.Status)
+		s.status.Health = observedState.ClusterHealth.Status
 	}
 	return s
 }

--- a/test/e2e/test/elasticsearch/checks_es.go
+++ b/test/e2e/test/elasticsearch/checks_es.go
@@ -74,7 +74,7 @@ func (e *esClusterChecks) CheckESHealthGreen() test.Step {
 			if err != nil {
 				return err
 			}
-			actualHealth := esv1.ElasticsearchHealth(health.Status)
+			actualHealth := health.Status
 			expectedHealth := esv1.ElasticsearchGreenHealth
 			if actualHealth != expectedHealth {
 				return fmt.Errorf("cluster health is not green, but %s", actualHealth)

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -212,7 +212,7 @@ func (hc *ContinuousHealthCheck) Start() {
 					continue
 				}
 				clusterUnavailability.markAvailable()
-				if esv1.ElasticsearchHealth(health.Status) == esv1.ElasticsearchRedHealth {
+				if health.Status == esv1.ElasticsearchRedHealth {
 					hc.AppendErr(errors.New("cluster health red"))
 					continue
 				}


### PR DESCRIPTION
This PR fixes #1643 by adding two predicates to the rolling upgrade process in order to allow some Pods to be restarted even if the cluster health is yellow.
The first predicate only allow for a Pod to be restarted in the following conditions:

* The version of the Pod does not match the version of the cluster
* All primaries are assigned, only replicas are actually not assigned
* There are no `initializing` or `relocating` shards

A second predicate ensures that the Pod with the last remaining started primary Shard is not deleted

This PR, in a nutshell, merely implements the recommendations found in the [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/rolling-upgrades.html#_upgrading_your_cluster):

>If it is not possible to assign the replica shards to another node (there is only one upgraded node in the cluster), the replica shards remain unassigned and status stays yellow.
> In this case, you can proceed once there are no initializing or relocating shards (check the init and relo columns).

As a side note I think I will open an other PR to refactor the predicates array which is becoming quite ... large.

