### PR TITLE
Bump AKS k8s version

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -40,7 +40,7 @@ plans:
   operation: create
   clusterName: ci
   provider: aks
-  kubernetesVersion: 1.18.2
+  kubernetesVersion: 1.16.9
   machineType: Standard_D8s_v3
   serviceAccount: true
   psp: false
@@ -51,7 +51,7 @@ plans:
   operation: create
   clusterName: dev
   provider: aks
-  kubernetesVersion: 1.18.2
+  kubernetesVersion: 1.16.9
   machineType: Standard_D8s_v3
   serviceAccount: false
   psp: false

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -40,7 +40,7 @@ plans:
   operation: create
   clusterName: ci
   provider: aks
-  kubernetesVersion: 1.16.7
+  kubernetesVersion: 1.18.2
   machineType: Standard_D8s_v3
   serviceAccount: true
   psp: false
@@ -51,7 +51,7 @@ plans:
   operation: create
   clusterName: dev
   provider: aks
-  kubernetesVersion: 1.16.7
+  kubernetesVersion: 1.18.2
   machineType: Standard_D8s_v3
   serviceAccount: false
   psp: false


### PR DESCRIPTION
This commit upgrades the Kubernetes version used in the job that run all E2E tests on AKS to the latest 1.16.x available version.

Resolves #3178.