### PR TITLE
Fix group permissions of the E2E tests job

### DIFF
--- a/config/e2e/batch_job.yaml
+++ b/config/e2e/batch_job.yaml
@@ -43,7 +43,7 @@ spec:
 {{ if not .Context.OcpCluster }}
         fsGroup: 101
         runAsUser: 101
-        runAsGroup: 101
+        runAsGroup: 0
 {{ end }}
       serviceAccountName: {{ .Context.E2EServiceAccount }}
       containers:


### PR DESCRIPTION
Changing the group to root of the filesystem of the E2E tests Docker
image was introduced in 43ef707 because it is the recommended way by the
OpenShift Container Platform Guidelines to create Docker images. This is
because the container user is always a member of the root group.

Since we set runAsGroup to 101 in the E2E tests job in non-OCP k8s
environments, the user of the E2E tests Docker image does not have
permissions to write files when running `go test`.

And since k8s 1.14 the `runAsGroup` feature is now in beta and enabled by
default. Thus all E2E tests executions with k8s >= 1.14 fail.

This commit fixes this by reproducing the OCP behaviour in non-OCP
environments by setting runAsGroup to 0.

Resolves #2576.
