### PR TITLE
Fix controller-gen installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ GOBIN := $(or $(shell go env GOBIN 2>/dev/null), $(shell go env GOPATH 2>/dev/nu
 
 # find or download controller-gen
 controller-gen:
-ifneq ($(shell controller-gen --version), Version: v0.2.5)
+ifneq ($(shell command -v controller-gen 1> /dev/null && controller-gen --version || true), Version: v0.2.5)
 	@(cd /tmp; GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5)
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else


### PR DESCRIPTION
It seems that `ifneq ($(shell controller-gen --version), Version: v0.2.5)` fails if `controller-gen` is not already installed:
 https://devops-ci.elastic.co/job/cloud-on-k8s-pr/2883/console