### PR TITLE
Reuse the same upscaleState across StatefulSets

### DIFF
--- a/pkg/controller/elasticsearch/driver/upscale.go
+++ b/pkg/controller/elasticsearch/driver/upscale.go
@@ -99,6 +99,8 @@ func adjustZenConfig(k8sClient k8s.Client, es esv1.Elasticsearch, resources node
 	return nil
 }
 
+// adjustStatefulSetReplicas updates the replicas count in expected according to
+// what is allowed by the upscaleState, that may be mutated as a result.
 func adjustStatefulSetReplicas(
 	upscaleState *upscaleState,
 	actualStatefulSets sset.StatefulSetList,

--- a/pkg/controller/elasticsearch/driver/upscale.go
+++ b/pkg/controller/elasticsearch/driver/upscale.go
@@ -73,7 +73,7 @@ func adjustResources(
 	upscaleState := newUpscaleState(ctx, actualStatefulSets, expectedResources)
 	adjustedResources := make(nodespec.ResourcesList, 0, len(expectedResources))
 	for _, nodeSpecRes := range expectedResources {
-		adjusted, err := adjustStatefulSetReplicas(*upscaleState, actualStatefulSets, *nodeSpecRes.StatefulSet.DeepCopy())
+		adjusted, err := adjustStatefulSetReplicas(upscaleState, actualStatefulSets, *nodeSpecRes.StatefulSet.DeepCopy())
 		if err != nil {
 			return nil, err
 		}
@@ -100,7 +100,7 @@ func adjustZenConfig(k8sClient k8s.Client, es esv1.Elasticsearch, resources node
 }
 
 func adjustStatefulSetReplicas(
-	upscaleState upscaleState,
+	upscaleState *upscaleState,
 	actualStatefulSets sset.StatefulSetList,
 	expected appsv1.StatefulSet,
 ) (appsv1.StatefulSet, error) {

--- a/pkg/controller/elasticsearch/driver/upscale_test.go
+++ b/pkg/controller/elasticsearch/driver/upscale_test.go
@@ -201,7 +201,7 @@ func Test_isReplicaIncrease(t *testing.T) {
 
 func Test_adjustStatefulSetReplicas(t *testing.T) {
 	type args struct {
-		state              upscaleState
+		state              *upscaleState
 		actualStatefulSets sset.StatefulSetList
 		expected           appsv1.StatefulSet
 	}
@@ -213,7 +213,7 @@ func Test_adjustStatefulSetReplicas(t *testing.T) {
 		{
 			name: "new StatefulSet to create",
 			args: args{
-				state:              upscaleState{isBootstrapped: true, allowMasterCreation: false, createsAllowed: pointer.Int32(3)},
+				state:              &upscaleState{isBootstrapped: true, allowMasterCreation: false, createsAllowed: pointer.Int32(3)},
 				actualStatefulSets: sset.StatefulSetList{},
 				expected:           sset.TestSset{Name: "new-sset", Replicas: 3}.Build(),
 			},
@@ -222,7 +222,7 @@ func Test_adjustStatefulSetReplicas(t *testing.T) {
 		{
 			name: "same StatefulSet already exists",
 			args: args{
-				state:              upscaleState{isBootstrapped: true, allowMasterCreation: false, createsAllowed: pointer.Int32(3)},
+				state:              &upscaleState{isBootstrapped: true, allowMasterCreation: false, createsAllowed: pointer.Int32(3)},
 				actualStatefulSets: sset.StatefulSetList{sset.TestSset{Name: "sset", Replicas: 3}.Build()},
 				expected:           sset.TestSset{Name: "sset", Replicas: 3}.Build(),
 			},
@@ -231,7 +231,7 @@ func Test_adjustStatefulSetReplicas(t *testing.T) {
 		{
 			name: "downscale case",
 			args: args{
-				state:              upscaleState{isBootstrapped: true, allowMasterCreation: false, createsAllowed: pointer.Int32(3)},
+				state:              &upscaleState{isBootstrapped: true, allowMasterCreation: false, createsAllowed: pointer.Int32(3)},
 				actualStatefulSets: sset.StatefulSetList{sset.TestSset{Name: "sset", Replicas: 3}.Build()},
 				expected:           sset.TestSset{Name: "sset", Replicas: 1}.Build(),
 			},
@@ -240,7 +240,7 @@ func Test_adjustStatefulSetReplicas(t *testing.T) {
 		{
 			name: "upscale case: data nodes",
 			args: args{
-				state:              upscaleState{isBootstrapped: true, allowMasterCreation: false, createsAllowed: pointer.Int32(3)},
+				state:              &upscaleState{isBootstrapped: true, allowMasterCreation: false, createsAllowed: pointer.Int32(3)},
 				actualStatefulSets: sset.StatefulSetList{sset.TestSset{Name: "sset", Replicas: 3, Master: false, Data: true}.Build()},
 				expected:           sset.TestSset{Name: "sset", Replicas: 5, Master: false, Data: true}.Build(),
 			},
@@ -249,7 +249,7 @@ func Test_adjustStatefulSetReplicas(t *testing.T) {
 		{
 			name: "upscale case: master nodes - one by one",
 			args: args{
-				state:              upscaleState{isBootstrapped: true, allowMasterCreation: true, createsAllowed: pointer.Int32(3)},
+				state:              &upscaleState{isBootstrapped: true, allowMasterCreation: true, createsAllowed: pointer.Int32(3)},
 				actualStatefulSets: sset.StatefulSetList{sset.TestSset{Name: "sset", Replicas: 3, Master: true, Data: true}.Build()},
 				expected:           sset.TestSset{Name: "sset", Replicas: 5, Master: true, Data: true}.Build(),
 			},
@@ -258,7 +258,7 @@ func Test_adjustStatefulSetReplicas(t *testing.T) {
 		{
 			name: "upscale case: new additional master sset - one by one",
 			args: args{
-				state:              upscaleState{isBootstrapped: true, allowMasterCreation: true, createsAllowed: pointer.Int32(3)},
+				state:              &upscaleState{isBootstrapped: true, allowMasterCreation: true, createsAllowed: pointer.Int32(3)},
 				actualStatefulSets: sset.StatefulSetList{sset.TestSset{Name: "sset", Replicas: 3, Master: true, Data: true}.Build()},
 				expected:           sset.TestSset{Name: "sset-2", Replicas: 3, Master: true, Data: true}.Build(),
 			},
@@ -354,6 +354,82 @@ func Test_adjustZenConfig(t *testing.T) {
 				hasInitialMasterNodes := len(res.Config.HasKeys([]string{esv1.ClusterInitialMasterNodes})) > 0
 				require.Equal(t, tt.wantInitialMasterNodesSet, hasInitialMasterNodes)
 			}
+		})
+	}
+}
+
+func Test_adjustResources(t *testing.T) {
+	type args struct {
+		es                 esv1.Elasticsearch
+		actualStatefulSets sset.StatefulSetList
+		expectedResources  nodespec.ResourcesList
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantSsets sset.StatefulSetList
+	}{
+		{
+			name: "initial cluster creation: add all masters from several nodeSets",
+			args: args{
+				es: esv1.Elasticsearch{
+					ObjectMeta: metav1.ObjectMeta{Name: "es", Namespace: "ns"},
+					Spec:       esv1.ElasticsearchSpec{Version: "7.5.0"},
+				},
+				actualStatefulSets: nil,
+				expectedResources: nodespec.ResourcesList{
+					{
+						StatefulSet: sset.TestSset{Name: "masters1", Master: true, Replicas: 3, Namespace: "ns", ClusterName: "es", Version: "7.5.0"}.Build(),
+						Config:      settings.NewCanonicalConfig(),
+					},
+					{
+						StatefulSet: sset.TestSset{Name: "masters2", Master: true, Replicas: 3, Namespace: "ns", ClusterName: "es", Version: "7.5.0"}.Build(),
+						Config:      settings.NewCanonicalConfig(),
+					},
+				},
+			},
+			wantSsets: sset.StatefulSetList{
+				sset.TestSset{Name: "masters1", Master: true, Replicas: 3, Namespace: "ns", ClusterName: "es", Version: "7.5.0"}.Build(),
+				sset.TestSset{Name: "masters2", Master: true, Replicas: 3, Namespace: "ns", ClusterName: "es", Version: "7.5.0"}.Build(),
+			},
+		},
+		{
+			name: "cluster already bootstrapped: add masters one by one",
+			args: args{
+				es: esv1.Elasticsearch{
+					ObjectMeta: metav1.ObjectMeta{Name: "es", Namespace: "ns", Annotations: map[string]string{bootstrap.ClusterUUIDAnnotationName: "uuid"}},
+					Spec:       esv1.ElasticsearchSpec{Version: "7.5.0"},
+				},
+				actualStatefulSets: nil,
+				expectedResources: nodespec.ResourcesList{
+					{
+						StatefulSet: sset.TestSset{Name: "masters1", Master: true, Replicas: 3, Namespace: "ns", ClusterName: "es", Version: "7.5.0"}.Build(),
+						Config:      settings.NewCanonicalConfig(),
+					},
+					{
+						StatefulSet: sset.TestSset{Name: "masters2", Master: true, Replicas: 3, Namespace: "ns", ClusterName: "es", Version: "7.5.0"}.Build(),
+						Config:      settings.NewCanonicalConfig(),
+					},
+				},
+			},
+			wantSsets: sset.StatefulSetList{
+				sset.TestSset{Name: "masters1", Master: true, Replicas: 1, Namespace: "ns", ClusterName: "es", Version: "7.5.0"}.Build(),
+				sset.TestSset{Name: "masters2", Master: true, Replicas: 0, Namespace: "ns", ClusterName: "es", Version: "7.5.0"}.Build(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient := k8s.WrappedFakeClient(&tt.args.es)
+			ctx := upscaleCtx{
+				es:           tt.args.es,
+				k8sClient:    k8sClient,
+				expectations: expectations.NewExpectations(k8sClient),
+				scheme:       k8s.Scheme(),
+			}
+			got, err := adjustResources(ctx, tt.args.actualStatefulSets, tt.args.expectedResources)
+			require.NoError(t, err)
+			require.Nil(t, deep.Equal(got.StatefulSets(), tt.wantSsets))
 		})
 	}
 }


### PR DESCRIPTION
We had a bug where the second StatefulSet containing master nodes would
have its replicas set to 0, because it is not allowed to add additional
masters.

Turns out that's because we pass the upscaleState by value, so any mutation
we do on it is not preserved at the next call for the next StatefulSet. Moreover
it contains a sync.Once initialization not reused the second time. The first
StatefulSet is allowed master nodes creation thanks to the upscale state
initialization, but the second StatefulSet isn't because its
upscaleState is zeroed-out and not re-initialized.

This commit fixes it by passing around a StatefulSet pointer, and adds a
unit test that fails without the fix.

Fixes https://github.com/elastic/cloud-on-k8s/issues/2338.