### PR TITLE
Use a user with minimal set of permissions for Beat

### DIFF
--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -579,6 +579,7 @@ spec:
                 etc.). Any string can be used, but well-known types will be recognized
                 and will allow to provide sane default configurations.
               maxLength: 20
+              pattern: '[a-zA-Z0-9-]+'
               type: string
             version:
               description: Version of the Beat.

--- a/config/crds/bases/beat.k8s.elastic.co_beats.yaml
+++ b/config/crds/bases/beat.k8s.elastic.co_beats.yaml
@@ -12184,6 +12184,7 @@ spec:
                 etc.). Any string can be used, but well-known types will be recognized
                 and will allow to provide sane default configurations.
               maxLength: 20
+              pattern: '[a-zA-Z0-9-]+'
               type: string
             version:
               description: Version of the Beat.

--- a/pkg/apis/beat/v1beta1/beat_types.go
+++ b/pkg/apis/beat/v1beta1/beat_types.go
@@ -16,6 +16,7 @@ type BeatSpec struct {
 	// Type is the type of the Beat to deploy (filebeat, metricbeat, etc.). Any string can be used,
 	// but well-known types will be recognized and will allow to provide sane default configurations.
 	// +kubebuilder:validation:MaxLength=20
+	// +kubebuilder:validation:Pattern=[a-zA-Z0-9-]+
 	Type string `json:"type"`
 
 	// Version of the Beat.

--- a/pkg/apis/beat/v1beta1/validations.go
+++ b/pkg/apis/beat/v1beta1/validations.go
@@ -1,0 +1,86 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package v1beta1
+
+import (
+	"regexp"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
+)
+
+var (
+	defaultChecks = []func(*Beat) field.ErrorList{
+		checkNoUnknownFields,
+		checkNameLength,
+		checkSupportedVersion,
+		checkAtMostOneDeploymentOption,
+		checkImageIfTypeUnknown,
+		checkBeatType,
+	}
+
+	updateChecks = []func(old, curr *Beat) field.ErrorList{
+		checkNoDowngrade,
+	}
+
+	typeRegex = regexp.MustCompile("[a-zA-Z0-9-]+")
+)
+
+func checkNoUnknownFields(b *Beat) field.ErrorList {
+	return commonv1.NoUnknownFields(b, b.ObjectMeta)
+}
+
+func checkNameLength(ent *Beat) field.ErrorList {
+	return commonv1.CheckNameLength(ent)
+}
+
+func checkSupportedVersion(b *Beat) field.ErrorList {
+	return commonv1.CheckSupportedStackVersion(b.Spec.Version, version.SupportedBeatVersions)
+}
+
+func checkAtMostOneDeploymentOption(b *Beat) field.ErrorList {
+	if b.Spec.DaemonSet != nil && b.Spec.Deployment != nil {
+		msg := "Specify either daemonSet or deployment, not both"
+		return field.ErrorList{
+			field.Forbidden(field.NewPath("spec").Child("daemonSet"), msg),
+			field.Forbidden(field.NewPath("spec").Child("deployment"), msg),
+		}
+	}
+
+	return nil
+}
+
+func checkImageIfTypeUnknown(b *Beat) field.ErrorList {
+	knownTypes := []string{"filebeat", "metricbeat"}
+	if !stringsutil.StringInSlice(b.Spec.Type, knownTypes) &&
+		b.Spec.Image == "" {
+		return field.ErrorList{
+			field.Required(
+				field.NewPath("spec").Child("image"),
+				"Image is required if Beat type is not one of [filebeat, metricbeat]"),
+		}
+	}
+	return nil
+}
+
+func checkBeatType(b *Beat) field.ErrorList {
+	if !typeRegex.MatchString(b.Spec.Type) {
+		return field.ErrorList{
+			field.Invalid(
+				field.NewPath("spec").Child("type"),
+				b.Spec.Type,
+				"Beat Type has to match [a-zA-Z0-9]"),
+		}
+	}
+
+	return nil
+}
+
+func checkNoDowngrade(prev, curr *Beat) field.ErrorList {
+	return commonv1.CheckNoDowngrade(prev.Spec.Version, curr.Spec.Version)
+}

--- a/pkg/apis/beat/v1beta1/validations.go
+++ b/pkg/apis/beat/v1beta1/validations.go
@@ -28,7 +28,7 @@ var (
 		checkNoDowngrade,
 	}
 
-	typeRegex = regexp.MustCompile("[a-zA-Z0-9-]+")
+	typeRegex = regexp.MustCompile("^[a-zA-Z0-9-]+$")
 )
 
 func checkNoUnknownFields(b *Beat) field.ErrorList {
@@ -74,7 +74,7 @@ func checkBeatType(b *Beat) field.ErrorList {
 			field.Invalid(
 				field.NewPath("spec").Child("type"),
 				b.Spec.Type,
-				"Beat Type has to match [a-zA-Z0-9]"),
+				"Beat Type has to match ^[a-zA-Z0-9-]+$"),
 		}
 	}
 

--- a/pkg/apis/beat/v1beta1/validations_test.go
+++ b/pkg/apis/beat/v1beta1/validations_test.go
@@ -25,16 +25,19 @@ func Test_checkBeatType(t *testing.T) {
 			typ:  "apachebeat",
 		},
 		{
-			name: "bad type - space",
-			typ:  "file beat",
+			name:    "bad type - space",
+			typ:     "file beat",
+			wantErr: true,
 		},
 		{
-			name: "bad type - illegal characters",
-			typ:  "filebeat-2",
+			name:    "bad type - illegal characters",
+			typ:     "filebeat$2",
+			wantErr: true,
 		},
 		{
-			name: "injection",
-			typ:  "filebeat,superuser",
+			name:    "injection",
+			typ:     "filebeat,superuser",
+			wantErr: true,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/beat/v1beta1/validations_test.go
+++ b/pkg/apis/beat/v1beta1/validations_test.go
@@ -1,0 +1,45 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_checkBeatType(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		typ     string
+		wantErr bool
+	}{
+		{
+			name: "official type",
+			typ:  "filebeat",
+		},
+		{
+			name: "community type",
+			typ:  "apachebeat",
+		},
+		{
+			name: "bad type - space",
+			typ:  "file beat",
+		},
+		{
+			name: "bad type - illegal characters",
+			typ:  "filebeat-2",
+		},
+		{
+			name: "injection",
+			typ:  "filebeat,superuser",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := checkBeatType(&Beat{Spec: BeatSpec{Type: tt.typ}})
+			require.Equal(t, tt.wantErr, len(got) > 0)
+		})
+	}
+}

--- a/pkg/apis/beat/v1beta1/webhook.go
+++ b/pkg/apis/beat/v1beta1/webhook.go
@@ -14,27 +14,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
-	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
 )
 
 var (
 	groupKind     = schema.GroupKind{Group: GroupVersion.Group, Kind: "Beat"}
 	validationLog = logf.Log.WithName("beat-v1beta1-validation")
-
-	defaultChecks = []func(*Beat) field.ErrorList{
-		checkNoUnknownFields,
-		checkNameLength,
-		checkSupportedVersion,
-		checkAtMostOneDeploymentOption,
-		checkImageIfTypeUnknown,
-	}
-
-	updateChecks = []func(old, curr *Beat) field.ErrorList{
-		checkNoDowngrade,
-	}
 )
 
 // +kubebuilder:webhook:path=/validate-beat-k8s-elastic-co-v1beta1-beat,mutating=false,failurePolicy=ignore,groups=beat.k8s.elastic.co,resources=beats,verbs=create;update,versions=v1beta1,name=elastic-beat-validation-v1beta1.k8s.elastic.co
@@ -91,45 +75,4 @@ func (b *Beat) validate(old *Beat) error {
 		return apierrors.NewInvalid(groupKind, b.Name, errors)
 	}
 	return nil
-}
-
-func checkNoUnknownFields(b *Beat) field.ErrorList {
-	return commonv1.NoUnknownFields(b, b.ObjectMeta)
-}
-
-func checkNameLength(ent *Beat) field.ErrorList {
-	return commonv1.CheckNameLength(ent)
-}
-
-func checkSupportedVersion(b *Beat) field.ErrorList {
-	return commonv1.CheckSupportedStackVersion(b.Spec.Version, version.SupportedBeatVersions)
-}
-
-func checkAtMostOneDeploymentOption(b *Beat) field.ErrorList {
-	if b.Spec.DaemonSet != nil && b.Spec.Deployment != nil {
-		msg := "Specify either daemonSet or deployment, not both"
-		return field.ErrorList{
-			field.Forbidden(field.NewPath("spec").Child("daemonSet"), msg),
-			field.Forbidden(field.NewPath("spec").Child("deployment"), msg),
-		}
-	}
-
-	return nil
-}
-
-func checkImageIfTypeUnknown(b *Beat) field.ErrorList {
-	knownTypes := []string{"filebeat", "metricbeat"}
-	if !stringsutil.StringInSlice(b.Spec.Type, knownTypes) &&
-		b.Spec.Image == "" {
-		return field.ErrorList{
-			field.Required(
-				field.NewPath("spec").Child("image"),
-				"Image is required if Beat type is not one of [filebeat, metricbeat]"),
-		}
-	}
-	return nil
-}
-
-func checkNoDowngrade(prev, curr *Beat) field.ErrorList {
-	return commonv1.CheckNoDowngrade(prev.Spec.Version, curr.Spec.Version)
 }

--- a/pkg/controller/association/controller/beat_es_test.go
+++ b/pkg/controller/association/controller/beat_es_test.go
@@ -1,0 +1,100 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package controller
+
+import (
+	"testing"
+
+	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
+	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+)
+
+func Test_getBeatRoles(t *testing.T) {
+
+	for _, tt := range []struct {
+		name    string
+		assoc   commonv1.Associated
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "invalid assoc",
+			assoc:   &apmv1.ApmServer{},
+			wantErr: true,
+		},
+		{
+			name:    "injecting a role should fail",
+			assoc:   &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "somebeat,superuser"}},
+			wantErr: true,
+		},
+		{
+			name:    "invalid version",
+			assoc:   &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Version: "7.7.0.1"}},
+			wantErr: true,
+		},
+		{
+			name:  "test roles for 7.0.0 official Beat",
+			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "filebeat", Version: "7.0.0"}},
+			want:  "kibana_user,ingest_admin,beats_admin,monitoring_user,eck_beat_filebeat_role_v70",
+		},
+		{
+			name:  "test roles for 7.2.99 official Beat",
+			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "filebeat", Version: "7.2.99"}},
+			want:  "kibana_user,ingest_admin,beats_admin,monitoring_user,eck_beat_filebeat_role_v70",
+		},
+		{
+			name:  "test roles for 7.3.0 official Beat",
+			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "filebeat", Version: "7.3.0"}},
+			want:  "kibana_user,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_filebeat_role_v73",
+		},
+		{
+			name:  "test roles for 7.4.99 official Beat",
+			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "filebeat", Version: "7.4.99"}},
+			want:  "kibana_user,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_filebeat_role_v73",
+		},
+		{
+			name:  "test roles for 7.5.0 official Beat",
+			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "filebeat", Version: "7.5.0"}},
+			want:  "kibana_user,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_filebeat_role_v75",
+		},
+		{
+			name:  "test roles for 7.6.99 official Beat",
+			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "filebeat", Version: "7.6.99"}},
+			want:  "kibana_user,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_filebeat_role_v75",
+		},
+		{
+			name:  "test roles for 7.7.0 official Beat",
+			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "metricbeat", Version: "7.7.0"}},
+			want:  "kibana_admin,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_metricbeat_role_v77",
+		},
+		{
+			name:  "test roles for 7.99.99 official Beat",
+			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "metricbeat", Version: "7.99.99"}},
+			want:  "kibana_admin,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_metricbeat_role_v77",
+		},
+		{
+			name:  "test roles for 7.0.0 community Beat",
+			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "somebeat", Version: "7.0.0"}},
+			want:  "kibana_user,ingest_admin,beats_admin,monitoring_user,eck_beat_somebeat_role_v70",
+		},
+		{
+			name:  "test roles for 7.99.99 community Beat",
+			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "somebeat", Version: "7.99.99"}},
+			want:  "kibana_admin,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_somebeat_role_v77",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getBeatRoles(tt.assoc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getBeatRoles() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getBeatRoles() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/elasticsearch/user/reconcile_test.go
+++ b/pkg/controller/elasticsearch/user/reconcile_test.go
@@ -75,6 +75,6 @@ func Test_aggregateRoles(t *testing.T) {
 	c := k8s.WrappedFakeClient(sampleUserProvidedRolesSecret...)
 	roles, err := aggregateRoles(c, sampleEsWithAuth, initDynamicWatches(), record.NewFakeRecorder(10))
 	require.NoError(t, err)
-	require.Len(t, roles, 7)
+	require.Len(t, roles, 15)
 	require.Contains(t, roles, ProbeUserRole, "role1", "role2")
 }


### PR DESCRIPTION
Resolves https://github.com/elastic/cloud-on-k8s/issues/3219.

With this PR we will get automatic user and role creation for all official Beats. Used user has minimal set of permissions that is needed for Beats setup, monitoring and publishing.

We won't get automatic role creation for other beats, so users will need to create a role with a well known format beforehand for it to work.

