### PR TITLE
Add E2E tests to cover breaking changes on secrets and services

### DIFF
--- a/test/e2e/test/apmserver/steps_deletion.go
+++ b/test/e2e/test/apmserver/steps_deletion.go
@@ -48,7 +48,7 @@ func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
 			}),
 		},
 		{
-			Name: "APM Server pods should be eventually be removed",
+			Name: "APM Server pods should eventually be removed",
 			Test: test.Eventually(func() error {
 				return k.CheckPodCount(0, test.ApmServerPodListOptions(b.ApmServer.Namespace, b.ApmServer.Name)...)
 			}),

--- a/test/e2e/test/checks.go
+++ b/test/e2e/test/checks.go
@@ -4,10 +4,44 @@
 
 package test
 
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
 // CheckTestSteps returns all test steps to verify a given resource in K8s is the expected one
 // and the given resource is running as expected.
 func CheckTestSteps(b Builder, k *K8sClient) StepList {
 	return StepList{}.
 		WithSteps(b.CheckK8sTestSteps(k)).
 		WithSteps(b.CheckStackTestSteps(k))
+}
+
+// CheckSecretsContent checks that expected secrets exist.
+// expected() returns a map[<secret name>] -> {<secret keys>}.
+func CheckSecretsContent(k *K8sClient, namespace string, expected func() map[string][]string) Step {
+	return Step{
+		Name: "Secrets should eventually be created",
+		Test: Eventually(func() error {
+			for secretName, keys := range expected() {
+				// secret should exist
+				var s corev1.Secret
+				if err := k.Client.Get(types.NamespacedName{Namespace: namespace, Name: secretName}, &s); err != nil {
+					return err
+				}
+				// and have the expected keys
+				if len(s.Data) != len(keys) {
+					return fmt.Errorf("expected %d keys in %s, got %d", len(keys), secretName, len(s.Data))
+				}
+				for _, k := range keys {
+					if _, exists := s.Data[k]; !exists {
+						return fmt.Errorf("expected key %s in secret %s not found", k, secretName)
+					}
+				}
+			}
+			return nil
+		}),
+	}
 }

--- a/test/e2e/test/checks.go
+++ b/test/e2e/test/checks.go
@@ -19,26 +19,50 @@ func CheckTestSteps(b Builder, k *K8sClient) StepList {
 		WithSteps(b.CheckStackTestSteps(k))
 }
 
+// ExpectedSecret represents a Secret we expect to exist.
+type ExpectedSecret struct {
+	Name   string
+	Labels map[string]string
+	Keys   []string
+}
+
+// MatchesActualSecret fetches the corresponding secret from k and returns an error if it mismatches.
+func (e ExpectedSecret) MatchesActualSecret(k *K8sClient, namespace string) error {
+	// secret should exist
+	var s corev1.Secret
+	if err := k.Client.Get(types.NamespacedName{Namespace: namespace, Name: e.Name}, &s); err != nil {
+		return err
+	}
+	// have the expected keys
+	if len(s.Data) != len(e.Keys) {
+		return fmt.Errorf("expected %d keys in %s, got %d", len(e.Keys), e.Name, len(s.Data))
+	}
+	for _, k := range e.Keys {
+		if _, exists := s.Data[k]; !exists {
+			return fmt.Errorf("expected key %s in secret %s not found", k, e.Name)
+		}
+	}
+	// and labels (actual secret can have more labels)
+	for k, v := range e.Labels {
+		actualValue, exists := s.Labels[k]
+		if !exists {
+			return fmt.Errorf("expected label %s not found in %s", k, e.Name)
+		}
+		if actualValue != v {
+			return fmt.Errorf("expected value %s for label %s in secret %s, found %s", v, k, e.Name, actualValue)
+		}
+	}
+	return nil
+}
+
 // CheckSecretsContent checks that expected secrets exist.
-// expected() returns a map[<secret name>] -> {<secret keys>}.
-func CheckSecretsContent(k *K8sClient, namespace string, expected func() map[string][]string) Step {
+func CheckSecretsContent(k *K8sClient, namespace string, expected func() []ExpectedSecret) Step {
 	return Step{
 		Name: "Secrets should eventually be created",
 		Test: Eventually(func() error {
-			for secretName, keys := range expected() {
-				// secret should exist
-				var s corev1.Secret
-				if err := k.Client.Get(types.NamespacedName{Namespace: namespace, Name: secretName}, &s); err != nil {
+			for _, e := range expected() {
+				if err := e.MatchesActualSecret(k, namespace); err != nil {
 					return err
-				}
-				// and have the expected keys
-				if len(s.Data) != len(keys) {
-					return fmt.Errorf("expected %d keys in %s, got %d", len(keys), secretName, len(s.Data))
-				}
-				for _, k := range keys {
-					if _, exists := s.Data[k]; !exists {
-						return fmt.Errorf("expected key %s in secret %s not found", k, secretName)
-					}
 				}
 			}
 			return nil

--- a/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/test/e2e/test/elasticsearch/checks_k8s.go
@@ -81,20 +81,90 @@ func CheckSecrets(b Builder, k *test.K8sClient) test.Step {
 		esName := b.Elasticsearch.Name
 		// hardcode all secret names and keys to catch any breaking change
 		expected := []test.ExpectedSecret{
-			{Name: esName + "-es-elastic-user", Keys: []string{"elastic"}},
-			{Name: esName + "-es-http-ca-internal", Keys: []string{"tls.crt", "tls.key"}},
-			{Name: esName + "-es-http-certs-internal", Keys: []string{"tls.crt", "tls.key", "ca.crt"}},
-			{Name: esName + "-es-http-certs-public", Keys: []string{"tls.crt", "ca.crt"}},
-			{Name: esName + "-es-internal-users", Keys: []string{"elastic-internal", "elastic-internal-probe"}},
-			{Name: esName + "-es-remote-ca", Keys: []string{"ca.crt"}},
-			{Name: esName + "-es-transport-ca-internal", Keys: []string{"tls.crt", "tls.key"}},
-			{Name: esName + "-es-transport-certs-public", Keys: []string{"ca.crt"}},
-			{Name: esName + "-es-xpack-file-realm", Keys: []string{"users", "users_roles", "roles.yml"}},
+			{
+				Name: esName + "-es-elastic-user",
+				Keys: []string{"elastic"},
+				Labels: map[string]string{
+					"common.k8s.elastic.co/type":                "elasticsearch",
+					"eck.k8s.elastic.co/credentials":            "true",
+					"elasticsearch.k8s.elastic.co/cluster-name": esName,
+				},
+			},
+			{
+				Name: esName + "-es-http-ca-internal",
+				Keys: []string{"tls.crt", "tls.key"},
+				Labels: map[string]string{
+					"common.k8s.elastic.co/type":                "elasticsearch",
+					"elasticsearch.k8s.elastic.co/cluster-name": esName,
+				},
+			},
+			{
+				Name: esName + "-es-http-certs-internal",
+				Keys: []string{"tls.crt", "tls.key", "ca.crt"},
+				Labels: map[string]string{
+					"common.k8s.elastic.co/type":                "elasticsearch",
+					"elasticsearch.k8s.elastic.co/cluster-name": esName,
+				},
+			},
+			{
+				Name: esName + "-es-http-certs-public",
+				Keys: []string{"tls.crt", "ca.crt"},
+				Labels: map[string]string{
+					"common.k8s.elastic.co/type":                "elasticsearch",
+					"elasticsearch.k8s.elastic.co/cluster-name": esName,
+				},
+			},
+			{
+				Name: esName + "-es-internal-users",
+				Keys: []string{"elastic-internal", "elastic-internal-probe"},
+				Labels: map[string]string{
+					"common.k8s.elastic.co/type":                "elasticsearch",
+					"eck.k8s.elastic.co/credentials":            "true",
+					"elasticsearch.k8s.elastic.co/cluster-name": esName,
+				},
+			},
+			{
+				Name: esName + "-es-remote-ca",
+				Keys: []string{"ca.crt"},
+				Labels: map[string]string{
+					"elasticsearch.k8s.elastic.co/cluster-name": esName,
+				},
+			},
+			{
+				Name: esName + "-es-transport-ca-internal",
+				Keys: []string{"tls.crt", "tls.key"},
+				Labels: map[string]string{
+					"common.k8s.elastic.co/type":                "elasticsearch",
+					"elasticsearch.k8s.elastic.co/cluster-name": esName,
+				},
+			},
+			{
+				Name: esName + "-es-transport-certs-public",
+				Keys: []string{"ca.crt"},
+				Labels: map[string]string{
+					"common.k8s.elastic.co/type":                "elasticsearch",
+					"elasticsearch.k8s.elastic.co/cluster-name": esName,
+				},
+			},
+			{
+				Name: esName + "-es-xpack-file-realm",
+				Keys: []string{"users", "users_roles", "roles.yml"},
+				Labels: map[string]string{
+					"common.k8s.elastic.co/type":                "elasticsearch",
+					"elasticsearch.k8s.elastic.co/cluster-name": esName,
+				},
+			},
 			// esName + "-es-transport-certificates" is handled in CheckPodCertificates
 		}
 		for _, nodeSet := range b.Elasticsearch.Spec.NodeSets {
 			expected = append(expected, test.ExpectedSecret{
-				Name: esName + "-es-" + nodeSet.Name + "-es-config", Keys: []string{"elasticsearch.yml"},
+				Name: esName + "-es-" + nodeSet.Name + "-es-config",
+				Keys: []string{"elasticsearch.yml"},
+				Labels: map[string]string{
+					"common.k8s.elastic.co/type":                    "elasticsearch",
+					"elasticsearch.k8s.elastic.co/cluster-name":     esName,
+					"elasticsearch.k8s.elastic.co/statefulset-name": esName + "-es-" + nodeSet.Name,
+				},
 			})
 		}
 		return expected

--- a/test/e2e/test/elasticsearch/steps_deletion.go
+++ b/test/e2e/test/elasticsearch/steps_deletion.go
@@ -53,7 +53,7 @@ func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
 			}),
 		},
 		{
-			Name: "Elasticsearch pods should be eventually be removed",
+			Name: "Elasticsearch pods should eventually be removed",
 			Test: test.Eventually(func() error {
 				return k.CheckPodCount(0, test.ESPodListOptions(b.Elasticsearch.Namespace, b.Elasticsearch.Name)...)
 			}),

--- a/test/e2e/test/k8s_client.go
+++ b/test/e2e/test/k8s_client.go
@@ -31,7 +31,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/name"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates/transport"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -245,35 +244,6 @@ func (k *K8sClient) GetCA(ownerNamespace, ownerName string, caType certificates.
 	}
 
 	return certificates.NewCA(pKey, caCerts[0]), nil
-}
-
-// GetTransportCert retrieves the certificate of the CA and the transport certificate
-func (k *K8sClient) GetTransportCert(esNamespace, esName, podName string) (caCert, transportCert []*x509.Certificate, err error) {
-	var secret corev1.Secret
-	key := types.NamespacedName{
-		Namespace: esNamespace,
-		Name:      esv1.TransportCertificatesSecret(esName),
-	}
-	if err = k.Client.Get(key, &secret); err != nil {
-		return nil, nil, err
-	}
-	caCertBytes, exists := secret.Data[certificates.CAFileName]
-	if !exists || len(caCertBytes) == 0 {
-		return nil, nil, fmt.Errorf("no value found for secret %s", certificates.CAFileName)
-	}
-	caCert, err = certificates.ParsePEMCerts(caCertBytes)
-	if err != nil {
-		return nil, nil, err
-	}
-	transportCertBytes, exists := secret.Data[transport.PodCertFileName(podName)]
-	if !exists || len(transportCertBytes) == 0 {
-		return nil, nil, fmt.Errorf("no value found for secret %s", transport.PodCertFileName(podName))
-	}
-	transportCert, err = certificates.ParsePEMCerts(transportCertBytes)
-	if err != nil {
-		return nil, nil, err
-	}
-	return
 }
 
 // Exec runs the given cmd into the given pod.

--- a/test/e2e/test/kibana/steps_deletion.go
+++ b/test/e2e/test/kibana/steps_deletion.go
@@ -49,7 +49,7 @@ func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
 			}),
 		},
 		{
-			Name: "Kibana pods should be eventually be removed",
+			Name: "Kibana pods should eventually be removed",
 			Test: test.Eventually(func() error {
 				return k.CheckPodCount(0, test.KibanaPodListOptions(b.Kibana.Namespace, b.Kibana.Name)...)
 			}),


### PR DESCRIPTION
Renaming a service, a secret or a secret key is a breaking change since
users may already rely on the naming convention.
Let's catch those in E2E tests.

Fixes https://github.com/elastic/cloud-on-k8s/issues/3036.