### PR TITLE
Fix trial license validation issues (#2889)

### DIFF
--- a/pkg/controller/common/license/trial.go
+++ b/pkg/controller/common/license/trial.go
@@ -9,74 +9,141 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/elastic/cloud-on-k8s/pkg/utils/chrono"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	pkgerrors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
 const (
 	TrialStatusSecretKey = "trial-status"
 	TrialPubkeyKey       = "pubkey"
+	TrialActivationKey   = "in-trial-activation"
 
 	TrialLicenseSecretName      = "trial.k8s.elastic.co/secret-name"      // nolint
 	TrialLicenseSecretNamespace = "trial.k8s.elastic.co/secret-namespace" // nolint
 )
 
-func InitTrial(c k8s.Client, operatorNamespace string, secret corev1.Secret, l *EnterpriseLicense) (*rsa.PublicKey, error) {
+// TrialState captures the in-memory representation of the trial status.
+type TrialState struct {
+	privateKey *rsa.PrivateKey
+	publicKey  *rsa.PublicKey
+}
+
+// NewTrialState creates a new trial state based on a new RSA key pair.
+func NewTrialState() (TrialState, error) {
+	key, err := newTrialKey()
+	if err != nil {
+		return TrialState{}, err
+	}
+	return TrialState{
+		privateKey: key,
+		publicKey:  &key.PublicKey,
+	}, nil
+}
+
+// NewTrialStateFromStatus reconstructs trial state from a trial status secret.
+func NewTrialStateFromStatus(trialStatus corev1.Secret) (TrialState, error) {
+	// reinstate pubkey from status secret e.g. after operator restart
+	pubKeyBytes := trialStatus.Data[TrialPubkeyKey]
+	key, err := ParsePubKey(pubKeyBytes)
+	if err != nil {
+		return TrialState{}, err
+	}
+	return TrialState{
+		publicKey: key,
+	}, nil
+}
+
+// IsTrialStarted returns true if a trial has been successfully started at some point in the past.
+func (tk *TrialState) IsTrialStarted() bool {
+	return tk.publicKey != nil && tk.privateKey == nil
+}
+
+// IsEmpty returns true on an empty state struct.
+func (tk *TrialState) IsEmpty() bool {
+	return tk.privateKey == nil && tk.publicKey == nil
+}
+
+// InitTrialLicense initialises and signs the given license based on the current state.
+func (tk *TrialState) InitTrialLicense(l *EnterpriseLicense) error {
+	if tk.privateKey == nil {
+		return errors.New("trial has already been activated")
+	}
 	if l == nil {
-		return nil, errors.New("license is nil")
+		return errors.New("license is nil")
+	}
+	if err := populateTrialLicense(l); err != nil {
+		return pkgerrors.Wrap(err, "failed to populate trial license")
 	}
 
-	if err := populateTrialLicense(l); err != nil {
-		return nil, pkgerrors.Wrap(err, "failed to populate trial license")
-	}
 	log.Info("Starting enterprise trial", "start", l.StartTime(), "end", l.ExpiryTime())
-	rnd := rand.Reader
-	tmpPrivKey, err := rsa.GenerateKey(rnd, 2048)
-	if err != nil {
-		return nil, err
-	}
 	// sign trial license
-	signer := NewSigner(tmpPrivKey)
+	signer := NewSigner(tk.privateKey)
 	sig, err := signer.Sign(*l)
 	if err != nil {
-		return nil, pkgerrors.Wrap(err, "failed to sign license")
+		return pkgerrors.Wrap(err, "failed to sign license")
 	}
-	pubkeyBytes, err := x509.MarshalPKIXPublicKey(&tmpPrivKey.PublicKey)
+
+	l.License.Signature = string(sig)
+	return nil
+}
+
+// CompleteTrialActivation should be called once a trial license has been successfully generated and verified.
+// Returns false if the trial activation had been completed previously.
+func (tk *TrialState) CompleteTrialActivation() bool {
+	if tk.privateKey == nil {
+		return false
+	}
+	tk.privateKey = nil
+	return true
+}
+
+// LicenseVerifier returns a verifier based on the current state/public key
+func (tk *TrialState) LicenseVerifier() *Verifier {
+	return &Verifier{PublicKey: tk.publicKey}
+}
+
+// ExpectedTrialStatus creates the expected state of the trial status secret for the given trial state for reconciliation purposes.
+func ExpectedTrialStatus(operatorNamespace string, license types.NamespacedName, state TrialState) (corev1.Secret, error) {
+	if state.IsEmpty() {
+		return corev1.Secret{}, errors.New("cannot create trial status from uninitialised trial state")
+	}
+	pubkeyBytes, err := x509.MarshalPKIXPublicKey(state.publicKey)
 	if err != nil {
-		return nil, pkgerrors.Wrap(err, "failed to marshal public key for trial status")
+		return corev1.Secret{}, err
 	}
-	trialStatus := corev1.Secret{
+	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: operatorNamespace,
 			Name:      TrialStatusSecretKey,
-			Labels: map[string]string{
-				LicenseLabelName: l.License.UID,
-			},
 			Annotations: map[string]string{
-				TrialLicenseSecretName:      secret.Name,
-				TrialLicenseSecretNamespace: secret.Namespace,
+				TrialLicenseSecretName:      license.Name,
+				TrialLicenseSecretNamespace: license.Namespace,
 			},
 		},
 		Data: map[string][]byte{
 			TrialPubkeyKey: pubkeyBytes,
 		},
 	}
-	err = c.Create(&trialStatus)
-	if err != nil {
-		return nil, pkgerrors.Wrap(err, "failed to create trial status")
+	if !state.IsTrialStarted() {
+		secret.Data[TrialActivationKey] = []byte("true")
 	}
-	l.License.Signature = string(sig)
-	// return pub key to retain in memory for later iterations
-	return &tmpPrivKey.PublicKey, pkgerrors.Wrap(
-		UpdateEnterpriseLicense(c, secret, *l),
-		"failed to update trial license",
-	)
+	return secret, nil
+}
+
+func newTrialKey() (*rsa.PrivateKey, error) {
+	rnd := rand.Reader
+	trialKey, err := rsa.GenerateKey(rnd, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("while generating trial key %w", err)
+	}
+	return trialKey, nil
 }
 
 // populateTrialLicense adds missing fields to a trial license.

--- a/pkg/controller/common/license/trial_test.go
+++ b/pkg/controller/common/license/trial_test.go
@@ -5,120 +5,83 @@
 package license
 
 import (
-	"crypto/rsa"
+	"crypto/x509"
+	"reflect"
 	"testing"
 	"time"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
-type failingClient struct {
-	k8s.Client
-}
-
-func (failingClient) Create(o runtime.Object, opts ...client.CreateOption) error {
-	return errors.New("boom")
-}
-
-func TestInitTrial(t *testing.T) {
+func TestInitTrialLicense(t *testing.T) {
 	licenseFixture := EnterpriseLicense{
 		License: LicenseSpec{
 			Type: LicenseTypeEnterpriseTrial,
 		},
 	}
 	type args struct {
-		c k8s.Client
 		l *EnterpriseLicense
 	}
 	tests := []struct {
 		name    string
+		state   TrialState
 		args    args
-		want    func(*EnterpriseLicense, *rsa.PublicKey)
+		want    func(*EnterpriseLicense)
 		wantErr bool
 	}{
 		{
 			name: "nil license",
 			args: args{
-				c: k8s.WrappedFakeClient(),
 				l: nil,
-			},
-			wantErr: true,
-		},
-		{
-			name: "failing client",
-			args: args{
-				c: failingClient{},
-				l: &EnterpriseLicense{
-					License: LicenseSpec{
-						Type: LicenseTypeEnterpriseTrial,
-					},
-				},
-			},
-			want: func(_ *EnterpriseLicense, key *rsa.PublicKey) {
-				require.Nil(t, key)
 			},
 			wantErr: true,
 		},
 		{
 			name: "not a trial license",
 			args: args{
-				c: k8s.WrappedFakeClient(),
 				l: &EnterpriseLicense{},
 			},
-			want: func(l *EnterpriseLicense, k *rsa.PublicKey) {
+			want: func(l *EnterpriseLicense) {
 				require.Equal(t, *l, EnterpriseLicense{})
-				require.Nil(t, k)
 			},
 			wantErr: true,
 		},
 		{
 			name: "successful trial start",
+			state: func() TrialState {
+				state, err := NewTrialState()
+				require.NoError(t, err)
+				return state
+			}(),
 			args: args{
-				c: k8s.WrappedFakeClient(&corev1.Secret{
-					ObjectMeta: v1.ObjectMeta{
-						Namespace: "elastic-system",
-						Name:      string(LicenseTypeEnterpriseTrial),
-					},
-				}),
 				l: &licenseFixture,
 			},
-			want: func(l *EnterpriseLicense, k *rsa.PublicKey) {
-				require.NotNil(t, k)
+			want: func(l *EnterpriseLicense) {
 				require.NoError(t, l.IsMissingFields())
 			},
 			wantErr: false,
 		},
+		{
+			name: "not in activation state",
+			args: args{
+				l: &licenseFixture,
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := InitTrial(
-				tt.args.c,
-				"elastic-system",
-				corev1.Secret{
-					ObjectMeta: v1.ObjectMeta{
-						Namespace: "elastic-system",
-						Name:      string(LicenseTypeEnterpriseTrial),
-						Labels: map[string]string{
-							common.TypeLabelName: Type,
-						},
-					},
-				},
-				tt.args.l,
-			)
+			err := tt.state.InitTrialLicense(tt.args.l)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("InitTrial() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if tt.want != nil {
-				tt.want(tt.args.l, got)
+				tt.want(tt.args.l)
 			}
 		})
 	}
@@ -202,5 +165,153 @@ func TestStartTrial(t *testing.T) {
 		if tt.assertions != nil {
 			tt.assertions(*tt.args.l)
 		}
+	}
+}
+
+func TestNewTrialStateFromStatus(t *testing.T) {
+	key, err := newTrialKey()
+	require.NoError(t, err)
+
+	keySerialized, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	require.NoError(t, err)
+
+	type args struct {
+		trialStatus v1.Secret
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    func(TrialState)
+		wantErr bool
+	}{
+		{
+			name: "reconstructs state",
+			args: args{
+				trialStatus: v1.Secret{
+					Data: map[string][]byte{
+						TrialPubkeyKey: keySerialized,
+					},
+				},
+			},
+			want: func(s TrialState) {
+				require.True(t, s.IsTrialStarted())
+				require.True(t, reflect.DeepEqual(s, TrialState{
+					publicKey: &key.PublicKey,
+				}))
+			},
+			wantErr: false,
+		},
+		{
+			name: "error on garbage status",
+			args: args{
+				trialStatus: v1.Secret{
+					Data: map[string][]byte{
+						TrialPubkeyKey: []byte("foo"),
+					},
+				},
+			},
+			wantErr: true,
+			want: func(state TrialState) {
+				require.False(t, state.IsTrialStarted())
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewTrialStateFromStatus(tt.args.trialStatus)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewTrialStateFromStatus() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.want != nil {
+				tt.want(got)
+			}
+		})
+	}
+}
+
+func TestExpectedTrialStatus(t *testing.T) {
+	sampleKey, err := newTrialKey()
+	require.NoError(t, err)
+	pubKey, err := x509.MarshalPKIXPublicKey(&sampleKey.PublicKey)
+	require.NoError(t, err)
+
+	type args struct {
+		state TrialState
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    v1.Secret
+		wantErr bool
+	}{
+		{
+			name: "status during activation",
+			args: args{
+				state: TrialState{
+					publicKey:  &sampleKey.PublicKey,
+					privateKey: sampleKey,
+				},
+			},
+			want: v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      TrialStatusSecretKey,
+					Annotations: map[string]string{
+						TrialLicenseSecretName:      "name",
+						TrialLicenseSecretNamespace: "ns",
+					},
+				},
+				Data: map[string][]byte{
+					TrialPubkeyKey:     pubKey,
+					TrialActivationKey: []byte("true"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "status after activation",
+			args: args{
+				state: TrialState{
+					publicKey: &sampleKey.PublicKey,
+				},
+			},
+			want: v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      TrialStatusSecretKey,
+					Annotations: map[string]string{
+						TrialLicenseSecretName:      "name",
+						TrialLicenseSecretNamespace: "ns",
+					},
+				},
+				Data: map[string][]byte{
+					TrialPubkeyKey: pubKey,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "with empty trial state",
+			args: args{
+				state: TrialState{},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExpectedTrialStatus("ns", types.NamespacedName{
+				Namespace: "ns",
+				Name:      "name",
+			}, tt.args.state)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExpectedTrialStatus() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExpectedTrialStatus() got = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/controller/license/trial/trial_controller.go
+++ b/pkg/controller/license/trial/trial_controller.go
@@ -6,9 +6,8 @@ package trial
 
 import (
 	"bytes"
-	"crypto/rsa"
-	"crypto/x509"
 	"fmt"
+	"reflect"
 	"sync/atomic"
 	"time"
 
@@ -49,7 +48,7 @@ type ReconcileTrials struct {
 	recorder record.EventRecorder
 	// iteration is the number of times this controller has run its Reconcile method.
 	iteration         int64
-	trialPubKey       *rsa.PublicKey
+	trialState        licensing.TrialState
 	operatorNamespace string
 }
 
@@ -76,89 +75,132 @@ func (r *ReconcileTrials) Reconcile(request reconcile.Request) (reconcile.Result
 
 	validationMsg := validateEULA(secret)
 	if validationMsg != "" {
-		setValidationMsg(&secret, validationMsg)
-		return reconcile.Result{}, licensing.UpdateEnterpriseLicense(r, secret, license)
+		return r.invalidOperation(secret, validationMsg)
 	}
 
-	// 1. fetch trial status secret
+	// 1. reconcile trial status secret
+	if err := r.reconcileTrialStatus(request.NamespacedName, license); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// 2. reconcile the trial license itself
+	trialLicensePopulated := license.IsMissingFields() == nil
+	licenseStatus := r.validateLicense(license)
+	switch {
+	case !trialLicensePopulated && r.trialState.IsTrialStarted():
+		// user wants to start a trial for the second time
+		return r.invalidOperation(secret, trialOnlyOnceMsg)
+	case !trialLicensePopulated && !r.trialState.IsTrialStarted():
+		// user wants to init a trial for the first time
+		return r.initTrialLicense(secret, license)
+	case trialLicensePopulated && !validLicense(licenseStatus):
+		// existing license is invalid (expired or tampered with)
+		return r.invalidOperation(secret, userFriendlyMsgs[licenseStatus])
+	case trialLicensePopulated && validLicense(licenseStatus) && !r.trialState.IsTrialStarted():
+		// valid license, let's consider the trial started and complete the activation
+		return r.completeTrialActivation(request.NamespacedName)
+	case trialLicensePopulated && validLicense(licenseStatus) && r.trialState.IsTrialStarted():
+		// all good nothing to do
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileTrials) reconcileTrialStatus(licenseName types.NamespacedName, license licensing.EnterpriseLicense) error {
 	var trialStatus corev1.Secret
-	err = r.Get(types.NamespacedName{Namespace: r.operatorNamespace, Name: licensing.TrialStatusSecretKey}, &trialStatus)
+	err := r.Get(types.NamespacedName{Namespace: r.operatorNamespace, Name: licensing.TrialStatusSecretKey}, &trialStatus)
 	if errors.IsNotFound(err) {
-		// 2. if not present create one
-		err := r.initTrial(secret, license)
+		if !r.trialState.IsTrialStarted() {
+			// we have no state in memory nor in the status secret: start the activation process
+			if err := r.startTrialActivation(); err != nil {
+				return err
+			}
+		}
+
+		// we have state in memory but the status secret is missing: recreate it
+		trialStatus, err = licensing.ExpectedTrialStatus(r.operatorNamespace, licenseName, r.trialState)
 		if err != nil {
-			return reconcile.Result{}, pkgerrors.Wrap(err, "failed to init trial")
+			return fmt.Errorf("while creating expected trial status %w", err)
 		}
-		return reconcile.Result{}, nil
+		return r.Create(&trialStatus)
 	}
 	if err != nil {
-		return reconcile.Result{}, pkgerrors.Wrap(err, "failed to retrieve trial status")
-	}
-	// 3. reconcile trial status
-	if err := r.reconcileTrialStatus(trialStatus); err != nil {
-		return reconcile.Result{}, pkgerrors.Wrap(err, "failed to reconcile trial status")
-	}
-	// 4. update trial secret if invalid to give user feedback
-	trialSecretPopulated := license.IsMissingFields() == nil
-	if r.isTrialRunning() && trialSecretPopulated {
-		verifier := licensing.Verifier{
-			PublicKey: r.trialPubKey,
-		}
-		status := verifier.Valid(license, time.Now())
-		if status != licensing.LicenseStatusValid {
-			setValidationMsg(&secret, userFriendlyMsgs[status])
-		}
-	} else {
-		// if the trial secret fields are not populated at this point a user is trying to start a trial a second time
-		// with an empty trial secret, which is not a supported use case.
-		setValidationMsg(&secret, trialOnlyOnceMsg)
-	}
-	return reconcile.Result{}, r.Update(&secret)
-}
-
-func (r *ReconcileTrials) isTrialRunning() bool {
-	return r.trialPubKey != nil
-}
-
-func (r *ReconcileTrials) initTrial(secret corev1.Secret, l licensing.EnterpriseLicense) error {
-	if r.isTrialRunning() {
-		setValidationMsg(&secret, trialOnlyOnceMsg)
-		return licensing.UpdateEnterpriseLicense(r, secret, l)
+		return fmt.Errorf("while fetching trial status %w", err)
 	}
 
-	trialPubKey, err := licensing.InitTrial(r, r.operatorNamespace, secret, &l)
-	if err != nil {
-		return err
-	}
-	// retain pub key in memory for later iterations
-	r.trialPubKey = trialPubKey
-	return nil
-}
-
-func (r *ReconcileTrials) reconcileTrialStatus(trialStatus corev1.Secret) error {
-	if !r.isTrialRunning() {
-		// reinstate pubkey from status secret e.g. after operator restart
-		pubKeyBytes := trialStatus.Data[licensing.TrialPubkeyKey]
-		key, err := licensing.ParsePubKey(pubKeyBytes)
+	// the status secret is there but we don't have anything in memory: recover the state
+	if r.trialState.IsEmpty() {
+		recoveredState, err := recoverState(license, trialStatus)
 		if err != nil {
 			return err
 		}
-		r.trialPubKey = key
-		return nil
+		r.trialState = recoveredState
 	}
-	pubkeyBytes, err := x509.MarshalPKIXPublicKey(r.trialPubKey)
+	// if trial status exists, but we need to update it because:
+	// - has been tampered with
+	// - we need to complete the trial activation because if failed on a previous attempt
+	// - we just regenerated the state after a crash
+	expected, err := licensing.ExpectedTrialStatus(r.operatorNamespace, licenseName, r.trialState)
 	if err != nil {
 		return err
 	}
-	if bytes.Equal(trialStatus.Data[licensing.TrialPubkeyKey], pubkeyBytes) {
+	if reflect.DeepEqual(expected.Data, trialStatus.Data) {
 		return nil
 	}
-	if trialStatus.Data == nil {
-		trialStatus.Data = map[string][]byte{} // if trial status has been tampered with
-	}
-	trialStatus.Data[licensing.TrialPubkeyKey] = pubkeyBytes
+	trialStatus.Data = expected.Data
 	return r.Update(&trialStatus)
+}
 
+func recoverState(license licensing.EnterpriseLicense, trialStatus corev1.Secret) (licensing.TrialState, error) {
+	// allow new trial state only if we don't have license that looks like it has been populated previously
+	allowNewState := license.IsMissingFields() != nil
+	// create new keys if the operator failed just before the trial was started
+	trialActivationInProgress := bytes.Equal(trialStatus.Data[licensing.TrialActivationKey], []byte("true"))
+	if trialActivationInProgress && allowNewState {
+		return licensing.NewTrialState()
+
+	}
+	// otherwise just recover the public key
+	return licensing.NewTrialStateFromStatus(trialStatus)
+}
+
+func (r *ReconcileTrials) startTrialActivation() error {
+	state, err := licensing.NewTrialState()
+	if err != nil {
+		return err
+	}
+	r.trialState = state
+	return nil
+}
+
+func (r *ReconcileTrials) completeTrialActivation(license types.NamespacedName) (reconcile.Result, error) {
+	if r.trialState.CompleteTrialActivation() {
+		status, err := licensing.ExpectedTrialStatus(r.operatorNamespace, license, r.trialState)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{}, r.Update(&status)
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileTrials) initTrialLicense(secret corev1.Secret, license licensing.EnterpriseLicense) (reconcile.Result, error) {
+	if err := r.trialState.InitTrialLicense(&license); err != nil {
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, licensing.UpdateEnterpriseLicense(r, secret, license)
+}
+
+func (r *ReconcileTrials) invalidOperation(secret corev1.Secret, msg string) (reconcile.Result, error) {
+	setValidationMsg(&secret, msg)
+	return reconcile.Result{}, r.Update(&secret)
+}
+
+func validLicense(status licensing.LicenseStatus) bool {
+	return status == licensing.LicenseStatusValid
+}
+
+func (r *ReconcileTrials) validateLicense(license licensing.EnterpriseLicense) licensing.LicenseStatus {
+	return r.trialState.LicenseVerifier().Valid(license, time.Now())
 }
 
 func validateEULA(trialSecret corev1.Secret) string {

--- a/pkg/controller/license/trial/trial_controller_test.go
+++ b/pkg/controller/license/trial/trial_controller_test.go
@@ -5,9 +5,7 @@
 package trial
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -16,25 +14,27 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/chrono"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const testNs = "ns-1"
-const trialSecretName = "eck-trial" // user's choice but constant simplifies test setup
+const (
+	testNs           = "ns-1"
+	trialLicenseName = "eck-trial" // user's choice but constant simplifies test setup
+)
 
-var trialSecretNsn = types.NamespacedName{
+var trialLicenseNsn = types.NamespacedName{
 	Namespace: testNs,
-	Name:      trialSecretName,
+	Name:      trialLicenseName,
 }
 
-func trialSecretSample(annotated bool, data map[string][]byte) *v1.Secret {
-	sec := v1.Secret{
+func trialLicenseSecretSample(annotated bool, data map[string][]byte) *corev1.Secret {
+	sec := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      trialSecretName,
+			Name:      trialLicenseName,
 			Namespace: testNs,
 			Labels: map[string]string{
 				licensing.LicenseLabelType: "enterprise-trial", // assume always there otherwise watch would not trigger
@@ -49,54 +49,87 @@ func trialSecretSample(annotated bool, data map[string][]byte) *v1.Secret {
 	return &sec
 }
 
+func trialStatusSecretSample(t *testing.T, state licensing.TrialState) *corev1.Secret {
+	status, err := licensing.ExpectedTrialStatus(testNs, trialLicenseNsn, state)
+	require.NoError(t, err)
+	return &status
+}
+
 func trialLicenseBytes() []byte {
 	return []byte(fmt.Sprintf(
 		`{"license": {"uid": "x", "type": "enterprise-trial", "issue_date_in_millis": 1, "expiry_date_in_millis": %d, "issued_to": "x", "issuer": "x", "start_date_in_millis": 1, "cluster_licenses": null, "Version": 0}}`,
 		chrono.ToMillis(time.Now().Add(24*time.Hour)), // simulate a license still valid for 24 hours
 	))
-
 }
 
-func testPubkey(t *testing.T) *rsa.PublicKey {
-	rnd := rand.Reader
-	key, err := rsa.GenerateKey(rnd, 2048)
+func trialStateSample(t *testing.T) licensing.TrialState {
+	state, err := licensing.NewTrialState()
 	require.NoError(t, err)
-	return &key.PublicKey
+	return state
 }
 
-func simulateRunningTrial(t *testing.T, k k8s.Client, secret v1.Secret) []byte {
+func runningTrialSample(t *testing.T) licensing.TrialState {
+	state := trialStateSample(t)
+	state.CompleteTrialActivation()
+	return state
+}
+
+func simulateRunningTrial(t *testing.T, k k8s.Client, secret corev1.Secret) {
 	l := licensing.EnterpriseLicense{
 		License: licensing.LicenseSpec{
 			Type: licensing.LicenseTypeEnterpriseTrial,
 		},
 	}
-	trialKey, err := licensing.InitTrial(k, testNs, secret, &l)
+	state, err := licensing.NewTrialState()
 	require.NoError(t, err)
-	keyBytes, err := x509.MarshalPKIXPublicKey(trialKey)
+	err = state.InitTrialLicense(&l)
 	require.NoError(t, err)
-	return keyBytes
+	require.NoError(t, licensing.UpdateEnterpriseLicense(k, secret, l))
+	state.CompleteTrialActivation()
+	statusSecret := trialStatusSecretSample(t, state)
+	require.NoError(t, k.Create(statusSecret))
 }
 
 func TestReconcileTrials_Reconcile(t *testing.T) {
+
 	requireValidationMsg := func(msg string) func(c k8s.Client) {
 		return func(c k8s.Client) {
-			var sec v1.Secret
-			require.NoError(t, c.Get(trialSecretNsn, &sec))
+			var sec corev1.Secret
+			require.NoError(t, c.Get(trialLicenseNsn, &sec))
 			err, ok := sec.Annotations[licensing.LicenseInvalidAnnotation]
 			require.True(t, ok, "invalid annotation present")
 			require.Equal(t, msg, err)
 		}
 	}
+
 	requireNoValidationMsg := func(c k8s.Client) {
-		var sec v1.Secret
-		require.NoError(t, c.Get(trialSecretNsn, &sec))
+		var sec corev1.Secret
+		require.NoError(t, c.Get(trialLicenseNsn, &sec))
 		_, ok := sec.Annotations[licensing.LicenseInvalidAnnotation]
 		require.False(t, ok, "no invalid annotation expected")
 	}
 
+	requireValidTrial := func(c k8s.Client) {
+		var sec corev1.Secret
+		require.NoError(t, c.Get(types.NamespacedName{
+			Namespace: testNs,
+			Name:      licensing.TrialStatusSecretKey,
+		}, &sec))
+		require.NoError(t, c.Get(trialLicenseNsn, &sec))
+		pubKeyBytes := sec.Data[licensing.TrialPubkeyKey]
+		key, err := licensing.ParsePubKey(pubKeyBytes)
+		require.NoError(t, err)
+		_, lic, err := licensing.TrialLicense(c, trialLicenseNsn)
+		require.NoError(t, err)
+		require.NoError(t, lic.IsMissingFields())
+		verifier := licensing.Verifier{PublicKey: key}
+		require.NoError(t, verifier.ValidSignature(lic))
+		requireNoValidationMsg(c)
+	}
+
 	type fields struct {
-		Client      k8s.Client
-		trialPubKey *rsa.PublicKey
+		Client     k8s.Client
+		trialState licensing.TrialState
 	}
 	tests := []struct {
 		name       string
@@ -107,7 +140,7 @@ func TestReconcileTrials_Reconcile(t *testing.T) {
 		{
 			name: "trial secret needs accepted EULA",
 			fields: fields{
-				Client: k8s.WrappedFakeClient(trialSecretSample(false, nil)),
+				Client: k8s.WrappedFakeClient(trialLicenseSecretSample(false, nil)),
 			},
 			wantErr:    false,
 			assertions: requireValidationMsg(EULAValidationMsg),
@@ -115,46 +148,76 @@ func TestReconcileTrials_Reconcile(t *testing.T) {
 		{
 			name: "valid trial secret inits trial",
 			fields: fields{
-				Client: k8s.WrappedFakeClient(trialSecretSample(true, nil)),
+				Client: k8s.WrappedFakeClient(trialLicenseSecretSample(true, nil)),
 			},
-			wantErr: false,
-			assertions: func(c k8s.Client) {
-				var sec v1.Secret
-				require.NoError(t, c.Get(types.NamespacedName{
-					Namespace: testNs,
-					Name:      licensing.TrialStatusSecretKey,
-				}, &sec))
-				require.NoError(t, c.Get(trialSecretNsn, &sec))
-				_, lic, err := licensing.TrialLicense(c, trialSecretNsn)
-				require.NoError(t, err)
-				require.NoError(t, lic.IsMissingFields())
-			},
+			wantErr:    false,
+			assertions: requireValidTrial,
 		},
 		{
 			name: "valid trial after operator restart",
 			fields: fields{
 				Client: func() k8s.Client {
-					trialLicense := trialSecretSample(
-						true,
-						map[string][]byte{
-							"license": trialLicenseBytes(),
-						})
-					client := k8s.WrappedFakeClient(
-						trialLicense,
-					)
+					trialLicense := trialLicenseSecretSample(true, nil)
+					client := k8s.WrappedFakeClient(trialLicense)
 					simulateRunningTrial(t, client, *trialLicense)
 					return client
 				}(),
-				trialPubKey: nil, // simulating restart
+				trialState: licensing.TrialState{}, // simulating restart
 			},
 			wantErr:    false,
-			assertions: requireNoValidationMsg,
+			assertions: requireValidTrial,
+		},
+		{
+			name: "can start trial after error during trial status creation",
+			fields: fields{
+				Client:     k8s.WrappedFakeClient(trialLicenseSecretSample(true, nil)), // no trial status
+				trialState: trialStateSample(t),
+			},
+			wantErr:    false,
+			assertions: requireValidTrial,
+		},
+		{
+			name: "can start trial after operator crash during trial activation",
+			fields: fields{
+				Client: func() k8s.Client {
+					// simulating operator crash right after trial status has been written
+					status, err := licensing.ExpectedTrialStatus(testNs, trialLicenseNsn, trialStateSample(t))
+					require.NoError(t, err)
+					return k8s.WrappedFakeClient(trialLicenseSecretSample(true, nil), &status)
+				}(),
+			},
+			wantErr:    false,
+			assertions: requireValidTrial,
+		},
+		{
+			name: "invalid: external trial status modification is not allowed once trial is running",
+			fields: fields{
+				Client: k8s.WrappedFakeClient(
+					trialLicenseSecretSample(true, nil),
+					trialStatusSecretSample(t, trialStateSample(t)), // simulate a different key
+				),
+				trialState: runningTrialSample(t),
+			},
+			wantErr:    false,
+			assertions: requireValidationMsg(trialOnlyOnceMsg),
+		},
+		{
+			name: "external trial status modification is compensated while trial is being activated",
+			fields: fields{
+				Client: k8s.WrappedFakeClient(
+					trialLicenseSecretSample(true, nil),
+					trialStatusSecretSample(t, trialStateSample(t)), // simulating a different key
+				),
+				trialState: trialStateSample(t),
+			},
+			wantErr:    false,
+			assertions: requireValidTrial,
 		},
 		{
 			name: "invalid: trial running but no status secret",
 			fields: fields{
-				Client:      k8s.WrappedFakeClient(trialSecretSample(true, nil)),
-				trialPubKey: testPubkey(t),
+				Client:     k8s.WrappedFakeClient(trialLicenseSecretSample(true, nil)),
+				trialState: runningTrialSample(t),
 			},
 			wantErr:    false,
 			assertions: requireValidationMsg(trialOnlyOnceMsg),
@@ -164,14 +227,10 @@ func TestReconcileTrials_Reconcile(t *testing.T) {
 			fields: fields{
 				Client: k8s.WrappedFakeClient(
 					// user creates a new trial secret
-					trialSecretSample(true, nil),
-					&v1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      licensing.TrialStatusSecretKey,
-							Namespace: testNs,
-						},
-					}),
-				trialPubKey: testPubkey(t), // but trial is already running
+					trialLicenseSecretSample(true, nil),
+					trialStatusSecretSample(t, trialStateSample(t)),
+				),
+				trialState: runningTrialSample(t), // but trial is already running
 			},
 			wantErr:    false,
 			assertions: requireValidationMsg(trialOnlyOnceMsg),
@@ -179,15 +238,25 @@ func TestReconcileTrials_Reconcile(t *testing.T) {
 		{
 			name: "invalid: license signature",
 			fields: fields{
-				Client: k8s.WrappedFakeClient(trialSecretSample(true, map[string][]byte{
+				Client: k8s.WrappedFakeClient(trialLicenseSecretSample(true, map[string][]byte{
 					"license": trialLicenseBytes(),
-				}), &v1.Secret{
+				}), &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      licensing.TrialStatusSecretKey,
 						Namespace: testNs,
 					},
 				}),
-				trialPubKey: testPubkey(t),
+				trialState: runningTrialSample(t),
+			},
+			wantErr:    false,
+			assertions: requireValidationMsg("trial license signature invalid"),
+		},
+		{
+			name: "invalid: trial license but no trial running",
+			fields: fields{
+				Client: k8s.WrappedFakeClient(trialLicenseSecretSample(true, map[string][]byte{
+					"license": trialLicenseBytes(),
+				})),
 			},
 			wantErr:    false,
 			assertions: requireValidationMsg("trial license signature invalid"),
@@ -199,13 +268,13 @@ func TestReconcileTrials_Reconcile(t *testing.T) {
 			r := &ReconcileTrials{
 				Client:            tt.fields.Client,
 				recorder:          record.NewFakeRecorder(10),
-				trialPubKey:       tt.fields.trialPubKey,
+				trialState:        tt.fields.trialState,
 				operatorNamespace: testNs,
 			}
 			_, err := r.Reconcile(reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: testNs,
-					Name:      trialSecretName,
+					Name:      trialLicenseName,
 				},
 			})
 			if (err != nil) != tt.wantErr {
@@ -214,6 +283,133 @@ func TestReconcileTrials_Reconcile(t *testing.T) {
 			}
 			if tt.assertions != nil {
 				tt.assertions(tt.fields.Client)
+			}
+		})
+	}
+}
+
+func TestReconcileTrials_reconcileTrialStatus(t *testing.T) {
+	var licenseSample licensing.EnterpriseLicense
+	require.NoError(t, json.Unmarshal(trialLicenseBytes(), &licenseSample))
+
+	assertTrialActivationState := func(r *ReconcileTrials, status corev1.Secret) {
+		require.False(t, r.trialState.IsTrialStarted())
+		require.Equal(t, status.Data[licensing.TrialActivationKey], []byte("true"))
+		require.Contains(t, status.Data, licensing.TrialPubkeyKey)
+	}
+
+	assertTrialRunningState := func(r *ReconcileTrials, status corev1.Secret) {
+		require.True(t, r.trialState.IsTrialStarted())
+		require.NotContains(t, status.Data, licensing.TrialActivationKey)
+		require.Contains(t, status.Data, licensing.TrialPubkeyKey)
+	}
+
+	type fields struct {
+		Client     k8s.Client
+		trialState licensing.TrialState
+		license    licensing.EnterpriseLicense
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		wantErr    bool
+		assertions func(*ReconcileTrials, corev1.Secret)
+	}{
+		{
+			name: "starts trial activation and creates status",
+			fields: fields{
+				Client: k8s.WrappedFakeClient(),
+			},
+			wantErr:    false,
+			assertions: assertTrialActivationState,
+		},
+		{
+			name: "recreates missing trial status during trial activation",
+			fields: fields{
+				Client:     k8s.WrappedFakeClient(),
+				trialState: trialStateSample(t),
+			},
+			wantErr:    false,
+			assertions: assertTrialActivationState,
+		},
+		{
+			name: "recreates missing trial status after trial activation",
+			fields: fields{
+				Client:     k8s.WrappedFakeClient(),
+				trialState: runningTrialSample(t),
+			},
+			wantErr:    false,
+			assertions: assertTrialRunningState,
+		},
+
+		{
+			name: "restore trial status memory on operator restart during activation: ok",
+			fields: fields{
+				Client: k8s.WrappedFakeClient(trialStatusSecretSample(t, trialStateSample(t))),
+			},
+			wantErr:    false,
+			assertions: assertTrialActivationState,
+		},
+		{
+			name: "restore trial status memory on operator restart during trial: ok",
+			fields: fields{
+				Client: k8s.WrappedFakeClient(trialStatusSecretSample(t, runningTrialSample(t))),
+			},
+			wantErr:    false,
+			assertions: assertTrialRunningState,
+		},
+		{
+			name: "restore trial status memory on operator restart: fail",
+			fields: fields{
+				Client: k8s.WrappedFakeClient(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      licensing.TrialStatusSecretKey,
+						Namespace: testNs,
+					},
+					Data: map[string][]byte{
+						licensing.TrialPubkeyKey: []byte("garbage"),
+					},
+				}),
+			},
+			wantErr: true,
+		},
+		{
+			name: "don't go back to activation state if a populated license exists",
+			fields: fields{
+				Client:  k8s.WrappedFakeClient(trialStatusSecretSample(t, trialStateSample(t))), // status still in activation phase
+				license: licenseSample,
+			},
+			wantErr:    false,
+			assertions: assertTrialRunningState,
+		},
+		{
+			name: "update trial status from memory",
+			fields: fields{
+				Client:     k8s.WrappedFakeClient(trialStatusSecretSample(t, trialStateSample(t))),
+				trialState: runningTrialSample(t),
+			},
+			wantErr:    false,
+			assertions: assertTrialRunningState,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ReconcileTrials{
+				Client:            tt.fields.Client,
+				recorder:          record.NewFakeRecorder(10),
+				trialState:        tt.fields.trialState,
+				operatorNamespace: testNs,
+			}
+			if err := r.reconcileTrialStatus(trialLicenseNsn, tt.fields.license); (err != nil) != tt.wantErr {
+				t.Errorf("reconcileTrialStatus() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.assertions != nil {
+				var sec corev1.Secret
+				require.NoError(t, r.Get(types.NamespacedName{
+					Namespace: testNs,
+					Name:      licensing.TrialStatusSecretKey,
+				}, &sec))
+				tt.assertions(r, sec)
 			}
 		})
 	}


### PR DESCRIPTION
 * introduce concept of trial activation where we keep the trial key around until trial successfully activated
 * fixes erroneous validation messages as seen in e2e tests
 * fixes a situation where an operator crash or a k8s API error would prevent users from ever successfully starting a trial (not yet observed in the wild but possible)

Backport of #2889

