### PR TITLE
Fix trial license validation issues

### DIFF
--- a/pkg/controller/common/license/trial.go
+++ b/pkg/controller/common/license/trial.go
@@ -29,7 +29,7 @@ const (
 	TrialLicenseSecretNamespace = "trial.k8s.elastic.co/secret-namespace" // nolint
 )
 
-// TrialKeys
+// TrialKeys capture the in-memory representation of the trial status.
 type TrialKeys struct {
 	PrivateKey *rsa.PrivateKey
 	PublicKey  *rsa.PublicKey

--- a/pkg/controller/common/license/trial.go
+++ b/pkg/controller/common/license/trial.go
@@ -10,7 +10,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/elastic/cloud-on-k8s/pkg/utils/chrono"
@@ -50,12 +49,6 @@ func NewTrialState() (TrialState, error) {
 
 // NewTrialStateFromStatus reconstructs trial state from a trial status secret.
 func NewTrialStateFromStatus(trialStatus corev1.Secret) (TrialState, error) {
-	// create new keys if the operator failed just before the trial was started
-	trialActivation, err := strconv.ParseBool(string(trialStatus.Data[TrialActivationKey]))
-	if err == nil && trialActivation {
-		return NewTrialState()
-	}
-
 	// reinstate pubkey from status secret e.g. after operator restart
 	pubKeyBytes := trialStatus.Data[TrialPubkeyKey]
 	key, err := ParsePubKey(pubKeyBytes)

--- a/pkg/controller/common/license/trial.go
+++ b/pkg/controller/common/license/trial.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/elastic/cloud-on-k8s/pkg/utils/chrono"
@@ -23,66 +24,93 @@ import (
 const (
 	TrialStatusSecretKey = "trial-status"
 	TrialPubkeyKey       = "pubkey"
-	TrialPrivateKey      = "key"
+	TrialActivationKey   = "in-trial-activation"
 
 	TrialLicenseSecretName      = "trial.k8s.elastic.co/secret-name"      // nolint
 	TrialLicenseSecretNamespace = "trial.k8s.elastic.co/secret-namespace" // nolint
 )
 
-// TrialKeys capture the in-memory representation of the trial status.
-type TrialKeys struct {
-	PrivateKey *rsa.PrivateKey
+// TrialState capture the in-memory representation of the trial status.
+type TrialState struct {
+	privateKey *rsa.PrivateKey
 	PublicKey  *rsa.PublicKey
 }
 
-// NewTrialKeys creates a set of trial keys by generating a new key.
-func NewTrialKeys() (TrialKeys, error) {
+// NewTrialState creates a set of trial keys by generating a new RSA key pair.
+func NewTrialState() (TrialState, error) {
 	key, err := NewTrialKey()
 	if err != nil {
-		return TrialKeys{}, err
+		return TrialState{}, err
 	}
-	return TrialKeys{
-		PrivateKey: key,
+	return TrialState{
+		privateKey: key,
 		PublicKey:  &key.PublicKey,
 	}, nil
 }
 
-// NewTrialKeysFromStatus reconstructs trial keys from a trial status secret.
-func NewTrialKeysFromStatus(trialStatus corev1.Secret) (TrialKeys, error) {
+// NewTrialStateFromStatus reconstructs trial keys from a trial status secret.
+func NewTrialStateFromStatus(trialStatus corev1.Secret) (TrialState, error) {
 	// reinstate pubkey from status secret e.g. after operator restart
 	pubKeyBytes := trialStatus.Data[TrialPubkeyKey]
 	key, err := ParsePubKey(pubKeyBytes)
 	if err != nil {
-		return TrialKeys{}, err
+		return TrialState{}, err
 	}
-	keys := TrialKeys{
+	keys := TrialState{
 		PublicKey: key,
 	}
-	// also reinstate the private key if the operator failed just before the trial was started
-	privKeyBytes, exists := trialStatus.Data[TrialPrivateKey]
-	if exists {
-		privateKey, err := x509.ParsePKCS1PrivateKey(privKeyBytes)
-		if err != nil {
-			return TrialKeys{}, fmt.Errorf("while parsing trial private key %w", err)
-		}
-		keys.PrivateKey = privateKey
+	// create new keys if the operator failed just before the trial was started
+	trialActivation, err := strconv.ParseBool(string(trialStatus.Data[TrialActivationKey]))
+	if err == nil && trialActivation {
+		return NewTrialState()
 	}
 	return keys, nil
 }
 
 // IsTrialRunning returns true if a trial has been successfully started at some point in the past.
-func (tk *TrialKeys) IsTrialRunning() bool {
-	return tk.PublicKey != nil && tk.PrivateKey == nil
+func (tk *TrialState) IsTrialRunning() bool {
+	return tk.PublicKey != nil && tk.privateKey == nil
 }
 
 // IsTrialActivtationInProgress returns true if we are in the process of starting a trial.
-func (tk *TrialKeys) IsTrialActivationInProgress() bool {
-	return tk.PrivateKey != nil && tk.PublicKey != nil
+func (tk *TrialState) IsTrialActivationInProgress() bool {
+	return tk.privateKey != nil && tk.PublicKey != nil
+}
+
+func (tk *TrialState) InitTrialLicense(l *EnterpriseLicense) error {
+	if !tk.IsTrialActivationInProgress() {
+		return errors.New("trial has already been activated")
+	}
+	if l == nil {
+		return errors.New("license is nil")
+	}
+	if err := populateTrialLicense(l); err != nil {
+		return pkgerrors.Wrap(err, "failed to populate trial license")
+	}
+
+	log.Info("Starting enterprise trial", "start", l.StartTime(), "end", l.ExpiryTime())
+	// sign trial license
+	signer := NewSigner(tk.privateKey)
+	sig, err := signer.Sign(*l)
+	if err != nil {
+		return pkgerrors.Wrap(err, "failed to sign license")
+	}
+
+	l.License.Signature = string(sig)
+	return nil
+}
+
+func (tk *TrialState) CompleteTrialActivation() bool {
+	if tk.privateKey == nil {
+		return false
+	}
+	tk.privateKey = nil
+	return true
 }
 
 // ExpectedTrialStatus creates the expected state of the trial status secret for the given keys for reconciliation.
-func ExpectedTrialStatus(operatorNamespace string, license types.NamespacedName, keys TrialKeys) (corev1.Secret, error) {
-	pubkeyBytes, err := x509.MarshalPKIXPublicKey(keys.PublicKey)
+func ExpectedTrialStatus(operatorNamespace string, license types.NamespacedName, state TrialState) (corev1.Secret, error) {
+	pubkeyBytes, err := x509.MarshalPKIXPublicKey(state.PublicKey)
 	if err != nil {
 		return corev1.Secret{}, err
 	}
@@ -96,13 +124,9 @@ func ExpectedTrialStatus(operatorNamespace string, license types.NamespacedName,
 			},
 		},
 		Data: map[string][]byte{
-			TrialPubkeyKey: pubkeyBytes,
+			TrialPubkeyKey:     pubkeyBytes,
+			TrialActivationKey: []byte(strconv.FormatBool(state.IsTrialActivationInProgress())),
 		},
-	}
-	if keys.PrivateKey != nil {
-		// handle a combination of operator crashes and API errors on trial activation by keeping this around
-		secret.Data[TrialPrivateKey] = x509.MarshalPKCS1PrivateKey(keys.PrivateKey)
-
 	}
 	return secret, nil
 }
@@ -114,26 +138,6 @@ func NewTrialKey() (*rsa.PrivateKey, error) {
 		return nil, fmt.Errorf("while generating trial key %w", err)
 	}
 	return trialKey, nil
-}
-
-func InitTrial(key *rsa.PrivateKey, l *EnterpriseLicense) error {
-	if l == nil {
-		return errors.New("license is nil")
-	}
-	if err := populateTrialLicense(l); err != nil {
-		return pkgerrors.Wrap(err, "failed to populate trial license")
-	}
-
-	log.Info("Starting enterprise trial", "start", l.StartTime(), "end", l.ExpiryTime())
-	// sign trial license
-	signer := NewSigner(key)
-	sig, err := signer.Sign(*l)
-	if err != nil {
-		return pkgerrors.Wrap(err, "failed to sign license")
-	}
-
-	l.License.Signature = string(sig)
-	return nil
 }
 
 // populateTrialLicense adds missing fields to a trial license.

--- a/pkg/controller/common/license/trial.go
+++ b/pkg/controller/common/license/trial.go
@@ -38,7 +38,7 @@ type TrialState struct {
 
 // NewTrialState creates a set of trial keys by generating a new RSA key pair.
 func NewTrialState() (TrialState, error) {
-	key, err := NewTrialKey()
+	key, err := newTrialKey()
 	if err != nil {
 		return TrialState{}, err
 	}
@@ -100,6 +100,8 @@ func (tk *TrialState) InitTrialLicense(l *EnterpriseLicense) error {
 	return nil
 }
 
+// CompleteTrialActivation should be called once a trial license has been successfully generated and verified.
+// Returns false if the trial activation had been completed previously.
 func (tk *TrialState) CompleteTrialActivation() bool {
 	if tk.privateKey == nil {
 		return false
@@ -131,7 +133,7 @@ func ExpectedTrialStatus(operatorNamespace string, license types.NamespacedName,
 	return secret, nil
 }
 
-func NewTrialKey() (*rsa.PrivateKey, error) {
+func newTrialKey() (*rsa.PrivateKey, error) {
 	rnd := rand.Reader
 	trialKey, err := rsa.GenerateKey(rnd, 2048)
 	if err != nil {

--- a/pkg/controller/common/license/trial_test.go
+++ b/pkg/controller/common/license/trial_test.go
@@ -202,24 +202,6 @@ func TestNewTrialStateFromStatus(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "can handle garbage in trial-activation flag",
-			args: args{
-				trialStatus: v1.Secret{
-					Data: map[string][]byte{
-						TrialPubkeyKey:     keySerialized,
-						TrialActivationKey: []byte("blub"),
-					},
-				},
-			},
-			want: func(s TrialState) {
-				require.True(t, s.IsTrialStarted())
-				require.True(t, reflect.DeepEqual(s, TrialState{
-					publicKey: &key.PublicKey,
-				}))
-			},
-			wantErr: false,
-		},
-		{
 			name: "error on garbage status",
 			args: args{
 				trialStatus: v1.Secret{
@@ -231,23 +213,6 @@ func TestNewTrialStateFromStatus(t *testing.T) {
 			wantErr: true,
 			want: func(state TrialState) {
 				require.False(t, state.IsTrialStarted())
-			},
-		},
-		{
-			name: "respects trial-activation flag",
-			args: args{
-				trialStatus: v1.Secret{
-					Data: map[string][]byte{
-						TrialPubkeyKey:     keySerialized,
-						TrialActivationKey: []byte("true"),
-					},
-				},
-			},
-			want: func(s TrialState) {
-				require.False(t, s.IsTrialStarted())
-				require.False(t, reflect.DeepEqual(s, TrialState{
-					publicKey: &key.PublicKey,
-				}))
 			},
 		},
 	}

--- a/pkg/controller/common/license/trial_test.go
+++ b/pkg/controller/common/license/trial_test.go
@@ -5,7 +5,6 @@
 package license
 
 import (
-	"crypto/rand"
 	"crypto/rsa"
 	"testing"
 	"time"
@@ -14,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInitTrial(t *testing.T) {
+func TestInitTrialLicense(t *testing.T) {
 	licenseFixture := EnterpriseLicense{
 		License: LicenseSpec{
 			Type: LicenseTypeEnterpriseTrial,
@@ -61,13 +60,9 @@ func TestInitTrial(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rnd := rand.Reader
-			tmpPrivKey, err := rsa.GenerateKey(rnd, 2048)
+			state, err := NewTrialState()
 			require.NoError(t, err)
-			err = InitTrial(
-				tmpPrivKey,
-				tt.args.l,
-			)
+			err = state.InitTrialLicense(tt.args.l)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("InitTrial() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/common/license/trial_test.go
+++ b/pkg/controller/common/license/trial_test.go
@@ -192,7 +192,7 @@ func TestNewTrialStateFromStatus(t *testing.T) {
 				},
 			},
 			want: func(s TrialState) {
-				require.True(t, s.IsTrialRunning())
+				require.True(t, s.IsTrialStarted())
 				require.True(t, reflect.DeepEqual(s, TrialState{
 					publicKey: &key.PublicKey,
 				}))
@@ -210,7 +210,7 @@ func TestNewTrialStateFromStatus(t *testing.T) {
 				},
 			},
 			want: func(s TrialState) {
-				require.True(t, s.IsTrialRunning())
+				require.True(t, s.IsTrialStarted())
 				require.True(t, reflect.DeepEqual(s, TrialState{
 					publicKey: &key.PublicKey,
 				}))
@@ -228,8 +228,7 @@ func TestNewTrialStateFromStatus(t *testing.T) {
 			},
 			wantErr: true,
 			want: func(state TrialState) {
-				require.False(t, state.IsTrialRunning())
-				require.False(t, state.IsTrialActivationInProgress())
+				require.False(t, state.IsTrialStarted())
 			},
 		},
 		{
@@ -243,7 +242,7 @@ func TestNewTrialStateFromStatus(t *testing.T) {
 				},
 			},
 			want: func(s TrialState) {
-				require.True(t, s.IsTrialActivationInProgress())
+				require.False(t, s.IsTrialStarted())
 				require.False(t, reflect.DeepEqual(s, TrialState{
 					publicKey: &key.PublicKey,
 				}))

--- a/pkg/controller/common/license/trial_test.go
+++ b/pkg/controller/common/license/trial_test.go
@@ -194,7 +194,7 @@ func TestNewTrialStateFromStatus(t *testing.T) {
 			want: func(s TrialState) {
 				require.True(t, s.IsTrialRunning())
 				require.True(t, reflect.DeepEqual(s, TrialState{
-					PublicKey: &key.PublicKey,
+					publicKey: &key.PublicKey,
 				}))
 			},
 			wantErr: false,
@@ -212,13 +212,13 @@ func TestNewTrialStateFromStatus(t *testing.T) {
 			want: func(s TrialState) {
 				require.True(t, s.IsTrialRunning())
 				require.True(t, reflect.DeepEqual(s, TrialState{
-					PublicKey: &key.PublicKey,
+					publicKey: &key.PublicKey,
 				}))
 			},
 			wantErr: false,
 		},
 		{
-			name: "err on garbage status",
+			name: "error on garbage status",
 			args: args{
 				trialStatus: v1.Secret{
 					Data: map[string][]byte{
@@ -245,7 +245,7 @@ func TestNewTrialStateFromStatus(t *testing.T) {
 			want: func(s TrialState) {
 				require.True(t, s.IsTrialActivationInProgress())
 				require.False(t, reflect.DeepEqual(s, TrialState{
-					PublicKey: &key.PublicKey,
+					publicKey: &key.PublicKey,
 				}))
 			},
 		},

--- a/pkg/controller/common/license/trial_test.go
+++ b/pkg/controller/common/license/trial_test.go
@@ -63,6 +63,7 @@ func TestInitTrial(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rnd := rand.Reader
 			tmpPrivKey, err := rsa.GenerateKey(rnd, 2048)
+			require.NoError(t, err)
 			err = InitTrial(
 				tmpPrivKey,
 				tt.args.l,

--- a/pkg/controller/license/trial/trial_controller.go
+++ b/pkg/controller/license/trial/trial_controller.go
@@ -96,10 +96,7 @@ func (r *ReconcileTrials) Reconcile(request reconcile.Request) (reconcile.Result
 			return reconcile.Result{}, err
 		}
 	case trialSecretPopulated:
-		verifier := licensing.Verifier{
-			PublicKey: r.trialState.PublicKey,
-		}
-		status := verifier.Valid(license, time.Now())
+		status := r.trialState.LicenseVerifier().Valid(license, time.Now())
 		if status != licensing.LicenseStatusValid {
 			setValidationMsg(&secret, userFriendlyMsgs[status])
 		} else {
@@ -134,7 +131,7 @@ func (r *ReconcileTrials) reconcileTrialStatus(license types.NamespacedName) err
 	}
 
 	// the status is there but we don't have anything in memory recover the keys
-	if r.trialState.PublicKey == nil {
+	if r.trialState.IsEmpty() {
 		recoveredKeys, err := licensing.NewTrialStateFromStatus(trialStatus)
 		if err != nil {
 			return err

--- a/pkg/controller/license/trial/trial_controller.go
+++ b/pkg/controller/license/trial/trial_controller.go
@@ -164,7 +164,6 @@ func (r *ReconcileTrials) completeTrialActivation(license types.NamespacedName) 
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		// requeue to update trial status
 		return reconcile.Result{}, r.Update(&status)
 	}
 	return reconcile.Result{}, nil

--- a/pkg/controller/license/trial/trial_controller.go
+++ b/pkg/controller/license/trial/trial_controller.go
@@ -129,7 +129,7 @@ func (r *ReconcileTrials) reconcileTrialStatus(licenseName types.NamespacedName,
 
 	// the status secret is there but we don't have anything in memory: recover the state
 	if r.trialState.IsEmpty() {
-		recoveredState, err := recoverState(license, trialStatus, err)
+		recoveredState, err := recoverState(license, trialStatus)
 		if err != nil {
 			return err
 		}
@@ -150,12 +150,12 @@ func (r *ReconcileTrials) reconcileTrialStatus(licenseName types.NamespacedName,
 	return r.Update(&trialStatus)
 }
 
-func recoverState(license licensing.EnterpriseLicense, trialStatus corev1.Secret, err error) (licensing.TrialState, error) {
+func recoverState(license licensing.EnterpriseLicense, trialStatus corev1.Secret) (licensing.TrialState, error) {
 	// allow new trial state only if we don't have license that looks like it has been populated previously
 	allowNewState := license.IsMissingFields() != nil
 	// create new keys if the operator failed just before the trial was started
 	trialActivation := bytes.Equal(trialStatus.Data[licensing.TrialActivationKey], []byte("true"))
-	if err == nil && trialActivation && allowNewState {
+	if trialActivation && allowNewState {
 		return licensing.NewTrialState()
 
 	}

--- a/pkg/controller/license/trial/trial_controller.go
+++ b/pkg/controller/license/trial/trial_controller.go
@@ -154,8 +154,8 @@ func recoverState(license licensing.EnterpriseLicense, trialStatus corev1.Secret
 	// allow new trial state only if we don't have license that looks like it has been populated previously
 	allowNewState := license.IsMissingFields() != nil
 	// create new keys if the operator failed just before the trial was started
-	trialActivation := bytes.Equal(trialStatus.Data[licensing.TrialActivationKey], []byte("true"))
-	if trialActivation && allowNewState {
+	trialActivationInProgress := bytes.Equal(trialStatus.Data[licensing.TrialActivationKey], []byte("true"))
+	if trialActivationInProgress && allowNewState {
 		return licensing.NewTrialState()
 
 	}

--- a/pkg/controller/license/trial/trial_controller.go
+++ b/pkg/controller/license/trial/trial_controller.go
@@ -50,6 +50,7 @@ type ReconcileTrials struct {
 	// iteration is the number of times this controller has run its Reconcile method.
 	iteration         int64
 	trialPubKey       *rsa.PublicKey
+	trialPrivateKey   *rsa.PrivateKey
 	operatorNamespace string
 }
 
@@ -80,63 +81,76 @@ func (r *ReconcileTrials) Reconcile(request reconcile.Request) (reconcile.Result
 		return reconcile.Result{}, licensing.UpdateEnterpriseLicense(r, secret, license)
 	}
 
-	// 1. fetch trial status secret
-	var trialStatus corev1.Secret
-	err = r.Get(types.NamespacedName{Namespace: r.operatorNamespace, Name: licensing.TrialStatusSecretKey}, &trialStatus)
-	if errors.IsNotFound(err) {
-		// 2. if not present create one
-		err := r.initTrial(secret, license)
-		if err != nil {
-			return reconcile.Result{}, pkgerrors.Wrap(err, "failed to init trial")
-		}
-		return reconcile.Result{}, nil
+	// 1. reconcile trial status secret
+	if err := r.reconcileTrialStatus(request.NamespacedName); err != nil {
+		return reconcile.Result{}, err
 	}
-	if err != nil {
-		return reconcile.Result{}, pkgerrors.Wrap(err, "failed to retrieve trial status")
-	}
-	// 3. reconcile trial status
-	if err := r.reconcileTrialStatus(trialStatus); err != nil {
-		return reconcile.Result{}, pkgerrors.Wrap(err, "failed to reconcile trial status")
-	}
-	// 4. update trial secret if invalid to give user feedback
+
+	// 2. reconcile the trial license itself
 	trialSecretPopulated := license.IsMissingFields() == nil
-	if r.isTrialRunning() && trialSecretPopulated {
+	switch {
+	case r.isTrialRunning() && !trialSecretPopulated:
+		// if the trial secret fields are not populated at this point a user is trying to start a trial a second time
+		// with an empty trial secret, which is not a supported use case.
+		setValidationMsg(&secret, trialOnlyOnceMsg)
+	case !trialSecretPopulated && r.isTrialActivationInProgress():
+		// trial is not running yet and the license secret is empty: init the trial
+		if err := licensing.InitTrial(r.trialPrivateKey, &license); err != nil {
+			return reconcile.Result{}, err
+		}
+	case trialSecretPopulated:
 		verifier := licensing.Verifier{
 			PublicKey: r.trialPubKey,
 		}
 		status := verifier.Valid(license, time.Now())
 		if status != licensing.LicenseStatusValid {
 			setValidationMsg(&secret, userFriendlyMsgs[status])
+		} else {
+			// complete the trial activation we don't need the private key anymore
+			return r.completeTrialActivation()
 		}
-	} else {
-		// if the trial secret fields are not populated at this point a user is trying to start a trial a second time
-		// with an empty trial secret, which is not a supported use case.
-		setValidationMsg(&secret, trialOnlyOnceMsg)
 	}
-	return reconcile.Result{}, r.Update(&secret)
+	return reconcile.Result{}, licensing.UpdateEnterpriseLicense(r, secret, license)
 }
 
 func (r *ReconcileTrials) isTrialRunning() bool {
-	return r.trialPubKey != nil
+	return r.trialPubKey != nil && r.trialPrivateKey == nil
 }
 
-func (r *ReconcileTrials) initTrial(secret corev1.Secret, l licensing.EnterpriseLicense) error {
-	if r.isTrialRunning() {
-		setValidationMsg(&secret, trialOnlyOnceMsg)
-		return licensing.UpdateEnterpriseLicense(r, secret, l)
-	}
+func (r *ReconcileTrials) isTrialActivationInProgress() bool {
+	return r.trialPrivateKey != nil && r.trialPubKey != nil
+}
 
-	trialPubKey, err := licensing.InitTrial(r, r.operatorNamespace, secret, &l)
+func (r *ReconcileTrials) reconcileTrialStatus(license types.NamespacedName) error {
+	var trialStatus corev1.Secret
+	var err error
+	err = r.Get(types.NamespacedName{Namespace: r.operatorNamespace, Name: licensing.TrialStatusSecretKey}, &trialStatus)
+	if errors.IsNotFound(err) {
+		if !r.isTrialRunning() {
+			// we have no key in memory nor in the status: generate a new one
+			if err := r.startTrialActivation(); err != nil {
+				return err
+			}
+		}
+
+		// we have the key in memory but the status secret is missing: recreate it
+		if r.trialPrivateKey != nil {
+			// handle a combination of operator crashes and API errors on trial activation by keeping the PK around
+			trialStatus, err = licensing.ExpectedTrialStatusWithPK(r.operatorNamespace, license, r.trialPrivateKey)
+		} else {
+			trialStatus, err = licensing.ExpectedTrialStatus(r.operatorNamespace, license, r.trialPubKey)
+		}
+		if err != nil {
+			return fmt.Errorf("while creating expected trial status %w", err)
+		}
+		return r.Create(&trialStatus)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("while fetching trial status %w", err)
 	}
-	// retain pub key in memory for later iterations
-	r.trialPubKey = trialPubKey
-	return nil
-}
 
-func (r *ReconcileTrials) reconcileTrialStatus(trialStatus corev1.Secret) error {
-	if !r.isTrialRunning() {
+	// the status is there but we don't have anything in memory
+	if r.trialPubKey == nil {
 		// reinstate pubkey from status secret e.g. after operator restart
 		pubKeyBytes := trialStatus.Data[licensing.TrialPubkeyKey]
 		key, err := licensing.ParsePubKey(pubKeyBytes)
@@ -144,21 +158,52 @@ func (r *ReconcileTrials) reconcileTrialStatus(trialStatus corev1.Secret) error 
 			return err
 		}
 		r.trialPubKey = key
+		// also reinstate the private key if the operator failed just before the trial was started
+		privKeyBytes, exists := trialStatus.Data[licensing.TrialPrivateKey]
+		if exists {
+			privateKey, err := x509.ParsePKCS1PrivateKey(privKeyBytes)
+			if err != nil {
+				return fmt.Errorf("while parsing trial private key %w", err)
+			}
+			r.trialPrivateKey = privateKey
+		}
 		return nil
 	}
+	// if trial status exists, but:
+	// - has been tampered with: reconstruct it
+	// - we need to update it to complete the trial activation
 	pubkeyBytes, err := x509.MarshalPKIXPublicKey(r.trialPubKey)
 	if err != nil {
 		return err
 	}
-	if bytes.Equal(trialStatus.Data[licensing.TrialPubkeyKey], pubkeyBytes) {
+	if bytes.Equal(trialStatus.Data[licensing.TrialPubkeyKey], pubkeyBytes) &&
+		trialStatus.Data[licensing.TrialPrivateKey] == nil {
 		return nil
 	}
-	if trialStatus.Data == nil {
-		trialStatus.Data = map[string][]byte{} // if trial status has been tampered with
-	}
-	trialStatus.Data[licensing.TrialPubkeyKey] = pubkeyBytes
-	return r.Update(&trialStatus)
 
+	trialStatus.Data = map[string][]byte{
+		licensing.TrialPubkeyKey: pubkeyBytes,
+	}
+	return r.Update(&trialStatus)
+}
+
+func (r *ReconcileTrials) startTrialActivation() error {
+	key, err := licensing.NewTrialKey()
+	if err != nil {
+		return err
+	}
+	r.trialPubKey = &key.PublicKey
+	r.trialPrivateKey = key
+	return nil
+}
+
+func (r *ReconcileTrials) completeTrialActivation() (reconcile.Result, error) {
+	if r.trialPrivateKey == nil {
+		return reconcile.Result{}, nil
+	}
+	r.trialPrivateKey = nil
+	// requeue to update trial status
+	return reconcile.Result{Requeue: true}, nil
 }
 
 func validateEULA(trialSecret corev1.Secret) string {

--- a/pkg/controller/license/trial/trial_controller.go
+++ b/pkg/controller/license/trial/trial_controller.go
@@ -109,8 +109,7 @@ func (r *ReconcileTrials) Reconcile(request reconcile.Request) (reconcile.Result
 
 func (r *ReconcileTrials) reconcileTrialStatus(license types.NamespacedName) error {
 	var trialStatus corev1.Secret
-	var err error
-	err = r.Get(types.NamespacedName{Namespace: r.operatorNamespace, Name: licensing.TrialStatusSecretKey}, &trialStatus)
+	err := r.Get(types.NamespacedName{Namespace: r.operatorNamespace, Name: licensing.TrialStatusSecretKey}, &trialStatus)
 	if errors.IsNotFound(err) {
 		if !r.trialState.IsTrialRunning() {
 			// we have no state in memory nor in the status secret: start the activation process
@@ -130,7 +129,7 @@ func (r *ReconcileTrials) reconcileTrialStatus(license types.NamespacedName) err
 		return fmt.Errorf("while fetching trial status %w", err)
 	}
 
-	// the status secret is there but we don't have anything in memory recover the state
+	// the status secret is there but we don't have anything in memory: recover the state
 	if r.trialState.IsEmpty() {
 		recoveredKeys, err := licensing.NewTrialStateFromStatus(trialStatus)
 		if err != nil {
@@ -154,11 +153,11 @@ func (r *ReconcileTrials) reconcileTrialStatus(license types.NamespacedName) err
 }
 
 func (r *ReconcileTrials) startTrialActivation() error {
-	keys, err := licensing.NewTrialState()
+	state, err := licensing.NewTrialState()
 	if err != nil {
 		return err
 	}
-	r.trialState = keys
+	r.trialState = state
 	return nil
 }
 

--- a/pkg/controller/license/trial/trial_controller.go
+++ b/pkg/controller/license/trial/trial_controller.go
@@ -204,7 +204,18 @@ func addWatches(c controller.Controller) error {
 					},
 				}
 			}
-			return nil
+
+			if obj.Meta.GetName() != licensing.TrialStatusSecretKey {
+				return nil
+			}
+			return []reconcile.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Namespace: secret.Annotations[licensing.TrialLicenseSecretNamespace],
+						Name:      secret.Annotations[licensing.TrialLicenseSecretName],
+					},
+				},
+			}
 		}),
 	}); err != nil {
 		return err

--- a/pkg/controller/license/trial/trial_controller.go
+++ b/pkg/controller/license/trial/trial_controller.go
@@ -90,7 +90,7 @@ func (r *ReconcileTrials) Reconcile(request reconcile.Request) (reconcile.Result
 	trialSecretPopulated := license.IsMissingFields() == nil
 	switch {
 	case r.isTrialRunning() && !trialSecretPopulated:
-		// if the trial secret fields are not populated at this point a user is trying to start a trial a second time
+		// if the trial license fields are not populated at this point a user is trying to start a trial a second time
 		// with an empty trial secret, which is not a supported use case.
 		setValidationMsg(&secret, trialOnlyOnceMsg)
 	case !trialSecretPopulated && r.isTrialActivationInProgress():
@@ -106,7 +106,7 @@ func (r *ReconcileTrials) Reconcile(request reconcile.Request) (reconcile.Result
 		if status != licensing.LicenseStatusValid {
 			setValidationMsg(&secret, userFriendlyMsgs[status])
 		} else {
-			// complete the trial activation we don't need the private key anymore
+			// valid trial license: complete trial activation
 			return r.completeTrialActivation()
 		}
 	}

--- a/pkg/controller/license/trial/trial_controller.go
+++ b/pkg/controller/license/trial/trial_controller.go
@@ -204,18 +204,7 @@ func addWatches(c controller.Controller) error {
 					},
 				}
 			}
-
-			if obj.Meta.GetName() != licensing.TrialStatusSecretKey {
-				return nil
-			}
-			return []reconcile.Request{
-				{
-					NamespacedName: types.NamespacedName{
-						Namespace: secret.Annotations[licensing.TrialLicenseSecretNamespace],
-						Name:      secret.Annotations[licensing.TrialLicenseSecretName],
-					},
-				},
-			}
+			return nil
 		}),
 	}); err != nil {
 		return err

--- a/pkg/controller/license/trial/trial_controller.go
+++ b/pkg/controller/license/trial/trial_controller.go
@@ -167,7 +167,6 @@ func (r *ReconcileTrials) completeTrialActivation() (reconcile.Result, error) {
 		return reconcile.Result{Requeue: true}, nil
 	}
 	return reconcile.Result{}, nil
-
 }
 
 func validateEULA(trialSecret corev1.Secret) string {

--- a/pkg/controller/license/trial/trial_controller.go
+++ b/pkg/controller/license/trial/trial_controller.go
@@ -74,8 +74,7 @@ func (r *ReconcileTrials) Reconcile(request reconcile.Request) (reconcile.Result
 
 	validationMsg := validateEULA(secret)
 	if validationMsg != "" {
-		setValidationMsg(&secret, validationMsg)
-		return reconcile.Result{}, licensing.UpdateEnterpriseLicense(r, secret, license)
+		return r.invalidOperation(secret, validationMsg)
 	}
 
 	// 1. reconcile trial status secret

--- a/pkg/controller/license/trial/trial_controller_test.go
+++ b/pkg/controller/license/trial/trial_controller_test.go
@@ -297,7 +297,7 @@ func TestReconcileTrials_reconcileTrialStatus(t *testing.T) {
 
 	assertTrialRunningState := func(r *ReconcileTrials, status corev1.Secret) {
 		require.True(t, r.trialState.IsTrialStarted())
-		require.Equal(t, status.Data[licensing.TrialActivationKey], []byte("false"))
+		require.NotContains(t, status.Data, licensing.TrialActivationKey)
 		require.Contains(t, status.Data, licensing.TrialPubkeyKey)
 	}
 

--- a/pkg/controller/license/trial/trial_controller_test.go
+++ b/pkg/controller/license/trial/trial_controller_test.go
@@ -290,13 +290,13 @@ func TestReconcileTrials_Reconcile(t *testing.T) {
 func TestReconcileTrials_reconcileTrialStatus(t *testing.T) {
 
 	assertTrialActivationState := func(r *ReconcileTrials, status corev1.Secret) {
-		require.True(t, r.trialState.IsTrialActivationInProgress())
+		require.False(t, r.trialState.IsTrialStarted())
 		require.Equal(t, status.Data[licensing.TrialActivationKey], []byte("true"))
 		require.Contains(t, status.Data, licensing.TrialPubkeyKey)
 	}
 
 	assertTrialRunningState := func(r *ReconcileTrials, status corev1.Secret) {
-		require.True(t, r.trialState.IsTrialRunning())
+		require.True(t, r.trialState.IsTrialStarted())
 		require.Equal(t, status.Data[licensing.TrialActivationKey], []byte("false"))
 		require.Contains(t, status.Data, licensing.TrialPubkeyKey)
 	}

--- a/pkg/controller/license/trial/trial_controller_test.go
+++ b/pkg/controller/license/trial/trial_controller_test.go
@@ -103,6 +103,7 @@ func TestReconcileTrials_Reconcile(t *testing.T) {
 			require.Equal(t, msg, err)
 		}
 	}
+
 	requireNoValidationMsg := func(c k8s.Client) {
 		var sec corev1.Secret
 		require.NoError(t, c.Get(trialLicenseNsn, &sec))

--- a/pkg/controller/license/trial/trial_controller_test.go
+++ b/pkg/controller/license/trial/trial_controller_test.go
@@ -5,7 +5,6 @@
 package trial
 
 import (
-	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
@@ -16,7 +15,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/chrono"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -24,17 +23,17 @@ import (
 )
 
 const testNs = "ns-1"
-const trialSecretName = "eck-trial" // user's choice but constant simplifies test setup
+const trialLicenseName = "eck-trial" // user's choice but constant simplifies test setup
 
-var trialSecretNsn = types.NamespacedName{
+var trialLicenseNsn = types.NamespacedName{
 	Namespace: testNs,
-	Name:      trialSecretName,
+	Name:      trialLicenseName,
 }
 
-func trialSecretSample(annotated bool, data map[string][]byte) *v1.Secret {
-	sec := v1.Secret{
+func trialLicenseSecretSample(annotated bool, data map[string][]byte) *corev1.Secret {
+	sec := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      trialSecretName,
+			Name:      trialLicenseName,
 			Namespace: testNs,
 			Labels: map[string]string{
 				licensing.LicenseLabelType: "enterprise-trial", // assume always there otherwise watch would not trigger
@@ -49,6 +48,18 @@ func trialSecretSample(annotated bool, data map[string][]byte) *v1.Secret {
 	return &sec
 }
 
+func trialStatusSecretSample(t *testing.T, key *rsa.PrivateKey, includePK bool) *corev1.Secret {
+	var status corev1.Secret
+	var err error
+	if includePK {
+		status, err = licensing.ExpectedTrialStatusWithPK(testNs, trialLicenseNsn, key)
+	} else {
+		status, err = licensing.ExpectedTrialStatus(testNs, trialLicenseNsn, &key.PublicKey)
+	}
+	require.NoError(t, err)
+	return &status
+}
+
 func trialLicenseBytes() []byte {
 	return []byte(fmt.Sprintf(
 		`{"license": {"uid": "x", "type": "enterprise-trial", "issue_date_in_millis": 1, "expiry_date_in_millis": %d, "issued_to": "x", "issuer": "x", "start_date_in_millis": 1, "cluster_licenses": null, "Version": 0}}`,
@@ -57,46 +68,70 @@ func trialLicenseBytes() []byte {
 
 }
 
-func testPubkey(t *testing.T) *rsa.PublicKey {
-	rnd := rand.Reader
-	key, err := rsa.GenerateKey(rnd, 2048)
+func testTrialKey(t *testing.T) *rsa.PrivateKey {
+	key, err := licensing.NewTrialKey()
 	require.NoError(t, err)
-	return &key.PublicKey
+	return key
 }
 
-func simulateRunningTrial(t *testing.T, k k8s.Client, secret v1.Secret) []byte {
+func simulateRunningTrial(t *testing.T, k k8s.Client, secret corev1.Secret) []byte {
 	l := licensing.EnterpriseLicense{
 		License: licensing.LicenseSpec{
 			Type: licensing.LicenseTypeEnterpriseTrial,
 		},
 	}
-	trialKey, err := licensing.InitTrial(k, testNs, secret, &l)
+	key := testTrialKey(t)
+	status := trialStatusSecretSample(t, key, false)
+	require.NoError(t, k.Create(status))
+	err := licensing.InitTrial(key, &l)
 	require.NoError(t, err)
-	keyBytes, err := x509.MarshalPKIXPublicKey(trialKey)
+	require.NoError(t, licensing.UpdateEnterpriseLicense(k, secret, l))
+	keyBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
 	require.NoError(t, err)
 	return keyBytes
 }
 
 func TestReconcileTrials_Reconcile(t *testing.T) {
+	trialKeySample := testTrialKey(t)
+
 	requireValidationMsg := func(msg string) func(c k8s.Client) {
 		return func(c k8s.Client) {
-			var sec v1.Secret
-			require.NoError(t, c.Get(trialSecretNsn, &sec))
+			var sec corev1.Secret
+			require.NoError(t, c.Get(trialLicenseNsn, &sec))
 			err, ok := sec.Annotations[licensing.LicenseInvalidAnnotation]
 			require.True(t, ok, "invalid annotation present")
 			require.Equal(t, msg, err)
 		}
 	}
 	requireNoValidationMsg := func(c k8s.Client) {
-		var sec v1.Secret
-		require.NoError(t, c.Get(trialSecretNsn, &sec))
+		var sec corev1.Secret
+		require.NoError(t, c.Get(trialLicenseNsn, &sec))
 		_, ok := sec.Annotations[licensing.LicenseInvalidAnnotation]
 		require.False(t, ok, "no invalid annotation expected")
 	}
 
+	requireValidTrial := func(c k8s.Client) {
+		var sec corev1.Secret
+		require.NoError(t, c.Get(types.NamespacedName{
+			Namespace: testNs,
+			Name:      licensing.TrialStatusSecretKey,
+		}, &sec))
+		require.NoError(t, c.Get(trialLicenseNsn, &sec))
+		pubKeyBytes := sec.Data[licensing.TrialPubkeyKey]
+		key, err := licensing.ParsePubKey(pubKeyBytes)
+		require.NoError(t, err)
+		_, lic, err := licensing.TrialLicense(c, trialLicenseNsn)
+		require.NoError(t, err)
+		require.NoError(t, lic.IsMissingFields())
+		verifier := licensing.Verifier{PublicKey: key}
+		require.NoError(t, verifier.ValidSignature(lic))
+		requireNoValidationMsg(c)
+	}
+
 	type fields struct {
-		Client      k8s.Client
-		trialPubKey *rsa.PublicKey
+		Client          k8s.Client
+		trialPubKey     *rsa.PublicKey
+		trialPrivateKey *rsa.PrivateKey
 	}
 	tests := []struct {
 		name       string
@@ -107,7 +142,7 @@ func TestReconcileTrials_Reconcile(t *testing.T) {
 		{
 			name: "trial secret needs accepted EULA",
 			fields: fields{
-				Client: k8s.WrappedFakeClient(trialSecretSample(false, nil)),
+				Client: k8s.WrappedFakeClient(trialLicenseSecretSample(false, nil)),
 			},
 			wantErr:    false,
 			assertions: requireValidationMsg(EULAValidationMsg),
@@ -115,30 +150,16 @@ func TestReconcileTrials_Reconcile(t *testing.T) {
 		{
 			name: "valid trial secret inits trial",
 			fields: fields{
-				Client: k8s.WrappedFakeClient(trialSecretSample(true, nil)),
+				Client: k8s.WrappedFakeClient(trialLicenseSecretSample(true, nil)),
 			},
-			wantErr: false,
-			assertions: func(c k8s.Client) {
-				var sec v1.Secret
-				require.NoError(t, c.Get(types.NamespacedName{
-					Namespace: testNs,
-					Name:      licensing.TrialStatusSecretKey,
-				}, &sec))
-				require.NoError(t, c.Get(trialSecretNsn, &sec))
-				_, lic, err := licensing.TrialLicense(c, trialSecretNsn)
-				require.NoError(t, err)
-				require.NoError(t, lic.IsMissingFields())
-			},
+			wantErr:    false,
+			assertions: requireValidTrial,
 		},
 		{
 			name: "valid trial after operator restart",
 			fields: fields{
 				Client: func() k8s.Client {
-					trialLicense := trialSecretSample(
-						true,
-						map[string][]byte{
-							"license": trialLicenseBytes(),
-						})
+					trialLicense := trialLicenseSecretSample(true, nil)
 					client := k8s.WrappedFakeClient(
 						trialLicense,
 					)
@@ -148,13 +169,64 @@ func TestReconcileTrials_Reconcile(t *testing.T) {
 				trialPubKey: nil, // simulating restart
 			},
 			wantErr:    false,
-			assertions: requireNoValidationMsg,
+			assertions: requireValidTrial,
+		},
+		{
+			name: "can start trial after error during trial status creation",
+			fields: fields{
+				Client:          k8s.WrappedFakeClient(trialLicenseSecretSample(true, nil)), // no trial status
+				trialPubKey:     &trialKeySample.PublicKey,                                  // but trial being activated
+				trialPrivateKey: trialKeySample,
+			},
+			wantErr:    false,
+			assertions: requireValidTrial,
+		},
+		{
+			name: "can start trial after operator crash during trial activation",
+			fields: fields{
+				Client: func() k8s.Client {
+					// simulating operator crash right after trial status has been written
+					status, err := licensing.ExpectedTrialStatusWithPK(testNs, trialLicenseNsn, trialKeySample)
+					require.NoError(t, err)
+					return k8s.WrappedFakeClient(trialLicenseSecretSample(true, nil), &status)
+				}(),
+				trialPubKey:     nil,
+				trialPrivateKey: nil,
+			},
+			wantErr:    false,
+			assertions: requireValidTrial,
+		},
+		{
+			name: "invalid: external trial status modification is not allowed once trial is running",
+			fields: fields{
+				Client: k8s.WrappedFakeClient(
+					trialLicenseSecretSample(true, nil),
+					trialStatusSecretSample(t, testTrialKey(t), true), // simulate a different key
+				),
+				trialPubKey:     &trialKeySample.PublicKey,
+				trialPrivateKey: nil,
+			},
+			wantErr:    false,
+			assertions: requireValidationMsg(trialOnlyOnceMsg),
+		},
+		{
+			name: "external trial status modification is compensated while trial is being activated",
+			fields: fields{
+				Client: k8s.WrappedFakeClient(
+					trialLicenseSecretSample(true, nil),
+					trialStatusSecretSample(t, testTrialKey(t), true), // simulating a different key
+				),
+				trialPubKey:     &trialKeySample.PublicKey,
+				trialPrivateKey: trialKeySample,
+			},
+			wantErr:    false,
+			assertions: requireValidTrial,
 		},
 		{
 			name: "invalid: trial running but no status secret",
 			fields: fields{
-				Client:      k8s.WrappedFakeClient(trialSecretSample(true, nil)),
-				trialPubKey: testPubkey(t),
+				Client:      k8s.WrappedFakeClient(trialLicenseSecretSample(true, nil)),
+				trialPubKey: &trialKeySample.PublicKey,
 			},
 			wantErr:    false,
 			assertions: requireValidationMsg(trialOnlyOnceMsg),
@@ -164,14 +236,10 @@ func TestReconcileTrials_Reconcile(t *testing.T) {
 			fields: fields{
 				Client: k8s.WrappedFakeClient(
 					// user creates a new trial secret
-					trialSecretSample(true, nil),
-					&v1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      licensing.TrialStatusSecretKey,
-							Namespace: testNs,
-						},
-					}),
-				trialPubKey: testPubkey(t), // but trial is already running
+					trialLicenseSecretSample(true, nil),
+					trialStatusSecretSample(t, trialKeySample, false),
+				),
+				trialPubKey: &trialKeySample.PublicKey, // but trial is already running
 			},
 			wantErr:    false,
 			assertions: requireValidationMsg(trialOnlyOnceMsg),
@@ -179,15 +247,15 @@ func TestReconcileTrials_Reconcile(t *testing.T) {
 		{
 			name: "invalid: license signature",
 			fields: fields{
-				Client: k8s.WrappedFakeClient(trialSecretSample(true, map[string][]byte{
+				Client: k8s.WrappedFakeClient(trialLicenseSecretSample(true, map[string][]byte{
 					"license": trialLicenseBytes(),
-				}), &v1.Secret{
+				}), &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      licensing.TrialStatusSecretKey,
 						Namespace: testNs,
 					},
 				}),
-				trialPubKey: testPubkey(t),
+				trialPubKey: &trialKeySample.PublicKey,
 			},
 			wantErr:    false,
 			assertions: requireValidationMsg("trial license signature invalid"),
@@ -200,12 +268,13 @@ func TestReconcileTrials_Reconcile(t *testing.T) {
 				Client:            tt.fields.Client,
 				recorder:          record.NewFakeRecorder(10),
 				trialPubKey:       tt.fields.trialPubKey,
+				trialPrivateKey:   tt.fields.trialPrivateKey,
 				operatorNamespace: testNs,
 			}
 			_, err := r.Reconcile(reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: testNs,
-					Name:      trialSecretName,
+					Name:      trialLicenseName,
 				},
 			})
 			if (err != nil) != tt.wantErr {
@@ -214,6 +283,128 @@ func TestReconcileTrials_Reconcile(t *testing.T) {
 			}
 			if tt.assertions != nil {
 				tt.assertions(tt.fields.Client)
+			}
+		})
+	}
+}
+
+func TestReconcileTrials_reconcileTrialStatus(t *testing.T) {
+	keySample := testTrialKey(t)
+
+	assertTrialActivationState := func(r *ReconcileTrials, status corev1.Secret) {
+		require.NotNil(t, r.trialPrivateKey)
+		require.NotNil(t, r.trialPubKey)
+		require.Contains(t, status.Data, licensing.TrialPrivateKey)
+		require.Contains(t, status.Data, licensing.TrialPubkeyKey)
+	}
+
+	assertTrialRunningState := func(r *ReconcileTrials, status corev1.Secret) {
+		require.Nil(t, r.trialPrivateKey)
+		require.NotNil(t, r.trialPubKey)
+		require.NotContains(t, status.Data, licensing.TrialPrivateKey)
+		require.Contains(t, status.Data, licensing.TrialPubkeyKey)
+	}
+
+	type fields struct {
+		Client          k8s.Client
+		trialPubKey     *rsa.PublicKey
+		trialPrivateKey *rsa.PrivateKey
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		wantErr    bool
+		assertions func(*ReconcileTrials, corev1.Secret)
+	}{
+		{
+			name: "starts trial activation and creates status",
+			fields: fields{
+				Client: k8s.WrappedFakeClient(),
+			},
+			wantErr:    false,
+			assertions: assertTrialActivationState,
+		},
+		{
+			name: "recreates missing trial status during trial activation",
+			fields: fields{
+				Client:          k8s.WrappedFakeClient(),
+				trialPubKey:     &keySample.PublicKey,
+				trialPrivateKey: keySample,
+			},
+			wantErr:    false,
+			assertions: assertTrialActivationState,
+		},
+		{
+			name: "recreates missing trial status after trial activation",
+			fields: fields{
+				Client:          k8s.WrappedFakeClient(),
+				trialPubKey:     &keySample.PublicKey,
+				trialPrivateKey: nil,
+			},
+			wantErr:    false,
+			assertions: assertTrialRunningState,
+		},
+
+		{
+			name: "restore trial status memory on operator restart during activation: ok",
+			fields: fields{
+				Client: k8s.WrappedFakeClient(trialStatusSecretSample(t, keySample, true)),
+			},
+			wantErr:    false,
+			assertions: assertTrialActivationState,
+		},
+		{
+			name: "restore trial status memory on operator restart during trial: ok",
+			fields: fields{
+				Client: k8s.WrappedFakeClient(trialStatusSecretSample(t, keySample, false)),
+			},
+			wantErr:    false,
+			assertions: assertTrialRunningState,
+		},
+		{
+			name: "restore trial status memory on operator restart: fail",
+			fields: fields{
+				Client: k8s.WrappedFakeClient(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      licensing.TrialStatusSecretKey,
+						Namespace: testNs,
+					},
+					Data: map[string][]byte{
+						licensing.TrialPubkeyKey: []byte("garbage"),
+					},
+				}),
+			},
+			wantErr: true,
+		},
+		{
+			name: "update trial status from memory",
+			fields: fields{
+				Client:      k8s.WrappedFakeClient(trialStatusSecretSample(t, testTrialKey(t), true)),
+				trialPubKey: &keySample.PublicKey,
+			},
+			wantErr:    false,
+			assertions: assertTrialRunningState, // never restore the private key
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ReconcileTrials{
+				Client:            tt.fields.Client,
+				recorder:          record.NewFakeRecorder(10),
+				trialPubKey:       tt.fields.trialPubKey,
+				trialPrivateKey:   tt.fields.trialPrivateKey,
+				operatorNamespace: testNs,
+			}
+			if err := r.reconcileTrialStatus(trialLicenseNsn); (err != nil) != tt.wantErr {
+				t.Errorf("reconcileTrialStatus() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.assertions != nil {
+				var sec corev1.Secret
+				require.NoError(t, r.Get(types.NamespacedName{
+					Namespace: testNs,
+					Name:      licensing.TrialStatusSecretKey,
+				}, &sec))
+				tt.assertions(r, sec)
 			}
 		})
 	}

--- a/pkg/controller/license/trial/trial_controller_test.go
+++ b/pkg/controller/license/trial/trial_controller_test.go
@@ -20,8 +20,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const testNs = "ns-1"
-const trialLicenseName = "eck-trial" // user's choice but constant simplifies test setup
+const (
+	testNs           = "ns-1"
+	trialLicenseName = "eck-trial" // user's choice but constant simplifies test setup
+)
 
 var trialLicenseNsn = types.NamespacedName{
 	Namespace: testNs,
@@ -57,7 +59,6 @@ func trialLicenseBytes() []byte {
 		`{"license": {"uid": "x", "type": "enterprise-trial", "issue_date_in_millis": 1, "expiry_date_in_millis": %d, "issued_to": "x", "issuer": "x", "start_date_in_millis": 1, "cluster_licenses": null, "Version": 0}}`,
 		chrono.ToMillis(time.Now().Add(24*time.Hour)), // simulate a license still valid for 24 hours
 	))
-
 }
 
 func trialStateSample(t *testing.T) licensing.TrialState {


### PR DESCRIPTION
Fixes #2878 

What this PR does:
* introduce concept of trial activation where we keep the trial key around until trial successfully activated
* fixes erroneous validation messages as seen in #2878 
* fixes a situation where an operator crash or a k8s API error would prevent users from ever successfully starting a trial (not yet observed in the wild but possible)