### PR TITLE
Retry getting the E2E tests Pod logs when the stream ends

### DIFF
--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -36,7 +36,6 @@ import (
 const (
 	jobTimeout           = 360 * time.Minute // time to wait for the test job to finish
 	kubePollInterval     = 10 * time.Second  // Kube API polling interval
-	logBufferSize        = 1024              // Size of the log buffer (1KiB)
 	testRunLabel         = "test-run"        // name of the label applied to resources
 	testsLogFile         = "e2e-tests.json"  // name of file to keep all test logs in JSON format
 	operatorReadyTimeout = 3 * time.Minute   // time to wait for the operator pod to be ready


### PR DESCRIPTION
In some environments (OCP mostly), we don't manage to get a full 6 hours
long Pod log stream with no interruptions. More generally, network isn't
reliable so this could happen in any environments.

Let's retry the log stream apiserver request when that happens.

The side-effect is that we now get duplicate log entries. In CI we have a
process that parses the logs to turn them into formatted test results.
In order to not make that process fail, we ask Kubernetes to
provide a timestamp with each log, so we can keep track of the last timestamp.
On a retry, we can therefore ignore logs whose timestamp is lower than
the last one we found.
This isn't a perfect system: if the stream drops in between several logs
that share the same timestamp, the second half will be lost. In our case,
for test results, I think that's unlikely to happen.

Fixes https://github.com/elastic/cloud-on-k8s/issues/3386.