### PR TITLE
CI failfast

### DIFF
--- a/.ci/pipelines/pr-gke.Jenkinsfile
+++ b/.ci/pipelines/pr-gke.Jenkinsfile
@@ -6,7 +6,6 @@ pipeline {
 
     options {
         timeout(time: 45, unit: 'MINUTES')
-        skipDefaultCheckout()
         skipStagesAfterUnstable()
     }
 
@@ -18,7 +17,11 @@ pipeline {
     }
 
     stages {
+        stage('Stash source code') {
+            stash name: "eck-source"
+        }
         stage('Validate Jenkins pipelines') {
+            unstash "eck-source"
             when {
                 expression {
                     notOnlyDocs()
@@ -29,6 +32,7 @@ pipeline {
             }
         }
         stage('Run checks') {
+            unstash "eck-source"
             when {
                 expression {
                     notOnlyDocs()
@@ -42,6 +46,7 @@ pipeline {
             failFast true
             parallel {
                 stage("Run unit and integration tests") {
+                    unstash "eck-source"
                     when {
                         expression {
                             notOnlyDocs()
@@ -62,6 +67,7 @@ pipeline {
                     }
                 }
                 stage("Run smoke E2E tests") {
+                    unstash "eck-source"
                     when {
                         expression {
                             notOnlyDocs()

--- a/.ci/pipelines/pr-gke.Jenkinsfile
+++ b/.ci/pipelines/pr-gke.Jenkinsfile
@@ -35,7 +35,6 @@ pipeline {
             }
             steps {
                 sh 'make -C .ci TARGET=ci-check ci'
-                stash name: "eck-source"
             }
         }
         stage('Run tests in parallel') {
@@ -44,14 +43,14 @@ pipeline {
                 stage("Run unit and integration tests") {
                     when {
                         expression {
+                            retry(3) {
+                                checkout scm
+                            }
                             notOnlyDocs()
                         }
                     }
                     agent {
-                        node {
-                            label 'linux'
-                            unstash "eck-source"
-                        }
+                        label 'linux'
                     }
                     steps {
                         script {

--- a/.ci/pipelines/pr-gke.Jenkinsfile
+++ b/.ci/pipelines/pr-gke.Jenkinsfile
@@ -17,11 +17,7 @@ pipeline {
     }
 
     stages {
-        stage('Stash source code') {
-            stash name: "eck-source"
-        }
         stage('Validate Jenkins pipelines') {
-            unstash "eck-source"
             when {
                 expression {
                     notOnlyDocs()
@@ -32,7 +28,6 @@ pipeline {
             }
         }
         stage('Run checks') {
-            unstash "eck-source"
             when {
                 expression {
                     notOnlyDocs()
@@ -40,13 +35,16 @@ pipeline {
             }
             steps {
                 sh 'make -C .ci TARGET=ci-check ci'
+                stash name: "eck-source"
             }
         }
         stage('Run tests in parallel') {
             failFast true
             parallel {
                 stage("Run unit and integration tests") {
-                    unstash "eck-source"
+                    node {
+                        unstash "eck-source"
+                    }
                     when {
                         expression {
                             notOnlyDocs()
@@ -67,7 +65,9 @@ pipeline {
                     }
                 }
                 stage("Run smoke E2E tests") {
-                    unstash "eck-source"
+                    node {
+                        unstash "eck-source"
+                    }
                     when {
                         expression {
                             notOnlyDocs()

--- a/.ci/pipelines/pr-gke.Jenkinsfile
+++ b/.ci/pipelines/pr-gke.Jenkinsfile
@@ -37,11 +37,11 @@ pipeline {
             }
         }
         stage('Run tests in parallel') {
+            failFast true
             parallel {
                 stage("Run unit and integration tests") {
                     when {
                         expression {
-                            checkout scm
                             notOnlyDocs()
                         }
                     }
@@ -62,7 +62,6 @@ pipeline {
                 stage("Run smoke E2E tests") {
                     when {
                         expression {
-                            checkout scm
                             notOnlyDocs()
                         }
                     }

--- a/.ci/pipelines/pr-gke.Jenkinsfile
+++ b/.ci/pipelines/pr-gke.Jenkinsfile
@@ -42,16 +42,16 @@ pipeline {
             failFast true
             parallel {
                 stage("Run unit and integration tests") {
-                    node {
-                        unstash "eck-source"
-                    }
                     when {
                         expression {
                             notOnlyDocs()
                         }
                     }
                     agent {
-                        label 'linux'
+                        node {
+                            label 'linux'
+                            unstash "eck-source"
+                        }
                     }
                     steps {
                         script {

--- a/.ci/pipelines/pr-gke.Jenkinsfile
+++ b/.ci/pipelines/pr-gke.Jenkinsfile
@@ -6,6 +6,8 @@ pipeline {
 
     options {
         timeout(time: 45, unit: 'MINUTES')
+        skipDefaultCheckout()
+        skipStagesAfterUnstable()
     }
 
     environment {

--- a/.ci/pipelines/pr-gke.Jenkinsfile
+++ b/.ci/pipelines/pr-gke.Jenkinsfile
@@ -65,9 +65,6 @@ pipeline {
                     }
                 }
                 stage("Run smoke E2E tests") {
-                    node {
-                        unstash "eck-source"
-                    }
                     when {
                         expression {
                             notOnlyDocs()


### PR DESCRIPTION
- Test to see if explicit `checkout scm` is necessary and whether we could use `stash/unstash` instead.
- Fail-fast if any of the parallel stages fail.
