### PR TITLE
Prevent pod deletion while ES node still contains shards

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/orchestration.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/orchestration.asciidoc
@@ -70,7 +70,7 @@ Here are a few examples based on the Elasticsearch specification above:
 
 ECK orchestrates `NodeSet` changes with no downtime and makes sure that:
 
-- Before a node is removed, the relevant data is migrated to other nodes.
+- Before a node is removed, the relevant data is migrated to other nodes (but see <<{p}-orchestration-limitations,Limitations>>).
 - When a cluster topology changes, the Elasticsearch orchestration settings `discovery.seed_hosts`, `cluster.initial_master_nodes`, `discovery.zen.minimum_master_nodes`, `_cluster/voting_config_exclusions` are adjusted accordingly.
 - Rolling upgrades are performed safely, reusing the `PersistentVolumes` of the upgraded Elasticsearch nodes.
 
@@ -132,3 +132,10 @@ The health of the cluster is deliberately ignored in the following cases:
 * Elasticsearch versions cannot be downgraded. For example it is impossible to downgrade an existing cluster from version 7.3.0 to 7.2.0. This is not supported by Elasticsearch.
 
 Advanced users may force an upgrade by manually deleting `Pods` themselves. The deleted `Pods` will be automatically recreated at the latest revision.
+
+Operations that reduce the number of nodes in the cluster cannot make progress without user intervention if the Elasticsearch index replica settings are incompatible with the intended downscale.
+Specifically if the Elasticsearch index settings demand a higher number of shard copies than data nodes in the cluster after the downscale operation, ECK cannot migrate the data away from the node about to be removed. Users can address this in the following ways:
+
+** Adjust the Elasticsearch link:https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html[index settings] to a number of replicas that allow the desired node removal
+** Use link:https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#dynamic-index-settings[`auto_expand_replicas`] to automatically adjust the replicas to the number of data nodes in the cluster
+

--- a/pkg/controller/elasticsearch/driver/downscale.go
+++ b/pkg/controller/elasticsearch/driver/downscale.go
@@ -57,7 +57,7 @@ func HandleDownscale(
 
 	for _, downscale := range downscales {
 		// attempt the StatefulSet downscale (may or may not remove nodes)
-		requeue, err := attemptDownscale(downscaleCtx, downscale, leavingNodes, actualStatefulSets)
+		requeue, err := attemptDownscale(downscaleCtx, downscale, actualStatefulSets)
 		if err != nil {
 			return results.WithError(err)
 		}
@@ -131,11 +131,10 @@ func calculateDownscales(
 func attemptDownscale(
 	ctx downscaleContext,
 	downscale ssetDownscale,
-	allLeavingNodes []string,
 	statefulSets sset.StatefulSetList,
 ) (bool, error) {
 	// adjust the theoretical downscale to one we can safely perform
-	performable, err := calculatePerformableDownscale(ctx, downscale, allLeavingNodes)
+	performable, err := calculatePerformableDownscale(ctx, downscale)
 	if err != nil {
 		return true, err
 	}
@@ -172,7 +171,6 @@ func deleteStatefulSetResources(k8sClient k8s.Client, es esv1.Elasticsearch, sta
 func calculatePerformableDownscale(
 	ctx downscaleContext,
 	downscale ssetDownscale,
-	allLeavingNodes []string,
 ) (ssetDownscale, error) {
 	// create another downscale based on the provided one, for which we'll slowly decrease target replicas
 	performableDownscale := ssetDownscale{

--- a/pkg/controller/elasticsearch/driver/downscale.go
+++ b/pkg/controller/elasticsearch/driver/downscale.go
@@ -183,7 +183,7 @@ func calculatePerformableDownscale(
 	}
 	// iterate on all leaving nodes (ordered by highest ordinal first)
 	for _, node := range downscale.leavingNodeNames() {
-		migrating, err := migration.IsMigratingData(ctx.parentCtx, ctx.shardLister, node, allLeavingNodes)
+		migrating, err := migration.IsMigratingData(ctx.parentCtx, ctx.shardLister, node)
 		if err != nil {
 			return performableDownscale, err
 		}

--- a/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -533,10 +533,9 @@ func Test_calculateDownscales(t *testing.T) {
 
 func Test_calculatePerformableDownscale(t *testing.T) {
 	type args struct {
-		ctx             downscaleContext
-		downscale       ssetDownscale
-		state           *downscaleState
-		allLeavingNodes []string
+		ctx       downscaleContext
+		downscale ssetDownscale
+		state     *downscaleState
 	}
 	tests := []struct {
 		name    string
@@ -553,8 +552,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 					targetReplicas:  3,
 					finalReplicas:   3,
 				},
-				state:           &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: pointer.Int32(1)},
-				allLeavingNodes: []string{"node-1", "node-2"},
+				state: &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: pointer.Int32(1)},
 			},
 			want: ssetDownscale{
 				initialReplicas: 3,
@@ -573,8 +571,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 					targetReplicas:  2,
 					finalReplicas:   2,
 				},
-				state:           &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: pointer.Int32(1)},
-				allLeavingNodes: []string{"node-1", "node-2"},
+				state: &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: pointer.Int32(1)},
 			},
 			want: ssetDownscale{
 				initialReplicas: 3,
@@ -594,8 +591,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 					targetReplicas:  3,
 					finalReplicas:   2,
 				},
-				state:           &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: pointer.Int32(0)},
-				allLeavingNodes: []string{"node-1", "node-2"},
+				state: &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: pointer.Int32(0)},
 			},
 			want: ssetDownscale{
 				initialReplicas: 3,
@@ -616,8 +612,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 					finalReplicas:   2,
 				},
 				// a master node has already been removed
-				state:           &downscaleState{masterRemovalInProgress: true, runningMasters: 3, removalsAllowed: pointer.Int32(1)},
-				allLeavingNodes: []string{"node-1", "node-2"},
+				state: &downscaleState{masterRemovalInProgress: true, runningMasters: 3, removalsAllowed: pointer.Int32(1)},
 			},
 			want: ssetDownscale{
 				statefulSet:     ssetMaster3Replicas,
@@ -639,8 +634,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 					finalReplicas:   1,
 				},
 				// invariants limits us to one master node downscale only
-				state:           &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: pointer.Int32(1)},
-				allLeavingNodes: []string{"node-1", "node-2"},
+				state: &downscaleState{masterRemovalInProgress: false, runningMasters: 3, removalsAllowed: pointer.Int32(1)},
 			},
 			want: ssetDownscale{
 				statefulSet:     ssetMaster3Replicas,
@@ -662,8 +656,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 					finalReplicas:   0,
 				},
 				// only one master is running
-				state:           &downscaleState{masterRemovalInProgress: false, runningMasters: 1, removalsAllowed: pointer.Int32(1)},
-				allLeavingNodes: []string{"node-1", "node-2"},
+				state: &downscaleState{masterRemovalInProgress: false, runningMasters: 1, removalsAllowed: pointer.Int32(1)},
 			},
 			want: ssetDownscale{
 				statefulSet:     ssetMaster3Replicas,
@@ -675,7 +668,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := calculatePerformableDownscale(tt.args.ctx, tt.args.downscale, tt.args.allLeavingNodes)
+			got, err := calculatePerformableDownscale(tt.args.ctx, tt.args.downscale)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("calculatePerformableDownscale() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -741,7 +734,7 @@ func Test_attemptDownscale(t *testing.T) {
 				esClient:       &fakeESClient{},
 			}
 			// do the downscale
-			_, err := attemptDownscale(downscaleCtx, tt.downscale, nil, tt.statefulSets)
+			_, err := attemptDownscale(downscaleCtx, tt.downscale, tt.statefulSets)
 			require.NoError(t, err)
 			// retrieve statefulsets
 			var ssets appsv1.StatefulSetList

--- a/pkg/controller/elasticsearch/migration/migrate_data.go
+++ b/pkg/controller/elasticsearch/migration/migrate_data.go
@@ -24,68 +24,28 @@ const (
 	AllocationExcludeAnnotationName = "elasticsearch.k8s.elastic.co/allocation-exclude"
 )
 
-func shardIsMigrating(toMigrate client.Shard, others []client.Shard) bool {
-	if toMigrate.IsRelocating() || toMigrate.IsInitializing() {
-		return true // being migrated away or weirdly just initializing
-	}
-	if !toMigrate.IsStarted() {
-		return false // early return as we are interested only in started shards for migration purposes
-	}
-	for _, otherCopy := range others {
-		if otherCopy.IsStarted() {
-			return false // found another shard copy
-		}
-	}
-	return true // we assume other copies are initializing or there are no other copies
-}
-
-// nodeIsMigratingData is the core of IsMigratingData just with any I/O
-// removed to facilitate testing. See IsMigratingData for a high-level description.
-func nodeIsMigratingData(nodeName string, shards client.Shards, exclusions map[string]struct{}) bool {
-	// all other shards not living on the node that is about to go away mapped to their corresponding shard keys
-	othersByShard := make(map[string][]client.Shard)
+// nodeIsMigratingData returns true if there are any shards left on the node to remove.
+func nodeIsMigratingData(nodeName string, shards client.Shards) bool {
 	// all shard copies currently living on the node leaving the cluster
-	candidates := make([]client.Shard, 0)
-
-	// divide all shards into the to groups: migration candidate or other shard copy
+	shardsToMigrate := make([]client.Shard, 0)
+	// filter shards affected by node removal
 	for _, shard := range shards {
-		_, ignore := exclusions[shard.NodeName]
 		if shard.NodeName == nodeName {
-			candidates = append(candidates, shard)
-		} else if !ignore {
-			key := shard.Key()
-			others, found := othersByShard[key]
-			if !found {
-				othersByShard[key] = []client.Shard{shard}
-			} else {
-				othersByShard[key] = append(others, shard)
-			}
+			shardsToMigrate = append(shardsToMigrate, shard)
 		}
 	}
-
-	// check if there is at least one shard on this node that is migrating or needs to migrate
-	for _, toMigrate := range candidates {
-		if shardIsMigrating(toMigrate, othersByShard[toMigrate.Key()]) {
-			return true
-		}
-	}
-	return false
-
+	return len(shardsToMigrate) > 0
 }
 
 // IsMigratingData looks only at the presence of shards on a given node
 // and checks if there is at least one other copy of the shard in the cluster
 // that is started and not relocating.
-func IsMigratingData(ctx context.Context, shardLister esclient.ShardLister, podName string, exclusions []string) (bool, error) {
+func IsMigratingData(ctx context.Context, shardLister esclient.ShardLister, podName string) (bool, error) {
 	shards, err := shardLister.GetShards(ctx)
 	if err != nil {
 		return false, err
 	}
-	excludedNodes := make(map[string]struct{}, len(exclusions))
-	for _, name := range exclusions {
-		excludedNodes[name] = struct{}{}
-	}
-	return nodeIsMigratingData(podName, shards, excludedNodes), nil
+	return nodeIsMigratingData(podName, shards), nil
 }
 
 // allocationExcludeFromAnnotation returns the allocation exclude value stored in an annotation.

--- a/pkg/controller/elasticsearch/migration/migrate_data.go
+++ b/pkg/controller/elasticsearch/migration/migrate_data.go
@@ -11,7 +11,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
@@ -32,16 +31,13 @@ func IsMigratingData(ctx context.Context, shardLister esclient.ShardLister, podN
 	if err != nil {
 		return false, err
 	}
-	// all shard copies currently living on the node leaving the cluster
-	shardsToMigrate := make([]client.Shard, 0)
 	// filter shards affected by node removal
 	for _, shard := range shards {
 		if shard.NodeName == podName {
-			shardsToMigrate = append(shardsToMigrate, shard)
+			return true, nil
 		}
 	}
-	return len(shardsToMigrate) > 0, nil
-
+	return false, nil
 }
 
 // allocationExcludeFromAnnotation returns the allocation exclude value stored in an annotation.

--- a/pkg/controller/elasticsearch/migration/migrate_data_test.go
+++ b/pkg/controller/elasticsearch/migration/migrate_data_test.go
@@ -23,7 +23,6 @@ func TestIsMigratingData(t *testing.T) {
 	type args struct {
 		shardLister client.ShardLister
 		podName     string
-		exclusions  []string
 	}
 	tests := []struct {
 		name    string
@@ -43,7 +42,7 @@ func TestIsMigratingData(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Test enough redundancy",
+			name: "Node needs to be completely evacuated",
 			args: args{
 				podName: "A",
 				shardLister: NewFakeShardLister([]client.Shard{
@@ -52,7 +51,7 @@ func TestIsMigratingData(t *testing.T) {
 					{Index: "index-1", Shard: "0", State: client.STARTED, NodeName: "C"},
 				}),
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "Nothing to migrate",
@@ -99,36 +98,10 @@ func TestIsMigratingData(t *testing.T) {
 			},
 			want: true,
 		},
-		{
-			name: "Valid copy exists",
-			args: args{
-				podName:    "A",
-				exclusions: []string{"A", "B"},
-				shardLister: NewFakeShardLister([]client.Shard{
-					{Index: "index-1", Shard: "0", State: client.STARTED, NodeName: "A"},
-					{Index: "index-1", Shard: "0", State: client.STARTED, NodeName: "B"},
-					{Index: "index-1", Shard: "0", State: client.STARTED, NodeName: "C"},
-				}),
-			},
-			want: false,
-		},
-		{
-			name: "No Valid copy exists, all nodes are excluded",
-			args: args{
-				podName:    "A",
-				exclusions: []string{"B", "C"},
-				shardLister: NewFakeShardLister([]client.Shard{
-					{Index: "index-1", Shard: "0", State: client.STARTED, NodeName: "A"},
-					{Index: "index-1", Shard: "0", State: client.STARTED, NodeName: "B"},
-					{Index: "index-1", Shard: "0", State: client.STARTED, NodeName: "C"},
-				}),
-			},
-			want: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := IsMigratingData(context.Background(), tt.args.shardLister, tt.args.podName, tt.args.exclusions)
+			got, err := IsMigratingData(context.Background(), tt.args.shardLister, tt.args.podName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("IsMigratingData() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/elasticsearch/reconcile/state.go
+++ b/pkg/controller/elasticsearch/reconcile/state.go
@@ -91,7 +91,7 @@ func (s *State) UpdateElasticsearchMigrating(
 	s.AddEvent(
 		corev1.EventTypeNormal,
 		events.EventReasonDelayed,
-		"Requested topology change delayed by data migration",
+		"Requested topology change delayed by data migration. Ensure index replica settings allow node removal.",
 	)
 	return s.updateWithPhase(esv1.ElasticsearchMigratingDataPhase, resourcesState, observedState)
 }

--- a/pkg/controller/elasticsearch/reconcile/state_test.go
+++ b/pkg/controller/elasticsearch/reconcile/state_test.go
@@ -296,7 +296,7 @@ func TestState_UpdateElasticsearchMigrating(t *testing.T) {
 			},
 			stateAssertions: func(s *State) {
 				assert.EqualValues(t, esv1.ElasticsearchMigratingDataPhase, s.status.Phase)
-				assert.Equal(t, []events.Event{{EventType: corev1.EventTypeNormal, Reason: events.EventReasonDelayed, Message: "Requested topology change delayed by data migration"}}, s.Recorder.Events())
+				assert.Equal(t, []events.Event{{EventType: corev1.EventTypeNormal, Reason: events.EventReasonDelayed, Message: "Requested topology change delayed by data migration. Ensure index replica settings allow node removal."}}, s.Recorder.Events())
 			},
 		},
 	}


### PR DESCRIPTION
Removes the logic that would declare a node evacuation as completed as soon as there was another copy of every shard on the node to be deleted on at least one other node. 

Instead we now require nodes to be completely evacuated before deletion can proceed. 

This opens up the possibility for downscale operations that cannot make progress. For now we only adjust the documentation to address this and advise users to adjust their index settings. 

Fixes #2710 

See the linked issue for more context and follow-up tasks. 