### PR TITLE
Fix Filebeat in OCP for E2E tests monitoring

### DIFF
--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -18,7 +18,7 @@ write_deployer_config() { cat > $ROOT/deployer-config.yml; }
 
 # detect dev local execution
 if [[ ${BUILD_ID:-} == "" ]]; then
-  BUILD_NUMBER=local-dev-$(date +%s)t
+  BUILD_NUMBER=0 # keeping all build_numbers as numbers
   BUILD_TAG=local-dev-$(date +%s)t
   # need to be declared but not required for local execution
   VAULT_ROLE_ID="dev"

--- a/config/e2e/filebeat.yaml
+++ b/config/e2e/filebeat.yaml
@@ -249,9 +249,6 @@ allowedCapabilities: []
 defaultAddCapabilities: []
 fsGroup:
   type: RunAsAny
-groups:
-  - system:cluster-admins
-  - system:nodes
 priority: 0
 readOnlyRootFilesystem: false
 requiredDropCapabilities: []

--- a/config/e2e/filebeat.yaml
+++ b/config/e2e/filebeat.yaml
@@ -112,8 +112,9 @@ spec:
                   fieldPath: spec.nodeName
           securityContext:
             runAsUser: 0
-            # If using Red Hat OpenShift uncomment this:
-            #privileged: true
+            {{ if .OcpCluster }}
+            privileged: true
+            {{end}}
           resources:
             limits:
               memory: 200Mi
@@ -231,3 +232,39 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: filebeat
+---
+{{ if .OcpCluster }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: filebeat
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities: []
+defaultAddCapabilities: []
+fsGroup:
+  type: RunAsAny
+groups:
+  - system:cluster-admins
+  - system:nodes
+priority: 0
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - '*'
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:{{ .E2ENamespace }}:filebeat
+volumes:
+  - '*'
+{{end}}


### PR DESCRIPTION
OpenShift needs SecurityContextConstraints correctly configured to deploy privileged Filebeat pods.