### PR TITLE
Use the NodeAMI variable when creating an EKS cluster

### DIFF
--- a/hack/deployer/runner/eks.go
+++ b/hack/deployer/runner/eks.go
@@ -35,7 +35,7 @@ nodeGroups:
   - name: ng-1
     instanceType: {{.MachineType}}
     desiredCapacity: {{.NodeCount}}
-    ami: static
+    ami: {{.NodeAMI}}
     iam:
       instanceProfileARN: {{.InstanceProfileARN}}
       instanceRoleARN: {{.InstanceRoleARN}}


### PR DESCRIPTION
This commit properly uses the configurable parameter `NodeAMI` when creating an EKS cluster instead of using statically `static`.
This does not change the current behaviour as the `NodeAMI` was already set to `static`.

https://github.com/elastic/cloud-on-k8s/blob/6c3f5eb9d50999b51ee63d7f9c19b8297ce80d42/hack/deployer/runner/settings.go#L80-L81

https://github.com/elastic/cloud-on-k8s/blob/24335cac199874cea86872e5a18a7830cb3ee758/hack/deployer/config/plans.yml#L82-L92

