### PR TITLE
Set Enterprise Search sample version to 7.7.0

### DIFF
--- a/config/samples/enterprisesearch/ent_es.yml
+++ b/config/samples/enterprisesearch/ent_es.yml
@@ -18,7 +18,7 @@ kind: EnterpriseSearch
 metadata:
   name: ent-sample
 spec:
-  version: 7.6.0
+  version: 7.7.0
   image: $DOCKER_IMAGE
   count: 1
   elasticsearchRef:


### PR DESCRIPTION
We only support 7.7.0+, and now have a validation webhook that prevents using 7.6.0.