### PR TITLE
Update auto labels

### DIFF
--- a/.github/relabel.yaml
+++ b/.github/relabel.yaml
@@ -1,3 +1,6 @@
 requiredLabels:
+  # add "triage" label for anything missing an ">enhancement" or similar label
   - missingLabel: triage
-    regex: >.*
+    regex: ">.*"
+  - missingLabel: needs-version
+    regex: "v.*"


### PR DESCRIPTION
Originally added in https://github.com/elastic/cloud-on-k8s/pull/1672

Docs here: https://github.com/lswith/probot-require-label

I think this was broken because the `>` needed to be wrapped in quotes for the yaml to parse. Also because the release note generator relies on a version label, added a rule for that. I assume we will want to adjust these in the near future (e.g. the CI label is `:ci` but maybe should be `>ci`?) but this seemed like a good start.