### PR TITLE
Mention default CA cert rotation in the remote clusters docs

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/remote-clusters.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/remote-clusters.asciidoc
@@ -75,7 +75,7 @@ You then need to configure the CA as one of the trusted CAs in `cluster-two`. If
 
 NOTE: Beware of copying the source Secret as-is into a different namespace. See <<{p}-common-problems-owner-refs, Common Problems: Owner References>> for more information.
 
-NOTE: CA certificates are automatically rotated after one year by default. You can link:k8s-operator-config.html[configure] this period. Make sure to keep up-to-date the copy of the certificates secret.
+NOTE: CA certificates are automatically rotated after one year by default. You can link:k8s-operator-config.html[configure] this period. Make sure to keep the copy of the certificates Secret up-to-date.
 
 If `cluster-two` is also managed by an ECK instance, proceed as follows:
 

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/remote-clusters.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/remote-clusters.asciidoc
@@ -75,6 +75,8 @@ You then need to configure the CA as one of the trusted CAs in `cluster-two`. If
 
 NOTE: Beware of copying the source Secret as-is into a different namespace. See <<{p}-common-problems-owner-refs, Common Problems: Owner References>> for more information.
 
+NOTE: CA certificates are automatically rotated after one year by default. This period is link:k8s-operator-config.html[configurable]. You should ensure the certificates secret copy is maintained up-to-date.
+
 If `cluster-two` is also managed by an ECK instance, proceed as follows:
 
 Create a secret with the CA certificate you just extracted:

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/remote-clusters.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/remote-clusters.asciidoc
@@ -75,7 +75,7 @@ You then need to configure the CA as one of the trusted CAs in `cluster-two`. If
 
 NOTE: Beware of copying the source Secret as-is into a different namespace. See <<{p}-common-problems-owner-refs, Common Problems: Owner References>> for more information.
 
-NOTE: CA certificates are automatically rotated after one year by default. This period is link:k8s-operator-config.html[configurable]. You should ensure the certificates secret copy is maintained up-to-date.
+NOTE: CA certificates are automatically rotated after one year by default. You can link:k8s-operator-config.html[configure] this period. Make sure to keep up-to-date the copy of the certificates secret.
 
 If `cluster-two` is also managed by an ECK instance, proceed as follows:
 


### PR DESCRIPTION
It may be confusing to users to have their remote cluster relationship
stop working after 1 hour, which is the default CA cert rotation period.
