### PR TITLE
Restrict APM Server user role

### DIFF
--- a/pkg/controller/apmserverelasticsearchassociation/apmserverelasticsearchassociation_controller.go
+++ b/pkg/controller/apmserverelasticsearchassociation/apmserverelasticsearchassociation_controller.go
@@ -61,6 +61,7 @@ func getRoles(v version.Version) string {
 		return strings.Join([]string{
 			user.ApmUserRoleV75, // Retrieve cluster details (e.g. version) and manage apm-* indices
 			"ingest_admin",      // Set up index templates
+			"apm_system",        // To collect metrics about APM Server
 		}, ",")
 	}
 
@@ -69,11 +70,15 @@ func getRoles(v version.Version) string {
 		return strings.Join([]string{
 			user.ApmUserRoleV7, // Retrieve cluster details (e.g. version) and manage apm-* indices
 			"ingest_admin",     // Set up index templates
+			"apm_system",       // To collect metrics about APM Server
 		}, ",")
 	}
 
 	// 6.8
-	return user.ApmUserRoleV6
+	return strings.Join([]string{
+		user.ApmUserRoleV6, // Retrieve cluster details (e.g. version) and manage apm-* indices
+		"apm_system",       // To collect metrics about APM Server
+	}, ",")
 }
 
 // Add creates a new ApmServerElasticsearchAssociation Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller

--- a/pkg/controller/apmserverelasticsearchassociation/apmserverelasticsearchassociation_controller.go
+++ b/pkg/controller/apmserverelasticsearchassociation/apmserverelasticsearchassociation_controller.go
@@ -55,7 +55,7 @@ var (
 	// apmDefaultRoles are the default roles used by APM Server instances
 	apmDefaultRoles = strings.Join([]string{
 		user.ApmDefaultUserRole, // Retrieve cluster details (e.g. version) and manage apm-* indices
-		"kibana_user",           // Load dependencies, such as example dashboards, if available, into Kibana
+		"apm_user",              // Load dependencies, such as example dashboards, if available, into Kibana
 		"ingest_admin",          // Set up index templates
 	}, ",")
 )

--- a/pkg/controller/elasticsearch/client/client.go
+++ b/pkg/controller/elasticsearch/client/client.go
@@ -33,14 +33,16 @@ type BasicAuth struct {
 	Password string
 }
 
+type IndexRole struct {
+	Names      []string `json:"names,omitempty"`
+	Privileges []string `json:",omitempty"`
+}
+
 // Role represents an Elasticsearch role.
 type Role struct {
-	Cluster []string `json:"cluster,omitempty"`
-	/*Indices []struct {
-		Names      []string `json:"names,omitempty"`
-		Privileges []string `json:",omitempty"`
-	} `json:"indices,omitempty"`
-	Applications []struct {
+	Cluster []string    `json:"cluster,omitempty"`
+	Indices []IndexRole `json:"indices,omitempty"`
+	/*Applications []struct {
 		Application string   `json:"application"`
 		Privileges  []string `json:"privileges"`
 		Resources   []string `json:"resources,omitempty"`

--- a/pkg/controller/elasticsearch/client/client.go
+++ b/pkg/controller/elasticsearch/client/client.go
@@ -42,18 +42,6 @@ type IndexRole struct {
 type Role struct {
 	Cluster []string    `json:"cluster,omitempty"`
 	Indices []IndexRole `json:"indices,omitempty"`
-	/*Applications []struct {
-		Application string   `json:"application"`
-		Privileges  []string `json:"privileges"`
-		Resources   []string `json:"resources,omitempty"`
-	} `json:"applications,omitempty"`
-	RunAs    []string `json:"run_as,omitempty"`
-	Metadata *struct {
-		Reserved bool `json:"_reserved"`
-	} `json:"metadata,omitempty"`
-	TransientMetadata *struct {
-		Enabled bool `json:"enabled"`
-	} `json:"transient_metadata,omitempty"`*/
 }
 
 // Client captures the information needed to interact with an Elasticsearch cluster via HTTP

--- a/pkg/controller/elasticsearch/user/reconcile_test.go
+++ b/pkg/controller/elasticsearch/user/reconcile_test.go
@@ -75,6 +75,6 @@ func Test_aggregateRoles(t *testing.T) {
 	c := k8s.WrappedFakeClient(sampleUserProvidedRolesSecret...)
 	roles, err := aggregateRoles(c, sampleEsWithAuth, initDynamicWatches(), record.NewFakeRecorder(10))
 	require.NoError(t, err)
-	require.Len(t, roles, 3)
+	require.Len(t, roles, 4)
 	require.Contains(t, roles, ProbeUserRole, "role1", "role2")
 }

--- a/pkg/controller/elasticsearch/user/reconcile_test.go
+++ b/pkg/controller/elasticsearch/user/reconcile_test.go
@@ -75,6 +75,6 @@ func Test_aggregateRoles(t *testing.T) {
 	c := k8s.WrappedFakeClient(sampleUserProvidedRolesSecret...)
 	roles, err := aggregateRoles(c, sampleEsWithAuth, initDynamicWatches(), record.NewFakeRecorder(10))
 	require.NoError(t, err)
-	require.Len(t, roles, 4)
+	require.Len(t, roles, 6)
 	require.Contains(t, roles, ProbeUserRole, "role1", "role2")
 }

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -18,16 +18,39 @@ const (
 	SuperUserBuiltinRole = "superuser"
 	// ProbeUserRole is the name of the role used by the internal probe user.
 	ProbeUserRole = "elastic_internal_probe_user"
-	// ApmDefaultUserRole is the name of the default role used by the APM Server instances.
-	ApmDefaultUserRole = "default_apm_user_role"
+
+	// ApmUserRoleV6 is the name of the role used by the association user for 6.8.x APMServer instances.
+	ApmUserRoleV6 = "eck_apm_user_role_v6"
+	// ApmUserRoleV7 is the name of the role used by the association user for APMServer instances from version 7.1 to 7.4 included.
+	ApmUserRoleV7 = "eck_apm_user_role_v7"
+	// ApmUserRoleV75 is the name of the role used by the association user for APMServer instances from version 7.5
+	ApmUserRoleV75 = "eck_apm_user_role_v75"
 )
 
 var (
 	// PredefinedRoles to create for internal needs.
 	PredefinedRoles = RolesFileContent{
 		ProbeUserRole: esclient.Role{Cluster: []string{"monitor"}},
-		ApmDefaultUserRole: esclient.Role{
-			Cluster: []string{"monitor", "manage_ilm", "manage_api_key"},
+		ApmUserRoleV6: esclient.Role{
+			Cluster: []string{"monitor", "manage_index_templates"},
+			Indices: []esclient.IndexRole{
+				{
+					Names:      []string{"apm-*"},
+					Privileges: []string{"write", "create_index"},
+				},
+			},
+		},
+		ApmUserRoleV7: esclient.Role{
+			Cluster: []string{"monitor", "manage_ilm", "manage_index_templates"},
+			Indices: []esclient.IndexRole{
+				{
+					Names:      []string{"apm-*"},
+					Privileges: []string{"manage", "write", "create_index"},
+				},
+			},
+		},
+		ApmUserRoleV75: esclient.Role{
+			Cluster: []string{"monitor", "manage_ilm", "manage_api_key"}, // manage_api_key has been introduced in 7.5
 			Indices: []esclient.IndexRole{
 				{
 					Names:      []string{"apm-*"},

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -19,11 +19,11 @@ const (
 	// ProbeUserRole is the name of the role used by the internal probe user.
 	ProbeUserRole = "elastic_internal_probe_user"
 
-	// ApmUserRoleV6 is the name of the role used by the association user for 6.8.x APMServer instances.
+	// ApmUserRoleV6 is the name of the role used by 6.8.x APMServer instances to connect to Elasticsearch.
 	ApmUserRoleV6 = "eck_apm_user_role_v6"
-	// ApmUserRoleV7 is the name of the role used by the association user for APMServer instances from version 7.1 to 7.4 included.
+	// ApmUserRoleV7 is the name of the role used by APMServer instances to connect to Elasticsearch from version 7.1 to 7.4 included.
 	ApmUserRoleV7 = "eck_apm_user_role_v7"
-	// ApmUserRoleV75 is the name of the role used by the association user for APMServer instances from version 7.5
+	// ApmUserRoleV75 is the name of the role used by APMServer instances to connect to Elasticsearch from version 7.5
 	ApmUserRoleV75 = "eck_apm_user_role_v75"
 )
 

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -18,12 +18,23 @@ const (
 	SuperUserBuiltinRole = "superuser"
 	// ProbeUserRole is the name of the role used by the internal probe user.
 	ProbeUserRole = "elastic_internal_probe_user"
+	// ApmDefaultUserRole is the name of the default role used by the APM Server instances.
+	ApmDefaultUserRole = "default_apm_user_role"
 )
 
 var (
 	// PredefinedRoles to create for internal needs.
 	PredefinedRoles = RolesFileContent{
 		ProbeUserRole: esclient.Role{Cluster: []string{"monitor"}},
+		ApmDefaultUserRole: esclient.Role{
+			Cluster: []string{"monitor", "manage_ilm"},
+			Indices: []esclient.IndexRole{
+				{
+					Names:      []string{"apm-*"},
+					Privileges: []string{"manage", "create_doc", "create_index"},
+				},
+			},
+		},
 	}
 )
 

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -27,7 +27,7 @@ var (
 	PredefinedRoles = RolesFileContent{
 		ProbeUserRole: esclient.Role{Cluster: []string{"monitor"}},
 		ApmDefaultUserRole: esclient.Role{
-			Cluster: []string{"monitor", "manage_ilm"},
+			Cluster: []string{"monitor", "manage_ilm", "manage_api_key"},
 			Indices: []esclient.IndexRole{
 				{
 					Names:      []string{"apm-*"},

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -35,7 +35,7 @@ var (
 			Cluster: []string{"monitor", "manage_index_templates"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{"apm-*"},
+					Names:      []string{"apm-*", ".monitoring-beats-*"},
 					Privileges: []string{"write", "create_index"},
 				},
 			},
@@ -44,7 +44,7 @@ var (
 			Cluster: []string{"monitor", "manage_ilm", "manage_index_templates"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{"apm-*"},
+					Names:      []string{"apm-*", ".monitoring-beats-*"},
 					Privileges: []string{"manage", "write", "create_index"},
 				},
 			},
@@ -53,7 +53,7 @@ var (
 			Cluster: []string{"monitor", "manage_ilm", "manage_api_key"}, // manage_api_key has been introduced in 7.5
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{"apm-*"},
+					Names:      []string{"apm-*", ".monitoring-beats-*"},
 					Privileges: []string{"manage", "create_doc", "create_index"},
 				},
 			},

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -35,7 +35,7 @@ var (
 			Cluster: []string{"monitor", "manage_index_templates"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{"apm-*", ".monitoring-beats-*"},
+					Names:      []string{"apm-*"},
 					Privileges: []string{"write", "create_index"},
 				},
 			},
@@ -44,7 +44,7 @@ var (
 			Cluster: []string{"monitor", "manage_ilm", "manage_index_templates"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{"apm-*", ".monitoring-beats-*"},
+					Names:      []string{"apm-*"},
 					Privileges: []string{"manage", "write", "create_index"},
 				},
 			},
@@ -53,7 +53,7 @@ var (
 			Cluster: []string{"monitor", "manage_ilm", "manage_api_key"}, // manage_api_key has been introduced in 7.5
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{"apm-*", ".monitoring-beats-*"},
+					Names:      []string{"apm-*"},
 					Privileges: []string{"manage", "create_doc", "create_index"},
 				},
 			},


### PR DESCRIPTION
Fixes #2661 

This PR:
 * Adds a role called `default_apm_user_role` _(name can be discussed ofc)_ to allow APM Server instances to setup and manage `apm-*` indices:
```yaml
default_apm_user_role:
      cluster:
      - monitor
      - manage_ilm
      indices:
      - names:
        - apm-*
        privileges:
        - manage
        - create_doc
        - create_index

```
* Adds the APM users to the role described above and also to the built-in roles `kibana_user` and `ingest_admin`

I did some tests and it seems to work fine but I would be glad to have a quick review of the role by @simitt or @graphaelli. Thanks 🙇 
