### PR TITLE
Fix Enterprise Search mounted volumes for restricted environments

### DIFF
--- a/pkg/controller/enterprisesearch/config.go
+++ b/pkg/controller/enterprisesearch/config.go
@@ -32,6 +32,7 @@ const (
 	ESCertsPath              = "/mnt/elastic-internal/es-certs"
 	ConfigMountPath          = "/usr/share/enterprise-search/config/enterprise-search.yml"
 	ConfigFilename           = "enterprise-search.yml"
+	ReadinessProbeMountPath  = "/mnt/elastic-internal/scripts/readiness-probe.sh"
 	ReadinessProbeFilename   = "readiness-probe.sh"
 	ReadinessProbeTimeoutSec = 5
 
@@ -42,6 +43,10 @@ const (
 func ConfigSecretVolume(ent entv1beta1.EnterpriseSearch) volume.SecretVolume {
 	return volume.NewSecretVolume(name.Config(ent.Name), "config", ConfigMountPath, ConfigFilename, 0644)
 }
+
+func ReadinessProbeSecretVolume(ent entv1beta1.EnterpriseSearch) volume.SecretVolume {
+	// reuse the config secret
+	return volume.NewSecretVolume(name.Config(ent.Name), "readiness-probe", ReadinessProbeMountPath, ReadinessProbeFilename, 0644)
 }
 
 // Reconcile reconciles the configuration of Enterprise Search: it generates the right configuration and

--- a/pkg/controller/enterprisesearch/config.go
+++ b/pkg/controller/enterprisesearch/config.go
@@ -273,8 +273,8 @@ func defaultConfig(ent entv1beta1.EnterpriseSearch) *settings.CanonicalConfig {
 	return settings.MustCanonicalConfig(map[string]interface{}{
 		"ent_search.external_url":        fmt.Sprintf("%s://localhost:%d", ent.Spec.HTTP.Protocol(), HTTPPort),
 		"ent_search.listen_host":         "0.0.0.0",
-		"filebeat_log_directory":         "/var/log/enterprise-search",
-		"log_directory":                  "/var/log/enterprise-search",
+		"filebeat_log_directory":         LogVolumeMountPath,
+		"log_directory":                  LogVolumeMountPath,
 		"allow_es_settings_modification": true,
 	})
 }

--- a/pkg/controller/enterprisesearch/config.go
+++ b/pkg/controller/enterprisesearch/config.go
@@ -41,12 +41,12 @@ const (
 )
 
 func ConfigSecretVolume(ent entv1beta1.EnterpriseSearch) volume.SecretVolume {
-	return volume.NewSecretVolume(name.Config(ent.Name), "config", ConfigMountPath, ConfigFilename, 0644)
+	return volume.NewSecretVolume(name.Config(ent.Name), "config", ConfigMountPath, ConfigFilename, 0444)
 }
 
 func ReadinessProbeSecretVolume(ent entv1beta1.EnterpriseSearch) volume.SecretVolume {
 	// reuse the config secret
-	return volume.NewSecretVolume(name.Config(ent.Name), "readiness-probe", ReadinessProbeMountPath, ReadinessProbeFilename, 0644)
+	return volume.NewSecretVolume(name.Config(ent.Name), "readiness-probe", ReadinessProbeMountPath, ReadinessProbeFilename, 0444)
 }
 
 // Reconcile reconciles the configuration of Enterprise Search: it generates the right configuration and

--- a/pkg/controller/enterprisesearch/config.go
+++ b/pkg/controller/enterprisesearch/config.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	ESCertsPath              = "/mnt/elastic-internal/es-certs"
-	ConfigMountPath          = "/mnt/elastic-internal/config"
+	ConfigMountPath          = "/usr/share/enterprise-search/config/enterprise-search.yml"
 	ConfigFilename           = "enterprise-search.yml"
 	ReadinessProbeFilename   = "readiness-probe.sh"
 	ReadinessProbeTimeoutSec = 5
@@ -40,7 +40,8 @@ const (
 )
 
 func ConfigSecretVolume(ent entv1beta1.EnterpriseSearch) volume.SecretVolume {
-	return volume.NewSecretVolumeWithMountPath(name.Config(ent.Name), "config", ConfigMountPath)
+	return volume.NewSecretVolume(name.Config(ent.Name), "config", ConfigMountPath, ConfigFilename, 0644)
+}
 }
 
 // Reconcile reconciles the configuration of Enterprise Search: it generates the right configuration and
@@ -267,6 +268,8 @@ func defaultConfig(ent entv1beta1.EnterpriseSearch) *settings.CanonicalConfig {
 	return settings.MustCanonicalConfig(map[string]interface{}{
 		"ent_search.external_url":        fmt.Sprintf("%s://localhost:%d", ent.Spec.HTTP.Protocol(), HTTPPort),
 		"ent_search.listen_host":         "0.0.0.0",
+		"filebeat_log_directory":         "/var/log/enterprise-search",
+		"log_directory":                  "/var/log/enterprise-search",
 		"allow_es_settings_modification": true,
 	})
 }

--- a/pkg/controller/enterprisesearch/config_test.go
+++ b/pkg/controller/enterprisesearch/config_test.go
@@ -268,7 +268,9 @@ func TestReconcileConfig(t *testing.T) {
 				"allow_es_settings_modification: true",
 				"ent_search:",
 				"external_url: https://localhost:3002",
+				"filebeat_log_directory: /var/log/enterprise-search",
 				"listen_host: 0.0.0.0",
+				"log_directory: /var/log/enterprise-search",
 				"ssl:",
 				"certificate: /mnt/elastic-internal/http-certs/tls.crt",
 				"certificate_authorities:",
@@ -306,7 +308,9 @@ func TestReconcileConfig(t *testing.T) {
 				"allow_es_settings_modification: true",
 				"ent_search:",
 				"external_url: https://localhost:3002",
+				"filebeat_log_directory: /var/log/enterprise-search",
 				"listen_host: 0.0.0.0",
+				"log_directory: /var/log/enterprise-search",
 				"ssl:",
 				"certificate: /mnt/elastic-internal/http-certs/tls.crt",
 				"certificate_authorities:",
@@ -352,7 +356,9 @@ func TestReconcileConfig(t *testing.T) {
 				"auth:",
 				"source: elasticsearch-native",
 				"external_url: https://localhost:3002",
+				"filebeat_log_directory: /var/log/enterprise-search",
 				"listen_host: 0.0.0.0",
+				"log_directory: /var/log/enterprise-search",
 				"ssl:",
 				"certificate: /mnt/elastic-internal/http-certs/tls.crt",
 				"certificate_authorities:",
@@ -384,8 +390,10 @@ func TestReconcileConfig(t *testing.T) {
 				"allow_es_settings_modification: true",
 				"ent_search:",
 				"external_url: https://my.own.dns.com", // overridden default setting
-				"foo: bar",                             // new setting
+				"filebeat_log_directory: /var/log/enterprise-search",
+				"foo: bar", // new setting
 				"listen_host: 0.0.0.0",
+				"log_directory: /var/log/enterprise-search",
 				"ssl:",
 				"certificate: /mnt/elastic-internal/http-certs/tls.crt",
 				"certificate_authorities:",
@@ -430,8 +438,10 @@ func TestReconcileConfig(t *testing.T) {
 				"allow_es_settings_modification: true",
 				"ent_search:",
 				"external_url: https://my.own.dns.from.configref.com", // overridden from configRef
+				"filebeat_log_directory: /var/log/enterprise-search",
 				"foo: bar", // new setting
 				"listen_host: 0.0.0.0",
+				"log_directory: /var/log/enterprise-search",
 				"ssl:",
 				"certificate: /mnt/elastic-internal/http-certs/tls.crt",
 				"certificate_authorities:",

--- a/pkg/controller/enterprisesearch/name/name.go
+++ b/pkg/controller/enterprisesearch/name/name.go
@@ -11,7 +11,6 @@ import (
 const (
 	httpServiceSuffix = "http"
 	configSuffix      = "config"
-	scriptsSuffix     = "scripts"
 )
 
 // EntNamer is a Namer that is configured with the defaults for resources related to an EnterpriseSearch resource.
@@ -27,8 +26,4 @@ func Deployment(entName string) string {
 
 func Config(entName string) string {
 	return EntNamer.Suffix(entName, configSuffix)
-}
-
-func Scripts(entName string) string {
-	return EntNamer.Suffix(entName, scriptsSuffix)
 }

--- a/pkg/controller/enterprisesearch/name/name.go
+++ b/pkg/controller/enterprisesearch/name/name.go
@@ -11,6 +11,7 @@ import (
 const (
 	httpServiceSuffix = "http"
 	configSuffix      = "config"
+	scriptsSuffix     = "scripts"
 )
 
 // EntNamer is a Namer that is configured with the defaults for resources related to an EnterpriseSearch resource.
@@ -26,4 +27,8 @@ func Deployment(entName string) string {
 
 func Config(entName string) string {
 	return EntNamer.Suffix(entName, configSuffix)
+}
+
+func Scripts(entName string) string {
+	return EntNamer.Suffix(entName, scriptsSuffix)
 }

--- a/pkg/controller/enterprisesearch/pod.go
+++ b/pkg/controller/enterprisesearch/pod.go
@@ -37,7 +37,6 @@ var (
 	}
 	DefaultEnv = []corev1.EnvVar{
 		{Name: "JAVA_OPTS", Value: DefaultJavaOpts},
-		{Name: "ENT_SEARCH_CONFIG_PATH", Value: filepath.Join(ConfigMountPath, ConfigFilename)},
 	}
 	ReadinessProbe = corev1.Probe{
 		FailureThreshold:    3,

--- a/test/e2e/ent/configuration_test.go
+++ b/test/e2e/ent/configuration_test.go
@@ -159,7 +159,7 @@ type PartialConfig struct {
 
 // GetConfigFromPod execs into the Pod to retrieve the Enterprise Search configuration file.
 func GetConfigFromPod(k *test.K8sClient, pod types.NamespacedName) (PartialConfig, error) {
-	stdout, stderr, err := k.Exec(pod, []string{"cat", "/mnt/elastic-internal/config/enterprise-search.yml"})
+	stdout, stderr, err := k.Exec(pod, []string{"cat", "/usr/share/enterprise-search/config/enterprise-search.yml"})
 	if err != nil {
 		return PartialConfig{}, errors.Wrap(err, fmt.Sprintf("failed to get config from Pod, stdout: %s; stderr: %s", stdout, stderr))
 	}


### PR DESCRIPTION
Running Enterprise Search on a restricted environment (Openshift) failed for a few reasons.
This PR fixes it.

## 1. Permission to write the configuration file

Enterprise Search attempts to overwrite the content of `/usr/share/enterprise-search/enterprise-search.yml` with configuration settings from environment variables, unless that file is already not the default one. Even though we mounted the configuration file in a different place. When that happens, the Enterprise Search process may not have permissions to write in that folder that is restricted to the `enterprise-search` user.

To deal with this, we can simply mount the configuration file directly in `/usr/share/enterprise-search/enterprise-search.yml`. Enterprise Search detects this file is not the default one and does not attempt to modify it.

To keep the number of secrets small, we keep the readiness probe in the same secret as the configuration file. For that reason, the PR introduces a second volume dedicated to the readiness probe script (mounted in `/mnt/elastic-internal/scripts/readiness-probe.sh`), that relies on the same Secret as the config volume.

## 2. Permission to write logs

Enterprise Search writes logs to `/var/log/enterprise-search` by default, but may not have permissions to create that directory. To fix it, we mount an emptyDir in `/var/log/enterprise-search`. Which is a good idea anyway in order to not have the container disk usage grow with logs. We already do the same for Elasticsearch.

Fixes https://github.com/elastic/cloud-on-k8s/issues/3274.