### PR TITLE
Freeze tern to version 2.0.0

### DIFF
--- a/hack/licence-detector/generate-image-deps.sh
+++ b/hack/licence-detector/generate-image-deps.sh
@@ -20,12 +20,12 @@ install_tern() {
     (
         cd "$SCRATCH_DIR"
         python3 -m venv ternenv
-        ternenv/bin/pip install tern
+        ternenv/bin/pip install tern==2.0.0
     )
 }
 
 generate_csv() {
-    "${SCRATCH_DIR}"/ternenv/bin/tern -l report -f json -i "${IMAGE_NAME}:${IMAGE_TAG}" | \
+    "${SCRATCH_DIR}"/ternenv/bin/tern report -f json -i "${IMAGE_NAME}:${IMAGE_TAG}" | \
         jq -r '.images[].image.layers[].packages |= sort_by(.name) | .images[].image.layers[].packages[] | [.name, .version, .pkg_license, .proj_url] | @csv' > "${OUT_FILE}"
 }
 


### PR DESCRIPTION
This will prevent something from being broken by unexpectedly getting
the latest version.

I was running the `hack/licence-detector/generate-image-deps.sh` script to update the dependency list of the container image. It was the first time and I got version 2.0.0 which no longer has the `-l` option.