### PR TITLE
Improve e2e runner logs

### DIFF
--- a/config/e2e/batch_job.yaml
+++ b/config/e2e/batch_job.yaml
@@ -35,6 +35,8 @@ spec:
   ttlSecondsAfterFinished: 360
   template:
     metadata:
+      annotations:
+        co.elastic.logs/json.keys_under_root: "true"
       labels:
         test-run: {{ .Context.TestRun }}
     spec:

--- a/config/e2e/filebeat.yaml
+++ b/config/e2e/filebeat.yaml
@@ -13,20 +13,19 @@ data:
         - type: kubernetes
           host: ${NODE_NAME}
           hints.enabled: true
-          templates:
-          - config:
-            - type: container
-              paths:
-              - /var/log/containers/*${data.kubernetes.container.id}.log
-              fields_under_root: true
-              fields:
-                pipeline: {{ .Pipeline }}
-                build_number: {{ .BuildNumber }}
-                provider: {{ .Provider }}
-                clusterName: {{ .ClusterName }}
-                kubernetes_version: {{ .KubernetesVersion }}
-                stack_version: {{ .ElasticStackVersion }}
-                e2e_test_id: {{ .Pipeline }}-{{ .BuildNumber }}-{{ .Provider }}-{{ .ClusterName }}-{{ .KubernetesVersion }}-{{ .ElasticStackVersion }}
+          hints.default_config:
+            type: container
+            paths:
+            - /var/log/containers/*${data.kubernetes.container.id}.log
+            fields_under_root: true
+            fields:
+              pipeline: {{ .Pipeline }}
+              build_number: {{ .BuildNumber }}
+              provider: {{ .Provider }}
+              clusterName: {{ .ClusterName }}
+              kubernetes_version: {{ .KubernetesVersion }}
+              stack_version: {{ .ElasticStackVersion }}
+              e2e_test_id: {{ .Pipeline }}-{{ .BuildNumber }}-{{ .Provider }}-{{ .ClusterName }}-{{ .KubernetesVersion }}-{{ .ElasticStackVersion }}
           appenders:
           - type: config
             condition:


### PR DESCRIPTION
Adds `json.keys_under_root` config setting via autodiscovery annotation for E2E runner pod. This allows indexing `Elapsed`, `Action`, `Output` and `Test`. It turns out that autodiscovery hints don't work with the way we currently specify config (config templates), so changing it to `hints.default_config` approach.