### PR TITLE
Fix license check path

### DIFF
--- a/hack/check/check-license-header.sh
+++ b/hack/check/check-license-header.sh
@@ -8,7 +8,7 @@
 
 set -eu
 
-: "${CHECK_PATH:=$(dirname $0)/../*}" # root project directory
+: "${CHECK_PATH:=$(dirname $0)/../../*}" # root project directory
 
 files=$(grep \
     --include=\*.go --exclude-dir=vendor \

--- a/pkg/controller/common/association/resources.go
+++ b/pkg/controller/common/association/resources.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package association
 
 import (


### PR DESCRIPTION
The license header checker was moved down a directory as part of https://github.com/elastic/cloud-on-k8s/pull/2502, but we did not update the relative path in the script. @pebrc caught it here: https://github.com/elastic/cloud-on-k8s/pull/2720#discussion_r394366507
