### PR TITLE
Make standalone Kibana e2e test compatible with api/status check

### DIFF
--- a/test/e2e/kb/standalone_test.go
+++ b/test/e2e/kb/standalone_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 	"text/template"
 
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/helper"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/kibana"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
@@ -51,7 +51,7 @@ func mkKibanaStandaloneBuilders(t *testing.T) []test.Builder {
 		case kibana.Builder:
 			return b.WithNamespace(namespace).
 				WithVersion(stackVersion).
-				WithExternalElasticsearchRef(types.NamespacedName{
+				WithExternalElasticsearchRef(commonv1.ObjectSelector{
 					Namespace: namespace,
 					Name:      esName,
 				}).

--- a/test/e2e/kb/telemetry_test.go
+++ b/test/e2e/kb/telemetry_test.go
@@ -30,7 +30,9 @@ func TestTelemetry(t *testing.T) {
 				Test: func(t *testing.T) {
 					uri := "/api/telemetry/v1/clusters/_stats"
 					payload := `{"timeRange":{"min":"0","max":"0"}}`
-					body, err := kibana.DoRequest(k, kbBuilder.Kibana, "POST", uri, []byte(payload))
+					password, err := k.GetElasticPassword(kbBuilder.ElasticsearchRef().NamespacedName())
+					require.NoError(t, err)
+					body, err := kibana.DoRequest(k, kbBuilder.Kibana, password, "POST", uri, []byte(payload))
 					require.NoError(t, err)
 
 					var stats ClusterStats

--- a/test/e2e/kb/telemetry_test.go
+++ b/test/e2e/kb/telemetry_test.go
@@ -30,7 +30,7 @@ func TestTelemetry(t *testing.T) {
 				Test: func(t *testing.T) {
 					uri := "/api/telemetry/v1/clusters/_stats"
 					payload := `{"timeRange":{"min":"0","max":"0"}}`
-					body, err := kibana.DoKibanaReq(k, kbBuilder.Kibana, "POST", uri, []byte(payload))
+					body, err := kibana.DoRequest(k, kbBuilder.Kibana, "POST", uri, []byte(payload))
 					require.NoError(t, err)
 
 					var stats ClusterStats

--- a/test/e2e/kb/testdata/kibana_standalone.yaml
+++ b/test/e2e/kb/testdata/kibana_standalone.yaml
@@ -2,7 +2,7 @@
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch
 metadata:
-  name: test-kibana-standalone-es-{{ .Suffix }}
+  name: {{ .ESName }}
 spec:
   version: 7.6.0
   nodeSets:
@@ -22,7 +22,7 @@ spec:
   count: 1
   config:
     elasticsearch.hosts:
-      - https://test-kibana-standalone-es-{{ .Suffix }}-es-http:9200
+      - https://{{ .ESName }}-es-http:9200
     elasticsearch.username: elastic
     elasticsearch.ssl.verificationMode: none
   podTemplate:
@@ -33,5 +33,5 @@ spec:
             - name: ELASTICSEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: test-kibana-standalone-es-{{ .Suffix }}-es-elastic-user
+                  name: {{ .ESName }}-es-elastic-user
                   key: elastic

--- a/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/test/e2e/test/elasticsearch/checks_k8s.go
@@ -227,7 +227,7 @@ func CheckESPassword(b Builder, k *test.K8sClient) test.Step {
 	return test.Step{
 		Name: "Elastic password should be available",
 		Test: test.Eventually(func() error {
-			password, err := k.GetElasticPassword(b.Elasticsearch.Namespace, b.Elasticsearch.Name)
+			password, err := k.GetElasticPassword(k8s.ExtractNamespacedName(&b.Elasticsearch))
 			if err != nil {
 				return err
 			}

--- a/test/e2e/test/elasticsearch/http_client.go
+++ b/test/e2e/test/elasticsearch/http_client.go
@@ -13,13 +13,14 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	esuser "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/pkg/dev/portforward"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/net"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 )
 
 // NewElasticsearchClient returns an ES client for the given ES cluster
 func NewElasticsearchClient(es esv1.Elasticsearch, k *test.K8sClient) (client.Client, error) {
-	password, err := k.GetElasticPassword(es.Namespace, es.Name)
+	password, err := k.GetElasticPassword(k8s.ExtractNamespacedName(&es))
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/test/k8s_client.go
+++ b/test/e2e/test/k8s_client.go
@@ -169,12 +169,12 @@ func (k *K8sClient) GetEvents(opts ...k8sclient.ListOption) ([]corev1.Event, err
 	return eventList.Items, nil
 }
 
-func (k *K8sClient) GetElasticPassword(namespace, esName string) (string, error) {
-	secretName := esName + "-es-elastic-user"
+func (k *K8sClient) GetElasticPassword(nsn types.NamespacedName) (string, error) {
+	secretName := nsn.Name + "-es-elastic-user"
 	elasticUserKey := "elastic"
 	var secret corev1.Secret
 	key := types.NamespacedName{
-		Namespace: namespace,
+		Namespace: nsn.Namespace,
 		Name:      secretName,
 	}
 	if err := k.Client.Get(key, &secret); err != nil {

--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
@@ -17,8 +18,9 @@ import (
 
 // Builder to create Kibana instances
 type Builder struct {
-	Kibana      kbv1.Kibana
-	MutatedFrom *Builder
+	Kibana                   kbv1.Kibana
+	ExternalElasticsearchRef types.NamespacedName
+	MutatedFrom              *Builder
 }
 
 var _ test.Builder = Builder{}
@@ -60,6 +62,11 @@ func (b Builder) WithSuffix(suffix string) Builder {
 
 func (b Builder) WithElasticsearchRef(ref commonv1.ObjectSelector) Builder {
 	b.Kibana.Spec.ElasticsearchRef = ref
+	return b
+}
+
+func (b Builder) WithExternalElasticsearchRef(ref types.NamespacedName) Builder {
+	b.ExternalElasticsearchRef = ref
 	return b
 }
 

--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -8,7 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
@@ -19,7 +18,7 @@ import (
 // Builder to create Kibana instances
 type Builder struct {
 	Kibana                   kbv1.Kibana
-	ExternalElasticsearchRef types.NamespacedName
+	ExternalElasticsearchRef commonv1.ObjectSelector
 	MutatedFrom              *Builder
 }
 
@@ -65,7 +64,7 @@ func (b Builder) WithElasticsearchRef(ref commonv1.ObjectSelector) Builder {
 	return b
 }
 
-func (b Builder) WithExternalElasticsearchRef(ref types.NamespacedName) Builder {
+func (b Builder) WithExternalElasticsearchRef(ref commonv1.ObjectSelector) Builder {
 	b.ExternalElasticsearchRef = ref
 	return b
 }

--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -134,3 +134,11 @@ func (b Builder) WithLabel(key, value string) Builder {
 func (b Builder) RuntimeObjects() []runtime.Object {
 	return []runtime.Object{&b.Kibana}
 }
+
+func (b Builder) ElasticsearchRef() commonv1.ObjectSelector {
+	if b.ExternalElasticsearchRef.IsDefined() {
+		return b.ExternalElasticsearchRef
+	}
+	// if no external Elasticsearch cluster is defined, use the ElasticsearchRef
+	return b.Kibana.ElasticsearchRef().WithDefaultNamespace(b.Kibana.Namespace)
+}

--- a/test/e2e/test/kibana/checks_kb.go
+++ b/test/e2e/test/kibana/checks_kb.go
@@ -10,6 +10,7 @@ import (
 
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type kbChecks struct {
@@ -34,6 +35,7 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 	}
 	return test.StepList{
 		checks.CheckKbStatusHealthy(b.Kibana),
+		checks.CheckKbWithExternalESStatusHealthy(b.Kibana, b.ExternalElasticsearchRef),
 	}
 }
 
@@ -42,7 +44,7 @@ func (check *kbChecks) CheckKbStatusHealthy(kb kbv1.Kibana) test.Step {
 	return test.Step{
 		Name: "Kibana should be able to connect to Elasticsearch",
 		Test: test.Eventually(func() error {
-			body, err := DoKibanaReq(check.client, kb, "GET", "/api/status", nil)
+			body, err := DoRequest(check.client, kb, "GET", "/api/status", nil)
 			if err != nil {
 				return err
 			}
@@ -56,5 +58,34 @@ func (check *kbChecks) CheckKbStatusHealthy(kb kbv1.Kibana) test.Step {
 			}
 			return nil
 		}),
+		Skip: func() bool {
+			ref := kb.ElasticsearchRef()
+			return ref.IsDefined() == false
+		},
+	}
+}
+
+func (check *kbChecks) CheckKbWithExternalESStatusHealthy(kb kbv1.Kibana, es types.NamespacedName) test.Step {
+	return test.Step{
+		Name: "Kibana should be able to connect to an external Elasticsearch",
+		Test: test.Eventually(func() error {
+			body, err := DoRequestWithES(check.client, kb, es, "GET", "/api/status", nil)
+			if err != nil {
+				return err
+			}
+			var status kbStatus
+			err = json.Unmarshal(body, &status)
+			if err != nil {
+				return err
+			}
+			if status.Status.Overall.State != "green" {
+				return fmt.Errorf("not ready: want 'green' but Kibana status was '%s'", status.Status.Overall.State)
+			}
+			return nil
+		}),
+		Skip: func() bool {
+			ref := kb.ElasticsearchRef()
+			return ref.IsDefined()
+		},
 	}
 }

--- a/test/e2e/test/kibana/checks_kb.go
+++ b/test/e2e/test/kibana/checks_kb.go
@@ -60,7 +60,7 @@ func (check *kbChecks) CheckKbStatusHealthy(kb kbv1.Kibana) test.Step {
 		}),
 		Skip: func() bool {
 			ref := kb.ElasticsearchRef()
-			return ref.IsDefined() == false
+			return !ref.IsDefined()
 		},
 	}
 }

--- a/test/e2e/test/kibana/http_client.go
+++ b/test/e2e/test/kibana/http_client.go
@@ -40,7 +40,7 @@ func DoRequest(k *test.K8sClient, kb kbv1.Kibana, method string, uri string, bod
 	)
 }
 
-// DoRequest executes an HTTP request against a Kibana instance connected to the given Elasticsearch instance.
+// DoRequestWithES executes an HTTP request against a Kibana instance connected to the given Elasticsearch instance.
 func DoRequestWithES(k *test.K8sClient, kb kbv1.Kibana, es types.NamespacedName, method string, uri string, body []byte) ([]byte, error) {
 	password, err := k.GetElasticPassword(es)
 	if err != nil {

--- a/test/e2e/test/kibana/http_client.go
+++ b/test/e2e/test/kibana/http_client.go
@@ -31,17 +31,8 @@ func NewKibanaClient(kb kbv1.Kibana, k *test.K8sClient) (*http.Client, error) {
 	return test.NewHTTPClient(caCerts), nil
 }
 
-// DoRequest executes an HTTP request against a Kibana instance.
-func DoRequest(k *test.K8sClient, kb kbv1.Kibana, method string, uri string, body []byte) ([]byte, error) {
-	password, err := k.GetElasticPassword(kb.Spec.ElasticsearchRef.WithDefaultNamespace(kb.Namespace).NamespacedName())
-	if err != nil {
-		return nil, errors.Wrap(err, "while getting elastic password")
-	}
-	return DoRequestWithPassword(k, kb, password, method, uri, body)
-}
-
-// DoRequestWithPassword executes an HTTP request against a Kibana instance using the given password for the elastic user.
-func DoRequestWithPassword(k *test.K8sClient, kb kbv1.Kibana, password string, method string, uri string, body []byte) ([]byte, error) {
+// DoRequest executes an HTTP request against a Kibana instance using the given password for the elastic user.
+func DoRequest(k *test.K8sClient, kb kbv1.Kibana, password string, method string, uri string, body []byte) ([]byte, error) {
 	scheme := "http"
 	if kb.Spec.HTTP.TLS.Enabled() {
 		scheme = "https"


### PR DESCRIPTION
#2730 broke the standalone Kibana e2e test because we rely on the presence of `ElasticsearchRef` to make an HTTP request to Kibana. 

* this extends the existing Kibana connectivity check to be executed also if `ElasticsearchRef` is not defined which relies on specifying an `ExternalElasticsearchRef` in the builder.
* refactors `DoKibanaReq` to `DoRequest` (`kibana` being implied by the package name) and `DoRequestWithEs` (open to better naming suggestions) which allows callers to specify a `NamespacedName` to define a standalone Elasticsearch cluster 