### PR TITLE
Do not report max ERUs for basic licenses

### DIFF
--- a/docs/licensing.asciidoc
+++ b/docs/licensing.asciidoc
@@ -75,7 +75,7 @@ The operator periodically writes the total amount of Elastic resources under man
 ----
 > kubectl -n elastic-system get configmap elastic-licensing -o json | jq .data
 {
-  "eck_license_level": "basic",
+  "eck_license_level": "enterprise",
   "enterprise_resource_units": "1",
   "max_enterprise_resource_units": "10",
   "timestamp": "2020-01-03T23:38:20Z",

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -64,8 +64,8 @@ func (r LicensingResolver) ToInfo(totalMemory resource.Quantity) (LicensingInfo,
 		EnterpriseResourceUnits: ERUs,
 	}
 
-	// include the max ERUs only for a non trial license
-	if operatorLicense != nil && !operatorLicense.IsTrial() {
+	// include the max ERUs only for a non trial/basic license
+	if maxERUs > 0 {
 		licensingInfo.MaxEnterpriseResourceUnits = strconv.Itoa(maxERUs)
 	}
 


### PR DESCRIPTION
2 small fixes:
- Update the license level to `enterprise` in the doc licensing to show a sample with `max_enterprise_resource_units`
- Do not report the `max_enterprise_resource_units` for basic licenses in the licensing info config map