### PR TITLE
Support Elastic stack version 8.0

### DIFF
--- a/pkg/apis/elasticsearch/v1/validations.go
+++ b/pkg/apis/elasticsearch/v1/validations.go
@@ -194,7 +194,7 @@ func validUpgradePath(current, proposed *Elasticsearch) field.ErrorList {
 		// this should not happen, since this is the already persisted version
 		errs = append(errs, field.Invalid(field.NewPath("spec").Child("version"), current.Spec.Version, parseStoredVersionErrMsg))
 	}
-	currVer, err := version.Parse(proposed.Spec.Version)
+	proposedVer, err := version.Parse(proposed.Spec.Version)
 	if err != nil {
 		errs = append(errs, field.Invalid(field.NewPath("spec").Child("version"), proposed.Spec.Version, parseVersionErrMsg))
 	}
@@ -202,7 +202,7 @@ func validUpgradePath(current, proposed *Elasticsearch) field.ErrorList {
 		return errs
 	}
 
-	v := esversion.SupportedVersions(*currVer)
+	v := esversion.SupportedVersions(*proposedVer)
 	if v == nil {
 		errs = append(errs, field.Invalid(field.NewPath("spec").Child("version"), proposed.Spec.Version, unsupportedVersionMsg))
 		return errs

--- a/pkg/controller/elasticsearch/client/base.go
+++ b/pkg/controller/elasticsearch/client/base.go
@@ -138,6 +138,10 @@ func versioned(b *baseClient, v version.Version) Client {
 		return &clientV7{
 			clientV6: v6,
 		}
+	case 8:
+		return &clientV8{
+			clientV7: clientV7{clientV6: v6},
+		}
 	default:
 		return &v6
 	}

--- a/pkg/controller/elasticsearch/client/v8.go
+++ b/pkg/controller/elasticsearch/client/v8.go
@@ -1,0 +1,20 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package client
+
+type clientV8 struct {
+	clientV7
+}
+
+// Equal returns true if c2 can be considered the same as c
+func (c *clientV8) Equal(c2 Client) bool {
+	other, ok := c2.(*clientV8)
+	if !ok {
+		return false
+	}
+	return c.baseClient.equal(&other.baseClient)
+}
+
+var _ Client = &clientV8{}

--- a/pkg/controller/elasticsearch/version/supported_versions.go
+++ b/pkg/controller/elasticsearch/version/supported_versions.go
@@ -32,6 +32,12 @@ func SupportedVersions(v version.Version) *LowestHighestSupportedVersions {
 			// higher may be possible, but not proven yet, lower may also be a requirement...
 			HighestSupportedVersion: version.MustParse("7.99.99"),
 		}
+	case 8:
+		return &LowestHighestSupportedVersions{
+			// 7.4.0 is the lowest version that offers a direct upgrade path to 8.0
+			LowestSupportedVersion:  version.MustParse("7.4.0"),
+			HighestSupportedVersion: version.MustParse("8.99.99"),
+		}
 	default:
 		return nil
 	}

--- a/pkg/controller/elasticsearch/version/supported_versions_test.go
+++ b/pkg/controller/elasticsearch/version/supported_versions_test.go
@@ -50,6 +50,19 @@ func TestSupportedVersions(t *testing.T) {
 				version.MustParse("8.0.0"),
 			},
 		},
+		{
+			name: "8.x",
+			args: args{
+				v: version.MustParse("8.0.0"),
+			},
+			supported: []version.Version{
+				version.MustParse("7.4.0"),
+				version.MustParse("8.9.0"),
+			},
+			unsupported: []version.Version{
+				version.MustParse("7.1.0"), // supported by ECK but no direct upgrade path to 8.x
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This commit adds version 8.x to the supported versions and add a stub implementation of a `v8` Elasticsearch client that currently delegates all calls to the `v7` version.

Fixes #2607 