### PR TITLE
Add build number to debug cleanup job

### DIFF
--- a/.ci/pipelines/e2e-tests-testmutationsecondmastersetdown.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-testmutationsecondmastersetdown.Jenkinsfile
@@ -94,7 +94,7 @@ pipeline {
             script {
                 if (notOnlyDocs() && failedTests.size() == 0) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
-                        parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-debug-e2e")],
+                        parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-debug-e2e-${BUILD_NUMBER}")],
                         wait: false
                 }
             }


### PR DESCRIPTION
Fixes the cleanup job to delete 

The .env actually has the build ID at the end when we create it (because the sed command in this file isn't changing that part of the `CLUSTER_NAME`):
https://github.com/elastic/cloud-on-k8s/blob/master/.ci/setenvconfig#L190-L197

but it was not included in the cleanup. This is not pretty but this job is just supposed to be temporary, so I'm okay with it. Thanks @thbkrkr for the assist


You can also see we do something similar here:
https://github.com/elastic/cloud-on-k8s/blob/master/.ci/pipelines/e2e-tests-custom-operator-image-gke.Jenkinsfile#L76