### PR TITLE
Revert "Add metadata for transform node role (#3361)"

### DIFF
--- a/pkg/apis/elasticsearch/v1/elasticsearch_config.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_config.go
@@ -5,18 +5,16 @@
 package v1
 
 import (
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/go-ucfg"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 )
 
 const (
-	NodeData      = "node.data"
-	NodeIngest    = "node.ingest"
-	NodeMaster    = "node.master"
-	NodeML        = "node.ml"
-	NodeTransform = "node.transform"
+	NodeData   = "node.data"
+	NodeIngest = "node.ingest"
+	NodeMaster = "node.master"
+	NodeML     = "node.ml"
 )
 
 // ClusterSettings is the cluster node in elasticsearch.yml.
@@ -26,11 +24,10 @@ type ClusterSettings struct {
 
 // Node is the node section in elasticsearch.yml.
 type Node struct {
-	Master    bool `config:"master"`
-	Data      bool `config:"data"`
-	Ingest    bool `config:"ingest"`
-	ML        bool `config:"ml"`
-	Transform bool `config:"transform"` // available as of 7.7.0
+	Master bool `config:"master"`
+	Data   bool `config:"data"`
+	Ingest bool `config:"ingest"`
+	ML     bool `config:"ml"`
 }
 
 // ElasticsearchSettings is a typed subset of elasticsearch.yml for purposes of the operator.
@@ -40,26 +37,18 @@ type ElasticsearchSettings struct {
 }
 
 // DefaultCfg is an instance of ElasticsearchSettings with defaults set as they are in Elasticsearch.
-func DefaultCfg(ver version.Version) ElasticsearchSettings {
-	settings := ElasticsearchSettings{
-		Node: Node{
-			Master:    true,
-			Data:      true,
-			Ingest:    true,
-			ML:        true,
-			Transform: true,
-		},
-	}
-	if !ver.IsSameOrAfter(version.From(7, 7, 0)) {
-		// this setting did not exist before 7.7.0 expressed here by setting it to false this allows us to keep working with just one model
-		settings.Node.Transform = false
-	}
-	return settings
+var DefaultCfg = ElasticsearchSettings{
+	Node: Node{
+		Master: true,
+		Data:   true,
+		Ingest: true,
+		ML:     true,
+	},
 }
 
 // Unpack unpacks Config into a typed subset.
-func UnpackConfig(c *commonv1.Config, ver version.Version) (ElasticsearchSettings, error) {
-	esSettings := DefaultCfg(ver)
+func UnpackConfig(c *commonv1.Config) (ElasticsearchSettings, error) {
+	esSettings := DefaultCfg // defensive copy
 	if c == nil {
 		// make this nil safe to allow a ptr value to work around Json serialization issues
 		return esSettings, nil

--- a/pkg/apis/elasticsearch/v1/elasticsearch_config_test.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_config_test.go
@@ -8,15 +8,13 @@ import (
 	"testing"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConfig_RoleDefaults(t *testing.T) {
 	type args struct {
-		c2  commonv1.Config
-		ver version.Version
+		c2 commonv1.Config
 	}
 	tests := []struct {
 		name string
@@ -63,36 +61,12 @@ func TestConfig_RoleDefaults(t *testing.T) {
 			},
 			want: false,
 		},
-		{
-			name: "version specific default differences 1",
-			c: commonv1.Config{
-				Data: map[string]interface{}{
-					NodeTransform: true,
-				},
-			},
-			args: args{
-				ver: version.From(7, 5, 0),
-			},
-			want: false,
-		},
-		{
-			name: "version specific default differences 2",
-			c: commonv1.Config{
-				Data: map[string]interface{}{
-					NodeTransform: true,
-				},
-			},
-			args: args{
-				ver: version.From(7, 7, 0),
-			},
-			want: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c1, err := UnpackConfig(&tt.c, tt.args.ver)
+			c1, err := UnpackConfig(&tt.c)
 			require.NoError(t, err)
-			c2, err := UnpackConfig(&tt.args.c2, tt.args.ver)
+			c2, err := UnpackConfig(&tt.args.c2)
 			require.NoError(t, err)
 			if got := c1.Node == c2.Node; got != tt.want {
 				t.Errorf("Config.EqualRoles() = %v, want %v", got, tt.want)
@@ -174,7 +148,6 @@ func TestConfig_DeepCopy(t *testing.T) {
 }
 
 func TestConfig_Unpack(t *testing.T) {
-	ver := version.From(7, 7, 0)
 	tests := []struct {
 		name    string
 		args    *commonv1.Config
@@ -196,11 +169,10 @@ func TestConfig_Unpack(t *testing.T) {
 			},
 			want: ElasticsearchSettings{
 				Node: Node{
-					Master:    false,
-					Data:      true,
-					Ingest:    true,
-					ML:        true,
-					Transform: true,
+					Master: false,
+					Data:   true,
+					Ingest: true,
+					ML:     true,
 				},
 				Cluster: ClusterSettings{
 					InitialMasterNodes: []string{"a", "b"},
@@ -211,13 +183,13 @@ func TestConfig_Unpack(t *testing.T) {
 		{
 			name:    "Unpack is nil safe",
 			args:    nil,
-			want:    DefaultCfg(ver),
+			want:    DefaultCfg,
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := UnpackConfig(tt.args, ver)
+			got, err := UnpackConfig(tt.args)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Config.Unpack() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/apis/elasticsearch/v1/validations.go
+++ b/pkg/apis/elasticsearch/v1/validations.go
@@ -94,12 +94,8 @@ func supportedVersion(es *Elasticsearch) field.ErrorList {
 func hasMaster(es *Elasticsearch) field.ErrorList {
 	var errs field.ErrorList
 	var hasMaster bool
-	v, err := version.Parse(es.Spec.Version)
-	if err != nil {
-		errs = append(errs, field.Invalid(field.NewPath("spec").Child("version"), es.Spec.Version, parseVersionErrMsg))
-	}
 	for i, t := range es.Spec.NodeSets {
-		cfg, err := UnpackConfig(t.Config, *v)
+		cfg, err := UnpackConfig(t.Config)
 		if err != nil {
 			errs = append(errs, field.Invalid(field.NewPath("spec").Child("nodeSets").Index(i), t.Config, cfgInvalidMsg))
 		}

--- a/pkg/controller/elasticsearch/label/label.go
+++ b/pkg/controller/elasticsearch/label/label.go
@@ -40,8 +40,6 @@ const (
 	NodeTypesIngestLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-ingest"
 	// NodeTypesMLLabelName is a label set to true on nodes with the ml role
 	NodeTypesMLLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-ml"
-	// NodeTypesTransformLabelName is a label set to true on nodes with the transform role
-	NodeTypesTransformLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-transform"
 
 	HTTPSchemeLabelName = "elasticsearch.k8s.elastic.co/http-scheme"
 
@@ -114,25 +112,21 @@ func NewLabels(es types.NamespacedName) map[string]string {
 func NewPodLabels(
 	es types.NamespacedName,
 	ssetName string,
-	ver version.Version,
+	version version.Version,
 	nodeRoles esv1.Node,
 	configHash string,
 	scheme string,
-) map[string]string {
+) (map[string]string, error) {
 	// cluster name based labels
 	labels := NewLabels(es)
 	// version label
-	labels[VersionLabelName] = ver.String()
+	labels[VersionLabelName] = version.String()
 
 	// node types labels
 	NodeTypesMasterLabelName.Set(nodeRoles.Master, labels)
 	NodeTypesDataLabelName.Set(nodeRoles.Data, labels)
 	NodeTypesIngestLabelName.Set(nodeRoles.Ingest, labels)
 	NodeTypesMLLabelName.Set(nodeRoles.ML, labels)
-	// transform nodes were only added in 7.7.0 so we should not annotate previous versions with them
-	if ver.IsSameOrAfter(version.From(7, 7, 0)) {
-		NodeTypesTransformLabelName.Set(nodeRoles.Transform, labels)
-	}
 
 	// config hash label, to rotate pods on config changes
 	labels[ConfigHashLabelName] = configHash
@@ -144,7 +138,7 @@ func NewPodLabels(
 		labels[k] = v
 	}
 
-	return labels
+	return labels, nil
 }
 
 // NewConfigLabels returns labels to apply for an Elasticsearch Config secret.

--- a/pkg/controller/elasticsearch/label/label_test.go
+++ b/pkg/controller/elasticsearch/label/label_test.go
@@ -8,10 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	v1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
-	"github.com/go-test/deep"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -168,95 +165,6 @@ func TestMinVersion(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("minVersion() = %v, want %v", got, tt.want)
 			}
-		})
-	}
-}
-
-func TestNewPodLabels(t *testing.T) {
-	type args struct {
-		es         types.NamespacedName
-		ssetName   string
-		ver        version.Version
-		nodeRoles  v1.Node
-		configHash string
-		scheme     string
-	}
-	nameFixture := types.NamespacedName{
-		Namespace: "ns",
-		Name:      "name",
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    map[string]string
-		wantErr bool
-	}{
-		{
-			name: "labels pre-7.7",
-			args: args{
-				es:       nameFixture,
-				ssetName: "sset",
-				ver:      version.From(7, 1, 0),
-				nodeRoles: v1.Node{
-					Master:    false,
-					Data:      false,
-					Ingest:    false,
-					ML:        false,
-					Transform: false,
-				},
-				configHash: "hash",
-				scheme:     "https",
-			},
-			want: map[string]string{
-				ClusterNameLabelName:             "name",
-				common.TypeLabelName:             "elasticsearch",
-				VersionLabelName:                 "7.1.0",
-				string(NodeTypesMasterLabelName): "false",
-				string(NodeTypesDataLabelName):   "false",
-				string(NodeTypesIngestLabelName): "false",
-				string(NodeTypesMLLabelName):     "false",
-				ConfigHashLabelName:              "hash",
-				HTTPSchemeLabelName:              "https",
-				StatefulSetNameLabelName:         "sset",
-			},
-			wantErr: false,
-		},
-		{
-			name: "labels post-7.7",
-			args: args{
-				es:       nameFixture,
-				ssetName: "sset",
-				ver:      version.From(7, 7, 0),
-				nodeRoles: v1.Node{
-					Master:    false,
-					Data:      true,
-					Ingest:    false,
-					ML:        false,
-					Transform: true,
-				},
-				configHash: "hash",
-				scheme:     "https",
-			},
-			want: map[string]string{
-				ClusterNameLabelName:                "name",
-				common.TypeLabelName:                "elasticsearch",
-				VersionLabelName:                    "7.7.0",
-				string(NodeTypesMasterLabelName):    "false",
-				string(NodeTypesDataLabelName):      "true",
-				string(NodeTypesIngestLabelName):    "false",
-				string(NodeTypesMLLabelName):        "false",
-				string(NodeTypesTransformLabelName): "true",
-				ConfigHashLabelName:                 "hash",
-				HTTPSchemeLabelName:                 "https",
-				StatefulSetNameLabelName:            "sset",
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := NewPodLabels(tt.args.es, tt.args.ssetName, tt.args.ver, tt.args.nodeRoles, tt.args.configHash, tt.args.scheme)
-			require.Nil(t, deep.Equal(got, tt.want))
 		})
 	}
 }

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -90,25 +90,28 @@ func buildLabels(
 	nodeSet esv1.NodeSet,
 	keystoreResources *keystore.Resources,
 ) (map[string]string, error) {
-	// label with version
-	ver, err := version.Parse(es.Spec.Version)
-	if err != nil {
-		return nil, err
-	}
-
 	// label with a hash of the config to rotate the pod on config changes
-	unpackedCfg, err := cfg.Unpack(*ver)
+	unpackedCfg, err := cfg.Unpack()
 	if err != nil {
 		return nil, err
 	}
 	nodeRoles := unpackedCfg.Node
 	cfgHash := hash.HashObject(cfg)
 
-	podLabels := label.NewPodLabels(
+	// label with version
+	ver, err := version.Parse(es.Spec.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	podLabels, err := label.NewPodLabels(
 		k8s.ExtractNamespacedName(&es),
 		esv1.StatefulSet(es.Name, nodeSet.Name),
 		*ver, nodeRoles, cfgHash, es.Spec.HTTP.Protocol(),
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	if keystoreResources != nil {
 		// label with a checksum of the secure settings to rotate the pod on secure settings change

--- a/pkg/controller/elasticsearch/settings/canonical_config.go
+++ b/pkg/controller/elasticsearch/settings/canonical_config.go
@@ -7,7 +7,6 @@ package settings
 import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	common "github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 )
 
 // CanonicalConfig contains configuration for Elasticsearch ("elasticsearch.yml"),
@@ -21,8 +20,8 @@ func NewCanonicalConfig() CanonicalConfig {
 }
 
 // Unpack returns a typed subset of Elasticsearch settings.
-func (c CanonicalConfig) Unpack(ver version.Version) (esv1.ElasticsearchSettings, error) {
-	cfg := esv1.DefaultCfg(ver)
+func (c CanonicalConfig) Unpack() (esv1.ElasticsearchSettings, error) {
+	cfg := esv1.DefaultCfg
 	err := c.CanonicalConfig.Unpack(&cfg)
 	return cfg, err
 }

--- a/test/e2e/test/elasticsearch/checks_es.go
+++ b/test/e2e/test/elasticsearch/checks_es.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -115,11 +114,6 @@ func (e *esClusterChecks) CheckESNodesTopology(es esv1.Elasticsearch) test.Step 
 				)
 			}
 
-			v, err := version.Parse(es.Spec.Version)
-			if err != nil {
-				return err
-			}
-
 			// flatten the topology
 			var expectedTopology []esv1.NodeSet
 			for _, node := range es.Spec.NodeSets {
@@ -154,7 +148,7 @@ func (e *esClusterChecks) CheckESNodesTopology(es esv1.Elasticsearch) test.Step 
 				nodeRoles := rolesToConfig(node.Roles)
 				nodeStats := nodesStats.Nodes[nodeID]
 				for i, topoElem := range expectedTopology {
-					cfg, err := esv1.UnpackConfig(topoElem.Config, *v)
+					cfg, err := esv1.UnpackConfig(topoElem.Config)
 					if err != nil {
 						return err
 					}
@@ -196,8 +190,6 @@ func rolesToConfig(roles []string) esv1.Node {
 			node.Data = true
 		case "ingest":
 			node.Ingest = true
-		case "transform":
-			node.Transform = true
 		}
 	}
 	return node

--- a/test/e2e/test/elasticsearch/settings.go
+++ b/test/e2e/test/elasticsearch/settings.go
@@ -7,24 +7,22 @@ package elasticsearch
 import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	common "github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
 )
 
 func MustNumDataNodes(es esv1.Elasticsearch) int {
 	var numNodes int
-	ver := version.MustParse(es.Spec.Version)
 	for _, n := range es.Spec.NodeSets {
-		if isDataNode(n, ver) {
+		if isDataNode(n) {
 			numNodes += int(n.Count)
 		}
 	}
 	return numNodes
 }
 
-func isDataNode(node esv1.NodeSet, ver version.Version) bool {
+func isDataNode(node esv1.NodeSet) bool {
 	if node.Config == nil {
-		return esv1.DefaultCfg(ver).Node.Data // if not specified use the default
+		return esv1.DefaultCfg.Node.Data // if not specified use the default
 	}
 	config, err := common.NewCanonicalConfigFrom(node.Config.Data)
 	if err != nil {
@@ -32,7 +30,7 @@ func isDataNode(node esv1.NodeSet, ver version.Version) bool {
 	}
 	nodeCfg, err := settings.CanonicalConfig{
 		CanonicalConfig: config,
-	}.Unpack(ver)
+	}.Unpack()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This reverts commit 284e16da33621a8d308d8467c96e39652b6cc9fb.

Revert the commit to stop e2e tests from failing. I will re-raise a PR with this change once I have figured out a good way to deal with the tricky `data` + `transform` inter-dependency uncovered in https://github.com/elastic/cloud-on-k8s/issues/3376