### PR TITLE
Cleanup e2e debug clusters if successful only

### DIFF
--- a/.ci/pipelines/e2e-tests-testdeleteservices.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-testdeleteservices.Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
     post {
         success {
             build job: 'cloud-on-k8s-e2e-cleanup',
-                parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-debug-e2e-${BUILD_NUMBER}")],
+                parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-debug-endpoints-e2e-${BUILD_NUMBER}")],
                 wait: false
         }
         unsuccessful {

--- a/.ci/pipelines/e2e-tests-testdeleteservices.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-testdeleteservices.Jenkinsfile
@@ -70,6 +70,11 @@ pipeline {
     }
 
     post {
+        success {
+            build job: 'cloud-on-k8s-e2e-cleanup',
+                parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-debug-e2e-${BUILD_NUMBER}")],
+                wait: false
+        }
         unsuccessful {
             script {
                 def msg = lib.generateSlackMessage("E2E tests failed!", env.BUILD_URL, failedTests)
@@ -85,14 +90,6 @@ pipeline {
             }
         }
         cleanup {
-            script {
-                if (failedTests.size() == 0) {
-                    build job: 'cloud-on-k8s-e2e-cleanup',
-                        parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-debug-endpoints-e2e-${BUILD_NUMBER}")],
-                        wait: false
-                }
-            }
-
             cleanWs()
         }
     }

--- a/.ci/pipelines/e2e-tests-testmutationsecondmastersetdown.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-testmutationsecondmastersetdown.Jenkinsfile
@@ -71,6 +71,11 @@ pipeline {
     }
 
     post {
+        success {
+            build job: 'cloud-on-k8s-e2e-cleanup',
+                parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-debug-e2e-${BUILD_NUMBER}")],
+                wait: false
+        }
         unsuccessful {
             script {
                 def msg = lib.generateSlackMessage("E2E tests failed!", env.BUILD_URL, failedTests)
@@ -86,14 +91,6 @@ pipeline {
             }
         }
         cleanup {
-            script {
-                if (failedTests.size() == 0) {
-                    build job: 'cloud-on-k8s-e2e-cleanup',
-                        parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-debug-e2e-${BUILD_NUMBER}")],
-                        wait: false
-                }
-            }
-
             cleanWs()
         }
     }


### PR DESCRIPTION
A quickfix to only clean up k8s clusters when the job was succesful,
since our logic of checking failed tests seems to fail. For temporary e2e debug tests only.