### PR TITLE
Clarify documentation about ECK support and licensing (#2747)

### DIFF
--- a/docs/operating-eck/licensing.asciidoc
+++ b/docs/operating-eck/licensing.asciidoc
@@ -9,6 +9,8 @@ endif::[]
 
 When you install the default distribution of ECK, you receive a Basic license. Any Elastic stack application you manage through ECK will also be Basic licensed. Go to https://www.elastic.co/subscriptions to see which features are included in the Basic license for free.
 
+IMPORTANT: ECK is only offered in two licensing tiers: Basic and Enterprise. Similar to the Elastic Stack, customers are able to download and use ECK with a Basic license for free. Basic license users can avail of support from GitHub or through our link:https://discuss.elastic.co[community]. A paid Enterprise subscription is required to engage the Elastic support team. For more details, see the link:https://www.elastic.co/subscriptions[Elastic subscriptions].
+
 [float]
 == Start a trial
 If you want to try the features included in the Enterprise subscription, you can start a 30-day trial. To start a trial create a Kubernetes secret as shown below. Note that it must be in the same namespace as the operator:


### PR DESCRIPTION
Backport of #2747.