### PR TITLE
Use a 15min RollingUpgradeTimeout for keystore checks in E2E tests

### DIFF
--- a/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/test/e2e/test/elasticsearch/checks_k8s.go
@@ -26,7 +26,7 @@ import (
 const (
 	// RollingUpgradeTimeout is used for checking a rolling upgrade is complete.
 	// Most tests require less than 5 minutes for all Pods to be running and ready,
-	// but it occasionally takes longer for various reasons (long pod Pod creation time, long volume binding, etc.).
+	// but it occasionally takes longer for various reasons (long Pod creation time, long volume binding, etc.).
 	// We use a longer timeout here to not be impacted too much by those external factors, and only fail
 	// if things seem to be stuck.
 	RollingUpgradeTimeout = 15 * time.Minute

--- a/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/test/e2e/test/elasticsearch/checks_k8s.go
@@ -23,6 +23,15 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const (
+	// RollingUpgradeTimeout is used for checking a rolling upgrade is complete.
+	// Most tests require less than 5 minutes for all Pods to be running and ready,
+	// but it occasionally takes longer for various reasons (long pod Pod creation time, long volume binding, etc.).
+	// We use a longer timeout here to not be impacted too much by those external factors, and only fail
+	// if things seem to be stuck.
+	RollingUpgradeTimeout = 15 * time.Minute
+)
+
 func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
 	return test.StepList{
 		CheckCertificateAuthority(b, k),
@@ -228,16 +237,11 @@ func CheckESPassword(b Builder, k *test.K8sClient) test.Step {
 }
 
 func CheckExpectedPodsEventuallyReady(b Builder, k *test.K8sClient) test.Step {
-	// Most tests require less than 5 minutes for all Pods to be running and ready,
-	// but it occasionally takes longer for various reasons (long pod Pod creation time, long volume binding, etc.).
-	// We use a longer timeout here to not be impacted too much by those external factors, and only fail
-	// if things seem to be stuck.
-	timeout := 15 * time.Minute
 	return test.Step{
 		Name: "All expected Pods should eventually be ready",
 		Test: test.UntilSuccess(func() error {
 			return checkExpectedPodsReady(b, k)
-		}, timeout),
+		}, RollingUpgradeTimeout),
 	}
 }
 

--- a/test/e2e/test/elasticsearch/checks_keystore.go
+++ b/test/e2e/test/elasticsearch/checks_keystore.go
@@ -19,7 +19,7 @@ import (
 func CheckESKeystoreEntries(k *test.K8sClient, b Builder, expectedKeys []string) test.Step {
 	return test.Step{
 		Name: "Elasticsearch secure settings should eventually be set in all nodes keystore",
-		Test: test.Eventually(func() error {
+		Test: test.UntilSuccess(func() error {
 			pods, err := k.GetPods(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name)...)
 			if err != nil {
 				return err
@@ -59,6 +59,6 @@ func CheckESKeystoreEntries(k *test.K8sClient, b Builder, expectedKeys []string)
 			}
 
 			return nil
-		}),
+		}, RollingUpgradeTimeout),
 	}
 }


### PR DESCRIPTION
Since we added a 30sec preStop wait, rolling upgrades take longer than
before. We recently updated the rolling upgrade timeout to 15 minutes,
but did not do it for the keystore rolling upgrade test which is written
differently.