### PR TITLE
Ensure that the list of nodes scheduled for upgrade is consistent in case of version change (#2411)

### DIFF
--- a/pkg/controller/common/version/version.go
+++ b/pkg/controller/common/version/version.go
@@ -93,6 +93,11 @@ func (v *Version) IsSameOrAfter(other Version) bool {
 		(v.Major == other.Major && v.Minor == other.Minor && v.Patch >= other.Patch)
 }
 
+// IsSame returns true if the receiver is the same version than the argument.
+func (v *Version) IsSame(other Version) bool {
+	return v.Major == other.Major && v.Minor == other.Minor && v.Patch == other.Patch
+}
+
 // Min returns the minimum version in vs or nil.
 func Min(vs []Version) *Version {
 	sort.SliceStable(vs, func(i, j int) bool {

--- a/pkg/controller/elasticsearch/driver/fixtures.go
+++ b/pkg/controller/elasticsearch/driver/fixtures.go
@@ -5,6 +5,7 @@
 package driver
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -24,9 +25,7 @@ const (
 )
 
 type testPod struct {
-	name                                                     string
-	version                                                  string
-	ssetName                                                 string
+	name, version, revision, ssetName                        string
 	master, data, healthy, toUpgrade, inCluster, terminating bool
 	uid                                                      types.UID
 }
@@ -45,6 +44,7 @@ func (t testPod) isHealthy(v bool) testPod              { t.healthy = v; return 
 func (t testPod) needsUpgrade(v bool) testPod           { t.toUpgrade = v; return t }
 func (t testPod) isTerminating(v bool) testPod          { t.terminating = v; return t }
 func (t testPod) withVersion(v string) testPod          { t.version = v; return t }
+func (t testPod) withRevision(v string) testPod         { t.revision = v; return t }
 func (t testPod) inStatefulset(ssetName string) testPod { t.ssetName = ssetName; return t } //nolint:unparam
 
 // filter to simulate a Pod that has been removed while upgrading
@@ -243,6 +243,7 @@ func (t testPod) toPod() corev1.Pod {
 	labels := map[string]string{}
 	labels[label.VersionLabelName] = t.version
 	labels[label.ClusterNameLabelName] = TestEsName
+	labels[appsv1.StatefulSetRevisionLabel] = t.revision
 	label.NodeTypesMasterLabelName.Set(t.master, labels)
 	label.NodeTypesDataLabelName.Set(t.data, labels)
 	labels[label.StatefulSetNameLabelName] = t.ssetName

--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -7,6 +7,7 @@ package driver
 import (
 	"fmt"
 
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
@@ -148,7 +149,7 @@ func (d *defaultDriver) reconcileNodeSpecs(
 
 	// When not reconciled, set the phase to ApplyingChanges only if it was Ready to avoid to
 	// override another "not Ready" phase like MigratingData.
-	if Reconciled(expectedResources.StatefulSets(), actualStatefulSets, d.Client) {
+	if Reconciled(d.ES, expectedResources.StatefulSets(), actualStatefulSets, d.Client) {
 		reconcileState.UpdateElasticsearchReady(resourcesState, observedState)
 	} else if reconcileState.IsElasticsearchReady(observedState) {
 		reconcileState.UpdateElasticsearchApplyingChanges(resourcesState.CurrentPods)
@@ -163,7 +164,7 @@ func (d *defaultDriver) reconcileNodeSpecs(
 // Reconciled reports whether the actual StatefulSets are reconciled to match the expected StatefulSets
 // by checking that the expected template hash label is reconciled for all StatefulSets, there are no
 // pod upgrades in progress and all pods are running.
-func Reconciled(expectedStatefulSets, actualStatefulSets sset.StatefulSetList, client k8s.Client) bool {
+func Reconciled(es esv1.Elasticsearch, expectedStatefulSets, actualStatefulSets sset.StatefulSetList, client k8s.Client) bool {
 	// actual sset should have the expected sset template hash label
 	for _, expectedSset := range expectedStatefulSets {
 		actualSset, ok := actualStatefulSets.GetByName(expectedSset.Name)
@@ -178,7 +179,7 @@ func Reconciled(expectedStatefulSets, actualStatefulSets sset.StatefulSetList, c
 	}
 
 	// all pods should have been upgraded
-	pods, err := podsToUpgrade(client, actualStatefulSets)
+	pods, err := podsToUpgrade(es, client, actualStatefulSets)
 	if err != nil {
 		return false
 	}

--- a/pkg/controller/elasticsearch/driver/upgrade.go
+++ b/pkg/controller/elasticsearch/driver/upgrade.go
@@ -10,7 +10,9 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/expectations"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/reconcile"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -42,7 +44,7 @@ func (d *defaultDriver) handleRollingUpgrades(
 	if err != nil {
 		return results.WithError(err)
 	}
-	podsToUpgrade, err := podsToUpgrade(d.Client, statefulSets)
+	podsToUpgrade, err := podsToUpgrade(d.ES, d.Client, statefulSets)
 	if err != nil {
 		return results.WithError(err)
 	}
@@ -169,9 +171,15 @@ func healthyPods(
 }
 
 func podsToUpgrade(
+	es esv1.Elasticsearch,
 	client k8s.Client,
 	statefulSets sset.StatefulSetList,
 ) ([]corev1.Pod, error) {
+	esVersion, err := version.Parse(es.Spec.Version)
+	if err != nil {
+		return nil, err
+	}
+
 	var toUpgrade []corev1.Pod
 	for _, statefulSet := range statefulSets {
 		if statefulSet.Status.UpdateRevision == "" {
@@ -194,7 +202,16 @@ func podsToUpgrade(
 				// Pod does not exist, continue the loop as the absence will be accounted by the deletion driver
 				continue
 			}
-			if sset.PodRevision(pod) != statefulSet.Status.UpdateRevision {
+			// We consider a Pod for an upgrade if at least one of the following conditions is met:
+			// 1. The update revision of the Pod does not match the one in the status of the StatefulSet
+			// 2. The Elasticsearch version run by the Pod does not match the expected one in the Elasticsearch object
+			// Relying only on Pod revision is not enough since it might not be propagated consistently across all the StatefulSets.
+			// See https://github.com/elastic/cloud-on-k8s/issues/2393#issuecomment-572951884
+			podVersion, err := label.ExtractVersion(pod.Labels)
+			if err != nil {
+				return toUpgrade, err
+			}
+			if sset.PodRevision(pod) != statefulSet.Status.UpdateRevision || !podVersion.IsSame(*esVersion) {
 				toUpgrade = append(toUpgrade, pod)
 			}
 		}

--- a/pkg/controller/elasticsearch/driver/upgrade_forced.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_forced.go
@@ -7,17 +7,16 @@ package driver
 import (
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
-
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func (d *defaultDriver) MaybeForceUpgrade(statefulSets sset.StatefulSetList) (bool, error) {
 	// Get the pods to upgrade
-	podsToUpgrade, err := podsToUpgrade(d.Client, statefulSets)
+	podsToUpgrade, err := podsToUpgrade(d.ES, d.Client, statefulSets)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -7,31 +7,23 @@ package driver
 import (
 	"testing"
 
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
-const testNamespace = "ns"
-
-func podWithRevision(name, revision string) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: testNamespace,
-			Labels:    map[string]string{appsv1.StatefulSetRevisionLabel: revision},
+func Test_podsToUpgrade(t *testing.T) {
+	defaultEs := esv1.Elasticsearch{
+		Spec: esv1.ElasticsearchSpec{
+			Version: "7.1.0",
 		},
 	}
-}
-
-func Test_podsToUpgrade(t *testing.T) {
 	type args struct {
-		pods         []runtime.Object
+		pods         upgradeTestPods
 		statefulSets sset.StatefulSetList
+		es           esv1.Elasticsearch
 	}
 	tests := []struct {
 		name    string
@@ -52,13 +44,14 @@ func Test_podsToUpgrade(t *testing.T) {
 						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-a", UpdateRevision: "rev-b", UpdatedReplicas: 0, Replicas: 3},
 					}.Build(),
 				},
-				pods: []runtime.Object{
-					podWithRevision("masters-0", "rev-a"),
-					podWithRevision("masters-1", "rev-a"),
-					podWithRevision("nodes-0", "rev-a"),
-					podWithRevision("nodes-1", "rev-a"),
-					podWithRevision("nodes-2", "rev-a"),
-				},
+				pods: newUpgradeTestPods(
+					newTestPod("masters-0").withRevision("rev-a").withVersion("7.1.0"),
+					newTestPod("masters-1").withRevision("rev-a").withVersion("7.1.0"),
+					newTestPod("nodes-0").withRevision("rev-a").withVersion("7.1.0"),
+					newTestPod("nodes-1").withRevision("rev-a").withVersion("7.1.0"),
+					newTestPod("nodes-2").withRevision("rev-a").withVersion("7.1.0"),
+				),
+				es: defaultEs,
 			},
 			want: []string{"masters-0", "masters-1", "nodes-0", "nodes-1", "nodes-2"},
 		},
@@ -75,10 +68,11 @@ func Test_podsToUpgrade(t *testing.T) {
 						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-b", UpdateRevision: "rev-b", UpdatedReplicas: 3, Replicas: 3},
 					}.Build(),
 				},
-				pods: []runtime.Object{
-					podWithRevision("masters-0", "rev-a"),
-					podWithRevision("masters-1", "rev-a"),
-				},
+				pods: newUpgradeTestPods(
+					newTestPod("masters-0").withRevision("rev-a").withVersion("7.1.0"),
+					newTestPod("masters-1").withRevision("rev-a").withVersion("7.1.0"),
+				),
+				es: defaultEs,
 			},
 			want: []string{"masters-0", "masters-1"},
 		},
@@ -95,10 +89,11 @@ func Test_podsToUpgrade(t *testing.T) {
 						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-b", UpdateRevision: "", UpdatedReplicas: 3, Replicas: 3},
 					}.Build(),
 				},
-				pods: []runtime.Object{
-					podWithRevision("masters-0", "rev-a"),
-					podWithRevision("masters-1", "rev-a"),
-				},
+				pods: newUpgradeTestPods(
+					newTestPod("masters-0").withRevision("rev-a").withVersion("7.1.0"),
+					newTestPod("masters-1").withRevision("rev-a").withVersion("7.1.0"),
+				),
+				es: defaultEs,
 			},
 			want: []string{},
 		},
@@ -115,18 +110,43 @@ func Test_podsToUpgrade(t *testing.T) {
 						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-b", UpdateRevision: "rev-b", UpdatedReplicas: 3, Replicas: 3},
 					}.Build(),
 				},
-				pods: []runtime.Object{
-					podWithRevision("masters-0", "rev-b"),
-					podWithRevision("masters-1", "rev-a"),
-				},
+				pods: newUpgradeTestPods(
+					newTestPod("masters-0").withRevision("rev-b").withVersion("7.1.0"),
+					newTestPod("masters-1").withRevision("rev-a").withVersion("7.1.0"),
+				),
+				es: defaultEs,
 			},
 			want: []string{"masters-1"},
+		},
+		{
+			name: "StatefulSet has been updated with a new ES version but StatefulSet update revision is not yet up to date",
+			args: args{
+				statefulSets: sset.StatefulSetList{
+					sset.TestSset{
+						Name: "masters", Replicas: 2, Master: true, Data: false,
+						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-master-a", UpdateRevision: "rev-master-b", UpdatedReplicas: 0, Replicas: 2},
+					}.Build(),
+					sset.TestSset{
+						Name: "nodes", Replicas: 3, Master: false, Data: true,
+						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-nodes-a", UpdateRevision: "rev-nodes-a", UpdatedReplicas: 0, Replicas: 3},
+					}.Build(),
+				},
+				pods: newUpgradeTestPods(
+					newTestPod("masters-0").withRevision("rev-master-a").withVersion("6.8.2"),
+					newTestPod("masters-1").withRevision("rev-master-a").withVersion("6.8.2"),
+					newTestPod("nodes-0").withRevision("rev-nodes-a").withVersion("6.8.2"),
+					newTestPod("nodes-1").withRevision("rev-nodes-a").withVersion("6.8.2"),
+					newTestPod("nodes-2").withRevision("rev-nodes-a").withVersion("6.8.2"),
+				),
+				es: defaultEs,
+			},
+			want: []string{"masters-0", "masters-1", "nodes-0", "nodes-1", "nodes-2"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := k8s.WrappedFakeClient(tt.args.pods...)
-			got, err := podsToUpgrade(client, tt.args.statefulSets)
+			client := k8s.WrappedFakeClient(tt.args.pods.toRuntimeObjects(tt.args.es.Spec.Version, 1, nothing)...)
+			got, err := podsToUpgrade(tt.args.es, client, tt.args.statefulSets)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("podsToUpgrade() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Backport of #2411 into 1.0