### PR TITLE
Skip manifest upload on nightly build job

### DIFF
--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -41,6 +41,9 @@ pipeline {
                     }
                 }
                 stage('Upload YAML manifest to S3') {
+                    when {
+                        buildingTag()
+                    }
                     steps {
                         script {
                             env.VERSION = readFromEnvFile("VERSION")


### PR DESCRIPTION
Skips uploading the `all-in-one.yaml` file during the nightly build. 
Without this change, any updates to the manifests on `master` will alter the installation file for the currently released version as well.