### PR TITLE
Add log for cert timeout (#2477)

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -426,6 +426,7 @@ func setupWebhook(mgr manager.Manager, certRotation certificates.RotationParams,
 	})
 
 	if err != nil {
+		log.Error(err, "Timeout elapsed waiting for webhook certificate to be available", "path", keyPath, "timeout_seconds", timeout.Seconds())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Backport this essential fix from https://github.com/elastic/cloud-on-k8s/pull/2477 for 1.0.1