### PR TITLE
Make some error messages more descriptive

### DIFF
--- a/pkg/apis/elasticsearch/v1/validations.go
+++ b/pkg/apis/elasticsearch/v1/validations.go
@@ -20,9 +20,9 @@ import (
 const (
 	cfgInvalidMsg            = "Configuration invalid"
 	masterRequiredMsg        = "Elasticsearch needs to have at least one master node"
-	parseVersionErrMsg       = "Cannot parse Elasticsearch version"
-	parseStoredVersionErrMsg = "Cannot parse current Elasticsearch version"
-	invalidSanIPErrMsg       = "Invalid SAN IP address"
+	parseVersionErrMsg       = "Cannot parse Elasticsearch version. String format must be {major}.{minor}.{patch}[-{label}"
+	parseStoredVersionErrMsg = "Cannot parse current Elasticsearch version. String format must be {major}.{minor}.{patch}[-{label}"
+	invalidSanIPErrMsg       = "Invalid SAN IP address. Must be a valid IPv4 address"
 	pvcImmutableMsg          = "Volume claim templates cannot be modified"
 	invalidNamesErrMsg       = "Elasticsearch configuration would generate resources with invalid names"
 	unsupportedVersionErrMsg = "Unsupported version"
@@ -30,7 +30,7 @@ const (
 	duplicateNodeSets        = "NodeSet names must be unique"
 	noDowngradesMsg          = "Downgrades are not supported"
 	unsupportedVersionMsg    = "Unsupported version"
-	unsupportedUpgradeMsg    = "Unsupported version upgrade path"
+	unsupportedUpgradeMsg    = "Unsupported version upgrade path. Check the Elasticsearch documentation."
 )
 
 type validation func(*Elasticsearch) field.ErrorList


### PR DESCRIPTION
This PRs improves the text of some error messages in 
`cloud-on-k8s/pkg/apis/elasticsearch/v1/validations.go` 

Relates to #2670.