### PR TITLE
Increase the days to keep builds in history

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -9,7 +9,7 @@
 
 - job:
     logrotate:
-      daysToKeep: 7
+      daysToKeep: 30
       numToKeep: 100
       artifactDaysToKeep: 5
       artifactNumToKeep: 10


### PR DESCRIPTION
It would have been useful recently to have a larger builds history.

Pass the `days to keep builds` from 7 to 30. The number of builds to
keep is left to 100.