### PR TITLE
Standardize config of ocp/aks E2E tests jobs

### DIFF
--- a/.ci/jobs/e2e-tests-aks.yml
+++ b/.ci/jobs/e2e-tests-aks.yml
@@ -3,9 +3,14 @@
     description: Run ECK E2E tests on AKS
     name: cloud-on-k8s-e2e-tests-aks
     project-type: pipeline
-    triggers:
-      - github
-    concurrent: true
+    parameters:
+      - string:
+          name: JKS_PARAM_OPERATOR_IMAGE
+          description: "ECK Docker image"
+      - bool:
+          name: SEND_NOTIFICATIONS
+          default: true
+          description: "Specified if job should send notifications to Slack. Enabled by default."
     pipeline-scm:
       scm:
         - git:

--- a/.ci/jobs/e2e-tests-ocp.yaml
+++ b/.ci/jobs/e2e-tests-ocp.yaml
@@ -3,9 +3,14 @@
     description: Run ECK E2E tests on OpenShift
     name: cloud-on-k8s-e2e-tests-ocp
     project-type: pipeline
-    triggers:
-      - github
-    concurrent: true
+    parameters:
+      - string:
+          name: JKS_PARAM_OPERATOR_IMAGE
+          description: "ECK Docker image"
+      - bool:
+          name: SEND_NOTIFICATIONS
+          default: true
+          description: "Specified if job should send notifications to Slack. Enabled by default."
     pipeline-scm:
       scm:
         - git:

--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -87,6 +87,10 @@ pipeline {
                 build job: 'cloud-on-k8s-e2e-tests-kind-k8s-versions',
                     parameters: [string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage)],
                     wait: false
+
+                build job: 'cloud-on-k8s-e2e-tests-ocp',
+                    parameters: [string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage)],
+                    wait: false
             }
         }
         unsuccessful {

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -43,6 +43,7 @@ GO_TAGS = release
 export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/.ci/license.key
 TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 
+OPERATOR_IMAGE = $JKS_PARAM_OPERATOR_IMAGE
 TEST_TIMEOUT = 10m
 ENV
 write_deployer_config <<CFG
@@ -178,6 +179,7 @@ GO_TAGS = release
 export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/.ci/license.key
 TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 
+OPERATOR_IMAGE = $JKS_PARAM_OPERATOR_IMAGE
 TEST_TIMEOUT = 10m
 ENV
 write_deployer_config <<CFG


### PR DESCRIPTION
There is no reason to do otherwise for these jobs compared to others.

* Stop triggering these jobs at each merge in master
* Trigger the OCP job after a nightly/release build
* Add the possibility of calling them by passing an operator image in parameter
