### PR TITLE
Increase AKS E2E tests job timeout

### DIFF
--- a/.ci/pipelines/e2e-tests-aks.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-aks.Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
     }
 
     environment {


### PR DESCRIPTION
Pass the timeout of the `cloud-on-k8s-e2e-tests-aks` job from 5h to 6h.

This is a best-effort fix until we understand the cause of the increase in the duration of the job and an appropriate solution.

Relates to #2898.