### PR TITLE
Restore transport certs public secret naming scheme from 1.0

### DIFF
--- a/pkg/controller/common/certificates/secret.go
+++ b/pkg/controller/common/certificates/secret.go
@@ -33,15 +33,15 @@ const (
 )
 
 func InternalCertsSecretName(namer name.Namer, ownerName string) string {
-	return namer.Suffix(ownerName, "http", certsInternalSecretName)
+	return namer.Suffix(ownerName, string(HTTPCAType), certsInternalSecretName)
 }
 
 func PublicCertsSecretName(namer name.Namer, ownerName string) string {
-	return namer.Suffix(ownerName, "http", certsPublicSecretName)
+	return namer.Suffix(ownerName, string(HTTPCAType), certsPublicSecretName)
 }
 
-func PublicCASecretName(namer name.Namer, ownerName string) string {
-	return namer.Suffix(ownerName, "ca", certsPublicSecretName)
+func PublicTransportCertsSecretName(namer name.Namer, ownerName string) string {
+	return namer.Suffix(ownerName, string(TransportCAType), certsPublicSecretName)
 }
 
 // PublicCertsSecretRef returns the NamespacedName for the Secret containing the publicly available HTTP CA.

--- a/pkg/controller/elasticsearch/certificates/transport/public_secret.go
+++ b/pkg/controller/elasticsearch/certificates/transport/public_secret.go
@@ -39,7 +39,7 @@ func ReconcileTransportCertsPublicSecret(
 // PublicCertsSecretRef returns the NamespacedName for the Secret containing the publicly available transport CA.
 func PublicCertsSecretRef(es types.NamespacedName) types.NamespacedName {
 	return types.NamespacedName{
-		Name:      certificates.PublicCASecretName(esv1.ESNamer, es.Name),
+		Name:      certificates.PublicTransportCertsSecretName(esv1.ESNamer, es.Name),
 		Namespace: es.Namespace,
 	}
 }


### PR DESCRIPTION
The name of the secret holding transport public certs was accidentally changed to
`<cluster>-es-ca-certs-public` in 608642b, but should have been kept
`<cluster-name>-es-transport-certs-public`.

Fixes https://github.com/elastic/cloud-on-k8s/issues/3034.