### PR TITLE
Increase E2E rolling upgrade timeout from 15 to 30min

### DIFF
--- a/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/test/e2e/test/elasticsearch/checks_k8s.go
@@ -34,7 +34,7 @@ const (
 	// but it occasionally takes longer for various reasons (long Pod creation time, long volume binding, etc.).
 	// We use a longer timeout here to not be impacted too much by those external factors, and only fail
 	// if things seem to be stuck.
-	RollingUpgradeTimeout = 15 * time.Minute
+	RollingUpgradeTimeout = 30 * time.Minute
 )
 
 func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {


### PR DESCRIPTION
We observed an AKS rolling upgrade to require 15min 3sec! Making that
test fail. Let's bump the timeout to 30min to avoid occasional flakiness
if volumes are slowly bound, or Pods are slow to come up.

Fixes https://github.com/elastic/cloud-on-k8s/issues/3518.