### PR TITLE
Increase all E2E tests timeout to 360min

### DIFF
--- a/.ci/pipelines/e2e-tests-eks.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-eks.Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
     }
 
     environment {

--- a/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
         skipDefaultCheckout(true)
     }
 

--- a/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
         skipDefaultCheckout(true)
     }
 

--- a/.ci/pipelines/e2e-tests-master-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-master-gke.Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
     }
 
     environment {

--- a/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
     }
 
     environment {

--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
         skipDefaultCheckout(true)
     }
 

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
         skipDefaultCheckout(true)
     }
 

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	jobTimeout           = 300 * time.Minute // time to wait for the test job to finish
+	jobTimeout           = 360 * time.Minute // time to wait for the test job to finish
 	kubePollInterval     = 10 * time.Second  // Kube API polling interval
 	logBufferSize        = 1024              // Size of the log buffer (1KiB)
 	testRunLabel         = "test-run"        // name of the label applied to resources


### PR DESCRIPTION
We used to have a 300 minutes timeout, except for AKS where we already
increased the timeout to 360 minutes.
It looks like we are very close to the 300 minutes timeout, at least for
the ocp test, since we recently added many additional tests.
Let's just use 360 minutes everywhere.