### PR TITLE
Fix header levels of documentation

### DIFF
--- a/docs/advanced-topics/custom-images.asciidoc
+++ b/docs/advanced-topics/custom-images.asciidoc
@@ -48,9 +48,6 @@ The steps are similar for https://docs.microsoft.com/en-us/azure/aks/tutorial-ku
 
 For more information, you can check the following references:
 
-[id="{p}-references"]
-== References
-
 - https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_c_customized_image[Elasticsearch doc on creating custom images]
 - https://cloud.google.com/container-registry/docs/how-to[Google Container Registry docs]
 - https://docs.microsoft.com/en-us/azure/container-registry/[Azure Container Registry docs]
@@ -58,6 +55,7 @@ For more information, you can check the following references:
 - https://docs.openshift.com/container-platform/4.1/registry/architecture-component-imageregistry.html[OpenShift Container Platform registry docs]
 
 
+[float]
 [id="{p}-container-registry-override"]
 == Override the default container registry
 

--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -14,10 +14,10 @@ This page shows how to run ECK on OpenShift.
 * <<{p}-openshift-deploy-elasticsearch,Deploy an Elasticsearch instance with a route>>
 * <<{p}-openshift-deploy-kibana,Deploy a Kibana instance with a route>>
 * <<{p}-openshift-apm,Deploy an APM Server instance with a route>>
-* <<{p}-openshift-es-plugins>>
 
 NOTE: Only Elasticsearch and Kibana are compatible with the `restricted` https://docs.openshift.com/container-platform/4.1/authentication/managing-security-context-constraints.html[Security Context Constraint]. To run the APM Server on OpenShift you must allow the Pod to run with the `anyuid` SCC as described in <<{p}-openshift-apm,Deploy an APM Server instance with a route>>
 
+[float]
 [id="{p}-openshift-before-you-begin"]
 == Before you begin
 
@@ -113,6 +113,12 @@ spec:
     name: elasticsearch-sample-es-http
 EOF
 ----
+
+[id="{p}-openshift-es-plugins"]
+=== Elasticsearch plugins
+
+Note that Elasticsearch plugins cannot be installed at runtime in most OpenShift environments. This is because the plugin installer must run as root, but Elasticsearch is restricted from running as root. To add plugins to Elasticsearch, you can use custom images as described in <<{p}-custom-images>>.
+
 
 [id="{p}-openshift-deploy-kibana"]
 == Deploy a Kibana instance with a route
@@ -232,8 +238,3 @@ elasticsearch-sample-es-6qk52mz5jk scc:restricted
 elasticsearch-sample-es-dg4vvpm2mr scc:restricted
 kibana-sample-kb-97c6b6b8d-lqfd2 scc:restricted
 ----
-
-[id="{p}-openshift-es-plugins"]
-== Elasticsearch plugins
-
-Note that Elasticsearch plugins cannot be installed at runtime in most OpenShift environments. This is because the plugin installer must run as root, but Elasticsearch is restricted from running as root. To add plugins to Elasticsearch, you can use custom images as described in <<{p}-custom-images>>.

--- a/docs/help.asciidoc
+++ b/docs/help.asciidoc
@@ -1,0 +1,2 @@
+* link:https://discuss.elastic.co/c/eck[ECK Discuss forums] to ask any question
+* link:https://github.com/elastic/cloud-on-k8s/issues[Github issues] for bugs and feature requests

--- a/docs/operating-eck/licensing.asciidoc
+++ b/docs/operating-eck/licensing.asciidoc
@@ -9,6 +9,7 @@ endif::[]
 
 When you install the default distribution of ECK, you receive a Basic license. Any Elastic stack application you manage through ECK will also be Basic licensed. Go to https://www.elastic.co/subscriptions to see which features are included in the Basic license for free.
 
+[float]
 == Start a trial
 If you want to try the features included in the Enterprise subscription, you can start a 30-day trial. To start a trial create a Kubernetes secret as shown below. Note that it must be in the same namespace as the operator:
 
@@ -33,6 +34,7 @@ NOTE: You can initiate a trial only if a trial has not previously been activated
 
 At the end of the trial period, the Platinum and Enterprise features operate in a link:https://www.elastic.co/guide/en/elastic-stack-overview/current/license-expiration.html[degraded mode]. You can revert to a Basic license, extend the trial, or purchase an Enterprise subscription.
 
+[float]
 == Add a license
 If you have a valid Enterprise subscription you will receive a license as a JSON file.
 
@@ -66,6 +68,7 @@ kubectl label secret eck-license "license.k8s.elastic.co/scope"=operator -n elas
 
 NOTE: After you install a license into ECK, all the Elastic stack applications you manage with ECK will have all Platinum and Enterprise features enabled. Applications created before you installed the license are upgraded to Platinum or Enterprise features without interruption of service after a short delay.
 
+[float]
 == Update your license
 Before your current Enterprise license expires, you will receive a new Enterprise license from Elastic (provided your subscription is valid).
 
@@ -73,6 +76,7 @@ To avoid any unintended downgrade of individual Elasticsearch clusters to a Basi
 
 Once you have created the new license secret you can safely delete the old license secret.
 
+[float]
 == Get usage data
 The operator periodically writes the total amount of Elastic resources under management to a config map. It is named `elastic-licensing` in the same namespace as the operator. Here is an example of retrieving the data:
 

--- a/docs/operating-eck/troubleshooting.asciidoc
+++ b/docs/operating-eck/troubleshooting.asciidoc
@@ -7,22 +7,24 @@ endif::[]
 [id="{p}-{page_id}"]
 = Troubleshoot ECK
 
-When things don't work as expected, you can investigate by taking the following actions:
+Most common issues can be identified and resolved by following these instructions:
 
-- <<{p}-get-resources,Get the list of resources>>
+- <<{p}-get-resources,View the list of resources>>
 - <<{p}-describe-failing-resources,Describe failing resources>>
-- <<{p}-get-elasticsearch-logs,Get Elasticsearch logs>>
-- <<{p}-get-init-container-logs,Get init container logs>>
-- <<{p}-get-eck-logs,Get ECK logs>>
+- <<{p}-view-logs>>
 - <<{p}-eck-debug-logs,Enable ECK debug logs>>
 - <<{p}-pause-controllers,Pause ECK controllers>>
 - <<{p}-get-k8s-events,Get Kubernetes events>>
 - <<{p}-exec-into-containers,Exec into containers>>
-- <<{p}-webhook-troubleshooting,Webhook troubleshooting>>
-- <<{p}-ask-for-help,Ask for help>>
+- <<{p}-webhook-troubleshooting,Troubleshoot webhook>>
+
+If you are still unable to find a solution to your problem after following the above instructions, ask for help:
+
+include::../help.asciidoc[]
+
 
 [id="{p}-get-resources"]
-== Get a list of resources
+== View the list of resources
 
 To deploy and manage the Elastic stack, ECK creates several resources in the namespace where the main resource is deployed.
 
@@ -97,48 +99,6 @@ Events:
 
 If you see an error with unbound persistent volume claims (PVCs), it means there is not currently a persistent volume that can satisfy the claim. If you are using automatically provisioned storage (e.g. Amazon EBS provisioner), sometimes the storage provider can take a few minutes to provision a volume, so this may resolve itself in a few minutes. You can also check the status by running `kubectl describe persistentvolumeclaims` to see events of the PVCs.
 
-[id="{p}-get-elasticsearch-logs"]
-== Get Elasticsearch logs
-
-Each Elasticsearch node name is mapped to the corresponding Pod name.
-To get the logs of a particular Elasticsearch node, just fetch the Pod logs:
-
-[source,sh]
-----
-kubectl logs -f elasticsearch-sample-es-lgphkv9p67
-
-(...)
-{"type": "server", "timestamp": "2019-07-22T08:48:10,859+0000", "level": "INFO", "component": "o.e.c.s.ClusterApplierService", "cluster.name": "elasticsearch-sample", "node.name": "elasticsearch-sample-es-lgphkv9p67", "cluster.uuid": "cX9uCx3uQrej9hMLGPhV0g", "node.id": "R_OcheBlRGeqme1IZzE4_Q",  "message": "added {{elasticsearch-sample-es-kqz4jmvj9p}{UGy5IX0UQcaKlztAoh4sLA}{3o_EUuZvRKW7R1C8b1zzzg}{10.16.2.232}{10.16.2.232:9300}{ml.machine_memory=27395555328, ml.max_open_jobs=20, xpack.installed=true},{elasticsearch-sample-es-stzz78k64p}{Sh_AzQcxRzeuIoOQWgru1w}{cwPoTFNnRAWtqsXWQtWbGA}{10.16.2.233}{10.16.2.233:9300}{ml.machine_memory=27395555328, ml.max_open_jobs=20, xpack.installed=true},}, term: 1, version: 164, reason: ApplyCommitRequest{term=1, version=164, sourceNode={elasticsearch-sample-es-9xzzhmgd4h}{tAi_bCPcSaO1OkLap4wmhQ}{E6VcWWWtSB2oo-2zmj9DMQ}{10.16.1.150}{10.16.1.150:9300}{ml.machine_memory=27395555328, ml.max_open_jobs=20, xpack.installed=true}}"  }
-{"type": "server", "timestamp": "2019-07-22T08:48:22,224+0000", "level": "INFO", "component": "o.e.c.s.ClusterApplierService", "cluster.name": "elasticsearch-sample", "node.name": "elasticsearch-sample-es-lgphkv9p67", "cluster.uuid": "cX9uCx3uQrej9hMLGPhV0g", "node.id": "R_OcheBlRGeqme1IZzE4_Q",  "message": "added {{elasticsearch-sample-es-fn9wvxw6sh}{_tbAciHTStaAlUO6GtD9LA}{1g7_qsXwR0qjjfom05VwMA}{10.16.1.154}{10.16.1.154:9300}{ml.machine_memory=27395555328, ml.max_open_jobs=20, xpack.installed=true},}, term: 1, version: 169, reason: ApplyCommitRequest{term=1, version=169, sourceNode={elasticsearch-sample-es-9xzzhmgd4h}{tAi_bCPcSaO1OkLap4wmhQ}{E6VcWWWtSB2oo-2zmj9DMQ}{10.16.1.150}{10.16.1.150:9300}{ml.machine_memory=27395555328, ml.max_open_jobs=20, xpack.installed=true}}"  }
-----
-
-You can run the same command for Kibana and APM Server.
-
-[id="{p}-get-init-container-logs"]
-== Get init container logs
-
-An Elasticsearch Pod runs a few init containers to prepare the file system of the main Elasticsearch container.
-In some scenarios, the Pod may fail to run (`Status: Error` or `Status: CrashloopBackOff`) because one of the init containers is failing to run.
-Look at the link:https://kubernetes.io/docs/tasks/debug-application-cluster/debug-init-containers/[init container statuses and logs] to get more details.
-
-
-[id="{p}-get-eck-logs"]
-== Get ECK logs
-
-Since the ECK operator is just a standard Pod running in the Kubernetes cluster, you can fetch its logs as you would for any other Pod:
-
-[source,sh]
-----
-kubectl -n elastic-system logs -f statefulset.apps/elastic-operator
-----
-
-The operator constantly attempts to reconcile Kubernetes resources to match the desired state.
-Logs with `INFO` level provide some insights about what is going on.
-Logs with `ERROR` level indicate something is not going as expected.
-
-Due to link:https://github.com/eBay/Kubernetes/blob/master/docs/devel/api-conventions.md#concurrency-control-and-consistency[optimistic locking],
-you can get errors reporting a conflict while updating a resource. You can ignore them, as the update goes through at the next reconciliation attempt, which will happen almost immediately.
-
 [id="{p}-eck-debug-logs"]
 == Enable ECK debug logs
 
@@ -159,6 +119,55 @@ change the `args` array as follows:
       - manager
       - --log-verbosity=1
 ----
+
+
+[id="{p}-view-logs"]
+== View logs
+
+[float]
+[id="{p}-get-elasticsearch-logs"]
+=== View Elasticsearch logs
+
+Each Elasticsearch node name is mapped to the corresponding Pod name.
+To get the logs of a particular Elasticsearch node, just fetch the Pod logs:
+
+[source,sh]
+----
+kubectl logs -f elasticsearch-sample-es-lgphkv9p67
+
+(...)
+{"type": "server", "timestamp": "2019-07-22T08:48:10,859+0000", "level": "INFO", "component": "o.e.c.s.ClusterApplierService", "cluster.name": "elasticsearch-sample", "node.name": "elasticsearch-sample-es-lgphkv9p67", "cluster.uuid": "cX9uCx3uQrej9hMLGPhV0g", "node.id": "R_OcheBlRGeqme1IZzE4_Q",  "message": "added {{elasticsearch-sample-es-kqz4jmvj9p}{UGy5IX0UQcaKlztAoh4sLA}{3o_EUuZvRKW7R1C8b1zzzg}{10.16.2.232}{10.16.2.232:9300}{ml.machine_memory=27395555328, ml.max_open_jobs=20, xpack.installed=true},{elasticsearch-sample-es-stzz78k64p}{Sh_AzQcxRzeuIoOQWgru1w}{cwPoTFNnRAWtqsXWQtWbGA}{10.16.2.233}{10.16.2.233:9300}{ml.machine_memory=27395555328, ml.max_open_jobs=20, xpack.installed=true},}, term: 1, version: 164, reason: ApplyCommitRequest{term=1, version=164, sourceNode={elasticsearch-sample-es-9xzzhmgd4h}{tAi_bCPcSaO1OkLap4wmhQ}{E6VcWWWtSB2oo-2zmj9DMQ}{10.16.1.150}{10.16.1.150:9300}{ml.machine_memory=27395555328, ml.max_open_jobs=20, xpack.installed=true}}"  }
+{"type": "server", "timestamp": "2019-07-22T08:48:22,224+0000", "level": "INFO", "component": "o.e.c.s.ClusterApplierService", "cluster.name": "elasticsearch-sample", "node.name": "elasticsearch-sample-es-lgphkv9p67", "cluster.uuid": "cX9uCx3uQrej9hMLGPhV0g", "node.id": "R_OcheBlRGeqme1IZzE4_Q",  "message": "added {{elasticsearch-sample-es-fn9wvxw6sh}{_tbAciHTStaAlUO6GtD9LA}{1g7_qsXwR0qjjfom05VwMA}{10.16.1.154}{10.16.1.154:9300}{ml.machine_memory=27395555328, ml.max_open_jobs=20, xpack.installed=true},}, term: 1, version: 169, reason: ApplyCommitRequest{term=1, version=169, sourceNode={elasticsearch-sample-es-9xzzhmgd4h}{tAi_bCPcSaO1OkLap4wmhQ}{E6VcWWWtSB2oo-2zmj9DMQ}{10.16.1.150}{10.16.1.150:9300}{ml.machine_memory=27395555328, ml.max_open_jobs=20, xpack.installed=true}}"  }
+----
+
+You can run the same command for Kibana and APM Server.
+
+[float]
+[id="{p}-get-init-container-logs"]
+=== View init container logs
+
+An Elasticsearch Pod runs a few init containers to prepare the file system of the main Elasticsearch container.
+In some scenarios, the Pod may fail to run (`Status: Error` or `Status: CrashloopBackOff`) because one of the init containers is failing to run.
+Look at the link:https://kubernetes.io/docs/tasks/debug-application-cluster/debug-init-containers/[init container statuses and logs] to get more details.
+
+
+[float]
+[id="{p}-get-eck-logs"]
+=== View ECK logs
+
+Since the ECK operator is just a standard Pod running in the Kubernetes cluster, you can fetch its logs as you would for any other Pod:
+
+[source,sh]
+----
+kubectl -n elastic-system logs -f statefulset.apps/elastic-operator
+----
+
+The operator constantly attempts to reconcile Kubernetes resources to match the desired state.
+Logs with `INFO` level provide some insights about what is going on.
+Logs with `ERROR` level indicate something is not going as expected.
+
+Due to link:https://github.com/eBay/Kubernetes/blob/master/docs/devel/api-conventions.md#concurrency-control-and-consistency[optimistic locking],
+you can get errors reporting a conflict while updating a resource. You can ignore them, as the update goes through at the next reconciliation attempt, which will happen almost immediately.
 
 
 [id="{p}-pause-controllers"]
@@ -242,16 +251,10 @@ On link:https://cloud.google.com/kubernetes-engine/docs/concepts/private-cluster
 
 Refer to <<{p}-webhook-network-policies>> for more information about network policies that might be preventing communication between the Kubernetes API server and the webhook server.
 
+[float]
 === Validation failures
 If the validation webhook is preventing you from making changes due to the unknown fields validation like below, you can force the webhook to ignore it by removing the`kubectl.kubernetes.io/last-applied-configuration` annotation from your resource.
 
 ```
 admission webhook "elastic-es-validation-v1.k8s.elastic.co" denied the request: Elasticsearch.elasticsearch.k8s.elastic.co "quickstart" is invalid: some-misspelled-field: Invalid value: "some-misspelled-field": some-misspelled-field field found in the kubectl.kubernetes.io/last-applied-configuration annotation is unknown
 ```
-
-
-[id="{p}-ask-for-help"]
-== Ask for help
-
-* link:https://discuss.elastic.co/c/eck[ECK Discuss forums] to ask any question
-* link:https://github.com/elastic/cloud-on-k8s/issues[Github issues] for bugs and feature requests

--- a/docs/operating-eck/troubleshooting.asciidoc
+++ b/docs/operating-eck/troubleshooting.asciidoc
@@ -11,8 +11,8 @@ Most common issues can be identified and resolved by following these instruction
 
 - <<{p}-get-resources,View the list of resources>>
 - <<{p}-describe-failing-resources,Describe failing resources>>
-- <<{p}-view-logs>>
 - <<{p}-eck-debug-logs,Enable ECK debug logs>>
+- <<{p}-view-logs>>
 - <<{p}-pause-controllers,Pause ECK controllers>>
 - <<{p}-get-k8s-events,Get Kubernetes events>>
 - <<{p}-exec-into-containers,Exec into containers>>

--- a/docs/operating-eck/upgrading-eck.asciidoc
+++ b/docs/operating-eck/upgrading-eck.asciidoc
@@ -7,6 +7,7 @@ endif::[]
 [id="{p}-{page_id}"]
 = Upgrade ECK
 
+[float]
 [id="{p}-ga-upgrade"]
 == Upgrade to ECK 1.0.0 from previous versions
 
@@ -18,6 +19,7 @@ After the upgrade, use the `v1` API version for all Elastic manifests.
 
 See the <<release-highlights-1.0.0>> for more information on new features.
 
+[float]
 [id="{p}-ga-openshift"]
 == Upgrades in earlier Kubernetes and OpenShift versions
 

--- a/docs/operating-eck/webhook.asciidoc
+++ b/docs/operating-eck/webhook.asciidoc
@@ -4,6 +4,8 @@
 
 A validating webhook provides additional validation of Elasticsearch resources: it provides immediate feedback on the Elasticsearch manifests you submit, allowing you to catch errors right away before ECK even tries to fulfill your request.
 
+[float]
+[id="{p}-webhook-architecture"]
 == Architecture
 The webhook is composed of 4 main components. Here is a brief description of each of them to understand how they interact, their naming, and how they are managed.
 
@@ -14,7 +16,14 @@ The webhook is composed of 4 main components. Here is a brief description of eac
 Like the ValidatingWebhookConfiguration, it must be created before starting the operator, even if it is empty. By default its name is `elastic-webhook-server-cert`.
 The content of this Secret and the lifecycle of the certificates are automatically managed for you. ECK generates a dedicated and separate certificate authority and ensures that all components are rotated before the expiration date. The certificate authority is also used to configure the `caBundle` field of the `ValidatingWebhookConfiguration`. You can disable this feature if you want to manage the certificates yourself or with https://github.com/jetstack/cert-manager[cert-manager]. See an example of the latter below.
 
-== Managing the webhook certificate with cert-manager
+
+[float]
+== Troubleshooting
+
+See the <<{p}-webhook-troubleshooting,Webhook troubleshooting>> section of the <<{p}-troubleshooting,Troubleshooting guide>>.
+
+
+== Manage the webhook certificate with cert-manager
 
 If ECK is currently running you first must ensure that the automatic certificate management feature is disabled. This can be done by updating the operator deployment manifest and adding the `--manage-webhook-certs=false` flag.
 
@@ -102,7 +111,7 @@ EOF
 NOTE: This example assumes that you have installed the operator in the `elastic-system` namespace.
 
 [id="{p}-webhook-network-policies"]
-== Network Policies
+== Network policies
 
 Webhooks require network connectivity between the Kubernetes API server and the operator. If the creation of an Elasticsearch resource times out with an error message similar to the following, then the Kubernetes API server might be unable to connect to the webhook to validate the manifest.
 
@@ -164,8 +173,3 @@ spec:
     ports:
       - port: 9443
 ----
-
-
-== Troubleshooting
-
-See the <<{p}-webhook-troubleshooting,Webhook troubleshooting>> section of the <<{p}-troubleshooting,Troubleshooting guide>>.

--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -10,7 +10,7 @@ endif::[]
 The <<{p}-deploy-kibana,quickstart>> is a good starting point to quickly setup a Kibana instance with ECK.
 The following sections describe how to customize a Kibana deployment to suit your requirements.
 
-* <<{p}-kibana-eck-managed-es,Use an Elasticsearch cluster managed by ECK>>
+* <<{p}-kibana-eck-managed-es,Connect to an Elasticsearch cluster managed by ECK>>
 * <<{p}-kibana-external-es,Connect to an Elasticsearch cluster not managed by ECK>>
 * <<{p}-kibana-advanced-configuration,Advanced configuration>>
 ** <<{p}-kibana-pod-configuration,Pod Configuration>>
@@ -23,8 +23,11 @@ The following sections describe how to customize a Kibana deployment to suit you
 ** <<{p}-kibana-http-disable-tls,Disable TLS>>
 
 
+[id="{p}-kibana-connect-to-es"]
+== Connect to an Elasticsearch cluster
+
 [id="{p}-kibana-eck-managed-es"]
-== Use an Elasticsearch cluster managed by ECK
+=== Connect to an Elasticsearch cluster managed by ECK
 
 It is quite straightforward to connect a Kibana instance to an Elasticsearch cluster managed by ECK:
 
@@ -49,7 +52,7 @@ NOTE: Any Kibana can reference (and thus access) any Elasticsearch instance as l
 The Kibana configuration file is automatically setup by ECK to establish a secure connection to Elasticsearch.
 
 [id="{p}-kibana-external-es"]
-== Connect to an Elasticsearch cluster not managed by ECK
+=== Connect to an Elasticsearch cluster not managed by ECK
 
 It is also possible to configure Kibana to connect to an Elasticsearch cluster that is being managed by a different installation of ECK or running outside the Kubernetes cluster. In this case, you need to know the IP address or URL of the Elasticsearch cluster and a valid username and password pair to access the cluster.
 
@@ -181,7 +184,7 @@ spec:
 ----
 
 [id="{p}-kibana-scaling"]
-== Scale out a Kibana deployment
+=== Scale out a Kibana deployment
 
 You may want to deploy more than one instance of Kibana. In this case all the instances must share the same encryption key. If you do not set one, the operator will generate one for you. If you would like to set your own encryption key, this can be done by setting the `xpack.security.encryptionKey` property using a secure setting as described in the next section.
 

--- a/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
@@ -9,11 +9,13 @@ endif::[]
 
 To help the Kubernetes scheduler correctly place Pods in available Kubernetes nodes and ensure quality of service (QoS), it is recommended to specify the CPU and memory requirements for objects managed by the operator (Elasticsearch, Kibana or APM Server). In Kubernetes, `requests` defines the minimum amount of resources that must be available for a Pod to be scheduled; `limits` defines the maximum amount of resources that a Pod is allowed to consume. For more information about how Kubernetes uses these concepts, see: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/[Managing Compute Resources for Containers].
 
+[float]
 [id="{p}-compute-resources"]
 == Set compute resources
 
 You can set compute resource constraints in the `podTemplate` of objects managed by the operator.
 
+[float]
 [id="{p}-compute-resources-elasticsearch"]
 === Set compute resources for Elasticsearch
 
@@ -54,7 +56,7 @@ spec:
               memory: 4Gi
 ----
 
-
+[float]
 [id="{p}-compute-resources-kibana-and-apm"]
 === Set compute resources for Kibana and APM Server
 

--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -29,3 +29,9 @@ include::supported-versions.asciidoc[]
 
 - link:https://www.elastic.co/elasticsearch-kubernetes[Orchestrate Elasticsearch on Kubernetes]
 - link:https://www.elastic.co/blog/introducing-elastic-cloud-on-kubernetes-the-elasticsearch-operator-and-beyond?elektra=products&storm=sub1[ECK post on the Elastic Blog]
+
+[float]
+[id="{p}-ask-for-help"]
+=== Ask for help
+
+include::help.asciidoc[]


### PR DESCRIPTION
Part of #2351 

#2634 fixed the book structure of the documentation pages that resulted in some sections being very short and separated from the surrounding context. This PR cleans up those issues.

Preview: http://cloud-on-k8s_2643.docs-preview.app.elstc.co/guide/en/cloud-on-k8s/master/index.html