### PR TITLE
Make readiness probes independent of the host/container network

### DIFF
--- a/pkg/controller/apmserver/apmserver_controller_test.go
+++ b/pkg/controller/apmserver/apmserver_controller_test.go
@@ -175,7 +175,7 @@ func expectedDeploymentParams() testParams {
 							Handler: corev1.Handler{
 								Exec: &corev1.ExecAction{
 									Command: []string{"bash", "-c",
-										`curl -o /dev/null -w "%{http_code}" https://127.0.0.1:8200/ -k -s`,
+										`curl -o /dev/null -w "%{http_code}" HTTPS://127.0.0.1:8200/ -k -s`,
 									},
 								},
 							},

--- a/pkg/controller/apmserver/apmserver_controller_test.go
+++ b/pkg/controller/apmserver/apmserver_controller_test.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -174,10 +173,10 @@ func expectedDeploymentParams() testParams {
 							SuccessThreshold:    1,
 							TimeoutSeconds:      5,
 							Handler: corev1.Handler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Port:   intstr.FromInt(8200),
-									Path:   "/",
-									Scheme: corev1.URISchemeHTTPS,
+								Exec: &corev1.ExecAction{
+									Command: []string{"bash", "-c",
+										`curl -o /dev/null -w "%{http_code}" https://127.0.0.1:8200/ -k -s`,
+									},
 								},
 							},
 						},

--- a/pkg/controller/apmserver/pod.go
+++ b/pkg/controller/apmserver/pod.go
@@ -49,7 +49,6 @@ func readinessProbe(tls bool) corev1.Probe {
 	if tls {
 		scheme = corev1.URISchemeHTTPS
 	}
-	protocol := strings.ToLower(fmt.Sprintf("%s", scheme))
 	return corev1.Probe{
 		FailureThreshold:    3,
 		InitialDelaySeconds: 10,
@@ -59,7 +58,7 @@ func readinessProbe(tls bool) corev1.Probe {
 		Handler: corev1.Handler{
 			Exec: &corev1.ExecAction{
 				Command: []string{"bash", "-c",
-					fmt.Sprintf(`curl -o /dev/null -w "%%{http_code}" %s://127.0.0.1:%d/ -k -s`, protocol, HTTPPort),
+					fmt.Sprintf(`curl -o /dev/null -w "%%{http_code}" %s://127.0.0.1:%d/ -k -s`, scheme, HTTPPort),
 				},
 			},
 		},

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -251,7 +251,7 @@ func TestDriverDeploymentParams(t *testing.T) {
 				params := expectedDeploymentParams()
 				params.PodTemplateSpec.Spec.Volumes = params.PodTemplateSpec.Spec.Volumes[:3]
 				params.PodTemplateSpec.Spec.Containers[0].VolumeMounts = params.PodTemplateSpec.Spec.Containers[0].VolumeMounts[:3]
-				params.PodTemplateSpec.Spec.Containers[0].ReadinessProbe.Handler.Exec.Command[2] = `curl -o /dev/null -w "%{http_code}" http://127.0.0.1:5601/login -k -s`
+				params.PodTemplateSpec.Spec.Containers[0].ReadinessProbe.Handler.Exec.Command[2] = `curl -o /dev/null -w "%{http_code}" HTTP://127.0.0.1:5601/login -k -s`
 				params.PodTemplateSpec.Spec.Containers[0].Ports[0].Name = "http"
 				return params
 			}(),
@@ -524,7 +524,7 @@ func expectedDeploymentParams() deployment.Params {
 						Handler: corev1.Handler{
 							Exec: &corev1.ExecAction{
 								Command: []string{"bash", "-c",
-									`curl -o /dev/null -w "%{http_code}" https://127.0.0.1:5601/login -k -s`,
+									`curl -o /dev/null -w "%{http_code}" HTTPS://127.0.0.1:5601/login -k -s`,
 								},
 							},
 						},

--- a/pkg/controller/kibana/pod/pod.go
+++ b/pkg/controller/kibana/pod/pod.go
@@ -6,7 +6,6 @@ package pod
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/annotation"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -51,7 +50,6 @@ func readinessProbe(useTLS bool) corev1.Probe {
 	if useTLS {
 		scheme = corev1.URISchemeHTTPS
 	}
-	protocol := strings.ToLower(fmt.Sprintf("%s", scheme))
 	return corev1.Probe{
 		FailureThreshold:    3,
 		InitialDelaySeconds: 10,
@@ -61,7 +59,7 @@ func readinessProbe(useTLS bool) corev1.Probe {
 		Handler: corev1.Handler{
 			Exec: &corev1.ExecAction{
 				Command: []string{"bash", "-c",
-					fmt.Sprintf(`curl -o /dev/null -w "%%{http_code}" %s://127.0.0.1:%d/login -k -s`, protocol, HTTPPort),
+					fmt.Sprintf(`curl -o /dev/null -w "%%{http_code}" %s://127.0.0.1:%d/login -k -s`, scheme, HTTPPort),
 				},
 			},
 		},


### PR DESCRIPTION
Switch from HttpGet action to an Exec action for the readiness probes
of Kibana and APM Server to support Kubernetes environments where
network traffic is blocked from hosts to containers for security
reasons.

Resolves #1819.