### PR TITLE
Specify webhook has no side effects

### DIFF
--- a/config/operator/all-in-one/webhook.template.yaml
+++ b/config/operator/all-in-one/webhook.template.yaml
@@ -12,6 +12,7 @@ webhooks:
       path: /validate-apm-k8s-elastic-co-v1-apmserver
   failurePolicy: Ignore
   name: elastic-apm-validation-v1.k8s.elastic.co
+  sideEffects: "None"
   rules:
   - apiGroups:
     - apm.k8s.elastic.co
@@ -30,6 +31,7 @@ webhooks:
       path: /validate-apm-k8s-elastic-co-v1beta1-apmserver
   failurePolicy: Ignore
   name: elastic-apm-validation-v1beta1.k8s.elastic.co
+  sideEffects: "None"
   rules:
   - apiGroups:
     - apm.k8s.elastic.co
@@ -48,6 +50,7 @@ webhooks:
       path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
   failurePolicy: Ignore
   name: elastic-es-validation-v1.k8s.elastic.co
+  sideEffects: "None"
   rules:
   - apiGroups:
     - elasticsearch.k8s.elastic.co
@@ -66,6 +69,7 @@ webhooks:
       path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
   failurePolicy: Ignore
   name: elastic-es-validation-v1beta1.k8s.elastic.co
+  sideEffects: "None"
   rules:
   - apiGroups:
     - elasticsearch.k8s.elastic.co
@@ -84,6 +88,7 @@ webhooks:
       path: /validate-enterprisesearch-k8s-elastic-co-v1beta1-enterprisesearch
   failurePolicy: Ignore
   name: elastic-ent-validation-v1beta1.k8s.elastic.co
+  sideEffects: "None"
   rules:
   - apiGroups:
     - enterprisesearch.k8s.elastic.co
@@ -102,6 +107,7 @@ webhooks:
       path: /validate-kibana-k8s-elastic-co-v1-kibana
   failurePolicy: Ignore
   name: elastic-kb-validation-v1.k8s.elastic.co
+  sideEffects: "None"
   rules:
   - apiGroups:
     - kibana.k8s.elastic.co
@@ -120,6 +126,7 @@ webhooks:
       path: /validate-kibana-k8s-elastic-co-v1beta1-kibana
   failurePolicy: Ignore
   name: elastic-kb-validation-v1beta1.k8s.elastic.co
+  sideEffects: "None"
   rules:
   - apiGroups:
     - kibana.k8s.elastic.co


### PR DESCRIPTION
Fix https://github.com/elastic/cloud-on-k8s/issues/1233

This allows users to dry run resources to see if the API server will accept the request without persisting it to storage. Dry run was [promoted to beta](https://kubernetes.io/blog/2019/01/14/apiserver-dry-run-and-kubectl-diff/) in 1.13 so will not work on older versions without the flag enabled, but does not cause errors applying the webhook in my testing.