### PR TITLE
Update users-and-roles.asciidoc

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/security/users-and-roles.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/users-and-roles.asciidoc
@@ -92,7 +92,7 @@ touch filerealm/users filerealm/users_roles
 
 # create user 'myuser' with role 'monitoring_user'
 docker run \
-    -v $(pwd)/filerealm:/usr/share/elasticsearch/config \
+    -v ${pwd}/filerealm:/usr/share/elasticsearch/config \
     docker.elastic.co/elasticsearch/elasticsearch:{version} \
     bin/elasticsearch-users useradd myuser -p mypassword -r monitoring_user
 

--- a/docs/orchestrating-elastic-stack-applications/security/users-and-roles.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/users-and-roles.asciidoc
@@ -92,7 +92,7 @@ touch filerealm/users filerealm/users_roles
 
 # create user 'myuser' with role 'monitoring_user'
 docker run \
-    -v ${PWD}/filerealm:/usr/share/elasticsearch/config \
+    -v $(pwd)/filerealm:/usr/share/elasticsearch/config \
     docker.elastic.co/elasticsearch/elasticsearch:{version} \
     bin/elasticsearch-users useradd myuser -p mypassword -r monitoring_user
 

--- a/docs/orchestrating-elastic-stack-applications/security/users-and-roles.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/users-and-roles.asciidoc
@@ -92,7 +92,7 @@ touch filerealm/users filerealm/users_roles
 
 # create user 'myuser' with role 'monitoring_user'
 docker run \
-    -v ${pwd}/filerealm:/usr/share/elasticsearch/config \
+    -v $(pwd)/filerealm:/usr/share/elasticsearch/config \
     docker.elastic.co/elasticsearch/elasticsearch:{version} \
     bin/elasticsearch-users useradd myuser -p mypassword -r monitoring_user
 


### PR DESCRIPTION
somehow ${PWD} is displayed as YOUR PASSWORD in the documentation

```
-v ${PWD}/filerealm:/usr/share/elasticsearch/config
```
result:

![image](https://user-images.githubusercontent.com/3482021/88522625-ed65d600-cff6-11ea-9476-805c766d812c.png)


<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/master/CONTRIBUTING.md)?
- If you submit code, is your pull request against master? We recommend pull requests against master. We will backport them as needed.
