### PR TITLE
Clarify Enterprise license requirement in docs

### DIFF
--- a/docs/licensing.asciidoc
+++ b/docs/licensing.asciidoc
@@ -31,6 +31,9 @@ At the end of the trial period, the Platinum and Enterprise features operate in 
 [float]
 === Adding a license
 If you have a valid Enterprise subscription you will receive a license as a JSON file.
+
+NOTE: Please note that ECK will only accept Enterprise licenses. You can not apply a single Platinum or Gold cluster license to ECK.
+
 To add the license to your ECK installation, create a Kubernetes secret of the following form:
 
 [source,yaml]


### PR DESCRIPTION
Added a note to clarify the need for an Enterprise license when installing a license in ECK.