### PR TITLE
Fix the name of the default e2e storage class for Kind

### DIFF
--- a/hack/kind/local-path-storage.yaml
+++ b/hack/kind/local-path-storage.yaml
@@ -86,7 +86,7 @@ kind: StorageClass
 metadata:
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
-  name: local-path
+  name: e2e-default
 provisioner: rancher.io/local-path
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete


### PR DESCRIPTION
This commit renames the default storage class created by [`hack/kind.sh`](https://github.com/elastic/cloud-on-k8s/blob/4ad5d7f79b30d1384ad111693a6121c9abe8c7ff/hack/kind/kind.sh#L100) and [expected by the E2E tests](https://github.com/elastic/cloud-on-k8s/blob/bed2c56aa163cef5ad8ebd679b21fdcab77ddbba/test/e2e/test/elasticsearch/builder.go#L26), to `e2e-default`.

Relates to #1096.