### PR TITLE
Run the ent upgrade E2E tests with a restricted security context

### DIFF
--- a/test/e2e/ent/ent_test.go
+++ b/test/e2e/ent/ent_test.go
@@ -60,7 +60,8 @@ func TestEnterpriseSearchVersionUpgradeToLatest7x(t *testing.T) {
 	ent := enterprisesearch.NewBuilder(name).
 		WithElasticsearchRef(es.Ref()).
 		WithNodeCount(2).
-		WithVersion(srcVersion)
+		WithVersion(srcVersion).
+		WithRestrictedSecurityContext()
 
 	if ent.SkipTest() {
 		t.SkipNow() // invalid version


### PR DESCRIPTION
Otherwise the Pod cannot be deployed: we require runAsNonRoot but don't
specify any user ID.

IIUC what I read in
https://stackoverflow.com/questions/51544003/using-runasnonroot-in-kubernetes/51544435
and
https://stackoverflow.com/questions/49720308/kubernetes-podsecuritypolicy-set-to-runasnonroot-container-has-runasnonroot-and/49729786#49729786,
the right fix would be in the Enterprise Search Docker image, so the
default user has a UID directly to run with.
I'll investigate and open an Enterprise Search issue if necessary. In
the meantime, this should fix the E2E test in a way that is consistent
with other stack resources.

Fixes https://github.com/elastic/cloud-on-k8s/issues/3373.