### PR TITLE
[DOC] Operating ECK - align landing page with TOC

### DIFF
--- a/docs/operating-eck/operating-eck.asciidoc
+++ b/docs/operating-eck/operating-eck.asciidoc
@@ -11,6 +11,7 @@ endif::[]
 --
 - <<{p}-operator-config>>
 - <<{p}-webhook>>
+- <<{p}-restrict-cross-namespace-associations>>
 - <<{p}-licensing>>
 - <<{p}-troubleshooting>>
 - <<{p}-upgrading-eck>>


### PR DESCRIPTION
This PR updates the [Operating ECK](https://www.elastic.co/guide/en/cloud-on-k8s/1.2/k8s-operating-eck.html) landing page with a link to [Restrict cross-namespace resource associations](https://www.elastic.co/guide/en/cloud-on-k8s/1.2/k8s-restrict-cross-namespace-associations.html).