### PR TITLE
Setup a single instance of Kibana 7.1.1 in TestVersionUpgradeToLatest7x

### DIFF
--- a/test/e2e/kb/version_upgrade_test.go
+++ b/test/e2e/kb/version_upgrade_test.go
@@ -74,9 +74,16 @@ func TestVersionUpgradeAndRespecToLatest7x(t *testing.T) {
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
 		WithVersion(dstVersion)
 
+	srcNodeCount := 3
+	if srcVersion == "7.1.1" {
+		// workaround for https://github.com/elastic/kibana/pull/37674 to avoid accidental .kibana index creation
+		// can be removed once we stop supporting 7.1.1
+		srcNodeCount = 1
+	}
+
 	kbBuilder1 := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
-		WithNodeCount(3).
+		WithNodeCount(srcNodeCount).
 		WithVersion(srcVersion)
 
 	// perform a Kibana version upgrade immediately followed by a Kibana configuration change.


### PR DESCRIPTION
Similar to https://github.com/elastic/cloud-on-k8s/pull/3385, there's an
issue in Kibana 7.1.1 that leads to a yellow health (.kibana index with
replicas).
Let's work around it for 7.1.1 only.
