### PR TITLE
Fix kibana saved object encryption keys pre-7.6.0

### DIFF
--- a/pkg/controller/kibana/config_settings.go
+++ b/pkg/controller/kibana/config_settings.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"path"
 
+	ucfg "github.com/elastic/go-ucfg"
 	"github.com/pkg/errors"
 	"go.elastic.co/apm"
 	corev1 "k8s.io/api/core/v1"
@@ -44,6 +45,7 @@ const (
 	XpackLicenseManagementUIEnabled                = "xpack.license_management.ui.enabled" // >= 7.6
 	XpackSecurityEncryptionKey                     = "xpack.security.encryptionKey"
 	XpackReportingEncryptionKey                    = "xpack.reporting.encryptionKey"
+	XpackEncryptedSavedObjects                     = "xpack.encryptedSavedObjects"
 	XpackEncryptedSavedObjectsEncryptionKey        = "xpack.encryptedSavedObjects.encryptionKey"
 
 	ElasticsearchSslCertificateAuthorities = "elasticsearch.ssl.certificateAuthorities"
@@ -71,6 +73,12 @@ func NewConfigSettings(ctx context.Context, client k8s.Client, kb kbv1.Kibana, v
 	defer span.End()
 
 	reusableSettings, err := getOrCreateReusableSettings(client, kb)
+	if err != nil {
+		return CanonicalConfig{}, err
+	}
+
+	// hack to support pre-7.6.0 Kibana configs as it errors out with unsupported keys, ideally we would not unpack empty values and could skip this
+	filteredReusableSettings, err := filterConfigSettings(kb, reusableSettings)
 	if err != nil {
 		return CanonicalConfig{}, err
 	}
@@ -108,7 +116,7 @@ func NewConfigSettings(ctx context.Context, client k8s.Client, kb kbv1.Kibana, v
 
 	// merge the configuration with userSettings last so they take precedence
 	err = cfg.MergeWith(
-		reusableSettings,
+		filteredReusableSettings,
 		versionSpecificCfg,
 		kibanaTLSCfg,
 		settings.MustCanonicalConfig(elasticsearchTLSSettings(kb)),
@@ -125,6 +133,19 @@ func NewConfigSettings(ctx context.Context, client k8s.Client, kb kbv1.Kibana, v
 	}
 
 	return CanonicalConfig{cfg}, nil
+}
+
+// Some previously-unsupported keys cause Kibana to error out even if the values are empty. ucfg cannot ignore fields easily so this is necessary to
+// support older versions
+func filterConfigSettings(kb kbv1.Kibana, cfg *settings.CanonicalConfig) (*settings.CanonicalConfig, error) {
+	ver, err := version.Parse(kb.Spec.Version)
+	if err != nil {
+		return cfg, err
+	}
+	if !ver.IsSameOrAfter(version.From(7, 6, 0)) {
+		_, err = (*ucfg.Config)(cfg).Remove(XpackEncryptedSavedObjects, -1, settings.Options...)
+	}
+	return cfg, err
 }
 
 // VersionDefaults generates any version specific settings that should exist by default.

--- a/pkg/controller/kibana/config_settings_test.go
+++ b/pkg/controller/kibana/config_settings_test.go
@@ -405,8 +405,6 @@ func TestNewConfigSettingsExplicitEncryptionKey(t *testing.T) {
 	v := version.MustParse(kb.Spec.Version)
 	got, err := NewConfigSettings(context.Background(), client, kb, v)
 	require.NoError(t, err)
-	// var gotCfg map[string]interface{}
-	// require.NoError(t, got.Unpack(&gotCfg))
 	val, err := (*ucfg.Config)(got.CanonicalConfig).String(XpackSecurityEncryptionKey, -1, settings.Options...)
 	require.NoError(t, err)
 	assert.Equal(t, key, val)
@@ -420,7 +418,7 @@ func TestNewConfigSettingsPre760(t *testing.T) {
 	v := version.MustParse(kb.Spec.Version)
 	got, err := NewConfigSettings(context.Background(), client, kb, v)
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(got.CanonicalConfig.HasKeys([]string{XpackEncryptedSavedObjectsEncryptionKey})))
+	assert.Equal(t, 0, len(got.CanonicalConfig.HasKeys([]string{XpackEncryptedSavedObjects})))
 }
 
 func mkKibana() kbv1.Kibana {

--- a/pkg/controller/kibana/config_settings_test.go
+++ b/pkg/controller/kibana/config_settings_test.go
@@ -194,7 +194,6 @@ func TestNewConfigSettings(t *testing.T) {
 							},
 						},
 					}
-
 					return kb
 				},
 			},
@@ -406,11 +405,22 @@ func TestNewConfigSettingsExplicitEncryptionKey(t *testing.T) {
 	v := version.MustParse(kb.Spec.Version)
 	got, err := NewConfigSettings(context.Background(), client, kb, v)
 	require.NoError(t, err)
-	var gotCfg map[string]interface{}
-	require.NoError(t, got.Unpack(&gotCfg))
+	// var gotCfg map[string]interface{}
+	// require.NoError(t, got.Unpack(&gotCfg))
 	val, err := (*ucfg.Config)(got.CanonicalConfig).String(XpackSecurityEncryptionKey, -1, settings.Options...)
 	require.NoError(t, err)
 	assert.Equal(t, key, val)
+}
+
+// Verifies that pre-7.6.0 keys are not present in the config
+func TestNewConfigSettingsPre760(t *testing.T) {
+	kb := mkKibana()
+	kb.Spec.Version = "7.5.0"
+	client := k8s.WrapClient(fake.NewFakeClient())
+	v := version.MustParse(kb.Spec.Version)
+	got, err := NewConfigSettings(context.Background(), client, kb, v)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(got.CanonicalConfig.HasKeys([]string{XpackEncryptedSavedObjectsEncryptionKey})))
 }
 
 func mkKibana() kbv1.Kibana {


### PR DESCRIPTION
Fix https://github.com/elastic/cloud-on-k8s/issues/3312

Removing just the value does not work as Kibana still chokes on the parent:

>{"type":"log","@timestamp":"2020-06-24T16:32:13Z","tags":["fatal","root"],"pid":1,"message":"{ Error: \"xpack.encryptedSavedObjects\" setting was not applied. Check for spelling errors and ensure that expected plugins are installed.\n    at KbnServer.exports.default (/usr/share/kibana/src/server/config/complete.js:88:17) code: 'InvalidConfig', processExitCode: 64 }"}

> FATAL  Error: "xpack.encryptedSavedObjects" setting was not applied. Check for spelling errors and ensure that expected plugins are installed.

Checking with the beats folks if they would be open to us adding an `omitempty` like tag for go-ucfg so we can avoid doing this in the future. From what I could see there was not a way to do something like that when unpacking currently, thus this method.