### PR TITLE
Increase global Jenkins timeout for E2E tests to 300min (#2372)

### DIFF
--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 180, unit: 'MINUTES')
+        timeout(time: 300, unit: 'MINUTES')
     }
 
     environment {

--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 150, unit: 'MINUTES')
+        timeout(time: 300, unit: 'MINUTES')
     }
 
     environment {

--- a/build/ci/e2e/custom_operator_image.jenkinsfile
+++ b/build/ci/e2e/custom_operator_image.jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 150, unit: 'MINUTES')
+        timeout(time: 300, unit: 'MINUTES')
     }
 
     environment {

--- a/build/ci/e2e/stack_versions.jenkinsfile
+++ b/build/ci/e2e/stack_versions.jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 150, unit: 'MINUTES')
+        timeout(time: 300, unit: 'MINUTES')
     }
 
     environment {

--- a/build/ci/e2e/vanilla_k8s.jenkinsfile
+++ b/build/ci/e2e/vanilla_k8s.jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 150, unit: 'MINUTES')
+        timeout(time: 300, unit: 'MINUTES')
     }
 
     environment {


### PR DESCRIPTION
Backport https://github.com/elastic/cloud-on-k8s/pull/2372 to 1.0, so E2E tests can run correctly.