### PR TITLE
Remove needs-version re-label rule

### DIFF
--- a/.github/relabel.yml
+++ b/.github/relabel.yml
@@ -2,5 +2,3 @@ requiredLabels:
   # add "triage" label for anything missing an ">enhancement" or similar label
   - missingLabel: triage
     regex: ">.*"
-  - missingLabel: needs-version
-    regex: "^v[0-9].*"


### PR DESCRIPTION
As it stands the bot only targets issues but we want this rule to be applied to pull requests.