### PR TITLE
Add EnterpriseSearch example to OLM template

### DIFF
--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -1,4 +1,4 @@
-newVersion: 1.2.0-bc3
+newVersion: 1.2.0
 prevVersion: 1.1.2
 stackVersion: 7.8.0
 operatorRepo: docker.elastic.co/eck/eck-operator

--- a/hack/operatorhub/go.sum
+++ b/hack/operatorhub/go.sum
@@ -274,6 +274,7 @@ github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -109,6 +109,23 @@ metadata:
                       "name": "elasticsearch-sample"
                   }
               }
+          },
+          {
+              "apiVersion": "enterprisesearch.k8s.elastic.co/v1beta1",
+              "kind": "EnterpriseSearch",
+              "metadata": {
+                  "name": "ent-sample"
+              },
+              "spec": {
+                  "version": "{{ .StackVersion }}",
+                  "config": {
+                      "ent_search.external_url": "https://localhost:3002"
+                  },
+                  "count": 1,
+                  "elasticsearchRef": {
+                      "name": "elasticsearch-sample"
+                  }
+              }
           }
       ]
   name: elastic-cloud-eck.v{{ .NewVersion }}


### PR DESCRIPTION
Add EnterpriseSearch to the examples list and change the config file to point to 1.2.0.