### PR TITLE
Add renovate label to PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:base"
   ],
+  "labels": [">renovate"],
   "packageRules": [
     {
       "packageNames": [


### PR DESCRIPTION
Automatically add the `>renovate` label to PRs so it does not get the `triage` label and can be filtered easily

https://docs.renovatebot.com/configuration-options/#labels