### PR TITLE
Replace the license observer by a sync call in the reconciliation

### DIFF
--- a/pkg/controller/elasticsearch/license/apply.go
+++ b/pkg/controller/elasticsearch/license/apply.go
@@ -57,10 +57,12 @@ func applyLinkedLicense(
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			if isTrial(&current) {
-				// this is the case if the user has started a trial on the ES cluster level
-				// e.g. from Kibana when trying to access a commercial feature.
-				// While this is not a supported use case we tolerate it to avoid a bad user
-				// experience because trials can only be started once on the ES cluster level
+				// Elasticsearch reports a trial license, but there's no ECK enterprise trial requested.
+				// This can be the case if:
+				// - an ECK trial was started previously, then stopped (secret removed)
+				// - the user manually started a trial at the stack level (eg. by clicking a button in Kibana when
+				// trying to access a commercial feature). While this is not a supported use case,
+				// we tolerate it to avoid a bad user experience because trials can only be started once.
 				log.V(1).Info("Preserving existing stack-level trial license",
 					"namespace", esCluster.Namespace, "es_name", esCluster.Name)
 				return nil

--- a/pkg/controller/elasticsearch/license/apply.go
+++ b/pkg/controller/elasticsearch/license/apply.go
@@ -61,6 +61,8 @@ func applyLinkedLicense(
 				// e.g. from Kibana when trying to access a commercial feature.
 				// While this is not a supported use case we tolerate it to avoid a bad user
 				// experience because trials can only be started once on the ES cluster level
+				log.V(1).Info("Preserving existing stack-level trial license",
+					"namespace", esCluster.Namespace, "es_name", esCluster.Name)
 				return nil
 			}
 			// no license linked to this cluster. Revert to basic.

--- a/pkg/controller/elasticsearch/license/apply_test.go
+++ b/pkg/controller/elasticsearch/license/apply_test.go
@@ -149,10 +149,19 @@ func Test_applyLinkedLicense(t *testing.T) {
 			},
 		},
 		{
-			name:    "no error: no license found",
-			wantErr: false,
+			name:           "no error: no license found but stack has an enterprise license",
+			wantErr:        false,
+			currentLicense: esclient.License{Type: string(esclient.ElasticsearchLicenseTypeEnterprise)},
 			clientAssertions: func(updater fakeLicenseUpdater) {
-				require.True(t, updater.startBasicCalled, "should call start_basic")
+				require.True(t, updater.startBasicCalled, "should call start_basic to remove the license")
+			},
+		},
+		{
+			name:           "no error: no license found, stack already in basic license",
+			wantErr:        false,
+			currentLicense: esclient.License{Type: string(esclient.ElasticsearchLicenseTypeBasic)},
+			clientAssertions: func(updater fakeLicenseUpdater) {
+				require.False(t, updater.startBasicCalled, "should not call start_basic if already basic")
 			},
 		},
 		{

--- a/pkg/controller/elasticsearch/license/apply_test.go
+++ b/pkg/controller/elasticsearch/license/apply_test.go
@@ -26,8 +26,12 @@ import (
 )
 
 func Test_updateLicense(t *testing.T) {
+	enterpriseLicense := esclient.License{
+		UID:  "enterpise-license",
+		Type: string(esclient.ElasticsearchLicenseTypeEnterprise),
+	}
 	type args struct {
-		current *esclient.License
+		current esclient.License
 		desired esclient.License
 	}
 	tests := []struct {
@@ -40,8 +44,7 @@ func Test_updateLicense(t *testing.T) {
 			name:    "error: HTTP error",
 			wantErr: true,
 			args: args{
-				current: nil,
-				desired: esclient.License{},
+				desired: enterpriseLicense,
 			},
 			reqFn: func(req *http.Request) *http.Response {
 				return esclient.NewMockResponse(400, req, "")
@@ -51,8 +54,7 @@ func Test_updateLicense(t *testing.T) {
 			name:    "error: ES error",
 			wantErr: true,
 			args: args{
-				current: nil,
-				desired: esclient.License{},
+				desired: enterpriseLicense,
 			},
 			reqFn: func(req *http.Request) *http.Response {
 				return esclient.NewMockResponse(
@@ -65,8 +67,7 @@ func Test_updateLicense(t *testing.T) {
 		{
 			name: "happy path",
 			args: args{
-				current: nil,
-				desired: esclient.License{},
+				desired: enterpriseLicense,
 			},
 			reqFn: func(req *http.Request) *http.Response {
 				return esclient.NewMockResponse(
@@ -79,7 +80,6 @@ func Test_updateLicense(t *testing.T) {
 		{
 			name: "start a trial",
 			args: args{
-				current: nil,
 				desired: esclient.License{
 					Type: string(esclient.ElasticsearchLicenseTypeTrial),
 				},
@@ -95,7 +95,7 @@ func Test_updateLicense(t *testing.T) {
 		{
 			name: "short-circuit: already up to date",
 			args: args{
-				current: &esclient.License{
+				current: esclient.License{
 					UID: "this-is-a-uid",
 				},
 				desired: esclient.License{
@@ -109,7 +109,6 @@ func Test_updateLicense(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			c := esclient.NewMockClient(version.MustParse("6.8.0"), tt.reqFn)
 			if err := updateLicense(context.Background(), types.NamespacedName{}, c, tt.args.current, tt.args.desired); (err != nil) != tt.wantErr {
 				t.Errorf("updateLicense() error = %v, wantErr %v", err, tt.wantErr)
@@ -126,7 +125,7 @@ func Test_applyLinkedLicense(t *testing.T) {
 	tests := []struct {
 		name             string
 		initialObjs      []runtime.Object
-		currentLicense   *esclient.License
+		currentLicense   esclient.License
 		errors           map[client.ObjectKey]error
 		wantErr          bool
 		clientAssertions func(updater fakeLicenseUpdater)
@@ -159,7 +158,7 @@ func Test_applyLinkedLicense(t *testing.T) {
 		{
 			name:           "no error: no license found but tolerate a cluster level trial",
 			wantErr:        false,
-			currentLicense: &esclient.License{Type: string(esclient.ElasticsearchLicenseTypeTrial)},
+			currentLicense: esclient.License{Type: string(esclient.ElasticsearchLicenseTypeTrial)},
 			clientAssertions: func(updater fakeLicenseUpdater) {
 				require.False(t, updater.startBasicCalled, "should not call start_basic")
 			},
@@ -208,12 +207,11 @@ func Test_applyLinkedLicense(t *testing.T) {
 				Client: k8s.WrappedFakeClient(tt.initialObjs...),
 				errors: tt.errors,
 			}
-			updater := fakeLicenseUpdater{}
+			updater := fakeLicenseUpdater{license: tt.currentLicense}
 			if err := applyLinkedLicense(
 				context.Background(),
 				c,
 				clusterName,
-				tt.currentLicense,
 				&updater,
 			); (err != nil) != tt.wantErr {
 				t.Errorf("applyLinkedLicense() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/controller/elasticsearch/license/reconcile.go
+++ b/pkg/controller/elasticsearch/license/reconcile.go
@@ -18,8 +18,7 @@ func Reconcile(
 	c k8s.Client,
 	esCluster esv1.Elasticsearch,
 	clusterClient esclient.Client,
-	current *esclient.License,
 ) error {
 	clusterName := k8s.ExtractNamespacedName(&esCluster)
-	return applyLinkedLicense(ctx, c, clusterName, current, clusterClient)
+	return applyLinkedLicense(ctx, c, clusterName, clusterClient)
 }

--- a/pkg/controller/elasticsearch/observer/state.go
+++ b/pkg/controller/elasticsearch/observer/state.go
@@ -16,40 +16,14 @@ type State struct {
 	// TODO: verify usages of the below never assume they are set (check for nil)
 	// ClusterHealth is the current traffic light health as reported by Elasticsearch.
 	ClusterHealth *esclient.Health
-	// TODO should probably be a separate observer
-	// ClusterLicense is the current license applied to this cluster
-	ClusterLicense *esclient.License
 }
 
 // RetrieveState returns the current Elasticsearch cluster state
 func RetrieveState(ctx context.Context, cluster types.NamespacedName, esClient esclient.Client) State {
-	// retrieve cluster health and license in parallel
-	healthChan := make(chan *esclient.Health)
-	licenseChan := make(chan *esclient.License)
-
-	go func() {
-		health, err := esClient.GetClusterHealth(ctx)
-		if err != nil {
-			log.V(1).Info("Unable to retrieve cluster health", "error", err, "namespace", cluster.Namespace, "es_name", cluster.Name)
-			healthChan <- nil
-			return
-		}
-		healthChan <- &health
-	}()
-
-	go func() {
-		license, err := esClient.GetLicense(ctx)
-		if err != nil {
-			log.V(1).Info("Unable to retrieve cluster license", "error", err, "namespace", cluster.Namespace, "es_name", cluster.Name)
-			licenseChan <- nil
-			return
-		}
-		licenseChan <- &license
-	}()
-
-	// return the state when ready, may contain nil values
-	return State{
-		ClusterHealth:  <-healthChan,
-		ClusterLicense: <-licenseChan,
+	health, err := esClient.GetClusterHealth(ctx)
+	if err != nil {
+		log.V(1).Info("Unable to retrieve cluster health", "error", err, "namespace", cluster.Namespace, "es_name", cluster.Name)
+		return State{ClusterHealth: nil}
 	}
+	return State{ClusterHealth: &health}
 }

--- a/pkg/controller/elasticsearch/observer/state_test.go
+++ b/pkg/controller/elasticsearch/observer/state_test.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func fakeEsClient(healthRespErr, licenseRespErr bool) client.Client {
+func fakeEsClient(healthRespErr bool) client.Client {
 	return client.NewMockClient(version.MustParse("6.8.0"), func(req *http.Request) *http.Response {
 		statusCode := 200
 		var respBody io.ReadCloser
@@ -30,14 +30,6 @@ func fakeEsClient(healthRespErr, licenseRespErr bool) client.Client {
 			if healthRespErr {
 				statusCode = 500
 			}
-		}
-
-		if strings.Contains(req.URL.RequestURI(), "license") {
-			respBody = ioutil.NopCloser(bytes.NewBufferString(fixtures.LicenseGetSample))
-			if licenseRespErr {
-				statusCode = 500
-			}
-
 		}
 
 		return &http.Response{
@@ -51,54 +43,27 @@ func fakeEsClient(healthRespErr, licenseRespErr bool) client.Client {
 
 func TestRetrieveState(t *testing.T) {
 	tests := []struct {
-		name        string
-		wantHealth  bool
-		wantLicense bool
+		name       string
+		wantHealth bool
 	}{
 		{
-			name:        "health, license and keystore ok",
-			wantHealth:  true,
-			wantLicense: true,
+			name:       "health ok",
+			wantHealth: true,
 		},
 		{
-			name:        "info error",
-			wantHealth:  true,
-			wantLicense: true,
-		},
-		{
-			name:        "health error",
-			wantHealth:  false,
-			wantLicense: true,
-		},
-		{
-			name:        "license error",
-			wantHealth:  false,
-			wantLicense: true,
-		},
-		{
-			name:        "info and state error",
-			wantHealth:  false,
-			wantLicense: true,
-		},
-		{
-			name:        "keystore error",
-			wantHealth:  true,
-			wantLicense: true,
+			name:       "health error",
+			wantHealth: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cluster := types.NamespacedName{Namespace: "ns1", Name: "es1"}
-			esClient := fakeEsClient(!tt.wantHealth, !tt.wantLicense)
+			esClient := fakeEsClient(!tt.wantHealth)
 			state := RetrieveState(context.Background(), cluster, esClient)
 			if tt.wantHealth {
 				require.NotNil(t, state.ClusterHealth)
 				require.Equal(t, 3, state.ClusterHealth.NumberOfNodes)
-			}
-			if tt.wantLicense {
-				require.NotNil(t, state.ClusterLicense)
-				require.Equal(t, "893361dc-9749-4997-93cb-802e3d7fa4xx", state.ClusterLicense.UID)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/3163.
Fixes a bug introduced in https://github.com/elastic/cloud-on-k8s/pull/3150.

We used to rely on the license fetched by the observers on a regular
basis, but this can lead to a race condition as described in
#3163 (comment).

Instead, let's keep things simple, and do a synchronous request to
get the license as part of the normal reconciliation, to then decide
whether or not it should be updated.

In case of error (eg. Elasticsearch req timeout), enqueue a new
reconciliation, but don't abort the current reconciliation.

This PR also adds some minor refactoring of the code, and avoids
a call to `start_basic` if the current license is already basic.