### PR TITLE
Fix Beat name label

### DIFF
--- a/pkg/controller/beat/common/labels.go
+++ b/pkg/controller/beat/common/labels.go
@@ -20,6 +20,6 @@ const (
 func NewLabels(beat beatv1beta1.Beat) map[string]string {
 	return map[string]string{
 		common.TypeLabelName: TypeLabelValue,
-		NameLabelName:        Name(beat.Name, beat.Spec.Type),
+		NameLabelName:        beat.Name,
 	}
 }


### PR DESCRIPTION
For Beat resource with name `auditbeat`:

Before:
`beat.k8s.elastic.co/name=auditbeat-beat-auditbeat`

After:
`beat.k8s.elastic.co/name=auditbeat`

This makes it consistent with other resources.