### PR TITLE
Add remote cluster e2e test

### DIFF
--- a/test/e2e/es/remote_cluster_test.go
+++ b/test/e2e/es/remote_cluster_test.go
@@ -1,0 +1,103 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package es
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	followerSetting = `{"remote_cluster" : "%s", "leader_index" : "%s"}`
+)
+
+// TestRemoteCluster tests the local K8S remote cluster feature.
+// 1. In a first Elasticsearch cluster some data are indexed in the "data-integrity-check" index.
+// 2. A second cluster is created with the first cluster declared as a remote cluster.
+// 3. Finally an index follower is created in the second cluster to follow the "data-integrity-check" index from the first one.
+func TestRemoteCluster(t *testing.T) {
+	// only execute this test if we have a test license to work with
+	if test.Ctx().TestLicense == "" {
+		t.SkipNow()
+	}
+
+	name := "test-remote-cluster"
+	ns1 := test.Ctx().ManagedNamespace(0)
+	es1Builder := elasticsearch.NewBuilder(name).
+		WithNamespace(ns1).
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithRestrictedSecurityContext()
+	es1LicenseTestContext := elasticsearch.NewLicenseTestContext(test.NewK8sClientOrFatal(), es1Builder.Elasticsearch)
+
+	ns2 := test.Ctx().ManagedNamespace(1)
+	es2Builder := elasticsearch.NewBuilder(name).
+		WithNamespace(ns2).
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithRestrictedSecurityContext().
+		WithRemoteCluster(es1Builder)
+	es2LicenseTestContext := elasticsearch.NewLicenseTestContext(test.NewK8sClientOrFatal(), es2Builder.Elasticsearch)
+	licenseBytes, err := ioutil.ReadFile(test.Ctx().TestLicense)
+	require.NoError(t, err)
+	trialSecretName := "eck-license" // nolint
+
+	before := func(k *test.K8sClient) test.StepList {
+		// Deploy a Trial license
+		return test.StepList{es1LicenseTestContext.CreateEnterpriseLicenseSecret(trialSecretName, licenseBytes)}
+	}
+
+	followerIndex := "data-integrity-check-follower"
+	stepsFn := func(k *test.K8sClient) test.StepList {
+		return test.StepList{
+			// Init license test context
+			es1LicenseTestContext.Init(),
+			es2LicenseTestContext.Init(),
+			// Check that the first cluster is using a Platinum license
+			es1LicenseTestContext.CheckElasticsearchLicense(client.ElasticsearchLicenseTypePlatinum),
+			// Check that the second cluster is using a Platinum license
+			es1LicenseTestContext.CheckElasticsearchLicense(client.ElasticsearchLicenseTypePlatinum),
+			test.Step{
+				Name: "Add some data to the first cluster",
+				Test: func(t *testing.T) {
+					require.NoError(t, elasticsearch.NewDataIntegrityCheck(k, es1Builder).Init())
+				},
+			},
+			test.Step{
+				Name: "Create a follower index on the second cluster",
+				Test: func(t *testing.T) {
+					esClient, err := elasticsearch.NewElasticsearchClient(es2Builder.Elasticsearch, k)
+					require.NoError(t, err)
+					// create the index with controlled settings
+					followerCreation, err := http.NewRequest(
+						http.MethodPut,
+						fmt.Sprintf("/%s/_ccr/follow", followerIndex),
+						bytes.NewBufferString(fmt.Sprintf(followerSetting, es1Builder.Ref().Name, elasticsearch.DataIntegrityIndex)),
+					)
+					require.NoError(t, err)
+					resp, err := esClient.Request(context.Background(), followerCreation)
+					require.NoError(t, err)
+					defer resp.Body.Close()
+				},
+			},
+			test.Step{
+				Name: "Check data in the second cluster",
+				Test: test.Eventually(func() error {
+					return elasticsearch.NewDataIntegrityCheck(k, es2Builder).ForIndex(followerIndex).Verify()
+				}),
+			},
+			es1LicenseTestContext.DeleteEnterpriseLicenseSecret(trialSecretName),
+		}
+	}
+
+	test.Sequence(before, stepsFn, es1Builder, es2Builder).RunSequential(t)
+}

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -94,6 +94,16 @@ func (b Builder) WithRestrictedSecurityContext() Builder {
 	return b
 }
 
+func (b Builder) WithRemoteCluster(remoteEs Builder) Builder {
+	b.Elasticsearch.Spec.RemoteClusters =
+		append(b.Elasticsearch.Spec.RemoteClusters,
+			esv1.RemoteCluster{
+				Name:             remoteEs.Ref().Name,
+				ElasticsearchRef: remoteEs.Ref(),
+			})
+	return b
+}
+
 func (b Builder) WithNamespace(namespace string) Builder {
 	b.Elasticsearch.ObjectMeta.Namespace = namespace
 	return b

--- a/test/e2e/test/elasticsearch/checks_data.go
+++ b/test/e2e/test/elasticsearch/checks_data.go
@@ -19,6 +19,10 @@ import (
 	"github.com/go-test/deep"
 )
 
+const (
+	DataIntegrityIndex = "data-integrity-check"
+)
+
 type DataIntegrityCheck struct {
 	clientFactory func() (client.Client, error) // recreate clients for cases where we switch scheme in tests
 	indexName     string
@@ -33,7 +37,7 @@ func NewDataIntegrityCheck(k *test.K8sClient, b Builder) *DataIntegrityCheck {
 		clientFactory: func() (client.Client, error) {
 			return NewElasticsearchClient(b.Elasticsearch, k)
 		},
-		indexName: "data-integrity-check",
+		indexName: DataIntegrityIndex,
 		sampleData: map[string]interface{}{
 			"foo": "bar",
 		},
@@ -41,6 +45,11 @@ func NewDataIntegrityCheck(k *test.K8sClient, b Builder) *DataIntegrityCheck {
 		numShards:   3,
 		numReplicas: dataIntegrityReplicas(b),
 	}
+}
+
+func (dc *DataIntegrityCheck) ForIndex(indexName string) *DataIntegrityCheck {
+	dc.indexName = indexName
+	return dc
 }
 
 func (dc *DataIntegrityCheck) Init() error {

--- a/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/test/e2e/test/elasticsearch/checks_k8s.go
@@ -81,7 +81,7 @@ func CheckPodCertificates(b Builder, k *test.K8sClient) test.Step {
 				return err
 			}
 			for _, pod := range pods {
-				_, _, err := k.GetTransportCert(b.Elasticsearch.Name, pod.Name)
+				_, _, err := k.GetTransportCert(b.Elasticsearch.Namespace, b.Elasticsearch.Name, pod.Name)
 				if err != nil {
 					return err
 				}

--- a/test/e2e/test/k8s_client.go
+++ b/test/e2e/test/k8s_client.go
@@ -248,10 +248,10 @@ func (k *K8sClient) GetCA(ownerNamespace, ownerName string, caType certificates.
 }
 
 // GetTransportCert retrieves the certificate of the CA and the transport certificate
-func (k *K8sClient) GetTransportCert(esName, podName string) (caCert, transportCert []*x509.Certificate, err error) {
+func (k *K8sClient) GetTransportCert(esNamespace, esName, podName string) (caCert, transportCert []*x509.Certificate, err error) {
 	var secret corev1.Secret
 	key := types.NamespacedName{
-		Namespace: Ctx().ManagedNamespace(0),
+		Namespace: esNamespace,
 		Name:      esv1.TransportCertificatesSecret(esName),
 	}
 	if err = k.Client.Get(key, &secret); err != nil {


### PR DESCRIPTION
This PR fixes #2647 

It adds an e2e test with a data integrity check on the follower index.