### PR TITLE
ClusterIP type dont have high port 3000-31756,

### DIFF
--- a/docs/accessing-elastic-services.asciidoc
+++ b/docs/accessing-elastic-services.asciidoc
@@ -51,9 +51,9 @@ For each resource, `Elasticsearch`, `Kibana` or `ApmServer`, the operator manage
 > kubectl get svc
 
 NAME                TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)          AGE
-hulk-apm-http       ClusterIP      10.19.212.105   <none>           8200:31000/TCP   1m
-hulk-es-http        ClusterIP      10.19.252.160   <none>           9200:31320/TCP   1m
-hulk-kb-http        ClusterIP      10.19.247.151   <none>           5601:31380/TCP   1m
+hulk-apm-http       ClusterIP      10.19.212.105   <none>           8200/TCP   1m
+hulk-es-http        ClusterIP      10.19.252.160   <none>           9200/TCP   1m
+hulk-kb-http        ClusterIP      10.19.247.151   <none>           5601/TCP   1m
 ----
 
 [float]


### PR DESCRIPTION
If the type of a `Service` is not set to LoadBalancer the NodePort is not displayed.
In "Accessing Elastic Stack services" it is the case in the second example, not in the first.