### PR TITLE
Add HTTP selector customization docs

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/http-settings-tls-sans.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/http-settings-tls-sans.asciidoc
@@ -8,30 +8,94 @@ endif::[]
 [id="{p}-{page_id}"]
 = HTTP settings and TLS SANs
 
-In the `spec.http.service.spec` section, you can change the Kubernetes service used to expose Elasticsearch:
+[float]
+[id="{p}-elasticsearch-http-service-type"]
+== Change Kubernetes service type
 
-[source,yaml]
+The default service (`<cluster_name>-es-http`) created by the operator is a `ClusterIP` service that makes the Elasticsearch cluster accessible from within the Kubernetes cluster. You can change the service type by updating the `spec.http.service.spec.type` field as follows:
+
+[source,yaml,subs="attributes"]
 ----
+apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
+kind: Elasticsearch
+metadata:
+  name: quickstart
 spec:
+  version: {version}
   http:
     service:
       spec:
         type: LoadBalancer
+  nodeSets:
+  - name: default
+    count: 3
 ----
 
-Check the https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types[Kubernetes Publishing Services (ServiceTypes)] that are currently available.
+Refer to the link:https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types[Kubernetes service types documentation] for more information about different service types available.
 
-NOTE: Please note that when you change the `clusterIP` setting of the service, ECK will delete and re-create the service as `clusterIP` is an immutable field. Depending on your client implementation this might have an a short impact on the ability to resolve the service's DNS name to endpoints.
+CAUTION: When you change the `clusterIP` setting of the service, ECK will delete and re-create the service as `clusterIP` is an immutable field. Depending on your client implementation, this might result in a short disruption until the service DNS entries refresh to point to the new endpoints.
 
-You can add an IP or a DNS name in the SAN of the self-signed certificate configured by default to secure the HTTP layer with TLS in the `spec.http.tls.selfSignedCertificate` section.
 
-[source,yaml]
+[float]
+[id="{p}-elasticsearch-http-service-selector"]
+== Change exposed Elasticsearch nodes
+
+By default, the service created by the operator encompasses all Elasticsearch nodes in the cluster. If you prefer to restrict the set of accessible Elasticsearch nodes, you can do so by specifying a new `selector`. For example, to exclude master nodes from receiving requests, override the service definition as follows:
+
+[source,yaml,subs="attributes"]
 ----
+apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
+kind: Elasticsearch
+metadata:
+  name: quickstart
 spec:
+  version: {version}
+  http:
+    service:
+      spec:
+        selector:
+          elasticsearch.k8s.elastic.co/cluster-name: "quickstart"
+          elasticsearch.k8s.elastic.co/node-master: "false"
+  nodeSets:
+  - name: master
+    count: 1
+    config:
+      node.master: true
+      node.data: false
+      node.ingest: false
+      node.ml: false
+  - name: data
+    count: 5
+    config:
+      node.master: false
+      node.data: true
+      node.ingest: false
+      node.ml: false
+----
+
+See <<{p}-traffic-splitting>> for information about more advanced traffic-splitting configurations.
+
+[float]
+[id="{p}-elasticsearch-http-service-san"]
+== Customize the self-signed certificate
+
+The operator generates a self-signed TLS certificate to secure the Elasticsearch HTTP layer. You can add extra IP addresses or DNS names to the generated certificate as follows:
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
+kind: Elasticsearch
+metadata:
+  name: quickstart
+spec:
+  version: {version}
   http:
     tls:
       selfSignedCertificate:
         subjectAltNames:
         - ip: 1.2.3.4
         - dns: hulk.example.com
+  nodeSets:
+  - name: default
+    count: 3
 ----


### PR DESCRIPTION
Adds documentation about changing the default `selector` of the HTTP service.

Fixes #2963 