### PR TITLE
Run yum update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
 # Copy the operator binary into a lighter image
 FROM centos:8
 
+RUN yum update --setopt=tsflags=nodocs -y && yum clean all
+
 RUN set -x \
     && groupadd --system --gid 101 elastic \
     && useradd --system -g elastic -m --home /eck -c "eck user" --shell /bin/false --uid 101 elastic \


### PR DESCRIPTION
The centos images are not kept as up to date as we would like. Running this against the centos:8 image now gives the output attached. This should help keep us up to date and minimize the amount of false positives in container vulnerability scans. The [Elasticsearch image](https://github.com/elastic/elasticsearch/blob/master/distribution/docker/src/docker/Dockerfile) already does this, as does the [Kibana image](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/templates/dockerfile.template.js#L58).

In the future I think we should consider changing the base, but in the meantime we can at least do this.

```
================================================================================
 Package                Arch   Version                          Repo       Size
================================================================================
Upgrading:
 audit-libs             x86_64 3.0-0.13.20190507gitf58ec40.el8  BaseOS    116 k
 binutils               x86_64 2.30-58.el8_1.2                  BaseOS    5.7 M
 centos-gpg-keys        noarch 8.1-1.1911.0.9.el8               BaseOS     12 k
 centos-release         x86_64 8.1-1.1911.0.9.el8               BaseOS     21 k
 centos-repos           x86_64 8.1-1.1911.0.9.el8               BaseOS     13 k
 coreutils-single       x86_64 8.30-6.el8_1.1                   BaseOS    630 k
 glibc                  x86_64 2.28-72.el8_1.1                  BaseOS    3.7 M
 glibc-common           x86_64 2.28-72.el8_1.1                  BaseOS    836 k
 glibc-minimal-langpack x86_64 2.28-72.el8_1.1                  BaseOS     48 k
 kexec-tools            x86_64 2.0.19-12.el8_1.2                BaseOS    482 k
 libarchive             x86_64 3.3.2-8.el8_1                    BaseOS    359 k
 openldap               x86_64 2.4.46-11.el8_1                  BaseOS    352 k
 openssl-libs           x86_64 1:1.1.1c-2.el8_1.1               BaseOS    1.5 M
 python3-rpm            x86_64 4.14.2-26.el8_1                  BaseOS    156 k
 rpm                    x86_64 4.14.2-26.el8_1                  BaseOS    539 k
 rpm-build-libs         x86_64 4.14.2-26.el8_1                  BaseOS    153 k
 rpm-libs               x86_64 4.14.2-26.el8_1                  BaseOS    336 k
 sqlite-libs            x86_64 3.26.0-4.el8_1                   BaseOS    579 k
 systemd                x86_64 239-18.el8_1.5                   BaseOS    3.5 M
 systemd-libs           x86_64 239-18.el8_1.5                   BaseOS    562 k
 systemd-pam            x86_64 239-18.el8_1.5                   BaseOS    232 k
 systemd-udev           x86_64 239-18.el8_1.5                   BaseOS    1.3 M
Installing dependencies:
 xkeyboard-config       noarch 2.24-3.el8                       AppStream 828 k
 kbd-legacy             noarch 2.0.4-8.el8                      BaseOS    481 k
 kbd-misc               noarch 2.0.4-8.el8                      BaseOS    1.4 M
 openssl                x86_64 1:1.1.1c-2.el8_1.1               BaseOS    686 k
Installing weak dependencies:
 libxkbcommon           x86_64 0.8.2-1.el8                      AppStream 116 k
 diffutils              x86_64 3.6-5.el8                        BaseOS    359 k
 glibc-langpack-en      x86_64 2.28-72.el8_1.1                  BaseOS    818 k
 kbd                    x86_64 2.0.4-8.el8                      BaseOS    392 k
 openssl-pkcs11         x86_64 0.4.8-2.el8                      BaseOS     64 k

Transaction Summary
================================================================================
Install   9 Packages
Upgrade  22 Packages
```