### PR TITLE
Readiness probe: do not log tail errors

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/readiness_probe.go
+++ b/pkg/controller/elasticsearch/nodespec/readiness_probe.go
@@ -33,7 +33,7 @@ const ReadinessProbeScript = `#!/usr/bin/env bash
 # fail should be called as a last resort to help the user to understand why the probe failed
 function fail {
   timestamp=$(date --iso-8601=seconds)
-  echo "{\"timestamp\": \"${timestamp}\", \"message\": \"readiness probe failed\", "$1"}" | tee /proc/1/fd/2
+  echo "{\"timestamp\": \"${timestamp}\", \"message\": \"readiness probe failed\", "$1"}" | tee /proc/1/fd/2 2> /dev/null
   exit 1
 }
 


### PR DESCRIPTION
In some cases it is not possible for the readiness script to log into `stderr` of PID 1.
It is the case for example if the container is started with the `root` user: `uid` of `pid` 1 is changed to `1000` by the startup script, hence the readiness script, which is running with the UID 0, is not able to write into `/proc/1/fd/2`

This is harmless but it generates the following message in the events:


```
  Warning  Unhealthy               36s                    kubelet, aks-nodepool1-41410888-1  Readiness probe failed: {"timestamp": "2020-01-07T14:55:14+0000", "message": "readiness probe failed", "curl_rc": "7"}
tee: /proc/1/fd/2: Permission denied
```

Since the log redirection is done as a best effort this PR skips any error message from `tail`, this prevents the error to appear in the `events` of the Pod.

Note that if the security context is correctly set (i.e. container is not running as `root`) this issue does not happen.

_credits goes to @david-kow_