### PR TITLE
Init containers image defaulting

### DIFF
--- a/pkg/controller/beat/common/pod_test.go
+++ b/pkg/controller/beat/common/pod_test.go
@@ -1,0 +1,75 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package common
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/container"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_buildPodTemplate(t *testing.T) {
+	tests := []struct {
+		name       string
+		beat       v1beta1.Beat
+		assertions func(pod corev1.PodTemplateSpec)
+	}{
+		{
+			name: "deployment user-provided init containers should inherit from the default main container image",
+			beat: v1beta1.Beat{Spec: v1beta1.BeatSpec{
+				Version: "7.8.0",
+				Deployment: &v1beta1.DeploymentSpec{
+					PodTemplate: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name: "user-init-container",
+								},
+							},
+						},
+					},
+				},
+			}},
+			assertions: func(pod corev1.PodTemplateSpec) {
+				assert.Len(t, pod.Spec.InitContainers, 1)
+				assert.Equal(t, pod.Spec.Containers[0].Image, pod.Spec.InitContainers[0].Image)
+			},
+		},
+		{
+			name: "daemonset user-provided init containers should inherit from the default main container image",
+			beat: v1beta1.Beat{Spec: v1beta1.BeatSpec{
+				Version: "7.8.0",
+				DaemonSet: &v1beta1.DaemonSetSpec{
+					PodTemplate: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name: "user-init-container",
+								},
+							},
+						},
+					},
+				},
+			}},
+			assertions: func(pod corev1.PodTemplateSpec) {
+				assert.Len(t, pod.Spec.InitContainers, 1)
+				assert.Equal(t, pod.Spec.Containers[0].Image, pod.Spec.InitContainers[0].Image)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := DriverParams{Beat: tt.beat}
+			got := buildPodTemplate(params, container.AuditbeatImage, nil, sha256.New224())
+			tt.assertions(got)
+		})
+	}
+}

--- a/pkg/controller/enterprisesearch/pod_test.go
+++ b/pkg/controller/enterprisesearch/pod_test.go
@@ -1,0 +1,50 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package enterprisesearch
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_newPodSpec(t *testing.T) {
+	tests := []struct {
+		name       string
+		ent        entv1beta1.EnterpriseSearch
+		assertions func(pod corev1.PodTemplateSpec)
+	}{
+		{
+			name: "user-provided init containers should inherit from the default main container image",
+			ent: entv1beta1.EnterpriseSearch{
+				Spec: entv1beta1.EnterpriseSearchSpec{
+					Version: "7.8.0",
+					PodTemplate: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name: "user-init-container",
+								},
+							},
+						},
+					},
+				}},
+			assertions: func(pod corev1.PodTemplateSpec) {
+				assert.Len(t, pod.Spec.InitContainers, 1)
+				assert.Equal(t, pod.Spec.Containers[0].Image, pod.Spec.InitContainers[0].Image)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newPodSpec(tt.ent, "amFpbWVsZXNjaGF0c2V0dm91cz8=")
+			tt.assertions(got)
+		})
+	}
+}

--- a/pkg/controller/kibana/pod_test.go
+++ b/pkg/controller/kibana/pod_test.go
@@ -128,6 +128,7 @@ func TestNewPodTemplateSpec(t *testing.T) {
 			keystore: nil,
 			assertions: func(pod corev1.PodTemplateSpec) {
 				assert.Len(t, pod.Spec.InitContainers, 1)
+				assert.Equal(t, pod.Spec.Containers[0].Image, pod.Spec.InitContainers[0].Image)
 			},
 		},
 		{


### PR DESCRIPTION
This commit makes sure that user provided init containers inherit from the default values including the main container image.

I refactored a bit the functions that build the PodTemplateSpec to try to make them boring and always have the same pattern by preparing the volumes, volumeMounts, initContainers and then only call:

```go
		WithVolumes(volumes...).
		WithVolumeMounts(volumeMounts...).
		WithInitContainers(initContainers...).
		WithInitContainerDefaults()
```

Resolves #3453.