### PR TITLE
Introduce a restricted role for agent configuration

### DIFF
--- a/pkg/apis/apm/v1/webhook.go
+++ b/pkg/apis/apm/v1/webhook.go
@@ -24,7 +24,7 @@ var (
 	validationLog = logf.Log.WithName("apm-v1-validation")
 
 	// apmAgentConfigurationMinVersion is the minimum required version to establish an association with Kibana
-	apmAgentConfigurationMinVersion = version.MustParse("7.5.0")
+	apmAgentConfigurationMinVersion = version.MustParse("7.5.1")
 
 	defaultChecks = []func(*ApmServer) field.ErrorList{
 		checkNoUnknownFields,

--- a/pkg/apis/apm/v1/webhook.go
+++ b/pkg/apis/apm/v1/webhook.go
@@ -24,7 +24,7 @@ var (
 	validationLog = logf.Log.WithName("apm-v1-validation")
 
 	// apmAgentConfigurationMinVersion is the minimum required version to establish an association with Kibana
-	apmAgentConfigurationMinVersion = version.MustParse("7.3.0")
+	apmAgentConfigurationMinVersion = version.MustParse("7.5.0")
 
 	defaultChecks = []func(*ApmServer) field.ErrorList{
 		checkNoUnknownFields,

--- a/pkg/apis/apm/v1/webhook_test.go
+++ b/pkg/apis/apm/v1/webhook_test.go
@@ -97,20 +97,20 @@ func TestWebhook(t *testing.T) {
 			Operation: admissionv1beta1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				apm := mkApmServer(uid)
-				apm.Spec.Version = "7.2.0"
+				apm.Spec.Version = "7.4.0"
 				apm.Spec.KibanaRef = commonv1.ObjectSelector{Name: "kbname", Namespace: "kbns"}
 				return serialize(t, apm)
 			},
 			Check: test.ValidationWebhookFailed(
-				`spec.kibanaRef: Forbidden: required version for Kibana association is 7.3.0 but desired version is 7.2.0`,
+				`spec.kibanaRef: Forbidden: required version for Kibana association is 7.5.0 but desired version is 7.4.0`,
 			),
 		},
 		{
-			Name:      "support-72-if-kibana-ref-not-set",
+			Name:      "support-74-if-kibana-ref-not-set",
 			Operation: admissionv1beta1.Create,
 			Object: func(t *testing.T, uid string) []byte {
 				apm := mkApmServer(uid)
-				apm.Spec.Version = "7.2.0"
+				apm.Spec.Version = "7.4.0"
 				return serialize(t, apm)
 			},
 			Check: test.ValidationWebhookSucceeded,

--- a/pkg/apis/apm/v1/webhook_test.go
+++ b/pkg/apis/apm/v1/webhook_test.go
@@ -102,7 +102,7 @@ func TestWebhook(t *testing.T) {
 				return serialize(t, apm)
 			},
 			Check: test.ValidationWebhookFailed(
-				`spec.kibanaRef: Forbidden: required version for Kibana association is 7.5.0 but desired version is 7.4.0`,
+				`spec.kibanaRef: Forbidden: required version for Kibana association is 7.5.1 but desired version is 7.4.0`,
 			),
 		},
 		{

--- a/pkg/controller/association/controller/apm_kibana.go
+++ b/pkg/controller/association/controller/apm_kibana.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/rbac"
@@ -40,7 +41,7 @@ func AddApmKibana(mgr manager.Manager, accessReviewer rbac.AccessReviewer, param
 		UserSecretSuffix:  "apm-kb-user",
 		CASecretLabelName: kibana.KibanaNameLabelName,
 		ESUserRole: func(_ commonv1.Associated) (string, error) {
-			return "kibana_user", nil
+			return user.ApmAgentUserRole, nil
 		},
 		SetDynamicWatches: func(association commonv1.Association, w watches.DynamicWatches) error {
 			kibanaKey := association.AssociationRef().NamespacedName()

--- a/pkg/controller/elasticsearch/client/client.go
+++ b/pkg/controller/elasticsearch/client/client.go
@@ -35,10 +35,17 @@ type IndexRole struct {
 	Privileges []string `json:",omitempty"`
 }
 
+type ApplicationRole struct {
+	Application string   `json:"application,omitempty"`
+	Privileges  []string `json:"privileges,omitempty"`
+	Resources   []string `json:"resources,omitempty"`
+}
+
 // Role represents an Elasticsearch role.
 type Role struct {
-	Cluster []string    `json:"cluster,omitempty"`
-	Indices []IndexRole `json:"indices,omitempty"`
+	Cluster      []string          `json:"cluster,omitempty"`
+	Indices      []IndexRole       `json:"indices,omitempty"`
+	Applications []ApplicationRole `json:"applications,omitempty"`
 }
 
 // Client captures the information needed to interact with an Elasticsearch cluster via HTTP

--- a/pkg/controller/elasticsearch/user/reconcile_test.go
+++ b/pkg/controller/elasticsearch/user/reconcile_test.go
@@ -75,6 +75,6 @@ func Test_aggregateRoles(t *testing.T) {
 	c := k8s.WrappedFakeClient(sampleUserProvidedRolesSecret...)
 	roles, err := aggregateRoles(c, sampleEsWithAuth, initDynamicWatches(), record.NewFakeRecorder(10))
 	require.NoError(t, err)
-	require.Len(t, roles, 6)
+	require.Len(t, roles, 7)
 	require.Contains(t, roles, ProbeUserRole, "role1", "role2")
 }

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -25,6 +25,9 @@ const (
 	ApmUserRoleV7 = "eck_apm_user_role_v7"
 	// ApmUserRoleV75 is the name of the role used by APMServer instances to connect to Elasticsearch from version 7.5
 	ApmUserRoleV75 = "eck_apm_user_role_v75"
+
+	// ApmAgentUserRole is the name of the role used by APMServer instances to connect to Kibana
+	ApmAgentUserRole = "eck_apm_agent_user_role"
 )
 
 var (
@@ -55,6 +58,17 @@ var (
 				{
 					Names:      []string{"apm-*"},
 					Privileges: []string{"manage", "create_doc", "create_index"},
+				},
+			},
+		},
+		ApmAgentUserRole: esclient.Role{
+			Cluster: []string{},
+			Indices: []esclient.IndexRole{},
+			Applications: []esclient.ApplicationRole{
+				{
+					Application: "kibana-.kibana",
+					Resources:   []string{"space:default"},
+					Privileges:  []string{"feature_apm.read"},
 				},
 			},
 		},


### PR DESCRIPTION
While doing some manual testing with the APM Agent configuration I realized that the `kibana_user` role used in #3043  does not work for 7.3 and 7.4

This PR: 
* Set 7.5.1 as the minimum version required to use agent configuration. This feature is GA since 7.5 and supporting older versions would [require to setup](https://github.com/elastic/apm-server/issues/3596#issuecomment-634872770) some dedicated roles.
* Introduce a restricted role to be used by the agent configuration user:

```yaml
eck_apm_agent_user_role:
  cluster: []
  indices: []
  applications:
  - application: kibana-.kibana
    privileges:
    - feature_apm.read
    resources:
    - space:default
```

This PR has been tested with 7.5.2 , 7.6.2 and 7.7.0