### PR TITLE
Increase global Jenkins timeout for E2E tests to 300min

### DIFF
--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 180, unit: 'MINUTES')
+        timeout(time: 300, unit: 'MINUTES')
     }
 
     environment {

--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 150, unit: 'MINUTES')
+        timeout(time: 300, unit: 'MINUTES')
     }
 
     environment {

--- a/build/ci/e2e/custom_operator_image.jenkinsfile
+++ b/build/ci/e2e/custom_operator_image.jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 150, unit: 'MINUTES')
+        timeout(time: 300, unit: 'MINUTES')
     }
 
     environment {

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 150, unit: 'MINUTES')
+        timeout(time: 300, unit: 'MINUTES')
     }
 
     environment {

--- a/build/ci/e2e/vanilla_k8s.jenkinsfile
+++ b/build/ci/e2e/vanilla_k8s.jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 150, unit: 'MINUTES')
+        timeout(time: 300, unit: 'MINUTES')
     }
 
     environment {


### PR DESCRIPTION
We used to set 150 minutes, but have now reached this timeout since we
added more wait time in Pods preStop hooks.

Let's just increase Jenkins timeout, we can optimize E2E tests parallel execution later.