### PR TITLE
Add drivers for packetbeat, journalbeat and auditbeat

### DIFF
--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -626,10 +626,9 @@ spec:
             type:
               description: Type is the type of the Beat to deploy (filebeat, metricbeat,
                 heartbeat, auditbeat, journalbeat, packetbeat, etc.). Any string can
-                be used, but well-known types will be recognized and will allow to
-                use the correct image and Elasticsearch roles. It will also allow
-                for the initial setup if the type supports it and `kibanaRef` field
-                is specified.
+                be used, but well-known types will have the image field defaulted
+                and have the appropriate Elasticsearch roles created automatically.
+                It also allows for dashboard setup when combined with a `KibanaRef`.
               maxLength: 20
               pattern: '[a-zA-Z0-9-]+'
               type: string

--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -625,8 +625,11 @@ spec:
               type: string
             type:
               description: Type is the type of the Beat to deploy (filebeat, metricbeat,
-                heartbeat, etc.). Any string can be used, but well-known types will
-                be recognized and will allow to provide sane default configurations.
+                heartbeat, auditbeat, journalbeat, packetbeat, etc.). Any string can
+                be used, but well-known types will be recognized and will allow to
+                use the correct image and Elasticsearch roles. It will also allow
+                for the initial setup if the type supports it and `kibanaRef` field
+                is specified.
               maxLength: 20
               pattern: '[a-zA-Z0-9-]+'
               type: string

--- a/config/crds/bases/beat.k8s.elastic.co_beats.yaml
+++ b/config/crds/bases/beat.k8s.elastic.co_beats.yaml
@@ -12231,10 +12231,9 @@ spec:
             type:
               description: Type is the type of the Beat to deploy (filebeat, metricbeat,
                 heartbeat, auditbeat, journalbeat, packetbeat, etc.). Any string can
-                be used, but well-known types will be recognized and will allow to
-                use the correct image and Elasticsearch roles. It will also allow
-                for the initial setup if the type supports it and `kibanaRef` field
-                is specified.
+                be used, but well-known types will have the image field defaulted
+                and have the appropriate Elasticsearch roles created automatically.
+                It also allows for dashboard setup when combined with a `KibanaRef`.
               maxLength: 20
               pattern: '[a-zA-Z0-9-]+'
               type: string

--- a/config/crds/bases/beat.k8s.elastic.co_beats.yaml
+++ b/config/crds/bases/beat.k8s.elastic.co_beats.yaml
@@ -12230,8 +12230,11 @@ spec:
               type: string
             type:
               description: Type is the type of the Beat to deploy (filebeat, metricbeat,
-                heartbeat, etc.). Any string can be used, but well-known types will
-                be recognized and will allow to provide sane default configurations.
+                heartbeat, auditbeat, journalbeat, packetbeat, etc.). Any string can
+                be used, but well-known types will be recognized and will allow to
+                use the correct image and Elasticsearch roles. It will also allow
+                for the initial setup if the type supports it and `kibanaRef` field
+                is specified.
               maxLength: 20
               pattern: '[a-zA-Z0-9-]+'
               type: string

--- a/config/dev/elastic-psp.yaml
+++ b/config/dev/elastic-psp.yaml
@@ -144,3 +144,108 @@
       - min: 1
         max: 65535
     readOnlyRootFilesystem: false
+---
+  # PSP needed for Packetbeat.
+  apiVersion: policy/v1beta1
+  kind: PodSecurityPolicy
+  metadata:
+    name: elastic.packetbeat.restricted
+    annotations:
+      seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+      apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+      seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+      apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+  spec:
+    privileged: false
+    allowPrivilegeEscalation: false
+    # Allow core volume types.
+    volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    # Assume that persistentVolumes set up by the cluster admin are safe to use.
+    - 'persistentVolumeClaim'
+    - 'hostPath'
+    allowedCapabilities:
+    - 'NET_ADMIN'
+    hostNetwork: true
+    hostIPC: false
+    hostPID: false
+    runAsUser:
+      # Allow the container to run as root.
+      rule: 'RunAsAny'
+    seLinux:
+      # This policy assumes the nodes are using AppArmor rather than SELinux.
+      rule: 'RunAsAny'
+    supplementalGroups:
+      rule: 'MustRunAs'
+      ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+    fsGroup:
+      rule: 'MustRunAs'
+      ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+    readOnlyRootFilesystem: false
+---
+  # PSP needed for Journalbeat.
+  apiVersion: policy/v1beta1
+  kind: PodSecurityPolicy
+  metadata:
+    name: elastic.journalbeat.restricted
+    annotations:
+      seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+      apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+      seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+      apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+  spec:
+    privileged: false
+    allowPrivilegeEscalation: false
+    # Allow core volume types.
+    volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    # Assume that persistentVolumes set up by the cluster admin are safe to use.
+    - 'persistentVolumeClaim'
+    - 'hostPath'
+    allowedCapabilities:
+    - KILL
+    - CHOWN
+    - FSETID
+    - FOWNER
+    - SETGID
+    - SETUID
+    - SETFCAP
+    - SETPCAP
+    - AUDIT_WRITE
+    - NET_BIND_SERVICE
+    hostNetwork: false
+    hostIPC: false
+    hostPID: false
+    runAsUser:
+      # Allow the container to run as root.
+      rule: 'RunAsAny'
+    seLinux:
+      # This policy assumes the nodes are using AppArmor rather than SELinux.
+      rule: 'RunAsAny'
+    supplementalGroups:
+      rule: 'MustRunAs'
+      ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+    fsGroup:
+      rule: 'MustRunAs'
+      ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+    readOnlyRootFilesystem: false

--- a/config/dev/elastic-psp.yaml
+++ b/config/dev/elastic-psp.yaml
@@ -47,7 +47,7 @@
           max: 65535
     readOnlyRootFilesystem: false
 ---
-  # PSP needed for DaemonSet running Filebeat. Allows for hostNetwork, running as root and using hostPath volume type.
+  # Base PSP needed for running Beats. Allows for hostNetwork, running as root and using hostPath volume type.
   apiVersion: policy/v1beta1
   kind: PodSecurityPolicy
   metadata:
@@ -92,4 +92,55 @@
         # Forbid adding the root group.
         - min: 1
           max: 65535
+    readOnlyRootFilesystem: false
+---
+  # PSP needed for Auditbeat.
+  apiVersion: policy/v1beta1
+  kind: PodSecurityPolicy
+  metadata:
+    name: elastic.auditbeat.restricted
+    annotations:
+      seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+      apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+      seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+      apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+  spec:
+    privileged: false
+    allowPrivilegeEscalation: false
+    # Allow core volume types.
+    volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    # Assume that persistentVolumes set up by the cluster admin are safe to use.
+    - 'persistentVolumeClaim'
+    # Allow access to the host for log files.
+    - 'hostPath'
+    allowedCapabilities:
+    - 'AUDIT_READ'
+    - 'AUDIT_WRITE'
+    - 'AUDIT_CONTROL'
+    hostNetwork: true
+    hostIPC: false
+    hostPID: true
+    runAsUser:
+      # Allow the container to run as root.
+      rule: 'RunAsAny'
+    seLinux:
+      # This policy assumes the nodes are using AppArmor rather than SELinux.
+      rule: 'RunAsAny'
+    supplementalGroups:
+      rule: 'MustRunAs'
+      ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+    fsGroup:
+      rule: 'MustRunAs'
+      ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
     readOnlyRootFilesystem: false

--- a/config/e2e/beat-roles.yaml
+++ b/config/e2e/beat-roles.yaml
@@ -75,3 +75,18 @@ rules:
   - elastic.beat.restricted
   verbs:
   - use
+---
+# ClusterRole allowing use of Auditbeat-specific PSP
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: elastic-auditbeat-restricted
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - elastic.auditbeat.restricted
+  verbs:
+  - use

--- a/config/e2e/beat-roles.yaml
+++ b/config/e2e/beat-roles.yaml
@@ -90,3 +90,33 @@ rules:
   - elastic.auditbeat.restricted
   verbs:
   - use
+---
+# ClusterRole allowing use of Packetbeat-specific PSP
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: elastic-packetbeat-restricted
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - elastic.packetbeat.restricted
+  verbs:
+  - use
+---
+# ClusterRole allowing use of Packetbeat-specific PSP
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: elastic-journalbeat-restricted
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - elastic.journalbeat.restricted
+  verbs:
+  - use

--- a/config/e2e/beat-roles.yaml
+++ b/config/e2e/beat-roles.yaml
@@ -106,7 +106,7 @@ rules:
   verbs:
   - use
 ---
-# ClusterRole allowing use of Packetbeat-specific PSP
+# ClusterRole allowing use of Journalbeat-specific PSP
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/docs/reference/api-docs.asciidoc
+++ b/docs/reference/api-docs.asciidoc
@@ -173,7 +173,7 @@ BeatSpec defines the desired state of a Beat.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`type`* __string__ | Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, etc.). Any string can be used, but well-known types will be recognized and will allow to provide sane default configurations.
+| *`type`* __string__ | Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, auditbeat, journalbeat, packetbeat, etc.). Any string can be used, but well-known types will be recognized and will allow to use the correct image and Elasticsearch roles. It will also allow for the initial setup if the type supports it and `kibanaRef` field is specified.
 | *`version`* __string__ | Version of the Beat.
 | *`elasticsearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster.
 | *`kibanaRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster. It allows automatic setup of dashboards and visualizations.

--- a/docs/reference/api-docs.asciidoc
+++ b/docs/reference/api-docs.asciidoc
@@ -173,7 +173,7 @@ BeatSpec defines the desired state of a Beat.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`type`* __string__ | Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, auditbeat, journalbeat, packetbeat, etc.). Any string can be used, but well-known types will be recognized and will allow to use the correct image and Elasticsearch roles. It will also allow for the initial setup if the type supports it and `kibanaRef` field is specified.
+| *`type`* __string__ | Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, auditbeat, journalbeat, packetbeat, etc.). Any string can be used, but well-known types will have the image field defaulted and have the appropriate Elasticsearch roles created automatically. It also allows for dashboard setup when combined with a `KibanaRef`.
 | *`version`* __string__ | Version of the Beat.
 | *`elasticsearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster.
 | *`kibanaRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster. It allows automatic setup of dashboards and visualizations.

--- a/pkg/apis/beat/v1beta1/beat_types.go
+++ b/pkg/apis/beat/v1beta1/beat_types.go
@@ -14,8 +14,8 @@ import (
 // BeatSpec defines the desired state of a Beat.
 type BeatSpec struct {
 	// Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, auditbeat, journalbeat, packetbeat, etc.).
-	// Any string can be used, but well-known types will be recognized and will allow to use the correct image and
-	// Elasticsearch roles. It will also allow for the initial setup if the type supports it and `kibanaRef` field is specified.
+	// Any string can be used, but well-known types will have the image field defaulted and have the appropriate
+	// Elasticsearch roles created automatically. It also allows for dashboard setup when combined with a `KibanaRef`.
 	// +kubebuilder:validation:MaxLength=20
 	// +kubebuilder:validation:Pattern=[a-zA-Z0-9-]+
 	Type string `json:"type"`

--- a/pkg/apis/beat/v1beta1/beat_types.go
+++ b/pkg/apis/beat/v1beta1/beat_types.go
@@ -13,8 +13,9 @@ import (
 
 // BeatSpec defines the desired state of a Beat.
 type BeatSpec struct {
-	// Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, etc.). Any string can be used,
-	// but well-known types will be recognized and will allow to provide sane default configurations.
+	// Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, auditbeat, journalbeat, packetbeat, etc.).
+	// Any string can be used, but well-known types will be recognized and will allow to use the correct image and
+	// Elasticsearch roles. It will also allow for the initial setup if the type supports it and `kibanaRef` field is specified.
 	// +kubebuilder:validation:MaxLength=20
 	// +kubebuilder:validation:Pattern=[a-zA-Z0-9-]+
 	Type string `json:"type"`

--- a/pkg/apis/beat/v1beta1/validations.go
+++ b/pkg/apis/beat/v1beta1/validations.go
@@ -58,13 +58,13 @@ func checkAtMostOneDeploymentOption(b *Beat) field.ErrorList {
 }
 
 func checkImageIfTypeUnknown(b *Beat) field.ErrorList {
-	knownTypes := []string{"filebeat", "metricbeat", "heartbeat"}
+	knownTypes := []string{"filebeat", "metricbeat", "heartbeat", "auditbeat", "journalbeat", "packetbeat"}
 	if !stringsutil.StringInSlice(b.Spec.Type, knownTypes) &&
 		b.Spec.Image == "" {
 		return field.ErrorList{
 			field.Required(
 				field.NewPath("spec").Child("image"),
-				"Image is required if Beat type is not one of [filebeat, metricbeat, heartbeat]"),
+				"Image is required if Beat type is not one of [filebeat, metricbeat, heartbeat, auditbeat, journalbeat, packetbeat]"),
 		}
 	}
 	return nil

--- a/pkg/controller/beat/auditbeat/auditbeat.go
+++ b/pkg/controller/beat/auditbeat/auditbeat.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package filebeat
+package auditbeat
 
 import (
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	Type beatcommon.Type = "filebeat"
+	Type beatcommon.Type = "auditbeat"
 )
 
 type Driver struct {
@@ -30,9 +30,5 @@ func (d *Driver) Reconcile() *reconciler.Results {
 		return reconciler.NewResult(d.DriverParams.Context).WithError(err)
 	}
 
-	return beatcommon.Reconcile(
-		d.DriverParams,
-		managedConfig,
-		container.FilebeatImage,
-	)
+	return beatcommon.Reconcile(d.DriverParams, managedConfig, container.AuditbeatImage)
 }

--- a/pkg/controller/beat/controller.go
+++ b/pkg/controller/beat/controller.go
@@ -22,11 +22,14 @@ import (
 
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/auditbeat"
 	beatcommon "github.com/elastic/cloud-on-k8s/pkg/controller/beat/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/filebeat"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/heartbeat"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/journalbeat"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/metricbeat"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/otherbeat"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/packetbeat"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
@@ -223,6 +226,12 @@ func newDriver(
 		return metricbeat.NewDriver(dp)
 	case string(heartbeat.Type):
 		return heartbeat.NewDriver(dp)
+	case string(auditbeat.Type):
+		return auditbeat.NewDriver(dp)
+	case string(journalbeat.Type):
+		return journalbeat.NewDriver(dp)
+	case string(packetbeat.Type):
+		return packetbeat.NewDriver(dp)
 	default:
 		return otherbeat.NewDriver(dp)
 	}

--- a/pkg/controller/beat/journalbeat/journalbeat.go
+++ b/pkg/controller/beat/journalbeat/journalbeat.go
@@ -5,7 +5,6 @@
 package journalbeat
 
 import (
-	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
 	beatcommon "github.com/elastic/cloud-on-k8s/pkg/controller/beat/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/container"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
@@ -25,10 +24,5 @@ func NewDriver(params beatcommon.DriverParams) beatcommon.Driver {
 }
 
 func (d *Driver) Reconcile() *reconciler.Results {
-	managedConfig, err := beatcommon.BuildKibanaConfig(d.Client, beatv1beta1.BeatKibanaAssociation{Beat: &d.Beat})
-	if err != nil {
-		return reconciler.NewResult(d.DriverParams.Context).WithError(err)
-	}
-
-	return beatcommon.Reconcile(d.DriverParams, managedConfig, container.JournalbeatImage)
+	return beatcommon.Reconcile(d.DriverParams, nil, container.JournalbeatImage)
 }

--- a/pkg/controller/beat/journalbeat/journalbeat.go
+++ b/pkg/controller/beat/journalbeat/journalbeat.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package filebeat
+package journalbeat
 
 import (
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	Type beatcommon.Type = "filebeat"
+	Type beatcommon.Type = "journalbeat"
 )
 
 type Driver struct {
@@ -30,9 +30,5 @@ func (d *Driver) Reconcile() *reconciler.Results {
 		return reconciler.NewResult(d.DriverParams.Context).WithError(err)
 	}
 
-	return beatcommon.Reconcile(
-		d.DriverParams,
-		managedConfig,
-		container.FilebeatImage,
-	)
+	return beatcommon.Reconcile(d.DriverParams, managedConfig, container.JournalbeatImage)
 }

--- a/pkg/controller/beat/metricbeat/metricbeat.go
+++ b/pkg/controller/beat/metricbeat/metricbeat.go
@@ -25,14 +25,14 @@ func NewDriver(params beatcommon.DriverParams) beatcommon.Driver {
 }
 
 func (d *Driver) Reconcile() *reconciler.Results {
-	defaultConfig, err := beatcommon.BuildKibanaConfig(d.Client, beatv1beta1.BeatKibanaAssociation{Beat: &d.Beat})
+	managedConfig, err := beatcommon.BuildKibanaConfig(d.Client, beatv1beta1.BeatKibanaAssociation{Beat: &d.Beat})
 	if err != nil {
 		return reconciler.NewResult(d.DriverParams.Context).WithError(err)
 	}
 
 	return beatcommon.Reconcile(
 		d.DriverParams,
-		defaultConfig,
+		managedConfig,
 		container.MetricbeatImage,
 	)
 }

--- a/pkg/controller/beat/packetbeat/packetbeat.go
+++ b/pkg/controller/beat/packetbeat/packetbeat.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package filebeat
+package packetbeat
 
 import (
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	Type beatcommon.Type = "filebeat"
+	Type beatcommon.Type = "packetbeat"
 )
 
 type Driver struct {
@@ -30,9 +30,5 @@ func (d *Driver) Reconcile() *reconciler.Results {
 		return reconciler.NewResult(d.DriverParams.Context).WithError(err)
 	}
 
-	return beatcommon.Reconcile(
-		d.DriverParams,
-		managedConfig,
-		container.FilebeatImage,
-	)
+	return beatcommon.Reconcile(d.DriverParams, managedConfig, container.PacketbeatImage)
 }

--- a/pkg/controller/common/container/container.go
+++ b/pkg/controller/common/container/container.go
@@ -27,6 +27,9 @@ const (
 	FilebeatImage         Image = "beats/filebeat"
 	MetricbeatImage       Image = "beats/metricbeat"
 	HeartbeatImage        Image = "beats/heartbeat"
+	AuditbeatImage        Image = "beats/auditbeat"
+	JournalbeatImage      Image = "beats/journalbeat"
+	PacketbeatImage       Image = "beats/packetbeat"
 )
 
 // ImageRepository returns the full container image name by concatenating the current container registry and the image path with the given version.

--- a/pkg/controller/elasticsearch/user/reconcile_test.go
+++ b/pkg/controller/elasticsearch/user/reconcile_test.go
@@ -75,6 +75,6 @@ func Test_aggregateRoles(t *testing.T) {
 	c := k8s.WrappedFakeClient(sampleUserProvidedRolesSecret...)
 	roles, err := aggregateRoles(c, sampleEsWithAuth, initDynamicWatches(), record.NewFakeRecorder(10))
 	require.NoError(t, err)
-	require.Len(t, roles, 19)
+	require.Len(t, roles, 31)
 	require.Contains(t, roles, ProbeUserRole, "role1", "role2")
 }

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -90,7 +90,7 @@ var (
 )
 
 func init() {
-	for _, beat := range []string{"filebeat", "metricbeat", "heartbeat"} {
+	for _, beat := range []string{"filebeat", "metricbeat", "heartbeat", "auditbeat", "journalbeat", "packetbeat"} {
 		PredefinedRoles[BeatRoleName(V77, beat)] = esclient.Role{
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml", "read_ilm", "cluster:admin/ingest/pipeline/get"},
 			Indices: []esclient.IndexRole{

--- a/test/e2e/beat/config.go
+++ b/test/e2e/beat/config.go
@@ -151,4 +151,104 @@ processors:
   - hostPath:
       path: /proc
     name: proc`
+
+	e2eAuditbeatConfig = `auditbeat.modules:
+- module: file_integrity
+  paths:
+  - /hostfs/bin
+  - /hostfs/usr/bin
+  - /hostfs/sbin
+  - /hostfs/usr/sbin
+  - /hostfs/etc
+  exclude_files:
+  - '(?i)\.sw[nop]$'
+  - '~$'
+  - '/\.git($|/)'
+  scan_at_start: true
+  scan_rate_per_sec: 50 MiB
+  max_file_size: 100 MiB
+  hash_types: [sha1]
+  recursive: true
+- module: auditd
+  audit_rules: |
+    # Executions
+    -a always,exit -F arch=b64 -S execve,execveat -k exec
+
+    # Unauthorized access attempts
+    -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
+    -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access
+
+processors:
+  - add_cloud_metadata: {}
+  - add_process_metadata:
+      match_pids: ['process.pid']
+      include_fields: ['container.id']
+  - add_kubernetes_metadata:
+      host: ${HOSTNAME}
+      default_indexers.enabled: false
+      default_matchers.enabled: false
+      indexers:
+        - container:
+      matchers:
+        - fields.lookup_fields: ['container.id']
+`
+
+	e2eAuditbeatPodTemplate = `spec:
+  hostPID: true  # Required by auditd module
+  dnsPolicy: ClusterFirstWithHostNet
+  hostNetwork: true
+  securityContext:
+    runAsUser: 0
+  volumes:
+  - name: bin
+    hostPath:
+      path: /bin
+  - name: usrbin
+    hostPath:
+      path: /usr/bin
+  - name: sbin
+    hostPath:
+      path: /sbin
+  - name: usrsbin
+    hostPath:
+      path: /usr/sbin
+  - name: etc
+    hostPath:
+      path: /etc
+  - name: run-containerd
+    hostPath:
+      path: /run/containerd
+      type: DirectoryOrCreate
+  containers:
+  - name: auditbeat
+    securityContext:
+      capabilities:
+        add:
+        # Capabilities needed for auditd module
+        - 'AUDIT_READ'
+        - 'AUDIT_WRITE'
+        - 'AUDIT_CONTROL'
+    volumeMounts:
+    - name: bin
+      mountPath: /hostfs/bin
+      readOnly: true
+    - name: sbin
+      mountPath: /hostfs/sbin
+      readOnly: true
+    - name: usrbin
+      mountPath: /hostfs/usr/bin
+      readOnly: true
+    - name: usrsbin
+      mountPath: /hostfs/usr/sbin
+      readOnly: true
+    - name: etc
+      mountPath: /hostfs/etc
+      readOnly: true
+    # Directory with root filesystems of containers executed with containerd, this can be
+    # different with other runtimes. This volume is needed to monitor the file integrity
+    # of files in containers.
+    - name: run-containerd
+      mountPath: /run/containerd
+      readOnly: true
+`
 )

--- a/test/e2e/beat/setup_test.go
+++ b/test/e2e/beat/setup_test.go
@@ -59,7 +59,7 @@ func TestBeatKibanaRef(t *testing.T) {
 		WithType(metricbeat.Type).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithKibanaRef(kbBuilder.Ref()).
-		WithRBAC()
+		WithRoles(beat.MetricbeatClusterRoleName)
 
 	mbBuilder = applyYamls(t, mbBuilder, e2eMetricbeatConfig, e2eMetricbeatPodTemplate)
 

--- a/test/e2e/samples_test.go
+++ b/test/e2e/samples_test.go
@@ -91,8 +91,7 @@ func createBuilders(t *testing.T, decoder *helper.YAMLDecoder, sampleFile, testN
 				WithElasticsearchRef(tweakServiceRef(b.Beat.Spec.ElasticsearchRef, suffix)).
 				WithLabel(run.TestNameLabel, testName).
 				WithPodLabel(run.TestNameLabel, testName).
-				WithRBAC().
-				WithPSP().
+				WithRoles(beat.AutodiscoverClusterRoleName, beat.PSPClusterRoleName).
 				WithESValidations(beat.HasEventFromBeat(beatcommon.Type(b.Beat.Spec.Type)))
 		case enterprisesearch.Builder:
 			return b.WithNamespace(namespace).

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -76,8 +76,7 @@ func TestSmoke(t *testing.T) {
 		WithLabel(run.TestNameLabel, testName).
 		WithPodLabel(run.TestNameLabel, testName).
 		WithESValidations(beat.HasEventFromBeat(filebeat.Type)).
-		WithRBAC().
-		WithPSP()
+		WithRoles(beat.AutodiscoverClusterRoleName, beat.PSPClusterRoleName)
 
 	test.Sequence(nil, test.EmptySteps, esBuilder, kbBuilder, apmBuilder, beatBuilder).
 		RunSequential(t)

--- a/test/e2e/test/beat/builder.go
+++ b/test/e2e/test/beat/builder.go
@@ -23,8 +23,10 @@ import (
 )
 
 const (
-	PSPClusterRoleName          = "elastic-beat-restricted"
-	AuditbeatPSPClusterRoleName = "elastic-auditbeat-restricted"
+	PSPClusterRoleName            = "elastic-beat-restricted"
+	AuditbeatPSPClusterRoleName   = "elastic-auditbeat-restricted"
+	PacketbeatPSPClusterRoleName  = "elastic-packetbeat-restricted"
+	JournalbeatPSPClusterRoleName = "elastic-journalbeat-restricted"
 
 	AutodiscoverClusterRoleName = "elastic-beat-autodiscover"
 	MetricbeatClusterRoleName   = "elastic-beat-metricbeat"

--- a/test/e2e/test/beat/builder.go
+++ b/test/e2e/test/beat/builder.go
@@ -16,7 +16,6 @@ import (
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	beatcommon "github.com/elastic/cloud-on-k8s/pkg/controller/beat/common"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/metricbeat"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
@@ -25,6 +24,8 @@ import (
 
 const (
 	PSPClusterRoleName          = "elastic-beat-restricted"
+	AuditbeatPSPClusterRoleName = "elastic-auditbeat-restricted"
+
 	AutodiscoverClusterRoleName = "elastic-beat-autodiscover"
 	MetricbeatClusterRoleName   = "elastic-beat-metricbeat"
 )
@@ -71,8 +72,7 @@ func newBuilder(name string, suffix string) Builder {
 		WithSuffix(suffix).
 		WithLabel(run.TestNameLabel, name).
 		WithDaemonSet().
-		WithRBAC().
-		WithPSP()
+		WithRoles(AutodiscoverClusterRoleName, PSPClusterRoleName)
 }
 
 type ValidationFunc func(client.Client) error
@@ -185,16 +185,12 @@ func (b Builder) WithPodTemplateServiceAccount(name string) Builder {
 	return b
 }
 
-func (b Builder) WithRBAC() Builder {
-	clusterRoleName := AutodiscoverClusterRoleName
-	if b.Beat.Spec.Type == string(metricbeat.Type) {
-		clusterRoleName = MetricbeatClusterRoleName
+func (b Builder) WithRoles(clusterRoleNames ...string) Builder {
+	for _, clusterRoleName := range clusterRoleNames {
+		b = bind(b, clusterRoleName)
 	}
-	return bind(b, clusterRoleName)
-}
 
-func (b Builder) WithPSP() Builder {
-	return bind(b, PSPClusterRoleName)
+	return b
 }
 
 func bind(b Builder, clusterRoleName string) Builder {


### PR DESCRIPTION
This PR adds packetbeat, journalbeat and auditbeat as well-known Beat types. This allows to setup dashboards when `kibanaRef` is provided (when Beat supports it), precreate roles for those Beat types and choose the right image.

All three Beats have E2E tests added with exemplary configs together with required PSPs.