### PR TITLE
Do not stop running trial even when ECK not in trial mode

### DIFF
--- a/pkg/controller/elasticsearch/license/apply.go
+++ b/pkg/controller/elasticsearch/license/apply.go
@@ -48,6 +48,13 @@ func applyLinkedLicense(
 	)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			if isTrial(current) {
+				// this is the case if the user has started a trial on the ES cluster level
+				// e.g. from Kibana when trying to access a commercial feature.
+				// While this is not a supported use case we tolerate it to avoid a bad user
+				// experience because trials can only be started once on the ES cluster level
+				return nil
+			}
 			// no license linked to this cluster. Revert to basic.
 			return startBasic(ctx, updater)
 		}

--- a/pkg/controller/elasticsearch/license/apply_test.go
+++ b/pkg/controller/elasticsearch/license/apply_test.go
@@ -7,6 +7,7 @@ package license
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -76,6 +77,22 @@ func Test_updateLicense(t *testing.T) {
 			},
 		},
 		{
+			name: "start a trial",
+			args: args{
+				current: nil,
+				desired: esclient.License{
+					Type: "trial",
+				},
+			},
+			reqFn: func(req *http.Request) *http.Response {
+				if strings.Contains(req.URL.Path, "start_trial") {
+					return esclient.NewMockResponse(200, req, `{"acknowledged": true, "trial_started": true}`)
+				}
+				panic("should only call start_trial")
+			},
+			wantErr: false,
+		},
+		{
 			name: "short-circuit: already up to date",
 			args: args{
 				current: &esclient.License{
@@ -127,6 +144,9 @@ func Test_applyLinkedLicense(t *testing.T) {
 						"anything": []byte(fixtures.LicenseSample),
 					},
 				},
+			},
+			clientAssertions: func(updater fakeLicenseUpdater) {
+				require.True(t, updater.updateLicenseCalled, "should update license")
 			},
 		},
 		{
@@ -206,8 +226,9 @@ func Test_applyLinkedLicense(t *testing.T) {
 }
 
 type fakeLicenseUpdater struct {
-	license          esclient.License
-	startBasicCalled bool
+	license             esclient.License
+	startBasicCalled    bool
+	updateLicenseCalled bool
 }
 
 func (f *fakeLicenseUpdater) StartTrial(ctx context.Context) (esclient.StartTrialResponse, error) {
@@ -222,6 +243,7 @@ func (f *fakeLicenseUpdater) GetLicense(ctx context.Context) (esclient.License, 
 }
 
 func (f *fakeLicenseUpdater) UpdateLicense(ctx context.Context, licenses esclient.LicenseUpdateRequest) (esclient.LicenseUpdateResponse, error) {
+	f.updateLicenseCalled = true
 	return esclient.LicenseUpdateResponse{
 		Acknowledged:  true,
 		LicenseStatus: "valid",

--- a/pkg/controller/elasticsearch/license/apply_test.go
+++ b/pkg/controller/elasticsearch/license/apply_test.go
@@ -81,7 +81,7 @@ func Test_updateLicense(t *testing.T) {
 			args: args{
 				current: nil,
 				desired: esclient.License{
-					Type: "trial",
+					Type: string(esclient.ElasticsearchLicenseTypeTrial),
 				},
 			},
 			reqFn: func(req *http.Request) *http.Response {
@@ -159,7 +159,7 @@ func Test_applyLinkedLicense(t *testing.T) {
 		{
 			name:           "no error: no license found but tolerate a cluster level trial",
 			wantErr:        false,
-			currentLicense: &esclient.License{Type: "trial"},
+			currentLicense: &esclient.License{Type: string(esclient.ElasticsearchLicenseTypeTrial)},
 			clientAssertions: func(updater fakeLicenseUpdater) {
 				require.False(t, updater.startBasicCalled, "should not call start_basic")
 			},

--- a/pkg/controller/elasticsearch/license/apply_test.go
+++ b/pkg/controller/elasticsearch/license/apply_test.go
@@ -109,6 +109,7 @@ func Test_applyLinkedLicense(t *testing.T) {
 	tests := []struct {
 		name             string
 		initialObjs      []runtime.Object
+		currentLicense   *esclient.License
 		errors           map[client.ObjectKey]error
 		wantErr          bool
 		clientAssertions func(updater fakeLicenseUpdater)
@@ -133,6 +134,14 @@ func Test_applyLinkedLicense(t *testing.T) {
 			wantErr: false,
 			clientAssertions: func(updater fakeLicenseUpdater) {
 				require.True(t, updater.startBasicCalled, "should call start_basic")
+			},
+		},
+		{
+			name:           "no error: no license found but tolerate a cluster level trial",
+			wantErr:        false,
+			currentLicense: &esclient.License{Type: "trial"},
+			clientAssertions: func(updater fakeLicenseUpdater) {
+				require.False(t, updater.startBasicCalled, "should not call start_basic")
 			},
 		},
 		{
@@ -184,7 +193,7 @@ func Test_applyLinkedLicense(t *testing.T) {
 				context.Background(),
 				c,
 				clusterName,
-				nil,
+				tt.currentLicense,
 				&updater,
 			); (err != nil) != tt.wantErr {
 				t.Errorf("applyLinkedLicense() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Trials on Elasticsearch level can only be started once.
The intention behind this change is to avoid a bad user experience.
We encourage users to start trials via ECK but the Kibana UI also
advertises trials in various places when users try to access commercial features.
We don't want to change the Kibana behaviour to keep this easy way to try out a feature.
This change therefore tolerates a cluster running in trial mode even if ECK's license level
would require us to downgrade this cluster to a Basic license.

Fixes #3141 