### PR TITLE
Enforce a strict upgrade order between stack components

### DIFF
--- a/pkg/apis/common/v1/association.go
+++ b/pkg/apis/common/v1/association.go
@@ -67,13 +67,16 @@ type Association interface {
 	SetAssociationStatus(status AssociationStatus)
 }
 
-// AssociationConf holds the association configuration of an Elasticsearch cluster.
+// AssociationConf holds the association configuration of a referenced resource in an association.
 type AssociationConf struct {
 	AuthSecretName string `json:"authSecretName"`
 	AuthSecretKey  string `json:"authSecretKey"`
 	CACertProvided bool   `json:"caCertProvided"`
 	CASecretName   string `json:"caSecretName"`
 	URL            string `json:"url"`
+	// Version of the referenced resource. If a version upgrade is in progress,
+	// matches the lowest running version. May be empty if unknown.
+	Version string `json:"version"`
 }
 
 // IsConfigured returns true if all the fields are set.
@@ -138,4 +141,11 @@ func (ac *AssociationConf) GetURL() string {
 		return ""
 	}
 	return ac.URL
+}
+
+func (ac *AssociationConf) GetVersion() string {
+	if ac == nil {
+		return ""
+	}
+	return ac.Version
 }

--- a/pkg/controller/apmserver/controller.go
+++ b/pkg/controller/apmserver/controller.go
@@ -263,7 +263,7 @@ func (r *ReconcileApmServer) doReconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, err
 	}
 	logger := log.WithValues("namespace", as.Namespace, "as_name", as.Name)
-	if !association.AllowVersion(*asVersion, as, logger) {
+	if !association.AllowVersion(*asVersion, as, logger, r.recorder) {
 		return reconcile.Result{}, nil // will eventually retry
 	}
 

--- a/pkg/controller/association/conf.go
+++ b/pkg/controller/association/conf.go
@@ -107,7 +107,7 @@ func ElasticsearchAuthSettings(c k8s.Client, association commonv1.Association) (
 	return assocConf.AuthSecretKey, string(data), nil
 }
 
-// AllowVersion returns true if the given resourceVersion is lower or equal to the associations version.
+// AllowVersion returns true if the given resourceVersion is lower or equal to the associations' versions.
 // For example: Kibana in version 7.8.0 cannot be deployed if its Elasticsearch association reports version 7.7.0.
 // Referenced resources version is parsed from the association conf annotation.
 func AllowVersion(resourceVersion version.Version, associated commonv1.Associated, logger logr.Logger) bool {

--- a/pkg/controller/association/conf.go
+++ b/pkg/controller/association/conf.go
@@ -76,6 +76,8 @@ func IsConfiguredIfSet(association commonv1.Association, r record.EventRecorder)
 			"kind", association.GetObjectKind().GroupVersionKind().Kind,
 			"namespace", association.GetNamespace(),
 			"name", association.GetName(),
+			"ref_namespace", ref.Namespace,
+			"ref_name", ref.Name,
 		)
 		return false
 	}

--- a/pkg/controller/association/conf.go
+++ b/pkg/controller/association/conf.go
@@ -110,7 +110,7 @@ func ElasticsearchAuthSettings(c k8s.Client, association commonv1.Association) (
 
 // AllowVersion returns true if the given resourceVersion is lower or equal to the associations' versions.
 // For example: Kibana in version 7.8.0 cannot be deployed if its Elasticsearch association reports version 7.7.0.
-// A difference in the patch version is ignored: Kibana 7.8.1 can be deployed alongside Elasticsearch 7.8.0.
+// A difference in the patch version is ignored: Kibana 7.8.1+ can be deployed alongside Elasticsearch 7.8.0.
 // Referenced resources version is parsed from the association conf annotation.
 func AllowVersion(resourceVersion version.Version, associated commonv1.Associated, logger logr.Logger, recorder record.EventRecorder) bool {
 	for _, assoc := range associated.GetAssociations() {

--- a/pkg/controller/association/conf.go
+++ b/pkg/controller/association/conf.go
@@ -126,7 +126,7 @@ func AllowVersion(resourceVersion version.Version, associated commonv1.Associate
 		}
 		refVer, err := version.Parse(assoc.AssociationConf().Version)
 		if err != nil {
-			logger.Error(err, "Invalid version found in association conf", "association_version", assoc.AssociationConf().Version)
+			logger.Error(err, "Invalid version found in association configuration", "association_version", assoc.AssociationConf().Version)
 			return false
 		}
 		if !refVer.IsSameOrAfter(resourceVersion) {

--- a/pkg/controller/association/conf.go
+++ b/pkg/controller/association/conf.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"go.elastic.co/apm"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -69,7 +68,7 @@ func IsConfiguredIfSet(association commonv1.Association, r record.EventRecorder)
 	if (&ref).IsDefined() && !association.AssociationConf().IsConfigured() {
 		r.Event(
 			association,
-			v1.EventTypeWarning,
+			corev1.EventTypeWarning,
 			events.EventAssociationError,
 			"Association backend for "+association.AssociatedType()+" is not configured",
 		)
@@ -95,7 +94,7 @@ func ElasticsearchAuthSettings(c k8s.Client, association commonv1.Association) (
 	}
 
 	secretObjKey := types.NamespacedName{Namespace: association.GetNamespace(), Name: assocConf.AuthSecretName}
-	var secret v1.Secret
+	var secret corev1.Secret
 	if err := c.Get(secretObjKey, &secret); err != nil {
 		return "", "", err
 	}

--- a/pkg/controller/association/conf.go
+++ b/pkg/controller/association/conf.go
@@ -7,6 +7,7 @@ package association
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"unsafe"
 
@@ -131,9 +132,11 @@ func AllowVersion(resourceVersion version.Version, associated commonv1.Associate
 		if !refVer.IsSameOrAfter(resourceVersion) {
 			// the version of the referenced resource (example: Elasticsearch) is lower than
 			// the desired version of the reconciled resource (example: Kibana)
-			msg := "Delaying version deployment since an associated resource is not upgraded yet"
-			logger.Info(msg, "version", resourceVersion, "ref_namespace", assocRef.Namespace, "ref_name", assocRef.Name, "ref_version", refVer)
-			recorder.Event(associated, corev1.EventTypeWarning, events.EventReasonDelayed, msg)
+			logger.Info("Delaying version deployment since a referenced resource is not upgraded yet",
+				"version", resourceVersion, "ref_version", refVer,
+				"ref_type", assoc.AssociatedType(), "ref_namespace", assocRef.Namespace, "ref_name", assocRef.Name)
+			recorder.Event(associated, corev1.EventTypeWarning, events.EventReasonDelayed,
+				fmt.Sprintf("Delaying version deployment since the referenced %s is not upgraded yet", assoc.AssociatedType()))
 			return false
 		}
 	}

--- a/pkg/controller/association/conf.go
+++ b/pkg/controller/association/conf.go
@@ -137,7 +137,7 @@ func AllowVersion(resourceVersion version.Version, associated commonv1.Associate
 				"version", resourceVersion, "ref_version", refVer,
 				"ref_type", assoc.AssociatedType(), "ref_namespace", assocRef.Namespace, "ref_name", assocRef.Name)
 			recorder.Event(associated, corev1.EventTypeWarning, events.EventReasonDelayed,
-				fmt.Sprintf("Delaying version deployment since the referenced %s is not upgraded yet", assoc.AssociatedType()))
+				fmt.Sprintf("Delaying deployment of version %s since the referenced %s is not upgraded yet", resourceVersion, assoc.AssociatedType()))
 			return false
 		}
 	}

--- a/pkg/controller/association/conf.go
+++ b/pkg/controller/association/conf.go
@@ -125,7 +125,7 @@ func AllowVersion(resourceVersion version.Version, associated commonv1.Associate
 		}
 		refVer, err := version.Parse(assoc.AssociationConf().Version)
 		if err != nil {
-			logger.Error(err, "Invalid version found in association conf", "association_version", refVer)
+			logger.Error(err, "Invalid version found in association conf", "association_version", assoc.AssociationConf().Version)
 			return false
 		}
 		if !refVer.IsSameOrAfter(resourceVersion) {

--- a/pkg/controller/association/conf_test.go
+++ b/pkg/controller/association/conf_test.go
@@ -18,6 +18,7 @@ import (
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
@@ -410,4 +411,91 @@ func TestRemoveAssociationConf(t *testing.T) {
 	require.Equal(t, "test-image", got.Spec.Image)
 	require.EqualValues(t, 1, got.Spec.Count)
 	require.Nil(t, got.AssociationConf())
+}
+
+func TestAllowVersion(t *testing.T) {
+	apmNoAssoc := &apmv1.ApmServer{}
+	apmTwoAssoc := &apmv1.ApmServer{Spec: apmv1.ApmServerSpec{
+		ElasticsearchRef: commonv1.ObjectSelector{Name: "some-es"}, KibanaRef: commonv1.ObjectSelector{Name: "some-kb"}}}
+	apmTwoAssocWithVersions := func(versions []string) *apmv1.ApmServer {
+		apm := apmTwoAssoc.DeepCopy()
+		for i, assoc := range apm.GetAssociations() {
+			assoc.SetAssociationConf(&commonv1.AssociationConf{Version: versions[i]})
+		}
+		return apm
+	}
+	type args struct {
+		resourceVersion version.Version
+		associated      commonv1.Associated
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "no association specified: allow",
+			args: args{
+				resourceVersion: version.MustParse("7.7.0"),
+				associated:      apmNoAssoc.DeepCopy(),
+			},
+			want: true,
+		},
+		{
+			name: "referenced resources run the same version: allow",
+			args: args{
+				resourceVersion: version.MustParse("7.7.0"),
+				associated:      apmTwoAssocWithVersions([]string{"7.7.0", "7.7.0"}),
+			},
+			want: true,
+		},
+		{
+			name: "some referenced resources run a higher version: allow",
+			args: args{
+				resourceVersion: version.MustParse("7.7.0"),
+				associated:      apmTwoAssocWithVersions([]string{"7.8.0", "7.7.0"}),
+			},
+			want: true,
+		},
+		{
+			name: "one referenced resource runs a lower version: don't allow",
+			args: args{
+				resourceVersion: version.MustParse("7.7.0"),
+				associated:      apmTwoAssocWithVersions([]string{"7.7.0", "7.6.0"}),
+			},
+			want: false,
+		},
+		{
+			name: "no version set in the association conf: don't allow",
+			args: args{
+				resourceVersion: version.MustParse("7.7.0"),
+				associated:      apmTwoAssocWithVersions([]string{"", ""}),
+			},
+			want: false,
+		},
+		{
+			name: "association conf annotation is not set yet: don't allow",
+			args: args{
+				resourceVersion: version.MustParse("7.7.0"),
+				associated:      apmTwoAssoc,
+			},
+			want: false,
+		},
+		{
+			name: "invalid version in the association conf: don't allow",
+			args: args{
+				resourceVersion: version.MustParse("7.7.0"),
+				associated:      apmTwoAssocWithVersions([]string{"7.7.0", "invalid"}),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		logger := log.WithValues("a", "b")
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AllowVersion(tt.args.resourceVersion, tt.args.associated, logger); got != tt.want {
+				t.Errorf("AllowVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/controller/association/controller/beat_es.go
+++ b/pkg/controller/association/controller/beat_es.go
@@ -39,10 +39,11 @@ func AddBeatES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params o
 		ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.ObjectSelector, error) {
 			return true, association.AssociationRef(), nil
 		},
-		ExternalServiceURL:  getElasticsearchExternalURL,
-		AssociatedNamer:     esv1.ESNamer,
-		AssociationName:     "beat-es",
-		AssociatedShortName: "beat",
+		ReferencedResourceVersion: referencedElasticsearchStatusVersion,
+		ExternalServiceURL:        getElasticsearchExternalURL,
+		AssociatedNamer:           esv1.ESNamer,
+		AssociationName:           "beat-es",
+		AssociatedShortName:       "beat",
 		AssociationLabels: func(associated types.NamespacedName) map[string]string {
 			return map[string]string{
 				BeatAssociationLabelName:      associated.Name,

--- a/pkg/controller/association/controller/beat_kibana.go
+++ b/pkg/controller/association/controller/beat_kibana.go
@@ -25,12 +25,13 @@ import (
 
 func AddBeatKibana(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params operator.Parameters) error {
 	return association.AddAssociationController(mgr, accessReviewer, params, association.AssociationInfo{
-		AssociationObjTemplate: func() commonv1.Association { return &beatv1beta1.BeatKibanaAssociation{} },
-		ElasticsearchRef:       getElasticsearchFromKibana,
-		ExternalServiceURL:     getKibanaExternalURL,
-		AssociatedNamer:        kibana.Namer,
-		AssociationName:        "beat-kibana",
-		AssociatedShortName:    "beat",
+		AssociationObjTemplate:    func() commonv1.Association { return &beatv1beta1.BeatKibanaAssociation{} },
+		ElasticsearchRef:          getElasticsearchFromKibana,
+		ExternalServiceURL:        getKibanaExternalURL,
+		ReferencedResourceVersion: referencedKibanaStatusVersion,
+		AssociatedNamer:           kibana.Namer,
+		AssociationName:           "beat-kibana",
+		AssociatedShortName:       "beat",
 		AssociationLabels: func(associated types.NamespacedName) map[string]string {
 			return map[string]string{
 				BeatAssociationLabelName:      associated.Name,

--- a/pkg/controller/association/controller/ent_es.go
+++ b/pkg/controller/association/controller/ent_es.go
@@ -5,6 +5,9 @@
 package controller
 
 import (
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
@@ -14,8 +17,6 @@ import (
 	esuser "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/rbac"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 const (
@@ -31,10 +32,11 @@ func AddEntES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params op
 		ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.ObjectSelector, error) {
 			return true, association.AssociationRef(), nil
 		},
-		ExternalServiceURL:  getElasticsearchExternalURL,
-		AssociatedNamer:     esv1.ESNamer,
-		AssociationName:     "ent-es",
-		AssociatedShortName: "ent",
+		ReferencedResourceVersion: referencedElasticsearchStatusVersion,
+		ExternalServiceURL:        getElasticsearchExternalURL,
+		AssociatedNamer:           esv1.ESNamer,
+		AssociationName:           "ent-es",
+		AssociatedShortName:       "ent",
 		AssociationLabels: func(associated types.NamespacedName) map[string]string {
 			return map[string]string{
 				EntESAssociationLabelName:      associated.Name,

--- a/pkg/controller/association/controller/kibana_es.go
+++ b/pkg/controller/association/controller/kibana_es.go
@@ -5,6 +5,9 @@
 package controller
 
 import (
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
@@ -13,8 +16,6 @@ import (
 	eslabel "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/rbac"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 const (
@@ -33,10 +34,11 @@ func AddKibanaES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params
 		ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.ObjectSelector, error) {
 			return true, association.AssociationRef(), nil
 		},
-		ExternalServiceURL:  getElasticsearchExternalURL,
-		AssociatedNamer:     esv1.ESNamer,
-		AssociationName:     "kb-es",
-		AssociatedShortName: "kb",
+		ReferencedResourceVersion: referencedElasticsearchStatusVersion,
+		ExternalServiceURL:        getElasticsearchExternalURL,
+		AssociatedNamer:           esv1.ESNamer,
+		AssociationName:           "kb-es",
+		AssociatedShortName:       "kb",
 		AssociationLabels: func(associated types.NamespacedName) map[string]string {
 			return map[string]string{
 				KibanaESAssociationLabelName:      associated.Name,

--- a/pkg/controller/association/reconciler.go
+++ b/pkg/controller/association/reconciler.go
@@ -67,6 +67,9 @@ type AssociationInfo struct {
 	SetDynamicWatches func(association commonv1.Association, watches watches.DynamicWatches) error
 	// ClearDynamicWatches is called when the controller needs to clear the specific watches set for this association.
 	ClearDynamicWatches func(associated types.NamespacedName, watches watches.DynamicWatches)
+	// ReferencedResourceVersion returns the currently running version of the referenced resource.
+	// It may return an empty string if the version is unknown.
+	ReferencedResourceVersion func(c k8s.Client, referencedRes types.NamespacedName) (string, error)
 }
 
 // userLabelSelector returns labels selecting the ES user secret, including association labels and user type label.
@@ -241,6 +244,13 @@ func (r *Reconciler) doReconcile(ctx context.Context, association commonv1.Assoc
 		return commonv1.AssociationPending, err // maybe not created yet
 	}
 
+	// Propagate the currently running version of the referenced resource (example: Elasticsearch version).
+	// The Kibana controller (for example) can then delay a Kibana version upgrade if Elasticsearch is not upgraded yet.
+	ver, err := r.ReferencedResourceVersion(r.Client, associationRef.NamespacedName())
+	if err != nil {
+		return commonv1.AssociationPending, err
+	}
+
 	// construct the expected association configuration
 	authSecretRef := UserSecretKeySelector(association, r.UserSecretSuffix)
 	expectedAssocConf := &commonv1.AssociationConf{
@@ -249,6 +259,7 @@ func (r *Reconciler) doReconcile(ctx context.Context, association commonv1.Assoc
 		CACertProvided: caSecret.CACertProvided,
 		CASecretName:   caSecret.Name,
 		URL:            url,
+		Version:        ver,
 	}
 
 	// update the association configuration if necessary
@@ -312,12 +323,12 @@ func (r *Reconciler) updateAssocConf(
 	defer span.End()
 
 	if !reflect.DeepEqual(expectedAssocConf, association.AssociationConf()) {
-		r.log(association).Info("Updating spec with Elasticsearch association configuration")
+		r.log(association).Info("Updating association configuration")
 		if err := UpdateAssociationConf(r.Client, association.Associated(), expectedAssocConf, association.AssociationConfAnnotationName()); err != nil {
 			if apierrors.IsConflict(err) {
 				return commonv1.AssociationPending, nil
 			}
-			r.log(association).Error(err, "Failed to update EnterpriseSearch association configuration")
+			r.log(association).Error(err, "Failed to update association configuration")
 			return commonv1.AssociationPending, err
 		}
 		association.SetAssociationConf(expectedAssocConf)

--- a/pkg/controller/association/reconciler.go
+++ b/pkg/controller/association/reconciler.go
@@ -293,7 +293,7 @@ func (r *Reconciler) getElasticsearch(
 		if apierrors.IsNotFound(err) {
 			// ES is not found, remove any existing backend configuration and retry in a bit.
 			if err := RemoveAssociationConf(r.Client, association.Associated(), association.AssociationConfAnnotationName()); err != nil && !apierrors.IsConflict(err) {
-				r.log(association).Error(err, "Failed to remove Elasticsearch association conf")
+				r.log(association).Error(err, "Failed to remove Elasticsearch association configuration")
 				return esv1.Elasticsearch{}, commonv1.AssociationPending, err
 			}
 			return esv1.Elasticsearch{}, commonv1.AssociationPending, nil

--- a/pkg/controller/association/reconciler.go
+++ b/pkg/controller/association/reconciler.go
@@ -293,7 +293,7 @@ func (r *Reconciler) getElasticsearch(
 		if apierrors.IsNotFound(err) {
 			// ES is not found, remove any existing backend configuration and retry in a bit.
 			if err := RemoveAssociationConf(r.Client, association.Associated(), association.AssociationConfAnnotationName()); err != nil && !apierrors.IsConflict(err) {
-				r.log(association).Error(err, "Failed to remove Elasticsearch output from EnterpriseSearch object")
+				r.log(association).Error(err, "Failed to remove Elasticsearch association conf")
 				return esv1.Elasticsearch{}, commonv1.AssociationPending, err
 			}
 			return esv1.Elasticsearch{}, commonv1.AssociationPending, nil

--- a/pkg/controller/association/reconciler_test.go
+++ b/pkg/controller/association/reconciler_test.go
@@ -63,12 +63,20 @@ var (
 			}
 			return services.ExternalServiceURL(es), nil
 		},
+		ReferencedResourceVersion: func(c k8s.Client, esRef types.NamespacedName) (string, error) {
+			var es esv1.Elasticsearch
+			if err := c.Get(esRef, &es); err != nil {
+				return "", err
+			}
+			return es.Status.Version, nil
+		},
 		CASecretLabelName: "elasticsearch.k8s.elastic.co/cluster-name",
 	}
 
-	kibanaNamespace     = "kbns"
-	esNamespace         = "esns"
-	sampleES            = esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: esNamespace, Name: "esname"}}
+	kibanaNamespace = "kbns"
+	esNamespace     = "esns"
+	sampleES        = esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: esNamespace, Name: "esname"},
+		Status: esv1.ElasticsearchStatus{Version: "7.7.0"}}
 	sampleKibanaNoEsRef = func() kbv1.Kibana {
 		return kbv1.Kibana{
 			ObjectMeta: metav1.ObjectMeta{
@@ -87,7 +95,7 @@ var (
 		sample := sampleKibanaWithESRef()
 		kb := (&sample).DeepCopy()
 		kb.Annotations = map[string]string{
-			kb.AssociationConfAnnotationName(): "{\"authSecretName\":\"kbname-kibana-user\",\"authSecretKey\":\"kbns-kbname-kibana-user\",\"caCertProvided\":true,\"caSecretName\":\"kbname-kb-es-ca\",\"url\":\"https://esname-es-http.esns.svc:9200\"}",
+			kb.AssociationConfAnnotationName(): "{\"authSecretName\":\"kbname-kibana-user\",\"authSecretKey\":\"kbns-kbname-kibana-user\",\"caCertProvided\":true,\"caSecretName\":\"kbname-kb-es-ca\",\"url\":\"https://esname-es-http.esns.svc:9200\",\"version\":\"7.7.0\"}",
 		}
 		return *kb
 	}

--- a/pkg/controller/beat/common/driver.go
+++ b/pkg/controller/beat/common/driver.go
@@ -79,7 +79,7 @@ func Reconcile(
 	if err != nil {
 		return results.WithError(err)
 	}
-	if !association.AllowVersion(*beatVersion, &params.Beat, params.Logger) {
+	if !association.AllowVersion(*beatVersion, &params.Beat, params.Logger, params.Recorder()) {
 		return results // will eventually retry
 	}
 

--- a/pkg/controller/common/version/version.go
+++ b/pkg/controller/common/version/version.go
@@ -115,9 +115,27 @@ func MustParse(version string) Version {
 	return *v
 }
 
+func (v *Version) Copy() *Version {
+	return &Version{
+		Major: v.Major,
+		Minor: v.Minor,
+		Patch: v.Patch,
+		Label: v.Label,
+	}
+}
+
 // IsSameOrAfter returns true if the receiver is the same version or newer than the argument. Labels are ignored.
 func (v *Version) IsSameOrAfter(other Version) bool {
 	return v.IsSame(other) || v.IsAfter(other)
+}
+
+// IsSameOrAfterIgnoringPatch returns true if the receiver is the same version or newer than the argument,
+// considering major and minor versions only (patch is ignored).
+func (v *Version) IsSameOrAfterIgnoringPatch(other Version) bool {
+	other.Patch = 0
+	vCopy := v.Copy()
+	vCopy.Patch = 0
+	return vCopy.IsSameOrAfter(other)
 }
 
 // IsSameOrAfter returns true if the receiver is the same version as the argument. Labels are ignored.

--- a/pkg/controller/common/version/version_test.go
+++ b/pkg/controller/common/version/version_test.go
@@ -555,3 +555,67 @@ func TestMinInStatefulSets(t *testing.T) {
 		})
 	}
 }
+
+func TestVersion_IsSameOrAfterIgnoringPatch(t *testing.T) {
+	tests := []struct {
+		name  string
+		v     Version
+		other Version
+		want  bool
+	}{
+		{
+			name:  "same version",
+			v:     MustParse("7.8.1"),
+			other: MustParse("7.8.1"),
+			want:  true,
+		},
+		{
+			name:  "lower patch version",
+			v:     MustParse("7.8.1"),
+			other: MustParse("7.8.2"),
+			want:  true,
+		},
+		{
+			name:  "higher patch version",
+			v:     MustParse("7.8.2"),
+			other: MustParse("7.8.1"),
+			want:  true,
+		},
+		{
+			name:  "lower minor",
+			v:     MustParse("7.7.1"),
+			other: MustParse("7.8.1"),
+			want:  false,
+		},
+		{
+			name:  "higher minor",
+			v:     MustParse("7.8.1"),
+			other: MustParse("7.7.1"),
+			want:  true,
+		},
+		{
+			name:  "lower major",
+			v:     MustParse("6.7.1"),
+			other: MustParse("7.7.1"),
+			want:  false,
+		},
+		{
+			name:  "higher major",
+			v:     MustParse("7.7.1"),
+			other: MustParse("6.7.1"),
+			want:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vCopy := tt.v.Copy()
+			otherCopy := tt.other.Copy()
+			if got := tt.v.IsSameOrAfterIgnoringPatch(tt.other); got != tt.want {
+				t.Errorf("IsSameOrAfterIgnoringPatch() = %v, want %v", got, tt.want)
+			}
+			// ensure v and other haven't been modified
+			require.Equal(t, *vCopy, tt.v)
+			require.Equal(t, *otherCopy, tt.other)
+		})
+	}
+}

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller.go
@@ -230,7 +230,7 @@ func (r *ReconcileEnterpriseSearch) doReconcile(ctx context.Context, ent entv1be
 		return reconcile.Result{}, err
 	}
 	logger := log.WithValues("namespace", ent.Namespace, "ent_name", ent.Name)
-	if !association.AllowVersion(*entVersion, ent.Associated(), logger) {
+	if !association.AllowVersion(*entVersion, ent.Associated(), logger, r.recorder) {
 		return reconcile.Result{}, nil // will eventually retry once updated
 	}
 

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	entName "github.com/elastic/cloud-on-k8s/pkg/controller/enterprisesearch/name"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -241,6 +242,15 @@ func (r *ReconcileEnterpriseSearch) doReconcile(ctx context.Context, ent entv1be
 		res, err := results.Aggregate()
 		k8s.EmitErrorEvent(r.recorder, err, &ent, events.EventReconciliationError, "Certificate reconciliation error: %v", err)
 		return res, err
+	}
+
+	entVersion, err := version.Parse(ent.Spec.Version)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	logger := log.WithValues("namespace", ent.Namespace, "ent_name", ent.Name)
+	if !association.AllowVersion(*entVersion, ent.Associated(), logger) {
+		return reconcile.Result{}, nil // will eventually retry once updated
 	}
 
 	configSecret, err := ReconcileConfig(r, ent)

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller_test.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller_test.go
@@ -302,6 +302,7 @@ func TestReconcileEnterpriseSearch_doReconcile_AssociationDelaysVersionUpgrade(t
 	err = r.Client.Update(&ent)
 	require.NoError(t, err)
 	_, err = r.doReconcile(context.Background(), ent)
+	require.NoError(t, err)
 	err = r.Client.Get(types.NamespacedName{Namespace: "ns", Name: entName.Deployment(ent.Name)}, &dep)
 	require.NoError(t, err)
 	require.Equal(t, "7.8.1", dep.Spec.Template.Labels[VersionLabelName])

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -138,6 +138,11 @@ func (d *driver) Reconcile(
 		return results
 	}
 
+	logger := log.WithValues("namespace", kb.Namespace, "kb_name", kb.Name)
+	if !association.AllowVersion(d.version, kb, logger) {
+		return results // will eventually retry
+	}
+
 	kbSettings, err := NewConfigSettings(ctx, d.client, *kb, d.version)
 	if err != nil {
 		return results.WithError(err)

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -139,7 +139,7 @@ func (d *driver) Reconcile(
 	}
 
 	logger := log.WithValues("namespace", kb.Namespace, "kb_name", kb.Name)
-	if !association.AllowVersion(d.version, kb, logger) {
+	if !association.AllowVersion(d.version, kb, logger, d.Recorder()) {
 		return results // will eventually retry
 	}
 

--- a/test/e2e/beat/config.go
+++ b/test/e2e/beat/config.go
@@ -5,7 +5,7 @@
 package beat
 
 var (
-	e2eFilebeatConfig = `filebeat:
+	E2EFilebeatConfig = `filebeat:
   autodiscover:
     providers:
     - type: kubernetes
@@ -21,7 +21,7 @@ processors:
 - add_host_metadata: {}
 `
 
-	e2eFilebeatPodTemplate = `spec:
+	E2EFilebeatPodTemplate = `spec:
   automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
   containers:
   - name: filebeat

--- a/test/e2e/beat/setup_test.go
+++ b/test/e2e/beat/setup_test.go
@@ -54,7 +54,7 @@ func TestBeatKibanaRef(t *testing.T) {
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithKibanaRef(kbBuilder.Ref())
 
-	fbBuilder = applyYamls(t, fbBuilder, e2eFilebeatConfig, e2eFilebeatPodTemplate)
+	fbBuilder = beat.ApplyYamls(t, fbBuilder, E2EFilebeatConfig, E2EFilebeatPodTemplate)
 
 	mbBuilder := beat.NewBuilder(name).
 		WithType(metricbeat.Type).
@@ -63,7 +63,7 @@ func TestBeatKibanaRef(t *testing.T) {
 		WithKibanaRef(kbBuilder.Ref()).
 		WithRoles(beat.MetricbeatClusterRoleName)
 
-	mbBuilder = applyYamls(t, mbBuilder, e2eMetricbeatConfig, e2eMetricbeatPodTemplate)
+	mbBuilder = beat.ApplyYamls(t, mbBuilder, e2eMetricbeatConfig, e2eMetricbeatPodTemplate)
 
 	hbBuilder := beat.NewBuilder(name).
 		WithType(heartbeat.Type).
@@ -73,7 +73,7 @@ func TestBeatKibanaRef(t *testing.T) {
 
 	configYaml := fmt.Sprintf(e2eHeartBeatConfigTpl, esv1.HTTPService(esBuilder.Elasticsearch.Name), esBuilder.Elasticsearch.Namespace)
 
-	hbBuilder = applyYamls(t, hbBuilder, configYaml, e2eHeartbeatPodTemplate)
+	hbBuilder = beat.ApplyYamls(t, hbBuilder, configYaml, e2eHeartbeatPodTemplate)
 
 	dashboardCheck := func(client *test.K8sClient) test.StepList {
 		return test.StepList{

--- a/test/e2e/beat/setup_test.go
+++ b/test/e2e/beat/setup_test.go
@@ -56,7 +56,7 @@ func TestBeatKibanaRefWithTLSDisabled(t *testing.T) {
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithKibanaRef(kbBuilder.Ref())
 
-	fbBuilder = applyYamls(t, fbBuilder, e2eFilebeatConfig, e2eFilebeatPodTemplate)
+	fbBuilder = beat.ApplyYamls(t, fbBuilder, E2EFilebeatConfig, E2EFilebeatPodTemplate)
 
 	dashboardCheck := getDashboardCheck(
 		esBuilder,

--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -1,0 +1,219 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
+	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
+	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/filebeat"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	beattests "github.com/elastic/cloud-on-k8s/test/e2e/beat"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/apmserver"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/beat"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/enterprisesearch"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/kibana"
+)
+
+const (
+	// upgrading the entire stack can take some time, since we need to account for (in order):
+	// - Elasticsearch rolling upgrade
+	// - Kibana + Enterprise Search deployments upgrade
+	// - APMServer deployment upgrade + Beat daemonset upgrade
+	stackVersionUpgradeTimeout = 30 * time.Minute
+)
+
+// TestVersionUpgradeOrdering deploys the entire stack, with resources associated together.
+// Then, it updates their version, and ensures a strict ordering is respected during the version upgrade.
+func TestVersionUpgradeOrdering(t *testing.T) {
+	initialVersion := "7.7.0"
+	updatedVersion := "7.8.0"
+
+	// Single-node ES clusters cannot be green with APM indices (see https://github.com/elastic/apm-server/issues/414).
+	es := elasticsearch.NewBuilder("es").
+		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
+		WithVersion(initialVersion)
+	esUpdated := es.WithVersion(updatedVersion)
+	esRef := commonv1.ObjectSelector{Namespace: es.Elasticsearch.Namespace, Name: es.Elasticsearch.Name}
+	kb := kibana.NewBuilder("kb").
+		WithNodeCount(1).
+		WithVersion(initialVersion).
+		WithElasticsearchRef(esRef)
+	kbUpdated := kb.WithVersion(updatedVersion)
+	kbRef := commonv1.ObjectSelector{Namespace: kb.Kibana.Namespace, Name: kb.Kibana.Name}
+	apm := apmserver.NewBuilder("apm").
+		WithNodeCount(1).
+		WithVersion(initialVersion).
+		WithElasticsearchRef(esRef).
+		WithKibanaRef(kbRef)
+	apmUpdated := apm.WithVersion(updatedVersion)
+	ent := enterprisesearch.NewBuilder("ent").
+		WithNodeCount(1).
+		WithVersion(initialVersion).
+		WithElasticsearchRef(esRef)
+	entUpdated := ent.WithVersion(updatedVersion)
+	fb := beat.NewBuilder("fb").
+		WithType(filebeat.Type).
+		WithRoles(beat.PSPClusterRoleName, beat.AutodiscoverClusterRoleName).
+		WithVersion(initialVersion).
+		WithElasticsearchRef(esRef).
+		WithKibanaRef(kbRef)
+	fb = beat.ApplyYamls(t, fb, beattests.E2EFilebeatConfig, beattests.E2EFilebeatPodTemplate)
+	fbUpdated := fb.WithVersion(updatedVersion)
+
+	initialBuilders := []test.Builder{es, kb, apm, ent, fb}
+	updatedBuilders := []test.Builder{esUpdated, kbUpdated, apmUpdated, entUpdated, fbUpdated}
+
+	versionUpgrade := func(k *test.K8sClient) test.StepList {
+		steps := test.StepList{}
+		// upgrade the version of all resources
+		for _, b := range updatedBuilders {
+			steps = steps.WithSteps(b.UpgradeTestSteps(k))
+		}
+		// wait until they're all upgraded, while ensuring the upgrade order is respected
+		return steps.WithStep(test.Step{
+			Name: "Check all resources are eventually upgraded in the right order",
+			Test: test.UntilSuccess(func() error {
+				// retrieve the version from the status of all resources
+				stackVersions := StackResourceVersions{
+					Elasticsearch:    ref(k8s.ExtractNamespacedName(&es.Elasticsearch)),
+					Kibana:           ref(k8s.ExtractNamespacedName(&kb.Kibana)),
+					ApmServer:        ref(k8s.ExtractNamespacedName(&apm.ApmServer)),
+					EnterpriseSearch: ref(k8s.ExtractNamespacedName(&ent.EnterpriseSearch)),
+					Beat:             ref(k8s.ExtractNamespacedName(&fb.Beat)),
+				}
+				err := stackVersions.Retrieve(k.Client)
+				// check the retrieved versions first (before returning on err)
+				t.Log(stackVersions)
+				if !stackVersions.IsValid() {
+					t.Fatal("invalid stack versions upgrade order", stackVersions)
+				}
+				if err != nil {
+					return err
+				}
+				if !stackVersions.AllSetTo(updatedVersion) {
+					return fmt.Errorf("some versions are still not updated: %+v", stackVersions)
+				}
+				return nil
+			}, stackVersionUpgradeTimeout),
+		})
+	}
+
+	test.Sequence(nil, versionUpgrade, initialBuilders...).RunSequential(t)
+}
+
+type StackResourceVersions struct {
+	Elasticsearch    refVersion
+	Kibana           refVersion
+	ApmServer        refVersion
+	EnterpriseSearch refVersion
+	Beat             refVersion
+}
+
+func (s StackResourceVersions) IsValid() bool {
+	// ES >= Kibana >= (Beats, APM)
+	return s.Elasticsearch.IsSameOrAfter(s.Kibana) &&
+		s.Kibana.IsSameOrAfter(s.Beat) &&
+		s.Kibana.IsSameOrAfter(s.ApmServer) &&
+		// ES >= EnterpriseSearch
+		s.Elasticsearch.IsSameOrAfter(s.EnterpriseSearch)
+}
+
+func (s StackResourceVersions) AllSetTo(version string) bool {
+	for _, ref := range []refVersion{s.Elasticsearch, s.Kibana, s.ApmServer, s.EnterpriseSearch, s.Beat} {
+		if ref.version != version {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *StackResourceVersions) Retrieve(client k8s.Client) error {
+	calls := []func(c k8s.Client) error{s.retrieveBeat, s.retrieveApmServer, s.retrieveKibana, s.retrieveEnterpriseSearch, s.retrieveElasticsearch}
+	// grab at least one error if multiple occur
+	var callsErr error
+	for _, f := range calls {
+		if err := f(client); err != nil {
+			callsErr = err
+		}
+	}
+	return callsErr
+}
+
+type refVersion struct {
+	ref     types.NamespacedName
+	version string
+}
+
+func (r refVersion) IsSameOrAfter(r2 refVersion) bool {
+	if r.version == "" || r2.version == "" {
+		// empty version, consider it's ok
+		return true
+	}
+	rVersion := version.MustParse(r.version)
+	r2Version := version.MustParse(r2.version)
+	return rVersion.IsSameOrAfter(r2Version)
+}
+
+func ref(ref types.NamespacedName) refVersion {
+	return refVersion{ref: ref}
+}
+
+func (s *StackResourceVersions) retrieveElasticsearch(c k8s.Client) error {
+	var es esv1.Elasticsearch
+	if err := c.Get(s.Elasticsearch.ref, &es); err != nil {
+		return err
+	}
+	s.Elasticsearch.version = es.Status.Version
+	return nil
+}
+
+func (s *StackResourceVersions) retrieveKibana(c k8s.Client) error {
+	var kb kbv1.Kibana
+	if err := c.Get(s.Kibana.ref, &kb); err != nil {
+		return err
+	}
+	s.Kibana.version = kb.Status.Version
+	return nil
+}
+
+func (s *StackResourceVersions) retrieveApmServer(c k8s.Client) error {
+	var as apmv1.ApmServer
+	if err := c.Get(s.ApmServer.ref, &as); err != nil {
+		return err
+	}
+	s.ApmServer.version = as.Status.Version
+	return nil
+}
+
+func (s *StackResourceVersions) retrieveEnterpriseSearch(c k8s.Client) error {
+	var ent entv1beta1.EnterpriseSearch
+	if err := c.Get(s.EnterpriseSearch.ref, &ent); err != nil {
+		return err
+	}
+	s.EnterpriseSearch.version = ent.Status.Version
+	return nil
+}
+
+func (s *StackResourceVersions) retrieveBeat(c k8s.Client) error {
+	var beat beatv1beta1.Beat
+	if err := c.Get(s.Beat.ref, &beat); err != nil {
+		return err
+	}
+	s.Beat.version = beat.Status.Version
+	return nil
+}

--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -46,32 +46,37 @@ func TestVersionUpgradeOrdering(t *testing.T) {
 	// Single-node ES clusters cannot be green with APM indices (see https://github.com/elastic/apm-server/issues/414).
 	es := elasticsearch.NewBuilder("es").
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		WithVersion(initialVersion)
+		WithVersion(initialVersion).
+		WithRestrictedSecurityContext()
 	esUpdated := es.WithVersion(updatedVersion)
 	esRef := commonv1.ObjectSelector{Namespace: es.Elasticsearch.Namespace, Name: es.Elasticsearch.Name}
 	kb := kibana.NewBuilder("kb").
 		WithNodeCount(1).
 		WithVersion(initialVersion).
-		WithElasticsearchRef(esRef)
+		WithElasticsearchRef(esRef).
+		WithRestrictedSecurityContext()
 	kbUpdated := kb.WithVersion(updatedVersion)
 	kbRef := commonv1.ObjectSelector{Namespace: kb.Kibana.Namespace, Name: kb.Kibana.Name}
 	apm := apmserver.NewBuilder("apm").
 		WithNodeCount(1).
 		WithVersion(initialVersion).
 		WithElasticsearchRef(esRef).
-		WithKibanaRef(kbRef)
+		WithKibanaRef(kbRef).
+		WithRestrictedSecurityContext()
 	apmUpdated := apm.WithVersion(updatedVersion)
 	ent := enterprisesearch.NewBuilder("ent").
 		WithNodeCount(1).
 		WithVersion(initialVersion).
-		WithElasticsearchRef(esRef)
+		WithElasticsearchRef(esRef).
+		WithRestrictedSecurityContext()
 	entUpdated := ent.WithVersion(updatedVersion)
 	fb := beat.NewBuilder("fb").
 		WithType(filebeat.Type).
 		WithRoles(beat.PSPClusterRoleName, beat.AutodiscoverClusterRoleName).
 		WithVersion(initialVersion).
 		WithElasticsearchRef(esRef).
-		WithKibanaRef(kbRef)
+		WithKibanaRef(kbRef).
+		WithRestrictedSecurityContext()
 	fb = beat.ApplyYamls(t, fb, beattests.E2EFilebeatConfig, beattests.E2EFilebeatPodTemplate)
 	fbUpdated := fb.WithVersion(updatedVersion)
 

--- a/test/e2e/test/apmserver/steps_mutation.go
+++ b/test/e2e/test/apmserver/steps_mutation.go
@@ -4,14 +4,30 @@
 
 package apmserver
 
-import "github.com/elastic/cloud-on-k8s/test/e2e/test"
+import (
+	"testing"
+
+	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/stretchr/testify/require"
+)
 
 func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 	panic("not implemented")
 }
 
 func (b Builder) UpgradeTestSteps(k *test.K8sClient) test.StepList {
-	panic("not implemented")
+	return test.StepList{
+		{
+			Name: "Applying the ApmServer mutation should succeed",
+			Test: func(t *testing.T) {
+				var as apmv1.ApmServer
+				require.NoError(t, k.Client.Get(k8s.ExtractNamespacedName(&b.ApmServer), &as))
+				as.Spec = b.ApmServer.Spec
+				require.NoError(t, k.Client.Update(&as))
+			},
+		}}
 }
 
 func (b Builder) MutationReversalTestContext() test.ReversalTestContext {

--- a/test/e2e/test/beat/builder.go
+++ b/test/e2e/test/beat/builder.go
@@ -278,3 +278,19 @@ func (b Builder) RuntimeObjects() []runtime.Object {
 }
 
 var _ test.Builder = Builder{}
+
+func ApplyYamls(t *testing.T, b Builder, configYaml, podTemplateYaml string) Builder {
+	if configYaml != "" {
+		b.Beat.Spec.Config = &commonv1.Config{}
+		err := settings.MustParseConfig([]byte(configYaml)).Unpack(&b.Beat.Spec.Config.Data)
+		require.NoError(t, err)
+	}
+
+	if podTemplateYaml != "" {
+		// use ghodss as settings package has issues with unpacking volumes part of the yamls
+		err := ghodssyaml.Unmarshal([]byte(podTemplateYaml), b.PodTemplate)
+		require.NoError(t, err)
+	}
+
+	return b
+}

--- a/test/e2e/test/beat/builder.go
+++ b/test/e2e/test/beat/builder.go
@@ -6,7 +6,9 @@ package beat
 
 import (
 	"fmt"
+	"testing"
 
+	ghodssyaml "github.com/ghodss/yaml"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,10 +18,12 @@ import (
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	beatcommon "github.com/elastic/cloud-on-k8s/pkg/controller/beat/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -96,6 +100,11 @@ type ValidationFunc func(client.Client) error
 
 func (b Builder) WithType(typ beatcommon.Type) Builder {
 	b.Beat.Spec.Type = string(typ)
+	return b
+}
+
+func (b Builder) WithVersion(version string) Builder {
+	b.Beat.Spec.Version = version
 	return b
 }
 


### PR DESCRIPTION
Ensure individual stack resources can only have their version upgraded if referenced resources are also upgraded.
Implicitly, this implements the following upgrade order:
- Elasticsearch > Kibana > Beats, APM
- Elasticsearch > EnterpriseSearch

Example: if a user upgrades both Elasticsearch and Kibana from 7.7.0 to 7.8.0, the Kibana upgrade is delayed until Elasticsearch runs 7.8.0.

This restriction only applies to major and minor versions. Patch versions are ignored: Kibana 7.8.1 can be deployed alongside Elasticsearch 7.8.0.

In order to do so, the association controller adds a `version` field to the existing associationConf annotation, in the resource holding associations.
Example: the ApmServer resource that specifies a reference to Kibana and Elasticsearch will have the (lowest) currently running Kibana version and currently running Elasticsearch version in its annotations, set by both association controllers.

Each resource controller can then inspect its own association configurations annotations, and requeue in case the referenced resource is running an older version. Or if its version is not reported yet (resource in the process of being created): this slows down the initial resource creation slightly (Kibana is not created before the first Elasticsearch Pod is created), but I think that's short enough to not bother much.

We do not try to be smart in decoupling version upgrades from other upgrades (for example: decide to apply a config change but not a version change yet even though the spec specifies both): this would be tricky to implement.

**Breaking change**: we used to allow several associated resources to coexist with different versions, and apply any spec change immediately. We now enforce a strict version upgrade ordering that delays any spec changes until the resource version allows it. For example: when updating both Elasticsearch and Kibana from 7.7.0 to 7.8.0, any change to the Kibana spec will be delayed until Elasticsearch has been successfully updated to 7.8.0. Only `major.minor` in the version is considered by this.

Fixes https://github.com/elastic/cloud-on-k8s/issues/2600.
Fixes https://github.com/elastic/cloud-on-k8s/issues/3535.
Depends on https://github.com/elastic/cloud-on-k8s/pull/3534 for the E2E test to pass.