### PR TITLE
Fix v1beta1 webhook

### DIFF
--- a/config/e2e/global_operator.yaml
+++ b/config/e2e/global_operator.yaml
@@ -221,7 +221,7 @@ webhooks:
         # this is the path controller-runtime automatically generates
         path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
     failurePolicy: {{ if .IgnoreWebhookFailures }}Ignore{{ else }}Fail{{ end }}
-    name: elastic-es-validation.k8s.elastic.co
+    name: elastic-es-validation-v1beta1.k8s.elastic.co
     rules:
       - apiGroups:
           - elasticsearch.k8s.elastic.co
@@ -240,7 +240,7 @@ webhooks:
         # this is the path controller-runtime automatically generates
         path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
     failurePolicy: {{ if .IgnoreWebhookFailures }}Ignore{{ else }}Fail{{ end }}
-    name: elastic-es-validation.k8s.elastic.co
+    name: elastic-es-validation-v1.k8s.elastic.co
     rules:
       - apiGroups:
           - elasticsearch.k8s.elastic.co

--- a/config/operator/global/webhook.template.yaml
+++ b/config/operator/global/webhook.template.yaml
@@ -11,7 +11,7 @@ webhooks:
         # this is the path controller-runtime automatically generates
         path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
     failurePolicy: Ignore
-    name: elastic-es-validation.k8s.elastic.co
+    name: elastic-es-validation-v1.k8s.elastic.co
     rules:
       - apiGroups:
           - elasticsearch.k8s.elastic.co
@@ -30,7 +30,7 @@ webhooks:
         # this is the path controller-runtime automatically generates
         path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
     failurePolicy: Ignore
-    name: elastic-es-validation.k8s.elastic.co
+    name: elastic-es-validation-v1beta1.k8s.elastic.co
     rules:
       - apiGroups:
           - elasticsearch.k8s.elastic.co

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -13,7 +13,7 @@ webhooks:
       namespace: system
       path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
   failurePolicy: Ignore
-  name: elastic-es-validation.k8s.elastic.co
+  name: elastic-es-validation-v1.k8s.elastic.co
   rules:
   - apiGroups:
     - elasticsearch.k8s.elastic.co
@@ -31,7 +31,7 @@ webhooks:
       namespace: system
       path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
   failurePolicy: Ignore
-  name: elastic-es-validation.k8s.elastic.co
+  name: elastic-es-validation-v1beta1.k8s.elastic.co
   rules:
   - apiGroups:
     - elasticsearch.k8s.elastic.co

--- a/docs/webhook.asciidoc
+++ b/docs/webhook.asciidoc
@@ -7,7 +7,7 @@ A validating webhook provides additional validation of Elasticsearch resources: 
 === Architecture
 The webhook is composed of 4 main components. Here is a brief description of each of them to understand how they interact, their naming, and how they are managed.
 
-. A `ValidatingWebhookConfiguration` object that defines the validating webhook, named `elastic-es-validation-{eck_crd_version}.k8s.elastic.co`. It must be created before starting the operator. The `caBundle` field can be automatically managed as part of the automatic certificate management _(see below)_.
+. A `ValidatingWebhookConfiguration` object that defines the validating webhook, targeting the right webhook path and resource. It must be created before starting the operator. The `caBundle` field can be automatically managed as part of the automatic certificate management _(see below)_.
 . A Kubernetes Service is used to expose the validating server, named `elastic-webhook-server`. It is in the same Namespace as the webhook server.
 . A webhook server that actually validates the submitted resources. In ECK it is the operator itself when it is configured with the `webhook` role. See <<{p}-operator-config,Configuring ECK>> for more information about the `operator-roles` flag.
 . A Secret containing the required certificates to secure the connection between the API server and the webhook server.

--- a/docs/webhook.asciidoc
+++ b/docs/webhook.asciidoc
@@ -7,7 +7,7 @@ A validating webhook provides additional validation of Elasticsearch resources: 
 === Architecture
 The webhook is composed of 4 main components. Here is a brief description of each of them to understand how they interact, their naming, and how they are managed.
 
-. A `ValidatingWebhookConfiguration` object that defines the validating webhook, named `elastic-es-validation.k8s.elastic.co`. It must be created before starting the operator. The `caBundle` field can be automatically managed as part of the automatic certificate management _(see below)_.
+. A `ValidatingWebhookConfiguration` object that defines the validating webhook, named `elastic-es-validation-{eck_crd_version}.k8s.elastic.co`. It must be created before starting the operator. The `caBundle` field can be automatically managed as part of the automatic certificate management _(see below)_.
 . A Kubernetes Service is used to expose the validating server, named `elastic-webhook-server`. It is in the same Namespace as the webhook server.
 . A webhook server that actually validates the submitted resources. In ECK it is the operator itself when it is configured with the `webhook` role. See <<{p}-operator-config,Configuring ECK>> for more information about the `operator-roles` flag.
 . A Secret containing the required certificates to secure the connection between the API server and the webhook server.
@@ -85,7 +85,7 @@ webhooks:
       # this is the path controller-runtime automatically generates
       path: /validate-elasticsearch-k8s-elastic-co-{eck_crd_version}-elasticsearch
   failurePolicy: Ignore
-  name: elastic-es-validation.k8s.elastic.co
+  name: elastic-es-validation-{eck_crd_version}.k8s.elastic.co
   sideEffects: None
   rules:
   - apiGroups:

--- a/pkg/apis/elasticsearch/v1/webhook.go
+++ b/pkg/apis/elasticsearch/v1/webhook.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1,name=elastic-es-validation.k8s.elastic.co
+// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1,name=elastic-es-validation-v1.k8s.elastic.co
 
 func (r *Elasticsearch) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).

--- a/pkg/apis/elasticsearch/v1beta1/webhook.go
+++ b/pkg/apis/elasticsearch/v1beta1/webhook.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1beta1,name=elastic-es-validation.k8s.elastic.co
+// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1beta1,name=elastic-es-validation-v1beta1.k8s.elastic.co
 
 func (r *Elasticsearch) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).

--- a/pkg/controller/common/scheme/scheme.go
+++ b/pkg/controller/common/scheme/scheme.go
@@ -8,9 +8,13 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
+	apmv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1beta1"
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	commonv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1beta1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	esv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	kbv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1beta1"
 )
 
 // SetupScheme sets up a scheme with all of the relevant types. This is only needed once for the manager but is often used for tests
@@ -33,5 +37,29 @@ func SetupScheme() error {
 		return err
 	}
 	err = kbv1.AddToScheme(clientgoscheme.Scheme)
+	return err
+}
+
+// SetupV1beta1Scheme sets up a scheme with v1beta1 resources.
+// Should only be used for the v1beta1 admission webhook.
+// The operator should otherwise deal with a single resource version.
+func SetupV1beta1Scheme() error {
+	err := clientgoscheme.AddToScheme(clientgoscheme.Scheme)
+	if err != nil {
+		return err
+	}
+	err = apmv1beta1.AddToScheme(clientgoscheme.Scheme)
+	if err != nil {
+		return err
+	}
+	err = commonv1beta1.AddToScheme(clientgoscheme.Scheme)
+	if err != nil {
+		return err
+	}
+	err = esv1beta1.AddToScheme(clientgoscheme.Scheme)
+	if err != nil {
+		return err
+	}
+	err = kbv1beta1.AddToScheme(clientgoscheme.Scheme)
 	return err
 }

--- a/pkg/controller/webhook/reconcile_test.go
+++ b/pkg/controller/webhook/reconcile_test.go
@@ -43,7 +43,7 @@ func TestParams_ReconcileResources(t *testing.T) {
 				},
 				Webhooks: []v1beta1.ValidatingWebhook{
 					{
-						Name:         "elastic-es-validation.k8s.elastic.co",
+						Name:         "elastic-es-validation-v1.k8s.elastic.co",
 						ClientConfig: v1beta1.WebhookClientConfig{},
 					},
 				},

--- a/test/e2e/es/naming_test.go
+++ b/test/e2e/es/naming_test.go
@@ -104,7 +104,7 @@ func testRejectionOfLongName(t *testing.T) {
 					err := k.Client.Create(obj)
 					if err != nil {
 						// validating webhook is active and rejected the request
-						require.Contains(t, err.Error(), `admission webhook "elastic-es-validation.k8s.elastic.co" denied the request`)
+						require.Contains(t, err.Error(), `admission webhook "elastic-es-validation-v1.k8s.elastic.co" denied the request`)
 						return
 					}
 


### PR DESCRIPTION
The v1 webhook did work as expected, but not the v1beta1 webhook before
this commit.

To fix this, it:

* creates 2 distinct webhooks with distinct names
(`elastic-es-validation-v1beta1.k8s.elastic.co` and
`elastic-es-validation-v1.k8s.elastic.co`) in the
ValidatingWebhookConfiguration
* ensures the v1beta1 webhook is created along with the v1 webhook at
operator startup
* registers v1beta1 resources in the schema, required for the v1beta1
webhook to run

To test it, I deployed the operator and webhook configurations, then:
- tried applying a v1beta1 resource: the v1beta1 webhook was triggered,
returning an error mentioning v1beta1.NodeSet
- tried applying a v1 resource: the v1 webhook was triggered, returning
an error mentioning v1.NodeSet

Fixes https://github.com/elastic/cloud-on-k8s/issues/2355.