### PR TITLE
Backport 30sec preStop timeout & associated docs

### DIFF
--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -30,6 +30,7 @@ Before you deploy and run ECK, take some time to look at the basic and advanced 
 - <<{p}-orchestration>>
 - <<{p}-snapshots,Create automated snapshots>>
 - <<{p}-readiness>>
+- <<{p}-prestop>>
 
 [id="{p}-pod-template"]
 === Pod Template
@@ -548,10 +549,10 @@ include::snapshots.asciidoc[]
 
 By default, the readiness probe checks that the pod can successfully respond to HTTP requests within a three second timeout. This is acceptable in most cases. In some cases (such as when the cluster is under heavy load), it may be helpful to increase the timeout. This allows the pod to stay in a `Ready` state and thus be part of the Elasticsearch service even if it is responding slowly. To adjust the timeout, set the `READINESS_PROBE_TIMEOUT` environment variable in the pod template. The readiness probe configuration also must be updated with the new timeout. For example, to increase the API call timeout to ten seconds and the overall check time to twelve seconds:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 spec:
-  version: 7.4.2
+  version: {version}
   nodeSets:
     - name: default
       count: 1
@@ -578,3 +579,28 @@ spec:
 ----
 
 Note that this will require restarting the pods.
+
+[id="{p}-prestop"]
+=== Pod PreStop hook
+
+When an Elasticsearch `Pod` is terminated, its `Endpoint` is removed from the `Service` and the Elasticsearch process is terminated. As these two operations happen in parallel, a race condition exists. If the Elasticsearch process is already shut down, but the `Endpoint` is still a part of the `Service`, any new connection might fail. For more information, see link:https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods[Termination of pods].
+
+To address this issue and guarantee no downtime for new connections, ECK relies on a link:https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/[PreStop lifecycle hook]. This waits to terminate the Elasticsearch process until the `Service` DNS record does not contain the IP of the `Pod`. First, the PreStop lifecycle hook will keep querying DNS for `MAX_WAIT_SECONDS` (defaulting to 20) and then it will wait for `ADDITIONAL_WAIT_SECONDS` (defaulting to 1). Additional wait is used to give clients time to use an IP resolved just before DNS record was updated. The exact behavior is configurable using environment variables, for example:
+
+[source,yaml,subs="attributes"]
+----
+spec:
+  version: {version}
+  nodeSets:
+    - name: default
+      count: 1
+      podTemplate:
+        spec:
+          containers:
+          - name: elasticsearch
+            env:
+            - name: MAX_WAIT_SECONDS
+              value: "10"
+            - name: ADDITIONAL_WAIT_SECONDS
+              value: "5"
+----

--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -585,7 +585,17 @@ Note that this will require restarting the pods.
 
 When an Elasticsearch `Pod` is terminated, its `Endpoint` is removed from the `Service` and the Elasticsearch process is terminated. As these two operations happen in parallel, a race condition exists. If the Elasticsearch process is already shut down, but the `Endpoint` is still a part of the `Service`, any new connection might fail. For more information, see link:https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods[Termination of pods].
 
-To address this issue and guarantee no downtime for new connections, ECK relies on a link:https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/[PreStop lifecycle hook]. This waits to terminate the Elasticsearch process until the `Service` DNS record does not contain the IP of the `Pod`. First, the PreStop lifecycle hook will keep querying DNS for `MAX_WAIT_SECONDS` (defaulting to 20) and then it will wait for `ADDITIONAL_WAIT_SECONDS` (defaulting to 1). Additional wait is used to give clients time to use an IP resolved just before DNS record was updated. The exact behavior is configurable using environment variables, for example:
+Moreover, kube-proxy resynchronizes its rules link:https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/#options[every 30 seconds by default]. During that 30 second time window, the terminating Pod IP may still be used when targeting the service. Please note the resync operation itself may take some time, especially if kube-proxy is configured to use iptables with a lot of services and rules to apply.
+
+To address this issue and minimise unavailability, ECK relies on a link:https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/[PreStop lifecycle hook]. This waits to terminate the Elasticsearch process until the `Service` DNS record does not contain the IP of the `Pod`.
+First, the PreStop lifecycle hook will keep querying DNS for `PRE_STOP_MAX_WAIT_SECONDS` (defaulting to 20) until the Pod IP is not referenced anymore.
+Then, it waits for an additional `PRE_STOP_ADDITIONAL_WAIT_SECONDS` (defaulting to 30). Additional wait is used to:
+
+1. give time to in-flight requests to be completed
+2. give clients time to use the terminating Pod IP resolved just before DNS record was updated
+3. give kube-proxy time to refresh ipvs or iptables rules on all nodes, depending on its sync period setting
+
+The exact behavior is configurable using environment variables, for example:
 
 [source,yaml,subs="attributes"]
 ----
@@ -599,8 +609,8 @@ spec:
           containers:
           - name: elasticsearch
             env:
-            - name: MAX_WAIT_SECONDS
+            - name: PRE_STOP_MAX_WAIT_SECONDS
               value: "10"
-            - name: ADDITIONAL_WAIT_SECONDS
+            - name: PRE_STOP_ADDITIONAL_WAIT_SECONDS
               value: "5"
 ----

--- a/pkg/controller/elasticsearch/nodespec/defaults.go
+++ b/pkg/controller/elasticsearch/nodespec/defaults.go
@@ -25,7 +25,7 @@ const (
 	DefaultImageRepository string = "docker.elastic.co/elasticsearch/elasticsearch"
 
 	// DefaultTerminationGracePeriodSeconds is the termination grace period for the Elasticsearch containers
-	DefaultTerminationGracePeriodSeconds int64 = 120
+	DefaultTerminationGracePeriodSeconds int64 = 180
 )
 
 var (

--- a/pkg/controller/elasticsearch/nodespec/lifecycle_hook.go
+++ b/pkg/controller/elasticsearch/nodespec/lifecycle_hook.go
@@ -23,31 +23,34 @@ const PreStopHookScript = `#!/usr/bin/env bash
 
 set -eux
 
-# This script will wait for up to $MAX_WAIT_SECONDS for $POD_IP to disappear from DNS record,
-# then it will wait additional $ADDITIONAL_WAIT_SECONDS and exit. This slows down the process shutdown
+# This script will wait for up to $PRE_STOP_MAX_WAIT_SECONDS for $POD_IP to disappear from DNS record,
+# then it will wait additional $PRE_STOP_ADDITIONAL_WAIT_SECONDS and exit. This slows down the process shutdown
 # and allows to make changes to the pool gracefully, without blackholing traffic when DNS
 # contains IP that is already inactive. Assumes $HEADLESS_SERVICE_NAME and $POD_IP env variables are defined.
 
-# max time to wait for pods IP to disappear from DNS. As this runs in parallel to grace period
-# (defaulting to 30s) after which process is SIGKILLed, it should be set to allow enough time
-# for the process to gracefully terminate.
-MAX_WAIT_SECONDS=${MAX_WAIT_SECONDS:=20}
+# Max time to wait for pods IP to disappear from DNS.
+# As this runs in parallel to grace period after which process is SIGKILLed,
+# it should be set to allow enough time for the process to gracefully terminate.
+PRE_STOP_MAX_WAIT_SECONDS=${PRE_STOP_MAX_WAIT_SECONDS:=20}
 
-# additional wait, allows queries to successfully use IP from DNS from before pod termination
-# this gives a little bit more time for clients that resolved DNS just before DNS record
-# was updated.
-ADDITIONAL_WAIT_SECONDS=${ADDITIONAL_WAIT_SECONDS:=1}
+# Additional wait before shutting down Elasticsearch.
+# It allows kube-proxy to refresh its rules and remove the terminating Pod IP.
+# Kube-proxy refresh period defaults to every 30 seconds, but the operation itself can take much longer if
+# using iptables with a lot of services, in which case the default 30sec might not be enough.
+# Also gives some additional bonus time to in-flight requests to terminate, and new requests to still
+# target the Pod IP before Elasticsearch stops.
+PRE_STOP_ADDITIONAL_WAIT_SECONDS=${PRE_STOP_ADDITIONAL_WAIT_SECONDS:=30}
 
 START_TIME=$(date +%s)
 while true; do
    ELAPSED_TIME=$(($(date +%s) - $START_TIME))
 
-   if [ $ELAPSED_TIME -gt $MAX_WAIT_SECONDS ]; then
+   if [ $ELAPSED_TIME -gt $PRE_STOP_MAX_WAIT_SECONDS ]; then
       exit 1
    fi
 
    if ! getent hosts $HEADLESS_SERVICE_NAME | grep $POD_IP; then
-      sleep $ADDITIONAL_WAIT_SECONDS
+      sleep $PRE_STOP_ADDITIONAL_WAIT_SECONDS
       exit 0
    fi
 

--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -237,13 +237,11 @@ func TestMutationWithLargerMaxUnavailable(t *testing.T) {
 
 func TestMutationWhileLoadTesting(t *testing.T) {
 	b := elasticsearch.NewBuilder("test-while-load-testing").
-		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		WithEnvironmentVariable("ADDITIONAL_WAIT_SECONDS", "10")
+		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
 
 	// force a rolling upgrade through label change
 	mutated := b.WithNoESTopology().
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		WithEnvironmentVariable("ADDITIONAL_WAIT_SECONDS", "10").
 		WithPodLabel("some_label_name", "some_new_value")
 
 	var metrics vegeta.Metrics


### PR DESCRIPTION
Backport https://github.com/elastic/cloud-on-k8s/pull/2274 and https://github.com/elastic/cloud-on-k8s/pull/2360 into 1.0.
