### PR TITLE
Add retry library

### DIFF
--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -1,3 +1,5 @@
+// This library overrides the default checkout behavior to enable sleep+retries if there are errors
+// Added to help overcome some recurring github connection issues
 @Library('apm@current') _
 
 pipeline {

--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('apm@current') _
+
 pipeline {
 
     agent {

--- a/.ci/pipelines/cleanup-gke.Jenkinsfile
+++ b/.ci/pipelines/cleanup-gke.Jenkinsfile
@@ -1,3 +1,5 @@
+// This library overrides the default checkout behavior to enable sleep+retries if there are errors
+// Added to help overcome some recurring github connection issues
 @Library('apm@current') _
 
 pipeline {

--- a/.ci/pipelines/cleanup-gke.Jenkinsfile
+++ b/.ci/pipelines/cleanup-gke.Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('apm@current') _
+
 pipeline {
 
     agent {

--- a/.ci/pipelines/e2e-tests-aks.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-aks.Jenkinsfile
@@ -1,3 +1,5 @@
+// This library overrides the default checkout behavior to enable sleep+retries if there are errors
+// Added to help overcome some recurring github connection issues
 @Library('apm@current') _
 
 pipeline {

--- a/.ci/pipelines/e2e-tests-aks.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-aks.Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('apm@current') _
+
 pipeline {
 
     agent {

--- a/.ci/pipelines/e2e-tests-custom-operator-image-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-custom-operator-image-gke.Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('apm@current') _
+
 def failedTests = []
 def lib
 

--- a/.ci/pipelines/e2e-tests-custom-operator-image-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-custom-operator-image-gke.Jenkinsfile
@@ -1,3 +1,5 @@
+// This library overrides the default checkout behavior to enable sleep+retries if there are errors
+// Added to help overcome some recurring github connection issues
 @Library('apm@current') _
 
 def failedTests = []

--- a/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('apm@current') _
+
 def failedTests = []
 def lib
 

--- a/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
@@ -1,3 +1,5 @@
+// This library overrides the default checkout behavior to enable sleep+retries if there are errors
+// Added to help overcome some recurring github connection issues
 @Library('apm@current') _
 
 def failedTests = []

--- a/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('apm@current') _
+
 def failedTests = []
 def lib
 

--- a/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
@@ -1,3 +1,5 @@
+// This library overrides the default checkout behavior to enable sleep+retries if there are errors
+// Added to help overcome some recurring github connection issues
 @Library('apm@current') _
 
 def failedTests = []

--- a/.ci/pipelines/e2e-tests-master-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-master-gke.Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('apm@current') _
+
 def failedTests = []
 def lib
 

--- a/.ci/pipelines/e2e-tests-master-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-master-gke.Jenkinsfile
@@ -1,3 +1,5 @@
+// This library overrides the default checkout behavior to enable sleep+retries if there are errors
+// Added to help overcome some recurring github connection issues
 @Library('apm@current') _
 
 def failedTests = []

--- a/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
@@ -1,3 +1,5 @@
+// This library overrides the default checkout behavior to enable sleep+retries if there are errors
+// Added to help overcome some recurring github connection issues
 @Library('apm@current') _
 
 pipeline {

--- a/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('apm@current') _
+
 pipeline {
 
     agent {

--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('apm@current') _
+
 def failedTests = []
 def lib
 

--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -1,3 +1,5 @@
+// This library overrides the default checkout behavior to enable sleep+retries if there are errors
+// Added to help overcome some recurring github connection issues
 @Library('apm@current') _
 
 def failedTests = []

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('apm@current') _
+
 def failedTests = []
 def lib
 

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -1,3 +1,5 @@
+// This library overrides the default checkout behavior to enable sleep+retries if there are errors
+// Added to help overcome some recurring github connection issues
 @Library('apm@current') _
 
 def failedTests = []

--- a/.ci/pipelines/pr-gke.Jenkinsfile
+++ b/.ci/pipelines/pr-gke.Jenkinsfile
@@ -1,3 +1,5 @@
+// This library overrides the default checkout behavior to enable sleep+retries if there are errors
+// Added to help overcome some recurring github connection issues
 @Library('apm@current') _
 
 pipeline {

--- a/.ci/pipelines/pr-gke.Jenkinsfile
+++ b/.ci/pipelines/pr-gke.Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('apm@current') _
+
 pipeline {
 
     agent {


### PR DESCRIPTION
Adds a shared library that overrides the default checkout behavior to include a sleep+retry, which should help with our checkout/github connection failures. Related PR is needed to add this library to the devops-ci jenkins