### PR TITLE
Switch to /api/status for Kibana e2e tests

### DIFF
--- a/test/e2e/kb/telemetry_test.go
+++ b/test/e2e/kb/telemetry_test.go
@@ -30,7 +30,7 @@ func TestTelemetry(t *testing.T) {
 				Test: func(t *testing.T) {
 					uri := "/api/telemetry/v1/clusters/_stats"
 					payload := `{"timeRange":{"min":"0","max":"0"}}`
-					body, err := kibana.DoKibanaReq(k, kbBuilder, "POST", uri, []byte(payload))
+					body, err := kibana.DoKibanaReq(k, kbBuilder.Kibana, "POST", uri, []byte(payload))
 					require.NoError(t, err)
 
 					var stats ClusterStats

--- a/test/e2e/test/kibana/checks_kb.go
+++ b/test/e2e/test/kibana/checks_kb.go
@@ -5,21 +5,23 @@
 package kibana
 
 import (
+	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"strings"
-	"testing"
 
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana/name"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/require"
 )
 
 type kbChecks struct {
-	client *http.Client
+	client *test.K8sClient
+}
+
+type kbStatus struct {
+	Status struct {
+		Overall struct {
+			State string `json:"state"`
+		} `json:"overall"`
+	} `json:"status"`
 }
 
 func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
@@ -28,49 +30,29 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 	}
 
 	checks := kbChecks{
-		client: test.NewHTTPClient(nil),
+		client: k,
 	}
 	return test.StepList{
-		checks.CreateKbClient(b.Kibana),
-		checks.CheckKbLoginHealthy(b.Kibana),
+		checks.CheckKbStatusHealthy(b.Kibana),
 	}
 }
 
-func (check *kbChecks) CreateKbClient(kb kbv1.Kibana) test.Step {
-	return test.Step{
-		Name: "Create Kibana client",
-		Test: func(t *testing.T) {
-			k := test.NewK8sClientOrFatal()
-			client, err := NewKibanaClient(kb, k)
-			require.NoError(t, err)
-			check.client = client
-		},
-	}
-}
-
-// CheckKbLoginHealthy checks that Kibana is able to connect to Elasticsearch by inspecting its login page.
-func (check *kbChecks) CheckKbLoginHealthy(kb kbv1.Kibana) test.Step {
+// CheckKbStatusHealthy checks that Kibana is able to connect to Elasticsearch by inspecting its login page.
+func (check *kbChecks) CheckKbStatusHealthy(kb kbv1.Kibana) test.Step {
 	return test.Step{
 		Name: "Kibana should be able to connect to Elasticsearch",
 		Test: test.Eventually(func() error {
-			scheme := "http"
-			if kb.Spec.HTTP.TLS.Enabled() {
-				scheme = "https"
-			}
-			resp, err := check.client.Get(fmt.Sprintf("%s://%s.%s.svc:5601", scheme, name.HTTPService(kb.Name), kb.Namespace))
-
+			body, err := DoKibanaReq(check.client, kb, "GET", "/api/status", nil)
 			if err != nil {
 				return err
 			}
-			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
+			var status kbStatus
+			err = json.Unmarshal(body, &status)
 			if err != nil {
 				return err
 			}
-			// this is of course fragile and relying on potentially version specific implementation detail
-			// verified to be present in 6.x and 7.x
-			if !strings.Contains(string(body), "allowLogin&quot;:true") {
-				return errors.New("initial Kibana UI state forbids login which indicates an error in the ES/Kibana setup")
+			if status.Status.Overall.State != "green" {
+				return fmt.Errorf("not ready: want 'green' but Kibana status was '%s'", status.Status.Overall.State)
 			}
 			return nil
 		}),

--- a/test/e2e/test/kibana/checks_kb.go
+++ b/test/e2e/test/kibana/checks_kb.go
@@ -37,7 +37,7 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 	}
 }
 
-// CheckKbStatusHealthy checks that Kibana is able to connect to Elasticsearch by inspecting its login page.
+// CheckKbStatusHealthy checks that Kibana is able to connect to Elasticsearch by inspecting its API status.
 func (check *kbChecks) CheckKbStatusHealthy(kb kbv1.Kibana) test.Step {
 	return test.Step{
 		Name: "Kibana should be able to connect to Elasticsearch",

--- a/test/e2e/test/kibana/http_client.go
+++ b/test/e2e/test/kibana/http_client.go
@@ -33,16 +33,17 @@ func NewKibanaClient(kb kbv1.Kibana, k *test.K8sClient) (*http.Client, error) {
 }
 
 // DoKibanaReq executes an HTTP request against a Kibana instance.
-func DoKibanaReq(k *test.K8sClient, b Builder, method string, uri string, body []byte) ([]byte, error) {
-	password, err := k.GetElasticPassword(b.Kibana.Spec.ElasticsearchRef.Namespace, b.Kibana.Spec.ElasticsearchRef.Name)
+func DoKibanaReq(k *test.K8sClient, kb kbv1.Kibana, method string, uri string, body []byte) ([]byte, error) {
+	password, err := k.GetElasticPassword(kb.Spec.ElasticsearchRef.Namespace, kb.Spec.ElasticsearchRef.Name)
 	if err != nil {
 		return nil, errors.Wrap(err, "while getting elastic password")
 	}
 	scheme := "http"
-	if b.Kibana.Spec.HTTP.TLS.Enabled() {
+	if kb.Spec.HTTP.TLS.Enabled() {
 		scheme = "https"
 	}
-	u, err := url.Parse(fmt.Sprintf("%s://%s.%s:5601", scheme, kbname.HTTPService(b.Kibana.Name), b.Kibana.Namespace))
+	// add .svc suffix so that requests work when using the port-forwarder during local test runs
+	u, err := url.Parse(fmt.Sprintf("%s://%s.%s.svc:5601", scheme, kbname.HTTPService(kb.Name), kb.Namespace))
 	if err != nil {
 		return nil, errors.Wrap(err, "while parsing url")
 	}
@@ -56,8 +57,8 @@ func DoKibanaReq(k *test.K8sClient, b Builder, method string, uri string, body [
 	req.SetBasicAuth("elastic", password)
 	req.Header.Set("Content-Type", "application/json")
 	// send the kbn-version header expected by the Kibana server to protect against xsrf attacks
-	req.Header.Set("kbn-version", b.Kibana.Spec.Version)
-	client, err := NewKibanaClient(b.Kibana, k)
+	req.Header.Set("kbn-version", kb.Spec.Version)
+	client, err := NewKibanaClient(kb, k)
 	if err != nil {
 		return nil, errors.Wrap(err, "while creating kibana client")
 	}


### PR DESCRIPTION
Instead of checking for the presence of a string in the login page make an authenticated request to the Kibana status API. 

This should be slightly more resilient against changes between different stack versions.
The expected behaviour is as follows:
> -  api/status will respond with 503 until the server is ready and able to talk to Elasticsearch and run migrations
> - If Kibana loses communication with ES and the status.allowAnonymous is not set to true then you will get 401 from Kibana on this endpoint
> - If Kibana loses communication with ES and the status.allowAnonymous is set to true then you will get 200 from Kibana on this endpoint with a status.overall.state property set to red (edited) 

In practice I have seen it simply timing out when Elasticsearch is not available which is a bit worse than the current behaviour on the login page, but I guess the API check is less brittle.

Fixes #2717 