### PR TITLE
[Ronan Lehane] ECK Support Clarification

### DIFF
--- a/docs/licensing.asciidoc
+++ b/docs/licensing.asciidoc
@@ -3,7 +3,7 @@
 
 When you install the default distribution of ECK, you receive a Basic license. Any Elastic stack application you manage through ECK will also be Basic licensed. Go to https://www.elastic.co/subscriptions to see which features are included in the Basic license for free.
 
-IMPORTANT: ECK is offered in two licensing tiers only: Basic and Enterprise. Similar to the Elastic Stack today, customers can download and use ECK for free, but a subscription is required for support. ECK support requires an Enterprise subscription.
+IMPORTANT: ECK is offered in two licensing tiers only: Basic and Enterprise. Similar to the Elastic Stack, customers can download and use ECK for free, but a subscription is required for support. ECK support requires an Enterprise subscription.
 
 [float]
 === Starting a trial

--- a/docs/licensing.asciidoc
+++ b/docs/licensing.asciidoc
@@ -3,7 +3,7 @@
 
 When you install the default distribution of ECK, you receive a Basic license. Any Elastic stack application you manage through ECK will also be Basic licensed. Go to https://www.elastic.co/subscriptions to see which features are included in the Basic license for free.
 
-IMPORTANT: ECK is offered in two licensing tiers only: basic and enterprise. Similar to the Elastic Stack today, customers can download and use ECK for free but a subscription is required for support. ECK support requires an Enterprise subscription. 
+IMPORTANT: ECK is offered in two licensing tiers only: Basic and Enterprise. Similar to the Elastic Stack today, customers can download and use ECK for free, but a subscription is required for support. ECK support requires an Enterprise subscription.
 
 [float]
 === Starting a trial

--- a/docs/licensing.asciidoc
+++ b/docs/licensing.asciidoc
@@ -3,6 +3,8 @@
 
 When you install the default distribution of ECK, you receive a Basic license. Any Elastic stack application you manage through ECK will also be Basic licensed. Go to https://www.elastic.co/subscriptions to see which features are included in the Basic license for free.
 
+IMPORTANT: ECK is offered in two licensing tiers only: basic and enterprise. Similar to the Elastic Stack today, customers can download and use ECK for free but a subscription is required for support. ECK support requires an Enterprise subscription. 
+
 [float]
 === Starting a trial
 If you want to try the features included in the Enterprise subscription, you can start a 30-day trial. To start a trial create a Kubernetes secret as shown below. Note that it must be in the same namespace as the operator:


### PR DESCRIPTION
Added the following clarification regarding licensing for ECK as we are getting a significant numbers of cases from Gold/Platinum customers asking for support on ECK. ECK support is only available to Enterprise customers. 

IMPORTANT: ECK is offered in two licensing tiers only: basic and enterprise. Similar to the Elastic Stack today, customers can download and use ECK for free but a subscription is required for support. ECK support requires an Enterprise subscription.

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/master/CONTRIBUTING.md)?
- If you submit code, is your pull request against master? We recommend pull requests against master. We will backport them as needed.
