### PR TITLE
Add PodTemplate semantic validation for Elasticsearch

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -39,6 +39,38 @@ THE SOFTWARE.
 
 
 --------------------------------------------------------------------------------
+Module  : github.com/blang/semver
+Version : v3.5.0+incompatible
+Time    : 2017-01-30T17:05:46Z
+Licence : MIT
+
+Contents of probable licence file $GOMODCACHE/github.com/blang/semver@v3.5.0+incompatible/LICENSE:
+
+The MIT License
+
+Copyright (c) 2014 Benedikt Lang <github at benediktlang.de>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+
+--------------------------------------------------------------------------------
 Module  : github.com/davecgh/go-spew
 Version : v1.1.1
 Time    : 2018-02-21T23:26:28Z
@@ -6608,38 +6640,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-
---------------------------------------------------------------------------------
-Module  : github.com/blang/semver
-Version : v3.5.0+incompatible
-Time    : 2017-01-30T17:05:46Z
-Licence : MIT
-
-Contents of probable licence file $GOMODCACHE/github.com/blang/semver@v3.5.0+incompatible/LICENSE:
-
-The MIT License
-
-Copyright (c) 2014 Benedikt Lang <github at benediktlang.de>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
 
 
 --------------------------------------------------------------------------------

--- a/docs/reference/dependencies.asciidoc
+++ b/docs/reference/dependencies.asciidoc
@@ -20,6 +20,7 @@ This page lists the third-party dependencies used to build {n}.
 | Name | Version | Licence
 
 | link:https://github.com/Masterminds/sprig[$$github.com/Masterminds/sprig$$] | v2.20.0+incompatible | MIT
+| link:https://github.com/blang/semver[$$github.com/blang/semver$$] | v3.5.0+incompatible | MIT
 | link:https://github.com/davecgh/go-spew[$$github.com/davecgh/go-spew$$] | v1.1.1 | ISC
 | link:https://github.com/elastic/go-ucfg[$$github.com/elastic/go-ucfg$$] | v0.7.0 | Apache-2.0
 | link:https://github.com/ghodss/yaml[$$github.com/ghodss/yaml$$] | v1.0.0 | MIT
@@ -89,7 +90,6 @@ This page lists the third-party dependencies used to build {n}.
 | link:https://github.com/asaskevich/govalidator[$$github.com/asaskevich/govalidator$$] | v0.0.0-20190424111038-f61b66f89f4a | MIT
 | link:https://github.com/beorn7/perks[$$github.com/beorn7/perks$$] | v1.0.1 | MIT
 | link:https://github.com/bgentry/speakeasy[$$github.com/bgentry/speakeasy$$] | v0.1.0 | MIT
-| link:https://github.com/blang/semver[$$github.com/blang/semver$$] | v3.5.0+incompatible | MIT
 | link:https://github.com/bmizerany/perks[$$github.com/bmizerany/perks$$] | v0.0.0-20141205001514-d9a9656a3a4b | MIT
 | link:https://github.com/cespare/xxhash[$$github.com/cespare/xxhash$$] | v1.1.0 | MIT
 | link:https://github.com/client9/misspell[$$github.com/client9/misspell$$] | v0.3.4 | MIT

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/goutils v1.1.0 // indirect
 	github.com/Masterminds/semver v1.4.2 // indirect
 	github.com/Masterminds/sprig v2.20.0+incompatible
+	github.com/blang/semver v3.5.0+incompatible
 	github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b // indirect
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgryski/go-gk v0.0.0-20140819190930-201884a44051 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDfD5VcY4CIfh1hRXBUavxrvELjTiOE=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=

--- a/pkg/controller/common/reconciler/reconciler.go
+++ b/pkg/controller/common/reconciler/reconciler.go
@@ -44,9 +44,9 @@ type Params struct {
 	// UpdateReconciled modifies the resource pointed to by Reconciled to reflect the state of Expected
 	UpdateReconciled func()
 	// PreCreate is called just before the creation of the resource.
-	PreCreate func()
+	PreCreate func() error
 	// PreUpdate is called just before the update of the resource.
-	PreUpdate func()
+	PreUpdate func() error
 	// PostUpdate is called immediately after the resource is successfully updated.
 	PostUpdate func()
 }
@@ -96,7 +96,10 @@ func ReconcileResource(params Params) error {
 	create := func() error {
 		log.Info("Creating resource", "kind", kind, "namespace", namespace, "name", name)
 		if params.PreCreate != nil {
-			params.PreCreate()
+			if err := params.PreCreate(); err != nil {
+				return err
+			}
+
 		}
 
 		// Copy the content of params.Expected into params.Reconciled.
@@ -149,7 +152,9 @@ func ReconcileResource(params Params) error {
 	if params.NeedsUpdate() {
 		log.Info("Updating resource", "kind", kind, "namespace", namespace, "name", name)
 		if params.PreUpdate != nil {
-			params.PreUpdate()
+			if err := params.PreUpdate(); err != nil {
+				return err
+			}
 		}
 		params.UpdateReconciled()
 		err := params.Client.Update(params.Reconciled)

--- a/pkg/controller/elasticsearch/settings/masters.go
+++ b/pkg/controller/elasticsearch/settings/masters.go
@@ -93,8 +93,9 @@ func UpdateSeedHostsConfigMap(
 			UpdateReconciled: func() {
 				reconciled.Data = expected.Data
 			},
-			PreCreate: func() {
+			PreCreate: func() error {
 				log.Info("Creating seed hosts", "namespace", es.Namespace, "es_name", es.Name, "hosts", seedHosts)
+				return nil
 			},
 			PostUpdate: func() {
 				log.Info("Seed hosts updated", "namespace", es.Namespace, "es_name", es.Name, "hosts", seedHosts)

--- a/pkg/controller/elasticsearch/sset/validation.go
+++ b/pkg/controller/elasticsearch/sset/validation.go
@@ -33,7 +33,10 @@ func (e *PodTemplateError) Error() string {
 	)
 }
 
-// validatePodTemplate validates a Pod Template by issuing a dry API request.
+// validatePodTemplate validates a Pod Template by issuing a dry-run API request.
+// This check is performed as "best-effort" for the following reasons:
+// * It is only supported by the API server starting 1.13
+// * There might be some admission webhooks on the validation path that are not compatible with dry-run requests.
 func validatePodTemplate(
 	c k8s.Client,
 	parent metav1.Object,

--- a/pkg/controller/elasticsearch/sset/validation.go
+++ b/pkg/controller/elasticsearch/sset/validation.go
@@ -1,0 +1,92 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package sset
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type PodTemplateError struct {
+	Parent      metav1.Object
+	StatefulSet appsv1.StatefulSet
+	Causes      []metav1.StatusCause
+}
+
+func (e *PodTemplateError) Error() string {
+	return fmt.Sprintf(
+		"Validation of PodTemplate for StatefulSet %s in Elasticsearch %s/%s failed for the following reasons: %v",
+		e.StatefulSet.Name,
+		e.Parent.GetNamespace(),
+		e.Parent.GetName(),
+		e.Causes,
+	)
+}
+
+// validatePodTemplate validates a Pod Template by issuing a dry API request.
+func validatePodTemplate(
+	c k8s.Client,
+	parent metav1.Object,
+	sset appsv1.StatefulSet,
+) error {
+	template := sset.Spec.Template
+	// Create a dummy Pod with the pod template
+	dummyPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   sset.GetNamespace(),
+			Name:        sset.GetName() + "-dummy-" + rand.String(5),
+			Labels:      template.Labels,
+			Annotations: template.Annotations,
+		},
+		Spec: template.Spec,
+	}
+	if err := c.Create(dummyPod, client.DryRunAll); err != nil {
+		return toPodTemplateError(parent, sset, err)
+	}
+	return nil
+}
+
+// toPodTemplateError attempts to extract the meaningful information from the dry run API call by converting the original
+// error into a PodTemplateError.
+func toPodTemplateError(
+	parent metav1.Object,
+	sset appsv1.StatefulSet,
+	err error,
+) error {
+	var statusErr *k8serrors.StatusError
+	if !errors.As(err, &statusErr) {
+		// Not a Kubernetes API error (e.g. timeout)
+		return err
+	}
+
+	switch statusErr.ErrStatus.Reason {
+	case metav1.StatusReasonBadRequest:
+		// Dry run is beta and available since Kubernetes 1.13
+		// Openshift 3.11 and K8S 1.12 don't support dryRun but returns "400 - BadRequest" in that case
+		return nil
+	case metav1.StatusReasonInvalid:
+		// If the Pod spec is invalid the expected error is 422.
+		// Since "details" is a pointer let's check that it's not nil before going further.
+		if statusErr.ErrStatus.Details == nil {
+			return statusErr
+		}
+		// We are only interested in the causes, other information is not relevant since it is a "dummy" Pod
+		return &PodTemplateError{
+			Parent:      parent,
+			StatefulSet: sset,
+			Causes:      statusErr.ErrStatus.Details.Causes,
+		}
+	}
+	// The Kubernetes API returns an error which is not related to the spec. of the Pod, let's retry again later
+	return statusErr
+}

--- a/pkg/controller/elasticsearch/sset/validation_test.go
+++ b/pkg/controller/elasticsearch/sset/validation_test.go
@@ -1,0 +1,123 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package sset
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type clientWithError struct {
+	k8s.Client
+	error
+}
+
+func newClientWithError(err error) *clientWithError {
+	return &clientWithError{
+		Client: k8s.WrappedFakeClient(),
+		error:  err,
+	}
+}
+
+func (c *clientWithError) Create(_ runtime.Object, _ ...client.CreateOption) error {
+	return c.error
+}
+
+func Test_validatePodTemplate(t *testing.T) {
+	es := esv1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "es",
+		},
+	}
+	ssetSample := appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: es.Namespace,
+			Name:      "sset",
+		},
+	}
+	type args struct {
+		c      k8s.Client
+		parent metav1.Object
+		sset   appsv1.StatefulSet
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			name: "Client returns a validation error",
+			args: args{
+				c: newClientWithError(&errors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  metav1.StatusFailure,
+						Message: "Pod dummy is invalid",
+						Reason:  metav1.StatusReasonInvalid,
+						Details: &metav1.StatusDetails{
+							Name: "es-sample-dummy-vd4kq",
+							Kind: "Pod",
+							Causes: []metav1.StatusCause{
+								{
+									Type:    metav1.CauseTypeFieldValueInvalid,
+									Message: "Invalid value: \"6\": must be less than or equl to cpu limit",
+									Field:   "spec.containers[0].resources.requests",
+								},
+							},
+						},
+					},
+				}),
+				parent: &es,
+				sset:   ssetSample,
+			},
+			wantErr: &PodTemplateError{
+				Parent:      &es,
+				StatefulSet: ssetSample,
+				Causes: []metav1.StatusCause{
+					{
+						Type:    metav1.CauseTypeFieldValueInvalid,
+						Message: "Invalid value: \"6\": must be less than or equl to cpu limit",
+						Field:   "spec.containers[0].resources.requests",
+					},
+				},
+			},
+		},
+		{
+			name: "Skip BadRequest error from Openshift 3.11 or K8S 1.12",
+			args: args{
+				c:      newClientWithError(errors.NewBadRequest("not supported yet")),
+				parent: &es,
+				sset:   ssetSample,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Return non StatusError as is",
+			args: args{
+				c:      newClientWithError(fmt.Errorf("foo")),
+				parent: &es,
+				sset:   ssetSample,
+			},
+			wantErr: fmt.Errorf("foo"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePodTemplate(tt.args.c, tt.args.parent, tt.args.sset)
+			if !reflect.DeepEqual(err, tt.wantErr) {
+				t.Errorf("validatePodTemplate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/test/e2e/es/podtemplate_test.go
+++ b/test/e2e/es/podtemplate_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/blang/semver"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -27,6 +28,15 @@ import (
 // TestPodTemplateValidation simulates a cluster update with a temporary invalid pod template.
 // The invalid pod template should not prevent the update to be eventually applied.
 func TestPodTemplateValidation(t *testing.T) {
+
+	kubernetesVersion, err := semver.ParseTolerant(test.Ctx().KubernetesVersion)
+	if err != nil {
+		t.Fatalf(
+			"Failed to parse the Kubernetes version: %v, err is %v", test.Ctx().KubernetesVersion, err)
+	}
+	if kubernetesVersion.LT(semver.MustParse("1.15.0")) {
+		t.SkipNow()
+	}
 
 	b := elasticsearch.NewBuilder("podtemplatevalidation").
 		WithESMasterDataNodes(1, corev1.ResourceRequirements{

--- a/test/e2e/es/podtemplate_test.go
+++ b/test/e2e/es/podtemplate_test.go
@@ -7,19 +7,99 @@ package es
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"testing"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
 	"github.com/magiconair/properties/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// TestPodTemplateValidation simulates a cluster update with a temporary invalid pod template.
+// The invalid pod template should not prevent the update to be eventually applied.
+func TestPodTemplateValidation(t *testing.T) {
+
+	b := elasticsearch.NewBuilder("podtemplatevalidation").
+		WithESMasterDataNodes(1, corev1.ResourceRequirements{
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			Limits: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		})
+
+	stepsFn := func(k *test.K8sClient) test.StepList {
+		return test.StepList{}.
+			WithStep(
+				test.Step{
+					Name: "Update Elasticsearch spec with an invalid podTemplate",
+					Test: func(t *testing.T) {
+						b.WithPodTemplate(elasticsearch.ESPodTemplate(
+							corev1.ResourceRequirements{
+								// We are requesting more memory than the limit, this is invalid and prevents the Pods creation.
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+								Limits: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceMemory: resource.MustParse("2Gi"),
+								},
+							}),
+						)
+					},
+				}).
+			WithSteps(
+				// Mutate Elasticsearch with an invalid PodTemplate
+				b.UpgradeTestSteps(k),
+			).WithStep(
+			test.Step{
+				Name: "Phase should eventually be \"invalid\"",
+				Test: test.Eventually(func() error {
+					var es esv1.Elasticsearch
+					err := k.Client.Get(k8s.ExtractNamespacedName(&b.Elasticsearch), &es)
+					if err != nil {
+						return err
+					}
+					if es.Status.Phase != esv1.ElasticsearchResourceInvalid {
+						return fmt.Errorf("phase is %s", es.Status.Phase)
+					}
+					return nil
+				}),
+			}).WithStep(
+			test.Step{
+				Name: "Fix the podTemplate",
+				Test: func(t *testing.T) {
+					b.WithPodTemplate(elasticsearch.ESPodTemplate(
+						corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceMemory: resource.MustParse("4Gi"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceMemory: resource.MustParse("4Gi"),
+							},
+						}),
+					)
+				},
+			}).WithSteps(
+			// Mutate Elasticsearch with the fixed PodTemplate
+			b.UpgradeTestSteps(k),
+		).
+			WithSteps(b.CheckK8sTestSteps(k)).
+			// CheckStackTestSteps checks that the memory resource of the current Pod does match the new spec
+			WithSteps(b.CheckStackTestSteps(k))
+	}
+
+	test.Sequence(nil, stepsFn, b).RunSequential(t)
+}
 
 func TestCustomConfiguration(t *testing.T) {
 	const synonyms = "synonyms"


### PR DESCRIPTION
This PR adds a semantic validation for the content of the `podTemplate` field of the Elasticsearch resources.

It is achieved by performing a dry-run request which attempts to create a Pod reusing the content of the `podTemplate`. The validation is only performed when a `StatefulSet` is created or updated.

Fixes #2266 