### PR TITLE
Set the mininum character length for the abbreviated Git SHA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ REPOSITORY  ?= eck
 NAME        ?= eck-operator
 SNAPSHOT    ?= true
 VERSION     ?= $(shell cat VERSION)
-TAG         ?= $(shell git rev-parse --short --verify HEAD)
+TAG         ?= $(shell git rev-parse --short=8 --verify HEAD)
 IMG_NAME    ?= $(NAME)$(IMG_SUFFIX)
 IMG_VERSION ?= $(VERSION)-$(TAG)
 


### PR DESCRIPTION
We use this in image names and it appears this can vary if left in the default 'auto' mode depending on the number of objects in the repository.
This seems to have lead to CI failures where we derive the expected image name from the
state of the currently checked out repository.
