### PR TITLE
Remove docs link

### DIFF
--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -329,8 +329,8 @@ spec:
                 affinity rules, resource requests, and so on) for the APM Server pods.
               type: object
             secureSettings:
-              description: 'SecureSettings is a list of references to Kubernetes secrets
-                containing sensitive configuration options for APM Server. See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-apm-server.html#k8s-apm-secure-settings'
+              description: SecureSettings is a list of references to Kubernetes secrets
+                containing sensitive configuration options for APM Server.
               items:
                 description: SecretSource defines a data source based on a Kubernetes
                   Secret.

--- a/config/crds/bases/apm.k8s.elastic.co_apmservers.yaml
+++ b/config/crds/bases/apm.k8s.elastic.co_apmservers.yaml
@@ -6015,8 +6015,8 @@ spec:
                   type: object
               type: object
             secureSettings:
-              description: 'SecureSettings is a list of references to Kubernetes secrets
-                containing sensitive configuration options for APM Server. See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-apm-server.html#k8s-apm-secure-settings'
+              description: SecureSettings is a list of references to Kubernetes secrets
+                containing sensitive configuration options for APM Server.
               items:
                 description: SecretSource defines a data source based on a Kubernetes
                   Secret.

--- a/docs/api-docs.asciidoc
+++ b/docs/api-docs.asciidoc
@@ -69,7 +69,6 @@ ElasticsearchRef is a reference to the output Elasticsearch cluster running in t
 PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the APM Server pods.
 *`secureSettings`* _xref:common-k8s-elastic-co-v1-secretsource[$$[]SecretSource$$]_::
 SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for APM Server.
-See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-apm-server.html#k8s-apm-secure-settings
 |===
 
 [id="apm-k8s-elastic-co-v1-apmserverspec"]
@@ -119,7 +118,6 @@ PodTemplate provides customisation options (labels, annotations, affinity rules,
 _xref:common-k8s-elastic-co-v1-secretsource[$$[]SecretSource$$]_
 |
 SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for APM Server.
-See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-apm-server.html#k8s-apm-secure-settings
 |===
 [id="{p}-apm-k8s-elastic-co-v1beta1"]
 === apm.k8s.elastic.co/v1beta1
@@ -175,7 +173,6 @@ ElasticsearchRef is a reference to the output Elasticsearch cluster running in t
 PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the APM Server pods.
 *`secureSettings`* _xref:common-k8s-elastic-co-v1beta1-secretsource[$$[]SecretSource$$]_::
 SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for APM Server.
-See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-apm-server.html#k8s-apm-secure-settings
 |===
 
 [id="apm-k8s-elastic-co-v1beta1-apmserverspec"]
@@ -225,7 +222,6 @@ PodTemplate provides customisation options (labels, annotations, affinity rules,
 _xref:common-k8s-elastic-co-v1beta1-secretsource[$$[]SecretSource$$]_
 |
 SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for APM Server.
-See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-apm-server.html#k8s-apm-secure-settings
 |===
 [id="{p}-common-k8s-elastic-co-v1"]
 === common.k8s.elastic.co/v1

--- a/pkg/apis/apm/v1/apmserver_types.go
+++ b/pkg/apis/apm/v1/apmserver_types.go
@@ -38,7 +38,6 @@ type ApmServerSpec struct {
 	PodTemplate corev1.PodTemplateSpec `json:"podTemplate,omitempty"`
 
 	// SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for APM Server.
-	// See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-apm-server.html#k8s-apm-secure-settings
 	SecureSettings []commonv1.SecretSource `json:"secureSettings,omitempty"`
 }
 

--- a/pkg/apis/apm/v1beta1/apmserver_types.go
+++ b/pkg/apis/apm/v1beta1/apmserver_types.go
@@ -37,7 +37,6 @@ type ApmServerSpec struct {
 	PodTemplate corev1.PodTemplateSpec `json:"podTemplate,omitempty"`
 
 	// SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for APM Server.
-	// See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-apm-server.html#k8s-apm-secure-settings
 	SecureSettings []commonv1beta1.SecretSource `json:"secureSettings,omitempty"`
 }
 


### PR DESCRIPTION
Fixes now broken docs links.

Similar to https://github.com/elastic/cloud-on-k8s/pull/2984 but created new for 1.0, but the CRDs have changed so much I could not realistically cherry-pick it.