### PR TITLE
Backport - Fix Kibana certs secret labels

### DIFF
--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -18,7 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/apmserver/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/association"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
@@ -225,7 +224,7 @@ func (d *driver) Reconcile(
 		Object:                kb,
 		TLSOptions:            kb.Spec.HTTP.TLS,
 		Namer:                 kbname.KBNamer,
-		Labels:                labels.NewLabels(kb.Name),
+		Labels:                label.NewLabels(kb.Name),
 		Services:              []corev1.Service{*svc},
 		CACertRotation:        params.CACertRotation,
 		CertRotation:          params.CertRotation,


### PR DESCRIPTION
Backport https://github.com/elastic/cloud-on-k8s/pull/3098 on 1.1.

We were accidentally using (and importing) APMServer labels instead of
using Kibana labels...

Caught as part of https://github.com/elastic/cloud-on-k8s/pull/3093,
which will include additional tests for those labels names and values.