### PR TITLE
Restore E2E tests for 7.5.2

### DIFF
--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -80,6 +80,17 @@ pipeline {
                         }
                     }
                 }
+                stage("7.5.2") {
+                    agent {
+                        label 'linux'
+                    }
+                    steps {
+                        checkout scm
+                        script {
+                            runWith(lib, failedTests, "eck-75-${BUILD_NUMBER}-e2e", "7.5.2")
+                        }
+                    }
+                }
                 stage("7.6.0") {
                     agent {
                         label 'linux'
@@ -126,7 +137,8 @@ pipeline {
                     "eck-72-${BUILD_NUMBER}-e2e",
                     "eck-73-${BUILD_NUMBER}-e2e",
                     "eck-74-${BUILD_NUMBER}-e2e",
-                    "eck-75-${BUILD_NUMBER}-e2e"
+                    "eck-75-${BUILD_NUMBER}-e2e",
+                    "eck-76-${BUILD_NUMBER}-e2e"
                 ]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',


### PR DESCRIPTION
Removed in https://github.com/elastic/cloud-on-k8s/pull/2546#discussion_r378101299 a little in doubt.