### PR TITLE
Use eksctl AMIs auto resolver

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -89,7 +89,7 @@ plans:
   eks:
     region: eu-central-1
     nodeCount: 3
-    nodeAMI: static
+    nodeAMI: auto
     diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
 - id: eks-dev
   operation: create


### PR DESCRIPTION
The AMIs static resolver still uses an old AMI that uses an old version of
the AWS CLI that doesnet have the `aws eks get-token` required since eksctl
`0.18.0`.

Resolves #3196.