### PR TITLE
Update docs to include annotation required by new versions of Istio.

### DIFF
--- a/docs/advanced-topics/service-meshes.asciidoc
+++ b/docs/advanced-topics/service-meshes.asciidoc
@@ -84,6 +84,7 @@ spec:
     podTemplate:
       metadata:
         annotations:
+          traffic.sidecar.istio.io/includeInboundPorts: "*"
           traffic.sidecar.istio.io/excludeOutboundPorts: "9300" <2>
           traffic.sidecar.istio.io/excludeInboundPorts: "9300"
       spec:


### PR DESCRIPTION
Newer versions of Istio require the `traffic.sidecar.istio.io/includeInboundPorts` annotation to be defined in order for the `traffic.sidecar.istio.io/excludeInboundPorts` annotation to take effect. We need the latter to exclude the transport port from being proxied as we do not allow transport TLS to be disabled.