### PR TITLE
Fix Kibana version upgrade E2E tests

### DIFF
--- a/test/e2e/kb/version_upgrade_test.go
+++ b/test/e2e/kb/version_upgrade_test.go
@@ -24,7 +24,7 @@ func TestVersionUpgradeToLatest7x(t *testing.T) {
 	srcVersion := test.Ctx().ElasticStackVersion
 	dstVersion := test.LatestVersion7x
 
-	test.SkipInvalidUpgrade(t, srcVersion, srcVersion)
+	test.SkipInvalidUpgrade(t, srcVersion, dstVersion)
 
 	name := "test-version-upgrade-to-7x"
 	esBuilder := elasticsearch.NewBuilder(name).
@@ -60,7 +60,7 @@ func TestVersionUpgradeAndRespecToLatest7x(t *testing.T) {
 	srcVersion := test.Ctx().ElasticStackVersion
 	dstVersion := test.LatestVersion7x
 
-	test.SkipInvalidUpgrade(t, srcVersion, srcVersion)
+	test.SkipInvalidUpgrade(t, srcVersion, dstVersion)
 
 	name := "test-upgrade-and-respec-to-7x"
 	esBuilder := elasticsearch.NewBuilder(name).


### PR DESCRIPTION
We were skipping all Kibana upgrade E2E tests since ignoring cases where
`srcVersion == srcVersion`. We should be comparing srcVersion vs.
dstVersion instead.