### PR TITLE
Remove the OPERATOR_IMAGE env var from ECK manifest

### DIFF
--- a/config/e2e/operator.yaml
+++ b/config/e2e/operator.yaml
@@ -192,8 +192,6 @@ spec:
                 fieldPath: metadata.namespace
           - name: WEBHOOK_SECRET
             value: webhook-server-secret
-          - name: OPERATOR_IMAGE
-            value: {{ .OperatorImage }}
         resources:
           limits:
             cpu: 1

--- a/config/operator/all-in-one/operator.template.yaml
+++ b/config/operator/all-in-one/operator.template.yaml
@@ -31,8 +31,6 @@ spec:
                 fieldPath: metadata.namespace
           - name: WEBHOOK_SECRET
             value: elastic-webhook-server-cert
-          - name: OPERATOR_IMAGE
-            value: <OPERATOR_IMAGE>
         resources:
           limits:
             cpu: 1

--- a/config/operator/namespace/operator.template.yaml
+++ b/config/operator/namespace/operator.template.yaml
@@ -29,8 +29,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: OPERATOR_IMAGE
-            value: <OPERATOR_IMAGE>
         resources:
           limits:
             cpu: 1


### PR DESCRIPTION
This is actually useless. I think the last time it was useful was when
we ran an init container with the operator image for the Elasticsearch
process manager. A long time ago.
(https://github.com/elastic/cloud-on-k8s/blob/0.8/operators/cmd/manager/main.go#L157-L162)
