### PR TITLE
Add Elasticsearch client cache

### DIFF
--- a/pkg/controller/elasticsearch/client/cache.go
+++ b/pkg/controller/elasticsearch/client/cache.go
@@ -1,0 +1,137 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package client
+
+import (
+	"context"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var log = logf.Log.WithName("cached-client")
+
+type CachedClientBuilder interface {
+
+	// NewElasticsearchCachedClient returns an Elasticsearch client that relies on a cache for some operations.
+	// Important: do not use the client concurrently for a same operation. Concurrent calls of a given operation is not thread-safe.
+	NewElasticsearchCachedClient(
+		es types.NamespacedName,
+		client Client,
+	) Client
+
+	Forget(es types.NamespacedName)
+}
+
+// NewCachedClientBuilder returns a builder to create cached clients.
+func NewCachedClientBuilder() CachedClientBuilder {
+	return &cache{states: map[types.NamespacedName]*cachedState{}}
+}
+
+type cachedState struct {
+	es                     types.NamespacedName
+	allocationSettings     *string
+	zen1MinimumMasterNodes *int
+}
+
+var _ CachedClientBuilder = &cache{}
+
+type cache struct {
+	mu     sync.RWMutex
+	states map[types.NamespacedName]*cachedState
+}
+
+var _ Client = &cachedClient{}
+
+type cachedClient struct {
+	Client
+	*cachedState
+}
+
+func (c *cache) getState(es types.NamespacedName) (value *cachedState, ok bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	value, ok = c.states[es]
+	return
+}
+
+func (c *cache) newState(es types.NamespacedName) *cachedState {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if value, ok := c.states[es]; ok {
+		return value
+	}
+	c.states[es] = &cachedState{es: es}
+	return c.states[es]
+}
+
+func (c *cache) Forget(es types.NamespacedName) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.states, es)
+}
+
+func (c *cache) NewElasticsearchCachedClient(
+	es types.NamespacedName,
+	client Client,
+) Client {
+	cachedState, ok := c.getState(es)
+	if !ok {
+		cachedState = c.newState(es)
+	}
+	return &cachedClient{
+		Client:      client,
+		cachedState: cachedState,
+	}
+}
+
+func (c *cachedClient) Equal(c2 Client) bool {
+	other, ok := c2.(*cachedClient)
+	if !ok {
+		return false
+	}
+	return c.Client.Equal(other.Client)
+}
+
+func (c *cachedClient) SetMinimumMasterNodes(ctx context.Context, minimumMasterNodes int) error {
+	if c.zen1MinimumMasterNodes != nil && *c.zen1MinimumMasterNodes == minimumMasterNodes {
+		log.V(1).Info("Cached minimum master nodes",
+			"how", "api",
+			"namespace", c.es.Namespace,
+			"es_name", c.es.Name,
+			"minimum_master_nodes", minimumMasterNodes,
+		)
+		return nil
+	}
+	log.Info("Updating minimum master nodes",
+		"how", "api",
+		"namespace", c.es.Namespace,
+		"es_name", c.es.Name,
+		"minimum_master_nodes", minimumMasterNodes,
+	)
+	if err := c.Client.SetMinimumMasterNodes(ctx, minimumMasterNodes); err != nil {
+		c.zen1MinimumMasterNodes = nil
+		return err
+	}
+	// Update cache
+	c.zen1MinimumMasterNodes = &minimumMasterNodes
+	return nil
+}
+
+func (c *cachedClient) ExcludeFromShardAllocation(ctx context.Context, nodes string) error {
+	if c.allocationSettings != nil && *c.allocationSettings == nodes {
+		log.V(1).Info("Cached routing allocation excludes", "namespace", c.es.Namespace, "es_name", c.es.Name, "value", nodes)
+		return nil
+	}
+	log.Info("Setting routing allocation excludes", "namespace", c.es.Namespace, "es_name", c.es.Name, "value", nodes)
+	if err := c.Client.ExcludeFromShardAllocation(ctx, nodes); err != nil {
+		c.allocationSettings = nil
+		return err
+	}
+	// Update cache
+	c.allocationSettings = &nodes
+	return nil
+}

--- a/pkg/controller/elasticsearch/client/cache.go
+++ b/pkg/controller/elasticsearch/client/cache.go
@@ -19,12 +19,13 @@ var log = logf.Log.WithName("cached-client")
 type CachedClientBuilder interface {
 
 	// NewElasticsearchCachedClient returns an Elasticsearch client that relies on a cache for some operations.
-	// Important: do not use the client concurrently for a same operation. Concurrent calls of a given operation is not thread-safe.
+	// Do not use the resulting client concurrently for a same operation. Concurrent calls of a given operation is not thread-safe.
 	NewElasticsearchCachedClient(
 		es types.NamespacedName,
 		client Client,
 	) Client
 
+	// Forget deletes data stored in memory for a given Elasticsearch cluster.
 	Forget(es types.NamespacedName)
 }
 
@@ -33,6 +34,7 @@ func NewCachedClientBuilder() CachedClientBuilder {
 	return &cache{states: map[types.NamespacedName]*cachedState{}}
 }
 
+// cachedState holds the cached state for a given Elasticsearch cluster.
 type cachedState struct {
 	es                          types.NamespacedName
 	allocationSettings          *string
@@ -47,6 +49,7 @@ type votingConfigExclusionsState struct {
 
 var _ CachedClientBuilder = &cache{}
 
+// cache is the internal structure that holds the states of the ES clusters.
 type cache struct {
 	mu     sync.RWMutex
 	states map[types.NamespacedName]*cachedState

--- a/pkg/controller/elasticsearch/client/cache_test.go
+++ b/pkg/controller/elasticsearch/client/cache_test.go
@@ -7,7 +7,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -278,31 +277,5 @@ func Test_cachedClient_SetMinimumMasterNodes(t *testing.T) {
 		if step.es2ExpectedValue != nil {
 			assert.Equal(t, *step.es2ExpectedValue, es2FakeClient.minimumMasterNodes)
 		}
-	}
-}
-
-func Test_cache_Forget(t *testing.T) {
-	type fields struct {
-		mu     sync.RWMutex
-		states map[types.NamespacedName]*cachedState
-	}
-	type args struct {
-		es types.NamespacedName
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-	}{
-		{},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &cache{
-				mu:     tt.fields.mu,
-				states: tt.fields.states,
-			}
-			c.Forget(tt.args.es)
-		})
 	}
 }

--- a/pkg/controller/elasticsearch/client/cache_test.go
+++ b/pkg/controller/elasticsearch/client/cache_test.go
@@ -1,0 +1,228 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func Test_cache_Forget(t *testing.T) {
+	type fields struct {
+		mu     sync.RWMutex
+		states map[types.NamespacedName]*cachedState
+	}
+	type args struct {
+		es types.NamespacedName
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cache{
+				mu:     tt.fields.mu,
+				states: tt.fields.states,
+			}
+			c.Forget(tt.args.es)
+		})
+	}
+}
+
+type fakeESClient struct {
+	excludeFromShardAllocationCalled, setMinimumMasterNodesCalled int
+	excludedNodesFromShardAllocation                              string
+	minimumMasterNodes                                            int
+	err                                                           error
+	Client
+}
+
+func (f *fakeESClient) ExcludeFromShardAllocation(_ context.Context, nodes string) error {
+	f.excludeFromShardAllocationCalled++
+	f.excludedNodesFromShardAllocation = nodes
+	return f.err
+}
+
+func (f *fakeESClient) SetMinimumMasterNodes(_ context.Context, n int) error {
+	f.setMinimumMasterNodesCalled++
+	f.minimumMasterNodes = n
+	return f.err
+}
+
+var (
+	es1 = types.NamespacedName{
+		Name:      "es1",
+		Namespace: "ns",
+	}
+	es2 = types.NamespacedName{
+		Name:      "es2",
+		Namespace: "ns",
+	}
+)
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func Test_cachedClient_ExcludeFromShardAllocation(t *testing.T) {
+	cacheClientBuilder := NewCachedClientBuilder()
+
+	es1FakeClient := fakeESClient{}
+	es1FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
+
+	es2FakeClient := fakeESClient{}
+	es2FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es2, &es2FakeClient)
+
+	steps := []struct {
+		es1Value, es2Value                   *string
+		es1ExpectedValue, es2ExpectedValue   *string
+		es1ExpectedCalled, es2ExpectedCalled int
+		es1Error, es2Error                   error
+	}{
+		{
+			es1Value:          stringPtr("node1"),
+			es1ExpectedValue:  stringPtr("node1"),
+			es1ExpectedCalled: 1,
+			es2ExpectedCalled: 0,
+		},
+		{
+			es1Value:          stringPtr("node1"),
+			es1ExpectedValue:  stringPtr("node1"),
+			es2Value:          stringPtr("node2"),
+			es2ExpectedValue:  stringPtr("node2"),
+			es1ExpectedCalled: 1, // same value, es1 is not called
+			es2ExpectedCalled: 1,
+		},
+		{
+			es1Value:          stringPtr("node1_2"),
+			es1ExpectedValue:  stringPtr("node1_2"),
+			es1ExpectedCalled: 2,
+			es2ExpectedCalled: 1,
+		},
+		{
+			es1Value:          stringPtr("node1"),
+			es1Error:          fmt.Errorf("error"),
+			es2ExpectedValue:  stringPtr("node2"),
+			es1ExpectedCalled: 3,
+			es2ExpectedCalled: 1,
+		},
+		{
+			es1Value:          stringPtr("node1_2"),
+			es1ExpectedValue:  stringPtr("node1_2"),
+			es2ExpectedValue:  stringPtr("node2"), // es2 value should still be in memory
+			es1ExpectedCalled: 4,                  // API must be called after the error at the previous step
+			es2ExpectedCalled: 1,
+		},
+	}
+
+	for _, step := range steps {
+		// Set error field in fake client
+		es1FakeClient.err = step.es1Error
+		es2FakeClient.err = step.es2Error
+
+		// Simulate API calls
+		if step.es1Value != nil {
+			_ = es1FakeCachedClient.ExcludeFromShardAllocation(nil, *step.es1Value)
+		}
+		if step.es2Value != nil {
+			_ = es2FakeCachedClient.ExcludeFromShardAllocation(nil, *step.es2Value)
+		}
+		assert.Equal(t, step.es1ExpectedCalled, es1FakeClient.excludeFromShardAllocationCalled)
+		assert.Equal(t, step.es2ExpectedCalled, es2FakeClient.excludeFromShardAllocationCalled)
+		if step.es1ExpectedValue != nil {
+			assert.Equal(t, *step.es1ExpectedValue, es1FakeClient.excludedNodesFromShardAllocation)
+		}
+		if step.es2ExpectedValue != nil {
+			assert.Equal(t, *step.es2ExpectedValue, es2FakeClient.excludedNodesFromShardAllocation)
+		}
+	}
+}
+
+func intPtr(value int) *int {
+	return &value
+}
+
+func Test_cachedClient_SetMinimumMasterNodes(t *testing.T) {
+	cacheClientBuilder := NewCachedClientBuilder()
+
+	es1FakeClient := fakeESClient{}
+	es1FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
+
+	es2FakeClient := fakeESClient{}
+	es2FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es2, &es2FakeClient)
+
+	steps := []struct {
+		es1Value, es2Value                   *int
+		es1ExpectedValue, es2ExpectedValue   *int
+		es1ExpectedCalled, es2ExpectedCalled int
+		es1Error, es2Error                   error
+	}{
+		{
+			es1Value:          intPtr(1),
+			es1ExpectedValue:  intPtr(1),
+			es1ExpectedCalled: 1,
+			es2ExpectedCalled: 0,
+		},
+		{
+			es1Value:          intPtr(1),
+			es1ExpectedValue:  intPtr(1),
+			es2Value:          intPtr(2),
+			es2ExpectedValue:  intPtr(2),
+			es1ExpectedCalled: 1, // same value, es1 is not called
+			es2ExpectedCalled: 1,
+		},
+		{
+			es1Value:          intPtr(3),
+			es1ExpectedValue:  intPtr(3),
+			es1ExpectedCalled: 2,
+			es2ExpectedCalled: 1,
+		},
+		{
+			es1Value:          intPtr(1),
+			es1Error:          fmt.Errorf("error"),
+			es2ExpectedValue:  intPtr(2),
+			es1ExpectedCalled: 3,
+			es2ExpectedCalled: 1,
+		},
+		{
+			es1Value:          intPtr(3),
+			es1ExpectedValue:  intPtr(3),
+			es2ExpectedValue:  intPtr(2), // es2 value should still be in memory
+			es1ExpectedCalled: 4,         // API must be called after the error at the previous step
+			es2ExpectedCalled: 1,
+		},
+	}
+
+	for _, step := range steps {
+		// Set error field in fake client
+		es1FakeClient.err = step.es1Error
+		es2FakeClient.err = step.es2Error
+
+		// Simulate API calls
+		if step.es1Value != nil {
+			_ = es1FakeCachedClient.SetMinimumMasterNodes(nil, *step.es1Value)
+		}
+		if step.es2Value != nil {
+			_ = es2FakeCachedClient.SetMinimumMasterNodes(nil, *step.es2Value)
+		}
+		assert.Equal(t, step.es1ExpectedCalled, es1FakeClient.setMinimumMasterNodesCalled)
+		assert.Equal(t, step.es2ExpectedCalled, es2FakeClient.setMinimumMasterNodesCalled)
+		if step.es1ExpectedValue != nil {
+			assert.Equal(t, *step.es1ExpectedValue, es1FakeClient.minimumMasterNodes)
+		}
+		if step.es2ExpectedValue != nil {
+			assert.Equal(t, *step.es2ExpectedValue, es2FakeClient.minimumMasterNodes)
+		}
+	}
+}

--- a/pkg/controller/elasticsearch/client/cache_test.go
+++ b/pkg/controller/elasticsearch/client/cache_test.go
@@ -41,11 +41,15 @@ func Test_cache_Forget(t *testing.T) {
 }
 
 type fakeESClient struct {
-	excludeFromShardAllocationCalled, setMinimumMasterNodesCalled int
-	excludedNodesFromShardAllocation                              string
-	minimumMasterNodes                                            int
-	err                                                           error
 	Client
+	err error
+
+	excludeFromShardAllocationCalled, setMinimumMasterNodesCalled,
+	addVotingConfigExclusionsCalled, deleteVotingConfigExclusionsCalled int
+
+	excludedNodesFromShardAllocation string
+	minimumMasterNodes               int
+	votingConfigExclusions           []string
 }
 
 func (f *fakeESClient) ExcludeFromShardAllocation(_ context.Context, nodes string) error {
@@ -57,6 +61,18 @@ func (f *fakeESClient) ExcludeFromShardAllocation(_ context.Context, nodes strin
 func (f *fakeESClient) SetMinimumMasterNodes(_ context.Context, n int) error {
 	f.setMinimumMasterNodesCalled++
 	f.minimumMasterNodes = n
+	return f.err
+}
+
+func (f *fakeESClient) AddVotingConfigExclusions(_ context.Context, nodeNames []string, _ string) error {
+	f.addVotingConfigExclusionsCalled++
+	f.votingConfigExclusions = nodeNames
+	return f.err
+}
+
+func (f *fakeESClient) DeleteVotingConfigExclusions(_ context.Context, _ bool) error {
+	f.deleteVotingConfigExclusionsCalled++
+	f.votingConfigExclusions = nil
 	return f.err
 }
 
@@ -73,6 +89,74 @@ var (
 
 func stringPtr(value string) *string {
 	return &value
+}
+
+func Test_cachedClient_DeleteVotingConfigExclusions(t *testing.T) {
+	cacheClientBuilder := NewCachedClientBuilder()
+	es1FakeClient := fakeESClient{}
+
+	// DeleteVotingConfigExclusions should be called on a new client
+	es1FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
+	assert.NoError(t, es1FakeCachedClient.DeleteVotingConfigExclusions(nil, false))
+	assert.Equal(t, 1, es1FakeClient.deleteVotingConfigExclusionsCalled)
+
+	// second call should hit the cache
+	es1FakeCachedClient = cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
+	assert.NoError(t, es1FakeCachedClient.DeleteVotingConfigExclusions(nil, false))
+	assert.Equal(t, 1, es1FakeClient.deleteVotingConfigExclusionsCalled)
+
+	// Set a config exclusion
+	es1FakeCachedClient = cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
+	assert.NoError(t, es1FakeCachedClient.AddVotingConfigExclusions(nil, []string{"foo"}, ""))
+	assert.Equal(t, 1, es1FakeClient.addVotingConfigExclusionsCalled)
+	assert.Equal(t, []string{"foo"}, es1FakeClient.votingConfigExclusions)
+
+	// call returns an error
+	es1FakeCachedClient = cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
+	es1FakeClient.err = fmt.Errorf("error")
+	assert.Error(t, es1FakeCachedClient.DeleteVotingConfigExclusions(nil, false))
+	assert.Equal(t, 2, es1FakeClient.deleteVotingConfigExclusionsCalled)
+
+	es1FakeClient.err = nil
+	es1FakeCachedClient = cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
+	assert.NoError(t, es1FakeCachedClient.DeleteVotingConfigExclusions(nil, false))
+	assert.Equal(t, 3, es1FakeClient.deleteVotingConfigExclusionsCalled)
+	assert.Equal(t, []string(nil), es1FakeClient.votingConfigExclusions)
+
+}
+
+func Test_cachedClient_AddVotingConfigExclusions(t *testing.T) {
+	cacheClientBuilder := NewCachedClientBuilder()
+	es1FakeClient := fakeESClient{}
+
+	// AddVotingConfigExclusions should be called on a new client
+	es1FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
+	assert.NoError(t, es1FakeCachedClient.AddVotingConfigExclusions(nil, []string{"foo"}, ""))
+	assert.Equal(t, 1, es1FakeClient.addVotingConfigExclusionsCalled)
+	assert.Equal(t, []string{"foo"}, es1FakeClient.votingConfigExclusions)
+
+	// second call should hit the cache
+	es1FakeCachedClient = cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
+	assert.NoError(t, es1FakeCachedClient.AddVotingConfigExclusions(nil, []string{"foo"}, ""))
+	assert.Equal(t, 1, es1FakeClient.addVotingConfigExclusionsCalled)
+	assert.Equal(t, []string{"foo"}, es1FakeClient.votingConfigExclusions)
+
+	// Update config exclusion
+	es1FakeCachedClient = cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
+	assert.NoError(t, es1FakeCachedClient.AddVotingConfigExclusions(nil, []string{"foo", "bar"}, ""))
+	assert.Equal(t, 2, es1FakeClient.addVotingConfigExclusionsCalled)
+	assert.Equal(t, []string{"bar", "foo"}, es1FakeClient.votingConfigExclusions)
+
+	// call returns an error
+	es1FakeClient.err = fmt.Errorf("error")
+	es1FakeCachedClient = cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
+	assert.Error(t, es1FakeCachedClient.AddVotingConfigExclusions(nil, []string{"foo"}, ""))
+	assert.Equal(t, 3, es1FakeClient.addVotingConfigExclusionsCalled)
+
+	es1FakeClient.err = nil
+	assert.NoError(t, es1FakeCachedClient.AddVotingConfigExclusions(nil, []string{"foo", "bar"}, ""))
+	assert.Equal(t, 4, es1FakeClient.addVotingConfigExclusionsCalled)
+
 }
 
 func Test_cachedClient_ExcludeFromShardAllocation(t *testing.T) {

--- a/pkg/controller/elasticsearch/client/cache_test.go
+++ b/pkg/controller/elasticsearch/client/cache_test.go
@@ -14,32 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func Test_cache_Forget(t *testing.T) {
-	type fields struct {
-		mu     sync.RWMutex
-		states map[types.NamespacedName]*cachedState
-	}
-	type args struct {
-		es types.NamespacedName
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &cache{
-				mu:     tt.fields.mu,
-				states: tt.fields.states,
-			}
-			c.Forget(tt.args.es)
-		})
-	}
-}
-
 type fakeESClient struct {
 	Client
 	err error
@@ -160,43 +134,36 @@ func Test_cachedClient_AddVotingConfigExclusions(t *testing.T) {
 }
 
 func Test_cachedClient_ExcludeFromShardAllocation(t *testing.T) {
-	cacheClientBuilder := NewCachedClientBuilder()
-
-	es1FakeClient := fakeESClient{}
-	es1FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
-
-	es2FakeClient := fakeESClient{}
-	es2FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es2, &es2FakeClient)
 
 	steps := []struct {
-		es1Value, es2Value                   *string
-		es1ExpectedValue, es2ExpectedValue   *string
-		es1ExpectedCalled, es2ExpectedCalled int
-		es1Error, es2Error                   error
+		es1Value, es2Value                   *string // value to set when calling the api
+		es1ExpectedValue, es2ExpectedValue   *string // expected value stored in the fake client
+		es1ExpectedCalled, es2ExpectedCalled int     // number of time an api is called
+		es1Error, es2Error                   error   // used to simulate an error
 	}{
 		{
-			es1Value:          stringPtr("node1"),
+			es1Value:          stringPtr("node1"), // exclude node "node1" on es1
 			es1ExpectedValue:  stringPtr("node1"),
-			es1ExpectedCalled: 1,
-			es2ExpectedCalled: 0,
+			es1ExpectedCalled: 1, // es1 api should be called once
+			es2ExpectedCalled: 0, // es2 api should not be called
 		},
 		{
-			es1Value:          stringPtr("node1"),
+			es1Value:          stringPtr("node1"), // "node1" is still the only node excluded on es1
 			es1ExpectedValue:  stringPtr("node1"),
-			es2Value:          stringPtr("node2"),
+			es2Value:          stringPtr("node2"), // exclude node "node2" on es2
 			es2ExpectedValue:  stringPtr("node2"),
 			es1ExpectedCalled: 1, // same value, es1 is not called
-			es2ExpectedCalled: 1,
+			es2ExpectedCalled: 1, // es2 api should be called once
 		},
 		{
-			es1Value:          stringPtr("node1_2"),
+			es1Value:          stringPtr("node1_2"), // "node1_2" is a new excluded node on es1
 			es1ExpectedValue:  stringPtr("node1_2"),
-			es1ExpectedCalled: 2,
+			es1ExpectedCalled: 2, // es1 api should be called
 			es2ExpectedCalled: 1,
 		},
 		{
 			es1Value:          stringPtr("node1"),
-			es1Error:          fmt.Errorf("error"),
+			es1Error:          fmt.Errorf("error"), // simulate error while calling es1 api
 			es2ExpectedValue:  stringPtr("node2"),
 			es1ExpectedCalled: 3,
 			es2ExpectedCalled: 1,
@@ -210,6 +177,9 @@ func Test_cachedClient_ExcludeFromShardAllocation(t *testing.T) {
 		},
 	}
 
+	es1FakeClient := fakeESClient{}
+	es2FakeClient := fakeESClient{}
+	cacheClientBuilder := NewCachedClientBuilder()
 	for _, step := range steps {
 		// Set error field in fake client
 		es1FakeClient.err = step.es1Error
@@ -217,9 +187,11 @@ func Test_cachedClient_ExcludeFromShardAllocation(t *testing.T) {
 
 		// Simulate API calls
 		if step.es1Value != nil {
+			es1FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
 			_ = es1FakeCachedClient.ExcludeFromShardAllocation(nil, *step.es1Value)
 		}
 		if step.es2Value != nil {
+			es2FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es2, &es2FakeClient)
 			_ = es2FakeCachedClient.ExcludeFromShardAllocation(nil, *step.es2Value)
 		}
 		assert.Equal(t, step.es1ExpectedCalled, es1FakeClient.excludeFromShardAllocationCalled)
@@ -238,43 +210,36 @@ func intPtr(value int) *int {
 }
 
 func Test_cachedClient_SetMinimumMasterNodes(t *testing.T) {
-	cacheClientBuilder := NewCachedClientBuilder()
-
-	es1FakeClient := fakeESClient{}
-	es1FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
-
-	es2FakeClient := fakeESClient{}
-	es2FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es2, &es2FakeClient)
 
 	steps := []struct {
-		es1Value, es2Value                   *int
-		es1ExpectedValue, es2ExpectedValue   *int
-		es1ExpectedCalled, es2ExpectedCalled int
-		es1Error, es2Error                   error
+		es1Value, es2Value                   *int  // value to set when calling the api
+		es1ExpectedValue, es2ExpectedValue   *int  // expected value stored in the fake client
+		es1ExpectedCalled, es2ExpectedCalled int   // number of time an api is called
+		es1Error, es2Error                   error // used to simulate an error
 	}{
 		{
-			es1Value:          intPtr(1),
+			es1Value:          intPtr(1), // set initial m_m_n for es1 to 1
 			es1ExpectedValue:  intPtr(1),
-			es1ExpectedCalled: 1,
-			es2ExpectedCalled: 0,
+			es1ExpectedCalled: 1, // es1 api should be called once
+			es2ExpectedCalled: 0, // es2 api should not be called
 		},
 		{
 			es1Value:          intPtr(1),
 			es1ExpectedValue:  intPtr(1),
-			es2Value:          intPtr(2),
+			es2Value:          intPtr(2), // set m_m_n for es2 to 2
 			es2ExpectedValue:  intPtr(2),
-			es1ExpectedCalled: 1, // same value, es1 is not called
-			es2ExpectedCalled: 1,
+			es1ExpectedCalled: 1, // same value, es1 should not be called
+			es2ExpectedCalled: 1, // es2 api should be called
 		},
 		{
-			es1Value:          intPtr(3),
+			es1Value:          intPtr(3), // update m_m_n for es1 to 3
 			es1ExpectedValue:  intPtr(3),
-			es1ExpectedCalled: 2,
+			es1ExpectedCalled: 2, // es1 api should be called
 			es2ExpectedCalled: 1,
 		},
 		{
 			es1Value:          intPtr(1),
-			es1Error:          fmt.Errorf("error"),
+			es1Error:          fmt.Errorf("error"), // simulate error while calling es1 api
 			es2ExpectedValue:  intPtr(2),
 			es1ExpectedCalled: 3,
 			es2ExpectedCalled: 1,
@@ -282,12 +247,15 @@ func Test_cachedClient_SetMinimumMasterNodes(t *testing.T) {
 		{
 			es1Value:          intPtr(3),
 			es1ExpectedValue:  intPtr(3),
-			es2ExpectedValue:  intPtr(2), // es2 value should still be in memory
-			es1ExpectedCalled: 4,         // API must be called after the error at the previous step
+			es2ExpectedValue:  intPtr(2),
+			es1ExpectedCalled: 4, // es1 api must be called after the error at the previous step
 			es2ExpectedCalled: 1,
 		},
 	}
 
+	es1FakeClient := fakeESClient{}
+	es2FakeClient := fakeESClient{}
+	cacheClientBuilder := NewCachedClientBuilder()
 	for _, step := range steps {
 		// Set error field in fake client
 		es1FakeClient.err = step.es1Error
@@ -295,9 +263,11 @@ func Test_cachedClient_SetMinimumMasterNodes(t *testing.T) {
 
 		// Simulate API calls
 		if step.es1Value != nil {
+			es1FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
 			_ = es1FakeCachedClient.SetMinimumMasterNodes(nil, *step.es1Value)
 		}
 		if step.es2Value != nil {
+			es2FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es2, &es2FakeClient)
 			_ = es2FakeCachedClient.SetMinimumMasterNodes(nil, *step.es2Value)
 		}
 		assert.Equal(t, step.es1ExpectedCalled, es1FakeClient.setMinimumMasterNodesCalled)
@@ -308,5 +278,31 @@ func Test_cachedClient_SetMinimumMasterNodes(t *testing.T) {
 		if step.es2ExpectedValue != nil {
 			assert.Equal(t, *step.es2ExpectedValue, es2FakeClient.minimumMasterNodes)
 		}
+	}
+}
+
+func Test_cache_Forget(t *testing.T) {
+	type fields struct {
+		mu     sync.RWMutex
+		states map[types.NamespacedName]*cachedState
+	}
+	type args struct {
+		es types.NamespacedName
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cache{
+				mu:     tt.fields.mu,
+				states: tt.fields.states,
+			}
+			c.Forget(tt.args.es)
+		})
 	}
 }

--- a/pkg/controller/elasticsearch/client/cache_test.go
+++ b/pkg/controller/elasticsearch/client/cache_test.go
@@ -71,29 +71,29 @@ func Test_cachedClient_DeleteVotingConfigExclusions(t *testing.T) {
 
 	// DeleteVotingConfigExclusions should be called on a new client
 	es1FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
-	assert.NoError(t, es1FakeCachedClient.DeleteVotingConfigExclusions(nil, false))
+	assert.NoError(t, es1FakeCachedClient.DeleteVotingConfigExclusions(context.Background(), false))
 	assert.Equal(t, 1, es1FakeClient.deleteVotingConfigExclusionsCalled)
 
 	// second call should hit the cache
 	es1FakeCachedClient = cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
-	assert.NoError(t, es1FakeCachedClient.DeleteVotingConfigExclusions(nil, false))
+	assert.NoError(t, es1FakeCachedClient.DeleteVotingConfigExclusions(context.Background(), false))
 	assert.Equal(t, 1, es1FakeClient.deleteVotingConfigExclusionsCalled)
 
 	// Set a config exclusion
 	es1FakeCachedClient = cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
-	assert.NoError(t, es1FakeCachedClient.AddVotingConfigExclusions(nil, []string{"foo"}, ""))
+	assert.NoError(t, es1FakeCachedClient.AddVotingConfigExclusions(context.Background(), []string{"foo"}, ""))
 	assert.Equal(t, 1, es1FakeClient.addVotingConfigExclusionsCalled)
 	assert.Equal(t, []string{"foo"}, es1FakeClient.votingConfigExclusions)
 
 	// call returns an error
 	es1FakeCachedClient = cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
 	es1FakeClient.err = fmt.Errorf("error")
-	assert.Error(t, es1FakeCachedClient.DeleteVotingConfigExclusions(nil, false))
+	assert.Error(t, es1FakeCachedClient.DeleteVotingConfigExclusions(context.Background(), false))
 	assert.Equal(t, 2, es1FakeClient.deleteVotingConfigExclusionsCalled)
 
 	es1FakeClient.err = nil
 	es1FakeCachedClient = cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
-	assert.NoError(t, es1FakeCachedClient.DeleteVotingConfigExclusions(nil, false))
+	assert.NoError(t, es1FakeCachedClient.DeleteVotingConfigExclusions(context.Background(), false))
 	assert.Equal(t, 3, es1FakeClient.deleteVotingConfigExclusionsCalled)
 	assert.Equal(t, []string(nil), es1FakeClient.votingConfigExclusions)
 
@@ -105,30 +105,30 @@ func Test_cachedClient_AddVotingConfigExclusions(t *testing.T) {
 
 	// AddVotingConfigExclusions should be called on a new client
 	es1FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
-	assert.NoError(t, es1FakeCachedClient.AddVotingConfigExclusions(nil, []string{"foo"}, ""))
+	assert.NoError(t, es1FakeCachedClient.AddVotingConfigExclusions(context.Background(), []string{"foo"}, ""))
 	assert.Equal(t, 1, es1FakeClient.addVotingConfigExclusionsCalled)
 	assert.Equal(t, []string{"foo"}, es1FakeClient.votingConfigExclusions)
 
 	// second call should hit the cache
 	es1FakeCachedClient = cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
-	assert.NoError(t, es1FakeCachedClient.AddVotingConfigExclusions(nil, []string{"foo"}, ""))
+	assert.NoError(t, es1FakeCachedClient.AddVotingConfigExclusions(context.Background(), []string{"foo"}, ""))
 	assert.Equal(t, 1, es1FakeClient.addVotingConfigExclusionsCalled)
 	assert.Equal(t, []string{"foo"}, es1FakeClient.votingConfigExclusions)
 
 	// Update config exclusion
 	es1FakeCachedClient = cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
-	assert.NoError(t, es1FakeCachedClient.AddVotingConfigExclusions(nil, []string{"foo", "bar"}, ""))
+	assert.NoError(t, es1FakeCachedClient.AddVotingConfigExclusions(context.Background(), []string{"foo", "bar"}, ""))
 	assert.Equal(t, 2, es1FakeClient.addVotingConfigExclusionsCalled)
 	assert.Equal(t, []string{"bar", "foo"}, es1FakeClient.votingConfigExclusions)
 
 	// call returns an error
 	es1FakeClient.err = fmt.Errorf("error")
 	es1FakeCachedClient = cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
-	assert.Error(t, es1FakeCachedClient.AddVotingConfigExclusions(nil, []string{"foo"}, ""))
+	assert.Error(t, es1FakeCachedClient.AddVotingConfigExclusions(context.Background(), []string{"foo"}, ""))
 	assert.Equal(t, 3, es1FakeClient.addVotingConfigExclusionsCalled)
 
 	es1FakeClient.err = nil
-	assert.NoError(t, es1FakeCachedClient.AddVotingConfigExclusions(nil, []string{"foo", "bar"}, ""))
+	assert.NoError(t, es1FakeCachedClient.AddVotingConfigExclusions(context.Background(), []string{"foo", "bar"}, ""))
 	assert.Equal(t, 4, es1FakeClient.addVotingConfigExclusionsCalled)
 
 }
@@ -188,11 +188,11 @@ func Test_cachedClient_ExcludeFromShardAllocation(t *testing.T) {
 		// Simulate API calls
 		if step.es1Value != nil {
 			es1FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
-			_ = es1FakeCachedClient.ExcludeFromShardAllocation(nil, *step.es1Value)
+			_ = es1FakeCachedClient.ExcludeFromShardAllocation(context.Background(), *step.es1Value)
 		}
 		if step.es2Value != nil {
 			es2FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es2, &es2FakeClient)
-			_ = es2FakeCachedClient.ExcludeFromShardAllocation(nil, *step.es2Value)
+			_ = es2FakeCachedClient.ExcludeFromShardAllocation(context.Background(), *step.es2Value)
 		}
 		assert.Equal(t, step.es1ExpectedCalled, es1FakeClient.excludeFromShardAllocationCalled)
 		assert.Equal(t, step.es2ExpectedCalled, es2FakeClient.excludeFromShardAllocationCalled)
@@ -264,11 +264,11 @@ func Test_cachedClient_SetMinimumMasterNodes(t *testing.T) {
 		// Simulate API calls
 		if step.es1Value != nil {
 			es1FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es1, &es1FakeClient)
-			_ = es1FakeCachedClient.SetMinimumMasterNodes(nil, *step.es1Value)
+			_ = es1FakeCachedClient.SetMinimumMasterNodes(context.Background(), *step.es1Value)
 		}
 		if step.es2Value != nil {
 			es2FakeCachedClient := cacheClientBuilder.NewElasticsearchCachedClient(es2, &es2FakeClient)
-			_ = es2FakeCachedClient.SetMinimumMasterNodes(nil, *step.es2Value)
+			_ = es2FakeCachedClient.SetMinimumMasterNodes(context.Background(), *step.es2Value)
 		}
 		assert.Equal(t, step.es1ExpectedCalled, es1FakeClient.setMinimumMasterNodesCalled)
 		assert.Equal(t, step.es2ExpectedCalled, es2FakeClient.setMinimumMasterNodesCalled)

--- a/pkg/controller/elasticsearch/driver/downscale.go
+++ b/pkg/controller/elasticsearch/driver/downscale.go
@@ -51,7 +51,7 @@ func HandleDownscale(
 	// migrate data away from nodes that should be removed
 	// if leavingNodes is empty, it clears any existing settings
 	leavingNodes := leavingNodeNames(downscales)
-	if err := migration.MigrateData(downscaleCtx.parentCtx, downscaleCtx.k8sClient, downscaleCtx.es, downscaleCtx.esClient, leavingNodes); err != nil {
+	if err := migration.MigrateData(downscaleCtx.parentCtx, downscaleCtx.esClient, leavingNodes); err != nil {
 		return results.WithError(err)
 	}
 
@@ -286,5 +286,5 @@ func maybeUpdateZen1ForDownscale(
 		"Downscaling from 2 to 1 master nodes: unsafe operation",
 	)
 	minimumMasterNodes := 1
-	return zen1.UpdateMinimumMasterNodesTo(ctx, es, c, esClient, minimumMasterNodes)
+	return zen1.UpdateMinimumMasterNodesTo(ctx, esClient, minimumMasterNodes)
 }

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -66,6 +66,9 @@ type DefaultDriverParameters struct {
 
 	// ES is the Elasticsearch resource to reconcile
 	ES esv1.Elasticsearch
+	// ES cached client builder
+	EsCachedClientBuilder esclient.CachedClientBuilder
+
 	// SupportedVersions verifies whether we can support upgrading from the current pods.
 	SupportedVersions esversion.LowestHighestSupportedVersions
 
@@ -276,7 +279,10 @@ func (d *defaultDriver) newElasticsearchClient(
 	caCerts []*x509.Certificate,
 ) esclient.Client {
 	url := services.ElasticsearchURL(d.ES, state.CurrentPodsByPhase[corev1.PodRunning])
-	return esclient.NewElasticsearchClient(d.OperatorParameters.Dialer, url, user, v, caCerts)
+	return d.EsCachedClientBuilder.NewElasticsearchCachedClient(
+		k8s.ExtractNamespacedName(&d.ES),
+		esclient.NewElasticsearchClient(d.OperatorParameters.Dialer, url, user, v, caCerts),
+	)
 }
 
 // warnUnsupportedDistro sends an event of type warning if the Elasticsearch Docker image is not a supported

--- a/pkg/controller/elasticsearch/migration/migrate_data.go
+++ b/pkg/controller/elasticsearch/migration/migrate_data.go
@@ -8,12 +8,8 @@ import (
 	"context"
 	"strings"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 )
-
-var log = logf.Log.WithName("migrate-data")
 
 // NodeHasShard returns true if the given ES Pod is holding at least one shard (primary or replica).
 func NodeHasShard(ctx context.Context, shardLister esclient.ShardLister, podName string) (bool, error) {

--- a/pkg/controller/elasticsearch/migration/migrate_data.go
+++ b/pkg/controller/elasticsearch/migration/migrate_data.go
@@ -10,18 +10,10 @@ import (
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
 var log = logf.Log.WithName("migrate-data")
-
-const (
-	// AllocationExcludeAnnotationName is the name of the annotation that stores the last
-	// cluster.routing.allocation._name setting applied to the Elasticsearch cluster.
-	AllocationExcludeAnnotationName = "elasticsearch.k8s.elastic.co/allocation-exclude"
-)
 
 // NodeHasShard returns true if the given ES Pod is holding at least one shard (primary or replica).
 func NodeHasShard(ctx context.Context, shardLister esclient.ShardLister, podName string) (bool, error) {
@@ -38,27 +30,9 @@ func NodeHasShard(ctx context.Context, shardLister esclient.ShardLister, podName
 	return false, nil
 }
 
-// allocationExcludeFromAnnotation returns the allocation exclude value stored in an annotation.
-// May be empty if not set.
-func allocationExcludeFromAnnotation(es esv1.Elasticsearch) string {
-	return es.Annotations[AllocationExcludeAnnotationName]
-}
-
-// updateAllocationExcludeAnnotation sets an annotation in ES with the given cluster routing allocation exclude value.
-// This is to avoid making the same ES API call over and over again.
-func updateAllocationExcludeAnnotation(c k8s.Client, es esv1.Elasticsearch, value string) error {
-	if es.Annotations == nil {
-		es.Annotations = map[string]string{}
-	}
-	es.Annotations[AllocationExcludeAnnotationName] = value
-	return c.Update(&es)
-}
-
 // MigrateData sets allocation filters for the given nodes.
 func MigrateData(
 	ctx context.Context,
-	c k8s.Client,
-	es esv1.Elasticsearch,
 	allocationSetter esclient.AllocationSetter,
 	leavingNodes []string,
 ) error {
@@ -67,16 +41,5 @@ func MigrateData(
 	if len(leavingNodes) > 0 {
 		exclusions = strings.Join(leavingNodes, ",")
 	}
-	// compare with what was set previously
-	// Note the user may have changed it behind our back through the ES API. It is considered their responsibility.
-	// Manually removing the annotation to force a refresh of the allocations exclude setting is a valid use case.
-	if exclusions == allocationExcludeFromAnnotation(es) {
-		return nil
-	}
-	log.Info("Setting routing allocation excludes", "namespace", es.Namespace, "es_name", es.Name, "value", exclusions)
-	if err := allocationSetter.ExcludeFromShardAllocation(ctx, exclusions); err != nil {
-		return err
-	}
-	// store updated value in an annotation so we don't make the same call over and over again
-	return updateAllocationExcludeAnnotation(c, es, exclusions)
+	return allocationSetter.ExcludeFromShardAllocation(ctx, exclusions)
 }

--- a/pkg/controller/elasticsearch/migration/migrate_data_test.go
+++ b/pkg/controller/elasticsearch/migration/migrate_data_test.go
@@ -9,11 +9,7 @@ import (
 	"fmt"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -82,130 +78,32 @@ func TestNodeHasShard(t *testing.T) {
 func TestMigrateData(t *testing.T) {
 	tests := []struct {
 		name         string
-		es           esv1.Elasticsearch
 		leavingNodes []string
 		want         string
-		wantEs       esv1.Elasticsearch
 	}{
 		{
-			name:         "no nodes to migrate, no annotation on ES",
-			es:           esv1.Elasticsearch{},
+			name:         "no nodes to migrate, allocation setting should be set to none_excluded",
 			leavingNodes: []string{},
 			want:         "none_excluded",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "none_excluded"},
-			}},
 		},
 		{
-			name: "no nodes to migrate, annotation already set on ES",
-			es: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "none_excluded"},
-			}},
-			leavingNodes: []string{},
-			want:         "",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "none_excluded"},
-			}},
+			name:         "a node to migrate",
+			leavingNodes: []string{"test-node1"},
+			want:         "test-node1",
 		},
 		{
-			name: "no nodes to migrate, annotation set with some exclusions on ES",
-			es: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node1,test-node2"},
-			}},
-			leavingNodes: []string{},
-			want:         "none_excluded",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "none_excluded"},
-			}},
-		},
-		{
-			name:         "one node to migrate, no annotation set on ES",
-			es:           esv1.Elasticsearch{},
-			leavingNodes: []string{"test-node"},
-			want:         "test-node",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node"},
-			}},
-		},
-		{
-			name: "one node to migrate, no exclusions in ES annotation",
-			es: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "none_excluded"},
-			}},
-			leavingNodes: []string{"test-node"},
-			want:         "test-node",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node"},
-			}},
-		},
-		{
-			name: "one node to migrate, different exclusions in ES annotation",
-			es: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node2"},
-			}},
-			leavingNodes: []string{"test-node"},
-			want:         "test-node",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node"},
-			}},
-		},
-		{
-			name: "one node to migrate, already present in ES annotation",
-			es: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node"},
-			}},
-			leavingNodes: []string{"test-node"},
-			want:         "",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node"},
-			}},
-		},
-		{
-			name: "multiple node to migrate, no exclusions in ES annotation",
-			es: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "none_excluded"},
-			}},
+			name:         "multiple nodes to migrate",
 			leavingNodes: []string{"test-node1", "test-node2"},
 			want:         "test-node1,test-node2",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node1,test-node2"},
-			}},
-		},
-		{
-			name: "multiple node to migrate, different exclusions in ES annotation",
-			es: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node1,test-node3"},
-			}},
-			leavingNodes: []string{"test-node1", "test-node2"},
-			want:         "test-node1,test-node2",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node1,test-node2"},
-			}},
-		},
-		{
-			name: "multiple node to migrate, already present in ES annotation",
-			es: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node1,test-node2"},
-			}},
-			leavingNodes: []string{"test-node1", "test-node2"},
-			want:         "",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node1,test-node2"},
-			}},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			allocationSetter := fakeAllocationSetter{}
-			c := k8s.WrappedFakeClient(&tt.es)
-			err := MigrateData(context.Background(), c, tt.es, &allocationSetter, tt.leavingNodes)
+			err := MigrateData(context.Background(), &allocationSetter, tt.leavingNodes)
 			require.NoError(t, err)
-			assert.Contains(t, allocationSetter.value, tt.want)
-			var retrievedES esv1.Elasticsearch
-			err = c.Get(k8s.ExtractNamespacedName(&tt.es), &retrievedES)
-			require.NoError(t, err)
-			require.Equal(t, tt.wantEs.Annotations, retrievedES.Annotations)
+			assert.Equal(t, tt.want, allocationSetter.value)
 		})
 	}
 }

--- a/pkg/controller/elasticsearch/version/zen1/minimum_masters.go
+++ b/pkg/controller/elasticsearch/version/zen1/minimum_masters.go
@@ -24,10 +24,6 @@ var (
 	log = logf.Log.WithName("zen1")
 )
 
-const (
-	Zen1MiniumMasterNodesAnnotationName = "elasticsearch.k8s.elastic.co/minimum-master-nodes"
-)
-
 // SetupMinimumMasterNodesConfig modifies the ES config of the given resources to setup
 // zen1 minimum master nodes.
 // This function should not be called unless all the expectations are met.
@@ -126,7 +122,7 @@ func UpdateMinimumMasterNodes(
 		return true, nil
 	}
 
-	return false, UpdateMinimumMasterNodesTo(ctx, es, c, esClient, minimumMasterNodes)
+	return false, UpdateMinimumMasterNodesTo(ctx, esClient, minimumMasterNodes)
 }
 
 // UpdateMinimumMasterNodesTo calls the ES API to update the value of zen1 minimum_master_nodes
@@ -134,48 +130,10 @@ func UpdateMinimumMasterNodes(
 // Should only be called it there are some Zen1 compatible masters
 func UpdateMinimumMasterNodesTo(
 	ctx context.Context,
-	es esv1.Elasticsearch,
-	c k8s.Client,
 	esClient client.Client,
 	minimumMasterNodes int,
 ) error {
-	// Check if we really need to update minimum_master_nodes with an API call
-	if minimumMasterNodes == minimumMasterNodesFromAnnotation(es) {
-		return nil
-	}
-
-	log.Info("Updating minimum master nodes",
-		"how", "api",
-		"namespace", es.Namespace,
-		"es_name", es.Name,
-		"minimum_master_nodes", minimumMasterNodes,
-	)
 	ctx, cancel := context.WithTimeout(ctx, client.DefaultReqTimeout)
 	defer cancel()
-	if err := esClient.SetMinimumMasterNodes(ctx, minimumMasterNodes); err != nil {
-		return nil
-	}
-	// Save the current value in an annotation
-	return annotateWithMinimumMasterNodes(c, es, minimumMasterNodes)
-}
-
-func minimumMasterNodesFromAnnotation(es esv1.Elasticsearch) int {
-	annotationStr, set := es.Annotations[Zen1MiniumMasterNodesAnnotationName]
-	if !set {
-		return 0
-	}
-	mmn, err := strconv.Atoi(annotationStr)
-	if err != nil {
-		// this is an optimization only, drop the error
-		return 0
-	}
-	return mmn
-}
-
-func annotateWithMinimumMasterNodes(c k8s.Client, es esv1.Elasticsearch, minimumMasterNodes int) error {
-	if es.Annotations == nil {
-		es.Annotations = make(map[string]string)
-	}
-	es.Annotations[Zen1MiniumMasterNodesAnnotationName] = strconv.Itoa(minimumMasterNodes)
-	return c.Update(&es)
+	return esClient.SetMinimumMasterNodes(ctx, minimumMasterNodes)
 }

--- a/pkg/controller/elasticsearch/version/zen1/minimum_masters_test.go
+++ b/pkg/controller/elasticsearch/version/zen1/minimum_masters_test.go
@@ -162,38 +162,7 @@ func TestUpdateMinimumMasterNodes(t *testing.T) {
 			c:                  k8s.WrappedFakeClient(createMasterPodsWithVersion("nodes", "7.1.0", 3)...),
 		},
 		{
-			name:               "correct mmn already set in ES annotation",
-			c:                  k8s.WrappedFakeClient(&podsReady3[0], &podsReady3[1], &podsReady3[2]),
-			actualStatefulSets: sset.StatefulSetList{ssetSample},
-			es: esv1.Elasticsearch{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      esName,
-					Namespace: ns,
-					Annotations: map[string]string{
-						Zen1MiniumMasterNodesAnnotationName: "2",
-					},
-				},
-			},
-			wantCalled: false,
-		},
-		{
-			name:               "mmn should be updated, it's different in the ES annotation",
-			c:                  k8s.WrappedFakeClient(&podsReady3[0], &podsReady3[1], &podsReady3[2]),
-			actualStatefulSets: sset.StatefulSetList{ssetSample},
-			es: esv1.Elasticsearch{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      esName,
-					Namespace: ns,
-					Annotations: map[string]string{
-						Zen1MiniumMasterNodesAnnotationName: "1",
-					},
-				},
-			},
-			wantCalled:     true,
-			wantCalledWith: 2,
-		},
-		{
-			name:               "mmn should be updated, it isn't set in the ES annotation",
+			name:               "mmn should be updated",
 			c:                  k8s.WrappedFakeClient(&podsReady3[0], &podsReady3[1], &podsReady3[2]),
 			actualStatefulSets: sset.StatefulSetList{ssetSample},
 			es:                 esv1.Elasticsearch{ObjectMeta: k8s.ToObjectMeta(nsn)},

--- a/pkg/controller/elasticsearch/version/zen2/voting_exclusions.go
+++ b/pkg/controller/elasticsearch/version/zen2/voting_exclusions.go
@@ -6,8 +6,6 @@ package zen2
 
 import (
 	"context"
-	"sort"
-	"strings"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -21,40 +19,6 @@ var (
 	log = logf.Log.WithName("zen2")
 )
 
-const (
-	// VotingConfigExclusionsAnnotationName is an annotation that stores the last applied voting config exclusions.
-	// An empty value means no voting config exclusions are set.
-	VotingConfigExclusionsAnnotationName = "elasticsearch.k8s.elastic.co/voting-config-exclusions"
-)
-
-// serializeExcludedNodesForAnnotation returns a sorted comma-separated representation of the given slice.
-func serializeExcludedNodesForAnnotation(excludedNodes []string) string {
-	// sort a copy to not mutate the given slice
-	sliceCopy := make([]string, len(excludedNodes))
-	copy(sliceCopy, excludedNodes)
-	sort.Strings(sliceCopy)
-	return strings.Join(sliceCopy, ",")
-}
-
-// votingConfigAnnotationMatches returns true if the voting config exclusions annotation value
-// matches the given excluded nodes.
-func votingConfigAnnotationMatches(es esv1.Elasticsearch, excludedNodes []string) bool {
-	value, exists := es.Annotations[VotingConfigExclusionsAnnotationName]
-	if !exists {
-		return false
-	}
-	return value == serializeExcludedNodesForAnnotation(excludedNodes)
-}
-
-// setVotingConfigAnnotation sets the value of the voting config exclusions annotation to the given excluded nodes.
-func setVotingConfigAnnotation(c k8s.Client, es esv1.Elasticsearch, excludedNodes []string) error {
-	if es.Annotations == nil {
-		es.Annotations = map[string]string{}
-	}
-	es.Annotations[VotingConfigExclusionsAnnotationName] = serializeExcludedNodesForAnnotation(excludedNodes)
-	return c.Update(&es)
-}
-
 // AddToVotingConfigExclusions adds the given node names to exclude from voting config exclusions.
 func AddToVotingConfigExclusions(ctx context.Context, c k8s.Client, esClient client.Client, es esv1.Elasticsearch, excludeNodes []string) error {
 	compatible, err := AllMastersCompatibleWithZen2(c, es)
@@ -65,19 +29,9 @@ func AddToVotingConfigExclusions(ctx context.Context, c k8s.Client, esClient cli
 		return nil
 	}
 
-	if votingConfigAnnotationMatches(es, excludeNodes) {
-		// nothing to do, we already applied that setting
-		return nil
-	}
-
-	log.Info("Setting voting config exclusions", "namespace", es.Namespace, "nodes", excludeNodes)
 	ctx, cancel := context.WithTimeout(ctx, client.DefaultReqTimeout)
 	defer cancel()
-	if err := esClient.AddVotingConfigExclusions(ctx, excludeNodes, ""); err != nil {
-		return err
-	}
-	// store the excluded nodes value in an annotation so we don't perform the same API call over and over again
-	return setVotingConfigAnnotation(c, es, excludeNodes)
+	return esClient.AddVotingConfigExclusions(ctx, excludeNodes, "")
 }
 
 // canClearVotingConfigExclusions returns true if it is safe to clear voting config exclusions.
@@ -106,12 +60,6 @@ func ClearVotingConfigExclusions(ctx context.Context, es esv1.Elasticsearch, c k
 		return false, nil
 	}
 
-	var noExcludedNodes []string = nil
-	if votingConfigAnnotationMatches(es, noExcludedNodes) {
-		// nothing to do, we already applied that setting
-		return false, nil
-	}
-
 	canClear, err := canClearVotingConfigExclusions(c, actualStatefulSets)
 	if err != nil {
 		return false, err
@@ -123,11 +71,9 @@ func ClearVotingConfigExclusions(ctx context.Context, es esv1.Elasticsearch, c k
 
 	ctx, cancel := context.WithTimeout(ctx, client.DefaultReqTimeout)
 	defer cancel()
-	log.Info("Ensuring no voting exclusions are set", "namespace", es.Namespace, "es_name", es.Name)
 	if err := esClient.DeleteVotingConfigExclusions(ctx, false); err != nil {
 		return false, err
 	}
 
-	// store the excluded nodes value in an annotation so we don't perform the same API call over and over again
-	return false, setVotingConfigAnnotation(c, es, noExcludedNodes)
+	return false, nil
 }


### PR DESCRIPTION
ECK attempts to reduce the number of API calls to Elasticsearch by storing the api call arguments in annotations.
Unfortunately when ECK fails to update the annotation it may lead to some consistencies: see #2788 and #2864 

This PR adds an in memory cache to keep track of the last arguments used when calling the ES API for the following operations:
- [X] Allocation settings
- [X] Voting config exclusions
- [X] Zen1 minimum master nodes
- [ ] Remote clusters

_still a draft but ready for review re. the overall architecture_
