### PR TITLE
Add heartbeat driver

### DIFF
--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -625,8 +625,8 @@ spec:
               type: string
             type:
               description: Type is the type of the Beat to deploy (filebeat, metricbeat,
-                etc.). Any string can be used, but well-known types will be recognized
-                and will allow to provide sane default configurations.
+                heartbeat, etc.). Any string can be used, but well-known types will
+                be recognized and will allow to provide sane default configurations.
               maxLength: 20
               pattern: '[a-zA-Z0-9-]+'
               type: string

--- a/config/crds/bases/beat.k8s.elastic.co_beats.yaml
+++ b/config/crds/bases/beat.k8s.elastic.co_beats.yaml
@@ -12230,8 +12230,8 @@ spec:
               type: string
             type:
               description: Type is the type of the Beat to deploy (filebeat, metricbeat,
-                etc.). Any string can be used, but well-known types will be recognized
-                and will allow to provide sane default configurations.
+                heartbeat, etc.). Any string can be used, but well-known types will
+                be recognized and will allow to provide sane default configurations.
               maxLength: 20
               pattern: '[a-zA-Z0-9-]+'
               type: string

--- a/docs/reference/api-docs.asciidoc
+++ b/docs/reference/api-docs.asciidoc
@@ -173,7 +173,7 @@ BeatSpec defines the desired state of a Beat.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`type`* __string__ | Type is the type of the Beat to deploy (filebeat, metricbeat, etc.). Any string can be used, but well-known types will be recognized and will allow to provide sane default configurations.
+| *`type`* __string__ | Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, etc.). Any string can be used, but well-known types will be recognized and will allow to provide sane default configurations.
 | *`version`* __string__ | Version of the Beat.
 | *`elasticsearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster.
 | *`kibanaRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster. It allows automatic setup of dashboards and visualizations.

--- a/pkg/apis/beat/v1beta1/beat_types.go
+++ b/pkg/apis/beat/v1beta1/beat_types.go
@@ -13,7 +13,7 @@ import (
 
 // BeatSpec defines the desired state of a Beat.
 type BeatSpec struct {
-	// Type is the type of the Beat to deploy (filebeat, metricbeat, etc.). Any string can be used,
+	// Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, etc.). Any string can be used,
 	// but well-known types will be recognized and will allow to provide sane default configurations.
 	// +kubebuilder:validation:MaxLength=20
 	// +kubebuilder:validation:Pattern=[a-zA-Z0-9-]+

--- a/pkg/apis/beat/v1beta1/validations.go
+++ b/pkg/apis/beat/v1beta1/validations.go
@@ -57,13 +57,13 @@ func checkAtMostOneDeploymentOption(b *Beat) field.ErrorList {
 }
 
 func checkImageIfTypeUnknown(b *Beat) field.ErrorList {
-	knownTypes := []string{"filebeat", "metricbeat"}
+	knownTypes := []string{"filebeat", "metricbeat", "heartbeat"}
 	if !stringsutil.StringInSlice(b.Spec.Type, knownTypes) &&
 		b.Spec.Image == "" {
 		return field.ErrorList{
 			field.Required(
 				field.NewPath("spec").Child("image"),
-				"Image is required if Beat type is not one of [filebeat, metricbeat]"),
+				"Image is required if Beat type is not one of [filebeat, metricbeat, heartbeat]"),
 		}
 	}
 	return nil

--- a/pkg/controller/beat/controller.go
+++ b/pkg/controller/beat/controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
 	beatcommon "github.com/elastic/cloud-on-k8s/pkg/controller/beat/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/filebeat"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/heartbeat"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/metricbeat"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/otherbeat"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
@@ -220,6 +221,8 @@ func newDriver(
 		return filebeat.NewDriver(dp)
 	case string(metricbeat.Type):
 		return metricbeat.NewDriver(dp)
+	case string(heartbeat.Type):
+		return heartbeat.NewDriver(dp)
 	default:
 		return otherbeat.NewDriver(dp)
 	}

--- a/pkg/controller/beat/heartbeat/heartbeat.go
+++ b/pkg/controller/beat/heartbeat/heartbeat.go
@@ -1,0 +1,28 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package heartbeat
+
+import (
+	beatcommon "github.com/elastic/cloud-on-k8s/pkg/controller/beat/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/container"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+)
+
+const (
+	Type beatcommon.Type = "heartbeat"
+)
+
+type Driver struct {
+	beatcommon.DriverParams
+	beatcommon.Driver
+}
+
+func NewDriver(params beatcommon.DriverParams) beatcommon.Driver {
+	return &Driver{DriverParams: params}
+}
+
+func (d *Driver) Reconcile() *reconciler.Results {
+	return beatcommon.Reconcile(d.DriverParams, nil, container.HeartbeatImage)
+}

--- a/pkg/controller/common/container/container.go
+++ b/pkg/controller/common/container/container.go
@@ -26,6 +26,7 @@ const (
 	EnterpriseSearchImage Image = "enterprise-search/enterprise-search"
 	FilebeatImage         Image = "beats/filebeat"
 	MetricbeatImage       Image = "beats/metricbeat"
+	HeartbeatImage        Image = "beats/heartbeat"
 )
 
 // ImageRepository returns the full container image name by concatenating the current container registry and the image path with the given version.

--- a/pkg/controller/elasticsearch/user/reconcile_test.go
+++ b/pkg/controller/elasticsearch/user/reconcile_test.go
@@ -75,6 +75,6 @@ func Test_aggregateRoles(t *testing.T) {
 	c := k8s.WrappedFakeClient(sampleUserProvidedRolesSecret...)
 	roles, err := aggregateRoles(c, sampleEsWithAuth, initDynamicWatches(), record.NewFakeRecorder(10))
 	require.NoError(t, err)
-	require.Len(t, roles, 15)
+	require.Len(t, roles, 19)
 	require.Contains(t, roles, ProbeUserRole, "role1", "role2")
 }

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -90,7 +90,7 @@ var (
 )
 
 func init() {
-	for _, beat := range []string{"filebeat", "metricbeat"} {
+	for _, beat := range []string{"filebeat", "metricbeat", "heartbeat"} {
 		PredefinedRoles[BeatRoleName(V77, beat)] = esclient.Role{
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml", "read_ilm", "cluster:admin/ingest/pipeline/get"},
 			Indices: []esclient.IndexRole{

--- a/test/e2e/beat/config_test.go
+++ b/test/e2e/beat/config_test.go
@@ -16,6 +16,7 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	v1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/filebeat"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/heartbeat"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/metricbeat"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
@@ -78,12 +79,11 @@ func TestHeartbeatConfig(t *testing.T) {
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
 
 	hbBuilder := beat.NewBuilder(name).
-		WithType("heartbeat").
+		WithType(heartbeat.Type).
 		WithDeployment().
 		WithElasticsearchRef(esBuilder.Ref()).
-		WithImage("docker.elastic.co/beats/heartbeat:7.7.0").
 		WithESValidations(
-			beat.HasEventFromBeat("heartbeat"),
+			beat.HasEventFromBeat(heartbeat.Type),
 			beat.HasEvent("monitor.status:up"))
 
 	podTemplateYaml := `spec:


### PR DESCRIPTION
Adds heartbeat as a well-known type. This makes `spec.image` not required and creates appropriate roles in ES. The latter fixes current E2E test failure.