### PR TITLE
Ignore x/net and x/oauth2 digest updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,7 +31,9 @@
     {
       "packageNames": [
         "k8s.io/utils",
-        "golang.org/x/crypto"
+        "golang.org/x/crypto",
+        "golang.org/x/net",
+        "golang.org/x/oauth2"
       ],
       "updateTypes": [
         "digest"


### PR DESCRIPTION
Ignore digest PRs like https://github.com/elastic/cloud-on-k8s/pull/3340 and https://github.com/elastic/cloud-on-k8s/pull/3339

I wonder if we just want to ignore digest PRs altogether