### PR TITLE
Bump Elastic Stack version to 7.8.0

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -17,6 +17,6 @@ docker pull kindest/node:v1.16.9
 docker pull kindest/node:v1.17.5
 
 # Elastic Stack images
-docker pull docker.elastic.co/elasticsearch/elasticsearch:7.7.1
-docker pull docker.elastic.co/kibana/kibana:7.7.1
-docker pull docker.elastic.co/apm/apm-server:7.7.1
+docker pull docker.elastic.co/elasticsearch/elasticsearch:7.8.0
+docker pull docker.elastic.co/kibana/kibana:7.8.0
+docker pull docker.elastic.co/apm/apm-server:7.8.0

--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -58,14 +58,14 @@ pipeline {
                 )}"""
             }
             parallel {
-                stage("7.8.0-SNAPSHOT") {
+                stage("7.9.0-SNAPSHOT") {
                      agent {
                         label 'linux'
                     }
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-78-snapshot-${BUILD_NUMBER}-e2e", "7.8.0-SNAPSHOT")
+                            runWith(lib, failedTests, "eck-79-snapshot-${BUILD_NUMBER}-e2e", "7.9.0-SNAPSHOT")
                         }
                     }
                 }
@@ -99,7 +99,7 @@ pipeline {
         cleanup {
             script {
                 clusters = [
-                    "eck-78-snapshot-${BUILD_NUMBER}-e2e"
+                    "eck-79-snapshot-${BUILD_NUMBER}-e2e"
                 ]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',

--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-79-snapshot-${BUILD_NUMBER}-e2e", "7.9.0-SNAPSHOT")
+                            runWith(lib, failedTests, "eck-7x-snapshot-${BUILD_NUMBER}-e2e", "7.9.0-SNAPSHOT")
                         }
                     }
                 }
@@ -99,7 +99,7 @@ pipeline {
         cleanup {
             script {
                 clusters = [
-                    "eck-79-snapshot-${BUILD_NUMBER}-e2e"
+                    "eck-7x-snapshot-${BUILD_NUMBER}-e2e"
                 ]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -123,6 +123,17 @@ pipeline {
                         }
                     }
                 }
+                stage("7.8.0") {
+                    agent {
+                        label 'linux'
+                    }
+                    steps {
+                        unstash "source"
+                        script {
+                            runWith(lib, failedTests, "eck-78-${BUILD_NUMBER}-e2e", "7.8.0")
+                        }
+                    }
+                }
             }
         }
     }
@@ -160,7 +171,8 @@ pipeline {
                     "eck-74-${BUILD_NUMBER}-e2e",
                     "eck-75-${BUILD_NUMBER}-e2e",
                     "eck-76-${BUILD_NUMBER}-e2e",
-                    "eck-77-${BUILD_NUMBER}-e2e"
+                    "eck-77-${BUILD_NUMBER}-e2e",
+                    "eck-78-${BUILD_NUMBER}-e2e"
                 ]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',

--- a/Makefile
+++ b/Makefile
@@ -352,7 +352,7 @@ switch-registry-dev: # just use the default values of variables
 E2E_REGISTRY_NAMESPACE ?= eck-dev
 E2E_IMG                ?= $(REGISTRY)/$(E2E_REGISTRY_NAMESPACE)/eck-e2e-tests:$(TAG)
 TESTS_MATCH            ?= "^Test" # can be overriden to eg. TESTS_MATCH=TestMutationMoreNodes to match a single test
-STACK_VERSION          ?= 7.7.1
+STACK_VERSION          ?= 7.8.0
 E2E_JSON               ?= false
 TEST_TIMEOUT           ?= 5m
 E2E_SKIP_CLEANUP       ?= false

--- a/config/e2e/filebeat.yaml
+++ b/config/e2e/filebeat.yaml
@@ -88,7 +88,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: filebeat
-          image: docker.elastic.co/beats/filebeat:7.7.1
+          image: docker.elastic.co/beats/filebeat:7.8.0
           args: [
             "-c", "/etc/filebeat.yml",
             "-e",

--- a/config/e2e/metricbeat.yaml
+++ b/config/e2e/metricbeat.yaml
@@ -131,7 +131,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: metricbeat
-          image: docker.elastic.co/beats/metricbeat:7.7.0
+          image: docker.elastic.co/beats/metricbeat:7.8.0
           args: [
             "-c", "/etc/metricbeat.yml",
             "-e",

--- a/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
+++ b/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
@@ -4,7 +4,7 @@ metadata:
   name: apm-server-quickstart
   namespace: default
 spec:
-  version: 7.7.1
+  version: 7.8.0
   count: 1
   config:
     name: elastic-apm

--- a/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
+++ b/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
@@ -84,7 +84,7 @@ metadata:
   name: elasticsearch-sample
   namespace: elasticsearch-ns
 spec:
-  version: 7.7.1
+  version: 7.8.0
   nodeSets:
     - name: default
       count: 1
@@ -97,7 +97,7 @@ metadata:
   name: kibana-sample
   namespace: kibana-ns
 spec:
-  version: 7.7.1
+  version: 7.8.0
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"
@@ -111,7 +111,7 @@ metadata:
   name: apm-apm-sample
   namespace: apmserver-ns
 spec:
-  version: 7.7.1
+  version: 7.8.0
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/config/recipes/beats/1_monitor.yaml
+++ b/config/recipes/beats/1_monitor.yaml
@@ -6,7 +6,7 @@ metadata:
   name: monitor
   namespace: beats
 spec:
-  version: 7.7.1
+  version: 7.8.0
   nodeSets:
   - name: mdi
     count: 3
@@ -28,7 +28,7 @@ metadata:
   name: monitor
   namespace: beats
 spec:
-  version: 7.7.1
+  version: 7.8.0
   count: 1
   elasticsearchRef:
     name: "monitor"

--- a/config/recipes/beats/2_filebeat-kubernetes.yaml
+++ b/config/recipes/beats/2_filebeat-kubernetes.yaml
@@ -51,7 +51,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: filebeat
-        image: docker.elastic.co/beats/filebeat:7.7.1
+        image: docker.elastic.co/beats/filebeat:7.8.0
         args: [
           "-c", "/etc/filebeat.yml",
           "-e",

--- a/config/recipes/beats/3_metricbeat-kubernetes.yaml
+++ b/config/recipes/beats/3_metricbeat-kubernetes.yaml
@@ -112,7 +112,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:7.7.1
+        image: docker.elastic.co/beats/metricbeat:7.8.0
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",
@@ -265,7 +265,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:7.7.1
+        image: docker.elastic.co/beats/metricbeat:7.8.0
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",

--- a/config/recipes/gclb/01-elastic-stack.yaml
+++ b/config/recipes/gclb/01-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 7.7.1
+  version: 7.8.0
   http:
     service:
       metadata:
@@ -45,7 +45,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 7.7.1
+  version: 7.8.0
   count: 1
   http:
     service:

--- a/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
+++ b/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 7.7.1
+  version: 7.8.0
   http:
     tls:
       selfSignedCertificate:
@@ -97,7 +97,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 7.7.1
+  version: 7.8.0
   count: 1
   http:
     tls:

--- a/config/recipes/traefik/02-elastic-stack.yaml
+++ b/config/recipes/traefik/02-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 7.7.1
+  version: 7.8.0
   nodeSets:
   - name: master
     count: 1
@@ -56,7 +56,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 7.7.1
+  version: 7.8.0
   count: 1
   elasticsearchRef:
     name: hulk
@@ -68,7 +68,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 7.7.1
+  version: 7.8.0
   count: 1
   elasticsearchRef:
     name: hulk

--- a/config/samples/apm/apm_es_kibana.yaml
+++ b/config/samples/apm/apm_es_kibana.yaml
@@ -5,7 +5,7 @@ kind: Elasticsearch
 metadata:
   name: es-apm-sample
 spec:
-  version: 7.7.1
+  version: 7.8.0
   nodeSets:
   - name: default
     count: 3
@@ -19,7 +19,7 @@ kind: Kibana
 metadata:
   name: kb-apm-sample
 spec:
-  version: 7.7.1
+  version: 7.8.0
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"
@@ -29,7 +29,7 @@ kind: ApmServer
 metadata:
   name: apm-apm-sample
 spec:
-  version: 7.7.1
+  version: 7.8.0
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"

--- a/config/samples/apm/apmserver.yaml
+++ b/config/samples/apm/apmserver.yaml
@@ -3,7 +3,7 @@ kind: ApmServer
 metadata:
   name: apmserver-sample
 spec:
-  version: 7.7.1
+  version: 7.8.0
   count: 1
   config:
     output.console:

--- a/config/samples/beat/filebeat_es_kibana_apm.yaml
+++ b/config/samples/beat/filebeat_es_kibana_apm.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 7.7.1
+  version: 7.8.0
   nodeSets:
   - name: default
     count: 3
@@ -18,7 +18,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: 7.7.1
+  version: 7.8.0
   count: 1
   elasticsearchRef:
     name: elasticsearch-sample
@@ -39,7 +39,7 @@ kind: ApmServer
 metadata:
   name: apm-sample
 spec:
-  version: 7.7.1
+  version: 7.8.0
   count: 1
   elasticsearchRef:
     name: elasticsearch-sample
@@ -50,7 +50,7 @@ metadata:
   name: filebeat-sample
 spec:
   type: filebeat
-  version: 7.7.1
+  version: 7.8.0
   elasticsearchRef:
     name: elasticsearch-sample
   config:

--- a/config/samples/elasticsearch/elasticsearch.yaml
+++ b/config/samples/elasticsearch/elasticsearch.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 7.7.1
+  version: 7.8.0
   nodeSets:
   - name: default
     config:

--- a/config/samples/enterprisesearch/ent_es.yaml
+++ b/config/samples/enterprisesearch/ent_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 7.7.1
+  version: 7.8.0
   nodeSets:
     - name: default
       count: 1
@@ -18,7 +18,7 @@ kind: EnterpriseSearch
 metadata:
   name: ent-sample
 spec:
-  version: 7.7.1
+  version: 7.8.0
   count: 1
   elasticsearchRef:
     name: elasticsearch-sample

--- a/config/samples/kibana/kibana_es.yaml
+++ b/config/samples/kibana/kibana_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 7.7.1
+  version: 7.8.0
   nodeSets:
   - name: default
     count: 1
@@ -18,7 +18,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: 7.7.1
+  version: 7.8.0
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/test/e2e/kb/testdata/kibana_standalone.yaml
+++ b/test/e2e/kb/testdata/kibana_standalone.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: {{ .ESName }}
 spec:
-  version: 7.7.1
+  version: 7.8.0
   nodeSets:
   - count: 1
     name: mdi
@@ -18,7 +18,7 @@ kind: Kibana
 metadata:
   name: test-kibana-standalone-{{ .Suffix }}
 spec:
-  version: 7.7.1
+  version: 7.8.0
   count: 1
   config:
     elasticsearch.hosts:

--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -16,7 +16,7 @@ const (
 	// Minimum version for 6.8.x tested with the operator
 	MinVersion68x = "6.8.10"
 	// Current latest version for 7.x
-	LatestVersion7x = "7.7.1" // version to synchronize with the latest release of the Elastic Stack
+	LatestVersion7x = "7.8.0" // version to synchronize with the latest release of the Elastic Stack
 )
 
 // SkipInvalidUpgrade skips a test that would do an invalid upgrade.


### PR DESCRIPTION
Make `7.8.0` the new default Elastic Stack version.