### PR TITLE
Fix remote cluster e2e test with 6.x

### DIFF
--- a/test/e2e/es/remote_cluster_test.go
+++ b/test/e2e/es/remote_cluster_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
@@ -70,11 +69,8 @@ func TestRemoteCluster(t *testing.T) {
 			test.Step{
 				Name: "Add some data to the first cluster",
 				Test: func(t *testing.T) {
-					dataIntegrityCheck := elasticsearch.NewDataIntegrityCheck(k, es1Builder)
-					if strings.HasPrefix(es1Builder.Elasticsearch.Spec.Version, "6") {
-						dataIntegrityCheck.WithSoftDeletesEnabled(true)
-					}
-					require.NoError(t, dataIntegrityCheck.Init())
+					// Always enable soft deletes on test index. This is required to create follower indices but disabled by default on 6.x
+					require.NoError(t, elasticsearch.NewDataIntegrityCheck(k, es1Builder).WithSoftDeletesEnabled(true).Init())
 				},
 			},
 			test.Step{

--- a/test/e2e/es/remote_cluster_test.go
+++ b/test/e2e/es/remote_cluster_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
@@ -69,7 +70,11 @@ func TestRemoteCluster(t *testing.T) {
 			test.Step{
 				Name: "Add some data to the first cluster",
 				Test: func(t *testing.T) {
-					require.NoError(t, elasticsearch.NewDataIntegrityCheck(k, es1Builder).Init())
+					dataIntegrityCheck := elasticsearch.NewDataIntegrityCheck(k, es1Builder)
+					if strings.HasPrefix(es1Builder.Elasticsearch.Spec.Version, "6") {
+						dataIntegrityCheck.WithSoftDeletesEnabled(true)
+					}
+					require.NoError(t, dataIntegrityCheck.Init())
 				},
 			},
 			test.Step{

--- a/test/e2e/test/elasticsearch/checks_data.go
+++ b/test/e2e/test/elasticsearch/checks_data.go
@@ -50,9 +50,9 @@ func NewDataIntegrityCheck(k *test.K8sClient, b Builder) *DataIntegrityCheck {
 	}
 }
 
-func (d *DataIntegrityCheck) WithSoftDeletesEnabled(value bool) *DataIntegrityCheck {
-	d.createIndexSettings.SoftDeletesEnabled = &value
-	return d
+func (dc *DataIntegrityCheck) WithSoftDeletesEnabled(value bool) *DataIntegrityCheck {
+	dc.createIndexSettings.SoftDeletesEnabled = &value
+	return dc
 }
 
 type createIndexSettings struct {

--- a/test/e2e/test/elasticsearch/checks_data.go
+++ b/test/e2e/test/elasticsearch/checks_data.go
@@ -24,12 +24,11 @@ const (
 )
 
 type DataIntegrityCheck struct {
-	clientFactory func() (client.Client, error) // recreate clients for cases where we switch scheme in tests
-	indexName     string
-	numShards     int
-	numReplicas   int
-	sampleData    map[string]interface{}
-	docCount      int
+	clientFactory       func() (client.Client, error) // recreate clients for cases where we switch scheme in tests
+	indexName           string
+	createIndexSettings createIndexSettings
+	sampleData          map[string]interface{}
+	docCount            int
 }
 
 func NewDataIntegrityCheck(k *test.K8sClient, b Builder) *DataIntegrityCheck {
@@ -41,10 +40,29 @@ func NewDataIntegrityCheck(k *test.K8sClient, b Builder) *DataIntegrityCheck {
 		sampleData: map[string]interface{}{
 			"foo": "bar",
 		},
-		docCount:    5,
-		numShards:   3,
-		numReplicas: dataIntegrityReplicas(b),
+		docCount: 5,
+		createIndexSettings: createIndexSettings{
+			IndexSettings{
+				NumberOfShards:   3,
+				NumberOfReplicas: dataIntegrityReplicas(b),
+			},
+		},
 	}
+}
+
+func (d *DataIntegrityCheck) WithSoftDeletesEnabled(value bool) *DataIntegrityCheck {
+	d.createIndexSettings.SoftDeletesEnabled = &value
+	return d
+}
+
+type createIndexSettings struct {
+	IndexSettings `json:"settings"`
+}
+
+type IndexSettings struct {
+	NumberOfShards     int   `json:"number_of_shards"`
+	NumberOfReplicas   int   `json:"number_of_replicas"`
+	SoftDeletesEnabled *bool `json:"soft_deletes.enabled,omitempty"`
 }
 
 func (dc *DataIntegrityCheck) ForIndex(indexName string) *DataIntegrityCheck {
@@ -57,16 +75,11 @@ func (dc *DataIntegrityCheck) Init() error {
 	if err != nil {
 		return err
 	}
-	indexSettings := `
-{
-    "settings" : {
-        "index" : {
-            "number_of_shards" : %d,
-            "number_of_replicas" : %d
-        }
-    }
-}
-`
+	createIndexSettings, err := json.Marshal(dc.createIndexSettings)
+	if err != nil {
+		return err
+	}
+
 	// delete index if running check multiple times
 	indexDeletion, err := http.NewRequest(
 		http.MethodDelete,
@@ -86,7 +99,7 @@ func (dc *DataIntegrityCheck) Init() error {
 	indexCreation, err := http.NewRequest(
 		http.MethodPut,
 		fmt.Sprintf("/%s", dc.indexName),
-		bytes.NewBufferString(fmt.Sprintf(indexSettings, dc.numShards, dc.numReplicas)),
+		bytes.NewBuffer(createIndexSettings),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #2761 by creating test index with `soft_deletes.enabled` when testing on Elastic stack 6.x

Tested on 6.8.5 and 7.1.1