### PR TITLE
[Backport] Documentation updates (#3473, #3476, #3477, #3484)

### DIFF
--- a/docs/operating-eck/licensing.asciidoc
+++ b/docs/operating-eck/licensing.asciidoc
@@ -9,9 +9,18 @@ endif::[]
 
 When you install the default distribution of ECK, you receive a Basic license. Any Elastic stack application you manage through ECK will also be Basic licensed. Go to https://www.elastic.co/subscriptions to see which features are included in the Basic license for free.
 
-IMPORTANT: ECK is only offered in two licensing tiers: Basic and Enterprise. Similar to the Elastic Stack, customers are able to download and use ECK with a Basic license for free. Basic license users can obtain support from GitHub or through our link:https://discuss.elastic.co[community]. A paid Enterprise subscription is required to engage the Elastic support team. For more details, see the link:https://www.elastic.co/subscriptions[Elastic subscriptions].
+IMPORTANT: ECK is only offered in two licensing tiers: Basic and Enterprise. Similar to the Elastic Stack, customers can download and use ECK with a Basic license for free. Basic license users can obtain support from GitHub or through our link:https://discuss.elastic.co[community]. A paid Enterprise subscription is required to engage the Elastic support team. For more details, see the link:https://www.elastic.co/subscriptions[Elastic subscriptions].
+
+In this section, you are going to learn how to:
+
+- <<{p}-start-trial>>
+- <<{p}-add-license>>
+- <<{p}-update-license>>
+- <<{p}-get-usage-data>>
+
 
 [float]
+[id="{p}-start-trial"]
 == Start a trial
 If you want to try the features included in the Enterprise subscription, you can start a 30-day trial. To start a trial create a Kubernetes secret as shown below. Note that it must be in the same namespace as the operator:
 
@@ -32,15 +41,16 @@ EOF
 
 <1> By setting this annotation to `accepted` you are expressing that you have accepted the Elastic EULA which can be found at https://www.elastic.co/eula.
 
-NOTE: You can initiate a trial only if a trial has not previously been activated.
+NOTE: You can initiate a trial only if a trial has not been previously  activated.
 
 At the end of the trial period, the Platinum and Enterprise features operate in a link:https://www.elastic.co/guide/en/elastic-stack-overview/current/license-expiration.html[degraded mode]. You can revert to a Basic license, extend the trial, or purchase an Enterprise subscription.
 
 [float]
+[id="{p}-add-license"]
 == Add a license
 If you have a valid Enterprise subscription or a trial license extension, you will receive a license as a JSON file.
 
-NOTE: Please note that ECK will only accept Enterprise licenses. You can not apply a single Platinum or Gold cluster license to ECK.
+NOTE: ECK will only accept Enterprise licenses. You can not apply a single Platinum or Gold cluster license to ECK.
 
 To add the license to your ECK installation, create a Kubernetes secret of the following form:
 
@@ -60,7 +70,7 @@ data:
 <1> This label is required for ECK to identify your license secret.
 <2> The license file can have any name.
 
-You can easily create this secret using `kubectl` 's built-in support for secrets.  Note that it must be in the same namespace as the operator:
+You can easily create this secret using `kubectl` built-in support for secrets.  Note that it must be in the same namespace as the operator:
 
 [source,shell script]
 ----
@@ -71,16 +81,18 @@ kubectl label secret eck-license "license.k8s.elastic.co/scope"=operator -n elas
 NOTE: After you install a license into ECK, all the Elastic stack applications you manage with ECK will have all Platinum and Enterprise features enabled. Applications created before you installed the license are upgraded to Platinum or Enterprise features without interruption of service after a short delay.
 
 [float]
+[id="{p}-update-license"]
 == Update your license
-Before your current Enterprise license expires, you will receive a new Enterprise license from Elastic (provided your subscription is valid).
+Before your current Enterprise license expires, you will receive a new Enterprise license from Elastic (provided that your subscription is valid).
 
-To avoid any unintended downgrade of individual Elasticsearch clusters to a Basic license while installing the new license we recommend you install the new Enterprise license as a new Kubernetes secret next to your existing Enterprise license. Just replace `eck-license` with a different name from the examples above. ECK will use the correct license automatically.
+To avoid any unintended downgrade of individual Elasticsearch clusters to a Basic license while installing the new license, we recommend to install the new Enterprise license as a new Kubernetes secret next to your existing Enterprise license. Just replace `eck-license` with a different name from the examples above. ECK will use the correct license automatically.
 
 Once you have created the new license secret you can safely delete the old license secret.
 
 [float]
+[id="{p}-get-usage-data"]
 == Get usage data
-The operator periodically writes the total amount of Elastic resources under management to a config map. It is named `elastic-licensing` in the same namespace as the operator. Here is an example of retrieving the data:
+The operator periodically writes the total amount of Elastic resources under management to a configmap named `elastic-licensing`, which is in the same namespace as the operator. Here is an example of retrieving the data:
 
 [source,shell]
 ----

--- a/docs/operating-eck/operating-eck.asciidoc
+++ b/docs/operating-eck/operating-eck.asciidoc
@@ -11,6 +11,7 @@ endif::[]
 --
 - <<{p}-operator-config>>
 - <<{p}-webhook>>
+- <<{p}-restrict-cross-namespace-associations>>
 - <<{p}-licensing>>
 - <<{p}-troubleshooting>>
 - <<{p}-upgrading-eck>>

--- a/docs/operating-eck/operator-config.asciidoc
+++ b/docs/operating-eck/operator-config.asciidoc
@@ -21,10 +21,10 @@ ECK can be configured using either command line flags or environment variables.
 |container-registry |docker.elastic.co | Container registry to use for pulling Elastic Stack container images.
 |debug-http-listen |localhost:6060 |Listen address for the debug HTTP server. Only available in development mode.
 |development |false |Enable development mode. Only available as a CLI flag.
-|enable-tracing | false | Enable APM tracing in the operator process. APM server URL, credentials etc. can be configured via environment variables. See the link:https://www.elastic.co/guide/en/apm/agent/go/1.x/configuration.html[Apm Go Agent reference] for details.
+|enable-tracing | false | Enable APM tracing in the operator process. Use environment variables to configure APM server URL, credentials, and so on. See link:https://www.elastic.co/guide/en/apm/agent/go/1.x/configuration.html[Apm Go Agent reference] for details.
 |enable-webhook | false | Enables a validating webhook server in the operator process.
-|enforce-rbac-on-refs| false | Enables restrictions on cross-namespace resource association through RBAC
-|log-verbosity |0 |Verbosity level of logs. `-2`=Error, `-1`=Warn, `0`=Info, `0` and above=Debug
+|enforce-rbac-on-refs| false | Enables restrictions on cross-namespace resource association through RBAC.
+|log-verbosity |0 |Verbosity level of logs. `-2`=Error, `-1`=Warn, `0`=Info, `0` and above=Debug.
 |manage-webhook-certs |true |Enables automatic webhook certificate management.
 |max-concurrent-reconciles |3 | Maximum number of concurrent reconciles per controller (Elasticsearch, Kibana, APM Server). Affects the ability of the operator to process changes concurrently.
 |metrics-port |0 |Prometheus metrics port. Set to 0 to disable the metrics endpoint.

--- a/docs/operating-eck/webhook.asciidoc
+++ b/docs/operating-eck/webhook.asciidoc
@@ -14,16 +14,16 @@ The webhook is composed of 4 main components. Here is a brief description of eac
 . A webhook server that actually validates the submitted resources. In ECK it is the operator itself when it is configured with the `webhook` enabled. See <<{p}-operator-config,Configuring ECK>> for more information about the `enable-webhook` flag.
 . A Secret containing the required certificates to secure the connection between the API server and the webhook server.
 Like the ValidatingWebhookConfiguration, it must be created before starting the operator, even if it is empty. By default its name is `elastic-webhook-server-cert`.
-The content of this Secret and the lifecycle of the certificates are automatically managed for you. ECK generates a dedicated and separate certificate authority and ensures that all components are rotated before the expiration date. The certificate authority is also used to configure the `caBundle` field of the `ValidatingWebhookConfiguration`. You can disable this feature if you want to manage the certificates yourself or with https://github.com/jetstack/cert-manager[cert-manager]. See an example of the latter below.
+The content of this Secret and the lifecycle of the certificates are automatically managed for you. ECK generates a dedicated and separate certificate authority and ensures that all components are rotated before the expiration date. The certificate authority is also used to configure the `caBundle` field of the `ValidatingWebhookConfiguration`. You can disable this feature if you want to manage the certificates yourself or with https://github.com/jetstack/cert-manager[cert-manager]. See <<{p}-webhook-cert-manager,this example>>.
 
-
+[id="{p}-webhook-cert-manager"]
 == Manage the webhook certificate with cert-manager
 
-If ECK is currently running you first must ensure that the automatic certificate management feature is disabled. This can be done by updating the operator deployment manifest and adding the `--manage-webhook-certs=false` flag.
+If ECK is currently running, first make sure that the automatic certificate management feature is disabled. To do this, add the `--manage-webhook-certs=false` flag to the operator deployment manifest.
 
-Then, cert-manager v0.11+ must be installed as described in the https://docs.cert-manager.io/en/latest/getting-started/install/[cert-manager documentation].
+Then, install cert-manager v0.11+ as described in the https://docs.cert-manager.io/en/latest/getting-started/install/[cert-manager documentation].
 
-The following example shows how to create all the resources that a webhook requires to function.
+This example shows how to create all the resources that a webhook requires to function.
 
 [source,yaml,subs="attributes,+macros"]
 ----
@@ -112,13 +112,13 @@ On startup, the operator deploys an https://kubernetes.io/docs/reference/access-
 
 For troubleshooting, you can change the https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy[`failurePolicy`] of the webhook configuration to `Fail`, which will cause creations and updates to error out if there is an error contacting the webhook.
 
-On link:https://cloud.google.com/kubernetes-engine/docs/concepts/private-cluster-concept[GKE private clusters], you may see requests creating or updating Elastic resources take a long time to complete or timeout. If so, you will need to add a firewall rule allowing port 9443 from the API server so that it can contact the webhook. See the link:https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules[GKE documentation on adding rules] and the link:https://github.com/kubernetes/kubernetes/issues/79739[Kubernetes issue] for more detail.
+On link:https://cloud.google.com/kubernetes-engine/docs/concepts/private-cluster-concept[GKE private clusters], requests for creating or updating Elastic resources might take a long time to complete or time out. In this case, you have to add a firewall rule allowing port 9443 from the API server so that it can contact the webhook. See the link:https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules[GKE documentation on adding rules] and the link:https://github.com/kubernetes/kubernetes/issues/79739[Kubernetes issue] for more details.
 
 Refer to <<{p}-webhook-network-policies>> for more information about network policies that might be preventing communication between the Kubernetes API server and the webhook server.
 
 [float]
 === Validation failures
-If the validation webhook is preventing you from making changes due to the unknown fields validation like below, you can force the webhook to ignore it by removing the`kubectl.kubernetes.io/last-applied-configuration` annotation from your resource.
+If the validation webhook is preventing you from making changes due to the unknown fields validation like in the example below, you can force the webhook to ignore it by removing the`kubectl.kubernetes.io/last-applied-configuration` annotation from your resource.
 
 ```
 admission webhook "elastic-es-validation-v1.k8s.elastic.co" denied the request: Elasticsearch.elasticsearch.k8s.elastic.co "quickstart" is invalid: some-misspelled-field: Invalid value: "some-misspelled-field": some-misspelled-field field found in the kubectl.kubernetes.io/last-applied-configuration annotation is unknown
@@ -133,14 +133,14 @@ Webhooks require network connectivity between the Kubernetes API server and the 
 Error from server (Timeout): error when creating "elasticsearch.yaml": Timeout: request did not complete within requested timeout 30s
 ....
 
-If you encounter the above error, try re-running the command with a higher request timeout as follows:
+If you get this error, try re-running the command with a higher request timeout as follows:
 
 [source,sh,subs="attributes"]
 ----
 kubectl --request-timeout=1m apply -f elasticsearch.yaml
 ----
 
-As the default link:https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy[`failurePolicy`] of the webhook is `Ignore`, the above command should succeed after about 30 seconds. This is an indication that the API server cannot contact the webhook server and has foregone validation when creating the resource. One possible reason for this is that a link:https://kubernetes.io/docs/concepts/services-networking/network-policies/[network policy] might be blocking any incoming requests to the webhook server. Consult your system administrator to determine whether that is the case and create an appropriate policy to allow communication between the Kubernetes API server and the webhook server. For example, the following network policy simply opens up the webhook port to the world:
+As the default link:https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy[`failurePolicy`] of the webhook is `Ignore`, the above command should succeed after about 30 seconds. This is an indication that the API server cannot contact the webhook server and has foregone validation when creating the resource. It is possible that a link:https://kubernetes.io/docs/concepts/services-networking/network-policies/[network policy] is blocking any incoming requests to the webhook server. Consult your system administrator to determine whether that is the case, and create an appropriate policy to allow communication between the Kubernetes API server and the webhook server. For example, the following network policy simply opens up the webhook port to the world:
 
 
 [source,yaml,subs="attributes"]
@@ -160,7 +160,7 @@ spec:
       - port: 9443
 ----
 
-You may want to restrict webhook access to just the Kubernetes API server. Currently this requires knowing the IP address of the API server -- which can be obtained through the command:
+If you want to restrict the webhook access only to the Kubernetes API server, you must know the IP address of the API server, that you can obtain through this command:
 
 [source,sh,subs="attributes"]
 ----


### PR DESCRIPTION
Backport of documentation changes from #3473, #3476, #3477, and #3484.

Even though we normally try to keep backports 1:1, I think grouping these minor documentation PRs together is justified. I'll be happy to reconsider if there are any objections.