### PR TITLE
[1.2] Removes no-op kibanaRef (#3516)

### DIFF
--- a/config/recipes/beats/heartbeat_es_kb_health.yaml
+++ b/config/recipes/beats/heartbeat_es_kb_health.yaml
@@ -7,8 +7,6 @@ spec:
   version: 7.8.0
   elasticsearchRef:
     name: elasticsearch
-  kibanaRef:
-    name: kibana
   config:
     heartbeat.monitors:
     - type: tcp

--- a/config/recipes/beats/journalbeat_hosts.yaml
+++ b/config/recipes/beats/journalbeat_hosts.yaml
@@ -7,8 +7,6 @@ spec:
   version: 7.8.0
   elasticsearchRef:
     name: elasticsearch
-  kibanaRef:
-    name: kibana
   config:
     journalbeat.inputs:
     - paths: []


### PR DESCRIPTION
Backports the following commits to 1.2:
 - Removes no-op kibanaRef (#3516)