### PR TITLE
Fix kind script

### DIFF
--- a/hack/kind/kind.sh
+++ b/hack/kind/kind.sh
@@ -14,11 +14,8 @@
 # Exit immediately for non zero status
 set -e
 
-if [ -n "${KIND_LOGGING}" ]; then
-  IFS=' ' read -r -a log_lvl <<< "${KIND_LOGGING}"
-else
-  log_lvl=("-v" "1")
-fi
+KIND_LOG_LEVEL=${KIND_LOG_LEVEL:-"1"}
+log_lvl=("-v" "$KIND_LOG_LEVEL")
 
 CLUSTER_NAME=${KIND_CLUSTER_NAME:-eck-e2e}
 NODES=3

--- a/hack/kind/kind.sh
+++ b/hack/kind/kind.sh
@@ -13,8 +13,6 @@
 
 # Exit immediately for non zero status
 set -e
-# Print commands
-set -x
 
 KIND_LOGGING=${KIND_LOGGING:-"-v 1"}
 CLUSTER_NAME=${KIND_CLUSTER_NAME:-eck-e2e}
@@ -52,7 +50,7 @@ EOT
 
     done
   else
-    # There's only the controle plane, no nodes
+    # There's only the control plane, no nodes
     workers=${CLUSTER_NAME}-control-plane
   fi
 
@@ -86,7 +84,9 @@ function setup_kind_cluster() {
     config_opts="--config ${MANIFEST}"
   fi
   # Create Kind cluster
-  if ! (kind "${KIND_LOGGING}" create cluster --name="${CLUSTER_NAME}" "${config_opts}" --retain --image "${NODE_IMAGE}"); then
+  # TODO: see if this lint rule can be re-enabled
+  # shellcheck disable=SC2086
+  if ! (kind ${KIND_LOGGING} create cluster --name="${CLUSTER_NAME}" ${config_opts} --retain --image "${NODE_IMAGE}"); then
     echo "Could not setup Kind environment. Something wrong with Kind setup."
     exit 1
   fi
@@ -137,9 +137,11 @@ fi
 
 # Load images in the nodes, e.g. the operator image or the e2e container
 if [[ -n "${LOAD_IMAGES}" ]]; then
-  IMAGES=("${LOAD_IMAGES//,/ }")
+  IFS=',' read -r -a IMAGES <<< "${LOAD_IMAGES}"
   for image in "${IMAGES[@]}"; do
-          kind "${KIND_LOGGING}" --name "${CLUSTER_NAME}" load docker-image --nodes "${workers}" "${image}"
+          # TODO: see if this lint rule can be re-enabled
+          # shellcheck disable=SC2086
+          kind ${KIND_LOGGING} --name "${CLUSTER_NAME}" load docker-image --nodes "${workers}" "${image}"
   done
 fi
 


### PR DESCRIPTION
Fixes some errors introduced in https://github.com/elastic/cloud-on-k8s/pull/2752

You can see the error [here](
https://devops-ci.elastic.co/job/cloud-on-k8s-e2e-tests-kind-k8s-versions/33/console).

Shellcheck is upset that both `${KIND_LOGGING}` and `${config_opts}` are unquoted, but quoting them also causes problems. [This](https://github.com/koalaman/shellcheck/wiki/SC2086) is the article for that error. If I understand it correctly, we want to split on spaces, so it suggests we read from an array. But then I run into other issues that I don't quite understand. 

For these I just disabled the lint check to get it up and running, and added a TODO for someone better at bash to figure out if there's a better way.


Also fixes [SC2206](https://github.com/koalaman/shellcheck/wiki/SC2206) by switching to `read -ra`.

To verify it works locally, you can use
```
LOAD_IMAGES=docker.elastic.co/k8s/build-tools,gcr.io/distroless/base  NODE_IMAGE="kindest/node:v1.15.3" ./hack/kind/kind.sh
```
or substitute other images you have downloaded locally.