### PR TITLE
Fix affinity docs typo

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
@@ -119,10 +119,9 @@ spec:
         affinity:
           podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    elasticsearch.k8s.elastic.co/cluster-name: quickstart
+            - labelSelector:
+                matchLabels:
+                  elasticsearch.k8s.elastic.co/cluster-name: quickstart
               topologyKey: kubernetes.io/hostname
 ----
 


### PR DESCRIPTION
I was trying to test out some affinity settings and noticed our docs had an invalid example. `requiredDuringSchedulingIgnoredDuringExecution` is just an array of `PodAffinityTerms`. See the example here:
https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#an-example-of-a-pod-that-uses-pod-affinity

and the docs here:
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#podaffinity-v1-core

I was running 1.0.1, but I think the new extra validation would have caught this. I had to look at the pod to see it was getting silently dropped.