### PR TITLE
Make Beat role name version-independent for Community Beats

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/beat.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/beat.asciidoc
@@ -203,8 +203,12 @@ You can specify the Beat to deploy and its version through `type` and `version` 
 
 ECK supports the deployment of any Community Beat. `type` and `version` specification elements have to be provided. In addition:
 
-- `image` element in the specification must point to the image to be deployed
--  a role must exist in Elasticsearch and have the permissions required by the Beat. The role name must be `eck_beat_$type_role`, where `$type` is the Beat type. For example, when deploying `type: kafkabeat`, the role name would be `eck_beat_kafkabeat_role`. See the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html[Elasticsearch documentation] for more details.
+1. `image` element in the specification must point to the image to be deployed
+2. the following roles must exist in Elasticsearch:ave the permissions required by the Bea
+- if `elasticsearchRef` is provided, a role with `eck_beat_es_$type_role` name must exist, where `$type` is the Beat type. For example, when deploying `type: kafkabeat`, the role name would be `eck_beat_es_kafkabeat_role`. This role must have the permissions required by the Beat. See the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html[Elasticsearch documentation] for more details.
+- if `kibanaRef` is provided, then, similarily to the above, a role with `eck_beat_kibana_$type_role` name must exist. This role must have the permissions required by the Beat for the dashboard setup purposes.
+
+Alternatively to the 2. above, a user can be created in Elasticsearch and its credentials included in Beats `config` specification element  for Elasticsearch output, Kibana setup or both. If `elasticsearchRef` and `kibanaRef` are also used, ECK will still manage CA mounting and rollover, while using the provided user credentials.
 
 
 [id="{p}-beat-set-up-kibana-dashboards"]

--- a/docs/orchestrating-elastic-stack-applications/beat.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/beat.asciidoc
@@ -205,11 +205,10 @@ ECK supports the deployment of any Community Beat. `type` and `version` specific
 
 1. `image` element in the specification must point to the image to be deployed
 2. the following roles must exist in Elasticsearch:ave the permissions required by the Bea
-- if `elasticsearchRef` is provided, a role with `eck_beat_es_$type_role` name must exist, where `$type` is the Beat type. For example, when deploying `type: kafkabeat`, the role name would be `eck_beat_es_kafkabeat_role`. This role must have the permissions required by the Beat. See the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html[Elasticsearch documentation] for more details.
-- if `kibanaRef` is provided, then, similarily to the above, a role with `eck_beat_kibana_$type_role` name must exist. This role must have the permissions required by the Beat for the dashboard setup purposes.
+- if `elasticsearchRef` is provided, a role with `eck_beat_es_$type_role` name must exist, where `$type` is the Beat type. For example, when deploying `kafkabeat`, the role name would be `eck_beat_es_kafkabeat_role`. This role must have the permissions required by the Beat. See the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html[Elasticsearch documentation] for more details.
+- if `kibanaRef` is provided, then, as above, a role named `eck_beat_kibana_$type_role` must exist with the permissions required to setup Kibana dashboards.
 
-Alternatively to the 2. above, a user can be created in Elasticsearch and its credentials included in Beats `config` specification element  for Elasticsearch output, Kibana setup or both. If `elasticsearchRef` and `kibanaRef` are also used, ECK will still manage CA mounting and rollover, while using the provided user credentials.
-
+Alternatively, create a user in Elasticsearch and include the credentials in the Beats `config` for Elasticsearch output, Kibana setup or both. If `elasticsearchRef` and `kibanaRef` are also defined, ECK will use the provided user credentials when setting up the connections.
 
 [id="{p}-beat-set-up-kibana-dashboards"]
 === Set up Kibana dashboards

--- a/docs/orchestrating-elastic-stack-applications/beat.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/beat.asciidoc
@@ -204,7 +204,7 @@ You can specify the Beat to deploy and its version through `type` and `version` 
 ECK supports the deployment of any Community Beat. `type` and `version` specification elements have to be provided. In addition:
 
 1. `image` element in the specification must point to the image to be deployed
-2. the following roles must exist in Elasticsearch:ave the permissions required by the Bea
+2. the following roles must exist in Elasticsearch:
 - if `elasticsearchRef` is provided, a role with `eck_beat_es_$type_role` name must exist, where `$type` is the Beat type. For example, when deploying `kafkabeat`, the role name would be `eck_beat_es_kafkabeat_role`. This role must have the permissions required by the Beat. See the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html[Elasticsearch documentation] for more details.
 - if `kibanaRef` is provided, then, as above, a role named `eck_beat_kibana_$type_role` must exist with the permissions required to setup Kibana dashboards.
 

--- a/pkg/apis/beat/v1beta1/beat_types.go
+++ b/pkg/apis/beat/v1beta1/beat_types.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	KnownTypes = []string{"filebeat", "metricbeat", "heartbeat", "auditbeat", "journalbeat", "packetbeat"}
+	KnownTypes = map[string]struct{}{"filebeat": {}, "metricbeat": {}, "heartbeat": {}, "auditbeat": {}, "journalbeat": {}, "packetbeat": {}}
 )
 
 // BeatSpec defines the desired state of a Beat.

--- a/pkg/apis/beat/v1beta1/beat_types.go
+++ b/pkg/apis/beat/v1beta1/beat_types.go
@@ -11,6 +11,10 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 )
 
+var (
+	KnownTypes = []string{"filebeat", "metricbeat", "heartbeat", "auditbeat", "journalbeat", "packetbeat"}
+)
+
 // BeatSpec defines the desired state of a Beat.
 type BeatSpec struct {
 	// Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, auditbeat, journalbeat, packetbeat, etc.).

--- a/pkg/apis/beat/v1beta1/validations.go
+++ b/pkg/apis/beat/v1beta1/validations.go
@@ -11,7 +11,6 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
 )
 
 var (
@@ -58,8 +57,7 @@ func checkAtMostOneDeploymentOption(b *Beat) field.ErrorList {
 }
 
 func checkImageIfTypeUnknown(b *Beat) field.ErrorList {
-	if !stringsutil.StringInSlice(b.Spec.Type, KnownTypes) &&
-		b.Spec.Image == "" {
+	if _, ok := KnownTypes[b.Spec.Type]; !ok && b.Spec.Image == "" {
 		return field.ErrorList{
 			field.Required(
 				field.NewPath("spec").Child("image"),

--- a/pkg/apis/beat/v1beta1/validations.go
+++ b/pkg/apis/beat/v1beta1/validations.go
@@ -58,8 +58,7 @@ func checkAtMostOneDeploymentOption(b *Beat) field.ErrorList {
 }
 
 func checkImageIfTypeUnknown(b *Beat) field.ErrorList {
-	knownTypes := []string{"filebeat", "metricbeat", "heartbeat", "auditbeat", "journalbeat", "packetbeat"}
-	if !stringsutil.StringInSlice(b.Spec.Type, knownTypes) &&
+	if !stringsutil.StringInSlice(b.Spec.Type, KnownTypes) &&
 		b.Spec.Image == "" {
 		return field.ErrorList{
 			field.Required(

--- a/pkg/controller/association/controller/beat_es.go
+++ b/pkg/controller/association/controller/beat_es.go
@@ -22,6 +22,7 @@ import (
 	esuser "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/rbac"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
 )
 
 const (
@@ -68,6 +69,10 @@ func getBeatRoles(assoc commonv1.Associated) (string, error) {
 
 	if strings.Contains(beat.Spec.Type, ",") {
 		return "", fmt.Errorf("beat type %s should not contain a comma", beat.Spec.Type)
+	}
+
+	if !stringsutil.StringInSlice(beat.Spec.Type, beatv1beta1.KnownTypes) {
+		return fmt.Sprintf("eck_beat_es_%s_role", beat.Spec.Type), nil
 	}
 
 	v, err := version.Parse(beat.Spec.Version)

--- a/pkg/controller/association/controller/beat_es.go
+++ b/pkg/controller/association/controller/beat_es.go
@@ -22,7 +22,6 @@ import (
 	esuser "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/rbac"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
 )
 
 const (
@@ -70,8 +69,7 @@ func getBeatRoles(assoc commonv1.Associated) (string, error) {
 	if strings.Contains(beat.Spec.Type, ",") {
 		return "", fmt.Errorf("beat type %s should not contain a comma", beat.Spec.Type)
 	}
-
-	if !stringsutil.StringInSlice(beat.Spec.Type, beatv1beta1.KnownTypes) {
+	if _, ok := beatv1beta1.KnownTypes[beat.Spec.Type]; !ok {
 		return fmt.Sprintf("eck_beat_es_%s_role", beat.Spec.Type), nil
 	}
 

--- a/pkg/controller/association/controller/beat_es_test.go
+++ b/pkg/controller/association/controller/beat_es_test.go
@@ -26,14 +26,24 @@ func Test_getBeatRoles(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "injecting a role should fail",
+			name:    "injecting a role with official Beat should fail",
+			assoc:   &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "filebeat,superuser"}},
+			wantErr: true,
+		},
+		{
+			name:    "injecting a role with community Beat should fail",
 			assoc:   &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "somebeat,superuser"}},
 			wantErr: true,
 		},
 		{
-			name:    "invalid version",
-			assoc:   &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Version: "7.7.0.1"}},
+			name:    "invalid official Beat version",
+			assoc:   &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Version: "7.7.0.1a", Type: "filebeat"}},
 			wantErr: true,
+		},
+		{
+			name:  "different Community Beat version", // we are not able to validate community Beat version
+			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Version: "7.7.0.1a", Type: "somebeat"}},
+			want:  "eck_beat_es_somebeat_role",
 		},
 		{
 			name:  "test roles for 7.0.0 official Beat",
@@ -76,14 +86,14 @@ func Test_getBeatRoles(t *testing.T) {
 			want:  "kibana_admin,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_es_metricbeat_role_v77",
 		},
 		{
-			name:  "test roles for 7.0.0 community Beat",
-			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "somebeat", Version: "7.0.0"}},
-			want:  "kibana_user,ingest_admin,beats_admin,monitoring_user,eck_beat_es_somebeat_role_v70",
+			name:  "test roles for 1.2.0 community Beat",
+			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "somebeat", Version: "1.2.0"}},
+			want:  "eck_beat_es_somebeat_role",
 		},
 		{
-			name:  "test roles for 7.99.99 community Beat",
-			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "somebeat", Version: "7.99.99"}},
-			want:  "kibana_admin,ingest_admin,beats_admin,remote_monitoring_user,eck_beat_es_somebeat_role_v77",
+			name:  "test roles for 3.4.0 community Beat",
+			assoc: &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Type: "somebeat", Version: "3.4.0"}},
+			want:  "eck_beat_es_somebeat_role",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/association/controller/beat_kibana.go
+++ b/pkg/controller/association/controller/beat_kibana.go
@@ -18,7 +18,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/rbac"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
 	pkgerrors "github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -77,7 +76,7 @@ func getBeatKibanaRoles(associated commonv1.Associated) (string, error) {
 		return "", fmt.Errorf("beat type %s should not contain a comma", beat.Spec.Type)
 	}
 
-	if !stringsutil.StringInSlice(beat.Spec.Type, beatv1beta1.KnownTypes) {
+	if _, ok := beatv1beta1.KnownTypes[beat.Spec.Type]; !ok {
 		return fmt.Sprintf("eck_beat_kibana_%s_role", beat.Spec.Type), nil
 	}
 

--- a/pkg/controller/association/controller/beat_kibana.go
+++ b/pkg/controller/association/controller/beat_kibana.go
@@ -18,6 +18,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/rbac"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
 	pkgerrors "github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -74,6 +75,10 @@ func getBeatKibanaRoles(associated commonv1.Associated) (string, error) {
 
 	if strings.Contains(beat.Spec.Type, ",") {
 		return "", fmt.Errorf("beat type %s should not contain a comma", beat.Spec.Type)
+	}
+
+	if !stringsutil.StringInSlice(beat.Spec.Type, beatv1beta1.KnownTypes) {
+		return fmt.Sprintf("eck_beat_kibana_%s_role", beat.Spec.Type), nil
 	}
 
 	v, err := version.Parse(beat.Spec.Version)

--- a/pkg/controller/association/controller/beat_kibana_test.go
+++ b/pkg/controller/association/controller/beat_kibana_test.go
@@ -27,8 +27,14 @@ func Test_getBeatKibanaRoles(t *testing.T) {
 		},
 		{
 			name:    "not a valid version",
-			args:    &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Version: "not-a-version"}},
+			args:    &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Version: "not-a-version", Type: "filebeat"}},
 			wantErr: true,
+		},
+		{
+			name:    "different Community Beat version", // we are not able to validate community Beat version
+			args:    &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Version: "not-a-version", Type: "community_beat"}},
+			want:    "eck_beat_kibana_community_beat_role",
+			wantErr: false,
 		},
 		{
 			name:    "<7.3 Beat",
@@ -46,6 +52,12 @@ func Test_getBeatKibanaRoles(t *testing.T) {
 			name:    ">=7.8 Beat",
 			args:    &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Version: "7.8.0", Type: string(filebeat.Type)}},
 			want:    "kibana_admin,ingest_admin,beats_admin,eck_beat_kibana_filebeat_role_v77",
+			wantErr: false,
+		},
+		{
+			name:    "community Beat",
+			args:    &beatv1beta1.Beat{Spec: beatv1beta1.BeatSpec{Version: "1.2.0", Type: "community_beat"}},
+			want:    "eck_beat_kibana_community_beat_role",
 			wantErr: false,
 		},
 	}

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -91,7 +91,7 @@ var (
 )
 
 func init() {
-	for _, beat := range beatv1beta1.KnownTypes {
+	for beat := range beatv1beta1.KnownTypes {
 		PredefinedRoles[BeatEsRoleName(V77, beat)] = esclient.Role{
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml", "read_ilm", "cluster:admin/ingest/pipeline/get"},
 			Indices: []esclient.IndexRole{

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -7,6 +7,7 @@ package user
 import (
 	"fmt"
 
+	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 
 	"gopkg.in/yaml.v2"
@@ -90,7 +91,7 @@ var (
 )
 
 func init() {
-	for _, beat := range []string{"filebeat", "metricbeat", "heartbeat", "auditbeat", "journalbeat", "packetbeat"} {
+	for _, beat := range beatv1beta1.KnownTypes {
 		PredefinedRoles[BeatEsRoleName(V77, beat)] = esclient.Role{
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml", "read_ilm", "cluster:admin/ingest/pipeline/get"},
 			Indices: []esclient.IndexRole{


### PR DESCRIPTION
1) Defines well-known Beats list in a single place.
2) For community Beats:
    - the role name used no longer depends on the Beat version. Community Beats can be versioned differently than official Beats so we shouldn't expect users to follow version changes in role names that come from official Beats changes.
    - don't include other role names (`kibana_admin`, etc.). I think we could go either way on this one, but I wouldn't make any assumptions about needed permissions.

Note that the alternative option to creating right role is to create a user in ES and pass username/password in the config while still providing `elasticsearchRef` - we will take credentials from user config, but still mount/use the right CA in Beat pods.

Fixes https://github.com/elastic/cloud-on-k8s/issues/3363.