### PR TITLE
Backport doc changes to update strategy and Stack upgrade

### DIFF
--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -447,7 +447,10 @@ The init container inherits the image of the main container image if one is not 
 [id="{p}-update-strategy"]
 === Update strategy
 
-Sometimes the operator must take a Pod down, for example, to restart a node and apply a new configuration value. Other times the operator must spin up pods above what is currently in the specification, say to migrate to a new node set. You can limit the number of these simultaneous changes  using an `updateStrategy` as follows:
+You can use the `updateStrategy` specification to limit the number of simultaneous changes, like for example in the following cases:
+
+* The operator takes a Pod down to restart a node and applies a new configuration value.
+* The operator must spin up Pods above what is currently in the specification to migrate to a new node set.
 
 [source,yaml]
 ----
@@ -457,20 +460,20 @@ spec:
       maxSurge: 3
       maxUnavailable: 1
 ----
-`maxSurge` refers to the number of Pods that can be scheduled above the total number of Pods in the currently applied specification. This setting might be useful when the new specification has similar number of Pods, but different node sets (for example, when migrating Pods to a new node set). It will prevent the operator from creating all new Pods before removing the old ones thus preventing having (temporarily) as many as two times more pods than the specification defines.
+`maxSurge`: Refers to the number of extra Pods that can be temporarily scheduled exceeding the number of Pods  defined in the specification. This setting is useful for controlling the resource usage of the Kubernetes cluster when new Pods need to be spun up to replace existing Pods. For example, when applying a configuration change to a Node Set, ECK creates a clone of the Node Set with the desired configuration and shuts down the old Pods. Without the `MaxSurge` restriction, the cluster would temporarily contain twice as many Pods as usual while this operation is in progress.
 
-`maxUnavailable` refers to the number of Pods that can be unavailable out of the total number of Pods in the currently applied specification. Unavailable is defined as a Pod being not ready from Kubernetes perspective.
+`maxUnavailable`: Refers to the number of Pods that can be unavailable out of the total number of Pods in the currently applied specification. A Pod is defined unavailable when it is not ready from a Kubernetes perspective.
 
-As these constraints are enforced immediately after the specification is applied, it is possible the the actual state of the cluster might violate these constraints. When the cluster is outside these constraints, the operator can add or remove nodes only with the purpose of getting closer to these constraints. When the cluster is within these constraints, the operator can either add or remove nodes, as long as the cluster remains within the predefined constraints.
+The operator only tries to apply these constraints when a new specification is being applied. It is possible that the cluster state does not conform to the constraints at the beginning of the operation due to external factors. The operator will attempt to get to the desired state by adding or removing Pods as necessary while ensuring that the constraints are still satisfied.
 
 For example, if a new specification defines a larger cluster with `maxUnavailable: 0`, the operator creates the missing Pods according to the best practices. Similarly, if a new specification defines a smaller cluster with `maxSurge: 0`, the operator safely removes the unnecessary Pods.
 
 ==== Specifying changeBudget
 For both `maxSurge` and `maxUnavailable` you can specify the following values:
 
-* `null` - the default value is used
-* non-negative - the value is used as is
-* negative - the value is unbounded
+* `null` - The default value is used.
+* non-negative - The value is used as is.
+* negative - The value is unbounded.
 
 ==== Default behavior
 When `updateStrategy` is not present in the specification, it defaults to the following:
@@ -484,13 +487,13 @@ spec:
       maxUnavailable: 1
 ----
 
-`maxSurge` is unbounded: this means that all the missing Pods are immediately created according to the best practices at any given time.
-`maxUnavailable` defaults to `1`: this assures that clusters have at most one unavailable Pod at any given time.
+`maxSurge` is unbounded: This means that all the required Pods are created immediately.
+`maxUnavailable` defaults to `1`: This ensures that the cluster has no more than one unavailable Pod at any given point in time.
 
 ==== Caveats
 * With both `maxSurge` and `maxUnavailable` set to `0`, the operator cannot bring down an existing Pod nor create a new Pod.
-* Due to the safety measures employed by the operator, a particular changeBudget might be insufficient to perform the requested update. For example, with `maxSurge` set to 0 you cannot remove the last data node from one nodeSet and add a data node to a different nodeSet. In this case the operator cannot remove the old node and migrate data as other nodes are not available, and can't add the new node because `maxSurge` is set to 0.
-* Currently, the operator has a limited understanding of the cluster topology and during the update might not pick the optimal order of Pods being added or removed. This can block the update process and you might need to specify a higher `maxSurge` than theoretically needed.
+* Due to the safety measures employed by the operator, certain `changeBudget`s might prevent the operator from making any progress . For example, with `maxSurge` set to 0, you cannot remove the last data node from one `nodeSet` and add a data node to a different `nodeSet`. In this case, the operator cannot create the new node because `maxSurge` is 0, and it cannot remove the old node because there are no other data nodes to migrate the data to.
+* For certain complex configurations, the operator might not be able to deduce the optimal order of operations necessary to achieve the desired outcome. If progress is blocked,  you may need to update the `maxSurge` setting to a higher value than the theoretical best to help the operator make progress in that case.
 
 If any of the above occurs, the operator generates logs to indicate that upscaling or downscaling are limited by `maxSurge` or `maxUnavailable` settings.
 

--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -4,10 +4,10 @@ link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-upgrading-stack.htm
 ****
 endif::[]
 [id="{p}-upgrading-stack"]
-== Upgrading the Elastic stack version
+== Upgrading the Elastic Stack version
 
 The operator can safely perform upgrades to newer versions of the various Elastic Stack resources.
 
-Note that you should still follow the instructions in the link:https://www.elastic.co/guide/en/elastic-stack/current/upgrading-elastic-stack.html[Elasticsearch documentation] and ensure that your cluster is compatible with the target version, take backups, and follow the specific upgrade instructions for each resource type (especially the order in which the upgrade should be carried out). When you are ready to proceed, simply modify the `version` field in the resource spec to the desired stack version and the operator will start the upgrade process automatically.
+Follow the instructions in the link:https://www.elastic.co/guide/en/elastic-stack/current/upgrading-elastic-stack.html[Elasticsearch documentation]. Make sure that your cluster is compatible with the target version, take backups, and follow the specific upgrade instructions for each resource type, especially the order in which the upgrade should be carried out. When you are ready, modify the `version` field in the resource spec to the desired stack version and the operator will start the upgrade process automatically.
 
 See <<{p}-orchestration>> for more information on how the operator performs upgrades and how to tune its behavior.


### PR DESCRIPTION
This PR ports some docs changes made only in the `1.0` branch back to `master`.