### PR TITLE
Rename registry field as it clashes with ECS

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -221,7 +221,7 @@ func execute() {
 
 	// set the default container registry
 	containerRegistry := viper.GetString(operator.ContainerRegistryFlag)
-	log.Info("Setting default container registry", "registry", containerRegistry)
+	log.Info("Setting default container registry", "container_registry", containerRegistry)
 	container.SetContainerRegistry(containerRegistry)
 
 	// Get a config to talk to the apiserver


### PR DESCRIPTION
Currently Filebeat will throw:

```json
{"type":"mapper_parsing_exception","reason":"object mapping for [registry] tried to parse field [registry] as object, but found a concrete value"}
```

as `registry` is [reserved](https://www.elastic.co/guide/en/ecs/current/ecs-registry.html) by ECS. 

Renaming this field to `container_registry`.

