### PR TITLE
Print e2e json file for junit rendering debugging purposes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ e2e-run:
 		--skip-cleanup=$(E2E_SKIP_CLEANUP)
 
 e2e-generate-xml:
-	@ gotestsum --junitfile e2e-tests.xml --raw-command cat e2e-tests.json
+	@ gotestsum --junitfile e2e-tests.xml --raw-command cat e2e-tests.json || echo "Failed to generate xml report" && cat e2e-tests.json && false
 
 # Verify e2e tests compile with no errors, don't run them
 e2e-compile:

--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ e2e-run:
 		--skip-cleanup=$(E2E_SKIP_CLEANUP)
 
 e2e-generate-xml:
-	@ gotestsum --junitfile e2e-tests.xml --raw-command cat e2e-tests.json || echo "Failed to generate xml report" && cat e2e-tests.json && false
+	@ gotestsum --junitfile e2e-tests.xml --raw-command cat e2e-tests.json || (echo "Failed to generate xml report" && cat e2e-tests.json && false)
 
 # Verify e2e tests compile with no errors, don't run them
 e2e-compile:


### PR DESCRIPTION
This commit temporarily prints the entire content of e2e-tests.json when
it cannot be parsed for junit rendering.

The idea is to have the content of this file available in Jenkins for
further debugging. I suspect something wrong somewhere in the JSON
formatting of this file.

Relates https://github.com/elastic/cloud-on-k8s/issues/3413.