### PR TITLE
Ensure status.version is reconciled by watching Pods

### DIFF
--- a/pkg/controller/apmserver/controller.go
+++ b/pkg/controller/apmserver/controller.go
@@ -112,6 +112,12 @@ func addWatches(c controller.Controller, r *ReconcileApmServer) error {
 		return err
 	}
 
+	// Watch Pods, to ensure `status.version` and version upgrades are correctly reconciled on any change.
+	// Watching Deployments only may lead to missing some events.
+	if err := watches.WatchPods(c, ApmServerNameLabelName); err != nil {
+		return err
+	}
+
 	// Watch services
 	if err := c.Watch(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,

--- a/pkg/controller/beat/controller.go
+++ b/pkg/controller/beat/controller.go
@@ -92,6 +92,12 @@ func addWatches(c controller.Controller, r *ReconcileBeat) error {
 		return err
 	}
 
+	// Watch Pods, to ensure `status.version` is correctly reconciled on any change.
+	// Watching Deployments or DaemonSets only may lead to missing some events.
+	if err := watches.WatchPods(c, beatcommon.NameLabelName); err != nil {
+		return err
+	}
+
 	// Watch Secrets
 	if err := c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,

--- a/pkg/controller/common/watches/pods.go
+++ b/pkg/controller/common/watches/pods.go
@@ -1,0 +1,42 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package watches
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// WatchPods updates the given controller to enqueue reconciliation requests triggered by changes on Pods.
+// The resource to reconcile is identified by a label on the Pods.
+func WatchPods(c controller.Controller, objNameLabel string) error {
+	return c.Watch(
+		&source.Kind{Type: &corev1.Pod{}},
+		&handler.EnqueueRequestsFromMapFunc{ToRequests: handler.ToRequestsFunc(objToReconcileRequest(objNameLabel))},
+	)
+}
+
+// objToReconcileRequest returns a function to enqueue reconcile requests for the resource name set at objNameLabel.
+func objToReconcileRequest(objNameLabel string) func(object handler.MapObject) []reconcile.Request {
+	return func(object handler.MapObject) []reconcile.Request {
+		labels := object.Meta.GetLabels()
+		objectName, isSet := labels[objNameLabel]
+		if !isSet {
+			return nil
+		}
+		return []reconcile.Request{
+			{
+				NamespacedName: types.NamespacedName{
+					Namespace: object.Meta.GetNamespace(),
+					Name:      objectName,
+				},
+			},
+		}
+	}
+}

--- a/pkg/controller/common/watches/pods_test.go
+++ b/pkg/controller/common/watches/pods_test.go
@@ -1,0 +1,61 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package watches
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func Test_objToReconcileRequest(t *testing.T) {
+	labelName := "obj-name-label"
+	fn := objToReconcileRequest(labelName)
+
+	tests := []struct {
+		name string
+		obj  runtime.Object
+		want []reconcile.Request
+	}{
+		{
+			name: "reconcile based on the Pod label",
+			obj: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns", Name: "my-pod",
+				Labels: map[string]string{labelName: "my-obj-name"},
+			}},
+			want: []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "my-obj-name"}}},
+		},
+		{
+			name: "don't reconcile if no labels",
+			obj: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns", Name: "my-pod",
+			}},
+			want: nil,
+		},
+		{
+			name: "don't reconcile if label not set",
+			obj: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns", Name: "my-pod",
+				Labels: map[string]string{"other": "label"},
+			}},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objMeta, err := meta.Accessor(tt.obj)
+			require.NoError(t, err)
+			got := fn(handler.MapObject{Meta: objMeta, Object: tt.obj})
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -98,25 +98,7 @@ func addWatches(c controller.Controller, r *ReconcileElasticsearch) error {
 	}
 
 	// Watch pods belonging to ES clusters
-	if err := c.Watch(&source.Kind{Type: &corev1.Pod{}},
-		&handler.EnqueueRequestsFromMapFunc{
-			ToRequests: handler.ToRequestsFunc(
-				func(object handler.MapObject) []reconcile.Request {
-					labels := object.Meta.GetLabels()
-					clusterName, isSet := labels[label.ClusterNameLabelName]
-					if !isSet {
-						return nil
-					}
-					return []reconcile.Request{
-						{
-							NamespacedName: types.NamespacedName{
-								Namespace: object.Meta.GetNamespace(),
-								Name:      clusterName,
-							},
-						},
-					}
-				}),
-		}); err != nil {
+	if err := watches.WatchPods(c, label.ClusterNameLabelName); err != nil {
 		return err
 	}
 

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller.go
@@ -69,22 +69,6 @@ func newReconciler(mgr manager.Manager, params operator.Parameters) *ReconcileEn
 	}
 }
 
-func podsToReconcilerequest(object handler.MapObject) []reconcile.Request {
-	labels := object.Meta.GetLabels()
-	entName, isSet := labels[EnterpriseSearchNameLabelName]
-	if !isSet {
-		return nil
-	}
-	return []reconcile.Request{
-		{
-			NamespacedName: types.NamespacedName{
-				Namespace: object.Meta.GetNamespace(),
-				Name:      entName,
-			},
-		},
-	}
-}
-
 func addWatches(c controller.Controller, r *ReconcileEnterpriseSearch) error {
 	// Watch for changes to EnterpriseSearch
 	err := c.Watch(&source.Kind{Type: &entv1beta1.EnterpriseSearch{}}, &handler.EnqueueRequestForObject{})
@@ -100,12 +84,9 @@ func addWatches(c controller.Controller, r *ReconcileEnterpriseSearch) error {
 		return err
 	}
 
-	// Watch Pods to be notified about Pods going up/down during version upgrades.
-	// Unfortunately watching deployment only is not enough since we may miss a Pod deletion event.
-	if err := c.Watch(&source.Kind{Type: &corev1.Pod{}},
-		&handler.EnqueueRequestsFromMapFunc{
-			ToRequests: handler.ToRequestsFunc(podsToReconcilerequest),
-		}); err != nil {
+	// Watch Pods, to ensure `status.version` and version upgrades are correctly reconciled on any change.
+	// Watching Deployments only may lead to missing some events.
+	if err := watches.WatchPods(c, EnterpriseSearchNameLabelName); err != nil {
 		return err
 	}
 

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller_test.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller_test.go
@@ -5,7 +5,6 @@
 package enterprisesearch
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/elastic/cloud-on-k8s/pkg/about"
@@ -28,49 +26,6 @@ import (
 	entName "github.com/elastic/cloud-on-k8s/pkg/controller/enterprisesearch/name"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
-
-func Test_podsToReconcilerequest(t *testing.T) {
-	tests := []struct {
-		name   string
-		object handler.MapObject
-		want   []reconcile.Request
-	}{
-		{
-			name: "ent search pod",
-			object: handler.MapObject{
-				Meta: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: "ns",
-					Labels: map[string]string{EnterpriseSearchNameLabelName: "name"}},
-				},
-				Object: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: "ns",
-					Labels: map[string]string{EnterpriseSearchNameLabelName: "name"}},
-				},
-			},
-			want: []reconcile.Request{
-				{
-					NamespacedName: types.NamespacedName{
-						Namespace: "ns",
-						Name:      "name",
-					},
-				},
-			},
-		},
-		{
-			name: "not an ent search pod",
-			object: handler.MapObject{
-				Meta:   &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: "ns"}},
-				Object: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: "ns"}},
-			},
-			want: nil,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := podsToReconcilerequest(tt.object); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("podsToReconcilerequest() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestReconcileEnterpriseSearch_Reconcile_Unmanaged(t *testing.T) {
 	// unmanaged resource, should do nothing

--- a/pkg/controller/kibana/controller.go
+++ b/pkg/controller/kibana/controller.go
@@ -79,6 +79,12 @@ func addWatches(c controller.Controller, r *ReconcileKibana) error {
 		return err
 	}
 
+	// Watch Pods, to ensure `status.version` and version upgrades are correctly reconciled on any change.
+	// Watching Deployments only may lead to missing some events.
+	if err := watches.WatchPods(c, KibanaNameLabelName); err != nil {
+		return err
+	}
+
 	// Watch services
 	if err := c.Watch(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,


### PR DESCRIPTION
We did not enqueue reconciliations on Pods changes in Kibana, APMServer
and Beats controllers. We did on Elasticsearch and EnterpriseSearch
controllers.
When controllers rely on information retrieved from Pods as
part of the reconciliation, not watching Pods can lead to missing some
events.
This is especially true for the `status.version` field in all resources.
Note this particular case could have been worked out differently, by
checking the ReplicaSets for example. I think the implementation would
be more complicated, and we already watch all Pods due to the
Elasticsearch and EnterpriseSearch controllers anyway.

This commit sets up a single helper function called from all
controllers.

Fixes https://github.com/elastic/cloud-on-k8s/issues/3533.