### PR TITLE
Fix remote cluster annotation handling

### DIFF
--- a/pkg/controller/elasticsearch/remotecluster/annotations.go
+++ b/pkg/controller/elasticsearch/remotecluster/annotations.go
@@ -44,6 +44,8 @@ func annotateWithCreatedRemoteClusters(c k8s.Client, es esv1.Elasticsearch, remo
 			delete(es.Annotations, ManagedRemoteClustersAnnotationName)
 			return c.Update(&es)
 		}
+
+		return nil
 	}
 
 	if es.Annotations == nil {

--- a/pkg/controller/elasticsearch/remotecluster/elasticsearch_test.go
+++ b/pkg/controller/elasticsearch/remotecluster/elasticsearch_test.go
@@ -41,6 +41,17 @@ func Test_getCurrentRemoteClusters(t *testing.T) {
 			want: map[string]struct{}{},
 		},
 		{
+			name: "Read from an empty annotation",
+			args: args{es: esv1.Elasticsearch{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "ns1",
+					Namespace:   "es1",
+					Annotations: map[string]string{ManagedRemoteClustersAnnotationName: ""},
+				},
+			}},
+			want: map[string]struct{}{},
+		},
+		{
 			name: "Decode annotation into a list of remote cluster",
 			args: args{es: esv1.Elasticsearch{
 				ObjectMeta: metav1.ObjectMeta{
@@ -138,6 +149,20 @@ func TestUpdateSettings(t *testing.T) {
 					"ns1",
 					"es1",
 					nil,
+				),
+			},
+			wantRequeue:  false,
+			wantEsCalled: false,
+		},
+		{
+			name: "Empty annotation",
+			args: args{
+				esClient:       &fakeESClient{existingSettings: emptySettings},
+				licenseChecker: &fakeLicenseChecker{true},
+				es: newEsWithRemoteClusters(
+					"ns1",
+					"es1",
+					map[string]string{"foo": "bar", ManagedRemoteClustersAnnotationName: ""},
 				),
 			},
 			wantRequeue:  false,


### PR DESCRIPTION
This fixes two issues with the remote cluster annotation:
- Don't apply the annotation if there are no remote clusters configured. Previously, the annotation was always applied to the Elasticsearch object with the value set to the empty string.
- Ignore empty strings in the annotation value. Previously, parsing the empty string resulted in a cluster named `""` (https://play.golang.org/p/MFB9yfZxxQ1)

Fixes #3090