### PR TITLE
Remove beta banner from docs

### DIFF
--- a/docs/page_header.html
+++ b/docs/page_header.html
@@ -1,1 +1,0 @@
-You are looking at the documentation for a beta release.


### PR DESCRIPTION
Removes the "You are looking at the documentation for a beta release" banner from the documentation.