### PR TITLE
Move stack verson upgrade outside the quickstart (#2350)

### DIFF
--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -4,7 +4,7 @@ link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-upgrading-stack.htm
 ****
 endif::[]
 [id="{p}-upgrading-stack"]
-=== Upgrading to newer versions of the Elastic stack
+== Upgrading the Elastic stack version
 
 The operator can safely perform upgrades to newer versions of the various Elastic Stack resources.
 


### PR DESCRIPTION
Backport https://github.com/elastic/cloud-on-k8s/pull/2350 to 1.0 (docs only).