### PR TITLE
Backport - Retry k8s api calls in the test init phase (#2881)

### DIFF
--- a/test/e2e/test/apmserver/steps_init.go
+++ b/test/e2e/test/apmserver/steps_init.go
@@ -5,12 +5,9 @@
 package apmserver
 
 import (
-	"testing"
-
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -19,49 +16,43 @@ func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
 	return []test.Step{
 		{
 			Name: "K8S should be accessible",
-			Test: func(t *testing.T) {
+			Test: test.Eventually(func() error {
 				pods := corev1.PodList{}
-				err := k.Client.List(&pods)
-				require.NoError(t, err)
-			},
+				return k.Client.List(&pods)
+			}),
 		},
 		{
 			Name: "Label test pods",
-			Test: func(t *testing.T) {
-				err := test.LabelTestPods(
+			Test: test.Eventually(func() error {
+				return test.LabelTestPods(
 					k.Client,
 					test.Ctx(),
 					run.TestNameLabel,
 					b.ApmServer.Labels[run.TestNameLabel])
-				require.NoError(t, err)
-			},
+			}),
 			Skip: func() bool {
 				return test.Ctx().Local
 			},
 		},
 		{
 			Name: "APM Server CRDs should exist",
-			Test: func(t *testing.T) {
-				err := k.Client.List(&apmv1.ApmServerList{})
-				require.NoError(t, err)
-			},
+			Test: test.Eventually(func() error {
+				return k.Client.List(&apmv1.ApmServerList{})
+			}),
 		},
 
 		{
 			Name: "Remove the resources if they already exist",
-			Test: func(t *testing.T) {
+			Test: test.Eventually(func() error {
 				for _, obj := range b.RuntimeObjects() {
 					err := k.Client.Delete(obj)
-					if err != nil {
-						// might not exist, which is ok
-						require.True(t, apierrors.IsNotFound(err))
+					if err != nil && !apierrors.IsNotFound(err) {
+						return err
 					}
 				}
-				// wait for ES pods to disappear
-				test.Eventually(func() error {
-					return k.CheckPodCount(0, test.ApmServerPodListOptions(b.ApmServer.Namespace, b.ApmServer.Name)...)
-				})(t)
-			},
+				// wait for APM pods to disappear
+				return k.CheckPodCount(0, test.ApmServerPodListOptions(b.ApmServer.Namespace, b.ApmServer.Name)...)
+			}),
 		},
 	}
 }


### PR DESCRIPTION
Backport https://github.com/elastic/cloud-on-k8s/pull/2881 on 1.1.

Any network blip would cause the entire E2E test suite to fail in the
init phase where we just perform a few basic api calls that are ok to
retry.
