### PR TITLE
Ignore digest updates for golang.org/x/crypto

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,7 +30,8 @@
     },
     {
       "packageNames": [
-        "k8s.io/utils"
+        "k8s.io/utils",
+        "golang.org/x/crypto"
       ],
       "updateTypes": [
         "digest"


### PR DESCRIPTION
Ignore digest updates for the `golang.org/x/crypto` dependency. Currently it will open a PR for every commit, because the repo does not include any tags.

This means we will need to manually update this dependency but our use is pretty limited at the moment (`bcrypt.CompareHashAndPassword(x,y)` and `bcrypt.GenerateFromPassword(p,c)`) and the `bcrypt` package is very stable.

We chose the same strategy for `k8s.io/utils`.