### PR TITLE
Add traffic splitting documentation

### DIFF
--- a/docs/advanced-topics/advanced-topics.asciidoc
+++ b/docs/advanced-topics/advanced-topics.asciidoc
@@ -12,8 +12,10 @@ endif::[]
 - <<{p}-openshift>>
 - <<{p}-custom-images>>
 - <<{p}-service-meshes>>
+- <<{p}-traffic-splitting>>
 --
 
 include::openshift.asciidoc[leveloffset=+1]
 include::custom-images.asciidoc[leveloffset=+1]
 include::service-meshes.asciidoc[leveloffset=+1]
+include::traffic-splitting.asciidoc[leveloffset=+1]

--- a/docs/advanced-topics/traffic-splitting.asciidoc
+++ b/docs/advanced-topics/traffic-splitting.asciidoc
@@ -70,10 +70,10 @@ spec:
 [id="{p}-traffic-splitting-by-node-type"]
 == Create services for exposing different node types
 
-The following examples illustrate how to create services for accessing different types of Elasticsearch nodes. The procedure for exposing services publicly is the same as described in <<{p}-allow-public-accss>>.
+The following examples illustrate how to create services for accessing different types of Elasticsearch nodes. The procedure for exposing services publicly is the same as described in <<{p}-allow-public-access>>.
 
 .Coordinator nodes
-[id="{p}-traffic-splitting-coordinator-nodes"]
+[[{p}-traffic-splitting-coordinator-nodes]]
 [source,yaml]
 ----
 apiVersion: v1
@@ -94,7 +94,7 @@ spec:
 ----
 
 .Ingest nodes
-[id="{p}-traffic-splitting-ingest-nodes"]
+[[{p}-traffic-splitting-ingest-nodes]]
 [source,yaml]
 ----
 apiVersion: v1
@@ -112,7 +112,7 @@ spec:
 ----
 
 .Non-master nodes
-[id="{p}-traffic-splitting-non-master-nodes"]
+[[{p}-traffic-splitting-non-master-nodes]]
 [source,yaml]
 ----
 apiVersion: v1

--- a/docs/advanced-topics/traffic-splitting.asciidoc
+++ b/docs/advanced-topics/traffic-splitting.asciidoc
@@ -1,0 +1,130 @@
+:page_id: traffic-splitting
+ifdef::env-github[]
+****
+link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-{page_id}.html[View this document on the Elastic website]
+****
+endif::[]
+
+[id="{p}-{page_id}"]
+= Traffic Splitting
+
+The default Kubernetes service created by ECK -- named `<cluster_name>-es-http` -- is configured to include all the Elasticsearch nodes in that cluster. This configuration is good enough to get started and adequate for most simple use cases. However, if you are operating an Elasticsearch cluster with link:https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[different node types] and want control over which nodes handle which types of traffic, you should create additional Kubernetes services yourself to do so. Alternatively, you could make use of features provided by third-party software such as service meshes and ingress controllers to achieve more advanced traffic management configurations.
+
+NOTE: The link:https://github.com/elastic/cloud-on-k8s/tree/master/config/recipes[recipes directory] in the ECK source repository contains several examples of using third-party service meshes and ingress controllers for managing traffic to ECK resources.
+
+
+The service configurations shown in the following sections are based on this definition of an Elasticsearch cluster:
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
+kind: Elasticsearch
+metadata:
+  name: hulk
+spec:
+  version: {version}
+  nodeSets:
+  # Dedicated master nodes
+  - name: master
+    count: 3
+    config:
+      node.master: true
+      node.data: false
+      node.ingest: false
+      node.ml: false
+  # Dedicated data nodes
+  - name: data
+    count: 6
+    config:
+      node.master: false
+      node.data: true
+      node.ingest: false
+      node.ml: false
+  # Dedicated ingest nodes
+  - name: ingest
+    count: 3
+    config:
+      node.master: false
+      node.data: false
+      node.ingest: true
+      node.ml: false
+  # Dedicated coordinator nodes
+  - name: coordinator
+    count: 3
+    config:
+      node.master: false
+      node.data: false
+      node.ingest: false
+      node.ml: false
+  # Dedicated machine learning nodes
+  - name: ml
+    count: 3
+    config:
+      node.master: false
+      node.data: false
+      node.ingest: false
+      node.ml: true
+----
+
+[float]
+[id="{p}-traffic-splitting-by-node-type"]
+== Create services for exposing different node types
+
+The following examples illustrate how to create services for accessing different types of Elasticsearch nodes. The procedure for exposing services publicly is the same as described in <<{p}-allow-public-accss>>.
+
+.Coordinator nodes
+[id="{p}-traffic-splitting-coordinator-nodes"]
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  name: hulk-es-coordinator-nodes
+spec:
+  ports:
+    - name: https
+      port: 9200
+      targetPort: 9200
+  selector:
+    elasticsearch.k8s.elastic.co/cluster-name: "hulk"
+    elasticsearch.k8s.elastic.co/node-master: "false"
+    elasticsearch.k8s.elastic.co/node-data: "false"
+    elasticsearch.k8s.elastic.co/node-ingest: "false"
+    elasticsearch.k8s.elastic.co/node-ml: "false"
+----
+
+.Ingest nodes
+[id="{p}-traffic-splitting-ingest-nodes"]
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  name: hulk-es-ingest-nodes
+spec:
+  ports:
+    - name: https
+      port: 9200
+      targetPort: 9200
+  selector:
+    elasticsearch.k8s.elastic.co/cluster-name: "hulk"
+    elasticsearch.k8s.elastic.co/node-ingest: "true"
+----
+
+.Non-master nodes
+[id="{p}-traffic-splitting-non-master-nodes"]
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  name: hulk-es-non-master-nodes
+spec:
+  ports:
+    - name: https
+      port: 9200
+      targetPort: 9200
+  selector:
+    elasticsearch.k8s.elastic.co/cluster-name: "hulk"
+    elasticsearch.k8s.elastic.co/node-master: "false"
+----

--- a/docs/orchestrating-elastic-stack-applications/accessing-elastic-services.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/accessing-elastic-services.asciidoc
@@ -59,6 +59,9 @@ hulk-kb-http        ClusterIP      10.19.247.151   <none>           5601/TCP   1
 You can expose services in link:https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types[different ways] by specifying an `http.service.spec.type` in the `spec` of the resource manifest.
 On cloud providers which support external load balancers, you can set the `type` field to `LoadBalancer` to provision a load balancer for the `Service`, and populate the column `EXTERNAL-IP` after a short delay. Depending on the cloud provider, it may incur costs.
 
+NOTE: By default, the Elasticsearch service created by ECK is configured to route traffic to all Elasticsearch nodes in the cluster. Depending on your cluster configuration, you may want more control over the set of nodes that handle different types of traffic (query, ingest, and so on). See <<{p}-traffic-splitting>> for more information.
+
+
 [source,yaml,subs="attributes"]
 ----
 apiVersion: <kind>.k8s.elastic.co/{eck_crd_version}


### PR DESCRIPTION
Shows how to create services to expose different node types.

Fixes #2161 