### PR TITLE
Add port to STS headless service

### DIFF
--- a/pkg/controller/elasticsearch/driver/downscale.go
+++ b/pkg/controller/elasticsearch/driver/downscale.go
@@ -150,7 +150,7 @@ func attemptDownscale(
 // deleteStatefulSetResources deletes the given StatefulSet along with the corresponding
 // headless service and configuration secret.
 func deleteStatefulSetResources(k8sClient k8s.Client, es esv1.Elasticsearch, statefulSet appsv1.StatefulSet) error {
-	headlessSvc := nodespec.HeadlessService(k8s.ExtractNamespacedName(&es), statefulSet.Name)
+	headlessSvc := nodespec.HeadlessService(&es, statefulSet.Name)
 	err := k8sClient.Delete(&headlessSvc)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err

--- a/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -915,7 +915,7 @@ func Test_deleteStatefulSetResources(t *testing.T) {
 	es := esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster"}}
 	sset := sset.TestSset{Namespace: "ns", Name: "sset", ClusterName: es.Name}.Build()
 	cfg := settings.ConfigSecret(es, sset.Name, []byte("fake config data"))
-	svc := nodespec.HeadlessService(k8s.ExtractNamespacedName(&es), sset.Name)
+	svc := nodespec.HeadlessService(&es, sset.Name)
 
 	tests := []struct {
 		name      string

--- a/pkg/controller/elasticsearch/nodespec/resources.go
+++ b/pkg/controller/elasticsearch/nodespec/resources.go
@@ -15,7 +15,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
 // Resources contain per-NodeSet resources to be created.
@@ -63,7 +62,7 @@ func BuildExpectedResources(
 		if err != nil {
 			return nil, err
 		}
-		headlessSvc := HeadlessService(k8s.ExtractNamespacedName(&es), statefulSet.Name)
+		headlessSvc := HeadlessService(&es, statefulSet.Name)
 
 		nodesResources = append(nodesResources, Resources{
 			StatefulSet:     statefulSet,


### PR DESCRIPTION
This is a tentative PR to add the Elasticsearch port to the headless service created for each node set. I have [documented a couple of concerns regarding this change in the issue](https://github.com/elastic/cloud-on-k8s/issues/2843#issuecomment-621098345) but I don't think they are egregious enough to avoid doing this completely. 

Fixes #2843 