### PR TITLE
Override GKE Pods CIDR IP range to allow more clusters to be created

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -26,6 +26,12 @@ plans:
     adminUsername: admin
     localSsdCount: 1
     nodeCountPerZone: 1
+    # gke creates a secondary IP range for all Pods of a cluster
+    # it defaults to a /14 subnet, which allows 262k Pods per cluster, but only 62 subnets to be created
+    # /20 allows 4094 subnets, with up to 4094 IPs (Pods) per subnet
+    # more clusters can therefore be created in the same VPC network
+    clusterIpv4Cidr: /20
+    servicesIpv4Cidr: /20
     gcpScopes: https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append
 - id: aks-ci
   operation: create

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -167,17 +167,17 @@ func (d *GkeDriver) clusterExists() (bool, error) {
 
 func (d *GkeDriver) create() error {
 	log.Println("Creating cluster...")
-	pspOption := ""
+
+	opts := []string{}
 	if d.plan.Psp {
-		pspOption = "--enable-pod-security-policy "
+		opts = append(opts, "--enable-pod-security-policy")
 	}
 
-	cidrOptions := ""
 	if d.plan.Gke.ClusterIPv4CIDR != "" {
-		cidrOptions += fmt.Sprintf("--cluster-ipv4-cidr=%s ", d.plan.Gke.ClusterIPv4CIDR)
+		opts = append(opts, fmt.Sprintf("--cluster-ipv4-cidr=%s ", d.plan.Gke.ClusterIPv4CIDR))
 	}
 	if d.plan.Gke.ServicesIPv4CIDR != "" {
-		cidrOptions += fmt.Sprintf("--services-ipv4-cidr=%s ", d.plan.Gke.ServicesIPv4CIDR)
+		opts = append(opts, fmt.Sprintf("--services-ipv4-cidr=%s ", d.plan.Gke.ServicesIPv4CIDR))
 	}
 
 	return NewCommand(`gcloud beta container --project {{.GCloudProject}} clusters create {{.ClusterName}} ` +
@@ -188,7 +188,7 @@ func (d *GkeDriver) create() error {
 		`--no-enable-autoupgrade --no-enable-autorepair --enable-ip-alias --metadata disable-legacy-endpoints=true ` +
 		`--network projects/{{.GCloudProject}}/global/networks/default ` +
 		`--subnetwork projects/{{.GCloudProject}}/regions/{{.Region}}/subnetworks/default ` +
-		cidrOptions + pspOption).
+		strings.Join(opts, " ")).
 		AsTemplate(d.ctx).
 		Run()
 }

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -47,6 +47,8 @@ type GkeSettings struct {
 	LocalSsdCount    int    `yaml:"localSsdCount"`
 	NodeCountPerZone int    `yaml:"nodeCountPerZone"`
 	GcpScopes        string `yaml:"gcpScopes"`
+	ClusterIPv4CIDR  string `yaml:"clusterIpv4Cidr"`
+	ServicesIPv4CIDR string `yaml:"servicesIpv4Cidr"`
 }
 
 // AksSettings encapsulates settings specific to AKS


### PR DESCRIPTION
For each k8s cluster, GKE creates 2 additional secondary IP ranges:
- a /14 range for Pods (262k Pods per cluster)
- a /20 range for Services (4094 Services per cluster)

The downside of using the default /14 range is that there are only 62
possible /64 ranges that can be created.
Overriding it to /20 allows up to 4094 of those subnets to be defined instead,
with up to 4094 Pods per cluster.

I hope this mitigates the IP range hard limit we sometimes hit against
our default GKE VPC.

Both Pods CIDR range and Services CIDR range can now be overridden through
the gke settings in the deployer.

Should help with https://github.com/elastic/cloud-on-k8s/issues/2461.