### PR TITLE
[1.2] Fix typo in recipe link (#3515)

### DIFF
--- a/config/recipes/beats/README.asciidoc
+++ b/config/recipes/beats/README.asciidoc
@@ -30,7 +30,7 @@ Deploys Filebeat as a DaemonSet with the autodiscover feature disabled. Uses the
 
 Deploys Metricbeat configured for Elasticsearch and Kibana link:https://www.elastic.co/guide/en/kibana/current/xpack-monitoring.html[Stack Monitoring]. Deploys one monitored Elasticsearch cluster and one monitoring Elasticsearch cluster. You can access the Stack Monitoring app in the monitoring cluster's Kibana. Combine with one of the Filebeat recipes but update the `elasticsearchRef` to point to the `elasticsearch-monitoring` cluster for the full Stack Monitoring experience.
 
-==== Heartbeat monitoring Elasticsearch and Kibana health - `heartbeat_es_kb_heatlh.yaml`
+==== Heartbeat monitoring Elasticsearch and Kibana health - `heartbeat_es_kb_health.yaml`
 
 Deploys Heartbeat as a single Pod deployment that monitors the health of Elasticsearch and Kibana by TCP probing their Service endpoints. Note that Heartbeat expects that Elasticsearch and Kibana are deployed in the `default` namespace.
 

--- a/docs/orchestrating-elastic-stack-applications/beat.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/beat.asciidoc
@@ -428,7 +428,7 @@ Deploys Metricbeat configured for Elasticsearch and Kibana link:https://www.elas
 
 [source,sh,subs="attributes"]
 ----
-kubectl apply -f {beats_url}/heartbeat_es_kb_heatlh.yaml
+kubectl apply -f {beats_url}/heartbeat_es_kb_health.yaml
 ----
 
 Deploys Heartbeat as a single Pod deployment that monitors the health of Elasticsearch and Kibana by TCP probing their Service endpoints. Note that Heartbeat expects that Elasticsearch and Kibana are deployed in the `default` namespace.


### PR DESCRIPTION
Backports the following commits to 1.2:
 - Fix typo in recipe link (#3515)