### PR TITLE
Ack license put requests and inspect acknowledged field in response

### DIFF
--- a/pkg/controller/elasticsearch/client/model.go
+++ b/pkg/controller/elasticsearch/client/model.go
@@ -337,7 +337,7 @@ type LicenseUpdateResponse struct {
 }
 
 func (lr LicenseUpdateResponse) IsSuccess() bool {
-	return lr.LicenseStatus == "valid"
+	return lr.Acknowledged && lr.LicenseStatus == "valid"
 }
 
 // StartTrialResponse is the response to the start trial API call.

--- a/pkg/controller/elasticsearch/client/model_test.go
+++ b/pkg/controller/elasticsearch/client/model_test.go
@@ -67,3 +67,51 @@ func TestClusterRoutingAllocation(t *testing.T) {
 	require.Equal(t, expected, settings)
 	require.Equal(t, false, settings.Transient.IsShardsAllocationEnabled())
 }
+
+func TestLicenseUpdateResponse_IsSuccess(t *testing.T) {
+	type fields struct {
+		Acknowledged  bool
+		LicenseStatus string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "success: valid & ack'ed",
+			fields: fields{
+				Acknowledged:  true,
+				LicenseStatus: "valid",
+			},
+			want: true,
+		},
+		{
+			name: "no success: not valid",
+			fields: fields{
+				Acknowledged:  true,
+				LicenseStatus: "invalid",
+			},
+			want: false,
+		},
+		{
+			name: "no success: not ack'ed",
+			fields: fields{
+				Acknowledged:  false,
+				LicenseStatus: "valid",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lr := LicenseUpdateResponse{
+				Acknowledged:  tt.fields.Acknowledged,
+				LicenseStatus: tt.fields.LicenseStatus,
+			}
+			if got := lr.IsSuccess(); got != tt.want {
+				t.Errorf("IsSuccess() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/elasticsearch/client/v6.go
+++ b/pkg/controller/elasticsearch/client/v6.go
@@ -91,7 +91,7 @@ func (c *clientV6) GetLicense(ctx context.Context) (License, error) {
 
 func (c *clientV6) UpdateLicense(ctx context.Context, licenses LicenseUpdateRequest) (LicenseUpdateResponse, error) {
 	var response LicenseUpdateResponse
-	return response, c.post(ctx, "/_xpack/license", licenses, &response)
+	return response, c.post(ctx, "/_xpack/license?acknowledge=true", licenses, &response)
 }
 
 func (c *clientV6) StartTrial(ctx context.Context) (StartTrialResponse, error) {

--- a/pkg/controller/elasticsearch/client/v7.go
+++ b/pkg/controller/elasticsearch/client/v7.go
@@ -24,7 +24,7 @@ func (c *clientV7) GetLicense(ctx context.Context) (License, error) {
 
 func (c *clientV7) UpdateLicense(ctx context.Context, licenses LicenseUpdateRequest) (LicenseUpdateResponse, error) {
 	var response LicenseUpdateResponse
-	return response, c.post(ctx, "/_license", licenses, &response)
+	return response, c.post(ctx, "/_license?acknowledge=true", licenses, &response)
 }
 
 func (c *clientV7) StartBasic(ctx context.Context) (StartBasicResponse, error) {


### PR DESCRIPTION
Backport of #2398

This fixes an issue where ECK would not be able to install a valid license into a cluster if the cluster already had a license installed.
It also now inspects the acknowledge response attribute to ensure the license registered successfully with the cluster.

