### PR TITLE
Add additional Kibana encryption keys

### DIFF
--- a/pkg/controller/kibana/config_settings.go
+++ b/pkg/controller/kibana/config_settings.go
@@ -189,7 +189,13 @@ func getOrCreateReusableSettings(c k8s.Client, kb kbv1.Kibana) (*settings.Canoni
 	if len(r.ReportingKey) == 0 {
 		r.ReportingKey = string(common.RandomBytes(64))
 	}
-	if len(r.SavedObjectsKey) == 0 {
+
+	kbVer, err := version.Parse(kb.Spec.Version)
+	if err != nil {
+		return nil, err
+	}
+	// xpack.encryptedSavedObjects.encryptionKey was only added in 7.6.0 and earlier versions error out
+	if len(r.SavedObjectsKey) == 0 && kbVer.IsSameOrAfter(version.MustParse("7.6.0")) {
 		r.SavedObjectsKey = string(common.RandomBytes(64))
 	}
 	return settings.MustCanonicalConfig(r), nil

--- a/pkg/controller/kibana/config_settings.go
+++ b/pkg/controller/kibana/config_settings.go
@@ -43,6 +43,8 @@ const (
 	XpackMonitoringUIContainerElasticsearchEnabled = "xpack.monitoring.ui.container.elasticsearch.enabled"
 	XpackLicenseManagementUIEnabled                = "xpack.license_management.ui.enabled" // >= 7.6
 	XpackSecurityEncryptionKey                     = "xpack.security.encryptionKey"
+	XpackReportingEncryptionKey                    = "xpack.reporting.encryptionKey"
+	XpackEncryptedSavedObjectsEncryptionKey        = "xpack.encrypted_saved_objects.encryptionKey"
 
 	ElasticsearchSslCertificateAuthorities = "elasticsearch.ssl.certificateAuthorities"
 	ElasticsearchSslVerificationMode       = "elasticsearch.ssl.verificationMode"
@@ -137,7 +139,9 @@ func VersionDefaults(kb *kbv1.Kibana, v version.Version) *settings.CanonicalConf
 
 // reusableSettings captures secrets settings in the Kibana configuration that we want to reuse.
 type reusableSettings struct {
-	EncryptionKey string `config:"xpack.security.encryptionKey"`
+	EncryptionKey   string `config:"xpack.security.encryptionKey"`
+	ReportingKey    string `config:"xpack.reporting.encryptionKey"`
+	SavedObjectsKey string `config:"xpack.encrypted_saved_objects.encryptionKey"`
 }
 
 // getExistingConfig retrieves the canonical config for a given Kibana, if one exists
@@ -182,13 +186,19 @@ func getOrCreateReusableSettings(c k8s.Client, kb kbv1.Kibana) (*settings.Canoni
 	if len(r.EncryptionKey) == 0 {
 		r.EncryptionKey = string(common.RandomBytes(64))
 	}
+	if len(r.ReportingKey) == 0 {
+		r.ReportingKey = string(common.RandomBytes(64))
+	}
+	if len(r.SavedObjectsKey) == 0 {
+		r.SavedObjectsKey = string(common.RandomBytes(64))
+	}
 	return settings.MustCanonicalConfig(r), nil
 }
 
 func baseSettings(kb *kbv1.Kibana) map[string]interface{} {
 	conf := map[string]interface{}{
 		ServerName: kb.Name,
-		ServerHost: "0",
+		ServerHost: "0.0.0.0",
 		XpackMonitoringUIContainerElasticsearchEnabled: true,
 	}
 

--- a/pkg/controller/kibana/config_settings.go
+++ b/pkg/controller/kibana/config_settings.go
@@ -195,7 +195,7 @@ func getOrCreateReusableSettings(c k8s.Client, kb kbv1.Kibana) (*settings.Canoni
 		return nil, err
 	}
 	// xpack.encryptedSavedObjects.encryptionKey was only added in 7.6.0 and earlier versions error out
-	if len(r.SavedObjectsKey) == 0 && kbVer.IsSameOrAfter(version.From(7,6,0)) {
+	if len(r.SavedObjectsKey) == 0 && kbVer.IsSameOrAfter(version.From(7, 6, 0)) {
 		r.SavedObjectsKey = string(common.RandomBytes(64))
 	}
 	return settings.MustCanonicalConfig(r), nil

--- a/pkg/controller/kibana/config_settings.go
+++ b/pkg/controller/kibana/config_settings.go
@@ -195,7 +195,7 @@ func getOrCreateReusableSettings(c k8s.Client, kb kbv1.Kibana) (*settings.Canoni
 		return nil, err
 	}
 	// xpack.encryptedSavedObjects.encryptionKey was only added in 7.6.0 and earlier versions error out
-	if len(r.SavedObjectsKey) == 0 && kbVer.IsSameOrAfter(version.MustParse("7.6.0")) {
+	if len(r.SavedObjectsKey) == 0 && kbVer.IsSameOrAfter(version.From(7,6,0)) {
 		r.SavedObjectsKey = string(common.RandomBytes(64))
 	}
 	return settings.MustCanonicalConfig(r), nil

--- a/pkg/controller/kibana/config_settings.go
+++ b/pkg/controller/kibana/config_settings.go
@@ -44,7 +44,7 @@ const (
 	XpackLicenseManagementUIEnabled                = "xpack.license_management.ui.enabled" // >= 7.6
 	XpackSecurityEncryptionKey                     = "xpack.security.encryptionKey"
 	XpackReportingEncryptionKey                    = "xpack.reporting.encryptionKey"
-	XpackEncryptedSavedObjectsEncryptionKey        = "xpack.encrypted_saved_objects.encryptionKey"
+	XpackEncryptedSavedObjectsEncryptionKey        = "xpack.encryptedSavedObjects.encryptionKey"
 
 	ElasticsearchSslCertificateAuthorities = "elasticsearch.ssl.certificateAuthorities"
 	ElasticsearchSslVerificationMode       = "elasticsearch.ssl.verificationMode"
@@ -141,7 +141,7 @@ func VersionDefaults(kb *kbv1.Kibana, v version.Version) *settings.CanonicalConf
 type reusableSettings struct {
 	EncryptionKey   string `config:"xpack.security.encryptionKey"`
 	ReportingKey    string `config:"xpack.reporting.encryptionKey"`
-	SavedObjectsKey string `config:"xpack.encrypted_saved_objects.encryptionKey"`
+	SavedObjectsKey string `config:"xpack.encryptedSavedObjects.encryptionKey"`
 }
 
 // getExistingConfig retrieves the canonical config for a given Kibana, if one exists

--- a/pkg/controller/kibana/config_settings_test.go
+++ b/pkg/controller/kibana/config_settings_test.go
@@ -35,7 +35,7 @@ server:
     key: /mnt/elastic-internal/http-certs/tls.key
     certificate: /mnt/elastic-internal/http-certs/tls.crt
 xpack:
-  encrypted_saved_objects:
+  encryptedSavedObjects:
     encryptionKey: thisismyobjectkey
   reporting:
     encryptionKey: thisismyreportingkey
@@ -136,7 +136,7 @@ func TestNewConfigSettings(t *testing.T) {
 			Namespace: defaultKb.Namespace,
 		},
 		Data: map[string][]byte{
-			SettingsFilename: []byte("xpack.security.encryptionKey: thisismyencryptionkey\nxpack.reporting.encryptionKey: thisismyreportingkey\nxpack.encrypted_saved_objects.encryptionKey: thisismyobjectkey"),
+			SettingsFilename: []byte("xpack.security.encryptionKey: thisismyencryptionkey\nxpack.reporting.encryptionKey: thisismyreportingkey\nxpack.encryptedSavedObjects.encryptionKey: thisismyobjectkey"),
 		},
 	}
 	type args struct {

--- a/pkg/controller/kibana/config_settings_test.go
+++ b/pkg/controller/kibana/config_settings_test.go
@@ -6,10 +6,12 @@ package kibana
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	ucfg "github.com/elastic/go-ucfg"
 	uyaml "github.com/elastic/go-ucfg/yaml"
+	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -26,13 +28,17 @@ import (
 var defaultConfig = []byte(`
 elasticsearch:
 server:
-  host: "0"
+  host: "0.0.0.0"
   name: "testkb"
   ssl:
     enabled: true
     key: /mnt/elastic-internal/http-certs/tls.key
     certificate: /mnt/elastic-internal/http-certs/tls.crt
 xpack:
+  encrypted_saved_objects:
+    encryptionKey: thisismyobjectkey
+  reporting:
+    encryptionKey: thisismyreportingkey
   security:
     encryptionKey: thisismyencryptionkey
   monitoring:
@@ -80,7 +86,9 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 			},
 			assertion: func(t *testing.T, got *settings.CanonicalConfig, err error) {
 				expectedSettings := settings.MustCanonicalConfig(map[string]interface{}{
-					"xpack.security.encryptionKey": "thisismyencryptionkey",
+					XpackSecurityEncryptionKey:              "thisismyencryptionkey",
+					XpackReportingEncryptionKey:             "thisismyreportingkey",
+					XpackEncryptedSavedObjectsEncryptionKey: "thisismyobjectkey",
 				})
 				assert.Equal(t, expectedSettings, got)
 			},
@@ -102,7 +110,9 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 				// Unpack the configuration to check that some default reusable settings have been generated
 				var r reusableSettings
 				assert.NoError(t, got.Unpack(&r))
-				assert.Equal(t, len(r.EncryptionKey), 64) // Kibana encryption key length should be 64
+				assert.Equal(t, len(r.EncryptionKey), 64) // key length should be 64
+				assert.Equal(t, len(r.ReportingKey), 64)
+				assert.Equal(t, len(r.SavedObjectsKey), 64)
 			},
 		},
 	}
@@ -126,7 +136,7 @@ func TestNewConfigSettings(t *testing.T) {
 			Namespace: defaultKb.Namespace,
 		},
 		Data: map[string][]byte{
-			SettingsFilename: []byte("xpack.security.encryptionKey: thisismyencryptionkey"),
+			SettingsFilename: []byte("xpack.security.encryptionKey: thisismyencryptionkey\nxpack.reporting.encryptionKey: thisismyreportingkey\nxpack.encrypted_saved_objects.encryptionKey: thisismyobjectkey"),
 		},
 	}
 	type args struct {
@@ -254,7 +264,7 @@ func TestNewConfigSettings(t *testing.T) {
 						Namespace: defaultKb.Namespace,
 					},
 					Data: map[string][]byte{
-						SettingsFilename: []byte("xpack.security.encryptionKey: thisismyencryptionkey\nlogging.verbose: true"),
+						SettingsFilename: append(defaultConfig, []byte(`logging.verbose: true`)...),
 					},
 				}),
 				kb: func() kbv1.Kibana {
@@ -280,7 +290,7 @@ func TestNewConfigSettings(t *testing.T) {
 						Namespace: defaultKb.Namespace,
 					},
 					Data: map[string][]byte{
-						SettingsFilename: []byte("xpack.security.encryptionKey: thisismyencryptionkey\nlogging.verbose: true"),
+						SettingsFilename: append(defaultConfig, []byte(`logging.verbose: true`)...),
 					},
 				}),
 				kb: func() kbv1.Kibana {
@@ -311,33 +321,39 @@ func TestNewConfigSettings(t *testing.T) {
 			var wantCfg map[string]interface{}
 			require.NoError(t, cfg.Unpack(&wantCfg))
 
-			require.Equal(t, wantCfg, gotCfg)
+			assert.Empty(t, deep.Equal(wantCfg, gotCfg))
 		})
 	}
 }
 
-// TestNewConfigSettingsCreateEncryptionKey checks that we generate a new key if none is specified
-func TestNewConfigSettingsCreateEncryptionKey(t *testing.T) {
+// TestNewConfigSettingsCreateEncryptionKeys checks that we generate new keys if none are specified
+func TestNewConfigSettingsCreateEncryptionKeys(t *testing.T) {
 	client := k8s.WrapClient(fake.NewFakeClient())
 	kb := mkKibana()
 	v := version.MustParse(kb.Spec.Version)
 	got, err := NewConfigSettings(context.Background(), client, kb, v)
 	require.NoError(t, err)
-	val, err := (*ucfg.Config)(got.CanonicalConfig).String(XpackSecurityEncryptionKey, -1, settings.Options...)
-	require.NoError(t, err)
-	assert.NotEmpty(t, val)
+	for _, key := range []string{XpackSecurityEncryptionKey, XpackReportingEncryptionKey, XpackEncryptedSavedObjectsEncryptionKey} {
+		val, err := (*ucfg.Config)(got.CanonicalConfig).String(key, -1, settings.Options...)
+		require.NoError(t, err)
+		assert.NotEmpty(t, val)
+	}
+
 }
 
 // TestNewConfigSettingsExistingEncryptionKey tests that we do not override the existing key if one is already specified
 func TestNewConfigSettingsExistingEncryptionKey(t *testing.T) {
 	kb := mkKibana()
+	securityKey := "securityKey"
+	reportKey := "reportKey"
+	savedObjsKey := "savedObjsKey"
 	existingSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      SecretName(kb),
 			Namespace: kb.Namespace,
 		},
 		Data: map[string][]byte{
-			SettingsFilename: []byte("xpack.security.encryptionKey: thisismyencryptionkey"),
+			SettingsFilename: []byte(fmt.Sprintf("%s: %s\n%s: %s\n%s: %s", XpackSecurityEncryptionKey, securityKey, XpackReportingEncryptionKey, reportKey, XpackEncryptedSavedObjectsEncryptionKey, savedObjsKey)),
 		},
 	}
 	client := k8s.WrapClient(fake.NewFakeClient(existingSecret))
@@ -346,9 +362,18 @@ func TestNewConfigSettingsExistingEncryptionKey(t *testing.T) {
 	require.NoError(t, err)
 	var gotCfg map[string]interface{}
 	require.NoError(t, got.Unpack(&gotCfg))
+
 	val, err := (*ucfg.Config)(got.CanonicalConfig).String(XpackSecurityEncryptionKey, -1, settings.Options...)
 	require.NoError(t, err)
-	assert.Equal(t, "thisismyencryptionkey", val)
+	assert.Equal(t, securityKey, val)
+
+	val, err = (*ucfg.Config)(got.CanonicalConfig).String(XpackReportingEncryptionKey, -1, settings.Options...)
+	require.NoError(t, err)
+	assert.Equal(t, reportKey, val)
+
+	val, err = (*ucfg.Config)(got.CanonicalConfig).String(XpackEncryptedSavedObjectsEncryptionKey, -1, settings.Options...)
+	require.NoError(t, err)
+	assert.Equal(t, savedObjsKey, val)
 }
 
 // TestNewConfigSettingsExplicitEncryptionKey tests that we do not override the existing key if one is already specified in the Spec


### PR DESCRIPTION
Fix https://github.com/elastic/cloud-on-k8s/issues/2279 by setting the additional encryption keys if they are not explicitly set already

Also changes `server.host` from `0` to `0.0.0.0` because this was being thrown in the logs:
>{"type":"log","@timestamp":"2020-06-17T19:39:10Z","tags":["error","reporting"],"pid":6,"message":"Error: Found 'server.host: \"0\"' in settings. This is incompatible with Reporting. To enable Reporting to work, 'xpack.reporting.kibanaServer.hostname: 0.0.0.0' is being automatically to the configuration. You can change to 'server.host: 0.0.0.0' or add 'xpack.reporting.kibanaServer.hostname: 0.0.0.0' in kibana.yml to prevent this message.\n    at validateServerHost (/usr/share/kibana/x-pack/legacy/plugins/reporting/server/lib/validate/validate_server_host.js:24:11)\n    at runValidations (/usr/share/kibana/x-pack/legacy/plugins/reporting/server/lib/validate/index.js:25:256)\n    at ReportingPlugin.setup (/usr/share/kibana/x-pack/legacy/plugins/reporting/server/plugin.js:40:5)"}

And there wasn't any mention in the [Kibana config docs](https://www.elastic.co/guide/en/kibana/current/settings.html), but the [ES docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html) indicate 0 should be semantically equivalent to 0.0.0.0

This resolved most of the startup warnings for Kibana, another one that stands out is:

>{"type":"log","@timestamp":"2020-06-17T19:39:07Z","tags":["warning","reporting"],"pid":6,"message":"Enabling the Chromium sandbox provides an additional layer of protection."}

Which seems like a false alarm since the [docs](https://www.elastic.co/guide/en/kibana/current/reporting-chromium-sandbox.html#_docker) recommend disabling it in docker. Reached out to the kibana team for clarity there
