### PR TITLE
Add temporary logs to debug test failure

### DIFF
--- a/pkg/controller/license/list.go
+++ b/pkg/controller/license/list.go
@@ -23,6 +23,7 @@ func reconcileRequestsForAllClusters(c k8s.Client) ([]reconcile.Request, error) 
 	// create a reconcile request for each cluster
 	requests := make([]reconcile.Request, len(clusters.Items))
 	for i, cl := range clusters.Items {
+		log.V(1).Info("Generating license reconcile event for ES cluster", "name", cl.Name, "namespace", cl.Namespace)
 		requests[i] = reconcile.Request{NamespacedName: types.NamespacedName{
 			Namespace: cl.Namespace,
 			Name:      cl.Name,


### PR DESCRIPTION
Related #3173 

To understand better why we see outdated reconcile events in the license controller I am adding an additional log statement to see when and for what cluster we are generating reconcile events.