### PR TITLE
Fix snapshot test pipeline and include 7.6.2

### DIFF
--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -45,10 +45,16 @@ pipeline {
         stage('Run tests for different stack versions in GKE') {
             environment {
                // use the image we just built
-               OPERATOR_IMAGE = "${sh(returnStdout: true, script: 'make print-operator-image').trim()}"
+               OPERATOR_IMAGE = """${sh(
+                returnStdout: true,
+                script: 'make print-operator-image'
+                )}"""
             }
             parallel {
-                stage("7.6.1-SNAPSHOT") {
+                stage("7.6.2-SNAPSHOT") {
+                     agent {
+                        label 'linux'
+                    }
                     steps {
                         checkout scm
                         script {
@@ -57,6 +63,9 @@ pipeline {
                     }
                 }
                 stage("7.7.0-SNAPSHOT") {
+                     agent {
+                        label 'linux'
+                    }
                     steps {
                         checkout scm
                         script {


### PR DESCRIPTION
* for reasons that I don't understand the single line makefile invocation was cutting off the last character of the docker image tag, this uses a multiline string which does not seem to have this problem 
* removes 7.6.1 which was released and switches to 7.6.2
* adds the missing agent directives to avoid running parallel steps on the same agent (which explains the git lock issues we have seen)
