### PR TITLE
Disable checking http events in Packetbeat for kind 1.12

### DIFF
--- a/test/e2e/beat/config_test.go
+++ b/test/e2e/beat/config_test.go
@@ -255,8 +255,12 @@ func TestPacketbeatConfig(t *testing.T) {
 			beat.HasEventFromBeat(packetbeat.Type),
 			beat.HasEvent("event.dataset:flow"),
 			beat.HasEvent("event.dataset:dns"),
-			beat.HasEvent("event.dataset:http"),
 		)
+
+	if test.Ctx().Provider != "kind" || test.Ctx().KubernetesVersion != "1.12" {
+		// there are some issues with kind 1.12 and tracking http traffic
+		pbBuilder = pbBuilder.WithESValidations(beat.HasEvent("event.dataset:http"))
+	}
 
 	pbBuilder = applyYamls(t, pbBuilder, e2ePacketbeatConfig, e2ePacketbeatPodTemplate)
 


### PR DESCRIPTION
In [kind e2e test run](https://devops-ci.elastic.co/blue/organizations/jenkins/cloud-on-k8s-e2e-tests-kind-k8s-versions/detail/cloud-on-k8s-e2e-tests-kind-k8s-versions/136/pipeline) it can be seen that Packetbeat test is failing on detecting any http events:

```
hit count should be more than 0 for /*beat*/_search?q=event.dataset:http
```

I repro'ed locally and I can confirm the same thing. I'm not sure exactly what is the reason for this, but as this works correctly in more recent kind versions I'm just disabling this check for kind in this particular version.