### PR TITLE
Remove the WEBHOOK_PODS_LABEL env var

### DIFF
--- a/config/e2e/operator.yaml
+++ b/config/e2e/operator.yaml
@@ -188,8 +188,6 @@ spec:
                 fieldPath: metadata.namespace
           - name: WEBHOOK_SECRET
             value: webhook-server-secret
-          - name: WEBHOOK_PODS_LABEL
-            value: {{ .Operator.Name }}
           - name: OPERATOR_IMAGE
             value: {{ .OperatorImage }}
         resources:

--- a/config/operator/all-in-one/operator.template.yaml
+++ b/config/operator/all-in-one/operator.template.yaml
@@ -31,8 +31,6 @@ spec:
                 fieldPath: metadata.namespace
           - name: WEBHOOK_SECRET
             value: elastic-webhook-server-cert
-          - name: WEBHOOK_PODS_LABEL
-            value: elastic-operator
           - name: OPERATOR_IMAGE
             value: <OPERATOR_IMAGE>
         resources:


### PR DESCRIPTION
This environment variable does not seem to be used anywhere. To specify
a label selector for the Pods, one can just edit the label selector in
the webhook service, as part of ECK manifests.

Fixes https://github.com/elastic/cloud-on-k8s/issues/2582