### PR TITLE
Move stack verson upgrade outside the quickstart

### DIFF
--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -4,7 +4,7 @@ link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-upgrading-stack.htm
 ****
 endif::[]
 [id="{p}-upgrading-stack"]
-=== Upgrading to newer versions of the Elastic stack
+== Upgrading the Elastic stack version
 
 The operator can safely perform upgrades to newer versions of the various Elastic Stack resources.
 


### PR DESCRIPTION
The stack version upgrade doc renders as a sub-page of the quickstart,
which is probably not intended. Let's bring it to a higher level.

![image](https://user-images.githubusercontent.com/1050393/71814672-6dd5e100-307d-11ea-957e-2806a83341f3.png)

Also, shorten the title name so it fits the rendered page nicely.
