### PR TITLE
Disable the monitoring addon in AKS

### DIFF
--- a/hack/deployer/runner/aks.go
+++ b/hack/deployer/runner/aks.go
@@ -177,7 +177,8 @@ func (d *AksDriver) create() error {
 
 	cmd := `az aks create --resource-group {{.ResourceGroup}} --name {{.ClusterName}} --location {{.Location}} ` +
 		`--node-count {{.NodeCount}} --node-vm-size {{.MachineType}} --kubernetes-version {{.KubernetesVersion}} ` +
-		`--node-osdisk-size 30 --enable-addons http_application_routing,monitoring --generate-ssh-keys` + servicePrincipal
+		`--node-osdisk-size 30 --enable-addons http_application_routing --generate-ssh-keys` + servicePrincipal
+
 	if err := NewCommand(cmd).AsTemplate(d.ctx).Run(); err != nil {
 		return err
 	}


### PR DESCRIPTION
In most situations we don't need that addon since clusters are created then deleted regularly.
It can probably be manually added if needed on dev clusters.
