### PR TITLE
Fix user http tls certificate watch leak

### DIFF
--- a/pkg/controller/apmserver/apmserver_controller.go
+++ b/pkg/controller/apmserver/apmserver_controller.go
@@ -288,6 +288,8 @@ func (r *ReconcileApmServer) validate(ctx context.Context, as *apmv1.ApmServer) 
 func (r *ReconcileApmServer) onDelete(obj types.NamespacedName) {
 	// Clean up watches set on secure settings
 	r.dynamicWatches.Secrets.RemoveHandlerForKey(keystore.SecureSettingsWatchName(obj))
+	// Clean up watches set on custom http tls certificates
+	r.dynamicWatches.Secrets.RemoveHandlerForKey(certificates.CertificateWatchKey(apmname.APMNamer, obj.Name))
 }
 
 // reconcileApmServerToken reconciles a Secret containing the APM Server token.

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller.go
@@ -199,6 +199,8 @@ func (r *ReconcileEnterpriseSearch) Reconcile(request reconcile.Request) (reconc
 func (r *ReconcileEnterpriseSearch) onDelete(obj types.NamespacedName) {
 	// Clean up watches
 	r.dynamicWatches.Secrets.RemoveHandlerForKey(configRefWatchName(obj))
+	// Clean up watches set on custom http tls certificates
+	r.dynamicWatches.Secrets.RemoveHandlerForKey(certificates.CertificateWatchKey(entName.EntNamer, obj.Name))
 }
 
 func (r *ReconcileEnterpriseSearch) isCompatible(ctx context.Context, ent *entv1beta1.EnterpriseSearch) (bool, error) {

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller_test.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller_test.go
@@ -95,8 +95,9 @@ func TestReconcileEnterpriseSearch_Reconcile_NotFound(t *testing.T) {
 	}
 	// simulate existing watches
 	nsn := types.NamespacedName{Name: "sample", Namespace: "ns"}
-	err := watches.WatchUserProvidedSecrets(nsn, r.DynamicWatches(), configRefWatchName(nsn), []string{"watched-secret"})
-	require.NoError(t, err)
+	require.NoError(t, watches.WatchUserProvidedSecrets(nsn, r.DynamicWatches(), configRefWatchName(nsn), []string{"watched-secret"}))
+	// simulate a custom http tls secret
+	require.NoError(t, watches.WatchUserProvidedSecrets(nsn, r.dynamicWatches, "sample-ent-http-certificate", []string{"user-tls-secret"}))
 	require.NotEmpty(t, r.dynamicWatches.Secrets.Registrations())
 
 	result, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})

--- a/pkg/controller/kibana/controller.go
+++ b/pkg/controller/kibana/controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/annotation"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/finalizer"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
@@ -240,6 +241,8 @@ func (r *ReconcileKibana) updateStatus(ctx context.Context, state State) error {
 func (r *ReconcileKibana) onDelete(obj types.NamespacedName) {
 	// Clean up watches set on secure settings
 	r.dynamicWatches.Secrets.RemoveHandlerForKey(keystore.SecureSettingsWatchName(obj))
+	// Clean up watches set on custom http tls certificates
+	r.dynamicWatches.Secrets.RemoveHandlerForKey(certificates.CertificateWatchKey(Namer, obj.Name))
 }
 
 // State holds the accumulated state during the reconcile loop including the response and a pointer to a Kibana


### PR DESCRIPTION
This PR fixes a watch leak on custom HTTP TLS secrets.

I only updated the existing Enterprisearch unit test, other unit tests should be updated as part of https://github.com/elastic/cloud-on-k8s/issues/249