### PR TITLE
Check version of go and kubectl prerequisites

### DIFF
--- a/hack/check-requisites.sh
+++ b/hack/check-requisites.sh
@@ -64,8 +64,8 @@ check_go_version() {
 }
 
 check_kubectl_version() {
-    local major=$(kubectl --client=true version | grep -Eo 'Major:"[0-9]*' | grep -Eo '[0-9]*')
-    local minor=$(kubectl --client=true version | grep -Eo 'Minor:"[0-9]*' | grep -Eo '[0-9]*')
+    local major=$(kubectl --client=true version | grep -Eo 'Major:"[0-9]*' | grep -Eo '[0-9]+')
+    local minor=$(kubectl --client=true version | grep -Eo 'Minor:"[0-9]*' | grep -Eo '[0-9]+')
 
     printf "Checking for kubectl >= 1.$MIN_KUBECTL_VERSION... "
     if [[ "$major" -gt 1 ]] || [[ "$minor" -ge $MIN_KUBECTL_VERSION ]]; then

--- a/hack/check-requisites.sh
+++ b/hack/check-requisites.sh
@@ -8,30 +8,36 @@
 
 set -eu
 
+MIN_GO_VERSION=13
+MIN_KUBECTL_VERSION=14
+
+green="\e[32m"
+red="\e[31m"
+reset="\e[39m"
 all_found=true
 
-function check {
+check() {
     local exec_name="$@"
     printf "Checking for $exec_name... "
     if ! command -v $exec_name >/dev/null 2>&1; then
-        printf "missing!"
+        printf "${red}missing${reset}"
         all_found=false
     else
-        printf "found."
+        printf "${green}found${reset}"
     fi
     printf "\n"
 }
 
-function check_oneof {
+check_oneof() {
     local found_one=false
 
     for exec_name in $@
     do
         printf "Checking for (optional) $exec_name... "
         if ! command -v $exec_name >/dev/null 2>&1; then
-            printf "not found."
+            printf "${red}missing${reset}"
         else
-            printf "found."
+            printf "${green}found${reset}"
             found_one=true
         fi
         printf "\n"
@@ -43,16 +49,46 @@ function check_oneof {
     fi
 }
 
+check_go_version() {
+    local major=$(go version | sed -r "s|.* go([1-9]).[0-9]*[0-9.]* .*|\1|")
+    local minor=$(go version | sed -r "s|.* go[1-9].([0-9]*)[0-9.]* .*|\1|")
+
+    printf "Checking for go >= 1.$MIN_GO_VERSION... "
+    if [[ "$major" -gt 1 ]] || [[ "$minor" -ge $MIN_GO_VERSION ]]; then
+        printf "${green}ok${reset} ($major.$minor)"
+    else
+        printf "${red}ko${reset} ($major.$minor)"
+        all_found=false
+    fi
+    printf "\n"
+}
+
+check_kubectl_version() {
+    local major=$(kubectl --client=true version | grep -Eo 'Major:"[0-9]*' | grep -o '[0-9]*')
+    local minor=$(kubectl --client=true version | grep -Eo 'Minor:"[0-9]*' | grep -o '[0-9]*')
+
+    printf "Checking for kubectl >= 1.$MIN_KUBECTL_VERSION... "
+    if [[ "$major" -gt 1 ]] || [[ "$minor" -ge $MIN_KUBECTL_VERSION ]]; then
+        printf "${green}ok${reset} ($major.$minor)"
+    else
+        printf "${red}ko${reset} ($major.$minor)"
+        all_found=false
+    fi
+    printf "\n"
+}
+
 check go
 check golangci-lint
 check kubectl
 check kubebuilder
 check_oneof gcloud minikube kind
+check_go_version
+check_kubectl_version
 
 echo
 if [[ "$all_found" != "true" ]]; then
-    echo "Some tools are missing."
+    printf "${red}Error${reset}: requirements could not be met.\n" >&2
     exit 1
 else
-    echo "All tools are present."
+    printf "${green}OK${reset}: all requirements met.\n"
 fi

--- a/hack/check-requisites.sh
+++ b/hack/check-requisites.sh
@@ -50,8 +50,8 @@ check_oneof() {
 }
 
 check_go_version() {
-    local major=$(go version | sed -r "s|.* go([1-9]).[0-9]*[0-9.]* .*|\1|")
-    local minor=$(go version | sed -r "s|.* go[1-9].([0-9]*)[0-9.]* .*|\1|")
+    local major=$(go version | sed -E "s|.* go([1-9]).[0-9]*[0-9.]* .*|\1|")
+    local minor=$(go version | sed -E "s|.* go[1-9].([0-9]*)[0-9.]* .*|\1|")
 
     printf "Checking for go >= 1.$MIN_GO_VERSION... "
     if [[ "$major" -gt 1 ]] || [[ "$minor" -ge $MIN_GO_VERSION ]]; then
@@ -64,8 +64,8 @@ check_go_version() {
 }
 
 check_kubectl_version() {
-    local major=$(kubectl --client=true version | grep -Eo 'Major:"[0-9]*' | grep -o '[0-9]*')
-    local minor=$(kubectl --client=true version | grep -Eo 'Minor:"[0-9]*' | grep -o '[0-9]*')
+    local major=$(kubectl --client=true version | grep -Eo 'Major:"[0-9]*' | grep -Eo '[0-9]*')
+    local minor=$(kubectl --client=true version | grep -Eo 'Minor:"[0-9]*' | grep -Eo '[0-9]*')
 
     printf "Checking for kubectl >= 1.$MIN_KUBECTL_VERSION... "
     if [[ "$major" -gt 1 ]] || [[ "$minor" -ge $MIN_KUBECTL_VERSION ]]; then

--- a/hack/check-requisites.sh
+++ b/hack/check-requisites.sh
@@ -20,7 +20,7 @@ check() {
     local exec_name="$@"
     printf "Checking for $exec_name... "
     if ! command -v $exec_name >/dev/null 2>&1; then
-        printf "${red}missing${reset}"
+        printf "${red}not found${reset}"
         all_found=false
     else
         printf "${green}found${reset}"
@@ -35,7 +35,7 @@ check_oneof() {
     do
         printf "Checking for (optional) $exec_name... "
         if ! command -v $exec_name >/dev/null 2>&1; then
-            printf "${red}missing${reset}"
+            printf "${red}not found${reset}"
         else
             printf "${green}found${reset}"
             found_one=true
@@ -87,7 +87,7 @@ check_kubectl_version
 
 echo
 if [[ "$all_found" != "true" ]]; then
-    printf "${red}Error${reset}: requirements could not be met.\n" >&2
+    printf "${red}Error${reset}: some requirements not satified.\n" >&2
     exit 1
 else
     printf "${green}OK${reset}: all requirements met.\n"


### PR DESCRIPTION
This commit adds two checks to the `hack/check-requisites.sh` script:
- `go version` must have: a major version > 1 **or** a minor version > 13
- `kubectl --client=true version` must have: a major version > 1 **or** a minor version > 14

_and some fancy colors._

Follow-up #2494.
Resolves #2526.
