### PR TITLE
Stop setting up local disks by default

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -28,8 +28,6 @@ plans:
     adminUsername: admin
     localSsdCount: 1
     nodeCountPerZone: 1
-    # use kustomize in GKE to remove the NVMe provisioning already taken care of by the platform
-    diskSetup: kubectl apply -k hack/deployer/config/local-disks
     # gke creates a secondary IP range for all Pods of a cluster
     # gke defaults to a /14 subnet, which allows 262k Pods per cluster, but only 62 subnets to be created
     # /20 allows 4094 subnets, with up to 4094 IPs (Pods) per subnet
@@ -103,7 +101,6 @@ plans:
     region: eu-west-2
     nodeCount: 3
     nodeAMI: static
-    diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
 - id: e2e-monitor
   operation: create
   clusterName: e2e-monitor


### PR DESCRIPTION
By default we set up local disks when creating a cluster on GKE and EKS. This is not needed for the general case of creating a Kubernetes cluster and was a surprising artifact for some users creating their clusters, so I've removed it from the default (`gke-dev` and `eks-dev`) plans. If it's still needed for testing "locally" it can be added directly in `hack/deployer/config/deployer-config-gke|eks.yml` file.