### PR TITLE
Enable JSON output for E2E tests with kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -484,6 +484,7 @@ else
 	$(MAKE) go-generate docker-build
 endif
 
+kind-e2e: export E2E_JSON := true
 kind-e2e: export KUBECONFIG = ${HOME}/.kube/kind-config-eck-e2e
 kind-e2e: export NODE_IMAGE = ${KIND_NODE_IMAGE}
 kind-e2e: kind-node-variable-check set-kind-e2e-image e2e-docker-build


### PR DESCRIPTION
This commit enables the JSON output for E2E tests with kind to avoid to fail the `e2e-generate-xml` target.

Relates to https://github.com/elastic/cloud-on-k8s/issues/1096#issuecomment-591486860.