### PR TITLE
Fix operator memory limit regression

### DIFF
--- a/hack/manifest-gen/assets/charts/eck/values.yaml
+++ b/hack/manifest-gen/assets/charts/eck/values.yaml
@@ -13,10 +13,10 @@ operator:
   resources:
     limits:
       cpu: 1
-      memory: 150Mi
+      memory: 512Mi
     requests:
       cpu: 100m
-      memory: 50Mi
+      memory: 150Mi
 
 config:
   createClusterScopedResources: true


### PR DESCRIPTION
The default memory limit increase introduced in #3046 got lost during the long journey to merge the manifest generator. This PR reintroduces those limits.

