### PR TITLE
Add docs for Enterprise Search in ECK

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/accessing-elastic-services.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/accessing-elastic-services.asciidoc
@@ -25,7 +25,7 @@ All Elastic Stack resources deployed by the ECK Operator are secured by default.
 [id="{p}-authentication"]
 === Authentication
 
-To access Elasticsearch, Kibana or APM Server, the operator manages a default user named `elastic` with the `superuser` role. Its password is stored in a `Secret` named `<name>-elastic-user`.
+To access Elasticsearch, Kibana, APM Server and Enterprise Search, the operator manages a default user named `elastic` with the `superuser` role. Its password is stored in a `Secret` named `<name>-elastic-user`.
 
 [source,sh]
 ----
@@ -36,12 +36,12 @@ To access Elasticsearch, Kibana or APM Server, the operator manages a default us
 [id="{p}-services"]
 == Services
 
-You can access Elasticsearch, Kibana or APM Server by using native Kubernetes services that are not reachable from the public Internet by default.
+You can access Elasticsearch, Kibana, APM Server and Enterprise Search by using native Kubernetes services that are not reachable from the public Internet by default.
 
 [id="{p}-kubernetes-service"]
 === Manage Kubernetes services
 
-For each resource, `Elasticsearch`, `Kibana` or `ApmServer`, the operator manages a Kubernetes service named `<name>-[es|kb|apm]-http`, which is of type `ClusterIP` by default. `ClusterIP` exposes the service on a cluster-internal IP and makes the service only reachable from the cluster.
+For each resource, `Elasticsearch`, `Kibana`, `ApmServer` or `Enterprise Search`, the operator manages a Kubernetes service named `<name>-[es|kb|apm|ent]-http`, which is of type `ClusterIP` by default. `ClusterIP` exposes the service on a cluster-internal IP and makes the service only reachable from the cluster.
 
 [source,sh]
 ----
@@ -95,7 +95,7 @@ This section only covers TLS certificates for the HTTP layer. Those for the tran
 [id="{p}-default-self-signed-certificate"]
 === Default self-signed certificate
 
-By default, the operator manages a self-signed certificate with a custom CA for Elasticsearch, Kibana and APM Server.
+By default, the operator manages a self-signed certificate with a custom CA for Elasticsearch, Kibana, APM Server and Enterprise Search.
 The CA, the certificate and the private key are each stored in a separate `Secret`.
 
 [source,sh]
@@ -106,7 +106,7 @@ hulk-es-http-certs-internal      Opaque                                2      28
 hulk-es-http-certs-public        Opaque                                1      28m
 ----
 
-The public certificate is stored in a secret named `<name>-[es|kb]-http-certs-public`.
+The public certificate is stored in a secret named `<name>-[es|kb|apm|ent]-http-certs-public`.
 
 [source,sh]
 ----
@@ -167,7 +167,7 @@ spec:
 [id="{p}-disable-tls"]
 === Disable TLS
 
-You can explicitly disable TLS for Kibana or APM Server and the HTTP layer of Elasticsearch.
+You can explicitly disable TLS for Kibana, APM Server, Enterprise Search and the HTTP layer of Elasticsearch.
 
 [source,yaml]
 ----

--- a/docs/orchestrating-elastic-stack-applications/accessing-elastic-services.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/accessing-elastic-services.asciidoc
@@ -25,7 +25,7 @@ All Elastic Stack resources deployed by the ECK Operator are secured by default.
 [id="{p}-authentication"]
 === Authentication
 
-To access Elasticsearch, Kibana, APM Server and Enterprise Search, the operator manages a default user named `elastic` with the `superuser` role. Its password is stored in a `Secret` named `<name>-elastic-user`.
+To access Elastic resources, the operator manages a default user named `elastic` with the `superuser` role. Its password is stored in a `Secret` named `<name>-elastic-user`.
 
 [source,sh]
 ----
@@ -36,12 +36,12 @@ To access Elasticsearch, Kibana, APM Server and Enterprise Search, the operator 
 [id="{p}-services"]
 == Services
 
-You can access Elasticsearch, Kibana, APM Server and Enterprise Search by using native Kubernetes services that are not reachable from the public Internet by default.
+You can access Elastic resources by using native Kubernetes services that are not reachable from the public Internet by default.
 
 [id="{p}-kubernetes-service"]
 === Manage Kubernetes services
 
-For each resource, `Elasticsearch`, `Kibana`, `ApmServer` or `Enterprise Search`, the operator manages a Kubernetes service named `<name>-[es|kb|apm|ent]-http`, which is of type `ClusterIP` by default. `ClusterIP` exposes the service on a cluster-internal IP and makes the service only reachable from the cluster.
+For each resource, the operator manages a Kubernetes service named `<name>-[es|kb|apm|ent]-http`, which is of type `ClusterIP` by default. `ClusterIP` exposes the service on a cluster-internal IP and makes the service only reachable from the cluster.
 
 [source,sh]
 ----
@@ -95,7 +95,7 @@ This section only covers TLS certificates for the HTTP layer. Those for the tran
 [id="{p}-default-self-signed-certificate"]
 === Default self-signed certificate
 
-By default, the operator manages a self-signed certificate with a custom CA for Elasticsearch, Kibana, APM Server and Enterprise Search.
+By default, the operator manages a self-signed certificate with a custom CA for each resource.
 The CA, the certificate and the private key are each stored in a separate `Secret`.
 
 [source,sh]

--- a/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
@@ -109,10 +109,9 @@ ECK detects those changes and ensures a smooth rolling upgrade of all Enterprise
 [id="{p}-enterprise-search-custom-configuration"]
 === Customize Enterprise Search configuration
 
-ECK sets up a default Enterprise Search configuration automatically.
-It can can be customized with link:https://www.elastic.co/guide/en/enterprise-search/current/configuration.html#configuration[Enterprise Search configuration] through the `config` element in the specification.
+ECK sets up a default Enterprise Search link:https://www.elastic.co/guide/en/enterprise-search/current/configuration.html#configuration[configuration]. Customize it through the ``config element in the specification.
 
-Especially, `ent_search.external_url` must be set to the desired URL.
+At a minimum, you must set `ent_search.external_url` to the desired URL.
 
 [source,yaml,subs="attributes"]
 ----
@@ -176,7 +175,7 @@ ECK merges the content of `config` and `configRef` into a single internal Secret
 [id="{p}-enterprise-search-custom-pod-template"]
 === Customize the Pod template
 
-Enterprise Search Pods specification can be overridden through the `podTemplate` element.
+You can override the Enterprise Search Pods specification through the `podTemplate` element.
 
 This example overrides the default 4Gi deployment to use 8Gi instead, and makes the deployment highly-available with 3 Pods:
 
@@ -221,7 +220,7 @@ NOTE: When exposed outside the scope of `localhost`, make sure to set `ent_searc
 
 The `elasticsearchRef` element allows ECK to automatically configure Enterprise Search to establish a secured connection to a managed Elasticsearch cluster.
 
-Enterprise Search can also be manually configured to access any available Elasticsearch cluster:
+Also, you can manually configure Enterprise Search to access any available Elasticsearch cluster:
 
 [source,yaml,subs="attributes,+macros"]
 ----

--- a/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
@@ -69,7 +69,7 @@ kubectl logs -f enterprise-search-quickstart-ent-58b84db85-dl7c6
 
 . Access Enterprise Search
 +
-A ClusterIP service is automatically created for the deployment, and can be used to access the Enterprise Search API from within the Kubernetes cluster:
+A ClusterIP Service is automatically created for the deployment, and can be used to access the Enterprise Search API from within the Kubernetes cluster:
 +
 [source,sh]
 ----
@@ -128,9 +128,9 @@ spec:
 ----
 
 [id="{p}-enterprise-search-secret-configuration"]
-=== Reference Kubernetes secrets for sensitive settings
+=== Reference Kubernetes Secrets for sensitive settings
 
-Some sensitive settings are best stored in Kubernetes secrets, referenced in the Enterprise Search specification.
+Some sensitive settings are best stored in Kubernetes Secrets, referenced in the Enterprise Search specification.
 
 This example sets up a Secret with SMTP credentials:
 

--- a/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
@@ -1,0 +1,242 @@
+:page_id: enterprise-search
+ifdef::env-github[]
+****
+link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-{page_id}.html[View this document on the Elastic website]
+****
+endif::[]
+[id="{p}-{page_id}"]
+= Run Enterprise Search on ECK
+
+This section describes how to deploy, configure and access Enterprise Search with ECK.
+
+* <<{p}-enterprise-search-quickstart,Quickstart>>
+* <<{p}-enterprise-search-configuration,Configuration>>
+
+[id="{p}-enterprise-search-quickstart"]
+== Quickstart
+
+. Apply the following specification to deploy Enterprise Search. ECK automatically configures the secured connection
+to an Elasticsearch cluster named `quickstart`, created in link:../k8s-quickstart.html[Elasticsearch quickstart].
++
+[source,yaml,subs="attributes,+macros"]
+----
+cat $$<<$$EOF | kubectl apply -f -
+apiVersion: enterprisesearch.k8s.elastic.co/v1beta1
+kind: EnterpriseSearch
+metadata:
+  name: enterprise-search-quickstart
+spec:
+  version: {version}
+  count: 1
+  elasticsearchRef:
+    name: quickstart
+EOF
+----
+
+. Monitor the Enterprise Search deployment.
++
+Retrieve details about the Enterprise Search deployment:
++
+[source,sh]
+----
+kubectl get enterprisesearch
+----
++
+[source,sh,subs="attributes"]
+----
+NAME                            HEALTH    NODES    VERSION   AGE
+enterprise-search-quickstart    green     1        {version}      8m
+----
++
+List all the Pods belonging to a given deployment:
++
+[source,sh]
+----
+kubectl get pods --selector='enterprisesearch.k8s.elastic.co/name=enterprise-search-quickstart'
+----
++
+[source,sh]
+----
+NAME                                                READY   STATUS    RESTARTS   AGE
+enterprise-search-quickstart-ent-58b84db85-dl7c6    1/1     Running   0          2m50s
+----
++
+. Access logs for that Pod:
++
+[source,sh]
+----
+kubectl logs -f enterprise-search-quickstart-ent-58b84db85-dl7c6
+----
+
+. Access Enterprise Search
++
+A ClusterIP service is automatically created for the deployment,
+and can be used to access the Enterprise Search API from within the Kubernetes cluster:
++
+[source,sh]
+----
+kubectl get service enterprise-search-quickstart-ent-http
+----
++
+Use `kubectl-portforward` to access Enterprise Search from your local workstation:
++
+[source,sh]
+----
+kubectl port-forward service/enterprise-search-quickstart-ent-http 3002
+----
++
+Open `https://localhost:3002` in your browser.
++
+NOTE: Your browser will show a warning because the self-signed certificate configured by default is not verified by a third party certificate authority and not trusted by your browser. Acknowledge the warning for the purposes of this quickstart but it is highly recommended that you <<{p}-enterprise-search-expose,configure valid certificates>> for any production deployments.
++
+Login as the `elastic` user created link:../k8s-quickstart.html[with the Elasticsearch cluster]. Its password can be obtained with:
++
+[source,sh]
+----
+kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | base64 --decode; echo
+----
+
+[id="{p}-enterprise-search-configuration"]
+== Configuration
+
+[id="{p}-enterprise-search-upgrade-specification"]
+=== Upgrade the Enterprise Search specification
+
+Any setting can be changed in the Enterprise Search yaml specification, including version upgrades.
+
+ECK detects those changes and ensures a smooth rolling upgrade of all Enterprise Search Pods.
+
+[id="{p}-enterprise-search-custom-configuration"]
+=== Customize Enterprise Search configuration
+
+ECK sets up a default Enterprise Search configuration automatically.
+It can can be customized with link:https://www.elastic.co/guide/en/enterprise-search/current/configuration.html#configuration[Enterprise Search configuration] through the `config` element in the specification.
+
+Especially, `ent_search.external_url` must be set to the desired URL.
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: enterprisesearch.k8s.elastic.co/v1beta1
+kind: EnterpriseSearch
+metadata:
+  name: enterprise-search-quickstart
+spec:
+  version: {version}
+  count: 1
+  elasticsearchRef:
+    name: quickstart
+  config:
+    # define the exposed URL at which users will reach Enterprise Search
+    ent_search.external_url: https://my-custom-domain:3002
+    # configure app search document size
+    app_search.engine.document_size.limit: 100kb
+----
+
+[id="{p}-enterprise-search-secret-configuration"]
+=== Reference Kubernetes secrets for sensitive settings
+
+Some sensitive settings are best stored in Kubernetes secrets, referenced in the Enterprise Search specification.
+
+This example sets up a Secret with SMTP credentials:
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: enterprisesearch.k8s.elastic.co/v1beta1
+kind: EnterpriseSearch
+metadata:
+  name: enterprise-search-quickstart
+spec:
+  version: {version}
+  count: 1
+  elasticsearchRef:
+    name: quickstart
+  config:
+    ent_search.external_url: https://my-custom-domain:3002
+  configRef:
+  - secretName: smtp-credentials
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: smtp-credentials
+stringData:
+  enterprise-search.yml: |-
+    email.account.enabled: true
+    email.account.smtp.auth: plain
+    email.account.smtp.starttls.enable: false
+    email.account.smtp.host: 127.0.0.1
+    email.account.smtp.port: 25
+    email.account.smtp.user: myuser
+    email.account.smtp.password: mypassword
+    email.account.email_defaults.from: my@email.com
+----
+
+ECK merges the content of `config` and `configRef` into a single internal Secret. In case of duplicate settings, the last referenced Secret takes precedence.
+
+[id="{p}-enterprise-search-custom-pod-template"]
+=== Customize the Pod template
+
+Enterprise Search Pods specification can be overridden through the `podTemplate` element.
+
+This example overrides the default 4Gi deployment to use 8Gi instead, and makes the deployment highly-available with 3 Pods:
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: enterprisesearch.k8s.elastic.co/v1beta1
+kind: EnterpriseSearch
+metadata:
+  name: enterprise-search-quickstart
+spec:
+  version: {version}
+  count: 3
+  elasticsearchRef:
+    name: quickstart
+  podTemplate:
+    spec:
+      containers:
+      - name: enterprise-search
+        resources:
+          requests:
+            cpu: 3
+            memory: 8Gi
+          limits:
+            memory: 8Gi
+        env:
+        - name: JAVA_OPTS
+          value: -Xms7500m -Xmx7500m
+----
+
+[id="{p}-enterprise-search-expose"]
+=== Expose Enterprise Search
+
+By default ECK manages self-signed TLS certificates to secure the connection to Enterprise Search.
+It also restricts the Kubernetes service to `ClusterIP` type that cannot be accessed publicly.
+
+See link:../k8s-accessing-elastic-services.html[how to access Elastic Stack services] to customize TLS settings and expose the service.
+
+NOTE: When exposed outside the scope of `localhost`, make sure to set `ent_search.external_url` accordingly in Enterprise Search configuration.
+
+[id="{p}-enterprise-search-connect-non-eck-es"]
+=== Connect to an external Elasticsearch cluster
+
+The `elasticsearchRef` element allows ECK to automatically configure Enterprise Search to establish a secured connection to a managed Elasticsearch cluster.
+
+Enterprise Search can also be manually configured to access any available Elasticsearch cluster:
+
+[source,yaml,subs="attributes,+macros"]
+----
+cat $$<<$$EOF | kubectl apply -f -
+apiVersion: enterprisesearch.k8s.elastic.co/v1beta1
+kind: EnterpriseSearch
+metadata:
+  name: enterprise-search-quickstart
+spec:
+  version: {version}
+  count: 1
+  config:
+    elasticsearch.host: https://elasticsearch-url:9200
+    elasticsearch.username: elastic
+    elasticsearch.password: my-password
+    elasticsearch.ssl.enabled: true
+EOF
+----

--- a/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
@@ -15,7 +15,7 @@ This section describes how to deploy, configure and access Enterprise Search wit
 [id="{p}-enterprise-search-quickstart"]
 == Quickstart
 
-. Apply the following specification to deploy Enterprise Search. ECK automatically configures the secured connection to an Elasticsearch cluster named `quickstart`, created in link:../k8s-quickstart.html[Elasticsearch quickstart].
+. Apply the following specification to deploy Enterprise Search. ECK automatically configures the secured connection to an Elasticsearch cluster named `quickstart`, created in link:k8s-quickstart.html[Elasticsearch quickstart].
 +
 [source,yaml,subs="attributes,+macros"]
 ----
@@ -105,7 +105,7 @@ Any setting can be changed in the Enterprise Search yaml specification, includin
 [id="{p}-enterprise-search-custom-configuration"]
 === Customize Enterprise Search configuration
 
-ECK sets up a default Enterprise Search link:https://www.elastic.co/guide/en/enterprise-search/current/configuration.html#configuration[configuration]. Customize it through the ``config element in the specification.
+ECK sets up a default Enterprise Search link:https://www.elastic.co/guide/en/enterprise-search/current/configuration.html#configuration[configuration]. Customize it through the `config` element in the specification.
 
 At a minimum, you must set `ent_search.external_url` to the desired URL.
 
@@ -206,7 +206,7 @@ spec:
 
 By default ECK manages self-signed TLS certificates to secure the connection to Enterprise Search. It also restricts the Kubernetes service to `ClusterIP` type that cannot be accessed publicly.
 
-See link:../k8s-accessing-elastic-services.html[how to access Elastic Stack services] to customize TLS settings and expose the service.
+See link:k8s-accessing-elastic-services.html[how to access Elastic Stack services] to customize TLS settings and expose the service.
 
 NOTE: When exposed outside the scope of `localhost`, make sure to set `ent_search.external_url` accordingly in the Enterprise Search configuration.
 

--- a/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
@@ -87,7 +87,7 @@ Open `https://localhost:3002` in your browser.
 +
 NOTE: Your browser will show a warning because the self-signed certificate configured by default is not verified by a known certificate authority and not trusted by your browser. Acknowledge the warning for the purposes of this quickstart but it is highly recommended that you <<{p}-enterprise-search-expose,configure valid certificates>> for any production deployments.
 +
-Login as the `elastic` user created link:../k8s-quickstart.html[with the Elasticsearch cluster]. Its password can be obtained with:
+Login as the `elastic` user created link:k8s-quickstart.html[with the Elasticsearch cluster]. Its password can be obtained with:
 +
 [source,sh]
 ----

--- a/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
@@ -15,8 +15,7 @@ This section describes how to deploy, configure and access Enterprise Search wit
 [id="{p}-enterprise-search-quickstart"]
 == Quickstart
 
-. Apply the following specification to deploy Enterprise Search. ECK automatically configures the secured connection
-to an Elasticsearch cluster named `quickstart`, created in link:../k8s-quickstart.html[Elasticsearch quickstart].
+. Apply the following specification to deploy Enterprise Search. ECK automatically configures the secured connection to an Elasticsearch cluster named `quickstart`, created in link:../k8s-quickstart.html[Elasticsearch quickstart].
 +
 [source,yaml,subs="attributes,+macros"]
 ----
@@ -70,15 +69,14 @@ kubectl logs -f enterprise-search-quickstart-ent-58b84db85-dl7c6
 
 . Access Enterprise Search
 +
-A ClusterIP service is automatically created for the deployment,
-and can be used to access the Enterprise Search API from within the Kubernetes cluster:
+A ClusterIP service is automatically created for the deployment, and can be used to access the Enterprise Search API from within the Kubernetes cluster:
 +
 [source,sh]
 ----
 kubectl get service enterprise-search-quickstart-ent-http
 ----
 +
-Use `kubectl-portforward` to access Enterprise Search from your local workstation:
+Use `kubectl port-forward` to access Enterprise Search from your local workstation:
 +
 [source,sh]
 ----
@@ -87,7 +85,7 @@ kubectl port-forward service/enterprise-search-quickstart-ent-http 3002
 +
 Open `https://localhost:3002` in your browser.
 +
-NOTE: Your browser will show a warning because the self-signed certificate configured by default is not verified by a third party certificate authority and not trusted by your browser. Acknowledge the warning for the purposes of this quickstart but it is highly recommended that you <<{p}-enterprise-search-expose,configure valid certificates>> for any production deployments.
+NOTE: Your browser will show a warning because the self-signed certificate configured by default is not verified by a known certificate authority and not trusted by your browser. Acknowledge the warning for the purposes of this quickstart but it is highly recommended that you <<{p}-enterprise-search-expose,configure valid certificates>> for any production deployments.
 +
 Login as the `elastic` user created link:../k8s-quickstart.html[with the Elasticsearch cluster]. Its password can be obtained with:
 +
@@ -102,9 +100,7 @@ kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | ba
 [id="{p}-enterprise-search-upgrade-specification"]
 === Upgrade the Enterprise Search specification
 
-Any setting can be changed in the Enterprise Search yaml specification, including version upgrades.
-
-ECK detects those changes and ensures a smooth rolling upgrade of all Enterprise Search Pods.
+Any setting can be changed in the Enterprise Search yaml specification, including version upgrades. ECK detects those changes and ensures a smooth rolling upgrade of all Enterprise Search Pods.
 
 [id="{p}-enterprise-search-custom-configuration"]
 === Customize Enterprise Search configuration
@@ -127,7 +123,7 @@ spec:
   config:
     # define the exposed URL at which users will reach Enterprise Search
     ent_search.external_url: https://my-custom-domain:3002
-    # configure app search document size
+    # configure app search document size limit
     app_search.engine.document_size.limit: 100kb
 ----
 
@@ -208,12 +204,11 @@ spec:
 [id="{p}-enterprise-search-expose"]
 === Expose Enterprise Search
 
-By default ECK manages self-signed TLS certificates to secure the connection to Enterprise Search.
-It also restricts the Kubernetes service to `ClusterIP` type that cannot be accessed publicly.
+By default ECK manages self-signed TLS certificates to secure the connection to Enterprise Search. It also restricts the Kubernetes service to `ClusterIP` type that cannot be accessed publicly.
 
 See link:../k8s-accessing-elastic-services.html[how to access Elastic Stack services] to customize TLS settings and expose the service.
 
-NOTE: When exposed outside the scope of `localhost`, make sure to set `ent_search.external_url` accordingly in Enterprise Search configuration.
+NOTE: When exposed outside the scope of `localhost`, make sure to set `ent_search.external_url` accordingly in the Enterprise Search configuration.
 
 [id="{p}-enterprise-search-connect-non-eck-es"]
 === Connect to an external Elasticsearch cluster
@@ -224,7 +219,6 @@ Also, you can manually configure Enterprise Search to access any available Elast
 
 [source,yaml,subs="attributes,+macros"]
 ----
-cat $$<<$$EOF | kubectl apply -f -
 apiVersion: enterprisesearch.k8s.elastic.co/v1beta1
 kind: EnterpriseSearch
 metadata:
@@ -232,10 +226,17 @@ metadata:
 spec:
   version: {version}
   count: 1
-  config:
+  configRef:
+  - secretName: elasticsearch-credentials
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: elasticsearch-credentials
+stringData:
+  enterprise-search.yml: |-
     elasticsearch.host: https://elasticsearch-url:9200
     elasticsearch.username: elastic
     elasticsearch.password: my-password
     elasticsearch.ssl.enabled: true
-EOF
 ----

--- a/docs/orchestrating-elastic-stack-applications/orchestrating-elastic-stack-applications.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/orchestrating-elastic-stack-applications.asciidoc
@@ -12,6 +12,7 @@ endif::[]
 - <<{p}-elasticsearch-specification>>
 - <<{p}-kibana>>
 - <<{p}-apm-server>>
+- <<{p}-enterprise-search>>
 - <<{p}-accessing-elastic-services>>
 - <<{p}-customize-pods>>
 - <<{p}-managing-compute-resources>>
@@ -22,6 +23,7 @@ endif::[]
 include::elasticsearch-specification.asciidoc[leveloffset=+1]
 include::kibana.asciidoc[leveloffset=+1]
 include::apm-server.asciidoc[leveloffset=+1]
+include::enterprise-search.asciidoc[leveloffset=+1]
 include::accessing-elastic-services.asciidoc[leveloffset=+1]
 include::customize-pods.asciidoc[leveloffset=+1]
 include::managing-compute-resources.asciidoc[leveloffset=+1]

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -233,7 +233,7 @@ Use `kubectl port-forward` to access Kibana from your local workstation:
 kubectl port-forward service/quickstart-kb-http 5601
 ----
 +
-Open `https://localhost:5601` in your browser. Your browser will show a warning because the self-signed certificate configured by default is not verified by a third party certificate authority and not trusted by your browser. You can temporarily acknowledge the warning for the purposes of this quick start but it is highly recommended that you <<{p}-setting-up-your-own-certificate,configure valid certificates>> for any production deployments.
+Open `https://localhost:5601` in your browser. Your browser will show a warning because the self-signed certificate configured by default is not verified by a known certificate authority and not trusted by your browser. You can temporarily acknowledge the warning for the purposes of this quick start but it is highly recommended that you <<{p}-setting-up-your-own-certificate,configure valid certificates>> for any production deployments.
 +
 Login as the `elastic` user. The password can be obtained with the following command:
 +


### PR DESCRIPTION
I divided the docs into 2 main sections:

- quickstart: deploy Enterprise Search with the quickstart Elasticsearch
  cluster (links to the Elasticsearch quickstart)
- configuration: everything you need to know about the Enterprise Search
  resource spec (also links to "how to expose the Elastic stack")