### PR TITLE
Add a tool to recreate a deleted cluster from existing PersistentVolumeClaims

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ PSP ?= 0
 ##  --       Development       --  ##
 #####################################
 
-all: dependencies lint check-license-header unit integration e2e-compile elastic-operator
+all: dependencies lint check-license-header unit integration e2e-compile elastic-operator reattach-pv
 
 ## -- build
 
@@ -118,6 +118,10 @@ elastic-operator: generate
 
 clean:
 	rm -f pkg/controller/common/license/zz_generated.pubkey.go
+
+reattach-pv:
+	# just check that reattach-pv still compiles
+	go build -o /dev/null hack/reattach-pv/main.go
 
 ## -- tests
 
@@ -406,7 +410,7 @@ e2e-local:
 ##########################################
 ci-check: check-license-header lint generate check-local-changes
 
-ci: unit_xml integration_xml docker-build
+ci: unit_xml integration_xml docker-build reattach-pv
 
 # Run e2e tests in a dedicated cluster.
 ci-e2e: e2e-compile run-deployer install-crds apply-psp e2e

--- a/hack/reattach-pv/README.md
+++ b/hack/reattach-pv/README.md
@@ -1,6 +1,6 @@
 # Reattach-PV
 
-This tool can be used to recreate an Elasticsearch cluster by reusing existing PersistentVolumes, that belonged to that cluster before it was deleted.
+This tool can be used to recreate an Elasticsearch cluster by reusing orphaned PersistentVolumes that used to belong to that cluster before it was deleted.
 
 ## Expectations
 

--- a/hack/reattach-pv/README.md
+++ b/hack/reattach-pv/README.md
@@ -2,6 +2,8 @@
 
 This tool can be used to recreate an Elasticsearch cluster by reusing orphaned PersistentVolumes that used to belong to that cluster before it was deleted.
 
+**Warning**: to be used at your own risk. This tool has not been tested extensively with multiple Kubernetes distributions and PersistentVolume providers. You may want to backup data from existing volumes first. Also make sure you perform a dry-run first.
+
 ## Expectations
 
 This tool can only be used when the following conditions are met:

--- a/hack/reattach-pv/README.md
+++ b/hack/reattach-pv/README.md
@@ -24,7 +24,6 @@ Flags:
       --dry-run                         do not apply any Kubernetes resource change
       --elasticsearch-manifest string   path pointing to the Elasticsearch yaml manifest
   -h, --help                            help for reattach-pv
-      --pv-backup-path string           path to the file where a backup of existing PersistentVolumes will be stored before update, set empty to disable (default "pv_backup_{timestamp}.json")
 ```
 
 Example:
@@ -32,7 +31,6 @@ Example:
 ```
 # perform a dry run first
 ./reattach-pv --elasticsearch-manifest elasticsearch.yml --dry-run
-# inspect stdout, and notice a backup of existing volumes has been created in the current directory
 # then, execute again without the dry-run flag
 ./reattach-pv --elasticsearch-manifest elasticsearch.yml
 ```

--- a/hack/reattach-pv/README.md
+++ b/hack/reattach-pv/README.md
@@ -2,7 +2,7 @@
 
 This tool can be used to recreate an Elasticsearch cluster by reusing orphaned PersistentVolumes that used to belong to that cluster before it was deleted.
 
-**Warning**: to be used at your own risk. This tool has not been tested extensively with multiple Kubernetes distributions and PersistentVolume providers. You may want to backup data from existing volumes first. Also make sure you perform a dry-run first.
+**Warning**: to be used at your own risk. This tool has not been tested extensively with multiple Kubernetes distributions and PersistentVolume providers. You should backup the data in the underlying storage system before attempting to use this tool. Also make sure you perform a dry-run first.
 
 ## Expectations
 

--- a/hack/reattach-pv/README.md
+++ b/hack/reattach-pv/README.md
@@ -8,7 +8,7 @@ This tool can only be used when the following conditions are met:
 
 * The Elasticsearch resource to re-create does not exist in Kubernetes.
 * All PersistentVolumeClaims of the previous cluster do not exist anymore.
-* All PersistentVolumes of the previous cluster still exist. Their status report they are `Released`.
+* All PersistentVolumes of the previous cluster still exist with the status `Released`.
 * The Elasticsearch resource to re-create has the exact same specs as the deleted one. Same cluster name, same node sets, same count, etc.
 * The current default kubectl context targets the desired Kubernetes cluster.
 

--- a/hack/reattach-pv/README.md
+++ b/hack/reattach-pv/README.md
@@ -1,0 +1,54 @@
+# Reattach-PV
+
+This tool can be used to recreate an Elasticsearch cluster by reusing existing PersistentVolumes, that belonged to that cluster before it was deleted.
+
+## Expectations
+
+This tool can only be used when the following conditions are met:
+
+* The Elasticsearch resource to re-create does not exist in Kubernetes.
+* All PersistentVolumeClaims of the previous cluster do not exist anymore.
+* All PersistentVolumes of the previous cluster still exist. Their status report they are `Released`.
+* The Elasticsearch resource to re-create has the exact same specs as the deleted one. Same cluster name, same node sets, same count, etc.
+* The current default kubectl context targets the desired Kubernetes cluster.
+
+## Usage
+
+```
+Recreate an Elasticsearch cluster by reattaching existing released PersistentVolumes
+
+Usage:
+  reattach-pv [flags]
+
+Flags:
+      --dry-run                         do not apply any Kubernetes resource change
+      --elasticsearch-manifest string   path pointing to the Elasticsearch yaml manifest
+  -h, --help                            help for reattach-pv
+      --pv-backup-path string           path to the file where a backup of existing PersistentVolumes will be stored before update, set empty to disable (default "pv_backup_{timestamp}.json")
+```
+
+Example:
+
+```
+# perform a dry run first
+./reattach-pv --elasticsearch-manifest elasticsearch.yml --dry-run
+# inspect stdout, and notice a backup of existing volumes has been created in the current directory
+# then, execute again without the dry-run flag
+./reattach-pv --elasticsearch-manifest elasticsearch.yml
+```
+
+## How it works
+
+This tool basically does the following:
+
+* Ensure the Elasticsearch resource and the corresponding PersistentVolumeClaims do not exist in the APIServer.
+* Generate the list of PersistentVolumeClaims that would normally be created for this Elasticsearch cluster.
+* Retrieve the list of existing Released PersistentVolumes. Match their `claimRef` to the generated PersistentVolumeClaims, based on their name.
+* Create the expected PersistentVolumeClaims, with a status set to `Bound`.
+* Update the existing PersistentVolumes to reference the newly created PersistentVolumeClaims.
+* Create the Elasticsearch resource. The created PersistentVolumeClaims will automatically be used for the Elasticsearch Pods, since they have the correct name convention.
+
+## Limitations
+
+* PersistentVolumsClaims are not created the exact same way they would normally be created by the StatefulSet controller. Especially, they don't have the usual annotations and labels.
+* PersistentVolumeClaims are not created with an OwnerReference pointing to the Elasticsearch resource, because they are created before that resource. Therefore, they will not be automatically removed upon Elasticsearch resource deletion.

--- a/hack/reattach-pv/integ-test-gke/elasticsearch.yml
+++ b/hack/reattach-pv/integ-test-gke/elasticsearch.yml
@@ -1,0 +1,41 @@
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: mycluster
+spec:
+  version: 7.5.0
+  nodeSets:
+    - name: master-nodes
+      count: 3
+      config:
+        node.master: true
+        node.data: false
+        node.store.allow_mmap: false
+        xpack.monitoring.collection.enabled: true
+      volumeClaimTemplates:
+      - metadata:
+          name: elasticsearch-data
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+          storageClassName: integ-test-gke-storage-class
+    - name: data-nodes
+      count: 3
+      config:
+        node.master: false
+        node.data: true
+        node.store.allow_mmap: false
+        xpack.monitoring.collection.enabled: true
+      volumeClaimTemplates:
+        - metadata:
+            name: elasticsearch-data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+            storageClassName: integ-test-gke-storage-class

--- a/hack/reattach-pv/integ-test-gke/run.sh
+++ b/hack/reattach-pv/integ-test-gke/run.sh
@@ -1,0 +1,100 @@
+#! /usr/bin/env bash
+
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+# This script runs the following test scenario:
+# - setup a storage class with `reclaimPolicy: Retain`
+# - setup an Elasticsearch cluster with 3 master + 3 data using that storage class
+# - delete the Elasticsearch resource
+# - run the reattach-pv program which should recreate 6 PVCs and the Elasticsearch cluster
+# - expect the cluster to have kept its UUID
+# - clean things up
+#
+# We expect the current kubectl config to target a GKE cluster.
+
+set -euo pipefail
+
+## global vars
+
+MANIFEST="elasticsearch.yml"
+CLUSTER_NAME="mycluster"
+PODS="mycluster-es-master-nodes-0 mycluster-es-master-nodes-1 mycluster-es-master-nodes-2 mycluster-es-data-nodes-0 mycluster-es-data-nodes-1 mycluster-es-data-nodes-2"
+
+## functions
+
+function wait_for_pods_exist() {
+  wait_sec=5
+  for pod in $PODS; do
+    for i in {1..5}; do kubectl get pod "$pod" > /dev/null && break || sleep $wait_sec; done
+  done
+}
+
+function wait_for_pods_deleted() {
+  timeout=180s
+  kubectl wait pods -l "elasticsearch.k8s.elastic.co/cluster-name=$CLUSTER_NAME" --for delete --timeout "$timeout"
+}
+
+function wait_for_pods_ready() {
+  timeout=60s
+  for pod in $PODS; do
+    kubectl wait pods "$pod" --for condition=Ready --timeout "$timeout"
+  done
+}
+
+function cluster_uuid() {
+  kubectl get elasticsearch $CLUSTER_NAME -o json | jq -r '.metadata.annotations["elasticsearch.k8s.elastic.co/cluster-uuid"]'
+}
+
+## main
+
+echo "Applying custom storage class"
+kubectl apply -f storageclass.yml
+
+echo "Applying Elasticsearch resource"
+kubectl apply -f $MANIFEST
+
+echo "Waiting until all Pods are ready"
+wait_for_pods_exist
+wait_for_pods_ready
+
+echo "Retrieving cluster UUID"
+uuid=$(cluster_uuid)
+echo "Cluster UUID: $uuid"
+
+echo "Deleting Elasticsearch resource"
+kubectl delete -f $MANIFEST
+
+echo "Waiting until all Pods are deleted"
+wait_for_pods_deleted
+
+echo "Running reattach-pv in dry-run mode"
+go run ../main.go --elasticsearch-manifest $MANIFEST --dry-run
+
+echo "Running reattach-pv"
+go run ../main.go --elasticsearch-manifest $MANIFEST
+
+echo "Waiting until all Pods are ready"
+wait_for_pods_exist
+wait_for_pods_ready
+
+echo "Retrieving new cluster UUID"
+new_uuid=$(cluster_uuid)
+echo "New cluster UUID: $uuid"
+
+exit_code=0
+if [ "$uuid" = "$new_uuid" ]; then
+    echo "UUIDs match: success"
+else
+    echo "UUIDs don't match: failure"
+    exit_code=1
+fi
+
+echo "Cleaning up test resources"
+kubectl delete -f elasticsearch.yml
+kubectl get pvc | grep "elasticsearch-data-$CLUSTER_NAME" | awk '{print $1}' | xargs kubectl delete pvc
+kubectl get pv | grep "elasticsearch-data-$CLUSTER_NAME" | awk '{print $1}' | xargs kubectl delete pv
+kubectl delete -f storageclass.yml
+
+exit $exit_code

--- a/hack/reattach-pv/integ-test-gke/storageclass.yml
+++ b/hack/reattach-pv/integ-test-gke/storageclass.yml
@@ -1,0 +1,10 @@
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: integ-test-gke-storage-class
+parameters:
+  type: pd-standard
+provisioner: kubernetes.io/gce-pd
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer 

--- a/hack/reattach-pv/main.go
+++ b/hack/reattach-pv/main.go
@@ -112,12 +112,15 @@ func esFromFile(path string) (esv1.Elasticsearch, error) {
 	if err != nil {
 		return esv1.Elasticsearch{}, err
 	}
-	es := *obj.(*esv1.Elasticsearch)
+	es, ok := obj.(*esv1.Elasticsearch)
+	if !ok {
+		return esv1.Elasticsearch{}, fmt.Errorf("cannot serialize content of %s into an Elasticsearch object", path)
+	}
 	if es.Namespace == "" {
 		fmt.Println("Setting Elasticsearch namespace to 'default'")
 		es.Namespace = "default"
 	}
-	return es, nil
+	return *es, nil
 }
 
 // createClient creates a Kubernetes client targeting the current default K8s cluster.

--- a/hack/reattach-pv/main.go
+++ b/hack/reattach-pv/main.go
@@ -141,7 +141,7 @@ func checkElasticsearchNotFound(c k8s.Client, es esv1.Elasticsearch) error {
 	var retrieved esv1.Elasticsearch
 	err := c.Get(k8s.ExtractNamespacedName(&es), &retrieved)
 	if err == nil {
-		return fmt.Errorf("elasticsearch resource %s exists in the apiserver: it should be deleted first", es.Name)
+		return fmt.Errorf("elasticsearch resource %s exists in the apiserver; this tool can only recover clusters that don't exist anymore", es.Name)
 	}
 	if !apierrors.IsNotFound(err) {
 		return err

--- a/hack/reattach-pv/main.go
+++ b/hack/reattach-pv/main.go
@@ -110,7 +110,7 @@ func esFromFile(path string) (esv1.Elasticsearch, error) {
 	}
 	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(data, nil, nil)
 	if err != nil {
-		return esv1.Elasticsearch{}, nil
+		return esv1.Elasticsearch{}, err
 	}
 	es := *obj.(*esv1.Elasticsearch)
 	if es.Namespace == "" {

--- a/hack/reattach-pv/main.go
+++ b/hack/reattach-pv/main.go
@@ -1,0 +1,307 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // allow gcp authentication
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+)
+
+const (
+	esManifestFlag      = "elasticsearch-manifest"
+	dryRunFlag          = "dry-run"
+	pvBackupFlag        = "pv-backup-path"
+	defaultPVBackupPath = "pv_backup_{timestamp}.json"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "reattach-pv",
+	Short: "Recreate an Elasticsearch cluster by reattaching existing released PersistentVolumes",
+	Run: func(cmd *cobra.Command, args []string) {
+		dryRun := viper.GetBool(dryRunFlag)
+		if dryRun {
+			fmt.Println("Running in dry run mode")
+		}
+
+		err := esv1.AddToScheme(scheme.Scheme)
+		exitOnErr(err)
+
+		es, err := esFromFile(viper.GetString(esManifestFlag))
+		exitOnErr(err)
+
+		c, err := createClient()
+		exitOnErr(err)
+
+		err = checkElasticsearchNotFound(c, es)
+		exitOnErr(err)
+
+		expectedClaims := expectedVolumeClaims(es)
+		err = checkClaimsNotFound(c, expectedClaims)
+		exitOnErr(err)
+
+		releasedPVs, err := findReleasedPVs(c, es)
+		exitOnErr(err)
+
+		matches, err := matchPVsWithClaim(releasedPVs, expectedClaims)
+		exitOnErr(err)
+
+		err = backupPVs(matches, pvBackupFilepath(viper.GetString(pvBackupFlag)))
+		exitOnErr(err)
+
+		err = createAndBindClaims(c, matches, dryRun)
+		exitOnErr(err)
+
+		es, err = createElasticsearch(c, es, dryRun)
+		exitOnErr(err)
+	},
+}
+
+func init() {
+	Cmd.Flags().String(
+		esManifestFlag,
+		"",
+		"path pointing to the Elasticsearch yaml manifest",
+	)
+	Cmd.Flags().Bool(
+		dryRunFlag,
+		false,
+		"do not apply any Kubernetes resource change",
+	)
+	Cmd.Flags().String(
+		pvBackupFlag,
+		defaultPVBackupPath,
+		"path to the file where a backup of existing PersistentVolumes will be stored before update, set empty to disable",
+	)
+	exitOnErr(viper.BindPFlags(Cmd.Flags()))
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.AutomaticEnv()
+}
+
+func main() {
+	exitOnErr(Cmd.Execute())
+}
+
+// esFromFile parses an Elasticsearch resource from the given yaml manifest path.
+func esFromFile(path string) (esv1.Elasticsearch, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return esv1.Elasticsearch{}, err
+	}
+	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(data, nil, nil)
+	if err != nil {
+		return esv1.Elasticsearch{}, nil
+	}
+	es := *obj.(*esv1.Elasticsearch)
+	if es.Namespace == "" {
+		fmt.Println("Setting Elasticsearch namespace to 'default'")
+		es.Namespace = "default"
+	}
+	return es, nil
+}
+
+// createClient creates a Kubernetes client targeting the current default K8s cluster.
+func createClient() (k8s.Client, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	c, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		return nil, err
+	}
+	return k8s.WrapClient(c), nil
+}
+
+// checkElasticsearchNotFound returns an error if the given Elasticsearch resource already exists.
+func checkElasticsearchNotFound(c k8s.Client, es esv1.Elasticsearch) error {
+	var retrieved esv1.Elasticsearch
+	err := c.Get(k8s.ExtractNamespacedName(&es), &retrieved)
+	if err == nil {
+		return fmt.Errorf("elasticsearch resource %s exists in the apiserver: it should be deleted first", es.Name)
+	}
+	if !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+// checkClaimsNotFound returns an error if the given PersistentVolumeClaims already exist.
+func checkClaimsNotFound(c k8s.Client, claims map[types.NamespacedName]v1.PersistentVolumeClaim) error {
+	for nsn := range claims {
+		err := c.Get(nsn, &v1.PersistentVolumeClaim{})
+		if err == nil {
+			return fmt.Errorf("PersistentVolumeClaim %s seems to exist in the apiserver", nsn)
+		}
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// expectedVolumeClaims builds the list of PersistentVolumeClaim that we expect to exist for the given
+// Elasticsearch cluster.
+func expectedVolumeClaims(es esv1.Elasticsearch) map[types.NamespacedName]v1.PersistentVolumeClaim {
+	claims := make(map[types.NamespacedName]v1.PersistentVolumeClaim, es.Spec.NodeCount())
+	for _, nodeSet := range es.Spec.NodeSets {
+		for i := int32(0); i < nodeSet.Count; i++ {
+			var claim v1.PersistentVolumeClaim
+			for _, claimTemplate := range nodeSet.VolumeClaimTemplates {
+				if claimTemplate.Name == volume.ElasticsearchDataVolumeName {
+					claim = claimTemplate
+				}
+			}
+			claim.Name = fmt.Sprintf(
+				"%s-%s",
+				volume.ElasticsearchDataVolumeName,
+				sset.PodName(esv1.StatefulSet(es.Name, nodeSet.Name), i))
+			claim.Namespace = es.Namespace
+			if claim.Namespace == "" {
+				claim.Namespace = "default"
+			}
+			// simulate a bound status
+			claim.Status = v1.PersistentVolumeClaimStatus{
+				Phase:       v1.ClaimBound,
+				AccessModes: claim.Spec.AccessModes,
+				Capacity:    claim.Spec.Resources.Requests,
+			}
+			claims[types.NamespacedName{Namespace: es.Namespace, Name: claim.Name}] = claim
+			fmt.Printf("Expecting claim %s\n", claim.Name)
+		}
+	}
+	return claims
+}
+
+// findReleasedPVs returns the list of Released PersistentVolumes.
+func findReleasedPVs(c k8s.Client, es esv1.Elasticsearch) ([]v1.PersistentVolume, error) {
+	var pvs v1.PersistentVolumeList
+	if err := c.List(&pvs); err != nil {
+		return nil, err
+	}
+	var released []v1.PersistentVolume
+	for _, pv := range pvs.Items {
+		if pv.Status.Phase == v1.VolumeReleased {
+			released = append(released, pv)
+		}
+	}
+	fmt.Printf("Found %d released PersistentVolumes\n", len(pvs.Items))
+	return pvs.Items, nil
+}
+
+// pvBackupFilepath injects a timestamp in the default PV backup file.
+func pvBackupFilepath(flagValue string) string {
+	if flagValue == defaultPVBackupPath {
+		// set the current timestamp
+		return strings.Replace(flagValue, "{timestamp}", fmt.Sprintf("%d", time.Now().Unix()), 1)
+	}
+	return flagValue
+}
+
+// backupPVs stores a JSON backup of the given PersistentVolumes in toFile.
+func backupPVs(matches []MatchingVolumeClaim, toFile string) error {
+	if toFile == "" {
+		fmt.Println("Skipping PV backup file creation")
+		return nil
+	}
+	pvs := make([]v1.PersistentVolume, 0, len(matches))
+	for _, match := range matches {
+		pvs = append(pvs, match.volume)
+	}
+	asJson, err := json.Marshal(pvs)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Creating a backup of released PersistentVolumes in %s\n", toFile)
+	return ioutil.WriteFile(toFile, asJson, 0644)
+}
+
+// MatchingVolumeClaim matches an existing PersistentVolume with a new PersistentVolumeClaim.
+type MatchingVolumeClaim struct {
+	claim  v1.PersistentVolumeClaim
+	volume v1.PersistentVolume
+}
+
+// matchPVsWithClaim iterates over existing pvs to match them to an expected pvc.
+func matchPVsWithClaim(pvs []v1.PersistentVolume, claims map[types.NamespacedName]v1.PersistentVolumeClaim) ([]MatchingVolumeClaim, error) {
+	var matches []MatchingVolumeClaim
+	for _, pv := range pvs {
+		if pv.Spec.ClaimRef == nil {
+			continue
+		}
+		claim, expected := claims[types.NamespacedName{Namespace: pv.Spec.ClaimRef.Namespace, Name: pv.Spec.ClaimRef.Name}]
+		if !expected {
+			continue
+		}
+		fmt.Printf("Found matching volume %s for claim %s\n", pv.Name, claim.Name)
+		matches = append(matches, MatchingVolumeClaim{
+			claim:  claim,
+			volume: pv,
+		})
+	}
+	if len(matches) != len(claims) {
+		return nil, fmt.Errorf("found %d matching volumes but expected %d", len(matches), len(claims))
+	}
+	return matches, nil
+}
+
+// bindNewClaims creates the given PersistentVolumeClaims, and update the matching PersistentVolumes
+// to reference the claim.
+func createAndBindClaims(c k8s.Client, volumeClaims []MatchingVolumeClaim, dryRun bool) error {
+	for _, match := range volumeClaims {
+		fmt.Printf("Creating claim %s\n", match.claim.Name)
+		if !dryRun {
+			if err := c.Create(&match.claim); err != nil {
+				return err
+			}
+		}
+		fmt.Printf("Updating volume %s to reference claim %s\n", match.volume.Name, match.claim.Name)
+		// match.claim now stores the created claim metadata
+		// patch the volume spec to match the new claim
+		match.volume.Spec.ClaimRef.UID = match.claim.UID
+		match.volume.Spec.ClaimRef.ResourceVersion = match.claim.ResourceVersion
+		if !dryRun {
+			if err := c.Update(&match.volume); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// createElasticsearch creates the given Elasticsearch resource.
+func createElasticsearch(c k8s.Client, es esv1.Elasticsearch, dryRun bool) (esv1.Elasticsearch, error) {
+	fmt.Printf("Creating Elasticsearch %s\n", es.Name)
+	if dryRun {
+		return es, nil
+	}
+	return es, c.Create(&es, &client.CreateOptions{})
+}
+
+// exitOnErr prints the given error then exits with status code 1
+func exitOnErr(err error) {
+	if err != nil {
+		println("Fatal error:", err.Error())
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Add a tool called `reattach-pv` into our `hack` directory.

It allows recreating a deleted Elasticsearch cluster while reusing existing PersistentVolumes. This is intended for catastrophic failures (or accidental cluster removal) that are not supposed to happen under normal conditions. More details in `README.md`.

Also add a basic test to check the script behaves as expected when targeting a GKE cluster.

And include compilation of this tool as part of CI: since it relies on "internal" operator code, we may accidentally break it if we change the operator code.
