### PR TITLE
Clarify statement regarding k8s Ingress

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/remote-clusters.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/remote-clusters.asciidoc
@@ -106,7 +106,7 @@ spec:
     port: 9300
     targetPort: 9300
 ----
-<1> On cloud providers which support external load balancers, setting the type field to LoadBalancer provisions a load balancer for your Service. Alternatively expose the service via a Kubernetes link:https://kubernetes.io/docs/concepts/services-networking/ingress/[Ingress].
+<1> On cloud providers which support external load balancers, setting the type field to LoadBalancer provisions a load balancer for your Service. Alternatively expose the service via one of the Kubernetes Ingress controllers that support TCP services.
 
 Finally, configure `cluster-one` as a remote cluster in `cluster-two` using the Elasticsearch REST API:
 


### PR DESCRIPTION
I realised that the current statement regarding Ingress controllers in the remote cluster doc is misleading at best if not plain wrong. Kubernetes Ingress is HTTP by definition, we need TCP for remote cluster connections. 

All of the popular ingress controllers do support TCP services as non-standardised extension though (nginx, traefik, istio gateway, haproxy, contour) 