### PR TITLE
Add metadata for transform node role

### DIFF
--- a/pkg/apis/elasticsearch/v1/elasticsearch_config.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_config.go
@@ -30,7 +30,7 @@ type Node struct {
 	Data      bool `config:"data"`
 	Ingest    bool `config:"ingest"`
 	ML        bool `config:"ml"`
-	Transform bool `config:transform` // available as of 7.7.0
+	Transform bool `config:"transform"` // available as of 7.7.0
 }
 
 // ElasticsearchSettings is a typed subset of elasticsearch.yml for purposes of the operator.

--- a/pkg/apis/elasticsearch/v1/elasticsearch_config.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_config.go
@@ -12,10 +12,11 @@ import (
 )
 
 const (
-	NodeData   = "node.data"
-	NodeIngest = "node.ingest"
-	NodeMaster = "node.master"
-	NodeML     = "node.ml"
+	NodeData      = "node.data"
+	NodeIngest    = "node.ingest"
+	NodeMaster    = "node.master"
+	NodeML        = "node.ml"
+	NodeTransform = "node.transform"
 )
 
 // ClusterSettings is the cluster node in elasticsearch.yml.
@@ -50,7 +51,8 @@ func DefaultCfg(ver version.Version) ElasticsearchSettings {
 		},
 	}
 	if !ver.IsSameOrAfter(version.From(7, 7, 0)) {
-		settings.Node.Transform = false // this setting did not exist before 7.7.0 expessed here by setting it to false
+		// this setting did not exist before 7.7.0 expressed here by setting it to false this allows us to keep working with just one model
+		settings.Node.Transform = false
 	}
 	return settings
 }

--- a/pkg/apis/elasticsearch/v1/elasticsearch_config.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_config.go
@@ -5,6 +5,7 @@
 package v1
 
 import (
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/go-ucfg"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
@@ -24,10 +25,11 @@ type ClusterSettings struct {
 
 // Node is the node section in elasticsearch.yml.
 type Node struct {
-	Master bool `config:"master"`
-	Data   bool `config:"data"`
-	Ingest bool `config:"ingest"`
-	ML     bool `config:"ml"`
+	Master    bool `config:"master"`
+	Data      bool `config:"data"`
+	Ingest    bool `config:"ingest"`
+	ML        bool `config:"ml"`
+	Transform bool `config:transform` // available as of 7.7.0
 }
 
 // ElasticsearchSettings is a typed subset of elasticsearch.yml for purposes of the operator.
@@ -37,18 +39,25 @@ type ElasticsearchSettings struct {
 }
 
 // DefaultCfg is an instance of ElasticsearchSettings with defaults set as they are in Elasticsearch.
-var DefaultCfg = ElasticsearchSettings{
-	Node: Node{
-		Master: true,
-		Data:   true,
-		Ingest: true,
-		ML:     true,
-	},
+func DefaultCfg(ver version.Version) ElasticsearchSettings {
+	settings := ElasticsearchSettings{
+		Node: Node{
+			Master:    true,
+			Data:      true,
+			Ingest:    true,
+			ML:        true,
+			Transform: true,
+		},
+	}
+	if !ver.IsSameOrAfter(version.From(7, 7, 0)) {
+		settings.Node.Transform = false // this setting did not exist before 7.7.0 expessed here by setting it to false
+	}
+	return settings
 }
 
 // Unpack unpacks Config into a typed subset.
-func UnpackConfig(c *commonv1.Config) (ElasticsearchSettings, error) {
-	esSettings := DefaultCfg // defensive copy
+func UnpackConfig(c *commonv1.Config, ver version.Version) (ElasticsearchSettings, error) {
+	esSettings := DefaultCfg(ver)
 	if c == nil {
 		// make this nil safe to allow a ptr value to work around Json serialization issues
 		return esSettings, nil

--- a/pkg/apis/elasticsearch/v1/elasticsearch_config_test.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_config_test.go
@@ -63,6 +63,30 @@ func TestConfig_RoleDefaults(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "version specific default differences 1",
+			c: commonv1.Config{
+				Data: map[string]interface{}{
+					NodeTransform: true,
+				},
+			},
+			args: args{
+				ver: version.From(7, 5, 0),
+			},
+			want: false,
+		},
+		{
+			name: "version specific default differences 2",
+			c: commonv1.Config{
+				Data: map[string]interface{}{
+					NodeTransform: true,
+				},
+			},
+			args: args{
+				ver: version.From(7, 7, 0),
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/elasticsearch/v1/elasticsearch_config_test.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_config_test.go
@@ -8,13 +8,15 @@ import (
 	"testing"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConfig_RoleDefaults(t *testing.T) {
 	type args struct {
-		c2 commonv1.Config
+		c2  commonv1.Config
+		ver version.Version
 	}
 	tests := []struct {
 		name string
@@ -64,9 +66,9 @@ func TestConfig_RoleDefaults(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c1, err := UnpackConfig(&tt.c)
+			c1, err := UnpackConfig(&tt.c, tt.args.ver)
 			require.NoError(t, err)
-			c2, err := UnpackConfig(&tt.args.c2)
+			c2, err := UnpackConfig(&tt.args.c2, tt.args.ver)
 			require.NoError(t, err)
 			if got := c1.Node == c2.Node; got != tt.want {
 				t.Errorf("Config.EqualRoles() = %v, want %v", got, tt.want)
@@ -148,6 +150,7 @@ func TestConfig_DeepCopy(t *testing.T) {
 }
 
 func TestConfig_Unpack(t *testing.T) {
+	ver := version.From(7, 7, 0)
 	tests := []struct {
 		name    string
 		args    *commonv1.Config
@@ -169,10 +172,11 @@ func TestConfig_Unpack(t *testing.T) {
 			},
 			want: ElasticsearchSettings{
 				Node: Node{
-					Master: false,
-					Data:   true,
-					Ingest: true,
-					ML:     true,
+					Master:    false,
+					Data:      true,
+					Ingest:    true,
+					ML:        true,
+					Transform: true,
 				},
 				Cluster: ClusterSettings{
 					InitialMasterNodes: []string{"a", "b"},
@@ -183,13 +187,13 @@ func TestConfig_Unpack(t *testing.T) {
 		{
 			name:    "Unpack is nil safe",
 			args:    nil,
-			want:    DefaultCfg,
+			want:    DefaultCfg(ver),
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := UnpackConfig(tt.args)
+			got, err := UnpackConfig(tt.args, ver)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Config.Unpack() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/apis/elasticsearch/v1/validations.go
+++ b/pkg/apis/elasticsearch/v1/validations.go
@@ -94,8 +94,12 @@ func supportedVersion(es *Elasticsearch) field.ErrorList {
 func hasMaster(es *Elasticsearch) field.ErrorList {
 	var errs field.ErrorList
 	var hasMaster bool
+	v, err := version.Parse(es.Spec.Version)
+	if err != nil {
+		errs = append(errs, field.Invalid(field.NewPath("spec").Child("version"), es.Spec.Version, parseVersionErrMsg))
+	}
 	for i, t := range es.Spec.NodeSets {
-		cfg, err := UnpackConfig(t.Config)
+		cfg, err := UnpackConfig(t.Config, *v)
 		if err != nil {
 			errs = append(errs, field.Invalid(field.NewPath("spec").Child("nodeSets").Index(i), t.Config, cfgInvalidMsg))
 		}

--- a/pkg/controller/elasticsearch/label/label.go
+++ b/pkg/controller/elasticsearch/label/label.go
@@ -129,7 +129,7 @@ func NewPodLabels(
 	NodeTypesDataLabelName.Set(nodeRoles.Data, labels)
 	NodeTypesIngestLabelName.Set(nodeRoles.Ingest, labels)
 	NodeTypesMLLabelName.Set(nodeRoles.ML, labels)
-	// transform nodes where only added in 7.7.0 so we should not annotate previous versions with them
+	// transform nodes were only added in 7.7.0 so we should not annotate previous versions with them
 	if ver.IsSameOrAfter(version.From(7, 7, 0)) {
 		NodeTypesTransformLabelName.Set(nodeRoles.Transform, labels)
 	}

--- a/pkg/controller/elasticsearch/label/label.go
+++ b/pkg/controller/elasticsearch/label/label.go
@@ -40,6 +40,8 @@ const (
 	NodeTypesIngestLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-ingest"
 	// NodeTypesMLLabelName is a label set to true on nodes with the ml role
 	NodeTypesMLLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-ml"
+	// NodeTypesTransformLabelName is a label set to true on nodes with the transform role
+	NodeTypesTransformLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-transform"
 
 	HTTPSchemeLabelName = "elasticsearch.k8s.elastic.co/http-scheme"
 
@@ -112,21 +114,25 @@ func NewLabels(es types.NamespacedName) map[string]string {
 func NewPodLabels(
 	es types.NamespacedName,
 	ssetName string,
-	version version.Version,
+	ver version.Version,
 	nodeRoles esv1.Node,
 	configHash string,
 	scheme string,
-) (map[string]string, error) {
+) map[string]string {
 	// cluster name based labels
 	labels := NewLabels(es)
 	// version label
-	labels[VersionLabelName] = version.String()
+	labels[VersionLabelName] = ver.String()
 
 	// node types labels
 	NodeTypesMasterLabelName.Set(nodeRoles.Master, labels)
 	NodeTypesDataLabelName.Set(nodeRoles.Data, labels)
 	NodeTypesIngestLabelName.Set(nodeRoles.Ingest, labels)
 	NodeTypesMLLabelName.Set(nodeRoles.ML, labels)
+	// transform nodes where only added in 7.7.0 so we should not annotate previous versions with them
+	if ver.IsSameOrAfter(version.From(7, 7, 0)) {
+		NodeTypesTransformLabelName.Set(nodeRoles.Transform, labels)
+	}
 
 	// config hash label, to rotate pods on config changes
 	labels[ConfigHashLabelName] = configHash
@@ -138,7 +144,7 @@ func NewPodLabels(
 		labels[k] = v
 	}
 
-	return labels, nil
+	return labels
 }
 
 // NewConfigLabels returns labels to apply for an Elasticsearch Config secret.

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -91,28 +91,25 @@ func buildLabels(
 	nodeSet esv1.NodeSet,
 	keystoreResources *keystore.Resources,
 ) (map[string]string, error) {
-	// label with a hash of the config to rotate the pod on config changes
-	unpackedCfg, err := cfg.Unpack()
-	if err != nil {
-		return nil, err
-	}
-	nodeRoles := unpackedCfg.Node
-	cfgHash := hash.HashObject(cfg)
-
 	// label with version
 	ver, err := version.Parse(es.Spec.Version)
 	if err != nil {
 		return nil, err
 	}
 
-	podLabels, err := label.NewPodLabels(
+	// label with a hash of the config to rotate the pod on config changes
+	unpackedCfg, err := cfg.Unpack(*ver)
+	if err != nil {
+		return nil, err
+	}
+	nodeRoles := unpackedCfg.Node
+	cfgHash := hash.HashObject(cfg)
+
+	podLabels := label.NewPodLabels(
 		k8s.ExtractNamespacedName(&es),
 		esv1.StatefulSet(es.Name, nodeSet.Name),
 		*ver, nodeRoles, cfgHash, es.Spec.HTTP.Protocol(),
 	)
-	if err != nil {
-		return nil, err
-	}
 
 	if keystoreResources != nil {
 		// label with a checksum of the secure settings to rotate the pod on secure settings change

--- a/pkg/controller/elasticsearch/settings/canonical_config.go
+++ b/pkg/controller/elasticsearch/settings/canonical_config.go
@@ -7,6 +7,7 @@ package settings
 import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	common "github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 )
 
 // CanonicalConfig contains configuration for Elasticsearch ("elasticsearch.yml"),
@@ -20,8 +21,8 @@ func NewCanonicalConfig() CanonicalConfig {
 }
 
 // Unpack returns a typed subset of Elasticsearch settings.
-func (c CanonicalConfig) Unpack() (esv1.ElasticsearchSettings, error) {
-	cfg := esv1.DefaultCfg
+func (c CanonicalConfig) Unpack(ver version.Version) (esv1.ElasticsearchSettings, error) {
+	cfg := esv1.DefaultCfg(ver)
 	err := c.CanonicalConfig.Unpack(&cfg)
 	return cfg, err
 }

--- a/test/e2e/test/elasticsearch/checks_es.go
+++ b/test/e2e/test/elasticsearch/checks_es.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -114,6 +115,11 @@ func (e *esClusterChecks) CheckESNodesTopology(es esv1.Elasticsearch) test.Step 
 				)
 			}
 
+			v, err := version.Parse(es.Spec.Version)
+			if err != nil {
+				return err
+			}
+
 			// flatten the topology
 			var expectedTopology []esv1.NodeSet
 			for _, node := range es.Spec.NodeSets {
@@ -148,7 +154,7 @@ func (e *esClusterChecks) CheckESNodesTopology(es esv1.Elasticsearch) test.Step 
 				nodeRoles := rolesToConfig(node.Roles)
 				nodeStats := nodesStats.Nodes[nodeID]
 				for i, topoElem := range expectedTopology {
-					cfg, err := esv1.UnpackConfig(topoElem.Config)
+					cfg, err := esv1.UnpackConfig(topoElem.Config, *v)
 					if err != nil {
 						return err
 					}
@@ -190,6 +196,8 @@ func rolesToConfig(roles []string) esv1.Node {
 			node.Data = true
 		case "ingest":
 			node.Ingest = true
+		case "transform":
+			node.Transform = true
 		}
 	}
 	return node


### PR DESCRIPTION
Elasticsearch 7.7.0 introduces the transform node role. 
* add this new node type to the pod metadata when running a version of Elasticsearch that supports transform. 
* adjust test cases and default values.

The complication here is that we now have version specific default configurations. I chose to just toggle the `transform` value off in the default config to be able to keep using just one config struct. Technically the `transform` value does not even exist prior to 7.7.0 

I am targeting this for 1.3.0 as discussed out-of-band but I am happy to reconsider given that documenting the workaround for users might be unnecessarily complex and confusing. 