### PR TITLE
Cleanup license after e2e trial extension test

### DIFF
--- a/test/e2e/es/license_test.go
+++ b/test/e2e/es/license_test.go
@@ -183,6 +183,8 @@ func TestEnterpriseTrialExtension(t *testing.T) {
 				client.ElasticsearchLicenseTypePlatinum, // depends on ES version
 				client.ElasticsearchLicenseTypeEnterprise,
 			),
+			// cleanup license for the next tests
+			licenseTestContext.DeleteAllEnterpriseLicenseSecrets(),
 		}
 	}
 

--- a/test/e2e/es/remote_cluster_test.go
+++ b/test/e2e/es/remote_cluster_test.go
@@ -53,7 +53,10 @@ func TestRemoteCluster(t *testing.T) {
 
 	before := func(k *test.K8sClient) test.StepList {
 		// Deploy a Trial license
-		return test.StepList{es1LicenseTestContext.CreateEnterpriseLicenseSecret(trialSecretName, licenseBytes)}
+		return test.StepList{
+			es1LicenseTestContext.DeleteAllEnterpriseLicenseSecrets(),
+			es1LicenseTestContext.CreateEnterpriseLicenseSecret(trialSecretName, licenseBytes),
+		}
 	}
 
 	followerIndex := "data-integrity-check-follower"


### PR DESCRIPTION
Fixes #3028 by removing the license `Secret` once the test is completed.