### PR TITLE
Fix Beat E2E tests for OCP and stack versions pipelines

### DIFF
--- a/test/e2e/beat/config_test.go
+++ b/test/e2e/beat/config_test.go
@@ -227,7 +227,7 @@ func TestAuditbeatConfig(t *testing.T) {
 	abBuilder := beat.NewBuilder(name).
 		WithType(auditbeat.Type).
 		WithKibanaRef(kbBuilder.Ref()).
-		WithRoles(beat.AuditbeatPSPClusterRoleName).
+		WithRoles(beat.AuditbeatPSPClusterRoleName, beat.AutodiscoverClusterRoleName).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithESValidations(
 			beat.HasEventFromBeat(auditbeat.Type),
@@ -253,7 +253,7 @@ func TestPacketbeatConfig(t *testing.T) {
 	pbBuilder := beat.NewBuilder(name).
 		WithType(packetbeat.Type).
 		WithKibanaRef(kbBuilder.Ref()).
-		WithRoles(beat.PacketbeatPSPClusterRoleName).
+		WithRoles(beat.PacketbeatPSPClusterRoleName, beat.AutodiscoverClusterRoleName).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithESValidations(
 			beat.HasEventFromBeat(packetbeat.Type),
@@ -279,7 +279,7 @@ func TestJournalbeatConfig(t *testing.T) {
 
 	jbBuilder := beat.NewBuilder(name).
 		WithType(journalbeat.Type).
-		WithRoles(beat.JournalbeatPSPClusterRoleName).
+		WithRoles(beat.JournalbeatPSPClusterRoleName, beat.AutodiscoverClusterRoleName).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithESValidations(
 			beat.HasEventFromBeat(journalbeat.Type),

--- a/test/e2e/beat/recipes_test.go
+++ b/test/e2e/beat/recipes_test.go
@@ -186,6 +186,12 @@ func runBeatRecipe(
 			t.SkipNow()
 		}
 
+		// OpenShift requires different securityContext than provided in the recipe.
+		// Skipping it altogether to reduce maintenance burden.
+		if test.Ctx().Provider == "ocp" {
+			t.SkipNow()
+		}
+
 		if customize != nil {
 			beatBuilder = customize(beatBuilder)
 		}

--- a/test/e2e/beat/recipes_test.go
+++ b/test/e2e/beat/recipes_test.go
@@ -10,10 +10,12 @@ import (
 	"strings"
 	"testing"
 
+	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	beatcommon "github.com/elastic/cloud-on-k8s/pkg/controller/beat/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/beat"
@@ -180,6 +182,10 @@ func runBeatRecipe(
 			return builder
 		}
 
+		if isStackIncompatible(beatBuilder.Beat) {
+			t.SkipNow()
+		}
+
 		if customize != nil {
 			beatBuilder = customize(beatBuilder)
 		}
@@ -189,6 +195,13 @@ func runBeatRecipe(
 	}
 
 	helper.RunFile(t, filePath, namespace, suffix, additionalObjects, transformationsWrapped)
+}
+
+// isStackIncompatible returns true iff Beat version is higher than tested Stack version
+func isStackIncompatible(beat beatv1beta1.Beat) bool {
+	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
+	beatVersion := version.MustParse(beat.Spec.Version)
+	return beatVersion.IsAfter(stackVersion)
 }
 
 func loggingTestPod(name string) (*corev1.Pod, string) {


### PR DESCRIPTION
1. As recipes have static versions we should only validate them versus the same (most often) or higher (if latest is temporary higher than recipe) stack version.
2. OCP requires per-Beat config alterations. As we clearly state that recipes might not work there ootb I think we don't need to validate them right now.
3. Adding `autodiscover` role was previously done when constructing `BeatBuilder` struct, but was removed. Not all tests that still require it were updated.