### PR TITLE
Use docker.elastic.co rather than push.docker.elastic.co

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -55,9 +55,9 @@ ci-build-image: DOCKER_PASSWORD = $(shell VAULT_TOKEN=$(VAULT_TOKEN) $(vault) re
 ci-build-image: write-ci-docker-creds
 	@ docker pull -q $(CI_IMAGE) | grep -v -E 'Downloading|Extracting|Verifying|complete' || \
 	( \
-		docker build -f $(ROOT_DIR)/.ci/Dockerfile -t push.$(CI_IMAGE) --label "commit.hash=$(shell git rev-parse --short --verify HEAD)" $(ROOT_DIR) && \
-		docker login -u $(DOCKER_LOGIN) -p $(DOCKER_PASSWORD) push.docker.elastic.co 2> /dev/null && \
-		docker push push.$(CI_IMAGE) | grep -v -E 'Waiting|Layer already|Preparing|Pushing|Pushed' \
+		docker build -f $(ROOT_DIR)/.ci/Dockerfile -t $(CI_IMAGE) --label "commit.hash=$(shell git rev-parse --short --verify HEAD)" $(ROOT_DIR) && \
+		docker login -u $(DOCKER_LOGIN) -p $(DOCKER_PASSWORD) docker.elastic.co 2> /dev/null && \
+		docker push $(CI_IMAGE) | grep -v -E 'Waiting|Layer already|Preparing|Pushing|Pushed' \
 	)
 
 # make Docker creds available from inside the CI container through the .registry.env file

--- a/dev-setup.md
+++ b/dev-setup.md
@@ -52,7 +52,7 @@ Run `make check-requisites` to check that all dependencies are installed.
 
 The `docker.elastic.co` registry and the `eck-dev` namespace are setup by default.
 
-It is up to you to manage the authentication (`docker login -u $username push.docker.elastic.co`) to be able to push images into it.
+It is up to you to manage the authentication (`docker login -u $username docker.elastic.co`) to be able to push images into it.
 
 A file `.registry.env` can be created to use another Docker registry.
 

--- a/hack/docker-push.sh
+++ b/hack/docker-push.sh
@@ -6,9 +6,8 @@
 
 # Script to handle exoticisms related to 'docker login' and 'docker push'.
 #
-# Log in to push.docker.elastic.co if the namespace eck, eck-ci or eck-snapshots is used
+# Log in to docker.elastic.co if the namespace eck, eck-ci or eck-snapshots is used
 # Log in to gcloud if GCR is used
-# Add a 'push.' prefix when using docker.elastic.co
 
 set -euo pipefail
 
@@ -31,7 +30,7 @@ docker-login() {
 
         */eck/*|*/eck-ci/*|*/eck-snapshots/*)
             echo "Authentication to ${registry}..."
-            docker login -u "${DOCKER_LOGIN}" -p "${DOCKER_PASSWORD}" push.docker.elastic.co 2> /dev/null
+            docker login -u "${DOCKER_LOGIN}" -p "${DOCKER_PASSWORD}" docker.elastic.co 2> /dev/null
         ;;
 
         *.gcr.io/*)
@@ -50,17 +49,6 @@ docker-login() {
 
 docker-push() {
     local image=$1
-
-    # add the 'push.' prefix for docker.elastic.co
-    case ${image} in
-
-        docker.elastic.co/*)
-            docker tag "$image" "push.$image"
-            image="push.$image"
-        ;;
-
-    esac
-
     echo "Push $image..."
     # silence the verbose output of the `docker push` command
     docker push "$image" | grep -v -E 'Waiting|Layer already|Preparing|Pushing|Pushed'


### PR DESCRIPTION
It was recommended by the infra team that we use docker.elastic.co rather than push.