### PR TITLE
Watch only trial license secret (not trial status)

### DIFF
--- a/pkg/controller/license/trial/trial_controller.go
+++ b/pkg/controller/license/trial/trial_controller.go
@@ -204,18 +204,7 @@ func addWatches(c controller.Controller) error {
 					},
 				}
 			}
-
-			if obj.Meta.GetName() != licensing.TrialStatusSecretKey {
-				return nil
-			}
-			return []reconcile.Request{
-				{
-					NamespacedName: types.NamespacedName{
-						Namespace: secret.Annotations[licensing.TrialLicenseSecretNamespace],
-						Name:      secret.Annotations[licensing.TrialLicenseSecretName],
-					},
-				},
-			}
+			return nil
 		}),
 	}); err != nil {
 		return err


### PR DESCRIPTION
This is to avoid client cache issues on the trial license secret which lead to incorrect (in)validation of trial licenses. The change is simply to not watch the trial-status anymore. 

My theory as to what causes the flaky test is as follow: 
* we watch both secrets: trial-status and trial license secret
* we create the trial status and update the trial license here at the same time: https://github.com/elastic/cloud-on-k8s/blob/24b311e3c65701983102a87ff6ff0d848b03e84d/pkg/controller/common/license/trial.go#L70-L77
* this triggers two events: one for the trial license and one for the trial-status, we used to coalesce both events into one for the trial license and reconcile on that
* this created the possibility of the client cache for the trial license still being out of date when the event for the trial status hits the reconcile loop first
* that in turn created the unexpected situation where a trial was started but the trial license was not correctly populated

Fixes #2878 (I hope)
