### PR TITLE
Wrap Kibana telemetry E2E API call in a retry block

### DIFF
--- a/test/e2e/kb/telemetry_test.go
+++ b/test/e2e/kb/telemetry_test.go
@@ -59,7 +59,7 @@ func TestTelemetry(t *testing.T) {
 					}
 					eck := stats[0].StackStats.Kibana.Plugins.StaticTelemetry.Eck
 					if !eck.IsDefined() {
-							return fmt.Errorf("eck info not defined properly in telemetry data: %+v", eck)
+						return fmt.Errorf("eck info not defined properly in telemetry data: %+v", eck)
 					}
 					return nil
 				}),


### PR DESCRIPTION
The API request for Kibana telemetry may fail with an error 500 when the
following sequence of events occur:

1. The .security-7 index creation starts. No primary shard available yet.
2. We do the Kibana API request, which in turn requests Elasticsearch,
which fails since .security-7 is not fully initialized yet.
3. The .security-7 index creation is complete, with primary shards
available.

A simple fix is to retry that step until it succeeds. It catches more
than this exact error since it retries on any error, but it also catches
any network glitch. Which is fine, I think.

Fixes https://github.com/elastic/cloud-on-k8s/issues/2970.