### PR TITLE
Add release highlights

### DIFF
--- a/docs/release-notes/1.0.0.asciidoc
+++ b/docs/release-notes/1.0.0.asciidoc
@@ -8,8 +8,7 @@
 [float]
 === Breaking changes
 
-* Remove v1alpha1 CRD version &amp; generate a single trivial all-in-one flavor {pull}2119[#2119] (issue: {issue}2044[#2044])
-* Add multi-namespace cache support {pull}1995[#1995]
+* Remove v1alpha1 CRD version and generate a single trivial all-in-one flavor {pull}2119[#2119] (issue: {issue}2044[#2044])
 
 
 [[feature-1.0.0]]
@@ -26,25 +25,26 @@
 * Readiness probe: do not log tail errors {pull}2366[#2366]
 * Wait 30sec in the preStop hook to account for kube-proxy refresh {pull}2360[#2360] (issue: {issue}2318[#2318])
 * Allow user to override readiness timeout {pull}2260[#2260] (issue: {issue}2259[#2259])
-* Support 7.6 and new stack level enterprise license type. {pull}2242[#2242]
-* Minimize downtime during pod recycling {pull}2233[#2233] (issue: {issue}1927[#1927])
+* Support 7.6 and new stack level enterprise license type {pull}2242[#2242]
+* Minimize downtime during Pod recycling {pull}2233[#2233] (issue: {issue}1927[#1927])
 * Bump ctrl-runtime dependency {pull}2232[#2232]
 * Do not reconcile APM Server if association is not fully configured {pull}2224[#2224]
-* Upgrade from trial to platinum/enterprise license {pull}2206[#2206]
+* Upgrade from trial to Platinum/Enterprise license {pull}2206[#2206]
 * Remove finalizers {pull}2195[#2195]
-* Downgrade to basic if user deletes license secret {pull}2188[#2188]
+* Downgrade to Basic if user deletes license secret {pull}2188[#2188]
 * Add default requests and limits to the init containers {pull}2186[#2186] (issue: {issue}2179[#2179])
 * Sort seed hosts to avoid unecessary configmap updates {pull}2171[#2171]
 * Turn blacklist into warning events and logs statements {pull}2162[#2162]
 * Autostart trial {pull}2160[#2160]
 * Reconcile all clusters on license change {pull}2145[#2145]
 * Pods upgrade: log a summary of failed predicates {pull}2128[#2128]
-* Add webhook Secret and ValidatingWebhookConfiguration certificate management {pull}2126[#2126]
+* Add webhook secret and ValidatingWebhookConfiguration certificate management {pull}2126[#2126]
 * Name service ports based on protocol {pull}2083[#2083]
 * Simplify license installation {pull}2073[#2073]
 * Check resource version when deleting a Pod during force-upgrades {pull}2066[#2066] (issue: {issue}1916[#1916])
 * Perform forced rolling upgrade even if ES is reachable {pull}2022[#2022]
 * Refactor expectations with proper garbage collection {pull}2000[#2000] (issue: {issue}1611[#1611])
+* Add multi-namespace cache support {pull}1995[#1995]
 
 [[bug-1.0.0]]
 [float]
@@ -52,12 +52,12 @@
 
 * Do not report max ERUs for basic licenses {pull}2377[#2377]
 * Fix v1beta1 webhook {pull}2358[#2358] (issue: {issue}2355[#2355])
-* Preserve environment variable order in pod spec {pull}2341[#2341]
+* Preserve environment variable order in Pod specification {pull}2341[#2341]
 * Reuse the same upscaleState across StatefulSets {pull}2339[#2339] (issue: {issue}2338[#2338])
 * Allow node restart even if cluster health is yellow {pull}2330[#2330]
-* Don&#39;t upgrade pods if empty StatefulSet UpdateRevision {pull}2321[#2321] (issue: {issue}2320[#2320])
+* Do not upgrade Pods if empty StatefulSet UpdateRevision {pull}2321[#2321] (issue: {issue}2320[#2320])
 * Fix how cluster.initial_master_nodes is set {pull}2315[#2315] (issue: {issue}2291[#2291])
-* Wait for webhook key to be present in fs {pull}2312[#2312]
+* Wait for webhook key to be present in filesystem {pull}2312[#2312]
 * Do not fail if annotations file does not exist {pull}2275[#2275]
 * Fix readiness probe {pull}2272[#2272]
 * Change priority order of reconcile results {pull}2250[#2250]
@@ -69,9 +69,9 @@
 * Update service when labels and annotations are modified {pull}2210[#2210]
 * Fix readiness script in case of operator upgrade {pull}2208[#2208]
 * Restore v1alpha1 in the list of crds {pull}2199[#2199] (issue: {issue}2196[#2196])
-* Don&#39;t use env variables ending in _FILE with Elasticsearch {pull}2180[#2180]
+* Do not use env variables ending in _FILE with Elasticsearch {pull}2180[#2180]
 * Ignore and do not use an empty CA {pull}2140[#2140]
-* Fix Kibana to terminate all pods before restarting during version change {pull}2137[#2137]
+* Fix Kibana to terminate all Pods before restarting during version change {pull}2137[#2137]
 * Perform StatefulSets deletions before replicas downscale {pull}2062[#2062]
 * Always enable native realm {pull}2038[#2038]
 * Fix nil pointer in upgrade predicates {pull}2035[#2035]

--- a/docs/release-notes/1.0.0.asciidoc
+++ b/docs/release-notes/1.0.0.asciidoc
@@ -22,27 +22,42 @@
 [float]
 === Enhancements
 
+* Report max ERUs in the licensing info configmap {pull}2371[#2371]
+* Readiness probe: do not log tail errors {pull}2366[#2366]
+* Wait 30sec in the preStop hook to account for kube-proxy refresh {pull}2360[#2360] (issue: {issue}2318[#2318])
+* Allow user to override readiness timeout {pull}2260[#2260] (issue: {issue}2259[#2259])
 * Support 7.6 and new stack level enterprise license type. {pull}2242[#2242]
 * Minimize downtime during pod recycling {pull}2233[#2233] (issue: {issue}1927[#1927])
+* Bump ctrl-runtime dependency {pull}2232[#2232]
 * Do not reconcile APM Server if association is not fully configured {pull}2224[#2224]
 * Upgrade from trial to platinum/enterprise license {pull}2206[#2206]
 * Remove finalizers {pull}2195[#2195]
 * Downgrade to basic if user deletes license secret {pull}2188[#2188]
-* Added limits to initpod {pull}2186[#2186] (issue: {issue}2179[#2179])
+* Add default requests and limits to the init containers {pull}2186[#2186] (issue: {issue}2179[#2179])
+* Sort seed hosts to avoid unecessary configmap updates {pull}2171[#2171]
 * Turn blacklist into warning events and logs statements {pull}2162[#2162]
 * Autostart trial {pull}2160[#2160]
 * Reconcile all clusters on license change {pull}2145[#2145]
 * Pods upgrade: log a summary of failed predicates {pull}2128[#2128]
 * Add webhook Secret and ValidatingWebhookConfiguration certificate management {pull}2126[#2126]
+* Name service ports based on protocol {pull}2083[#2083]
+* Simplify license installation {pull}2073[#2073]
 * Check resource version when deleting a Pod during force-upgrades {pull}2066[#2066] (issue: {issue}1916[#1916])
 * Perform forced rolling upgrade even if ES is reachable {pull}2022[#2022]
 * Refactor expectations with proper garbage collection {pull}2000[#2000] (issue: {issue}1611[#1611])
-* Add multi-namespace cache support {pull}1995[#1995]
 
 [[bug-1.0.0]]
 [float]
 === Bug fixes
 
+* Do not report max ERUs for basic licenses {pull}2377[#2377]
+* Fix v1beta1 webhook {pull}2358[#2358] (issue: {issue}2355[#2355])
+* Preserve environment variable order in pod spec {pull}2341[#2341]
+* Reuse the same upscaleState across StatefulSets {pull}2339[#2339] (issue: {issue}2338[#2338])
+* Allow node restart even if cluster health is yellow {pull}2330[#2330]
+* Don&#39;t upgrade pods if empty StatefulSet UpdateRevision {pull}2321[#2321] (issue: {issue}2320[#2320])
+* Fix how cluster.initial_master_nodes is set {pull}2315[#2315] (issue: {issue}2291[#2291])
+* Wait for webhook key to be present in fs {pull}2312[#2312]
 * Do not fail if annotations file does not exist {pull}2275[#2275]
 * Fix readiness probe {pull}2272[#2272]
 * Change priority order of reconcile results {pull}2250[#2250]
@@ -57,9 +72,16 @@
 * Don&#39;t use env variables ending in _FILE with Elasticsearch {pull}2180[#2180]
 * Ignore and do not use an empty CA {pull}2140[#2140]
 * Fix Kibana to terminate all pods before restarting during version change {pull}2137[#2137]
+* Perform StatefulSets deletions before replicas downscale {pull}2062[#2062]
 * Always enable native realm {pull}2038[#2038]
 * Fix nil pointer in upgrade predicates {pull}2035[#2035]
 * Use discovery.seed_providers instead of discovery.zen.hosts_provider starting 7.x {pull}2029[#2029]
 * Make association optional for Kibana {pull}2021[#2021]
 * Fix result of the APM Server controller  {pull}1991[#1991]
 * Mitigate memory leaks from long RequeueAfter periods {pull}1989[#1989]
+
+[[nogroup-1.0.0]]
+[float]
+=== Misc
+
+* Change rolling upgrades predicate log error to info level {pull}2099[#2099]

--- a/docs/release-notes/highlights-1.0.0.asciidoc
+++ b/docs/release-notes/highlights-1.0.0.asciidoc
@@ -11,7 +11,7 @@ Elastic Cloud on Kubernetes has graduated from beta and is now in general availa
 [id="{p}-release-v1"]
 === Resource version promotion
 
-Custom resources have graduated to version `v1`.  `v1beta1` manifests will still function, but are deprecated and should be updated to `v1`. Support for `v1beta1` will be removed in a future release. See <<{p}-upgrading-eck>> for more information.
+Custom resources have graduated to version `v1`.  Manifests for `v1beta1` will still function, but are deprecated and should be updated to `v1`. Support for `v1beta1` will be removed in a future release. Support for `v1alpha1` has been removed. See <<{p}-upgrading-eck>> for more information.
 
 [float]
 [id="{p}-release-webhook"]
@@ -23,7 +23,7 @@ Webhook validation has been re-introduced. This allows for additional validation
 [id="{p}-multi-namespace"]
 === Multiple namespace management
 
-ECK can now manage multiple specific namespaces simultaneously (previously only all namespaces or a single namespace was possible).  See <<{p}-operator-config>> for more information.
+ECK can now manage multiple specific namespaces simultaneously. Previously a single instance of ECK could manage either all namespaces or a single namespace. See <<{p}-operator-config>> for more information.
 
 [float]
 [id="{p}-release-license-mgmt"]

--- a/docs/release-notes/highlights-1.0.0.asciidoc
+++ b/docs/release-notes/highlights-1.0.0.asciidoc
@@ -1,0 +1,32 @@
+[[release-highlights-1.0.0]]
+== 1.0.0 release highlights
+
+[float]
+[id="{p}-general-availability"]
+=== General availability
+
+Elastic Cloud on Kubernetes has graduated from beta and is now in general availability.
+
+[float]
+[id="{p}-release-v1"]
+=== Resource version promotion
+
+Custom resources have graduated to version `v1`.  `v1beta1` manifests will still function, but are deprecated and should be updated to `v1`. Support for `v1beta1` will be removed in a future release. See <<{p}-upgrading-eck>> for more information.
+
+[float]
+[id="{p}-release-webhook"]
+=== Webhook validation
+
+Webhook validation has been re-introduced. This allows for additional validation when Elastic resources are created or updated. See <<{p}-webhook>> for more information.
+
+[float]
+[id="{p}-multi-namespace"]
+=== Multiple namespace management
+
+ECK can now manage multiple specific namespaces simultaneously (previously only all namespaces or a single namespace was possible).  See <<{p}-operator-config>> for more information.
+
+[float]
+[id="{p}-release-license-mgmt"]
+=== License management
+
+Handling of licenses has been greatly improved. If the license changes, all new clusters will use it and all existing clusters will be upgraded to the new cluster. See <<{p}-licensing>> for more information.

--- a/docs/release-notes/highlights-1.0.0.asciidoc
+++ b/docs/release-notes/highlights-1.0.0.asciidoc
@@ -30,3 +30,9 @@ ECK can now manage multiple specific namespaces simultaneously (previously only 
 === License management
 
 Handling of licenses has been greatly improved. If the license changes, all new clusters will use it and all existing clusters will be upgraded to the new cluster. See <<{p}-licensing>> for more information.
+
+[float]
+[id="{p}-release-mesh-compat"]
+=== Service mesh compatibility
+
+Compatibility with service mesh systems such as Istio has been improved, with changes such as link:https://github.com/elastic/cloud-on-k8s/pull/2083[#2038].

--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -6,8 +6,10 @@
 This section summarizes the most important changes in each release. For the
 full list, see <<eck-release-notes>>.
 
+* <<release-highlights-1.0.0>>
 * <<release-highlights-1.0.0-beta1>>
 
 --
 
+include::highlights-1.0.0.asciidoc[]
 include::highlights-1.0.0-beta1.asciidoc[]


### PR DESCRIPTION
First stab at release highlights. Edits veeeeeeeery welcome. Release notes are here:
https://www.elastic.co/guide/en/cloud-on-k8s/1.0/release-notes-1.0.0.html
Which is what I used to cultivate this. I wonder if it's worth calling out all the various upgrade resiliency changes we made?

We will still want to flesh out the upgrading ECK doc when we decide on this
https://github.com/elastic/cloud-on-k8s/issues/2308