### PR TITLE
Suggest starting an ECK trial license in Enterprise Search docs

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
@@ -15,7 +15,7 @@ This section describes how to deploy, configure and access Enterprise Search wit
 [id="{p}-enterprise-search-quickstart"]
 == Quickstart
 
-NOTE: Workplace Search requires an Elastic license. Give it a try by enabling an link:k8s-licensing.html[ECK trial license].
+NOTE: Workplace Search requires an Enterprise license on ECK. Give it a try with a link:k8s-licensing.html[trial license].
 
 . Apply the following specification to deploy Enterprise Search. ECK automatically configures the secured connection to an Elasticsearch cluster named `quickstart`, created in link:k8s-quickstart.html[Elasticsearch quickstart].
 +

--- a/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
@@ -15,6 +15,8 @@ This section describes how to deploy, configure and access Enterprise Search wit
 [id="{p}-enterprise-search-quickstart"]
 == Quickstart
 
+NOTE: Workplace Search requires an Elastic license. Give it a try by enabling an link:k8s-licensing.html[ECK trial license].
+
 . Apply the following specification to deploy Enterprise Search. ECK automatically configures the secured connection to an Elasticsearch cluster named `quickstart`, created in link:k8s-quickstart.html[Elasticsearch quickstart].
 +
 [source,yaml,subs="attributes,+macros"]


### PR DESCRIPTION
In order to start Workplace Search users will need an Elastic license. A
great way to try it is to start a trial license.
While a trial can be started by clicking a button on the UI, we want to
encourage users to start a trial at ECK level, so that:
* they also benefit from ECK licensed features
* they don't hit a bug in Enterprise Search 7.7.0 (fixed in 7.8.0) where
  the start trial call returns an error 500 (once)