### PR TITLE
Set some resources for the keystore init container

### DIFF
--- a/pkg/controller/apmserver/controller.go
+++ b/pkg/controller/apmserver/controller.go
@@ -31,6 +31,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -61,6 +62,16 @@ var (
 		KeystoreAddCommand:            ApmServerBin + ` keystore add "$key" --stdin < "$filename"`,
 		SecureSettingsVolumeMountPath: keystore.SecureSettingsVolumeMountPath,
 		DataVolumePath:                DataVolumePath,
+		Resources: corev1.ResourceRequirements{
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
+			Limits: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
+		},
 	}
 )
 

--- a/pkg/controller/common/keystore/initcontainer.go
+++ b/pkg/controller/common/keystore/initcontainer.go
@@ -26,6 +26,8 @@ type InitContainerParameters struct {
 	KeystoreAddCommand string
 	// Keystore create command
 	KeystoreCreateCommand string
+	// Resources for the init container
+	Resources corev1.ResourceRequirements
 }
 
 // script is a small bash script to create a Kibana or APM keystore,
@@ -80,5 +82,6 @@ func initContainer(
 			// write the keystore in the data volume
 			DataVolume(volumePrefix, parameters.DataVolumePath).VolumeMount(),
 		},
+		Resources: parameters.Resources,
 	}, nil
 }

--- a/pkg/controller/common/keystore/resources_test.go
+++ b/pkg/controller/common/keystore/resources_test.go
@@ -7,6 +7,8 @@ package keystore
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	"github.com/magiconair/properties/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -26,6 +28,16 @@ var (
 		KeystoreAddCommand:            `/keystore/bin/keystore add "$key" "$filename"`,
 		SecureSettingsVolumeMountPath: "/foo/secret",
 		DataVolumePath:                "/bar/data",
+		Resources: corev1.ResourceRequirements{
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
+			Limits: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
+		},
 	}
 
 	testSecureSettingsSecretName = "secure-settings-secret"
@@ -120,6 +132,16 @@ echo "Keystore initialization successful."
 				SecurityContext: &corev1.SecurityContext{
 					Privileged: &varFalse,
 				},
+				Resources: corev1.ResourceRequirements{
+					Requests: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+					},
+					Limits: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+					},
+				},
 			},
 			// since this will be created, it will be incremented
 			wantVersion: "1",
@@ -151,6 +173,7 @@ echo "Keystore initialization successful."
 				assert.Equal(t, resources.InitContainer.Command, tt.wantContainers.Command)
 				assert.Equal(t, resources.InitContainer.VolumeMounts, tt.wantContainers.VolumeMounts)
 				assert.Equal(t, resources.InitContainer.SecurityContext, tt.wantContainers.SecurityContext)
+				assert.Equal(t, resources.InitContainer.Resources, tt.wantContainers.Resources)
 				assert.Equal(t, resources.Version, tt.wantVersion)
 			}
 

--- a/pkg/controller/elasticsearch/initcontainer/keystore.go
+++ b/pkg/controller/elasticsearch/initcontainer/keystore.go
@@ -7,6 +7,8 @@ package initcontainer
 import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	esvolume "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (
@@ -19,4 +21,14 @@ var KeystoreParams = keystore.InitContainerParameters{
 	KeystoreAddCommand:            KeystoreBinPath + ` add-file "$key" "$filename"`,
 	SecureSettingsVolumeMountPath: keystore.SecureSettingsVolumeMountPath,
 	DataVolumePath:                esvolume.ElasticsearchDataMountPath,
+	Resources: corev1.ResourceRequirements{
+		Requests: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceMemory: resource.MustParse("196Mi"),
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+		},
+		Limits: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceMemory: resource.MustParse("196Mi"),
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+		},
+	},
 }

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -13,6 +13,7 @@ import (
 	"go.elastic.co/apm"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,6 +42,16 @@ var initContainersParameters = keystore.InitContainerParameters{
 	KeystoreAddCommand:            `/usr/share/kibana/bin/kibana-keystore add "$key" --stdin < "$filename"`,
 	SecureSettingsVolumeMountPath: keystore.SecureSettingsVolumeMountPath,
 	DataVolumePath:                DataVolumeMountPath,
+	Resources: corev1.ResourceRequirements{
+		Requests: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+		},
+		Limits: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+		},
+	},
 }
 
 // minSupportedVersion is the minimum version of Kibana supported by ECK. Currently this is set to version 6.8.0.


### PR DESCRIPTION
This PR adds some resources on the init container used to set the secure settings.

Fix #2660 