### PR TITLE
Remove GKE 1.13 and switch to 1.14

### DIFF
--- a/.ci/jobs/e2e-tests-custom-operator-image-gke.yml
+++ b/.ci/jobs/e2e-tests-custom-operator-image-gke.yml
@@ -9,8 +9,8 @@
           description: "ECK Docker image"
       - string:
           name: JKS_PARAM_K8S_VERSION
-          default: 1.13
-          description: "Kubernetes version, default is 1.13"
+          default: 1.14
+          description: "Kubernetes version, default is 1.14"
       - bool:
           name: SEND_NOTIFICATIONS
           default: true

--- a/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
@@ -28,17 +28,6 @@ pipeline {
         }
         stage('Run tests for different k8s versions in GKE') {
             parallel {
-                stage("1.13") {
-                    agent {
-                        label 'linux'
-                    }
-                    steps {
-                        checkout scm
-                        script {
-                            runWith(lib, failedTests, '1.13', "eck-gke13-${BUILD_NUMBER}-e2e")
-                        }
-                    }
-                }
                 stage("1.14") {
                     agent {
                         label 'linux'
@@ -86,7 +75,7 @@ pipeline {
         }
         cleanup {
             script {
-                clusters = ["eck-gke13-${BUILD_NUMBER}-e2e", "eck-gke14-${BUILD_NUMBER}-e2e", "eck-gke15-${BUILD_NUMBER}-e2e"]
+                clusters = ["eck-gke14-${BUILD_NUMBER}-e2e", "eck-gke15-${BUILD_NUMBER}-e2e"]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
                         parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: clusters[i])],

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -3,7 +3,7 @@ plans:
   operation: create
   clusterName: ci
   provider: gke
-  kubernetesVersion: 1.13
+  kubernetesVersion: 1.14
   machineType: n1-standard-8
   serviceAccount: true
   psp: true
@@ -17,7 +17,7 @@ plans:
   operation: create
   clusterName: dev
   provider: gke
-  kubernetesVersion: 1.13
+  kubernetesVersion: 1.14
   machineType: n1-standard-8
   serviceAccount: false
   psp: false


### PR DESCRIPTION
https://cloud.google.com/kubernetes-engine/docs/release-notes#march_16_2020

The latest GKE release seems to have removed support for 1.13 masters which means we cannot create new 1.13 k8s clusters for testing anymore. 

This PR should removes 1.13 clusters from our k8s versions build job and replaces 1.13 with 1.14 in other jobs.