### PR TITLE
Revert "Make readiness probes independent of the host/container... (#2528)

### DIFF
--- a/pkg/controller/apmserver/deployment_test.go
+++ b/pkg/controller/apmserver/deployment_test.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
@@ -167,10 +168,10 @@ func expectedDeploymentParams() testParams {
 							SuccessThreshold:    1,
 							TimeoutSeconds:      5,
 							Handler: corev1.Handler{
-								Exec: &corev1.ExecAction{
-									Command: []string{"bash", "-c",
-										`curl -o /dev/null -w "%{http_code}" HTTPS://127.0.0.1:8200/ -k -s`,
-									},
+								HTTPGet: &corev1.HTTPGetAction{
+									Port:   intstr.FromInt(8200),
+									Path:   "/",
+									Scheme: corev1.URISchemeHTTPS,
 								},
 							},
 						},

--- a/pkg/controller/apmserver/pod.go
+++ b/pkg/controller/apmserver/pod.go
@@ -5,12 +5,12 @@
 package apmserver
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/container"
@@ -54,10 +54,10 @@ func readinessProbe(tls bool) corev1.Probe {
 		SuccessThreshold:    1,
 		TimeoutSeconds:      5,
 		Handler: corev1.Handler{
-			Exec: &corev1.ExecAction{
-				Command: []string{"bash", "-c",
-					fmt.Sprintf(`curl -o /dev/null -w "%%{http_code}" %s://127.0.0.1:%d/ -k -s`, scheme, HTTPPort),
-				},
+			HTTPGet: &corev1.HTTPGetAction{
+				Port:   intstr.FromInt(HTTPPort),
+				Path:   "/",
+				Scheme: scheme,
 			},
 		},
 	}

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -246,7 +247,7 @@ func TestDriverDeploymentParams(t *testing.T) {
 				params := expectedDeploymentParams()
 				params.PodTemplateSpec.Spec.Volumes = params.PodTemplateSpec.Spec.Volumes[:3]
 				params.PodTemplateSpec.Spec.Containers[0].VolumeMounts = params.PodTemplateSpec.Spec.Containers[0].VolumeMounts[:3]
-				params.PodTemplateSpec.Spec.Containers[0].ReadinessProbe.Handler.Exec.Command[2] = `curl -o /dev/null -w "%{http_code}" HTTP://127.0.0.1:5601/login -k -s`
+				params.PodTemplateSpec.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Scheme = corev1.URISchemeHTTP
 				params.PodTemplateSpec.Spec.Containers[0].Ports[0].Name = "http"
 				return params
 			}(),
@@ -513,10 +514,10 @@ func expectedDeploymentParams() deployment.Params {
 						SuccessThreshold:    1,
 						TimeoutSeconds:      5,
 						Handler: corev1.Handler{
-							Exec: &corev1.ExecAction{
-								Command: []string{"bash", "-c",
-									`curl -o /dev/null -w "%{http_code}" HTTPS://127.0.0.1:5601/login -k -s`,
-								},
+							HTTPGet: &corev1.HTTPGetAction{
+								Port:   intstr.FromInt(5601),
+								Path:   "/login",
+								Scheme: corev1.URISchemeHTTPS,
 							},
 						},
 					},

--- a/pkg/controller/kibana/pod.go
+++ b/pkg/controller/kibana/pod.go
@@ -5,20 +5,17 @@
 package kibana
 
 import (
-	"fmt"
-
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/annotation"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/container"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/annotation"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/container"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/pod"
-
-	corev1 "k8s.io/api/core/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
 )
 
 const (
@@ -63,10 +60,10 @@ func readinessProbe(useTLS bool) corev1.Probe {
 		SuccessThreshold:    1,
 		TimeoutSeconds:      5,
 		Handler: corev1.Handler{
-			Exec: &corev1.ExecAction{
-				Command: []string{"bash", "-c",
-					fmt.Sprintf(`curl -o /dev/null -w "%%{http_code}" %s://127.0.0.1:%d/login -k -s`, scheme, HTTPPort),
-				},
+			HTTPGet: &corev1.HTTPGetAction{
+				Port:   intstr.FromInt(HTTPPort),
+				Path:   "/login",
+				Scheme: scheme,
 			},
 		},
 	}


### PR DESCRIPTION
This reverts commit c580860a22645d31a537a3baf3be977963d55070.

Relates to #3054.

Will be backported in `1.1`.