### PR TITLE
Grammatical mistake in manage compute resources page

### DIFF
--- a/docs/managing-compute-resources.asciidoc
+++ b/docs/managing-compute-resources.asciidoc
@@ -66,7 +66,7 @@ spec:
             cpu: 2
 ----
 
-For the container name, you can use `apm-server` for `kibana` as appropriate.
+For the container name, you can use `apm-server` or `kibana` as appropriate.
 
 [float]
 [id="{p}-default-behavior"]


### PR DESCRIPTION
Self explanatory grammatical mistake in the documentation of manage compute resources doc.