### PR TITLE
License check: update remote cluster logs and events

### DIFF
--- a/pkg/controller/elasticsearch/remotecluster/elasticsearch.go
+++ b/pkg/controller/elasticsearch/remotecluster/elasticsearch.go
@@ -36,11 +36,12 @@ func UpdateSettings(
 	span, _ := apm.StartSpan(ctx, "update_remote_clusters", tracing.SpanTypeApp)
 	defer span.End()
 
+	expectedRemoteClusters := getExpectedRemoteClusters(es)
 	enabled, err := licenseChecker.EnterpriseFeaturesEnabled()
 	if err != nil {
 		return err
 	}
-	if !enabled {
+	if !enabled && len(expectedRemoteClusters) > 0 {
 		log.Info(
 			enterpriseFeaturesDisabledMsg,
 			"namespace", es.Namespace, "es_name", es.Name,
@@ -53,7 +54,6 @@ func UpdateSettings(
 	if err != nil {
 		return err
 	}
-	expectedRemoteClusters := getExpectedRemoteClusters(es)
 
 	remoteClusters := make(map[string]esclient.RemoteCluster)
 	// RemoteClusters to add or update


### PR DESCRIPTION
Fixes #2738 

Note that with this PR remote clusters can be removed even if the license is no more valid. It allows the user to gently clean up the resources even if the trial has expired for example. 