### PR TITLE
Add 1.1.2 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-1.1.2>>
 * <<release-notes-1.1.1>>
 * <<release-notes-1.1.0>>
 * <<release-notes-1.0.1>>
@@ -13,6 +14,8 @@ This section summarizes the changes in each release.
 * <<release-notes-1.0.0-beta1>>
 
 --
+
+include::release-notes/1.1.2.asciidoc[]
 include::release-notes/1.1.1.asciidoc[]
 include::release-notes/1.1.0.asciidoc[]
 include::release-notes/1.0.1.asciidoc[]

--- a/docs/release-notes/1.1.0.asciidoc
+++ b/docs/release-notes/1.1.0.asciidoc
@@ -65,6 +65,7 @@
 * Watch only trial license secret (not trial status) {pull}2879[#2879]
 * Do not reject PVC update when a different unit is used {pull}2857[#2857] (issue: {issue}2856[#2856])
 * Revert transport TLS certs verification from full to certificate {pull}2831[#2831] (issue: {issue}2823[#2823])
+* Compatibility check: add Service ownership test {pull}2803[#2803]
 * Fix labels on ES CA secret for Kibana association {pull}2773[#2773] (issue: {issue}2698[#2698])
 * Ensure that HTTP CA cert is always set {pull}2772[#2772]
 * License check: update remote cluster logs and events {pull}2746[#2746]

--- a/docs/release-notes/1.1.2.asciidoc
+++ b/docs/release-notes/1.1.2.asciidoc
@@ -1,0 +1,18 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-1.1.2]]
+== {n} version 1.1.2
+
+
+
+
+
+[[bug-1.1.2]]
+[float]
+=== Bug fixes
+
+* Fix remote cluster annotation handling {pull}3101[#3101]
+* Fix Kibana certs secret labels {pull}3098[#3098]
+* Avoid overwriting default IPFamily of services {pull}3084[#3084]
+* Do not propagate Elasticsearch CA if none is provided {pull}3083[#3083] (issues: {issue}2243[#2243], {issue}3082[#3082])

--- a/docs/release-notes/highlights-1.1.2.asciidoc
+++ b/docs/release-notes/highlights-1.1.2.asciidoc
@@ -1,0 +1,20 @@
+[[release-highlights-1.1.2]]
+== 1.1.2 release highlights
+
+[float]
+[id="{p}-112-new-and-notable"]
+=== New and notable
+This release contains bug fixes especially relevant for
+
+* users with custom certificates configured
+* users deploying ECK into dual-stack Kubernetes clusters
+
+as well as some minor bug fixes.
+
+[float]
+[id="{p}-112-breaking-changes"]
+=== Upgrade notes
+
+In ECK 1.1.0, users using custom certificates would be required to specify a cerificate authority (CA), even if the CA was present in the system certificates. This was a regression in 1.1.0 and has been fixed in 1.1.2. Users with custom certificates that are signed by a well-known CA will now function without the user specifying the CA explicitly.
+
+In dual-stack (IPv4 and IPv6) clusters, the `ipFamily` field of any `Service` is defaulted and immutable. Previous versions of ECK would try to reset this field and fail. ECK 1.1.2 resolves this behavior and will leave the `ipFamily` field intact. Note that at this time ECK does not support running on IPv6, this simply allows it to run in Kubernetes clusters with the `IPv6DualStack` feature flag enabled.

--- a/docs/release-notes/highlights-1.1.2.asciidoc
+++ b/docs/release-notes/highlights-1.1.2.asciidoc
@@ -15,6 +15,6 @@ as well as some minor bug fixes.
 [id="{p}-112-breaking-changes"]
 === Upgrade notes
 
-In ECK 1.1.0, users using custom certificates would be required to specify a cerificate authority (CA), even if the CA was present in the system certificates. This was a regression in 1.1.0 and has been fixed in 1.1.2. Users with custom certificates that are signed by a well-known CA will now function without the user specifying the CA explicitly.
+In ECK 1.1.0, users using custom certificates would be required to specify a certificate authority (CA), even if the CA was present in the system certificates. This was a regression in 1.1.0 and has been fixed in 1.1.2. Users with custom certificates that are signed by a well-known CA will now function without the user specifying the CA explicitly.
 
 In dual-stack (IPv4 and IPv6) clusters, the `ipFamily` field of any `Service` is defaulted and immutable. Previous versions of ECK would try to reset this field and fail. ECK 1.1.2 resolves this behavior and will leave the `ipFamily` field intact. Note that at this time ECK does not support running on IPv6, this simply allows it to run in Kubernetes clusters with the `IPv6DualStack` feature flag enabled.

--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the most important changes in each release. For the full list, see <<eck-release-notes>>.
 
+* <<release-highlights-1.1.2>>
 * <<release-highlights-1.1.1>>
 * <<release-highlights-1.1.0>>
 * <<release-highlights-1.0.1>>
@@ -13,6 +14,7 @@ This section summarizes the most important changes in each release. For the full
 
 --
 
+include::highlights-1.1.2.asciidoc[]
 include::highlights-1.1.1.asciidoc[]
 include::highlights-1.1.0.asciidoc[]
 include::highlights-1.0.1.asciidoc[]


### PR DESCRIPTION
Also updates 1.1.0 release notes since I forgot to tag a specific PR for that release when I backported it 🤦‍♀️ 