### PR TITLE
Avoid unnecessary bcrypt computation

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,7 +24,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/apmserver"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association/controller"
-	associationctl "github.com/elastic/cloud-on-k8s/pkg/controller/association/controller"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/container"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
@@ -347,7 +346,7 @@ func execute() {
 		log.Error(err, "unable to create controller", "controller", "EnterpriseSearch")
 		os.Exit(1)
 	}
-	if err = associationctl.AddApmES(mgr, accessReviewer, params); err != nil {
+	if err = controller.AddApmES(mgr, accessReviewer, params); err != nil {
 		log.Error(err, "unable to create controller", "controller", "apm-es-association")
 		os.Exit(1)
 	}
@@ -410,9 +409,9 @@ func garbageCollectUsers(cfg *rest.Config, managedNamespaces []string) {
 		os.Exit(1)
 	}
 	err = ugc.
-		For(&apmv1.ApmServerList{}, associationctl.ApmESAssociationLabelNamespace, associationctl.ApmESAssociationLabelName).
-		For(&kbv1.KibanaList{}, associationctl.KibanaESAssociationLabelNamespace, associationctl.KibanaESAssociationLabelName).
-		For(&entv1beta1.EnterpriseSearchList{}, associationctl.EntESAssociationLabelNamespace, associationctl.EntESAssociationLabelName).
+		For(&apmv1.ApmServerList{}, controller.ApmESAssociationLabelNamespace, controller.ApmESAssociationLabelName).
+		For(&kbv1.KibanaList{}, controller.KibanaESAssociationLabelNamespace, controller.KibanaESAssociationLabelName).
+		For(&entv1beta1.EnterpriseSearchList{}, controller.EntESAssociationLabelNamespace, controller.EntESAssociationLabelName).
 		DoGarbageCollection()
 	if err != nil {
 		log.Error(err, "user garbage collector failed")

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -23,7 +23,7 @@ import (
 	kbv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/apmserver"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/association/controller"
+	associationctl "github.com/elastic/cloud-on-k8s/pkg/controller/association/controller"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/container"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
@@ -346,15 +346,15 @@ func execute() {
 		log.Error(err, "unable to create controller", "controller", "EnterpriseSearch")
 		os.Exit(1)
 	}
-	if err = controller.AddApmES(mgr, accessReviewer, params); err != nil {
+	if err = associationctl.AddApmES(mgr, accessReviewer, params); err != nil {
 		log.Error(err, "unable to create controller", "controller", "apm-es-association")
 		os.Exit(1)
 	}
-	if err = controller.AddKibanaES(mgr, accessReviewer, params); err != nil {
+	if err = associationctl.AddKibanaES(mgr, accessReviewer, params); err != nil {
 		log.Error(err, "unable to create controller", "controller", "kibana-es-association")
 		os.Exit(1)
 	}
-	if err = controller.AddEntES(mgr, accessReviewer, params); err != nil {
+	if err = associationctl.AddEntES(mgr, accessReviewer, params); err != nil {
 		log.Error(err, "unable to create controller", "controller", "ent-es-association")
 		os.Exit(1)
 	}
@@ -409,9 +409,9 @@ func garbageCollectUsers(cfg *rest.Config, managedNamespaces []string) {
 		os.Exit(1)
 	}
 	err = ugc.
-		For(&apmv1.ApmServerList{}, controller.ApmESAssociationLabelNamespace, controller.ApmESAssociationLabelName).
-		For(&kbv1.KibanaList{}, controller.KibanaESAssociationLabelNamespace, controller.KibanaESAssociationLabelName).
-		For(&entv1beta1.EnterpriseSearchList{}, controller.EntESAssociationLabelNamespace, controller.EntESAssociationLabelName).
+		For(&apmv1.ApmServerList{}, associationctl.ApmESAssociationLabelNamespace, associationctl.ApmESAssociationLabelName).
+		For(&kbv1.KibanaList{}, associationctl.KibanaESAssociationLabelNamespace, associationctl.KibanaESAssociationLabelName).
+		For(&entv1beta1.EnterpriseSearchList{}, associationctl.EntESAssociationLabelNamespace, associationctl.EntESAssociationLabelName).
 		DoGarbageCollection()
 	if err != nil {
 		log.Error(err, "user garbage collector failed")

--- a/pkg/controller/enterprisesearch/config_test.go
+++ b/pkg/controller/enterprisesearch/config_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -150,7 +149,7 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 			name: "Do not override existing keys",
 			args: args{
 				c: k8s.WrappedFakeClient(
-					&v1.Secret{
+					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "ent-sample-ent-config"},
 						Data: map[string][]byte{
 							ConfigFilename: []byte(existingConfigWithReusableSettings),
@@ -173,7 +172,7 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 			name: "Do not override existing encryption keys, create missing session key",
 			args: args{
 				c: k8s.WrappedFakeClient(
-					&v1.Secret{
+					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "ent-sample-ent-config"},
 						Data: map[string][]byte{
 							ConfigFilename: []byte(existingConfig),
@@ -197,7 +196,7 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 			name: "Create missing keys",
 			args: args{
 				c: k8s.WrappedFakeClient(
-					&v1.Secret{
+					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "ent-sample-ent-config"},
 						Data: map[string][]byte{
 							ConfigFilename: []byte(existingConfig),


### PR DESCRIPTION
Noticed during profiling that the association controller was spending a lot of time on a bcrypt computation that gets thrown away most of the time. This patch avoids the computation if it is not necessary.

Also includes linter fixes to remove duplicate imports in `cmd/manager/main.go` and `pkg/controller/enterprisesearch/config_test.go`.