### PR TITLE
Always clean before e2e-docker-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,10 +356,10 @@ E2E_JSON ?= false
 TEST_TIMEOUT ?= 5m
 
 # Run e2e tests as a k8s batch job
-# clean between operator build and e2e build to remove irrelevant/build-breaking generated public keys
-e2e: build-operator-image clean e2e-docker-build e2e-docker-push e2e-run
+e2e: build-operator-image e2e-docker-build e2e-docker-push e2e-run
 
-e2e-docker-build:
+# clean to remove irrelevant/build-breaking generated public keys
+e2e-docker-build: clean
 	docker build --build-arg E2E_JSON=$(E2E_JSON) -t $(E2E_IMG) -f test/e2e/Dockerfile .
 
 e2e-docker-push:
@@ -488,7 +488,7 @@ kind-e2e: kind-node-variable-check set-kind-e2e-image e2e-docker-build
 	./hack/kind/kind.sh \
 		--load-images $(OPERATOR_IMAGE),$(E2E_IMG) \
 		--nodes 3 \
-		make clean e2e-run OPERATOR_IMAGE=$(OPERATOR_IMAGE)
+		make e2e-run OPERATOR_IMAGE=$(OPERATOR_IMAGE)
 
 ## Cleanup
 delete-kind:


### PR DESCRIPTION
The `.../license/zz_generated.pubkey.go` file (generated during the operator build) is present in the Docker container used to run the e2e job.

This container uses the image built with `e2e-docker-build`. So, we need to call `clean` before `e2e-docker-build` and not before `e2e-run`.

Let's attach `clean` to `e2e-docker-build` to benefit `ci-e2e` and `kind-e2e`.

Resolves https://github.com/elastic/cloud-on-k8s/issues/1096#issuecomment-581829566.