### PR TITLE
Add an OCP deployer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,9 @@ switch-gke:
 switch-aks:
 	@ echo "aks" > hack/deployer/config/provider
 
+switch-ocp:
+	@ echo "ocp" > hack/deployer/config/provider
+
 #################################
 ##  --    Docker images    --  ##
 #################################

--- a/hack/deployer/cmd/create.go
+++ b/hack/deployer/cmd/create.go
@@ -59,6 +59,17 @@ func CreateCommand() *cobra.Command {
 				if err := ioutil.WriteFile(fullPath, []byte(data), 0644); err != nil {
 					return err
 				}
+			case runner.OcpDriverID:
+				gCloudProject, err := GetEnvVar("GCLOUD_PROJECT")
+				if err != nil {
+					return err
+				}
+
+				data := fmt.Sprintf(runner.DefaultOcpRunConfigTemplate, user, gCloudProject)
+				fullPath := path.Join(filePath, runner.OcpConfigFileName)
+				if err := ioutil.WriteFile(fullPath, []byte(data), 0644); err != nil {
+					return err
+				}
 			default:
 				return fmt.Errorf("unknown provider %s", provider)
 			}

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -57,4 +57,13 @@ plans:
   serviceAccount: true
   ocp:
     region: europe-west2
-    nodeCount: 1
+    nodeCount: 3
+- id: ocp-dev
+  operation: create
+  clusterName: dev
+  provider: ocp
+  machineType: n1-standard-8
+  serviceAccount: false
+  ocp:
+    region: europe-west1
+    nodeCount: 3

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -49,3 +49,12 @@ plans:
   aks:
     nodeCount: 3
     location: northeurope
+- id: ocp-ci
+  operation: create
+  clusterName: ci
+  provider: ocp
+  machineType: n1-standard-8
+  serviceAccount: true
+  ocp:
+    region: europe-west2
+    nodeCount: 1

--- a/hack/deployer/runner/aks.go
+++ b/hack/deployer/runner/aks.go
@@ -89,7 +89,7 @@ func (d *AksDriver) Execute() error {
 	}
 
 	switch d.plan.Operation {
-	case "delete":
+	case DeleteAction:
 		if exists {
 			if err := d.delete(); err != nil {
 				return err
@@ -97,7 +97,7 @@ func (d *AksDriver) Execute() error {
 		} else {
 			log.Printf("not deleting as cluster doesn't exist")
 		}
-	case "create":
+	case CreateAction:
 		if exists {
 			log.Printf("not creating as cluster exists")
 		} else {

--- a/hack/deployer/runner/driver.go
+++ b/hack/deployer/runner/driver.go
@@ -11,6 +11,11 @@ import (
 	"github.com/imdario/mergo"
 )
 
+const (
+	CreateAction = "create"
+	DeleteAction = "delete"
+)
+
 var (
 	drivers = make(map[string]DriverFactory)
 )

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -75,13 +75,13 @@ func (d *GkeDriver) Execute() error {
 	}
 
 	switch d.plan.Operation {
-	case "delete":
+	case DeleteAction:
 		if exists {
 			err = d.delete()
 		} else {
 			log.Printf("not deleting as cluster doesn't exist")
 		}
-	case "create":
+	case CreateAction:
 		if exists {
 			log.Printf("not creating as cluster exists")
 		} else {

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -91,7 +91,7 @@ func (gdf *OcpDriverFactory) Create(plan Plan) (Driver, error) {
 			"LocalSsdCount":     plan.Ocp.LocalSsdCount,
 			"NodeCount":         plan.Ocp.NodeCount,
 			"BaseDomain":        baseDomain,
-			"WorkDir":           plan.WorkDir,
+			"WorkDir":           plan.Ocp.WorkDir,
 			"OcpStateBucket":    OcpStateBucket,
 		},
 	}, nil

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -132,13 +132,13 @@ func (d *OcpDriver) Execute() error {
 	}
 
 	switch d.plan.Operation {
-	case "delete":
+	case DeleteAction:
 		if exists {
 			err = d.delete()
 		} else {
 			log.Printf("not deleting as cluster doesn't exist")
 		}
-	case "create":
+	case CreateAction:
 		if exists {
 			log.Printf("not creating as cluster exists")
 

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -1,0 +1,325 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package runner
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"text/template"
+)
+
+const (
+	OcpDriverID                     = "ocp"
+	OcpVaultPath                    = "secret/devops-ci/cloud-on-k8s/ci-ocp-k8s-operator"
+	OcpServiceAccountVaultFieldName = "service-account"
+	OcpPullSecretFieldName          = "ocp-pull-secret"
+	OcpStateBucket                  = "eck-deployer-ocp-clusters-state"
+
+	OcpInstallerConfigTemplate = `apiVersion: v1
+baseDomain: {{.BaseDomain}}
+compute:
+- hyperthreading: Enabled
+  name: worker
+  platform:
+    gcp:
+      type: {{.MachineType}}
+  replicas: {{.NodeCount}}
+controlPlane:
+  hyperthreading: Enabled
+  name: master
+  platform:
+    gcp:
+      type: {{.MachineType}}
+  replicas: {{.NodeCount}}
+metadata:
+  creationTimestamp: null
+  name: {{.ClusterName}}
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineCIDR: 10.0.0.0/16
+  networkType: OpenShiftSDN
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  gcp:
+    projectID: {{.GCloudProject}}
+    region: {{.Region}}
+pullSecret: '{{.PullSecret}}'`
+)
+
+var (
+	// GKE uses 18 chars to prefix the pvc created by a cluster
+	OcppvcPrefixMaxLength = 18
+	OcpStorageProvisioner = "kubernetes.io/no-provisioner"
+)
+
+func init() {
+	drivers[OcpDriverID] = &OcpDriverFactory{}
+}
+
+type OcpDriverFactory struct {
+}
+
+type OcpDriver struct {
+	plan Plan
+	ctx  map[string]interface{}
+}
+
+func (gdf *OcpDriverFactory) Create(plan Plan) (Driver, error) {
+	pvcPrefix := plan.ClusterName
+	if len(pvcPrefix) > pvcPrefixMaxLength {
+		pvcPrefix = pvcPrefix[0:pvcPrefixMaxLength]
+	}
+
+	baseDomain := plan.Ocp.BaseDomain
+	if baseDomain == "" {
+		baseDomain = "ocp.elastic.dev"
+	}
+	return &OcpDriver{
+		plan: plan,
+		ctx: map[string]interface{}{
+			"GCloudProject":     plan.Ocp.GCloudProject,
+			"ClusterName":       plan.ClusterName,
+			"PVCPrefix":         pvcPrefix,
+			"Region":            plan.Ocp.Region,
+			"AdminUsername":     plan.Ocp.AdminUsername,
+			"KubernetesVersion": plan.KubernetesVersion,
+			"MachineType":       plan.MachineType,
+			"LocalSsdCount":     plan.Ocp.LocalSsdCount,
+			"NodeCount":         plan.Ocp.NodeCount,
+			"SshPubKey":         plan.Ocp.SshPubKey,
+			"BaseDomain":        baseDomain,
+			"WorkDir":           plan.WorkDir,
+			"OcpStateBucket":    OcpStateBucket,
+		},
+	}, nil
+}
+
+func (d *OcpDriver) Execute() error {
+	if d.ctx["WorkDir"] == "" {
+		dir, err := ioutil.TempDir("", d.ctx["ClusterName"].(string))
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		defer os.RemoveAll(dir)
+		d.ctx["WorkDir"] = dir
+	}
+
+	log.Printf("Using WorkDir: %s", d.ctx["WorkDir"])
+	d.ctx["ClusterStateDir"] = filepath.Join(d.ctx["WorkDir"].(string), d.ctx["ClusterName"].(string))
+	os.MkdirAll(d.ctx["ClusterStateDir"].(string), os.ModePerm)
+
+	if err := d.auth(); err != nil {
+		return err
+	}
+
+	client, err := NewClient(*d.plan.VaultInfo)
+	if err != nil {
+		return err
+	}
+
+	d.ctx["PullSecret"], err = client.Get(OcpVaultPath, "pull-secret")
+
+	exists, err := d.clusterExists()
+	if err != nil {
+		return err
+	}
+
+	switch d.plan.Operation {
+	case "delete":
+		if exists {
+			err = d.delete()
+		} else {
+			log.Printf("not deleting as cluster doesn't exist")
+		}
+	case "create":
+		if exists {
+			log.Printf("not creating as cluster exists")
+
+			if err := d.UploadCredentials(); err != nil {
+				return err
+			}
+
+		} else {
+			if err := d.create(); err != nil {
+				return err
+			}
+		}
+
+		if err := d.GetCredentials(); err != nil {
+			return err
+		}
+
+	default:
+		err = fmt.Errorf("unknown operation %s", d.plan.Operation)
+	}
+
+	return err
+}
+
+func (d *OcpDriver) auth() error {
+	if d.plan.ServiceAccount {
+		log.Println("Authenticating as service account...")
+
+		client, err := NewClient(*d.plan.VaultInfo)
+		if err != nil {
+			return err
+		}
+
+		keyFileName := "gke_service_account_key.json"
+		defer os.Remove(keyFileName)
+		if err := client.ReadIntoFile(keyFileName, OcpVaultPath, OcpServiceAccountVaultFieldName); err != nil {
+			return err
+		}
+
+		return NewCommand("gcloud auth activate-service-account --key-file=" + keyFileName).Run()
+	}
+
+	log.Println("Authenticating as user...")
+	accounts, err := NewCommand(`gcloud auth list "--format=value(account)"`).StdoutOnly().WithoutStreaming().Output()
+	if err != nil {
+		return err
+	}
+
+	if len(accounts) > 0 {
+		return nil
+	}
+
+	return NewCommand("gcloud auth login").Run()
+}
+
+func (d *OcpDriver) clusterExists() (bool, error) {
+	log.Println("Checking if cluster exists...")
+
+	err := d.GetCredentials()
+
+	if err != nil {
+		// No need to send this error back
+		// in this case. We're checking whether
+		// the cluster exists and an error
+		// getting the credentials is expected for non
+		// existing clusters.
+		return false, nil
+	} else {
+		log.Println("Cluster state synced: Testing that the OpenShift cluster is alive... ")
+		kubeConfig := filepath.Join(d.ctx["WorkDir"].(string), d.ctx["ClusterName"].(string), "auth", "kubeconfig")
+		cmd := "kubectl version"
+		alive, err := NewCommand(cmd).AsTemplate(d.ctx).WithoutStreaming().WithVariable("KUBECONFIG", kubeConfig).OutputContainsAny("Server Version")
+
+		if !alive {
+			log.Printf("A cluster state dir was found in %s but the cluster is not responding to `kubectl version`", d.ctx["ClusterStateDir"])
+		}
+
+		return alive, err
+	}
+
+	return false, err
+}
+
+func (d *OcpDriver) create() error {
+	log.Println("Creating cluster...")
+
+	var tpl bytes.Buffer
+	if err := template.Must(template.New("").Parse(OcpInstallerConfigTemplate)).Execute(&tpl, d.ctx); err != nil {
+		return err
+	}
+
+	installConfig := filepath.Join(d.ctx["ClusterStateDir"].(string), "install-config.yaml")
+	err := ioutil.WriteFile(installConfig, tpl.Bytes(), 0644)
+
+	if err != nil {
+		return err
+	}
+
+	err = NewCommand("openshift-install create cluster --log-level debug --dir {{.ClusterStateDir}}").
+		AsTemplate(d.ctx).
+		Run()
+
+	if err != nil {
+		return err
+	}
+
+	return d.UploadCredentials()
+}
+
+func (d *OcpDriver) ensureBucketExists() error {
+	cmd := "gsutil mb gs://{{.OcpStateBucket}}"
+	_ = NewCommand(cmd).AsTemplate(d.ctx).WithoutStreaming().Run()
+	return nil
+}
+
+func (d *OcpDriver) UploadCredentials() error {
+	// We do this check twice to avoid re-downloading files
+	// from the bucket when we already have them locally.
+	// The second time is further down in this function and it's
+	// done when the rsync succeedes
+	if _, err := os.Stat(d.ctx["ClusterStateDir"].(string)); os.IsNotExist(err) {
+		log.Printf("ClusterStateDir %s not present", d.ctx["ClusterStateDir"])
+		return nil
+	}
+
+	d.ensureBucketExists()
+
+	log.Printf("Uploading cluster state %s to gs://%s/%s", d.ctx["ClusterStateDir"], OcpStateBucket, d.ctx["ClusterName"])
+	cmd := "gsutil rsync -r -d {{.ClusterStateDir}} gs://{{.OcpStateBucket}}/{{.ClusterName}}"
+	return NewCommand(cmd).AsTemplate(d.ctx).WithoutStreaming().Run()
+}
+
+func (d *OcpDriver) GetCredentials() error {
+	kubeConfig := filepath.Join(d.ctx["ClusterStateDir"].(string), "auth", "kubeconfig")
+
+	// We do this check twice to avoid re-downloading files
+	// from the bucket when we already have them locally.
+	// The second time is further down in this function and it's
+	// done when the rsync succeedes
+	if _, err := os.Stat(kubeConfig); !os.IsNotExist(err) {
+		return nil
+	}
+
+	cmd := "gsutil rsync -r -d gs://{{.OcpStateBucket}}/{{.ClusterName}} {{.ClusterStateDir}}"
+	exists, err := NewCommand(cmd).AsTemplate(d.ctx).WithoutStreaming().OutputContainsAny("BucketNotFoundException")
+
+	// Let's assume the rsync succeeded and go straight to
+	// checking whether the kubeconfig file exists. If it doesn't
+	// we can assume that either the cluster doesn't exist or
+	// the gsutil command failed misserably
+	if _, serr := os.Stat(kubeConfig); !os.IsNotExist(serr) {
+		return nil
+	}
+
+	// If the string didn't match and there was an error
+	// it means something else might have happened. Let's
+	// make sure this error gets logged.
+	if !exists && err != nil {
+		log.Printf("gsutil failed: %s", err)
+	}
+
+	return fmt.Errorf("Credentials not found")
+
+}
+
+func (d *OcpDriver) delete() error {
+	log.Println("Deleting cluster...")
+
+	err := NewCommand("openshift-install destroy cluster --log-level debug --dir {{.ClusterStateDir}}").
+		AsTemplate(d.ctx).
+		Run()
+
+	if err != nil {
+		return err
+	}
+
+	// No need to check whether this `rb` command succeeds
+	cmd := "gsutil rb gs://{{.OcpStateBucket}}"
+	NewCommand(cmd).AsTemplate(d.ctx).WithoutStreaming().Run()
+	return nil
+}

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -24,20 +24,23 @@ type Plan struct {
 	KubernetesVersion string `yaml:"kubernetesVersion"`
 	MachineType       string `yaml:"machineType"`
 	ServiceAccount    bool   `yaml:"serviceAccount"`
+	WorkDir           string `yaml: "workDir"`
 
 	Psp bool `yaml:"psp"`
 
 	Gke *GkeSettings `yaml:"gke,omitempty"`
 	Aks *AksSettings `yaml:"aks,omitempty"`
+	Ocp *OcpSettings `yaml:"ocp,omitempty"`
 
 	VaultInfo *VaultInfo `yaml:"vaultInfo,omitempty"`
 }
 
 type VaultInfo struct {
-	Address  string `yaml:"address"`
-	RoleId   string `yaml:"roleId"`   //nolint
-	SecretId string `yaml:"secretId"` //nolint
-	Token    string `yaml:"token"`
+	Address     string `yaml:"address"`
+	RoleId      string `yaml:"roleId"`   //nolint
+	SecretId    string `yaml:"secretId"` //nolint
+	Token       string `yaml:"token"`
+	ClientToken string `yaml:"clientToken"`
 }
 
 // GkeSettings encapsulates settings specific to GKE
@@ -56,6 +59,17 @@ type AksSettings struct {
 	Location      string `yaml:"location"`
 	AcrName       string `yaml:"acrName"`
 	NodeCount     int    `yaml:"nodeCount"`
+}
+
+// GkeSettings encapsulates settings specific to GKE
+type OcpSettings struct {
+	BaseDomain    string `yaml:"baseDomain"`
+	GCloudProject string `yaml:"gCloudProject"`
+	Region        string `yaml:"region"`
+	AdminUsername string `yaml:"adminUsername"`
+	LocalSsdCount int    `yaml:"localSsdCount"`
+	NodeCount     int    `yaml:"nodeCountPerZone"`
+	SshPubKey     string `yaml:"sshPubKey"`
 }
 
 // RunConfig encapsulates Id used to choose a plan and a map of overrides to apply to the plan, expected to map to a file

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -23,7 +23,6 @@ type Plan struct {
 	Provider          string       `yaml:"provider"`
 	KubernetesVersion string       `yaml:"kubernetesVersion"`
 	MachineType       string       `yaml:"machineType"`
-	WorkDir           string       `yaml:"workDir"`
 	Gke               *GkeSettings `yaml:"gke,omitempty"`
 	Aks               *AksSettings `yaml:"aks,omitempty"`
 	Ocp               *OcpSettings `yaml:"ocp,omitempty"`
@@ -64,8 +63,9 @@ type OcpSettings struct {
 	GCloudProject string `yaml:"gCloudProject"`
 	Region        string `yaml:"region"`
 	AdminUsername string `yaml:"adminUsername"`
+	WorkDir       string `yaml:"workDir"`
 	LocalSsdCount int    `yaml:"localSsdCount"`
-	NodeCount     int    `yaml:"nodeCountPerZone"`
+	NodeCount     int    `yaml:"nodeCount"`
 }
 
 // RunConfig encapsulates Id used to choose a plan and a map of overrides to apply to the plan, expected to map to a file

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -17,22 +17,19 @@ type Plans struct {
 
 // Plan encapsulates information needed to provision a cluster
 type Plan struct {
-	Id                string `yaml:"id"` //nolint
-	Operation         string `yaml:"operation"`
-	ClusterName       string `yaml:"clusterName"`
-	Provider          string `yaml:"provider"`
-	KubernetesVersion string `yaml:"kubernetesVersion"`
-	MachineType       string `yaml:"machineType"`
-	ServiceAccount    bool   `yaml:"serviceAccount"`
-	WorkDir           string `yaml: "workDir"`
-
-	Psp bool `yaml:"psp"`
-
-	Gke *GkeSettings `yaml:"gke,omitempty"`
-	Aks *AksSettings `yaml:"aks,omitempty"`
-	Ocp *OcpSettings `yaml:"ocp,omitempty"`
-
-	VaultInfo *VaultInfo `yaml:"vaultInfo,omitempty"`
+	Id                string       `yaml:"id"` //nolint
+	Operation         string       `yaml:"operation"`
+	ClusterName       string       `yaml:"clusterName"`
+	Provider          string       `yaml:"provider"`
+	KubernetesVersion string       `yaml:"kubernetesVersion"`
+	MachineType       string       `yaml:"machineType"`
+	WorkDir           string       `yaml:"workDir"`
+	Gke               *GkeSettings `yaml:"gke,omitempty"`
+	Aks               *AksSettings `yaml:"aks,omitempty"`
+	Ocp               *OcpSettings `yaml:"ocp,omitempty"`
+	VaultInfo         *VaultInfo   `yaml:"vaultInfo,omitempty"`
+	ServiceAccount    bool         `yaml:"serviceAccount"`
+	Psp               bool         `yaml:"psp"`
 }
 
 type VaultInfo struct {
@@ -69,7 +66,6 @@ type OcpSettings struct {
 	AdminUsername string `yaml:"adminUsername"`
 	LocalSsdCount int    `yaml:"localSsdCount"`
 	NodeCount     int    `yaml:"nodeCountPerZone"`
-	SshPubKey     string `yaml:"sshPubKey"`
 }
 
 // RunConfig encapsulates Id used to choose a plan and a map of overrides to apply to the plan, expected to map to a file


### PR DESCRIPTION
This PR adds a new ocp deployer to be able to create openshift clusters
on the CI clouds. Future commits will add the ability to run tests on an
OpenShift cluster deployed by the deployer

Related #2170 