### PR TITLE
Add an E2E test to cover Enterprise Search with TLS disabled

### DIFF
--- a/test/e2e/ent/ent_test.go
+++ b/test/e2e/ent/ent_test.go
@@ -30,3 +30,18 @@ func TestEnterpriseSearchCrossNSAssociation(t *testing.T) {
 
 	test.Sequence(nil, test.EmptySteps, esBuilder, entBuilder).RunSequential(t)
 }
+
+func TestEnterpriseSearchTLSDisabled(t *testing.T) {
+	name := "test-ent-tls-disabled"
+
+	esBuilder := elasticsearch.NewBuilder(name).
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithRestrictedSecurityContext()
+	entBuilder := enterprisesearch.NewBuilder(name).
+		WithElasticsearchRef(esBuilder.Ref()).
+		WithNodeCount(1).
+		WithTLSDisabled(true).
+		WithRestrictedSecurityContext()
+
+	test.Sequence(nil, test.EmptySteps, esBuilder, entBuilder).RunSequential(t)
+}

--- a/test/e2e/test/enterprisesearch/builder.go
+++ b/test/e2e/test/enterprisesearch/builder.go
@@ -95,6 +95,14 @@ func (b Builder) WithNodeCount(count int) Builder {
 	return b
 }
 
+func (b Builder) WithTLSDisabled(disabled bool) Builder {
+	if b.EnterpriseSearch.Spec.HTTP.TLS.SelfSignedCertificate == nil {
+		b.EnterpriseSearch.Spec.HTTP.TLS.SelfSignedCertificate = &commonv1.SelfSignedCertificate{}
+	}
+	b.EnterpriseSearch.Spec.HTTP.TLS.SelfSignedCertificate.Disabled = disabled
+	return b
+}
+
 func (b Builder) WithConfig(cfg map[string]interface{}) Builder {
 	if b.EnterpriseSearch.Spec.Config == nil || b.EnterpriseSearch.Spec.Config.Data == nil {
 		b.EnterpriseSearch.Spec.Config = &commonv1.Config{


### PR DESCRIPTION
This can help catch regressions on TLS stuff.

Fixes https://github.com/elastic/cloud-on-k8s/issues/3261.