### PR TITLE
Always change Beat health to red if none of pods are ready

### DIFF
--- a/pkg/controller/beat/common/health.go
+++ b/pkg/controller/beat/common/health.go
@@ -18,6 +18,8 @@ func CalculateHealth(associations []v1.Association, ready, desired int32) beatv1
 	}
 
 	switch {
+	case ready == 0:
+		return beatv1beta1.BeatRedHealth
 	case ready == desired:
 		return beatv1beta1.BeatGreenHealth
 	case ready > 0:

--- a/pkg/controller/beat/common/health_test.go
+++ b/pkg/controller/beat/common/health_test.go
@@ -63,7 +63,7 @@ func Test_CalculateHealth(t *testing.T) {
 			associations: noAssociation,
 			ready:        0,
 			desired:      0,
-			want:         beatv1beta1.BeatGreenHealth,
+			want:         beatv1beta1.BeatRedHealth,
 		},
 		{
 			name:         "no association, all ready",
@@ -96,7 +96,7 @@ func Test_CalculateHealth(t *testing.T) {
 		{
 			name:         "association established, 0 desired",
 			associations: createAssociation(params{esAssoc: true, esAssocEstablished: true}),
-			want:         beatv1beta1.BeatGreenHealth,
+			want:         beatv1beta1.BeatRedHealth,
 		},
 		{
 			name:         "association established, all ready",


### PR DESCRIPTION
Right now Beat health is green if `ready` count is equal to `desired` count. This works well if Beat is scaled down to 0 and indicates that manifest was applied successfully. Unfortunately, `desired` is taken from deployment/daemonSet status which can be 0 when there is an issue with creating Pods. This happens, for example, when appropriate PSP can't be found. 

This PR always sets health to red if no Pods are ready as this seems to better reflect what user would be expecting.