### PR TITLE
[1.2] Fix beat webhook setup #3327

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/about"
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	apmv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1beta1"
+	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	esv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1beta1"
 	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
@@ -468,6 +469,7 @@ func setupWebhook(mgr manager.Manager, certRotation certificates.RotationParams,
 	}{
 		&apmv1.ApmServer{},
 		&apmv1beta1.ApmServer{},
+		&beatv1beta1.Beat{},
 		&entv1beta1.EnterpriseSearch{},
 		&esv1.Elasticsearch{},
 		&esv1beta1.Elasticsearch{},

--- a/config/e2e/operator.yaml
+++ b/config/e2e/operator.yaml
@@ -303,6 +303,25 @@ webhooks:
           - UPDATE
         resources:
           - elasticsearches
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: elastic-webhook-server
+        namespace: {{ .Operator.Namespace }}
+        # this is the path controller-runtime automatically generates
+        path: /validate-beat-k8s-elastic-co-v1beta1-beat
+    failurePolicy: {{ if .IgnoreWebhookFailures }}Ignore{{ else }}Fail{{ end }}
+    name: elastic-beat-validation-v1beta1.k8s.elastic.co
+    rules:
+    - apiGroups:
+      - beat.k8s.elastic.co
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - beats
 ---
 apiVersion: v1
 kind: Service

--- a/test/e2e/beat/webhook_test.go
+++ b/test/e2e/beat/webhook_test.go
@@ -1,0 +1,36 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package beat
+
+import (
+	"testing"
+
+	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestWebhook(t *testing.T) {
+	beat := beatv1beta1.Beat{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-webhook",
+			Namespace: test.Ctx().ManagedNamespace(0),
+		},
+		Spec: beatv1beta1.BeatSpec{
+			Type:    "filebeat",
+			Version: "7.8.0",
+		},
+	}
+
+	err := test.NewK8sClientOrFatal().Client.Create(&beat)
+
+	require.Error(t, err)
+	require.Contains(
+		t,
+		err.Error(),
+		`admission webhook "elastic-beat-validation-v1beta1.k8s.elastic.co" denied the request: Beat.beat.k8s.elastic.co "test-webhook" is invalid`,
+	)
+}


### PR DESCRIPTION
Backports [Fix beat webhook setup #3327](https://github.com/elastic/cloud-on-k8s/pull/3327) and [Add Beat webhook to E2E yaml](https://github.com/elastic/cloud-on-k8s/pull/3331).