### PR TITLE
Logging: add minimal support for ECS

### DIFF
--- a/config/e2e/global_operator.yaml
+++ b/config/e2e/global_operator.yaml
@@ -158,6 +158,8 @@ spec:
   template:
     metadata:
       annotations:
+        # Rename the fields "error" to "error.message" and "source" to "event.source"
+        # This is to avoid a conflict with the ECS "error" and "service" documents.
         "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
       labels:
         control-plane: {{ .GlobalOperator.Name }}

--- a/config/e2e/global_operator.yaml
+++ b/config/e2e/global_operator.yaml
@@ -157,6 +157,8 @@ spec:
   serviceName: {{ .GlobalOperator.Name }}
   template:
     metadata:
+      annotations:
+        "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
       labels:
         control-plane: {{ .GlobalOperator.Name }}
         test-run: {{ .TestRun }}

--- a/config/e2e/global_operator.yaml
+++ b/config/e2e/global_operator.yaml
@@ -159,7 +159,7 @@ spec:
     metadata:
       annotations:
         # Rename the fields "error" to "error.message" and "source" to "event.source"
-        # This is to avoid a conflict with the ECS "error" and "service" documents.
+        # This is to avoid a conflict with the ECS "error" and "source" documents.
         "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
       labels:
         control-plane: {{ .GlobalOperator.Name }}

--- a/config/e2e/namespace_operator.yaml
+++ b/config/e2e/namespace_operator.yaml
@@ -194,6 +194,8 @@ spec:
   template:
     metadata:
       annotations:
+        # Rename the fields "error" to "error.message" and "source" to "event.source"
+        # This is to avoid a conflict with the ECS "error" and "service" documents.
         "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
       labels:
         control-plane: {{ .NamespaceOperator.Name }}

--- a/config/e2e/namespace_operator.yaml
+++ b/config/e2e/namespace_operator.yaml
@@ -195,7 +195,7 @@ spec:
     metadata:
       annotations:
         # Rename the fields "error" to "error.message" and "source" to "event.source"
-        # This is to avoid a conflict with the ECS "error" and "service" documents.
+        # This is to avoid a conflict with the ECS "error" and "source" documents.
         "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
       labels:
         control-plane: {{ .NamespaceOperator.Name }}

--- a/config/e2e/namespace_operator.yaml
+++ b/config/e2e/namespace_operator.yaml
@@ -193,6 +193,8 @@ spec:
   serviceName: {{ .NamespaceOperator.Name }}
   template:
     metadata:
+      annotations:
+        "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
       labels:
         control-plane: {{ .NamespaceOperator.Name }}
         test-run: {{ $testRun }}

--- a/config/operator/all-in-one/operator.template.yaml
+++ b/config/operator/all-in-one/operator.template.yaml
@@ -15,12 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        "co.elastic.logs/raw": "[{\"type\":\"container\", \"json.keys_under_root\": true, \"paths\": [\"/var/log/containers/*${data.kubernetes.container.id}.log\"], \"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}}]}]"
-        #"co.elastic.logs/json.keys_under_root": "true"
-        #"co.elastic.logs/json.add_error_key": "true"
-        #"co.elastic.logs/json.message_key": "message"
-        #"co.elastic.logs/processors.rename.fields.from": "error"
-        #"co.elastic.logs/processors.rename.fields.to": "error.message"
+        "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
       labels:
         control-plane: elastic-operator
     spec:

--- a/config/operator/all-in-one/operator.template.yaml
+++ b/config/operator/all-in-one/operator.template.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
         # Rename the fields "error" to "error.message" and "source" to "event.source"
-        # This is to avoid a conflict with the ECS "error" and "service" documents.
+        # This is to avoid a conflict with the ECS "error" and "source" documents.
         "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
       labels:
         control-plane: elastic-operator

--- a/config/operator/all-in-one/operator.template.yaml
+++ b/config/operator/all-in-one/operator.template.yaml
@@ -14,6 +14,13 @@ spec:
   serviceName: elastic-operator
   template:
     metadata:
+      annotations:
+        "co.elastic.logs/raw": "[{\"type\":\"container\", \"json.keys_under_root\": true, \"paths\": [\"/var/log/containers/*${data.kubernetes.container.id}.log\"], \"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}}]}]"
+        #"co.elastic.logs/json.keys_under_root": "true"
+        #"co.elastic.logs/json.add_error_key": "true"
+        #"co.elastic.logs/json.message_key": "message"
+        #"co.elastic.logs/processors.rename.fields.from": "error"
+        #"co.elastic.logs/processors.rename.fields.to": "error.message"
       labels:
         control-plane: elastic-operator
     spec:

--- a/config/operator/all-in-one/operator.template.yaml
+++ b/config/operator/all-in-one/operator.template.yaml
@@ -15,6 +15,8 @@ spec:
   template:
     metadata:
       annotations:
+        # Rename the fields "error" to "error.message" and "source" to "event.source"
+        # This is to avoid a conflict with the ECS "error" and "service" documents.
         "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
       labels:
         control-plane: elastic-operator

--- a/config/operator/global/operator.template.yaml
+++ b/config/operator/global/operator.template.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: elastic-global-operator
   template:
     metadata:
+      annotations:
+        "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
       labels:
         control-plane: elastic-global-operator
     spec:

--- a/config/operator/global/operator.template.yaml
+++ b/config/operator/global/operator.template.yaml
@@ -15,6 +15,8 @@ spec:
   template:
     metadata:
       annotations:
+        # Rename the fields "error" to "error.message" and "source" to "event.source"
+        # This is to avoid a conflict with the ECS "error" and "service" documents.
         "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
       labels:
         control-plane: elastic-global-operator

--- a/config/operator/global/operator.template.yaml
+++ b/config/operator/global/operator.template.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
         # Rename the fields "error" to "error.message" and "source" to "event.source"
-        # This is to avoid a conflict with the ECS "error" and "service" documents.
+        # This is to avoid a conflict with the ECS "error" and "source" documents.
         "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
       labels:
         control-plane: elastic-global-operator

--- a/config/operator/namespace/operator.template.yaml
+++ b/config/operator/namespace/operator.template.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
         # Rename the fields "error" to "error.message" and "source" to "event.source"
-        # This is to avoid a conflict with the ECS "error" and "service" documents.
+        # This is to avoid a conflict with the ECS "error" and "source" documents.
         "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
       labels:
         control-plane: elastic-namespace-operator

--- a/config/operator/namespace/operator.template.yaml
+++ b/config/operator/namespace/operator.template.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: elastic-namespace-operator
   template:
     metadata:
+      annotations:
+        "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
       labels:
         control-plane: elastic-namespace-operator
     spec:

--- a/config/operator/namespace/operator.template.yaml
+++ b/config/operator/namespace/operator.template.yaml
@@ -15,6 +15,8 @@ spec:
   template:
     metadata:
       annotations:
+        # Rename the fields "error" to "error.message" and "source" to "event.source"
+        # This is to avoid a conflict with the ECS "error" and "service" documents.
         "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
       labels:
         control-plane: elastic-namespace-operator

--- a/pkg/controller/apmserver/apmserver_controller.go
+++ b/pkg/controller/apmserver/apmserver_controller.go
@@ -175,7 +175,7 @@ var _ driver.Interface = &ReconcileApmServer{}
 // Reconcile reads that state of the cluster for a ApmServer object and makes changes based on the state read
 // and what is in the ApmServer.Spec
 func (r *ReconcileApmServer) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	defer common.LogReconciliationRun(log, request, &r.iteration)()
+	defer common.LogReconciliationRun(log, request, "as_name", &r.iteration)()
 
 	var as apmv1.ApmServer
 	if err := association.FetchWithAssociation(r.Client, request, &as); err != nil {

--- a/pkg/controller/apmserverelasticsearchassociation/apmserverelasticsearchassociation_controller.go
+++ b/pkg/controller/apmserverelasticsearchassociation/apmserverelasticsearchassociation_controller.go
@@ -134,7 +134,7 @@ func (r *ReconcileApmServerElasticsearchAssociation) onDelete(obj types.Namespac
 // Reconcile reads that state of the cluster for a ApmServerElasticsearchAssociation object and makes changes based on the state read
 // and what is in the ApmServerElasticsearchAssociation.Spec
 func (r *ReconcileApmServerElasticsearchAssociation) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	defer common.LogReconciliationRun(log, request, &r.iteration)()
+	defer common.LogReconciliationRun(log, request, "as_name", &r.iteration)()
 
 	var apmServer apmv1.ApmServer
 	if err := association.FetchWithAssociation(r.Client, request, &apmServer); err != nil {

--- a/pkg/controller/common/logging.go
+++ b/pkg/controller/common/logging.go
@@ -13,12 +13,12 @@ import (
 )
 
 // LogReconciliationRun is the common logging function used to record a reconciliation run.
-func LogReconciliationRun(log logr.Logger, request reconcile.Request, iteration *uint64) func() {
+func LogReconciliationRun(log logr.Logger, request reconcile.Request, nameField string, iteration *uint64) func() {
 	currentIteration := atomic.AddUint64(iteration, 1)
 	startTime := time.Now()
-	log.Info("Starting reconciliation run", "iteration", currentIteration, "namespace", request.Namespace, "name", request.Name)
+	log.Info("Starting reconciliation run", "iteration", currentIteration, "namespace", request.Namespace, nameField, request.Name)
 	return func() {
 		totalTime := time.Since(startTime)
-		log.Info("Ending reconciliation run", "iteration", currentIteration, "namespace", request.Namespace, "name", request.Name, "took", totalTime)
+		log.Info("Ending reconciliation run", "iteration", currentIteration, "namespace", request.Namespace, nameField, request.Name, "took", totalTime)
 	}
 }

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -174,7 +174,7 @@ type ReconcileElasticsearch struct {
 // Reconcile reads the state of the cluster for an Elasticsearch object and makes changes based on the state read and
 // what is in the Elasticsearch.Spec
 func (r *ReconcileElasticsearch) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	defer common.LogReconciliationRun(log, request, &r.iteration)()
+	defer common.LogReconciliationRun(log, request, "es_name", &r.iteration)()
 
 	// Fetch the Elasticsearch instance
 	es := esv1.Elasticsearch{}

--- a/pkg/controller/kibana/kibana_controller.go
+++ b/pkg/controller/kibana/kibana_controller.go
@@ -127,7 +127,7 @@ type ReconcileKibana struct {
 // Reconcile reads that state of the cluster for a Kibana object and makes changes based on the state read and what is
 // in the Kibana.Spec
 func (r *ReconcileKibana) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	defer common.LogReconciliationRun(log, request, &r.iteration)()
+	defer common.LogReconciliationRun(log, request, "kibana_name", &r.iteration)()
 
 	// retrieve the kibana object
 	var kb kbv1.Kibana

--- a/pkg/controller/kibanaassociation/association_controller.go
+++ b/pkg/controller/kibanaassociation/association_controller.go
@@ -126,7 +126,7 @@ func (r *ReconcileAssociation) onDelete(obj types.NamespacedName) error {
 // Reconcile reads that state of the cluster for an Association object and makes changes based on the state read and what is in
 // the Association.Spec
 func (r *ReconcileAssociation) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	defer common.LogReconciliationRun(log, request, &r.iteration)()
+	defer common.LogReconciliationRun(log, request, "kibana_name", &r.iteration)()
 
 	var kibana kbv1.Kibana
 	if err := association.FetchWithAssociation(r.Client, request, &kibana); err != nil {

--- a/pkg/controller/license/license_controller.go
+++ b/pkg/controller/license/license_controller.go
@@ -54,7 +54,7 @@ var log = logf.Log.WithName(name)
 // In any case it schedules a new reconcile request to be processed when the license is about to expire.
 // This happens independently from any watch triggered reconcile request.
 func (r *ReconcileLicenses) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	defer common.LogReconciliationRun(log, request, &r.iteration)()
+	defer common.LogReconciliationRun(log, request, "es_name", &r.iteration)()
 	results := r.reconcileInternal(request)
 	current, err := results.Aggregate()
 	log.V(1).Info("Reconcile result", "requeue", current.Requeue, "requeueAfter", current.RequeueAfter)

--- a/pkg/controller/webhook/webhook_certificates_controller.go
+++ b/pkg/controller/webhook/webhook_certificates_controller.go
@@ -47,7 +47,7 @@ type ReconcileWebhookResources struct {
 }
 
 func (r *ReconcileWebhookResources) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	defer common.LogReconciliationRun(log, request, &r.iteration)()
+	defer common.LogReconciliationRun(log, request, "validating_webhook_configuration", &r.iteration)()
 	res := r.reconcileInternal()
 	return res.Aggregate()
 }

--- a/pkg/utils/log/log.go
+++ b/pkg/utils/log/log.go
@@ -20,6 +20,11 @@ import (
 	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
+const (
+	EcsVersion     = "1.4.0"
+	EcsServiceType = "eck"
+)
+
 var verbosity = flag.Int("log-verbosity", 0, "Verbosity level of logs (-2=Error, -1=Warn, 0=Info, >0=Debug)")
 
 // BindFlags attaches logging flags to the given flag set.
@@ -75,8 +80,8 @@ func setLogger(v *int) {
 		encoder = zapcore.NewJSONEncoder(encoderConf)
 		opts = append(opts,
 			zap.Fields(
-				zap.String("service.type", "eck"),
-				zap.String("ecs.version", "1.4.0"),
+				zap.String("service.type", EcsServiceType),
+				zap.String("ecs.version", EcsVersion),
 			))
 	}
 


### PR DESCRIPTION
This PR adds a primitive support for ECS by adding the following fields:

* log.level
* log.logger
* service.type
* service.version

It also adds the required processor as an annotation to avoid a conflict on the `error` key/document and generates the following ECS fields:

* error.message
* error.stack_trace

I think that this PR can be considered as a fix for #2002, however as pointed out in https://github.com/elastic/cloud-on-k8s/issues/2002#issuecomment-576700627 I would open at least 2 others issues to track some additional improvements that can be done to improve our support of ECS. 