### PR TITLE
Consistently rely on the global scheme.Scheme across the codebase

### DIFF
--- a/pkg/controller/apmserver/apmserver_controller_test.go
+++ b/pkg/controller/apmserver/apmserver_controller_test.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -333,10 +332,8 @@ func TestReconcileApmServer_deploymentParams(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			client := k8s.WrappedFakeClient(tt.args.initialObjects...)
 			w := watches.NewDynamicWatches()
-			require.NoError(t, w.Secrets.InjectScheme(scheme.Scheme))
 			r := &ReconcileApmServer{
 				Client:         client,
-				scheme:         scheme.Scheme,
 				recorder:       record.NewFakeRecorder(100),
 				dynamicWatches: w,
 			}
@@ -400,7 +397,6 @@ func TestReconcileApmServer_doReconcile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &ReconcileApmServer{
 				Client:         k8s.WrappedFakeClient(&tt.as),
-				scheme:         scheme.Scheme,
 				recorder:       tt.fields.recorder,
 				dynamicWatches: tt.fields.dynamicWatches,
 				Parameters:     tt.fields.Parameters,

--- a/pkg/controller/apmserver/certificates/reconcile.go
+++ b/pkg/controller/apmserver/certificates/reconcile.go
@@ -44,7 +44,6 @@ func Reconcile(
 	// reconcile CA certs first
 	httpCa, err := certificates.ReconcileCAForOwner(
 		driver.K8sClient(),
-		driver.Scheme(),
 		name.APMNamer,
 		as,
 		labels,
@@ -84,6 +83,6 @@ func Reconcile(
 	})
 
 	// reconcile http public cert secret
-	results.WithError(http.ReconcileHTTPCertsPublicSecret(driver.K8sClient(), driver.Scheme(), as, name.APMNamer, httpCertificates))
+	results.WithError(http.ReconcileHTTPCertsPublicSecret(driver.K8sClient(), as, name.APMNamer, httpCertificates))
 	return results
 }

--- a/pkg/controller/apmserver/config/reconcile.go
+++ b/pkg/controller/apmserver/config/reconcile.go
@@ -9,7 +9,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
@@ -25,7 +24,7 @@ var log = logf.Log.WithName("apmserver-config")
 
 // Reconcile reconciles the configuration of the APM server: it first creates the configuration from the APM
 // specification and then reconcile the underlying secret.
-func Reconcile(client k8s.Client, scheme *runtime.Scheme, as *apmv1.ApmServer) (*corev1.Secret, error) {
+func Reconcile(client k8s.Client, as *apmv1.ApmServer) (*corev1.Secret, error) {
 
 	// Create a new configuration from the APM object spec.
 	cfg, err := NewConfigFromSpec(client, as)
@@ -54,7 +53,6 @@ func Reconcile(client k8s.Client, scheme *runtime.Scheme, as *apmv1.ApmServer) (
 	if err := reconciler.ReconcileResource(
 		reconciler.Params{
 			Client: client,
-			Scheme: scheme,
 
 			Owner:      as,
 			Expected:   expectedConfigSecret,

--- a/pkg/controller/apmserverelasticsearchassociation/apmserverelasticsearchassociation_controller.go
+++ b/pkg/controller/apmserverelasticsearchassociation/apmserverelasticsearchassociation_controller.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -72,7 +71,6 @@ func newReconciler(mgr manager.Manager, accessReviewer rbac.AccessReviewer, para
 	return &ReconcileApmServerElasticsearchAssociation{
 		Client:         client,
 		accessReviewer: accessReviewer,
-		scheme:         mgr.GetScheme(),
 		watches:        watches.NewDynamicWatches(),
 		recorder:       mgr.GetEventRecorderFor(name),
 		Parameters:     params,
@@ -122,7 +120,6 @@ var _ reconcile.Reconciler = &ReconcileApmServerElasticsearchAssociation{}
 type ReconcileApmServerElasticsearchAssociation struct {
 	k8s.Client
 	accessReviewer rbac.AccessReviewer
-	scheme         *runtime.Scheme
 	recorder       record.EventRecorder
 	watches        watches.DynamicWatches
 	operator.Parameters
@@ -284,7 +281,6 @@ func (r *ReconcileApmServerElasticsearchAssociation) reconcileInternal(ctx conte
 	if err := association.ReconcileEsUser(
 		ctx,
 		r.Client,
-		r.scheme,
 		apmServer,
 		map[string]string{
 			AssociationLabelName:      apmServer.Name,
@@ -393,7 +389,6 @@ func (r *ReconcileApmServerElasticsearchAssociation) reconcileElasticsearchCA(ct
 	labels[AssociationLabelName] = as.Name
 	return association.ReconcileCASecret(
 		r.Client,
-		r.scheme,
 		as,
 		es,
 		labels,

--- a/pkg/controller/common/association/ca.go
+++ b/pkg/controller/common/association/ca.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
@@ -37,7 +36,6 @@ func ElasticsearchCACertSecretName(associated commonv1.Associated, suffix string
 // It is the responsibility of the controller to set a watch on the ES CA.
 func ReconcileCASecret(
 	client k8s.Client,
-	scheme *runtime.Scheme,
 	associated commonv1.Associated,
 	es types.NamespacedName,
 	labels map[string]string,
@@ -66,7 +64,6 @@ func ReconcileCASecret(
 	var reconciledSecret corev1.Secret
 	if err := reconciler.ReconcileResource(reconciler.Params{
 		Client:     client,
-		Scheme:     scheme,
 		Owner:      associated,
 		Expected:   &expectedSecret,
 		Reconciled: &reconciledSecret,

--- a/pkg/controller/common/association/ca_test.go
+++ b/pkg/controller/common/association/ca_test.go
@@ -7,25 +7,20 @@ package association
 import (
 	"testing"
 
-	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
+
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
 const ElasticsearchCASecretSuffix = "xx-es-ca" // nolint
 
 func TestReconcileAssociation_reconcileCASecret(t *testing.T) {
-	// init watches
-	w := watches.NewDynamicWatches()
-	require.NoError(t, w.Secrets.InjectScheme(scheme.Scheme))
-
 	// mock existing ES resource
 	es := esv1.Elasticsearch{
 		ObjectMeta: metav1.ObjectMeta{
@@ -146,7 +141,6 @@ func TestReconcileAssociation_reconcileCASecret(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ReconcileCASecret(
 				tt.client,
-				scheme.Scheme,
 				&tt.kibana,
 				k8s.ExtractNamespacedName(&tt.es),
 				map[string]string{},

--- a/pkg/controller/common/association/user.go
+++ b/pkg/controller/common/association/user.go
@@ -13,7 +13,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
@@ -74,7 +73,6 @@ func ClearTextSecretKeySelector(associated commonv1.Associated, userSuffix strin
 func ReconcileEsUser(
 	ctx context.Context,
 	c k8s.Client,
-	s *runtime.Scheme,
 	associated commonv1.Associated,
 	labels map[string]string,
 	userRoles string,
@@ -102,7 +100,6 @@ func ReconcileEsUser(
 	reconciledSecret := corev1.Secret{}
 	err := reconciler.ReconcileResource(reconciler.Params{
 		Client:     c,
-		Scheme:     s,
 		Owner:      associated,
 		Expected:   &expectedSecret,
 		Reconciled: &reconciledSecret,
@@ -151,7 +148,6 @@ func ReconcileEsUser(
 	reconciledEsSecret := corev1.Secret{}
 	return reconciler.ReconcileResource(reconciler.Params{
 		Client:     c,
-		Scheme:     s,
 		Owner:      &es, // user is owned by the ES resource
 		Expected:   expectedEsUser,
 		Reconciled: &reconciledEsSecret,

--- a/pkg/controller/common/association/user_test.go
+++ b/pkg/controller/common/association/user_test.go
@@ -8,8 +8,6 @@ import (
 	"context"
 	"testing"
 
-	"k8s.io/client-go/kubernetes/scheme"
-
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
@@ -256,7 +254,6 @@ func Test_reconcileEsUser(t *testing.T) {
 			if err := ReconcileEsUser(
 				context.Background(),
 				c,
-				scheme.Scheme,
 				&tt.args.kibana,
 				map[string]string{
 					associationLabelName:      tt.args.kibana.Name,

--- a/pkg/controller/common/certificates/ca_reconcile.go
+++ b/pkg/controller/common/certificates/ca_reconcile.go
@@ -15,7 +15,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -46,7 +45,6 @@ func CAInternalSecretName(namer name.Namer, ownerName string, caType CAType) str
 // The CA cert and private key are rotated if they become invalid (or soon to expire).
 func ReconcileCAForOwner(
 	cl k8s.Client,
-	scheme *runtime.Scheme,
 	namer name.Namer,
 	owner v1.Object,
 	labels map[string]string,
@@ -66,20 +64,20 @@ func ReconcileCAForOwner(
 	}
 	if apierrors.IsNotFound(err) {
 		log.Info("No internal CA certificate Secret found, creating a new one", "owner_namespace", owner.GetNamespace(), "owner_name", owner.GetName(), "ca_type", caType)
-		return renewCA(cl, namer, owner, labels, rotationParams.Validity, scheme, caType)
+		return renewCA(cl, namer, owner, labels, rotationParams.Validity, caType)
 	}
 
 	// build CA
 	ca := BuildCAFromSecret(caInternalSecret)
 	if ca == nil {
 		log.Info("Cannot build CA from secret, creating a new one", "owner_namespace", owner.GetNamespace(), "owner_name", owner.GetName(), "ca_type", caType)
-		return renewCA(cl, namer, owner, labels, rotationParams.Validity, scheme, caType)
+		return renewCA(cl, namer, owner, labels, rotationParams.Validity, caType)
 	}
 
 	// renew if cannot reuse
 	if !CanReuseCA(ca, rotationParams.RotateBefore) {
 		log.Info("Cannot reuse existing CA, creating a new one", "owner_namespace", owner.GetNamespace(), "owner_name", owner.GetName(), "ca_type", caType)
-		return renewCA(cl, namer, owner, labels, rotationParams.Validity, scheme, caType)
+		return renewCA(cl, namer, owner, labels, rotationParams.Validity, caType)
 	}
 
 	// reuse existing CA
@@ -93,7 +91,6 @@ func renewCA(
 	owner v1.Object,
 	labels map[string]string,
 	expireIn time.Duration,
-	scheme *runtime.Scheme,
 	caType CAType,
 ) (*CA, error) {
 	ca, err := NewSelfSignedCA(CABuilderOptions{
@@ -116,7 +113,6 @@ func renewCA(
 		NeedsUpdate:      func() bool { return true },
 		Owner:            owner,
 		Reconciled:       &reconciledCAInternalSecret,
-		Scheme:           scheme,
 		UpdateReconciled: func() { reconciledCAInternalSecret.Data = caInternalSecret.Data },
 	}); err != nil {
 		return nil, err

--- a/pkg/controller/common/certificates/ca_reconcile_test.go
+++ b/pkg/controller/common/certificates/ca_reconcile_test.go
@@ -12,16 +12,16 @@ import (
 	"testing"
 	"time"
 
-	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/name"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/client-go/kubernetes/scheme"
+
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/name"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
 var testNamer = name.Namer{
@@ -214,7 +214,7 @@ func Test_renewCA(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ca, err := renewCA(tt.client, testNamer, &testCluster, nil, tt.expireIn, scheme.Scheme, TransportCAType)
+			ca, err := renewCA(tt.client, testNamer, &testCluster, nil, tt.expireIn, TransportCAType)
 			require.NoError(t, err)
 			require.NotNil(t, ca)
 			assert.Equal(t, ca.Cert.Issuer.CommonName, testName+"-"+string(TransportCAType))
@@ -285,7 +285,7 @@ func TestReconcileCAForCluster(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ca, err := ReconcileCAForOwner(
-				tt.cl, scheme.Scheme, testNamer, &testCluster, nil, TransportCAType, RotationParams{
+				tt.cl, testNamer, &testCluster, nil, TransportCAType, RotationParams{
 					Validity:     tt.caCertValidity,
 					RotateBefore: DefaultRotateBefore,
 				},

--- a/pkg/controller/common/certificates/http/public_secret.go
+++ b/pkg/controller/common/certificates/http/public_secret.go
@@ -14,7 +14,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -22,7 +21,6 @@ import (
 // the certificate if available.
 func ReconcileHTTPCertsPublicSecret(
 	c k8s.Client,
-	scheme *runtime.Scheme,
 	owner metav1.Object,
 	namer name.Namer,
 	httpCertificates *CertificatesSecret,
@@ -41,7 +39,6 @@ func ReconcileHTTPCertsPublicSecret(
 
 	return reconciler.ReconcileResource(reconciler.Params{
 		Client:     c,
-		Scheme:     scheme,
 		Owner:      owner,
 		Expected:   expected,
 		Reconciled: reconciled,

--- a/pkg/controller/common/certificates/http/public_secret_test.go
+++ b/pkg/controller/common/certificates/http/public_secret_test.go
@@ -126,7 +126,7 @@ func TestReconcileHTTPCertsPublicSecret(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			client := tt.client(t)
-			err := ReconcileHTTPCertsPublicSecret(client, scheme.Scheme, owner, esv1.ESNamer, certificate)
+			err := ReconcileHTTPCertsPublicSecret(client, owner, esv1.ESNamer, certificate)
 			if tt.wantErr {
 				require.Error(t, err, "Failed to reconcile")
 				return

--- a/pkg/controller/common/certificates/http/reconcile.go
+++ b/pkg/controller/common/certificates/http/reconcile.go
@@ -23,8 +23,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -55,7 +55,7 @@ func ReconcileHTTPCertificates(
 	}
 
 	internalCerts, err := reconcileHTTPInternalCertificatesSecret(
-		driver.K8sClient(), driver.Scheme(), owner, namer, tls, labels, services, customCertificates, ca, rotationParams,
+		driver.K8sClient(), owner, namer, tls, labels, services, customCertificates, ca, rotationParams,
 	)
 	if err != nil {
 		return nil, err
@@ -67,7 +67,6 @@ func ReconcileHTTPCertificates(
 // reconcileHTTPInternalCertificatesSecret ensures that the internal HTTP certificate secret has the correct content.
 func reconcileHTTPInternalCertificatesSecret(
 	c k8s.Client,
-	scheme *runtime.Scheme,
 	owner metav1.Object,
 	namer name.Namer,
 	tls commonv1.TLSOptions,
@@ -106,7 +105,7 @@ func reconcileHTTPInternalCertificatesSecret(
 		}
 	}
 
-	if err := controllerutil.SetControllerReference(owner, &secret, scheme); err != nil {
+	if err := controllerutil.SetControllerReference(owner, &secret, scheme.Scheme); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/common/certificates/http/reconcile_test.go
+++ b/pkg/controller/common/certificates/http/reconcile_test.go
@@ -21,10 +21,8 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
 const (
@@ -157,11 +155,9 @@ func TestReconcileHTTPCertificates(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := watches.NewDynamicWatches()
-			require.NoError(t, w.InjectScheme(scheme.Scheme))
 			testDriver := driver.TestDriver{
-				Client:        tt.args.c,
-				RuntimeScheme: scheme.Scheme,
-				Watches:       w,
+				Client:  tt.args.c,
+				Watches: w,
 			}
 
 			got, err := ReconcileHTTPCertificates(

--- a/pkg/controller/common/deployment/reconcile.go
+++ b/pkg/controller/common/deployment/reconcile.go
@@ -8,7 +8,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
@@ -56,7 +55,6 @@ func New(params Params) appsv1.Deployment {
 // ReconcileDeployment creates or updates the given deployment for the specified owner.
 func Reconcile(
 	k8sClient k8s.Client,
-	scheme *runtime.Scheme,
 	expected appsv1.Deployment,
 	owner metav1.Object,
 ) (appsv1.Deployment, error) {
@@ -66,7 +64,6 @@ func Reconcile(
 	reconciled := &appsv1.Deployment{}
 	err := reconciler.ReconcileResource(reconciler.Params{
 		Client:     k8sClient,
-		Scheme:     scheme,
 		Owner:      owner,
 		Expected:   &expected,
 		Reconciled: reconciled,

--- a/pkg/controller/common/deployment/reconcile_test.go
+++ b/pkg/controller/common/deployment/reconcile_test.go
@@ -7,16 +7,16 @@ package deployment
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/comparison"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
 	commonscheme "github.com/elastic/cloud-on-k8s/pkg/controller/common/scheme"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
-	"github.com/stretchr/testify/require"
-	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
 func TestWithTemplateHash(t *testing.T) {
@@ -65,7 +65,7 @@ func TestReconcile(t *testing.T) {
 	owner := esv1.Elasticsearch{} // can be any type
 
 	// should create a new deployment
-	reconciled, err := Reconcile(k8sClient, scheme.Scheme, expected, &owner)
+	reconciled, err := Reconcile(k8sClient, expected, &owner)
 	require.NoError(t, err)
 	// reconciled should match expected spec, and have the hash label set
 	require.Equal(t, pointer.Int32(2), reconciled.Spec.Replicas)
@@ -78,13 +78,13 @@ func TestReconcile(t *testing.T) {
 	comparison.RequireEqual(t, &reconciled, &retrieved)
 
 	// reconciling the same should be a no-op
-	reconciledAgain, err := Reconcile(k8sClient, scheme.Scheme, expected, &owner)
+	reconciledAgain, err := Reconcile(k8sClient, expected, &owner)
 	require.NoError(t, err)
 	comparison.RequireEqual(t, &reconciled, &reconciledAgain)
 
 	// update with a new spec
 	expected.Spec.Replicas = pointer.Int32(3)
-	reconciled, err = Reconcile(k8sClient, scheme.Scheme, expected, &owner)
+	reconciled, err = Reconcile(k8sClient, expected, &owner)
 	require.NoError(t, err)
 	// both returned and retrieved should match that new spec
 	require.Equal(t, pointer.Int32(3), reconciled.Spec.Replicas)

--- a/pkg/controller/common/driver/interface.go
+++ b/pkg/controller/common/driver/interface.go
@@ -7,32 +7,25 @@ package driver
 import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 )
 
 // Interface describes attributes typically found on reconciler or 'driver' implementations.
 type Interface interface {
 	K8sClient() k8s.Client
-	Scheme() *runtime.Scheme
 	DynamicWatches() watches.DynamicWatches
 	Recorder() record.EventRecorder
 }
 
 // TestDriver is a struct implementing the common driver interface for testing purposes.
 type TestDriver struct {
-	Client        k8s.Client
-	RuntimeScheme *runtime.Scheme
-	Watches       watches.DynamicWatches
-	FakeRecorder  *record.FakeRecorder
+	Client       k8s.Client
+	Watches      watches.DynamicWatches
+	FakeRecorder *record.FakeRecorder
 }
 
 func (t TestDriver) K8sClient() k8s.Client {
 	return t.Client
-}
-
-func (t TestDriver) Scheme() *runtime.Scheme {
-	return t.RuntimeScheme
 }
 
 func (t TestDriver) DynamicWatches() watches.DynamicWatches {

--- a/pkg/controller/common/keystore/resources_test.go
+++ b/pkg/controller/common/keystore/resources_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -138,12 +137,10 @@ echo "Keystore initialization successful."
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testDriver := driver.TestDriver{
-				Client:        tt.client,
-				RuntimeScheme: scheme.Scheme,
-				Watches:       watches2.NewDynamicWatches(),
-				FakeRecorder:  record.NewFakeRecorder(1000),
+				Client:       tt.client,
+				Watches:      watches2.NewDynamicWatches(),
+				FakeRecorder: record.NewFakeRecorder(1000),
 			}
-			require.NoError(t, testDriver.Watches.InjectScheme(scheme.Scheme))
 			resources, err := NewResources(testDriver, &tt.kb, name.KBNamer, nil, initContainersParameters)
 			require.NoError(t, err)
 			if tt.wantNil {

--- a/pkg/controller/common/keystore/user_secret.go
+++ b/pkg/controller/common/keystore/user_secret.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 
@@ -52,7 +51,7 @@ func secureSettingsVolume(
 	if err != nil {
 		return nil, "", err
 	}
-	secret, err := reconcileSecureSettings(r.K8sClient(), r.Scheme(), hasKeystore, secrets, namer, labels)
+	secret, err := reconcileSecureSettings(r.K8sClient(), hasKeystore, secrets, namer, labels)
 	if err != nil {
 		return nil, "", err
 	}
@@ -76,7 +75,6 @@ func secureSettingsVolume(
 
 func reconcileSecureSettings(
 	c k8s.Client,
-	scheme *runtime.Scheme,
 	hasKeystore HasKeystore,
 	userSecrets []corev1.Secret,
 	namer name.Namer,
@@ -111,7 +109,6 @@ func reconcileSecureSettings(
 	reconciled := corev1.Secret{}
 	return &reconciled, reconciler.ReconcileResource(reconciler.Params{
 		Client:     c,
-		Scheme:     scheme,
 		Owner:      hasKeystore,
 		Expected:   &expected,
 		Reconciled: &reconciled,

--- a/pkg/controller/common/keystore/user_secret_test.go
+++ b/pkg/controller/common/keystore/user_secret_test.go
@@ -12,8 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
@@ -39,7 +37,6 @@ func Test_secureSettingsVolume(t *testing.T) {
 	)
 	createWatches := func(handlerName string) watches.DynamicWatches {
 		w := watches.NewDynamicWatches()
-		require.NoError(t, w.InjectScheme(scheme.Scheme))
 		if handlerName != "" {
 			require.NoError(t, w.Secrets.AddHandler(watches.NamedWatch{
 				Name: handlerName,
@@ -99,10 +96,9 @@ func Test_secureSettingsVolume(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testDriver := driver.TestDriver{
-				Client:        tt.c,
-				RuntimeScheme: scheme.Scheme,
-				Watches:       tt.w,
-				FakeRecorder:  record.NewFakeRecorder(1000),
+				Client:       tt.c,
+				Watches:      tt.w,
+				FakeRecorder: record.NewFakeRecorder(1000),
 			}
 			vol, version, err := secureSettingsVolume(testDriver, &tt.kb, nil, kbname.KBNamer)
 			require.NoError(t, err)
@@ -304,7 +300,7 @@ func Test_reconcileSecureSettings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := reconcileSecureSettings(tt.args.c, clientgoscheme.Scheme, tt.args.hasKeystore, tt.args.userSecrets, tt.args.namer, nil)
+			got, err := reconcileSecureSettings(tt.args.c, tt.args.hasKeystore, tt.args.userSecrets, tt.args.namer, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("reconcileSecureSettings() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/common/reconciler/reconciler.go
+++ b/pkg/controller/common/reconciler/reconciler.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -28,8 +29,6 @@ var (
 // Params is a parameter object for the ReconcileResources function
 type Params struct {
 	Client k8s.Client
-	// Scheme with all custom resources kinds registered.
-	Scheme *runtime.Scheme
 	// Owner will be set as the controller reference
 	Owner metav1.Object
 	// Expected the expected state of the resource going into reconciliation.
@@ -79,14 +78,14 @@ func ReconcileResource(params Params) error {
 	}
 	namespace := metaObj.GetNamespace()
 	name := metaObj.GetName()
-	gvk, err := apiutil.GVKForObject(params.Expected, params.Scheme)
+	gvk, err := apiutil.GVKForObject(params.Expected, scheme.Scheme)
 	if err != nil {
 		return err
 	}
 	kind := gvk.Kind
 
 	if params.Owner != nil {
-		if err := controllerutil.SetControllerReference(params.Owner, metaObj, params.Scheme); err != nil {
+		if err := controllerutil.SetControllerReference(params.Owner, metaObj, scheme.Scheme); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/common/reconciler/reconciler_test.go
+++ b/pkg/controller/common/reconciler/reconciler_test.go
@@ -18,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
 func withoutControllerRef(obj runtime.Object) runtime.Object {
@@ -266,7 +265,6 @@ func TestReconcileResource(t *testing.T) {
 			args := tt.args()
 			p := Params{
 				Client:           client,
-				Scheme:           scheme.Scheme,
 				Owner:            &appsv1.Deployment{}, //just a dummy
 				Expected:         args.Expected,
 				Reconciled:       args.Reconciled,

--- a/pkg/controller/common/service_control.go
+++ b/pkg/controller/common/service_control.go
@@ -16,7 +16,6 @@ import (
 	"go.elastic.co/apm"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -27,7 +26,6 @@ var log = logf.Log.WithName("common")
 func ReconcileService(
 	ctx context.Context,
 	c k8s.Client,
-	scheme *runtime.Scheme,
 	expected *corev1.Service,
 	owner metav1.Object,
 ) (*corev1.Service, error) {
@@ -37,7 +35,6 @@ func ReconcileService(
 	reconciled := &corev1.Service{}
 	err := reconciler.ReconcileResource(reconciler.Params{
 		Client:     c,
-		Scheme:     scheme,
 		Owner:      owner,
 		Expected:   expected,
 		Reconciled: reconciled,

--- a/pkg/controller/common/service_control_test.go
+++ b/pkg/controller/common/service_control_test.go
@@ -27,7 +27,6 @@ func TestReconcileService(t *testing.T) {
 	}
 
 	existingSvc := mkService()
-	scheme := k8s.Scheme()
 	client := k8s.WrappedFakeClient(owner, existingSvc)
 
 	expectedSvc := mkService()
@@ -40,7 +39,7 @@ func TestReconcileService(t *testing.T) {
 	wantSvc.Labels["lbl3"] = "lblval3"
 	wantSvc.Annotations["ann3"] = "annval3"
 
-	haveSvc, err := ReconcileService(context.Background(), client, scheme, expectedSvc, owner)
+	haveSvc, err := ReconcileService(context.Background(), client, expectedSvc, owner)
 	require.NoError(t, err)
 	comparison.AssertEqual(t, wantSvc, haveSvc)
 }

--- a/pkg/controller/common/watches/handler_test.go
+++ b/pkg/controller/common/watches/handler_test.go
@@ -41,22 +41,13 @@ var _ HandlerRegistration = &fakeHandler{}
 func TestDynamicEnqueueRequest_AddHandler(t *testing.T) {
 	tests := []struct {
 		name               string
-		setup              func(handler *DynamicEnqueueRequest)
 		args               HandlerRegistration
 		wantErr            bool
 		registeredHandlers int
 	}{
 		{
-			name:    "fail on uninitialized handler",
-			args:    &fakeHandler{},
-			wantErr: true,
-		},
-		{
-			name: "succeed on initialized handler",
-			args: &fakeHandler{},
-			setup: func(handler *DynamicEnqueueRequest) {
-				assert.NoError(t, handler.InjectScheme(scheme.Scheme))
-			},
+			name:               "registers the given handler with no error",
+			args:               &fakeHandler{},
 			wantErr:            false,
 			registeredHandlers: 1,
 		},
@@ -64,9 +55,6 @@ func TestDynamicEnqueueRequest_AddHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := NewDynamicEnqueueRequest()
-			if tt.setup != nil {
-				tt.setup(d)
-			}
 			if err := d.AddHandler(tt.args); (err != nil) != tt.wantErr {
 				t.Errorf("DynamicEnqueueRequest.AddHandler() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -90,7 +78,6 @@ func TestDynamicEnqueueRequest_RemoveHandler(t *testing.T) {
 			name: "succeed on initialized handler",
 			args: &fakeHandler{},
 			setup: func(handler *DynamicEnqueueRequest) {
-				assert.NoError(t, handler.InjectScheme(scheme.Scheme))
 				assert.NoError(t, handler.AddHandler(&fakeHandler{}))
 				assert.Equal(t, len(handler.registrations), 1)
 			},
@@ -102,7 +89,6 @@ func TestDynamicEnqueueRequest_RemoveHandler(t *testing.T) {
 				name: "bar",
 			},
 			setup: func(handler *DynamicEnqueueRequest) {
-				assert.NoError(t, handler.InjectScheme(scheme.Scheme))
 				assert.NoError(t, handler.AddHandler(&fakeHandler{
 					name: "foo",
 				}))
@@ -151,7 +137,6 @@ func TestDynamicEnqueueRequest_EventHandler(t *testing.T) {
 	}
 
 	d := NewDynamicEnqueueRequest()
-	require.NoError(t, d.InjectScheme(scheme.Scheme))
 	require.NoError(t, d.InjectMapper(getRESTMapper()))
 	q := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
@@ -379,7 +364,6 @@ func TestDynamicEnqueueRequest_OwnerWatch(t *testing.T) {
 	updated2.Labels = map[string]string{"updated": "2"}
 
 	d := NewDynamicEnqueueRequest()
-	require.NoError(t, d.InjectScheme(scheme.Scheme))
 	require.NoError(t, d.InjectMapper(getRESTMapper()))
 	q := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 

--- a/pkg/controller/common/watches/state.go
+++ b/pkg/controller/common/watches/state.go
@@ -4,11 +4,6 @@
 
 package watches
 
-import (
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
-)
-
 // NewDynamicWatches creates an initialized DynamicWatches container.
 func NewDynamicWatches() DynamicWatches {
 	return DynamicWatches{
@@ -27,13 +22,3 @@ type DynamicWatches struct {
 	ElasticsearchClusters *DynamicEnqueueRequest
 	Kibanas               *DynamicEnqueueRequest
 }
-
-// InjectScheme is used by the ControllerManager to inject Scheme into Sources, EventHandlers, Predicates, and
-// Reconciles
-func (w DynamicWatches) InjectScheme(scheme *runtime.Scheme) error {
-	return w.Secrets.InjectScheme(scheme)
-}
-
-// DynamicWatches implements inject.Scheme mostly to facilitate testing. In production code injection happens on
-// the individual watch level.
-var _ inject.Scheme = DynamicWatches{}

--- a/pkg/controller/elasticsearch/certificates/ca_reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/ca_reconcile.go
@@ -58,7 +58,6 @@ func Reconcile(
 
 	httpCA, err := certificates.ReconcileCAForOwner(
 		driver.K8sClient(),
-		driver.Scheme(),
 		esv1.ESNamer,
 		&es,
 		labels,
@@ -98,13 +97,12 @@ func Reconcile(
 	})
 
 	// reconcile http public certs secret:
-	if err := http.ReconcileHTTPCertsPublicSecret(driver.K8sClient(), driver.Scheme(), &es, esv1.ESNamer, httpCertificates); err != nil {
+	if err := http.ReconcileHTTPCertsPublicSecret(driver.K8sClient(), &es, esv1.ESNamer, httpCertificates); err != nil {
 		return nil, results.WithError(err)
 	}
 
 	transportCA, err := certificates.ReconcileCAForOwner(
 		driver.K8sClient(),
-		driver.Scheme(),
 		esv1.ESNamer,
 		&es,
 		labels,
@@ -120,14 +118,13 @@ func Reconcile(
 	})
 
 	// reconcile transport public certs secret
-	if err := transport.ReconcileTransportCertsPublicSecret(driver.K8sClient(), driver.Scheme(), es, transportCA); err != nil {
+	if err := transport.ReconcileTransportCertsPublicSecret(driver.K8sClient(), es, transportCA); err != nil {
 		return nil, results.WithError(err)
 	}
 
 	// reconcile transport certificates
 	transportResults := transport.ReconcileTransportCertificatesSecrets(
 		driver.K8sClient(),
-		driver.Scheme(),
 		transportCA,
 		es,
 		certRotation,

--- a/pkg/controller/elasticsearch/certificates/remoteca/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/remoteca/reconcile.go
@@ -18,7 +18,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -63,7 +62,6 @@ func Reconcile(
 	var reconciled v1.Secret
 	return reconciler.ReconcileResource(reconciler.Params{
 		Client:     c,
-		Scheme:     scheme.Scheme,
 		Owner:      &es,
 		Expected:   &expected,
 		Reconciled: &reconciled,

--- a/pkg/controller/elasticsearch/certificates/transport/public_secret.go
+++ b/pkg/controller/elasticsearch/certificates/transport/public_secret.go
@@ -14,7 +14,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -22,7 +21,6 @@ import (
 // information.
 func ReconcileTransportCertsPublicSecret(
 	c k8s.Client,
-	scheme *runtime.Scheme,
 	es esv1.Elasticsearch,
 	ca *certificates.CA,
 ) error {
@@ -40,7 +38,6 @@ func ReconcileTransportCertsPublicSecret(
 
 	return reconciler.ReconcileResource(reconciler.Params{
 		Client:     c,
-		Scheme:     scheme,
 		Owner:      &es,
 		Expected:   expected,
 		Reconciled: reconciled,

--- a/pkg/controller/elasticsearch/certificates/transport/public_secret_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/public_secret_test.go
@@ -125,7 +125,7 @@ func TestReconcileTransportCertsPublicSecret(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			client := tt.client(t)
-			err := ReconcileTransportCertsPublicSecret(client, scheme.Scheme, *owner, ca)
+			err := ReconcileTransportCertsPublicSecret(client, *owner, ca)
 			if tt.wantErr {
 				require.Error(t, err, "Failed to reconcile")
 				return

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile.go
@@ -20,7 +20,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -32,7 +31,6 @@ var log = logf.Log.WithName("transport")
 // cluster.
 func ReconcileTransportCertificatesSecrets(
 	c k8s.Client,
-	scheme *runtime.Scheme,
 	ca *certificates.CA,
 	es esv1.Elasticsearch,
 	rotationParams certificates.RotationParams,
@@ -45,7 +43,7 @@ func ReconcileTransportCertificatesSecrets(
 		return results.WithError(errors.WithStack(err))
 	}
 
-	secret, err := ensureTransportCertificatesSecretExists(c, scheme, es)
+	secret, err := ensureTransportCertificatesSecretExists(c, es)
 	if err != nil {
 		return results.WithError(err)
 	}
@@ -121,7 +119,6 @@ func ReconcileTransportCertificatesSecrets(
 // in time will contain the transport certificates.
 func ensureTransportCertificatesSecretExists(
 	c k8s.Client,
-	scheme *runtime.Scheme,
 	es esv1.Elasticsearch,
 ) (*corev1.Secret, error) {
 	expected := corev1.Secret{
@@ -140,7 +137,6 @@ func ensureTransportCertificatesSecretExists(
 	var reconciled corev1.Secret
 	if err := reconciler.ReconcileResource(reconciler.Params{
 		Client:     c,
-		Scheme:     scheme,
 		Owner:      &es,
 		Expected:   &expected,
 		Reconciled: &reconciled,

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
@@ -13,9 +13,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
 func Test_ensureTransportCertificateSecretExists(t *testing.T) {
@@ -37,9 +35,8 @@ func Test_ensureTransportCertificateSecretExists(t *testing.T) {
 	}
 
 	type args struct {
-		c      k8s.Client
-		scheme *runtime.Scheme
-		owner  esv1.Elasticsearch
+		c     k8s.Client
+		owner esv1.Elasticsearch
 	}
 	tests := []struct {
 		name    string
@@ -93,11 +90,7 @@ func Test_ensureTransportCertificateSecretExists(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.args.scheme == nil {
-				tt.args.scheme = scheme.Scheme
-			}
-
-			got, err := ensureTransportCertificatesSecretExists(tt.args.c, tt.args.scheme, tt.args.owner)
+			got, err := ensureTransportCertificatesSecretExists(tt.args.c, tt.args.owner)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("EnsureTransportCertificateSecretExists() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/elasticsearch/configmap/configmap.go
+++ b/pkg/controller/elasticsearch/configmap/configmap.go
@@ -11,7 +11,6 @@ import (
 	"go.elastic.co/apm"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
@@ -35,7 +34,7 @@ func NewConfigMapWithData(es types.NamespacedName, data map[string]string) corev
 
 // ReconcileScriptsConfigMap reconciles a configmap containing scripts used by
 // init containers and readiness probe.
-func ReconcileScriptsConfigMap(ctx context.Context, c k8s.Client, scheme *runtime.Scheme, es esv1.Elasticsearch) error {
+func ReconcileScriptsConfigMap(ctx context.Context, c k8s.Client, es esv1.Elasticsearch) error {
 	span, _ := apm.StartSpan(ctx, "reconcile_scripts", tracing.SpanTypeApp)
 	defer span.End()
 
@@ -53,5 +52,5 @@ func ReconcileScriptsConfigMap(ctx context.Context, c k8s.Client, scheme *runtim
 		},
 	)
 
-	return ReconcileConfigMap(c, scheme, es, scriptsConfigMap)
+	return ReconcileConfigMap(c, es, scriptsConfigMap)
 }

--- a/pkg/controller/elasticsearch/configmap/configmap_control.go
+++ b/pkg/controller/elasticsearch/configmap/configmap_control.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
@@ -18,7 +17,6 @@ import (
 // ReconcileConfigMap checks for an existing config map and updates it or creates one if it does not exist.
 func ReconcileConfigMap(
 	c k8s.Client,
-	scheme *runtime.Scheme,
 	es esv1.Elasticsearch,
 	expected corev1.ConfigMap,
 ) error {
@@ -26,7 +24,6 @@ func ReconcileConfigMap(
 	return reconciler.ReconcileResource(
 		reconciler.Params{
 			Client:     c,
-			Scheme:     scheme,
 			Owner:      &es,
 			Expected:   &expected,
 			Reconciled: reconciled,

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -10,6 +10,10 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	controller "sigs.k8s.io/controller-runtime/pkg/reconcile"
+
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	commondriver "github.com/elastic/cloud-on-k8s/pkg/controller/common/driver"
@@ -37,10 +41,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/user"
 	esversion "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/version"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
-	controller "sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var (
@@ -73,7 +73,6 @@ type DefaultDriverParameters struct {
 	Version version.Version
 	// Client is used to access the Kubernetes API.
 	Client   k8s.Client
-	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 
 	// LicenseChecker is used for some features to check if an appropriate license is setup
@@ -99,10 +98,6 @@ func (d *defaultDriver) K8sClient() k8s.Client {
 	return d.Client
 }
 
-func (d *defaultDriver) Scheme() *runtime.Scheme {
-	return d.DefaultDriverParameters.Scheme
-}
-
 func (d *defaultDriver) DynamicWatches() watches.DynamicWatches {
 	return d.DefaultDriverParameters.DynamicWatches
 }
@@ -122,16 +117,16 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 		return results.WithError(err)
 	}
 
-	if err := configmap.ReconcileScriptsConfigMap(ctx, d.Client, d.Scheme(), d.ES); err != nil {
+	if err := configmap.ReconcileScriptsConfigMap(ctx, d.Client, d.ES); err != nil {
 		return results.WithError(err)
 	}
 
-	_, err := common.ReconcileService(ctx, d.Client, d.Scheme(), services.NewTransportService(d.ES), &d.ES)
+	_, err := common.ReconcileService(ctx, d.Client, services.NewTransportService(d.ES), &d.ES)
 	if err != nil {
 		return results.WithError(err)
 	}
 
-	externalService, err := common.ReconcileService(ctx, d.Client, d.Scheme(), services.NewExternalService(d.ES), &d.ES)
+	externalService, err := common.ReconcileService(ctx, d.Client, services.NewExternalService(d.ES), &d.ES)
 	if err != nil {
 		return results.WithError(err)
 	}
@@ -148,7 +143,7 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 		return results
 	}
 
-	internalUsers, err := user.ReconcileUsers(ctx, d.Client, d.Scheme(), d.ES)
+	internalUsers, err := user.ReconcileUsers(ctx, d.Client, d.ES)
 	if err != nil {
 		return results.WithError(err)
 	}
@@ -236,7 +231,7 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	}
 
 	// Compute seed hosts based on current masters with a podIP
-	if err := settings.UpdateSeedHostsConfigMap(ctx, d.Client, d.Scheme(), d.ES, resourcesState.AllPods); err != nil {
+	if err := settings.UpdateSeedHostsConfigMap(ctx, d.Client, d.ES, resourcesState.AllPods); err != nil {
 		return results.WithError(err)
 	}
 

--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -55,7 +55,7 @@ func (d *defaultDriver) reconcileNodeSpecs(
 		return results.WithError(err)
 	}
 
-	expectedResources, err := nodespec.BuildExpectedResources(d.ES, keystoreResources, d.Scheme(), certResources, actualStatefulSets)
+	expectedResources, err := nodespec.BuildExpectedResources(d.ES, keystoreResources, certResources, actualStatefulSets)
 	if err != nil {
 		return results.WithError(err)
 	}
@@ -71,7 +71,6 @@ func (d *defaultDriver) reconcileNodeSpecs(
 		parentCtx:     ctx,
 		k8sClient:     d.K8sClient(),
 		es:            d.ES,
-		scheme:        d.Scheme(),
 		observedState: observedState,
 		esState:       esState,
 		expectations:  d.Expectations,
@@ -83,7 +82,7 @@ func (d *defaultDriver) reconcileNodeSpecs(
 	}
 
 	// Update PDB to account for new replicas.
-	if err := pdb.Reconcile(d.Client, d.Scheme(), d.ES, actualStatefulSets); err != nil {
+	if err := pdb.Reconcile(d.Client, d.ES, actualStatefulSets); err != nil {
 		return results.WithError(err)
 	}
 

--- a/pkg/controller/elasticsearch/driver/upscale.go
+++ b/pkg/controller/elasticsearch/driver/upscale.go
@@ -18,14 +18,12 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/version/zen2"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type upscaleCtx struct {
 	parentCtx     context.Context
 	k8sClient     k8s.Client
 	es            esv1.Elasticsearch
-	scheme        *runtime.Scheme
 	observedState observer.State
 	esState       ESState
 	expectations  *expectations.Expectations
@@ -55,10 +53,10 @@ func HandleUpscaleAndSpecChanges(
 		if err := settings.ReconcileConfig(ctx.k8sClient, ctx.es, res.StatefulSet.Name, res.Config); err != nil {
 			return nil, err
 		}
-		if _, err := common.ReconcileService(ctx.parentCtx, ctx.k8sClient, ctx.scheme, &res.HeadlessService, &ctx.es); err != nil {
+		if _, err := common.ReconcileService(ctx.parentCtx, ctx.k8sClient, &res.HeadlessService, &ctx.es); err != nil {
 			return nil, err
 		}
-		reconciled, err := sset.ReconcileStatefulSet(ctx.k8sClient, ctx.scheme, ctx.es, res.StatefulSet, ctx.expectations)
+		reconciled, err := sset.ReconcileStatefulSet(ctx.k8sClient, ctx.es, res.StatefulSet, ctx.expectations)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/elasticsearch/driver/upscale_test.go
+++ b/pkg/controller/elasticsearch/driver/upscale_test.go
@@ -16,7 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/comparison"
@@ -46,7 +45,6 @@ func TestHandleUpscaleAndSpecChanges(t *testing.T) {
 	ctx := upscaleCtx{
 		k8sClient:    k8sClient,
 		es:           es,
-		scheme:       scheme.Scheme,
 		esState:      nil,
 		expectations: expectations.NewExpectations(k8sClient),
 		parentCtx:    context.Background(),
@@ -435,7 +433,6 @@ func Test_adjustResources(t *testing.T) {
 				es:           tt.args.es,
 				k8sClient:    k8sClient,
 				expectations: expectations.NewExpectations(k8sClient),
-				scheme:       k8s.Scheme(),
 			}
 			got, err := adjustResources(ctx, tt.args.actualStatefulSets, tt.args.expectedResources)
 			require.NoError(t, err)

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -33,7 +33,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -67,7 +66,6 @@ func newReconciler(mgr manager.Manager, params operator.Parameters) *ReconcileEl
 	observerSettings.Tracer = params.Tracer
 	return &ReconcileElasticsearch{
 		Client:         client,
-		scheme:         mgr.GetScheme(),
 		recorder:       mgr.GetEventRecorderFor(name),
 		licenseChecker: license.NewLicenseChecker(client, params.OperatorNamespace),
 		esObservers:    observer.NewManager(observerSettings),
@@ -161,7 +159,6 @@ var _ reconcile.Reconciler = &ReconcileElasticsearch{}
 type ReconcileElasticsearch struct {
 	k8s.Client
 	operator.Parameters
-	scheme         *runtime.Scheme
 	recorder       record.EventRecorder
 	licenseChecker license.Checker
 
@@ -305,7 +302,6 @@ func (r *ReconcileElasticsearch) internalReconcile(
 		ES:                 es,
 		ReconcileState:     reconcileState,
 		Client:             r.Client,
-		Scheme:             r.scheme,
 		Recorder:           r.recorder,
 		Version:            *ver,
 		Expectations:       r.expectations.ForCluster(k8s.ExtractNamespacedName(&es)),

--- a/pkg/controller/elasticsearch/nodespec/resources.go
+++ b/pkg/controller/elasticsearch/nodespec/resources.go
@@ -7,7 +7,6 @@ package nodespec
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
@@ -40,7 +39,6 @@ func (l ResourcesList) StatefulSets() sset.StatefulSetList {
 func BuildExpectedResources(
 	es esv1.Elasticsearch,
 	keystoreResources *keystore.Resources,
-	scheme *runtime.Scheme,
 	certResources *certificates.CertificateResources,
 	existingStatefulSets sset.StatefulSetList,
 ) (ResourcesList, error) {
@@ -63,7 +61,7 @@ func BuildExpectedResources(
 		}
 
 		// build stateful set and associated headless service
-		statefulSet, err := BuildStatefulSet(es, nodeSpec, cfg, keystoreResources, existingStatefulSets, scheme)
+		statefulSet, err := BuildStatefulSet(es, nodeSpec, cfg, keystoreResources, existingStatefulSets)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/elasticsearch/nodespec/statefulset_test.go
+++ b/pkg/controller/elasticsearch/nodespec/statefulset_test.go
@@ -8,14 +8,16 @@ import (
 	"reflect"
 	"testing"
 
-	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/scheme"
 )
 
 func Test_setVolumeClaimsControllerReference(t *testing.T) {
+	_ = scheme.SetupScheme()
 	varTrue := true
 	varFalse := false
 	es := esv1.Elasticsearch{
@@ -176,7 +178,7 @@ func Test_setVolumeClaimsControllerReference(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := setVolumeClaimsControllerReference(tt.persistentVolumeClaims, tt.existingClaims, es, k8s.Scheme())
+			got, err := setVolumeClaimsControllerReference(tt.persistentVolumeClaims, tt.existingClaims, es)
 			require.NoError(t, err)
 			require.Equal(t, tt.wantClaims, got)
 		})

--- a/pkg/controller/elasticsearch/pdb/reconcile.go
+++ b/pkg/controller/elasticsearch/pdb/reconcile.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
@@ -25,8 +25,8 @@ import (
 // Reconcile ensures that a PodDisruptionBudget exists for this cluster, inheriting the spec content.
 // The default PDB we setup dynamically adapts MinAvailable to the number of nodes in the cluster.
 // If the spec has disabled the default PDB, it will ensure none exist.
-func Reconcile(k8sClient k8s.Client, scheme *runtime.Scheme, es esv1.Elasticsearch, statefulSets sset.StatefulSetList) error {
-	expected, err := expectedPDB(es, statefulSets, scheme)
+func Reconcile(k8sClient k8s.Client, es esv1.Elasticsearch, statefulSets sset.StatefulSetList) error {
+	expected, err := expectedPDB(es, statefulSets)
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func deleteDefaultPDB(k8sClient k8s.Client, es esv1.Elasticsearch) error {
 
 // expectedPDB returns a PDB according to the given ES spec.
 // It may return nil if the PDB has been explicitly disabled in the ES spec.
-func expectedPDB(es esv1.Elasticsearch, statefulSets sset.StatefulSetList, scheme *runtime.Scheme) (*v1beta1.PodDisruptionBudget, error) {
+func expectedPDB(es esv1.Elasticsearch, statefulSets sset.StatefulSetList) (*v1beta1.PodDisruptionBudget, error) {
 	template := es.Spec.PodDisruptionBudget.DeepCopy()
 	if template.IsDisabled() {
 		return nil, nil
@@ -101,7 +101,7 @@ func expectedPDB(es esv1.Elasticsearch, statefulSets sset.StatefulSetList, schem
 	// and append our labels
 	expected.Labels = maps.MergePreservingExistingKeys(expected.Labels, label.NewLabels(k8s.ExtractNamespacedName(&es)))
 	// set owner reference for deletion upon ES resource deletion
-	if err := controllerutil.SetControllerReference(&es, &expected, scheme); err != nil {
+	if err := controllerutil.SetControllerReference(&es, &expected, scheme.Scheme); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/elasticsearch/pdb/reconcile_test.go
+++ b/pkg/controller/elasticsearch/pdb/reconcile_test.go
@@ -113,7 +113,7 @@ func TestReconcile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := Reconcile(tt.args.k8sClient, scheme.Scheme, tt.args.es, tt.args.statefulSets)
+			err := Reconcile(tt.args.k8sClient, tt.args.es, tt.args.statefulSets)
 			require.NoError(t, err)
 			pdbNsn := types.NamespacedName{Namespace: tt.args.es.Namespace, Name: esv1.DefaultPodDisruptionBudget(tt.args.es.Name)}
 			var retrieved v1beta1.PodDisruptionBudget
@@ -248,7 +248,7 @@ func Test_expectedPDB(t *testing.T) {
 				// set owner ref
 				tt.want = withOwnerRef(tt.want, tt.args.es)
 			}
-			got, err := expectedPDB(tt.args.es, tt.args.statefulSets, scheme.Scheme)
+			got, err := expectedPDB(tt.args.es, tt.args.statefulSets)
 			require.NoError(t, err)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("expectedPDB() got = %v, want %v", got, tt.want)

--- a/pkg/controller/elasticsearch/remotecluster/remoteca/controller.go
+++ b/pkg/controller/elasticsearch/remotecluster/remoteca/controller.go
@@ -23,7 +23,6 @@ import (
 	"go.elastic.co/apm"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,7 +46,6 @@ func NewReconciler(mgr manager.Manager, accessReviewer rbac.AccessReviewer, para
 	return &ReconcileRemoteCa{
 		Client:         c,
 		accessReviewer: accessReviewer,
-		scheme:         mgr.GetScheme(),
 		watches:        watches.NewDynamicWatches(),
 		recorder:       mgr.GetEventRecorderFor(name),
 		licenseChecker: license.NewLicenseChecker(c, params.OperatorNamespace),
@@ -62,7 +60,6 @@ type ReconcileRemoteCa struct {
 	k8s.Client
 	operator.Parameters
 	accessReviewer rbac.AccessReviewer
-	scheme         *runtime.Scheme
 	recorder       record.EventRecorder
 	watches        watches.DynamicWatches
 	licenseChecker license.Checker

--- a/pkg/controller/elasticsearch/remotecluster/remoteca/controller_test.go
+++ b/pkg/controller/elasticsearch/remotecluster/remoteca/controller_test.go
@@ -17,13 +17,11 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/rbac"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -433,11 +431,9 @@ func TestReconcileRemoteCa_Reconcile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := watches.NewDynamicWatches()
-			require.NoError(t, w.Secrets.InjectScheme(scheme.Scheme))
 			r := &ReconcileRemoteCa{
 				Client:         k8s.WrappedFakeClient(tt.fields.clusters...),
 				accessReviewer: tt.fields.accessReviewer,
-				scheme:         k8s.Scheme(),
 				watches:        w,
 				licenseChecker: tt.fields.licenseChecker,
 				recorder:       record.NewFakeRecorder(10),

--- a/pkg/controller/elasticsearch/remotecluster/remoteca/secret.go
+++ b/pkg/controller/elasticsearch/remotecluster/remoteca/secret.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
 // createOrUpdateCertificateAuthorities creates the two Secrets that are needed to establish a trust relationship between
@@ -170,7 +169,6 @@ func reconcileRemoteCA(
 	var reconciled corev1.Secret
 	return reconciler.ReconcileResource(reconciler.Params{
 		Client:     c,
-		Scheme:     scheme.Scheme,
 		Owner:      target,
 		Expected:   &expected,
 		Reconciled: &reconciled,

--- a/pkg/controller/elasticsearch/settings/config_volume.go
+++ b/pkg/controller/elasticsearch/settings/config_volume.go
@@ -11,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
@@ -105,7 +104,6 @@ func ReconcileConfig(client k8s.Client, es esv1.Elasticsearch, ssetName string, 
 		},
 		Owner:            &es,
 		Reconciled:       &reconciled,
-		Scheme:           scheme.Scheme,
 		UpdateReconciled: func() { reconciled.Data = expected.Data },
 	}); err != nil {
 		return err

--- a/pkg/controller/elasticsearch/settings/masters.go
+++ b/pkg/controller/elasticsearch/settings/masters.go
@@ -22,7 +22,6 @@ import (
 	"go.elastic.co/apm"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -39,7 +38,6 @@ func Quorum(nMasters int) int {
 func UpdateSeedHostsConfigMap(
 	ctx context.Context,
 	c k8s.Client,
-	scheme *runtime.Scheme,
 	es esv1.Elasticsearch,
 	pods []corev1.Pod,
 ) error {
@@ -86,7 +84,6 @@ func UpdateSeedHostsConfigMap(
 	return reconciler.ReconcileResource(
 		reconciler.Params{
 			Client:     c,
-			Scheme:     scheme,
 			Owner:      &es,
 			Expected:   &expected,
 			Reconciled: reconciled,

--- a/pkg/controller/elasticsearch/settings/masters_test.go
+++ b/pkg/controller/elasticsearch/settings/masters_test.go
@@ -15,9 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
 // newPodWithIP creates a new Pod potentially labeled as master with a given podIP
@@ -46,10 +44,9 @@ func TestUpdateSeedHostsConfigMap(t *testing.T) {
 		},
 	}
 	type args struct {
-		c      k8s.Client
-		scheme *runtime.Scheme
-		es     esv1.Elasticsearch
-		pods   []corev1.Pod
+		c    k8s.Client
+		es   esv1.Elasticsearch
+		pods []corev1.Pod
 	}
 	tests := []struct {
 		name            string
@@ -67,9 +64,8 @@ func TestUpdateSeedHostsConfigMap(t *testing.T) {
 					newPodWithIP("node1", "", false),
 					newPodWithIP("node2", "10.0.2.8", false),
 				},
-				c:      k8s.WrappedFakeClient(),
-				es:     es,
-				scheme: scheme.Scheme,
+				c:  k8s.WrappedFakeClient(),
+				es: es,
 			},
 			wantErr:         false,
 			expectedContent: "",
@@ -81,9 +77,8 @@ func TestUpdateSeedHostsConfigMap(t *testing.T) {
 					newPodWithIP("node1", "", false),
 					newPodWithIP("node2", "10.0.2.8", false),
 				},
-				c:      k8s.WrappedFakeClient(),
-				es:     es,
-				scheme: scheme.Scheme,
+				c:  k8s.WrappedFakeClient(),
+				es: es,
 			},
 			wantErr:         false,
 			expectedContent: "",
@@ -98,9 +93,8 @@ func TestUpdateSeedHostsConfigMap(t *testing.T) {
 					newPodWithIP("node1", "10.0.9.3", false),
 					newPodWithIP("node2", "10.0.2.8", false),
 				},
-				c:      k8s.WrappedFakeClient(),
-				es:     es,
-				scheme: scheme.Scheme,
+				c:  k8s.WrappedFakeClient(),
+				es: es,
 			},
 			wantErr:         false,
 			expectedContent: "10.0.3.3:9300\n10.0.9.2:9300",
@@ -115,9 +109,8 @@ func TestUpdateSeedHostsConfigMap(t *testing.T) {
 					newPodWithIP("node1", "", false),
 					newPodWithIP("node2", "10.0.2.8", false),
 				},
-				c:      k8s.WrappedFakeClient(),
-				es:     es,
-				scheme: scheme.Scheme,
+				c:  k8s.WrappedFakeClient(),
+				es: es,
 			},
 			wantErr:         false,
 			expectedContent: "10.0.3.3:9300\n10.0.6.5:9300\n10.0.9.2:9300",
@@ -130,9 +123,8 @@ func TestUpdateSeedHostsConfigMap(t *testing.T) {
 					newPodWithIP("master3", "10.0.3.3", true),
 					newPodWithIP("master1", "10.0.9.2", true),
 				},
-				c:      k8s.WrappedFakeClient(),
-				es:     es,
-				scheme: scheme.Scheme,
+				c:  k8s.WrappedFakeClient(),
+				es: es,
 			},
 			wantErr:         false,
 			expectedContent: "10.0.3.3:9300\n10.0.6.5:9300\n10.0.9.2:9300",
@@ -140,7 +132,7 @@ func TestUpdateSeedHostsConfigMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := UpdateSeedHostsConfigMap(context.Background(), tt.args.c, tt.args.scheme, tt.args.es, tt.args.pods)
+			err := UpdateSeedHostsConfigMap(context.Background(), tt.args.c, tt.args.es, tt.args.pods)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("UpdateSeedHostsConfigMap() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/elasticsearch/sset/reconcile.go
+++ b/pkg/controller/elasticsearch/sset/reconcile.go
@@ -6,7 +6,6 @@ package sset
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/expectations"
@@ -16,11 +15,10 @@ import (
 )
 
 // ReconcileStatefulSet creates or updates the expected StatefulSet.
-func ReconcileStatefulSet(c k8s.Client, scheme *runtime.Scheme, es esv1.Elasticsearch, expected appsv1.StatefulSet, expectations *expectations.Expectations) (appsv1.StatefulSet, error) {
+func ReconcileStatefulSet(c k8s.Client, es esv1.Elasticsearch, expected appsv1.StatefulSet, expectations *expectations.Expectations) (appsv1.StatefulSet, error) {
 	var reconciled appsv1.StatefulSet
 	err := reconciler.ReconcileResource(reconciler.Params{
 		Client:     c,
-		Scheme:     scheme,
 		Owner:      &es,
 		Expected:   &expected,
 		Reconciled: &reconciled,

--- a/pkg/controller/elasticsearch/sset/reconcile_test.go
+++ b/pkg/controller/elasticsearch/sset/reconcile_test.go
@@ -78,7 +78,7 @@ func TestReconcileStatefulSet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			exp := expectations.NewExpectations(tt.c)
-			returned, err := ReconcileStatefulSet(tt.c, scheme.Scheme, es, tt.expected, exp)
+			returned, err := ReconcileStatefulSet(tt.c, es, tt.expected, exp)
 			require.NoError(t, err)
 
 			// expect owner ref to be set to the es resource

--- a/pkg/controller/kibana/certificates/reconcile.go
+++ b/pkg/controller/kibana/certificates/reconcile.go
@@ -44,7 +44,6 @@ func Reconcile(
 	// reconcile CA certs first
 	httpCa, err := certificates.ReconcileCAForOwner(
 		d.K8sClient(),
-		d.Scheme(),
 		name.KBNamer,
 		&kb,
 		labels,
@@ -84,6 +83,6 @@ func Reconcile(
 	})
 
 	// reconcile http public cert secret
-	results.WithError(http.ReconcileHTTPCertsPublicSecret(d.K8sClient(), d.Scheme(), &kb, name.KBNamer, httpCertificates))
+	results.WithError(http.ReconcileHTTPCertsPublicSecret(d.K8sClient(), &kb, name.KBNamer, httpCertificates))
 	return &results
 }

--- a/pkg/controller/kibana/config/reconciler.go
+++ b/pkg/controller/kibana/config/reconciler.go
@@ -17,7 +17,6 @@ import (
 	"go.elastic.co/apm"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
 // ReconcileConfigSecret reconciles the expected Kibana config secret for the given Kibana resource.
@@ -56,7 +55,6 @@ func ReconcileConfigSecret(
 	reconciled := corev1.Secret{}
 	if err := reconciler.ReconcileResource(reconciler.Params{
 		Client:     client,
-		Scheme:     scheme.Scheme,
 		Owner:      &kb,
 		Expected:   &expected,
 		Reconciled: &reconciled,

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -36,7 +36,6 @@ import (
 	"go.elastic.co/apm"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,7 +54,6 @@ var minSupportedVersion = version.From(6, 8, 0)
 
 type driver struct {
 	client         k8s.Client
-	scheme         *runtime.Scheme
 	dynamicWatches watches.DynamicWatches
 	recorder       record.EventRecorder
 	version        version.Version
@@ -71,10 +69,6 @@ func (d *driver) K8sClient() k8s.Client {
 
 func (d *driver) Recorder() record.EventRecorder {
 	return d.recorder
-}
-
-func (d *driver) Scheme() *runtime.Scheme {
-	return d.scheme
 }
 
 var _ driver2.Interface = &driver{}
@@ -243,7 +237,7 @@ func (d *driver) Reconcile(
 		return results
 	}
 
-	svc, err := common.ReconcileService(ctx, d.client, d.scheme, NewService(*kb), kb)
+	svc, err := common.ReconcileService(ctx, d.client, NewService(*kb), kb)
 	if err != nil {
 		// TODO: consider updating some status here?
 		return results.WithError(err)
@@ -273,7 +267,7 @@ func (d *driver) Reconcile(
 	}
 
 	expectedDp := deployment.New(deploymentParams)
-	reconciledDp, err := deployment.Reconcile(d.client, d.scheme, expectedDp, kb)
+	reconciledDp, err := deployment.Reconcile(d.client, expectedDp, kb)
 	if err != nil {
 		return results.WithError(err)
 	}
@@ -283,7 +277,6 @@ func (d *driver) Reconcile(
 
 func newDriver(
 	client k8s.Client,
-	scheme *runtime.Scheme,
 	watches watches.DynamicWatches,
 	recorder record.EventRecorder,
 	kb *kbv1.Kibana,
@@ -302,7 +295,6 @@ func newDriver(
 
 	return &driver{
 		client:         client,
-		scheme:         scheme,
 		dynamicWatches: watches,
 		recorder:       recorder,
 		version:        *ver,

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -179,8 +178,6 @@ func Test_getStrategyType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := watches.NewDynamicWatches()
-			err := w.Secrets.InjectScheme(scheme.Scheme)
-			assert.NoError(t, err)
 
 			kb := kibanaFixture()
 			kb.Name = tt.expectedKbName
@@ -191,7 +188,7 @@ func Test_getStrategyType(t *testing.T) {
 				client = &failingClient{}
 			}
 
-			d, err := newDriver(client, scheme.Scheme, w, record.NewFakeRecorder(100), kb)
+			d, err := newDriver(client, w, record.NewFakeRecorder(100), kb)
 			assert.NoError(t, err)
 
 			strategy, err := d.getStrategyType(kb)
@@ -369,10 +366,8 @@ func TestDriverDeploymentParams(t *testing.T) {
 
 			client := k8s.WrappedFakeClient(initialObjects...)
 			w := watches.NewDynamicWatches()
-			err := w.Secrets.InjectScheme(scheme.Scheme)
-			require.NoError(t, err)
 
-			d, err := newDriver(client, scheme.Scheme, w, record.NewFakeRecorder(100), kb)
+			d, err := newDriver(client, w, record.NewFakeRecorder(100), kb)
 			require.NoError(t, err)
 
 			got, err := d.deploymentParams(kb)
@@ -417,10 +412,8 @@ func TestMinSupportedVersion(t *testing.T) {
 			kb.Spec.Version = tc.version
 			client := k8s.WrappedFakeClient(defaultInitialObjects()...)
 			w := watches.NewDynamicWatches()
-			err := w.Secrets.InjectScheme(scheme.Scheme)
-			require.NoError(t, err)
 
-			_, err = newDriver(client, scheme.Scheme, w, record.NewFakeRecorder(100), kb)
+			_, err := newDriver(client, w, record.NewFakeRecorder(100), kb)
 			if tc.wantErr {
 				require.Error(t, err)
 			} else {

--- a/pkg/controller/kibana/kibana_controller.go
+++ b/pkg/controller/kibana/kibana_controller.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -60,7 +59,6 @@ func newReconciler(mgr manager.Manager, params operator.Parameters) *ReconcileKi
 	client := k8s.WrapClient(mgr.GetClient())
 	return &ReconcileKibana{
 		Client:         client,
-		scheme:         mgr.GetScheme(),
 		recorder:       mgr.GetEventRecorderFor(name),
 		dynamicWatches: watches.NewDynamicWatches(),
 		params:         params,
@@ -116,7 +114,6 @@ var _ reconcile.Reconciler = &ReconcileKibana{}
 // ReconcileKibana reconciles a Kibana object
 type ReconcileKibana struct {
 	k8s.Client
-	scheme   *runtime.Scheme
 	recorder record.EventRecorder
 
 	dynamicWatches watches.DynamicWatches
@@ -190,7 +187,7 @@ func (r *ReconcileKibana) isCompatible(ctx context.Context, kb *kbv1.Kibana) (bo
 }
 
 func (r *ReconcileKibana) doReconcile(ctx context.Context, request reconcile.Request, kb *kbv1.Kibana) (reconcile.Result, error) {
-	driver, err := newDriver(r, r.scheme, r.dynamicWatches, r.recorder, kb)
+	driver, err := newDriver(r, r.dynamicWatches, r.recorder, kb)
 	if err != nil {
 		return reconcile.Result{}, tracing.CaptureError(ctx, err)
 	}

--- a/pkg/controller/kibanaassociation/association_controller.go
+++ b/pkg/controller/kibanaassociation/association_controller.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -91,7 +90,6 @@ func newReconciler(mgr manager.Manager, accessReviewer rbac.AccessReviewer, para
 	return &ReconcileAssociation{
 		Client:         client,
 		accessReviewer: accessReviewer,
-		scheme:         mgr.GetScheme(),
 		watches:        watches.NewDynamicWatches(),
 		recorder:       mgr.GetEventRecorderFor(name),
 		Parameters:     params,
@@ -114,7 +112,6 @@ var _ reconcile.Reconciler = &ReconcileAssociation{}
 type ReconcileAssociation struct {
 	k8s.Client
 	accessReviewer rbac.AccessReviewer
-	scheme         *runtime.Scheme
 	recorder       record.EventRecorder
 	watches        watches.DynamicWatches
 	operator.Parameters
@@ -287,7 +284,6 @@ func (r *ReconcileAssociation) reconcileInternal(ctx context.Context, kibana *kb
 	if err := association.ReconcileEsUser(
 		ctx,
 		r.Client,
-		r.scheme,
 		kibana,
 		map[string]string{
 			AssociationLabelName:      kibana.Name,
@@ -393,7 +389,6 @@ func (r *ReconcileAssociation) reconcileElasticsearchCA(ctx context.Context, kib
 	labels[AssociationLabelName] = kibana.Name
 	return association.ReconcileCASecret(
 		r.Client,
-		r.scheme,
 		kibana,
 		es,
 		labels,

--- a/pkg/controller/license/license_controller.go
+++ b/pkg/controller/license/license_controller.go
@@ -14,9 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -72,7 +70,6 @@ func newReconciler(mgr manager.Manager, params operator.Parameters) *ReconcileLi
 	c := k8s.WrapClient(mgr.GetClient())
 	return &ReconcileLicenses{
 		Client:  c,
-		scheme:  mgr.GetScheme(),
 		checker: license.NewLicenseChecker(c, params.OperatorNamespace),
 	}
 }
@@ -147,7 +144,6 @@ var _ reconcile.Reconciler = &ReconcileLicenses{}
 // ReconcileLicenses reconciles EnterpriseLicenses with existing Elasticsearch clusters and creates ClusterLicenses for them.
 type ReconcileLicenses struct {
 	k8s.Client
-	scheme *runtime.Scheme
 	// iteration is the number of times this controller has run its Reconcile method
 	iteration uint64
 	checker   license.Checker
@@ -195,7 +191,6 @@ func reconcileSecret(
 	var reconciled corev1.Secret
 	err = reconciler.ReconcileResource(reconciler.Params{
 		Client:     c,
-		Scheme:     scheme.Scheme,
 		Owner:      &cluster,
 		Expected:   &expected,
 		Reconciled: &reconciled,

--- a/pkg/controller/license/license_controller_integration_test.go
+++ b/pkg/controller/license/license_controller_integration_test.go
@@ -41,7 +41,6 @@ func TestReconcile(t *testing.T) {
 	c, stop := test.StartManager(t, func(mgr manager.Manager, p operator.Parameters) error {
 		return add(mgr, &ReconcileLicenses{
 			Client:  k8s.WrapClient(mgr.GetClient()),
-			scheme:  mgr.GetScheme(),
 			checker: license.MockChecker{},
 		})
 	}, operator.Parameters{})

--- a/pkg/controller/license/license_controller_test.go
+++ b/pkg/controller/license/license_controller_test.go
@@ -20,7 +20,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -176,7 +175,6 @@ func TestReconcileLicenses_reconcileInternal(t *testing.T) {
 			client := k8s.WrappedFakeClient(tt.k8sResources...)
 			r := &ReconcileLicenses{
 				Client:  client,
-				scheme:  scheme.Scheme,
 				checker: commonlicense.MockChecker{},
 			}
 			nsn := k8s.ExtractNamespacedName(tt.cluster)

--- a/pkg/controller/license/trial/trial_controller.go
+++ b/pkg/controller/license/trial/trial_controller.go
@@ -19,7 +19,6 @@ import (
 	pkgerrors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -41,7 +40,6 @@ var (
 // ReconcileTrials reconciles Enterprise trial licenses.
 type ReconcileTrials struct {
 	k8s.Client
-	scheme   *runtime.Scheme
 	recorder record.EventRecorder
 	// iteration is the number of times this controller has run its Reconcile method.
 	iteration         int64
@@ -155,7 +153,6 @@ func (r *ReconcileTrials) reconcileTrialStatus(trialStatus corev1.Secret) error 
 func newReconciler(mgr manager.Manager, params operator.Parameters) *ReconcileTrials {
 	return &ReconcileTrials{
 		Client:            k8s.WrapClient(mgr.GetClient()),
-		scheme:            mgr.GetScheme(),
 		recorder:          mgr.GetEventRecorderFor(name),
 		operatorNamespace: params.OperatorNamespace,
 	}


### PR DESCRIPTION
We manipulate the scheme inconsistently across the code base.
Sometimes through the global `scheme.Scheme` from client-go, sometimes by
passing it as a parameter across the entire function stack.

It turns out the parameter we pass to functions is just a pointer
reference to the global `scheme.Scheme`, so we loose any benefit from not
using a global variable.

Therefore, I think it's safe (and less verbose), to just rely on the
global client go-scheme everywhere. The only gotcha is to make sure it
is properly initialized with all CRDs, which is done when the manager
is bootstrapped, and when we create the fake k8s client in unit tests.

Fixes https://github.com/elastic/cloud-on-k8s/issues/2625.