### PR TITLE
Run go mod tidy before generating notice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,10 @@ dependencies:
 
 # Generate code, CRDs and documentation
 ALL_CRDS=config/crds/all-crds.yaml
-generate: generate-crds generate-api-docs generate-notice-file
+generate: tidy generate-crds generate-api-docs generate-notice-file
+
+tidy:
+	go mod tidy
 
 go-generate:
 	# we use this in pkg/controller/common/license


### PR DESCRIPTION
Ensures we are pruning any unused dependencies as part of PR checks / notice generation. Should catch issues like this https://github.com/elastic/cloud-on-k8s/pull/2926 where we were still shipping unused dependencies


>Tidy makes sure go.mod matches the source code in the module. It adds any missing modules necessary to build the current module's packages and dependencies, and it removes unused modules that don't provide any relevant packages. It also adds any missing entries to go.sum and removes any unnecessary ones. 