### PR TITLE
Fix TestMutationHTTPToHTTPS and TestMutationHTTPSToHTTP test builders

### DIFF
--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -32,7 +32,7 @@ func TestMutationHTTPToHTTPS(t *testing.T) {
 	// mutate to https
 	mutated := b.WithTLSDisabled(false)
 
-	test.RunMutation(t, b, mutated)
+	RunESMutation(t, b, mutated)
 }
 
 // TestMutationHTTPSToHTTP creates a 3 node cluster
@@ -45,7 +45,7 @@ func TestMutationHTTPSToHTTP(t *testing.T) {
 	// mutate to http
 	mutated := b.WithTLSDisabled(true)
 
-	test.RunMutation(t, b, mutated)
+	RunESMutation(t, b, mutated)
 }
 
 // TestMdiToDedicatedMutation creates a 1 master + data cluster,


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/2745.

Our mutation test logic relies on computing a hash of the existing Pod
and comparing it with the hash of mutated Pods.
This only works fine if builder.MutatedFrom is correctly set, which is
done in `RunESMutation()`.

Because this function was not used in the 2 tests, the hash comparison
was not correct. Leading the test to finish successfully before the mutation
was complete (or even started).

This highlights how our e2e test builder framework is quite brittle...