### PR TITLE
Enable EKS e2e tests

### DIFF
--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -95,6 +95,10 @@ pipeline {
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                     parameters: [string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage)],
                     wait: false
+
+                build job: 'cloud-on-k8s-e2e-tests-eks',
+                    parameters: [string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage)],
+                    wait: false
             }
         }
         unsuccessful {


### PR DESCRIPTION
Run the EKS job after nightly or release builds.