### PR TITLE
Backport e2e timeout bump

### DIFF
--- a/test/e2e/test/elasticsearch/checks_keystore.go
+++ b/test/e2e/test/elasticsearch/checks_keystore.go
@@ -19,7 +19,7 @@ import (
 func CheckESKeystoreEntries(k *test.K8sClient, b Builder, expectedKeys []string) test.Step {
 	return test.Step{
 		Name: "Elasticsearch secure settings should eventually be set in all nodes keystore",
-		Test: test.Eventually(func() error {
+		Test: test.UntilSuccess(func() error {
 			pods, err := k.GetPods(test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name)...)
 			if err != nil {
 				return err
@@ -59,6 +59,6 @@ func CheckESKeystoreEntries(k *test.K8sClient, b Builder, expectedKeys []string)
 			}
 
 			return nil
-		}),
+		}, RollingUpgradeTimeout),
 	}
 }

--- a/test/e2e/test/utils.go
+++ b/test/e2e/test/utils.go
@@ -66,16 +66,19 @@ func ExitOnErr(err error) {
 	}
 }
 
-// Eventually runs the given function until success,
-// with a default timeout
+// Eventually runs the given function until success with a default timeout.
 func Eventually(f func() error) func(*testing.T) {
+	return UntilSuccess(f, ctx.TestTimeout)
+}
+
+// UntilSuccess executes f until it succeeds, or the timeout is reached.
+func UntilSuccess(f func() error, timeout time.Duration) func(*testing.T) {
 	return func(t *testing.T) {
-		defaultTimeout := Ctx().TestTimeout
-		fmt.Printf("Retries (%s timeout): ", defaultTimeout)
+		fmt.Printf("Retries (%s timeout): ", timeout)
 		err := retry.UntilSuccess(func() error {
 			fmt.Print(".") // super modern progress bar 2.0!
 			return f()
-		}, defaultTimeout, DefaultRetryDelay)
+		}, timeout, DefaultRetryDelay)
 		fmt.Println()
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
Backport https://github.com/elastic/cloud-on-k8s/pull/2348 and https://github.com/elastic/cloud-on-k8s/pull/2388 on 1.0 for E2E tests to pass correctly.