### PR TITLE
Disable json output in e2e test

### DIFF
--- a/.ci/pipelines/e2e-tests-testmutationsecondmastersetdown.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-testmutationsecondmastersetdown.Jenkinsfile
@@ -56,6 +56,8 @@ pipeline {
                 
                 sh 'echo TESTS_MATCH = TestMutationSecondMasterSetDown >> .env'
                 sh 'echo E2E_SKIP_CLEANUP = true >> .env'
+                // temporarily disabling json output to work around parsing errors
+                sh 'echo E2E_JSON = false >> .env'
                 sh 'sed "s/CLUSTER_NAME=eck-e2e/CLUSTER_NAME=eck-debug-e2e/" -i .env'
                 
                 script {


### PR DESCRIPTION
I'm not able to repro locally, but this should help this job from spamming failures 🤞 

For error examples see:
https://devops-ci.elastic.co/job/cloud-on-k8s-e2e-tests-testmutationsecondmastersetdown/2//testReport
https://devops-ci.elastic.co/job/cloud-on-k8s-e2e-tests-testmutationsecondmastersetdown/1//testReport