### PR TITLE
Fix trial extension e2e

### DIFF
--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -279,6 +279,7 @@ CFG
 clusterName=$2
 stackVersion=$3
 isSnapshotVersion=$(case $stackVersion in (*-SNAPSHOT)  echo Yes;; esac)
+testLicensePKeyPath=$(case $isSnapshotVersion in (Yes) echo "/go/src/github.com/elastic/cloud-on-k8s/.ci/dev-private.key";; esac)
 operatorImage=${OPERATOR_IMAGE:-$JKS_PARAM_OPERATOR_IMAGE}
 
 write_env <<ENV
@@ -287,7 +288,7 @@ REPOSITORY = $GCLOUD_PROJECT
 IMG_SUFFIX = -ci
 IS_SNAPSHOT_BUILD = ${isSnapshotVersion}
 TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
-TEST_LICENSE_PKEY_PATH = /go/src/github.com/elastic/cloud-on-k8s/.ci/dev-private.key
+TEST_LICENSE_PKEY_PATH = $testLicensePKeyPath
 MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
 
 OPERATOR_IMAGE = ${operatorImage}

--- a/test/e2e/es/license_test.go
+++ b/test/e2e/es/license_test.go
@@ -133,7 +133,6 @@ func TestEnterpriseTrialLicense(t *testing.T) {
 // TestEnterpriseTrialExtension tests that trial extensions can be successfully applied and take effect.
 // Generates a development version of an Enterprise trial extension license with a development Elasticsearch license inside.
 // Then tests that ECK accepts this license and propagates the Elasticsearch license to the test Elasticsearch cluster.
-// Also tests that this trial extension license is preferred by ECK over any ECK-managed trial.
 // Finally tests that trial extensions can be applied repeatedly as opposed to ECK-managed trials which are one-offs.
 func TestEnterpriseTrialExtension(t *testing.T) {
 	if test.Ctx().TestLicensePKeyPath == "" {
@@ -168,8 +167,6 @@ func TestEnterpriseTrialExtension(t *testing.T) {
 	stepsFn := func(k *test.K8sClient) test.StepList {
 		return test.StepList{
 			licenseTestContext.Init(),
-			licenseTestContext.CheckElasticsearchLicense(client.ElasticsearchLicenseTypeTrial),
-			licenseTestContext.CheckEnterpriseTrialLicenseValid(trialSecretName),
 			// simulate a trial extension
 			licenseTestContext.CreateTrialExtension(licenseSecretName, privateKey.(*rsa.PrivateKey)),
 			licenseTestContext.CheckElasticsearchLicense(


### PR DESCRIPTION
The original PR #2960  to test trial extensions had two flaws that remained hidden until a full e2e test run: 
* I refactored the private key handling to rely on the presence of the key path in a flag to the e2e runner to decide whether to run the test. But I forgot to apply this refactoring to the `setenvconfig` script. This manifests in a failure of the regular stack versions test job.
* I only tested the new e2e test in isolation. When run in the context of the whole test suite the test fails because we have another test that start an ECK-managed trial and you can do that only once. 

This PR tries to address these shortcomings by:
* only set `TEST_LICENSE_PKEY_PATH` when we running a snapshot test in `sentenvconfig`
* remove the ECK-managed trial from the new test: we have unit tests that show that we prefer a  trial extensions over an ECK-managed trial so we should not lose any coverage and this is by far the simplest solution to this problem. 