### PR TITLE
Preserve environment variable order in pod spec

### DIFF
--- a/pkg/controller/apmserver/apmserver_controller_test.go
+++ b/pkg/controller/apmserver/apmserver_controller_test.go
@@ -75,7 +75,7 @@ func (tp testParams) withInitContainer() testParams {
 			},
 			Name:  "",
 			Image: "docker.elastic.co/apm/apm-server:1.0",
-			Env:   defaults.PodDownwardEnvVars,
+			Env:   defaults.PodDownwardEnvVars(),
 		},
 	}
 	return tp
@@ -152,7 +152,7 @@ func expectedDeploymentParams() testParams {
 							"-c",
 							"config/config-secret/apm-server.yml",
 						},
-						Env: append(defaults.PodDownwardEnvVars, corev1.EnvVar{
+						Env: defaults.ExtendPodDownwardEnvVars(corev1.EnvVar{
 							Name: "SECRET_TOKEN",
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{

--- a/pkg/controller/apmserver/pod.go
+++ b/pkg/controller/apmserver/pod.go
@@ -100,7 +100,7 @@ func newPodSpec(as *apmv1.ApmServer, p PodSpecParams) corev1.PodTemplateSpec {
 		filepath.Join(ConfigVolumePath, "config-secret"),
 	)
 
-	env := append(defaults.PodDownwardEnvVars, corev1.EnvVar{
+	env := defaults.ExtendPodDownwardEnvVars(corev1.EnvVar{
 		Name: "SECRET_TOKEN",
 		ValueFrom: &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{

--- a/pkg/controller/common/defaults/pod_template_test.go
+++ b/pkg/controller/common/defaults/pod_template_test.go
@@ -597,10 +597,10 @@ func TestPodTemplateBuilder_WithEnv(t *testing.T) {
 			want:        []corev1.EnvVar{{Name: "var1"}, {Name: "var2"}},
 		},
 		{
-			name:        "env vars should be sorted alphabetically",
+			name:        "env var order should be preserved",
 			PodTemplate: corev1.PodTemplateSpec{},
 			vars:        []corev1.EnvVar{{Name: "cc"}, {Name: "aa"}, {Name: "bb"}},
-			want:        []corev1.EnvVar{{Name: "aa"}, {Name: "bb"}, {Name: "cc"}},
+			want:        []corev1.EnvVar{{Name: "cc"}, {Name: "aa"}, {Name: "bb"}},
 		},
 		{
 			name: "append to but don't override user provided env vars",
@@ -754,13 +754,13 @@ func TestPodTemplateBuilder_WithInitContainerDefaults(t *testing.T) {
 				{
 					Name:         "user-init-container1",
 					Image:        "user-image",
-					Env:          PodDownwardEnvVars,
+					Env:          PodDownwardEnvVars(),
 					VolumeMounts: defaultVolumeMounts,
 				},
 				{
 					Name:  "user-init-container2",
 					Image: "default-image",
-					Env:   PodDownwardEnvVars,
+					Env:   PodDownwardEnvVars(),
 					VolumeMounts: []corev1.VolumeMount{{
 						Name:      "foo",
 						MountPath: "/foo",
@@ -770,7 +770,7 @@ func TestPodTemplateBuilder_WithInitContainerDefaults(t *testing.T) {
 				{
 					Name:  "user-init-container3",
 					Image: "default-image",
-					Env:   PodDownwardEnvVars,
+					Env:   PodDownwardEnvVars(),
 					// uses the same mount path as a default mount, so default mount should not be used
 					VolumeMounts: []corev1.VolumeMount{{
 						Name:      "bar",
@@ -780,7 +780,7 @@ func TestPodTemplateBuilder_WithInitContainerDefaults(t *testing.T) {
 				{
 					Name:  "user-init-container4",
 					Image: "default-image",
-					Env:   PodDownwardEnvVars,
+					Env:   PodDownwardEnvVars(),
 					// uses the same name as a default mount, so default mount should not be used
 					VolumeMounts: []corev1.VolumeMount{{
 						Name:      defaultVolumeMount.Name,

--- a/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
+++ b/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
@@ -121,7 +121,7 @@ func NewPrepareFSInitContainer(
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: &privileged,
 		},
-		Env:     defaults.PodDownwardEnvVars,
+		Env:     defaults.PodDownwardEnvVars(),
 		Command: []string{"bash", "-c", path.Join(esvolume.ScriptsVolumeMountPath, PrepareFsScriptConfigKey)},
 		VolumeMounts: append(
 			PluginVolumes.InitContainerVolumeMounts(),

--- a/pkg/controller/elasticsearch/nodespec/defaults.go
+++ b/pkg/controller/elasticsearch/nodespec/defaults.go
@@ -53,8 +53,7 @@ var (
 
 // DefaultEnvVars are environment variables injected into Elasticsearch pods.
 func DefaultEnvVars(httpCfg commonv1.HTTPConfig, headlessServiceName string) []corev1.EnvVar {
-	return append(
-		defaults.PodDownwardEnvVars,
+	return defaults.ExtendPodDownwardEnvVars(
 		[]corev1.EnvVar{
 			{Name: settings.EnvProbePasswordPath, Value: path.Join(esvolume.ProbeUserSecretMountPath, user.InternalProbeUserName)},
 			{Name: settings.EnvProbeUsername, Value: user.InternalProbeUserName},


### PR DESCRIPTION
Preserves the original order in which the environment variables were declared in the pod template. Previously they were being sorted to make pod spec comparisons stable but as the `Env` field is immutable and stored as an array, sorting is not necessary. Sorting also breaks expectations for users who want to reference previously declared variables when defining a new variable.

Also converts the `PodDownwardEnvVars` global variable to a function to prevent accidental modifications.

Fixes #2327 

