### PR TITLE
Remove portforward logs from the `make go-run` output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,8 @@ go-run:
 				--ca-cert-validity=10h --ca-cert-rotate-before=1h \
 				--operator-namespace=default \
 				--namespaces=$(MANAGED_NAMESPACES) \
-				--manage-webhook-certs=false
+				--manage-webhook-certs=false \
+				2>&1 | grep -v "dev-portforward" # remove dev-portforward logs from the output
 
 go-debug:
 	@(cd cmd &&	AUTO_PORT_FORWARD=true dlv debug \

--- a/pkg/dev/portforward/doc.go
+++ b/pkg/dev/portforward/doc.go
@@ -16,5 +16,5 @@ import (
 )
 
 var (
-	log = logf.Log.WithName("portforward")
+	log = logf.Log.WithName("dev-portforward")
 )


### PR DESCRIPTION
I'm getting annoyed with the portforward logs that spam the (already
verbose) log output. I think we're fairly confident the dev portforward mode
works well so it's OK to remove them from the `make go-run` target?

I also renamed the logger to `dev-portforward` for a smaller chance to
ignore important logs with the word "portforward".