### PR TITLE
Fix case of nodeset name in troubleshooting doc

### DIFF
--- a/docs/operating-eck/troubleshooting/troubleshooting-methods.asciidoc
+++ b/docs/operating-eck/troubleshooting/troubleshooting-methods.asciidoc
@@ -272,7 +272,7 @@ metadata:
 spec:
   version: {version}
   nodeSets:
-  - name: default-10Gi
+  - name: default-10gi
     count: 3
     config:
       node.master: true


### PR DESCRIPTION
The nodeset name requires a name that can be used as a DNS subdomain
name as defined in RFC 1123.

Resolves #3241.