### PR TITLE
Set kubernetes version for kind e2e test results reporting

### DIFF
--- a/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
                     steps {
                         checkout scm
                         script {
-                            runTests(lib, failedTests, "kindest/node:v1.12.10")
+                            runTests(lib, failedTests, "kindest/node:v1.12.10", "1.12")
                         }
                     }
                 }
@@ -51,7 +51,7 @@ pipeline {
                     steps {
                         checkout scm
                         script {
-                            runTests(lib, failedTests, "kindest/node:v1.16.4")
+                            runTests(lib, failedTests, "kindest/node:v1.16.4", "1.16")
                         }
                     }
                 }
@@ -62,7 +62,7 @@ pipeline {
                     steps {
                         checkout scm
                         script {
-                            runTests(lib, failedTests, "kindest/node:v1.17.0")
+                            runTests(lib, failedTests, "kindest/node:v1.17.0", "1.17")
                         }
                     }
                 }
@@ -96,8 +96,8 @@ pipeline {
 
 }
 
-def runTests(lib, failedTests, kindNodeImage) {
-    sh ".ci/setenvconfig e2e/kind-k8s-versions $kindNodeImage"
+def runTests(lib, failedTests, kindNodeImage, clusterVersion) {
+    sh ".ci/setenvconfig e2e/kind-k8s-versions $kindNodeImage $clusterVersion"
     script {
         env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-test-artifacts TARGET=kind-e2e ci')
 

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -147,6 +147,7 @@ CFG
 ######################################
 
 kindNodeImage=$2
+clusterVersion=$3
 
 write_env <<ENV
 REGISTRY = eu.gcr.io
@@ -165,7 +166,7 @@ PIPELINE=e2e/kind-k8s-versions
 BUILD_NUMBER=$BUILD_NUMBER
 E2E_PROVIDER=kind
 CLUSTER_NAME=kind-$BUILD_NUMBER
-KUBERNETES_VERSION=default
+KUBERNETES_VERSION=${clusterVersion}
 TEST_OPTS=-race
 ENV
 ;;


### PR DESCRIPTION
Start passing version information about kubernetes used in kind runs. Patch part omitted for consistency with GKE where we only provider major and minor.