### PR TITLE
Rename log.logger to event.dataset as recommended in ECS

### DIFF
--- a/pkg/utils/log/log.go
+++ b/pkg/utils/log/log.go
@@ -74,7 +74,7 @@ func setLogger(v *int) {
 		encoderConf.MessageKey = "message"
 		encoderConf.TimeKey = "@timestamp"
 		encoderConf.LevelKey = "log.level"
-		encoderConf.NameKey = "log.logger"
+		encoderConf.NameKey = "event.dataset"
 		encoderConf.StacktraceKey = "error.stack_trace"
 		encoderConf.EncodeTime = zapcore.ISO8601TimeEncoder
 		encoder = zapcore.NewJSONEncoder(encoderConf)


### PR DESCRIPTION
Instead of 

![Screenshot 2020-02-07 at 11 16 57](https://user-images.githubusercontent.com/697790/74021476-e93bf280-499b-11ea-8967-81b11a9df88e.png)

we get

![Screenshot 2020-02-07 at 11 15 20](https://user-images.githubusercontent.com/697790/74021503-f78a0e80-499b-11ea-8f5c-e4dc93b45569.png)

in Kibanas log UI by following the ECS recommendation for `event.dataset`