### PR TITLE
Mount containers and pods logs dirs in filebeat pod

### DIFF
--- a/config/e2e/filebeat.yaml
+++ b/config/e2e/filebeat.yaml
@@ -16,7 +16,7 @@ data:
           hints.default_config:
             type: container
             paths:
-              - /var/lib/docker/containers/${data.kubernetes.container.id}/*.log
+              - /var/log/containers/*${data.kubernetes.container.id}.log
 
     processors:
       - add_cloud_metadata:
@@ -100,6 +100,12 @@ spec:
             - name: varlibdockercontainers
               mountPath: /var/lib/docker/containers
               readOnly: true
+            - name: varlogpods
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: varlogcontainers
+              mountPath: /var/log/containers
+              readOnly: true
             - name: monitoring-ca
               mountPath: /mnt/elastic/monitoring-ca.crt
               readOnly: true
@@ -112,6 +118,12 @@ spec:
         - name: varlibdockercontainers
           hostPath:
             path: /var/lib/docker/containers
+        - name: varlogcontainers
+          hostPath:
+            path: /var/log/containers
+        - name: varlogpods
+          hostPath:
+            path: /var/log/pods
         # data folder stores a registry of read status for all files, so we don't send everything again on a Filebeat pod restart
         - name: data
           hostPath:


### PR DESCRIPTION
When setting up Filebeat for E2E tests I was running into issues with Filebeat not being able to follow symlinks, so I mounted and used `/var/lib/docker/containers` directly for logs. The annotation we have on the operator provide a raw config that overrides the default one. This override tries to use `/var/log/containers` that is not mounted which causes operator logs to not be shipped. I retried with `/log/containers` and I didn't see the issues I had before so to avoid special casing annotations for e2e tests I changed the config that our Filebeat defaults to match the one we have in the operator annotation.

All three are needed as symlinks go from `/var/log/containers` to `/var/log/pods` to `/var/lib/docker/containers`.
