### PR TITLE
Backport - Don't reject PVC update when different unit is used (#2857)

### DIFF
--- a/pkg/apis/elasticsearch/v1/validations_test.go
+++ b/pkg/apis/elasticsearch/v1/validations_test.go
@@ -365,7 +365,35 @@ func Test_pvcModified(t *testing.T) {
 			},
 			expectErrors: true,
 		},
-
+		{
+			name:    "same size with different unit accepted",
+			current: current,
+			proposed: &Elasticsearch{
+				Spec: ElasticsearchSpec{
+					Version: "7.2.0",
+					NodeSets: []NodeSet{
+						{
+							Name: "master",
+							VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+								{
+									ObjectMeta: metav1.ObjectMeta{
+										Name: "elasticsearch-data",
+									},
+									Spec: corev1.PersistentVolumeClaimSpec{
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												corev1.ResourceStorage: resource.MustParse("5120Mi"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErrors: false,
+		},
 		{
 			name:    "same size accepted",
 			current: current,


### PR DESCRIPTION
Backport https://github.com/elastic/cloud-on-k8s/pull/2857 on 1.1.

When we apply a manifest with a 1024Gi storage requirement, it may be
internally persisted with a different storage unit (eg. 1Ti). When doing
a strict deep equal comparison, 1Ti and 1024Gi are different.
A user applying such a manifest will not have any update allowed, even
though he keeps using 1024Gi.

This fixes it by relying on `apiequality.Semantic.DeepEqual`, which is
used in Kubernetes itself:
https://github.com/kubernetes/kubernetes/blob/c369cf187ea765c0a2387f2b39abe6ed18c8e6a8/pkg/apis/apps/validation/validation.go#L156
