### PR TITLE
Enable filebeat annotation on operator if monitoring secret is provided

### DIFF
--- a/config/e2e/operator.yaml
+++ b/config/e2e/operator.yaml
@@ -212,7 +212,7 @@ spec:
         co.elastic.metrics/hosts: '${data.host}:9090'
         co.elastic.metrics/period: 10s
         # if monitoring secrets are specified, filebeat is deployed and provides the below configuration
-        {{ if not .MonitoringSecrets }}
+        {{ if .MonitoringSecrets }}
         # Rename the fields "error" to "error.message" and "source" to "event.source"
         # This is to avoid a conflict with the ECS "error" and "source" documents.
         "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"


### PR DESCRIPTION
While investigating a drop in the logs produced in the ECS format I found out that the required annotation to parse them was actually disabled. 