### PR TITLE
Reflect currently running version from status.version in additionalPrinterColumns

### DIFF
--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -6,21 +6,6 @@ metadata:
   creationTimestamp: null
   name: apmservers.apm.k8s.elastic.co
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.health
-    name: health
-    type: string
-  - JSONPath: .status.availableNodes
-    description: Available nodes
-    name: nodes
-    type: integer
-  - JSONPath: .spec.version
-    description: APM version
-    name: version
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: apm.k8s.elastic.co
   names:
     categories:
@@ -454,10 +439,40 @@ spec:
           type: object
   version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .status.version
+      description: APM version
+      name: version
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1
     served: true
     storage: true
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .spec.version
+      description: APM version
+      name: version
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1beta1
     served: true
     storage: false
   - name: v1alpha1
@@ -494,7 +509,7 @@ spec:
     description: Beat type
     name: type
     type: string
-  - JSONPath: .spec.version
+  - JSONPath: .status.version
     description: Beat version
     name: version
     type: string
@@ -697,24 +712,6 @@ metadata:
   creationTimestamp: null
   name: elasticsearches.elasticsearch.k8s.elastic.co
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.health
-    name: health
-    type: string
-  - JSONPath: .status.availableNodes
-    description: Available nodes
-    name: nodes
-    type: integer
-  - JSONPath: .spec.version
-    description: Elasticsearch version
-    name: version
-    type: string
-  - JSONPath: .status.phase
-    name: phase
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: elasticsearch.k8s.elastic.co
   names:
     categories:
@@ -1748,10 +1745,46 @@ spec:
           type: object
   version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .status.version
+      description: Elasticsearch version
+      name: version
+      type: string
+    - JSONPath: .status.phase
+      name: phase
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1
     served: true
     storage: true
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .spec.version
+      description: Elasticsearch version
+      name: version
+      type: string
+    - JSONPath: .status.phase
+      name: phase
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1beta1
     served: true
     storage: false
   - name: v1alpha1
@@ -1780,7 +1813,7 @@ spec:
     description: Available nodes
     name: nodes
     type: integer
-  - JSONPath: .spec.version
+  - JSONPath: .status.version
     description: Enterprise Search version
     name: version
     type: string
@@ -2189,21 +2222,6 @@ metadata:
   creationTimestamp: null
   name: kibanas.kibana.k8s.elastic.co
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.health
-    name: health
-    type: string
-  - JSONPath: .status.availableNodes
-    description: Available nodes
-    name: nodes
-    type: integer
-  - JSONPath: .spec.version
-    description: Kibana version
-    name: version
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: kibana.k8s.elastic.co
   names:
     categories:
@@ -2608,10 +2626,40 @@ spec:
           type: object
   version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .status.version
+      description: Kibana version
+      name: version
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1
     served: true
     storage: true
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .spec.version
+      description: Kibana version
+      name: version
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1beta1
     served: true
     storage: false
   - name: v1alpha1

--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -6,6 +6,21 @@ metadata:
   creationTimestamp: null
   name: apmservers.apm.k8s.elastic.co
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.health
+    name: health
+    type: string
+  - JSONPath: .status.availableNodes
+    description: Available nodes
+    name: nodes
+    type: integer
+  - JSONPath: .status.version
+    description: APM version
+    name: version
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: apm.k8s.elastic.co
   names:
     categories:
@@ -439,40 +454,10 @@ spec:
           type: object
   version: v1
   versions:
-  - additionalPrinterColumns:
-    - JSONPath: .status.health
-      name: health
-      type: string
-    - JSONPath: .status.availableNodes
-      description: Available nodes
-      name: nodes
-      type: integer
-    - JSONPath: .status.version
-      description: APM version
-      name: version
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
-    name: v1
+  - name: v1
     served: true
     storage: true
-  - additionalPrinterColumns:
-    - JSONPath: .status.health
-      name: health
-      type: string
-    - JSONPath: .status.availableNodes
-      description: Available nodes
-      name: nodes
-      type: integer
-    - JSONPath: .spec.version
-      description: APM version
-      name: version
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
-    name: v1beta1
+  - name: v1beta1
     served: true
     storage: false
   - name: v1alpha1
@@ -712,6 +697,24 @@ metadata:
   creationTimestamp: null
   name: elasticsearches.elasticsearch.k8s.elastic.co
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.health
+    name: health
+    type: string
+  - JSONPath: .status.availableNodes
+    description: Available nodes
+    name: nodes
+    type: integer
+  - JSONPath: .status.version
+    description: Elasticsearch version
+    name: version
+    type: string
+  - JSONPath: .status.phase
+    name: phase
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: elasticsearch.k8s.elastic.co
   names:
     categories:
@@ -1745,46 +1748,10 @@ spec:
           type: object
   version: v1
   versions:
-  - additionalPrinterColumns:
-    - JSONPath: .status.health
-      name: health
-      type: string
-    - JSONPath: .status.availableNodes
-      description: Available nodes
-      name: nodes
-      type: integer
-    - JSONPath: .status.version
-      description: Elasticsearch version
-      name: version
-      type: string
-    - JSONPath: .status.phase
-      name: phase
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
-    name: v1
+  - name: v1
     served: true
     storage: true
-  - additionalPrinterColumns:
-    - JSONPath: .status.health
-      name: health
-      type: string
-    - JSONPath: .status.availableNodes
-      description: Available nodes
-      name: nodes
-      type: integer
-    - JSONPath: .spec.version
-      description: Elasticsearch version
-      name: version
-      type: string
-    - JSONPath: .status.phase
-      name: phase
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
-    name: v1beta1
+  - name: v1beta1
     served: true
     storage: false
   - name: v1alpha1
@@ -2222,6 +2189,21 @@ metadata:
   creationTimestamp: null
   name: kibanas.kibana.k8s.elastic.co
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.health
+    name: health
+    type: string
+  - JSONPath: .status.availableNodes
+    description: Available nodes
+    name: nodes
+    type: integer
+  - JSONPath: .status.version
+    description: Kibana version
+    name: version
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: kibana.k8s.elastic.co
   names:
     categories:
@@ -2626,40 +2608,10 @@ spec:
           type: object
   version: v1
   versions:
-  - additionalPrinterColumns:
-    - JSONPath: .status.health
-      name: health
-      type: string
-    - JSONPath: .status.availableNodes
-      description: Available nodes
-      name: nodes
-      type: integer
-    - JSONPath: .status.version
-      description: Kibana version
-      name: version
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
-    name: v1
+  - name: v1
     served: true
     storage: true
-  - additionalPrinterColumns:
-    - JSONPath: .status.health
-      name: health
-      type: string
-    - JSONPath: .status.availableNodes
-      description: Available nodes
-      name: nodes
-      type: integer
-    - JSONPath: .spec.version
-      description: Kibana version
-      name: version
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
-    name: v1beta1
+  - name: v1beta1
     served: true
     storage: false
   - name: v1alpha1

--- a/config/crds/bases/apm.k8s.elastic.co_apmservers.yaml
+++ b/config/crds/bases/apm.k8s.elastic.co_apmservers.yaml
@@ -8,21 +8,6 @@ metadata:
   creationTimestamp: null
   name: apmservers.apm.k8s.elastic.co
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.health
-    name: health
-    type: string
-  - JSONPath: .status.availableNodes
-    description: Available nodes
-    name: nodes
-    type: integer
-  - JSONPath: .spec.version
-    description: APM version
-    name: version
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: apm.k8s.elastic.co
   names:
     categories:
@@ -38,7 +23,22 @@ spec:
     status: {}
   version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .status.version
+      description: APM version
+      name: version
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: ApmServer represents an APM Server resource in a Kubernetes cluster.
@@ -6351,7 +6351,22 @@ spec:
         type: object
     served: true
     storage: true
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .spec.version
+      description: APM version
+      name: version
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ApmServer represents an APM Server resource in a Kubernetes cluster.

--- a/config/crds/bases/beat.k8s.elastic.co_beats.yaml
+++ b/config/crds/bases/beat.k8s.elastic.co_beats.yaml
@@ -24,7 +24,7 @@ spec:
     description: Beat type
     name: type
     type: string
-  - JSONPath: .spec.version
+  - JSONPath: .status.version
     description: Beat version
     name: version
     type: string

--- a/config/crds/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
+++ b/config/crds/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
@@ -8,24 +8,6 @@ metadata:
   creationTimestamp: null
   name: elasticsearches.elasticsearch.k8s.elastic.co
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.health
-    name: health
-    type: string
-  - JSONPath: .status.availableNodes
-    description: Available nodes
-    name: nodes
-    type: integer
-  - JSONPath: .spec.version
-    description: Elasticsearch version
-    name: version
-    type: string
-  - JSONPath: .status.phase
-    name: phase
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: elasticsearch.k8s.elastic.co
   names:
     categories:
@@ -41,7 +23,25 @@ spec:
     status: {}
   version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .status.version
+      description: Elasticsearch version
+      name: version
+      type: string
+    - JSONPath: .status.phase
+      name: phase
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: Elasticsearch represents an Elasticsearch resource in a Kubernetes
@@ -7385,7 +7385,25 @@ spec:
         type: object
     served: true
     storage: true
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .spec.version
+      description: Elasticsearch version
+      name: version
+      type: string
+    - JSONPath: .status.phase
+      name: phase
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Elasticsearch represents an Elasticsearch resource in a Kubernetes

--- a/config/crds/bases/enterprisesearch.k8s.elastic.co_enterprisesearches.yaml
+++ b/config/crds/bases/enterprisesearch.k8s.elastic.co_enterprisesearches.yaml
@@ -16,7 +16,7 @@ spec:
     description: Available nodes
     name: nodes
     type: integer
-  - JSONPath: .spec.version
+  - JSONPath: .status.version
     description: Enterprise Search version
     name: version
     type: string

--- a/config/crds/bases/kibana.k8s.elastic.co_kibanas.yaml
+++ b/config/crds/bases/kibana.k8s.elastic.co_kibanas.yaml
@@ -8,21 +8,6 @@ metadata:
   creationTimestamp: null
   name: kibanas.kibana.k8s.elastic.co
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.health
-    name: health
-    type: string
-  - JSONPath: .status.availableNodes
-    description: Available nodes
-    name: nodes
-    type: integer
-  - JSONPath: .spec.version
-    description: Kibana version
-    name: version
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: kibana.k8s.elastic.co
   names:
     categories:
@@ -38,7 +23,22 @@ spec:
     status: {}
   version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .status.version
+      description: Kibana version
+      name: version
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: Kibana represents a Kibana resource in a Kubernetes cluster.
@@ -6321,7 +6321,22 @@ spec:
         type: object
     served: true
     storage: true
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .spec.version
+      description: Kibana version
+      name: version
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Kibana represents a Kibana resource in a Kubernetes cluster.

--- a/config/crds/patches/apm-kibana-patches.yaml
+++ b/config/crds/patches/apm-kibana-patches.yaml
@@ -8,6 +8,13 @@
   path: /spec/validation
 - op: remove
   path: /spec/versions/1/schema
+# Move additionalPrinterColumns of the v1 version to the top-level, and remove it from the v1beta1 version.
+# This is in order to be compatible with k8s 1.11.
+- op: move
+  from: /spec/versions/0/additionalPrinterColumns
+  path: /spec/additionalPrinterColumns
+- op: remove
+  path: /spec/versions/1/additionalPrinterColumns
 # Remove validation.openAPIV3Schema.type that causes failures on k8s 1.11.
 # This should have been fixed with https://github.com/kubernetes-sigs/controller-tools/pull/72, but it looks like
 # this commit has been lost in history. See https://github.com/kubernetes-sigs/controller-tools/issues/296.

--- a/config/crds/patches/elasticsearch-patches.yaml
+++ b/config/crds/patches/elasticsearch-patches.yaml
@@ -8,6 +8,13 @@
   path: /spec/validation
 - op: remove
   path: /spec/versions/1/schema
+# Move additionalPrinterColumns of the v1 version to the top-level, and remove it from the v1beta1 version.
+# This is in order to be compatible with k8s 1.11.
+- op: move
+  from: /spec/versions/0/additionalPrinterColumns
+  path: /spec/additionalPrinterColumns
+- op: remove
+  path: /spec/versions/1/additionalPrinterColumns
 # Remove validation.openAPIV3Schema.type that causes failures on k8s 1.11.
 # This should have been fixed with https://github.com/kubernetes-sigs/controller-tools/pull/72, but it looks like
 # this commit has been lost in history. See https://github.com/kubernetes-sigs/controller-tools/issues/296.

--- a/hack/manifest-gen/assets/charts/eck/crds/all-crds.yaml
+++ b/hack/manifest-gen/assets/charts/eck/crds/all-crds.yaml
@@ -6,21 +6,6 @@ metadata:
   creationTimestamp: null
   name: apmservers.apm.k8s.elastic.co
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.health
-    name: health
-    type: string
-  - JSONPath: .status.availableNodes
-    description: Available nodes
-    name: nodes
-    type: integer
-  - JSONPath: .spec.version
-    description: APM version
-    name: version
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: apm.k8s.elastic.co
   names:
     categories:
@@ -454,10 +439,40 @@ spec:
           type: object
   version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .status.version
+      description: APM version
+      name: version
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1
     served: true
     storage: true
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .spec.version
+      description: APM version
+      name: version
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1beta1
     served: true
     storage: false
   - name: v1alpha1
@@ -494,7 +509,7 @@ spec:
     description: Beat type
     name: type
     type: string
-  - JSONPath: .spec.version
+  - JSONPath: .status.version
     description: Beat version
     name: version
     type: string
@@ -697,24 +712,6 @@ metadata:
   creationTimestamp: null
   name: elasticsearches.elasticsearch.k8s.elastic.co
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.health
-    name: health
-    type: string
-  - JSONPath: .status.availableNodes
-    description: Available nodes
-    name: nodes
-    type: integer
-  - JSONPath: .spec.version
-    description: Elasticsearch version
-    name: version
-    type: string
-  - JSONPath: .status.phase
-    name: phase
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: elasticsearch.k8s.elastic.co
   names:
     categories:
@@ -1748,10 +1745,46 @@ spec:
           type: object
   version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .status.version
+      description: Elasticsearch version
+      name: version
+      type: string
+    - JSONPath: .status.phase
+      name: phase
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1
     served: true
     storage: true
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .spec.version
+      description: Elasticsearch version
+      name: version
+      type: string
+    - JSONPath: .status.phase
+      name: phase
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1beta1
     served: true
     storage: false
   - name: v1alpha1
@@ -1780,7 +1813,7 @@ spec:
     description: Available nodes
     name: nodes
     type: integer
-  - JSONPath: .spec.version
+  - JSONPath: .status.version
     description: Enterprise Search version
     name: version
     type: string
@@ -2189,21 +2222,6 @@ metadata:
   creationTimestamp: null
   name: kibanas.kibana.k8s.elastic.co
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.health
-    name: health
-    type: string
-  - JSONPath: .status.availableNodes
-    description: Available nodes
-    name: nodes
-    type: integer
-  - JSONPath: .spec.version
-    description: Kibana version
-    name: version
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: kibana.k8s.elastic.co
   names:
     categories:
@@ -2608,10 +2626,40 @@ spec:
           type: object
   version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .status.version
+      description: Kibana version
+      name: version
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1
     served: true
     storage: true
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .spec.version
+      description: Kibana version
+      name: version
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1beta1
     served: true
     storage: false
   - name: v1alpha1

--- a/hack/manifest-gen/assets/charts/eck/crds/all-crds.yaml
+++ b/hack/manifest-gen/assets/charts/eck/crds/all-crds.yaml
@@ -6,6 +6,21 @@ metadata:
   creationTimestamp: null
   name: apmservers.apm.k8s.elastic.co
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.health
+    name: health
+    type: string
+  - JSONPath: .status.availableNodes
+    description: Available nodes
+    name: nodes
+    type: integer
+  - JSONPath: .status.version
+    description: APM version
+    name: version
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: apm.k8s.elastic.co
   names:
     categories:
@@ -439,40 +454,10 @@ spec:
           type: object
   version: v1
   versions:
-  - additionalPrinterColumns:
-    - JSONPath: .status.health
-      name: health
-      type: string
-    - JSONPath: .status.availableNodes
-      description: Available nodes
-      name: nodes
-      type: integer
-    - JSONPath: .status.version
-      description: APM version
-      name: version
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
-    name: v1
+  - name: v1
     served: true
     storage: true
-  - additionalPrinterColumns:
-    - JSONPath: .status.health
-      name: health
-      type: string
-    - JSONPath: .status.availableNodes
-      description: Available nodes
-      name: nodes
-      type: integer
-    - JSONPath: .spec.version
-      description: APM version
-      name: version
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
-    name: v1beta1
+  - name: v1beta1
     served: true
     storage: false
   - name: v1alpha1
@@ -712,6 +697,24 @@ metadata:
   creationTimestamp: null
   name: elasticsearches.elasticsearch.k8s.elastic.co
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.health
+    name: health
+    type: string
+  - JSONPath: .status.availableNodes
+    description: Available nodes
+    name: nodes
+    type: integer
+  - JSONPath: .status.version
+    description: Elasticsearch version
+    name: version
+    type: string
+  - JSONPath: .status.phase
+    name: phase
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: elasticsearch.k8s.elastic.co
   names:
     categories:
@@ -1745,46 +1748,10 @@ spec:
           type: object
   version: v1
   versions:
-  - additionalPrinterColumns:
-    - JSONPath: .status.health
-      name: health
-      type: string
-    - JSONPath: .status.availableNodes
-      description: Available nodes
-      name: nodes
-      type: integer
-    - JSONPath: .status.version
-      description: Elasticsearch version
-      name: version
-      type: string
-    - JSONPath: .status.phase
-      name: phase
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
-    name: v1
+  - name: v1
     served: true
     storage: true
-  - additionalPrinterColumns:
-    - JSONPath: .status.health
-      name: health
-      type: string
-    - JSONPath: .status.availableNodes
-      description: Available nodes
-      name: nodes
-      type: integer
-    - JSONPath: .spec.version
-      description: Elasticsearch version
-      name: version
-      type: string
-    - JSONPath: .status.phase
-      name: phase
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
-    name: v1beta1
+  - name: v1beta1
     served: true
     storage: false
   - name: v1alpha1
@@ -2222,6 +2189,21 @@ metadata:
   creationTimestamp: null
   name: kibanas.kibana.k8s.elastic.co
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.health
+    name: health
+    type: string
+  - JSONPath: .status.availableNodes
+    description: Available nodes
+    name: nodes
+    type: integer
+  - JSONPath: .status.version
+    description: Kibana version
+    name: version
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: kibana.k8s.elastic.co
   names:
     categories:
@@ -2626,40 +2608,10 @@ spec:
           type: object
   version: v1
   versions:
-  - additionalPrinterColumns:
-    - JSONPath: .status.health
-      name: health
-      type: string
-    - JSONPath: .status.availableNodes
-      description: Available nodes
-      name: nodes
-      type: integer
-    - JSONPath: .status.version
-      description: Kibana version
-      name: version
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
-    name: v1
+  - name: v1
     served: true
     storage: true
-  - additionalPrinterColumns:
-    - JSONPath: .status.health
-      name: health
-      type: string
-    - JSONPath: .status.availableNodes
-      description: Available nodes
-      name: nodes
-      type: integer
-    - JSONPath: .spec.version
-      description: Kibana version
-      name: version
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
-    name: v1beta1
+  - name: v1beta1
     served: true
     storage: false
   - name: v1alpha1

--- a/pkg/apis/apm/v1/apmserver_types.go
+++ b/pkg/apis/apm/v1/apmserver_types.go
@@ -72,7 +72,7 @@ type ApmServerStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="health",type="string",JSONPath=".status.health"
 // +kubebuilder:printcolumn:name="nodes",type="integer",JSONPath=".status.availableNodes",description="Available nodes"
-// +kubebuilder:printcolumn:name="version",type="string",JSONPath=".spec.version",description="APM version"
+// +kubebuilder:printcolumn:name="version",type="string",JSONPath=".status.version",description="APM version"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:storageversion
 type ApmServer struct {

--- a/pkg/apis/beat/v1beta1/beat_types.go
+++ b/pkg/apis/beat/v1beta1/beat_types.go
@@ -127,7 +127,7 @@ const (
 // +kubebuilder:printcolumn:name="available",type="integer",JSONPath=".status.availableNodes",description="Available nodes"
 // +kubebuilder:printcolumn:name="expected",type="integer",JSONPath=".status.expectedNodes",description="Expected nodes"
 // +kubebuilder:printcolumn:name="type",type="string",JSONPath=".spec.type",description="Beat type"
-// +kubebuilder:printcolumn:name="version",type="string",JSONPath=".spec.version",description="Beat version"
+// +kubebuilder:printcolumn:name="version",type="string",JSONPath=".status.version",description="Beat version"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:storageversion
 type Beat struct {

--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -326,7 +326,7 @@ func (es ElasticsearchStatus) IsDegraded(prev ElasticsearchStatus) bool {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="health",type="string",JSONPath=".status.health"
 // +kubebuilder:printcolumn:name="nodes",type="integer",JSONPath=".status.availableNodes",description="Available nodes"
-// +kubebuilder:printcolumn:name="version",type="string",JSONPath=".spec.version",description="Elasticsearch version"
+// +kubebuilder:printcolumn:name="version",type="string",JSONPath=".status.version",description="Elasticsearch version"
 // +kubebuilder:printcolumn:name="phase",type="string",JSONPath=".status.phase"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:storageversion

--- a/pkg/apis/enterprisesearch/v1beta1/enterprisesearch_types.go
+++ b/pkg/apis/enterprisesearch/v1beta1/enterprisesearch_types.go
@@ -119,7 +119,7 @@ var _ commonv1.Association = &EnterpriseSearch{}
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="health",type="string",JSONPath=".status.health"
 // +kubebuilder:printcolumn:name="nodes",type="integer",JSONPath=".status.availableNodes",description="Available nodes"
-// +kubebuilder:printcolumn:name="version",type="string",JSONPath=".spec.version",description="Enterprise Search version"
+// +kubebuilder:printcolumn:name="version",type="string",JSONPath=".status.version",description="Enterprise Search version"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:storageversion
 type EnterpriseSearch struct {

--- a/pkg/apis/kibana/v1/kibana_types.go
+++ b/pkg/apis/kibana/v1/kibana_types.go
@@ -115,7 +115,7 @@ var _ commonv1.Association = &Kibana{}
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="health",type="string",JSONPath=".status.health"
 // +kubebuilder:printcolumn:name="nodes",type="integer",JSONPath=".status.availableNodes",description="Available nodes"
-// +kubebuilder:printcolumn:name="version",type="string",JSONPath=".spec.version",description="Kibana version"
+// +kubebuilder:printcolumn:name="version",type="string",JSONPath=".status.version",description="Kibana version"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:storageversion
 type Kibana struct {


### PR DESCRIPTION
When running for example `kubectl get elastic`, we get the version
displayed from `spec.version`. It represents the desired version but not
the version currently running.

Now that we have `status.version` available to represent the version
currently running, let's use it instead!