### PR TITLE
User-provided config take precedence over operator config

### DIFF
--- a/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/pkg/controller/elasticsearch/settings/merged_config.go
@@ -18,7 +18,7 @@ import (
 )
 
 // NewMergedESConfig merges user provided Elasticsearch configuration with configuration derived from the given
-// parameters.
+// parameters. The user provided config overrides have precedence over the ECK config.
 func NewMergedESConfig(
 	clusterName string,
 	ver version.Version,
@@ -26,13 +26,14 @@ func NewMergedESConfig(
 	userConfig commonv1.Config,
 	certResources *escerts.CertificateResources,
 ) (CanonicalConfig, error) {
-	config, err := common.NewCanonicalConfigFrom(userConfig.Data)
+	userCfg, err := common.NewCanonicalConfigFrom(userConfig.Data)
 	if err != nil {
 		return CanonicalConfig{}, err
 	}
+	config := baseConfig(clusterName, ver).CanonicalConfig
 	err = config.MergeWith(
-		baseConfig(clusterName, ver).CanonicalConfig,
 		xpackConfig(ver, httpConfig, certResources).CanonicalConfig,
+		userCfg,
 	)
 	if err != nil {
 		return CanonicalConfig{}, err

--- a/pkg/controller/elasticsearch/settings/merged_config_test.go
+++ b/pkg/controller/elasticsearch/settings/merged_config_test.go
@@ -147,7 +147,7 @@ func TestNewMergedESConfig(t *testing.T) {
 			name:    "user-provided Elasticsearch config overrides should have precedence over ECK config",
 			version: "7.6.0",
 			cfgData: map[string]interface{}{
-				esv1.NetworkHost:        "1.2.3.4",
+				esv1.NetworkHost: "1.2.3.4",
 			},
 			assert: func(cfg CanonicalConfig) {
 				cfgBytes, err := cfg.Render()

--- a/pkg/controller/elasticsearch/settings/merged_config_test.go
+++ b/pkg/controller/elasticsearch/settings/merged_config_test.go
@@ -5,6 +5,8 @@
 package settings
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -139,6 +141,20 @@ func TestNewMergedESConfig(t *testing.T) {
 			cfgData: map[string]interface{}{},
 			assert: func(cfg CanonicalConfig) {
 				require.Equal(t, 1, len(cfg.HasKeys([]string{esv1.XPackLicenseUploadTypes})))
+			},
+		},
+		{
+			name:    "user-provided Elasticsearch config overrides should have precedence over ECK config",
+			version: "7.6.0",
+			cfgData: map[string]interface{}{
+				esv1.NetworkHost:        "1.2.3.4",
+			},
+			assert: func(cfg CanonicalConfig) {
+				cfgBytes, err := cfg.Render()
+				require.NoError(t, err)
+				fmt.Println(string(cfgBytes))
+				require.True(t, bytes.Contains(cfgBytes, []byte("publish_host: ${POD_IP}")))
+				require.True(t, bytes.Contains(cfgBytes, []byte("host: 1.2.3.4")))
 			},
 		},
 	}

--- a/pkg/controller/elasticsearch/settings/merged_config_test.go
+++ b/pkg/controller/elasticsearch/settings/merged_config_test.go
@@ -6,7 +6,6 @@ package settings
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -147,14 +146,16 @@ func TestNewMergedESConfig(t *testing.T) {
 			name:    "user-provided Elasticsearch config overrides should have precedence over ECK config",
 			version: "7.6.0",
 			cfgData: map[string]interface{}{
-				esv1.NetworkHost: "1.2.3.4",
+				esv1.DiscoverySeedProviders: "something-else",
 			},
 			assert: func(cfg CanonicalConfig) {
 				cfgBytes, err := cfg.Render()
 				require.NoError(t, err)
-				fmt.Println(string(cfgBytes))
+				// default config is still there
 				require.True(t, bytes.Contains(cfgBytes, []byte("publish_host: ${POD_IP}")))
-				require.True(t, bytes.Contains(cfgBytes, []byte("host: 1.2.3.4")))
+				// but has been overridden
+				require.True(t, bytes.Contains(cfgBytes, []byte("seed_providers: something-else")))
+				require.Equal(t, 1, bytes.Count(cfgBytes, []byte("seed_providers:")))
 			},
 		},
 	}


### PR DESCRIPTION
This commit implements the same behaviour that we have for Kibana and APM Server where
the user-provided config overrides have precedence over ECK config.

Resolves #2573.