### PR TITLE
Reorganize and edit the section "Restrict cross namespace resource associations"

### DIFF
--- a/docs/operating-eck/restrict-cross-namespace-associations.asciidoc
+++ b/docs/operating-eck/restrict-cross-namespace-associations.asciidoc
@@ -81,6 +81,6 @@ spec:
 In the above example, `associated-resource` can be of any `Kind` that requires an association to be created, for example `Kibana` or `ApmServer`.
 You can find https://github.com/elastic/cloud-on-k8s/blob/master/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml[a complete example in the ECK GitHub repository].
 
-NOTE: If the `serviceAccountName` is not set, ECK uses the `ServiceAccount` called `default`.
+NOTE: If the `serviceAccountName` is not set, ECK uses the default service account assigned to the pod by the link:https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#service-account-admission-controller[Service Account Admission Controller].
 
 The associated resource `associated-resource` is now allowed to create an association with any Elasticsearch cluster in the namespace `elasticsearch-ns`.

--- a/docs/operating-eck/restrict-cross-namespace-associations.asciidoc
+++ b/docs/operating-eck/restrict-cross-namespace-associations.asciidoc
@@ -9,7 +9,7 @@ endif::[]
 
 This section describes how to restrict associations that can be created between resources managed by ECK.
 
-When using the `elasticsearchRef` field to establish a trust relationship between Elasticsearch, Kibana, or APM Server resources, by default the association is allowed as long as both resources are deployed to namespaces managed by that particular ECK instance. The association is successful even if the user does not have access to one of the namespaces, or has only access to Kibana resources and not Elasticsearch resources.
+When using the `elasticsearchRef` field to establish a connection to Elasticsearch from Kibana, APM Server, Enterprise Search, or Beats resources, by default the association is allowed as long as both resources are deployed to namespaces managed by that particular ECK instance. The association will succeed even if the user creating the association does not have access to one of the namespaces or the Elasticsearch resource.
 
 The restriction of cross-namespace associations is disabled by default. Once enabled, it only enforces an access control for resources deployed across two different namespaces. You can still create associations between resources deployed in a same namespace.
 

--- a/docs/operating-eck/restrict-cross-namespace-associations.asciidoc
+++ b/docs/operating-eck/restrict-cross-namespace-associations.asciidoc
@@ -78,7 +78,7 @@ spec:
   serviceAccountName: associated-resource-sa
 ----
 
-In the above example, `associated-resource` can be of any `Kind` that requires an association to be created, for example `Kibana` or the `APMServer`.
+In the above example, `associated-resource` can be of any `Kind` that requires an association to be created, for example `Kibana` or `ApmServer`.
 You can find https://github.com/elastic/cloud-on-k8s/blob/master/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml[a complete example in the ECK GitHub repository].
 
 NOTE: If the `serviceAccountName` is not set, ECK uses the `ServiceAccount` called `default`.

--- a/docs/operating-eck/restrict-cross-namespace-associations.asciidoc
+++ b/docs/operating-eck/restrict-cross-namespace-associations.asciidoc
@@ -13,7 +13,7 @@ When using the `elasticsearchRef` field to establish a connection to Elasticsear
 
 The restriction of cross-namespace associations is disabled by default. Once enabled, it only enforces an access control for resources deployed across two different namespaces. You can still create associations between resources deployed in a same namespace.
 
-Associations are allowed as long as the `ServiceAccount` specified in the associated resource can execute HTTP `GET` requests against the referenced Elasticsearch object.
+Associations are allowed as long as the `ServiceAccount` used by the associated resource can execute HTTP `GET` requests against the referenced Elasticsearch object.
 
 IMPORTANT: ECK automatically removes any associations that do not have the correct access rights. If you have existing associations, do not enable this feature without creating the required `Roles` and `RoleBindings` as described in the following sections.
 

--- a/docs/operating-eck/restrict-cross-namespace-associations.asciidoc
+++ b/docs/operating-eck/restrict-cross-namespace-associations.asciidoc
@@ -11,7 +11,7 @@ This section describes how to restrict associations that can be created between 
 
 When using the `elasticsearchRef` field to establish a connection to Elasticsearch from Kibana, APM Server, Enterprise Search, or Beats resources, by default the association is allowed as long as both resources are deployed to namespaces managed by that particular ECK instance. The association will succeed even if the user creating the association does not have access to one of the namespaces or the Elasticsearch resource.
 
-The restriction of cross-namespace associations is disabled by default. Once enabled, it only enforces an access control for resources deployed across two different namespaces. You can still create associations between resources deployed in a same namespace.
+The enforcement of access control rules for cross-namespace associations is disabled by default. Once enabled, it only enforces access control for resources deployed across two different namespaces. Associations between resources deployed in the same namespace are not affected.
 
 Associations are allowed as long as the `ServiceAccount` used by the associated resource can execute HTTP `GET` requests against the referenced Elasticsearch object.
 

--- a/docs/operating-eck/restrict-cross-namespace-associations.asciidoc
+++ b/docs/operating-eck/restrict-cross-namespace-associations.asciidoc
@@ -5,24 +5,22 @@ link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-{page_id}.html[View
 ****
 endif::[]
 [id="{p}-{page_id}"]
-= Restrict cross namespace resource associations
+= Restrict cross-namespace resource associations
 
-When using the `elasticsearchRef` field to establish a trust relationship between Elasticsearch and a Kibana or an APM Server resource, the default behaviour is to allow association as long as both resources are deployed to namespaces managed by that particular ECK instance. Association succeeds even if the user does not have access to one of the namespaces, or only has access to Kibana resources and not Elasticsearch resources.
+This section describes how to restrict associations that can be created between resources managed by ECK.
 
-This section describes how you can restrict the associations that can be created between resources managed by ECK.
+When using the `elasticsearchRef` field to establish a trust relationship between Elasticsearch, Kibana, or APM Server resources, by default the association is allowed as long as both resources are deployed to namespaces managed by that particular ECK instance. The association is successful even if the user does not have access to one of the namespaces, or has only access to Kibana resources and not Elasticsearch resources.
 
-== Enabling cross-namespace association restrictions
+The restriction of cross-namespace associations is disabled by default. Once enabled, it only enforces an access control for resources deployed across two different namespaces. You can still create associations between resources deployed in a same namespace.
 
-This feature is disabled by default. To enable it, start the operator with the `--enforce-rbac-on-refs` flag.
-
-NOTE: This feature only enforces an access control for resources deployed across two different namespaces. You can still create associations between resources deployed in a same namespace.
-
-Once enabled, associations are allowed as long as the `ServiceAccount` specified in the associated resource can execute HTTP `GET` requests against the referenced Elasticsearch object.
+Associations are allowed as long as the `ServiceAccount` specified in the associated resource can execute HTTP `GET` requests against the referenced Elasticsearch object.
 
 IMPORTANT: ECK automatically removes any associations that do not have the correct access rights. If you have existing associations, do not enable this feature without creating the required `Roles` and `RoleBindings` as described in the following sections.
 
-First create a `ClusterRole` to allow HTTP `GET` requests to be run against Elasticsearch objects:
+To enable the restriction of cross-namespace associations, start the operator with the `--enforce-rbac-on-refs` flag. 
 
+. Create a `ClusterRole` to allow HTTP `GET` requests to be run against Elasticsearch objects:
++
 [source,yaml]
 ----
 apiVersion: rbac.authorization.k8s.io/v1
@@ -38,13 +36,13 @@ rules:
       - get
 ----
 
-Then, create a `ServiceAccount` and a `RoleBinding` in the Elasticsearch namespace to allow any resource using the `ServiceAccount` to associate with the Elasticsearch cluster:
-
+. Create a `ServiceAccount` and a `RoleBinding` in the Elasticsearch namespace to allow any resource using the `ServiceAccount` to associate with the Elasticsearch cluster:
++
 [source,sh]
 ----
 > kubectl create serviceaccount associated-resource-sa
 ----
-
++
 [source,yaml]
 ----
 apiVersion: rbac.authorization.k8s.io/v1
@@ -62,8 +60,8 @@ subjects:
     namespace: associated-resource-ns
 ----
 
-Finally set the `serviceAccountName` field in the associated resource to specify which `ServiceAccount` is used to create the association:
-
+. Set the `serviceAccountName` field in the associated resource to specify which `ServiceAccount` is used to create the association:
++
 [source,yaml,subs="attributes"]
 ----
 apiVersion: kibana.k8s.elastic.co/{eck_crd_version}
@@ -80,9 +78,9 @@ spec:
   serviceAccountName: associated-resource-sa
 ----
 
-In the above example, `associated-resource` can be of any `Kind` that requires an association to be created (for example `Kibana` or the `APMServer`).
+In the above example, `associated-resource` can be of any `Kind` that requires an association to be created, for example `Kibana` or the `APMServer`.
 You can find https://github.com/elastic/cloud-on-k8s/blob/master/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml[a complete example in the ECK GitHub repository].
 
-NOTE: If the `serviceAccountName` is not set, then ECK uses the `ServiceAccount` called `default`.
+NOTE: If the `serviceAccountName` is not set, ECK uses the `ServiceAccount` called `default`.
 
 The associated resource `associated-resource` is now allowed to create an association with any Elasticsearch cluster in the namespace `elasticsearch-ns`.


### PR DESCRIPTION
The PR:
- Consolidates the two original sections ([Restrict cross namespace resource associations](https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-restrict-cross-namespace-associations.html) and [Enabling cross-namespace association restrictions](https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s_enabling_cross_namespace_association_restrictions.html)) into one single page
- Proposes a minor reorg of the introductory text
- Adds numbered steps