### PR TITLE
Update crd-ref-docs version

### DIFF
--- a/hack/api-docs/build.sh
+++ b/hack/api-docs/build.sh
@@ -26,7 +26,7 @@ build_docs() {
     local REPO_ROOT="${SCRIPT_DIR}/../.."
     local DOCS_DIR="${SCRIPT_DIR}/../../docs"
     local REFDOCS_REPO="${REFDOCS_REPO:-github.com/elastic/crd-ref-docs}"
-    local REFDOCS_VER="${REFDOCS_VER:-v0.0.3}"
+    local REFDOCS_VER="${REFDOCS_VER:-v0.0.4}"
     local BIN_DIR=${SCRATCH_DIR}/bin
 
     (


### PR DESCRIPTION
For #3014, a new version of crd-ref-docs had to be released to support excluding group-versions from API docs. 