### PR TITLE
Document file realm and roles in the ES spec

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch-specification.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch-specification.asciidoc
@@ -22,6 +22,7 @@ Before you deploy and run ECK, take some time to look at the basic and advanced 
 - <<{p}-custom-http-certificate>>
 - <<{p}-reserved-settings>>
 - <<{p}-es-secure-settings>>
+- <<{p}-users-and-roles>>
 - <<{p}-bundles-plugins>>
 - <<{p}-init-containers-plugin-downloads>>
 - <<{p}-update-strategy>>
@@ -42,6 +43,7 @@ include::elasticsearch/virtual-memory.asciidoc[leveloffset=+1]
 include::elasticsearch/custom-http-certificate.asciidoc[leveloffset=+1]
 include::elasticsearch/reserved-settings.asciidoc[leveloffset=+1]
 include::elasticsearch/es-secure-settings.asciidoc[leveloffset=+1]
+include::elasticsearch/users-and-roles.asciidoc[leveloffset=+1]
 include::elasticsearch/bundles-plugins.asciidoc[leveloffset=+1]
 include::elasticsearch/init-containers-plugin-downloads.asciidoc[leveloffset=+1]
 include::elasticsearch/update-strategy.asciidoc[leveloffset=+1]

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
@@ -10,9 +10,10 @@ endif::[]
 
 == Default elastic user
 
-A default user named `elastic` is created automatically. Its password can be retrieved in a Kubernetes secret, whose name
+A default user named `elastic` is created automatically, and is assigned the `superuser` role.
+
+Its password can be retrieved in a Kubernetes secret, whose name
 is based on the Elasticsearch resource name: `<elasticsearch-name>-es-elastic-user`.
-The password is stored in the `elastic` secret entry.
 
 For example, the password of the `elastic` user for an Elasticsearch cluster named `quickstart` can be retrieved with:
 
@@ -20,8 +21,6 @@ For example, the password of the `elastic` user for an Elasticsearch cluster nam
 ----
 kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | base64 --decode
 ----
-
-The `elastic` user is assigned the `superuser` role.
 
 == Creating custom users
 
@@ -32,7 +31,7 @@ Custom users can be created in the link:https://www.elastic.co/guide/en/elastics
 === File realm
 
 Custom users can also be created by providing the desired link:https://www.elastic.co/guide/en/elasticsearch/reference/current/file-realm.html[file realm content]
-in a Kubernetes secret, referenced in the Elasticsearch resource.
+in Kubernetes secrets, referenced in the Elasticsearch resource.
 
 [source,yaml]
 ----

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
@@ -19,7 +19,7 @@ For example, the password of the `elastic` user for an Elasticsearch cluster nam
 
 [source,sh]
 ----
-kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | base64 --decode
+kubectl get secret quickstart-es-elastic-user -o go-template='{{.data.elastic | base64decode}}'
 ----
 
 == Creating custom users

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
@@ -53,13 +53,13 @@ spec:
 You can reference several secrets in the Elasticsearch specification.
 ECK aggregates their content into a single secret, mounted in every Elasticsearch Pod.
 
-Referenced secrets may be composed of 2 entries:
+Referenced secrets may be composed of 2 entries. You can provide either entry or both entry in each secret:
 
 - `users`: content of the `users` file. It specifies user names and password hashes, as described in the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/file-realm.html[file realm documentation].
 - `users_roles`: content of the `users_roles` file. It associates each role to a list of users, as described in the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/file-realm.html[file realm documentation].
 
 If you specify multiple users with the same name in more than one secret, the last one takes precedence.
-If you specify multiple roles with the same name in more than one secret, a single entry per role is be derived from the concatenation of its corresponding users from all secrets.
+If you specify multiple roles with the same name in more than one secret, a single entry per role is derived from the concatenation of its corresponding users from all secrets.
 
 The following Secret specifies three users and their respective roles:
 
@@ -128,7 +128,7 @@ spec:
 Several secrets can be referenced in the Elasticsearch specification.
 ECK aggregates their content into a single secret, mounted in every Elasticsearch Pod.
 
-Each secret must have a `roles.yml` entry, containing the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html#roles-management-file[roles configuration].
+Each secret must have a `roles.yml` entry, containing the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html#roles-management-file[roles definition].
 
 If you specify multiple roles with the same name in more than one secret, the last one takes precedence.
 

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
@@ -33,7 +33,7 @@ You can create custom users in the link:https://www.elastic.co/guide/en/elastics
 Custom users can also be created by providing the desired link:https://www.elastic.co/guide/en/elasticsearch/reference/current/file-realm.html[file realm content]
 in Kubernetes secrets, referenced in the Elasticsearch resource.
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
 kind: Elasticsearch
@@ -108,7 +108,7 @@ or the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/defi
 
 Additionally, link:https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html#roles-management-file[file-based role management] can be achieved by referencing Kubernetes secrets containing the roles specification.
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
 kind: Elasticsearch

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
@@ -10,7 +10,7 @@ endif::[]
 
 == Default elastic user
 
-A default user named `elastic` is created automatically, and is assigned the `superuser` role.
+When the Elasticsearch resource is created, a default user named `elastic` is created automatically, and is assigned the `superuser` role.
 
 Its password can be retrieved in a Kubernetes secret, whose name
 is based on the Elasticsearch resource name: `<elasticsearch-name>-es-elastic-user`.
@@ -26,7 +26,7 @@ kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | ba
 
 === Native realm
 
-Custom users can be created in the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/native-realm.html[Elasticsearch native realm] using link:https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api.html#security-user-apis[Elasticsearch user management APIs].
+You can create custom users in the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/native-realm.html[Elasticsearch native realm] using link:https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api.html#security-user-apis[Elasticsearch user management APIs].
 
 === File realm
 
@@ -50,7 +50,7 @@ spec:
     count: 1
 ----
 
-Several secrets can be referenced in the Elasticsearch specification.
+You can reference several secrets in the Elasticsearch specification.
 ECK aggregates their content into a single secret, mounted in every Elasticsearch Pod.
 
 Referenced secrets may be composed of 2 entries:
@@ -58,8 +58,8 @@ Referenced secrets may be composed of 2 entries:
 - `users`: content of the `users` file. It specifies user names and password hashes, as described in the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/file-realm.html[file realm documentation].
 - `users_roles`: content of the `users_roles` file. It associates each role to a list of users, as described in the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/file-realm.html[file realm documentation].
 
-If multiple users with the same name are specified in more than one secret, the last one takes precedence.
-If multiple roles are specified in more than one secret, a single entry per role will be derived from the concatenation of its corresponding users from all secrets.
+If you specify multiple users with the same name in more than one secret, the last one takes precedence.
+If you specify multiple roles with the same name in more than one secret, a single entry per role is be derived from the concatenation of its corresponding users from all secrets.
 
 The following Secret specifies three users and their respective roles:
 
@@ -80,7 +80,7 @@ stringData:
     user:jacknich
 ----
 
-The content of both `users` and `users_roles` can be populated using the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/users-command.html[elasticsearch-users] tool.
+You can populate the content of both `users` and `users_roles` using the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/users-command.html[elasticsearch-users] tool.
 
 For example, invoking the tool in a Docker container:
 
@@ -130,7 +130,7 @@ ECK aggregates their content into a single secret, mounted in every Elasticsearc
 
 Each secret must have a `roles.yml` entry, containing the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html#roles-management-file[roles configuration].
 
-If multiple roles with the same name are specified in more than one secret, the last one takes precedence.
+If you specify multiple roles with the same name in more than one secret, the last one takes precedence.
 
 The following Secret specifies one role named `click_admins`:
 

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
@@ -1,0 +1,155 @@
+:parent_page_id: elasticsearch-specification
+:page_id: users-and-roles
+ifdef::env-github[]
+****
+link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-{parent_page_id}.html#k8s-{page_id}[View this document on the Elastic website]
+****
+endif::[]
+[id="{p}-{page_id}"]
+= Users and roles
+
+== Default elastic user
+
+A default user named `elastic` is created automatically. Its password can be retrieved in a Kubernetes secret, whose name
+is based on the Elasticsearch resource name: `<elasticsearch-name>-es-elastic-user`.
+The password is stored in the `elastic` secret entry.
+
+For example, the password of the `elastic` user for an Elasticsearch cluster named `quickstart` can be retrieved with:
+
+[source,sh]
+----
+kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | base64 --decode
+----
+
+The `elastic` user is assigned the `superuser` role.
+
+== Creating custom users
+
+=== Native realm
+
+Custom users can be created in the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/native-realm.html[Elasticsearch native realm] using link:https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api.html#security-user-apis[Elasticsearch user management APIs].
+
+=== File realm
+
+Custom users can also be created by providing the desired link:https://www.elastic.co/guide/en/elasticsearch/reference/current/file-realm.html[file realm content]
+in a Kubernetes secret, referenced in the Elasticsearch resource.
+
+[source,yaml]
+----
+apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
+kind: Elasticsearch
+metadata:
+  name: elasticsearch-sample
+spec:
+  version: {version}
+  auth:
+    fileRealm:
+    - secretName: my-filerealm-secret-1
+    - secretName: my-filerealm-secret-2
+  nodeSets:
+  - name: default
+    count: 1
+----
+
+Several secrets can be referenced in the Elasticsearch specification.
+ECK aggregates their content into a single secret, mounted in every Elasticsearch Pod.
+
+Referenced secrets may be composed of 2 entries:
+
+- `users`: content of the `users` file. It specifies user names and password hashes, as described in the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/file-realm.html[file realm documentation].
+- `users_roles`: content of the `users_roles` file. It associates each role to a list of users, as described in the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/file-realm.html[file realm documentation].
+
+If multiple users with the same name are specified in more than one secret, the last one takes precedence.
+If multiple roles are specified in more than one secret, a single entry per role will be derived from the concatenation of its corresponding users from all secrets.
+
+The following Secret specifies three users and their respective roles:
+
+[source,yaml]
+----
+kind: Secret
+apiVersion: v1
+metadata:
+  name: my-filerealm-secret
+stringData:
+  users: |-
+    rdeniro:$2a$10$BBJ/ILiyJ1eBTYoRKxkqbuDEdYECplvxnqQ47uiowE7yGqvCEgj9W
+    alpacino:$2a$10$cNwHnElYiMYZ/T3K4PvzGeJ1KbpXZp2PfoQD.gfaVdImnHOwIuBKS
+    jacknich:{PBKDF2}50000$z1CLJt0MEFjkIK5iEfgvfnA6xq7lF25uasspsTKSo5Q=$XxCVLbaKDimOdyWgLCLJiyoiWpA/XDMe/xtVgn1r5Sg=
+  users_roles: |-
+    admin:rdeniro
+    power_user:alpacino,jacknich
+    user:jacknich
+----
+
+The content of both `users` and `users_roles` can be populated using the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/users-command.html[elasticsearch-users] tool.
+
+For example, invoking the tool in a Docker container:
+
+[source,sh]
+----
+# create a folder with the 2 files
+mkdir filerealm
+touch filerealm/users filerealm/users_roles
+
+# create user 'myuser' with role 'monitoring_user'
+docker run \
+    -v ${PWD}/filerealm:/usr/share/elasticsearch/config \
+    docker.elastic.co/elasticsearch/elasticsearch:{version} \
+    bin/elasticsearch-users useradd myuser -p mypassword -r monitoring_user
+
+# create a Kubernetes secret with the file realm content
+kubectl create secret generic my-file-realm-secret --from-file filerealm
+----
+
+== Creating custom roles
+
+link:https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html[Roles] can be specified using the
+link:https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html#roles-management-api[Role management API],
+or the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html#roles-management-ui[Role management UI in Kibana].
+
+Additionally, link:https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html#roles-management-file[file-based role management] can be achieved by referencing Kubernetes secrets containing the roles specification.
+
+[source,yaml]
+----
+apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
+kind: Elasticsearch
+metadata:
+  name: elasticsearch-sample
+spec:
+  version: {version}
+  auth:
+    roles:
+    - secretName: my-roles-secret-1
+    - secretName: my-roles-secret-2
+  nodeSets:
+  - name: default
+    count: 1
+----
+
+Several secrets can be referenced in the Elasticsearch specification.
+ECK aggregates their content into a single secret, mounted in every Elasticsearch Pod.
+
+Each secret must have a `roles.yml` entry, containing the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html#roles-management-file[roles configuration].
+
+If multiple roles with the same name are specified in more than one secret, the last one takes precedence.
+
+The following Secret specifies one role named `click_admins`:
+
+[source,yaml]
+----
+kind: Secret
+apiVersion: v1
+metadata:
+  name: my-roles-secret
+stringData:
+  roles.yml: |-
+    click_admins:
+      run_as: [ 'clicks_watcher_1' ]
+      cluster: [ 'monitor' ]
+      indices:
+      - names: [ 'events-*' ]
+        privileges: [ 'read' ]
+        field_security:
+          grant: ['category', '@timestamp', 'message' ]
+        query: '{"match": {"category": "click"}}'
+----

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -140,7 +140,7 @@ A default user named `elastic` is automatically created with the password stored
 +
 [source,sh]
 ----
-PASSWORD=$(kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | base64 --decode)
+PASSWORD=$(kubectl get secret quickstart-es-elastic-user -o go-template='{{.data.elastic | base64decode}}')
 ----
 
 . Request the Elasticsearch endpoint.


### PR DESCRIPTION
Provide documentation on how to create custom users and roles, by
referencing secrets in the Elasticsearch specification.

Reates https://github.com/elastic/cloud-on-k8s/pull/2682 and https://github.com/elastic/cloud-on-k8s/pull/2682.
Closes https://github.com/elastic/cloud-on-k8s/issues/2696.