### PR TITLE
Backport 1.0 - Remove warning about APMServer and ES in different namespaces (#3107)

### DIFF
--- a/docs/apm-server.asciidoc
+++ b/docs/apm-server.asciidoc
@@ -43,8 +43,6 @@ spec:
     name: quickstart
 EOF
 ----
-+
-NOTE: Deploying the APM Server and Elasticsearch in two different namespaces is currently not supported.
 
 . Monitor APM Server deployment.
 +


### PR DESCRIPTION
Backport`74045fa` on 1.0.

Running APMServer and Elasticsearch in different namespaces is
definitely supported.