### PR TITLE
Fix flaky namespace creation in integration tests

### DIFF
--- a/pkg/controller/license/license_controller_integration_test.go
+++ b/pkg/controller/license/license_controller_integration_test.go
@@ -75,12 +75,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 	}
-	testNS := corev1.Namespace{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "elastic-system",
-		},
-	}
-	require.NoError(t, c.Create(&testNS))
+	require.NoError(t, test.EnsureNamespace(c, "elastic-system"))
 
 	// Create the EnterpriseLicense object
 	require.NoError(t, CreateEnterpriseLicense(

--- a/pkg/controller/license/trial/trial_controller_integration_test.go
+++ b/pkg/controller/license/trial/trial_controller_integration_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -40,12 +39,8 @@ func TestReconcile(t *testing.T) {
 	defer stop()
 
 	now := time.Now()
-	testNS := corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: operatorNs,
-		},
-	}
-	require.NoError(t, c.Create(&testNS))
+
+	require.NoError(t, test.EnsureNamespace(c, operatorNs))
 
 	// Create trial initialisation is controlled via config
 	require.NoError(t, license.CreateTrialLicense(c, testLicenseNSN))

--- a/pkg/utils/test/integration.go
+++ b/pkg/utils/test/integration.go
@@ -84,7 +84,9 @@ func StartManager(t *testing.T, addToMgrFunc func(manager.Manager, operator.Para
 	go func() {
 		stopped <- mgr.Start(stopChan)
 	}()
+
 	mgr.GetCache().WaitForCacheSync(nil) // wait until k8s client cache is initialized
+
 	client := k8s.WrapClient(mgr.GetClient())
 	stopFunc := func() {
 		// stop the manager and wait until stopped

--- a/pkg/utils/test/integration.go
+++ b/pkg/utils/test/integration.go
@@ -84,7 +84,7 @@ func StartManager(t *testing.T, addToMgrFunc func(manager.Manager, operator.Para
 	go func() {
 		stopped <- mgr.Start(stopChan)
 	}()
-
+	mgr.GetCache().WaitForCacheSync(nil) // wait until k8s client cache is initialized
 	client := k8s.WrapClient(mgr.GetClient())
 	stopFunc := func() {
 		// stop the manager and wait until stopped

--- a/pkg/utils/test/namespace.go
+++ b/pkg/utils/test/namespace.go
@@ -23,5 +23,5 @@ func EnsureNamespace(c k8s.Client, ns string) error {
 	if errors.IsNotFound(err) {
 		return c.Create(&expected)
 	}
-	return nil
+	return err
 }

--- a/pkg/utils/test/namespace.go
+++ b/pkg/utils/test/namespace.go
@@ -1,0 +1,27 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package test
+
+import (
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func EnsureNamespace(c k8s.Client, ns string) error {
+	expected := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ns,
+		},
+	}
+	existing := corev1.Namespace{}
+	err := c.Get(types.NamespacedName{Name: ns}, &existing)
+	if errors.IsNotFound(err) {
+		return c.Create(&expected)
+	}
+	return nil
+}


### PR DESCRIPTION
* Make sure cache is synched before integration test API interactions
* Defensively check if namespace already exists

Partial fix for  #3483 