### PR TITLE
Get endpoints as part of the diagnostics bundle

### DIFF
--- a/hack/diagnostics/eck-dump.sh
+++ b/hack/diagnostics/eck-dump.sh
@@ -110,6 +110,7 @@ main() {
     get_resources $ns persistentvolumes
     get_resources $ns persistentvolumeclaims
     get_resources $ns services
+    get_resources $ns endpoints
     get_resources $ns configmaps
     get_resources $ns events
     get_resources $ns networkpolicies


### PR DESCRIPTION
Some flaky E2E tests report no endpoints exist for the Elasticsearch
HTTP service. This may help to understand what is happening.

May help with https://github.com/elastic/cloud-on-k8s/issues/2602.