### PR TITLE
Update CI jobs to reflect 7.6.2 release

### DIFF
--- a/.ci/jobs/e2e-tests-snapshot-versions-gke.yml
+++ b/.ci/jobs/e2e-tests-snapshot-versions-gke.yml
@@ -8,7 +8,7 @@
     parameters:
       - bool:
           name: SEND_NOTIFICATIONS
-          default: false
+          default: true
           description: "Specified if job should send notifications to Slack. Enabled by default."
     pipeline-scm:
       scm:

--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -55,17 +55,6 @@ pipeline {
                 )}"""
             }
             parallel {
-                stage("7.6.2-SNAPSHOT") {
-                     agent {
-                        label 'linux'
-                    }
-                    steps {
-                        checkout scm
-                        script {
-                            runWith(lib, failedTests, "eck-76-snapshot-${BUILD_NUMBER}-e2e", "7.6.1-SNAPSHOT")
-                        }
-                    }
-                }
                 stage("7.7.0-SNAPSHOT") {
                      agent {
                         label 'linux'
@@ -107,7 +96,6 @@ pipeline {
         cleanup {
             script {
                 clusters = [
-                    "eck-76-snapshot-${BUILD_NUMBER}-e2e",
                     "eck-77-snapshot-${BUILD_NUMBER}-e2e"
                 ]
                 for (int i = 0; i < clusters.size(); i++) {

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -95,14 +95,14 @@ pipeline {
                         }
                     }
                 }
-                stage("7.6.0") {
+                stage("7.6.2") {
                     agent {
                         label 'linux'
                     }
                     steps {
                         checkout scm
                         script {
-                            runWith(lib, failedTests, "eck-76-${BUILD_NUMBER}-e2e", "7.6.0")
+                            runWith(lib, failedTests, "eck-76-${BUILD_NUMBER}-e2e", "7.6.2")
                         }
                     }
                 }


### PR DESCRIPTION
* Remove 7.6.2 from snapshot tests
* Add 7.6.2 to stack version tests
* Turn on notifications for snapshot tests