### PR TITLE
Add APM/Kibana association e2e test

### DIFF
--- a/pkg/apis/apm/v1/webhook.go
+++ b/pkg/apis/apm/v1/webhook.go
@@ -122,7 +122,7 @@ func checkAgentConfigurationMinVersion(as *ApmServer) field.ErrorList {
 		return field.ErrorList{field.Forbidden(
 			field.NewPath("spec").Child("kibanaRef"),
 			fmt.Sprintf(
-				"required version for Kibana association is %s but desired version is %s",
+				"minimum required version for Kibana association is %s but desired version is %s",
 				ApmAgentConfigurationMinVersion,
 				apmVersion,
 			),

--- a/pkg/apis/apm/v1/webhook.go
+++ b/pkg/apis/apm/v1/webhook.go
@@ -23,8 +23,8 @@ var (
 	groupKind     = schema.GroupKind{Group: GroupVersion.Group, Kind: "ApmServer"}
 	validationLog = logf.Log.WithName("apm-v1-validation")
 
-	// apmAgentConfigurationMinVersion is the minimum required version to establish an association with Kibana
-	apmAgentConfigurationMinVersion = version.MustParse("7.5.1")
+	// ApmAgentConfigurationMinVersion is the minimum required version to establish an association with Kibana
+	ApmAgentConfigurationMinVersion = version.MustParse("7.5.1")
 
 	defaultChecks = []func(*ApmServer) field.ErrorList{
 		checkNoUnknownFields,
@@ -118,12 +118,12 @@ func checkAgentConfigurationMinVersion(as *ApmServer) field.ErrorList {
 	if err != nil {
 		return err
 	}
-	if !apmVersion.IsSameOrAfter(apmAgentConfigurationMinVersion) {
+	if !apmVersion.IsSameOrAfter(ApmAgentConfigurationMinVersion) {
 		return field.ErrorList{field.Forbidden(
 			field.NewPath("spec").Child("kibanaRef"),
 			fmt.Sprintf(
 				"required version for Kibana association is %s but desired version is %s",
-				apmAgentConfigurationMinVersion,
+				ApmAgentConfigurationMinVersion,
 				apmVersion,
 			),
 		),

--- a/pkg/apis/apm/v1/webhook_test.go
+++ b/pkg/apis/apm/v1/webhook_test.go
@@ -102,7 +102,7 @@ func TestWebhook(t *testing.T) {
 				return serialize(t, apm)
 			},
 			Check: test.ValidationWebhookFailed(
-				`spec.kibanaRef: Forbidden: required version for Kibana association is 7.5.1 but desired version is 7.4.0`,
+				`spec.kibanaRef: Forbidden: minimum required version for Kibana association is 7.5.1 but desired version is 7.4.0`,
 			),
 		},
 		{

--- a/test/e2e/test/apmserver/checks_apm.go
+++ b/test/e2e/test/apmserver/checks_apm.go
@@ -274,7 +274,7 @@ const sampleDefaultAgentConfiguration = `{"service":{},"settings":{"transaction_
 func (c *apmClusterChecks) CheckAgentConfiguration(apm apmv1.ApmServer, k *test.K8sClient) test.StepList {
 	apmVersion := version.MustParse(apm.Spec.Version)
 
-	if !(apmVersion.IsSameOrAfter(apmv1.ApmAgentConfigurationMinVersion) && apm.Spec.KibanaRef.IsDefined()) {
+	if !apm.Spec.KibanaRef.IsDefined() {
 		return []test.Step{}
 	}
 

--- a/test/e2e/test/apmserver/checks_apm.go
+++ b/test/e2e/test/apmserver/checks_apm.go
@@ -15,10 +15,13 @@ import (
 
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/kibana"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
@@ -38,7 +41,7 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 		a.CheckEventsAPI(),
 		a.CheckEventsInElasticsearch(b.ApmServer, k),
 		a.CheckRUMEventsAPI(b.RUMEnabled()),
-	}
+	}.WithSteps(a.CheckAgentConfiguration(b.ApmServer, k))
 }
 
 func (c *apmClusterChecks) BuildApmServerClient(apm apmv1.ApmServer, k *test.K8sClient,
@@ -263,4 +266,54 @@ func countIndex(esClient client.Client, indexName string) (int, error) {
 		return 0, err
 	}
 	return countResult.Count, nil
+}
+
+const sampleDefaultAgentConfiguration = `{"service":{},"settings":{"transaction_sample_rate":"1","capture_body":"errors","transaction_max_spans":"99"}}`
+
+// CheckAgentConfiguration creates an agent configuration through Kibana and then check that the APM Server is able to retrieve it.
+func (c *apmClusterChecks) CheckAgentConfiguration(apm apmv1.ApmServer, k *test.K8sClient) test.StepList {
+	apmVersion := version.MustParse(apm.Spec.Version)
+
+	if !(apmVersion.IsSameOrAfter(apmv1.ApmAgentConfigurationMinVersion) && apm.Spec.KibanaRef.IsDefined()) {
+		return []test.Step{}
+	}
+
+	return []test.Step{
+		{
+			Name: "Create the default Agent Configuration in Kibana",
+			Test: func(t *testing.T) {
+				kb := kbv1.Kibana{}
+				assert.NoError(t, k.Client.Get(apm.Spec.KibanaRef.WithDefaultNamespace(apm.Namespace).NamespacedName(), &kb))
+
+				password, err := k.GetElasticPassword(apm.Spec.ElasticsearchRef.WithDefaultNamespace(apm.Namespace).NamespacedName())
+				assert.NoError(t, err)
+
+				uri := "/api/apm/settings/agent-configuration"
+
+				// URI is slightly different before 7.7.0, we need to add "/new" at the end
+				if !apmVersion.IsSameOrAfter(version.MustParse("7.7.0")) {
+					uri = uri + "/new"
+				}
+				_, err = kibana.DoRequest(k, kb, password, "PUT", uri, []byte(sampleDefaultAgentConfiguration))
+				assert.NoError(t, err)
+			},
+		},
+		{
+			Name: "Read back the agent default configuration from the APM Server",
+			Test: func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(context.Background(), DefaultReqTimeout)
+				defer cancel()
+
+				agentConfig, err := c.apmClient.AgentsDefaultConfig(ctx)
+				assert.NoError(t, err)
+
+				expectedAgentConfiguration := AgentConfig{
+					CaptureBody:           "errors",
+					TransactionMaxSpans:   "99",
+					TransactionSampleRate: "1",
+				}
+				assert.Equal(t, expectedAgentConfiguration, agentConfig)
+			},
+		},
+	}
 }

--- a/test/e2e/test/apmserver/checks_apm.go
+++ b/test/e2e/test/apmserver/checks_apm.go
@@ -292,7 +292,7 @@ func (c *apmClusterChecks) CheckAgentConfiguration(apm apmv1.ApmServer, k *test.
 
 				// URI is slightly different before 7.7.0, we need to add "/new" at the end
 				if !apmVersion.IsSameOrAfter(version.MustParse("7.7.0")) {
-					uri = uri + "/new"
+					uri += "/new"
 				}
 				_, err = kibana.DoRequest(k, kb, password, "PUT", uri, []byte(sampleDefaultAgentConfiguration))
 				assert.NoError(t, err)


### PR DESCRIPTION
Add an e2e test for the APM/Kibana association. The test scenario is the one described [here](https://github.com/elastic/cloud-on-k8s/issues/3154#issuecomment-635360186).

Fix #3154