### PR TITLE
Remove duplicated link to Transport settings

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch-specification.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch-specification.asciidoc
@@ -30,7 +30,6 @@ Before you deploy and run ECK, take some time to look at the basic and advanced 
 - <<{p}-orchestration>>
 - <<{p}-snapshots,Create automated snapshots>>
 - <<{p}-remote-clusters,Remote clusters>>
-- <<{p}-transport-settings>>
 - <<{p}-readiness>>
 - <<{p}-prestop>>
 


### PR DESCRIPTION
On the page [Run Elasticsearch on ECK](https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-elasticsearch-specification.html#k8s-elasticsearch-specification), the section [Transport settings](https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-transport-settings.html#k8s-transport-settings) is referenced twice.
This PR removes the reference from the Advanced settings block.

Relates to #2673.

