### PR TITLE
Upgrade local volume provisioner to v2.3.4

### DIFF
--- a/hack/deployer/config/local-disks/ssd-provisioner.yaml
+++ b/hack/deployer/config/local-disks/ssd-provisioner.yaml
@@ -123,7 +123,7 @@ spec:
             name: e2e-default
             mountPropagation: Bidirectional
       containers:
-        - image: "quay.io/external_storage/local-volume-provisioner:v2.2.0"
+        - image: "quay.io/external_storage/local-volume-provisioner:v2.3.4"
           imagePullPolicy: "Always"
           name: provisioner
           securityContext:


### PR DESCRIPTION
Upgrade the local volume provisioner from 2.2.0 to 2.3.4.

Let's hope https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/pull/174
fixes the bug we recently observed with data not being cleaned up.

Fixes https://github.com/elastic/cloud-on-k8s/issues/2937.