### PR TITLE
Mention the Kubernetes issue with CPU limits throttling in the docs

### DIFF
--- a/docs/managing-compute-resources.asciidoc
+++ b/docs/managing-compute-resources.asciidoc
@@ -24,9 +24,15 @@ A good rule of thumb is to size it to half the size of RAM allocated to the Pod.
 To minimize disruption caused by Pod evictions due to resource contention, you should run Elasticsearch pods at the "Guaranteed" QoS level by setting both `requests` and `limits` to the same value.
 
 Consider also that Kubernetes throttles containers exceeding the CPU limit defined in the `limits` section. Do not set this value too low or it would affect the performance of Elasticsearch, even if you have enough resources available in the Kubernetes cluster.
-A link:https://github.com/kubernetes/kubernetes/issues/51135[known Kubernetes issue] may lead to over-aggressive CPU limits throttling. If the host Linux Kernel does not include link:https://github.com/kubernetes/kubernetes/issues/67577[this CFS quota fix], you may want to keep CPU limits unset, or link:https://github.com/kubernetes/kubernetes/pull/63437[tweak the CFS quota period].
 
+[NOTE]
+===============================
+A link:https://github.com/kubernetes/kubernetes/issues/51135[known Kubernetes issue] may lead to over-aggressive CPU limits throttling. If the host Linux Kernel does not include link:https://github.com/kubernetes/kubernetes/issues/67577[this CFS quota fix], you may want to:
 
+* not set any CPU limit in the Elasticsearch resource (Burstable QoS)
+* link:https://github.com/kubernetes/kubernetes/pull/63437[reduce the CFS quota period] in kubelet configuration
+* link:https://github.com/kubernetes/kubernetes/issues/51135#issuecomment-386319185[disable CFS quotas] in kubelet configuration
+===============================
 
 [source,yaml]
 ----

--- a/docs/managing-compute-resources.asciidoc
+++ b/docs/managing-compute-resources.asciidoc
@@ -72,10 +72,9 @@ spec:
         resources:
           requests:
             memory: 1Gi
-            cpu: 0.5
+            cpu: 1
           limits:
             memory: 2Gi
-            cpu: 2
 ----
 
 For the container name, you can use `apm-server` for `kibana` as appropriate.

--- a/docs/managing-compute-resources.asciidoc
+++ b/docs/managing-compute-resources.asciidoc
@@ -18,7 +18,14 @@ You can set compute resource constraints in the `podTemplate` of objects managed
 [id="{p}-compute-resources-elasticsearch"]
 ==== Set compute resources for Elasticsearch
 
-For Elasticsearch objects, make sure to consider the heap size when you set resource requirements. The heap size should be half the size of RAM allocated to the Pod. To minimize disruption caused by Pod evictions due to resource contention, you should run Elasticsearch pods at the "Guaranteed" QoS level by setting both `requests` and `limits` to the same value. Consider also that Kubernetes throttles containers exceeding the CPU limit defined in the `limits` section. Do not set this value too low or it would affect the performance of Elasticsearch even if you have enough resources available in the Kubernetes cluster.
+For Elasticsearch objects, make sure to consider the heap size when you set resource requirements.
+A good rule of thumb is to size it to half the size of RAM allocated to the Pod.
+
+To minimize disruption caused by Pod evictions due to resource contention, you should run Elasticsearch pods at the "Guaranteed" QoS level by setting both `requests` and `limits` to the same value.
+
+Consider also that Kubernetes throttles containers exceeding the CPU limit defined in the `limits` section. Do not set this value too low or it would affect the performance of Elasticsearch, even if you have enough resources available in the Kubernetes cluster.
+A link:https://github.com/kubernetes/kubernetes/issues/51135[known Kubernetes issue] may lead to over-aggressive CPU limits throttling. If the host Linux Kernel does not include link:https://github.com/kubernetes/kubernetes/issues/67577[this CFS quota fix], you may want to keep CPU limits unset, or link:https://github.com/kubernetes/kubernetes/pull/63437[tweak the CFS quota period].
+
 
 
 [source,yaml]

--- a/docs/managing-compute-resources.asciidoc
+++ b/docs/managing-compute-resources.asciidoc
@@ -50,10 +50,9 @@ spec:
           resources:
             requests:
               memory: 4Gi
-              cpu: 0.5
+              cpu: 1
             limits:
               memory: 4Gi
-              cpu: 2
 ----
 
 


### PR DESCRIPTION
Some users may experience poor performance correlated with the usage of
cpu limits. This is due to a bug in the Kernel that has been fixed in
recent Kernel versions.
A workaround is to not use limits at all, or tweak the CFS quota period.

---

I'm wondering whether this PR is worth the trouble: it's hard to get into this level of details without saying too much. Also depends on various factors (Kernel version, bugfixed or not, can the user tweak the CFS period, etc.).
I'd be happy to hear other people thoughts, we may want to close this PR if it seems too complicated to explain.