### PR TITLE
Remove duplicate checkout

### DIFF
--- a/.ci/pipelines/e2e-tests-aks.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-aks.Jenkinsfile
@@ -19,16 +19,6 @@ pipeline {
     }
 
     stages {
-        stage('Checkout from GitHub') {
-            steps {
-                checkout scm
-            }
-        }
-        stage('Run Checks') {
-            steps {
-                sh 'make -C .ci TARGET=ci-check ci'
-            }
-        }
         stage("Run E2E tests") {
             steps {
                 sh '.ci/setenvconfig e2e/aks'

--- a/.ci/pipelines/e2e-tests-eks.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-eks.Jenkinsfile
@@ -19,16 +19,6 @@ pipeline {
     }
 
     stages {
-        stage('Checkout from GitHub') {
-            steps {
-                checkout scm
-            }
-        }
-        stage('Run Checks') {
-            steps {
-                sh 'make -C .ci TARGET=ci-check ci'
-            }
-        }
         stage("Run E2E tests") {
             steps {
                 sh '.ci/setenvconfig e2e/eks'

--- a/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
@@ -20,16 +20,6 @@ pipeline {
     }
 
     stages {
-        stage('Checkout from GitHub') {
-            steps {
-                checkout scm
-            }
-        }
-        stage('Run Checks') {
-            steps {
-                sh 'make -C .ci TARGET=ci-check ci'
-            }
-        }
         stage("Run E2E tests") {
             steps {
                 sh '.ci/setenvconfig e2e/ocp'


### PR DESCRIPTION
Declarative Jenkins pipelines have an implicit default automatic
source control checkout so there is no need to have an explicit
checkout.

I also deleted the `ci-check` that is already run for each PR (in the `cloud-on-k8s-pr` job) and each merge in master (in the `cloud-on-k8s-e2e-tests-master` job) in order to be consistent with others E2E tests jobs.

Relates to #3066.