### PR TITLE
Validate duplicated nodeSet names

### DIFF
--- a/pkg/apis/elasticsearch/v1/name.go
+++ b/pkg/apis/elasticsearch/v1/name.go
@@ -54,8 +54,14 @@ func validateNames(es *Elasticsearch) error {
 	if len(es.Name) > common_name.MaxResourceNameLength {
 		return errors.Errorf("name exceeds maximum allowed length of %d", common_name.MaxResourceNameLength)
 	}
+	nodeSetNames := map[string]struct{}{}
 	// validate ssets
 	for _, nodeSet := range es.Spec.NodeSets {
+		if _, ok := nodeSetNames[nodeSet.Name]; ok {
+			return errors.Errorf("duplicated nodeSet name: '%s'", nodeSet.Name)
+		}
+		nodeSetNames[nodeSet.Name] = struct{}{}
+
 		if errs := apimachineryvalidation.NameIsDNSSubdomain(nodeSet.Name, false); len(errs) > 0 {
 			return errors.Errorf("invalid nodeSet name '%s': [%s]", nodeSet.Name, strings.Join(errs, ","))
 		}

--- a/pkg/apis/elasticsearch/v1/name_test.go
+++ b/pkg/apis/elasticsearch/v1/name_test.go
@@ -47,7 +47,7 @@ func TestValidate(t *testing.T) {
 			wantErrMsg:    "invalid nodeSet name",
 		},
 		{
-			name:          "duplidated names in nodeSpec name",
+			name:          "duplicated nodeSet names",
 			esName:        "test-es",
 			nodeSpecNames: []string{"default", "default"},
 			wantErr:       true,

--- a/pkg/apis/elasticsearch/v1/name_test.go
+++ b/pkg/apis/elasticsearch/v1/name_test.go
@@ -46,6 +46,13 @@ func TestValidate(t *testing.T) {
 			wantErr:       true,
 			wantErrMsg:    "invalid nodeSet name",
 		},
+		{
+			name:          "duplidated names in nodeSpec name",
+			esName:        "test-es",
+			nodeSpecNames: []string{"default", "default"},
+			wantErr:       true,
+			wantErrMsg:    "duplicated nodeSet name",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/apis/elasticsearch/v1beta1/name.go
+++ b/pkg/apis/elasticsearch/v1beta1/name.go
@@ -54,8 +54,14 @@ func validateNames(es *Elasticsearch) error {
 	if len(es.Name) > common_name.MaxResourceNameLength {
 		return errors.Errorf("name exceeds maximum allowed length of %d", common_name.MaxResourceNameLength)
 	}
+	nodeSetNames := map[string]struct{}{}
 	// validate ssets
 	for _, nodeSet := range es.Spec.NodeSets {
+		if _, ok := nodeSetNames[nodeSet.Name]; ok {
+			return errors.Errorf("duplicated nodeSet name: '%s'", nodeSet.Name)
+		}
+
+		nodeSetNames[nodeSet.Name] = struct{}{}
 		if errs := apimachineryvalidation.NameIsDNSSubdomain(nodeSet.Name, false); len(errs) > 0 {
 			return errors.Errorf("invalid nodeSet name '%s': [%s]", nodeSet.Name, strings.Join(errs, ","))
 		}

--- a/pkg/apis/elasticsearch/v1beta1/name_test.go
+++ b/pkg/apis/elasticsearch/v1beta1/name_test.go
@@ -47,7 +47,7 @@ func TestValidate(t *testing.T) {
 			wantErrMsg:    "invalid nodeSet name",
 		},
 		{
-			name:          "duplidated names in nodeSpec name",
+			name:          "duplicated nodeSet names",
 			esName:        "test-es",
 			nodeSpecNames: []string{"default", "default"},
 			wantErr:       true,

--- a/pkg/apis/elasticsearch/v1beta1/name_test.go
+++ b/pkg/apis/elasticsearch/v1beta1/name_test.go
@@ -46,6 +46,13 @@ func TestValidate(t *testing.T) {
 			wantErr:       true,
 			wantErrMsg:    "invalid nodeSet name",
 		},
+		{
+			name:          "duplidated names in nodeSpec name",
+			esName:        "test-es",
+			nodeSpecNames: []string{"default", "default"},
+			wantErr:       true,
+			wantErrMsg:    "duplicated nodeSet name",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
If the names of the nodeSets are duplicated, the reconciliation never converges. The validationWebhook should validate such a case.

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->
<!--
- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/master/CONTRIBUTING.md)?
- If you submit code, is your pull request against master? We recommend pull requests against master. We will backport them as needed.
-->