### PR TITLE
Report max ERUs in the licensing info configmap

### DIFF
--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -65,7 +65,7 @@ func (r LicensingResolver) ToInfo(totalMemory resource.Quantity) (LicensingInfo,
 	}
 
 	// include the max ERUs only for a non trial license
-	if !operatorLicense.IsTrial() {
+	if operatorLicense != nil && !operatorLicense.IsTrial() {
 		licensingInfo.MaxEnterpriseResourceUnits = strconv.Itoa(maxERUs)
 	}
 

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"strconv"
 	"time"
 
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
@@ -31,10 +32,11 @@ const (
 // LicensingInfo represents information about the operator license including the total memory of all Elastic managed
 // components
 type LicensingInfo struct {
-	Timestamp               string `json:"timestamp"`
-	EckLicenseLevel         string `json:"eck_license_level"`
-	TotalManagedMemory      string `json:"total_managed_memory"`
-	EnterpriseResourceUnits string `json:"enterprise_resource_units"`
+	Timestamp                  string `json:"timestamp"`
+	EckLicenseLevel            string `json:"eck_license_level"`
+	TotalManagedMemory         string `json:"total_managed_memory"`
+	MaxEnterpriseResourceUnits string `json:"max_enterprise_resource_units,omitempty"`
+	EnterpriseResourceUnits    string `json:"enterprise_resource_units"`
 }
 
 // LicensingResolver resolves the licensing information of the operator
@@ -45,19 +47,29 @@ type LicensingResolver struct {
 
 // ToInfo returns licensing information given the total memory of all Elastic managed components
 func (r LicensingResolver) ToInfo(totalMemory resource.Quantity) (LicensingInfo, error) {
-	eru := inEnterpriseResourceUnits(totalMemory)
+	ERUs := inEnterpriseResourceUnits(totalMemory)
 	memoryInGB := inGB(totalMemory)
-	licenseLevel, err := r.getOperatorLicenseLevel()
+	operatorLicense, err := r.getOperatorLicense()
 	if err != nil {
 		return LicensingInfo{}, err
 	}
 
-	return LicensingInfo{
+	licenseLevel := r.getOperatorLicenseLevel(operatorLicense)
+	maxERUs := r.getMaxEnterpriseResourceUnits(operatorLicense)
+
+	licensingInfo := LicensingInfo{
 		Timestamp:               time.Now().Format(time.RFC3339),
 		EckLicenseLevel:         licenseLevel,
 		TotalManagedMemory:      memoryInGB,
-		EnterpriseResourceUnits: eru,
-	}, nil
+		EnterpriseResourceUnits: ERUs,
+	}
+
+	// include the max ERUs only for a non trial license
+	if !operatorLicense.IsTrial() {
+		licensingInfo.MaxEnterpriseResourceUnits = strconv.Itoa(maxERUs)
+	}
+
+	return licensingInfo, nil
 }
 
 // Save updates or creates licensing information in a config map
@@ -85,20 +97,33 @@ func (r LicensingResolver) Save(info LicensingInfo, operatorNs string) error {
 	return err
 }
 
-// getOperatorLicenseLevel gets the level of the operator license.
-// If no license is found, the defaultOperatorLicenseLevel is returned.
-func (r LicensingResolver) getOperatorLicenseLevel() (string, error) {
+// getOperatorLicense gets the operator license.
+func (r LicensingResolver) getOperatorLicense() (*license.EnterpriseLicense, error) {
 	checker := license.NewLicenseChecker(r.client, r.operatorNs)
-	lic, err := checker.CurrentEnterpriseLicense()
-	if err != nil {
-		return "", err
-	}
+	return checker.CurrentEnterpriseLicense()
+}
 
+// getOperatorLicenseLevel gets the level of the operator license.
+// If no license is given, the defaultOperatorLicenseLevel is returned.
+func (r LicensingResolver) getOperatorLicenseLevel(lic *license.EnterpriseLicense) string {
 	if lic == nil {
-		return defaultOperatorLicenseLevel, nil
+		return defaultOperatorLicenseLevel
 	}
+	return string(lic.License.Type)
+}
 
-	return string(lic.License.Type), nil
+// getMaxEnterpriseResourceUnits returns the maximum of enterprise resources units that is allowed for a given license.
+// For old style enterprise orchestration licenses which only have max_instances, the maximum of enterprise resources
+// units is derived by dividing max_instances by 2.
+func (r LicensingResolver) getMaxEnterpriseResourceUnits(lic *license.EnterpriseLicense) int {
+	if lic == nil {
+		return 0
+	}
+	maxERUs := lic.License.MaxResourceUnits
+	if maxERUs == 0 {
+		maxERUs = lic.License.MaxInstances / 2
+	}
+	return maxERUs
 }
 
 // inGB converts a resource.Quantity in gigabytes

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -15,10 +15,10 @@ func TestToMap(t *testing.T) {
 	i := LicensingInfo{}
 	data, err := i.toMap()
 	assert.NoError(t, err)
-	assert.Equal(t, 5, len(data))
+	assert.Equal(t, 4, len(data))
 	assert.Equal(t, "", data["eck_license_level"])
 
-	i = LicensingInfo{EckLicenseLevel: "basic"}
+	i = LicensingInfo{EckLicenseLevel: "basic", MaxEnterpriseResourceUnits: "10"}
 	data, err = i.toMap()
 	assert.NoError(t, err)
 	assert.Equal(t, 5, len(data))

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -7,6 +7,7 @@ package license
 import (
 	"testing"
 
+	commonlicense "github.com/elastic/cloud-on-k8s/pkg/controller/common/license"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,12 +15,33 @@ func TestToMap(t *testing.T) {
 	i := LicensingInfo{}
 	data, err := i.toMap()
 	assert.NoError(t, err)
-	assert.Equal(t, 4, len(data))
+	assert.Equal(t, 5, len(data))
 	assert.Equal(t, "", data["eck_license_level"])
 
 	i = LicensingInfo{EckLicenseLevel: "basic"}
 	data, err = i.toMap()
 	assert.NoError(t, err)
-	assert.Equal(t, 4, len(data))
+	assert.Equal(t, 5, len(data))
 	assert.Equal(t, "basic", data["eck_license_level"])
+}
+
+func TestMaxEnterpriseResourceUnits(t *testing.T) {
+	r := LicensingResolver{}
+
+	maxERUs := r.getMaxEnterpriseResourceUnits(nil)
+	assert.Equal(t, 0, maxERUs)
+
+	maxERUs = r.getMaxEnterpriseResourceUnits(&commonlicense.EnterpriseLicense{
+		License: commonlicense.LicenseSpec{
+			MaxResourceUnits: 42,
+		},
+	})
+	assert.Equal(t, 42, maxERUs)
+
+	maxERUs = r.getMaxEnterpriseResourceUnits(&commonlicense.EnterpriseLicense{
+		License: commonlicense.LicenseSpec{
+			MaxInstances: 10,
+		},
+	})
+	assert.Equal(t, 5, maxERUs)
 }


### PR DESCRIPTION
This commit includes the `max_enterprise_resource_units` in the licensing info config map to make it easier for users to see whether they are in compliance with their license.

For old style enterprise orchestration licenses which only have `max_instances`, the `max_enterprise_resource_units` by dividing `max_instances` by 2.

For trial enterprise licenses, the field is omitted.