### PR TITLE
Make E2E tests bootstrap more resilient

### DIFF
--- a/test/e2e/cmd/run/command.go
+++ b/test/e2e/cmd/run/command.go
@@ -67,7 +67,11 @@ func Command() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			flags.logVerbosity, _ = cmd.PersistentFlags().GetInt("log-verbosity")
-			return doRun(flags)
+			err := doRun(flags)
+			if err != nil {
+				log.Error(err, "Failed to run e2e tests")
+			}
+			return err
 		},
 	}
 

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	sprig "github.com/Masterminds/sprig/v3"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/retry"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/command"
 	"github.com/pkg/errors"
@@ -31,11 +33,12 @@ import (
 )
 
 const (
-	jobTimeout       = 300 * time.Minute // time to wait for the test job to finish
-	kubePollInterval = 10 * time.Second  // Kube API polling interval
-	logBufferSize    = 1024              // Size of the log buffer (1KiB)
-	testRunLabel     = "test-run"        // name of the label applied to resources
-	testsLogFile     = "e2e-tests.json"  // name of file to keep all test logs in JSON format
+	jobTimeout           = 300 * time.Minute // time to wait for the test job to finish
+	kubePollInterval     = 10 * time.Second  // Kube API polling interval
+	logBufferSize        = 1024              // Size of the log buffer (1KiB)
+	testRunLabel         = "test-run"        // name of the label applied to resources
+	testsLogFile         = "e2e-tests.json"  // name of file to keep all test logs in JSON format
+	operatorReadyTimeout = 3 * time.Minute   // time to wait for the operator pod to be ready
 
 	TestNameLabel = "test-name" // name of the label applied to resources during each test
 )
@@ -68,6 +71,7 @@ func doRun(flags runFlags) error {
 			helper.createOperatorNamespaces,
 			helper.createManagedNamespaces,
 			helper.deployOperator,
+			helper.waitForOperatorToBeReady,
 			helper.deployFilebeat,
 			helper.deployTestJob,
 			helper.runTestJob,
@@ -252,6 +256,28 @@ func (h *helper) createManagedNamespaces() error {
 func (h *helper) deployOperator() error {
 	log.Info("Deploying operator")
 	return h.kubectlApplyTemplateWithCleanup("config/e2e/operator.yaml", h.testContext)
+}
+
+func (h *helper) waitForOperatorToBeReady() error {
+	log.Info("Waiting for the operator pod to be ready")
+	client, err := h.createKubeClient()
+	if err != nil {
+		return errors.Wrap(err, "failed to create kubernetes client")
+	}
+
+	// operator pod name takes the form <statefulset name>-<ordinal>
+	podName := fmt.Sprintf("%s-0", h.testContext.Operator.Name)
+
+	return retry.UntilSuccess(func() error {
+		pod, err := client.CoreV1().Pods(h.testContext.Operator.Namespace).Get(podName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if !k8s.IsPodReady(*pod) {
+			return fmt.Errorf("operator pod `%s` not ready", podName)
+		}
+		return nil
+	}, operatorReadyTimeout, 10*time.Second)
 }
 
 func (h *helper) deployFilebeat() error {


### PR DESCRIPTION
While waiting for the operator pod to be ready before continuing to run the
tests.

Relates to #2632.