### PR TITLE
Use annotation to track created remote clusters

### DIFF
--- a/pkg/controller/elasticsearch/client/client.go
+++ b/pkg/controller/elasticsearch/client/client.go
@@ -78,6 +78,8 @@ type Client interface {
 	ClusterBootstrappedForZen2(ctx context.Context) (bool, error)
 	// UpdateRemoteClusterSettings updates the remote clusters of a cluster.
 	UpdateRemoteClusterSettings(ctx context.Context, settings RemoteClustersSettings) error
+	// GetRemoteClusterSettings retrieves the remote clusters of a cluster.
+	GetRemoteClusterSettings(ctx context.Context) (RemoteClustersSettings, error)
 	// AddVotingConfigExclusions sets the transient and persistent setting of the same name in cluster settings.
 	//
 	// If timeout is the empty string, the default is used.

--- a/pkg/controller/elasticsearch/client/v6.go
+++ b/pkg/controller/elasticsearch/client/v6.go
@@ -92,6 +92,11 @@ func (c *clientV6) UpdateRemoteClusterSettings(ctx context.Context, settings Rem
 	return c.put(ctx, "/_cluster/settings", &settings, nil)
 }
 
+func (c *clientV6) GetRemoteClusterSettings(ctx context.Context) (RemoteClustersSettings, error) {
+	remoteClustersSettings := RemoteClustersSettings{}
+	return remoteClustersSettings, c.get(ctx, "/_cluster/settings", &remoteClustersSettings)
+}
+
 func (c *clientV6) GetLicense(ctx context.Context) (License, error) {
 	var license LicenseResponse
 	return license.License, c.get(ctx, "/_xpack/license", &license)

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -221,12 +221,15 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	)
 
 	if esReachable {
-		err = remotecluster.UpdateSettings(ctx, d.Client, esClient, d.Recorder(), d.LicenseChecker, d.ES)
+		requeue, err := remotecluster.UpdateSettings(ctx, d.Client, esClient, d.Recorder(), d.LicenseChecker, d.ES)
 		if err != nil {
 			msg := "Could not update remote clusters in Elasticsearch settings"
 			d.ReconcileState.AddEvent(corev1.EventTypeWarning, events.EventReasonUnexpected, msg)
 			log.Error(err, msg, "namespace", d.ES.Namespace, "es_name", d.ES.Name)
 			results.WithResult(defaultRequeue)
+		}
+		if requeue {
+			results = results.WithResult(defaultRequeue)
 		}
 	}
 

--- a/pkg/controller/elasticsearch/remotecluster/annotations.go
+++ b/pkg/controller/elasticsearch/remotecluster/annotations.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	// CreatedRemoteClustersAnnotationName holds the list of the remote clusters which have been created
-	CreatedRemoteClustersAnnotationName = "elasticsearch.k8s.elastic.co/managed-remote-clusters"
+	// ManagedRemoteClustersAnnotationName holds the list of the remote clusters which have been created
+	ManagedRemoteClustersAnnotationName = "elasticsearch.k8s.elastic.co/managed-remote-clusters"
 )
 
 // getRemoteClustersInAnnotation returns a set that contains a list of remote clusters that may have been declared in Elasticsearch.
@@ -22,7 +22,7 @@ const (
 // If there's no remote clusters the map is empty but not nil.
 func getRemoteClustersInAnnotation(es esv1.Elasticsearch) map[string]struct{} {
 	remoteClusters := make(map[string]struct{})
-	serializedRemoteClusters, ok := es.Annotations[CreatedRemoteClustersAnnotationName]
+	serializedRemoteClusters, ok := es.Annotations[ManagedRemoteClustersAnnotationName]
 	if !ok {
 		return remoteClusters
 	}
@@ -41,6 +41,6 @@ func annotateWithCreatedRemoteClusters(c k8s.Client, es esv1.Elasticsearch, remo
 		annotation = append(annotation, remoteCluster)
 	}
 	sort.Strings(annotation)
-	es.Annotations[CreatedRemoteClustersAnnotationName] = strings.Join(annotation, ",")
+	es.Annotations[ManagedRemoteClustersAnnotationName] = strings.Join(annotation, ",")
 	return c.Update(&es)
 }

--- a/pkg/controller/elasticsearch/remotecluster/annotations.go
+++ b/pkg/controller/elasticsearch/remotecluster/annotations.go
@@ -5,58 +5,42 @@
 package remotecluster
 
 import (
-	"encoding/json"
+	"sort"
+	"strings"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
-	"github.com/pkg/errors"
 )
 
 const (
-	RemoteClustersAnnotationName = "elasticsearch.k8s.elastic.co/remote-clusters"
+	// CreatedRemoteClustersAnnotationName holds the list of the remote clusters which have been created
+	CreatedRemoteClustersAnnotationName = "elasticsearch.k8s.elastic.co/managed-remote-clusters"
 )
 
-type expectedRemoteClusterConfiguration struct {
-	esv1.RemoteCluster
-
-	// ConfigHash is the hash of the remote cluster configuration. It is used to detect when the settings must be updated.
-	ConfigHash string `json:"configHash"`
-}
-
-// getCurrentRemoteClusters returns a map with the current configuration hash of the remote clusters declared in Elasticsearch.
+// getRemoteClustersInAnnotation returns a set that contains a list of remote clusters that may have been declared in Elasticsearch.
 // A map is returned here to quickly compare with the ones that are new or missing.
 // If there's no remote clusters the map is empty but not nil.
-func getCurrentRemoteClusters(es esv1.Elasticsearch) (map[string]string, error) {
-	serializedRemoteClusters, ok := es.Annotations[RemoteClustersAnnotationName]
-	remoteClusters := make(map[string]string)
+func getRemoteClustersInAnnotation(es esv1.Elasticsearch) map[string]struct{} {
+	remoteClusters := make(map[string]struct{})
+	serializedRemoteClusters, ok := es.Annotations[CreatedRemoteClustersAnnotationName]
 	if !ok {
-		return remoteClusters, nil
+		return remoteClusters
 	}
-	if err := json.Unmarshal([]byte(serializedRemoteClusters), &remoteClusters); err != nil {
-		return nil, err
+	for _, remoteClusterInAnnotation := range strings.Split(serializedRemoteClusters, ",") {
+		remoteClusters[remoteClusterInAnnotation] = struct{}{}
 	}
-
-	return remoteClusters, nil
+	return remoteClusters
 }
 
-func annotateWithRemoteClusters(c k8s.Client, es esv1.Elasticsearch, remoteClusters map[string]expectedRemoteClusterConfiguration) error {
-	// Store a map with the configuration hash for every remote cluster
-	remoteClusterConfigurations := make(map[string]string, len(remoteClusters))
-	for _, remoteCluster := range remoteClusters {
-		// remoteCluster.Name is set by the user, it is supposed to be unique
-		remoteClusterConfigurations[remoteCluster.Name] = remoteCluster.RemoteCluster.ConfigHash()
-	}
-
-	// serialize the remote clusters list and update the object
-	serializedRemoteClusters, err := json.Marshal(remoteClusterConfigurations)
-	if err != nil {
-		return errors.Wrapf(err, "failed to serialize configuration")
-	}
-
+func annotateWithCreatedRemoteClusters(c k8s.Client, es esv1.Elasticsearch, remoteClusters map[string]struct{}) error {
 	if es.Annotations == nil {
 		es.Annotations = make(map[string]string)
 	}
-
-	es.Annotations[RemoteClustersAnnotationName] = string(serializedRemoteClusters)
+	annotation := make([]string, 0, len(remoteClusters))
+	for remoteCluster := range remoteClusters {
+		annotation = append(annotation, remoteCluster)
+	}
+	sort.Strings(annotation)
+	es.Annotations[CreatedRemoteClustersAnnotationName] = strings.Join(annotation, ",")
 	return c.Update(&es)
 }

--- a/pkg/controller/elasticsearch/remotecluster/elasticsearch.go
+++ b/pkg/controller/elasticsearch/remotecluster/elasticsearch.go
@@ -26,6 +26,8 @@ var log = logf.Log.WithName("remotecluster")
 const enterpriseFeaturesDisabledMsg = "Remote cluster is an enterprise feature. Enterprise features are disabled"
 
 // UpdateSettings updates the remote clusters in the persistent settings by calling the Elasticsearch API.
+// A boolean is returned to indicate if a requeue should be scheduled to sync the annotation on the Elasticsearch object
+// when the remote clusters that are not expected anymore are actually deleted from the Elasticsearch settings.
 // See the documentation of updateSettingsInternal for more information about the algorithm.
 func UpdateSettings(
 	ctx context.Context,

--- a/pkg/controller/elasticsearch/remotecluster/elasticsearch.go
+++ b/pkg/controller/elasticsearch/remotecluster/elasticsearch.go
@@ -98,7 +98,7 @@ func updateSettingsInternal(
 		}
 	}
 
-	var remoteClustersToUpdate []string // only used for logging
+	remoteClustersToUpdate := make([]string, 0, len(remoteClustersInSpec)) // only used for logging
 	// remoteClustersToApply are clusters to add (or update) based on what is specified in the Elasticsearch spec.
 	remoteClustersToApply := make(map[string]esclient.RemoteCluster)
 	for name, remoteCluster := range remoteClustersInSpec {


### PR DESCRIPTION
The PR fixes an issue where the annotation used to cache the Elasticsearch state wrt remote clusters may become inconsistent and could prevent some updates to be applied.

The annotation is kept but only to track the remote clusters that have been previously managed by ECK. In order to be consistent with the other API calls in ECK the algorithm never tries to optimize the number of calls performed on the ES cluster.

It can be noted that it still exists an edge case where ECK may delete a cluster managed by the user:
1. Remote cluster `remote-foo` is declared as remote in the Spec
2. User decides to manage this cluster itself, `remote-foo` is removed from the spec
3. ECK is stopped or is to slow to update the annotation
4. User creates `remote-foo` manually
5. ECK is started or is finally proceeding the cluster removal from the spec, deleting `remote-foo` 💥 

At each iteration a log is printed with the upserted and deleted remote clusters.

Last PR to completely fix #2864 , related to #2880 

@anyasabo I think it should be included in `1.1.0` to avoid a mix of "remote clusters related" labels on Elasticsearch resources in the future.
