### PR TITLE
Label e2e runner, operator and stack pods for log correlation

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -21,7 +21,7 @@ VAULT_TOKEN = $(shell vault write -address=$(VAULT_ADDR) -field=token auth/appro
 else
 VAULT_TOKEN = $(shell vault write -address=$(VAULT_ADDR) -field=token auth/github/login token=$(GITHUB_TOKEN))
 # we use roleId as a string that has to be there for authn/z for CI, but it's empty and not needed for local execution
-NOT_USED := $(shell test -e $(ROOT_DIR)/deployer-config.yml && sed "s;roleId:.*;token: $(GITHUB_TOKEN);g" $(ROOT_DIR)/deployer-config.yml > tmp && mv tmp deployer-config.yml)
+NOT_USED := $(shell test -e $(ROOT_DIR)/deployer-config.yml && sed "s;roleId:.*;token: $(GITHUB_TOKEN);g" $(ROOT_DIR)/deployer-config.yml > tmp && mv tmp $(ROOT_DIR)/deployer-config.yml)
 endif
 endif
 

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -46,6 +46,12 @@ MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secr
 
 OPERATOR_IMAGE = $JKS_PARAM_OPERATOR_IMAGE
 TEST_TIMEOUT = 10m
+
+PIPELINE=e2e/aks
+BUILD_NUMBER=$BUILD_NUMBER
+E2E_PROVIDER=aks
+CLUSTER_NAME=$BUILD_TAG
+KUBERNETES_VERSION=default
 ENV
 write_deployer_config <<CFG
 id: aks-ci
@@ -73,6 +79,12 @@ TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
 
 OPERATOR_IMAGE = $JKS_PARAM_OPERATOR_IMAGE
+
+PIPELINE=e2e/custom-operator-image
+BUILD_NUMBER=$BUILD_NUMBER
+E2E_PROVIDER=gke
+CLUSTER_NAME=eck-e2e-$BUILD_NUMBER
+KUBERNETES_VERSION=$JKS_PARAM_K8S_VERSION
 ENV
 write_deployer_config <<CFG
 id: gke-ci
@@ -106,6 +118,12 @@ TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
 
 OPERATOR_IMAGE = $JKS_PARAM_OPERATOR_IMAGE
+
+PIPELINE=e2e/gke-k8s-versions
+BUILD_NUMBER=$BUILD_NUMBER
+E2E_PROVIDER=gke
+CLUSTER_NAME=${clusterName}
+KUBERNETES_VERSION="${clusterVersion}"
 ENV
 write_deployer_config <<CFG
 id: gke-ci
@@ -140,6 +158,12 @@ MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secr
 
 OPERATOR_IMAGE = $JKS_PARAM_OPERATOR_IMAGE
 KIND_NODE_IMAGE = ${kindNodeImage}
+
+PIPELINE=e2e/kind-k8s-versions
+BUILD_NUMBER=$BUILD_NUMBER
+E2E_PROVIDER=kind
+CLUSTER_NAME=kind-$BUILD_NUMBER
+KUBERNETES_VERSION=default
 ENV
 ;;
 
@@ -156,6 +180,12 @@ GO_TAGS = release
 export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/.ci/license.key
 TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
+
+PIPELINE=e2e/master
+BUILD_NUMBER=$BUILD_NUMBER
+E2E_PROVIDER=gke
+CLUSTER_NAME=eck-e2e-$BUILD_NUMBER
+KUBERNETES_VERSION=default
 ENV
 write_deployer_config <<CFG
 id: gke-ci
@@ -186,6 +216,12 @@ MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secr
 
 OPERATOR_IMAGE = $JKS_PARAM_OPERATOR_IMAGE
 TEST_TIMEOUT = 10m
+
+PIPELINE=e2e/ocp
+BUILD_NUMBER=$BUILD_NUMBER
+E2E_PROVIDER=ocp
+CLUSTER_NAME=$BUILD_TAG
+KUBERNETES_VERSION=default
 ENV
 write_deployer_config <<CFG
 id: ocp-ci
@@ -219,6 +255,12 @@ MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secr
 
 OPERATOR_IMAGE = ${operatorImage}
 STACK_VERSION = ${stackVersion}
+
+PIPELINE=e2e/stack-versions
+BUILD_NUMBER=$BUILD_NUMBER
+E2E_PROVIDER=gke
+CLUSTER_NAME=${clusterName}
+KUBERNETES_VERSION=default
 ENV
 write_deployer_config <<CFG
 id: gke-ci
@@ -246,6 +288,11 @@ IMG_SUFFIX = -ci
 TESTS_MATCH = TestSmoke
 MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
 
+PIPELINE=pr
+BUILD_NUMBER=$BUILD_NUMBER
+E2E_PROVIDER=gke
+CLUSTER_NAME=eck-pr-$BUILD_NUMBER
+KUBERNETES_VERSION=default
 ENV
 write_deployer_config <<CFG
 id: gke-ci
@@ -288,7 +335,6 @@ IMG_NAME = eck-operator
 
 GO_TAGS = release
 export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/.ci/license.key
-MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
 
 ELASTIC_DOCKER_LOGIN = eckadmin
 

--- a/Makefile
+++ b/Makefile
@@ -379,6 +379,11 @@ e2e-run:
 		--log-verbosity=$(LOG_VERBOSITY) \
 		--log-to-file=$(E2E_JSON) \
 		--test-timeout=$(TEST_TIMEOUT) \
+		--pipeline=$(PIPELINE) \
+		--build-number=$(BUILD_NUMBER) \
+		--provider=$(E2E_PROVIDER) \
+		--clusterName=$(CLUSTER_NAME) \
+		--kubernetes-version=$(KUBERNETES_VERSION) \
 		--monitoring-secrets=$(MONITORING_SECRETS)
 
 e2e-generate-xml:

--- a/config/e2e/filebeat.yaml
+++ b/config/e2e/filebeat.yaml
@@ -13,10 +13,39 @@ data:
         - type: kubernetes
           host: ${NODE_NAME}
           hints.enabled: true
-          hints.default_config:
-            type: container
-            paths:
+          templates:
+          - config:
+            - type: container
+              paths:
               - /var/log/containers/*${data.kubernetes.container.id}.log
+              fields_under_root: true
+              fields:
+                pipeline: {{ .Pipeline }}
+                build_number: {{ .BuildNumber }}
+                provider: {{ .Provider }}
+                clusterName: {{ .ClusterName }}
+                kubernetes_version: {{ .KubernetesVersion }}
+                stack_version: {{ .ElasticStackVersion }}
+                e2e_test_id: {{ .Pipeline }}-{{ .BuildNumber }}-{{ .Provider }}-{{ .ClusterName }}-{{ .KubernetesVersion }}-{{ .ElasticStackVersion }}
+          appenders:
+          - type: config
+            condition:
+              equals:
+                kubernetes.pod.labels.control-plane: {{ .Operator.Name }}
+            config:
+              json.keys_under_root: true
+              processors:
+              - convert:
+                  mode: rename
+                  ignore_missing: true
+                  fields:
+                  - { from: error, to: _error}
+                  - { from: source, to: event.source }
+              - convert:
+                  mode: rename
+                  ignore_missing: true
+                  fields:
+                  - { from: _error, to: error.message }
 
     processors:
       - add_cloud_metadata:

--- a/config/e2e/operator.yaml
+++ b/config/e2e/operator.yaml
@@ -168,10 +168,13 @@ spec:
   serviceName: {{ .Operator.Name }}
   template:
     metadata:
+      # if monitoring secrets are specified, filebeat is deployed and provides the below configuration
+      {{ if not .MonitoringSecrets }}
       annotations:
         # Rename the fields "error" to "error.message" and "source" to "event.source"
         # This is to avoid a conflict with the ECS "error" and "source" documents.
         "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
+      {{end}}
       labels:
         control-plane: {{ .Operator.Name }}
         test-run: {{ .TestRun }}

--- a/test/e2e/cmd/run/command.go
+++ b/test/e2e/cmd/run/command.go
@@ -40,6 +40,11 @@ type runFlags struct {
 	ignoreWebhookFailures bool
 	logVerbosity          int
 	testTimeout           time.Duration
+	pipeline              string
+	buildNumber           string
+	provider              string
+	clusterName           string
+	kubernetesVersion     string
 }
 
 var log logr.Logger
@@ -81,6 +86,11 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&flags.testRegex, "test-regex", "", "Regex to pass to the test runner")
 	cmd.Flags().StringVar(&flags.testRunName, "test-run-name", randomTestRunName(), "Name of this test run")
 	cmd.Flags().DurationVar(&flags.testTimeout, "test-timeout", 5*time.Minute, "Timeout before failing a test")
+	cmd.Flags().StringVar(&flags.pipeline, "pipeline", "", "E2E test pipeline name")
+	cmd.Flags().StringVar(&flags.buildNumber, "build-number", "", "E2E test build number")
+	cmd.Flags().StringVar(&flags.provider, "provider", "", "E2E test infrastructure provider")
+	cmd.Flags().StringVar(&flags.clusterName, "clusterName", "", "E2E test Kubernetes cluster name")
+	cmd.Flags().StringVar(&flags.kubernetesVersion, "kubernetes-version", "", "Kubernetes version")
 	cmd.Flags().BoolVar(&flags.logToFile, "log-to-file", false, "Specifies if should log test output to file. Disabled by default.")
 	cmd.Flags().BoolVar(&flags.ignoreWebhookFailures, "ignore-webhook-failures", false, "Specifies if webhook errors should be ignored. Useful when running test locally. False by default")
 	logutil.BindFlags(cmd.PersistentFlags())

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -36,6 +36,8 @@ const (
 	logBufferSize    = 1024              // Size of the log buffer (1KiB)
 	testRunLabel     = "test-run"        // name of the label applied to resources
 	testsLogFile     = "e2e-tests.json"  // name of file to keep all test logs in JSON format
+
+	TestNameLabel = "test-name" // name of the label applied to resources during each test
 )
 
 type stepFunc func() error
@@ -143,6 +145,11 @@ func (h *helper) initTestContext() error {
 		TestRegex:             h.testRegex,
 		TestRun:               h.testRunName,
 		TestTimeout:           h.testTimeout,
+		Pipeline:              h.pipeline,
+		BuildNumber:           h.buildNumber,
+		Provider:              h.provider,
+		ClusterName:           h.clusterName,
+		KubernetesVersion:     h.kubernetesVersion,
 		IgnoreWebhookFailures: h.ignoreWebhookFailures,
 		OcpCluster:            h.kubectl("get", "clusterversion") == nil,
 	}

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/apmserver"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
@@ -36,16 +37,21 @@ func TestSmoke(t *testing.T) {
 
 	ns := test.Ctx().ManagedNamespace(0)
 	randSuffix := rand.String(4)
+	testName := "TestSmoke"
 	esBuilder = esBuilder.
 		WithSuffix(randSuffix).
 		WithNamespace(ns).
 		WithRestrictedSecurityContext().
-		WithDefaultPersistentVolumes()
+		WithDefaultPersistentVolumes().
+		WithLabel(run.TestNameLabel, testName).
+		WithPodLabel(run.TestNameLabel, testName)
 	kbBuilder = kbBuilder.
 		WithSuffix(randSuffix).
 		WithNamespace(ns).
 		WithElasticsearchRef(esBuilder.Ref()).
-		WithRestrictedSecurityContext()
+		WithRestrictedSecurityContext().
+		WithLabel(run.TestNameLabel, testName).
+		WithPodLabel(run.TestNameLabel, testName)
 	apmBuilder = apmBuilder.
 		WithSuffix(randSuffix).
 		WithNamespace(ns).
@@ -53,7 +59,9 @@ func TestSmoke(t *testing.T) {
 		WithConfig(map[string]interface{}{
 			"apm-server.ilm.enabled": false,
 		}).
-		WithRestrictedSecurityContext()
+		WithRestrictedSecurityContext().
+		WithLabel(run.TestNameLabel, testName).
+		WithPodLabel(run.TestNameLabel, testName)
 
 	test.Sequence(nil, test.EmptySteps, esBuilder, kbBuilder, apmBuilder).
 		RunSequential(t)

--- a/test/e2e/test/apmserver/builder.go
+++ b/test/e2e/test/apmserver/builder.go
@@ -7,6 +7,7 @@ package apmserver
 import (
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,7 +64,10 @@ func newBuilder(name, randSuffix string) Builder {
 				},
 			},
 		},
-	}.WithSuffix(randSuffix)
+	}.
+		WithSuffix(randSuffix).
+		WithLabel(run.TestNameLabel, name).
+		WithPodLabel(run.TestNameLabel, name)
 }
 
 func (b Builder) WithSuffix(suffix string) Builder {
@@ -122,6 +126,27 @@ func (b Builder) WithRUM(enabled bool) Builder {
 
 func (b Builder) WithHTTPCfg(cfg commonv1.HTTPConfig) Builder {
 	b.ApmServer.Spec.HTTP = cfg
+	return b
+}
+
+func (b Builder) WithLabel(key, value string) Builder {
+	if b.ApmServer.Labels == nil {
+		b.ApmServer.Labels = make(map[string]string)
+	}
+	b.ApmServer.Labels[key] = value
+
+	return b
+}
+
+// WithPodLabel sets the label in the pod template. All invocations can be removed when
+// https://github.com/elastic/cloud-on-k8s/issues/2652 is implemented.
+func (b Builder) WithPodLabel(key, value string) Builder {
+	labels := b.ApmServer.Spec.PodTemplate.Labels
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[key] = value
+	b.ApmServer.Spec.PodTemplate.Labels = labels
 	return b
 }
 

--- a/test/e2e/test/apmserver/steps_init.go
+++ b/test/e2e/test/apmserver/steps_init.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
+	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -24,7 +25,17 @@ func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
 				require.NoError(t, err)
 			},
 		},
-
+		{
+			Name: "Label test pods",
+			Test: func(t *testing.T) {
+				err := test.LabelTestPods(
+					k.Client,
+					test.Ctx(),
+					run.TestNameLabel,
+					b.ApmServer.Labels[run.TestNameLabel])
+				require.NoError(t, err)
+			},
+		},
 		{
 			Name: "APM Server CRDs should exist",
 			Test: func(t *testing.T) {

--- a/test/e2e/test/apmserver/steps_init.go
+++ b/test/e2e/test/apmserver/steps_init.go
@@ -35,6 +35,9 @@ func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
 					b.ApmServer.Labels[run.TestNameLabel])
 				require.NoError(t, err)
 			},
+			Skip: func() bool {
+				return test.Ctx().Local
+			},
 		},
 		{
 			Name: "APM Server CRDs should exist",

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -94,6 +94,11 @@ type Context struct {
 	Local                 bool              `json:"local"`
 	IgnoreWebhookFailures bool              `json:"ignore_webhook_failures"`
 	OcpCluster            bool              `json:"ocp_cluster"`
+	Pipeline              string            `json:"pipeline"`
+	BuildNumber           string            `json:"build_number"`
+	Provider              string            `json:"provider"`
+	ClusterName           string            `json:"clusterName"`
+	KubernetesVersion     string            `json:"kubernetes_version"`
 }
 
 // ManagedNamespace returns the nth managed namespace.

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -332,7 +332,7 @@ func (b Builder) WithLabel(key, value string) Builder {
 	return b
 }
 
-// WithPodLabel sets the label in pod templates accross all node sets.
+// WithPodLabel sets the label in pod templates across all node sets.
 // All invocations can be removed when
 // https://github.com/elastic/cloud-on-k8s/issues/2652 is implemented.
 func (b Builder) WithPodLabel(key, value string) Builder {

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -7,6 +7,7 @@ package elasticsearch
 import (
 	"reflect"
 
+	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,7 +61,9 @@ func newBuilder(name, randSuffix string) Builder {
 	meta := metav1.ObjectMeta{
 		Name:      name,
 		Namespace: test.Ctx().ManagedNamespace(0),
+		Labels:    map[string]string{run.TestNameLabel: name},
 	}
+
 	return Builder{
 		Elasticsearch: esv1.Elasticsearch{
 			ObjectMeta: meta,
@@ -68,7 +71,9 @@ func newBuilder(name, randSuffix string) Builder {
 				Version: test.Ctx().ElasticStackVersion,
 			},
 		},
-	}.WithSuffix(randSuffix)
+	}.
+		WithSuffix(randSuffix).
+		WithLabel(run.TestNameLabel, name)
 }
 
 func (b Builder) WithSuffix(suffix string) Builder {
@@ -197,6 +202,14 @@ func (b Builder) WithNodeSet(nodeSet esv1.NodeSet) Builder {
 		nodeSet.Config = &commonv1.Config{Data: map[string]interface{}{}}
 	}
 	nodeSet.Config.Data["node.store.allow_mmap"] = false
+
+	// Propagates test-name label from top level resource.
+	// Can be removed when https://github.com/elastic/cloud-on-k8s/issues/2652 is implemented.
+	if nodeSet.PodTemplate.Labels == nil {
+		nodeSet.PodTemplate.Labels = map[string]string{}
+	}
+	nodeSet.PodTemplate.Labels[run.TestNameLabel] = b.Elasticsearch.Labels[run.TestNameLabel]
+
 	b.Elasticsearch.Spec.NodeSets = append(b.Elasticsearch.Spec.NodeSets, nodeSet)
 	return b.WithDefaultPersistentVolumes()
 }
@@ -263,6 +276,7 @@ func (b Builder) WithDefaultPersistentVolumes() Builder {
 
 func (b Builder) WithPodTemplate(pt corev1.PodTemplateSpec) Builder {
 	for i := range b.Elasticsearch.Spec.NodeSets {
+		pt.Labels[run.TestNameLabel] = b.Elasticsearch.Labels[run.TestNameLabel]
 		b.Elasticsearch.Spec.NodeSets[i].PodTemplate = pt
 	}
 	return b
@@ -309,6 +323,18 @@ func (b Builder) WithEnvironmentVariable(name, value string) Builder {
 	return b
 }
 
+func (b Builder) WithLabel(key, value string) Builder {
+	if b.Elasticsearch.Labels == nil {
+		b.Elasticsearch.Labels = make(map[string]string)
+	}
+	b.Elasticsearch.Labels[key] = value
+
+	return b
+}
+
+// WithPodLabel sets the label in pod templates accross all node sets.
+// All invocations can be removed when
+// https://github.com/elastic/cloud-on-k8s/issues/2652 is implemented.
 func (b Builder) WithPodLabel(key, value string) Builder {
 	for i := range b.Elasticsearch.Spec.NodeSets {
 		if b.Elasticsearch.Spec.NodeSets[i].PodTemplate.Labels == nil {

--- a/test/e2e/test/elasticsearch/steps_init.go
+++ b/test/e2e/test/elasticsearch/steps_init.go
@@ -42,6 +42,9 @@ func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
 					b.Elasticsearch.Labels[run.TestNameLabel])
 				require.NoError(t, err)
 			},
+			Skip: func() bool {
+				return test.Ctx().Local
+			},
 		},
 		{
 			Name: "Elasticsearch CRDs should exist",

--- a/test/e2e/test/elasticsearch/steps_init.go
+++ b/test/e2e/test/elasticsearch/steps_init.go
@@ -11,6 +11,7 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/webhook"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +29,17 @@ func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
 			Test: func(t *testing.T) {
 				pods := corev1.PodList{}
 				err := k.Client.List(&pods)
+				require.NoError(t, err)
+			},
+		},
+		{
+			Name: "Label test pods",
+			Test: func(t *testing.T) {
+				err := test.LabelTestPods(
+					k.Client,
+					test.Ctx(),
+					run.TestNameLabel,
+					b.Elasticsearch.Labels[run.TestNameLabel])
 				require.NoError(t, err)
 			},
 		},

--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -5,6 +5,7 @@
 package kibana
 
 import (
+	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -48,7 +49,10 @@ func newBuilder(name, randSuffix string) Builder {
 				},
 			},
 		},
-	}.WithSuffix(randSuffix)
+	}.
+		WithSuffix(randSuffix).
+		WithLabel(run.TestNameLabel, name).
+		WithPodLabel(run.TestNameLabel, name)
 }
 
 func (b Builder) WithSuffix(suffix string) Builder {
@@ -114,6 +118,17 @@ func (b Builder) WithMutatedFrom(mutatedFrom *Builder) Builder {
 }
 
 func (b Builder) WithLabel(key, value string) Builder {
+	if b.Kibana.Labels == nil {
+		b.Kibana.Labels = make(map[string]string)
+	}
+	b.Kibana.Labels[key] = value
+
+	return b
+}
+
+// WithPodLabel sets the label in the pod template. All invocations can be removed when
+// https://github.com/elastic/cloud-on-k8s/issues/2652 is implemented.
+func (b Builder) WithPodLabel(key, value string) Builder {
 	labels := b.Kibana.Spec.PodTemplate.Labels
 	if labels == nil {
 		labels = make(map[string]string)

--- a/test/e2e/test/kibana/steps_init.go
+++ b/test/e2e/test/kibana/steps_init.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -22,6 +23,17 @@ func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
 			Test: func(t *testing.T) {
 				pods := corev1.PodList{}
 				err := k.Client.List(&pods)
+				require.NoError(t, err)
+			},
+		},
+		{
+			Name: "Label test pods",
+			Test: func(t *testing.T) {
+				err := test.LabelTestPods(
+					k.Client,
+					test.Ctx(),
+					run.TestNameLabel,
+					b.Kibana.Labels[run.TestNameLabel])
 				require.NoError(t, err)
 			},
 		},

--- a/test/e2e/test/kibana/steps_init.go
+++ b/test/e2e/test/kibana/steps_init.go
@@ -36,6 +36,9 @@ func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
 					b.Kibana.Labels[run.TestNameLabel])
 				require.NoError(t, err)
 			},
+			Skip: func() bool {
+				return test.Ctx().Local
+			},
 		},
 		{
 			Name: "Kibana CRDs should exist",

--- a/test/e2e/test/utils.go
+++ b/test/e2e/test/utils.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -117,4 +118,58 @@ func ValidateBuilderHashAnnotation(pod corev1.Pod, hash string) error {
 		return fmt.Errorf("pod %s was not upgraded (yet?) to match the expected specification", pod.Name)
 	}
 	return nil
+}
+
+// LabelTestPods labels:
+// - operator pod,
+// - e2e runner pod (if running in cluster)
+func LabelTestPods(c k8s.Client, ctx Context, key, value string) error {
+	// label operator pod
+	if err := labelPod(
+		c,
+		ctx.Operator.Name+"-0",
+		ctx.Operator.Namespace,
+		key,
+		value); err != nil {
+		return err
+	}
+
+	// during local run there is no e2e test runner pod so we are done
+	if ctx.Local {
+		return nil
+	}
+
+	// find and label E2E test runner pod
+	podList := corev1.PodList{}
+	ns := client.InNamespace(ctx.E2ENamespace)
+	if err := c.List(&podList, ns); err != nil {
+		return err
+	}
+
+	for _, pod := range podList.Items {
+		if strings.HasPrefix(pod.Name, "eck-"+ctx.TestRun) {
+			return labelPod(
+				c,
+				pod.Name,
+				ctx.E2ENamespace,
+				key,
+				value)
+		}
+	}
+
+	return errors.New("e2e runner pod not found")
+
+}
+
+func labelPod(client k8s.Client, name, namespace, key, value string) error {
+	pod := corev1.Pod{}
+	if err := client.Get(types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}, &pod); err != nil {
+		return err
+	}
+
+	pod.Labels[key] = value
+	return client.Update(&pod)
 }

--- a/test/e2e/test/utils.go
+++ b/test/e2e/test/utils.go
@@ -122,7 +122,7 @@ func ValidateBuilderHashAnnotation(pod corev1.Pod, hash string) error {
 
 // LabelTestPods labels:
 // - operator pod,
-// - e2e runner pod (if running in cluster)
+// - e2e runner pod
 func LabelTestPods(c k8s.Client, ctx Context, key, value string) error {
 	// label operator pod
 	if err := labelPod(
@@ -132,11 +132,6 @@ func LabelTestPods(c k8s.Client, ctx Context, key, value string) error {
 		key,
 		value); err != nil {
 		return err
-	}
-
-	// during local run there is no e2e test runner pod so we are done
-	if ctx.Local {
-		return nil
 	}
 
 	// find and label E2E test runner pod


### PR DESCRIPTION
This PRs enables:
1. labeling operator pod, e2e test runner pod and stack pods with test name that is currently being ran. Note that while labels are added to stack pods on creation, e2e test runner and operator pods are relabelled during each test.
2. injecting additional correlation information (pipeline name, build number, infrastructure provider, k8s cluster name, k8s version, stack version) in each log.

These will allow to correlate each log with particular test in particular test run.


Note:
- Today, we use a raw autodiscovery annotation on the operator which prevents from appending any other config via other annotations or filebeat config, so for non-local e2e test runs raw annotation is not added now. Instead, filebeat config [adds needed config](https://github.com/elastic/cloud-on-k8s/compare/master...david-kow:labels_for_e2e?expand=1#diff-0a7b2591f7d2ce1f79d60ff9592eac71R30).
- Pods had to have labels added in multiple places:
  - when creating a Builder (Kibana/APM)
  - when adding node sets to a Builder (ES)
  - when setting PodTemplate (ES)
  - when not using Builder constructor (Smoke/Samples tests)

  Right now, both main resource and pods are labelled. Labelling pods can be removed when https://github.com/elastic/cloud-on-k8s/issues/2652 is implemented.

Resolves #2606.
