### PR TITLE
Add some temporary debugging to diagnose e2e test failures

### DIFF
--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -202,6 +202,8 @@ func (b Builder) WithNodeSet(nodeSet esv1.NodeSet) Builder {
 		nodeSet.Config = &commonv1.Config{Data: map[string]interface{}{}}
 	}
 	nodeSet.Config.Data["node.store.allow_mmap"] = false
+	// temporarily added to debug test failures with red cluster health
+	nodeSet.Config.Data["logger.org.elasticsearch.cluster.service.MasterService"] = "trace"
 
 	// Propagates test-name label from top level resource.
 	// Can be removed when https://github.com/elastic/cloud-on-k8s/issues/2652 is implemented.

--- a/test/e2e/test/elasticsearch/checks_es.go
+++ b/test/e2e/test/elasticsearch/checks_es.go
@@ -81,6 +81,7 @@ func (e *esClusterChecks) CheckESHealthGreen() test.Step {
 			}
 			return nil
 		}),
+		OnFailure: printShards(e.newESClient),
 	}
 }
 

--- a/test/e2e/test/elasticsearch/checks_es.go
+++ b/test/e2e/test/elasticsearch/checks_es.go
@@ -81,7 +81,7 @@ func (e *esClusterChecks) CheckESHealthGreen() test.Step {
 			}
 			return nil
 		}),
-		OnFailure: printShards(e.newESClient),
+		OnFailure: printShardsAndAllocation(e.newESClient),
 	}
 }
 

--- a/test/e2e/test/elasticsearch/debug.go
+++ b/test/e2e/test/elasticsearch/debug.go
@@ -26,7 +26,7 @@ func printShardsAndAllocation(clientFactory func() (client.Client, error)) func(
 }
 
 func printResponse(esClient client.Client, url string) {
-	catShards, err := http.NewRequest(
+	request, err := http.NewRequest(
 		http.MethodGet,
 		url,
 		nil,
@@ -36,13 +36,13 @@ func printResponse(esClient client.Client, url string) {
 		return
 	}
 	fmt.Println("GET " + url)
-	shards, err := esClient.Request(context.Background(), catShards)
+	response, err := esClient.Request(context.Background(), request)
 	if err != nil {
-		fmt.Printf("error while fetching shards: %v \n", err)
+		fmt.Printf("error while making request %s: %v \n", url, err)
 		return
 	}
-	defer shards.Body.Close()
-	bytes, err := ioutil.ReadAll(shards.Body)
+	defer response.Body.Close()
+	bytes, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		fmt.Printf("error while reading response body: %v \n", err)
 		return

--- a/test/e2e/test/elasticsearch/debug.go
+++ b/test/e2e/test/elasticsearch/debug.go
@@ -13,34 +13,39 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 )
 
-func printShards(clientFactory func() (client.Client, error)) func() {
+func printShardsAndAllocation(clientFactory func() (client.Client, error)) func() {
 	return func() {
 		esClient, err := clientFactory()
 		if err != nil {
 			fmt.Printf("error while creating es client: %v", err)
 			return
 		}
-		catShards, err := http.NewRequest(
-			http.MethodGet,
-			"/_cat/shards?v",
-			nil,
-		)
-		if err != nil {
-			fmt.Printf("error while creating request: %v \n", err)
-			return
-		}
-		shards, err := esClient.Request(context.Background(), catShards)
-		if err != nil {
-			fmt.Printf("error while fetching shards: %v \n", err)
-			return
-		}
-		defer shards.Body.Close()
-		bytes, err := ioutil.ReadAll(shards.Body)
-		if err != nil {
-			fmt.Printf("error while reading response body: %v \n", err)
-			return
-		}
-		fmt.Println("GET _cat/shards")
-		fmt.Printf("%s \n", bytes)
+		printResponse(esClient, "/_cat/shards?v")
+		printResponse(esClient, "/_cluster/allocation/explain")
 	}
+}
+
+func printResponse(esClient client.Client, url string) {
+	catShards, err := http.NewRequest(
+		http.MethodGet,
+		url,
+		nil,
+	)
+	if err != nil {
+		fmt.Printf("error while creating request: %v \n", err)
+		return
+	}
+	fmt.Println("GET " + url)
+	shards, err := esClient.Request(context.Background(), catShards)
+	if err != nil {
+		fmt.Printf("error while fetching shards: %v \n", err)
+		return
+	}
+	defer shards.Body.Close()
+	bytes, err := ioutil.ReadAll(shards.Body)
+	if err != nil {
+		fmt.Printf("error while reading response body: %v \n", err)
+		return
+	}
+	fmt.Printf("%s \n", bytes)
 }

--- a/test/e2e/test/elasticsearch/debug.go
+++ b/test/e2e/test/elasticsearch/debug.go
@@ -1,0 +1,46 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package elasticsearch
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
+)
+
+func printShards(clientFactory func() (client.Client, error)) func() {
+	return func() {
+		esClient, err := clientFactory()
+		if err != nil {
+			fmt.Printf("while creating es client %v", err)
+			return
+		}
+		catShards, err := http.NewRequest(
+			http.MethodGet,
+			"/_cat/shards",
+			nil,
+		)
+		if err != nil {
+			fmt.Printf("err while creating request: %v \n", err)
+			return
+		}
+		shards, err := esClient.Request(context.Background(), catShards)
+		if err != nil {
+			fmt.Printf("err while fetching shards: %v \n", err)
+			return
+		}
+		defer shards.Body.Close()
+		bytes, err := ioutil.ReadAll(shards.Body)
+		if err != nil {
+			fmt.Printf("err while reading response body: %v \n", err)
+			return
+		}
+		fmt.Println("GET _cat/shards")
+		fmt.Printf("%s \n", bytes)
+	}
+}

--- a/test/e2e/test/elasticsearch/debug.go
+++ b/test/e2e/test/elasticsearch/debug.go
@@ -22,7 +22,7 @@ func printShards(clientFactory func() (client.Client, error)) func() {
 		}
 		catShards, err := http.NewRequest(
 			http.MethodGet,
-			"/_cat/shards",
+			"/_cat/shards?v",
 			nil,
 		)
 		if err != nil {

--- a/test/e2e/test/elasticsearch/debug.go
+++ b/test/e2e/test/elasticsearch/debug.go
@@ -17,7 +17,7 @@ func printShards(clientFactory func() (client.Client, error)) func() {
 	return func() {
 		esClient, err := clientFactory()
 		if err != nil {
-			fmt.Printf("while creating es client %v", err)
+			fmt.Printf("error while creating es client: %v", err)
 			return
 		}
 		catShards, err := http.NewRequest(
@@ -26,18 +26,18 @@ func printShards(clientFactory func() (client.Client, error)) func() {
 			nil,
 		)
 		if err != nil {
-			fmt.Printf("err while creating request: %v \n", err)
+			fmt.Printf("error while creating request: %v \n", err)
 			return
 		}
 		shards, err := esClient.Request(context.Background(), catShards)
 		if err != nil {
-			fmt.Printf("err while fetching shards: %v \n", err)
+			fmt.Printf("error while fetching shards: %v \n", err)
 			return
 		}
 		defer shards.Body.Close()
 		bytes, err := ioutil.ReadAll(shards.Body)
 		if err != nil {
-			fmt.Printf("err while reading response body: %v \n", err)
+			fmt.Printf("error while reading response body: %v \n", err)
 			return
 		}
 		fmt.Println("GET _cat/shards")

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -125,7 +125,7 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 				Test: test.Eventually(func() error { // nolint
 					return dataIntegrityCheck.Verify()
 				}),
-				OnFailure: printShards(func() (esclient.Client, error) {
+				OnFailure: printShardsAndAllocation(func() (esclient.Client, error) {
 					return NewElasticsearchClient(b.Elasticsearch, k)
 				}),
 			},

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -125,6 +125,9 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 				Test: test.Eventually(func() error { // nolint
 					return dataIntegrityCheck.Verify()
 				}),
+				OnFailure: printShards(func() (esclient.Client, error) {
+					return NewElasticsearchClient(b.Elasticsearch, k)
+				}),
 			},
 		})
 }

--- a/test/e2e/test/step.go
+++ b/test/e2e/test/step.go
@@ -13,9 +13,10 @@ import (
 
 // Step represents a single test
 type Step struct {
-	Name string
-	Test func(t *testing.T)
-	Skip func() bool // returns true if the test should be skipped
+	Name      string
+	Test      func(t *testing.T)
+	Skip      func() bool // returns true if the test should be skipped
+	OnFailure func()      // additional step specific callback on failure
 }
 
 // StepList defines a list of Step
@@ -40,6 +41,9 @@ func (l StepList) RunSequential(t *testing.T) {
 		}
 		if !t.Run(ts.Name, ts.Test) {
 			logf.Log.Error(errors.New("test failure"), "stopping early")
+			if ts.OnFailure != nil {
+				ts.OnFailure()
+			}
 			t.FailNow()
 		}
 	}


### PR DESCRIPTION
* Print result of cat shards when health check tests fail.
* Set master service logging to trace to dianose cluster health issues.