### PR TITLE
Propagate metadata to children

### DIFF
--- a/pkg/controller/apmserver/config.go
+++ b/pkg/controller/apmserver/config.go
@@ -15,6 +15,7 @@ import (
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -40,7 +41,7 @@ func certificatesDir(associatedType string) string {
 
 // reconcileApmServerConfig reconciles the configuration of the APM server: it first creates the configuration from the APM
 // specification and then reconcile the underlying secret.
-func reconcileApmServerConfig(client k8s.Client, as *apmv1.ApmServer) (corev1.Secret, error) {
+func reconcileApmServerConfig(client k8s.Client, as *apmv1.ApmServer, meta metadata.Metadata) (corev1.Secret, error) {
 	// Create a new configuration from the APM object spec.
 	cfg, err := newConfigFromSpec(client, as)
 	if err != nil {
@@ -55,9 +56,10 @@ func reconcileApmServerConfig(client k8s.Client, as *apmv1.ApmServer) (corev1.Se
 	// reconcile the configuration in a secret
 	expectedConfigSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: as.Namespace,
-			Name:      Config(as.Name),
-			Labels:    NewLabels(as.Name),
+			Namespace:   as.Namespace,
+			Name:        Config(as.Name),
+			Labels:      meta.Labels,
+			Annotations: meta.Annotations,
 		},
 		Data: map[string][]byte{
 			ApmCfgSecretKey: cfgBytes,

--- a/pkg/controller/apmserver/deployment_test.go
+++ b/pkg/controller/apmserver/deployment_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/deployment"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
@@ -88,8 +89,10 @@ func expectedDeploymentParams() testParams {
 			Name:      "test-apm-server-apm-server",
 			Namespace: "",
 			Selector:  map[string]string{"apm.k8s.elastic.co/name": "test-apm-server", "common.k8s.elastic.co/type": "apm-server"},
-			Labels:    map[string]string{"apm.k8s.elastic.co/name": "test-apm-server", "common.k8s.elastic.co/type": "apm-server"},
-			Strategy:  appsv1.RollingUpdateDeploymentStrategyType,
+			Meta: metadata.Metadata{
+				Labels: map[string]string{"apm.k8s.elastic.co/name": "test-apm-server", "common.k8s.elastic.co/type": "apm-server"},
+			},
+			Strategy: appsv1.RollingUpdateDeploymentStrategyType,
 			PodTemplateSpec: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -453,7 +456,9 @@ func TestReconcileApmServer_deploymentParams(t *testing.T) {
 				recorder:       record.NewFakeRecorder(100),
 				dynamicWatches: w,
 			}
-			got, err := r.deploymentParams(tt.args.as, tt.args.podSpecParams)
+			got, err := r.deploymentParams(tt.args.as, tt.args.podSpecParams, metadata.Metadata{
+				Labels: map[string]string{"apm.k8s.elastic.co/name": "test-apm-server", "common.k8s.elastic.co/type": "apm-server"},
+			})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReconcileApmServer.deploymentParams() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/beat/common/reconcile.go
+++ b/pkg/controller/beat/common/reconcile.go
@@ -18,6 +18,7 @@ import (
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/daemonset"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/deployment"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
@@ -95,7 +96,7 @@ func reconcileDeployment(rp ReconciliationParams) (int32, int32, error) {
 		Name:            Name(rp.beat.Name, rp.beat.Spec.Type),
 		Namespace:       rp.beat.Namespace,
 		Selector:        NewLabels(rp.beat),
-		Labels:          NewLabels(rp.beat),
+		Meta:            metadata.Metadata{Labels: NewLabels(rp.beat)},
 		PodTemplateSpec: rp.podTemplate,
 		Replicas:        pointer.Int32OrDefault(rp.beat.Spec.Deployment.Replicas, int32(1)),
 	})

--- a/pkg/controller/common/annotation/meta_propagation.go
+++ b/pkg/controller/common/annotation/meta_propagation.go
@@ -1,0 +1,89 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package annotation
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// PropagateAnnotationsAnnotation is the annotation used to indicate which annotations should be propagated to child objects.
+	PropagateAnnotationsAnnotation = "eck.k8s.elastic.co/propagate-annotations"
+	// PropagateLabelsAnnotation is the annotation used to indicate which labels should be propagated to child objects.
+	PropagateLabelsAnnotation = "eck.k8s.elastic.co/propagate-labels"
+)
+
+var eckAnnotationsRegex = regexp.MustCompile(`.*\.k8s\.elastic\.co/.*`)
+
+// MetadataToPropagate holds the annotations and labels that should be propagated to children.
+type MetadataToPropagate struct {
+	Annotations map[string]string
+	Labels      map[string]string
+}
+
+// GetMetadataToPropagate returns the annotations and labels that should be propagated.
+// The annotations and labels to propagate are determined by the values of the eck.k8s.elastic.co/propagate-(annotations|labels) annotations.
+// Users are expected to provide a comma separated list of annotations or labels they wish to have propagated. The special value of "*" signals
+// that all existing annotations/labels should be propagated.
+// When propagating annotations, any ECK annotations and the kubectl last applied configuration annotation are ignored.
+func GetMetadataToPropagate(obj metav1.Object) MetadataToPropagate {
+	md := MetadataToPropagate{}
+
+	if obj == nil || len(obj.GetAnnotations()) == 0 {
+		return md
+	}
+
+	if annotationsToPropagate, ok := obj.GetAnnotations()[PropagateAnnotationsAnnotation]; ok {
+		md.Annotations = parseList(annotationsToPropagate, removeExcludedAnnotations(obj.GetAnnotations()))
+	}
+
+	if labelsToPropagate, ok := obj.GetAnnotations()[PropagateLabelsAnnotation]; ok {
+		md.Labels = parseList(labelsToPropagate, obj.GetLabels())
+	}
+
+	return md
+}
+
+func removeExcludedAnnotations(annotations map[string]string) map[string]string {
+	m := make(map[string]string, len(annotations))
+
+	for k, v := range annotations {
+		if k == corev1.LastAppliedConfigAnnotation || eckAnnotationsRegex.MatchString(k) {
+			continue
+		}
+
+		m[k] = v
+	}
+
+	return m
+}
+
+func parseList(listStr string, existingValues map[string]string) map[string]string {
+	listStr = strings.TrimSpace(listStr)
+	if listStr == "" {
+		return nil
+	}
+
+	if listStr == "*" {
+		return maps.Clone(existingValues)
+	}
+
+	keys := strings.Split(listStr, ",")
+	values := make(map[string]string, len(keys))
+
+	for _, key := range keys {
+		k := strings.TrimSpace(key)
+		if v, ok := existingValues[k]; ok {
+			values[k] = v
+		}
+	}
+
+	return values
+}

--- a/pkg/controller/common/annotation/meta_propagation_test.go
+++ b/pkg/controller/common/annotation/meta_propagation_test.go
@@ -1,0 +1,113 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package annotation
+
+import (
+	"testing"
+
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetMetadataToPropagate(t *testing.T) {
+	testCases := []struct {
+		name    string
+		objMeta metav1.ObjectMeta
+		want    MetadataToPropagate
+	}{
+		{
+			name:    "no annotations or labels",
+			objMeta: metav1.ObjectMeta{},
+			want:    MetadataToPropagate{},
+		},
+		{
+			name: "propagation not configured",
+			objMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"foo": "bar"},
+				Labels:      map[string]string{"wibble": "wobble"},
+			},
+			want: MetadataToPropagate{},
+		},
+		{
+			name: "propagate all annotations",
+			objMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{PropagateAnnotationsAnnotation: "*", corev1.LastAppliedConfigAnnotation: "{}", "foo": "bar"},
+				Labels:      map[string]string{"wibble": "wobble"},
+			},
+			want: MetadataToPropagate{
+				Annotations: map[string]string{"foo": "bar"},
+			},
+		},
+		{
+			name: "propagate some annotations",
+			objMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{PropagateAnnotationsAnnotation: "foo, baz", "foo": "bar", "baz": "quux", "quuz": "corge"},
+				Labels:      map[string]string{"wibble": "wobble"},
+			},
+			want: MetadataToPropagate{
+				Annotations: map[string]string{"foo": "bar", "baz": "quux"},
+			},
+		},
+		{
+			name: "propagate all labels",
+			objMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{PropagateLabelsAnnotation: "*", "foo": "bar"},
+				Labels:      map[string]string{"wibble": "wobble", "wubble": "flub"},
+			},
+			want: MetadataToPropagate{
+				Labels: map[string]string{"wibble": "wobble", "wubble": "flub"},
+			},
+		},
+		{
+			name: "propagate some labels",
+			objMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{PropagateLabelsAnnotation: "wibble, wubble"},
+				Labels:      map[string]string{"wibble": "wobble", "wubble": "flub", "globble": "nobble"},
+			},
+			want: MetadataToPropagate{
+				Labels: map[string]string{"wibble": "wobble", "wubble": "flub"},
+			},
+		},
+		{
+			name: "propagate all labels and annotations",
+			objMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{PropagateAnnotationsAnnotation: "*", PropagateLabelsAnnotation: "*", "foo": "bar"},
+				Labels:      map[string]string{"wibble": "wobble"},
+			},
+			want: MetadataToPropagate{
+				Annotations: map[string]string{"foo": "bar"},
+				Labels:      map[string]string{"wibble": "wobble"},
+			},
+		},
+		{
+			name: "nil labels",
+			objMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{PropagateLabelsAnnotation: "*", "foo": "bar"},
+			},
+			want: MetadataToPropagate{},
+		},
+		{
+			name: "empty string as propagation list",
+			objMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{PropagateAnnotationsAnnotation: "", PropagateLabelsAnnotation: " ", "foo": "bar"},
+				Labels:      map[string]string{"wibble": "wobble"},
+			},
+			want: MetadataToPropagate{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &esv1.Elasticsearch{
+				ObjectMeta: tc.objMeta,
+			}
+
+			have := GetMetadataToPropagate(obj)
+			require.Equal(t, tc.want, have)
+		})
+	}
+}

--- a/pkg/controller/common/certificates/http_reconcile.go
+++ b/pkg/controller/common/certificates/http_reconcile.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/name"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -81,12 +82,11 @@ func (r Reconciler) ReconcileInternalHTTPCerts(ca *CA) (*CertificatesSecret, err
 	needsUpdate := false
 
 	// check whether labels and annotations need to be updated
-	labelsToAdd := maps.MergePreservingExistingKeys(maps.Clone(secret.Labels), r.Metadata.Labels)
-	annotationsToAdd := maps.MergePreservingExistingKeys(maps.Clone(secret.Annotations), r.Metadata.Annotations)
+	mergedMeta := r.Metadata.Merge(metadata.Metadata{Annotations: secret.Annotations, Labels: secret.Labels})
 
-	if !maps.Equal(labelsToAdd, secret.Labels) || !maps.Equal(annotationsToAdd, secret.Annotations) {
-		secret.Labels = labelsToAdd
-		secret.Annotations = annotationsToAdd
+	if !maps.Equal(mergedMeta.Labels, secret.Labels) || !maps.Equal(mergedMeta.Annotations, secret.Annotations) {
+		secret.Labels = mergedMeta.Labels
+		secret.Annotations = mergedMeta.Annotations
 		needsUpdate = true
 	}
 

--- a/pkg/controller/common/certificates/reconcile.go
+++ b/pkg/controller/common/certificates/reconcile.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	commonname "github.com/elastic/cloud-on-k8s/pkg/controller/common/name"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
@@ -36,7 +37,7 @@ type Reconciler struct {
 	TLSOptions commonv1.TLSOptions // TLS options of the object
 
 	Namer    commonname.Namer  // helps naming the reconciled secrets
-	Labels   map[string]string // to set on the reconciled cert secrets
+	Metadata metadata.Metadata // labels and annotations to set on reconcile cert secrets
 	Services []corev1.Service  // to be used for TLS SANs
 
 	CACertRotation RotationParams // to requeue a reconciliation before CA cert expiration
@@ -65,7 +66,7 @@ func (r Reconciler) ReconcileCAAndHTTPCerts(ctx context.Context) (*CertificatesS
 		r.K8sClient,
 		r.Namer,
 		r.Object,
-		r.Labels,
+		r.Metadata,
 		HTTPCAType,
 		r.CACertRotation,
 	)

--- a/pkg/controller/common/certificates/reconcile_test.go
+++ b/pkg/controller/common/certificates/reconcile_test.go
@@ -16,6 +16,7 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
@@ -25,8 +26,8 @@ var (
 		Validity:     DefaultCertValidity,
 		RotateBefore: DefaultRotateBefore,
 	}
-	labels = map[string]string{
-		"foo": "bar",
+	meta = metadata.Metadata{
+		Labels: map[string]string{"foo": "bar"},
 	}
 	// tested on Elasticsearch but could be any resource
 	obj = esv1.Elasticsearch{
@@ -48,7 +49,7 @@ func TestReconcileCAAndHTTPCerts(t *testing.T) {
 		Object:                &obj,
 		TLSOptions:            commonv1.TLSOptions{},
 		Namer:                 esv1.ESNamer,
-		Labels:                labels,
+		Metadata:              meta,
 		Services:              nil,
 		CACertRotation:        rotation,
 		CertRotation:          rotation,
@@ -75,7 +76,7 @@ func TestReconcileCAAndHTTPCerts(t *testing.T) {
 		require.Len(t, caCerts.Data, 2)
 		require.NotEmpty(t, caCerts.Data[CertFileName])
 		require.NotEmpty(t, caCerts.Data[KeyFileName])
-		require.Equal(t, labels, caCerts.Labels)
+		require.Equal(t, meta.Labels, caCerts.Labels)
 
 		var internalCerts corev1.Secret
 		err = c.Get(types.NamespacedName{Namespace: obj.Namespace, Name: InternalCertsSecretName(esv1.ESNamer, obj.Name)}, &internalCerts)
@@ -84,7 +85,7 @@ func TestReconcileCAAndHTTPCerts(t *testing.T) {
 		require.NotEmpty(t, internalCerts.Data[CAFileName])
 		require.NotEmpty(t, internalCerts.Data[CertFileName])
 		require.NotEmpty(t, internalCerts.Data[KeyFileName])
-		require.Equal(t, labels, internalCerts.Labels)
+		require.Equal(t, meta.Labels, internalCerts.Labels)
 
 		var publicCerts corev1.Secret
 		err = c.Get(types.NamespacedName{Namespace: obj.Namespace, Name: PublicCertsSecretName(esv1.ESNamer, obj.Name)}, &publicCerts)
@@ -92,7 +93,7 @@ func TestReconcileCAAndHTTPCerts(t *testing.T) {
 		require.Len(t, publicCerts.Data, 2)
 		require.NotEmpty(t, publicCerts.Data[CAFileName])
 		require.NotEmpty(t, publicCerts.Data[CertFileName])
-		require.Equal(t, labels, publicCerts.Labels)
+		require.Equal(t, meta.Labels, publicCerts.Labels)
 
 	}
 	checkCertsSecrets()

--- a/pkg/controller/common/defaults/service.go
+++ b/pkg/controller/common/defaults/service.go
@@ -5,6 +5,7 @@
 package defaults
 
 import (
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
 	v1 "k8s.io/api/core/v1"
 )
@@ -12,11 +13,12 @@ import (
 // SetServiceDefaults updates the service with the provided defaults if they are not already set.
 func SetServiceDefaults(
 	svc *v1.Service,
-	defaultLabels map[string]string,
+	defaultMetadata metadata.Metadata,
 	defaultSelector map[string]string,
 	defaultPorts []v1.ServicePort,
 ) *v1.Service {
-	svc.Labels = maps.MergePreservingExistingKeys(svc.Labels, defaultLabels)
+	svc.Labels = maps.MergePreservingExistingKeys(svc.Labels, defaultMetadata.Labels)
+	svc.Annotations = maps.MergePreservingExistingKeys(svc.Annotations, defaultMetadata.Annotations)
 
 	if svc.Spec.Selector == nil {
 		svc.Spec.Selector = defaultSelector

--- a/pkg/controller/common/deployment/reconcile.go
+++ b/pkg/controller/common/deployment/reconcile.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
@@ -24,7 +25,7 @@ type Params struct {
 	Name            string
 	Namespace       string
 	Selector        map[string]string
-	Labels          map[string]string
+	Meta            metadata.Metadata
 	PodTemplateSpec corev1.PodTemplateSpec
 	Replicas        int32
 	Strategy        appsv1.DeploymentStrategyType
@@ -34,9 +35,10 @@ type Params struct {
 func New(params Params) appsv1.Deployment {
 	return appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      params.Name,
-			Namespace: params.Namespace,
-			Labels:    params.Labels,
+			Name:        params.Name,
+			Namespace:   params.Namespace,
+			Labels:      params.Meta.Labels,
+			Annotations: params.Meta.Annotations,
 		},
 		Spec: appsv1.DeploymentSpec{
 			RevisionHistoryLimit: pointer.Int32(defaultRevisionHistoryLimit),

--- a/pkg/controller/common/keystore/resources.go
+++ b/pkg/controller/common/keystore/resources.go
@@ -14,6 +14,7 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/driver"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/name"
 )
 
@@ -53,11 +54,11 @@ func NewResources(
 	r driver.Interface,
 	hasKeystore HasKeystore,
 	namer name.Namer,
-	labels map[string]string,
+	meta metadata.Metadata,
 	initContainerParams InitContainerParameters,
 ) (*Resources, error) {
 	// setup a volume from the user-provided secure settings secret
-	secretVolume, version, err := secureSettingsVolume(r, hasKeystore, labels, namer)
+	secretVolume, version, err := secureSettingsVolume(r, hasKeystore, meta, namer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/common/keystore/resources_test.go
+++ b/pkg/controller/common/keystore/resources_test.go
@@ -18,6 +18,7 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/driver"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	watches2 "github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
@@ -163,7 +164,7 @@ echo "Keystore initialization successful."
 				Watches:      watches2.NewDynamicWatches(),
 				FakeRecorder: record.NewFakeRecorder(1000),
 			}
-			resources, err := NewResources(testDriver, &tt.kb, kbNamer, nil, initContainersParameters)
+			resources, err := NewResources(testDriver, &tt.kb, kbNamer, metadata.Metadata{}, initContainersParameters)
 			require.NoError(t, err)
 			if tt.wantNil {
 				require.Nil(t, resources)

--- a/pkg/controller/common/keystore/user_secret_test.go
+++ b/pkg/controller/common/keystore/user_secret_test.go
@@ -18,6 +18,7 @@ import (
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/comparison"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/driver"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/name"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
@@ -101,7 +102,7 @@ func Test_secureSettingsVolume(t *testing.T) {
 				Watches:      tt.w,
 				FakeRecorder: record.NewFakeRecorder(1000),
 			}
-			vol, version, err := secureSettingsVolume(testDriver, &tt.kb, nil, kbNamer)
+			vol, version, err := secureSettingsVolume(testDriver, &tt.kb, metadata.Metadata{}, kbNamer)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantVolume, vol)
 			assert.Equal(t, tt.wantVersion, version)
@@ -301,7 +302,7 @@ func Test_reconcileSecureSettings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := reconcileSecureSettings(tt.args.c, tt.args.hasKeystore, tt.args.userSecrets, tt.args.namer, nil)
+			got, err := reconcileSecureSettings(tt.args.c, tt.args.hasKeystore, tt.args.userSecrets, tt.args.namer, metadata.Metadata{})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("reconcileSecureSettings() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/common/metadata/propagation.go
+++ b/pkg/controller/common/metadata/propagation.go
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package metadata
+
+import (
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/annotation"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Metadata is a container for labels and annotations.
+type Metadata struct {
+	Labels      map[string]string
+	Annotations map[string]string
+}
+
+// Merge the given set of metadata with the existing ones.
+func (md Metadata) Merge(other Metadata) Metadata {
+	return Metadata{
+		Annotations: maps.Merge(maps.Clone(md.Annotations), other.Annotations),
+		Labels:      maps.Merge(maps.Clone(md.Labels), other.Labels),
+	}
+}
+
+// Propagate returns a new set of metadata to apply to child objects.
+// Behaviour is driven by the presence of annotation and label propagation annotations in the object.
+// Elements chosen for propagation are merged with the elements to add giving precedence to the latter.
+func Propagate(obj metav1.Object, toAdd Metadata) Metadata {
+	inherited := annotation.GetMetadataToPropagate(obj)
+
+	return Metadata{
+		Annotations: merge(toAdd.Annotations, inherited.Annotations),
+		Labels:      merge(toAdd.Labels, inherited.Labels),
+	}
+}
+
+func merge(toAdd map[string]string, inherited map[string]string) map[string]string {
+	newElements := maps.Clone(toAdd)
+
+	if len(inherited) == 0 {
+		return newElements
+	}
+
+	return maps.MergePreservingExistingKeys(newElements, inherited)
+}

--- a/pkg/controller/common/metadata/propagation_test.go
+++ b/pkg/controller/common/metadata/propagation_test.go
@@ -1,0 +1,173 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package metadata
+
+import (
+	"testing"
+
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/annotation"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPropagate(t *testing.T) {
+	testCases := []struct {
+		name    string
+		objMeta metav1.ObjectMeta
+		toAdd   Metadata
+		want    Metadata
+	}{
+		{
+			name: "everything nil",
+		},
+		{
+			name: "no propagation and nothing to add",
+			objMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"foo": "bar"},
+				Labels:      map[string]string{"wibble": "wobble"},
+			},
+			toAdd: Metadata{},
+			want:  Metadata{},
+		},
+		{
+			name: "no propagation",
+			objMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"foo": "bar"},
+				Labels:      map[string]string{"wibble": "wobble"},
+			},
+			toAdd: Metadata{
+				Annotations: map[string]string{"bar": "baz"},
+				Labels:      map[string]string{"wubble": "flub"},
+			},
+			want: Metadata{
+				Annotations: map[string]string{"bar": "baz"},
+				Labels:      map[string]string{"wubble": "flub"},
+			},
+		},
+		{
+			name: "annotation propagation without conflict",
+			objMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{annotation.PropagateAnnotationsAnnotation: "*", "foo": "bar"},
+				Labels:      map[string]string{"wibble": "wobble"},
+			},
+			toAdd: Metadata{
+				Annotations: map[string]string{"bar": "baz"},
+				Labels:      map[string]string{"wubble": "flub"},
+			},
+			want: Metadata{
+				Annotations: map[string]string{"foo": "bar", "bar": "baz"},
+				Labels:      map[string]string{"wubble": "flub"},
+			},
+		},
+		{
+			name: "annotation propagation with conflict",
+			objMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{annotation.PropagateAnnotationsAnnotation: "*", "foo": "bar"},
+				Labels:      map[string]string{"wibble": "wobble"},
+			},
+			toAdd: Metadata{
+				Annotations: map[string]string{"foo": "baz"},
+				Labels:      map[string]string{"wubble": "flub"},
+			},
+			want: Metadata{
+				Annotations: map[string]string{"foo": "baz"},
+				Labels:      map[string]string{"wubble": "flub"},
+			},
+		},
+		{
+			name: "label propagation without conflict",
+			objMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{annotation.PropagateLabelsAnnotation: "*", "foo": "bar"},
+				Labels:      map[string]string{"wibble": "wobble"},
+			},
+			toAdd: Metadata{
+				Annotations: map[string]string{"foo": "baz"},
+				Labels:      map[string]string{"wubble": "flub"},
+			},
+			want: Metadata{
+				Annotations: map[string]string{"foo": "baz"},
+				Labels:      map[string]string{"wibble": "wobble", "wubble": "flub"},
+			},
+		},
+		{
+			name: "label propagation with conflict",
+			objMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{annotation.PropagateLabelsAnnotation: "*", "foo": "bar"},
+				Labels:      map[string]string{"wibble": "wobble"},
+			},
+			toAdd: Metadata{
+				Annotations: map[string]string{"foo": "baz"},
+				Labels:      map[string]string{"wibble": "flub"},
+			},
+			want: Metadata{
+				Annotations: map[string]string{"foo": "baz"},
+				Labels:      map[string]string{"wibble": "flub"},
+			},
+		},
+		{
+			name: "propagation with nils",
+			objMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{annotation.PropagateLabelsAnnotation: "*", annotation.PropagateAnnotationsAnnotation: "*"},
+			},
+			toAdd: Metadata{},
+			want:  Metadata{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &esv1.Elasticsearch{
+				ObjectMeta: tc.objMeta,
+			}
+
+			have := Propagate(obj, tc.toAdd)
+			require.Equal(t, tc.want, have)
+		})
+	}
+
+}
+
+func TestMetadataMerge(t *testing.T) {
+	testCases := []struct {
+		name  string
+		md    Metadata
+		input Metadata
+		want  Metadata
+	}{
+		{
+			name:  "empty receiver",
+			md:    Metadata{},
+			input: Metadata{Labels: map[string]string{"foo": "bar"}, Annotations: map[string]string{"wibble": "wobble"}},
+			want:  Metadata{Labels: map[string]string{"foo": "bar"}, Annotations: map[string]string{"wibble": "wobble"}},
+		},
+		{
+			name:  "empty input",
+			md:    Metadata{Labels: map[string]string{"foo": "bar"}, Annotations: map[string]string{"wibble": "wobble"}},
+			input: Metadata{},
+			want:  Metadata{Labels: map[string]string{"foo": "bar"}, Annotations: map[string]string{"wibble": "wobble"}},
+		},
+		{
+			name:  "merge without conflicts",
+			md:    Metadata{Labels: map[string]string{"foo": "bar"}, Annotations: map[string]string{"wibble": "wobble"}},
+			input: Metadata{Labels: map[string]string{"baz": "quux"}, Annotations: map[string]string{"wubble": "flub"}},
+			want:  Metadata{Labels: map[string]string{"foo": "bar", "baz": "quux"}, Annotations: map[string]string{"wibble": "wobble", "wubble": "flub"}},
+		},
+		{
+			name:  "merge with conflicts",
+			md:    Metadata{Labels: map[string]string{"foo": "bar"}, Annotations: map[string]string{"wibble": "wobble"}},
+			input: Metadata{Labels: map[string]string{"foo": "baz", "baz": "quux"}, Annotations: map[string]string{"wibble": "wubble", "wubble": "flub"}},
+			want:  Metadata{Labels: map[string]string{"foo": "baz", "baz": "quux"}, Annotations: map[string]string{"wibble": "wubble", "wubble": "flub"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			have := tc.md.Merge(tc.input)
+
+			require.Equal(t, tc.want, have)
+		})
+	}
+}

--- a/pkg/controller/elasticsearch/certificates/remoteca/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/remoteca/reconcile.go
@@ -15,6 +15,7 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -36,6 +37,7 @@ func Labels(esName string) client.MatchingLabels {
 func Reconcile(
 	c k8s.Client,
 	es esv1.Elasticsearch,
+	meta metadata.Metadata,
 ) error {
 	// Get all the remote certificate authorities
 	var remoteCAList v1.SecretList
@@ -59,11 +61,10 @@ func Reconcile(
 
 	expected := v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      esv1.RemoteCaSecretName(es.Name),
-			Namespace: es.Namespace,
-			Labels: map[string]string{
-				label.ClusterNameLabelName: es.Name,
-			},
+			Name:        esv1.RemoteCaSecretName(es.Name),
+			Namespace:   es.Namespace,
+			Labels:      meta.Labels,
+			Annotations: meta.Annotations,
 		},
 		Data: map[string][]byte{
 			certificates.CAFileName: bytes.Join(remoteCertificateAuthorities, nil),

--- a/pkg/controller/elasticsearch/certificates/remoteca/reconcile_test.go
+++ b/pkg/controller/elasticsearch/certificates/remoteca/reconcile_test.go
@@ -16,6 +16,7 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
@@ -108,7 +109,8 @@ func TestReconcile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			k8sClient := k8s.WrappedFakeClient(tt.args.secrets...)
-			if err := Reconcile(k8sClient, tt.args.es); (err != nil) != tt.wantErr {
+			meta := metadata.Propagate(&tt.args.es, metadata.Metadata{Labels: label.NewLabels(k8s.ExtractNamespacedName(&tt.args.es))})
+			if err := Reconcile(k8sClient, tt.args.es, meta); (err != nil) != tt.wantErr {
 				t.Errorf("Reconcile() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			remoteCaList := v1.Secret{}

--- a/pkg/controller/elasticsearch/certificates/transport/public_secret.go
+++ b/pkg/controller/elasticsearch/certificates/transport/public_secret.go
@@ -10,8 +10,8 @@ import (
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
@@ -21,13 +21,15 @@ func ReconcileTransportCertsPublicSecret(
 	c k8s.Client,
 	es esv1.Elasticsearch,
 	ca *certificates.CA,
+	nsn types.NamespacedName,
+	meta metadata.Metadata,
 ) error {
-	esNSN := k8s.ExtractNamespacedName(&es)
-	meta := k8s.ToObjectMeta(PublicCertsSecretRef(esNSN))
-	meta.Labels = label.NewLabels(esNSN)
+	objectMeta := k8s.ToObjectMeta(PublicCertsSecretRef(nsn))
+	objectMeta.Labels = meta.Labels
+	objectMeta.Annotations = meta.Annotations
 
 	expected := corev1.Secret{
-		ObjectMeta: meta,
+		ObjectMeta: objectMeta,
 		Data: map[string][]byte{
 			certificates.CAFileName: certificates.EncodePEMCert(ca.Cert.Raw),
 		},

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
@@ -9,6 +9,7 @@ import (
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/comparison"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
@@ -111,7 +112,8 @@ func Test_ensureTransportCertificateSecretExists(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ensureTransportCertificatesSecretExists(tt.args.c, tt.args.owner)
+			meta := metadata.Propagate(&tt.args.owner, metadata.Metadata{Labels: map[string]string{label.ClusterNameLabelName: testES.Name}})
+			got, err := ensureTransportCertificatesSecretExists(tt.args.c, tt.args.owner, meta)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("EnsureTransportCertificateSecretExists() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -915,8 +915,9 @@ func Test_doDownscale_zen1MinimumMasterNodes(t *testing.T) {
 func Test_deleteStatefulSetResources(t *testing.T) {
 	es := esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster"}}
 	sset := sset.TestSset{Namespace: "ns", Name: "sset", ClusterName: es.Name}.Build()
-	cfg := settings.ConfigSecret(es, sset.Name, []byte("fake config data"))
+
 	meta := metadata.Metadata{}
+	cfg := settings.ConfigSecret(es, sset.Name, []byte("fake config data"), meta)
 	svc := nodespec.HeadlessService(&es, sset.Name, meta)
 
 	tests := []struct {

--- a/pkg/controller/elasticsearch/driver/downscale_utils.go
+++ b/pkg/controller/elasticsearch/driver/downscale_utils.go
@@ -9,6 +9,7 @@ import (
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/expectations"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/observer"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/reconcile"
@@ -30,7 +31,8 @@ type downscaleContext struct {
 	reconcileState *reconcile.State
 	expectations   *expectations.Expectations
 	// ES cluster
-	es esv1.Elasticsearch
+	es   esv1.Elasticsearch
+	meta metadata.Metadata
 
 	parentCtx context.Context
 }
@@ -45,6 +47,7 @@ func newDownscaleContext(
 	expectations *expectations.Expectations,
 	// ES cluster
 	es esv1.Elasticsearch,
+	meta metadata.Metadata,
 ) downscaleContext {
 	return downscaleContext{
 		k8sClient:      k8sClient,
@@ -56,6 +59,7 @@ func newDownscaleContext(
 		es:             es,
 		expectations:   expectations,
 		parentCtx:      ctx,
+		meta:           meta,
 	}
 }
 

--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -75,6 +75,7 @@ func (d *defaultDriver) reconcileNodeSpecs(
 		observedState: observedState,
 		esState:       esState,
 		expectations:  d.Expectations,
+		meta:          meta,
 	}
 	actualStatefulSets, err = HandleUpscaleAndSpecChanges(upscaleCtx, actualStatefulSets, expectedResources)
 	if err != nil {

--- a/pkg/controller/elasticsearch/driver/upscale.go
+++ b/pkg/controller/elasticsearch/driver/upscale.go
@@ -10,6 +10,7 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/expectations"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/observer"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
@@ -27,6 +28,7 @@ type upscaleCtx struct {
 	observedState observer.State
 	esState       ESState
 	expectations  *expectations.Expectations
+	meta          metadata.Metadata
 }
 
 // HandleUpscaleAndSpecChanges reconciles expected NodeSet resources.
@@ -50,7 +52,7 @@ func HandleUpscaleAndSpecChanges(
 	}
 	// reconcile all resources
 	for _, res := range adjusted {
-		if err := settings.ReconcileConfig(ctx.k8sClient, ctx.es, res.StatefulSet.Name, res.Config); err != nil {
+		if err := settings.ReconcileConfig(ctx.k8sClient, ctx.es, res.StatefulSet.Name, res.Config, ctx.meta); err != nil {
 			return nil, err
 		}
 		if _, err := common.ReconcileService(ctx.parentCtx, ctx.k8sClient, &res.HeadlessService, &ctx.es); err != nil {

--- a/pkg/controller/elasticsearch/nodespec/resources.go
+++ b/pkg/controller/elasticsearch/nodespec/resources.go
@@ -11,6 +11,7 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
@@ -38,6 +39,7 @@ func BuildExpectedResources(
 	es esv1.Elasticsearch,
 	keystoreResources *keystore.Resources,
 	existingStatefulSets sset.StatefulSetList,
+	meta metadata.Metadata,
 ) (ResourcesList, error) {
 	nodesResources := make(ResourcesList, 0, len(es.Spec.NodeSets))
 
@@ -58,11 +60,11 @@ func BuildExpectedResources(
 		}
 
 		// build stateful set and associated headless service
-		statefulSet, err := BuildStatefulSet(es, nodeSpec, cfg, keystoreResources, existingStatefulSets)
+		statefulSet, err := BuildStatefulSet(es, nodeSpec, cfg, keystoreResources, existingStatefulSets, meta)
 		if err != nil {
 			return nil, err
 		}
-		headlessSvc := HeadlessService(&es, statefulSet.Name)
+		headlessSvc := HeadlessService(&es, statefulSet.Name, meta)
 
 		nodesResources = append(nodesResources, Resources{
 			StatefulSet:     statefulSet,

--- a/pkg/controller/elasticsearch/pdb/reconcile.go
+++ b/pkg/controller/elasticsearch/pdb/reconcile.go
@@ -15,17 +15,17 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
 )
 
 // Reconcile ensures that a PodDisruptionBudget exists for this cluster, inheriting the spec content.
 // The default PDB we setup dynamically adapts MinAvailable to the number of nodes in the cluster.
 // If the spec has disabled the default PDB, it will ensure none exist.
-func Reconcile(k8sClient k8s.Client, es esv1.Elasticsearch, statefulSets sset.StatefulSetList) error {
-	expected, err := expectedPDB(es, statefulSets)
+func Reconcile(k8sClient k8s.Client, es esv1.Elasticsearch, statefulSets sset.StatefulSetList, meta metadata.Metadata) error {
+	expected, err := expectedPDB(es, statefulSets, meta)
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func deleteDefaultPDB(k8sClient k8s.Client, es esv1.Elasticsearch) error {
 
 // expectedPDB returns a PDB according to the given ES spec.
 // It may return nil if the PDB has been explicitly disabled in the ES spec.
-func expectedPDB(es esv1.Elasticsearch, statefulSets sset.StatefulSetList) (*v1beta1.PodDisruptionBudget, error) {
+func expectedPDB(es esv1.Elasticsearch, statefulSets sset.StatefulSetList, meta metadata.Metadata) (*v1beta1.PodDisruptionBudget, error) {
 	template := es.Spec.PodDisruptionBudget.DeepCopy()
 	if template.IsDisabled() {
 		return nil, nil
@@ -97,8 +97,15 @@ func expectedPDB(es esv1.Elasticsearch, statefulSets sset.StatefulSetList) (*v1b
 	// inherit user-provided ObjectMeta, but set our own name & namespace
 	expected.Name = esv1.DefaultPodDisruptionBudget(es.Name)
 	expected.Namespace = es.Namespace
-	// and append our labels
-	expected.Labels = maps.MergePreservingExistingKeys(expected.Labels, label.NewLabels(k8s.ExtractNamespacedName(&es)))
+
+	// Add labels and annotations
+	mergedMeta := meta.Merge(metadata.Metadata{
+		Labels:      expected.Labels,
+		Annotations: expected.Annotations,
+	})
+	expected.Labels = mergedMeta.Labels
+	expected.Annotations = mergedMeta.Annotations
+
 	// set owner reference for deletion upon ES resource deletion
 	if err := controllerutil.SetControllerReference(&es, &expected, scheme.Scheme); err != nil {
 		return nil, err

--- a/pkg/controller/elasticsearch/settings/config_volume.go
+++ b/pkg/controller/elasticsearch/settings/config_volume.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	common "github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
@@ -73,12 +74,14 @@ func GetESConfigSecret(client k8s.Client, namespace string, ssetName string) (co
 	return secret, nil
 }
 
-func ConfigSecret(es esv1.Elasticsearch, ssetName string, configData []byte) corev1.Secret {
+func ConfigSecret(es esv1.Elasticsearch, ssetName string, configData []byte, meta metadata.Metadata) corev1.Secret {
+	mergedMeta := meta.Merge(metadata.Metadata{Labels: label.NewConfigLabels(k8s.ExtractNamespacedName(&es), ssetName)})
 	return corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: es.Namespace,
-			Name:      ConfigSecretName(ssetName),
-			Labels:    label.NewConfigLabels(k8s.ExtractNamespacedName(&es), ssetName),
+			Namespace:   es.Namespace,
+			Name:        ConfigSecretName(ssetName),
+			Annotations: mergedMeta.Annotations,
+			Labels:      mergedMeta.Labels,
 		},
 		Data: map[string][]byte{
 			ConfigFileName: configData,
@@ -87,12 +90,12 @@ func ConfigSecret(es esv1.Elasticsearch, ssetName string, configData []byte) cor
 }
 
 // ReconcileConfig ensures the ES config for the pod is set in the apiserver.
-func ReconcileConfig(client k8s.Client, es esv1.Elasticsearch, ssetName string, config CanonicalConfig) error {
+func ReconcileConfig(client k8s.Client, es esv1.Elasticsearch, ssetName string, config CanonicalConfig, meta metadata.Metadata) error {
 	rendered, err := config.Render()
 	if err != nil {
 		return err
 	}
-	expected := ConfigSecret(es, ssetName, rendered)
+	expected := ConfigSecret(es, ssetName, rendered, meta)
 	_, err = reconciler.ReconcileSecret(client, expected, &es)
 	return err
 }

--- a/pkg/controller/elasticsearch/settings/config_volume_test.go
+++ b/pkg/controller/elasticsearch/settings/config_volume_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	common "github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -148,7 +149,8 @@ func TestReconcileConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := ReconcileConfig(tt.client, tt.es, tt.ssetName, tt.config); (err != nil) != tt.wantErr {
+			meta := metadata.Propagate(&tt.es, metadata.Metadata{Labels: label.NewStatefulSetLabels(k8s.ExtractNamespacedName(&tt.es), tt.ssetName)})
+			if err := ReconcileConfig(tt.client, tt.es, tt.ssetName, tt.config, meta); (err != nil) != tt.wantErr {
 				t.Errorf("ReconcileConfig() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			// config in the apiserver should be the expected one

--- a/pkg/controller/elasticsearch/settings/masters.go
+++ b/pkg/controller/elasticsearch/settings/masters.go
@@ -13,6 +13,7 @@ import (
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/annotation"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
@@ -40,6 +41,7 @@ func UpdateSeedHostsConfigMap(
 	c k8s.Client,
 	es esv1.Elasticsearch,
 	pods []corev1.Pod,
+	meta metadata.Metadata,
 ) error {
 	span, _ := apm.StartSpan(ctx, "update_seed_hosts", tracing.SpanTypeApp)
 	defer span.End()
@@ -69,11 +71,13 @@ func UpdateSeedHostsConfigMap(
 		sort.Strings(seedHosts)
 		hosts = strings.Join(seedHosts, "\n")
 	}
+
 	expected := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      esv1.UnicastHostsConfigMap(es.Name),
-			Namespace: es.Namespace,
-			Labels:    label.NewLabels(k8s.ExtractNamespacedName(&es)),
+			Name:        esv1.UnicastHostsConfigMap(es.Name),
+			Namespace:   es.Namespace,
+			Labels:      meta.Labels,
+			Annotations: meta.Annotations,
 		},
 		Data: map[string]string{
 			volume.UnicastHostsFile: hosts,

--- a/pkg/controller/elasticsearch/settings/masters_test.go
+++ b/pkg/controller/elasticsearch/settings/masters_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -132,7 +133,7 @@ func TestUpdateSeedHostsConfigMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := UpdateSeedHostsConfigMap(context.Background(), tt.args.c, tt.args.es, tt.args.pods)
+			err := UpdateSeedHostsConfigMap(context.Background(), tt.args.c, tt.args.es, tt.args.pods, metadata.Metadata{})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("UpdateSeedHostsConfigMap() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/elasticsearch/user/predefined_test.go
+++ b/pkg/controller/elasticsearch/user/predefined_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/user/filerealm"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 
@@ -105,7 +106,7 @@ func Test_reconcileElasticUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := k8s.WrappedFakeClient(tt.existingSecrets...)
-			got, err := reconcileElasticUser(c, es, tt.existingFileRealm)
+			got, err := reconcileElasticUser(c, es, tt.existingFileRealm, metadata.Metadata{})
 			require.NoError(t, err)
 			// check returned user
 			require.Len(t, got, 1)
@@ -216,7 +217,7 @@ func Test_reconcileInternalUsers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := k8s.WrappedFakeClient(tt.existingSecrets...)
-			got, err := reconcileInternalUsers(c, es, tt.existingFileRealm)
+			got, err := reconcileInternalUsers(c, es, tt.existingFileRealm, metadata.Metadata{})
 			require.NoError(t, err)
 			// check returned users
 			require.Len(t, got, 2)

--- a/pkg/controller/elasticsearch/user/reconcile.go
+++ b/pkg/controller/elasticsearch/user/reconcile.go
@@ -55,7 +55,7 @@ func ReconcileUsersAndRoles(
 	if err != nil {
 		return esclient.BasicAuth{}, err
 	}
-	fileRealm, controllerUser, err := aggregateFileRealm(c, es, watched, recorder)
+	fileRealm, controllerUser, err := aggregateFileRealm(c, es, watched, recorder, meta)
 	if err != nil {
 		return esclient.BasicAuth{}, err
 	}
@@ -83,6 +83,7 @@ func aggregateFileRealm(
 	es esv1.Elasticsearch,
 	watched watches.DynamicWatches,
 	recorder record.EventRecorder,
+	meta metadata.Metadata,
 ) (filerealm.Realm, esclient.BasicAuth, error) {
 	// retrieve existing file realm to reuse predefined users password hashes if possible
 	existingFileRealm, err := getExistingFileRealm(c, es)
@@ -94,11 +95,11 @@ func aggregateFileRealm(
 	}
 
 	// reconcile predefined users
-	elasticUser, err := reconcileElasticUser(c, es, existingFileRealm)
+	elasticUser, err := reconcileElasticUser(c, es, existingFileRealm, meta)
 	if err != nil {
 		return filerealm.Realm{}, esclient.BasicAuth{}, err
 	}
-	internalUsers, err := reconcileInternalUsers(c, es, existingFileRealm)
+	internalUsers, err := reconcileInternalUsers(c, es, existingFileRealm, meta)
 	if err != nil {
 		return filerealm.Realm{}, esclient.BasicAuth{}, err
 	}

--- a/pkg/controller/elasticsearch/user/reconcile_test.go
+++ b/pkg/controller/elasticsearch/user/reconcile_test.go
@@ -68,7 +68,7 @@ func Test_ReconcileRolesFileRealmSecret(t *testing.T) {
 
 func Test_aggregateFileRealm(t *testing.T) {
 	c := k8s.WrappedFakeClient(sampleUserProvidedFileRealmSecrets...)
-	fileRealm, controllerUser, err := aggregateFileRealm(c, sampleEsWithAuth, initDynamicWatches(), record.NewFakeRecorder(10))
+	fileRealm, controllerUser, err := aggregateFileRealm(c, sampleEsWithAuth, initDynamicWatches(), record.NewFakeRecorder(10), metadata.Metadata{})
 	require.NoError(t, err)
 	require.NotEmpty(t, controllerUser.Password)
 	actualUsers := fileRealm.UserNames()

--- a/pkg/controller/enterprisesearch/config_test.go
+++ b/pkg/controller/enterprisesearch/config_test.go
@@ -17,6 +17,7 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -453,8 +454,10 @@ func TestReconcileConfig(t *testing.T) {
 				dynamicWatches: watches.NewDynamicWatches(),
 			}
 
+			meta := metadata.Metadata{Labels: Labels("sample")}
+
 			// secret metadata should be correct
-			got, err := ReconcileConfig(driver, tt.ent)
+			got, err := ReconcileConfig(driver, tt.ent, meta)
 			require.NoError(t, err)
 			assert.Equal(t, "sample-ent-config", got.Name)
 			assert.Equal(t, "ns", got.Namespace)
@@ -576,7 +579,8 @@ func TestReconcileConfig_ReadinessProbe(t *testing.T) {
 				dynamicWatches: watches.NewDynamicWatches(),
 			}
 
-			got, err := ReconcileConfig(driver, tt.ent)
+			meta := metadata.Metadata{Labels: Labels(tt.ent.Name)}
+			got, err := ReconcileConfig(driver, tt.ent, meta)
 			require.NoError(t, err)
 
 			require.Contains(t, string(got.Data[ReadinessProbeFilename]), tt.wantCmd)

--- a/pkg/controller/enterprisesearch/deployment.go
+++ b/pkg/controller/enterprisesearch/deployment.go
@@ -12,6 +12,7 @@ import (
 
 	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/deployment"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
 	entName "github.com/elastic/cloud-on-k8s/pkg/controller/enterprisesearch/name"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
@@ -21,15 +22,16 @@ func (r *ReconcileEnterpriseSearch) reconcileDeployment(
 	ctx context.Context,
 	ent entv1beta1.EnterpriseSearch,
 	configHash string,
+	meta metadata.Metadata,
 ) (appsv1.Deployment, error) {
 	span, _ := apm.StartSpan(ctx, "reconcile_deployment", tracing.SpanTypeApp)
 	defer span.End()
 
-	deploy := deployment.New(r.deploymentParams(ent, configHash))
+	deploy := deployment.New(r.deploymentParams(ent, configHash, meta))
 	return deployment.Reconcile(r.K8sClient(), deploy, &ent)
 }
 
-func (r *ReconcileEnterpriseSearch) deploymentParams(ent entv1beta1.EnterpriseSearch, configHash string) deployment.Params {
+func (r *ReconcileEnterpriseSearch) deploymentParams(ent entv1beta1.EnterpriseSearch, configHash string, meta metadata.Metadata) deployment.Params {
 	podSpec := newPodSpec(ent, configHash)
 
 	deploymentLabels := Labels(ent.Name)
@@ -43,7 +45,7 @@ func (r *ReconcileEnterpriseSearch) deploymentParams(ent entv1beta1.EnterpriseSe
 		Namespace:       ent.Namespace,
 		Replicas:        ent.Spec.Count,
 		Selector:        deploymentLabels,
-		Labels:          deploymentLabels,
+		Meta:            meta,
 		PodTemplateSpec: podSpec,
 		Strategy:        appsv1.RollingUpdateDeploymentStrategyType,
 	}

--- a/pkg/controller/kibana/config_reconcile_test.go
+++ b/pkg/controller/kibana/config_reconcile_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/elastic/cloud-on-k8s/pkg/about"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -106,7 +107,15 @@ func TestReconcileConfigSecret(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			k8sClient := k8s.WrappedFakeClient(tt.args.initialObjects...)
 
-			err := ReconcileConfigSecret(context.Background(), k8sClient, tt.args.kb, CanonicalConfig{settings.NewCanonicalConfig()}, about.OperatorInfo{})
+			meta := metadata.Metadata{Labels: NewLabels(tt.args.kb.Name)}
+			err := ReconcileConfigSecret(
+				context.Background(),
+				k8sClient,
+				tt.args.kb,
+				CanonicalConfig{settings.NewCanonicalConfig()},
+				about.OperatorInfo{},
+				meta,
+			)
 			assert.NoError(t, err)
 
 			var secrets corev1.SecretList

--- a/pkg/utils/maps/maps.go
+++ b/pkg/utils/maps/maps.go
@@ -62,3 +62,32 @@ func ContainsKeys(m map[string]string, labels ...string) bool {
 	}
 	return true
 }
+
+// Clone creates a new map containing copies of the elements of the given map.
+func Clone(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+
+	clone := make(map[string]string, len(m))
+	for k, v := range m {
+		clone[k] = v
+	}
+
+	return clone
+}
+
+// Equal compares two maps and returns true if both contain the same keys and values.
+func Equal(m1, m2 map[string]string) bool {
+	if len(m1) != len(m2) {
+		return false
+	}
+
+	for k1, v1 := range m1 {
+		if v2, ok := m2[k1]; !ok || v1 != v2 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/utils/maps/maps_test.go
+++ b/pkg/utils/maps/maps_test.go
@@ -278,3 +278,47 @@ func TestContainsKeys(t *testing.T) {
 		})
 	}
 }
+
+func TestEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		m1   map[string]string
+		m2   map[string]string
+		want bool
+	}{
+		{
+			name: "when both maps are nil",
+			want: true,
+		},
+		{
+			name: "when one map is nil",
+			m1:   map[string]string{"a": "b"},
+			want: false,
+		},
+		{
+			name: "when both maps are empty",
+			m1:   map[string]string{},
+			m2:   map[string]string{},
+			want: true,
+		},
+		{
+			name: "when both maps are equal",
+			m1:   map[string]string{"a": "b", "c": "d"},
+			m2:   map[string]string{"c": "d", "a": "b"},
+			want: true,
+		},
+		{
+			name: "when maps are not equal",
+			m1:   map[string]string{"a": "b"},
+			m2:   map[string]string{"c": "d", "a": "b"},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			have := Equal(tc.m1, tc.m2)
+			require.Equal(t, tc.want, have)
+		})
+	}
+}

--- a/test/e2e/stack/metadata_propagation_test.go
+++ b/test/e2e/stack/metadata_propagation_test.go
@@ -35,6 +35,7 @@ import (
 func TestMetadataPropagation(t *testing.T) {
 	builders := mkMetadataPropBuilders(t)
 
+	// nolint:prealloc
 	var children []child
 	for _, b := range builders {
 		children = append(children, expectedChildren(b)...)

--- a/test/e2e/stack/metadata_propagation_test.go
+++ b/test/e2e/stack/metadata_propagation_test.go
@@ -1,0 +1,251 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package stack
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"testing"
+	"text/template"
+
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/metadata"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/apmserver"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/helper"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/kibana"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestMetadataPropagation(t *testing.T) {
+	builders := mkMetadataPropBuilders(t)
+
+	var children []child
+	for _, b := range builders {
+		children = append(children, expectedChildren(b)...)
+	}
+
+	want := metadata.Metadata{
+		Annotations: map[string]string{"my-annotation": "my-annotation-value"},
+		Labels:      map[string]string{"my-label": "my-label-value"},
+	}
+
+	steps := func(k *test.K8sClient) test.StepList {
+		return []test.Step{
+			{
+				Name: "check metadata of children",
+				Test: func(t *testing.T) {
+					k, err := test.NewK8sClient()
+					require.NoError(t, err, "Failed to create new Kube client")
+
+					for _, c := range children {
+						c := c
+						t.Run(c.key.String(), func(t *testing.T) {
+							t.Parallel()
+
+							have := c.getMetadata(t, k)
+							require.True(t, maps.IsSubset(want.Annotations, have.Annotations),
+								"Expected annotations not found: \nwant=%++v\nhave=%++v", want.Annotations, have.Annotations)
+							require.True(t, maps.IsSubset(want.Labels, have.Labels),
+								"Expected labels not found: \nwant=%++v\nhave=%++v", want.Labels, have.Labels)
+						})
+					}
+				},
+			},
+		}
+	}
+
+	test.Sequence(nil, steps, builders...).RunSequential(t)
+}
+
+func mkMetadataPropBuilders(t *testing.T) []test.Builder {
+	t.Helper()
+
+	tmpl, err := template.ParseFiles("testdata/metadata_propagation.yaml")
+	require.NoError(t, err, "Failed to parse template")
+
+	buf := new(bytes.Buffer)
+	rndSuffix := rand.String(4)
+
+	require.NoError(t, tmpl.Execute(buf, map[string]string{
+		"Suffix": rndSuffix,
+	}))
+
+	namespace := test.Ctx().ManagedNamespace(0)
+	stackVersion := test.Ctx().ElasticStackVersion
+
+	transform := func(builder test.Builder) test.Builder {
+		switch b := builder.(type) {
+		case elasticsearch.Builder:
+			return b.WithNamespace(namespace).
+				WithVersion(stackVersion).
+				WithRestrictedSecurityContext()
+		case kibana.Builder:
+			return b.WithNamespace(namespace).
+				WithVersion(stackVersion).
+				WithRestrictedSecurityContext()
+		case apmserver.Builder:
+			return b.WithNamespace(namespace).
+				WithVersion(stackVersion).
+				WithRestrictedSecurityContext()
+		default:
+			return b
+		}
+	}
+
+	decoder := helper.NewYAMLDecoder()
+	builders, err := decoder.ToBuilders(bufio.NewReader(buf), transform)
+	require.NoError(t, err, "Failed to create builders")
+
+	return builders
+}
+
+func expectedChildren(builder test.Builder) []child {
+	switch b := builder.(type) {
+	case elasticsearch.Builder:
+		return expectedChidrenForElasticsearch(b)
+	case kibana.Builder:
+		return expectedChidrenForKibana(b)
+	case apmserver.Builder:
+		return expectedChidrenForAPMServer(b)
+	default:
+		return nil
+	}
+}
+
+func expectedChidrenForElasticsearch(b elasticsearch.Builder) []child {
+	ns := b.Elasticsearch.Namespace
+	name := b.Elasticsearch.Name
+	children := []child{
+		{
+			key: client.ObjectKey{Namespace: ns, Name: esv1.ElasticUserSecret(name)},
+			obj: func() runtime.Object { return &corev1.Secret{} },
+		},
+		{
+			key: client.ObjectKey{Namespace: ns, Name: esv1.HTTPService(name)},
+			obj: func() runtime.Object { return &corev1.Service{} },
+		},
+		{
+			key: client.ObjectKey{Namespace: ns, Name: certificates.CAInternalSecretName(esv1.ESNamer, name, certificates.HTTPCAType)},
+			obj: func() runtime.Object { return &corev1.Secret{} },
+		},
+		{
+			key: client.ObjectKey{Namespace: ns, Name: certificates.InternalCertsSecretName(esv1.ESNamer, name)},
+			obj: func() runtime.Object { return &corev1.Secret{} },
+		},
+		{
+			key: client.ObjectKey{Namespace: ns, Name: certificates.PublicCertsSecretName(esv1.ESNamer, name)},
+			obj: func() runtime.Object { return &corev1.Secret{} },
+		},
+		{
+			key: client.ObjectKey{Namespace: ns, Name: esv1.InternalUsersSecret(name)},
+			obj: func() runtime.Object { return &corev1.Secret{} },
+		},
+		{
+			key: client.ObjectKey{Namespace: ns, Name: esv1.RemoteCaSecretName(name)},
+			obj: func() runtime.Object { return &corev1.Secret{} },
+		},
+		{
+			key: client.ObjectKey{Namespace: ns, Name: esv1.ScriptsConfigMap(name)},
+			obj: func() runtime.Object { return &corev1.ConfigMap{} },
+		},
+		{
+			key: client.ObjectKey{Namespace: ns, Name: esv1.TransportService(name)},
+			obj: func() runtime.Object { return &corev1.Service{} },
+		},
+		{
+			key: client.ObjectKey{Namespace: ns, Name: certificates.CAInternalSecretName(esv1.ESNamer, name, certificates.TransportCAType)},
+			obj: func() runtime.Object { return &corev1.Secret{} },
+		},
+		{
+			key: client.ObjectKey{Namespace: ns, Name: esv1.TransportCertificatesSecret(name)},
+			obj: func() runtime.Object { return &corev1.Secret{} },
+		},
+		{
+			key: client.ObjectKey{Namespace: ns, Name: certificates.PublicTransportCertsSecretName(esv1.ESNamer, name)},
+			obj: func() runtime.Object { return &corev1.Secret{} },
+		},
+		{
+			key: client.ObjectKey{Namespace: ns, Name: esv1.UnicastHostsConfigMap(name)},
+			obj: func() runtime.Object { return &corev1.ConfigMap{} },
+		},
+		{
+			key: client.ObjectKey{Namespace: ns, Name: esv1.RolesAndFileRealmSecret(name)},
+			obj: func() runtime.Object { return &corev1.Secret{} },
+		},
+	}
+
+	for _, nodeSet := range b.Elasticsearch.Spec.NodeSets {
+		ssetName := esv1.StatefulSet(name, nodeSet.Name)
+		stsChildren := []child{
+			{
+				key: client.ObjectKey{Namespace: ns, Name: ssetName},
+				obj: func() runtime.Object { return &appsv1.StatefulSet{} },
+			},
+			{
+				key: client.ObjectKey{Namespace: ns, Name: nodespec.HeadlessServiceName(ssetName)},
+				obj: func() runtime.Object { return &corev1.Service{} },
+			},
+			{
+				key: client.ObjectKey{Namespace: ns, Name: esv1.ConfigSecret(ssetName)},
+				obj: func() runtime.Object { return &corev1.Secret{} },
+			},
+		}
+
+		for i := 0; i < int(nodeSet.Count); i++ {
+			stsChildren = append(stsChildren, child{
+				key: client.ObjectKey{Namespace: ns, Name: fmt.Sprintf("%s-%d", ssetName, i)},
+				obj: func() runtime.Object { return &corev1.Pod{} },
+			})
+		}
+
+		children = append(children, stsChildren...)
+	}
+
+	return children
+}
+
+func expectedChidrenForKibana(b kibana.Builder) []child {
+	return nil
+}
+
+func expectedChidrenForAPMServer(b apmserver.Builder) []child {
+	return nil
+}
+
+type child struct {
+	key client.ObjectKey
+	obj func() runtime.Object
+}
+
+func (c child) getMetadata(t *testing.T, k *test.K8sClient) metadata.Metadata {
+	t.Helper()
+	t.Logf("Getting %s", c.key.String())
+
+	obj := c.obj()
+	err := k.Client.Get(c.key, obj)
+	require.NoError(t, err, "Failed to get object")
+
+	accessor := meta.NewAccessor()
+
+	haveAnnotations, err := accessor.Annotations(obj)
+	require.NoError(t, err, "Failed to get annotations")
+
+	haveLabels, err := accessor.Labels(obj)
+	require.NoError(t, err, "Failed to get labels")
+
+	return metadata.Metadata{Annotations: haveAnnotations, Labels: haveLabels}
+}

--- a/test/e2e/stack/testdata/metadata_propagation.yaml
+++ b/test/e2e/stack/testdata/metadata_propagation.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: "test-meta-prop-{{ .Suffix }}"
+  labels:
+    my-label: my-label-value
+  annotations:
+    eck.k8s.elastic.co/propagate-annotations: "*"
+    eck.k8s.elastic.co/propagate-labels: "*"
+    my-annotation: my-annotation-value
+spec:
+  version: 7.7.0
+  nodeSets:
+  - name: nsa
+    count: 2
+    podTemplate:
+      metadata:
+        labels:
+          my-template-label: my-template-label-value
+        annotations:
+          my-template-ann: my-template-ann-value
+    config:
+      node.store.allow_mmap: false
+  - name: nsb
+    count: 1
+    config:
+      node.store.allow_mmap: false
+---
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: "test-meta-prop-{{ .Suffix }}"
+  labels:
+    my-label: my-label-value
+  annotations:
+    eck.k8s.elastic.co/propagate-annotations: "*"
+    eck.k8s.elastic.co/propagate-labels: "*"
+    my-annotation: my-annotation-value
+spec:
+  version: 7.7.0
+  count: 1
+  podTemplate:
+    metadata:
+      labels:
+        my-template-label: my-template-label-value
+      annotations:
+        my-template-ann: my-template-ann-value
+  elasticsearchRef:
+    name: "test-meta-prop-{{ .Suffix }}"
+    #---
+    #apiVersion: apm.k8s.elastic.co/v1
+    #kind: ApmServer
+    #metadata:
+    #  name: "test-meta-prop-{{ .Suffix }}"
+    #  labels:
+    #    my-label: my-label-value
+    #  annotations:
+    #    eck.k8s.elastic.co/propagate-annotations: "{{ .PropagateAnnotations }}"
+    #    eck.k8s.elastic.co/propagate-labels: "{{ .PropagateLabels }}"
+    #    my-annotation: my-annotation-value
+    #spec:
+    #  version: 7.7.0
+    #  count: 1
+    #  podTemplate:
+    #    metadata:
+    #      labels:
+    #        my-template-label: my-template-label-value
+    #      annotations:
+    #        my-template-ann: my-template-ann-value
+    #  elasticsearchRef:
+    #    name: "test-meta-prop-{{ .Suffix }}"

--- a/test/e2e/stack/testdata/metadata_propagation.yaml
+++ b/test/e2e/stack/testdata/metadata_propagation.yaml
@@ -48,25 +48,28 @@ spec:
         my-template-ann: my-template-ann-value
   elasticsearchRef:
     name: "test-meta-prop-{{ .Suffix }}"
-    #---
-    #apiVersion: apm.k8s.elastic.co/v1
-    #kind: ApmServer
-    #metadata:
-    #  name: "test-meta-prop-{{ .Suffix }}"
-    #  labels:
-    #    my-label: my-label-value
-    #  annotations:
-    #    eck.k8s.elastic.co/propagate-annotations: "{{ .PropagateAnnotations }}"
-    #    eck.k8s.elastic.co/propagate-labels: "{{ .PropagateLabels }}"
-    #    my-annotation: my-annotation-value
-    #spec:
-    #  version: 7.7.0
-    #  count: 1
-    #  podTemplate:
-    #    metadata:
-    #      labels:
-    #        my-template-label: my-template-label-value
-    #      annotations:
-    #        my-template-ann: my-template-ann-value
-    #  elasticsearchRef:
-    #    name: "test-meta-prop-{{ .Suffix }}"
+---
+apiVersion: apm.k8s.elastic.co/v1
+kind: ApmServer
+metadata:
+  name: "test-meta-prop-{{ .Suffix }}"
+  labels:
+    my-label: my-label-value
+  annotations:
+    eck.k8s.elastic.co/propagate-annotations: "*"
+    eck.k8s.elastic.co/propagate-labels: "*"
+    my-annotation: my-annotation-value
+spec:
+  version: 7.7.0
+  count: 1
+  podTemplate:
+    metadata:
+      labels:
+        my-template-label: my-template-label-value
+      annotations:
+        my-template-ann: my-template-ann-value
+  elasticsearchRef:
+    name: "test-meta-prop-{{ .Suffix }}"
+  config:
+    apm-server.ilm.enabled: false
+    setup.template.settings.index.number_of_replicas: 0

--- a/test/e2e/test/apmserver/builder.go
+++ b/test/e2e/test/apmserver/builder.go
@@ -162,6 +162,10 @@ func (b Builder) RuntimeObjects() []runtime.Object {
 }
 
 func (b Builder) RUMEnabled() bool {
+	if b.ApmServer.Spec.Config == nil || b.ApmServer.Spec.Config.Data == nil {
+		return false
+	}
+
 	rumEnabledConfig, ok := b.ApmServer.Spec.Config.Data["apm-server.rum.enabled"]
 	if ok {
 		if v, ok := rumEnabledConfig.(bool); ok {


### PR DESCRIPTION
This PR introduces two annotations that can be added to any ECK CR to specify which labels and/or annotations from the CR should be propagated to child objects. 

```yaml
eck.k8s.elastic.co/propagate-annotations: "comma,separated,list,of,annotations,to,propagate"
eck.k8s.elastic.co/propagate-labels: "comma,separated,list,of,labels,to,propagate"
```
Setting the annotation value to `*` would propagate all metadata of that kind.

This approach was taken for the following reasons:
- Blindly propagating all labels/annotations to child objects can cause confusion and/or misbehaviour because some have special meanings to other humans or controllers.
- Making the feature opt-in preserves backwards compatibility and avoids making this change a breaking change.

Output comparison: https://gist.github.com/charith-elastic/a456c44c6be6ea0dd3a72d2a3e58d432

Fixes #2652 