### PR TITLE
Test snapshot versions of the stack 

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -56,19 +56,21 @@ ci-build-image:
 		docker push push.$(CI_IMAGE) \
 	)
 
+ifneq (,$(findstring -SNAPSHOT,$(STACK_VERSION)))
+       SECRET_FIELD_PREFIX ?= dev-
+endif
+
 ##  Build
 
 # read Elastic public key from Vault into license.key, to build the operator for E2E tests or for a release
-get-elastic-public-key: FIELD = $(if $(SNAPSHOT_TEST_TARGET),dev-pubkey,pubkey)
 get-elastic-public-key:
-	@ VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=$(FIELD) secret/devops-ci/cloud-on-k8s/license | base64 --decode > license.key
+	@ VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=$(SECRET_FIELD_PREFIX)pubkey secret/devops-ci/cloud-on-k8s/license | base64 --decode > license.key
 
 ##  Test
 
 # read some test licenses from Vault for E2E license tests
-get-test-license: FIELD = $(if $(SNAPSHOT_TEST_TARGET),dev-enterprise,enterprise)
 get-test-license:
-	@ VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=$(FIELD)  secret/devops-ci/cloud-on-k8s/test-licenses > test-license.json
+	@ VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=$(SECRET_FIELD_PREFIX)enterprise  secret/devops-ci/cloud-on-k8s/test-licenses > test-license.json
 
 # read connection info and credentials to the E2E tests monitoring Elasticsearch cluster, to be used during E2E tests
 get-monitoring-secrets:

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -9,6 +9,8 @@ GO_MOUNT_PATH ?= /go/src/github.com/elastic/cloud-on-k8s
 ALL_IN_ONE_OUTPUT_FILE ?= config/all-in-one.yaml
 S3_ECK_DIR             ?= s3://download.elasticsearch.org/downloads/eck
 
+-include $(ROOT_DIR)/.env
+
 # This is set to avoid the issue described in https://github.com/hashicorp/vault/issues/6710
 VAULT_CLIENT_TIMEOUT = 120
 
@@ -22,9 +24,6 @@ VAULT_TOKEN = $(shell vault write -address=$(VAULT_ADDR) -field=token auth/githu
 NOT_USED := $(shell test -e $(ROOT_DIR)/deployer-config.yml && sed "s;roleId:.*;token: $(GITHUB_TOKEN);g" $(ROOT_DIR)/deployer-config.yml > tmp && mv tmp deployer-config.yml)
 endif
 endif
-
-# are we running any e2e tests in this build against SNAPSHOT versions of the stack?
-SNAPSHOT_TEST_TARGET ?= $(findstring -SNAPSHOT,$(STACK_VERSION))
 
 CI_IMAGE ?= docker.elastic.co/eck/eck-ci:$(shell md5sum $(ROOT_DIR)/go.mod $(ROOT_DIR)/.ci/Dockerfile | awk '{print $$1}' | md5sum | awk '{print $$1}')
 

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -23,6 +23,9 @@ NOT_USED := $(shell test -e $(ROOT_DIR)/deployer-config.yml && sed "s;roleId:.*;
 endif
 endif
 
+# are we running any e2e tests in this build against SNAPSHOT versions of the stack?
+SNAPSHOT_TEST_TARGET ?= $(findstring -SNAPSHOT,$(STACK_VERSION))
+
 CI_IMAGE ?= docker.elastic.co/eck/eck-ci:$(shell md5sum $(ROOT_DIR)/go.mod $(ROOT_DIR)/.ci/Dockerfile | awk '{print $$1}' | md5sum | awk '{print $$1}')
 
 print-ci-image:
@@ -57,14 +60,16 @@ ci-build-image:
 ##  Build
 
 # read Elastic public key from Vault into license.key, to build the operator for E2E tests or for a release
+get-elastic-public-key: FIELD = $(if $(SNAPSHOT_TEST_TARGET),dev-pubkey,pubkey)
 get-elastic-public-key:
 	@ VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=pubkey secret/devops-ci/cloud-on-k8s/license | base64 --decode > license.key
 
 ##  Test
 
 # read some test licenses from Vault for E2E license tests
+get-test-license: FIELD = $(if $(SNAPSHOT_TEST_TARGET),dev-enterprise,enterprise)
 get-test-license:
-	@ VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=enterprise  secret/devops-ci/cloud-on-k8s/test-licenses > test-license.json
+	@ VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=$(FIELD)  secret/devops-ci/cloud-on-k8s/test-licenses > test-license.json
 
 # read connection info and credentials to the E2E tests monitoring Elasticsearch cluster, to be used during E2E tests
 get-monitoring-secrets:

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -62,7 +62,7 @@ ci-build-image:
 # read Elastic public key from Vault into license.key, to build the operator for E2E tests or for a release
 get-elastic-public-key: FIELD = $(if $(SNAPSHOT_TEST_TARGET),dev-pubkey,pubkey)
 get-elastic-public-key:
-	@ VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=pubkey secret/devops-ci/cloud-on-k8s/license | base64 --decode > license.key
+	@ VAULT_TOKEN=$(VAULT_TOKEN) vault read -address=$(VAULT_ADDR) -field=$(FIELD) secret/devops-ci/cloud-on-k8s/license | base64 --decode > license.key
 
 ##  Test
 

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -167,7 +167,7 @@ pipeline {
 def runWith(lib, failedTests, clusterName, stackVersion) {
     sh ".ci/setenvconfig e2e/stack-versions $clusterName $stackVersion"
     script {
-        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: "make -C .ci STACK_VERSION=$stackVersion get-test-license get-elastic-public-key TARGET=ci-e2e ci")
+        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: "make -C .ci get-test-license get-elastic-public-key TARGET=ci-e2e ci")
 
         sh 'make -C .ci TARGET=e2e-generate-xml ci'
         junit "e2e-tests.xml"

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -102,6 +102,17 @@ pipeline {
                         }
                     }
                 }
+                stage("7.7.0-SNAPSHOT") {
+                    agent {
+                        label 'linux'
+                    }
+                    steps {
+                        checkout scm
+                        script {
+                            runWith(lib, failedTests, "eck-77-${BUILD_NUMBER}-e2e", "7.7.0-SNAPSHOT")
+                        }
+                    }
+                }
             }
         }
     }
@@ -138,7 +149,8 @@ pipeline {
                     "eck-73-${BUILD_NUMBER}-e2e",
                     "eck-74-${BUILD_NUMBER}-e2e",
                     "eck-75-${BUILD_NUMBER}-e2e",
-                    "eck-76-${BUILD_NUMBER}-e2e"
+                    "eck-76-${BUILD_NUMBER}-e2e",
+                    "eck-77-${BUILD_NUMBER}-e2e"
                 ]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
@@ -155,7 +167,7 @@ pipeline {
 def runWith(lib, failedTests, clusterName, stackVersion) {
     sh ".ci/setenvconfig e2e/stack-versions $clusterName $stackVersion"
     script {
-        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-test-license get-elastic-public-key TARGET=ci-e2e ci')
+        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: "make -C .ci STACK_VERSION=$stackVersion get-test-license get-elastic-public-key TARGET=ci-e2e ci")
 
         sh 'make -C .ci TARGET=e2e-generate-xml ci'
         junit "e2e-tests.xml"

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -199,6 +199,7 @@ CFG
 
 clusterName=$2
 stackVersion=$3
+snapshotVersion=$(case $stackVersion in (*-SNAPSHOT)  echo Yes;; esac)
 
 write_env <<ENV
 REGISTRY = eu.gcr.io
@@ -211,6 +212,7 @@ TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 
 OPERATOR_IMAGE = $JKS_PARAM_OPERATOR_IMAGE
 STACK_VERSION = ${stackVersion}
+SNAPSHOT_TEST_TARGET = $snapshotVersion
 ENV
 write_deployer_config <<CFG
 id: gke-ci

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -199,7 +199,6 @@ CFG
 
 clusterName=$2
 stackVersion=$3
-snapshotVersion=$(case $stackVersion in (*-SNAPSHOT)  echo Yes;; esac)
 
 write_env <<ENV
 REGISTRY = eu.gcr.io
@@ -212,7 +211,6 @@ TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 
 OPERATOR_IMAGE = $JKS_PARAM_OPERATOR_IMAGE
 STACK_VERSION = ${stackVersion}
-SNAPSHOT_TEST_TARGET = $snapshotVersion
 ENV
 write_deployer_config <<CFG
 id: gke-ci

--- a/pkg/apis/apm/v1/apmserver_types.go
+++ b/pkg/apis/apm/v1/apmserver_types.go
@@ -5,6 +5,8 @@
 package v1
 
 import (
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -129,4 +131,9 @@ func (as *ApmServer) ServiceAccountName() string {
 
 func (as *ApmServer) SetAssociationConf(assocConf *commonv1.AssociationConf) {
 	as.assocConf = assocConf
+}
+
+// EffectiveVersion returns the version reported by APM server. For development builds APM server does not use the SNAPSHOT suffix.
+func (as *ApmServer) EffectiveVersion() string {
+	return strings.TrimSuffix(as.Spec.Version, "-SNAPSHOT")
 }

--- a/test/e2e/test/apmserver/checks_apm.go
+++ b/test/e2e/test/apmserver/checks_apm.go
@@ -108,7 +108,7 @@ func (c *apmClusterChecks) CheckApmServerVersion(apm apmv1.ApmServer) test.Step 
 			info, err := c.apmClient.ServerInfo(ctx)
 			require.NoError(t, err)
 
-			require.Equal(t, apm.Spec.Version, info.Version)
+			require.Equal(t, apm.EffectiveVersion(), info.Version)
 		},
 	}
 }
@@ -196,7 +196,7 @@ func (c *apmClusterChecks) CheckEventsInElasticsearch(apm apmv1.ApmServer, k *te
 			}
 			err := assertCountIndexEqual(
 				c.esClient,
-				fmt.Sprintf(metricIndexPattern, updatedApmServer.Spec.Version),
+				fmt.Sprintf(metricIndexPattern, updatedApmServer.EffectiveVersion()),
 				1,
 			)
 			if err != nil {
@@ -211,7 +211,7 @@ func (c *apmClusterChecks) CheckEventsInElasticsearch(apm apmv1.ApmServer, k *te
 			}
 			err = assertCountIndexEqual(
 				c.esClient,
-				fmt.Sprintf(errorIndexPattern, updatedApmServer.Spec.Version),
+				fmt.Sprintf(errorIndexPattern, updatedApmServer.EffectiveVersion()),
 				1,
 			)
 			if err != nil {


### PR DESCRIPTION
* Adds a new build stage for `7.7.0-SNAPSHOT` builds to the stack versions test run
* Parameterizes the `get-elastic-public-key` and `get-test-license` make targets to be dependent on the target version of our e2e tests i.e. use a dev key and license for snapshot builds
* APM Server does not report SNAPSHOT builds as such in the server info structs, adjust tests to not expect that and expect the version without the suffix instead

Fixes #2565 

What's not included:
* running 8.0 snapshots, I ran into some trouble with Kibana optimize runs in the current dev builds for 8.0 so I excluded it for now given that we have #2608 