### PR TITLE
Using host instead of node in the config

### DIFF
--- a/pkg/controller/beat/filebeat/config.go
+++ b/pkg/controller/beat/filebeat/config.go
@@ -12,7 +12,7 @@ var (
   autodiscover:
     providers:
     - type: kubernetes
-      node: ${NODE_NAME}
+      host: ${NODE_NAME}
       hints:
         enabled: true
         default_config:


### PR DESCRIPTION
As `host` was renamed to `node` in https://github.com/elastic/beats/pull/14738 for 7.6 and it wasn't backported, changing our default config to `host`.