### PR TITLE
Reorder Kibana/APM declarations in sample

### DIFF
--- a/config/samples/apm/apm_es_kibana.yaml
+++ b/config/samples/apm/apm_es_kibana.yaml
@@ -14,6 +14,16 @@ spec:
       # See: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
       node.store.allow_mmap: false
 ---
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: kb-apm-sample
+spec:
+  version: 7.7.0
+  count: 1
+  elasticsearchRef:
+    name: "es-apm-sample"
+---
 apiVersion: apm.k8s.elastic.co/v1
 kind: ApmServer
 metadata:
@@ -26,13 +36,3 @@ spec:
   # this allows ECK to configure automatically the Kibana endpoint as described in https://www.elastic.co/guide/en/apm/server/current/setup-kibana-endpoint.html
   kibanaRef:
     name: "kb-apm-sample"
----
-apiVersion: kibana.k8s.elastic.co/v1
-kind: Kibana
-metadata:
-  name: kb-apm-sample
-spec:
-  version: 7.7.0
-  count: 1
-  elasticsearchRef:
-    name: "es-apm-sample"


### PR DESCRIPTION
[`TestSamples`](https://github.com/elastic/cloud-on-k8s/blob/0fb10064280ebb1ac3561512e3810c4bd44d24a5/test/e2e/samples_test.go#L25) runs checks on stack applications [according to their order](https://github.com/elastic/cloud-on-k8s/blob/0fb10064280ebb1ac3561512e3810c4bd44d24a5/test/e2e/test/helper/yaml.go#L45-L53) in the sample file.

This PR swap the APM and Kibana declaration in `config/samples/apm/apm_es_kibana.yaml` so that Kibana checks are run before the APM ones.

Fix #3188 