### PR TITLE
Synchronously request the Cluster UUID

### DIFF
--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -231,8 +231,12 @@ func (d *defaultDriver) Reconcile() *reconciler.Results {
 	}
 
 	// set an annotation with the ClusterUUID, if bootstrapped
-	if err := bootstrap.ReconcileClusterUUID(d.Client, &d.ES, observedState); err != nil {
+	requeue, err := bootstrap.ReconcileClusterUUID(d.Client, &d.ES, esClient, esReachable)
+	if err != nil {
 		return results.WithError(err)
+	}
+	if requeue {
+		results = results.WithResult(defaultRequeue)
 	}
 
 	// reconcile StatefulSets and nodes configuration

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -166,9 +166,7 @@ func (d *defaultDriver) Reconcile() *reconciler.Results {
 		))
 
 	// always update the elasticsearch state bits
-	if observedState.ClusterInfo != nil && observedState.ClusterHealth != nil {
-		d.ReconcileState.UpdateElasticsearchState(*resourcesState, observedState)
-	}
+	d.ReconcileState.UpdateElasticsearchState(*resourcesState, observedState)
 
 	if err := d.verifySupportsExistingPods(resourcesState.CurrentPods); err != nil {
 		return results.WithError(err)

--- a/pkg/controller/elasticsearch/reconcile/state_test.go
+++ b/pkg/controller/elasticsearch/reconcile/state_test.go
@@ -170,7 +170,6 @@ func TestState_Apply(t *testing.T) {
 			effects: func(s *State) {
 				s.UpdateElasticsearchState(ResourcesState{}, observer.State{
 					ClusterHealth: nil,
-					ClusterInfo:   nil,
 				})
 			},
 			wantEvents: []events.Event{},


### PR DESCRIPTION
Since we only perform that request when:
- the cluster is not marked as bootstrapped yet
- es is supposed to be reachable

It's fine to do it synchronously, and not rely on state observed every
10 seconds asynchronously.

Doing a sync requests reduces a bit the time window where we could wrongly
assume the cluster has not been bootstrapped yet, and removes some
complexity in the code.

This commit also refactors a bit the unit tests with a single function
that should cover all cases.

And removes the unused `ObservedState.ClusterInfo`.

Relates https://github.com/elastic/cloud-on-k8s/issues/2397.