### PR TITLE
Close idle connections on the http client directly

### DIFF
--- a/pkg/controller/elasticsearch/client/base.go
+++ b/pkg/controller/elasticsearch/client/base.go
@@ -17,22 +17,21 @@ import (
 )
 
 type baseClient struct {
-	User      BasicAuth
-	HTTP      *http.Client
-	transport *http.Transport
-	Endpoint  string
-	caCerts   []*x509.Certificate
+	User     BasicAuth
+	HTTP     *http.Client
+	Endpoint string
+	caCerts  []*x509.Certificate
 }
 
 // Close idle connections in the underlying http client.
 // Should be called once this client is not used anymore.
 func (c *baseClient) Close() {
-	if c.transport != nil {
+	if c.HTTP != nil {
 		// When the http transport goes out of scope, the underlying goroutines responsible
 		// for handling keep-alive connections are not closed automatically.
 		// Since this client gets recreated frequently we would effectively be leaking goroutines.
 		// Let's make sure this does not happen by closing idle connections.
-		c.transport.CloseIdleConnections()
+		c.HTTP.CloseIdleConnections()
 	}
 }
 

--- a/pkg/controller/elasticsearch/client/client.go
+++ b/pkg/controller/elasticsearch/client/client.go
@@ -152,10 +152,9 @@ func NewElasticsearchClient(
 	}
 
 	base := &baseClient{
-		Endpoint:  esURL,
-		User:      esUser,
-		caCerts:   caCerts,
-		transport: &transportConfig,
+		Endpoint: esURL,
+		User:     esUser,
+		caCerts:  caCerts,
 		HTTP: &http.Client{
 			Transport: apmelasticsearch.WrapRoundTripper(&transportConfig),
 		},


### PR DESCRIPTION
I realized while refactoring this piece of code for being used by
another controller that we don't need to keep track of the
http.Transport, since calling Close() on the client propagates
to the underlying transport directly.

This simplifies the ES client structure a little bit, and will be useful
for the refactoring I'm working on.

To make sure this still works as expected, I tested the goroutine leaks using
the methodology [outlined in this comment](https://github.com/elastic/cloud-on-k8s/issues/854#issuecomment-491773323). Closing the client has the same effect
as closing the underlying transport.
