### PR TITLE
Revert transport TLS certs verification from "full" to "certificate"

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -138,7 +138,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 			Labels: map[string]string{
 				"common.k8s.elastic.co/type":                    "elasticsearch",
 				"elasticsearch.k8s.elastic.co/cluster-name":     "name",
-				"elasticsearch.k8s.elastic.co/config-hash":      "2535617526",
+				"elasticsearch.k8s.elastic.co/config-hash":      "4065866170",
 				"elasticsearch.k8s.elastic.co/http-scheme":      "https",
 				"elasticsearch.k8s.elastic.co/node-data":        "false",
 				"elasticsearch.k8s.elastic.co/node-ingest":      "true",

--- a/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/pkg/controller/elasticsearch/settings/merged_config.go
@@ -72,7 +72,7 @@ func xpackConfig(ver version.Version, httpCfg commonv1.HTTPConfig) *CanonicalCon
 		// x-pack security general settings
 		esv1.XPackSecurityEnabled:                      "true",
 		esv1.XPackSecurityAuthcReservedRealmEnabled:    "false",
-		esv1.XPackSecurityTransportSslVerificationMode: "full",
+		esv1.XPackSecurityTransportSslVerificationMode: "certificate",
 
 		// x-pack security http settings
 		esv1.XPackSecurityHttpSslEnabled:     httpCfg.TLS.Enabled(),


### PR DESCRIPTION
A bug in Elasticsearch
(https://github.com/elastic/elasticsearch/issues/54867) leads to TLS
certificates not being picked up during rolling upgrades. Impacted ES
nodes present a certificate with the wrong (old) Pod IP address.

Full TLS verification in those conditions lead to nodes not being able
to trust each other during (and after) rolling upgrades.

Let's switch TLS verification back to "certificate" (IP address is
ignored in the certificate but we still validate the cert signature),
until we figure out the proper way to reintroduce "full" verification.

Fixes https://github.com/elastic/cloud-on-k8s/issues/2823.