### PR TITLE
Ensure StatefulSets have been processed by the StatefulSet controller before doing any upgrade

### DIFF
--- a/pkg/controller/common/version/version.go
+++ b/pkg/controller/common/version/version.go
@@ -93,11 +93,6 @@ func (v *Version) IsSameOrAfter(other Version) bool {
 		(v.Major == other.Major && v.Minor == other.Minor && v.Patch >= other.Patch)
 }
 
-// IsSame returns true if the receiver is the same version than the argument.
-func (v *Version) IsSame(other Version) bool {
-	return v.Major == other.Major && v.Minor == other.Minor && v.Patch == other.Patch
-}
-
 // Min returns the minimum version in vs or nil.
 func Min(vs []Version) *Version {
 	sort.SliceStable(vs, func(i, j int) bool {

--- a/pkg/controller/elasticsearch/driver/expectations_test.go
+++ b/pkg/controller/elasticsearch/driver/expectations_test.go
@@ -46,8 +46,14 @@ func Test_defaultDriver_expectationSatisfied(t *testing.T) {
 	satisfied, err = d.expectationsSatisfied()
 	require.NoError(t, err)
 	require.False(t, satisfied)
-	// satisfied now
+	// satisfied now, but not from the StatefulSet controller point of view (status.observedGeneration)
 	statefulSet.Generation = 123
+	require.NoError(t, client.Update(&statefulSet))
+	satisfied, err = d.expectationsSatisfied()
+	require.NoError(t, err)
+	require.False(t, satisfied)
+	// satisfied now, with matching status.observedGeneration
+	statefulSet.Status.ObservedGeneration = 123
 	require.NoError(t, client.Update(&statefulSet))
 	satisfied, err = d.expectationsSatisfied()
 	require.NoError(t, err)

--- a/pkg/controller/elasticsearch/driver/fixtures.go
+++ b/pkg/controller/elasticsearch/driver/fixtures.go
@@ -5,7 +5,6 @@
 package driver
 
 import (
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,7 +24,9 @@ const (
 )
 
 type testPod struct {
-	name, version, revision, ssetName                        string
+	name                                                     string
+	version                                                  string
+	ssetName                                                 string
 	master, data, healthy, toUpgrade, inCluster, terminating bool
 	uid                                                      types.UID
 }
@@ -44,7 +45,6 @@ func (t testPod) isHealthy(v bool) testPod              { t.healthy = v; return 
 func (t testPod) needsUpgrade(v bool) testPod           { t.toUpgrade = v; return t }
 func (t testPod) isTerminating(v bool) testPod          { t.terminating = v; return t }
 func (t testPod) withVersion(v string) testPod          { t.version = v; return t }
-func (t testPod) withRevision(v string) testPod         { t.revision = v; return t }
 func (t testPod) inStatefulset(ssetName string) testPod { t.ssetName = ssetName; return t } //nolint:unparam
 
 // filter to simulate a Pod that has been removed while upgrading
@@ -243,7 +243,6 @@ func (t testPod) toPod() corev1.Pod {
 	labels := map[string]string{}
 	labels[label.VersionLabelName] = t.version
 	labels[label.ClusterNameLabelName] = TestEsName
-	labels[appsv1.StatefulSetRevisionLabel] = t.revision
 	label.NodeTypesMasterLabelName.Set(t.master, labels)
 	label.NodeTypesDataLabelName.Set(t.data, labels)
 	labels[label.StatefulSetNameLabelName] = t.ssetName

--- a/pkg/controller/elasticsearch/driver/upgrade_forced.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_forced.go
@@ -15,7 +15,7 @@ import (
 
 func (d *defaultDriver) MaybeForceUpgrade(statefulSets sset.StatefulSetList) (bool, error) {
 	// Get the pods to upgrade
-	podsToUpgrade, err := podsToUpgrade(d.ES, d.Client, statefulSets)
+	podsToUpgrade, err := podsToUpgrade(d.Client, statefulSets)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -7,23 +7,31 @@ package driver
 import (
 	"testing"
 
-	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func Test_podsToUpgrade(t *testing.T) {
-	defaultEs := esv1.Elasticsearch{
-		Spec: esv1.ElasticsearchSpec{
-			Version: "7.1.0",
+const testNamespace = "ns"
+
+func podWithRevision(name, revision string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			Labels:    map[string]string{appsv1.StatefulSetRevisionLabel: revision},
 		},
 	}
+}
+
+func Test_podsToUpgrade(t *testing.T) {
 	type args struct {
-		pods         upgradeTestPods
+		pods         []runtime.Object
 		statefulSets sset.StatefulSetList
-		es           esv1.Elasticsearch
 	}
 	tests := []struct {
 		name    string
@@ -44,14 +52,13 @@ func Test_podsToUpgrade(t *testing.T) {
 						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-a", UpdateRevision: "rev-b", UpdatedReplicas: 0, Replicas: 3},
 					}.Build(),
 				},
-				pods: newUpgradeTestPods(
-					newTestPod("masters-0").withRevision("rev-a").withVersion("7.1.0"),
-					newTestPod("masters-1").withRevision("rev-a").withVersion("7.1.0"),
-					newTestPod("nodes-0").withRevision("rev-a").withVersion("7.1.0"),
-					newTestPod("nodes-1").withRevision("rev-a").withVersion("7.1.0"),
-					newTestPod("nodes-2").withRevision("rev-a").withVersion("7.1.0"),
-				),
-				es: defaultEs,
+				pods: []runtime.Object{
+					podWithRevision("masters-0", "rev-a"),
+					podWithRevision("masters-1", "rev-a"),
+					podWithRevision("nodes-0", "rev-a"),
+					podWithRevision("nodes-1", "rev-a"),
+					podWithRevision("nodes-2", "rev-a"),
+				},
 			},
 			want: []string{"masters-0", "masters-1", "nodes-0", "nodes-1", "nodes-2"},
 		},
@@ -68,11 +75,10 @@ func Test_podsToUpgrade(t *testing.T) {
 						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-b", UpdateRevision: "rev-b", UpdatedReplicas: 3, Replicas: 3},
 					}.Build(),
 				},
-				pods: newUpgradeTestPods(
-					newTestPod("masters-0").withRevision("rev-a").withVersion("7.1.0"),
-					newTestPod("masters-1").withRevision("rev-a").withVersion("7.1.0"),
-				),
-				es: defaultEs,
+				pods: []runtime.Object{
+					podWithRevision("masters-0", "rev-a"),
+					podWithRevision("masters-1", "rev-a"),
+				},
 			},
 			want: []string{"masters-0", "masters-1"},
 		},
@@ -89,11 +95,10 @@ func Test_podsToUpgrade(t *testing.T) {
 						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-b", UpdateRevision: "", UpdatedReplicas: 3, Replicas: 3},
 					}.Build(),
 				},
-				pods: newUpgradeTestPods(
-					newTestPod("masters-0").withRevision("rev-a").withVersion("7.1.0"),
-					newTestPod("masters-1").withRevision("rev-a").withVersion("7.1.0"),
-				),
-				es: defaultEs,
+				pods: []runtime.Object{
+					podWithRevision("masters-0", "rev-a"),
+					podWithRevision("masters-1", "rev-a"),
+				},
 			},
 			want: []string{},
 		},
@@ -110,43 +115,18 @@ func Test_podsToUpgrade(t *testing.T) {
 						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-b", UpdateRevision: "rev-b", UpdatedReplicas: 3, Replicas: 3},
 					}.Build(),
 				},
-				pods: newUpgradeTestPods(
-					newTestPod("masters-0").withRevision("rev-b").withVersion("7.1.0"),
-					newTestPod("masters-1").withRevision("rev-a").withVersion("7.1.0"),
-				),
-				es: defaultEs,
+				pods: []runtime.Object{
+					podWithRevision("masters-0", "rev-b"),
+					podWithRevision("masters-1", "rev-a"),
+				},
 			},
 			want: []string{"masters-1"},
-		},
-		{
-			name: "StatefulSet has been updated with a new ES version but StatefulSet update revision is not yet up to date",
-			args: args{
-				statefulSets: sset.StatefulSetList{
-					sset.TestSset{
-						Name: "masters", Replicas: 2, Master: true, Data: false,
-						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-master-a", UpdateRevision: "rev-master-b", UpdatedReplicas: 0, Replicas: 2},
-					}.Build(),
-					sset.TestSset{
-						Name: "nodes", Replicas: 3, Master: false, Data: true,
-						Status: appsv1.StatefulSetStatus{CurrentRevision: "rev-nodes-a", UpdateRevision: "rev-nodes-a", UpdatedReplicas: 0, Replicas: 3},
-					}.Build(),
-				},
-				pods: newUpgradeTestPods(
-					newTestPod("masters-0").withRevision("rev-master-a").withVersion("6.8.2"),
-					newTestPod("masters-1").withRevision("rev-master-a").withVersion("6.8.2"),
-					newTestPod("nodes-0").withRevision("rev-nodes-a").withVersion("6.8.2"),
-					newTestPod("nodes-1").withRevision("rev-nodes-a").withVersion("6.8.2"),
-					newTestPod("nodes-2").withRevision("rev-nodes-a").withVersion("6.8.2"),
-				),
-				es: defaultEs,
-			},
-			want: []string{"masters-0", "masters-1", "nodes-0", "nodes-1", "nodes-2"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := k8s.WrappedFakeClient(tt.args.pods.toRuntimeObjects(tt.args.es.Spec.Version, 1, nothing)...)
-			got, err := podsToUpgrade(tt.args.es, client, tt.args.statefulSets)
+			client := k8s.WrappedFakeClient(tt.args.pods...)
+			got, err := podsToUpgrade(client, tt.args.statefulSets)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("podsToUpgrade() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/elasticsearch/sset/list.go
+++ b/pkg/controller/elasticsearch/sset/list.go
@@ -159,6 +159,20 @@ func (l StatefulSetList) PodReconciliationDone(c k8s.Client) (bool, error) {
 	return true, nil
 }
 
+// StatusReconciliationDone returns true if status.observedGeneration matches the metadata.generation
+// in all StatefulSets.
+// The status is automatically updated by the StatefulSet controller: if the observedGeneration does not match
+// the metadata generation, it means the resource has not been processed by the StatefulSet controller yet.
+// When that happens, other fields in the StatefulSet status (eg. "updateRevision") may not be up to date.
+func (l StatefulSetList) StatusReconciliationDone() bool {
+	for _, s := range l {
+		if s.Generation != s.Status.ObservedGeneration {
+			return false
+		}
+	}
+	return true
+}
+
 // DeepCopy returns a copy of the StatefulSetList with no reference to the original StatefulSetList.
 func (l StatefulSetList) DeepCopy() StatefulSetList {
 	result := make(StatefulSetList, 0, len(l))


### PR DESCRIPTION
Compare StatefulSets `status.observedGeneration`with `metadata.generation` and requeue if they differ.

This PR is composed of 2 commits that are better reviewed separately.

## 1. Check StatefulSets generations in expectations

This commit ensures the Elasticsearch driver is not working based on a
StatefulSet that has not been processed by the StatefulSet controller
yet. This is particularly important in rolling upgrades where we check
the value of `status.updateRevision`.

When a change is made to a StatefulSet spec, the `metadata.generation`
field gets incremented by the apiserver. This concerns the spec only,
not other metadata (eg. annotations or labels).
Since Kubernetes 1.6, the StatefulSet controller sets
`status.observedGeneration` to the value of `metadata.generation`. An
easy way to know if the StatefulSet has been processed by the
StatefulSet controller yet is to compare generation vs.
observedGeneration.

## 2. Revert changes introduced to workaround version changes inconsistencies

This PR reverts changes introduced in commit https://github.com/elastic/cloud-on-k8s/commit/3c97cf5c730489305fecd96434a33939958456ae (PR  https://github.com/elastic/cloud-on-k8s/pull/2411).
I think this PR's approach is a better alternative than what we did in https://github.com/elastic/cloud-on-k8s/pull/2411. It considers any StatefulSet spec change, not only version upgrades, and the implementation seems simpler and cleaner to me.

Fixes https://github.com/elastic/cloud-on-k8s/issues/2393 and https://github.com/elastic/cloud-on-k8s/issues/2434.
