### PR TITLE
Do not assume docker-push.sh is always run from repo root

### DIFF
--- a/hack/docker-push.sh
+++ b/hack/docker-push.sh
@@ -12,13 +12,13 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
+REGISTRY_ENV="$SCRIPT_DIR/../.registry.env"
 retry() { "$SCRIPT_DIR/retry.sh" 5 "$@"; }
 
 # source variables if present
-if [[ -f .registry.env ]]; then
+if [[ -f ${REGISTRY_ENV} ]]; then
     # shellcheck disable=SC2046
-    export $(sed "s|[[:space:]]*=[[:space:]]*|=|g" .registry.env)
+    export $(sed "s|[[:space:]]*=[[:space:]]*|=|g" "${REGISTRY_ENV}")
 fi
 
 docker-login() {

--- a/hack/docker-push.sh
+++ b/hack/docker-push.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REGISTRY_ENV="$SCRIPT_DIR/../.registry.env"
+
 retry() { "$SCRIPT_DIR/retry.sh" 5 "$@"; }
 
 # source variables if present


### PR DESCRIPTION
`docker-push.sh` was assuming it was always called from repo root and looked for `registry.env` in the current directory. But we also call it from the `.ci` directory.

Fixes #3156