### PR TITLE
Setup e2e tests to run with filebeat logging to e2e monitor cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ license.key
 # test licenses used in the E2E tests
 test-license.json
 
+# Monitoring secrets
+monitoring-secrets.json
+
 # generated from merging multiple files in the Makefile
 config/all-in-one.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -374,7 +374,8 @@ e2e-run:
 		--elastic-stack-version=$(STACK_VERSION) \
 		--log-verbosity=$(LOG_VERBOSITY) \
 		--log-to-file=$(E2E_JSON) \
-		--test-timeout=$(TEST_TIMEOUT)
+		--test-timeout=$(TEST_TIMEOUT) \
+		--monitoring-secrets=$(MONITORING_SECRETS)
 
 e2e-generate-xml:
 	@ gotestsum --junitfile e2e-tests.xml --raw-command cat e2e-tests.json

--- a/build/ci/Makefile
+++ b/build/ci/Makefile
@@ -69,3 +69,6 @@ get-test-license:
 
 get-docker-creds:
 	@ echo "ELASTIC_DOCKER_PASSWORD = $(shell VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=value secret/devops-ci/cloud-on-k8s/eckadmin)" >> ../../.env
+
+get-monitoring-secrets:
+	@ VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=data -format=json secret/devops-ci/cloud-on-k8s/monitoring-cluster > monitoring-secrets.json

--- a/build/ci/e2e/Jenkinsfile
+++ b/build/ci/e2e/Jenkinsfile
@@ -59,6 +59,7 @@ GO_TAGS = release
 export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/build/ci/license.key
 IMG_SUFFIX = -ci
 E2E_JSON = true
+MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/build/ci/monitoring-secrets.json
 EOF
                     cat >deployer-config.yml <<EOF
 id: gke-ci
@@ -73,7 +74,7 @@ overrides:
 EOF
                 """
                 script {
-                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci get-test-license get-elastic-public-key TARGET=ci-e2e ci')
+                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C build/ci get-monitoring-secrets get-test-license get-elastic-public-key TARGET=ci-e2e ci')
 
                     sh 'make -C build/ci TARGET=e2e-generate-xml ci'
                     junit "e2e-tests.xml"

--- a/config/dev/elastic-psp.yaml
+++ b/config/dev/elastic-psp.yaml
@@ -46,3 +46,54 @@
         - min: 1
           max: 65535
     readOnlyRootFilesystem: false
+---
+  apiVersion: policy/v1beta1
+  kind: PodSecurityPolicy
+  metadata:
+    name: elastic.filebeat.restricted
+    annotations:
+      seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+      apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+      seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+      apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+  spec:
+    privileged: false
+    # Required to prevent escalations to root.
+    allowPrivilegeEscalation: false
+    # This is redundant with non-root + disallow privilege escalation,
+    # but we can provide it for defense in depth.
+    requiredDropCapabilities:
+      - ALL
+    # Allow core volume types.
+    volumes:
+      - 'configMap'
+      - 'emptyDir'
+      - 'projected'
+      - 'secret'
+      - 'downwardAPI'
+      # Assume that persistentVolumes set up by the cluster admin are safe to use.
+      - 'persistentVolumeClaim'
+      # Allow access to the host for log files.
+      - 'hostPath'
+    hostNetwork: true
+    hostIPC: false
+    hostPID: false
+    runAsUser:
+      # Allow the container to run with root privileges.
+      rule: 'RunAsAny'
+    seLinux:
+      # This policy assumes the nodes are using AppArmor rather than SELinux.
+      rule: 'RunAsAny'
+    supplementalGroups:
+      rule: 'MustRunAs'
+      ranges:
+        # Forbid adding the root group.
+        - min: 1
+          max: 65535
+    fsGroup:
+      rule: 'MustRunAs'
+      ranges:
+        # Forbid adding the root group.
+        - min: 1
+          max: 65535
+    readOnlyRootFilesystem: false

--- a/config/dev/elastic-psp.yaml
+++ b/config/dev/elastic-psp.yaml
@@ -47,6 +47,7 @@
           max: 65535
     readOnlyRootFilesystem: false
 ---
+  # PSP needed for DaemonSet running Filebeat. Allows for hostNetwork, running as root and using hostPath volume type.
   apiVersion: policy/v1beta1
   kind: PodSecurityPolicy
   metadata:
@@ -79,7 +80,7 @@
     hostIPC: false
     hostPID: false
     runAsUser:
-      # Allow the container to run with root privileges.
+      # Allow the container to run as root.
       rule: 'RunAsAny'
     seLinux:
       # This policy assumes the nodes are using AppArmor rather than SELinux.

--- a/config/e2e/filebeat.yaml
+++ b/config/e2e/filebeat.yaml
@@ -1,0 +1,191 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: filebeat-config
+  namespace: {{ .E2ENamespace }}
+  labels:
+    k8s-app: filebeat
+data:
+  filebeat.yml: |-
+    filebeat.autodiscover:
+      providers:
+        - type: kubernetes
+          host: ${NODE_NAME}
+          hints.enabled: true
+          hints.default_config:
+            type: container
+            paths:
+              - /var/lib/docker/containers/${data.kubernetes.container.id}/*.log
+
+    processors:
+      - add_cloud_metadata:
+      - add_host_metadata:
+
+    output.elasticsearch:
+      hosts: ['https://${MONITORING_IP}:${ELASTICSEARCH_PORT}']
+      username: ${MONITORING_USER}
+      password: ${MONITORING_PASS}
+      ssl.certificate_authorities:
+      - /mnt/elastic/monitoring-ca.crt
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: filebeat
+  namespace: {{ .E2ENamespace }}
+  labels:
+    k8s-app: filebeat
+spec:
+  selector:
+    matchLabels:
+      k8s-app: filebeat
+  template:
+    metadata:
+      labels:
+        k8s-app: filebeat
+    spec:
+      serviceAccountName: filebeat
+      terminationGracePeriodSeconds: 30
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: filebeat
+          image: docker.elastic.co/beats/filebeat:7.5.1
+          args: [
+            "-c", "/etc/filebeat.yml",
+            "-e",
+          ]
+          env:
+            - name: ELASTICSEARCH_HOST
+              value: monitor-es-http
+            - name: ELASTICSEARCH_PORT
+              value: "9200"
+            - name: MONITORING_USER
+              valueFrom:
+                secretKeyRef:
+                  name: "eck-{{ .TestRun }}"
+                  key: monitoring-user
+            - name: MONITORING_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: "eck-{{ .TestRun }}"
+                  key: monitoring-pass
+            - name: MONITORING_IP
+              valueFrom:
+                secretKeyRef:
+                  name: "eck-{{ .TestRun }}"
+                  key: monitoring-ip
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            runAsUser: 0
+            # If using Red Hat OpenShift uncomment this:
+            #privileged: true
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/filebeat.yml
+              readOnly: true
+              subPath: filebeat.yml
+            - name: data
+              mountPath: /usr/share/filebeat/data
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: monitoring-ca
+              mountPath: /mnt/elastic/monitoring-ca.crt
+              readOnly: true
+              subPath: monitoring-ca
+      volumes:
+        - name: config
+          configMap:
+            defaultMode: 0600
+            name: filebeat-config
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        # data folder stores a registry of read status for all files, so we don't send everything again on a Filebeat pod restart
+        - name: data
+          hostPath:
+            path: /var/lib/filebeat-data
+            type: DirectoryOrCreate
+        - name: monitoring-ca
+          secret:
+            secretName: "eck-{{ .TestRun }}"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: filebeat
+subjects:
+  - kind: ServiceAccount
+    name: filebeat
+    namespace: {{ .E2ENamespace }}
+roleRef:
+  kind: ClusterRole
+  name: filebeat
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: filebeat
+  labels:
+    k8s-app: filebeat
+rules:
+  - apiGroups: [""] # "" indicates the core API group
+    resources:
+      - namespaces
+      - pods
+    verbs:
+      - get
+      - watch
+      - list
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: filebeat
+  namespace: {{ .E2ENamespace }}
+  labels:
+    k8s-app: filebeat
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: elastic-filebeat-restricted
+  namespace: {{ .E2ENamespace }}
+  labels:
+    test-run: {{ .TestRun }}
+rules:
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - elastic.filebeat.restricted
+    verbs:
+      - use
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: elastic-filebeat-restricted-binding
+  namespace: {{ .E2ENamespace }}
+  labels:
+    test-run: {{ .TestRun }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: elastic-filebeat-restricted
+subjects:
+  - kind: ServiceAccount
+    name: filebeat

--- a/config/e2e/filebeat.yaml
+++ b/config/e2e/filebeat.yaml
@@ -51,7 +51,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: filebeat
-          image: docker.elastic.co/beats/filebeat:7.5.1
+          image: docker.elastic.co/beats/filebeat:7.5.2
           args: [
             "-c", "/etc/filebeat.yml",
             "-e",

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -73,3 +73,17 @@ plans:
   ocp:
     region: europe-west1
     nodeCount: 3
+- id: e2e-monitor
+  operation: create
+  clusterName: e2e-monitor
+  provider: gke
+  kubernetesVersion: 1.15
+  machineType: n1-standard-8
+  serviceAccount: false
+  psp: false
+  gke:
+    region: europe-west2
+    adminUsername: admin
+    localSsdCount: 1
+    nodeCountPerZone: 1
+    gcpScopes: https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append

--- a/test/e2e/cmd/run/command.go
+++ b/test/e2e/cmd/run/command.go
@@ -30,6 +30,7 @@ type runFlags struct {
 	scratchDirRoot        string
 	testRegex             string
 	testRunName           string
+	monitoringSecrets     string
 	commandTimeout        time.Duration
 	autoPortForwarding    bool
 	skipCleanup           bool
@@ -74,6 +75,7 @@ func Command() *cobra.Command {
 	cmd.Flags().BoolVar(&flags.skipCleanup, "skip-cleanup", false, "Do not run cleanup actions after test run")
 	cmd.Flags().StringVar(&flags.testContextOutPath, "test-context-out", "", "Write the test context to the given path")
 	cmd.Flags().StringVar(&flags.testLicense, "test-license", "", "Test license to apply")
+	cmd.Flags().StringVar(&flags.monitoringSecrets, "monitoring-secrets", "", "Monitoring secrets to use")
 	cmd.Flags().StringVar(&flags.scratchDirRoot, "scratch-dir", "/tmp/eck-e2e", "Path under which temporary files should be created")
 	cmd.Flags().StringVar(&flags.testRegex, "test-regex", "", "Regex to pass to the test runner")
 	cmd.Flags().StringVar(&flags.testRunName, "test-run-name", randomTestRunName(), "Name of this test run")

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -248,7 +248,7 @@ func (h *helper) deployNamespaceOperator() error {
 
 func (h *helper) deployFilebeat() error {
 	if h.monitoringSecrets == "" {
-		log.Info("Not deploying filebeat")
+		log.Info("No monitoring secrets provided, filebeat is not deployed")
 		return nil
 	}
 

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -191,7 +191,7 @@ func (h *helper) initTestSecrets() error {
 		}
 
 		monitoringSecrets := struct {
-			MonitoringIp   string `json:"monitoringIp"` //nolint
+			MonitoringIP   string `json:"monitoringIp"`
 			MonitoringUser string `json:"monitoringUser"`
 			MonitoringPass string `json:"monitoringPass"`
 			MonitoringCa   string `json:"monitoringCa"`
@@ -201,7 +201,7 @@ func (h *helper) initTestSecrets() error {
 			return err
 		}
 
-		h.testSecrets["monitoring-ip"] = monitoringSecrets.MonitoringIp //nolint
+		h.testSecrets["monitoring-ip"] = monitoringSecrets.MonitoringIP
 		h.testSecrets["monitoring-user"] = monitoringSecrets.MonitoringUser
 		h.testSecrets["monitoring-pass"] = monitoringSecrets.MonitoringPass
 		h.testSecrets["monitoring-ca"] = monitoringSecrets.MonitoringCa

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -67,6 +67,7 @@ func doRun(flags runFlags) error {
 			helper.createManagedNamespaces,
 			helper.deployGlobalOperator,
 			helper.deployNamespaceOperator,
+			helper.deployFilebeat,
 			helper.deployTestJob,
 			helper.runTestJob,
 		}
@@ -143,6 +144,7 @@ func (h *helper) initTestContext() error {
 		},
 		OperatorImage:         h.operatorImage,
 		TestLicense:           h.testLicense,
+		MonitoringSecrets:     h.monitoringSecrets,
 		TestRegex:             h.testRegex,
 		TestRun:               h.testRunName,
 		TestTimeout:           h.testTimeout,
@@ -181,6 +183,30 @@ func (h *helper) initTestSecrets() error {
 		h.testSecrets["test-license.json"] = string(bytes)
 		h.testContext.TestLicense = "/var/run/secrets/e2e/test-license.json"
 	}
+
+	if h.monitoringSecrets != "" {
+		bytes, err := ioutil.ReadFile(h.monitoringSecrets)
+		if err != nil {
+			return err
+		}
+
+		monitoringSecrets := struct {
+			MonitoringIp   string `json:"monitoringIp"` //nolint
+			MonitoringUser string `json:"monitoringUser"`
+			MonitoringPass string `json:"monitoringPass"`
+			MonitoringCa   string `json:"monitoringCa"`
+		}{}
+
+		if err := json.Unmarshal(bytes, &monitoringSecrets); err != nil {
+			return err
+		}
+
+		h.testSecrets["monitoring-ip"] = monitoringSecrets.MonitoringIp //nolint
+		h.testSecrets["monitoring-user"] = monitoringSecrets.MonitoringUser
+		h.testSecrets["monitoring-pass"] = monitoringSecrets.MonitoringPass
+		h.testSecrets["monitoring-ca"] = monitoringSecrets.MonitoringCa
+	}
+
 	return nil
 }
 
@@ -218,6 +244,16 @@ func (h *helper) deployGlobalOperator() error {
 func (h *helper) deployNamespaceOperator() error {
 	log.Info("Deploying namespace operator")
 	return h.kubectlApplyTemplateWithCleanup("config/e2e/namespace_operator.yaml", h.testContext)
+}
+
+func (h *helper) deployFilebeat() error {
+	if h.monitoringSecrets == "" {
+		log.Info("Not deploying filebeat")
+		return nil
+	}
+
+	log.Info("Deploying filebeat")
+	return h.kubectlApplyTemplateWithCleanup("config/e2e/filebeat.yaml", h.testContext)
 }
 
 func (h *helper) deployTestJob() error {

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -92,6 +92,7 @@ type Context struct {
 	TestLicense           string            `json:"test_license"`
 	TestRegex             string            `json:"test_regex"`
 	TestRun               string            `json:"test_run"`
+	MonitoringSecrets     string            `json:"monitoring_secrets"`
 	TestTimeout           time.Duration     `json:"test_timeout"`
 	AutoPortForwarding    bool              `json:"auto_port_forwarding"`
 	Local                 bool              `json:"local"`


### PR DESCRIPTION
This PR:
- allows instrumenting in-cluster E2E test runs with Filebeat
- enables this instrumentation for the main E2E test

Data needed by Filebeat to output the logs is stored in Vault and accessed when preparing the run.

Resolves https://github.com/elastic/cloud-on-k8s/issues/2270.