### PR TITLE
Reconcile Enterprise Search status

### DIFF
--- a/pkg/apis/enterprisesearch/v1beta1/enterprisesearch_types.go
+++ b/pkg/apis/enterprisesearch/v1beta1/enterprisesearch_types.go
@@ -96,7 +96,7 @@ type EnterpriseSearchStatus struct {
 
 // IsDegraded returns true if the current status is worse than the previous.
 func (ent EnterpriseSearchStatus) IsDegraded(prev EnterpriseSearchStatus) bool {
-	return prev.Health == EnterpriseSearchGreen && ent.Health != EnterpriseSearchRed
+	return prev.Health == EnterpriseSearchGreen && ent.Health != EnterpriseSearchGreen
 }
 
 // IsMarkedForDeletion returns true if the EnterpriseSearch is going to be deleted

--- a/pkg/controller/enterprisesearch/deployment.go
+++ b/pkg/controller/enterprisesearch/deployment.go
@@ -19,20 +19,14 @@ import (
 
 func (r *ReconcileEnterpriseSearch) reconcileDeployment(
 	ctx context.Context,
-	state State,
 	ent entv1beta1.EnterpriseSearch,
 	configHash string,
-) (State, error) {
+) (appsv1.Deployment, error) {
 	span, _ := apm.StartSpan(ctx, "reconcile_deployment", tracing.SpanTypeApp)
 	defer span.End()
 
 	deploy := deployment.New(r.deploymentParams(ent, configHash))
-	result, err := deployment.Reconcile(r.K8sClient(), deploy, &ent)
-	if err != nil {
-		return state, err
-	}
-	state.UpdateEnterpriseSearchState(result)
-	return state, nil
+	return deployment.Reconcile(r.K8sClient(), deploy, &ent)
 }
 
 func (r *ReconcileEnterpriseSearch) deploymentParams(ent entv1beta1.EnterpriseSearch, configHash string) deployment.Params {

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"reflect"
+	"sync/atomic"
 
 	"go.elastic.co/apm"
 	appsv1 "k8s.io/api/apps/v1"
@@ -22,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
@@ -193,7 +196,7 @@ func (r *ReconcileEnterpriseSearch) Reconcile(request reconcile.Request) (reconc
 		return reconcile.Result{}, nil
 	}
 
-	return r.doReconcile(ctx, request, ent)
+	return r.doReconcile(ctx, ent)
 }
 
 func (r *ReconcileEnterpriseSearch) onDelete(obj types.NamespacedName) {
@@ -210,13 +213,11 @@ func (r *ReconcileEnterpriseSearch) isCompatible(ctx context.Context, ent *entv1
 	return compat, err
 }
 
-func (r *ReconcileEnterpriseSearch) doReconcile(ctx context.Context, request reconcile.Request, ent entv1beta1.EnterpriseSearch) (reconcile.Result, error) {
+func (r *ReconcileEnterpriseSearch) doReconcile(ctx context.Context, ent entv1beta1.EnterpriseSearch) (reconcile.Result, error) {
 	// Run validation in case the webhook is disabled
 	if err := r.validate(ctx, &ent); err != nil {
 		return reconcile.Result{}, err
 	}
-
-	state := NewState(request, &ent)
 
 	svc, err := common.ReconcileService(ctx, r.Client, NewService(ent), &ent)
 	if err != nil {
@@ -258,23 +259,17 @@ func (r *ReconcileEnterpriseSearch) doReconcile(ctx context.Context, request rec
 		return reconcile.Result{}, err
 	}
 
-	state, err = r.reconcileDeployment(ctx, state, ent, configHash)
+	deploy, err := r.reconcileDeployment(ctx, ent, configHash)
 	if err != nil {
-		if apierrors.IsConflict(err) {
-			log.V(1).Info("Conflict while updating status")
-			return reconcile.Result{Requeue: true}, nil
-		}
-		k8s.EmitErrorEvent(r.recorder, err, &ent, events.EventReconciliationError, "Deployment reconciliation error: %v", err)
-		return state.Result, tracing.CaptureError(ctx, err)
+		return reconcile.Result{}, err
 	}
 
-	state.UpdateEnterpriseSearchExternalService(*svc)
+	err = r.updateStatus(ent, deploy, svc.Name)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
 
-	// TODO: update status
-
-	res, err := results.WithError(err).Aggregate()
-	k8s.EmitErrorEvent(r.recorder, err, &ent, events.EventReconciliationError, "Reconciliation error: %v", err)
-	return res, nil
+	return results.Aggregate()
 }
 
 func (r *ReconcileEnterpriseSearch) validate(ctx context.Context, ent *entv1beta1.EnterpriseSearch) error {
@@ -288,6 +283,37 @@ func (r *ReconcileEnterpriseSearch) validate(ctx context.Context, ent *entv1beta
 	}
 
 	return nil
+}
+
+func (r *ReconcileEnterpriseSearch) updateStatus(ent entv1beta1.EnterpriseSearch, deploy appsv1.Deployment, svcName string) error {
+	newStatus := entv1beta1.EnterpriseSearchStatus{
+		Health: entv1beta1.EnterpriseSearchRed,
+		ReconcilerStatus: commonv1.ReconcilerStatus{
+			AvailableNodes: deploy.Status.AvailableReplicas,
+		},
+		ExternalService: svcName,
+		Association:     ent.Status.Association,
+	}
+	for _, c := range deploy.Status.Conditions {
+		if c.Type == appsv1.DeploymentAvailable && c.Status == corev1.ConditionTrue {
+			newStatus.Health = entv1beta1.EnterpriseSearchGreen
+		}
+	}
+
+	if reflect.DeepEqual(newStatus, ent.Status) {
+		return nil // nothing to do
+	}
+	if newStatus.IsDegraded(ent.Status) {
+		r.recorder.Event(&ent, corev1.EventTypeWarning, events.EventReasonUnhealthy, "Enterprise Search health degraded")
+	}
+	log.V(1).Info("Updating status",
+		"iteration", atomic.LoadUint64(&r.iteration),
+		"namespace", ent.Namespace,
+		"ent_name", ent.Name,
+		"status", newStatus,
+	)
+	ent.Status = newStatus
+	return common.UpdateStatus(r.Client, &ent)
 }
 
 func NewService(ent entv1beta1.EnterpriseSearch) *corev1.Service {

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller_test.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller_test.go
@@ -487,35 +487,3 @@ func TestReconcileEnterpriseSearch_updateStatus(t *testing.T) {
 		})
 	}
 }
-
-//
-//func TestReconcileEnterpriseSearch_noUpdate(t *testing.T) {
-//	// don't update the status if expected == actual
-//
-//	ent := entv1beta1.EnterpriseSearch{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "ent"},
-//		Status: entv1beta1.EnterpriseSearchStatus{
-//			ReconcilerStatus: commonv1.ReconcilerStatus{
-//				AvailableNodes: 3,
-//			},
-//			Health:          "green",
-//			ExternalService: "http-service",
-//		}}
-//	deploy := appsv1.Deployment{Status: appsv1.DeploymentStatus{
-//		AvailableReplicas: 3,
-//		Conditions: []appsv1.DeploymentCondition{
-//			{
-//				Type:   appsv1.DeploymentAvailable,
-//				Status: corev1.ConditionTrue,
-//			},
-//		},
-//	}}
-//	expectedStatus := *(ent.Status.DeepCopy())
-//	r := &ReconcileEnterpriseSearch{Client: c}
-//	err := r.updateStatus(ent, deploy, "http-service")
-//	require.NoError(t, err)
-//
-//	var updatedEnt entv1beta1.EnterpriseSearch
-//	err = c.Get(k8s.ExtractNamespacedName(&ent), &updatedEnt)
-//	require.NoError(t, err)
-//	require.Equal(t, expectedStatus, updatedEnt.Status)
-//}


### PR DESCRIPTION
Similar to what we do for other CRDs, update the resource status
at the end of the reconciliation, with:

- red/green health
- number of available pods in the deployment
- service name