### PR TITLE
Fix Beat E2E tests issues

### DIFF
--- a/config/e2e/filebeat.yaml
+++ b/config/e2e/filebeat.yaml
@@ -248,16 +248,16 @@ metadata:
 allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: true
-allowHostPID: true
+allowHostPID: true # required for Auditbeat
 allowHostPorts: false
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
 allowedCapabilities:
-  - AUDIT_READ
+  - AUDIT_READ     # required for Auditbeat
   - AUDIT_WRITE
   - AUDIT_CONTROL
-  - NET_ADMIN
-  - KILL
+  - NET_ADMIN      # required for Packetbeat
+  - KILL           # required for Journalbeat
   - CHOWN
   - FSETID
   - FOWNER

--- a/config/e2e/filebeat.yaml
+++ b/config/e2e/filebeat.yaml
@@ -248,11 +248,25 @@ metadata:
 allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: true
-allowHostPID: false
+allowHostPID: true
 allowHostPorts: false
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
-allowedCapabilities: []
+allowedCapabilities:
+  - AUDIT_READ
+  - AUDIT_WRITE
+  - AUDIT_CONTROL
+  - NET_ADMIN'
+  - KILL
+  - CHOWN
+  - FSETID
+  - FOWNER
+  - SETGID
+  - SETUID
+  - SETFCAP
+  - SETPCAP
+  - AUDIT_WRITE
+  - NET_BIND_SERVICE
 defaultAddCapabilities: []
 fsGroup:
   type: RunAsAny

--- a/config/e2e/filebeat.yaml
+++ b/config/e2e/filebeat.yaml
@@ -256,7 +256,7 @@ allowedCapabilities:
   - AUDIT_READ
   - AUDIT_WRITE
   - AUDIT_CONTROL
-  - NET_ADMIN'
+  - NET_ADMIN
   - KILL
   - CHOWN
   - FSETID

--- a/pkg/controller/association/controller/beat_es.go
+++ b/pkg/controller/association/controller/beat_es.go
@@ -86,7 +86,7 @@ func getBeatRoles(assoc commonv1.Associated) (string, error) {
 			"ingest_admin",
 			"beats_admin",
 			"remote_monitoring_user",
-			esuser.BeatRoleName(esuser.V77, beat.Spec.Type),
+			esuser.BeatEsRoleName(esuser.V77, beat.Spec.Type),
 		}, ","), nil
 	case v.IsSameOrAfter(version.From(7, 5, 0)):
 		return strings.Join([]string{
@@ -94,7 +94,7 @@ func getBeatRoles(assoc commonv1.Associated) (string, error) {
 			"ingest_admin",
 			"beats_admin",
 			"remote_monitoring_user",
-			esuser.BeatRoleName(esuser.V75, beat.Spec.Type),
+			esuser.BeatEsRoleName(esuser.V75, beat.Spec.Type),
 		}, ","), nil
 	case v.IsSameOrAfter(version.From(7, 3, 0)):
 		return strings.Join([]string{
@@ -102,7 +102,7 @@ func getBeatRoles(assoc commonv1.Associated) (string, error) {
 			"ingest_admin",
 			"beats_admin",
 			"remote_monitoring_user",
-			esuser.BeatRoleName(esuser.V73, beat.Spec.Type),
+			esuser.BeatEsRoleName(esuser.V73, beat.Spec.Type),
 		}, ","), nil
 	default:
 		return strings.Join([]string{
@@ -110,7 +110,7 @@ func getBeatRoles(assoc commonv1.Associated) (string, error) {
 			"ingest_admin",
 			"beats_admin",
 			"monitoring_user",
-			esuser.BeatRoleName(esuser.V70, beat.Spec.Type),
+			esuser.BeatEsRoleName(esuser.V70, beat.Spec.Type),
 		}, ","), nil
 	}
 }

--- a/pkg/controller/association/controller/beat_es_test.go
+++ b/pkg/controller/association/controller/beat_es_test.go
@@ -38,52 +38,52 @@ func Test_getBeatRoles(t *testing.T) {
 		{
 			name:  "test roles for 7.0.0 official Beat",
 			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "filebeat", Version: "7.0.0"}},
-			want:  "kibana_user,ingest_admin,beats_admin,monitoring_user,eck_beat_filebeat_role_v70",
+			want:  "kibana_user,ingest_admin,beats_admin,monitoring_user,eck_beat_es_filebeat_role_v70",
 		},
 		{
 			name:  "test roles for 7.2.99 official Beat",
 			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "filebeat", Version: "7.2.99"}},
-			want:  "kibana_user,ingest_admin,beats_admin,monitoring_user,eck_beat_filebeat_role_v70",
+			want:  "kibana_user,ingest_admin,beats_admin,monitoring_user,eck_beat_es_filebeat_role_v70",
 		},
 		{
 			name:  "test roles for 7.3.0 official Beat",
 			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "filebeat", Version: "7.3.0"}},
-			want:  "kibana_user,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_filebeat_role_v73",
+			want:  "kibana_user,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_es_filebeat_role_v73",
 		},
 		{
 			name:  "test roles for 7.4.99 official Beat",
 			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "filebeat", Version: "7.4.99"}},
-			want:  "kibana_user,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_filebeat_role_v73",
+			want:  "kibana_user,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_es_filebeat_role_v73",
 		},
 		{
 			name:  "test roles for 7.5.0 official Beat",
 			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "filebeat", Version: "7.5.0"}},
-			want:  "kibana_user,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_filebeat_role_v75",
+			want:  "kibana_user,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_es_filebeat_role_v75",
 		},
 		{
 			name:  "test roles for 7.6.99 official Beat",
 			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "filebeat", Version: "7.6.99"}},
-			want:  "kibana_user,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_filebeat_role_v75",
+			want:  "kibana_user,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_es_filebeat_role_v75",
 		},
 		{
 			name:  "test roles for 7.7.0 official Beat",
 			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "metricbeat", Version: "7.7.0"}},
-			want:  "kibana_admin,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_metricbeat_role_v77",
+			want:  "kibana_admin,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_es_metricbeat_role_v77",
 		},
 		{
 			name:  "test roles for 7.99.99 official Beat",
 			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "metricbeat", Version: "7.99.99"}},
-			want:  "kibana_admin,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_metricbeat_role_v77",
+			want:  "kibana_admin,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_es_metricbeat_role_v77",
 		},
 		{
 			name:  "test roles for 7.0.0 community Beat",
 			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "somebeat", Version: "7.0.0"}},
-			want:  "kibana_user,ingest_admin,beats_admin,monitoring_user,eck_beat_somebeat_role_v70",
+			want:  "kibana_user,ingest_admin,beats_admin,monitoring_user,eck_beat_es_somebeat_role_v70",
 		},
 		{
 			name:  "test roles for 7.99.99 community Beat",
 			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "somebeat", Version: "7.99.99"}},
-			want:  "kibana_admin,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_somebeat_role_v77",
+			want:  "kibana_admin,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_es_somebeat_role_v77",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/association/controller/beat_kibana.go
+++ b/pkg/controller/association/controller/beat_kibana.go
@@ -82,7 +82,7 @@ func getBeatKibanaRoles(associated commonv1.Associated) (string, error) {
 	}
 
 	// Roles for supported Beats are based on:
-	// https://www.elastic.co/guide/en/beats/filebeat/7.6/feature-roles.html#privileges-to-setup-beats
+	// https://www.elastic.co/guide/en/beats/filebeat/current/feature-roles.html#privileges-to-setup-beats
 	// Docs are the same for all Beats. For a specific version docs change "current" to major.minor, eg:
 	// https://www.elastic.co/guide/en/beats/filebeat/7.1/feature-roles.html#privileges-to-setup-beats
 	switch {

--- a/pkg/controller/association/controller/beat_kibana_test.go
+++ b/pkg/controller/association/controller/beat_kibana_test.go
@@ -10,6 +10,7 @@ import (
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/filebeat"
 )
 
 func Test_getBeatKibanaRoles(t *testing.T) {
@@ -30,15 +31,21 @@ func Test_getBeatKibanaRoles(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "<7.5 kibana_user",
-			args:    &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Version: "6.8.0"}},
-			want:    "kibana_user",
+			name:    "<7.3 Beat",
+			args:    &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Version: "7.0.0", Type: string(filebeat.Type)}},
+			want:    "kibana_user,ingest_admin,beats_admin,eck_beat_kibana_filebeat_role_v70",
 			wantErr: false,
 		},
 		{
-			name:    ">=7.5 kibana_admin",
-			args:    &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Version: "7.5.0"}},
-			want:    "kibana_admin",
+			name:    "<7.7 Beat",
+			args:    &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Version: "7.6.0", Type: string(filebeat.Type)}},
+			want:    "kibana_user,ingest_admin,beats_admin,eck_beat_kibana_filebeat_role_v73",
+			wantErr: false,
+		},
+		{
+			name:    ">=7.8 Beat",
+			args:    &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Version: "7.8.0", Type: string(filebeat.Type)}},
+			want:    "kibana_admin,ingest_admin,beats_admin,eck_beat_kibana_filebeat_role_v77",
 			wantErr: false,
 		},
 	}

--- a/pkg/controller/elasticsearch/user/reconcile_test.go
+++ b/pkg/controller/elasticsearch/user/reconcile_test.go
@@ -75,6 +75,6 @@ func Test_aggregateRoles(t *testing.T) {
 	c := k8s.WrappedFakeClient(sampleUserProvidedRolesSecret...)
 	roles, err := aggregateRoles(c, sampleEsWithAuth, initDynamicWatches(), record.NewFakeRecorder(10))
 	require.NoError(t, err)
-	require.Len(t, roles, 31)
+	require.Len(t, roles, 49)
 	require.Contains(t, roles, ProbeUserRole, "role1", "role2")
 }

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -91,7 +91,7 @@ var (
 
 func init() {
 	for _, beat := range []string{"filebeat", "metricbeat", "heartbeat", "auditbeat", "journalbeat", "packetbeat"} {
-		PredefinedRoles[BeatRoleName(V77, beat)] = esclient.Role{
+		PredefinedRoles[BeatEsRoleName(V77, beat)] = esclient.Role{
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml", "read_ilm", "cluster:admin/ingest/pipeline/get"},
 			Indices: []esclient.IndexRole{
 				{
@@ -101,7 +101,7 @@ func init() {
 			},
 		}
 
-		PredefinedRoles[BeatRoleName(V75, beat)] = esclient.Role{
+		PredefinedRoles[BeatEsRoleName(V75, beat)] = esclient.Role{
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml", "read_ilm", "cluster:admin/ingest/pipeline/get"},
 			Indices: []esclient.IndexRole{
 				{
@@ -111,7 +111,7 @@ func init() {
 			},
 		}
 
-		PredefinedRoles[BeatRoleName(V73, beat)] = esclient.Role{
+		PredefinedRoles[BeatEsRoleName(V73, beat)] = esclient.Role{
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml", "read_ilm", "manage_pipeline"},
 			Indices: []esclient.IndexRole{
 				{
@@ -121,7 +121,7 @@ func init() {
 			},
 		}
 
-		PredefinedRoles[BeatRoleName(V70, beat)] = esclient.Role{
+		PredefinedRoles[BeatEsRoleName(V70, beat)] = esclient.Role{
 			Cluster: []string{"manage_index_templates", "monitor", "manage_ilm", "manage_ml", "manage_pipeline"},
 			Indices: []esclient.IndexRole{
 				{
@@ -130,11 +130,45 @@ func init() {
 				},
 			},
 		}
+
+		PredefinedRoles[BeatKibanaRoleName(V77, beat)] = esclient.Role{
+			Cluster: []string{"monitor", "manage_ilm", "manage_ml"},
+			Indices: []esclient.IndexRole{
+				{
+					Names:      []string{fmt.Sprintf("%s-*", beat)},
+					Privileges: []string{"manage", "read"},
+				},
+			},
+		}
+
+		PredefinedRoles[BeatKibanaRoleName(V73, beat)] = esclient.Role{
+			Cluster: []string{"monitor", "manage_ilm", "manage_ml"},
+			Indices: []esclient.IndexRole{
+				{
+					Names:      []string{fmt.Sprintf("%s-*", beat)},
+					Privileges: []string{"manage", "read"},
+				},
+			},
+		}
+
+		PredefinedRoles[BeatKibanaRoleName(V70, beat)] = esclient.Role{
+			Cluster: []string{"manage_index_templates", "monitor", "manage_ilm", "manage_ml"},
+			Indices: []esclient.IndexRole{
+				{
+					Names:      []string{fmt.Sprintf("%s-*", beat)},
+					Privileges: []string{"manage", "read"},
+				},
+			},
+		}
 	}
 }
 
-func BeatRoleName(version, beatType string) string {
-	return fmt.Sprintf("eck_beat_%s_role_%s", beatType, version)
+func BeatEsRoleName(version, beatType string) string {
+	return fmt.Sprintf("eck_beat_es_%s_role_%s", beatType, version)
+}
+
+func BeatKibanaRoleName(version, beatType string) string {
+	return fmt.Sprintf("eck_beat_kibana_%s_role_%s", beatType, version)
 }
 
 // RolesFileContent is a map {role name -> yaml role spec}.

--- a/test/e2e/beat/config.go
+++ b/test/e2e/beat/config.go
@@ -22,7 +22,7 @@ processors:
 `
 
 	e2eFilebeatPodTemplate = `spec:
-  automountServiceAccountToken: true
+  automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
   containers:
   - name: filebeat
     volumeMounts:
@@ -120,7 +120,7 @@ processors:
 `
 
 	e2eMetricbeatPodTemplate = `spec:
-  automountServiceAccountToken: true
+  automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
   containers:
   - args:
     - -e
@@ -196,7 +196,7 @@ processors:
   hostPID: true  # Required by auditd module
   dnsPolicy: ClusterFirstWithHostNet
   hostNetwork: true
-  automountServiceAccountToken: true
+  automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
   securityContext:
     runAsUser: 0
   volumes:
@@ -277,7 +277,7 @@ processors:
 spec:
   terminationGracePeriodSeconds: 30
   hostNetwork: true
-  automountServiceAccountToken: true
+  automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
   dnsPolicy: ClusterFirstWithHostNet
   containers:
   - name: packetbeat
@@ -312,7 +312,7 @@ processors:
 
 	e2eJournalbeatPodTemplate = `
 spec:
-  automountServiceAccountToken: true
+  automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
   dnsPolicy: ClusterFirstWithHostNet
   containers:
   - name: journalbeat

--- a/test/e2e/beat/config.go
+++ b/test/e2e/beat/config.go
@@ -196,6 +196,7 @@ processors:
   hostPID: true  # Required by auditd module
   dnsPolicy: ClusterFirstWithHostNet
   hostNetwork: true
+  automountServiceAccountToken: true
   securityContext:
     runAsUser: 0
   volumes:
@@ -276,6 +277,7 @@ processors:
 spec:
   terminationGracePeriodSeconds: 30
   hostNetwork: true
+  automountServiceAccountToken: true
   dnsPolicy: ClusterFirstWithHostNet
   containers:
   - name: packetbeat
@@ -310,6 +312,7 @@ processors:
 
 	e2eJournalbeatPodTemplate = `
 spec:
+  automountServiceAccountToken: true
   dnsPolicy: ClusterFirstWithHostNet
   containers:
   - name: journalbeat


### PR DESCRIPTION
This PR fixes three Beats E2E tests issues:

1. SCC for OCP has capabilities added allowing for Auditbeat/Packetbeat/Journalbeat to run. This is a bit different than our non-OCP approach where we currently have a separate PSP for each. I think this is fine.

```
[2020-06-26T01:55:35.054Z] {"reason":"FailedCreate","message":"Error creating: pods \"test-ab-cfg-bzhr-beat-auditbeat-\" is forbidden: unable to validate against any security context constraint: [provider restricted: .spec.securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used provider restricted: .spec.securityContext.hostPID: Invalid value: true: Host PID is not allowed to be used spec.volumes[0]: Invalid value: \"hostPath\": hostPath volumes are not allowed to be used spec.volumes[1]: Invalid value: \"hostPath\": hostPath volumes are not allowed to be used spec.volumes[4]: Invalid value: \"hostPath\": hostPath volumes are not allowed to be used spec.volumes[6]: Invalid value: \"hostPath\": hostPath volumes are not allowed to be used spec.volumes[7]: Invalid value: \"hostPath\": hostPath volumes are not allowed to be used spec.volumes[8]: Invalid value: \"hostPath\": hostPath volumes are not allowed to be used spec.volumes[9]: Invalid value: \"hostPath\": hostPath volumes are not allowed to be used spec.containers[0].securityContext.securityContext.runAsUser: Invalid value: 0: must be in the ranges: [1000550000, 1000559999] capabilities.add: Invalid value: \"AUDIT_CONTROL\": capability may not be added capabilities.add: Invalid value: \"AUDIT_READ\": capability may not be added capabilities.add: Invalid value: \"AUDIT_WRITE\": capability may not be added spec.containers[0].securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used spec.containers[0].securityContext.hostPID: Invalid value: true: Host PID is not allowed to be used provider beat: .spec.securityContext.hostPID: Invalid value: true: Host PID is not allowed to be used capabilities.add: Invalid value: \"AUDIT_READ\": capability may not be added capabilities.add: Invalid value: \"AUDIT_WRITE\": capability may not be added capabilities.add: Invalid value: \"AUDIT_CONTROL\": capability may not be added spec.containers[0].securityContext.hostPID: Invalid value: true: Host PID is not allowed to be used]","kind":"DaemonSet","name":"test-ab-cfg-bzhr-beat-auditbeat","namespace":"e2e-ftrer-mercury"}
```

2. Add `automountServiceAccountToken` to all Beat configs. Lower version Beats [depended](https://github.com/elastic/beats/pull/6146) on `/var/run/secrets/kubernetes.io/serviceaccount/namespace` to exists in the pod.

```
Exiting: error initializing processors: Unable to get in cluster configuration: open /var/run/secrets/kubernetes.io/serviceaccount/namespace: no such file or directory
```

3. Beats need more permissions than just `kibana_admin` or `kibana_role` to do the dashboard setup below certain Beat version.

```
{"type":"response","@timestamp":"2020-06-26T07:22:01Z","tags":["api"],"pid":6,"method":"post","statusCode":403,"req":{"url":"/api/kibana/dashboards/import?exclude=index-pattern&force=true","method":"post","headers":{"host":"test-ab-cfg-wftc-kb-http.e2e-mercury.svc:5601","user-agent":"Go-http-client/1.1","content-length":"37053","accept":"application/json","content-type":"application/json","kbn-xsrf":"1","accept-encoding":"gzip"},"remoteAddress":"10.0.88.2","userAgent":"10.0.88.2"},"res":{"statusCode":403,"responseTime":46,"contentLength":9},"message":"POST /api/kibana/dashboards/import?exclude=index-pattern&force=true 403 46ms - 9.0B"}
{"type":"log","@timestamp":"2020-06-26T07:22:01Z","tags":["debug","http","server","Kibana","cookie-session-storage"],"pid":6,"message":"Error: Unauthorized"}
```