### PR TITLE
Fix external user "password" field to "hash"

### DIFF
--- a/pkg/controller/common/user/external.go
+++ b/pkg/controller/common/user/external.go
@@ -26,9 +26,9 @@ const (
 // ExternalUser represents a user that is not created or managed by Elasticsearch.
 // For example in the case of Kibana a user with the right role is provided by the Kibana association controller.
 type ExternalUser struct {
-	name     string
-	password []byte
-	roles    []string
+	name  string
+	hash  []byte
+	roles []string
 }
 
 // NewExternalUserFromSecret reads an external user from a secret.
@@ -44,8 +44,8 @@ func NewExternalUserFromSecret(secret v1.Secret) (ExternalUser, error) {
 		return user, pkgerrors.Errorf(fieldNotFound, UserName, secret.Namespace, secret.Name)
 	}
 
-	if password, ok := secret.Data[PasswordHash]; ok && len(password) > 0 {
-		user.password = password
+	if hash, ok := secret.Data[PasswordHash]; ok && len(hash) > 0 {
+		user.hash = hash
 	} else {
 		return user, pkgerrors.Errorf(fieldNotFound, PasswordHash, secret.Namespace, secret.Name)
 	}
@@ -62,14 +62,14 @@ func (u ExternalUser) Id() string {
 	return u.name
 }
 
-// PasswordHash is the password hash and returns it or error.
+// PasswordHash returns the password hash.
 func (u ExternalUser) PasswordHash() ([]byte, error) {
-	return u.password, nil
+	return u.hash, nil
 }
 
-// PasswordMatches compares the given hash with the password of this user.
+// PasswordMatches compares the user password hash with the given one.
 func (u *ExternalUser) PasswordMatches(hash []byte) bool {
-	return bytes.Equal(u.password, hash)
+	return bytes.Equal(u.hash, hash)
 }
 
 // Roles are any Elasticsearch roles associated with this user

--- a/pkg/controller/common/user/external_test.go
+++ b/pkg/controller/common/user/external_test.go
@@ -39,9 +39,9 @@ func TestNewExternalUserFromSecret(t *testing.T) {
 				},
 			},
 			want: ExternalUser{
-				name:     "ns2-kibana-sample-kibana-user",
-				password: []byte("$2a$10$D6q/zdYfGJsJxipsZ4Jioul8tWIcL.o.Mhx/as1nlNdOX6EgqRRRS"),
-				roles:    []string{"kibana_system"},
+				name:  "ns2-kibana-sample-kibana-user",
+				hash:  []byte("$2a$10$D6q/zdYfGJsJxipsZ4Jioul8tWIcL.o.Mhx/as1nlNdOX6EgqRRRS"),
+				roles: []string{"kibana_system"},
 			},
 		},
 		{
@@ -61,9 +61,9 @@ func TestNewExternalUserFromSecret(t *testing.T) {
 				},
 			},
 			want: ExternalUser{
-				name:     "ns2-kibana-sample-kibana-user",
-				password: []byte("$2a$10$D6q/zdYfGJsJxipsZ4Jioul8tWIcL.o.Mhx/as1nlNdOX6EgqRRRS"),
-				roles:    []string{"kibana_system1", "kibana_system2", "kibana_system3"},
+				name:  "ns2-kibana-sample-kibana-user",
+				hash:  []byte("$2a$10$D6q/zdYfGJsJxipsZ4Jioul8tWIcL.o.Mhx/as1nlNdOX6EgqRRRS"),
+				roles: []string{"kibana_system1", "kibana_system2", "kibana_system3"},
 			},
 		},
 		{


### PR DESCRIPTION
This probably comes from a wrong copy-paste. I think we were using
"password" wereas this should definitely be "hash".