### PR TITLE
Fix typo in operator config doc

### DIFF
--- a/docs/operating-eck/operator-config.asciidoc
+++ b/docs/operating-eck/operator-config.asciidoc
@@ -20,7 +20,7 @@ ECK can be configured using either command line flags or environment variables.
 |cert-validity |8760h |Duration representing the validity period of a generated TLS certificate.
 |container-registry |docker.elastic.co | Container registry to use for pulling Elastic Stack container images.
 |debug-http-listen |localhost:6060 |Listen address for the debug HTTP server. Only available in development mode.
-|development |false |Enable developmenet mode. Only available as a CLI flag.
+|development |false |Enable development mode. Only available as a CLI flag.
 |enable-tracing | false | Enable APM tracing in the operator process. APM server URL, credentials etc. can be configured via environment variables. See the link:https://www.elastic.co/guide/en/apm/agent/go/1.x/configuration.html[Apm Go Agent reference] for details.
 |enable-webhook | false | Enables a validating webhook server in the operator process.
 |enforce-rbac-on-refs| false | Enables restrictions on cross-namespace resource association through RBAC


### PR DESCRIPTION
This PR fixes a small typo in the operator config documentation.