### PR TITLE
Fix Ent Search hash computation when TLS is disabled

### DIFF
--- a/pkg/controller/enterprisesearch/enterprisesearch_controller.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller.go
@@ -349,13 +349,15 @@ func buildConfigHash(c k8s.Client, ent entv1beta1.EnterpriseSearch, configSecret
 	_, _ = configHash.Write(configSecret.Data[ReadinessProbeFilename])
 
 	// - in the Enterprise Search TLS certificates
-	var tlsCertSecret corev1.Secret
-	tlsSecretKey := types.NamespacedName{Namespace: ent.Namespace, Name: certificates.InternalCertsSecretName(entName.EntNamer, ent.Name)}
-	if err := c.Get(tlsSecretKey, &tlsCertSecret); err != nil {
-		return "", err
-	}
-	if certPem, ok := tlsCertSecret.Data[certificates.CertFileName]; ok {
-		_, _ = configHash.Write(certPem)
+	if ent.Spec.HTTP.TLS.Enabled() {
+		var tlsCertSecret corev1.Secret
+		tlsSecretKey := types.NamespacedName{Namespace: ent.Namespace, Name: certificates.InternalCertsSecretName(entName.EntNamer, ent.Name)}
+		if err := c.Get(tlsSecretKey, &tlsCertSecret); err != nil {
+			return "", err
+		}
+		if certPem, ok := tlsCertSecret.Data[certificates.CertFileName]; ok {
+			_, _ = configHash.Write(certPem)
+		}
 	}
 
 	// - in the Elasticsearch TLS certificates


### PR DESCRIPTION
Due to a missing check on whether TLS is enabled or not, the
reconciliation did not make progress when TLS was disabled.

This is fixing it by adding the extra check. The PR also unit tests the
entire buildConfigHash function.

I'll add a follow-up E2E test to cover Enterprise Search with TLS
disabled.

Fixes https://github.com/elastic/cloud-on-k8s/issues/3257.