### PR TITLE
[1.2] Check if CA Secret is expected before validating its name (#3527)

### DIFF
--- a/pkg/apis/common/v1/association.go
+++ b/pkg/apis/common/v1/association.go
@@ -78,7 +78,11 @@ type AssociationConf struct {
 
 // IsConfigured returns true if all the fields are set.
 func (ac *AssociationConf) IsConfigured() bool {
-	return ac.AuthIsConfigured() && ac.CAIsConfigured() && ac.URLIsConfigured()
+	if ac.GetCACertProvided() && !ac.CAIsConfigured() {
+		return false
+	}
+
+	return ac.AuthIsConfigured() && ac.URLIsConfigured()
 }
 
 // AuthIsConfigured returns true if all the auth fields are set.

--- a/pkg/apis/common/v1/association_test.go
+++ b/pkg/apis/common/v1/association_test.go
@@ -25,6 +25,7 @@ func TestAssociationConfIsConfigured(t *testing.T) {
 			assocConf: &AssociationConf{
 				AuthSecretName: "auth-secret",
 				AuthSecretKey:  "elastic",
+				CACertProvided: true,
 				CASecretName:   "ca-secret",
 			},
 			want: false,
@@ -32,9 +33,10 @@ func TestAssociationConfIsConfigured(t *testing.T) {
 		{
 			name: "missing auth secret name",
 			assocConf: &AssociationConf{
-				AuthSecretKey: "elastic",
-				CASecretName:  "ca-secret",
-				URL:           "https://my-es.svc",
+				AuthSecretKey:  "elastic",
+				CACertProvided: true,
+				CASecretName:   "ca-secret",
+				URL:            "https://my-es.svc",
 			},
 			want: false,
 		},
@@ -42,6 +44,7 @@ func TestAssociationConfIsConfigured(t *testing.T) {
 			name: "missing auth secret key",
 			assocConf: &AssociationConf{
 				AuthSecretName: "auth-secret",
+				CACertProvided: true,
 				CASecretName:   "ca-secret",
 				URL:            "https://my-es.svc",
 			},
@@ -52,9 +55,20 @@ func TestAssociationConfIsConfigured(t *testing.T) {
 			assocConf: &AssociationConf{
 				AuthSecretName: "auth-secret",
 				AuthSecretKey:  "elastic",
+				CACertProvided: true,
 				URL:            "https://my-es.svc",
 			},
 			want: false,
+		},
+		{
+			name: "correctly configured without CA",
+			assocConf: &AssociationConf{
+				AuthSecretName: "auth-secret",
+				AuthSecretKey:  "elastic",
+				CACertProvided: false,
+				URL:            "https://my-es.svc",
+			},
+			want: true,
 		},
 		{
 			name: "correctly configured",

--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -156,6 +156,16 @@ func (b Builder) WithPodLabel(key, value string) Builder {
 	return b
 }
 
+func (b Builder) WithTLSDisabled(disabled bool) Builder {
+	if b.Kibana.Spec.HTTP.TLS.SelfSignedCertificate == nil {
+		b.Kibana.Spec.HTTP.TLS.SelfSignedCertificate = &commonv1.SelfSignedCertificate{}
+	} else {
+		b.Kibana.Spec.HTTP.TLS.SelfSignedCertificate = b.Kibana.Spec.HTTP.TLS.SelfSignedCertificate.DeepCopy()
+	}
+	b.Kibana.Spec.HTTP.TLS.SelfSignedCertificate.Disabled = disabled
+	return b
+}
+
 // -- Helper functions
 
 func (b Builder) RuntimeObjects() []runtime.Object {


### PR DESCRIPTION
Backports the following commits to 1.2:
 - Check if CA Secret is expected before validating its name (#3527)