### PR TITLE
Check node excluded from shard allocation before deleting

### DIFF
--- a/pkg/controller/elasticsearch/client/client.go
+++ b/pkg/controller/elasticsearch/client/client.go
@@ -43,7 +43,7 @@ type Role struct {
 
 // Client captures the information needed to interact with an Elasticsearch cluster via HTTP
 type Client interface {
-	AllocationSetter
+	AllocationFilter
 	ShardLister
 	LicenseClient
 	// Close idle connections in the underlying http client.

--- a/pkg/controller/elasticsearch/driver/downscale.go
+++ b/pkg/controller/elasticsearch/driver/downscale.go
@@ -181,11 +181,11 @@ func calculatePerformableDownscale(
 	}
 	// iterate on all leaving nodes (ordered by highest ordinal first)
 	for _, node := range downscale.leavingNodeNames() {
-		migrating, err := migration.NodeHasShard(ctx.parentCtx, ctx.shardLister, node)
+		evacuated, err := migration.NodeEvacuated(ctx.parentCtx, ctx.esClient, node)
 		if err != nil {
 			return performableDownscale, err
 		}
-		if migrating {
+		if !evacuated {
 			ssetLogger(downscale.statefulSet).V(1).Info("Data migration not over yet, skipping node deletion", "node", node)
 			ctx.reconcileState.UpdateElasticsearchMigrating(ctx.resourcesState, ctx.observedState)
 			// no need to check other nodes since we remove them in order and this one isn't ready anyway

--- a/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -534,7 +534,6 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 	type args struct {
 		ctx       downscaleContext
 		downscale ssetDownscale
-		state     *downscaleState
 	}
 	tests := []struct {
 		name    string

--- a/pkg/controller/elasticsearch/driver/downscale_utils.go
+++ b/pkg/controller/elasticsearch/driver/downscale_utils.go
@@ -21,9 +21,8 @@ import (
 // propagated from the main driver.
 type downscaleContext struct {
 	// clients
-	k8sClient   k8s.Client
-	esClient    esclient.Client
-	shardLister esclient.ShardLister
+	k8sClient k8s.Client
+	esClient  esclient.Client
 	// driver states
 	resourcesState reconcile.ResourcesState
 	observedState  observer.State
@@ -49,7 +48,6 @@ func newDownscaleContext(
 	return downscaleContext{
 		k8sClient:      k8sClient,
 		esClient:       esClient,
-		shardLister:    esClient,
 		resourcesState: resourcesState,
 		observedState:  observedState,
 		reconcileState: reconcileState,

--- a/pkg/controller/elasticsearch/driver/esstate_test.go
+++ b/pkg/controller/elasticsearch/driver/esstate_test.go
@@ -27,8 +27,8 @@ type fakeESClient struct { //nolint:maligned
 	AddVotingConfigExclusionsCalled     bool
 	AddVotingConfigExclusionsCalledWith []string
 
-	ExcludeFromShardAllocationCalled     bool
-	ExcludeFromShardAllocationCalledWith string
+	ExcludeFromShardAllocationCalled bool
+	CurrentAllocationFilters         string
 
 	DisableReplicaShardsAllocationCalled bool
 
@@ -45,6 +45,8 @@ type fakeESClient struct { //nolint:maligned
 
 	health                      esclient.Health
 	GetClusterHealthCalledCount int
+
+	shards esclient.Shards
 }
 
 func (f *fakeESClient) SetMinimumMasterNodes(_ context.Context, n int) error {
@@ -61,8 +63,12 @@ func (f *fakeESClient) AddVotingConfigExclusions(_ context.Context, nodeNames []
 
 func (f *fakeESClient) ExcludeFromShardAllocation(_ context.Context, nodes string) error {
 	f.ExcludeFromShardAllocationCalled = true
-	f.ExcludeFromShardAllocationCalledWith = nodes
+	f.CurrentAllocationFilters = nodes
 	return nil
+}
+
+func (f *fakeESClient) ExcludedFromShardAllocation(_ context.Context) (string, error) {
+	return f.CurrentAllocationFilters, nil
 }
 
 func (f *fakeESClient) DisableReplicaShardsAllocation(_ context.Context) error {
@@ -98,6 +104,10 @@ func (f *fakeESClient) GetClusterRoutingAllocation(_ context.Context) (esclient.
 func (f *fakeESClient) GetClusterHealth(_ context.Context) (esclient.Health, error) {
 	f.GetClusterHealthCalledCount++
 	return f.health, nil
+}
+
+func (f *fakeESClient) GetShards(_ context.Context) (esclient.Shards, error) {
+	return f.shards, nil
 }
 
 // -- ESState tests


### PR DESCRIPTION
Related to #2864 

I wrote this when experimenting with the bug described in #2788 and #2864 While this is not a fix for the bug itself, this amended check at least should have prevented the data loss we saw. Happy to close this PR if this is already part of the more comprehensive fix @barkbay  is working on for #2864 


This amends the checks we do to verify node evacuation is complete. Previously we only checked that no shards are present on the node in question.
This however was not good enough as a missing allocation filter for that node could mean that shards move back to the node just before deletion.
The new check looks at allocation filters and shards. While this check is not perfect as allocation filters can also be removed at the last moment before deletion, it narrows the
window for that to happen somewhat.
