### PR TITLE
Fix no such property testscript in kind job

### DIFF
--- a/.ci/pipelines/e2e-tests-custom-operator-image-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-custom-operator-image-gke.Jenkinsfile
@@ -1,5 +1,5 @@
 def failedTests = []
-def testScript
+def lib
 
 pipeline {
 
@@ -27,7 +27,7 @@ pipeline {
         stage('Load common scripts') {
             steps {
                 script {
-                    testScript = load ".ci/common/tests.groovy"
+                    lib = load ".ci/common/tests.groovy"
                 }
             }
         }
@@ -41,7 +41,7 @@ pipeline {
                     junit "e2e-tests.xml"
 
                     if (env.SHELL_EXIT_CODE != 0) {
-                        failedTests = testScript.getListOfFailedTests()
+                        failedTests = lib.getListOfFailedTests()
                     }
 
                     sh 'exit $SHELL_EXIT_CODE'
@@ -54,7 +54,7 @@ pipeline {
         unsuccessful {
             script {
                 if (params.SEND_NOTIFICATIONS) {
-                    def msg = testScript.generateSlackMessage("E2E tests failed!", env.BUILD_URL, failedTests)
+                    def msg = lib.generateSlackMessage("E2E tests failed!", env.BUILD_URL, failedTests)
 
                     slackSend(
                         channel: '#cloud-k8s',

--- a/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
                 if (params.SEND_NOTIFICATIONS) {
                     Set<String> filter = new HashSet<>()
                     filter.addAll(failedTests)
-                    def msg = testScript.generateSlackMessage("E2E tests for different versions of vanilla K8s failed!", env.BUILD_URL, filter)
+                    def msg = lib.generateSlackMessage("E2E tests for different versions of vanilla K8s failed!", env.BUILD_URL, filter)
 
                     slackSend(
                         channel: '#cloud-k8s',

--- a/.ci/pipelines/e2e-tests-master-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-master-gke.Jenkinsfile
@@ -1,5 +1,5 @@
 def failedTests = []
-def testScript
+def lib
 
 pipeline {
 
@@ -27,7 +27,7 @@ pipeline {
         stage('Load common scripts') {
             steps {
                 script {
-                    testScript = load ".ci/common/tests.groovy"
+                    lib = load ".ci/common/tests.groovy"
                 }
             }
         }
@@ -56,7 +56,7 @@ pipeline {
                     junit "e2e-tests.xml"
 
                     if (env.SHELL_EXIT_CODE != 0) {
-                        failedTests = testScript.getListOfFailedTests()
+                        failedTests = lib.getListOfFailedTests()
                     }
 
                     sh 'exit $SHELL_EXIT_CODE'
@@ -68,7 +68,7 @@ pipeline {
     post {
         unsuccessful {
             script {
-                def msg = testScript.generateSlackMessage("E2E tests failed!", env.BUILD_URL, failedTests)
+                def msg = lib.generateSlackMessage("E2E tests failed!", env.BUILD_URL, failedTests)
 
                 slackSend(
                       channel: '#cloud-k8s',


### PR DESCRIPTION
This commit fixes the variable name used to load the shared groovy script in the `cloud-on-k8s-e2e-tests-kind-k8s-versions` job:

```sh
04:42:52  Error when executing unsuccessful post condition:
04:42:52  groovy.lang.MissingPropertyException: No such property: testScript for class: groovy.lang.Binding
```

https://devops-ci.elastic.co/view/cloud-on-k8s/job/cloud-on-k8s-e2e-tests-kind-k8s-versions/7/console

And names the variable the same way in all E2E tests jobs.