### PR TITLE
Allow to pick location for AKS in deployer

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -37,6 +37,7 @@ plans:
   psp: false
   aks:
     nodeCount: 3
+    location: westeurope
 - id: aks-dev
   operation: create
   clusterName: dev
@@ -47,3 +48,4 @@ plans:
   psp: false
   aks:
     nodeCount: 3
+    location: northeurope

--- a/hack/deployer/runner/aks.go
+++ b/hack/deployer/runner/aks.go
@@ -64,6 +64,7 @@ func (gdf *AksDriverFactory) Create(plan Plan) (Driver, error) {
 			"MachineType":       plan.MachineType,
 			"KubernetesVersion": plan.KubernetesVersion,
 			"AcrName":           plan.Aks.AcrName,
+			"Location":          plan.Aks.Location,
 		},
 		vaultClient: vaultClient,
 	}, nil
@@ -166,7 +167,7 @@ func (d *AksDriver) create() error {
 		servicePrincipal = fmt.Sprintf(" --service-principal %s --client-secret %s", secrets[0], secrets[1])
 	}
 
-	cmd := `az aks create --resource-group {{.ResourceGroup}} --name {{.ClusterName}} ` +
+	cmd := `az aks create --resource-group {{.ResourceGroup}} --name {{.ClusterName}} --location {{.Location}} ` +
 		`--node-count {{.NodeCount}} --node-vm-size {{.MachineType}} --kubernetes-version {{.KubernetesVersion}} ` +
 		`--node-osdisk-size 30 --enable-addons http_application_routing,monitoring --generate-ssh-keys` + servicePrincipal
 	if err := NewCommand(cmd).AsTemplate(d.ctx).Run(); err != nil {

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -53,6 +53,7 @@ type GkeSettings struct {
 // AksSettings encapsulates settings specific to AKS
 type AksSettings struct {
 	ResourceGroup string `yaml:"resourceGroup"`
+	Location      string `yaml:"location"`
 	AcrName       string `yaml:"acrName"`
 	NodeCount     int    `yaml:"nodeCount"`
 }


### PR DESCRIPTION
Similarly to https://github.com/elastic/cloud-on-k8s/pull/2310, default ci and dev clusters to different Azure locations to utilize different resource limits.