### PR TITLE
Incorrect description of a node affinity example

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
@@ -200,7 +200,7 @@ spec:
                     - ssd
 ----
 
-This example restricts Elasticsearch nodes from being scheduled on Kubernetes hosts tagged with `environment: e2e` or `environment: production`. It favors nodes tagged with `diskType: ssd`.
+This example restricts Elasticsearch nodes so they are only scheduled on Kubernetes hosts tagged with `environment: e2e` or `environment: production`. It favors nodes tagged with `diskType: ssd`.
 
 [id="{p}-availability-zone-awareness"]
 == Availability zone awareness


### PR DESCRIPTION
The example shows a `nodeAffinity` for hosts tagged with `environment: e2e` or `environment: production`, but describes the example by saying:
> This example restricts Elasticsearch nodes from being scheduled on Kubernetes hosts tagged with environment: e2e or environment: production.

I think the opposite is true. So, I propose updating the example description to read:
"This example restricts Elasticsearch nodes so they are only scheduled on Kubernetes hosts tagged with `environment: e2e` or `environment: production`."