### PR TITLE
Set correct credentials for release job

### DIFF
--- a/.ci/jobs/build-release.yml
+++ b/.ci/jobs/build-release.yml
@@ -8,9 +8,11 @@
     script-path: .ci/pipelines/build.Jenkinsfile
     scm:
       - github:
+          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          ssh-checkout:
+            credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
           repo: 'cloud-on-k8s'
           repo-owner: 'elastic'
-          credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
           discover-tags: true
           wipe-workspace: true
           branch-discovery: false


### PR DESCRIPTION
Multibranch job definitions need a username+password credential and
not the SSH key configured previously.


Fixes #2564 
