### PR TITLE
Revert "Disable debug e2e job (#2865)"

### DIFF
--- a/.ci/jobs/e2e-tests-testmutationsecondmastersetdown.yml
+++ b/.ci/jobs/e2e-tests-testmutationsecondmastersetdown.yml
@@ -1,0 +1,17 @@
+---
+- job:
+    description: Run a particular ECK E2E tests on GKE
+    name: cloud-on-k8s-e2e-tests-testmutationsecondmastersetdown
+    project-type: pipeline
+    triggers:
+      - timed: 'H/30 * * * *'
+    concurrent: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/elastic/cloud-on-k8s
+            branches:
+              - master
+            credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
+      script-path: .ci/pipelines/e2e-tests-testmutationsecondmastersetdown.Jenkinsfile
+      lightweight-checkout: true

--- a/.ci/pipelines/e2e-tests-testmutationsecondmastersetdown.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-testmutationsecondmastersetdown.Jenkinsfile
@@ -91,7 +91,7 @@ pipeline {
         }
         cleanup {
             script {
-                if (notOnlyDocs() && failedTests.size == 0) {
+                if (notOnlyDocs() && failedTests.size() == 0) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
                         parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-e2e-${BUILD_NUMBER}")],
                         wait: false

--- a/.ci/pipelines/e2e-tests-testmutationsecondmastersetdown.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-testmutationsecondmastersetdown.Jenkinsfile
@@ -1,0 +1,112 @@
+// This library overrides the default checkout behavior to enable sleep+retries if there are errors
+// Added to help overcome some recurring github connection issues
+@Library('apm@current') _
+
+def failedTests = []
+def lib
+
+pipeline {
+
+    agent {
+        label 'linux'
+    }
+
+    options {
+        timeout(time: 300, unit: 'MINUTES')
+    }
+
+    environment {
+        VAULT_ADDR = credentials('vault-addr')
+        VAULT_ROLE_ID = credentials('vault-role-id')
+        VAULT_SECRET_ID = credentials('vault-secret-id')
+        GCLOUD_PROJECT = credentials('k8s-operators-gcloud-project')
+    }
+
+    stages {
+        stage('Checkout from GitHub') {
+            steps {
+                checkout scm
+            }
+        }
+        stage('Load common scripts') {
+            steps {
+                script {
+                    lib = load ".ci/common/tests.groovy"
+                }
+            }
+        }
+       /* stage('Run Checks') {
+            when {
+                expression {
+                    notOnlyDocs()
+                }
+            }
+            steps {
+                sh 'make -C .ci TARGET=ci-check ci'
+            }
+        }*/
+        stage("E2E tests") {
+            when {
+                expression {
+                    notOnlyDocs()
+                }
+            }
+            steps {
+                sh '.ci/setenvconfig e2e/master'
+                
+                sh 'echo TESTS_MATCH = TestMutationSecondMasterSetDown >> .env'
+                sh 'echo E2E_SKIP_CLEANUP = true >> .env'
+                sh 'sed "s/CLUSTER_NAME=eck-e2e/CLUSTER_NAME=eck-debug-e2e/" -i .env'
+                
+                script {
+                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-test-artifacts TARGET=ci-build-operator-e2e-run ci')
+
+                    //sh 'make -C .ci TARGET=e2e-generate-xml ci'
+                    //junit "e2e-tests.xml"
+
+                    if (env.SHELL_EXIT_CODE != 0) {
+                        failedTests = lib.getListOfFailedTests()
+                    }
+
+                    sh 'exit $SHELL_EXIT_CODE'
+                }
+            }
+        }
+    }
+
+    post {
+        unsuccessful {
+            script {
+                def msg = lib.generateSlackMessage("E2E tests failed!", env.BUILD_URL, failedTests)
+
+                slackSend(
+                      channel: '#cloud-k8s',
+                      color: 'danger',
+                      message: msg,
+                    tokenCredentialId: 'cloud-ci-slack-integration-token',
+                    botUser: true,
+                    failOnError: true
+                )
+            }
+        }
+        cleanup {
+            script {
+                if (notOnlyDocs() && failedTests.size == 0) {
+                    build job: 'cloud-on-k8s-e2e-cleanup',
+                        parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-e2e-${BUILD_NUMBER}")],
+                        wait: false
+                }
+            }
+
+            cleanWs()
+        }
+    }
+}
+
+def notOnlyDocs() {
+    // grep succeeds if there is at least one line without docs/
+    return sh (
+        script: "git diff --name-status HEAD~1 HEAD | grep -v docs/",
+        returnStatus: true
+    ) == 0
+}

--- a/.ci/pipelines/e2e-tests-testmutationsecondmastersetdown.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-testmutationsecondmastersetdown.Jenkinsfile
@@ -57,6 +57,7 @@ pipeline {
                 sh 'echo TESTS_MATCH = TestMutationSecondMasterSetDown >> .env'
                 sh 'echo E2E_SKIP_CLEANUP = true >> .env'
                 sh 'sed "s/CLUSTER_NAME=eck-e2e/CLUSTER_NAME=eck-debug-e2e/" -i .env'
+                sh 'sed "s/clusterName: eck-e2e/clusterName: eck-debug-e2e/" -i deployer-config.yml'
                 
                 script {
                     env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-test-artifacts TARGET=ci-build-operator-e2e-run ci')
@@ -93,7 +94,7 @@ pipeline {
             script {
                 if (notOnlyDocs() && failedTests.size() == 0) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
-                        parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-e2e-${BUILD_NUMBER}")],
+                        parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-debug-e2e")],
                         wait: false
                 }
             }


### PR DESCRIPTION
This reverts commit e242d414c9475f85752da53590f85124907d18e0.

Re-enables the test to make sure https://github.com/elastic/cloud-on-k8s/pull/2880 entirely fixes the issue and there are not any further bugs. We were able to reproduce the bug pretty soon last time we had it enabled, so we should only need it for the rest of the week to feel confident it's resolved.