### PR TITLE
Remove warning about running APMServer and ES in different namespaces

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
@@ -43,8 +43,6 @@ spec:
     name: quickstart
 EOF
 ----
-+
-NOTE: Deploying the APM Server and Elasticsearch in two different namespaces is currently not supported.
 
 . Monitor APM Server deployment.
 +


### PR DESCRIPTION
Running APMServer and Elasticsearch in different namespaces is
definitely supported.
We even have an E2E test to cover it.