### PR TITLE
Add the transport service DNS name to the CSR

### DIFF
--- a/pkg/controller/elasticsearch/certificates/transport/csr.go
+++ b/pkg/controller/elasticsearch/certificates/transport/csr.go
@@ -88,6 +88,7 @@ func buildGeneralNames(
 		{OtherName: *commonNameOtherName},
 		{DNSName: commonName},
 		// add the transport service name for remote cluster connections initially connecting through the service
+		// the DNS name has to match the seed hosts configured in the remote cluster settings
 		{DNSName: fmt.Sprintf("%s.%s.svc", esv1.TransportService(cluster.Name), cluster.Namespace)},
 		{IPAddress: netutil.MaybeIPTo4(podIP)},
 		{IPAddress: net.ParseIP("127.0.0.1").To4()},

--- a/pkg/controller/elasticsearch/certificates/transport/csr.go
+++ b/pkg/controller/elasticsearch/certificates/transport/csr.go
@@ -87,6 +87,8 @@ func buildGeneralNames(
 	generalNames := []certificates.GeneralName{
 		{OtherName: *commonNameOtherName},
 		{DNSName: commonName},
+		// add the transport service name for remote cluster connections initially connecting through the service
+		{DNSName: fmt.Sprintf("%s.%s.svc", esv1.TransportService(cluster.Name), cluster.Namespace)},
 		{IPAddress: netutil.MaybeIPTo4(podIP)},
 		{IPAddress: net.ParseIP("127.0.0.1").To4()},
 	}

--- a/pkg/controller/elasticsearch/certificates/transport/csr_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/csr_test.go
@@ -66,6 +66,7 @@ func Test_createValidatedCertificateTemplate(t *testing.T) {
 
 func Test_buildGeneralNames(t *testing.T) {
 	expectedCommonName := "test-pod-name.node.test-es-name.test-namespace.es.local"
+	expectedTransportSvcName := "test-es-name-es-transport.test-namespace.svc"
 	otherName, err := (&certificates.UTF8StringValuedOtherName{
 		OID:   certificates.CommonNameObjectIdentifier,
 		Value: expectedCommonName,
@@ -90,6 +91,7 @@ func Test_buildGeneralNames(t *testing.T) {
 			want: []certificates.GeneralName{
 				{OtherName: *otherName},
 				{DNSName: expectedCommonName},
+				{DNSName: expectedTransportSvcName},
 				{IPAddress: net.ParseIP(testIP).To4()},
 				{IPAddress: net.ParseIP("127.0.0.1").To4()},
 			},


### PR DESCRIPTION
We initially connect through the transport service to the remote
cluster. This should  ensure that the transport service is one of the trusted
DNS names.

I ran into errors like this one when testing remote cluster connection setup

```
[elasticsearch.server][WARN] failed to establish trust with server at [remote-src-es-transport.default.svc]; the server provided a certificate with subject name [CN=remote-src-es-default-2.node.remote-src.default.es.local,OU=remote-src] and fingerprint [effb883baf24e32229edbe17361034c23c6c1a61]; the certificate has subject alternative names [DNS:remote-src-es-default-2.node.remote-src.default.es.local,IP:10.73.0.8,IP:127.0.0.1]; the certificate is issued by [CN=remote-src-transport,OU=remote-src]; the certificate is signed by (subject [CN=remote-src-transport,OU=remote-src] fingerprint [1743d054ed76a38e7a212781318bacfdc3ea0748] {trusted issuer}) which is self-issued; the [CN=remote-src-transport,OU=remote-src] certificate is trusted in this ssl context ([xpack.security.transport.ssl])   
```


