### PR TITLE
Validate unknown fields in ES v1beta1

### DIFF
--- a/pkg/apis/elasticsearch/v1beta1/validations.go
+++ b/pkg/apis/elasticsearch/v1beta1/validations.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"reflect"
 
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	esversion "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/version"
 	netutil "github.com/elastic/cloud-on-k8s/pkg/utils/net"
@@ -35,6 +36,7 @@ type validation func(*Elasticsearch) field.ErrorList
 
 // validations are the validation funcs that apply to creates or updates
 var validations = []validation{
+	noUnknownFields,
 	validName,
 	hasMaster,
 	supportedVersion,
@@ -58,6 +60,11 @@ func (es *Elasticsearch) check(validations []validation) field.ErrorList {
 		}
 	}
 	return errs
+}
+
+// noUnknownFields checks whether the last applied config annotation contains json with unknown fields.
+func noUnknownFields(es *Elasticsearch) field.ErrorList {
+	return commonv1.NoUnknownFields(es, es.ObjectMeta)
 }
 
 // validName checks whether the name is valid.


### PR DESCRIPTION
As a followup to https://github.com/elastic/cloud-on-k8s/pull/2433

Also adds unknown field validation for v1beta1 (straight copy and paste). Yay manual testing? I was working through the manual testing and applying invalid resources, and noticed it rejected the requests for all other v1beta1 resource types, but not for Elasticsearch.