### PR TITLE
New make target to ease job chaining in CI

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -25,7 +25,7 @@ endif
 
 CI_IMAGE ?= docker.elastic.co/eck/eck-ci:$(shell md5sum $(ROOT_DIR)/go.mod $(ROOT_DIR)/.ci/Dockerfile | awk '{print $$1}' | md5sum | awk '{print $$1}')
 
-show-image:
+print-ci-image:
 	@ echo $(CI_IMAGE)
 
 # runs $TARGET in context of CI container and dev makefile

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -9,7 +9,7 @@
 set -eou pipefail
 
 # ECK CI tooling image
-docker pull $(make -C .ci --no-print-directory show-image)
+docker pull $(make -C .ci --no-print-directory print-ci-image)
 
 # Kind images (https://hub.docker.com/r/kindest/node/tags)
 docker pull kindest/node:v1.12.10

--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
     post {
         success {
             script {
-                def operatorImage = readFromEnvFile("OPERATOR_IMAGE")
+                def operatorImage = sh(returnStdout: true, script: 'make show-operator-image').trim()
 
                 build job: 'cloud-on-k8s-e2e-tests-stack-versions',
                     parameters: [string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage)],

--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
     post {
         success {
             script {
-                def operatorImage = sh(returnStdout: true, script: 'make show-operator-image').trim()
+                def operatorImage = sh(returnStdout: true, script: 'make print-operator-image').trim()
 
                 build job: 'cloud-on-k8s-e2e-tests-stack-versions',
                     parameters: [string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage)],

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,7 @@ KUBECTL_CLUSTER := $(shell kubectl config current-context 2> /dev/null)
 LOG_VERBOSITY ?= 1
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq ($(shell go env GOBIN 2>/dev/null),)
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
+GOBIN := $(or $(shell go env GOBIN 2>/dev/null), $(shell go env GOPATH 2>/dev/null)/bin)
 
 # find or download controller-gen
 # note this does not validate the version

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ KUBECTL_CLUSTER := $(shell kubectl config current-context 2> /dev/null)
 LOG_VERBOSITY ?= 1
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq ($(shell go env GOBIN),)
+ifeq ($(shell go env GOBIN 2>/dev/null),)
 GOBIN=$(shell go env GOPATH)/bin
 else
 GOBIN=$(shell go env GOBIN)
@@ -58,6 +58,8 @@ IMG_VERSION ?= $(VERSION)-$(TAG)
 BASE_IMG       := $(REGISTRY)/$(REPOSITORY)/$(IMG_NAME)
 OPERATOR_IMAGE ?= $(BASE_IMG):$(IMG_VERSION)
 
+show-operator-image:
+	@ echo $(OPERATOR_IMAGE)
 
 GO_LDFLAGS := -X github.com/elastic/cloud-on-k8s/pkg/about.version=$(VERSION) \
 	-X github.com/elastic/cloud-on-k8s/pkg/about.buildHash=$(TAG) \

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ IMG_VERSION ?= $(VERSION)-$(TAG)
 BASE_IMG       := $(REGISTRY)/$(REPOSITORY)/$(IMG_NAME)
 OPERATOR_IMAGE ?= $(BASE_IMG):$(IMG_VERSION)
 
-show-operator-image:
+print-operator-image:
 	@ echo $(OPERATOR_IMAGE)
 
 GO_LDFLAGS := -X github.com/elastic/cloud-on-k8s/pkg/about.version=$(VERSION) \


### PR DESCRIPTION
This commit fixes how the name of the operator image is retrieved in the
nightly and the release build jobs in order to trigger the different e2e
tests jobs.

Since #2502, we now rely on the `OPERATOR_IMAGE` variable computed
in the `Makefile` and stop to write it manually in the `.env` file. 