### PR TITLE
Make EKS deployer consistent with GKE one

### DIFF
--- a/hack/deployer/runner/eks.go
+++ b/hack/deployer/runner/eks.go
@@ -119,12 +119,13 @@ func (e *EKSDriver) Execute() error {
 			if err := e.newCmd(`eksctl create cluster -v 0 -f {{.CreateCfgFile}}`).Run(); err != nil {
 				return err
 			}
-			if err := createStorageClass(NoProvisioner); err != nil {
-				return err
-			}
-			return NewCommand(e.plan.EKS.DiskSetup).Run()
+		} else {
+			log.Printf("Not creating cluster as it already exists")
 		}
-		log.Printf("Not creating cluster as it already exists")
+		if err := createStorageClass(NoProvisioner); err != nil {
+			return err
+		}
+		return NewCommand(e.plan.EKS.DiskSetup).Run()
 	}
 	return nil
 }


### PR DESCRIPTION
We run disk setup in any case in the GKE deployer even if the k8s cluster already exists.
This changes the EKS deployer to have the same behaviour.