### PR TITLE
Do not use annotations to cache Elasticsearch API calls

### DIFF
--- a/pkg/controller/elasticsearch/driver/downscale.go
+++ b/pkg/controller/elasticsearch/driver/downscale.go
@@ -51,7 +51,7 @@ func HandleDownscale(
 	// migrate data away from nodes that should be removed
 	// if leavingNodes is empty, it clears any existing settings
 	leavingNodes := leavingNodeNames(downscales)
-	if err := migration.MigrateData(downscaleCtx.parentCtx, downscaleCtx.k8sClient, downscaleCtx.es, downscaleCtx.esClient, leavingNodes); err != nil {
+	if err := migration.MigrateData(downscaleCtx.parentCtx, downscaleCtx.es, downscaleCtx.esClient, leavingNodes); err != nil {
 		return results.WithError(err)
 	}
 
@@ -286,5 +286,5 @@ func maybeUpdateZen1ForDownscale(
 		"Downscaling from 2 to 1 master nodes: unsafe operation",
 	)
 	minimumMasterNodes := 1
-	return zen1.UpdateMinimumMasterNodesTo(ctx, es, c, esClient, minimumMasterNodes)
+	return zen1.UpdateMinimumMasterNodesTo(ctx, es, esClient, minimumMasterNodes)
 }

--- a/pkg/controller/elasticsearch/driver/downscale.go
+++ b/pkg/controller/elasticsearch/driver/downscale.go
@@ -181,7 +181,7 @@ func calculatePerformableDownscale(
 	}
 	// iterate on all leaving nodes (ordered by highest ordinal first)
 	for _, node := range downscale.leavingNodeNames() {
-		migrating, err := migration.IsMigratingData(ctx.parentCtx, ctx.shardLister, node)
+		migrating, err := migration.NodeHasShard(ctx.parentCtx, ctx.shardLister, node)
 		if err != nil {
 			return performableDownscale, err
 		}

--- a/pkg/controller/elasticsearch/migration/migrate_data.go
+++ b/pkg/controller/elasticsearch/migration/migrate_data.go
@@ -8,20 +8,12 @@ import (
 	"context"
 	"strings"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var log = logf.Log.WithName("migrate-data")
-
-const (
-	// AllocationExcludeAnnotationName is the name of the annotation that stores the last
-	// cluster.routing.allocation._name setting applied to the Elasticsearch cluster.
-	AllocationExcludeAnnotationName = "elasticsearch.k8s.elastic.co/allocation-exclude"
-)
 
 // NodeHasShard returns true if the given ES Pod is holding at least one shard (primary or replica).
 func NodeHasShard(ctx context.Context, shardLister esclient.ShardLister, podName string) (bool, error) {
@@ -38,26 +30,9 @@ func NodeHasShard(ctx context.Context, shardLister esclient.ShardLister, podName
 	return false, nil
 }
 
-// allocationExcludeFromAnnotation returns the allocation exclude value stored in an annotation.
-// May be empty if not set.
-func allocationExcludeFromAnnotation(es esv1.Elasticsearch) string {
-	return es.Annotations[AllocationExcludeAnnotationName]
-}
-
-// updateAllocationExcludeAnnotation sets an annotation in ES with the given cluster routing allocation exclude value.
-// This is to avoid making the same ES API call over and over again.
-func updateAllocationExcludeAnnotation(c k8s.Client, es esv1.Elasticsearch, value string) error {
-	if es.Annotations == nil {
-		es.Annotations = map[string]string{}
-	}
-	es.Annotations[AllocationExcludeAnnotationName] = value
-	return c.Update(&es)
-}
-
 // MigrateData sets allocation filters for the given nodes.
 func MigrateData(
 	ctx context.Context,
-	c k8s.Client,
 	es esv1.Elasticsearch,
 	allocationSetter esclient.AllocationSetter,
 	leavingNodes []string,
@@ -67,16 +42,6 @@ func MigrateData(
 	if len(leavingNodes) > 0 {
 		exclusions = strings.Join(leavingNodes, ",")
 	}
-	// compare with what was set previously
-	// Note the user may have changed it behind our back through the ES API. It is considered their responsibility.
-	// Manually removing the annotation to force a refresh of the allocations exclude setting is a valid use case.
-	if exclusions == allocationExcludeFromAnnotation(es) {
-		return nil
-	}
 	log.Info("Setting routing allocation excludes", "namespace", es.Namespace, "es_name", es.Name, "value", exclusions)
-	if err := allocationSetter.ExcludeFromShardAllocation(ctx, exclusions); err != nil {
-		return err
-	}
-	// store updated value in an annotation so we don't make the same call over and over again
-	return updateAllocationExcludeAnnotation(c, es, exclusions)
+	return allocationSetter.ExcludeFromShardAllocation(ctx, exclusions)
 }

--- a/pkg/controller/elasticsearch/migration/migrate_data.go
+++ b/pkg/controller/elasticsearch/migration/migrate_data.go
@@ -23,10 +23,8 @@ const (
 	AllocationExcludeAnnotationName = "elasticsearch.k8s.elastic.co/allocation-exclude"
 )
 
-// IsMigratingData looks only at the presence of shards on a given node
-// and checks if there is at least one other copy of the shard in the cluster
-// that is started and not relocating.
-func IsMigratingData(ctx context.Context, shardLister esclient.ShardLister, podName string) (bool, error) {
+// NodeHasShard returns true if the given ES Pod is holding at least one shard (primary or replica).
+func NodeHasShard(ctx context.Context, shardLister esclient.ShardLister, podName string) (bool, error) {
 	shards, err := shardLister.GetShards(ctx)
 	if err != nil {
 		return false, err

--- a/pkg/controller/elasticsearch/migration/migrate_data_test.go
+++ b/pkg/controller/elasticsearch/migration/migrate_data_test.go
@@ -9,11 +9,8 @@ import (
 	"fmt"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -82,130 +79,32 @@ func TestNodeHasShard(t *testing.T) {
 func TestMigrateData(t *testing.T) {
 	tests := []struct {
 		name         string
-		es           esv1.Elasticsearch
 		leavingNodes []string
 		want         string
-		wantEs       esv1.Elasticsearch
 	}{
 		{
-			name:         "no nodes to migrate, no annotation on ES",
-			es:           esv1.Elasticsearch{},
+			name:         "no nodes to migrate, allocation setting should be set to none_excluded",
 			leavingNodes: []string{},
 			want:         "none_excluded",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "none_excluded"},
-			}},
 		},
 		{
-			name: "no nodes to migrate, annotation already set on ES",
-			es: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "none_excluded"},
-			}},
-			leavingNodes: []string{},
-			want:         "",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "none_excluded"},
-			}},
+			name:         "a node to migrate",
+			leavingNodes: []string{"test-node1"},
+			want:         "test-node1",
 		},
 		{
-			name: "no nodes to migrate, annotation set with some exclusions on ES",
-			es: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node1,test-node2"},
-			}},
-			leavingNodes: []string{},
-			want:         "none_excluded",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "none_excluded"},
-			}},
-		},
-		{
-			name:         "one node to migrate, no annotation set on ES",
-			es:           esv1.Elasticsearch{},
-			leavingNodes: []string{"test-node"},
-			want:         "test-node",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node"},
-			}},
-		},
-		{
-			name: "one node to migrate, no exclusions in ES annotation",
-			es: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "none_excluded"},
-			}},
-			leavingNodes: []string{"test-node"},
-			want:         "test-node",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node"},
-			}},
-		},
-		{
-			name: "one node to migrate, different exclusions in ES annotation",
-			es: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node2"},
-			}},
-			leavingNodes: []string{"test-node"},
-			want:         "test-node",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node"},
-			}},
-		},
-		{
-			name: "one node to migrate, already present in ES annotation",
-			es: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node"},
-			}},
-			leavingNodes: []string{"test-node"},
-			want:         "",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node"},
-			}},
-		},
-		{
-			name: "multiple node to migrate, no exclusions in ES annotation",
-			es: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "none_excluded"},
-			}},
+			name:         "multiple nodes to migrate",
 			leavingNodes: []string{"test-node1", "test-node2"},
 			want:         "test-node1,test-node2",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node1,test-node2"},
-			}},
-		},
-		{
-			name: "multiple node to migrate, different exclusions in ES annotation",
-			es: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node1,test-node3"},
-			}},
-			leavingNodes: []string{"test-node1", "test-node2"},
-			want:         "test-node1,test-node2",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node1,test-node2"},
-			}},
-		},
-		{
-			name: "multiple node to migrate, already present in ES annotation",
-			es: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node1,test-node2"},
-			}},
-			leavingNodes: []string{"test-node1", "test-node2"},
-			want:         "",
-			wantEs: esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{AllocationExcludeAnnotationName: "test-node1,test-node2"},
-			}},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			allocationSetter := fakeAllocationSetter{}
-			c := k8s.WrappedFakeClient(&tt.es)
-			err := MigrateData(context.Background(), c, tt.es, &allocationSetter, tt.leavingNodes)
+			err := MigrateData(context.Background(), esv1.Elasticsearch{}, &allocationSetter, tt.leavingNodes)
 			require.NoError(t, err)
-			assert.Contains(t, allocationSetter.value, tt.want)
-			var retrievedES esv1.Elasticsearch
-			err = c.Get(k8s.ExtractNamespacedName(&tt.es), &retrievedES)
-			require.NoError(t, err)
-			require.Equal(t, tt.wantEs.Annotations, retrievedES.Annotations)
+			assert.Equal(t, tt.want, allocationSetter.value)
 		})
 	}
 }

--- a/pkg/controller/elasticsearch/migration/migrate_data_test.go
+++ b/pkg/controller/elasticsearch/migration/migrate_data_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsMigratingData(t *testing.T) {
+func TestNodeHasShard(t *testing.T) {
 	type args struct {
 		shardLister client.ShardLister
 		podName     string
@@ -42,72 +42,38 @@ func TestIsMigratingData(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Node needs to be completely evacuated",
+			name: "Node has one shard",
 			args: args{
 				podName: "A",
 				shardLister: NewFakeShardLister([]client.Shard{
-					{Index: "index-1", Shard: "0", State: client.STARTED, NodeName: "A"},
-					{Index: "index-1", Shard: "0", State: client.STARTED, NodeName: "B"},
-					{Index: "index-1", Shard: "0", State: client.STARTED, NodeName: "C"},
+					{Index: "index-1", Shard: "0", NodeName: "A"},
+					{Index: "index-1", Shard: "0", NodeName: "B"},
+					{Index: "index-1", Shard: "0", NodeName: "C"},
 				}),
 			},
 			want: true,
 		},
 		{
-			name: "Nothing to migrate",
+			name: "No shard on the node",
 			args: args{
 				podName: "A",
 				shardLister: NewFakeShardLister([]client.Shard{
-					{Index: "index-1", Shard: "0", State: client.STARTED, NodeName: "B"},
-					{Index: "index-1", Shard: "0", State: client.STARTED, NodeName: "C"},
+					{Index: "index-1", Shard: "0", NodeName: "B"},
+					{Index: "index-1", Shard: "0", NodeName: "C"},
 				}),
 			},
 			want: false,
 		},
-		{
-			name: "Only copy needs migration",
-			args: args{
-				podName: "A",
-				shardLister: NewFakeShardLister([]client.Shard{
-					{Index: "index-1", Shard: "0", State: client.STARTED, NodeName: "A"},
-					{Index: "index-1", Shard: "1", State: client.STARTED, NodeName: "B"},
-					{Index: "index-1", Shard: "2", State: client.STARTED, NodeName: "C"},
-				}),
-			},
-			want: true,
-		},
-		{
-			name: "Relocation is migration",
-			args: args{
-				podName: "A",
-				shardLister: NewFakeShardLister([]client.Shard{
-					{Index: "index-1", Shard: "0", State: client.RELOCATING, NodeName: "A"},
-					{Index: "index-1", Shard: "0", State: client.INITIALIZING, NodeName: "B"},
-				}),
-			},
-			want: true,
-		},
-		{
-			name: "Copy is initializing",
-			args: args{
-				podName: "A",
-				shardLister: NewFakeShardLister([]client.Shard{
-					{Index: "index-1", Shard: "0", State: client.STARTED, NodeName: "A"},
-					{Index: "index-1", Shard: "0", State: client.INITIALIZING, NodeName: "B"},
-				}),
-			},
-			want: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := IsMigratingData(context.Background(), tt.args.shardLister, tt.args.podName)
+			got, err := NodeHasShard(context.Background(), tt.args.shardLister, tt.args.podName)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("IsMigratingData() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("NodeHasShard() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("IsMigratingData() = %v, want %v", got, tt.want)
+				t.Errorf("NodeHasShard() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/controller/elasticsearch/version/zen1/minimum_masters_test.go
+++ b/pkg/controller/elasticsearch/version/zen1/minimum_masters_test.go
@@ -162,38 +162,7 @@ func TestUpdateMinimumMasterNodes(t *testing.T) {
 			c:                  k8s.WrappedFakeClient(createMasterPodsWithVersion("nodes", "7.1.0", 3)...),
 		},
 		{
-			name:               "correct mmn already set in ES annotation",
-			c:                  k8s.WrappedFakeClient(&podsReady3[0], &podsReady3[1], &podsReady3[2]),
-			actualStatefulSets: sset.StatefulSetList{ssetSample},
-			es: esv1.Elasticsearch{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      esName,
-					Namespace: ns,
-					Annotations: map[string]string{
-						Zen1MiniumMasterNodesAnnotationName: "2",
-					},
-				},
-			},
-			wantCalled: false,
-		},
-		{
-			name:               "mmn should be updated, it's different in the ES annotation",
-			c:                  k8s.WrappedFakeClient(&podsReady3[0], &podsReady3[1], &podsReady3[2]),
-			actualStatefulSets: sset.StatefulSetList{ssetSample},
-			es: esv1.Elasticsearch{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      esName,
-					Namespace: ns,
-					Annotations: map[string]string{
-						Zen1MiniumMasterNodesAnnotationName: "1",
-					},
-				},
-			},
-			wantCalled:     true,
-			wantCalledWith: 2,
-		},
-		{
-			name:               "mmn should be updated, it isn't set in the ES annotation",
+			name:               "mmn should be updated",
 			c:                  k8s.WrappedFakeClient(&podsReady3[0], &podsReady3[1], &podsReady3[2]),
 			actualStatefulSets: sset.StatefulSetList{ssetSample},
 			es:                 esv1.Elasticsearch{ObjectMeta: k8s.ToObjectMeta(nsn)},

--- a/pkg/controller/elasticsearch/version/zen2/voting_exclusions.go
+++ b/pkg/controller/elasticsearch/version/zen2/voting_exclusions.go
@@ -6,8 +6,6 @@ package zen2
 
 import (
 	"context"
-	"sort"
-	"strings"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -21,40 +19,6 @@ var (
 	log = logf.Log.WithName("zen2")
 )
 
-const (
-	// VotingConfigExclusionsAnnotationName is an annotation that stores the last applied voting config exclusions.
-	// An empty value means no voting config exclusions are set.
-	VotingConfigExclusionsAnnotationName = "elasticsearch.k8s.elastic.co/voting-config-exclusions"
-)
-
-// serializeExcludedNodesForAnnotation returns a sorted comma-separated representation of the given slice.
-func serializeExcludedNodesForAnnotation(excludedNodes []string) string {
-	// sort a copy to not mutate the given slice
-	sliceCopy := make([]string, len(excludedNodes))
-	copy(sliceCopy, excludedNodes)
-	sort.Strings(sliceCopy)
-	return strings.Join(sliceCopy, ",")
-}
-
-// votingConfigAnnotationMatches returns true if the voting config exclusions annotation value
-// matches the given excluded nodes.
-func votingConfigAnnotationMatches(es esv1.Elasticsearch, excludedNodes []string) bool {
-	value, exists := es.Annotations[VotingConfigExclusionsAnnotationName]
-	if !exists {
-		return false
-	}
-	return value == serializeExcludedNodesForAnnotation(excludedNodes)
-}
-
-// setVotingConfigAnnotation sets the value of the voting config exclusions annotation to the given excluded nodes.
-func setVotingConfigAnnotation(c k8s.Client, es esv1.Elasticsearch, excludedNodes []string) error {
-	if es.Annotations == nil {
-		es.Annotations = map[string]string{}
-	}
-	es.Annotations[VotingConfigExclusionsAnnotationName] = serializeExcludedNodesForAnnotation(excludedNodes)
-	return c.Update(&es)
-}
-
 // AddToVotingConfigExclusions adds the given node names to exclude from voting config exclusions.
 func AddToVotingConfigExclusions(ctx context.Context, c k8s.Client, esClient client.Client, es esv1.Elasticsearch, excludeNodes []string) error {
 	compatible, err := AllMastersCompatibleWithZen2(c, es)
@@ -65,19 +29,10 @@ func AddToVotingConfigExclusions(ctx context.Context, c k8s.Client, esClient cli
 		return nil
 	}
 
-	if votingConfigAnnotationMatches(es, excludeNodes) {
-		// nothing to do, we already applied that setting
-		return nil
-	}
-
 	log.Info("Setting voting config exclusions", "namespace", es.Namespace, "nodes", excludeNodes)
 	ctx, cancel := context.WithTimeout(ctx, client.DefaultReqTimeout)
 	defer cancel()
-	if err := esClient.AddVotingConfigExclusions(ctx, excludeNodes, ""); err != nil {
-		return err
-	}
-	// store the excluded nodes value in an annotation so we don't perform the same API call over and over again
-	return setVotingConfigAnnotation(c, es, excludeNodes)
+	return esClient.AddVotingConfigExclusions(ctx, excludeNodes, "")
 }
 
 // canClearVotingConfigExclusions returns true if it is safe to clear voting config exclusions.
@@ -106,12 +61,6 @@ func ClearVotingConfigExclusions(ctx context.Context, es esv1.Elasticsearch, c k
 		return false, nil
 	}
 
-	var noExcludedNodes []string = nil
-	if votingConfigAnnotationMatches(es, noExcludedNodes) {
-		// nothing to do, we already applied that setting
-		return false, nil
-	}
-
 	canClear, err := canClearVotingConfigExclusions(c, actualStatefulSets)
 	if err != nil {
 		return false, err
@@ -121,13 +70,8 @@ func ClearVotingConfigExclusions(ctx context.Context, es esv1.Elasticsearch, c k
 		return true, nil // requeue
 	}
 
+	log.Info("Ensuring no voting exclusions are set", "namespace", es.Namespace, "es_name", es.Name)
 	ctx, cancel := context.WithTimeout(ctx, client.DefaultReqTimeout)
 	defer cancel()
-	log.Info("Ensuring no voting exclusions are set", "namespace", es.Namespace, "es_name", es.Name)
-	if err := esClient.DeleteVotingConfigExclusions(ctx, false); err != nil {
-		return false, err
-	}
-
-	// store the excluded nodes value in an annotation so we don't perform the same API call over and over again
-	return false, setVotingConfigAnnotation(c, es, noExcludedNodes)
+	return false, esClient.DeleteVotingConfigExclusions(ctx, false)
 }


### PR DESCRIPTION
This PR is a backport of #2880 in 1.1.0
It also takes the opportunity to backport the naming improvement from #2845 