### PR TITLE
Update eck-attributes.asciidoc

### DIFF
--- a/docs/eck-attributes.asciidoc
+++ b/docs/eck-attributes.asciidoc
@@ -1,2 +1,2 @@
-:eck_version: 1.0.0
+:eck_version: 1.0.0-rc4
 :eck_crd_version: v1


### PR DESCRIPTION
bump version in asciidoc
In doc: https://www.elastic.co/guide/en/cloud-on-k8s/1.0/k8s-quickstart.html#k8s-deploy-eck
```
error: unable to read URL "https://download.elastic.co/downloads/eck/1.0.0/all-in-one.yaml", server reported 404 Not Found, status code=404```