### PR TITLE
Only provision Enterprise licenses as of 7.8.1

### DIFF
--- a/pkg/apis/elasticsearch/v1/fields.go
+++ b/pkg/apis/elasticsearch/v1/fields.go
@@ -40,7 +40,7 @@ const (
 	XPackSecurityTransportSslKey                    = "xpack.security.transport.ssl.key"
 	XPackSecurityTransportSslVerificationMode       = "xpack.security.transport.ssl.verification_mode"
 
-	XPackLicenseUploadTypes = "xpack.license.upload.types" // >= 7.6.0
+	XPackLicenseUploadTypes = "xpack.license.upload.types" // supported >= 7.6.0 used as of 7.8.1
 )
 
 var UnsupportedSettings = []string{

--- a/pkg/controller/common/license/match_test.go
+++ b/pkg/controller/common/license/match_test.go
@@ -297,25 +297,6 @@ func Test_bestMatchAt(t *testing.T) {
 			wantFound: true,
 		},
 		{
-			name: "no result: platinum post 7.8.1",
-			args: args{
-				minVersion: version.MustParse("7.8.1"),
-				licenses: []EnterpriseLicense{
-					{
-						License: LicenseSpec{
-							ExpiryDateInMillis: chrono.MustMillis("2020-01-31"),
-							StartDateInMillis:  chrono.MustMillis("2019-01-01"),
-							ClusterLicenses: []ElasticsearchLicense{
-								{License: license(twoMonth, platinum)},
-								{License: license(twelveMonth, platinum)},
-							},
-						},
-					},
-				},
-			},
-			wantFound: false,
-		},
-		{
 			name: "success: longest valid from multiple enterprise licenses",
 			args: args{
 				licenses: []EnterpriseLicense{

--- a/pkg/controller/common/license/match_test.go
+++ b/pkg/controller/common/license/match_test.go
@@ -297,6 +297,25 @@ func Test_bestMatchAt(t *testing.T) {
 			wantFound: true,
 		},
 		{
+			name: "no result: platinum post 7.8.1",
+			args: args{
+				minVersion: version.MustParse("7.8.1"),
+				licenses: []EnterpriseLicense{
+					{
+						License: LicenseSpec{
+							ExpiryDateInMillis: chrono.MustMillis("2020-01-31"),
+							StartDateInMillis:  chrono.MustMillis("2019-01-01"),
+							ClusterLicenses: []ElasticsearchLicense{
+								{License: license(twoMonth, platinum)},
+								{License: license(twelveMonth, platinum)},
+							},
+						},
+					},
+				},
+			},
+			wantFound: false,
+		},
+		{
 			name: "success: longest valid from multiple enterprise licenses",
 			args: args{
 				licenses: []EnterpriseLicense{

--- a/pkg/controller/common/license/match_test.go
+++ b/pkg/controller/common/license/match_test.go
@@ -256,7 +256,7 @@ func Test_bestMatchAt(t *testing.T) {
 			wantFound: true,
 		},
 		{
-			name: "success: mixed platinum/enterprise pre 7.6",
+			name: "success: mixed platinum/enterprise pre 7.8.1",
 			args: args{
 				licenses: []EnterpriseLicense{
 					{
@@ -276,9 +276,9 @@ func Test_bestMatchAt(t *testing.T) {
 			wantFound: true,
 		},
 		{
-			name: "success: mixed platinum/enterprise post 7.6",
+			name: "success: mixed platinum/enterprise post 7.8.1",
 			args: args{
-				minVersion: version.MustParse("7.6.0"),
+				minVersion: version.MustParse("7.8.1"),
 				licenses: []EnterpriseLicense{
 					{
 						License: LicenseSpec{
@@ -416,7 +416,7 @@ func Test_filterValidForType(t *testing.T) {
 			},
 		},
 		{
-			name: "matching is version specific: pre-7.6",
+			name: "matching is version specific: pre-7.8.1",
 			args: args{
 				minVersion: version.MustParse("7.5.0"),
 				licenses: []EnterpriseLicense{
@@ -440,9 +440,9 @@ func Test_filterValidForType(t *testing.T) {
 			want: []licenseWithTimeLeft{},
 		},
 		{
-			name: "matching is version specific: post-7.6",
+			name: "matching is version specific: post-7.8.1",
 			args: args{
-				minVersion: version.MustParse("7.7.0"),
+				minVersion: version.MustParse("7.8.1"),
 				licenses: []EnterpriseLicense{
 					{
 						License: LicenseSpec{

--- a/pkg/controller/elasticsearch/client/model.go
+++ b/pkg/controller/elasticsearch/client/model.go
@@ -319,7 +319,7 @@ func (l License) IsValid(instant time.Time) bool {
 
 // IsSupported returns true if the current license type is supported by the given version of Elasticsearch.
 func (l License) IsSupported(v *version.Version) bool {
-	if l.Type == string(ElasticsearchLicenseTypeEnterprise) && !v.IsSameOrAfter(version.MustParse("7.6.0")) {
+	if l.Type == string(ElasticsearchLicenseTypeEnterprise) && !v.IsSameOrAfter(version.MustParse("7.8.1")) {
 		return false
 	}
 	return true

--- a/pkg/controller/elasticsearch/client/model.go
+++ b/pkg/controller/elasticsearch/client/model.go
@@ -319,16 +319,7 @@ func (l License) IsValid(instant time.Time) bool {
 
 // IsSupported returns true if the current license type is supported by the given version of Elasticsearch.
 func (l License) IsSupported(v *version.Version) bool {
-	v7_8_1 := version.MustParse("7.8.1")
-	// 7.8.1 is the first version to fully support Enterprise licenses
-	if l.Type == string(ElasticsearchLicenseTypeEnterprise) && !v.IsSameOrAfter(v7_8_1) {
-		return false
-	}
-	// 7.8.1 does not allow upload of anything but Trial or Enteprise licenses
-	if stringsutil.StringInSlice(l.Type, []string{
-		string(ElasticsearchLicenseTypeGold),
-		string(ElasticsearchLicenseTypePlatinum),
-	}) && v.IsSameOrAfter(v7_8_1) {
+	if l.Type == string(ElasticsearchLicenseTypeEnterprise) && !v.IsSameOrAfter(version.MustParse("7.8.1")) {
 		return false
 	}
 	return true

--- a/pkg/controller/elasticsearch/client/model.go
+++ b/pkg/controller/elasticsearch/client/model.go
@@ -319,7 +319,16 @@ func (l License) IsValid(instant time.Time) bool {
 
 // IsSupported returns true if the current license type is supported by the given version of Elasticsearch.
 func (l License) IsSupported(v *version.Version) bool {
-	if l.Type == string(ElasticsearchLicenseTypeEnterprise) && !v.IsSameOrAfter(version.MustParse("7.8.1")) {
+	v7_8_1 := version.MustParse("7.8.1")
+	// 7.8.1 is the first version to fully support Enterprise licenses
+	if l.Type == string(ElasticsearchLicenseTypeEnterprise) && !v.IsSameOrAfter(v7_8_1) {
+		return false
+	}
+	// 7.8.1 does not allow upload of anything but Trial or Enteprise licenses
+	if stringsutil.StringInSlice(l.Type, []string{
+		string(ElasticsearchLicenseTypeGold),
+		string(ElasticsearchLicenseTypePlatinum),
+	}) && v.IsSameOrAfter(v7_8_1) {
 		return false
 	}
 	return true

--- a/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/pkg/controller/elasticsearch/settings/merged_config.go
@@ -111,7 +111,7 @@ func xpackConfig(ver version.Version, httpCfg commonv1.HTTPConfig) *CanonicalCon
 		cfg[esv1.XPackSecurityAuthcRealmsNativeNative1Order] = -99
 	}
 
-	if ver.IsSameOrAfter(version.MustParse("7.6.0")) {
+	if ver.IsSameOrAfter(version.MustParse("7.8.1")) {
 		cfg[esv1.XPackLicenseUploadTypes] = []string{
 			string(client.ElasticsearchLicenseTypeTrial), string(client.ElasticsearchLicenseTypeEnterprise),
 		}

--- a/pkg/controller/elasticsearch/settings/merged_config_test.go
+++ b/pkg/controller/elasticsearch/settings/merged_config_test.go
@@ -126,7 +126,7 @@ func TestNewMergedESConfig(t *testing.T) {
 			},
 		},
 		{
-			name:    "prior to 7.6.0, we should not set allowed license upload types",
+			name:    "prior to 7.8.1, we should not set allowed license upload types",
 			version: "7.5.0",
 			cfgData: map[string]interface{}{},
 			assert: func(cfg CanonicalConfig) {
@@ -134,8 +134,8 @@ func TestNewMergedESConfig(t *testing.T) {
 			},
 		},
 		{
-			name:    "starting 7.6.0, we should set allowed license upload types",
-			version: "7.6.0",
+			name:    "starting 7.8.1, we should set allowed license upload types",
+			version: "7.8.1",
 			cfgData: map[string]interface{}{},
 			assert: func(cfg CanonicalConfig) {
 				require.Equal(t, 1, len(cfg.HasKeys([]string{esv1.XPackLicenseUploadTypes})))

--- a/pkg/controller/license/license_controller_test.go
+++ b/pkg/controller/license/license_controller_test.go
@@ -131,37 +131,25 @@ func TestReconcileLicenses_reconcileInternal(t *testing.T) {
 			wantErr:          "",
 			wantNewLicense:   false,
 			wantRequeue:      false,
-			wantRequeueAfter: true,
+			wantRequeueAfter: false,
 		},
 		{
-			name:    "no match: existing gold license",
+			name:    "existing gold matching license",
 			cluster: cluster,
 			k8sResources: []runtime.Object{
 				enterpriseLicense(t, client.ElasticsearchLicenseTypeGold, 1, false),
 				cluster,
 			},
 			wantErr:          "",
-			wantNewLicense:   false,
+			wantNewLicense:   true,
 			wantRequeue:      false,
 			wantRequeueAfter: true,
 		},
 		{
-			name:    "no match: platinum license",
+			name:    "existing platinum matching license",
 			cluster: cluster,
 			k8sResources: []runtime.Object{
 				enterpriseLicense(t, client.ElasticsearchLicenseTypePlatinum, 1, false),
-				cluster,
-			},
-			wantErr:          "",
-			wantNewLicense:   false,
-			wantRequeue:      false,
-			wantRequeueAfter: true,
-		},
-		{
-			name:    "existing enterprise matching license",
-			cluster: cluster,
-			k8sResources: []runtime.Object{
-				enterpriseLicense(t, client.ElasticsearchLicenseTypeEnterprise, 1, false),
 				cluster,
 			},
 			wantErr:          "",
@@ -179,7 +167,7 @@ func TestReconcileLicenses_reconcileInternal(t *testing.T) {
 			wantErr:          "",
 			wantNewLicense:   false,
 			wantRequeue:      false,
-			wantRequeueAfter: true,
+			wantRequeueAfter: false,
 		},
 	}
 	for _, tt := range tests {
@@ -196,16 +184,13 @@ func TestReconcileLicenses_reconcileInternal(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			switch {
-			case tt.wantRequeue:
+			if tt.wantRequeue {
 				require.True(t, res.Requeue)
 				require.Zero(t, res.RequeueAfter)
-			case tt.wantRequeueAfter:
+			}
+			if tt.wantRequeueAfter {
 				require.False(t, res.Requeue)
 				require.NotZero(t, res.RequeueAfter)
-			default:
-				require.False(t, res.Requeue)
-				require.Zero(t, res.RequeueAfter)
 			}
 			// verify that a cluster license was created
 			// following the es naming convention


### PR DESCRIPTION
This is to avoid breakage in older clients that call the deprecated
'_xpack' API to query the license level which is not backwards compatible.

* Do no longer provision Enterprise licenses to clusters < 7.8.1
* Do not attempt to install platinum or gold licenses into cluster >= 7.8.1 (will lead to errors in the logs as they get rejected, but maybe that is a helpful diagnostic tool? Happy to back that last commit out again)


This is optimistically assuming that[ the fix ](https://github.com/elastic/elasticsearch/pull/58217) is landing in 7.8.1



Fixes #3272 