### PR TITLE
Upgrade kind and kind nodes versions

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -1,19 +1,22 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
-# This script used to "bake" Docker images into base image for Jenkins nodes.
+# This script is used to pre-pull Docker images into the immutable image of Jenkins workers.
 
 set -eou pipefail
 
-DOCKER_CI_IMAGE=$(cd build/ci/ && make show-image)
+# ECK CI tooling image
+docker pull $(make -C build/ci --no-print-directory show-image)
 
-declare -a docker_images=("$DOCKER_CI_IMAGE" "kindest/node:v1.11.10" "kindest/node:v1.15.3" "kindest/node:v1.16.2" "docker.elastic.co/elasticsearch/elasticsearch:7.4.0" "docker.elastic.co/kibana/kibana:7.4.0" "docker.elastic.co/apm/apm-server:7.4.0")
+# Kind images (https://hub.docker.com/r/kindest/node/tags)
+docker pull kindest/node:v1.12.10
+docker pull kindest/node:v1.16.4
+docker pull kindest/node:v1.17.0
 
-# Pull all the required docker images
-for image in "${docker_images[@]}"
-do
-  docker pull "$image"
-done
+# Elastic Stack images
+docker pull docker.elastic.co/elasticsearch/elasticsearch:7.4.0
+docker pull docker.elastic.co/kibana/kibana:7.4.0
+docker pull docker.elastic.co/apm/apm-server:7.4.0

--- a/build/ci/Dockerfile
+++ b/build/ci/Dockerfile
@@ -7,7 +7,7 @@ ENV KUBECTL_VERSION=1.14.7
 ENV DOCKER_VERSION=18.03.1-ce
 ENV GOLANGCILINT_VERSION=1.21.0
 ENV GOTESTSUM_VERSION=0.3.5
-ENV KIND_VERSION=0.5.1
+ENV KIND_VERSION=0.7.0
 
 # Install golangci-lint
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh \

--- a/build/ci/e2e/vanilla_k8s.jenkinsfile
+++ b/build/ci/e2e/vanilla_k8s.jenkinsfile
@@ -28,28 +28,28 @@ pipeline {
         }
         stage('Run tests on different versions of vanilla K8s') {
             parallel {
-                stage("1.11.10") {
+                stage("1.12.10") {
                     steps {
                         checkout scm
-                        runTests("kindest/node:v1.11.10")
+                        runTests("kindest/node:v1.12.10")
                     }
                 }
-                stage("1.15.3") {
+                stage("1.16.4") {
                     agent {
                         label 'eck'
                     }
                     steps {
                         checkout scm
-                        runTests("kindest/node:v1.15.3")
+                        runTests("kindest/node:v1.16.4")
                     }
                 }
-                stage("1.16.2") {
+                stage("1.17.0") {
                     agent {
                         label 'eck'
                     }
                     steps {
                         checkout scm
-                        runTests("kindest/node:v1.16.2")
+                        runTests("kindest/node:v1.17.0")
                     }
                 }
             }

--- a/build/ci/e2e/vanilla_k8s.jenkinsfile
+++ b/build/ci/e2e/vanilla_k8s.jenkinsfile
@@ -27,6 +27,7 @@ pipeline {
             }
         }
         stage('Run tests on different versions of vanilla K8s') {
+            // Do not forget to keep in sync the kind node image versions in `.ci/packer_cache.sh`.
             parallel {
                 stage("1.12.10") {
                     steps {


### PR DESCRIPTION
* Upgrade `kind` to the `0.7.0` version, to be on the latest version and to be in phase with the new setup brought in #2295
* Take this opportunity to upgrade the k8s versions tested with `kind`: replace `1.11, 1.15, 1.16` by `1.12, 1.16, 1.17`:

  * the cloud-on-k8s-versions-gke job tests the `1.13, 1.14 and 1.15` versions on gke
  * the minimal supported version is 1.12 since #1739

Kind node versions can be found in [the kind release notes](https://github.com/kubernetes-sigs/kind/releases) or by looking at the tags on the [docker hub](https://hub.docker.com/r/kindest/node/tags):
```sh
> curl https://github.com/kubernetes-sigs/kind/releases -s | grep -o 'v[0-9\.]* @'
v1.17.0 @
v1.16.4 @
v1.15.7 @
v1.14.10 @
v1.13.12 @
v1.12.10 @
v1.11.10 @
```

Relates to #1096.