### PR TITLE
Remove the default cpu limits in Elasticsearch E2E tests

### DIFF
--- a/test/e2e/test/elasticsearch/default.go
+++ b/test/e2e/test/elasticsearch/default.go
@@ -12,6 +12,5 @@ import (
 var DefaultResources = corev1.ResourceRequirements{
 	Limits: map[corev1.ResourceName]resource.Quantity{
 		corev1.ResourceMemory: resource.MustParse("2Gi"),
-		corev1.ResourceCPU:    resource.MustParse("2"),
 	},
 }


### PR DESCRIPTION
We set a default limits of 2 CPUs for Elasticsearch end-to-end tests.
I am not sure why that's the case: removing this default cpu limit
speeds up the e2e tests a bit.