### PR TITLE
Update e2e badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![Build Status](https://devops-ci.elastic.co/buildStatus/icon?job=cloud-on-k8s-e2e-tests&subject=E2E%20tests)](https://devops-ci.elastic.co/view/cloud-on-k8s/job/cloud-on-k8s-e2e-tests)
+[![Build Status](https://devops-ci.elastic.co/buildStatus/icon?job=cloud-on-k8s-e2e-tests-master&subject=E2E%20tests)](https://devops-ci.elastic.co/job/cloud-on-k8s-e2e-tests-master/)
 [![GitHub release](https://img.shields.io/github/v/release/elastic/cloud-on-k8s.svg)](https://github.com/elastic/cloud-on-k8s/releases/latest)
 
 # Elastic Cloud on Kubernetes (ECK)


### PR DESCRIPTION
Follow up to https://github.com/elastic/cloud-on-k8s/pull/2502 where we changed the job names around. Currently the badge says e2e tests are not running and the link 404s. We have a few different e2e tests we could use, but testing GKE against the last merge to master seems like a decent one to advertise in the readme.