### PR TITLE
Add support matrix link

### DIFF
--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -1,3 +1,5 @@
 * link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl] 1.11+
 * Kubernetes 1.12+ or OpenShift 3.11+
 * Elastic Stack: 6.8+, 7.1+
+
+Please see the full link:https://www.elastic.co/support/matrix#matrix_kubernetes[Elastic support matrix] for more information.


### PR DESCRIPTION
Our support matrix specifies the supported distros a little bit more clearly, calling out GKE AKS and EKS. Should we duplicate that information in our supported version doc? It was a little hard for me to find the matrix. I think we at least want to link to it from here. I also wonder if we want to spell out what we mean by "vanilla k8s" somewhere.

cc @agup006 