### PR TITLE
Allow webhook cert directory to be overridden

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -145,7 +145,7 @@ func init() {
 	Cmd.Flags().String(
 		WebhookSecretFlag,
 		"",
-		fmt.Sprintf("K8s secret mounted into to the path designed by %s to be used for webhook certificates", WebhookCertDirFlag),
+		fmt.Sprintf("K8s secret mounted into the path designated by %s to be used for webhook certificates", WebhookCertDirFlag),
 	)
 	Cmd.Flags().String(
 		WebhookCertDirFlag,

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -67,6 +67,7 @@ const (
 
 	ManageWebhookCertsFlag   = "manage-webhook-certs"
 	WebhookSecretFlag        = "webhook-secret"
+	WebhookCertDirFlag       = "webhook-cert-dir"
 	WebhookConfigurationName = "elastic-webhook.k8s.elastic.co"
 	WebhookPort              = 9443
 
@@ -134,17 +135,23 @@ func init() {
 	Cmd.Flags().Bool(
 		ManageWebhookCertsFlag,
 		true,
-		"enables automatic certificates management for the webhook. The Secret and the ValidatingWebhookConfiguration must be created before running the operator",
+		"Enables automatic certificates management for the webhook. The Secret and the ValidatingWebhookConfiguration must be created before running the operator",
 	)
 	Cmd.Flags().String(
 		OperatorNamespaceFlag,
 		"",
-		"k8s namespace the operator runs in",
+		"K8s namespace the operator runs in",
 	)
 	Cmd.Flags().String(
 		WebhookSecretFlag,
 		"",
-		"k8s secret mounted into /tmp/cert to be used for webhook certificates",
+		fmt.Sprintf("K8s secret mounted into to the path designed by %s to be used for webhook certificates", WebhookCertDirFlag),
+	)
+	Cmd.Flags().String(
+		WebhookCertDirFlag,
+		// this is controller-runtime's own default, copied here for making the default explicit when using `--help`
+		filepath.Join(os.TempDir(), "k8s-webhook-server", "serving-certs"),
+		"Path to the directory that contains the webhook server key and certificate",
 	)
 	Cmd.Flags().String(
 		DebugHTTPServerListenAddressFlag,
@@ -221,7 +228,8 @@ func execute() {
 	// Create a new Cmd to provide shared dependencies and start components
 	log.Info("Setting up manager")
 	opts := ctrl.Options{
-		Scheme: clientgoscheme.Scheme,
+		Scheme:  clientgoscheme.Scheme,
+		CertDir: viper.GetString(WebhookCertDirFlag),
 	}
 
 	// configure the manager cache based on the number of managed namespaces

--- a/docs/operator-config.asciidoc
+++ b/docs/operator-config.asciidoc
@@ -26,7 +26,7 @@ ECK can be configured using either command line flags or environment variables.
 |operator-namespace |"" |Namespace the operator runs in. Required.
 |operator-roles |all |Roles this operator should assume. Valid values are `namespace`, `global`, `webhook` or `all`. Accepts multiple comma separated values.
 |webhook-pods-label |"" |Label used to select pods running the webhook server.
-|webhook-secret |"" | Kubernetes secret containing the webhook certificates.
+|webhook-secret |"" | K8s secret mounted into the path designated by webhook-cert-dir to be used for webhook certificates.
 |webhook-cert-dir |"{TempDir}/k8s-webhook-server/serving-certs" |Path to the directory that contains the webhook server key and certificate.
 |===
 

--- a/docs/operator-config.asciidoc
+++ b/docs/operator-config.asciidoc
@@ -27,6 +27,7 @@ ECK can be configured using either command line flags or environment variables.
 |operator-roles |all |Roles this operator should assume. Valid values are `namespace`, `global`, `webhook` or `all`. Accepts multiple comma separated values.
 |webhook-pods-label |"" |Label used to select pods running the webhook server.
 |webhook-secret |"" | Kubernetes secret containing the webhook certificates.
+|webhook-cert-dir |"{TempDir}/k8s-webhook-server/serving-certs" |Path to the directory that contains the webhook server key and certificate.
 |===
 
 


### PR DESCRIPTION
Set a new `--webhook-cert-dir` flag that allows overriding the path to
the webhook certificates, most likely mounted from a Secret.

It's intended to be used this way:

```
args: ["manager", "--operator-roles", "all",
"--webhook-cert-dir=/tmp/whatever"]
```

(or by overriding the equivalent environment variable)

And the corresponding secret mount:

```
volumeMounts:
  - mountPath: /tmp/whatever
    name: cert
    readOnly: true
```

Fixes https://github.com/elastic/cloud-on-k8s/issues/2463.