### PR TITLE
Allow init containers modifications

### DIFF
--- a/pkg/controller/common/container/defaulter.go
+++ b/pkg/controller/common/container/defaulter.go
@@ -64,6 +64,10 @@ func (d Defaulter) WithPorts(ports []corev1.ContainerPort) Defaulter {
 			d.base.Ports = append(d.base.Ports, p)
 		}
 	}
+	// order ports by name to ensure stable pod spec comparison
+	sort.SliceStable(d.base.Ports, func(i, j int) bool {
+		return d.base.Ports[i].Name < d.base.Ports[j].Name
+	})
 	return d
 }
 

--- a/pkg/controller/common/container/defaulter.go
+++ b/pkg/controller/common/container/defaulter.go
@@ -1,0 +1,175 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package container
+
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Defaulter ensures that values are set if none exists in the base container.
+type Defaulter interface {
+	WithImage(image string) Defaulter
+	WithCommand(command []string) Defaulter
+	WithArgs(args []string) Defaulter
+	WithPorts(ports []corev1.ContainerPort) Defaulter
+	WithEnv(vars []corev1.EnvVar) Defaulter
+	WithResources(resources corev1.ResourceRequirements) Defaulter
+	WithVolumeMounts(volumeMounts []corev1.VolumeMount) Defaulter
+	WithReadinessProbe(readinessProbe *corev1.Probe) Defaulter
+	WithPreStopHook(handler *corev1.Handler) Defaulter
+
+	// From inherits default values from an other container.
+	From(other corev1.Container) Defaulter
+
+	// Container return a copy of the resulting container.
+	Container() corev1.Container
+}
+
+var _ Defaulter = &defaulter{}
+
+type defaulter struct {
+	base *corev1.Container
+}
+
+func (d defaulter) Container() corev1.Container {
+	return *d.base.DeepCopy()
+}
+
+func NewDefaulter(base *corev1.Container) Defaulter {
+	return &defaulter{
+		base: base,
+	}
+}
+
+func (d defaulter) From(other corev1.Container) Defaulter {
+
+	if other.Lifecycle != nil {
+		d.WithPreStopHook(other.Lifecycle.PreStop)
+	}
+
+	return d.
+		WithImage(other.Image).
+		WithCommand(other.Command).
+		WithArgs(other.Args).
+		WithPorts(other.Ports).
+		WithEnv(other.Env).
+		WithResources(other.Resources).
+		WithVolumeMounts(other.VolumeMounts).
+		WithReadinessProbe(other.ReadinessProbe)
+}
+
+func (d defaulter) WithCommand(command []string) Defaulter {
+	if len(d.base.Command) == 0 {
+		d.base.Command = command
+	}
+	return d
+}
+
+func (d defaulter) WithArgs(args []string) Defaulter {
+	if len(d.base.Args) == 0 {
+		d.base.Args = args
+	}
+	return d
+}
+
+func (d defaulter) WithPorts(ports []corev1.ContainerPort) Defaulter {
+	for _, p := range ports {
+		if !d.portExists(p.Name) {
+			d.base.Ports = append(d.base.Ports, p)
+		}
+	}
+	return d
+}
+
+// portExists checks if a port with the given name already exists in the Container.
+func (d defaulter) portExists(name string) bool {
+	for _, p := range d.base.Ports {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// WithImage sets up the Container Docker image, unless already provided.
+// The default image will be used unless customImage is not empty.
+func (d defaulter) WithImage(image string) Defaulter {
+	if d.base.Image == "" {
+		d.base.Image = image
+	}
+	return d
+}
+
+func (d defaulter) WithReadinessProbe(readinessProbe *corev1.Probe) Defaulter {
+	if d.base.ReadinessProbe == nil {
+		d.base.ReadinessProbe = readinessProbe
+	}
+	return d
+}
+
+// envExists checks if an env var with the given name already exists in the provided slice.
+func (d defaulter) envExists(name string) bool {
+	for _, v := range d.base.Env {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (d defaulter) WithEnv(vars []corev1.EnvVar) Defaulter {
+	for _, v := range vars {
+		if !d.envExists(v.Name) {
+			d.base.Env = append(d.base.Env, v)
+		}
+	}
+	return d
+}
+
+func (d defaulter) WithResources(resources corev1.ResourceRequirements) Defaulter {
+	// Ensure resources are set
+	if d.base.Resources.Requests == nil && d.base.Resources.Limits == nil {
+		d.base.Resources = resources
+	}
+	return d
+}
+
+// volumeExists checks if a volume mount with the given name already exists in the Container.
+func (d defaulter) volumeMountExists(volumeMount corev1.VolumeMount) bool {
+	for _, v := range d.base.VolumeMounts {
+		if v.Name == volumeMount.Name || v.MountPath == volumeMount.MountPath {
+			return true
+		}
+	}
+	return false
+}
+
+func (d defaulter) WithVolumeMounts(volumeMounts []corev1.VolumeMount) Defaulter {
+	for _, v := range volumeMounts {
+		if !d.volumeMountExists(v) {
+			d.base.VolumeMounts = append(d.base.VolumeMounts, v)
+		}
+	}
+	// order volume mounts by name to ensure stable pod spec comparison
+	sort.SliceStable(d.base.VolumeMounts, func(i, j int) bool {
+		return d.base.VolumeMounts[i].Name < d.base.VolumeMounts[j].Name
+	})
+	return d
+}
+
+func (d defaulter) WithPreStopHook(handler *corev1.Handler) Defaulter {
+	if d.base.Lifecycle == nil {
+		d.base.Lifecycle = &corev1.Lifecycle{}
+	}
+
+	if d.base.Lifecycle.PreStop == nil {
+		// no user-provided hook, we can use our own
+		d.base.Lifecycle.PreStop = handler
+	}
+
+	return d
+}

--- a/pkg/controller/common/defaults/pod_template.go
+++ b/pkg/controller/common/defaults/pod_template.go
@@ -7,10 +7,10 @@ package defaults
 import (
 	"sort"
 
-	corev1 "k8s.io/api/core/v1"
-
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/container"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // PodDownwardEnvVars returns default environment variables created from the downward API.
@@ -35,9 +35,9 @@ func ExtendPodDownwardEnvVars(vars ...corev1.EnvVar) []corev1.EnvVar {
 // from a user-provided pod template. It focuses on building a pod with
 // one main Container.
 type PodTemplateBuilder struct {
-	PodTemplate   corev1.PodTemplateSpec
-	containerName string
-	Container     *corev1.Container
+	PodTemplate        corev1.PodTemplateSpec
+	containerName      string
+	containerDefaulter container.Defaulter
 }
 
 // NewPodTemplateBuilder returns an initialized PodTemplateBuilder with some defaults.
@@ -45,7 +45,6 @@ func NewPodTemplateBuilder(base corev1.PodTemplateSpec, containerName string) *P
 	builder := &PodTemplateBuilder{
 		PodTemplate:   *base.DeepCopy(),
 		containerName: containerName,
-		Container:     nil, // will be set in setDefaults
 	}
 	return builder.setDefaults()
 }
@@ -62,11 +61,13 @@ func (b *PodTemplateBuilder) setDefaults() *PodTemplateBuilder {
 		}
 		return nil
 	}
-	b.Container = getContainer()
-	if b.Container == nil {
+	userContainer := getContainer()
+	if userContainer == nil {
 		// create the default Container if not provided by the user
 		b.PodTemplate.Spec.Containers = append(b.PodTemplate.Spec.Containers, corev1.Container{Name: b.containerName})
-		b.Container = getContainer()
+		b.containerDefaulter = container.NewDefaulter(getContainer())
+	} else {
+		b.containerDefaulter = container.NewDefaulter(userContainer)
 	}
 
 	// disable service account token auto mount, unless explicitly enabled by the user
@@ -90,28 +91,20 @@ func (b *PodTemplateBuilder) WithAnnotations(annotations map[string]string) *Pod
 	return b
 }
 
-// WithDockerImage sets up the Container Docker image, unless already provided.
+// WithImage sets up the Container Docker image, unless already provided.
 // The default image will be used unless customImage is not empty.
 func (b *PodTemplateBuilder) WithDockerImage(customImage string, defaultImage string) *PodTemplateBuilder {
-	switch {
-	case b.Container.Image != "":
-		// keep user-provided Container image name
-	case customImage != "":
-		// use user-provided custom image
-		b.Container.Image = customImage
-	default:
-		// use default image
-		b.Container.Image = defaultImage
+	if customImage != "" {
+		b.containerDefaulter.WithImage(customImage)
+	} else {
+		b.containerDefaulter.WithImage(defaultImage)
 	}
 	return b
 }
 
 // WithReadinessProbe sets up the given readiness probe, unless already provided in the template.
 func (b *PodTemplateBuilder) WithReadinessProbe(readinessProbe corev1.Probe) *PodTemplateBuilder {
-	if b.Container.ReadinessProbe == nil {
-		// no user-provided probe, use our own
-		b.Container.ReadinessProbe = &readinessProbe
-	}
+	b.containerDefaulter.WithReadinessProbe(&readinessProbe)
 	return b
 }
 
@@ -124,31 +117,15 @@ func (b *PodTemplateBuilder) WithAffinity(affinity *corev1.Affinity) *PodTemplat
 	return b
 }
 
-// portExists checks if a port with the given name already exists in the Container.
-func (b *PodTemplateBuilder) portExists(name string) bool {
-	for _, p := range b.Container.Ports {
-		if p.Name == name {
-			return true
-		}
-	}
-	return false
-}
-
 // WithPorts appends the given ports to the Container ports, unless already provided in the template.
 func (b *PodTemplateBuilder) WithPorts(ports []corev1.ContainerPort) *PodTemplateBuilder {
-	for _, p := range ports {
-		if !b.portExists(p.Name) {
-			b.Container.Ports = append(b.Container.Ports, p)
-		}
-	}
+	b.containerDefaulter.WithPorts(ports)
 	return b
 }
 
 // WithCommand sets the given command to the Container, unless already provided in the template.
 func (b *PodTemplateBuilder) WithCommand(command []string) *PodTemplateBuilder {
-	if len(b.Container.Command) == 0 {
-		b.Container.Command = command
-	}
+	b.containerDefaulter.WithCommand(command)
 	return b
 }
 
@@ -176,47 +153,15 @@ func (b *PodTemplateBuilder) WithVolumes(volumes ...corev1.Volume) *PodTemplateB
 	return b
 }
 
-// volumeExists checks if a volume mount with the given name already exists in the Container.
-func (b *PodTemplateBuilder) volumeMountExists(name string) bool {
-	for _, v := range b.Container.VolumeMounts {
-		if v.Name == name {
-			return true
-		}
-	}
-	return false
-}
-
 // WithVolumeMounts appends the given volume mounts to the Container, unless already provided in the template.
 func (b *PodTemplateBuilder) WithVolumeMounts(volumeMounts ...corev1.VolumeMount) *PodTemplateBuilder {
-	for _, v := range volumeMounts {
-		if !b.volumeMountExists(v.Name) {
-			b.Container.VolumeMounts = append(b.Container.VolumeMounts, v)
-		}
-	}
-	// order volume mounts by name to ensure stable pod spec comparison
-	sort.SliceStable(b.Container.VolumeMounts, func(i, j int) bool {
-		return b.Container.VolumeMounts[i].Name < b.Container.VolumeMounts[j].Name
-	})
+	b.containerDefaulter.WithVolumeMounts(volumeMounts)
 	return b
-}
-
-// envExists checks if an env var with the given name already exists in the provided slice.
-func (b *PodTemplateBuilder) envExists(name string) bool {
-	for _, v := range b.Container.Env {
-		if v.Name == name {
-			return true
-		}
-	}
-	return false
 }
 
 // WithEnv appends the given env vars to the Container, unless already provided in the template.
 func (b *PodTemplateBuilder) WithEnv(vars ...corev1.EnvVar) *PodTemplateBuilder {
-	for _, v := range vars {
-		if !b.envExists(v.Name) {
-			b.Container.Env = append(b.Container.Env, v)
-		}
-	}
+	b.containerDefaulter.WithEnv(vars)
 	return b
 }
 
@@ -228,20 +173,6 @@ func (b *PodTemplateBuilder) WithTerminationGracePeriod(period int64) *PodTempla
 	return b
 }
 
-// findVolumeMountByNameOrMountPath attempts to find a volume mount with the given name or mount path in the mounts
-// Returns the index of the volume mount or -1 if no volume mount by that name was found.
-func (b *PodTemplateBuilder) findVolumeMountByNameOrMountPath(
-	volumeMount corev1.VolumeMount,
-	mounts []corev1.VolumeMount,
-) int {
-	for i, vm := range mounts {
-		if vm.Name == volumeMount.Name || vm.MountPath == volumeMount.MountPath {
-			return i
-		}
-	}
-	return -1
-}
-
 // WithInitContainerDefaults sets default values for the current init containers.
 //
 // Defaults:
@@ -249,26 +180,15 @@ func (b *PodTemplateBuilder) findVolumeMountByNameOrMountPath(
 // - VolumeMounts from the main container are added to the init container VolumeMounts, unless they would conflict
 //   with a specified VolumeMount (by having the same VolumeMount.Name or VolumeMount.MountPath)
 func (b *PodTemplateBuilder) WithInitContainerDefaults() *PodTemplateBuilder {
+	mainContainer := b.containerDefaulter.Container()
 	for i := range b.PodTemplate.Spec.InitContainers {
-		c := &b.PodTemplate.Spec.InitContainers[i]
-
-		// default the init container image to the main container image
-		if c.Image == "" {
-			c.Image = b.Container.Image
-		}
-
-		// store a reference to the init container volume mounts for comparison purposes
-		providedMounts := c.VolumeMounts
-
-		// append the main container volume mounts that do not conflict in name or mount path with the init container
-		for _, volumeMount := range b.Container.VolumeMounts {
-			if b.findVolumeMountByNameOrMountPath(volumeMount, providedMounts) == -1 {
-				c.VolumeMounts = append(c.VolumeMounts, volumeMount)
-			}
-		}
-
-		// append the dynamic pod name and IP env vars
-		c.Env = append(c.Env, PodDownwardEnvVars()...)
+		b.PodTemplate.Spec.InitContainers[i] =
+			container.NewDefaulter(&b.PodTemplate.Spec.InitContainers[i]).
+				// Inherit image and volume mounts from main container in the Pod
+				WithImage(mainContainer.Image).
+				WithVolumeMounts(mainContainer.VolumeMounts).
+				WithEnv(PodDownwardEnvVars()).
+				Container()
 	}
 	return b
 }
@@ -290,12 +210,14 @@ func (b *PodTemplateBuilder) findInitContainerByName(name string) int {
 // - Provided init containers are prepended to the existing ones in the template.
 // - If an init container by the same name already exists in the template, the init container in the template
 // takes its place, and the provided init container is discarded.
-func (b *PodTemplateBuilder) WithInitContainers(initContainers ...corev1.Container) *PodTemplateBuilder {
+func (b *PodTemplateBuilder) WithInitContainers(
+	initContainers ...corev1.Container,
+) *PodTemplateBuilder {
 	var containers []corev1.Container
 
 	for _, c := range initContainers {
 		if index := b.findInitContainerByName(c.Name); index != -1 {
-			container := b.PodTemplate.Spec.InitContainers[index]
+			userContainer := b.PodTemplate.Spec.InitContainers[index]
 
 			// remove it from the podTemplate:
 			b.PodTemplate.Spec.InitContainers = append(
@@ -303,7 +225,15 @@ func (b *PodTemplateBuilder) WithInitContainers(initContainers ...corev1.Contain
 				b.PodTemplate.Spec.InitContainers[index+1:]...,
 			)
 
-			containers = append(containers, container)
+			// Create a container based on what the user specified but ensure that values
+			// are set if none are provided.
+			containers = append(containers,
+				container.
+					// Set the container provided by the user as the base.
+					NewDefaulter(userContainer.DeepCopy()).
+					// Inherit all other values from the container built by the controller.
+					From(c).
+					Container())
 		} else {
 			containers = append(containers, c)
 		}
@@ -319,29 +249,17 @@ func (b *PodTemplateBuilder) WithInitContainers(initContainers ...corev1.Contain
 // If a zero-value (empty map) for at least one of limits or request is provided, the given resource requirements
 // are not applied: the user may want to use a LimitRange.
 func (b *PodTemplateBuilder) WithResources(resources corev1.ResourceRequirements) *PodTemplateBuilder {
-	if b.Container.Resources.Requests == nil && b.Container.Resources.Limits == nil {
-		b.Container.Resources = resources
-	}
+	b.containerDefaulter.WithResources(resources)
 	return b
 }
 
 func (b *PodTemplateBuilder) WithPreStopHook(handler corev1.Handler) *PodTemplateBuilder {
-	if b.Container.Lifecycle == nil {
-		b.Container.Lifecycle = &corev1.Lifecycle{}
-	}
-
-	if b.Container.Lifecycle.PreStop == nil {
-		// no user-provided hook, we can use our own
-		b.Container.Lifecycle.PreStop = &handler
-	}
-
+	b.containerDefaulter.WithPreStopHook(&handler)
 	return b
 }
 
 func (b *PodTemplateBuilder) WithArgs(args ...string) *PodTemplateBuilder {
-	if b.Container.Args == nil {
-		b.Container.Args = args
-	}
+	b.containerDefaulter.WithArgs(args)
 	return b
 }
 

--- a/pkg/controller/common/defaults/pod_template.go
+++ b/pkg/controller/common/defaults/pod_template.go
@@ -220,7 +220,7 @@ func (b *PodTemplateBuilder) WithInitContainers(
 		if index := b.findInitContainerByName(c.Name); index != -1 {
 			userContainer := b.PodTemplate.Spec.InitContainers[index]
 
-			// remove it from the podTemplate:
+			// remove it from the podTemplate
 			b.PodTemplate.Spec.InitContainers = append(
 				b.PodTemplate.Spec.InitContainers[:index],
 				b.PodTemplate.Spec.InitContainers[index+1:]...,

--- a/pkg/controller/common/defaults/pod_template.go
+++ b/pkg/controller/common/defaults/pod_template.go
@@ -91,7 +91,7 @@ func (b *PodTemplateBuilder) WithAnnotations(annotations map[string]string) *Pod
 	return b
 }
 
-// WithImage sets up the Container Docker image, unless already provided.
+// WithDockerImage sets up the Container Docker image, unless already provided.
 // The default image will be used unless customImage is not empty.
 func (b *PodTemplateBuilder) WithDockerImage(customImage string, defaultImage string) *PodTemplateBuilder {
 	if customImage != "" {
@@ -179,6 +179,7 @@ func (b *PodTemplateBuilder) WithTerminationGracePeriod(period int64) *PodTempla
 // - If the init container contains an empty image field, it's inherited from the main container.
 // - VolumeMounts from the main container are added to the init container VolumeMounts, unless they would conflict
 //   with a specified VolumeMount (by having the same VolumeMount.Name or VolumeMount.MountPath)
+// - default environment variables
 func (b *PodTemplateBuilder) WithInitContainerDefaults() *PodTemplateBuilder {
 	mainContainer := b.containerDefaulter.Container()
 	for i := range b.PodTemplate.Spec.InitContainers {
@@ -208,8 +209,8 @@ func (b *PodTemplateBuilder) findInitContainerByName(name string) int {
 //
 // Ordering:
 // - Provided init containers are prepended to the existing ones in the template.
-// - If an init container by the same name already exists in the template, the init container in the template
-// takes its place, and the provided init container is discarded.
+// - If an init container by the same name already exists in the template, the two PodTemplates are merged, the values
+// provided by the user take precedence.
 func (b *PodTemplateBuilder) WithInitContainers(
 	initContainers ...corev1.Container,
 ) *PodTemplateBuilder {

--- a/pkg/controller/common/defaults/pod_template_test.go
+++ b/pkg/controller/common/defaults/pod_template_test.go
@@ -332,6 +332,35 @@ func TestPodTemplateBuilder_WithPorts(t *testing.T) {
 			},
 		},
 		{
+			name: "ports should be sorted",
+			PodTemplate: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: containerName,
+							Ports: []corev1.ContainerPort{
+								{Name: "b", ContainerPort: int32(8080), Protocol: corev1.ProtocolTCP},
+								{Name: "d", ContainerPort: int32(8081), Protocol: corev1.ProtocolTCP},
+								{Name: "c", ContainerPort: int32(8082), Protocol: corev1.ProtocolTCP},
+							},
+						},
+					},
+				},
+			},
+			ports: []corev1.ContainerPort{
+				{Name: "a", ContainerPort: int32(9999), Protocol: corev1.ProtocolTCP},
+				{Name: "e", ContainerPort: int32(7777), Protocol: corev1.ProtocolTCP},
+				{Name: "b", ContainerPort: int32(8083), Protocol: corev1.ProtocolTCP},
+			},
+			want: []corev1.ContainerPort{
+				{Name: "a", ContainerPort: int32(9999), Protocol: corev1.ProtocolTCP},
+				{Name: "b", ContainerPort: int32(8080), Protocol: corev1.ProtocolTCP},
+				{Name: "c", ContainerPort: int32(8082), Protocol: corev1.ProtocolTCP},
+				{Name: "d", ContainerPort: int32(8081), Protocol: corev1.ProtocolTCP},
+				{Name: "e", ContainerPort: int32(7777), Protocol: corev1.ProtocolTCP},
+			},
+		},
+		{
 			name: "append to but don't override user provided ports",
 			PodTemplate: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{

--- a/pkg/controller/elasticsearch/initcontainer/initcontainer.go
+++ b/pkg/controller/elasticsearch/initcontainer/initcontainer.go
@@ -15,13 +15,12 @@ const PrepareFilesystemContainerName = "elastic-internal-init-filesystem"
 
 // NewInitContainers creates init containers according to the given parameters
 func NewInitContainers(
-	elasticsearchImage string,
 	transportCertificatesVolume volume.SecretVolume,
 	clusterName string,
 	keystoreResources *keystore.Resources,
 ) ([]corev1.Container, error) {
 	var containers []corev1.Container
-	prepareFsContainer, err := NewPrepareFSInitContainer(elasticsearchImage, transportCertificatesVolume, clusterName)
+	prepareFsContainer, err := NewPrepareFSInitContainer(transportCertificatesVolume, clusterName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/elasticsearch/initcontainer/initcontainer_test.go
+++ b/pkg/controller/elasticsearch/initcontainer/initcontainer_test.go
@@ -36,7 +36,6 @@ func TestNewInitContainers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			containers, err := NewInitContainers(
-				tt.args.elasticsearchImage,
 				volume.SecretVolume{},
 				"clustername",
 				tt.args.keystoreResources,

--- a/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
+++ b/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
@@ -98,7 +98,6 @@ var (
 // Modified directories and files are meant to be persisted for reuse in the actual ES container.
 // This container does not need to be privileged.
 func NewPrepareFSInitContainer(
-	imageName string,
 	transportCertificatesVolume volume.SecretVolume,
 	clusterName string,
 ) (corev1.Container, error) {
@@ -116,7 +115,6 @@ func NewPrepareFSInitContainer(
 
 	privileged := false
 	container := corev1.Container{
-		Image:           imageName,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Name:            PrepareFilesystemContainerName,
 		SecurityContext: &corev1.SecurityContext{

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -42,7 +42,6 @@ func BuildPodTemplateSpec(
 		WithDockerImage(es.Spec.Image, container.ImageRepository(container.ElasticsearchImage, es.Spec.Version))
 
 	initContainers, err := initcontainer.NewInitContainers(
-		builder.Container.Image,
 		transportCertificatesVolume(es.Name),
 		es.Name,
 		keystoreResources,

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -108,7 +108,6 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 	sort.Slice(volumeMounts, func(i, j int) bool { return volumeMounts[i].Name < volumeMounts[j].Name })
 
 	initContainers, err := initcontainer.NewInitContainers(
-		"docker.elastic.co/elasticsearch/elasticsearch:7.2.0",
 		transportCertificatesVolume(sampleES.Name),
 		sampleES.Name,
 		nil,


### PR DESCRIPTION
This PR allows a user to customize the built-in init containers.

For example in the case of Elasticsearch:

```yaml
  nodeSets:
    - name: my-nodeset
      podTemplate:
        spec:
          initContainers:
          - name: elastic-internal-init-filesystem
            env:
              - name: MY_INIT_FS_ENV
                value: "MY_INIT_FS_ENV_VALUE"
          - name: elastic-internal-init-keystore
            env:
              - name: MY_KEYSTORE_ENV
                value: "MY_KEYSTORE_ENV_VALUE"
            resources:
              limits:
                cpu: 1000m
                memory: 368Mi
              requests:
                cpu: 1000m
                memory: 368Mi
```

Also note that this PR fixes a bug where some env variables are set twice on some Pods, e.g. :

```yaml
  initContainers:
  - command:
    - bash
    - -c
    - /mnt/elastic-internal/scripts/prepare-fs.sh
    env:
    - name: POD_IP
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: status.podIP
    - name: POD_NAME
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.name
    - name: POD_IP
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: status.podIP
    - name: POD_NAME
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.name
```

This triggers a rolling restart of the cluster when upgrading.

Follow-up issue:
- [ ] Update documentation

Fixes #2306 