### PR TITLE
Remove docs link for CRD comment

### DIFF
--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -349,8 +349,8 @@ spec:
                 affinity rules, resource requests, and so on) for the APM Server pods.
               type: object
             secureSettings:
-              description: 'SecureSettings is a list of references to Kubernetes secrets
-                containing sensitive configuration options for APM Server. See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-apm-server.html#k8s-apm-secure-settings'
+              description: SecureSettings is a list of references to Kubernetes secrets
+                containing sensitive configuration options for APM Server.
               items:
                 description: SecretSource defines a data source based on a Kubernetes
                   Secret.
@@ -1151,9 +1151,8 @@ spec:
                 type: object
               type: array
             secureSettings:
-              description: 'SecureSettings is a list of references to Kubernetes secrets
-                containing sensitive configuration options for Elasticsearch. See:
-                https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-es-secure-settings.html'
+              description: SecureSettings is a list of references to Kubernetes secrets
+                containing sensitive configuration options for Elasticsearch.
               items:
                 description: SecretSource defines a data source based on a Kubernetes
                   Secret.
@@ -2240,8 +2239,8 @@ spec:
                 affinity rules, resource requests, and so on) for the Kibana pods
               type: object
             secureSettings:
-              description: 'SecureSettings is a list of references to Kubernetes secrets
-                containing sensitive configuration options for Kibana. See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-kibana.html#k8s-kibana-secure-settings'
+              description: SecureSettings is a list of references to Kubernetes secrets
+                containing sensitive configuration options for Kibana.
               items:
                 description: SecretSource defines a data source based on a Kubernetes
                   Secret.

--- a/config/crds/bases/apm.k8s.elastic.co_apmservers.yaml
+++ b/config/crds/bases/apm.k8s.elastic.co_apmservers.yaml
@@ -6262,9 +6262,8 @@ spec:
                     type: object
                 type: object
               secureSettings:
-                description: 'SecureSettings is a list of references to Kubernetes
+                description: SecureSettings is a list of references to Kubernetes
                   secrets containing sensitive configuration options for APM Server.
-                  See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-apm-server.html#k8s-apm-secure-settings'
                 items:
                   description: SecretSource defines a data source based on a Kubernetes
                     Secret.
@@ -12559,9 +12558,8 @@ spec:
                     type: object
                 type: object
               secureSettings:
-                description: 'SecureSettings is a list of references to Kubernetes
+                description: SecureSettings is a list of references to Kubernetes
                   secrets containing sensitive configuration options for APM Server.
-                  See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-apm-server.html#k8s-apm-secure-settings'
                 items:
                   description: SecretSource defines a data source based on a Kubernetes
                     Secret.

--- a/config/crds/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
+++ b/config/crds/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
@@ -7045,9 +7045,8 @@ spec:
                   type: object
                 type: array
               secureSettings:
-                description: 'SecureSettings is a list of references to Kubernetes
+                description: SecureSettings is a list of references to Kubernetes
                   secrets containing sensitive configuration options for Elasticsearch.
-                  See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-es-secure-settings.html'
                 items:
                   description: SecretSource defines a data source based on a Kubernetes
                     Secret.
@@ -14321,9 +14320,8 @@ spec:
                     type: object
                 type: object
               secureSettings:
-                description: 'SecureSettings is a list of references to Kubernetes
+                description: SecureSettings is a list of references to Kubernetes
                   secrets containing sensitive configuration options for Elasticsearch.
-                  See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-es-secure-settings.html'
                 items:
                   description: SecretSource defines a data source based on a Kubernetes
                     Secret.

--- a/config/crds/bases/kibana.k8s.elastic.co_kibanas.yaml
+++ b/config/crds/bases/kibana.k8s.elastic.co_kibanas.yaml
@@ -6260,9 +6260,8 @@ spec:
                     type: object
                 type: object
               secureSettings:
-                description: 'SecureSettings is a list of references to Kubernetes
-                  secrets containing sensitive configuration options for Kibana. See:
-                  https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-kibana.html#k8s-kibana-secure-settings'
+                description: SecureSettings is a list of references to Kubernetes
+                  secrets containing sensitive configuration options for Kibana.
                 items:
                   description: SecretSource defines a data source based on a Kubernetes
                     Secret.
@@ -12545,9 +12544,8 @@ spec:
                     type: object
                 type: object
               secureSettings:
-                description: 'SecureSettings is a list of references to Kubernetes
-                  secrets containing sensitive configuration options for Kibana. See:
-                  https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-kibana.html#k8s-kibana-secure-settings'
+                description: SecureSettings is a list of references to Kubernetes
+                  secrets containing sensitive configuration options for Kibana.
                 items:
                   description: SecretSource defines a data source based on a Kubernetes
                     Secret.

--- a/docs/reference/api-docs.asciidoc
+++ b/docs/reference/api-docs.asciidoc
@@ -71,7 +71,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`http`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-httpconfig[$$HTTPConfig$$]__ | HTTP holds the HTTP layer configuration for the APM Server resource.
 | *`elasticsearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster.
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the APM Server pods.
-| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-secretsource[$$SecretSource$$]__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for APM Server. See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-apm-server.html#k8s-apm-secure-settings
+| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-secretsource[$$SecretSource$$]__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for APM Server.
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (eg. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
 |===
 
@@ -125,7 +125,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`http`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1beta1-httpconfig[$$HTTPConfig$$]__ | HTTP holds the HTTP layer configuration for the APM Server resource.
 | *`elasticsearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1beta1-objectselector[$$ObjectSelector$$]__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster.
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the APM Server pods.
-| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1beta1-secretsource[$$SecretSource$$]__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for APM Server. See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-apm-server.html#k8s-apm-secure-settings
+| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1beta1-secretsource[$$SecretSource$$]__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for APM Server.
 |===
 
 
@@ -643,7 +643,7 @@ ElasticsearchSpec holds the specification of an Elasticsearch cluster.
 | *`updateStrategy`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-elasticsearch-v1-updatestrategy[$$UpdateStrategy$$]__ | UpdateStrategy specifies how updates to the cluster should be performed.
 | *`podDisruptionBudget`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-poddisruptionbudgettemplate[$$PodDisruptionBudgetTemplate$$]__ | PodDisruptionBudget provides access to the default pod disruption budget for the Elasticsearch cluster. The default budget selects all cluster pods and sets `maxUnavailable` to 1. To disable, set `PodDisruptionBudget` to the empty value (`{}` in YAML).
 | *`auth`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-elasticsearch-v1-auth[$$Auth$$]__ | Auth contains user authentication and authorization security settings for Elasticsearch.
-| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-secretsource[$$SecretSource$$]__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Elasticsearch. See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-es-secure-settings.html
+| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-secretsource[$$SecretSource$$]__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Elasticsearch.
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (eg. a remote Elasticsearch cluster) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
 | *`remoteClusters`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-elasticsearch-v1-remotecluster[$$RemoteCluster$$] array__ | RemoteClusters enables you to establish uni-directional connections to a remote Elasticsearch cluster.
 |===
@@ -830,7 +830,7 @@ ElasticsearchSpec holds the specification of an Elasticsearch cluster.
 | *`nodeSets`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-elasticsearch-v1beta1-nodeset[$$NodeSet$$] array__ | NodeSets allow specifying groups of Elasticsearch nodes sharing the same configuration and Pod templates. See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-orchestration.html
 | *`updateStrategy`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-elasticsearch-v1beta1-updatestrategy[$$UpdateStrategy$$]__ | UpdateStrategy specifies how updates to the cluster should be performed.
 | *`podDisruptionBudget`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1beta1-poddisruptionbudgettemplate[$$PodDisruptionBudgetTemplate$$]__ | PodDisruptionBudget provides access to the default pod disruption budget for the Elasticsearch cluster. The default budget selects all cluster pods and sets `maxUnavailable` to 1. To disable, set `PodDisruptionBudget` to the empty value (`{}` in YAML).
-| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1beta1-secretsource[$$SecretSource$$]__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Elasticsearch. See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-es-secure-settings.html
+| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1beta1-secretsource[$$SecretSource$$]__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Elasticsearch.
 |===
 
 
@@ -997,7 +997,7 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`config`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-config[$$Config$$]__ | Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html
 | *`http`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-httpconfig[$$HTTPConfig$$]__ | HTTP holds the HTTP layer configuration for Kibana.
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods
-| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-secretsource[$$SecretSource$$]__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-kibana.html#k8s-kibana-secure-settings
+| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-secretsource[$$SecretSource$$]__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana.
 | *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (eg. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
 |===
 
@@ -1051,7 +1051,7 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`config`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1beta1-config[$$Config$$]__ | Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html
 | *`http`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1beta1-httpconfig[$$HTTPConfig$$]__ | HTTP holds the HTTP layer configuration for Kibana.
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods
-| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1beta1-secretsource[$$SecretSource$$]__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana. See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-kibana.html#k8s-kibana-secure-settings
+| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1beta1-secretsource[$$SecretSource$$]__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana.
 |===
 
 

--- a/pkg/apis/apm/v1/apmserver_types.go
+++ b/pkg/apis/apm/v1/apmserver_types.go
@@ -40,7 +40,6 @@ type ApmServerSpec struct {
 	PodTemplate corev1.PodTemplateSpec `json:"podTemplate,omitempty"`
 
 	// SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for APM Server.
-	// See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-apm-server.html#k8s-apm-secure-settings
 	SecureSettings []commonv1.SecretSource `json:"secureSettings,omitempty"`
 
 	// ServiceAccountName is used to check access from the current resource to a resource (eg. Elasticsearch) in a different namespace.

--- a/pkg/apis/apm/v1beta1/apmserver_types.go
+++ b/pkg/apis/apm/v1beta1/apmserver_types.go
@@ -37,7 +37,6 @@ type ApmServerSpec struct {
 	PodTemplate corev1.PodTemplateSpec `json:"podTemplate,omitempty"`
 
 	// SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for APM Server.
-	// See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-apm-server.html#k8s-apm-secure-settings
 	SecureSettings []commonv1beta1.SecretSource `json:"secureSettings,omitempty"`
 }
 

--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -51,7 +51,6 @@ type ElasticsearchSpec struct {
 	Auth Auth `json:"auth,omitempty"`
 
 	// SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Elasticsearch.
-	// See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-es-secure-settings.html
 	// +kubebuilder:validation:Optional
 	SecureSettings []commonv1.SecretSource `json:"secureSettings,omitempty"`
 

--- a/pkg/apis/elasticsearch/v1beta1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1beta1/elasticsearch_types.go
@@ -41,7 +41,6 @@ type ElasticsearchSpec struct {
 	PodDisruptionBudget *commonv1beta1.PodDisruptionBudgetTemplate `json:"podDisruptionBudget,omitempty"`
 
 	// SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Elasticsearch.
-	// See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-es-secure-settings.html
 	// +kubebuilder:validation:Optional
 	SecureSettings []commonv1beta1.SecretSource `json:"secureSettings,omitempty"`
 }

--- a/pkg/apis/kibana/v1/kibana_types.go
+++ b/pkg/apis/kibana/v1/kibana_types.go
@@ -38,7 +38,6 @@ type KibanaSpec struct {
 	PodTemplate corev1.PodTemplateSpec `json:"podTemplate,omitempty"`
 
 	// SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana.
-	// See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-kibana.html#k8s-kibana-secure-settings
 	SecureSettings []commonv1.SecretSource `json:"secureSettings,omitempty"`
 
 	// ServiceAccountName is used to check access from the current resource to a resource (eg. Elasticsearch) in a different namespace.

--- a/pkg/apis/kibana/v1beta1/kibana_types.go
+++ b/pkg/apis/kibana/v1beta1/kibana_types.go
@@ -38,7 +38,6 @@ type KibanaSpec struct {
 	PodTemplate corev1.PodTemplateSpec `json:"podTemplate,omitempty"`
 
 	// SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana.
-	// See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-kibana.html#k8s-kibana-secure-settings
 	SecureSettings []commonv1beta1.SecretSource `json:"secureSettings,omitempty"`
 }
 


### PR DESCRIPTION
https://github.com/elastic/docs/pull/1813 broke the docs build because we have a hardcoded link to `current`, but now that 1.1 is current, and 1.1 does not have that anchor on that page any longer, it does not work.

We will also want to backport this to past branches :/

We could work around this by changing the link in the golang src to `<<p-k8s-apm-secure-settings>>`, which would then get copied by the reference docs generator into the `docs/reference/api-docs.asciidoc` file, and then resolved as part of the docs build, but that feels weird to have an unresolved link in the golang source. For now I just opted to remove it. Definitely open to changing that though.

We will also update the docs repo so that PRs trigger a full build, which should catch this.