### PR TITLE
Increase total E2E job timeout and log when it is reached

### DIFF
--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	jobTimeout       = 200 * time.Minute // time to wait for the test job to finish
+	jobTimeout       = 300 * time.Minute // time to wait for the test job to finish
 	kubePollInterval = 10 * time.Second  // Kube API polling interval
 	logBufferSize    = 1024              // Size of the log buffer (1KiB)
 	testRunLabel     = "test-run"        // name of the label applied to resources

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -323,6 +323,9 @@ func (h *helper) monitorTestJob(client *kubernetes.Clientset) error {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), jobTimeout)
 	defer func() {
 		cancelFunc()
+		if deadline, _ := ctx.Deadline(); deadline.Before(time.Now()) {
+			log.Info("Test job timeout exceeded", "timeout", jobTimeout)
+		}
 		runtime.HandleCrash()
 	}()
 


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/2836.

Our total 200 minutes timeout is occasionally reached on tests that still make progress, especially when running on Kind. And we are still pretty close to that limit for other successful tests (180 minutes seem to be common).

I think it's fair to increase it to 300 minutes to give it enough time to complete. I'm pretty sure we'll increase it again in a few months but that's another issue.

Also, it's pretty hard to debug when this timeout is reached, because we suddenly delete all resources while the test job is still running, and we're still streaming its logs.
In https://github.com/elastic/cloud-on-k8s/issues/2836 logs indicate a test failure which is actually provoked by all resources being deleted after the timeout is reached.
Let's add a log when that timeout is reached.