### PR TITLE
Increase the operator default memory requirements

### DIFF
--- a/config/e2e/operator.yaml
+++ b/config/e2e/operator.yaml
@@ -200,7 +200,7 @@ spec:
             memory: 512Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 150Mi
         ports:
         - containerPort: 9443
           name: webhook-server

--- a/config/e2e/operator.yaml
+++ b/config/e2e/operator.yaml
@@ -197,7 +197,7 @@ spec:
         resources:
           limits:
             cpu: 1
-            memory: 100Mi
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/config/operator/all-in-one/operator.template.yaml
+++ b/config/operator/all-in-one/operator.template.yaml
@@ -39,7 +39,7 @@ spec:
             memory: 512Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 150Mi
         ports:
         - containerPort: 9443
           name: webhook-server

--- a/config/operator/all-in-one/operator.template.yaml
+++ b/config/operator/all-in-one/operator.template.yaml
@@ -36,7 +36,7 @@ spec:
         resources:
           limits:
             cpu: 1
-            memory: 150Mi
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 50Mi


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/3025.

Increase our defaults memory requirements to:
- limits: 512Mi
- requests: 150Mi

It also sets the same value for the operator manifests used for E2E tests.