### PR TITLE
Backport - Fix $PWD interpolation in the docs

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/users-and-roles.asciidoc
@@ -92,7 +92,7 @@ touch filerealm/users filerealm/users_roles
 
 # create user 'myuser' with role 'monitoring_user'
 docker run \
-    -v ${PWD}/filerealm:/usr/share/elasticsearch/config \
+    -v $(pwd)/filerealm:/usr/share/elasticsearch/config \
     docker.elastic.co/elasticsearch/elasticsearch:{version} \
     bin/elasticsearch-users useradd myuser -p mypassword -r monitoring_user
 


### PR DESCRIPTION
Backport https://github.com/elastic/cloud-on-k8s/pull/3546 on 1.1.

Due to https://github.com/elastic/docs/blob/5a9f4b641ef7f5d1568718dc3120b799825f8206/shared/attributes.asciidoc#L298, `${PWD}` is rendered as `$YOUR_PASSWORD` in the docs.
We want the real filesystem path here so let's use `$(pwd)`.