### PR TITLE
Fix Kibana certs secret labels

### DIFF
--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -18,7 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/apmserver"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
@@ -117,7 +116,7 @@ func (d *driver) Reconcile(
 		Object:                kb,
 		TLSOptions:            kb.Spec.HTTP.TLS,
 		Namer:                 Namer,
-		Labels:                apmserver.NewLabels(kb.Name),
+		Labels:                NewLabels(kb.Name),
 		Services:              []corev1.Service{*svc},
 		CACertRotation:        params.CACertRotation,
 		CertRotation:          params.CertRotation,


### PR DESCRIPTION
We were accidentally using (and importing) APMServer labels instead of
using Kibana labels...

Caught as part of https://github.com/elastic/cloud-on-k8s/pull/3093,
which will include additional tests for those labels names and values.