### PR TITLE
Regenerate 1.1.0 release notes

### DIFF
--- a/docs/release-notes/1.1.0.asciidoc
+++ b/docs/release-notes/1.1.0.asciidoc
@@ -24,6 +24,8 @@
 [float]
 === Enhancements
 
+* Validate unknown fields in ES v1beta1 {pull}2896[#2896]
+* Sort StatefulSets retrieved for a given ES cluster {pull}2882[#2882] (issue: {issue}2864[#2864])
 * Improve secure string generation {pull}2794[#2794]
 * Rename pause annotation {pull}2783[#2783]
 * Add validation webhook configurations for all resource types {pull}2781[#2781]
@@ -31,12 +33,9 @@
 * Add automaxprocs {pull}2724[#2724]
 * Make transport service customizable {pull}2691[#2691]
 * Add the transport service DNS name to the CSR {pull}2687[#2687]
-* Update transport cert verification to full {pull}2659[#2659]
-* Do not call the voting config exclusions API at every single reconciliation {pull}2642[#2642] (issue: {issue}2605[#2605])
 * User-provided config take precedence over operator config {pull}2636[#2636]
 * Validate duplicated nodeSet names {pull}2631[#2631]
 * Stub initial support for Elastic stack version 8.0 {pull}2613[#2613]
-* Do not request ES to clear routing allocation exclude at every reconciliation {pull}2610[#2610] (issue: {issue}1522[#1522])
 * Get endpoints as part of the diagnostics bundle {pull}2603[#2603] (issue: {issue}2602[#2602])
 * ECK dump: export controller revisions {pull}2538[#2538]
 * Add operator flag to define default container registry {pull}2537[#2537]
@@ -56,6 +55,15 @@
 [float]
 === Bug fixes
 
+* Upgrade apm agent to latest master commit {pull}2921[#2921]
+* Close client after noop observer comparisons {pull}2916[#2916]
+* Use annotation to track created remote clusters {pull}2891[#2891]
+* Fix trial license validation issues {pull}2889[#2889]
+* Do not use annotations to cache Elasticsearch API calls {pull}2880[#2880]
+* Watch only trial license secret (not trial status) {pull}2879[#2879]
+* Add Elasticsearch client cache {pull}2875[#2875]
+* Do not reject PVC update when a different unit is used {pull}2857[#2857] (issue: {issue}2856[#2856])
+* Revert transport TLS certs verification from full to certificate {pull}2831[#2831] (issue: {issue}2823[#2823])
 * Fix labels on ES CA secret for Kibana association {pull}2773[#2773] (issue: {issue}2698[#2698])
 * Ensure that HTTP CA cert is always set {pull}2772[#2772]
 * License check: update remote cluster logs and events {pull}2746[#2746]

--- a/hack/licence-detector/README.md
+++ b/hack/licence-detector/README.md
@@ -73,6 +73,6 @@ To generate the dependency list (`docs/container-image-dependencies.csv`) for a 
 IMAGE_TAG=1.0.1 ./generate-image-deps.sh
 ```
 
-Note that Tern requires sudo access to mount the procfs file system and inspect the container layers. The script will prompt for the sudo password when needed.
+Note that Tern is Linux only (there are Vagrant instructions for OSX in the Tern repo) and requires sudo access to mount the procfs file system and inspect the container layers. The script will prompt for the sudo password when needed.
 
 This script requires Docker, Python, and jq to be installed on the machine.


### PR DESCRIPTION
I also tried to update the base image release notes, but failed because the tool is Linux only. That said, to save some whoever runs it in the future some time, you will also need to remove the `-l` option as tern removed it in the 2.0 release: https://github.com/tern-tools/tern/blob/master/docs/releases/v2_0_0.md

I would have removed it in this PR but since I couldn't verify that was the only change needed I did not touch it.