### PR TITLE
Fix beat webhook setup

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/about"
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	apmv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1beta1"
+	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	esv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
@@ -468,6 +469,7 @@ func setupWebhook(mgr manager.Manager, certRotation certificates.RotationParams,
 	}{
 		&apmv1.ApmServer{},
 		&apmv1beta1.ApmServer{},
+		&beatv1beta1.Beat{},
 		&entv1beta1.EnterpriseSearch{},
 		&esv1.Elasticsearch{},
 		&esv1beta1.Elasticsearch{},

--- a/test/e2e/beat/webhook_test.go
+++ b/test/e2e/beat/webhook_test.go
@@ -1,0 +1,36 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package beat
+
+import (
+	"testing"
+
+	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestWebhook(t *testing.T) {
+	beat := beatv1beta1.Beat{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-webhook",
+			Namespace: test.Ctx().ManagedNamespace(0),
+		},
+		Spec: beatv1beta1.BeatSpec{
+			Type:    "filebeat",
+			Version: "7.8.0",
+		},
+	}
+
+	err := test.NewK8sClientOrFatal().Client.Create(&beat)
+
+	require.Error(t, err)
+	require.Contains(
+		t,
+		err.Error(),
+		`admission webhook "elastic-beat-validation-v1beta1.k8s.elastic.co" denied the request: Beat.beat.k8s.elastic.co "test-webhook" is invalid`,
+	)
+}

--- a/test/e2e/beat/webhook_test.go
+++ b/test/e2e/beat/webhook_test.go
@@ -10,7 +10,6 @@ import (
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/stretchr/testify/require"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -29,7 +28,6 @@ func TestWebhook(t *testing.T) {
 	err := test.NewK8sClientOrFatal().Client.Create(&beat)
 
 	require.Error(t, err)
-	require.True(t, apierrors.IsInvalid(err))
 	require.Contains(
 		t,
 		err.Error(),

--- a/test/e2e/beat/webhook_test.go
+++ b/test/e2e/beat/webhook_test.go
@@ -10,6 +10,7 @@ import (
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -28,6 +29,7 @@ func TestWebhook(t *testing.T) {
 	err := test.NewK8sClientOrFatal().Client.Create(&beat)
 
 	require.Error(t, err)
+	require.True(t, apierrors.IsInvalid(err))
 	require.Contains(
 		t,
 		err.Error(),


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/3326 and adds E2E test.

```
$ curl -k -i https://localhost:9090/validate-beat-k8s-elastic-co-v1beta1-beat
HTTP/2 200
content-type: text/plain; charset=utf-8
content-length: 128
date: Fri, 26 Jun 2020 13:53:31 GMT

{"response":{"uid":"","allowed":false,"status":{"metadata":{},"message":"contentType=, expected application/json","code":400}}}
```