### PR TITLE
Update go to 1.14.2

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image used for continuous integration
-FROM golang:1.13-stretch
+FROM golang:1.14.2
 
 # TODO: update to >1.24.0 once https://github.com/golangci/golangci-lint/issues/994 is fixed, as jenkins OOMs when running 1.24.0
 ENV GOLANGCILINT_VERSION=1.23.8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Build the manager binary
-FROM golang:1.13 as builder
+# Build the operator binary
+FROM golang:1.14.2 as builder
 
 ARG GO_LDFLAGS
 ARG GO_TAGS

--- a/hack/check/check-license-header.sh
+++ b/hack/check/check-license-header.sh
@@ -17,7 +17,7 @@ files=$(grep \
     --include=\*.sh \
     --include=Makefile \
     -L "Copyright Elasticsearch B.V." \
-    -r ${CHECK_PATH})
+    -r ${CHECK_PATH} || true)
 
 [ "$files" != "" ] \
     && echo -e "Error: file(s) without license header:\n$files" && exit 1 \

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,5 +1,5 @@
-# Run e2e tests
-FROM golang:1.13
+# Docker image for the E2E tests runner
+FROM golang:1.14.2
 
 ARG E2E_JSON
 ENV E2E_JSON $E2E_JSON


### PR DESCRIPTION
This commit updates the go version from `1.13` to `1.14.2`.

It also takes the opportunity to use the same base image for the 3 images (`-stretch` was used for the CI tools to gain 40 MB for the price of one more image pull).