### PR TITLE
Do not mutate object when validating unknown fields

### DIFF
--- a/pkg/apis/common/v1/validations.go
+++ b/pkg/apis/common/v1/validations.go
@@ -16,13 +16,13 @@ import (
 )
 
 // NoUnknownFields checks whether the last applied config annotation contains json with unknown fields.
-func NoUnknownFields(dest interface{}, meta metav1.ObjectMeta) field.ErrorList {
+func NoUnknownFields(dest runtime.Object, meta metav1.ObjectMeta) field.ErrorList {
 	var errs field.ErrorList
 	if cfg, ok := meta.Annotations[v1.LastAppliedConfigAnnotation]; ok {
 		d := json.NewDecoder(strings.NewReader(cfg))
 		d.DisallowUnknownFields()
 		// copy the resource to be validated to avoid mutation if the object in the annotation is different
-		destCopy := dest.(runtime.Object).DeepCopyObject()
+		destCopy := dest.DeepCopyObject()
 		if err := d.Decode(destCopy); err != nil {
 			errString := err.Error()
 			unknownPrefix := "json: unknown field "

--- a/pkg/apis/common/v1/validations.go
+++ b/pkg/apis/common/v1/validations.go
@@ -21,7 +21,7 @@ func NoUnknownFields(dest runtime.Object, meta metav1.ObjectMeta) field.ErrorLis
 	if cfg, ok := meta.Annotations[v1.LastAppliedConfigAnnotation]; ok {
 		d := json.NewDecoder(strings.NewReader(cfg))
 		d.DisallowUnknownFields()
-		// copy the resource to be validated to avoid mutation if the object in the annotation is different
+		// decode in a copy of the resource to be validated to avoid mutation if the object in the annotation is different
 		if err := d.Decode(dest.DeepCopyObject()); err != nil {
 			errString := err.Error()
 			unknownPrefix := "json: unknown field "

--- a/pkg/apis/common/v1/validations.go
+++ b/pkg/apis/common/v1/validations.go
@@ -22,8 +22,7 @@ func NoUnknownFields(dest runtime.Object, meta metav1.ObjectMeta) field.ErrorLis
 		d := json.NewDecoder(strings.NewReader(cfg))
 		d.DisallowUnknownFields()
 		// copy the resource to be validated to avoid mutation if the object in the annotation is different
-		destCopy := dest.DeepCopyObject()
-		if err := d.Decode(destCopy); err != nil {
+		if err := d.Decode(dest.DeepCopyObject()); err != nil {
 			errString := err.Error()
 			unknownPrefix := "json: unknown field "
 			if strings.HasPrefix(errString, unknownPrefix) {


### PR DESCRIPTION
This commit takes care not to reuse the object to be validated during the validation to detect unknown fields in order to avoid any mutation.
Indeed the object stored in this annotation can be slightly different from the object after it has been stored and retrieved by the operator (e.g.: `resources:{limits:{}}` became `resources:{}`, see #2207).

Relates to #2433 and #2207.