### PR TITLE
[1.2] Add a doc section about APM Agent configuration management (#3350)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
@@ -75,6 +75,28 @@ apm-server-quickstart-apm-server-69b447ddc5-fflc6   1/1     Running   0         
 [id="{p}-apm-advanced-configuration"]
 == Advanced configuration
 
+[id="{p}-apm-agent-central-configuration"]
+=== Use APM Agent central configuration
+link:https://www.elastic.co/guide/en/kibana/current/agent-configuration.html[APM Agent configuration management] added:[7.5.1] allows you to configure your APM Agents centrally from within the Kibana APM app. To use this feature, the APM Server needs to be configured with connection details of the Kibana instance. If Kibana is managed by ECK, you can simply add a `kibanaRef` attribute to the APM Server specification:
+
+[source,yaml,subs="attributes,+macros"]
+----
+cat $$<<$$EOF | kubectl apply -f -
+apiVersion: apm.k8s.elastic.co/{eck_crd_version}
+kind: ApmServer
+metadata:
+  name: apm-server-quickstart
+  namespace: default
+spec:
+  version: {version}
+  count: 1
+  elasticsearchRef:
+    name: quickstart
+  kibanaRef:
+    name: quickstart
+EOF
+----
+
 [id="{p}-apm-customize-configuration"]
 === Customize the APM Server configuration
 


### PR DESCRIPTION
Backports the following commits to 1.2:
 - Add a doc section about APM Agent configuration management (#3350)