### PR TITLE
Refactor invariant check during downscale

### DIFF
--- a/pkg/controller/elasticsearch/driver/downscale.go
+++ b/pkg/controller/elasticsearch/driver/downscale.go
@@ -104,22 +104,20 @@ func calculateDownscales(
 
 		case expectedReplicas < actualReplicas:
 			// the StatefulSet should be downscaled
-			if canDownscale, reason := checkDownscaleInvariants(state, actualSset); !canDownscale {
+			requestedDeletes := actualReplicas - expectedReplicas
+			allowedDeletes, reason := checkDownscaleInvariants(state, actualSset, requestedDeletes)
+			if allowedDeletes == 0 {
 				ssetLogger(actualSset).V(1).Info("Cannot downscale StatefulSet", "reason", reason)
 				continue
 			}
-			toDelete := actualReplicas - expectedReplicas
-			if label.IsMasterNodeSet(actualSset) {
-				toDelete = 1 // only one removal allowed for masters
-			}
-			toDelete = state.getMaxNodesToRemove(toDelete)
+
 			downscales = append(downscales, ssetDownscale{
 				statefulSet:     actualSset,
 				initialReplicas: actualReplicas,
-				targetReplicas:  actualReplicas - toDelete,
+				targetReplicas:  actualReplicas - allowedDeletes,
 				finalReplicas:   expectedReplicas,
 			})
-			state.recordNodeRemoval(actualSset, toDelete)
+			state.recordNodeRemoval(actualSset, allowedDeletes)
 
 		default:
 			// nothing to do

--- a/pkg/controller/elasticsearch/driver/downscale_invariants_test.go
+++ b/pkg/controller/elasticsearch/driver/downscale_invariants_test.go
@@ -228,7 +228,7 @@ func Test_checkDownscaleInvariants(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			toDelete, reason := checkDownscaleInvariants(*tt.state, tt.statefulSet, 1)
-			canDownscale := toDelete > 0
+			canDownscale := toDelete == 1
 			if canDownscale != tt.wantCanDownscale {
 				t.Errorf("canDownscale() canDownscale = %v, want %v", canDownscale, tt.wantCanDownscale)
 			}

--- a/pkg/controller/elasticsearch/driver/downscale_invariants_test.go
+++ b/pkg/controller/elasticsearch/driver/downscale_invariants_test.go
@@ -227,7 +227,8 @@ func Test_checkDownscaleInvariants(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			canDownscale, reason := checkDownscaleInvariants(*tt.state, tt.statefulSet)
+			toDelete, reason := checkDownscaleInvariants(*tt.state, tt.statefulSet, 1)
+			canDownscale := toDelete > 0
 			if canDownscale != tt.wantCanDownscale {
 				t.Errorf("canDownscale() canDownscale = %v, want %v", canDownscale, tt.wantCanDownscale)
 			}


### PR DESCRIPTION
Tries to address past comment: https://github.com/elastic/cloud-on-k8s/pull/1812#discussion_r330513119. While two functions are not merged (I feel that `getMaxNodesToRemove` should be a separate func), `checkDownscaleInvariants` no longer inspects `removalsAllowed` and the call site is cleaned up.