### PR TITLE
(DOCS) Adding alternative to reaching es in k8s

### DIFF
--- a/docs/accessing-elastic-services.asciidoc
+++ b/docs/accessing-elastic-services.asciidoc
@@ -230,11 +230,18 @@ curl: (51) SSL: no alternative certificate subject name matches target host name
 ----
 
 As the certificate subject by default is service name we can resolve this by using the service name 
-and specify the resolve information through an additional argument.  
+and specify the resolve information through an additional argument.
 
 [source,sh]
 ----
-curl --cacert tls.crt -u elastic:$PW https://$NAME-es-http:9200/ --resolve $NAME-es-http:9200:$IP
+> curl --cacert tls.crt -u elastic:$PW https://$NAME-es-http:9200/ --resolve $NAME-es-http:9200:$IP
+{
+  "name" : "hulk-es-4qk62zd928",
+  "cluster_name" : "hulk",
+  "cluster_uuid" : "q6itjqFqRqW576FXF0uohg",
+  "version" : {...},
+  "tagline" : "You Know, for Search"
+}
 ----
 
 Alternatively, and for other clients where the resolve information can't be specified, or when it is more convenient modify the server side, you can add the external IP of the service to the SANs of the certificate in the same Elasticsearch resource YAML manifest used to create the cluster and apply it again using `kubectl`.
@@ -252,21 +259,7 @@ spec:
         - ip: 35.198.131.115
 ----
 
-You can now reach Elasticsearch:
-
-[source,sh]
-----
-> curl --cacert tls.crt -u elastic:$PW https://$NAME-es-http:9200/ --resolve $NAME-es-http:9200:$IP
-{
-  "name" : "hulk-es-4qk62zd928",
-  "cluster_name" : "hulk",
-  "cluster_uuid" : "q6itjqFqRqW576FXF0uohg",
-  "version" : {...},
-  "tagline" : "You Know, for Search"
-}
-----
-
-If IP was added to the list of SANs: 
++You can now reach Elasticsearch without `--resolve`:
 
 [source,sh]
 ----

--- a/docs/accessing-elastic-services.asciidoc
+++ b/docs/accessing-elastic-services.asciidoc
@@ -229,7 +229,15 @@ Now you should get this message:
 curl: (51) SSL: no alternative certificate subject name matches target host name '35.198.131.115'
 ----
 
-Add the external IP of the service to the SANs of the certificate in the same Elasticsearch resource YAML manifest used to create the cluster and apply it again using `kubectl`.
+As the certificate subject by default is service name we can resolve this by using the service name 
+and specify the resolve information through an additional argument.  
+
+[source,sh]
+----
+curl --cacert tls.crt -u elastic:$PW https://$NAME-es-http:9200/ --resolve $NAME-es-http:9200:$IP
+----
+
+Alternatively, and for other clients where the resolve information can't be specified, or when it is more convenient modify the server side, you can add the external IP of the service to the SANs of the certificate in the same Elasticsearch resource YAML manifest used to create the cluster and apply it again using `kubectl`.
 
 [source,yaml]
 ----
@@ -244,18 +252,25 @@ spec:
         - ip: 35.198.131.115
 ----
 
-Or alternatively, if you only use curl, you can use the service name and specify the resolve information through an additional argument:
-
-[source,sh]
-----
-curl --cacert tls.crt -u elastic:$PW https://$NAME-es-http:9200/ --resolve $NAME-es-http:9200:$IP
-----
-
 You can now reach Elasticsearch:
 
 [source,sh]
 ----
-> curl --cacert tls.crt -u elastic:$PASSWORD https://$IP:9200/
+> curl --cacert tls.crt -u elastic:$PW https://$NAME-es-http:9200/ --resolve $NAME-es-http:9200:$IP
+{
+  "name" : "hulk-es-4qk62zd928",
+  "cluster_name" : "hulk",
+  "cluster_uuid" : "q6itjqFqRqW576FXF0uohg",
+  "version" : {...},
+  "tagline" : "You Know, for Search"
+}
+----
+
+If IP was added to the list of SANs: 
+
+[source,sh]
+----
+> curl --cacert tls.crt -u elastic:$PW https://$IP:9200/
 {
   "name" : "hulk-es-4qk62zd928",
   "cluster_name" : "hulk",

--- a/docs/accessing-elastic-services.asciidoc
+++ b/docs/accessing-elastic-services.asciidoc
@@ -244,6 +244,13 @@ spec:
         - ip: 35.198.131.115
 ----
 
+Or alternatively, if you only use curl, you can use the service name and specify the resolve information through an additional argument:
+
+[source,sh]
+----
+curl --cacert tls.crt -u elastic:$PW https://$NAME-es-http:9200/ --resolve $NAME-es-http:9200:$IP
+----
+
 You can now reach Elasticsearch:
 
 [source,sh]

--- a/docs/accessing-elastic-services.asciidoc
+++ b/docs/accessing-elastic-services.asciidoc
@@ -229,8 +229,7 @@ Now you should get this message:
 curl: (51) SSL: no alternative certificate subject name matches target host name '35.198.131.115'
 ----
 
-As the certificate subject by default is service name we can resolve this by using the service name 
-and specify the resolve information through an additional argument.
+As the certificate subject by default is service name we can resolve this by using the service name and specify the resolve information through an additional argument.
 
 [source,sh]
 ----
@@ -244,7 +243,7 @@ and specify the resolve information through an additional argument.
 }
 ----
 
-Alternatively, and for other clients where the resolve information can't be specified, or when it is more convenient modify the server side, you can add the external IP of the service to the SANs of the certificate in the same Elasticsearch resource YAML manifest used to create the cluster and apply it again using `kubectl`.
+As an alternative, you can edit the spec of the Elasticsearch resource to include the external IP in certificate subject alternative names (SANs) as described below. This is useful for other clients where resolve information cannot be specified, or when it is more convenient to make changes on the server rather than client.
 
 [source,yaml]
 ----
@@ -259,7 +258,7 @@ spec:
         - ip: 35.198.131.115
 ----
 
-+You can now reach Elasticsearch without `--resolve`:
+You can now reach Elasticsearch without `--resolve`:
 
 [source,sh]
 ----


### PR DESCRIPTION
.. without having to modify the loadbalancer k8s resource if curl is used

Small addition to the docs to alternatively make use of --resolve this could be useful for CI and other temporary hosts/use.