### PR TITLE
Clean up unnecessary env var for e2e/aks

### DIFF
--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -339,8 +339,6 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
-  gke:
-    gCloudProject: $GCLOUD_PROJECT
 CFG
 ;;
 


### PR DESCRIPTION
In 7684771, I have badly move the config for the deployer from the `Jenkinsfile` to the `setenvconfig` script. 

AKS does not use and does not need GKE. :confounded: