### PR TITLE
Update licence detector allowlist name

### DIFF
--- a/hack/licence-detector/generate-notice.sh
+++ b/hack/licence-detector/generate-notice.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR=${SCRIPT_DIR}/../..
 TEMP_DIR=$(mktemp -d)
-LICENCE_DETECTOR="go.elastic.co/go-licence-detector@v0.1.1"
+LICENCE_DETECTOR="go.elastic.co/go-licence-detector@v0.3.0"
 
 trap '[[ $TEMP_DIR ]] && rm -rf "$TEMP_DIR"' EXIT
 

--- a/hack/licence-detector/rules.json
+++ b/hack/licence-detector/rules.json
@@ -1,5 +1,5 @@
 {
-  "whitelist": [
+  "allowlist": [
     "Apache-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",


### PR DESCRIPTION
Follow up to https://github.com/elastic/cloud-on-k8s/pull/3266

When https://github.com/elastic/go-licence-detector/pull/6 is merged this will update our use of it