### PR TITLE
Ensure that the list of nodes scheduled for upgrade is consistent in case of version change

### DIFF
--- a/pkg/controller/common/version/version.go
+++ b/pkg/controller/common/version/version.go
@@ -93,6 +93,11 @@ func (v *Version) IsSameOrAfter(other Version) bool {
 		(v.Major == other.Major && v.Minor == other.Minor && v.Patch >= other.Patch)
 }
 
+// IsSame returns true if the receiver is the same version than the argument.
+func (v *Version) IsSame(other Version) bool {
+	return v.Major == other.Major && v.Minor == other.Minor && v.Patch == other.Patch
+}
+
 // Min returns the minimum version in vs or nil.
 func Min(vs []Version) *Version {
 	sort.SliceStable(vs, func(i, j int) bool {

--- a/pkg/controller/elasticsearch/driver/fixtures.go
+++ b/pkg/controller/elasticsearch/driver/fixtures.go
@@ -5,6 +5,7 @@
 package driver
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -24,9 +25,7 @@ const (
 )
 
 type testPod struct {
-	name                                                     string
-	version                                                  string
-	ssetName                                                 string
+	name, version, revision, ssetName                        string
 	master, data, healthy, toUpgrade, inCluster, terminating bool
 	uid                                                      types.UID
 }
@@ -45,6 +44,7 @@ func (t testPod) isHealthy(v bool) testPod              { t.healthy = v; return 
 func (t testPod) needsUpgrade(v bool) testPod           { t.toUpgrade = v; return t }
 func (t testPod) isTerminating(v bool) testPod          { t.terminating = v; return t }
 func (t testPod) withVersion(v string) testPod          { t.version = v; return t }
+func (t testPod) withRevision(v string) testPod         { t.revision = v; return t }
 func (t testPod) inStatefulset(ssetName string) testPod { t.ssetName = ssetName; return t } //nolint:unparam
 
 // filter to simulate a Pod that has been removed while upgrading
@@ -243,6 +243,7 @@ func (t testPod) toPod() corev1.Pod {
 	labels := map[string]string{}
 	labels[label.VersionLabelName] = t.version
 	labels[label.ClusterNameLabelName] = TestEsName
+	labels[appsv1.StatefulSetRevisionLabel] = t.revision
 	label.NodeTypesMasterLabelName.Set(t.master, labels)
 	label.NodeTypesDataLabelName.Set(t.data, labels)
 	labels[label.StatefulSetNameLabelName] = t.ssetName

--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"

--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -7,6 +7,8 @@ package driver
 import (
 	"fmt"
 
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
@@ -148,7 +150,7 @@ func (d *defaultDriver) reconcileNodeSpecs(
 
 	// When not reconciled, set the phase to ApplyingChanges only if it was Ready to avoid to
 	// override another "not Ready" phase like MigratingData.
-	if Reconciled(expectedResources.StatefulSets(), actualStatefulSets, d.Client) {
+	if Reconciled(d.ES, expectedResources.StatefulSets(), actualStatefulSets, d.Client) {
 		reconcileState.UpdateElasticsearchReady(resourcesState, observedState)
 	} else if reconcileState.IsElasticsearchReady(observedState) {
 		reconcileState.UpdateElasticsearchApplyingChanges(resourcesState.CurrentPods)
@@ -163,7 +165,7 @@ func (d *defaultDriver) reconcileNodeSpecs(
 // Reconciled reports whether the actual StatefulSets are reconciled to match the expected StatefulSets
 // by checking that the expected template hash label is reconciled for all StatefulSets, there are no
 // pod upgrades in progress and all pods are running.
-func Reconciled(expectedStatefulSets, actualStatefulSets sset.StatefulSetList, client k8s.Client) bool {
+func Reconciled(es esv1.Elasticsearch, expectedStatefulSets, actualStatefulSets sset.StatefulSetList, client k8s.Client) bool {
 	// actual sset should have the expected sset template hash label
 	for _, expectedSset := range expectedStatefulSets {
 		actualSset, ok := actualStatefulSets.GetByName(expectedSset.Name)
@@ -178,7 +180,7 @@ func Reconciled(expectedStatefulSets, actualStatefulSets sset.StatefulSetList, c
 	}
 
 	// all pods should have been upgraded
-	pods, err := podsToUpgrade(client, actualStatefulSets)
+	pods, err := podsToUpgrade(es, client, actualStatefulSets)
 	if err != nil {
 		return false
 	}

--- a/pkg/controller/elasticsearch/driver/upgrade.go
+++ b/pkg/controller/elasticsearch/driver/upgrade.go
@@ -203,8 +203,10 @@ func podsToUpgrade(
 				continue
 			}
 			// We consider that a Pod needs an update if at least one the following condition is met:
-			// 1. The update revision of the Pod does not match the one of the StatefulSet
+			// 1. The update revision of the Pod does not match the one in the status of the StatefulSet
 			// 2. The Elasticsearch version run by the Pod does not match the expected one in the Elasticsearch object
+			// Using the Pod revision might not be enough since it is not propagated consistently across all the StatefulSets.
+			// See https://github.com/elastic/cloud-on-k8s/issues/2393#issuecomment-572951884
 			podVersion, err := label.ExtractVersion(pod.Labels)
 			if err != nil {
 				return toUpgrade, err

--- a/pkg/controller/elasticsearch/driver/upgrade.go
+++ b/pkg/controller/elasticsearch/driver/upgrade.go
@@ -10,7 +10,9 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/expectations"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/reconcile"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -42,7 +44,7 @@ func (d *defaultDriver) handleRollingUpgrades(
 	if err != nil {
 		return results.WithError(err)
 	}
-	podsToUpgrade, err := podsToUpgrade(d.Client, statefulSets)
+	podsToUpgrade, err := podsToUpgrade(d.ES, d.Client, statefulSets)
 	if err != nil {
 		return results.WithError(err)
 	}
@@ -169,9 +171,15 @@ func healthyPods(
 }
 
 func podsToUpgrade(
+	es esv1.Elasticsearch,
 	client k8s.Client,
 	statefulSets sset.StatefulSetList,
 ) ([]corev1.Pod, error) {
+	esVersion, err := version.Parse(es.Spec.Version)
+	if err != nil {
+		return nil, err
+	}
+
 	var toUpgrade []corev1.Pod
 	for _, statefulSet := range statefulSets {
 		if statefulSet.Status.UpdateRevision == "" {
@@ -194,7 +202,14 @@ func podsToUpgrade(
 				// Pod does not exist, continue the loop as the absence will be accounted by the deletion driver
 				continue
 			}
-			if sset.PodRevision(pod) != statefulSet.Status.UpdateRevision {
+			// We consider that a Pod needs an update if at least one the following condition is met:
+			// 1. The update revision of the Pod does not match the one of the StatefulSet
+			// 2. The Elasticsearch version run by the Pod does not match the expected one in the Elasticsearch object
+			podVersion, err := label.ExtractVersion(pod.Labels)
+			if err != nil {
+				return toUpgrade, err
+			}
+			if sset.PodRevision(pod) != statefulSet.Status.UpdateRevision || !podVersion.IsSame(*esVersion) {
 				toUpgrade = append(toUpgrade, pod)
 			}
 		}

--- a/pkg/controller/elasticsearch/driver/upgrade.go
+++ b/pkg/controller/elasticsearch/driver/upgrade.go
@@ -202,10 +202,10 @@ func podsToUpgrade(
 				// Pod does not exist, continue the loop as the absence will be accounted by the deletion driver
 				continue
 			}
-// We consider a Pod for an upgrade if at least one the following conditions is met:
+			// We consider a Pod for an upgrade if at least one the following conditions is met:
 			// 1. The update revision of the Pod does not match the one in the status of the StatefulSet
 			// 2. The Elasticsearch version run by the Pod does not match the expected one in the Elasticsearch object
-// Relying only on Pod revision is not enough since it might not be propagated consistently across all the StatefulSets.
+			// Relying only on Pod revision is not enough since it might not be propagated consistently across all the StatefulSets.
 			// See https://github.com/elastic/cloud-on-k8s/issues/2393#issuecomment-572951884
 			podVersion, err := label.ExtractVersion(pod.Labels)
 			if err != nil {

--- a/pkg/controller/elasticsearch/driver/upgrade.go
+++ b/pkg/controller/elasticsearch/driver/upgrade.go
@@ -202,10 +202,10 @@ func podsToUpgrade(
 				// Pod does not exist, continue the loop as the absence will be accounted by the deletion driver
 				continue
 			}
-			// We consider that a Pod needs an update if at least one the following condition is met:
+// We consider a Pod for an upgrade if at least one the following conditions is met:
 			// 1. The update revision of the Pod does not match the one in the status of the StatefulSet
 			// 2. The Elasticsearch version run by the Pod does not match the expected one in the Elasticsearch object
-			// Using the Pod revision might not be enough since it is not propagated consistently across all the StatefulSets.
+// Relying only on Pod revision is not enough since it might not be propagated consistently across all the StatefulSets.
 			// See https://github.com/elastic/cloud-on-k8s/issues/2393#issuecomment-572951884
 			podVersion, err := label.ExtractVersion(pod.Labels)
 			if err != nil {

--- a/pkg/controller/elasticsearch/driver/upgrade.go
+++ b/pkg/controller/elasticsearch/driver/upgrade.go
@@ -202,7 +202,7 @@ func podsToUpgrade(
 				// Pod does not exist, continue the loop as the absence will be accounted by the deletion driver
 				continue
 			}
-			// We consider a Pod for an upgrade if at least one the following conditions is met:
+			// We consider a Pod for an upgrade if at least one of the following conditions is met:
 			// 1. The update revision of the Pod does not match the one in the status of the StatefulSet
 			// 2. The Elasticsearch version run by the Pod does not match the expected one in the Elasticsearch object
 			// Relying only on Pod revision is not enough since it might not be propagated consistently across all the StatefulSets.

--- a/pkg/controller/elasticsearch/driver/upgrade_forced.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_forced.go
@@ -7,17 +7,16 @@ package driver
 import (
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
-
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func (d *defaultDriver) MaybeForceUpgrade(statefulSets sset.StatefulSetList) (bool, error) {
 	// Get the pods to upgrade
-	podsToUpgrade, err := podsToUpgrade(d.Client, statefulSets)
+	podsToUpgrade, err := podsToUpgrade(d.ES, d.Client, statefulSets)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -137,20 +137,20 @@ func Test_podsToUpgrade(t *testing.T) {
 			args: args{
 				statefulSets: sset.StatefulSetList{
 					sset.TestSset{
-						Name: "masters", Replicas: 2, Master: true,
-						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-a", UpdateRevision: "rev-a", UpdatedReplicas: 0, Replicas: 2},
+						Name: "masters", Replicas: 2, Master: true, Data: false,
+						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-master-a", UpdateRevision: "rev-master-b", UpdatedReplicas: 0, Replicas: 2},
 					}.Build(),
 					sset.TestSset{
-						Name: "nodes", Replicas: 3, Master: true,
-						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-a", UpdateRevision: "rev-a", UpdatedReplicas: 0, Replicas: 3},
+						Name: "nodes", Replicas: 3, Master: false, Data: true,
+						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-nodes-a", UpdateRevision: "rev-nodes-a", UpdatedReplicas: 0, Replicas: 3},
 					}.Build(),
 				},
 				pods: newUpgradeTestPods(
-					newTestPod("masters-0").withRevision("rev-a").withVersion("6.8.2"),
-					newTestPod("masters-1").withRevision("rev-a").withVersion("6.8.2"),
-					newTestPod("nodes-0").withRevision("rev-a").withVersion("6.8.2"),
-					newTestPod("nodes-1").withRevision("rev-a").withVersion("6.8.2"),
-					newTestPod("nodes-2").withRevision("rev-a").withVersion("6.8.2"),
+					newTestPod("masters-0").withRevision("rev-master-a").withVersion("6.8.2"),
+					newTestPod("masters-1").withRevision("rev-master-a").withVersion("6.8.2"),
+					newTestPod("nodes-0").withRevision("rev-nodes-a").withVersion("6.8.2"),
+					newTestPod("nodes-1").withRevision("rev-nodes-a").withVersion("6.8.2"),
+					newTestPod("nodes-2").withRevision("rev-nodes-a").withVersion("6.8.2"),
 				),
 				es: defaultEs,
 			},

--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -12,21 +12,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-const testNamespace = "ns"
-
-func podWithRevision(name, revision string) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: testNamespace,
-			Labels:    map[string]string{appsv1.StatefulSetRevisionLabel: revision},
-		},
-	}
-}
 
 func Test_podsToUpgrade(t *testing.T) {
 	defaultEs := esv1.Elasticsearch{

--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
This PR fixes an issue where a single dedicated master can be restarted while remaining data nodes are still running an old version of Elasticsearch.

It could be the case if there are:
* Only 1 master node in a nodeSet
* *n* data nodes in an other nodeSet

In the above situation, if the nodeSet that contains the data nodes is not selected for an upgrade *(as it is the case in #2393)* then the master node will be upgraded while the data nodes are still running the previous version.

This is possible because the predicates are relying on a consistent list of the Pod that needs to be upgraded.

Note that this PR does not completely solve #2393 but mitigates the worst case scenario _(i.e. having all Elasticsearch masters running a newer version than the data nodes)_

I have decided to implement here what I think is the most simple fix because:
* I didn't want to introduce an important change in the code base while we are very close from a release.
* [podsToUpgrade](https://github.com/elastic/cloud-on-k8s/blob/c0155249e999a0fd52d3bc76351dd526f3e0c7f8/pkg/controller/elasticsearch/driver/upgrade.go#L171) is used at several places in the code, if we add some code to detect an inconsistency we need to figure out where it must be used and how other uses are impacted. It is ofc not impossible, just would require more work.
* This change will  trigger a new reconciliation anyway because of the use of [podsToUpgrade](https://github.com/elastic/cloud-on-k8s/blob/c0155249e999a0fd52d3bc76351dd526f3e0c7f8/pkg/controller/elasticsearch/driver/upgrade.go#L171) in [driver.Reconciled](https://github.com/elastic/cloud-on-k8s/blob/master/pkg/controller/elasticsearch/driver/nodes.go#L166)

*That said I'm happy to close this PR if a best solution is found in a reasonable timeframe :)*