### PR TITLE
Remove data dir from metricbeat recipe

### DIFF
--- a/config/recipes/beats/3_metricbeat-kubernetes.yaml
+++ b/config/recipes/beats/3_metricbeat-kubernetes.yaml
@@ -182,10 +182,6 @@ spec:
         configMap:
           defaultMode: 0600
           name: metricbeat-daemonset-modules
-      - name: data
-        hostPath:
-          path: /var/lib/metricbeat-data
-          type: DirectoryOrCreate
       - name: es-certs
         secret:
           secretName: monitor-es-http-certs-public


### PR DESCRIPTION
As discussed in https://github.com/elastic/cloud-on-k8s/pull/3212#discussion_r439951487 the data volume can be removed in the metricbeat recipe.