### PR TITLE
Correct GKE subnet size

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -27,11 +27,12 @@ plans:
     localSsdCount: 1
     nodeCountPerZone: 1
     # gke creates a secondary IP range for all Pods of a cluster
-    # it defaults to a /14 subnet, which allows 262k Pods per cluster, but only 62 subnets to be created
+    # gke defaults to a /14 subnet, which allows 262k Pods per cluster, but only 62 subnets to be created
     # /20 allows 4094 subnets, with up to 4094 IPs (Pods) per subnet
-    # more clusters can therefore be created in the same VPC network
-    clusterIpv4Cidr: /20
-    servicesIpv4Cidr: /20
+    # more clusters can therefore be created in the same VPC network.
+    # we set a default of /20 that can be overriden here
+    # clusterIpv4Cidr: /20
+    # servicesIpv4Cidr: /20
     gcpScopes: https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append
 - id: aks-ci
   operation: create

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -26,8 +26,10 @@ overrides:
 
 var (
 	// GKE uses 18 chars to prefix the pvc created by a cluster
-	pvcPrefixMaxLength    = 18
-	GkeStorageProvisioner = "kubernetes.io/no-provisioner"
+	pvcPrefixMaxLength      = 18
+	GkeStorageProvisioner   = "kubernetes.io/no-provisioner"
+	defaultClusterIPv4CIDR  = "/20"
+	defaultServicesIPv4CIDR = "/20"
 )
 
 func init() {
@@ -47,6 +49,17 @@ func (gdf *GkeDriverFactory) Create(plan Plan) (Driver, error) {
 	if len(pvcPrefix) > pvcPrefixMaxLength {
 		pvcPrefix = pvcPrefix[0:pvcPrefixMaxLength]
 	}
+	clusterIPv4CIDR := defaultClusterIPv4CIDR
+
+	if plan.Gke.ClusterIPv4CIDR != "" {
+		clusterIPv4CIDR = plan.Gke.ClusterIPv4CIDR
+	}
+
+	servicesIPv4CIDR := defaultServicesIPv4CIDR
+	if plan.Gke.ServicesIPv4CIDR != "" {
+		servicesIPv4CIDR = plan.Gke.ServicesIPv4CIDR
+	}
+
 	return &GkeDriver{
 		plan: plan,
 		ctx: map[string]interface{}{
@@ -60,8 +73,8 @@ func (gdf *GkeDriverFactory) Create(plan Plan) (Driver, error) {
 			"LocalSsdCount":     plan.Gke.LocalSsdCount,
 			"GcpScopes":         plan.Gke.GcpScopes,
 			"NodeCountPerZone":  plan.Gke.NodeCountPerZone,
-			"ClusterIPv4CIDR":   plan.Gke.ClusterIPv4CIDR,
-			"ServicesIPv4CIDR":  plan.Gke.ServicesIPv4CIDR,
+			"ClusterIPv4CIDR":   clusterIPv4CIDR,
+			"ServicesIPv4CIDR":  servicesIPv4CIDR,
 		},
 	}, nil
 }
@@ -173,13 +186,6 @@ func (d *GkeDriver) create() error {
 		opts = append(opts, "--enable-pod-security-policy")
 	}
 
-	if d.plan.Gke.ClusterIPv4CIDR != "" {
-		opts = append(opts, fmt.Sprintf("--cluster-ipv4-cidr=%s ", d.plan.Gke.ClusterIPv4CIDR))
-	}
-	if d.plan.Gke.ServicesIPv4CIDR != "" {
-		opts = append(opts, fmt.Sprintf("--services-ipv4-cidr=%s ", d.plan.Gke.ServicesIPv4CIDR))
-	}
-
 	return NewCommand(`gcloud beta container --project {{.GCloudProject}} clusters create {{.ClusterName}} ` +
 		`--region {{.Region}} --username {{.AdminUsername}} --cluster-version {{.KubernetesVersion}} ` +
 		`--machine-type {{.MachineType}} --image-type COS --disk-type pd-ssd --disk-size 30 ` +
@@ -187,7 +193,7 @@ func (d *GkeDriver) create() error {
 		`--enable-stackdriver-kubernetes --addons HorizontalPodAutoscaling,HttpLoadBalancing ` +
 		`--no-enable-autoupgrade --no-enable-autorepair --enable-ip-alias --metadata disable-legacy-endpoints=true ` +
 		`--network projects/{{.GCloudProject}}/global/networks/default ` +
-		`--create-subnetwork "" ` +
+		`--create-subnetwork range={{.ClusterIPv4CIDR}} --cluster-ipv4-cidr={{.ClusterIPv4CIDR}} --services-ipv4-cidr={{.ServicesIPv4CIDR}} ` +
 		strings.Join(opts, " ")).
 		AsTemplate(d.ctx).
 		Run()

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -49,8 +49,8 @@ func (gdf *GkeDriverFactory) Create(plan Plan) (Driver, error) {
 	if len(pvcPrefix) > pvcPrefixMaxLength {
 		pvcPrefix = pvcPrefix[0:pvcPrefixMaxLength]
 	}
-	clusterIPv4CIDR := defaultClusterIPv4CIDR
 
+	clusterIPv4CIDR := defaultClusterIPv4CIDR
 	if plan.Gke.ClusterIPv4CIDR != "" {
 		clusterIPv4CIDR = plan.Gke.ClusterIPv4CIDR
 	}


### PR DESCRIPTION
Fix https://github.com/elastic/cloud-on-k8s/issues/2704

It looks like GKE changed its behavior with [`create-subnetwork`](https://cloud.google.com/sdk/gcloud/reference/beta/container/clusters/create#--create-subnetwork). Some of the older clusters that were created since https://github.com/elastic/cloud-on-k8s/issues/2615 was merged (you can tell because the subnets are something like `gke-PERSONSNAME-dev-cluster-subnet-635849b0`) have the /20 (rather than the default /14) pod address range set correctly. But the newer ones spun up for E2E testing do not. You can also reproduce it by using

```
gcloud beta container clusters  --project yourproject create yourtest \
  --create-subnetwork range=/20 --region europe-west1 --enable-ip-alias \
  --cluster-ipv4-cidr=/20
```

And removing either the `range=/20` or `cidr=/20`. Before, we were specifying the cluster cidr but not the subnetwork range, but ti would still set it to /14. Setting just the subnetwork range parameter also ended up just using the /14 default. Setting both together (as in this PR) worked. I opened a docs issue with them because I'm a little bit grumpy about it.