### PR TITLE
Update AKS version to current default

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -38,7 +38,7 @@ plans:
   operation: create
   clusterName: ci
   provider: aks
-  kubernetesVersion: 1.15.5
+  kubernetesVersion: 1.15.10
   machineType: Standard_D8s_v3
   serviceAccount: true
   psp: false

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -49,7 +49,7 @@ plans:
   operation: create
   clusterName: dev
   provider: aks
-  kubernetesVersion: 1.15.5
+  kubernetesVersion: 1.15.10
   machineType: Standard_D8s_v3
   serviceAccount: false
   psp: false


### PR DESCRIPTION
Looks like the version we use in our AKS e2e tests is no longer supported. This PR updates the version to the current default you get when running `az aks get-versions --location westeurope`

Fixes #2760 