### PR TITLE
[1.2] Disable Auditbeat E2E test on kind (#3330)

### DIFF
--- a/test/e2e/beat/config_test.go
+++ b/test/e2e/beat/config_test.go
@@ -205,6 +205,12 @@ processors:
 }
 
 func TestAuditbeatConfig(t *testing.T) {
+	if test.Ctx().Provider == "kind" {
+		// kind doesn't support configuring required settings
+		// see https://github.com/elastic/cloud-on-k8s/issues/3328 for more context
+		t.SkipNow()
+	}
+
 	name := "test-ab-cfg"
 
 	esBuilder := elasticsearch.NewBuilder(name).


### PR DESCRIPTION
Backports the following commits to 1.2:
 - Disable Auditbeat E2E test on kind (#3330)