### PR TITLE
Add an info log on dev builds of ECK

### DIFF
--- a/pkg/controller/common/license/check.go
+++ b/pkg/controller/common/license/check.go
@@ -91,6 +91,10 @@ func (lc *checker) Valid(l EnterpriseLicense) (bool, error) {
 	if err != nil {
 		return false, errors.Wrap(err, "while loading signature secret")
 	}
+	if len(pk) == 0 {
+		log.Info("This is an unlicensed development build of ECK. License management and Enterprise features are disabled")
+		return false, nil
+	}
 	verifier, err := NewVerifier(pk)
 	if err != nil {
 		return false, err

--- a/pkg/controller/common/license/check_test.go
+++ b/pkg/controller/common/license/check_test.go
@@ -113,7 +113,7 @@ func TestChecker_EnterpriseFeaturesEnabled(t *testing.T) {
 				initialObjects: asRuntimeObjects(validLicenseFixture, signatureBytes),
 			},
 			want:    false,
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Creates a log message when an ECK build is neither licensed with a dev public key nor a production key to facilitate debugging of license issues.

I ran more than once into the issue that I was testing license related functionality with a PR build or local build that did not have any kind of public key. This should make this condition more obvious than 

```
"asn1: syntax error: sequence truncated",
```

instead we get
```
This is an unlicensed development build of ECK. License functionality and Enterprise features are disabled
```