### PR TITLE
Sort Kinds in API docs

### DIFF
--- a/hack/api-docs/build.sh
+++ b/hack/api-docs/build.sh
@@ -26,7 +26,7 @@ build_docs() {
     local REPO_ROOT="${SCRIPT_DIR}/../.."
     local DOCS_DIR="${SCRIPT_DIR}/../../docs"
     local REFDOCS_REPO="${REFDOCS_REPO:-github.com/elastic/crd-ref-docs}"
-    local REFDOCS_VER="${REFDOCS_VER:-v0.0.4}"
+    local REFDOCS_VER="${REFDOCS_VER:-v0.0.5}"
     local BIN_DIR=${SCRATCH_DIR}/bin
 
     (

--- a/hack/api-docs/templates/gv_details.tpl
+++ b/hack/api-docs/templates/gv_details.tpl
@@ -7,7 +7,7 @@
 
 {{- if $gv.Kinds  }}
 .Resource Types
-{{- range $gv.Kinds }}
+{{- range $gv.SortedKinds }}
 - {{ $gv.TypeForKind . | asciidocRenderTypeLink }}
 {{- end }}
 {{ end }}


### PR DESCRIPTION
Change the API docs template and the binary version to produce a sorted list of Kinds. Without this, the produced output would be non-deterministic and result in CI failures.