### PR TITLE
Exclude EnterpriseSearch from 1.1 API docs

### DIFF
--- a/docs/reference/api-docs.asciidoc
+++ b/docs/reference/api-docs.asciidoc
@@ -18,7 +18,6 @@ endif::[]
 - xref:{anchor_prefix}-common-k8s-elastic-co-v1beta1[$$common.k8s.elastic.co/v1beta1$$]
 - xref:{anchor_prefix}-elasticsearch-k8s-elastic-co-v1[$$elasticsearch.k8s.elastic.co/v1$$]
 - xref:{anchor_prefix}-elasticsearch-k8s-elastic-co-v1beta1[$$elasticsearch.k8s.elastic.co/v1beta1$$]
-- xref:{anchor_prefix}-enterprisesearch-k8s-elastic-co-v1beta1[$$enterprisesearch.k8s.elastic.co/v1beta1$$]
 - xref:{anchor_prefix}-kibana-k8s-elastic-co-v1[$$kibana.k8s.elastic.co/v1$$]
 - xref:{anchor_prefix}-kibana-k8s-elastic-co-v1beta1[$$kibana.k8s.elastic.co/v1beta1$$]
 
@@ -235,7 +234,6 @@ SecretRef is a reference to a secret that exists in the same namespace.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-enterprisesearch-v1beta1-configsource[$$ConfigSource$$]
 - xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-elasticsearch-v1-filerealmsource[$$FileRealmSource$$]
 - xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-elasticsearch-v1-rolesource[$$RoleSource$$]
 - xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-tlsoptions[$$TLSOptions$$]
@@ -869,16 +867,6 @@ UpdateStrategy specifies how updates to the cluster should be performed.
 | Field | Description
 | *`changeBudget`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-elasticsearch-v1beta1-changebudget[$$ChangeBudget$$]__ | ChangeBudget defines the constraints to consider when applying changes to the Elasticsearch cluster.
 |===
-
-
-
-
-
-[id="{anchor_prefix}-enterprisesearch-k8s-elastic-co-v1beta1"]
-== enterprisesearch.k8s.elastic.co/v1beta1
-
-Package v1beta1 contains API schema definitions for managing Enterprise Search resources.
-
 
 
 

--- a/docs/reference/api-docs.asciidoc
+++ b/docs/reference/api-docs.asciidoc
@@ -145,7 +145,6 @@ Config represents untyped YAML configuration.
 .Appears In:
 ****
 - xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-apm-v1-apmserverspec[$$ApmServerSpec$$]
-- xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-enterprisesearch-v1beta1-enterprisesearchspec[$$EnterpriseSearchSpec$$]
 - xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-kibana-v1-kibanaspec[$$KibanaSpec$$]
 - xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-elasticsearch-v1-nodeset[$$NodeSet$$]
 ****
@@ -161,7 +160,6 @@ HTTPConfig holds the HTTP layer configuration for resources.
 ****
 - xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-apm-v1-apmserverspec[$$ApmServerSpec$$]
 - xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-elasticsearch-v1-elasticsearchspec[$$ElasticsearchSpec$$]
-- xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-enterprisesearch-v1beta1-enterprisesearchspec[$$EnterpriseSearchSpec$$]
 - xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-kibana-v1-kibanaspec[$$KibanaSpec$$]
 ****
 
@@ -199,7 +197,6 @@ ObjectSelector defines a reference to a Kubernetes object.
 .Appears In:
 ****
 - xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-apm-v1-apmserverspec[$$ApmServerSpec$$]
-- xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-enterprisesearch-v1beta1-enterprisesearchspec[$$EnterpriseSearchSpec$$]
 - xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-kibana-v1-kibanaspec[$$KibanaSpec$$]
 - xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-elasticsearch-v1-remotecluster[$$RemoteCluster$$]
 ****
@@ -882,70 +879,8 @@ UpdateStrategy specifies how updates to the cluster should be performed.
 
 Package v1beta1 contains API schema definitions for managing Enterprise Search resources.
 
-.Resource Types
-- xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-enterprisesearch-v1beta1-enterprisesearch[$$EnterpriseSearch$$]
 
 
-
-[id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-enterprisesearch-v1beta1-configsource"]
-=== ConfigSource 
-
-
-
-.Appears In:
-****
-- xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-enterprisesearch-v1beta1-enterprisesearchspec[$$EnterpriseSearchSpec$$]
-****
-
-[cols="25a,75a", options="header"]
-|===
-| Field | Description
-| *`SecretRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-secretref[$$SecretRef$$]__ | SecretName references a Kubernetes secret in the same namespace as the EnterpriseSearch resource. Enterprise Search settings must be specified as yaml, under a single "enterprise-search.yml" entry. 
- Example: --- kind: Secret apiVersion: v1 metadata: 	name: smtp-credentials stringData:  enterprise-search.yml: |-    email.account.enabled: true    email.account.smtp.auth: plain    email.account.smtp.starttls.enable: false    email.account.smtp.host: 127.0.0.1    email.account.smtp.port: 25    email.account.smtp.user: myuser    email.account.smtp.password: mypassword    email.account.email_defaults.from: my@email.com ---
-|===
-
-
-[id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-enterprisesearch-v1beta1-enterprisesearch"]
-=== EnterpriseSearch 
-
-EnterpriseSearch is a Kubernetes CRD to represent Enterprise Search.
-
-
-
-[cols="25a,75a", options="header"]
-|===
-| Field | Description
-| *`apiVersion`* __string__ | `enterprisesearch.k8s.elastic.co/v1beta1`
-| *`kind`* __string__ | `EnterpriseSearch`
-| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
-
-| *`spec`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-enterprisesearch-v1beta1-enterprisesearchspec[$$EnterpriseSearchSpec$$]__ | 
-|===
-
-
-[id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-enterprisesearch-v1beta1-enterprisesearchspec"]
-=== EnterpriseSearchSpec 
-
-EnterpriseSearchSpec holds the specification of an Enterprise Search resource.
-
-.Appears In:
-****
-- xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-enterprisesearch-v1beta1-enterprisesearch[$$EnterpriseSearch$$]
-****
-
-[cols="25a,75a", options="header"]
-|===
-| Field | Description
-| *`version`* __string__ | Version of Enterprise Search.
-| *`image`* __string__ | Image is the Enterprise Search Docker image to deploy.
-| *`count`* __integer__ | Count of Enterprise Search instances to deploy.
-| *`config`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-config[$$Config$$]__ | Config holds the Enterprise Search configuration.
-| *`configRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-enterprisesearch-v1beta1-configsource[$$ConfigSource$$] array__ | ConfigRef contains references to Kubernetes Secrets holding the Enterprise Search configuration. Configuration settings are merged and have prcedence over plain text settings specified in  `config`. Multiple secrets can be referenced: if duplicate settings exist in multiple secrets, the last one takes precedence.
-| *`http`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-httpconfig[$$HTTPConfig$$]__ | HTTP holds the HTTP layer configuration for Enterprise Search resource.
-| *`elasticsearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | ElasticsearchRef is a reference to the Elasticsearch cluster running in the same Kubernetes cluster.
-| *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Enterprise Search pods.
-| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (eg. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
-|===
 
 
 

--- a/hack/api-docs/build.sh
+++ b/hack/api-docs/build.sh
@@ -26,7 +26,7 @@ build_docs() {
     local REPO_ROOT="${SCRIPT_DIR}/../.."
     local DOCS_DIR="${SCRIPT_DIR}/../../docs"
     local REFDOCS_REPO="${REFDOCS_REPO:-github.com/elastic/crd-ref-docs}"
-    local REFDOCS_VER="${REFDOCS_VER:-v0.0.3}"
+    local REFDOCS_VER="${REFDOCS_VER:-v0.0.4}"
     local BIN_DIR=${SCRATCH_DIR}/bin
 
     (

--- a/hack/api-docs/config.yaml
+++ b/hack/api-docs/config.yaml
@@ -5,6 +5,7 @@ processor:
     - "(Elasticsearch|Kibana|ApmServer|Reconciler|EnterpriseSearch)Status$"
     - "ElasticsearchSettings$"
     - "Associa(ted|tor|tionStatus|tionConf)$"
+    - "EnterpriseSearch"
   ignoreFields:
     - "status$"
     - "TypeMeta$"

--- a/hack/api-docs/config.yaml
+++ b/hack/api-docs/config.yaml
@@ -5,10 +5,12 @@ processor:
     - "(Elasticsearch|Kibana|ApmServer|Reconciler|EnterpriseSearch)Status$"
     - "ElasticsearchSettings$"
     - "Associa(ted|tor|tionStatus|tionConf)$"
-    - "EnterpriseSearch"
+    - "EnterpriseSearch.*"
   ignoreFields:
     - "status$"
     - "TypeMeta$"
+  ignoreGroupVersions:
+    - "enterprisesearch"
 
 render:
   kubernetesVersion: 1.17


### PR DESCRIPTION
Enterrprise Search is still visible in the API docs of 1.1.0 -- which can be confusing to users.

