### PR TITLE
Group renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,18 +16,26 @@
         "digest"
       ],
       "enabled": false
-    }
+    },
     {
       "packageNames": [
         "k8s.io/apimachinery",
         "k8s.io/client-go",
-        "k8s.io/api",
-        "k8s.io/utils"
+        "k8s.io/api"
       ],
       "updateTypes": [
         "patch"
       ],
       "groupName": "k8s"
+    },
+    {
+      "packageNames": [
+        "k8s.io/utils"
+      ],
+      "updateTypes": [
+        "digest"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,9 +11,23 @@
         "k8s.io/api"
       ],
       "updateTypes": [
-        "major"
+        "major",
+        "minor",
+        "digest"
       ],
       "enabled": false
+    }
+    {
+      "packageNames": [
+        "k8s.io/apimachinery",
+        "k8s.io/client-go",
+        "k8s.io/api",
+        "k8s.io/utils"
+      ],
+      "updateTypes": [
+        "patch"
+      ],
+      "groupName": "k8s"
     }
   ]
 }


### PR DESCRIPTION
The intent was to only bump k8s dependencies within a major, but I messed up originally because they version them as [`0.18.3`](https://github.com/elastic/cloud-on-k8s/pull/3119) etc. This changes it to:

- only bump k8s dependencies if they are a patch. minors can be handled with the controller-runtime bumps
- group k8s dependencies together into one PR
- ignore digest dependencies for k8s.io/utils. Currently it will open a PR for every commit, because the repo does not include any tags. I asked [in slack](https://kubernetes.slack.com/archives/C09R23FHP/p1590000806367800), if that will change, but no response yet. This means we will likely need to manually update this dependency if we want to, but I think that's okay since our use of this module is pretty limited at the moment (parsing ports safely [here](https://github.com/elastic/cloud-on-k8s/blob/master/pkg/dev/portforward/service_forwarder.go#L97)).


Config options described [here](https://docs.renovatebot.com/configuration-options/#digest)