### PR TITLE
Make it clearer that reattach-pv should be compiled from source

### DIFF
--- a/hack/reattach-pv/README.md
+++ b/hack/reattach-pv/README.md
@@ -31,6 +31,8 @@ Flags:
 Example:
 
 ```
+# build the binary with a recent Go version
+go build
 # perform a dry run first
 ./reattach-pv --elasticsearch-manifest elasticsearch.yml --dry-run
 # then, execute again without the dry-run flag


### PR DESCRIPTION
It may not be clear that reattach-pv must be compiled by the user. Example: https://discuss.elastic.co/t/reclaim-persistent-volume/228197/3.
I think it's also not worth it releasing a binary for it (maybe later if we have a generic ECK CLI).