### PR TITLE
Remove OPERATOR_IMAGE from ECK manifest

### DIFF
--- a/hack/manifest-gen/assets/charts/eck/templates/statefulset.yaml
+++ b/hack/manifest-gen/assets/charts/eck/templates/statefulset.yaml
@@ -60,8 +60,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: OPERATOR_IMAGE
-            value: "{{ .Values.operator.image.repository }}:{{ .Values.operator.version }}"
           {{- if .Values.config.webhook.enabled }}
           - name: WEBHOOK_SECRET
             value: "{{ .Values.config.webhook.certsSecret }}"


### PR DESCRIPTION
The `OPERATOR_IMAGE` variable is not needed to run the operator.
See https://github.com/elastic/cloud-on-k8s/pull/3135