### PR TITLE
Ensure secret keys exist in Enterprise Search configuration

### DIFF
--- a/pkg/controller/enterprisesearch/config.go
+++ b/pkg/controller/enterprisesearch/config.go
@@ -88,8 +88,8 @@ func ReconcileConfig(client k8s.Client, ents entsv1beta1.EnterpriseSearch) (*cor
 
 // reusableSettings captures secrets settings in the Enterprise Search configuration that we want to reuse.
 type reusableSettings struct {
-	SecretSessionKey  string   `config:"secret_session_key"`
-	EncryptionKeysKey []string `config:"secret_management.encryption_keys"`
+	SecretSession  string   `config:"secret_session_key"`
+	EncryptionKeys []string `config:"secret_management.encryption_keys"`
 }
 
 // reuseOrGenerateSecretKeys reads the current configuration and reuse existing secrets it they exist.
@@ -105,11 +105,11 @@ func reuseOrGenerateSecretKeys(c k8s.Client, ents entsv1beta1.EnterpriseSearch) 
 	} else if err := cfg.Unpack(&e); err != nil {
 		return nil, err
 	}
-	if len(e.SecretSessionKey) == 0 {
-		e.SecretSessionKey = rand.String(32)
+	if len(e.SecretSession) == 0 {
+		e.SecretSession = rand.String(32)
 	}
-	if len(e.EncryptionKeysKey) == 0 {
-		e.EncryptionKeysKey = []string{rand.String(32)}
+	if len(e.EncryptionKeys) == 0 {
+		e.EncryptionKeys = []string{rand.String(32)}
 	}
 	return settings.MustCanonicalConfig(e), nil
 }

--- a/pkg/controller/enterprisesearch/config.go
+++ b/pkg/controller/enterprisesearch/config.go
@@ -102,10 +102,8 @@ func reuseOrGenerateSecretKeys(c k8s.Client, ents entsv1beta1.EnterpriseSearch) 
 	var e enterpriseSearchSecrets
 	if cfg == nil {
 		e = enterpriseSearchSecrets{}
-	} else {
-		if err := cfg.Unpack(&e); err != nil {
-			return nil, err
-		}
+	} else if err := cfg.Unpack(&e); err != nil {
+		return nil, err
 	}
 	if len(e.SecretSessionKey) == 0 {
 		e.SecretSessionKey = rand.String(32)

--- a/pkg/controller/enterprisesearch/config.go
+++ b/pkg/controller/enterprisesearch/config.go
@@ -92,8 +92,8 @@ type reusableSettings struct {
 	EncryptionKeys []string `config:"secret_management.encryption_keys"`
 }
 
-// reuseOrGenerateSecretKeys reads the current configuration and reuse existing secrets it they exist.
-func reuseOrGenerateSecretKeys(c k8s.Client, ents entsv1beta1.EnterpriseSearch) (*settings.CanonicalConfig, error) {
+// getOrCreateReusableSettings reads the current configuration and reuse existing secrets it they exist.
+func getOrCreateReusableSettings(c k8s.Client, ents entsv1beta1.EnterpriseSearch) (*settings.CanonicalConfig, error) {
 	cfg, err := getExistingConfig(c, ents)
 	if err != nil {
 		return nil, err
@@ -117,7 +117,7 @@ func reuseOrGenerateSecretKeys(c k8s.Client, ents entsv1beta1.EnterpriseSearch) 
 func newConfig(c k8s.Client, ents entsv1beta1.EnterpriseSearch) (*settings.CanonicalConfig, error) {
 	cfg := defaultConfig(ents)
 
-	secretCfg, err := reuseOrGenerateSecretKeys(c, ents)
+	reusedCfg, err := getOrCreateReusableSettings(c, ents)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func newConfig(c k8s.Client, ents entsv1beta1.EnterpriseSearch) (*settings.Canon
 	}
 
 	// merge with user settings last so they take precedence
-	if err := cfg.MergeWith(secretCfg, associationCfg, tlsConfig(ents), userProvidedCfg); err != nil {
+	if err := cfg.MergeWith(reusedCfg, associationCfg, tlsConfig(ents), userProvidedCfg); err != nil {
 		return nil, err
 	}
 	return cfg, nil

--- a/pkg/controller/enterprisesearch/config.go
+++ b/pkg/controller/enterprisesearch/config.go
@@ -161,7 +161,7 @@ func getExistingConfig(client k8s.Client, ents entsv1beta1.EnterpriseSearch) (*s
 	}
 	rawCfg, exists := secret.Data[ConfigFilename]
 	if !exists {
-		return nil, fmt.Errorf("Enterprise Search config secret %v exists but missing config file key %s", key, ConfigFilename)
+		return nil, fmt.Errorf("%s:%s: config secret %v exists but config file key %s is missing", ents.Namespace, ents.Name, key, ConfigFilename)
 	}
 	cfg, err := settings.ParseConfig(rawCfg)
 	if err != nil {

--- a/pkg/controller/enterprisesearch/config_test.go
+++ b/pkg/controller/enterprisesearch/config_test.go
@@ -33,7 +33,7 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 					&v1.Secret{
 						ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "entsearch-sample-ents-config"},
 						Data: map[string][]byte{
-							ConfigFilename: []byte(existingConfigWithSecureSettings),
+							ConfigFilename: []byte(existingConfigWithReusableSettings),
 						},
 					},
 				),
@@ -65,7 +65,7 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 				},
 			},
 			assertion: func(t *testing.T, got *settings.CanonicalConfig, err error) {
-				// Unpack the configuration to check that some default secure settings have been generated
+				// Unpack the configuration to check that some default reusable settings have been generated
 				var e reusableSettings
 				assert.NoError(t, got.Unpack(&e))
 				assert.Equal(t, len(e.EncryptionKeys), 1)     // We set 1 encryption key by default
@@ -89,7 +89,7 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 				},
 			},
 			assertion: func(t *testing.T, got *settings.CanonicalConfig, err error) {
-				// Unpack the configuration to check that some default secure settings have been generated
+				// Unpack the configuration to check that some default reusable settings have been generated
 				var e reusableSettings
 				assert.NoError(t, got.Unpack(&e))
 				assert.Equal(t, len(e.EncryptionKeys), 1)     // We set 1 encryption key by default
@@ -106,7 +106,7 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 				},
 			},
 			assertion: func(t *testing.T, got *settings.CanonicalConfig, err error) {
-				// Unpack the configuration to check that some default secure settings have been generated
+				// Unpack the configuration to check that some default reusable settings have been generated
 				var e reusableSettings
 				assert.NoError(t, got.Unpack(&e))
 				assert.Equal(t, len(e.EncryptionKeys), 1)     // We set 1 encryption key by default
@@ -117,9 +117,9 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := reuseOrGenerateSecretKeys(tt.args.c, tt.args.ents)
+			got, err := getOrCreateReusableSettings(tt.args.c, tt.args.ents)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("reuseOrGenerateSecretKeys() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("getOrCreateReusableSettings() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			tt.assertion(t, got, err)

--- a/pkg/controller/enterprisesearch/config_test.go
+++ b/pkg/controller/enterprisesearch/config_test.go
@@ -68,9 +68,9 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 				// Unpack the configuration to check that some default secure settings have been generated
 				var e reusableSettings
 				assert.NoError(t, got.Unpack(&e))
-				assert.Equal(t, len(e.EncryptionKeysKey), 1)     // We set 1 encryption key by default
-				assert.Equal(t, len(e.EncryptionKeysKey[0]), 32) // encryption key length should be 32
-				assert.Equal(t, len(e.SecretSessionKey), 32)     // session key length should be 24
+				assert.Equal(t, len(e.EncryptionKeys), 1)     // We set 1 encryption key by default
+				assert.Equal(t, len(e.EncryptionKeys[0]), 32) // encryption key length should be 32
+				assert.Equal(t, len(e.SecretSession), 32)     // session key length should be 24
 			},
 		},
 		{
@@ -92,9 +92,9 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 				// Unpack the configuration to check that some default secure settings have been generated
 				var e reusableSettings
 				assert.NoError(t, got.Unpack(&e))
-				assert.Equal(t, len(e.EncryptionKeysKey), 1)     // We set 1 encryption key by default
-				assert.Equal(t, len(e.EncryptionKeysKey[0]), 32) // encryption key length should be 32
-				assert.Equal(t, len(e.SecretSessionKey), 32)     // session key length should be 32
+				assert.Equal(t, len(e.EncryptionKeys), 1)     // We set 1 encryption key by default
+				assert.Equal(t, len(e.EncryptionKeys[0]), 32) // encryption key length should be 32
+				assert.Equal(t, len(e.SecretSession), 32)     // session key length should be 32
 			},
 		},
 		{
@@ -109,9 +109,9 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 				// Unpack the configuration to check that some default secure settings have been generated
 				var e reusableSettings
 				assert.NoError(t, got.Unpack(&e))
-				assert.Equal(t, len(e.EncryptionKeysKey), 1)     // We set 1 encryption key by default
-				assert.Equal(t, len(e.EncryptionKeysKey[0]), 32) // encryption key length should be 32
-				assert.Equal(t, len(e.SecretSessionKey), 32)     // session key length should be 32
+				assert.Equal(t, len(e.EncryptionKeys), 1)     // We set 1 encryption key by default
+				assert.Equal(t, len(e.EncryptionKeys[0]), 32) // encryption key length should be 32
+				assert.Equal(t, len(e.SecretSession), 32)     // session key length should be 32
 			},
 		},
 	}

--- a/pkg/controller/enterprisesearch/config_test.go
+++ b/pkg/controller/enterprisesearch/config_test.go
@@ -43,8 +43,8 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 			},
 			assertion: func(t *testing.T, got *settings.CanonicalConfig, err error) {
 				expectedSettings := settings.MustCanonicalConfig(map[string]interface{}{
-					SecretSessionKey:  "alreadysetsessionkey",
-					EncryptionKeysKey: []string{"alreadysetencryptionkey1", "alreadysetencryptionkey2"},
+					SecretSessionSetting:  "alreadysetsessionkey",
+					EncryptionKeysSetting: []string{"alreadysetencryptionkey1", "alreadysetencryptionkey2"},
 				})
 				assert.Equal(t, expectedSettings, got)
 			},
@@ -66,7 +66,7 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 			},
 			assertion: func(t *testing.T, got *settings.CanonicalConfig, err error) {
 				// Unpack the configuration to check that some default secure settings have been generated
-				var e enterpriseSearchSecrets
+				var e reusableSettings
 				assert.NoError(t, got.Unpack(&e))
 				assert.Equal(t, len(e.EncryptionKeysKey), 1)     // We set 1 encryption key by default
 				assert.Equal(t, len(e.EncryptionKeysKey[0]), 32) // encryption key length should be 32
@@ -90,7 +90,7 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 			},
 			assertion: func(t *testing.T, got *settings.CanonicalConfig, err error) {
 				// Unpack the configuration to check that some default secure settings have been generated
-				var e enterpriseSearchSecrets
+				var e reusableSettings
 				assert.NoError(t, got.Unpack(&e))
 				assert.Equal(t, len(e.EncryptionKeysKey), 1)     // We set 1 encryption key by default
 				assert.Equal(t, len(e.EncryptionKeysKey[0]), 32) // encryption key length should be 32
@@ -107,7 +107,7 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 			},
 			assertion: func(t *testing.T, got *settings.CanonicalConfig, err error) {
 				// Unpack the configuration to check that some default secure settings have been generated
-				var e enterpriseSearchSecrets
+				var e reusableSettings
 				assert.NoError(t, got.Unpack(&e))
 				assert.Equal(t, len(e.EncryptionKeysKey), 1)     // We set 1 encryption key by default
 				assert.Equal(t, len(e.EncryptionKeysKey[0]), 32) // encryption key length should be 32

--- a/pkg/controller/enterprisesearch/config_test.go
+++ b/pkg/controller/enterprisesearch/config_test.go
@@ -1,0 +1,128 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package enterprisesearch
+
+import (
+	"testing"
+
+	entsv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_reuseOrGenerateSecrets(t *testing.T) {
+	type args struct {
+		c    k8s.Client
+		ents entsv1beta1.EnterpriseSearch
+	}
+	tests := []struct {
+		name      string
+		args      args
+		assertion func(*testing.T, *settings.CanonicalConfig, error)
+		wantErr   bool
+	}{
+		{
+			name: "Do not override existing keys",
+			args: args{
+				c: k8s.WrappedFakeClient(
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "entsearch-sample-ents-config"},
+						Data: map[string][]byte{
+							ConfigFilename: []byte(existingConfigWithSecureSettings),
+						},
+					},
+				),
+				ents: entsv1beta1.EnterpriseSearch{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "entsearch-sample"},
+				},
+			},
+			assertion: func(t *testing.T, got *settings.CanonicalConfig, err error) {
+				expectedSettings := settings.MustCanonicalConfig(map[string]interface{}{
+					SecretSessionKey:  "alreadysetsessionkey",
+					EncryptionKeysKey: []string{"alreadysetencryptionkey1", "alreadysetencryptionkey2"},
+				})
+				assert.Equal(t, expectedSettings, got)
+			},
+		},
+		{
+			name: "Do not override existing encryption keys, create missing session key",
+			args: args{
+				c: k8s.WrappedFakeClient(
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "entsearch-sample-ents-config"},
+						Data: map[string][]byte{
+							ConfigFilename: []byte(existingConfig),
+						},
+					},
+				),
+				ents: entsv1beta1.EnterpriseSearch{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "entsearch-sample"},
+				},
+			},
+			assertion: func(t *testing.T, got *settings.CanonicalConfig, err error) {
+				// Unpack the configuration to check that some default secure settings have been generated
+				var e enterpriseSearchSecrets
+				assert.NoError(t, got.Unpack(&e))
+				assert.Equal(t, len(e.EncryptionKeysKey), 1)     // We set 1 encryption key by default
+				assert.Equal(t, len(e.EncryptionKeysKey[0]), 32) // encryption key length should be 32
+				assert.Equal(t, len(e.SecretSessionKey), 32)     // session key length should be 24
+			},
+		},
+		{
+			name: "Create missing keys",
+			args: args{
+				c: k8s.WrappedFakeClient(
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "entsearch-sample-ents-config"},
+						Data: map[string][]byte{
+							ConfigFilename: []byte(existingConfig),
+						},
+					},
+				),
+				ents: entsv1beta1.EnterpriseSearch{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "entsearch-sample"},
+				},
+			},
+			assertion: func(t *testing.T, got *settings.CanonicalConfig, err error) {
+				// Unpack the configuration to check that some default secure settings have been generated
+				var e enterpriseSearchSecrets
+				assert.NoError(t, got.Unpack(&e))
+				assert.Equal(t, len(e.EncryptionKeysKey), 1)     // We set 1 encryption key by default
+				assert.Equal(t, len(e.EncryptionKeysKey[0]), 32) // encryption key length should be 32
+				assert.Equal(t, len(e.SecretSessionKey), 32)     // session key length should be 32
+			},
+		},
+		{
+			name: "No configuration to reuse",
+			args: args{
+				c: k8s.WrappedFakeClient(),
+				ents: entsv1beta1.EnterpriseSearch{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "entsearch-sample"},
+				},
+			},
+			assertion: func(t *testing.T, got *settings.CanonicalConfig, err error) {
+				// Unpack the configuration to check that some default secure settings have been generated
+				var e enterpriseSearchSecrets
+				assert.NoError(t, got.Unpack(&e))
+				assert.Equal(t, len(e.EncryptionKeysKey), 1)     // We set 1 encryption key by default
+				assert.Equal(t, len(e.EncryptionKeysKey[0]), 32) // encryption key length should be 32
+				assert.Equal(t, len(e.SecretSessionKey), 32)     // session key length should be 32
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := reuseOrGenerateSecretKeys(tt.args.c, tt.args.ents)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("reuseOrGenerateSecretKeys() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			tt.assertion(t, got, err)
+		})
+	}
+}

--- a/pkg/controller/enterprisesearch/fixtures.go
+++ b/pkg/controller/enterprisesearch/fixtures.go
@@ -25,7 +25,7 @@ ent_search:
     key: /mnt/elastic-internal/http-certs/tls.key
 `
 
-var existingConfigWithSecureSettings = existingConfig +
+var existingConfigWithReusableSettings = existingConfig +
 	`secret_management:
   encryption_keys:
   - alreadysetencryptionkey1

--- a/pkg/controller/enterprisesearch/fixtures.go
+++ b/pkg/controller/enterprisesearch/fixtures.go
@@ -1,0 +1,34 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package enterprisesearch
+
+var existingConfig = `allow_es_settings_modification: true
+elasticsearch:
+  host: https://mycluster-es-http.default.svc:9200
+  password: sc4q5cx8h88ghn7c5zq8wj4s
+  ssl:
+    certificate_authority: /mnt/elastic-internal/es-certs/tls.crt
+    enabled: true
+  username: default-entsearch-sample-entsearch-es-user
+ent_search:
+  auth:
+    source: elasticsearch-native
+  external_url: https://localhost:3002
+  listen_host: 0.0.0.0
+  ssl:
+    certificate: /mnt/elastic-internal/http-certs/tls.crt
+    certificate_authorities:
+    - /mnt/elastic-internal/http-certs/ca.crt
+    enabled: true
+    key: /mnt/elastic-internal/http-certs/tls.key
+`
+
+var existingConfigWithSecureSettings = existingConfig +
+	`secret_management:
+  encryption_keys:
+  - alreadysetencryptionkey1
+  - alreadysetencryptionkey2
+secret_session_key: alreadysetsessionkey
+`

--- a/pkg/controller/enterprisesearch/name/name.go
+++ b/pkg/controller/enterprisesearch/name/name.go
@@ -11,7 +11,6 @@ import (
 const (
 	httpServiceSuffix = "http"
 	configSuffix      = "config"
-	userSuffix        = "user"
 	deploymentSuffix  = "server"
 )
 
@@ -29,8 +28,4 @@ func Deployment(entsName string) string {
 
 func Config(entsName string) string {
 	return EntSearchNamer.Suffix(entsName, configSuffix)
-}
-
-func DefaultUser(entsName string) string {
-	return EntSearchNamer.Suffix(entsName, userSuffix)
 }


### PR DESCRIPTION
This PR ensures that the following keys are set, either reused from the current configuration or generated, in the Enterprise Search configuration:

* secret_session_key
* secret_management.encryption_keys