### PR TITLE
Update transport cert verification to full

### DIFF
--- a/pkg/controller/elasticsearch/client/client.go
+++ b/pkg/controller/elasticsearch/client/client.go
@@ -124,10 +124,13 @@ func NewElasticsearchClient(
 		TLSClientConfig: &tls.Config{
 			RootCAs: certPool,
 
+			// We use our own certificate verification because we permit users to provide their own certificates, which may not
+			// be valid for the k8s service URL (though our self-signed certificates are). For instance, users may use a certificate
+			// issued by a public CA for Elasticsearch. We opt to skip verifying here since we're not validating based on DNS names
+			// or IP addresses, which means we have to do our verification in the VerifyPeerCertificate instead.
+
 			// go requires either ServerName or InsecureSkipVerify (or both) when handshaking as a client since 1.3:
 			// https://github.com/golang/go/commit/fca335e91a915b6aae536936a7694c4a2a007a60
-			// we opt to skip verifying here because we're not validating based on DNS names or IP addresses, which means
-			// we have to do our verification in the VerifyPeerCertificate instead.
 			InsecureSkipVerify: true,
 			VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 				return errors.New("tls: verify peer certificate not setup")

--- a/pkg/controller/elasticsearch/client/client.go
+++ b/pkg/controller/elasticsearch/client/client.go
@@ -127,7 +127,7 @@ func NewElasticsearchClient(
 			// We use our own certificate verification because we permit users to provide their own certificates, which may not
 			// be valid for the k8s service URL (though our self-signed certificates are). For instance, users may use a certificate
 			// issued by a public CA for Elasticsearch. We opt to skip verifying here since we're not validating based on DNS names
-			// or IP addresses, which means we have to do our verification in the VerifyPeerCertificate instead.
+			// or IP addresses, which means we have to do our own verification in VerifyPeerCertificate instead.
 
 			// go requires either ServerName or InsecureSkipVerify (or both) when handshaking as a client since 1.3:
 			// https://github.com/golang/go/commit/fca335e91a915b6aae536936a7694c4a2a007a60

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -140,7 +140,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 			Labels: map[string]string{
 				"common.k8s.elastic.co/type":                    "elasticsearch",
 				"elasticsearch.k8s.elastic.co/cluster-name":     "name",
-				"elasticsearch.k8s.elastic.co/config-hash":      "4065866170",
+				"elasticsearch.k8s.elastic.co/config-hash":      "2535617526",
 				"elasticsearch.k8s.elastic.co/http-scheme":      "https",
 				"elasticsearch.k8s.elastic.co/node-data":        "false",
 				"elasticsearch.k8s.elastic.co/node-ingest":      "true",

--- a/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/pkg/controller/elasticsearch/settings/merged_config.go
@@ -73,7 +73,7 @@ func xpackConfig(ver version.Version, httpCfg commonv1.HTTPConfig, certResources
 		// x-pack security general settings
 		esv1.XPackSecurityEnabled:                      "true",
 		esv1.XPackSecurityAuthcReservedRealmEnabled:    "false",
-		esv1.XPackSecurityTransportSslVerificationMode: "certificate",
+		esv1.XPackSecurityTransportSslVerificationMode: "full",
 
 		// x-pack security http settings
 		esv1.XPackSecurityHttpSslEnabled:     httpCfg.TLS.Enabled(),


### PR DESCRIPTION
We can use [full certificate verification](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#ssl-tls-settings) for the transport layer since users cannot modify the transport certs, and we [issue certificates for each pod](https://github.com/elastic/cloud-on-k8s/blob/master/pkg/controller/elasticsearch/certificates/transport/pod_secret.go#L34). We do not have any open issues to allow users to modify the transport certs, and if we decide to change course later we can roll back this change pretty easily.

Also clarifies why we use our own cert validation for the ES HTTP client, since we do not need it when we manage certificates and it was confusing for me until dear @nkvoll pointed it out.