### PR TITLE
Rework Makefile targets to not be cloud specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,8 @@ docs/html/*
 
 # ignore deployer files
 hack/deployer/deployer
-hack/deployer/config/deployer-config.yml
+hack/deployer/config/deployer-config*.yml
+hack/deployer/config/provider
 
 # ignore CI config files
 deployer-config.yml

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SNAPSHOT   	?= true
 LOG_VERBOSITY ?= 1
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
+ifeq ($(shell go env GOBIN),)
 GOBIN=$(shell go env GOPATH)/bin
 else
 GOBIN=$(shell go env GOBIN)
@@ -32,7 +32,7 @@ endif
 # find or download controller-gen
 # note this does not validate the version
 controller-gen:
-ifeq (, $(shell command -v controller-gen))
+ifeq ($(shell command -v controller-gen),)
 	@(cd /tmp; GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.1)
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else
@@ -271,7 +271,7 @@ build-deployer:
 	@ go build -mod=readonly -o ./hack/deployer/deployer ./hack/deployer/main.go
 
 create-default-config:
-ifeq (,$(wildcard hack/deployer/config/deployer-config-$(PROVIDER).yml))
+ifeq ($(wildcard hack/deployer/config/deployer-config-$(PROVIDER).yml),)
 	@ ./hack/deployer/deployer create defaultConfig --path=hack/deployer/config --provider=$(PROVIDER)
 endif
 

--- a/dev-setup.md
+++ b/dev-setup.md
@@ -45,8 +45,8 @@ Run `make check-requisites` to check that all dependencies are installed.
 
       ```bash
       export GCLOUD_PROJECT=my-project-id
-      make bootstrap-gke
-      # Sets up GKE cluster with required resources
+      make bootstrap-cloud
+      # Sets up GKE cluster (by default) with required resources
       ```
 
     [Kind](https://kind.sigs.k8s.io/)

--- a/hack/deployer/cmd/create.go
+++ b/hack/deployer/cmd/create.go
@@ -75,9 +75,10 @@ func CreateCommand() *cobra.Command {
 }
 
 func GetEnvVar(name string) (string, error) {
-	if val, ok := os.LookupEnv(name); !ok {
+	val, ok := os.LookupEnv(name)
+	if !ok {
 		return "", fmt.Errorf("%s environment variable not present", name)
-	} else {
-		return val, nil
 	}
+
+	return val, nil
 }

--- a/hack/deployer/cmd/create.go
+++ b/hack/deployer/cmd/create.go
@@ -8,50 +8,76 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 
+	"github.com/elastic/cloud-on-k8s/hack/deployer/runner"
 	"github.com/spf13/cobra"
 )
 
-const defaultRunConfigTemplate = `id: gke-dev
-overrides:
-  clusterName: %s-dev-cluster
-  gke:
-    gCloudProject: %s
-`
-
 func CreateCommand() *cobra.Command {
-	var path string
+	var filePath string
+	var provider string
 
 	var createCommand = &cobra.Command{
 		Use:   "create",
-		Short: "Creates run config file.",
+		Short: "Creates run config file(s).",
 	}
-
 	var createDefaultConfigCommand = &cobra.Command{
 		Use:   "defaultConfig",
-		Short: "Creates default dev config using USER and GCLOUD_PROJECT env variables.",
+		Short: "Creates default dev config using env variables required for chosen provider.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			user, ok := os.LookupEnv("USER")
-			if !ok {
-				return fmt.Errorf("USER environment variable not present")
-			}
-
-			gCloudProject, ok := os.LookupEnv("GCLOUD_PROJECT")
-			if !ok {
-				return fmt.Errorf("GCLOUD_PROJECT environment variable not present")
-			}
-
-			data := fmt.Sprintf(defaultRunConfigTemplate, user, gCloudProject)
-			if err := ioutil.WriteFile(path, []byte(data), 0644); err != nil {
+			user, err := GetEnvVar("USER")
+			if err != nil {
 				return err
+			}
+
+			switch provider {
+			case runner.GkeDriverID:
+				gCloudProject, err := GetEnvVar("GCLOUD_PROJECT")
+				if err != nil {
+					return err
+				}
+
+				data := fmt.Sprintf(runner.DefaultGkeRunConfigTemplate, user, gCloudProject)
+				fullPath := path.Join(filePath, runner.GkeConfigFileName)
+				if err := ioutil.WriteFile(fullPath, []byte(data), 0644); err != nil {
+					return err
+				}
+			case runner.AksDriverID:
+				resourceGroup, err := GetEnvVar("RESOURCE_GROUP")
+				if err != nil {
+					return err
+				}
+
+				acrName, err := GetEnvVar("ACR_NAME")
+				if err != nil {
+					return err
+				}
+
+				data := fmt.Sprintf(runner.DefaultAksRunConfigTemplate, user, resourceGroup, acrName)
+				fullPath := path.Join(filePath, runner.AksConfigFileName)
+				if err := ioutil.WriteFile(fullPath, []byte(data), 0644); err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("unknown provider %s", provider)
 			}
 
 			return nil
 		},
 	}
 
-	createDefaultConfigCommand.Flags().StringVar(&path, "path", "config/deployer-config.yml", "Path where file should be created.")
+	createDefaultConfigCommand.Flags().StringVar(&filePath, "path", "config/", "Path where files should be created.")
+	createDefaultConfigCommand.Flags().StringVar(&provider, "provider", "gke", "Provider to use.")
 	createCommand.AddCommand(createDefaultConfigCommand)
 
 	return createCommand
+}
+
+func GetEnvVar(name string) (string, error) {
+	if val, ok := os.LookupEnv(name); !ok {
+		return "", fmt.Errorf("%s environment variable not present", name)
+	} else {
+		return val, nil
+	}
 }

--- a/hack/deployer/runner/aks.go
+++ b/hack/deployer/runner/aks.go
@@ -18,6 +18,14 @@ const (
 	AksVaultPath                   = "secret/devops-ci/cloud-on-k8s/ci-azr-k8s-operator"
 	AksResourceGroupVaultFieldName = "resource-group"
 	AksAcrNameVaultFieldName       = "acr-name"
+	AksConfigFileName              = "deployer-config-aks.yml"
+	DefaultAksRunConfigTemplate    = `id: aks-dev
+overrides:
+  clusterName: %s-dev-cluster
+  aks:
+    resourceGroup: %s
+    acrName: %s
+`
 )
 
 type AksDriverFactory struct {

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -15,6 +15,13 @@ const (
 	GkeDriverID                     = "gke"
 	GkeVaultPath                    = "secret/devops-ci/cloud-on-k8s/ci-gcp-k8s-operator"
 	GkeServiceAccountVaultFieldName = "service-account"
+	GkeConfigFileName               = "deployer-config-gke.yml"
+	DefaultGkeRunConfigTemplate     = `id: gke-dev
+overrides:
+  clusterName: %s-dev-cluster
+  gke:
+    gCloudProject: %s
+`
 )
 
 var (


### PR DESCRIPTION
While deployer supports targeting both GKE and AKS our Makefile targets are specific to GKE, which (after modifying deployer-config.yml manually) forced us to run `bootstrap-gke` to bootstrap AKS cluster. Now the targets where reworked similarly to what was mentioned in https://github.com/elastic/cloud-on-k8s/pull/1594#discussion_r316018647:
- each provider will have it's own file (`hack/deployer/config/deployer-config-PROVIDER.yml`)
- `make switch-gke` and `make switch-aks` can be used to switch between them
- `make bootstrap-cloud` and `make delete-cloud` can be used to create and delete a cluster in currently chosen provider
- deployer will supply a sane default config file for each provider if the file is not already present