### PR TITLE
Deploy metricbeat on e2e clusters

### DIFF
--- a/config/e2e/batch_job.yaml
+++ b/config/e2e/batch_job.yaml
@@ -1,19 +1,5 @@
 ---
 apiVersion: v1
-kind: Secret
-metadata:
-  name: "eck-{{ .Context.TestRun }}"
-  namespace: {{ .Context.E2ENamespace }}
-  labels:
-    test-run: {{ .Context.TestRun }}
-data:
-{{ range $key, $value := .Secrets }}
-  {{ $key }}: |
-    {{ $value | b64enc }}
-{{ end }}
-
----
-apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "eck-{{ .Context.TestRun }}"

--- a/config/e2e/filebeat.yaml
+++ b/config/e2e/filebeat.yaml
@@ -269,6 +269,7 @@ supplementalGroups:
   type: RunAsAny
 users:
   - system:serviceaccount:{{ .E2ENamespace }}:filebeat
+  - system:serviceaccount:{{ .E2ENamespace }}:metricbeat
 groups:
 {{- range .Operator.ManagedNamespaces }}
   - system:serviceaccounts:{{ . }}

--- a/config/e2e/metricbeat.yaml
+++ b/config/e2e/metricbeat.yaml
@@ -1,0 +1,294 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metricbeat
+  namespace: {{ .E2ENamespace }}
+  labels:
+    k8s-app: metricbeat
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metricbeat-daemonset-config
+  namespace: {{ .E2ENamespace }}
+  labels:
+    k8s-app: metricbeat
+data:
+  metricbeat.yml: |-
+    metricbeat.config.modules:
+      # Mounted `metricbeat-daemonset-modules` configmap:
+      path: ${path.config}/modules.d/*.yml
+      # Reload module configs as they change:
+      reload.enabled: false
+
+    metricbeat.autodiscover:
+      providers:
+        - type: kubernetes
+          node: ${NODE_NAME}
+          hints.enabled: true
+    processors:
+      - add_cloud_metadata:
+      - add_fields:
+          target: ''
+          fields:
+            pipeline: {{ .Pipeline }}
+            build_number: {{ .BuildNumber }}
+            provider: {{ .Provider }}
+            clusterName: {{ .ClusterName }}
+            kubernetes_version: {{ .KubernetesVersion }}
+            stack_version: {{ .ElasticStackVersion }}
+            e2e_test_id: {{ .Pipeline }}-{{ .BuildNumber }}-{{ .Provider }}-{{ .ClusterName }}-{{ .KubernetesVersion }}-{{ .ElasticStackVersion }}
+
+    setup.template.overwrite: true
+    setup.template.append_fields:
+    - name: stack_version
+      type: keyword
+    - name: kubernetes_version
+      type: keyword
+    - name: build_number
+      type: keyword
+    - name: pipeline
+      type: keyword
+    - name: e2e_test_id
+      type: keyword
+    - name: provider
+      type: keyword
+    - name: clusterName
+      type: keyword
+
+    output.elasticsearch:
+      hosts: ['https://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}']
+      username: ${ELASTICSEARCH_USERNAME}
+      password: ${ELASTICSEARCH_PASSWORD}
+      ssl.certificate_authorities:
+      - /mnt/elastic/monitoring-ca.crt
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metricbeat-daemonset-modules
+  namespace: {{ .E2ENamespace }}
+  labels:
+    k8s-app: metricbeat
+data:
+  kubernetes.yml: |-
+    - module: kubernetes
+      metricsets:
+        - node
+        - system
+        - pod
+        - container
+        - volume
+        - event
+      period: 10s
+      host: ${NODE_NAME}
+      hosts: ["https://${HOSTNAME}:10250"]
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      ssl.verification_mode: "none"
+  system.yml: |-
+    - module: system
+      period: 30s
+      metricsets:
+        - cpu
+        - load
+        - memory
+        - network
+        - process
+        - process_summary
+      processes: ['.*']
+      process.include_top_n:
+        by_cpu: 5      # include top 5 processes by CPU
+        by_memory: 5   # include top 5 processes by memory
+    - module: system
+      period: 1m
+      metricsets:
+        - filesystem
+        - fsstat
+      processors:
+      - drop_event.when.regexp:
+          system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib)($|/)'
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: metricbeat
+  namespace: {{ .E2ENamespace }}
+  labels:
+    k8s-app: metricbeat
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metricbeat
+  template:
+    metadata:
+      labels:
+        k8s-app: metricbeat
+    spec:
+      serviceAccountName: metricbeat
+      terminationGracePeriodSeconds: 30
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: metricbeat
+          image: docker.elastic.co/beats/metricbeat:7.7.0
+          args: [
+            "-c", "/etc/metricbeat.yml",
+            "-e",
+            "-system.hostfs=/hostfs",
+            "-d", "autodiscover",
+            "-d", "kubernetes",
+          ]
+          env:
+            - name: ELASTICSEARCH_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: "eck-{{ .TestRun }}"
+                  key: monitoring-ip
+            - name: ELASTICSEARCH_PORT
+              value: "9200"
+            - name: ELASTICSEARCH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: "eck-{{ .TestRun }}"
+                  key: monitoring-user
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "eck-{{ .TestRun }}"
+                  key: monitoring-pass
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            {{ if .OcpCluster }}
+            privileged: true
+            {{end}}
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/metricbeat.yml
+              readOnly: true
+              subPath: metricbeat.yml
+            - name: modules
+              mountPath: /usr/share/metricbeat/modules.d
+              readOnly: true
+            - name: dockersock
+              mountPath: /var/run/docker.sock
+            - name: proc
+              mountPath: /hostfs/proc
+              readOnly: true
+            - name: cgroup
+              mountPath: /hostfs/sys/fs/cgroup
+              readOnly: true
+            - name: monitoring-ca
+              mountPath: /mnt/elastic/monitoring-ca.crt
+              readOnly: true
+              subPath: monitoring-ca
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+        - name: dockersock
+          hostPath:
+            path: /var/run/docker.sock
+        - name: config
+          configMap:
+            defaultMode: 0600
+            name: metricbeat-daemonset-config
+        - name: modules
+          configMap:
+            defaultMode: 0600
+            name: metricbeat-daemonset-modules
+        - name: data
+          hostPath:
+            path: /var/lib/metricbeat-data
+            type: DirectoryOrCreate
+        - name: monitoring-ca
+          secret:
+            secretName: "eck-{{ .TestRun }}"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: metricbeat
+  labels:
+    k8s-app: metricbeat
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - namespaces
+      - events
+      - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources:
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - statefulsets
+      - deployments
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/stats
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metricbeat
+subjects:
+  - kind: ServiceAccount
+    name: metricbeat
+    namespace: {{ .E2ENamespace }}
+roleRef:
+  kind: ClusterRole
+  name: metricbeat
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: elastic-metricbeat-restricted
+  namespace: {{ .E2ENamespace }}
+  labels:
+    test-run: {{ .TestRun }}
+rules:
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - elastic.beat.restricted
+    verbs:
+      - use
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: elastic-metricbeat-restricted-binding
+  namespace: {{ .E2ENamespace }}
+  labels:
+    test-run: {{ .TestRun }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: elastic-metricbeat-restricted
+subjects:
+  - kind: ServiceAccount
+    name: metricbeat

--- a/config/e2e/metricbeat.yaml
+++ b/config/e2e/metricbeat.yaml
@@ -210,10 +210,6 @@ spec:
           configMap:
             defaultMode: 0600
             name: metricbeat-daemonset-modules
-        - name: data
-          hostPath:
-            path: /var/lib/metricbeat-data
-            type: DirectoryOrCreate
         - name: monitoring-ca
           secret:
             secretName: "eck-{{ .TestRun }}"

--- a/config/e2e/metricbeat.yaml
+++ b/config/e2e/metricbeat.yaml
@@ -162,9 +162,10 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           securityContext:
+            runAsUser: 0
             {{ if .OcpCluster }}
             privileged: true
-            {{end}}
+            {{ end }}
           resources:
             limits:
               memory: 200Mi

--- a/config/e2e/operator.yaml
+++ b/config/e2e/operator.yaml
@@ -206,13 +206,17 @@ spec:
   serviceName: {{ .Operator.Name }}
   template:
     metadata:
-      # if monitoring secrets are specified, filebeat is deployed and provides the below configuration
-      {{ if not .MonitoringSecrets }}
       annotations:
+        co.elastic.metrics/metricsets: collector
+        co.elastic.metrics/module: prometheus
+        co.elastic.metrics/hosts: '${data.host}:9090'
+        co.elastic.metrics/period: 10s
+        # if monitoring secrets are specified, filebeat is deployed and provides the below configuration
+        {{ if not .MonitoringSecrets }}
         # Rename the fields "error" to "error.message" and "source" to "event.source"
         # This is to avoid a conflict with the ECS "error" and "source" documents.
         "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
-      {{end}}
+        {{end}}
       labels:
         control-plane: {{ .Operator.Name }}
         test-run: {{ .TestRun }}
@@ -222,7 +226,7 @@ spec:
       - image: {{ .OperatorImage }}
         imagePullPolicy: IfNotPresent
         name: manager
-        args: ["manager", "--namespaces", "{{ .Operator.ManagedNamespaces | join "," }}", "--enable-webhook", "--log-verbosity=1"]
+        args: ["manager", "--namespaces", "{{ .Operator.ManagedNamespaces | join "," }}", "--enable-webhook", "--log-verbosity=1", "--metrics-port=9090"]
         env:
           - name: OPERATOR_NAMESPACE
             valueFrom:
@@ -240,6 +244,9 @@ spec:
         ports:
         - containerPort: 9443
           name: webhook-server
+          protocol: TCP
+        - containerPort: 9090
+          name: prometheus
           protocol: TCP
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs

--- a/config/e2e/secret.yaml
+++ b/config/e2e/secret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eck-{{ .Context.TestRun }}"
+  namespace: {{ .Context.E2ENamespace }}
+  labels:
+    test-run: {{ .Context.TestRun }}
+data:
+  {{ range $key, $value := .Secrets }}
+  {{ $key }}: |
+    {{ $value | b64enc }}
+  {{ end }}


### PR DESCRIPTION
This PR deploys `metricbeat` on e2e clusters.

A few notes for the reviewers:

* Creation of the `Secret` has been moved at the beginning of the process since it is needed for both filebeats and metricbeats
* I'm not grabbing metrics from `kube-state-metrics`, I'm not sure there are some interesting metrics for our case vs the complexity of implementing the [compatibility matrix](https://github.com/kubernetes/kube-state-metrics#compatibility-matrix).

I'm still working on some relevant visualizations.