### PR TITLE
Backport - Fix rendering of ES version in the filerealm doc example (#2952)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
@@ -84,7 +84,7 @@ You can populate the content of both `users` and `users_roles` using the link:ht
 
 For example, invoking the tool in a Docker container:
 
-[source,sh]
+[source,sh,subs="attributes"]
 ----
 # create a folder with the 2 files
 mkdir filerealm


### PR DESCRIPTION
Backports https://github.com/elastic/cloud-on-k8s/pull/2952 (doc fix only) on 1.1.

We were missing an attribute to render the {version} field dynamically.
