### PR TITLE
Retry entire cleanup pipeline on failure

### DIFF
--- a/.ci/pipelines/cleanup-gke.Jenkinsfile
+++ b/.ci/pipelines/cleanup-gke.Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
 
     options {
         timeout(time: 30, unit: 'MINUTES')
+        retry(3)
     }
 
     environment {


### PR DESCRIPTION
Test environments and related resources are not deleted when the cleanup pipeline fails. It is a pretty simple pipeline on which adding the `retry` option should improve the situation.