### PR TITLE
Silence the absence of controller-gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ GOBIN := $(or $(shell go env GOBIN 2>/dev/null), $(shell go env GOPATH 2>/dev/nu
 
 # find or download controller-gen
 controller-gen:
-ifneq ($(shell controller-gen --version), Version: v0.2.5)
+ifneq ($(shell controller-gen --version 2> /dev/null), Version: v0.2.5)
 	@(cd /tmp; GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5)
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else


### PR DESCRIPTION
80e3a62 changed how the existence of the `controller-gen` binary is
tested and make his absence verbose.
As the makefile is used in contexts where `controller-gen` is not present
(and not necessary), this pollutes the output a little.