### PR TITLE
Upgrade apm agent to latest master commit (#2921)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1831,11 +1831,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 Module  : go.elastic.co/apm
-Version : v1.7.0
-Time    : 2020-01-10T03:30:49Z
+Version : v1.7.2
+Time    : 2020-03-19T02:03:18Z
 Licence : Apache-2.0
 
-Contents of probable licence file $GOMODCACHE/go.elastic.co/apm@v1.7.0/LICENSE:
+Contents of probable licence file $GOMODCACHE/go.elastic.co/apm@v1.7.2/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004
@@ -2042,11 +2042,11 @@ Contents of probable licence file $GOMODCACHE/go.elastic.co/apm@v1.7.0/LICENSE:
 
 --------------------------------------------------------------------------------
 Module  : go.elastic.co/apm/module/apmelasticsearch
-Version : v1.7.0
-Time    : 2020-01-10T03:30:49Z
+Version : v1.7.3-0.20200421085619-eea0ff3c17de
+Time    : 2020-04-21T08:56:19Z
 Licence : Apache-2.0
 
-Contents of probable licence file $GOMODCACHE/go.elastic.co/apm/module/apmelasticsearch@v1.7.0/LICENSE:
+Contents of probable licence file $GOMODCACHE/go.elastic.co/apm/module/apmelasticsearch@v1.7.3-0.20200421085619-eea0ff3c17de/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004
@@ -8325,6 +8325,37 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
 OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+--------------------------------------------------------------------------------
+Module  : github.com/cucumber/godog
+Version : v0.8.1
+Time    : 2020-02-10T17:55:33Z
+Licence : MIT
+
+Contents of probable licence file $GOMODCACHE/github.com/cucumber/godog@v0.8.1/LICENSE:
+
+The MIT License (MIT)
+
+Copyright (c) SmartBear
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
 --------------------------------------------------------------------------------
@@ -25422,11 +25453,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 --------------------------------------------------------------------------------
 Module  : go.elastic.co/apm/module/apmhttp
-Version : v1.7.0
-Time    : 2020-01-10T03:30:49Z
+Version : v1.7.2
+Time    : 2020-03-19T02:03:18Z
 Licence : Apache-2.0
 
-Contents of probable licence file $GOMODCACHE/go.elastic.co/apm/module/apmhttp@v1.7.0/LICENSE:
+Contents of probable licence file $GOMODCACHE/go.elastic.co/apm/module/apmhttp@v1.7.2/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/docs/reference/dependencies.asciidoc
+++ b/docs/reference/dependencies.asciidoc
@@ -38,8 +38,8 @@ This page lists the third-party dependencies used to build {n}.
 | link:https://github.com/spf13/viper[$$github.com/spf13/viper$$] | v1.4.0 | MIT
 | link:https://github.com/stretchr/testify[$$github.com/stretchr/testify$$] | v1.4.0 | MIT
 | link:https://github.com/tsenart/vegeta[$$github.com/tsenart/vegeta$$] | v12.7.0+incompatible | MIT
-| link:https://go.elastic.co/apm[$$go.elastic.co/apm$$] | v1.7.0 | Apache-2.0
-| link:https://go.elastic.co/apm/module/apmelasticsearch[$$go.elastic.co/apm/module/apmelasticsearch$$] | v1.7.0 | Apache-2.0
+| link:https://go.elastic.co/apm[$$go.elastic.co/apm$$] | v1.7.2 | Apache-2.0
+| link:https://go.elastic.co/apm/module/apmelasticsearch[$$go.elastic.co/apm/module/apmelasticsearch$$] | v1.7.3-0.20200421085619-eea0ff3c17de | Apache-2.0
 | link:https://go.uber.org/automaxprocs[$$go.uber.org/automaxprocs$$] | v1.3.0 | MIT
 | link:https://go.uber.org/zap[$$go.uber.org/zap$$] | v1.12.0 | MIT
 | link:https://golang.org/x/crypto[$$golang.org/x/crypto$$] | v0.0.0-20191011191535-87dc89f01550 | BSD-3-Clause
@@ -104,6 +104,7 @@ This page lists the third-party dependencies used to build {n}.
 | link:https://github.com/coreos/pkg[$$github.com/coreos/pkg$$] | v0.0.0-20180928190104-399ea9e2e55f | Apache-2.0
 | link:https://github.com/cpuguy83/go-md2man[$$github.com/cpuguy83/go-md2man$$] | v1.0.10 | MIT
 | link:https://github.com/creack/pty[$$github.com/creack/pty$$] | v1.1.7 | MIT
+| link:https://github.com/cucumber/godog[$$github.com/cucumber/godog$$] | v0.8.1 | MIT
 | link:https://github.com/dgrijalva/jwt-go[$$github.com/dgrijalva/jwt-go$$] | v3.2.0+incompatible | MIT
 | link:https://github.com/dgryski/go-gk[$$github.com/dgryski/go-gk$$] | v0.0.0-20200319235926-a69029f61654 | MIT
 | link:https://github.com/dgryski/go-sip13[$$github.com/dgryski/go-sip13$$] | v0.0.0-20181026042036-e10d5fee7954 | MIT
@@ -248,7 +249,7 @@ This page lists the third-party dependencies used to build {n}.
 | link:https://github.com/vektah/gqlparser[$$github.com/vektah/gqlparser$$] | v1.1.2 | MIT
 | link:https://github.com/xiang90/probing[$$github.com/xiang90/probing$$] | v0.0.0-20190116061207-43a291ad63a2 | MIT
 | link:https://github.com/xordataexchange/crypt[$$github.com/xordataexchange/crypt$$] | v0.0.3-0.20170626215501-b2862e3d0a77 | MIT
-| link:https://go.elastic.co/apm/module/apmhttp[$$go.elastic.co/apm/module/apmhttp$$] | v1.7.0 | Apache-2.0
+| link:https://go.elastic.co/apm/module/apmhttp[$$go.elastic.co/apm/module/apmhttp$$] | v1.7.2 | Apache-2.0
 | link:https://go.elastic.co/fastjson[$$go.elastic.co/fastjson$$] | v1.0.0 | MIT
 | link:https://go.etcd.io/bbolt[$$go.etcd.io/bbolt$$] | v1.3.3 | MIT
 | link:https://go.etcd.io/etcd[$$go.etcd.io/etcd$$] | v0.0.0-20191023171146-3cf2f69b5738 | Apache-2.0

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/elastic/cloud-on-k8s
 go 1.13
 
 require (
+	github.com/DATA-DOG/godog v0.7.13 // indirect
 	github.com/Masterminds/goutils v1.1.0 // indirect
 	github.com/Masterminds/semver v1.4.2 // indirect
 	github.com/Masterminds/sprig v2.20.0+incompatible
@@ -41,8 +42,8 @@ require (
 	github.com/streadway/quantile v0.0.0-20150917103942-b0c588724d25 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/tsenart/vegeta v12.7.0+incompatible
-	go.elastic.co/apm v1.7.0
-	go.elastic.co/apm/module/apmelasticsearch v1.7.0
+	go.elastic.co/apm v1.7.2
+	go.elastic.co/apm/module/apmelasticsearch v1.7.3-0.20200421085619-eea0ff3c17de
 	go.uber.org/automaxprocs v1.3.0
 	go.uber.org/zap v1.12.0
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,7 @@ github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -473,10 +474,16 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.elastic.co/apm v1.7.0 h1:vd4ncfZ/Y2GIsWW7aFR4uQdqmfUbuHfUhglqOqEwrUI=
 go.elastic.co/apm v1.7.0/go.mod h1:IYfi/330rWC5Kfns1rM+kY+RPkIdgUziRF6Cbm9qlxQ=
+go.elastic.co/apm v1.7.2 h1:0nwzVIPp4PDBXSYYtN19+1W5V+sj+C25UjqxDVoKcA8=
+go.elastic.co/apm v1.7.2/go.mod h1:tCw6CkOJgkWnzEthFN9HUP1uL3Gjc/Ur6m7gRPLaoH0=
 go.elastic.co/apm/module/apmelasticsearch v1.7.0 h1:lcEOohYtLdnd1hBqsQlJX6p8djGWgRML1YXjv0L/Xfg=
 go.elastic.co/apm/module/apmelasticsearch v1.7.0/go.mod h1:EjopyfrJzqgwXp7ZpSX0lSWqzRrINrKMfUXIlBjeOXY=
+go.elastic.co/apm/module/apmelasticsearch v1.7.3-0.20200421085619-eea0ff3c17de h1:pH3DiXpr37z0rpH3TAhfR7AdiUJ1A0FTmjK0wgdAXLo=
+go.elastic.co/apm/module/apmelasticsearch v1.7.3-0.20200421085619-eea0ff3c17de/go.mod h1:ZyNFuyWdt42GBZkz0SogoLzDBrBGj4orxpiUuxYeYq8=
 go.elastic.co/apm/module/apmhttp v1.7.0 h1:dwUkUHlGR6W7FSAxdsZvO3tz+IaLxlXSnwH7ABahJdc=
 go.elastic.co/apm/module/apmhttp v1.7.0/go.mod h1:70/fYU6lgIII213g7As10lm2Ca/ZkGixeJBoyfrGKes=
+go.elastic.co/apm/module/apmhttp v1.7.2 h1:2mRh7SwBuEVLmJlX+hsMdcSg9xaielCLElaPn/+i34w=
+go.elastic.co/apm/module/apmhttp v1.7.2/go.mod h1:sTFWiWejnhSdZv6+dMgxGec2Nxe/ZKfHfz/xtRM+cRY=
 go.elastic.co/fastjson v1.0.0 h1:ooXV/ABvf+tBul26jcVViPT3sBir0PvXgibYB1IQQzg=
 go.elastic.co/fastjson v1.0.0/go.mod h1:PmeUOMMtLHQr9ZS9J9owrAVg0FkaZDRZJEFTTGHtchs=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=


### PR DESCRIPTION
This upgrades the APM agent to an unreleased but fixed version which propagates CloseIdleConnection calls to the underlying transport. Integrating this change should fix the goroutine leak we have observed.

Backport of #2921