### PR TITLE
Ensure that HTTP CA cert is always set

### DIFF
--- a/pkg/controller/common/certificates/http_reconcile.go
+++ b/pkg/controller/common/certificates/http_reconcile.go
@@ -107,8 +107,12 @@ func (r Reconciler) ReconcileInternalHTTPCerts(ca *CA) (*CertificatesSecret, err
 		expectedSecretData := make(map[string][]byte)
 		expectedSecretData[CertFileName] = customCertificates.CertPem()
 		expectedSecretData[KeyFileName] = customCertificates.KeyPem()
-		if caPem := customCertificates.CAPem(); caPem != nil {
+		if caPem := customCertificates.CAPem(); len(caPem) > 0 {
 			expectedSecretData[CAFileName] = caPem
+		} else {
+			// Ensure that the CA certificate is never empty, otherwise Elasticsearch is not able to reload the certificates.
+			// See https://github.com/elastic/cloud-on-k8s/issues/2243
+			expectedSecretData[CAFileName] = EncodePEMCert(ca.Cert.Raw)
 		}
 
 		if !reflect.DeepEqual(secret.Data, expectedSecretData) {

--- a/pkg/controller/common/certificates/http_reconcile.go
+++ b/pkg/controller/common/certificates/http_reconcile.go
@@ -111,6 +111,7 @@ func (r Reconciler) ReconcileInternalHTTPCerts(ca *CA) (*CertificatesSecret, err
 			expectedSecretData[CAFileName] = caPem
 		} else {
 			// Ensure that the CA certificate is never empty, otherwise Elasticsearch is not able to reload the certificates.
+			// Default to our self-signed (useless) CA if none is provided by the user.
 			// See https://github.com/elastic/cloud-on-k8s/issues/2243
 			expectedSecretData[CAFileName] = EncodePEMCert(ca.Cert.Raw)
 		}

--- a/pkg/controller/common/certificates/http_reconcile_test.go
+++ b/pkg/controller/common/certificates/http_reconcile_test.go
@@ -282,6 +282,9 @@ func TestReconcileInternalHTTPCerts(t *testing.T) {
 			want: func(t *testing.T, cs *CertificatesSecret) {
 				assert.Equal(t, cs.Data[KeyFileName], key)
 				assert.Equal(t, cs.Data[CertFileName], tls)
+				// Even if user didn't provide a CA cert we don't want it to be empty
+				assert.True(t, len(cs.Data[CAFileName]) > 0)
+				assert.Equal(t, cs.Data[CAFileName], EncodePEMCert(testCA.Cert.Raw))
 			},
 		},
 	}

--- a/pkg/controller/elasticsearch/certificates/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/reconcile.go
@@ -30,9 +30,6 @@ type CertificateResources struct {
 
 	// TransportCA is the CA used for Transport certificates
 	TransportCA *certificates.CA
-
-	// HTTPCACertProvided indicates whether ca.crt key is defined in the certificate secret.
-	HTTPCACertProvided bool
 }
 
 // Reconcile reconciles the certificates of a cluster.
@@ -116,10 +113,8 @@ func Reconcile(
 		return nil, results.WithError(err)
 	}
 
-	httpCACertProvided := len(httpCerts.Data[certificates.CAFileName]) > 0
 	return &CertificateResources{
 		TrustedHTTPCertificates: trustedHTTPCertificates,
 		TransportCA:             transportCA,
-		HTTPCACertProvided:      httpCACertProvided,
 	}, results
 }

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -257,7 +257,7 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	}
 
 	// reconcile StatefulSets and nodes configuration
-	res = d.reconcileNodeSpecs(ctx, esReachable, esClient, d.ReconcileState, observedState, *resourcesState, keystoreResources, certificateResources)
+	res = d.reconcileNodeSpecs(ctx, esReachable, esClient, d.ReconcileState, observedState, *resourcesState, keystoreResources)
 	results = results.WithResults(res)
 
 	if res.HasError() {

--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -55,7 +55,7 @@ func (d *defaultDriver) reconcileNodeSpecs(
 		return results.WithError(err)
 	}
 
-	expectedResources, err := nodespec.BuildExpectedResources(d.ES, keystoreResources, certResources, actualStatefulSets)
+	expectedResources, err := nodespec.BuildExpectedResources(d.ES, keystoreResources, actualStatefulSets)
 	if err != nil {
 		return results.WithError(err)
 	}

--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -12,7 +12,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/observer"
@@ -34,7 +33,6 @@ func (d *defaultDriver) reconcileNodeSpecs(
 	observedState observer.State,
 	resourcesState reconcile.ResourcesState,
 	keystoreResources *keystore.Resources,
-	certResources *certificates.CertificateResources,
 ) *reconciler.Results {
 	span, ctx := apm.StartSpan(ctx, "reconcile_node_spec", tracing.SpanTypeApp)
 	defer span.End()

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -89,7 +89,7 @@ var sampleES = esv1.Elasticsearch{
 }
 
 func TestBuildPodTemplateSpec(t *testing.T) {
-	certResources := certificates.CertificateResources{HTTPCACertProvided: true}
+	certResources := certificates.CertificateResources{}
 	nodeSet := sampleES.Spec.NodeSets[0]
 	ver, err := version.Parse(sampleES.Spec.Version)
 	require.NoError(t, err)

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -12,7 +12,6 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/initcontainer"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
 	"github.com/go-test/deep"
@@ -89,11 +88,10 @@ var sampleES = esv1.Elasticsearch{
 }
 
 func TestBuildPodTemplateSpec(t *testing.T) {
-	certResources := certificates.CertificateResources{}
 	nodeSet := sampleES.Spec.NodeSets[0]
 	ver, err := version.Parse(sampleES.Spec.Version)
 	require.NoError(t, err)
-	cfg, err := settings.NewMergedESConfig(sampleES.Name, *ver, sampleES.Spec.HTTP, *nodeSet.Config, &certResources)
+	cfg, err := settings.NewMergedESConfig(sampleES.Name, *ver, sampleES.Spec.HTTP, *nodeSet.Config)
 	require.NoError(t, err)
 
 	actual, err := BuildPodTemplateSpec(sampleES, sampleES.Spec.NodeSets[0], cfg, nil)

--- a/pkg/controller/elasticsearch/nodespec/resources.go
+++ b/pkg/controller/elasticsearch/nodespec/resources.go
@@ -12,7 +12,6 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
@@ -39,7 +38,6 @@ func (l ResourcesList) StatefulSets() sset.StatefulSetList {
 func BuildExpectedResources(
 	es esv1.Elasticsearch,
 	keystoreResources *keystore.Resources,
-	certResources *certificates.CertificateResources,
 	existingStatefulSets sset.StatefulSetList,
 ) (ResourcesList, error) {
 	nodesResources := make(ResourcesList, 0, len(es.Spec.NodeSets))
@@ -55,7 +53,7 @@ func BuildExpectedResources(
 		if nodeSpec.Config != nil {
 			userCfg = *nodeSpec.Config
 		}
-		cfg, err := settings.NewMergedESConfig(es.Name, *ver, es.Spec.HTTP, userCfg, certResources)
+		cfg, err := settings.NewMergedESConfig(es.Name, *ver, es.Spec.HTTP, userCfg)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/pkg/controller/elasticsearch/settings/merged_config.go
@@ -12,7 +12,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	common "github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
-	escerts "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
 )
@@ -24,7 +23,6 @@ func NewMergedESConfig(
 	ver version.Version,
 	httpConfig commonv1.HTTPConfig,
 	userConfig commonv1.Config,
-	certResources *escerts.CertificateResources,
 ) (CanonicalConfig, error) {
 	userCfg, err := common.NewCanonicalConfigFrom(userConfig.Data)
 	if err != nil {
@@ -32,7 +30,7 @@ func NewMergedESConfig(
 	}
 	config := baseConfig(clusterName, ver).CanonicalConfig
 	err = config.MergeWith(
-		xpackConfig(ver, httpConfig, certResources).CanonicalConfig,
+		xpackConfig(ver, httpConfig).CanonicalConfig,
 		userCfg,
 	)
 	if err != nil {
@@ -68,7 +66,7 @@ func baseConfig(clusterName string, ver version.Version) *CanonicalConfig {
 }
 
 // xpackConfig returns the configuration bit related to XPack settings
-func xpackConfig(ver version.Version, httpCfg commonv1.HTTPConfig, certResources *escerts.CertificateResources) *CanonicalConfig {
+func xpackConfig(ver version.Version, httpCfg commonv1.HTTPConfig) *CanonicalConfig {
 	// enable x-pack security, including TLS
 	cfg := map[string]interface{}{
 		// x-pack security general settings

--- a/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/pkg/controller/elasticsearch/settings/merged_config.go
@@ -97,10 +97,7 @@ func xpackConfig(ver version.Version, httpCfg commonv1.HTTPConfig, certResources
 			path.Join(volume.TransportCertificatesSecretVolumeMountPath, certificates.CAFileName),
 			path.Join(volume.RemoteCertificateAuthoritiesSecretVolumeMountPath, certificates.CAFileName),
 		},
-	}
-
-	if certResources.HTTPCACertProvided {
-		cfg[esv1.XPackSecurityHttpSslCertificateAuthorities] = path.Join(volume.HTTPCertificatesSecretVolumeMountPath, certificates.CAFileName)
+		esv1.XPackSecurityHttpSslCertificateAuthorities: path.Join(volume.HTTPCertificatesSecretVolumeMountPath, certificates.CAFileName),
 	}
 
 	// always enable the built-in file and native internal realms for user auth, ordered as first

--- a/pkg/controller/elasticsearch/settings/merged_config_test.go
+++ b/pkg/controller/elasticsearch/settings/merged_config_test.go
@@ -13,7 +13,6 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates"
 )
 
 func TestNewMergedESConfig(t *testing.T) {
@@ -168,7 +167,6 @@ func TestNewMergedESConfig(t *testing.T) {
 				*ver,
 				commonv1.HTTPConfig{},
 				commonv1.Config{Data: tt.cfgData},
-				&certificates.CertificateResources{},
 			)
 			require.NoError(t, err)
 			tt.assert(cfg)


### PR DESCRIPTION
Fix #2243 

Tested with the OpenShift Service CA Operator on Openshift 4.3 and with a Secret containing a Let's Encrypt cert. generated by the cert-manager.