### PR TITLE
Dynamic branch specifier for E2E tests jobs

### DIFF
--- a/.ci/jobs/e2e-tests-aks.yml
+++ b/.ci/jobs/e2e-tests-aks.yml
@@ -5,6 +5,10 @@
     project-type: pipeline
     parameters:
       - string:
+          name: branch_specifier
+          default: master
+          description: "the Git branch specifier to build (&lt;branchName&gt;,&lt;tagName&gt;, &lt;commitId&gt;, etc.)"
+      - string:
           name: JKS_PARAM_OPERATOR_IMAGE
           description: "ECK Docker image"
       - bool:
@@ -16,7 +20,7 @@
         - git:
             url: https://github.com/elastic/cloud-on-k8s
             branches:
-              - master
+              - ${branch_specifier}
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
       script-path: .ci/pipelines/e2e-tests-aks.Jenkinsfile
-      lightweight-checkout: true
+      lightweight-checkout: false

--- a/.ci/jobs/e2e-tests-eks.yml
+++ b/.ci/jobs/e2e-tests-eks.yml
@@ -5,6 +5,10 @@
     project-type: pipeline
     parameters:
       - string:
+          name: branch_specifier
+          default: master
+          description: "the Git branch specifier to build (&lt;branchName&gt;,&lt;tagName&gt;, &lt;commitId&gt;, etc.)"
+      - string:
           name: JKS_PARAM_OPERATOR_IMAGE
           description: "ECK Docker image"
       - bool:
@@ -16,7 +20,7 @@
         - git:
             url: https://github.com/elastic/cloud-on-k8s
             branches:
-              - master
+              - ${branch_specifier}
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
       script-path: .ci/pipelines/e2e-tests-eks.Jenkinsfile
-      lightweight-checkout: true
+      lightweight-checkout: false

--- a/.ci/jobs/e2e-tests-gke-k8s-versions.yml
+++ b/.ci/jobs/e2e-tests-gke-k8s-versions.yml
@@ -5,6 +5,10 @@
     project-type: pipeline
     parameters:
       - string:
+          name: branch_specifier
+          default: master
+          description: "the Git branch specifier to build (&lt;branchName&gt;,&lt;tagName&gt;, &lt;commitId&gt;, etc.)"
+      - string:
           name: JKS_PARAM_OPERATOR_IMAGE
           description: "ECK Docker image"
       - bool:
@@ -16,7 +20,7 @@
         - git:
             url: https://github.com/elastic/cloud-on-k8s
             branches:
-              - master
+              - ${branch_specifier}
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
       script-path: .ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
-      lightweight-checkout: true
+      lightweight-checkout: false

--- a/.ci/jobs/e2e-tests-kind-k8s-versions.yml
+++ b/.ci/jobs/e2e-tests-kind-k8s-versions.yml
@@ -5,6 +5,10 @@
     project-type: pipeline
     parameters:
       - string:
+          name: branch_specifier
+          default: master
+          description: "the Git branch specifier to build (&lt;branchName&gt;,&lt;tagName&gt;, &lt;commitId&gt;, etc.)"
+      - string:
           name: JKS_PARAM_OPERATOR_IMAGE
           description: "ECK Docker image"
       - bool:
@@ -16,7 +20,7 @@
         - git:
             url: https://github.com/elastic/cloud-on-k8s
             branches:
-              - master
+              - ${branch_specifier}
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
       script-path: .ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
-      lightweight-checkout: true
+      lightweight-checkout: false

--- a/.ci/jobs/e2e-tests-ocp.yaml
+++ b/.ci/jobs/e2e-tests-ocp.yaml
@@ -5,6 +5,10 @@
     project-type: pipeline
     parameters:
       - string:
+          name: branch_specifier
+          default: master
+          description: "the Git branch specifier to build (&lt;branchName&gt;,&lt;tagName&gt;, &lt;commitId&gt;, etc.)"
+      - string:
           name: JKS_PARAM_OPERATOR_IMAGE
           description: "ECK Docker image"
       - bool:
@@ -16,7 +20,7 @@
         - git:
             url: https://github.com/elastic/cloud-on-k8s
             branches:
-              - master
+              - ${branch_specifier}
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
       script-path: .ci/pipelines/e2e-tests-ocp.Jenkinsfile
-      lightweight-checkout: true
+      lightweight-checkout: false

--- a/.ci/jobs/e2e-tests-stack-versions-gke.yml
+++ b/.ci/jobs/e2e-tests-stack-versions-gke.yml
@@ -5,6 +5,10 @@
     project-type: pipeline
     parameters:
       - string:
+          name: branch_specifier
+          default: master
+          description: "the Git branch specifier to build (&lt;branchName&gt;,&lt;tagName&gt;, &lt;commitId&gt;, etc.)"
+      - string:
           name: JKS_PARAM_OPERATOR_IMAGE
           description: "ECK Docker image"
       - bool:
@@ -16,7 +20,7 @@
         - git:
             url: https://github.com/elastic/cloud-on-k8s
             branches:
-              - master
+              - ${branch_specifier}
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
       script-path: .ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
-      lightweight-checkout: true
+      lightweight-checkout: false

--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -77,27 +77,45 @@ pipeline {
                 def operatorImage = sh(returnStdout: true, script: 'make print-operator-image').trim()
 
                 build job: 'cloud-on-k8s-e2e-tests-stack-versions',
-                    parameters: [string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage)],
+                    parameters: [
+                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
+                        string(name: 'branch_specifier', value: GIT_COMMIT)
+                    ],
                     wait: false
 
                 build job: 'cloud-on-k8s-e2e-tests-gke-k8s-versions',
-                    parameters: [string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage)],
+                    parameters: [
+                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
+                        string(name: 'branch_specifier', value: GIT_COMMIT)
+                    ],
                     wait: false
 
                 build job: 'cloud-on-k8s-e2e-tests-aks',
-                    parameters: [string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage)],
+                    parameters: [
+                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
+                        string(name: 'branch_specifier', value: GIT_COMMIT)
+                    ],
                     wait: false
 
                 build job: 'cloud-on-k8s-e2e-tests-kind-k8s-versions',
-                    parameters: [string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage)],
+                    parameters: [
+                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
+                        string(name: 'branch_specifier', value: GIT_COMMIT)
+                    ],
                     wait: false
 
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
-                    parameters: [string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage)],
+                    parameters: [
+                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
+                        string(name: 'branch_specifier', value: GIT_COMMIT)
+                    ],
                     wait: false
 
                 build job: 'cloud-on-k8s-e2e-tests-eks',
-                    parameters: [string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage)],
+                    parameters: [
+                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
+                        string(name: 'branch_specifier', value: GIT_COMMIT)
+                    ],
                     wait: false
             }
         }


### PR DESCRIPTION
* Add a branch specifier parameter to dynamically checkout a given
sha1, branch or tag in the E2E tests jobs.
* Propagate the git commit that triggers a nightly or release build to
the E2E tests jobs that are triggered after a successful build.

Resolves #3066.