### PR TITLE
Cluster bootstrap: ignore ES error when retrieving cluster UUID

### DIFF
--- a/pkg/controller/elasticsearch/bootstrap/bootstrap.go
+++ b/pkg/controller/elasticsearch/bootstrap/bootstrap.go
@@ -41,7 +41,19 @@ func ReconcileClusterUUID(k8sClient k8s.Client, cluster *esv1.Elasticsearch, esC
 	}
 	clusterUUID, err := getClusterUUID(esClient)
 	if err != nil {
-		return false, err
+		// There was an error while retrieving the UUID of the Elasticsearch cluster.
+		// For example, it could be the case with ES 6.x if the cluster does not have a master yet, in this case an
+		// API call to get the cluster UUID returns a 503 error.
+		// However we don't want to stop the reconciliation loop here because it could prevent the user to apply
+		// an update to the cluster spec to fix a problem.
+		// Therefore we just log the error and notify the driver that the reconciliation should be eventually re-queued.
+		log.Info(
+			"Recoverable error while retrieving Elasticsearch cluster UUID",
+			"namespace", cluster.Namespace,
+			"es_name", cluster.Name,
+			"error", err,
+		)
+		return true, nil
 	}
 	if !isUUIDValid(clusterUUID) {
 		// retry later

--- a/pkg/controller/elasticsearch/bootstrap/bootstrap_test.go
+++ b/pkg/controller/elasticsearch/bootstrap/bootstrap_test.go
@@ -101,8 +101,8 @@ func TestReconcileClusterUUID1(t *testing.T) {
 				esReachable: true,
 				esClient:    &fakeESClient{uuid: "", err: errors.New("error")},
 			},
-			wantRequeue:    false,
-			wantErr:        true,
+			wantRequeue:    true,
+			wantErr:        false,
 			wantAnnotation: "",
 		},
 		{


### PR DESCRIPTION
Fix #2413 

This PR basically restores the behaviour before #2399 regarding what is done when the Elasticsearch client returns an error when retrieving the cluster UUID: the error is ignored in the reconciliation loop.

We still want to return an error to the driver if `annotateWithUUID` fails that why the error is not managed at the driver level.