### PR TITLE
Add unit test for Enterprise Search config reconciliation

### DIFF
--- a/pkg/controller/enterprisesearch/config_test.go
+++ b/pkg/controller/enterprisesearch/config_test.go
@@ -5,6 +5,7 @@
 package enterprisesearch
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,6 +47,17 @@ func secretWithConfig(name string, cfg []byte) *corev1.Secret {
 			ConfigFilename: cfg,
 		},
 	}
+}
+
+func entWithAssociation(name string, associationConf commonv1.AssociationConf) entv1beta1.EnterpriseSearch {
+	ent := entv1beta1.EnterpriseSearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      name,
+		},
+	}
+	ent.SetAssociationConf(&associationConf)
+	return ent
 }
 
 func Test_parseConfigRef(t *testing.T) {
@@ -231,6 +243,240 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 				return
 			}
 			tt.assertion(t, got, err)
+		})
+	}
+}
+
+func TestReconcileConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		runtimeObjs []runtime.Object
+		ent         entv1beta1.EnterpriseSearch
+		// we don't compare the exact secret content because some keys are random, but we at least check
+		// all entries in this array exist in the reconciled secret, and there are not more rows
+		wantSecretEntries []string
+	}{
+		{
+			name:        "create default config secret",
+			runtimeObjs: nil,
+			ent: entv1beta1.EnterpriseSearch{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "sample",
+				},
+			},
+			wantSecretEntries: []string{
+				"allow_es_settings_modification: true",
+				"ent_search:",
+				"external_url: https://localhost:3002",
+				"listen_host: 0.0.0.0",
+				"ssl:",
+				"certificate: /mnt/elastic-internal/http-certs/tls.crt",
+				"certificate_authorities:",
+				"- /mnt/elastic-internal/http-certs/ca.crt",
+				"enabled: true",
+				"key: /mnt/elastic-internal/http-certs/tls.key",
+				"secret_management:",
+				"encryption_keys:",
+				"-",                   // don't check the actual encryption key
+				"secret_session_key:", // don't check the actual secret session key
+			},
+		},
+		{
+			name: "update existing default config secret",
+			runtimeObjs: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "sample-ent-config",
+						// missing labels
+					},
+					Data: map[string][]byte{
+						// missing config settings
+						"enterprise-search.yml": []byte("allow_es_settings_modification: true"),
+					},
+				},
+			},
+			ent: entv1beta1.EnterpriseSearch{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "sample",
+				},
+			},
+			wantSecretEntries: []string{
+				"allow_es_settings_modification: true",
+				"ent_search:",
+				"external_url: https://localhost:3002",
+				"listen_host: 0.0.0.0",
+				"ssl:",
+				"certificate: /mnt/elastic-internal/http-certs/tls.crt",
+				"certificate_authorities:",
+				"- /mnt/elastic-internal/http-certs/ca.crt",
+				"enabled: true",
+				"key: /mnt/elastic-internal/http-certs/tls.key",
+				"secret_management:",
+				"encryption_keys:",
+				"-",                   // don't check the actual encryption key
+				"secret_session_key:", // don't check the actual secret session key
+			},
+		},
+		{
+			name: "with Elasticsearch association",
+			ent: entWithAssociation("sample", commonv1.AssociationConf{
+				AuthSecretName: "sample-ent-user",
+				AuthSecretKey:  "ns-sample-ent-user",
+				CACertProvided: true,
+				CASecretName:   "sample-ent-es-ca",
+				URL:            "https://elasticsearch-sample-es-http.default.svc:9200",
+			}),
+			runtimeObjs: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "sample-ent-user",
+					},
+					Data: map[string][]byte{
+						"default-sample-ent-user": []byte("password"),
+					},
+				},
+			},
+			wantSecretEntries: []string{
+				"allow_es_settings_modification: true",
+				"elasticsearch:",
+				"host: https://elasticsearch-sample-es-http.default.svc:9200",
+				"password: \"\"", // hmmm
+				"ssl:",
+				"certificate_authority: /mnt/elastic-internal/es-certs/tls.crt",
+				"enabled: true",
+				"username: ns-sample-ent-user",
+				"ent_search:",
+				"auth:",
+				"source: elasticsearch-native",
+				"external_url: https://localhost:3002",
+				"listen_host: 0.0.0.0",
+				"ssl:",
+				"certificate: /mnt/elastic-internal/http-certs/tls.crt",
+				"certificate_authorities:",
+				"- /mnt/elastic-internal/http-certs/ca.crt",
+				"enabled: true",
+				"key: /mnt/elastic-internal/http-certs/tls.key",
+				"secret_management:",
+				"encryption_keys:",
+				"-",                   // don't check the actual encryption key
+				"secret_session_key:", // don't check the actual secret session key
+			},
+		},
+		{
+			name:        "with user-provided config overrides",
+			runtimeObjs: nil,
+			ent: entv1beta1.EnterpriseSearch{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "sample",
+				},
+				Spec: entv1beta1.EnterpriseSearchSpec{
+					Config: &commonv1.Config{Data: map[string]interface{}{
+						"foo":                     "bar",                    // new setting
+						"ent_search.external_url": "https://my.own.dns.com", // override existing setting
+					}},
+				},
+			},
+			wantSecretEntries: []string{
+				"allow_es_settings_modification: true",
+				"ent_search:",
+				"external_url: https://my.own.dns.com", // overridden default setting
+				"foo: bar",                             // new setting
+				"listen_host: 0.0.0.0",
+				"ssl:",
+				"certificate: /mnt/elastic-internal/http-certs/tls.crt",
+				"certificate_authorities:",
+				"- /mnt/elastic-internal/http-certs/ca.crt",
+				"enabled: true",
+				"key: /mnt/elastic-internal/http-certs/tls.key",
+				"secret_management:",
+				"encryption_keys:",
+				"-",                   // don't check the actual encryption key
+				"secret_session_key:", // don't check the actual secret session key
+			},
+		},
+		{
+			name: "with user-provided config secret",
+			runtimeObjs: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "my-config",
+					},
+					Data: map[string][]byte{
+						"enterprise-search.yml": []byte("ent_search.external_url: https://my.own.dns.from.configref.com"),
+					},
+				},
+			},
+			ent: entv1beta1.EnterpriseSearch{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "sample",
+				},
+				Spec: entv1beta1.EnterpriseSearchSpec{
+					Config: &commonv1.Config{Data: map[string]interface{}{
+						"foo":                     "bar",                    // new setting
+						"ent_search.external_url": "https://my.own.dns.com", // override existing setting
+					}},
+					ConfigRef: []entv1beta1.ConfigSource{
+						{SecretRef: commonv1.SecretRef{SecretName: "my-config"}}, // override the external url from config
+					},
+				},
+			},
+			wantSecretEntries: []string{
+				"allow_es_settings_modification: true",
+				"ent_search:",
+				"external_url: https://my.own.dns.from.configref.com", // overridden from configRef
+				"foo: bar", // new setting
+				"listen_host: 0.0.0.0",
+				"ssl:",
+				"certificate: /mnt/elastic-internal/http-certs/tls.crt",
+				"certificate_authorities:",
+				"- /mnt/elastic-internal/http-certs/ca.crt",
+				"enabled: true",
+				"key: /mnt/elastic-internal/http-certs/tls.key",
+				"secret_management:",
+				"encryption_keys:",
+				"-",                   // don't check the actual encryption key
+				"secret_session_key:", // don't check the actual secret session key
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			driver := &ReconcileEnterpriseSearch{
+				Client:         k8s.WrappedFakeClient(tt.runtimeObjs...),
+				recorder:       record.NewFakeRecorder(10),
+				dynamicWatches: watches.NewDynamicWatches(),
+			}
+
+			// secret metadata should be correct
+			got, err := ReconcileConfig(driver, tt.ent)
+			require.NoError(t, err)
+			assert.Equal(t, "sample-ent-config", got.Name)
+			assert.Equal(t, "ns", got.Namespace)
+			assert.Equal(t, map[string]string{
+				"common.k8s.elastic.co/type":           "enterprise-search",
+				"eck.k8s.elastic.co/credentials":       "true",
+				"enterprisesearch.k8s.elastic.co/name": "sample",
+			}, got.Labels)
+
+			// secret data should contain the expected entries
+			data := bytes.TrimRight(got.Data["enterprise-search.yml"], "\n")
+			dataEntries := bytes.Split(data, []byte("\n"))
+			require.Len(t, dataEntries, len(tt.wantSecretEntries))
+			for _, setting := range tt.wantSecretEntries {
+				assert.Contains(t, string(got.Data["enterprise-search.yml"]), setting)
+			}
+
+			var updatedResource corev1.Secret
+			err = driver.K8sClient().Get(k8s.ExtractNamespacedName(&got), &updatedResource)
+			assert.NoError(t, err)
+			assert.Equal(t, got.Data, updatedResource.Data)
 		})
 	}
 }


### PR DESCRIPTION
Just add a few unit tests to cover the configuration secret
reconciliation (default content, secret update, es association, config
and configRef overrides).

Relates https://github.com/elastic/k8s-dev/issues/117.