### PR TITLE
Remove useless Keystore user in the file realm

### DIFF
--- a/pkg/controller/elasticsearch/user/credentials_test.go
+++ b/pkg/controller/elasticsearch/user/credentials_test.go
@@ -41,7 +41,7 @@ func TestNewUserSecrets(t *testing.T) {
 		{
 			subject:      NewInternalUserCredentials(testES),
 			expectedName: "my-cluster-es-internal-users",
-			expectedKeys: []string{InternalControllerUserName, InternalKeystoreUserName, InternalProbeUserName},
+			expectedKeys: []string{InternalControllerUserName, InternalProbeUserName},
 		},
 		{
 			subject:      NewExternalUserCredentials(testES),

--- a/pkg/controller/elasticsearch/user/predefined_users.go
+++ b/pkg/controller/elasticsearch/user/predefined_users.go
@@ -13,8 +13,6 @@ const (
 	InternalControllerUserName = "elastic-internal"
 	// InternalProbeUserName is a user to be used from the liveness/readiness probes when interacting with ES.
 	InternalProbeUserName = "elastic-internal-probe"
-	// InternalKeystoreUserName is a user to be used for reloading ES secure settings from the keystore.
-	InternalKeystoreUserName = "elastic-internal-keystore"
 
 	// SuperUserBuiltinRole is the name of the built-in superuser role
 	SuperUserBuiltinRole = "superuser"
@@ -22,8 +20,6 @@ const (
 	KibanaSystemUserBuiltinRole = "kibana_system"
 	// ProbeUserRole is the name of the custom elastic_internal_probe_user role
 	ProbeUserRole = "elastic_internal_probe_user"
-	// KeystoreUserRole is the name of the custom elastic_internal_keystore_user role
-	KeystoreUserRole = "elastic_internal_keystore_user"
 )
 
 // Predefined roles.
@@ -31,9 +27,6 @@ var (
 	PredefinedRoles = map[string]client.Role{
 		ProbeUserRole: {
 			Cluster: []string{"monitor"},
-		},
-		KeystoreUserRole: {
-			Cluster: []string{"all"},
 		},
 	}
 )
@@ -50,7 +43,6 @@ func newInternalUsers() []User {
 	return []User{
 		New(InternalControllerUserName, Roles(SuperUserBuiltinRole)),
 		New(InternalProbeUserName, Roles(ProbeUserRole)),
-		New(InternalKeystoreUserName, Roles(KeystoreUserRole)),
 	}
 }
 
@@ -58,7 +50,6 @@ func newInternalUsers() []User {
 type InternalUsers struct {
 	ControllerUser User
 	ProbeUser      User
-	KeystoreUser   User
 }
 
 // NewInternalUsersFrom constructs a new struct with internal users from the given credentials of those users.
@@ -70,9 +61,6 @@ func NewInternalUsersFrom(users ClearTextCredentials) *InternalUsers {
 		}
 		if user.Id() == InternalProbeUserName {
 			internalUsers.ProbeUser = user
-		}
-		if user.Id() == InternalKeystoreUserName {
-			internalUsers.KeystoreUser = user
 		}
 	}
 	return &internalUsers

--- a/pkg/controller/elasticsearch/user/reconciler_test.go
+++ b/pkg/controller/elasticsearch/user/reconciler_test.go
@@ -56,13 +56,13 @@ func Test_aggregateAllUsers(t *testing.T) {
 				},
 			},
 			assertions: func(users []user.User) {
-				assert.Equal(t, len(users), 5)
+				assert.Equal(t, len(users), 4)
 				containsAllNames(
 					t,
 					[]string{
 						"kibana-user",
 						ExternalUserName,
-						InternalControllerUserName, InternalProbeUserName, InternalKeystoreUserName,
+						InternalControllerUserName, InternalProbeUserName,
 					},
 					users,
 				)


### PR DESCRIPTION
We are handling keystore entries through a cmd line call in an
init container, and rotate Pods automatically on any keystore change.

As such, ECK does not make any API call to reload keystore entries.

Let's remove the dedicated keystore user and role, that are now useless.