### PR TITLE
Remove missing reference to notOnlyDocs() in E2E tests

### DIFF
--- a/.ci/pipelines/e2e-tests-testdeleteservices.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-testdeleteservices.Jenkinsfile
@@ -86,7 +86,7 @@ pipeline {
         }
         cleanup {
             script {
-                if (notOnlyDocs() && failedTests.size() == 0) {
+                if (failedTests.size() == 0) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
                         parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-debug-endpoints-e2e-${BUILD_NUMBER}")],
                         wait: false

--- a/.ci/pipelines/e2e-tests-testmutationsecondmastersetdown.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-testmutationsecondmastersetdown.Jenkinsfile
@@ -87,7 +87,7 @@ pipeline {
         }
         cleanup {
             script {
-                if (notOnlyDocs() && failedTests.size() == 0) {
+                if (failedTests.size() == 0) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
                         parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-debug-e2e-${BUILD_NUMBER}")],
                         wait: false


### PR DESCRIPTION
I missed that reference in https://github.com/elastic/cloud-on-k8s/pull/2912.