### PR TITLE
Add E2E tests for Enterprise Search

### DIFF
--- a/config/samples/enterprisesearch/ent_es.yaml
+++ b/config/samples/enterprisesearch/ent_es.yaml
@@ -1,4 +1,4 @@
-# This sample sets up an Elasticsearch cluster and a Enterprise Search instance preconfigured for that cluster
+# This sample sets up an Elasticsearch cluster and an Enterprise Search instance preconfigured for that cluster
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch
 metadata:
@@ -24,24 +24,3 @@ spec:
     name: elasticsearch-sample
   config:
     ent_search.external_url: https://localhost:3002
-#  configRef:
-#    - secretName: smtp-credentials
-  http:
-#    service:
-#      spec:
-#        type: LoadBalancer
-    tls:
-      selfSignedCertificate:
-        subjectAltNames:
-          - dns: localhost
-  # http:
-  #   service:
-  #     spec:
-  #       type: LoadBalancer
-  # podTemplate:
-  #   spec:
-  #     containers:
-  #       - name: enterprise-search
-  #         resources:
-  #           requests:
-  #             cpu: 4

--- a/test/e2e/ent/association_test.go
+++ b/test/e2e/ent/association_test.go
@@ -1,0 +1,32 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package ent
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/enterprisesearch"
+)
+
+// TestEnterpriseSearchCrossNSAssociation tests associating Elasticsearch and Enterprise Search running in different namespaces.
+func TestEnterpriseSearchCrossNSAssociation(t *testing.T) {
+	esNamespace := test.Ctx().ManagedNamespace(0)
+	entNamespace := test.Ctx().ManagedNamespace(1)
+	name := "test-cross-ns-ent-es"
+
+	esBuilder := elasticsearch.NewBuilder(name).
+		WithNamespace(esNamespace).
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithRestrictedSecurityContext()
+	entBuilder := enterprisesearch.NewBuilder(name).
+		WithNamespace(entNamespace).
+		WithElasticsearchRef(esBuilder.Ref()).
+		WithNodeCount(1).
+		WithRestrictedSecurityContext()
+
+	test.Sequence(nil, test.EmptySteps, esBuilder, entBuilder).RunSequential(t)
+}

--- a/test/e2e/ent/configuration_test.go
+++ b/test/e2e/ent/configuration_test.go
@@ -150,7 +150,7 @@ type PartialConfig struct {
 	} `yaml:"app_search"`
 	Email struct {
 		Account struct {
-			Smtp struct {
+			SMTP struct {
 				Password string `yaml:"password"`
 			} `yaml:"smtp"`
 		} `yaml:"account"`

--- a/test/e2e/ent/configuration_test.go
+++ b/test/e2e/ent/configuration_test.go
@@ -1,0 +1,168 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package ent
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/enterprisesearch"
+)
+
+// TestEnterpriseSearchConfigUpdate updates an existing EnterpriseSearch deployment twice:
+// 1. with an additional config
+// 2. with an additional configRef
+func TestEnterpriseSearchConfigUpdate(t *testing.T) {
+	name := "test-ent-config-ref"
+	es := elasticsearch.NewBuilder(name).
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithRestrictedSecurityContext()
+
+	// initial Enterprise Search with no custom config
+	entNoConfig := enterprisesearch.NewBuilder(name).
+		WithElasticsearchRef(es.Ref()).
+		WithNodeCount(1).
+		WithRestrictedSecurityContext()
+
+	// 1. additional config setting
+	entWithConfig := enterprisesearch.Builder{EnterpriseSearch: *entNoConfig.EnterpriseSearch.DeepCopy()}.
+		WithConfig(map[string]interface{}{"app_search.engine.document_size.limit": "100kb"}).
+		WithMutatedFrom(&entNoConfig)
+	var expectedAdditionalConfig PartialConfig
+	err := yaml.Unmarshal([]byte(`app_search:
+  engine:
+    document_size:
+      limit: 100kb`), &expectedAdditionalConfig)
+	require.NoError(t, err)
+
+	// 2. additional configRef
+	configRefSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ent-smtp-credentials",
+			Namespace: test.Ctx().ManagedNamespace(0),
+		},
+		Data: map[string][]byte{
+			"enterprise-search.yml": []byte(`email.account.enabled: true
+email.account.smtp.auth: plain
+email.account.smtp.starttls.enable: false
+email.account.smtp.host: 127.0.0.1
+email.account.smtp.port: 25
+email.account.smtp.user: myuser
+email.account.smtp.password: mypassword
+email.account.email_defaults.from: my@email.com`),
+		},
+	}
+	var expectedAdditionalCfgRef PartialConfig
+	// contains custom config + custom configRef (from which we just check one entry)
+	err = yaml.Unmarshal([]byte(
+		`app_search:
+  engine:
+    document_size:
+      limit: 100kb
+email:
+  account:
+    smtp:
+      password: mypassword`),
+		&expectedAdditionalCfgRef,
+	)
+	require.NoError(t, err)
+	entWithConfigRef := enterprisesearch.Builder{EnterpriseSearch: *entWithConfig.EnterpriseSearch.DeepCopy()}.
+		WithConfigRef(entv1beta1.ConfigSource{SecretRef: commonv1.SecretRef{SecretName: configRefSecret.Name}}).
+		WithMutatedFrom(&entWithConfig)
+
+	stepsFn := func(k *test.K8sClient) test.StepList {
+		return test.StepList{}.
+			// mutate with additional config
+			WithSteps(entWithConfig.MutationTestSteps(k)).
+			WithStep(test.Step{
+				Name: "Config file in the Pod should contain the additional config",
+				Test: func(t *testing.T) {
+					require.NoError(t, CheckPartialConfig(k, entWithConfig.EnterpriseSearch, expectedAdditionalConfig))
+				},
+			}).
+			// mutate with additional configRef
+			WithStep(test.Step{
+				Name: "Create configRef secret",
+				Test: func(t *testing.T) {
+					// remove if already exists (ignoring errors)
+					_ = k.Client.Delete(&configRefSecret)
+					// and create a fresh one
+					err := k.Client.Create(&configRefSecret)
+					require.NoError(t, err)
+				},
+			}).
+			WithSteps(entWithConfigRef.MutationTestSteps(k)).
+			WithStep(test.Step{
+				Name: "Config file in the Pod should contain the additional config & configRef",
+				Test: func(t *testing.T) {
+					require.NoError(t, CheckPartialConfig(k, entWithConfigRef.EnterpriseSearch, expectedAdditionalCfgRef))
+				},
+			})
+	}
+
+	test.Sequence(nil, stepsFn, es, entNoConfig).RunSequential(t)
+}
+
+// CheckPartialConfig retrieves the configuration file from all Pods and compares it with the expected PartialConfig.
+func CheckPartialConfig(k *test.K8sClient, ent entv1beta1.EnterpriseSearch, expected PartialConfig) error {
+	var pods corev1.PodList
+	err := k.Client.List(&pods, test.EnterpriseSearchPodListOptions(ent.Namespace, ent.Name)...)
+	if err != nil {
+		return err
+	}
+	if len(pods.Items) == 0 {
+		return errors.New("found 0 pod to check config from")
+	}
+	for _, p := range pods.Items {
+		cfg, err := GetConfigFromPod(k, types.NamespacedName{Namespace: p.Namespace, Name: p.Name})
+		if err != nil {
+			return err
+		}
+		if !reflect.DeepEqual(expected, cfg) {
+			return fmt.Errorf("expected config %+v, got %+v", expected, cfg)
+		}
+	}
+	return nil
+}
+
+// PartialConfig partially models an Enterprise Search configuration for test needs.
+type PartialConfig struct {
+	AppSearch struct {
+		Engine struct {
+			DocumentSize struct {
+				Limit string `yaml:"limit"`
+			} `yaml:"document_size"`
+		} `yaml:"engine"`
+	} `yaml:"app_search"`
+	Email struct {
+		Account struct {
+			Smtp struct {
+				Password string `yaml:"password"`
+			} `yaml:"smtp"`
+		} `yaml:"account"`
+	} `yaml:"email"`
+}
+
+// GetConfigFromPod execs into the Pod to retrieve the Enterprise Search configuration file.
+func GetConfigFromPod(k *test.K8sClient, pod types.NamespacedName) (PartialConfig, error) {
+	stdout, stderr, err := k.Exec(pod, []string{"cat", "/mnt/elastic-internal/config/enterprise-search.yml"})
+	if err != nil {
+		return PartialConfig{}, errors.Wrap(err, fmt.Sprintf("failed to get config from Pod, stdout: %s; stderr: %s", stdout, stderr))
+	}
+	var cfg PartialConfig
+	return cfg, yaml.Unmarshal([]byte(stdout), &cfg)
+}

--- a/test/e2e/kb/keystore_test.go
+++ b/test/e2e/kb/keystore_test.go
@@ -56,8 +56,7 @@ func TestUpdateKibanaSecureSettings(t *testing.T) {
 					// remove if already exists (ignoring errors)
 					_ = k.Client.Delete(&secureSettings)
 					// and create a fresh one
-					err := k.Client.Create(&secureSettings)
-					require.NoError(t, err)
+					require.NoError(t, k.Client.Create(&secureSettings))
 				},
 			},
 		}

--- a/test/e2e/samples_test.go
+++ b/test/e2e/samples_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/apmserver"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/beat"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/enterprisesearch"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/helper"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/kibana"
 	"github.com/stretchr/testify/require"
@@ -92,6 +93,13 @@ func createBuilders(t *testing.T, decoder *helper.YAMLDecoder, sampleFile, testN
 				WithLabel(run.TestNameLabel, testName).
 				WithPodLabel(run.TestNameLabel, testName).
 				WithESValidations(beat.HasEventFromBeat(beatcommon.Type(b.Beat.Spec.Type)))
+		case enterprisesearch.Builder:
+			return b.WithNamespace(namespace).
+				WithSuffix(suffix).
+				WithElasticsearchRef(tweakServiceRef(b.EnterpriseSearch.Spec.ElasticsearchRef, suffix)).
+				WithRestrictedSecurityContext().
+				WithLabel(run.TestNameLabel, fullTestName).
+				WithPodLabel(run.TestNameLabel, fullTestName)
 		default:
 			return b
 		}

--- a/test/e2e/test/apmserver/builder.go
+++ b/test/e2e/test/apmserver/builder.go
@@ -23,6 +23,10 @@ type Builder struct {
 
 var _ test.Builder = Builder{}
 
+func (b Builder) SkipTest() bool {
+	return false
+}
+
 func NewBuilder(name string) Builder {
 	return newBuilder(name, rand.String(4))
 }

--- a/test/e2e/test/beat/builder.go
+++ b/test/e2e/test/beat/builder.go
@@ -24,6 +24,10 @@ type Builder struct {
 	Validations []ValidationFunc
 }
 
+func (b Builder) SkipTest() bool {
+	return false
+}
+
 func NewBuilderWithoutSuffix(name string, typ beatcommon.Type) Builder {
 	return newBuilder(name, typ, "")
 }

--- a/test/e2e/test/beat/pod_builder.go
+++ b/test/e2e/test/beat/pod_builder.go
@@ -29,6 +29,10 @@ type PodBuilder struct {
 	Logged string
 }
 
+func (pb PodBuilder) SkipTest() bool {
+	return false
+}
+
 func NewPodBuilder(name string) PodBuilder {
 	return newPodBuilder(name, rand.String(4))
 }

--- a/test/e2e/test/builder.go
+++ b/test/e2e/test/builder.go
@@ -29,4 +29,6 @@ type Builder interface {
 	// We assume the resource to be ready and running.
 	// We assume the resource to be the same as the original resource after reversion.
 	MutationReversalTestContext() ReversalTestContext
+	// Skip the test if true.
+	SkipTest() bool
 }

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -49,6 +49,10 @@ type Builder struct {
 
 var _ test.Builder = Builder{}
 
+func (b Builder) SkipTest() bool {
+	return false
+}
+
 func NewBuilder(name string) Builder {
 	return newBuilder(name, rand.String(4))
 }

--- a/test/e2e/test/enterprisesearch/builder.go
+++ b/test/e2e/test/enterprisesearch/builder.go
@@ -11,8 +11,13 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+)
+
+var (
+	minVersion = version.MustParse("7.7.0")
 )
 
 // Builder to create Enterprise Search.
@@ -22,6 +27,12 @@ type Builder struct {
 }
 
 var _ test.Builder = Builder{}
+
+func (b Builder) SkipTest() bool {
+	// no Enterprise Search before 7.7.0
+	testVersion := version.MustParse(test.Ctx().ElasticStackVersion)
+	return !testVersion.IsSameOrAfter(minVersion)
+}
 
 func NewBuilder(name string) Builder {
 	return newBuilder(name, rand.String(4))

--- a/test/e2e/test/enterprisesearch/builder.go
+++ b/test/e2e/test/enterprisesearch/builder.go
@@ -1,0 +1,138 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package enterprisesearch
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
+	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+)
+
+// Builder to create Enterprise Search.
+type Builder struct {
+	EnterpriseSearch entv1beta1.EnterpriseSearch
+	MutatedFrom      *Builder
+}
+
+var _ test.Builder = Builder{}
+
+func NewBuilder(name string) Builder {
+	return newBuilder(name, rand.String(4))
+}
+
+func NewBuilderWithoutSuffix(name string) Builder {
+	return newBuilder(name, "")
+}
+
+func newBuilder(name, randSuffix string) Builder {
+	meta := metav1.ObjectMeta{
+		Name:      name,
+		Namespace: test.Ctx().ManagedNamespace(0),
+	}
+
+	return Builder{
+		EnterpriseSearch: entv1beta1.EnterpriseSearch{
+			ObjectMeta: meta,
+			Spec: entv1beta1.EnterpriseSearchSpec{
+				Count:   1,
+				Version: test.Ctx().ElasticStackVersion,
+			},
+		},
+	}.
+		WithSuffix(randSuffix).
+		WithLabel(run.TestNameLabel, name).
+		WithPodLabel(run.TestNameLabel, name)
+}
+
+func (b Builder) WithSuffix(suffix string) Builder {
+	if suffix != "" {
+		b.EnterpriseSearch.ObjectMeta.Name = b.EnterpriseSearch.ObjectMeta.Name + "-" + suffix
+	}
+	return b
+}
+
+// WithRestrictedSecurityContext helps to enforce a restricted security context on the objects.
+func (b Builder) WithRestrictedSecurityContext() Builder {
+	b.EnterpriseSearch.Spec.PodTemplate.Spec.SecurityContext = test.DefaultSecurityContext()
+	return b
+}
+
+func (b Builder) WithElasticsearchRef(ref commonv1.ObjectSelector) Builder {
+	b.EnterpriseSearch.Spec.ElasticsearchRef = ref
+	return b
+}
+
+func (b Builder) WithNamespace(namespace string) Builder {
+	b.EnterpriseSearch.ObjectMeta.Namespace = namespace
+	return b
+}
+
+func (b Builder) WithVersion(version string) Builder {
+	b.EnterpriseSearch.Spec.Version = version
+	return b
+}
+
+func (b Builder) WithNodeCount(count int) Builder {
+	b.EnterpriseSearch.Spec.Count = int32(count)
+	return b
+}
+
+func (b Builder) WithConfig(cfg map[string]interface{}) Builder {
+	if b.EnterpriseSearch.Spec.Config == nil || b.EnterpriseSearch.Spec.Config.Data == nil {
+		b.EnterpriseSearch.Spec.Config = &commonv1.Config{
+			Data: cfg,
+		}
+		return b
+	}
+	for k, v := range cfg {
+		b.EnterpriseSearch.Spec.Config.Data[k] = v
+	}
+	return b
+}
+
+func (b Builder) WithConfigRef(ref entv1beta1.ConfigSource) Builder {
+	if b.EnterpriseSearch.Spec.ConfigRef == nil {
+		b.EnterpriseSearch.Spec.ConfigRef = []entv1beta1.ConfigSource{}
+	}
+	b.EnterpriseSearch.Spec.ConfigRef = append(b.EnterpriseSearch.Spec.ConfigRef, ref)
+	return b
+}
+
+func (b Builder) WithMutatedFrom(mutatedFrom *Builder) Builder {
+	b.MutatedFrom = mutatedFrom
+	return b
+}
+
+func (b Builder) WithLabel(key, value string) Builder {
+	if b.EnterpriseSearch.Labels == nil {
+		b.EnterpriseSearch.Labels = make(map[string]string)
+	}
+	b.EnterpriseSearch.Labels[key] = value
+
+	return b
+}
+
+// WithPodLabel sets the label in the pod template. All invocations can be removed when
+// https://github.com/elastic/cloud-on-k8s/issues/2652 is implemented.
+func (b Builder) WithPodLabel(key, value string) Builder {
+	labels := b.EnterpriseSearch.Spec.PodTemplate.Labels
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[key] = value
+	b.EnterpriseSearch.Spec.PodTemplate.Labels = labels
+	return b
+}
+
+// -- Helper functions
+
+func (b Builder) RuntimeObjects() []runtime.Object {
+	return []runtime.Object{&b.EnterpriseSearch}
+}

--- a/test/e2e/test/enterprisesearch/checks_ent.go
+++ b/test/e2e/test/enterprisesearch/checks_ent.go
@@ -112,8 +112,10 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 				return nil
 			}),
 		},
-
-		// Workplace Search tests
-		// TODO: requires a trial license + what should we test here?
+		// Workplace Search tests are much harder to perform, so there are none so far:
+		// - we need a trial license (already manipulated once in other tests)
+		// - connecting to an external source (eg. Google Drive) is probably too much work
+		// Both the Healthcheck and AppSearch tests already validated the Enterprise Search instance can
+		// correctly communicate with Elasticsearch.
 	}
 }

--- a/test/e2e/test/enterprisesearch/checks_ent.go
+++ b/test/e2e/test/enterprisesearch/checks_ent.go
@@ -63,9 +63,7 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 		},
 		test.Step{
 			Name: "Enterprise Search health endpoint should eventually respond",
-			Test: test.Eventually(func() error {
-				return entClient.HealthCheck()
-			}),
+			Test: test.Eventually(entClient.HealthCheck),
 		},
 
 		// App Search tests

--- a/test/e2e/test/enterprisesearch/checks_ent.go
+++ b/test/e2e/test/enterprisesearch/checks_ent.go
@@ -1,0 +1,119 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package enterprisesearch
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+)
+
+const (
+	appSearchEngine     = "test-engine"
+	appSearchSampleDocs = `[
+	{
+		"id": "park_rocky-mountain",
+		"title": "Rocky Mountain",
+		"description": "Bisected north to south by the Continental Divide, this portion of the Rockies has ecosystems varying from over 150 riparian lakes to montane and subalpine forests to treeless alpine tundra. Wildlife including mule deer, bighorn sheep, black bears, and cougars inhabit its igneous mountains and glacial valleys. Longs Peak, a classic Colorado fourteener, and the scenic Bear Lake are popular destinations, as well as the historic Trail Ridge Road, which reaches an elevation of more than 12,000 feet (3,700 m).",
+		"nps_link": "https://www.nps.gov/romo/index.htm",
+		"states": [
+			"Colorado"
+	],
+		"visitors": 4517585,
+		"world_heritage_site": false,
+		"location": "40.4,-105.58",
+		"acres": 265795.2,
+		"square_km": 1075.6,
+		"date_established": "1915-01-26T06:00:00Z"
+	},
+	{
+		"id": "park_saguaro",
+		"title": "Saguaro",
+		"description": "Split into the separate Rincon Mountain and Tucson Mountain districts, this park is evidence that the dry Sonoran Desert is still home to a great variety of life spanning six biotic communities. Beyond the namesake giant saguaro cacti, there are barrel cacti, chollas, and prickly pears, as well as lesser long-nosed bats, spotted owls, and javelinas.",
+		"nps_link": "https://www.nps.gov/sagu/index.htm",
+		"states": [
+		"Arizona"
+		],
+		"visitors": 820426,
+		"world_heritage_site": false,
+		"location": "32.25,-110.5",
+		"acres": 91715.72,
+		"square_km": 371.2,
+		"date_established": "1994-10-14T05:00:00Z"
+	}
+	]`
+)
+
+func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
+	var entClient EnterpriseSearchClient
+	var appSearchClient AppSearchClient
+	return test.StepList{
+		test.Step{
+			Name: "Every secret should be set so that we can build an Enterprise Search client",
+			Test: test.Eventually(func() error {
+				var err error
+				entClient, err = NewEnterpriseSearchClient(b.EnterpriseSearch, k)
+				return err
+			}),
+		},
+		test.Step{
+			Name: "Enterprise Search health endpoint should eventually respond",
+			Test: test.Eventually(func() error {
+				return entClient.HealthCheck()
+			}),
+		},
+
+		// App Search tests
+		test.Step{
+			Name: "Retrieve the App Search API Key",
+			Test: func(t *testing.T) {
+				appSearchClient = entClient.AppSearch()
+				key, err := appSearchClient.GetAPIKey()
+				require.NoError(t, err)
+				appSearchClient = appSearchClient.WithAPIKey(key)
+			},
+		},
+		test.Step{
+			Name: "Create an App Search engine (if not already done)",
+			Test: func(t *testing.T) {
+				results, err := appSearchClient.GetEngines()
+				require.NoError(t, err)
+				if len(results.Results) == 0 {
+					require.NoError(t, appSearchClient.CreateEngine(appSearchEngine))
+				}
+			},
+		},
+		test.Step{
+			Name: "Index documents in the App Search engine (if not already done)",
+			Test: func(t *testing.T) {
+				results, err := appSearchClient.GetDocuments(appSearchEngine)
+				require.NoError(t, err)
+				if len(results.Results) == 0 {
+					require.NoError(t, appSearchClient.IndexDocument(appSearchEngine, appSearchSampleDocs))
+				}
+			},
+		},
+		test.Step{
+			Name: "Querying 'mountain' in App Search should eventually return 2 documents",
+			// the index operation is not atomic, hence the search retry
+			Test: test.Eventually(func() error {
+				results, err := appSearchClient.SearchDocuments(appSearchEngine, "mountain")
+				if err != nil {
+					return err
+				}
+				if len(results.Results) != 2 {
+					return fmt.Errorf("expected %d documents, got %d", 2, len(results.Results))
+				}
+				return nil
+			}),
+		},
+
+		// Workplace Search tests
+		// TODO: requires a trial license + what should we test here?
+	}
+}

--- a/test/e2e/test/enterprisesearch/checks_ent.go
+++ b/test/e2e/test/enterprisesearch/checks_ent.go
@@ -63,7 +63,9 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 		},
 		test.Step{
 			Name: "Enterprise Search health endpoint should eventually respond",
-			Test: test.Eventually(entClient.HealthCheck),
+			Test: test.Eventually(func() error { // nolint
+				return entClient.HealthCheck()
+			}),
 		},
 
 		// App Search tests

--- a/test/e2e/test/enterprisesearch/checks_k8s.go
+++ b/test/e2e/test/enterprisesearch/checks_k8s.go
@@ -1,0 +1,208 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package enterprisesearch
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+)
+
+func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
+	return test.StepList{
+		CheckDeployment(b, k),
+		CheckPods(b, k),
+		CheckServices(b, k),
+		CheckServicesEndpoints(b, k),
+		CheckSecrets(b, k),
+	}
+}
+
+// CheckApmServerDeployment checks the Deployment resource exists
+func CheckDeployment(b Builder, k *test.K8sClient) test.Step {
+	return test.Step{
+		Name: "EnterpriseSearch deployment should be created",
+		Test: test.Eventually(func() error {
+			var dep appsv1.Deployment
+			err := k.Client.Get(types.NamespacedName{
+				Namespace: b.EnterpriseSearch.Namespace,
+				Name:      b.EnterpriseSearch.Name + "-ent",
+			}, &dep)
+			if b.EnterpriseSearch.Spec.Count == 0 && apierrors.IsNotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			if *dep.Spec.Replicas != b.EnterpriseSearch.Spec.Count {
+				return fmt.Errorf("invalid EnterpriseSearch replicas count: expected %d, got %d", b.EnterpriseSearch.Spec.Count, *dep.Spec.Replicas)
+			}
+			return nil
+		}),
+	}
+}
+
+// CheckPods checks expected Enterprise Search pods are eventually ready.
+// TODO: use a common function for all deployments (kb, apm, ent)
+func CheckPods(b Builder, k *test.K8sClient) test.Step {
+	return test.Step{
+		Name: "Enterprise Search Pods should eventually be ready",
+		Test: test.Eventually(func() error {
+			var pods corev1.PodList
+			if err := k.Client.List(&pods, test.EnterpriseSearchPodListOptions(b.EnterpriseSearch.Namespace, b.EnterpriseSearch.Name)...); err != nil {
+				return err
+			}
+
+			// builder hash matches
+			goodBuilderHash := hash.HashObject(b.EnterpriseSearch.Spec)
+			for _, pod := range pods.Items {
+				if err := test.ValidateBuilderHashAnnotation(pod, goodBuilderHash); err != nil {
+					return err
+				}
+			}
+
+			// pod count matches
+			if len(pods.Items) != int(b.EnterpriseSearch.Spec.Count) {
+				return fmt.Errorf("invalid EnterpriseSearch pod count: expected %d, got %d", b.EnterpriseSearch.Spec.Count, len(pods.Items))
+			}
+
+			// pods are running
+			for _, pod := range pods.Items {
+				if pod.Status.Phase != corev1.PodRunning {
+					return fmt.Errorf("pod not running yet")
+				}
+			}
+
+			// pods are ready
+			for _, pod := range pods.Items {
+				if !k8s.IsPodReady(pod) {
+					return fmt.Errorf("pod not ready yet")
+				}
+			}
+
+			return nil
+		}),
+	}
+}
+
+// CheckServices checks that all Enterprise Search services are created
+// TODO: refactor with other resources
+func CheckServices(b Builder, k *test.K8sClient) test.Step {
+	return test.Step{
+		Name: "Enterprise Search services should be created",
+		Test: test.Eventually(func() error {
+			for _, s := range []string{
+				b.EnterpriseSearch.Name + "-ent-http",
+			} {
+				if _, err := k.GetService(b.EnterpriseSearch.Namespace, s); err != nil {
+					return err
+				}
+			}
+			return nil
+		}),
+	}
+}
+
+// CheckServicesEndpoints checks that services have the expected number of endpoints
+func CheckServicesEndpoints(b Builder, k *test.K8sClient) test.Step {
+	return test.Step{
+		Name: "EnterpriseSearch services should have endpoints",
+		Test: test.Eventually(func() error {
+			for endpointName, addrCount := range map[string]int{
+				b.EnterpriseSearch.Name + "-ent-http": int(b.EnterpriseSearch.Spec.Count),
+			} {
+				endpoints, err := k.GetEndpoints(b.EnterpriseSearch.Namespace, endpointName)
+				if err != nil {
+					return err
+				}
+				if len(endpoints.Subsets) == 0 {
+					return fmt.Errorf("no subset for endpoint %s", endpointName)
+				}
+				if len(endpoints.Subsets[0].Addresses) != addrCount {
+					return fmt.Errorf("%d addresses found for endpoint %s, expected %d", len(endpoints.Subsets[0].Addresses), endpointName, addrCount)
+				}
+			}
+			return nil
+		}),
+	}
+}
+
+// CheckSecrets checks that expected secrets have been created.
+func CheckSecrets(b Builder, k *test.K8sClient) test.Step {
+	return test.CheckSecretsContent(k, b.EnterpriseSearch.Namespace, func() []test.ExpectedSecret {
+		entName := b.EnterpriseSearch.Name
+		// hardcode all secret names and keys to catch any breaking change
+		expected := []test.ExpectedSecret{
+			{
+				Name: entName + "-ent-config",
+				Keys: []string{"enterprise-search.yml", "readiness-probe.sh"},
+				Labels: map[string]string{
+					"common.k8s.elastic.co/type":           "enterprise-search",
+					"eck.k8s.elastic.co/credentials":       "true",
+					"enterprisesearch.k8s.elastic.co/name": entName,
+				},
+			},
+		}
+		if b.EnterpriseSearch.Spec.ElasticsearchRef.Name != "" {
+			expected = append(expected,
+				test.ExpectedSecret{
+					Name: entName + "-ent-es-ca",
+					Keys: []string{"ca.crt", "tls.crt"},
+					Labels: map[string]string{
+						"elasticsearch.k8s.elastic.co/cluster-name": b.EnterpriseSearch.Spec.ElasticsearchRef.Name,
+						"entassociation.k8s.elastic.co/name":        entName,
+						"entassociation.k8s.elastic.co/namespace":   b.EnterpriseSearch.Namespace,
+					},
+				},
+				test.ExpectedSecret{
+					Name: entName + "-ent-user",
+					Keys: []string{b.EnterpriseSearch.Namespace + "-" + entName + "-ent-user"},
+					Labels: map[string]string{
+						"eck.k8s.elastic.co/credentials":            "true",
+						"elasticsearch.k8s.elastic.co/cluster-name": b.EnterpriseSearch.Spec.ElasticsearchRef.Name,
+						"entassociation.k8s.elastic.co/name":        entName,
+						"entassociation.k8s.elastic.co/namespace":   b.EnterpriseSearch.Namespace,
+					},
+				},
+			)
+		}
+		if b.EnterpriseSearch.Spec.HTTP.TLS.Enabled() {
+			expected = append(expected,
+				test.ExpectedSecret{
+					Name: entName + "-ent-http-ca-internal",
+					Keys: []string{"tls.crt", "tls.key"},
+					Labels: map[string]string{
+						"enterprisesearch.k8s.elastic.co/name": entName,
+						"common.k8s.elastic.co/type":           "enterprise-search",
+					},
+				},
+				test.ExpectedSecret{
+					Name: entName + "-ent-http-certs-internal",
+					Keys: []string{"tls.crt", "tls.key", "ca.crt"},
+					Labels: map[string]string{
+						"enterprisesearch.k8s.elastic.co/name": entName,
+						"common.k8s.elastic.co/type":           "enterprise-search",
+					},
+				},
+				test.ExpectedSecret{
+					Name: entName + "-ent-http-certs-public",
+					Keys: []string{"ca.crt", "tls.crt"},
+					Labels: map[string]string{
+						"enterprisesearch.k8s.elastic.co/name": entName,
+						"common.k8s.elastic.co/type":           "enterprise-search",
+					},
+				},
+			)
+		}
+		return expected
+	})
+}

--- a/test/e2e/test/enterprisesearch/checks_k8s.go
+++ b/test/e2e/test/enterprisesearch/checks_k8s.go
@@ -27,7 +27,7 @@ func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
 	}
 }
 
-// CheckApmServerDeployment checks the Deployment resource exists
+// CheckDeployment checks the Deployment resource exists
 func CheckDeployment(b Builder, k *test.K8sClient) test.Step {
 	return test.Step{
 		Name: "EnterpriseSearch deployment should be created",
@@ -63,9 +63,9 @@ func CheckPods(b Builder, k *test.K8sClient) test.Step {
 			}
 
 			// builder hash matches
-			goodBuilderHash := hash.HashObject(b.EnterpriseSearch.Spec)
+			expectedBuilderHash := hash.HashObject(b.EnterpriseSearch.Spec)
 			for _, pod := range pods.Items {
-				if err := test.ValidateBuilderHashAnnotation(pod, goodBuilderHash); err != nil {
+				if err := test.ValidateBuilderHashAnnotation(pod, expectedBuilderHash); err != nil {
 					return err
 				}
 			}

--- a/test/e2e/test/enterprisesearch/http_client.go
+++ b/test/e2e/test/enterprisesearch/http_client.go
@@ -1,0 +1,226 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package enterprisesearch
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/enterprisesearch"
+	entName "github.com/elastic/cloud-on-k8s/pkg/controller/enterprisesearch/name"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+)
+
+const (
+	ReqTimeout          = 1 * time.Minute
+	AppSearchPrivateKey = "private-key"
+)
+
+type EnterpriseSearchClient struct {
+	httpClient *http.Client
+	endpoint   string
+	username   string
+	password   string
+}
+
+func NewEnterpriseSearchClient(ent entv1beta1.EnterpriseSearch, k *test.K8sClient) (EnterpriseSearchClient, error) {
+	var caCerts []*x509.Certificate
+	scheme := "http"
+	if ent.Spec.HTTP.TLS.Enabled() {
+		scheme = "https"
+		crts, err := k.GetHTTPCerts(entName.EntNamer, ent.Namespace, ent.Name)
+		if err != nil {
+			return EnterpriseSearchClient{}, err
+		}
+		caCerts = crts
+	}
+	esNamespace := ent.Spec.ElasticsearchRef.Namespace
+	if len(esNamespace) == 0 {
+		esNamespace = ent.Namespace
+	}
+	password, err := k.GetElasticPassword(types.NamespacedName{Namespace: esNamespace, Name: ent.Spec.ElasticsearchRef.Name})
+	if err != nil {
+		return EnterpriseSearchClient{}, err
+	}
+	endpoint := fmt.Sprintf("%s://%s.%s.svc:%d", scheme, ent.Name+"-ent-http", ent.Namespace, enterprisesearch.HTTPPort)
+	return EnterpriseSearchClient{
+		httpClient: test.NewHTTPClient(caCerts),
+		endpoint:   endpoint,
+		username:   "elastic",
+		password:   password,
+	}, nil
+}
+
+func (e EnterpriseSearchClient) doRequest(request *http.Request) ([]byte, error) {
+	if len(request.Header.Get("Authorization")) == 0 {
+		// no api key set, use basic auth
+		request.SetBasicAuth(e.username, e.password)
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+
+	ctx, cancel := context.WithTimeout(context.Background(), ReqTimeout)
+	defer cancel()
+
+	resp, err := e.httpClient.Do(request.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("http response status code is %d)", resp.StatusCode)
+	}
+
+	defer resp.Body.Close()
+	return ioutil.ReadAll(resp.Body)
+}
+
+func (e EnterpriseSearchClient) HealthCheck() error {
+	// check the endpoint responds to requests
+	url := e.endpoint + "/api/ent/v1/internal/health"
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return err
+	}
+	_, err = e.doRequest(req)
+	return err
+}
+
+func (e EnterpriseSearchClient) AppSearch() AppSearchClient {
+	return AppSearchClient{EnterpriseSearchClient: e}
+}
+
+type AppSearchClient struct {
+	EnterpriseSearchClient
+	apiKey string
+}
+
+func (a AppSearchClient) WithAPIKey(key string) AppSearchClient {
+	a.apiKey = key
+	return a
+}
+
+func (a AppSearchClient) doRequest(request *http.Request) ([]byte, error) {
+	if len(a.apiKey) > 0 {
+		// set the api key header
+		request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", a.apiKey))
+	}
+	return a.EnterpriseSearchClient.doRequest(request)
+}
+
+type CredentialsCollection struct {
+	Results []struct {
+		Name string `json:"name"`
+		Key  string `json:"key"`
+	} `json:"results"`
+}
+
+func (a AppSearchClient) GetAPIKey() (string, error) {
+	url := a.endpoint + "/as/credentials/collection"
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := a.doRequest(req)
+	if err != nil {
+		return "", err
+	}
+
+	var credentials CredentialsCollection
+	if err := json.Unmarshal(resp, &credentials); err != nil {
+		return "", err
+	}
+	for _, res := range credentials.Results {
+		if res.Name == AppSearchPrivateKey {
+			return res.Key, nil
+		}
+	}
+
+	return "", fmt.Errorf("cannot find %s in results (len %d)", AppSearchPrivateKey, len(credentials.Results))
+}
+
+type Results struct {
+	Results []map[string]interface{} `json:"results"`
+}
+
+func (a AppSearchClient) GetEngines() (Results, error) {
+	url := a.endpoint + "/api/as/v1/engines"
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return Results{}, err
+	}
+	respBody, err := a.doRequest(req)
+	if err != nil {
+		return Results{}, err
+	}
+	var results Results
+	return results, json.Unmarshal(respBody, &results)
+}
+
+func (a AppSearchClient) CreateEngine(name string) error {
+	url := a.endpoint + "/api/as/v1/engines"
+	body := []byte(fmt.Sprintf(`{"name": "%s"}`, name))
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+	_, err = a.doRequest(req)
+	return err
+}
+
+func (a AppSearchClient) GetDocuments(engineName string) (Results, error) {
+	url := a.endpoint + fmt.Sprintf("/api/as/v1/engines/%s/documents/list", engineName)
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return Results{}, err
+	}
+	respBody, err := a.doRequest(req)
+	if err != nil {
+		return Results{}, err
+	}
+	var results Results
+	return results, json.Unmarshal(respBody, &results)
+}
+
+func (a AppSearchClient) IndexDocument(engineName string, document string) error {
+	url := a.endpoint + fmt.Sprintf("/api/as/v1/engines/%s/documents", engineName)
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer([]byte(document)))
+	if err != nil {
+		return err
+	}
+	_, err = a.doRequest(req)
+	return err
+}
+
+func (a AppSearchClient) SearchDocuments(engineName string, query string) (Results, error) {
+	url := a.endpoint + fmt.Sprintf("/api/as/v1/engines/%s/search", engineName)
+	body := fmt.Sprintf(`{"query": "%s"}`, query)
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer([]byte(body)))
+	if err != nil {
+		return Results{}, err
+	}
+
+	respBody, err := a.doRequest(req)
+	if err != nil {
+		return Results{}, err
+	}
+
+	var results Results
+	return results, json.Unmarshal(respBody, &results)
+}

--- a/test/e2e/test/enterprisesearch/steps_creation.go
+++ b/test/e2e/test/enterprisesearch/steps_creation.go
@@ -1,0 +1,38 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package enterprisesearch
+
+import (
+	"testing"
+
+	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/stretchr/testify/require"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // auth on gke
+)
+
+func (b Builder) CreationTestSteps(k *test.K8sClient) test.StepList {
+	return test.StepList{
+		{
+			Name: "Creating Enterprise Search should succeed",
+			Test: func(t *testing.T) {
+				for _, obj := range b.RuntimeObjects() {
+					err := k.Client.Create(obj)
+					require.NoError(t, err)
+				}
+			},
+		},
+		{
+			Name: "Enterprise Search should be created",
+			Test: func(t *testing.T) {
+				var createdEnt entv1beta1.EnterpriseSearch
+				err := k.Client.Get(k8s.ExtractNamespacedName(&b.EnterpriseSearch), &createdEnt)
+				require.NoError(t, err)
+				require.Equal(t, b.EnterpriseSearch.Spec.Version, createdEnt.Spec.Version)
+			},
+		},
+	}
+}

--- a/test/e2e/test/enterprisesearch/steps_deletion.go
+++ b/test/e2e/test/enterprisesearch/steps_deletion.go
@@ -1,0 +1,58 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package enterprisesearch
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
+	return test.StepList{
+		{
+			Name: "Deleting EnterpriseSearch should return no error",
+			Test: func(t *testing.T) {
+				for _, obj := range b.RuntimeObjects() {
+					err := k.Client.Delete(obj)
+					require.NoError(t, err)
+
+				}
+			},
+		},
+		{
+			Name: "EnterpriseSearch should not be there anymore",
+			Test: test.Eventually(func() error {
+				for _, obj := range b.RuntimeObjects() {
+					m, err := meta.Accessor(obj)
+					if err != nil {
+						return err
+					}
+					err = k.Client.Get(k8s.ExtractNamespacedName(m), obj.DeepCopyObject())
+					if err != nil {
+						if apierrors.IsNotFound(err) {
+							continue
+						}
+					}
+					return errors.Wrap(err, "expected 404 not found API error here")
+
+				}
+				return nil
+			}),
+		},
+		{
+			Name: "EnterpriseSearch pods should eventually be removed",
+			Test: test.Eventually(func() error {
+				return k.CheckPodCount(0, test.EnterpriseSearchPodListOptions(b.EnterpriseSearch.Namespace, b.EnterpriseSearch.Name)...)
+			}),
+		},
+	}
+}

--- a/test/e2e/test/enterprisesearch/steps_init.go
+++ b/test/e2e/test/enterprisesearch/steps_init.go
@@ -1,0 +1,66 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package enterprisesearch
+
+import (
+	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
+	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
+	return []test.Step{
+		{
+			Name: "K8S should be accessible",
+			Test: test.Eventually(func() error {
+				pods := corev1.PodList{}
+				return k.Client.List(&pods)
+			}),
+		},
+		{
+			Name: "Label test pods",
+			Test: test.Eventually(func() error {
+				return test.LabelTestPods(
+					k.Client,
+					test.Ctx(),
+					run.TestNameLabel,
+					b.EnterpriseSearch.Labels[run.TestNameLabel])
+			}),
+			Skip: func() bool {
+				return test.Ctx().Local
+			},
+		},
+		{
+			Name: "EnterpriseSearch CRDs should exist",
+			Test: test.Eventually(func() error {
+				crds := []runtime.Object{
+					&entv1beta1.EnterpriseSearchList{},
+				}
+				for _, crd := range crds {
+					if err := k.Client.List(crd); err != nil {
+						return err
+					}
+				}
+				return nil
+			}),
+		},
+		{
+			Name: "Remove EnterpriseSearch if it already exists",
+			Test: test.Eventually(func() error {
+				for _, obj := range b.RuntimeObjects() {
+					err := k.Client.Delete(obj)
+					if err != nil && !apierrors.IsNotFound(err) {
+						return err
+					}
+				}
+				// wait for pods to disappear
+				return k.CheckPodCount(0, test.EnterpriseSearchPodListOptions(b.EnterpriseSearch.Namespace, b.EnterpriseSearch.Name)...)
+			}),
+		},
+	}
+}

--- a/test/e2e/test/enterprisesearch/steps_mutation.go
+++ b/test/e2e/test/enterprisesearch/steps_mutation.go
@@ -1,0 +1,62 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package enterprisesearch
+
+import (
+	"testing"
+
+	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
+	return b.AnnotatePodsWithBuilderHash(k).
+		WithSteps(b.UpgradeTestSteps(k)).
+		WithSteps(b.CheckK8sTestSteps(k)).
+		WithSteps(b.CheckStackTestSteps(k))
+}
+
+func (b Builder) AnnotatePodsWithBuilderHash(k *test.K8sClient) test.StepList {
+	return []test.Step{
+		{
+			Name: "Annotate Pods with a hash of their Builder spec",
+			Test: test.Eventually(func() error {
+				var pods corev1.PodList
+				if err := k.Client.List(&pods, test.EnterpriseSearchPodListOptions(b.EnterpriseSearch.Namespace, b.EnterpriseSearch.Name)...); err != nil {
+					return err
+				}
+
+				expectedHash := hash.HashObject(b.MutatedFrom.EnterpriseSearch.Spec)
+				for _, pod := range pods.Items {
+					if err := test.AnnotatePodWithBuilderHash(k, pod, expectedHash); err != nil {
+						return err
+					}
+				}
+				return nil
+			}),
+		},
+	}
+}
+
+func (b Builder) MutationReversalTestContext() test.ReversalTestContext {
+	panic("not implemented")
+}
+
+func (b Builder) UpgradeTestSteps(k *test.K8sClient) test.StepList {
+	return test.StepList{
+		{
+			Name: "Applying the Enterprise Search mutation should succeed",
+			Test: func(t *testing.T) {
+				var ent entv1beta1.EnterpriseSearch
+				require.NoError(t, k.Client.Get(k8s.ExtractNamespacedName(&b.EnterpriseSearch), &ent))
+				ent.Spec = b.EnterpriseSearch.Spec
+				require.NoError(t, k.Client.Update(&ent))
+			},
+		}}
+}

--- a/test/e2e/test/helper/yaml.go
+++ b/test/e2e/test/helper/yaml.go
@@ -12,12 +12,14 @@ import (
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
 	beatcommon "github.com/elastic/cloud-on-k8s/pkg/controller/beat/common"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/apmserver"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/beat"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/enterprisesearch"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/kibana"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -37,6 +39,7 @@ func NewYAMLDecoder() *YAMLDecoder {
 	scheme.AddKnownTypes(kbv1.GroupVersion, &kbv1.Kibana{}, &kbv1.KibanaList{})
 	scheme.AddKnownTypes(apmv1.GroupVersion, &apmv1.ApmServer{}, &apmv1.ApmServerList{})
 	scheme.AddKnownTypes(beatv1beta1.GroupVersion, &beatv1beta1.Beat{}, &beatv1beta1.BeatList{})
+	scheme.AddKnownTypes(entv1beta1.GroupVersion, &entv1beta1.EnterpriseSearch{}, &entv1beta1.EnterpriseSearchList{})
 	decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
 
 	return &YAMLDecoder{decoder: decoder}
@@ -77,6 +80,9 @@ func (yd *YAMLDecoder) ToBuilders(reader *bufio.Reader, transform BuilderTransfo
 		case *beatv1beta1.Beat:
 			b := beat.NewBuilderWithoutSuffix(decodedObj.Name, beatcommon.Type(decodedObj.Spec.Type))
 			b.Beat = *decodedObj
+		case *entv1beta1.EnterpriseSearch:
+			b := enterprisesearch.NewBuilderWithoutSuffix(decodedObj.Name)
+			b.EnterpriseSearch = *decodedObj
 			builder = transform(b)
 		default:
 			return builders, fmt.Errorf("unexpected object type: %t", decodedObj)

--- a/test/e2e/test/k8s_client.go
+++ b/test/e2e/test/k8s_client.go
@@ -27,6 +27,7 @@ import (
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/apmserver"
 	beatcommon "github.com/elastic/cloud-on-k8s/pkg/controller/beat/common"
@@ -34,6 +35,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/name"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/enterprisesearch"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
@@ -76,6 +78,9 @@ func CreateClient() (k8s.Client, error) {
 		return nil, err
 	}
 	if err := beatv1beta1.AddToScheme(scheme.Scheme); err != nil {
+		return nil, err
+	}
+	if err := entv1beta1.AddToScheme(scheme.Scheme); err != nil {
 		return nil, err
 	}
 	client, err := k8sclient.New(cfg, k8sclient.Options{Scheme: scheme.Scheme})
@@ -317,7 +322,15 @@ func ApmServerPodListOptions(apmNamespace, apmName string) []k8sclient.ListOptio
 		apmserver.ApmServerNameLabelName: apmName,
 	})
 	return []k8sclient.ListOption{ns, matchLabels}
+}
 
+func EnterpriseSearchPodListOptions(entNamespace, entName string) []k8sclient.ListOption {
+	ns := k8sclient.InNamespace(entNamespace)
+	matchLabels := k8sclient.MatchingLabels(map[string]string{
+		common.TypeLabelName:                           enterprisesearch.Type,
+		enterprisesearch.EnterpriseSearchNameLabelName: entName,
+	})
+	return []k8sclient.ListOption{ns, matchLabels}
 }
 
 func BeatPodListOptions(beatNamespace, beatName, beatType string) []k8sclient.ListOption {

--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -5,11 +5,12 @@
 package kibana
 
 import (
-	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
@@ -24,6 +25,10 @@ type Builder struct {
 }
 
 var _ test.Builder = Builder{}
+
+func (b Builder) SkipTest() bool {
+	return false
+}
 
 func NewBuilder(name string) Builder {
 	return newBuilder(name, rand.String(4))

--- a/test/e2e/test/kibana/checks_k8s.go
+++ b/test/e2e/test/kibana/checks_k8s.go
@@ -50,9 +50,9 @@ func CheckKibanaPods(b Builder, k *test.K8sClient) test.Step {
 			}
 
 			// builder hash matches
-			goodBuilderHash := hash.HashObject(b.Kibana.Spec)
+			expectedBuilderHash := hash.HashObject(b.Kibana.Spec)
 			for _, pod := range pods.Items {
-				if err := test.ValidateBuilderHashAnnotation(pod, goodBuilderHash); err != nil {
+				if err := test.ValidateBuilderHashAnnotation(pod, expectedBuilderHash); err != nil {
 					return err
 				}
 			}

--- a/test/e2e/test/run.go
+++ b/test/e2e/test/run.go
@@ -7,9 +7,15 @@ package test
 // Sequence returns a list of steps corresponding to the basic workflow (some optional init steps, then init steps,
 // create steps, check steps, then something and delete steps to terminate).
 func Sequence(before StepsFunc, f StepsFunc, builders ...Builder) StepList {
-	k := NewK8sClientOrFatal()
-
 	steps := StepList{}
+	for _, b := range builders {
+		// ignore the test if some builders cannot be tested
+		if b.SkipTest() {
+			return steps
+		}
+	}
+
+	k := NewK8sClientOrFatal()
 
 	if before != nil {
 		steps = steps.WithSteps(before(k))


### PR DESCRIPTION
The tests cover:
- the Enterprise Search sample manifest
- configuration upgrades (through config and configRef)
- cross-namespace associations

They perform a few functional AppSearch tests: create an engine, index documents, search those documents.

Workplace Search tests are much harder to perform, so there are none so far:
- we need a trial license (already manipulated once in other tests)
- connecting to an external source (eg. Google Drive) is probably too much work

Both the Healthcheck and AppSearch tests already validated the Enterprise Search instance can correctly communicate with Elasticsearch.

Follow-up issues:
- [Setup a single http helper for all resources](https://github.com/elastic/cloud-on-k8s/issues/3205)