### PR TITLE
Remove whitelist references

### DIFF
--- a/docs/advanced-topics/service-meshes.asciidoc
+++ b/docs/advanced-topics/service-meshes.asciidoc
@@ -126,7 +126,7 @@ Refer to the link:https://istio.io/docs/tasks/security/authentication/mtls-migra
 [id="{p}-service-mesh-istio-cni"]
 ===== Using init containers with Istio CNI
 
-There are link:https://istio.io/docs/setup/additional-setup/cni/#compatibility-with-application-init-containers[known issues with init containers] when Istio CNI is configured. If you use init containers to <<{p}-init-containers-plugin-downloads,install Elasticsearch plugins>> or perform other initialization tasks that require network access, they may fail due to outbound traffic being blocked by the CNI plugin. To work around this issue, explicitly whitelist the external ports used by the init containers.
+There are link:https://istio.io/docs/setup/additional-setup/cni/#compatibility-with-application-init-containers[known issues with init containers] when Istio CNI is configured. If you use init containers to <<{p}-init-containers-plugin-downloads,install Elasticsearch plugins>> or perform other initialization tasks that require network access, they may fail due to outbound traffic being blocked by the CNI plugin. To work around this issue, explicitly allow the external ports used by the init containers.
 
 .Installing plugins using an init container
 [source,yaml,subs="attributes,callouts"]
@@ -161,7 +161,7 @@ spec:
                 bin/elasticsearch-plugin install --batch repository-gcs
 ----
 
-<1> Plugins are downloaded over the HTTPS port (443) and needs to be whitelisted when Istio CNI is installed.
+<1> Plugins are downloaded over the HTTPS port (443) and needs to be allowed when Istio CNI is installed.
 
 
 [id="{p}-service-mesh-istio-kibana"]

--- a/docs/operating-eck/troubleshooting/common-problems.asciidoc
+++ b/docs/operating-eck/troubleshooting/common-problems.asciidoc
@@ -30,7 +30,7 @@ Error from server (Timeout): error when creating "elasticsearch.yaml": Timeout: 
 ....
 
 
-This error is usually an indication of a problem communicating with the validating webhook. If you are running ECK on a private Google Kubernetes Engine (GKE) cluster, you may need to link:https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules[add a firewall rule] whitelisting port 9443 from the API server. Another possible cause for failure is if a strict <<{p}-webhook-network-policies,network policy>> is in effect. Refer to the <<{p}-webhook-troubleshooting,webhook troubleshooting>> documentation for  more details and workarounds.
+This error is usually an indication of a problem communicating with the validating webhook. If you are running ECK on a private Google Kubernetes Engine (GKE) cluster, you may need to link:https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules[add a firewall rule] allowing port 9443 from the API server. Another possible cause for failure is if a strict <<{p}-webhook-network-policies,network policy>> is in effect. Refer to the <<{p}-webhook-troubleshooting,webhook troubleshooting>> documentation for  more details and workarounds.
 
 [id="{p}-{page_id}-owner-refs"]
 == Copying secrets with Owner References

--- a/hack/licence-detector/README.md
+++ b/hack/licence-detector/README.md
@@ -18,9 +18,9 @@ In some cases, the licence-detector will not be able to detect the licence type 
 
 Current overrides file can be found in the `overrides` directory. Follow the existing directory layout (`licences/<domain>/<pkg>/LICENCE`) when adding new licence text overrides.
 
-### Whitelisting licence types
+### Allowing licence types
 
-Current list of allowed licence types can be found in the `rules.json` file. Refer to the documentation in the tool repo for more information about adding new licence types to the whitelist.
+Current list of allowed licence types can be found in the `rules.json` file. Refer to the documentation in the tool repo for more information about adding new licence types to the allowlist.
 
 
 generate-image-deps.sh


### PR DESCRIPTION
Similar to https://go-review.googlesource.com/c/go/+/236857/ and https://github.com/elastic/elasticsearch/issues/58087

Removes references to whitelist/blacklist where possible. Sometimes we still reference it in configuration settings outside of our control (e.g. traefik), but this changes everything we reasonably can I think. I'll follow up with a PR to the licence detector since we also control that.