### PR TITLE
Document how to rotate credentials

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/orchestrating-elastic-stack-applications.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/orchestrating-elastic-stack-applications.asciidoc
@@ -16,6 +16,7 @@ endif::[]
 - <<{p}-customize-pods>>
 - <<{p}-managing-compute-resources>>
 - <<{p}-upgrading-stack>>
+- <<{p}-rotate-credentials>>
 --
 
 include::elasticsearch-specification.asciidoc[leveloffset=+1]
@@ -25,3 +26,4 @@ include::accessing-elastic-services.asciidoc[leveloffset=+1]
 include::customize-pods.asciidoc[leveloffset=+1]
 include::managing-compute-resources.asciidoc[leveloffset=+1]
 include::upgrading-stack.asciidoc[leveloffset=+1]
+include::rotate-credentials.asciidoc[leveloffset=+1]

--- a/docs/orchestrating-elastic-stack-applications/rotate-credentials.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/rotate-credentials.asciidoc
@@ -7,7 +7,7 @@ endif::[]
 [id="{p}-{page_id}"]
 = Rotate auto-generated credentials
 
-When a deploying a Stack application, the operator generates a set of credentials essential for the operation of that application. Examples of these generated credentials include the default `elastic` user for Elasticsearch and the security token for APM Server. You can list all auto-generated credentials in a namespace by running the following command:
+When deploying an Elastic Stack application, the operator generates a set of credentials essential for the operation of that application. Examples of these generated credentials include the default `elastic` user for Elasticsearch and the security token for APM Server. You can list all auto-generated credentials in a namespace by running the following command:
 
 [source,sh]
 ----

--- a/docs/orchestrating-elastic-stack-applications/rotate-credentials.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/rotate-credentials.asciidoc
@@ -1,0 +1,33 @@
+:page_id: rotate-credentials
+ifdef::env-github[]
+****
+link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-{page_id}.html[View this document on the Elastic website]
+****
+endif::[]
+[id="{p}-{page_id}"]
+= Rotate auto-generated credentials
+
+When a deploying a Stack application, the operator generates a set of credentials essential for the operation of that application. Examples of these generated credentials include the default `elastic` user for Elasticsearch and the security token for APM Server. You can list all auto-generated credentials in a namespace by running the following command:
+
+[source,sh]
+----
+kubectl get secret -l eck.k8s.elastic.co/credentials=true
+----
+
+You can force the auto-generated credentials to be regenerated with new values by simply deleting the appropriate Secret. For example, to change the password for the `elastic` user from the <<{p}-quickstart,quickstart example>>, execute the following command:
+
+[source,sh]
+----
+kubectl delete secret quickstart-es-elastic-user
+----
+
+CAUTION: If you are using the `elastic` user credentials in your own applications, they will fail to connect to Elasticsearch and Kibana after the above step. It is not recommended to use `elastic` user credentials for production use cases. Always <<{p}-users-and-roles,create your own users with restricted roles>> to access Elasticsearch.
+
+You can regenerate all auto-generated credentials in a namespace by executing the following command:
+
+[source,sh]
+----
+kubectl delete secret -l eck.k8s.elastic.co/credentials=true
+----
+
+CAUTION: The above command regenerates auto-generated credentials of *all* Elastic Stack applications in the namespace.


### PR DESCRIPTION
Documents how to rotate credentials. 

Currently there's no good way of rotating credentials for a set of related resources due to #2846 so that has been omitted from the document.

Fixes #2796 