### PR TITLE
Allow single-node clusters disruption in the default PDB

### DIFF
--- a/pkg/controller/elasticsearch/pdb/reconcile.go
+++ b/pkg/controller/elasticsearch/pdb/reconcile.go
@@ -141,6 +141,11 @@ func buildPDBSpec(es esv1.Elasticsearch, statefulSets sset.StatefulSetList) v1be
 
 // allowedDisruptions returns the number of Pods that we allow to be disrupted while keeping the cluster healthy.
 func allowedDisruptions(es esv1.Elasticsearch, actualSsets sset.StatefulSetList) int32 {
+	if actualSsets.ExpectedNodeCount() == 1 {
+		// single node cluster (not highly-available)
+		// allow the node to be disrupted to ensure K8s nodes operations can be performed
+		return 1
+	}
 	if es.Status.Health != esv1.ElasticsearchGreenHealth {
 		// A non-green cluster may become red if we disrupt one node, don't allow it.
 		// The health information we're using here may be out-of-date, that's best effort.

--- a/pkg/controller/elasticsearch/pdb/reconcile_test.go
+++ b/pkg/controller/elasticsearch/pdb/reconcile_test.go
@@ -308,12 +308,12 @@ func Test_allowedDisruptions(t *testing.T) {
 			want: 1,
 		},
 		{
-			name: "green health but single-node cluster: 0 disruption allowed",
+			name: "single-node cluster (not high-available): 1 disruption allowed",
 			args: args{
 				es:          esv1.Elasticsearch{Status: esv1.ElasticsearchStatus{Health: esv1.ElasticsearchGreenHealth}},
 				actualSsets: sset.StatefulSetList{sset.TestSset{Replicas: 1, Master: true, Data: true}.Build()},
 			},
-			want: 0,
+			want: 1,
 		},
 		{
 			name: "green health but only 1 master: 0 disruption allowed",


### PR DESCRIPTION
See issue [PDB per Node type (Master, Data, Ingest) #2936](https://github.com/elastic/cloud-on-k8s/issues/2936)

This PR will make sure that when someone deploys a single node cluster, the pdb does not get set to 1.

If someone deploys a single node cluster now, it can make sure the k8s cluster cannot reboot.
The default setting for single node, IMHO, should not set the pdb to 1.
This change makes sure that when it is single node, the pdb is 0. When the elastic cluster is scaled up, the pdb is calculated as "normal".

> If you set maxUnavailable to 0% or 0, or you set minAvailable to 100% or the number of replicas, you are requiring zero voluntary evictions. When you set zero voluntary evictions for a workload object such as ReplicaSet, then you cannot successfully drain a Node running one of those Pods. If you try to drain a Node where an unevictable Pod is running, the drain never completes. This is permitted as per the semantics of PodDisruptionBudget.
[source](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget)


