### PR TITLE
Small fixes to CI docs

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -19,7 +19,7 @@ VAULT_TOKEN = $(shell vault write -address=$(VAULT_ADDR) -field=token auth/appro
 else
 VAULT_TOKEN = $(shell vault write -address=$(VAULT_ADDR) -field=token auth/github/login token=$(GITHUB_TOKEN))
 # we use roleId as a string that has to be there for authn/z for CI, but it's empty and not needed for local execution
-NOT_USED := $(shell test -e $(ROOT_DIR)/deployer-config.yml && sed -i '' -e "s;roleId: dev;token: $(GITHUB_TOKEN);g" $(ROOT_DIR)/deployer-config.yml)
+NOT_USED := $(shell test -e $(ROOT_DIR)/deployer-config.yml && sed "s;roleId:.*;token: $(GITHUB_TOKEN);g" $(ROOT_DIR)/deployer-config.yml > tmp && mv tmp deployer-config.yml)
 endif
 endif
 

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -19,7 +19,7 @@ VAULT_TOKEN = $(shell vault write -address=$(VAULT_ADDR) -field=token auth/appro
 else
 VAULT_TOKEN = $(shell vault write -address=$(VAULT_ADDR) -field=token auth/github/login token=$(GITHUB_TOKEN))
 # we use roleId as a string that has to be there for authn/z for CI, but it's empty and not needed for local execution
-NOT_USED := $(shell test -e $(ROOT_DIR)/deployer-config.yml && sed -i -e "s;roleId:;token: $(GITHUB_TOKEN);g" $(ROOT_DIR)/deployer-config.yml)
+NOT_USED := $(shell test -e $(ROOT_DIR)/deployer-config.yml && sed -i '' -e "s;roleId: dev;token: $(GITHUB_TOKEN);g" $(ROOT_DIR)/deployer-config.yml)
 endif
 endif
 

--- a/.ci/README.md
+++ b/.ci/README.md
@@ -18,28 +18,27 @@ For debugging and development purposes it's possible to run CI jobs from dev box
 
 Once, run:
 ```
-export BUILD_TAG=local-ci-$(USER//_)
-
 # fill out:
-export GCLOUD_PROJECT=YOUR_GCLOUD_PROJECT
 export VAULT_ADDR=YOUR_VAULT_INSTANCE_ADDRESS
 export GITHUB_TOKEN=YOUR_PERSONAL_ACCESS_TOKEN
 ``` 
 
-Per repro, depending on the job, set up `.env` and `deployer-config.yml` files by using [setenvconfig](setenvconfig) invocation from the respective Jenkinsfile. For example:
+Per repro, depending on the job, set up `.env` and `deployer-config.yml` files by using [setenvconfig](setenvconfig) invocation from the respective Jenkinsfile. The script will prompt for any missing environment variables that are required for a given job. See examples below. 
 
+Test the `cloud-on-k8s-e2e-tests-master` job:
 ```sh
-# Test the cloud-on-k8s-e2e-tests-master job
-> .ci/setenvvonfig e2e/master
-> make -C .ci get-monitoring-secrets get-test-license get-elastic-public-key TARGET=ci-build-operator-e2e-run ci
-
-# Test the cloud-on-k8s-e2e-tests-stack-versions
-> JKS_PARAM_OPERATOR_IMAGE=docker.elastic.co/eck-snapshots/eck-operator:1.0.1-SNAPSHOT-2020-02-05-7892889 \
-	.ci/setenvconfig e2e/stack-versions eck-75-dev-e2e 7.5.1
-> make -C .ci get-test-license get-elastic-public-key TARGET=ci-e2e ci
+.ci/setenvconfig e2e/master
+make -C .ci get-monitoring-secrets get-test-license get-elastic-public-key TARGET=ci-build-operator-e2e-run ci
 ```
 
-The CI Makefile will take care of setting up correct credentials in the `deployer-config.yml` file.
+Test the `cloud-on-k8s-e2e-tests-stack-versions` job:
+```sh
+JKS_PARAM_OPERATOR_IMAGE=docker.elastic.co/eck-snapshots/eck-operator:1.0.1-SNAPSHOT-2020-02-05-7892889 \
+  .ci/setenvconfig e2e/stack-versions eck-75-dev-e2e 7.5.1
+make -C .ci get-test-license get-elastic-public-key TARGET=ci-e2e ci
+```
+
+The CI Makefile will take care of setting up correct credentials in the `deployer-config.yml` file. For more details about settings in this file, see [deployer](/hack/deployer/README.md#advanced-usage).
 
 This will run e2e tests using the same:
 1. container


### PR DESCRIPTION
- point from CI docs to deployer as CI bits in deployer readme were removed in https://github.com/elastic/cloud-on-k8s/pull/2577
- fix `.ci/Makefile` to properly inject credentials to `deployer-config.yml` created by `.ci/setenvconfig`