### PR TITLE
Invoke common CI targets from a single target

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -60,6 +60,8 @@ ifneq (,$(IS_SNAPSHOT_BUILD))
        SECRET_FIELD_PREFIX ?= dev-
 endif
 
+get-test-artifacts: get-monitoring-secrets get-test-license get-elastic-public-key
+
 ##  Build
 
 # read Elastic public key from Vault into license.key, to build the operator for E2E tests or for a release

--- a/.ci/README.md
+++ b/.ci/README.md
@@ -28,7 +28,7 @@ Per repro, depending on the job, set up `.env` and `deployer-config.yml` files b
 Test the `cloud-on-k8s-e2e-tests-master` job:
 ```sh
 .ci/setenvconfig e2e/master
-make -C .ci get-monitoring-secrets get-test-license get-elastic-public-key TARGET=ci-build-operator-e2e-run ci
+make -C .ci get-test-artifacts TARGET=ci-build-operator-e2e-run ci
 ```
 
 Test the `cloud-on-k8s-e2e-tests-stack-versions` job:

--- a/.ci/pipelines/e2e-tests-aks.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-aks.Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
             steps {
                 sh '.ci/setenvconfig e2e/aks'
                 script {
-                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-monitoring-secrets get-test-license get-elastic-public-key TARGET=ci-e2e ci')
+                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-test-artifacts TARGET=ci-e2e ci')
 
                     sh 'make -C .ci TARGET=e2e-generate-xml ci'
                     junit "e2e-tests.xml"

--- a/.ci/pipelines/e2e-tests-custom-operator-image-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-custom-operator-image-gke.Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
             steps {
                 sh '.ci/setenvconfig e2e/custom-operator-image'
                 script {
-                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-monitoring-secrets get-test-license get-elastic-public-key TARGET=ci-e2e ci')
+                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-test-artifacts TARGET=ci-e2e ci')
 
                     sh 'make -C .ci TARGET=e2e-generate-xml ci'
                     junit "e2e-tests.xml"

--- a/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
@@ -90,7 +90,7 @@ pipeline {
 def runWith(lib, failedTests, clusterVersion, clusterName) {
     sh ".ci/setenvconfig e2e/gke-k8s-versions $clusterVersion $clusterName"
     script {
-        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-monitoring-secrets get-test-license get-elastic-public-key TARGET=ci-e2e ci')
+        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-test-artifacts TARGET=ci-e2e ci')
 
         sh 'make -C .ci TARGET=e2e-generate-xml ci'
         junit "e2e-tests.xml"

--- a/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
 def runTests(lib, failedTests, kindNodeImage) {
     sh ".ci/setenvconfig e2e/kind-k8s-versions $kindNodeImage"
     script {
-        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-monitoring-secrets get-test-license get-elastic-public-key TARGET=kind-e2e ci')
+        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-test-artifacts TARGET=kind-e2e ci')
 
         sh 'make -C .ci TARGET=e2e-generate-xml ci'
         junit "e2e-tests.xml"

--- a/.ci/pipelines/e2e-tests-master-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-master-gke.Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
             steps {
                 sh '.ci/setenvconfig e2e/master'
                 script {
-                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-monitoring-secrets get-test-license get-elastic-public-key TARGET=ci-build-operator-e2e-run ci')
+                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-test-artifacts TARGET=ci-build-operator-e2e-run ci')
 
                     sh 'make -C .ci TARGET=e2e-generate-xml ci'
                     junit "e2e-tests.xml"

--- a/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
             steps {
                 sh '.ci/setenvconfig e2e/ocp'
                 script {
-                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-monitoring-secrets get-test-license get-elastic-public-key TARGET=ci-e2e ci')
+                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-test-artifacts TARGET=ci-e2e ci')
 
                     sh 'make -C .ci TARGET=e2e-generate-xml ci'
                     junit "e2e-tests.xml"

--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -121,7 +121,7 @@ pipeline {
 def runWith(lib, failedTests, clusterName, stackVersion) {
     sh ".ci/setenvconfig e2e/stack-versions $clusterName $stackVersion"
     script {
-        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: "make -C .ci get-monitoring-secrets get-test-license get-elastic-public-key TARGET=ci-e2e ci")
+        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: "make -C .ci get-test-artifacts TARGET=ci-e2e ci")
 
         sh 'make -C .ci TARGET=e2e-generate-xml ci'
         junit "e2e-tests.xml"

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -155,7 +155,7 @@ pipeline {
 def runWith(lib, failedTests, clusterName, stackVersion) {
     sh ".ci/setenvconfig e2e/stack-versions $clusterName $stackVersion"
     script {
-        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: "make -C .ci get-monitoring-secrets get-test-license get-elastic-public-key TARGET=ci-e2e ci")
+        env.SHELL_EXIT_CODE = sh(returnStatus: true, script: "make -C .ci get-test-artifacts TARGET=ci-e2e ci")
 
         sh 'make -C .ci TARGET=e2e-generate-xml ci'
         junit "e2e-tests.xml"


### PR DESCRIPTION
Follow up to a comment from https://github.com/elastic/cloud-on-k8s/pull/2728#pullrequestreview-377681715. I'd be happy to change `get-test-artifacts` to something better if anyone has ideas.