### PR TITLE
Document how to set up remote clusters across k8s boundaries

### DIFF
--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -29,6 +29,7 @@ Before you deploy and run ECK, take some time to look at the basic and advanced 
 - <<{p}-advanced-node-scheduling,Advanced Elasticsearch node scheduling>>
 - <<{p}-orchestration>>
 - <<{p}-snapshots,Create automated snapshots>>
+- <<{p}-remote-clusters,Remote clusters>>
 - <<{p}-readiness>>
 - <<{p}-prestop>>
 
@@ -547,6 +548,7 @@ spec:
 include::orchestration.asciidoc[]
 include::advanced-node-scheduling.asciidoc[]
 include::snapshots.asciidoc[]
+include::remote-clusters.asciidoc[]
 
 
 [id="{p}-readiness"]

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -43,7 +43,7 @@ kubectl get secret cluster_one-es-transport-certs-public \
 -o go-template='{{index .data "ca.crt" | base64decode}}' > remote.ca.crt
 ----
 
-You then need to configure the CA as one of the trusted CAs in `cluster_two`. If that cluster is hosted outside of Kubernetes simply add the CA you extracted to the list of CAs in link:https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#_pem_encoded_files_3[`xpack.security.transport.ssl.certificate_authorities`]
+You then need to configure the CA as one of the trusted CAs in `cluster_two`. If that cluster is hosted outside of Kubernetes, simply add the CA certificate extracted in the above step to the list of CAs in link:https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#_pem_encoded_files_3[`xpack.security.transport.ssl.certificate_authorities`]
 
 If `cluster_two` is also managed by an ECK instance, proceed as follows:
 

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -30,7 +30,7 @@ For illustration purposes, consider the following example:
 * `cluster_one` resides inside Kubernetes and is managed by ECK
 * `cluster_two` is not hosted inside the same Kubernetes cluster as `cluster_one` and may not even be managed by ECK 
 
-We will configure `cluster_one` as a remote cluster in `cluster_two`.
+To configure `cluster_one` as a remote cluster in `cluster_two`:
 
 
 ===== Ensure both clusters trust each others certificate authority

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -79,7 +79,7 @@ spec:
         - name: remote-certs
           secret:
             secretName: remote-certs
-  version: 7.6.0
+  version: {version}
 ----
 
 Repeat the above steps to add the CA of `cluster_two` to `cluster_one` as well.

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -105,7 +105,7 @@ spec:
     targetPort: 9300
 ----
 
-Finally configure `cluster_one` as a remote cluster in `cluster_two` via the Elasticsearch REST API:
+Finally, configure `cluster_one` as a remote cluster in `cluster_two` using the Elasticsearch REST API:
 
 [source,sh]
 ----

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -25,7 +25,7 @@ You can configure a remote cluster connection to an ECK-managed Elasticsearch cl
 . Ensure that both clusters trust each other's certificate authority.
 . Configure the remote cluster connection via the Elasticsearch REST API.
 
-For the purposes of this guide we use the following running example:
+For illustration purposes, consider the following example:
 
 * `cluster_one` resides inside Kubernetes and is managed by ECK
 * `cluster_two` is not hosted inside the same Kubernetes cluster as `cluster_one` and may not even be managed by ECK 

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -124,4 +124,4 @@ PUT _cluster/settings
 }
 ----
 <1> setup the remote connection in "proxy" mode as `cluster_two` will connect to `cluster_one` only through the Kubernetes service abstraction and not to individual nodes directly.
-<2> `${LOADBALANCER_IP}` will be the IP address assigned to the `LoadBalancer` configured in the transport service above or it can also be a DNS name depending on your setup.
+<2> Replace `${LOADBALANCER_IP}` with the IP address assigned to the `LoadBalancer` configured above. if you have configured a DNS entry for the service, you can use the DNS name instead of the IP address as well.

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -86,7 +86,7 @@ Repeat the steps with reversed roles adding the CA of `cluster_two` to `cluster_
 
 ===== Configure the remote cluster connection via the Elasticsearch REST API
 
-Expose the transport layer of `cluster_one` to `cluster_two` which is residing outside of `cluster_one`'s Kubernetes cluster.
+Expose the transport layer of `cluster_one`.
 
 [source,yaml]
 ----

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -82,7 +82,7 @@ spec:
   version: 7.6.0
 ----
 
-Repeat the steps with reversed roles adding the CA of `cluster_two` to `cluster_one`.
+Repeat the above steps to add the CA of `cluster_two` to `cluster_one` as well.
 
 ===== Configure the remote cluster connection via the Elasticsearch REST API
 

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -57,7 +57,7 @@ Use this secret to configure `cluster_one`'s CA as a trusted CA in `cluster_two`
 
 [source,yaml,subs="attributes"]
 ----
-apiVersion: elasticsearch.k8s.elastic.co/{eck}
+apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
 kind: Elasticsearch
 metadata:
   name: cluster_two

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -123,5 +123,5 @@ PUT _cluster/settings
   }
 }
 ----
-<1> setup the remote connection in "proxy" mode as `cluster_two` will connect to `cluster_one` only through the Kubernetes service abstraction and not to individual nodes directly.
+<1> Use "proxy" mode as `cluster_two` will be connecting to `cluster_one` through the Kubernetes service abstraction.
 <2> Replace `${LOADBALANCER_IP}` with the IP address assigned to the `LoadBalancer` configured above. if you have configured a DNS entry for the service, you can use the DNS name instead of the IP address as well.

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -15,7 +15,8 @@ When using remote cluster connections with ECK the necessary setup depends on wh
 
 TBD
 
-==== One of the clusters is not in the same Kubernetes cluster
+[id="{p}-remote-clusters-connect-external"]
+==== Connect from an Elasticsearch cluster running outside the Kubernetes cluster
 
 NOTE: While it is technically possible to configure a remote cluster connection to an Elasticsearch cluster residing in Kubernetes in earlier versions, this guide only covers the setup for Elasticsearch 7.6 and later.  Elasticsearch 7.6 introduces improved support for the indirection introduced by Kubernetes services which significantly simplifies the setup.
 

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -8,7 +8,7 @@ endif::[]
 
 The link:https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-remote-clusters.html[remote clusters module] in Elasticsearch enables you to establish uni-directional connections to a remote cluster. This functionality is used in cross-cluster replication and cross-cluster search.
 
-When using remote cluster connections with ECK the necessary setup depends on where the remote cluster is deployed.
+When using remote cluster connections with ECK, the necessary setup depends on where the remote cluster is deployed.
 
 [id="{p}-remote-clusters-connect-internal"]
 ==== Connect from an Elasticsearch cluster running in the same Kubernetes cluster

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -18,7 +18,7 @@ TBD
 [id="{p}-remote-clusters-connect-external"]
 ==== Connect from an Elasticsearch cluster running outside the Kubernetes cluster
 
-NOTE: While it is technically possible to configure a remote cluster connection to an Elasticsearch cluster residing in Kubernetes in earlier versions, this guide only covers the setup for Elasticsearch 7.6 and later.  Elasticsearch 7.6 introduces improved support for the indirection introduced by Kubernetes services which significantly simplifies the setup.
+NOTE: While it is technically possible to configure remote cluster connections using older versions of Elasticsearch, this guide only covers the setup for Elasticsearch 7.6 and later. The setup process is significantly simplified in Elasticsearch 7.6 due to improved support for the indirection introduced by Kubernetes services.
 
 You can configure a remote cluster connection to an Elasticsearch cluster managed by ECK from another cluster outside of Kubernetes or hosted in a different Kubernetes cluster as follows.
 

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -35,7 +35,7 @@ To configure `cluster_one` as a remote cluster in `cluster_two`:
 
 ===== Ensure both clusters trust each others certificate authority
 
-The certificate authority used by ECK to issue certificates for the Elasticsearch transport layer is stored in a secret named `<cluster_name>-es-transport-certs-public`. Extract the certificate for `cluster_one` as follows:
+The certificate authority (CA) used by ECK to issue certificates for the Elasticsearch transport layer is stored in a secret named `<cluster_name>-es-transport-certs-public`. Extract the certificate for `cluster_one` as follows:
 
 [source,sh]
 ----

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -10,7 +10,8 @@ The link:https://www.elastic.co/guide/en/elasticsearch/reference/current/modules
 
 When using remote cluster connections with ECK the necessary setup depends on where the remote cluster is deployed.
 
-==== Both clusters are in the same Kubernetes cluster
+[id="{p}-remote-clusters-connect-internal"]
+==== Connect from an Elasticsearch cluster running in the same Kubernetes cluster
 
 TBD
 

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -22,7 +22,7 @@ NOTE: While it is technically possible to configure remote cluster connections u
 
 You can configure a remote cluster connection to an ECK-managed Elasticsearch cluster from another cluster running outside the Kubernetes cluster as follows:
 
-. Ensure that both clusters trust each others certificate authority.
+. Ensure that both clusters trust each other's certificate authority.
 . Configure the remote cluster connection via the Elasticsearch REST API.
 
 For the purposes of this guide we use the following running example:

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -43,7 +43,7 @@ kubectl get secret cluster_one-es-transport-certs-public \
 
 You then need to configure the CA as one of the trusted CAs in `cluster_two`. If that cluster is hosted outside of Kubernetes simply add the CA you extracted to the list of CAs in link:https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#_pem_encoded_files_3[`xpack.security.transport.ssl.certificate_authorities`]
 
-If `cluster_two` cluster is also managed by an ECK instance, proceed as follows:
+If `cluster_two` is also managed by an ECK instance, proceed as follows:
 
 Create a secret with the CA certificate you just extracted:
 [source,sh]

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -76,7 +76,7 @@ spec:
         volumes:
         - name: remote-certs
           secret:
-            secretName: remote-ca
+            secretName: remote-certs
   version: 7.6.0
 ----
 

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -8,7 +8,7 @@ endif::[]
 
 The link:https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-remote-clusters.html[remote clusters module] in Elasticsearch enables you to establish uni-directional connections to a remote cluster. This functionality is used in cross-cluster replication and cross-cluster search.
 
-When using remote cluster connections with ECK, the necessary setup depends on where the remote cluster is deployed.
+When using remote cluster connections with ECK, the setup process depends on where the remote cluster is deployed.
 
 [id="{p}-remote-clusters-connect-internal"]
 ==== Connect from an Elasticsearch cluster running in the same Kubernetes cluster
@@ -18,7 +18,7 @@ TBD
 [id="{p}-remote-clusters-connect-external"]
 ==== Connect from an Elasticsearch cluster running outside the Kubernetes cluster
 
-NOTE: While it is technically possible to configure remote cluster connections using older versions of Elasticsearch, this guide only covers the setup for Elasticsearch 7.6 and later. The setup process is significantly simplified in Elasticsearch 7.6 due to improved support for the indirection introduced by Kubernetes services.
+NOTE: While it is technically possible to configure remote cluster connections using older versions of Elasticsearch, this guide only covers the setup for Elasticsearch 7.6 and later. The setup process is significantly simplified in Elasticsearch 7.6 due to improved support for the indirection of Kubernetes services.
 
 You can configure a remote cluster connection to an ECK-managed Elasticsearch cluster from another cluster running outside the Kubernetes cluster as follows:
 
@@ -43,7 +43,7 @@ kubectl get secret cluster-one-es-transport-certs-public \
 -o go-template='{{index .data "ca.crt" | base64decode}}' > remote.ca.crt
 ----
 
-You then need to configure the CA as one of the trusted CAs in `cluster-two`. If that cluster is hosted outside of Kubernetes, simply add the CA certificate extracted in the above step to the list of CAs in link:https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#_pem_encoded_files_3[`xpack.security.transport.ssl.certificate_authorities`]
+You then need to configure the CA as one of the trusted CAs in `cluster-two`. If that cluster is hosted outside of Kubernetes, simply add the CA certificate extracted in the above step to the list of CAs in link:https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#_pem_encoded_files_3[`xpack.security.transport.ssl.certificate_authorities`].
 
 If `cluster-two` is also managed by an ECK instance, proceed as follows:
 
@@ -98,12 +98,13 @@ spec:
   selector:
     common.k8s.elastic.co/type: elasticsearch
     elasticsearch.k8s.elastic.co/cluster-name: cluster-one
-  type: LoadBalancer
+  type: LoadBalancer <1>
   ports:
   - protocol: TCP
     port: 9300
     targetPort: 9300
 ----
+<1> On cloud providers which support external load balancers, setting the type field to LoadBalancer provisions a load balancer for your Service. Alternatively expose the service via a Kubernetes link:https://kubernetes.io/docs/concepts/services-networking/ingress/[Ingress].
 
 Finally, configure `cluster-one` as a remote cluster in `cluster-two` using the Elasticsearch REST API:
 

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -1,0 +1,125 @@
+ifdef::env-github[]
+****
+link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-remote-clusters.html[View this document on the Elastic website]
+****
+endif::[]
+[id="{p}-remote-clusters"]
+=== Remote clusters
+
+The link:https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-remote-clusters.html[remote clusters module] in Elasticsearch enables you to establish uni-directional connections to a remote cluster. This functionality is used in cross-cluster replication and cross-cluster search.
+
+When using remote cluster connections with ECK the necessary setup depends on where the remote cluster is deployed.
+
+==== Both clusters are in the same Kubernetes cluster
+
+TBD
+
+==== One of the clusters is not in the same Kubernetes cluster
+
+NOTE: While it is technically possible to configure a remote cluster connection to an Elasticsearch cluster residing in Kubernetes in earlier versions, this guide only covers the setup for Elasticsearch 7.6 and later.  Elasticsearch 7.6 introduces improved support for the indirection introduced by Kubernetes services which significantly simplifies the setup.
+
+You can configure a remote cluster connection to an Elasticsearch cluster managed by ECK from another cluster outside of Kubernetes or hosted in a different Kubernetes cluster as follows.
+
+. Ensure that both clusters trust each others certificate authority.
+. Configure the remote cluster connection via the Elasticsearch REST API.
+
+For the purposes of this guide we use the following running example:
+
+* `cluster_one` resides inside Kubernetes and is managed by ECK
+* `cluster_two` is not hosted inside the same Kubernetes cluster as `cluster_one` and may even not be managed by an ECK instance
+
+We will configure `cluster_one` as a remote cluster in `cluster_two`.
+
+
+===== Ensure both clusters trust each others certificate authority
+
+The certificate authority used by ECK to issue certificates for the Elasticsearch transport layer is stored in a secret named `<cluster_name>-es-transport-certs-public`. Extract the certificate for `cluster_one` as follows:
+
+[source,sh]
+----
+kubectl get secret cluster_one-es-transport-certs-public \
+-o go-template='{{index .data "ca.crt" | base64decode}}' > remote.ca.crt
+----
+
+You then need to configure the CA as one of the trusted CAs in `cluster_two`. If that cluster is hosted outside of Kubernetes simply add the CA you extracted to the list of CAs in link:https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#_pem_encoded_files_3[`xpack.security.transport.ssl.certificate_authorities`]
+
+If `cluster_two` cluster is also managed by an ECK instance, proceed as follows:
+
+Create a secret with the CA certificate you just extracted:
+[source,sh]
+----
+kubectl create secret generic remote-certs --from-file=remote.ca.crt
+----
+
+Use this secret to configure `cluster_one`'s CA as a trusted CA in `cluster_two`:
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: elasticsearch.k8s.elastic.co/{eck}
+kind: Elasticsearch
+metadata:
+  name: cluster_two
+spec:
+  nodeSets:
+  - config:
+      xpack.security.transport.ssl.certificate_authorities:
+      - /usr/share/elasticsearch/config/other/remote.ca.crt
+    count: 3
+    name: default
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          volumeMounts:
+          - mountPath: /usr/share/elasticsearch/config/other
+            name: remote-certs
+        volumes:
+        - name: remote-certs
+          secret:
+            secretName: remote-ca
+  version: 7.6.0
+----
+
+Repeat the steps with reversed roles adding the CA of `cluster_two` to `cluster_one`.
+
+===== Configure the remote cluster connection via the Elasticsearch REST API
+
+Expose the transport layer of `cluster_one` to `cluster_two` which is residing outside of `cluster_one`'s Kubernetes cluster.
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster_one-es-transport
+spec:
+  selector:
+    common.k8s.elastic.co/type: elasticsearch
+    elasticsearch.k8s.elastic.co/cluster-name: cluster_one
+  type: LoadBalancer
+  ports:
+  - protocol: TCP
+    port: 9300
+    targetPort: 9300
+----
+
+Finally configure `cluster_one` as a remote cluster in `cluster_two` via the Elasticsearch REST API:
+
+[source,sh]
+----
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster": {
+      "remote": {
+        "cluster_one": {
+          "mode": "proxy", <1>
+          "proxy_address": "${LOADBALANCER_IP}:9300" <2>
+        }
+      }
+    }
+  }
+}
+----
+<1> setup the remote connection in "proxy" mode as `cluster_two` will connect to `cluster_one` only through the Kubernetes service abstraction and not to individual nodes directly.
+<2> `${LOADBALANCER_IP}` will be the IP address assigned to the `LoadBalancer` configured in the transport service above or it can also be a DNS name depending on your setup.

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -28,7 +28,7 @@ You can configure a remote cluster connection to an ECK-managed Elasticsearch cl
 For the purposes of this guide we use the following running example:
 
 * `cluster_one` resides inside Kubernetes and is managed by ECK
-* `cluster_two` is not hosted inside the same Kubernetes cluster as `cluster_one` and may even not be managed by an ECK instance
+* `cluster_two` is not hosted inside the same Kubernetes cluster as `cluster_one` and may not even be managed by ECK 
 
 We will configure `cluster_one` as a remote cluster in `cluster_two`.
 

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -20,7 +20,7 @@ TBD
 
 NOTE: While it is technically possible to configure remote cluster connections using older versions of Elasticsearch, this guide only covers the setup for Elasticsearch 7.6 and later. The setup process is significantly simplified in Elasticsearch 7.6 due to improved support for the indirection introduced by Kubernetes services.
 
-You can configure a remote cluster connection to an Elasticsearch cluster managed by ECK from another cluster outside of Kubernetes or hosted in a different Kubernetes cluster as follows.
+You can configure a remote cluster connection to an ECK-managed Elasticsearch cluster from another cluster running outside the Kubernetes cluster as follows:
 
 . Ensure that both clusters trust each others certificate authority.
 . Configure the remote cluster connection via the Elasticsearch REST API.

--- a/docs/remote-clusters.asciidoc
+++ b/docs/remote-clusters.asciidoc
@@ -27,25 +27,25 @@ You can configure a remote cluster connection to an ECK-managed Elasticsearch cl
 
 For illustration purposes, consider the following example:
 
-* `cluster_one` resides inside Kubernetes and is managed by ECK
-* `cluster_two` is not hosted inside the same Kubernetes cluster as `cluster_one` and may not even be managed by ECK 
+* `cluster-one` resides inside Kubernetes and is managed by ECK
+* `cluster-two` is not hosted inside the same Kubernetes cluster as `cluster-one` and may not even be managed by ECK 
 
-To configure `cluster_one` as a remote cluster in `cluster_two`:
+To configure `cluster-one` as a remote cluster in `cluster-two`:
 
 
 ===== Ensure both clusters trust each others certificate authority
 
-The certificate authority (CA) used by ECK to issue certificates for the Elasticsearch transport layer is stored in a secret named `<cluster_name>-es-transport-certs-public`. Extract the certificate for `cluster_one` as follows:
+The certificate authority (CA) used by ECK to issue certificates for the Elasticsearch transport layer is stored in a secret named `<cluster_name>-es-transport-certs-public`. Extract the certificate for `cluster-one` as follows:
 
 [source,sh]
 ----
-kubectl get secret cluster_one-es-transport-certs-public \
+kubectl get secret cluster-one-es-transport-certs-public \
 -o go-template='{{index .data "ca.crt" | base64decode}}' > remote.ca.crt
 ----
 
-You then need to configure the CA as one of the trusted CAs in `cluster_two`. If that cluster is hosted outside of Kubernetes, simply add the CA certificate extracted in the above step to the list of CAs in link:https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#_pem_encoded_files_3[`xpack.security.transport.ssl.certificate_authorities`]
+You then need to configure the CA as one of the trusted CAs in `cluster-two`. If that cluster is hosted outside of Kubernetes, simply add the CA certificate extracted in the above step to the list of CAs in link:https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#_pem_encoded_files_3[`xpack.security.transport.ssl.certificate_authorities`]
 
-If `cluster_two` is also managed by an ECK instance, proceed as follows:
+If `cluster-two` is also managed by an ECK instance, proceed as follows:
 
 Create a secret with the CA certificate you just extracted:
 [source,sh]
@@ -53,14 +53,14 @@ Create a secret with the CA certificate you just extracted:
 kubectl create secret generic remote-certs --from-file=remote.ca.crt
 ----
 
-Use this secret to configure `cluster_one`'s CA as a trusted CA in `cluster_two`:
+Use this secret to configure `cluster-one`'s CA as a trusted CA in `cluster-two`:
 
 [source,yaml,subs="attributes"]
 ----
 apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
 kind: Elasticsearch
 metadata:
-  name: cluster_two
+  name: cluster-two
 spec:
   nodeSets:
   - config:
@@ -82,22 +82,22 @@ spec:
   version: {version}
 ----
 
-Repeat the above steps to add the CA of `cluster_two` to `cluster_one` as well.
+Repeat the above steps to add the CA of `cluster-two` to `cluster-one` as well.
 
 ===== Configure the remote cluster connection via the Elasticsearch REST API
 
-Expose the transport layer of `cluster_one`.
+Expose the transport layer of `cluster-one`.
 
 [source,yaml]
 ----
 apiVersion: v1
 kind: Service
 metadata:
-  name: cluster_one-es-transport
+  name: cluster-one-es-transport
 spec:
   selector:
     common.k8s.elastic.co/type: elasticsearch
-    elasticsearch.k8s.elastic.co/cluster-name: cluster_one
+    elasticsearch.k8s.elastic.co/cluster-name: cluster-one
   type: LoadBalancer
   ports:
   - protocol: TCP
@@ -105,7 +105,7 @@ spec:
     targetPort: 9300
 ----
 
-Finally, configure `cluster_one` as a remote cluster in `cluster_two` using the Elasticsearch REST API:
+Finally, configure `cluster-one` as a remote cluster in `cluster-two` using the Elasticsearch REST API:
 
 [source,sh]
 ----
@@ -114,7 +114,7 @@ PUT _cluster/settings
   "persistent": {
     "cluster": {
       "remote": {
-        "cluster_one": {
+        "cluster-one": {
           "mode": "proxy", <1>
           "proxy_address": "${LOADBALANCER_IP}:9300" <2>
         }
@@ -123,5 +123,5 @@ PUT _cluster/settings
   }
 }
 ----
-<1> Use "proxy" mode as `cluster_two` will be connecting to `cluster_one` through the Kubernetes service abstraction.
+<1> Use "proxy" mode as `cluster-two` will be connecting to `cluster-one` through the Kubernetes service abstraction.
 <2> Replace `${LOADBALANCER_IP}` with the IP address assigned to the `LoadBalancer` configured above. if you have configured a DNS entry for the service, you can use the DNS name instead of the IP address as well.


### PR DESCRIPTION
Add a page to our documentation outlining how to setup remote clusters if one of the clusters is residing in a different environment e.g. another k8s cluster.