### PR TITLE
Clarify documentation about ECK support and licensing

### DIFF
--- a/docs/operating-eck/licensing.asciidoc
+++ b/docs/operating-eck/licensing.asciidoc
@@ -9,7 +9,7 @@ endif::[]
 
 When you install the default distribution of ECK, you receive a Basic license. Any Elastic stack application you manage through ECK will also be Basic licensed. Go to https://www.elastic.co/subscriptions to see which features are included in the Basic license for free.
 
-IMPORTANT: ECK is only offered in two licensing tiers: Basic and Enterprise. Similar to the Elastic Stack, customers are able to download and use ECK with a Basic license for free. Basic license users can avail of support from GitHub or through our link:https://discuss.elastic.co[community]. A paid Enterprise subscription is required to engage the Elastic support team. For more detail on Enterprise subscriptions, see link:https://www.elastic.co/subscriptions[here].
+IMPORTANT: ECK is only offered in two licensing tiers: Basic and Enterprise. Similar to the Elastic Stack, customers are able to download and use ECK with a Basic license for free. Basic license users can avail of support from GitHub or through our link:https://discuss.elastic.co[community]. A paid Enterprise subscription is required to engage the Elastic support team. For more details, see the link:https://www.elastic.co/subscriptions[Elastic subscriptions].
 
 [float]
 == Start a trial

--- a/docs/operating-eck/licensing.asciidoc
+++ b/docs/operating-eck/licensing.asciidoc
@@ -9,7 +9,7 @@ endif::[]
 
 When you install the default distribution of ECK, you receive a Basic license. Any Elastic stack application you manage through ECK will also be Basic licensed. Go to https://www.elastic.co/subscriptions to see which features are included in the Basic license for free.
 
-IMPORTANT: ECK is only offered in two licensing tiers: Basic and Enterprise. Similar to the Elastic Stack, customers are able to download and use ECK with a basic license for free. Basic license users can avail of support from Github or through our link:https://discuss.elastic.co[community]. A paid enterprise subscription is required to engage the elastic support team. For more detail on enterprise subscriptions, see link:https://www.elastic.co/subscriptions[here].
+IMPORTANT: ECK is only offered in two licensing tiers: Basic and Enterprise. Similar to the Elastic Stack, customers are able to download and use ECK with a Basic license for free. Basic license users can avail of support from GitHub or through our link:https://discuss.elastic.co[community]. A paid Enterprise subscription is required to engage the Elastic support team. For more detail on Enterprise subscriptions, see link:https://www.elastic.co/subscriptions[here].
 
 [float]
 == Start a trial

--- a/docs/operating-eck/licensing.asciidoc
+++ b/docs/operating-eck/licensing.asciidoc
@@ -9,6 +9,8 @@ endif::[]
 
 When you install the default distribution of ECK, you receive a Basic license. Any Elastic stack application you manage through ECK will also be Basic licensed. Go to https://www.elastic.co/subscriptions to see which features are included in the Basic license for free.
 
+IMPORTANT: ECK is offered in two licensing tiers only: Basic and Enterprise. Similar to the Elastic Stack, customers can download and use ECK for free, but a subscription is required for support. ECK support requires an Enterprise subscription.
+
 [float]
 == Start a trial
 If you want to try the features included in the Enterprise subscription, you can start a 30-day trial. To start a trial create a Kubernetes secret as shown below. Note that it must be in the same namespace as the operator:

--- a/docs/operating-eck/licensing.asciidoc
+++ b/docs/operating-eck/licensing.asciidoc
@@ -9,7 +9,7 @@ endif::[]
 
 When you install the default distribution of ECK, you receive a Basic license. Any Elastic stack application you manage through ECK will also be Basic licensed. Go to https://www.elastic.co/subscriptions to see which features are included in the Basic license for free.
 
-IMPORTANT: ECK is offered in two licensing tiers only: Basic and Enterprise. Similar to the Elastic Stack, customers can download and use ECK for free, but a subscription is required for support. ECK support requires an Enterprise subscription.
+IMPORTANT: ECK is only offered in two licensing tiers: Basic and Enterprise. Similar to the Elastic Stack, customers are able to download and use ECK with a basic license for free. Basic license users can avail of support from Github or through our link:https://discuss.elastic.co[community]. A paid enterprise subscription is required to engage the elastic support team. For more detail on enterprise subscriptions, see link:https://www.elastic.co/subscriptions[here].
 
 [float]
 == Start a trial


### PR DESCRIPTION
Added the following clarification regarding licensing for ECK as we are getting a significant numbers of cases from Gold/Platinum customers asking for support on ECK. ECK support is only available to Enterprise customers.

IMPORTANT: ECK is offered in two licensing tiers only: basic and enterprise. Similar to the Elastic Stack today, customers can download and use ECK for free but a subscription is required for support. ECK support requires an Enterprise subscription.

Taken from: https://github.com/elastic/cloud-on-k8s/pull/2684

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/master/CONTRIBUTING.md)?
- If you submit code, is your pull request against master? We recommend pull requests against master. We will backport them as needed.
