### PR TITLE
Enable dump upload on cloud-on-k8s-versions-vanilla job

### DIFF
--- a/build/ci/e2e/vanilla_k8s.jenkinsfile
+++ b/build/ci/e2e/vanilla_k8s.jenkinsfile
@@ -1,5 +1,5 @@
 def failedTests = []
-def testScript
+def lib
 
 pipeline {
 
@@ -22,7 +22,7 @@ pipeline {
         stage('Load common scripts') {
             steps {
                 script {
-                    testScript = load "build/ci/common/tests.groovy"
+                    lib = load "build/ci/common/tests.groovy"
                 }
             }
         }
@@ -32,7 +32,9 @@ pipeline {
                 stage("1.12.10") {
                     steps {
                         checkout scm
-                        runTests("kindest/node:v1.12.10")
+                        script {
+                            runTests(lib, failedTests, "kindest/node:v1.12.10")
+                        }
                     }
                 }
                 stage("1.16.4") {
@@ -41,7 +43,9 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runTests("kindest/node:v1.16.4")
+                        script {
+                            runTests(lib, failedTests, "kindest/node:v1.16.4")
+                        }
                     }
                 }
                 stage("1.17.0") {
@@ -50,7 +54,9 @@ pipeline {
                     }
                     steps {
                         checkout scm
-                        runTests("kindest/node:v1.17.0")
+                        script {
+                            runTests(lib, failedTests, "kindest/node:v1.17.0")
+                        }
                     }
                 }
             }
@@ -80,7 +86,7 @@ pipeline {
 
 }
 
-def runTests(kindImage) {
+def runTests(lib, failedTests, kindImage) {
     sh """
         cat >.env <<EOF
 OPERATOR_IMAGE = ${IMAGE}
@@ -102,7 +108,12 @@ EOF
         junit "e2e-tests.xml"
 
         if (env.SHELL_EXIT_CODE != 0) {
-            failedTests.addAll(testScript.getListOfFailedTests())
+            failedTests.addAll(lib.getListOfFailedTests())
+            googleStorageUpload bucket: "gs://devops-ci-artifacts/jobs/$JOB_NAME/$BUILD_NUMBER",
+                credentialsId: "devops-ci-gcs-plugin",
+                pattern: "*.tgz",
+                sharedPublicly: true,
+                showInline: true
         }
 
         sh 'exit $SHELL_EXIT_CODE'


### PR DESCRIPTION
This commit enables the dump upload when the `cloud-on-k8s-versions-vanilla ` job fails.
It's the last job that didn't have it yet.

And brings 2 fixes:
* Call the `runTests` method in a `script` block (like #2127)
* Pass the loaded `lib` and the `failedTests` variable in parameter to `runTests` (like #2114)

