### PR TITLE
Use Elastic Stack version in upgrade tests

### DIFF
--- a/test/e2e/cmd/run/command.go
+++ b/test/e2e/cmd/run/command.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	logutil "github.com/elastic/cloud-on-k8s/pkg/utils/log"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -67,7 +68,7 @@ func Command() *cobra.Command {
 	cmd.Flags().BoolVar(&flags.autoPortForwarding, "auto-port-forwarding", false, "Enable port forwarding to pods")
 	cmd.Flags().DurationVar(&flags.commandTimeout, "command-timeout", 90*time.Second, "Timeout for commands executed")
 	cmd.Flags().StringVar(&flags.e2eImage, "e2e-image", "", "E2E test image")
-	cmd.Flags().StringVar(&flags.elasticStackVersion, "elastic-stack-version", "7.6.0", "Elastic stack version")
+	cmd.Flags().StringVar(&flags.elasticStackVersion, "elastic-stack-version", test.LatestVersion7x, "Elastic Stack version")
 	cmd.Flags().StringVar(&flags.kubeConfig, "kubeconfig", "", "Path to kubeconfig")
 	cmd.Flags().BoolVar(&flags.local, "local", false, "Create the environment for running tests locally")
 	cmd.Flags().StringSliceVar(&flags.managedNamespaces, "managed-namespaces", []string{"mercury", "venus"}, "List of managed namespaces")

--- a/test/e2e/es/version_upgrade_test.go
+++ b/test/e2e/es/version_upgrade_test.go
@@ -8,54 +8,63 @@ import (
 	"testing"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
 )
 
-func TestVersionUpgradeSingleNode68xTo73x(t *testing.T) {
+func TestVersionUpgradeSingleNode68xTo7x(t *testing.T) {
+	test.SkipIfMinVersion68x(t)
+
 	// covers the case where the existing zen1 master needs to be upgraded/restarted to a zen2 master
-	initial := elasticsearch.NewBuilder("test-version-up-1-68x-to-73x").
-		WithVersion("6.8.5").
+	initial := elasticsearch.NewBuilder("test-version-up-1-68x-to-7x").
+		WithVersion(test.MinVersion68x).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
-		WithVersion("7.3.2").
+		WithVersion(test.Ctx().ElasticStackVersion).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	RunESMutation(t, initial, mutated)
 }
 
-func TestVersionUpgradeTwoNodes68xTo73x(t *testing.T) {
+func TestVersionUpgradeTwoNodes68xTo7x(t *testing.T) {
+	test.SkipIfMinVersion68x(t)
+
 	// covers the case where 2 existing zen1 masters get upgraded/restarted to zen2 masters
 	// due to minimum_master_nodes=2, the cluster is unavailable while the first master is upgraded
-	initial := elasticsearch.NewBuilder("test-version-up-2-68x-to-73x").
-		WithVersion("6.8.5").
+	initial := elasticsearch.NewBuilder("test-version-up-2-68x-to-7x").
+		WithVersion(test.MinVersion68x).
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
-		WithVersion("7.3.2").
+		WithVersion(test.Ctx().ElasticStackVersion).
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	RunESMutation(t, initial, mutated)
 }
 
-func TestVersionUpgrade3Nodes68xTo73x(t *testing.T) {
+func TestVersionUpgrade3Nodes68xTo7x(t *testing.T) {
+	test.SkipIfMinVersion68x(t)
+
 	// covers the case where 3 existing zen1 masters get upgraded/restarted to zen2 masters (standard rolling upgrade)
-	initial := elasticsearch.NewBuilder("test-version-up-3-68x-to-73x").
-		WithVersion("6.8.5").
+	initial := elasticsearch.NewBuilder("test-version-up-3-68x-to-7x").
+		WithVersion(test.MinVersion68x).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
-		WithVersion("7.3.0").
+		WithVersion(test.Ctx().ElasticStackVersion).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
 
 	RunESMutation(t, initial, mutated)
 }
 
-func TestVersionUpgradeSingleMaster68xToNewNodeSet73x(t *testing.T) {
+func TestVersionUpgradeSingleMaster68xToNewNodeSet7x(t *testing.T) {
+	test.SkipIfMinVersion68x(t)
+
 	// covers the case where the existing zen1 master get upgraded/restarted to a zen2 master
 	// but the new one is specified in a different NodeSet, hence gets created before the old one is removed
-	initial := elasticsearch.NewBuilder("test-version-up-68x-to-new-73x").
-		WithVersion("6.8.5").
+	initial := elasticsearch.NewBuilder("test-version-up-68x-to-new-7x").
+		WithVersion(test.MinVersion68x).
 		WithNodeSet(esv1.NodeSet{
 			Name:        "master68x",
 			Count:       int32(1),
@@ -63,9 +72,9 @@ func TestVersionUpgradeSingleMaster68xToNewNodeSet73x(t *testing.T) {
 		})
 
 	mutated := initial.WithNoESTopology().
-		WithVersion("7.3.0").
+		WithVersion(test.Ctx().ElasticStackVersion).
 		WithNodeSet(esv1.NodeSet{
-			Name:        "master73x",
+			Name:        "master7x",
 			Count:       int32(1),
 			PodTemplate: elasticsearch.ESPodTemplate(elasticsearch.DefaultResources),
 		})
@@ -73,39 +82,48 @@ func TestVersionUpgradeSingleMaster68xToNewNodeSet73x(t *testing.T) {
 	RunESMutation(t, initial, mutated)
 }
 
-func TestVersionUpgradeSingleMaster68xToMore73x(t *testing.T) {
+func TestVersionUpgradeSingleMaster68xToMore7x(t *testing.T) {
+	test.SkipIfMinVersion68x(t)
+	test.SkipIfFrom7xTo7x(t)
+
 	// covers the case where the existing zen1 master get upgraded/restarted to a zen2 master
 	// but the user defines an additional zen2 master that gets created before the old one is upgraded
-	initial := elasticsearch.NewBuilder("test-version-up-1-68x-more-73x").
-		WithVersion("6.8.5").
+	initial := elasticsearch.NewBuilder("test-version-up-1-68x-more-7x").
+		WithVersion(test.MinVersion68x).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
-		WithVersion("7.3.0").
+		WithVersion(test.Ctx().ElasticStackVersion).
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	RunESMutation(t, initial, mutated)
 }
 
-func TestVersionUpgradeSingle710To730(t *testing.T) {
-	initial := elasticsearch.NewBuilder("test-version-up-1-710-to-732").
-		WithVersion("7.1.0").
+func TestVersionUpgradeSingle7xTo7x(t *testing.T) {
+	test.SkipIfMinVersion68x(t)
+	test.SkipIfFrom7xTo7x(t)
+
+	initial := elasticsearch.NewBuilder("test-version-up-1-7x-to-7x").
+		WithVersion(test.Ctx().ElasticStackVersion).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
-		WithVersion("7.3.2").
+		WithVersion(test.LatestVersion7x).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	RunESMutation(t, initial, mutated)
 }
 
-func TestVersionUpgradeSingle740To760(t *testing.T) {
-	initial := elasticsearch.NewBuilder("test-version-up-1-742-to-760").
-		WithVersion("7.4.2").
+func TestVersionUpgradeTwoNodes7xTo7x(t *testing.T) {
+	test.SkipIfMinVersion68x(t)
+	test.SkipIfFrom7xTo7x(t)
+
+	initial := elasticsearch.NewBuilder("test-version-up-2-7x-to-7x").
+		WithVersion(test.Ctx().ElasticStackVersion).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
-		WithVersion("7.6.0").
+		WithVersion(test.LatestVersion7x).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	RunESMutation(t, initial, mutated)

--- a/test/e2e/es/version_upgrade_test.go
+++ b/test/e2e/es/version_upgrade_test.go
@@ -13,58 +13,70 @@ import (
 )
 
 func TestVersionUpgradeSingleNode68xTo7x(t *testing.T) {
-	test.SkipIfMinVersion68x(t)
+	srcVersion := test.MinVersion68x
+	dstVersion := test.Ctx().ElasticStackVersion
+
+	test.SkipInvalidUpgrade(t, srcVersion, dstVersion)
 
 	// covers the case where the existing zen1 master needs to be upgraded/restarted to a zen2 master
 	initial := elasticsearch.NewBuilder("test-version-up-1-68x-to-7x").
-		WithVersion(test.MinVersion68x).
+		WithVersion(srcVersion).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
-		WithVersion(test.Ctx().ElasticStackVersion).
+		WithVersion(dstVersion).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	RunESMutation(t, initial, mutated)
 }
 
 func TestVersionUpgradeTwoNodes68xTo7x(t *testing.T) {
-	test.SkipIfMinVersion68x(t)
+	srcVersion := test.MinVersion68x
+	dstVersion := test.Ctx().ElasticStackVersion
+
+	test.SkipInvalidUpgrade(t, srcVersion, dstVersion)
 
 	// covers the case where 2 existing zen1 masters get upgraded/restarted to zen2 masters
 	// due to minimum_master_nodes=2, the cluster is unavailable while the first master is upgraded
 	initial := elasticsearch.NewBuilder("test-version-up-2-68x-to-7x").
-		WithVersion(test.MinVersion68x).
+		WithVersion(srcVersion).
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
-		WithVersion(test.Ctx().ElasticStackVersion).
+		WithVersion(dstVersion).
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	RunESMutation(t, initial, mutated)
 }
 
 func TestVersionUpgrade3Nodes68xTo7x(t *testing.T) {
-	test.SkipIfMinVersion68x(t)
+	srcVersion := test.MinVersion68x
+	dstVersion := test.Ctx().ElasticStackVersion
+
+	test.SkipInvalidUpgrade(t, srcVersion, dstVersion)
 
 	// covers the case where 3 existing zen1 masters get upgraded/restarted to zen2 masters (standard rolling upgrade)
 	initial := elasticsearch.NewBuilder("test-version-up-3-68x-to-7x").
-		WithVersion(test.MinVersion68x).
+		WithVersion(srcVersion).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
-		WithVersion(test.Ctx().ElasticStackVersion).
+		WithVersion(dstVersion).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
 
 	RunESMutation(t, initial, mutated)
 }
 
 func TestVersionUpgradeSingleMaster68xToNewNodeSet7x(t *testing.T) {
-	test.SkipIfMinVersion68x(t)
+	srcVersion := test.MinVersion68x
+	dstVersion := test.Ctx().ElasticStackVersion
+
+	test.SkipInvalidUpgrade(t, srcVersion, dstVersion)
 
 	// covers the case where the existing zen1 master get upgraded/restarted to a zen2 master
 	// but the new one is specified in a different NodeSet, hence gets created before the old one is removed
 	initial := elasticsearch.NewBuilder("test-version-up-68x-to-new-7x").
-		WithVersion(test.MinVersion68x).
+		WithVersion(srcVersion).
 		WithNodeSet(esv1.NodeSet{
 			Name:        "master68x",
 			Count:       int32(1),
@@ -72,7 +84,7 @@ func TestVersionUpgradeSingleMaster68xToNewNodeSet7x(t *testing.T) {
 		})
 
 	mutated := initial.WithNoESTopology().
-		WithVersion(test.Ctx().ElasticStackVersion).
+		WithVersion(dstVersion).
 		WithNodeSet(esv1.NodeSet{
 			Name:        "master7x",
 			Count:       int32(1),
@@ -83,47 +95,53 @@ func TestVersionUpgradeSingleMaster68xToNewNodeSet7x(t *testing.T) {
 }
 
 func TestVersionUpgradeSingleMaster68xToMore7x(t *testing.T) {
-	test.SkipIfMinVersion68x(t)
-	test.SkipIfFrom7xTo7x(t)
+	srcVersion := test.MinVersion68x
+	dstVersion := test.Ctx().ElasticStackVersion
+
+	test.SkipInvalidUpgrade(t, srcVersion, dstVersion)
 
 	// covers the case where the existing zen1 master get upgraded/restarted to a zen2 master
 	// but the user defines an additional zen2 master that gets created before the old one is upgraded
 	initial := elasticsearch.NewBuilder("test-version-up-1-68x-more-7x").
-		WithVersion(test.MinVersion68x).
+		WithVersion(srcVersion).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
-		WithVersion(test.Ctx().ElasticStackVersion).
+		WithVersion(dstVersion).
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	RunESMutation(t, initial, mutated)
 }
 
-func TestVersionUpgradeSingle7xTo7x(t *testing.T) {
-	test.SkipIfMinVersion68x(t)
-	test.SkipIfFrom7xTo7x(t)
+func TestVersionUpgradeSingleToLatest7x(t *testing.T) {
+	srcVersion := test.Ctx().ElasticStackVersion
+	dstVersion := test.LatestVersion7x
 
-	initial := elasticsearch.NewBuilder("test-version-up-1-7x-to-7x").
-		WithVersion(test.Ctx().ElasticStackVersion).
+	test.SkipInvalidUpgrade(t, srcVersion, dstVersion)
+
+	initial := elasticsearch.NewBuilder("test-version-up-1-to-7x").
+		WithVersion(srcVersion).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
-		WithVersion(test.LatestVersion7x).
+		WithVersion(dstVersion).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
 	RunESMutation(t, initial, mutated)
 }
 
-func TestVersionUpgradeTwoNodes7xTo7x(t *testing.T) {
-	test.SkipIfMinVersion68x(t)
-	test.SkipIfFrom7xTo7x(t)
+func TestVersionUpgradeTwoNodesToLatest7x(t *testing.T) {
+	srcVersion := test.Ctx().ElasticStackVersion
+	dstVersion := test.LatestVersion7x
 
-	initial := elasticsearch.NewBuilder("test-version-up-2-7x-to-7x").
-		WithVersion(test.Ctx().ElasticStackVersion).
+	test.SkipInvalidUpgrade(t, srcVersion, dstVersion)
+
+	initial := elasticsearch.NewBuilder("test-version-up-2-to-7x").
+		WithVersion(dstVersion).
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
-		WithVersion(test.LatestVersion7x).
+		WithVersion(dstVersion).
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	RunESMutation(t, initial, mutated)

--- a/test/e2e/es/version_upgrade_test.go
+++ b/test/e2e/es/version_upgrade_test.go
@@ -120,11 +120,11 @@ func TestVersionUpgradeTwoNodes7xTo7x(t *testing.T) {
 
 	initial := elasticsearch.NewBuilder("test-version-up-2-7x-to-7x").
 		WithVersion(test.Ctx().ElasticStackVersion).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
 		WithVersion(test.LatestVersion7x).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	RunESMutation(t, initial, mutated)
 }

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -17,7 +17,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const defaultElasticStackVersion = "7.6.0"
+var defaultElasticStackVersion = LatestVersion7x
 
 var (
 	testContextPath = flag.String("testContextPath", "", "Path to the test context file")

--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -5,6 +5,7 @@
 package test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
@@ -22,7 +23,7 @@ const (
 func SkipInvalidUpgrade(t *testing.T, srcVersion string, dstVersion string) {
 	isValid, err := isValidUpgrade(srcVersion, dstVersion)
 	if err != nil {
-		t.Fatal("Fail to parse Elastic Stack version", "err", err.Error())
+		t.Fatalf("Failed to determine the validity of the upgrade path: %v", err)
 	}
 	if !isValid {
 		t.SkipNow()
@@ -33,11 +34,11 @@ func SkipInvalidUpgrade(t *testing.T, srcVersion string, dstVersion string) {
 func isValidUpgrade(from string, to string) (bool, error) {
 	srcVer, err := version.Parse(from)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to parse version '%s': %w", from, err)
 	}
 	dstVer, err := version.Parse(to)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to parse version '%s': %w", from, err)
 	}
 	// major digits must be equal or differ by only 1
 	validMajorDigit := dstVer.Major == srcVer.Major || dstVer.Major == srcVer.Major+1

--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -38,7 +38,7 @@ func isValidUpgrade(from string, to string) (bool, error) {
 	}
 	dstVer, err := version.Parse(to)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse version '%s': %w", from, err)
+		return false, fmt.Errorf("failed to parse version '%s': %w", to, err)
 	}
 	// major digits must be equal or differ by only 1
 	validMajorDigit := dstVer.Major == srcVer.Major || dstVer.Major == srcVer.Major+1

--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -6,19 +6,27 @@ package test
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/util/version"
 )
 
-// MinVersionOrSkip run this test only if the server has at least version v.
-func MinVersionOrSkip(t *testing.T, v string) {
-	info, err := ServerVersion()
-	require.NoError(t, err)
+// Elastic Stack versions used in the E2E tests
+var (
+	// Minimum version for 6.8.x tested with the operator
+	MinVersion68x = "6.8.5"
+	// Minimum version for 7.x tested with the operator
+	MinVersion7x = "7.1.1"
+	// Current latest version for 7.x
+	LatestVersion7x = "7.6.0" // version to synchronize with the latest release of the Elastic Stack
+)
 
-	min := version.MustParseGeneric(v)
-	actual := version.MustParseGeneric(info.GitVersion)
-	if !actual.AtLeast(min) {
+func SkipIfMinVersion68x(t *testing.T) {
+	if Ctx().ElasticStackVersion == MinVersion68x {
+		t.SkipNow()
+	}
+}
+
+func SkipIfFrom7xTo7x(t *testing.T) {
+	v := Ctx().ElasticStackVersion
+	if v == MinVersion7x || v == LatestVersion7x {
 		t.SkipNow()
 	}
 }

--- a/test/e2e/test/version_test.go
+++ b/test/e2e/test/version_test.go
@@ -1,0 +1,41 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsValidUpgrade(t *testing.T) {
+	tests := []struct {
+		from    string
+		to      string
+		isValid bool
+	}{
+		// valid upgrade paths
+		{from: "6.8.5", to: "6.8.6", isValid: true},
+		{from: "6.8.5", to: "7.1.1", isValid: true},
+		{from: "7.1.1", to: "7.6.0", isValid: true},
+		{from: "7.6.0", to: "8.0.0", isValid: true},
+		{from: "7.6.0", to: "8.0.0-SNAPSHOT", isValid: true},
+		// invalid upgrade paths
+		{from: "7.6.0", to: "7.6.0", isValid: false},
+		{from: "7.6.0", to: "7.5.0", isValid: false},
+		{from: "7.6.1", to: "7.6.0", isValid: false},
+		{from: "7.6.0", to: "6.8.5", isValid: false},
+		{from: "7.6.0", to: "9.0.0", isValid: false},
+	}
+
+	for _, tt := range tests {
+		isValid, err := isValidUpgrade(tt.from, tt.to)
+		require.NoError(t, err)
+		if tt.isValid != isValid {
+			t.Errorf(`isValidUpgrade("%s", "%s") = %v, want %v`, tt.from, tt.to, isValid, tt.isValid)
+		}
+		require.Equal(t, tt.isValid, isValid)
+	}
+}


### PR DESCRIPTION
This commit decreases the number of version of the Elastic Stack that is
involved when executing all the E2E tests. It also allows testing more
different combinations of version upgrades.

* Define static versions for min 68x, min 7x and latest 7x
* Use the Elastic Stack version in the version upgrade tests:
  * **from** the min 68x version **to** the Elastic Stack version
  * **from** the Elastic Stack Version **to** the latest 7x version
* Skip some tests if they are not relevant to the Elastic Stack version
* Use the latest version 7.x as the default value for the Elastic Stack version

Resolves #2560.
Relates to #2253, #2565.