### PR TITLE
Removes no-op kibanaRef

### DIFF
--- a/config/recipes/beats/heartbeat_es_kb_health.yaml
+++ b/config/recipes/beats/heartbeat_es_kb_health.yaml
@@ -7,8 +7,6 @@ spec:
   version: 7.8.0
   elasticsearchRef:
     name: elasticsearch
-  kibanaRef:
-    name: kibana
   config:
     heartbeat.monitors:
     - type: tcp

--- a/config/recipes/beats/journalbeat_hosts.yaml
+++ b/config/recipes/beats/journalbeat_hosts.yaml
@@ -7,8 +7,6 @@ spec:
   version: 7.8.0
   elasticsearchRef:
     name: elasticsearch
-  kibanaRef:
-    name: kibana
   config:
     journalbeat.inputs:
     - paths: []


### PR DESCRIPTION
In Heartbeat and Journalbeat we ignore `kibanaRef` since default images don't contain the dashboards to setup. Recipes suggest otherwise, hence removing it.