### PR TITLE
Point GitHub links in the docs to the correct branch

### DIFF
--- a/docs/advanced-topics/traffic-splitting.asciidoc
+++ b/docs/advanced-topics/traffic-splitting.asciidoc
@@ -10,7 +10,7 @@ endif::[]
 
 The default Kubernetes service created by ECK -- named `<cluster_name>-es-http` -- is configured to include all the Elasticsearch nodes in that cluster. This configuration is good enough to get started and adequate for most simple use cases. However, if you are operating an Elasticsearch cluster with link:https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[different node types] and want control over which nodes handle which types of traffic, you should create additional Kubernetes services yourself to do so. Alternatively, you could make use of features provided by third-party software such as service meshes and ingress controllers to achieve more advanced traffic management configurations.
 
-NOTE: The link:https://github.com/elastic/cloud-on-k8s/tree/master/config/recipes[recipes directory] in the ECK source repository contains several examples of using third-party service meshes and ingress controllers for managing traffic to ECK resources.
+NOTE: The link:{eck_github}/tree/{eck_release_branch}/config/recipes[recipes directory] in the ECK source repository contains several examples of using third-party service meshes and ingress controllers for managing traffic to ECK resources.
 
 
 The service configurations shown in the following sections are based on this definition of an Elasticsearch cluster:

--- a/docs/eck-attributes.asciidoc
+++ b/docs/eck-attributes.asciidoc
@@ -1,2 +1,4 @@
 :eck_version: 1.2.0
 :eck_crd_version: v1
+:eck_release_branch: 1.2
+:eck_github: https://github.com/elastic/cloud-on-k8s

--- a/docs/help.asciidoc
+++ b/docs/help.asciidoc
@@ -1,2 +1,2 @@
 * link:https://discuss.elastic.co/c/eck[ECK Discuss forums] to ask any question
-* link:https://github.com/elastic/cloud-on-k8s/issues[Github issues] for bugs and feature requests
+* link:{eck_github}/issues[Github issues] for bugs and feature requests

--- a/docs/operating-eck/restrict-cross-namespace-associations.asciidoc
+++ b/docs/operating-eck/restrict-cross-namespace-associations.asciidoc
@@ -17,7 +17,7 @@ Associations are allowed as long as the `ServiceAccount` used by the associated 
 
 IMPORTANT: ECK automatically removes any associations that do not have the correct access rights. If you have existing associations, do not enable this feature without creating the required `Roles` and `RoleBindings` as described in the following sections.
 
-To enable the restriction of cross-namespace associations, start the operator with the `--enforce-rbac-on-refs` flag. 
+To enable the restriction of cross-namespace associations, start the operator with the `--enforce-rbac-on-refs` flag.
 
 . Create a `ClusterRole` to allow HTTP `GET` requests to be run against Elasticsearch objects:
 +
@@ -79,7 +79,7 @@ spec:
 ----
 
 In the above example, `associated-resource` can be of any `Kind` that requires an association to be created, for example `Kibana` or `ApmServer`.
-You can find https://github.com/elastic/cloud-on-k8s/blob/master/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml[a complete example in the ECK GitHub repository].
+You can find link:{eck_github}/blob/{eck_release_branch}/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml[a complete example in the ECK GitHub repository].
 
 NOTE: If the `serviceAccountName` is not set, ECK uses the default service account assigned to the pod by the link:https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#service-account-admission-controller[Service Account Admission Controller].
 

--- a/docs/operating-eck/upgrading-eck.asciidoc
+++ b/docs/operating-eck/upgrading-eck.asciidoc
@@ -66,7 +66,7 @@ kubectl annotate elasticsearch quickstart $RM_ANNOTATION
 
 <1> Since ECK 1.1.0, this annotation has been superseded by `eck.k8s.elastic.co/managed-`.
 
-NOTE: The ECK source repository contains a link:https://github.com/elastic/cloud-on-k8s/tree/master/hack/annotator[shell script] to assist with mass addition/deletion of annotations.
+NOTE: The ECK source repository contains a link:{eck_github}/tree/{eck_release_branch}/hack/annotator[shell script] to assist with mass addition/deletion of annotations.
 
 
 [float]

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -278,11 +278,10 @@ The cluster that you deployed in this quickstart guide only allocates a persiste
 [id="{p}-check-samples"]
 == Check out the samples
 
-You can find a set of sample resources link:https://github.com/elastic/cloud-on-k8s/tree/master/config/samples[in the project repository].
-To customize the Elasticsearch resource, check the link:https://github.com/elastic/cloud-on-k8s/blob/master/config/samples/elasticsearch/elasticsearch.yaml[Elasticsearch sample].
+You can find a set of sample resources link:{eck_github}/tree/{eck_release_branch}/config/samples[in the project repository].
 
-For a full description of each `CustomResourceDefinition`, go to link:https://github.com/elastic/cloud-on-k8s/tree/master/config/crds[the project repository].
-You can also retrieve it from the cluster. For example, describe the Elasticsearch CRD specification with:
+For a full description of each `CustomResourceDefinition` (CRD), refer to the <<{p}-api-reference>> or view the CRD files in the link:{eck_github}/tree/{eck_release_branch}/config/crds[project repository].
+You can also retrieve information about a CRD from the cluster. For example, describe the Elasticsearch CRD specification with:
 
 [source,sh]
 ----


### PR DESCRIPTION
Changes the GitHub links to point to the correct release branch instead of `master`.

Fixes #3438 