### PR TITLE
Remove auditbeat config bit that is only supported on 7.7+

### DIFF
--- a/test/e2e/beat/config.go
+++ b/test/e2e/beat/config.go
@@ -182,7 +182,6 @@ processors:
   - add_cloud_metadata: {}
   - add_process_metadata:
       match_pids: ['process.pid']
-      include_fields: ['container.id']
   - add_kubernetes_metadata:
       host: ${HOSTNAME}
       default_indexers.enabled: false


### PR DESCRIPTION
This was introduced in [7.7](https://github.com/elastic/beats/pull/15947), so removing it and relying on defaults.