### PR TITLE
Perform a normal flush instead of a sync flush when targeting Elasticsearch 8.0

### DIFF
--- a/pkg/controller/elasticsearch/client/client.go
+++ b/pkg/controller/elasticsearch/client/client.go
@@ -71,9 +71,11 @@ type Client interface {
 	DisableReplicaShardsAllocation(ctx context.Context) error
 	// EnableShardAllocation enables shards allocation on the cluster.
 	EnableShardAllocation(ctx context.Context) error
-	// SyncedFlush requests a synced flush on the cluster.
+	// SyncedFlush requests a synced flush on the cluster. Deprecated in 7.6, removed in 8.0.
 	// This is "best-effort", see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-synced-flush.html.
 	SyncedFlush(ctx context.Context) error
+	// Flush requests a flush on the cluster.
+	Flush(ctx context.Context) error
 	// GetClusterHealth calls the _cluster/health api.
 	GetClusterHealth(ctx context.Context) (Health, error)
 	// SetMinimumMasterNodes sets the transient and persistent setting of the same name in cluster settings.

--- a/pkg/controller/elasticsearch/client/v6.go
+++ b/pkg/controller/elasticsearch/client/v6.go
@@ -55,6 +55,10 @@ func (c *clientV6) SyncedFlush(ctx context.Context) error {
 	return c.post(ctx, "/_flush/synced", nil, nil)
 }
 
+func (c *clientV6) Flush(ctx context.Context) error {
+	return c.post(ctx, "/_flush", nil, nil)
+}
+
 func (c *clientV6) GetClusterHealth(ctx context.Context) (Health, error) {
 	var result Health
 	return result, c.get(ctx, "/_cluster/health", &result)

--- a/pkg/controller/elasticsearch/client/v8.go
+++ b/pkg/controller/elasticsearch/client/v8.go
@@ -4,8 +4,17 @@
 
 package client
 
+import (
+	"context"
+	"errors"
+)
+
 type clientV8 struct {
 	clientV7
+}
+
+func (c *clientV8) SyncedFlush(ctx context.Context) error {
+	return errors.New("synced flush is not supported in Elasticsearch 8.x")
 }
 
 // Equal returns true if c2 can be considered the same as c

--- a/pkg/controller/elasticsearch/driver/esstate_test.go
+++ b/pkg/controller/elasticsearch/driver/esstate_test.go
@@ -35,6 +35,7 @@ type fakeESClient struct { //nolint:maligned
 	EnableShardAllocationCalled bool
 
 	SyncedFlushCalled bool
+	FlushCalled       bool
 
 	nodes             esclient.Nodes
 	GetNodesCallCount int
@@ -76,6 +77,11 @@ func (f *fakeESClient) EnableShardAllocation(_ context.Context) error {
 
 func (f *fakeESClient) SyncedFlush(_ context.Context) error {
 	f.SyncedFlushCalled = true
+	return nil
+}
+
+func (f *fakeESClient) Flush(_ context.Context) error {
+	f.FlushCalled = true
 	return nil
 }
 

--- a/pkg/controller/elasticsearch/driver/upgrade_pods_deletion.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_pods_deletion.go
@@ -62,7 +62,6 @@ func (ctx *rollingUpgradeCtx) Delete() ([]corev1.Pod, error) {
 		return podsToDelete, nil
 	}
 
-	// Disable shard allocation
 	if err := ctx.prepareClusterForNodeRestart(ctx.esClient, ctx.esState); err != nil {
 		return podsToDelete, err
 	}

--- a/pkg/controller/elasticsearch/driver/upgrade_predicates_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_predicates_test.go
@@ -192,6 +192,7 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 		{
 			name: "Do not attempt to delete an already terminating Pod",
 			fields: fields{
+				esVersion: "7.5.0",
 				upgradeTestPods: newUpgradeTestPods(
 					newTestPod("master-0").isMaster(true).isData(false).isHealthy(true).needsUpgrade(true).isInCluster(true),
 					newTestPod("node-0").isMaster(false).isData(true).isHealthy(true).needsUpgrade(true).isInCluster(true),
@@ -210,6 +211,7 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 		{
 			name: "All Pods are upgraded",
 			fields: fields{
+				esVersion: "7.5.0",
 				upgradeTestPods: newUpgradeTestPods(
 					newTestPod("masters-0").isMaster(true).isData(true).isHealthy(true).needsUpgrade(false).isInCluster(true),
 					newTestPod("masters-1").isMaster(true).isData(true).isHealthy(true).needsUpgrade(false).isInCluster(true),
@@ -227,6 +229,7 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 		{
 			name: "3 healthy master and data nodes, allow the last to be upgraded",
 			fields: fields{
+				esVersion: "7.5.0",
 				upgradeTestPods: newUpgradeTestPods(
 					newTestPod("masters-2").isMaster(true).isData(true).isHealthy(true).needsUpgrade(false).isInCluster(true),
 					newTestPod("masters-1").isMaster(true).isData(true).isHealthy(true).needsUpgrade(false).isInCluster(true),
@@ -244,6 +247,7 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 		{
 			name: "3 healthy masters, allow the deletion of 1",
 			fields: fields{
+				esVersion: "7.5.0",
 				upgradeTestPods: newUpgradeTestPods(
 					newTestPod("masters-2").isMaster(true).isData(true).isHealthy(true).needsUpgrade(true).isInCluster(true),
 					newTestPod("masters-1").isMaster(true).isData(true).isHealthy(true).needsUpgrade(true).isInCluster(true),
@@ -261,6 +265,7 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 		{
 			name: "3 healthy masters, allow the deletion of 1 even if maxUnavailable > 1",
 			fields: fields{
+				esVersion: "7.5.0",
 				upgradeTestPods: newUpgradeTestPods(
 					newTestPod("masters-2").isMaster(true).isData(true).isHealthy(true).needsUpgrade(true).isInCluster(true),
 					newTestPod("masters-1").isMaster(true).isData(true).isHealthy(true).needsUpgrade(true).isInCluster(true),
@@ -278,6 +283,7 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 		{
 			name: "2 healthy masters out of 5, maxUnavailable is 2, allow the deletion of the unhealthy one",
 			fields: fields{
+				esVersion: "7.5.0",
 				upgradeTestPods: newUpgradeTestPods(
 					newTestPod("master-0").isMaster(true).isData(true).isHealthy(true).needsUpgrade(true).isInCluster(true),
 					newTestPod("master-1").isMaster(true).isData(true).isHealthy(false).needsUpgrade(true).isInCluster(false),
@@ -297,6 +303,7 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 		{
 			name: "1 master and 1 data node, wait for the node to be upgraded first",
 			fields: fields{
+				esVersion: "7.5.0",
 				upgradeTestPods: newUpgradeTestPods(
 					newTestPod("master-0").isMaster(true).isData(false).isHealthy(true).needsUpgrade(true).isInCluster(true),
 					newTestPod("node-0").isMaster(false).isData(true).isHealthy(true).needsUpgrade(true).isInCluster(true),
@@ -313,6 +320,7 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 		{
 			name: "Do not delete healthy node if red",
 			fields: fields{
+				esVersion: "7.5.0",
 				upgradeTestPods: newUpgradeTestPods(
 					newTestPod("master-0").isMaster(true).isData(true).isHealthy(true).needsUpgrade(true).isInCluster(true),
 				),
@@ -328,6 +336,7 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 		{
 			name: "Do not delete healthy node if health is unknown",
 			fields: fields{
+				esVersion: "7.5.0",
 				upgradeTestPods: newUpgradeTestPods(
 					newTestPod("master-0").isMaster(true).isData(true).isHealthy(true).needsUpgrade(true).isInCluster(true),
 				),
@@ -343,6 +352,7 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 		{
 			name: "Allow deletion of unhealthy node if not green",
 			fields: fields{
+				esVersion: "7.5.0",
 				upgradeTestPods: newUpgradeTestPods(
 					newTestPod("masters-0").isMaster(true).isData(true).isHealthy(true).needsUpgrade(true).isInCluster(true),
 					newTestPod("masters-2").isMaster(true).isData(true).isHealthy(false).needsUpgrade(true).isInCluster(false),
@@ -393,6 +403,7 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 		{
 			name: "Allow deletion of healthy node if yellow and node is upgrading",
 			fields: fields{
+				esVersion: "7.5.0",
 				upgradeTestPods: newUpgradeTestPods(
 					newTestPod("masters-0").isMaster(true).isData(true).isHealthy(true).needsUpgrade(true).isInCluster(true).withVersion("7.4.0"),
 					newTestPod("masters-1").isMaster(true).isData(true).isHealthy(true).needsUpgrade(true).isInCluster(true).withVersion("7.4.0"),
@@ -574,6 +585,7 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 		{
 			name: "Do not delete last healthy master",
 			fields: fields{
+				esVersion: "7.5.0",
 				upgradeTestPods: newUpgradeTestPods(
 					newTestPod("masters-0").isMaster(true).isData(true).isHealthy(true).needsUpgrade(false).isInCluster(true),
 					newTestPod("masters-1").isMaster(true).isData(true).isHealthy(false).needsUpgrade(true).isInCluster(false),
@@ -590,6 +602,7 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 		{
 			name: "Pod deleted while upgrading",
 			fields: fields{
+				esVersion: "7.5.0",
 				upgradeTestPods: newUpgradeTestPods(
 					newTestPod("masters-0").isMaster(true).isData(true).isHealthy(true).needsUpgrade(true).isInCluster(true),
 					newTestPod("masters-1").isMaster(true).isData(true).isHealthy(true).needsUpgrade(true).isInCluster(true),
@@ -609,6 +622,7 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 			// some nodes. The fake cluster state used in this test is in the testdata/cluster_state.json
 			name: "Do not delete Pods that share some shards",
 			fields: fields{
+				esVersion: "7.5.0",
 				upgradeTestPods: newUpgradeTestPods(
 					// 5 data nodes
 					newTestPod("elasticsearch-sample-es-nodes-4").isMaster(false).isData(true).isHealthy(true).needsUpgrade(true).isInCluster(true),

--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -226,6 +226,8 @@ func Test_doFlush(t *testing.T) {
 			fakeClient := &fakeESClient{}
 			err := doFlush(context.Background(), tt.es, fakeClient)
 			require.NoError(t, err)
+			require.Equal(t, tt.wantSyncFlushCalled, fakeClient.SyncedFlushCalled)
+			require.Equal(t, tt.wantFlushCalled, fakeClient.FlushCalled)
 		})
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/2445.

Synced flush is deprecated starting 7.6, and removed starting 8.0.
Instead, we should perform a "normal" flush during rolling upgrades.

That's what this commit does.

One important implementation detail: it only inspects the expected ES
version, not the version of the currently running Pods, for simplicity.
When upgrading from 7.x to 8.x, a normal flush will be done.
In theory, we could do a synced flush for the first
pod to upgrade (since there are no 8.0 pods yet), then a normal flush
for the remaining pods (since the request may target the already
upgraded 8.0 pod).  We must make sure we don't do a synced flush if
an 8.x pod is running, or should be running.
Since synced flush is a best effort operation, and
7.x does also support normal flush, I think it's not worth the trouble.
Also, the [7.x to 8.x upgrade documentation](https://www.elastic.co/guide/en/elasticsearch/reference/master/rolling-upgrades.html) does not mention synced flush.

I noticed the current 8.0.0-SNAPSHOT still accepts `/_flush/synced` requests,
but that may disappear anytime.