### PR TITLE
Expand upgrading ECK doc + add annotator script

### DIFF
--- a/docs/operating-eck/upgrading-eck.asciidoc
+++ b/docs/operating-eck/upgrading-eck.asciidoc
@@ -53,7 +53,7 @@ Once the operator has been upgraded and you are ready to let the resource become
 
 
 [source,shell,subs="attributes,callouts"]
-.Resume Elastic resource managment by the operator
+.Resume Elastic resource management by the operator
 ----
 RM_ANNOTATION='common.k8s.elastic.co/pause-' <1>
 

--- a/docs/operating-eck/upgrading-eck.asciidoc
+++ b/docs/operating-eck/upgrading-eck.asciidoc
@@ -9,13 +9,14 @@ endif::[]
 
 [float]
 [id="{p}-ga-upgrade"]
-== Upgrade to newer releases of ECK
+== Upgrade to ECK {eck_version}
 
-ECK reached general availability (GA) status with the link:https://www.elastic.co/blog/elastic-cloud-on-kubernetes-ECK-is-now-generally-available[release of version 1.0.0]. It is compatible with the previous beta release (1.0.0-beta1) and can be upgraded in-place (<<{p}-ga-openshift, with a few exceptions>>). Previous alpha releases, up to and including version 0.9.0, are not compatible with the GA and beta releases and link:https://www.elastic.co/guide/en/cloud-on-k8s/1.0-beta/k8s-upgrading-eck.html[require extra work to upgrade].
+ECK reached general availability (GA) status with the link:https://www.elastic.co/blog/elastic-cloud-on-kubernetes-ECK-is-now-generally-available[release of version 1.0.0]. The latest available GA version is {eck_version}. It is compatible with the previous beta release (1.0.0-beta1) and can be upgraded in-place (<<{p}-ga-openshift, with a few exceptions>>). Previous alpha releases, up to and including version 0.9.0, are not compatible with the GA and beta releases and link:https://www.elastic.co/guide/en/cloud-on-k8s/1.0-beta/k8s-upgrading-eck.html[require extra work to upgrade].
+
 
 [float]
 [id="{p}-beta-to-ga-upgrade"]
-=== Upgrade from beta to GA
+=== Upgrade from beta to {eck_version}
 
 CAUTION: The upgrade process results in an update to all the existing managed resources. This triggers a rolling restart of all Elasticsearch and Kibana pods. <<{p}-beta-to-ga-rolling-restart, Guidance>> is available on controlling this process more gracefully.
 
@@ -23,6 +24,7 @@ IMPORTANT: If you are running Openshift 3.11 or a Kubernetes version older than 
 
 Follow the instructions in <<{p}-deploy-eck>> to upgrade from the beta version of ECK to a GA version. The versions are mostly compatible and all that is required is an update to the ECK binary and the CRDs. After the upgrade, ensure that your Elasticsearch, Kibana, and APM Server manifests are updated to use the `v1` API version instead of `v1beta1`.
 
+[float]
 [id="{p}-beta-to-ga-rolling-restart"]
 ==== Control rolling restarts during the upgrade
 
@@ -64,7 +66,8 @@ kubectl annotate elasticsearch quickstart $RM_ANNOTATION
 NOTE: The ECK source repository contains a link:https://github.com/elastic/cloud-on-k8s/tree/master/hack/annotator[shell script] to assist with mass addition/deletion of annotations.
 
 
+[float]
 [id="{p}-ga-openshift"]
-=== Upgrade from beta to GA in older versions of Kubernetes
+=== Upgrade from beta to {eck_version} in older versions of Kubernetes
 
 If you are running Openshift 3.11 or a Kubernetes version older than 1.13, in-place upgrade is not possible due to an link:https://github.com/kubernetes/kubernetes/issues/73752[upstream bug]. You should backup your existing manifests, <<{p}-snapshots,take snapshots>>, <<{p}-uninstalling-eck,uninstall ECK>> and then <<{p}-deploy-eck,install the new version of ECK>>. Afterwards, you can update your manifests to use the `v1` API version and restore state from the snapshots.

--- a/docs/operating-eck/upgrading-eck.asciidoc
+++ b/docs/operating-eck/upgrading-eck.asciidoc
@@ -9,24 +9,62 @@ endif::[]
 
 [float]
 [id="{p}-ga-upgrade"]
-== Upgrade to ECK 1.0.0 from previous versions
+== Upgrade to newer releases of ECK
 
-ECK 1.0.0 is largely compatible with the beta version of the operator (see <<{p}-ga-openshift,the exceptions for earlier Kubernetes and OpenShift versions>>). There is not a direct upgrade path from the alpha version.
-
-To upgrade from 1.0.0-beta1, follow the <<{p}-quickstart>>. Note that all Elasticsearch and Kibana Pods go through a rolling restart when the operator is upgraded.
-
-After the upgrade, use the `v1` API version for all Elastic manifests.
-
-See the <<release-highlights-1.0.0>> for more information on new features.
+ECK reached general availability (GA) status with the link:https://www.elastic.co/blog/elastic-cloud-on-kubernetes-ECK-is-now-generally-available[release of version 1.0.0]. It is compatible with the previous beta release (1.0.0-beta1) and can be upgraded in-place (<<{p}-ga-openshift, with a few exceptions>>). Previous alpha releases, up to and including version 0.9.0, are not compatible with the GA and beta releases and link:https://www.elastic.co/guide/en/cloud-on-k8s/1.0-beta/k8s-upgrading-eck.html[require extra work to upgrade].
 
 [float]
+[id="{p}-beta-to-ga-upgrade"]
+=== Upgrade from beta to GA
+
+CAUTION: The upgrade process results in an update to all the existing managed resources. This triggers a rolling restart of all Elasticsearch and Kibana pods. <<{p}-beta-to-ga-rolling-restart, Guidance>> is available on controlling this process more gracefully.
+
+IMPORTANT: If you are running Openshift 3.11 or a Kubernetes version older than 1.13, skip to the <<{p}-ga-openshift, upgrade instructions for older Kubernetes releases>>.
+
+Follow the instructions in <<{p}-deploy-eck>> to upgrade from the beta version of ECK to a GA version. The versions are mostly compatible and all that is required is an update to the ECK binary and the CRDs. After the upgrade, ensure that your Elasticsearch, Kibana, and APM Server manifests are updated to use the `v1` API version instead of `v1beta1`.
+
+[id="{p}-beta-to-ga-rolling-restart"]
+==== Control rolling restarts during the upgrade
+
+Upgrading the operator results in a one-time update to existing managed resources in the cluster. This triggers a rolling restart of pods by Kubernetes to apply those changes. If you have a very large Elasticsearch cluster or multiple Elastic Stack deployments, this rolling restart might be disruptive or inconvenient. To have more control over when the pods belonging to a particular deployment should be restarted, you can <<{p}-exclude-resource,add an annotation>> to the corresponding Elasticsearch, Kibana, or APM Server resources to temporarily exclude them from being managed by the operator. When the time is convenient, you can remove the annotation and let the rolling restart go through.
+
+CAUTION: Once a resource is excluded from being managed by ECK, you will not be able to add/remove nodes, upgrade Stack version, or perform other <<{p}-orchestrating-elastic-stack-applications, orchestration tasks>> by updating the resource manifest. You must remember to remove the exclusion to ensure that your Elastic Stack deployment is continually monitored and managed by the operator.
+
+[source,shell,subs="attributes,callouts"]
+.Exclude Elastic resources from being managed by the operator
+----
+ANNOTATION='common.k8s.elastic.co/pause=true' <1>
+
+# Exclude a single Elasticsearch resource named "quickstart"
+kubectl annotate --overwrite elasticsearch quickstart $ANNOTATION
+
+# Exclude all resources in the current namespace
+kubectl annotate --overwrite elastic --all $ANNOTATION
+
+# Exclude all resources in all of the namespaces:
+for NS in $(kubectl get ns -o=custom-columns='NAME:.metadata.name' --no-headers); do kubectl annotate --overwrite elastic --all $ANNOTATION -n $NS; done
+----
+
+<1> Since ECK 1.1.0, this annotation has been superseded by `eck.k8s.elastic.co/managed=false`
+
+Once the operator has been upgraded and you are ready to let the resource become managed again (triggering a rolling restart of pods in the process), remove the annotation.
+
+
+[source,shell,subs="attributes,callouts"]
+.Resume Elastic resource managment by the operator
+----
+RM_ANNOTATION='common.k8s.elastic.co/pause-' <1>
+
+# Resume management of a single Elasticsearch cluster named "quickstart"
+kubectl annotate elasticsearch quickstart $RM_ANNOTATION
+----
+
+<1> Since ECK 1.1.0, this annotation has been superseded by `eck.k8s.elastic.co/managed-`
+
+NOTE: The ECK source repository contains a link:https://github.com/elastic/cloud-on-k8s/tree/master/hack/annotator[shell script] to assist with mass addition/deletion of annotations.
+
+
 [id="{p}-ga-openshift"]
-== Upgrades in earlier Kubernetes and OpenShift versions
+=== Upgrade from beta to GA in older versions of Kubernetes
 
-Upgrading from ECK 1.0.0-beta1 to 1.0.0 has some special considerations for users running either:
-- Kubernetes versions < 1.13
-- OpenShift 3.11
-
-In this case, ECK must be uninstalled and reinstalled (due to link:https://github.com/kubernetes/kubernetes/issues/73752[an upstream bug] that was not backported). To uninstall ECK, see <<{p}-uninstalling-eck>>. Then you can follow the <<{p}-quickstart>> to install anew. You can save your existing `v1beta1` manifests, update them to the `v1` API version, <<{p}-snapshots,take snapshots>> and restore them as well.
-
-After the upgrade, use the `v1` API version for all Elastic manifests.
+If you are running Openshift 3.11 or a Kubernetes version older than 1.13, in-place upgrade is not possible due to an link:https://github.com/kubernetes/kubernetes/issues/73752[upstream bug]. You should backup your existing manifests, <<{p}-snapshots,take snapshots>>, <<{p}-uninstalling-eck,uninstall ECK>> and then <<{p}-deploy-eck,install the new version of ECK>>. Afterwards, you can update your manifests to use the `v1` API version and restore state from the snapshots.

--- a/hack/annotator/README.md
+++ b/hack/annotator/README.md
@@ -1,0 +1,18 @@
+Annotator Script
+================
+
+This script provides utilities for adding, removing, and listing annotations to/from Elastic resources deployed in a Kubernetes cluster.
+
+
+Usage:
+
+```
+# Add the my.domain/annotation=value annotation to all Elastic resources
+ANN_KEY="my.domain/annotation" ANN_VAL="value" ./annotator.sh add
+
+# List all Elastic resources that have the my.domain/annotation set
+ANN_KEY="my.domain/annotation" ./annotator.sh ls
+
+# Remove the my.domain/annotation from all Elastic resources
+ANN_KEY="my.domain/annotation" PAUSE_SECS=10 ./annotator.sh remove
+```

--- a/hack/annotator/annotator.sh
+++ b/hack/annotator/annotator.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+# Script to automate the task of adding or removing the "exclude" annotation from/to all Elastic resources in a Kubernetes cluster.
+
+set -euo pipefail
+
+ANN_KEY=${ANN_KEY:-"common.k8s.elastic.co/pause"}
+ANN_VAL=${ANN_VAL:-"true"}
+PAUSE_SECS=${PAUSE_SECS:-"900"}
+
+remove_all() {
+    mapfile -t OBJECTS < <(kubectl get elastic --all-namespaces -o=jsonpath='{range .items[*]}{.kind}{"|"}{.metadata.name}{"|"}{.metadata.namespace}{"\n"}{end}')
+
+    for OBJ in "${OBJECTS[@]}"; do
+        IFS='|' read -r -a ARGS <<< "$OBJ"
+
+        echo "Removing $ANN_KEY annotation from ${ARGS[0]} resource ${ARGS[1]} in namespace ${ARGS[2]}"
+        kubectl annotate "${ARGS[0],,}" "${ARGS[1]}" "${ANN_KEY}-" -n "${ARGS[2]}"
+        echo "Waiting $PAUSE_SECS seconds"
+        sleep "$PAUSE_SECS"
+    done
+}
+
+add_all() {
+    mapfile -t NAMESPACES < <(kubectl get ns -o=custom-columns='NAME:.metadata.name' --no-headers)
+
+    for NS in "${NAMESPACES[@]}"; do
+        echo "Adding $ANN_KEY=$ANN_VAL annotation to all Elastic resources in namespace $NS"
+        kubectl annotate --overwrite elastic --all "${ANN_KEY}=${ANN_VAL}" -n "$NS"
+    done
+}
+
+list_all() {
+    TEMPLATE="{{ range .items }}{{ if index .metadata.annotations \"${ANN_KEY}\" }}{{ printf \"%s|%s|%s\\n\" .kind .metadata.name .metadata.namespace }}{{ end }}{{ end }}"
+    mapfile -t ANNOTATED < <(kubectl get elastic --all-namespaces -o=go-template="$TEMPLATE")
+
+    printf "NAMESPACE\tTYPE\tNAME\n"
+    for OBJ in "${ANNOTATED[@]}"; do
+        IFS='|' read -r -a ARGS <<< "$OBJ"
+        printf   "%s\t%s\t%s\n" "${ARGS[2]}" "${ARGS[0]}" "${ARGS[1]}"
+    done
+}
+
+usage() {
+    echo "Usage: $0 ls|add|remove"
+    echo "ls: Lists all Elastic resources that have the $ANN_KEY annotation"
+    echo "add: Add the $ANN_KEY=$ANN_VAL annotation to all Elastic resources in all namespaces"
+    echo "remove: Remove the $ANN_KEY annotation from all Elastic resources in all namespaces"
+    exit 2
+}
+
+
+if [[ "$#" -ne 1 ]]; then
+    usage
+fi
+
+case "$1" in
+    ls)
+        list_all
+        ;;
+    add)
+        add_all
+        ;;
+    remove)
+        remove_all
+        ;;
+    help)
+        usage
+        ;;
+    *)
+        echo "Unknown action '$1'"
+        usage
+        ;;
+esac


### PR DESCRIPTION
Adds more information to the "Upgrading ECK" document to inform users about the rolling restart of all resources and how to manage them effectively.

Also adds a script to help with annotating all Elastic resources in a cluster.

Fixes: #2595
Depends on: #2783

Preview: http://cloud-on-k8s_2797.docs-preview.app.elstc.co/guide/en/cloud-on-k8s/master/k8s-upgrading-eck.html