### PR TITLE
Fix memory corruption from pod template validation

### DIFF
--- a/pkg/controller/elasticsearch/sset/reconcile.go
+++ b/pkg/controller/elasticsearch/sset/reconcile.go
@@ -54,8 +54,9 @@ func ReconcileStatefulSet(c k8s.Client, es esv1.Elasticsearch, expected appsv1.S
 
 // newPodTemplateValidator returns a function which can be used to validate the PodTemplateSpec in a StatefulSet
 func newPodTemplateValidator(c k8s.Client, es esv1.Elasticsearch, expected appsv1.StatefulSet) func() error {
+	sset := expected.DeepCopy()
 	return func() error {
-		return validatePodTemplate(c, &es, expected)
+		return validatePodTemplate(c, &es, *sset)
 	}
 }
 


### PR DESCRIPTION
Full description of the bug: https://github.com/elastic/cloud-on-k8s/issues/3421#issuecomment-663057459

Fixes #3421