### PR TITLE
Add Traefik recipe

### DIFF
--- a/config/recipes/traefik/00-prereq-cluster-issuer.yaml
+++ b/config/recipes/traefik/00-prereq-cluster-issuer.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: selfsigning-issuer
+spec:
+  selfSigned: {}

--- a/config/recipes/traefik/01-certificate.yaml
+++ b/config/recipes/traefik/01-certificate.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: hulk-certs
+  labels:
+    app: hulk
+spec:
+  secretName: hulk-certs
+  dnsNames:
+    - "elasticsearch.hulk"
+    - "kibana.hulk"
+    - "apm.hulk"
+  isCA: true
+  issuerRef:
+    name: selfsigning-issuer
+    kind: ClusterIssuer

--- a/config/recipes/traefik/02-elastic-stack.yaml
+++ b/config/recipes/traefik/02-elastic-stack.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: hulk
+  labels:
+    app: hulk
+spec:
+  version: 7.6.1
+  nodeSets:
+  - name: master
+    count: 1
+    config:
+      node.master: true
+      node.data: false
+      node.ingest: false
+      node.ml: false
+      node.store.allow_mmap: false
+  - name: data
+    count: 1
+    config:
+      node.master: false
+      node.data: true
+      node.ingest: false
+      node.ml: false
+      node.store.allow_mmap: false
+  - name: ingest
+    count: 1
+    config:
+      node.master: false
+      node.data: false
+      node.ingest: true
+      node.ml: false
+      node.store.allow_mmap: false
+  - name: coordinator
+    count: 1
+    config:
+      node.master: false
+      node.data: false
+      node.ingest: false
+      node.ml: false
+      node.store.allow_mmap: false
+  - name: ml
+    count: 1
+    config:
+      node.master: false
+      node.data: false
+      node.ingest: false
+      node.ml: true
+      node.store.allow_mmap: false
+---
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: hulk
+  labels:
+    app: hulk
+spec:
+  version: 7.6.1
+  count: 1
+  elasticsearchRef:
+    name: hulk
+---
+apiVersion: apm.k8s.elastic.co/v1
+kind: ApmServer
+metadata:
+  name: hulk
+spec:
+  version: 7.6.1
+  count: 1
+  elasticsearchRef:
+    name: hulk

--- a/config/recipes/traefik/02-elastic-stack.yaml
+++ b/config/recipes/traefik/02-elastic-stack.yaml
@@ -65,6 +65,8 @@ apiVersion: apm.k8s.elastic.co/v1
 kind: ApmServer
 metadata:
   name: hulk
+  labels:
+    app: hulk
 spec:
   version: 7.6.1
   count: 1

--- a/config/recipes/traefik/03-node-type-svc.yaml
+++ b/config/recipes/traefik/03-node-type-svc.yaml
@@ -11,6 +11,7 @@ spec:
       port: 9200
       targetPort: 9200
   selector:
+    # Select coordinator nodes
     elasticsearch.k8s.elastic.co/cluster-name: "hulk"
     elasticsearch.k8s.elastic.co/node-master: "false"
     elasticsearch.k8s.elastic.co/node-data: "false"
@@ -29,5 +30,6 @@ spec:
       port: 9200
       targetPort: 9200
   selector:
+    # Select ingest nodes
     elasticsearch.k8s.elastic.co/cluster-name: "hulk"
     elasticsearch.k8s.elastic.co/node-ingest: "true"

--- a/config/recipes/traefik/03-node-type-svc.yaml
+++ b/config/recipes/traefik/03-node-type-svc.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hulk-elasticsearch-read
+  labels:
+    app: hulk
+spec:
+  ports:
+    - name: https
+      port: 9200
+      targetPort: 9200
+  selector:
+    elasticsearch.k8s.elastic.co/cluster-name: "hulk"
+    elasticsearch.k8s.elastic.co/node-master: "false"
+    elasticsearch.k8s.elastic.co/node-data: "false"
+    elasticsearch.k8s.elastic.co/node-ingest: "false"
+    elasticsearch.k8s.elastic.co/node-ml: "false"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hulk-elasticsearch-write
+  labels:
+    app: hulk
+spec:
+  ports:
+    - name: https
+      port: 9200
+      targetPort: 9200
+  selector:
+    elasticsearch.k8s.elastic.co/cluster-name: "hulk"
+    elasticsearch.k8s.elastic.co/node-ingest: "true"

--- a/config/recipes/traefik/04-middleware.yaml
+++ b/config/recipes/traefik/04-middleware.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: hulk-middleware-chain
+spec:
+  chain:
+    middlewares:
+    #- name: hulk-ip-whitelist
+    - name: hulk-limit-concurrent
+    - name: hulk-circuit-breaker
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: hulk-ip-whitelist
+spec:
+  ipWhiteList:
+    sourceRange:
+      - 127.0.0.1/32
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: hulk-limit-concurrent
+spec:
+  inFlightReq:
+    amount: 10
+    sourceCriterion:
+      ipStrategy:
+        depth: 1
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: hulk-circuit-breaker
+spec:
+  circuitBreaker:
+    expression: "LatencyAtQuantileMS(50.0) > 500 || ResponseCodeRatio(400,600,0,600) > 0.25"
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: hulk-apm-ratelimit
+spec:
+  rateLimit:
+    average: 100
+    burst: 50

--- a/config/recipes/traefik/05-ingress-route.yaml
+++ b/config/recipes/traefik/05-ingress-route.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: hulk-elastic-stack
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: "Host(`elasticsearch.hulk`) && ((PathPrefix(`/_search`) && Method(`POST`)) || Method(`GET`))"
+      kind: Rule
+      services:
+        - name: hulk-elasticsearch-read
+          port: 9200
+          scheme: https
+      middlewares:
+        - name: hulk-middleware-chain
+    - match: "Host(`elasticsearch.hulk`) && Method(`DELETE`,`POST`,`PUT`)"
+      kind: Rule
+      services:
+        - name: hulk-elasticsearch-write
+          port: 9200
+          scheme: https
+      middlewares:
+        - name: hulk-middleware-chain
+    - match: "Host(`kibana.hulk`)"
+      kind: Rule
+      services:
+        - name: hulk-kb-http
+          port: 5601
+          scheme: https
+      middlewares:
+        - name: hulk-middleware-chain
+    - match: "Host(`apm.hulk`)"
+      kind: Rule
+      services:
+        - name: hulk-apm-http
+          port: 8200
+          scheme: https
+      middlewares:
+        - name: hulk-ip-whitelist
+        - name: hulk-circuit-breaker
+        - name: hulk-apm-ratelimit
+  tls:
+    secretName: hulk-certs
+    domains:
+      - sans:
+          - "elasticsearch.hulk"
+          - "kibana.hulk"
+          - "apm.hulk"

--- a/config/recipes/traefik/README.asciidoc
+++ b/config/recipes/traefik/README.asciidoc
@@ -1,0 +1,75 @@
+= Use Traefik to expose Elastic Stack applications
+
+This recipe illustrates how to use link:https://containo.us/traefik/[Traefik] to expose Elasticsearch, Kibana and APM Server resources to the outside world. It demonstrates how to route Elasticsearch traffic by node type and how to use Traefik middleware to add security and resiliency features.
+
+== Prerequisites
+
+- Traefik 2.1 or higher installed with the Kubernetes CRD provider. See: https://docs.traefik.io/providers/kubernetes-crd/
++
+NOTE: This recipe uses TLS to secure in-cluster communications. As the ECK generated certificates are self-signed, you will need to configure Traefik to trust those certificates. One way of doing this is to add the `--serverstransport.insecureskipverify=true` flag to the Traefik deployment.
+- link:https://cert-manager.io[cert-manager] to issue custom TLS certificates. A self-signed cluster issuer can be created with the following manifest:
++
+[source,yaml]
+----
+include::00-prereq-cluster-issuer.yaml[]
+----
+
+== Recipe
+
+Create a certificate with SANs for each of the services you wish to expose.
+
+[source,yaml]
+----
+include::01-certificate.yaml[]
+----
+
+Deploy Elastic Stack applications.
+
+[source,yaml]
+----
+include::02-elastic-stack.yaml[]
+----
+
+Create services to expose ingest nodes and coordinator nodes.
+
+[source,yaml]
+----
+include::03-node-type-svc.yaml[]
+----
+
+Create Traefik middleware for IP filtering, circuit breaking, and rate-limiting.
+
+[source,yaml]
+----
+include::04-middleware.yaml[]
+----
+
+Create the ingress route.
+
+[source,yaml]
+----
+include::05-ingress-route.yaml[]
+----
+
+== Testing
+
+Obtain the Traefik load balancer IP address. This assumes that Traefik is installed in the `traefik` namespace.
+
+[source,sh]
+----
+export INGRESS_HOST=$(kubectl get svc traefik -n traefik -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
+----
+
+Obtain the Elasticsearch password.
+
+[source,sh]
+----
+ELASTICSEARCH_PASSWORD=$(kubectl get secret hulk-es-elastic-user -o=go-template='{{ .data.elastic | base64decode}}')
+----
+
+Access Elasticsearch.
+
+[source,sh]
+----
+curl --resolve "elasticsearch.hulk:443:$INGRESS_HOST" -k -u "elastic:$ELASTICSEARCH_PASSWORD" -XGET 'https://elasticsearch.hulk/_cat/health?v'
+----


### PR DESCRIPTION
This recipe illustrates how to use [Traefik](https://containo.us/traefik/) to expose Elastic Stack applications to the outside world. 
It demonstrates:
- Splitting traffic by deployment type and node type
- Implementing security and resiliency using Traefik middleware