### PR TITLE
Always go generate when building the operator binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY cmd/    cmd/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+		go generate -tags="$GO_TAGS" ./pkg/... ./cmd/... && \
 		go build \
             -mod readonly \
 			-ldflags "$GO_LDFLAGS" -tags="$GO_TAGS" -a \


### PR DESCRIPTION
Always execute `go generate -tags="$GO_TAGS" ./pkg/... ./cmd/...` when building the operator binary to not forget to call this command (which is currently hidden in the make target `generate`).

As `go generate` must be executed when `$GO_TAGS` is equals to `release` to generate the license public key:

https://github.com/elastic/cloud-on-k8s/blob/cc0e96d22fa56066f7d97723ac11bd763fced95c/pkg/controller/common/license/pubkey.go#L5-L6

Relates to #1096.