### PR TITLE
Grammatical mistake in manage compute resources page (#2547)

### DIFF
--- a/docs/managing-compute-resources.asciidoc
+++ b/docs/managing-compute-resources.asciidoc
@@ -64,7 +64,7 @@ spec:
             cpu: 2
 ----
 
-For the container name, you can use `apm-server` for `kibana` as appropriate.
+For the container name, you can use `apm-server` or `kibana` as appropriate.
 
 [float]
 [id="{p}-default-behavior"]


### PR DESCRIPTION
Backport https://github.com/elastic/cloud-on-k8s/pull/2547 on 1.0-beta.