### PR TITLE
Close client after noop observer comparisons

### DIFF
--- a/pkg/controller/elasticsearch/observer/manager.go
+++ b/pkg/controller/elasticsearch/observer/manager.go
@@ -49,6 +49,7 @@ func (m *Manager) Observe(cluster types.NamespacedName, esClient client.Client) 
 		m.StopObserving(cluster)
 		return m.createObserver(cluster, esClient)
 	default:
+		esClient.Close()
 		return observer
 	}
 }


### PR DESCRIPTION
Fixes #2911 

Close newly created Elasticsearch client if observer comparison results in the new client not being used.