### PR TITLE
Fix snapshot version in cleanup job

### DIFF
--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
         cleanup {
             script {
                 clusters = [
-                    "eck-77-snapshot-${BUILD_NUMBER}-e2e"
+                    "eck-78-snapshot-${BUILD_NUMBER}-e2e"
                 ]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',


### PR DESCRIPTION
Snapshots clusters are never removed because of a typo in the parameter passed to the cleanup job.
I'm pretty sure that we can do something smarter but I'm not familiar enough with Jenkins.
I'm cleanup the remaining ones manually.

