### PR TITLE
Mention single-node clusters PDB exception in the docs

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/pod-disruption-budget.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/pod-disruption-budget.asciidoc
@@ -11,7 +11,7 @@ endif::[]
 A link:https://kubernetes.io/docs/tasks/run-application/configure-pdb/[Pod Disruption Budget] allows limiting disruptions on an existing set of Pods while the Kubernetes cluster administrator manages Kubernetes nodes.
 Elasticsearch makes sure some indices don't become unavailable.
 
-A default PDB is enforced by default: it allows one Elasticsearch Pod to be taken down as long as the cluster has a `green` health.
+ECK manages a default PDB per Elasticsearch resource. It allows one Elasticsearch Pod to be taken down, as long as the cluster has a `green` health. Single-node clusters are not considered highly available and can always be disrupted.
 
 This default can be tweaked in the Elasticsearch specification:
 


### PR DESCRIPTION
With https://github.com/elastic/cloud-on-k8s/pull/3167 we allow the
single Pod of a single node cluster to be disrupted, since we consider a
single-node cluster is not intended to be highly available anyway.