### PR TITLE
Fix log stream flush in E2E tests

### DIFF
--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -436,8 +436,9 @@ func (h *helper) monitorTestJob(client *kubernetes.Clientset) error {
 				if !jobStarted {
 					jobStarted = true
 					log.Info("Pod started", "name", newPod.Name)
+
+					logStreamWg.Add(1)
 					go func() {
-						logStreamWg.Add(1)
 						h.streamTestJobOutput(streamErrors, stopLogStream, client, newPod.Name)
 						logStreamWg.Done()
 					}()


### PR DESCRIPTION
This commit fixes several problems:
- the main e2e tests process could return before the log stream
  goroutine has enough time to run `defer jsonLog.Close()`, leading to a
  truncated json file
- the informer was stopped (stopping the tests) on any stream error, but
  we retry in case the stream stops so we should keep things running
- we did not wait for the end of the log stream in case the Pod is in
  failed state

We now rely on a `logStreamStopped` channel, and wait for it to be
closed before returning from the `monitorTestJob` function, so we know
all stream writers have been properly closed.
Also streamStatus is now only used for reporting errors, it does not
also indicate the end of the stream, which was a bit confusing.

I did not test this fixes our current tests results parsing issues
entirely (because not easy to reproduce), but I think it should help. We'll see
on the next set of e2e tests :)

Relates https://github.com/elastic/cloud-on-k8s/issues/3413.