### PR TITLE
Remove the snapshot tests from the stack versions job

### DIFF
--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -102,17 +102,6 @@ pipeline {
                         }
                     }
                 }
-                stage("7.7.0-SNAPSHOT") {
-                    agent {
-                        label 'linux'
-                    }
-                    steps {
-                        checkout scm
-                        script {
-                            runWith(lib, failedTests, "eck-77-${BUILD_NUMBER}-e2e", "7.7.0-SNAPSHOT")
-                        }
-                    }
-                }
             }
         }
     }
@@ -149,8 +138,7 @@ pipeline {
                     "eck-73-${BUILD_NUMBER}-e2e",
                     "eck-74-${BUILD_NUMBER}-e2e",
                     "eck-75-${BUILD_NUMBER}-e2e",
-                    "eck-76-${BUILD_NUMBER}-e2e",
-                    "eck-77-${BUILD_NUMBER}-e2e"
+                    "eck-76-${BUILD_NUMBER}-e2e"
                 ]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',


### PR DESCRIPTION
The SNAPSHOT tests in their current form cannot work because this build job is called from an upstream build job that builds the operator image under test. 

We need to re-introduce this as a separate job that builds its own image with dev keys for testing dev builds of the Elastic stack due to licensing issues. 

I missed this dependency originally because I tested only the test job after creating the correct image manually which is not what is happening on Jenkins :-( Will follow up with a separate PR to reinstate the snapshot tests but wanted to get the tests green first.