### PR TITLE
Correct number of masters in TestVersionUpgradeTwoNodes68xTo73x

### DIFF
--- a/test/e2e/es/version_upgrade_test.go
+++ b/test/e2e/es/version_upgrade_test.go
@@ -29,11 +29,11 @@ func TestVersionUpgradeTwoNodes68xTo73x(t *testing.T) {
 	// due to minimum_master_nodes=2, the cluster is unavailable while the first master is upgraded
 	initial := elasticsearch.NewBuilder("test-version-up-2-68x-to-73x").
 		WithVersion("6.8.5").
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
 		WithVersion("7.3.2").
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	RunESMutation(t, initial, mutated)
 }


### PR DESCRIPTION
Correct the test `TestVersionUpgradeTwoNodes68xTo73x` where we want to test the upgrade of a 2-master nodes Elasticsearch cluster.
The upgrade with a 1-master node Elasticsearch cluster is already tested in the previous test `TestVersionUpgradeSingleNode68xTo73x`.