### PR TITLE
Fix red cluster healh reported on tls toggle e2e test

### DIFF
--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -333,7 +333,7 @@ func (b Builder) TriggersRollingUpgrade() bool {
 	// Important: this only checks ES version and spec, other changes such as secure settings update
 	// are tricky to capture and ignored here.
 	isVersionUpgrade := b.MutatedFrom.Elasticsearch.Spec.Version != b.Elasticsearch.Spec.Version
-	httpOptionsChange := reflect.DeepEqual(b.MutatedFrom.Elasticsearch.Spec.HTTP, b.Elasticsearch.Spec.HTTP)
+	httpOptionsChange := !reflect.DeepEqual(b.MutatedFrom.Elasticsearch.Spec.HTTP, b.Elasticsearch.Spec.HTTP)
 	for _, initialNs := range b.MutatedFrom.Elasticsearch.Spec.NodeSets {
 		for _, mutatedNs := range b.Elasticsearch.Spec.NodeSets {
 			if initialNs.Name == mutatedNs.Name &&


### PR DESCRIPTION
When computing the number of replicas for the data integrity check, we
inspect the ES specs to figure out whether a rolling upgrade will
happen.

We trigger a rolling upgrade when TLS is toggled in the HTTP options,
but the test was checking the opposite (deepEqual instead of
!deepEqual).

As a result the data integrity index was created with 0 replicas, since
we though this was going to be a grown-and-shrink upgrade.

Fixes https://github.com/elastic/cloud-on-k8s/issues/2744 (when https://github.com/elastic/cloud-on-k8s/pull/2748 is applied).
