### PR TITLE
Fix volume slice initialization in beat pod builder

### DIFF
--- a/pkg/controller/beat/common/pod.go
+++ b/pkg/controller/beat/common/pod.go
@@ -104,8 +104,8 @@ func buildPodTemplate(
 		vols = append(vols, caVolume)
 	}
 
-	volumes := make([]corev1.Volume, len(vols))
-	volumeMounts := make([]corev1.VolumeMount, len(vols))
+	volumes := make([]corev1.Volume, 0, len(vols))
+	volumeMounts := make([]corev1.VolumeMount, 0, len(vols))
 	var initContainers []corev1.Container
 
 	for _, v := range vols {


### PR DESCRIPTION
We initialized the slice with a non-0 length with empty elements inside.

Fixes https://github.com/elastic/cloud-on-k8s/issues/3554.