### PR TITLE
Update deletion order sort test

### DIFF
--- a/pkg/controller/elasticsearch/driver/upgrade_pods_deletion.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_pods_deletion.go
@@ -106,8 +106,8 @@ func sortCandidates(allPods []corev1.Pod) {
 	sort.Slice(allPods, func(i, j int) bool {
 		pod1 := allPods[i]
 		pod2 := allPods[j]
+		// check if either is a master node. masters come after all other roles
 		if label.IsMasterNode(pod1) && !label.IsMasterNode(pod2) {
-			// pod2 has higher priority since it is not a master node
 			return false
 		}
 		if !label.IsMasterNode(pod1) && label.IsMasterNode(pod2) {

--- a/pkg/controller/elasticsearch/driver/upgrade_predicates_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_predicates_test.go
@@ -679,16 +679,17 @@ func TestDeletionStrategy_SortFunction(t *testing.T) {
 					// use "amasters" rather than "masters" to ensure we are not relying on the name sort accidentally
 					newTestPod("amasters-0").isMaster(true).needsUpgrade(true),
 					newTestPod("data-0").isData(true).needsUpgrade(true),
+					newTestPod("masters-0").isMaster(true).needsUpgrade(true),
 					newTestPod("amasters-1").isMaster(true).needsUpgrade(true),
 					newTestPod("data-1").isData(true).needsUpgrade(true),
 					newTestPod("amasters-2").isMaster(true).needsUpgrade(true),
 				),
 				esState: &testESState{
-					inCluster: []string{"data-1", "data-0", "amasters-2", "amasters-1", "amasters-0"},
+					inCluster: []string{"data-1", "data-0", "amasters-2", "amasters-1", "amasters-0", "masters-0"},
 					health:    esv1.ElasticsearchUnknownHealth,
 				},
 			},
-			want: []string{"data-1", "data-0", "amasters-2", "amasters-1", "amasters-0"},
+			want: []string{"data-1", "data-0", "amasters-2", "amasters-1", "amasters-0", "masters-0"},
 		},
 		{
 			name: "Masters first",


### PR DESCRIPTION
Edited*

Related https://github.com/elastic/cloud-on-k8s/issues/2393

Updated test cases and changed the names to make sure we are not falling back on the name sort. Some slight sort changes to clarify intent but logic is the same.