### PR TITLE
Fix rendering of ES version in the filerealm doc example

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
@@ -84,7 +84,7 @@ You can populate the content of both `users` and `users_roles` using the link:ht
 
 For example, invoking the tool in a Docker container:
 
-[source,sh]
+[source,sh,subs="attributes"]
 ----
 # create a folder with the 2 files
 mkdir filerealm


### PR DESCRIPTION
We were missing an attribute to render the `{version}` field dynamically.