### PR TITLE
Add log adapter for automaxprocs

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -183,6 +183,8 @@ func init() {
 func execute() {
 	// update GOMAXPROCS to container cpu limit if necessary
 	_, err := maxprocs.Set(maxprocs.Logger(func(s string, i ...interface{}) {
+		// maxprocs needs an sprintf format string with args, but our logger needs a string with optional key value pairs,
+		// so we need to do this translation
 		log.Info(fmt.Sprintf(s, i...))
 	}))
 	if err != nil {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -182,7 +182,9 @@ func init() {
 
 func execute() {
 	// update GOMAXPROCS to container cpu limit if necessary
-	_, err := maxprocs.Set(maxprocs.Logger(log.Info))
+	_, err := maxprocs.Set(maxprocs.Logger(func(s string, i ...interface{}) {
+		log.Info(fmt.Sprintf(s, i...))
+	}))
 	if err != nil {
 		log.Error(err, "Error setting GOMAXPROCS")
 		os.Exit(1)


### PR DESCRIPTION
Looks like automaxprocs expects a `printf` style interface for logging while our logger expects balanced key-value pairs. 

This adds a simple adapter function to translate between the two