### PR TITLE
Clean before execute e2e-run with kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -488,7 +488,7 @@ kind-e2e: kind-node-variable-check set-kind-e2e-image e2e-docker-build
 	./hack/kind/kind.sh \
 		--load-images $(OPERATOR_IMAGE),$(E2E_IMG) \
 		--nodes 3 \
-		make e2e-run OPERATOR_IMAGE=$(OPERATOR_IMAGE)
+		make clean e2e-run OPERATOR_IMAGE=$(OPERATOR_IMAGE)
 
 ## Cleanup
 delete-kind:


### PR DESCRIPTION
This is to remove irrelevant/build-breaking generated public
keys that could fail the compilation during `go test`.

More info here: https://github.com/elastic/cloud-on-k8s/issues/1096#issuecomment-581521890.

Resolves #1096.