### PR TITLE
Make go-generate reusable for kind-e2e

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ COPY cmd/    cmd/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
-		go generate -tags="$GO_TAGS" ./pkg/... ./cmd/... && \
 		go build \
             -mod readonly \
 			-ldflags "$GO_LDFLAGS" -tags="$GO_TAGS" -a \

--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,11 @@ dependencies:
 ALL_CRDS=config/crds/all-crds.yaml
 generate: generate-crds generate-api-docs generate-notice-file
 
-generate-crds: controller-gen
+go-generate:
 	# we use this in pkg/controller/common/license
 	go generate -tags='$(GO_TAGS)' ./pkg/... ./cmd/...
+
+generate-crds: go-generate controller-gen
 	$(CONTROLLER_GEN) webhook object:headerFile=./hack/boilerplate.go.txt paths=./pkg/apis/...
 	# Generate manifests e.g. CRD, RBAC etc.
 	# We generate CRDs with trivialVersions=true, to support pre-1.13 Kubernetes versions. This means the CRDs
@@ -479,7 +481,7 @@ ifneq ($(ECK_IMAGE),)
 	$(eval OPERATOR_IMAGE=$(ECK_IMAGE))
 	@docker pull $(OPERATOR_IMAGE)
 else
-	$(MAKE) docker-build
+	$(MAKE) go-generate docker-build
 endif
 
 kind-e2e: export KUBECONFIG = ${HOME}/.kube/kind-config-eck-e2e


### PR DESCRIPTION
Revert  507d134 (#2469) and move the `go generate` command in a new `go-generate` target to make it reusable in `set-kind-e2e-image` where it misses before building the operator.

That's one more make target but that seems the cleanest way for https://github.com/elastic/cloud-on-k8s/issues/1096#issuecomment-578191699.

Relates to #1096.