### PR TITLE
Improve filebeat configuration to prevent losing last logs

### DIFF
--- a/config/e2e/filebeat.yaml
+++ b/config/e2e/filebeat.yaml
@@ -8,6 +8,8 @@ metadata:
     k8s-app: filebeat
 data:
   filebeat.yml: |-
+    max_backoff: 1s
+    close_inactive: 1h
     filebeat.autodiscover:
       providers:
         - type: kubernetes

--- a/config/e2e/filebeat.yaml
+++ b/config/e2e/filebeat.yaml
@@ -8,8 +8,8 @@ metadata:
     k8s-app: filebeat
 data:
   filebeat.yml: |-
-    max_backoff: 1s
-    close_inactive: 1h
+    max_backoff: 1s # reduces worst case delay between log being written and picked up by Filebeat to 1s
+    close_inactive: 1h # keep harvester open for 1h on inactive files as our test timeout is longer than default 5m
     filebeat.autodiscover:
       providers:
         - type: kubernetes

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -17,3 +17,8 @@ for PKG in $(go list github.com/elastic/cloud-on-k8s/test/e2e/...); do
         go test -v -failfast -timeout=4h -tags=e2e -p=1 "$PKG" "$@"
     fi
 done
+
+# sleep 1s to allow filebeat to read all logs with 1s max_backoff
+# minimizes race condition in filebeat between reading log file and
+# stopping reading due to pod termination autodiscovery event
+sleep 1


### PR DESCRIPTION
We are currently losing last log lines from pods because, IIUC, the event about pod going away immediately removes configuration from Filebeat. In case of e2e test runner pod this is especially impacting as we lose logs which indicate test failure. This PR changes:
- `max_backoff` to 1s - this causes Filebeat to recheck every file that is open a second after hitting EOF. This means that, worst case, there is 1s delay between pod writing and Filebeat reading a particular log line. It was defaulted to 10s previously which meant that if it took less then that to receive a stop event from api-server (usually it's ~1s) we lost logs.
- `close_inactive` to 1h - this causes Filebeat to keep file open for 1h after last activity. Was defaulted to 5 minutes previously. With our test timeouts being more than that, log file was closed and rescanned every 10 seconds which had the same issue as described above.

In addition I'm adding 1s sleep to our e2e test runner script, to minimize chances of race condition happening.
