### PR TITLE
[1.2] Fix kibana saved object encryption keys pre-7.6.0 (#3315)

### DIFF
--- a/pkg/controller/kibana/config_settings.go
+++ b/pkg/controller/kibana/config_settings.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"path"
 
+	ucfg "github.com/elastic/go-ucfg"
 	"github.com/pkg/errors"
 	"go.elastic.co/apm"
 	corev1 "k8s.io/api/core/v1"
@@ -44,6 +45,7 @@ const (
 	XpackLicenseManagementUIEnabled                = "xpack.license_management.ui.enabled" // >= 7.6
 	XpackSecurityEncryptionKey                     = "xpack.security.encryptionKey"
 	XpackReportingEncryptionKey                    = "xpack.reporting.encryptionKey"
+	XpackEncryptedSavedObjects                     = "xpack.encryptedSavedObjects"
 	XpackEncryptedSavedObjectsEncryptionKey        = "xpack.encryptedSavedObjects.encryptionKey"
 
 	ElasticsearchSslCertificateAuthorities = "elasticsearch.ssl.certificateAuthorities"
@@ -71,6 +73,12 @@ func NewConfigSettings(ctx context.Context, client k8s.Client, kb kbv1.Kibana, v
 	defer span.End()
 
 	reusableSettings, err := getOrCreateReusableSettings(client, kb)
+	if err != nil {
+		return CanonicalConfig{}, err
+	}
+
+	// hack to support pre-7.6.0 Kibana configs as it errors out with unsupported keys, ideally we would not unpack empty values and could skip this
+	filteredReusableSettings, err := filterConfigSettings(kb, reusableSettings)
 	if err != nil {
 		return CanonicalConfig{}, err
 	}
@@ -108,7 +116,7 @@ func NewConfigSettings(ctx context.Context, client k8s.Client, kb kbv1.Kibana, v
 
 	// merge the configuration with userSettings last so they take precedence
 	err = cfg.MergeWith(
-		reusableSettings,
+		filteredReusableSettings,
 		versionSpecificCfg,
 		kibanaTLSCfg,
 		settings.MustCanonicalConfig(elasticsearchTLSSettings(kb)),
@@ -125,6 +133,19 @@ func NewConfigSettings(ctx context.Context, client k8s.Client, kb kbv1.Kibana, v
 	}
 
 	return CanonicalConfig{cfg}, nil
+}
+
+// Some previously-unsupported keys cause Kibana to error out even if the values are empty. ucfg cannot ignore fields easily so this is necessary to
+// support older versions
+func filterConfigSettings(kb kbv1.Kibana, cfg *settings.CanonicalConfig) (*settings.CanonicalConfig, error) {
+	ver, err := version.Parse(kb.Spec.Version)
+	if err != nil {
+		return cfg, err
+	}
+	if !ver.IsSameOrAfter(version.From(7, 6, 0)) {
+		_, err = (*ucfg.Config)(cfg).Remove(XpackEncryptedSavedObjects, -1, settings.Options...)
+	}
+	return cfg, err
 }
 
 // VersionDefaults generates any version specific settings that should exist by default.


### PR DESCRIPTION
Backports the following commits to 1.2:
 - Fix kibana saved object encryption keys pre-7.6.0 (#3315)