### PR TITLE
Make use of secure port when accessing Kubelet API

### DIFF
--- a/config/recipes/beats/3_metricbeat-kubernetes.yaml
+++ b/config/recipes/beats/3_metricbeat-kubernetes.yaml
@@ -75,11 +75,11 @@ data:
         - volume
       period: 10s
       host: ${NODE_NAME}
-      hosts: ["localhost:10255"]
-      # If using Red Hat OpenShift remove the previous hosts entry and 
+      hosts: ["https://${HOSTNAME}:10250"]
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      ssl.verification_mode: "none"
+      # If using Red Hat OpenShift remove ssl.verification_mode entry and
       # uncomment these settings:
-      #hosts: ["https://${HOSTNAME}:10250"]
-      #bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       #ssl.certificate_authorities:
         #- /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
     - module: kubernetes


### PR DESCRIPTION
## What does this PR do?

This PR switches Metricbeat k8s manifests and docs to point to Kubelet secure port over https instead of the insecure port.

## Why is it important?

Insecure port of Kubelet (10255/TCP) is now less common and discouraged and also in most cases it is not enabled by default (requiring to restart `kubelet` with `--read-only-port` flag)

Related to https://github.com/elastic/beats/pull/16063