### PR TITLE
Remove GKE 1.12 from the e2e tests, replace it with 1.15

### DIFF
--- a/.ci/jobs/e2e-custom.yml
+++ b/.ci/jobs/e2e-custom.yml
@@ -10,7 +10,7 @@
       - string:
           name: VERSION
           default: 1.13
-          description: "Kubernetes version, default is 1.12"
+          description: "Kubernetes version, default is 1.13"
       - bool:
           name: SEND_NOTIFICATIONS
           default: true

--- a/build/ci/README.md
+++ b/build/ci/README.md
@@ -39,7 +39,7 @@ EOF
 cat >deployer-config.yml <<EOF
 id: gke-ci
 overrides:
-  kubernetesVersion: "1.12"
+  kubernetesVersion: "1.13"
   clusterName: $BUILD_TAG
   vaultInfo:
     address: $VAULT_ADDR

--- a/build/ci/e2e/GKE_k8s_versions.jenkinsfile
+++ b/build/ci/e2e/GKE_k8s_versions.jenkinsfile
@@ -28,17 +28,6 @@ pipeline {
         }
         stage('Run tests for different k8s versions in GKE') {
             parallel {
-                stage("1.12") {
-                    agent {
-                        label 'linux'
-                    }
-                    steps {
-                        checkout scm
-                        script {
-                            runWith(lib, failedTests, '1.12', "eck-gke12-${BUILD_NUMBER}-e2e")
-                        }
-                    }
-                }
                 stage("1.13") {
                     agent {
                         label 'linux'
@@ -58,6 +47,17 @@ pipeline {
                         checkout scm
                         script {
                             runWith(lib, failedTests, '1.14', "eck-gke14-${BUILD_NUMBER}-e2e")
+                        }
+                    }
+                }
+                stage("1.15") {
+                    agent {
+                        label 'linux'
+                    }
+                    steps {
+                        checkout scm
+                        script {
+                            runWith(lib, failedTests, '1.15', "eck-gke15-${BUILD_NUMBER}-e2e")
                         }
                     }
                 }
@@ -83,7 +83,7 @@ pipeline {
         }
         cleanup {
             script {
-                clusters = ["eck-gke12-${BUILD_NUMBER}-e2e", "eck-gke13-${BUILD_NUMBER}-e2e", "eck-gke14-${BUILD_NUMBER}-e2e"]
+                clusters = ["eck-gke13-${BUILD_NUMBER}-e2e", "eck-gke14-${BUILD_NUMBER}-e2e", "eck-gke15-${BUILD_NUMBER}-e2e"]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
                         parameters: [string(name: 'GKE_CLUSTER', value: clusters[i])],


### PR DESCRIPTION
Fix #2436 
I will open an other issue to depict the fact we still need an environment to test ECK against K8S 1.12