### PR TITLE
Fix makeObjectSteps tests name rendering

### DIFF
--- a/test/e2e/test/helper/yaml.go
+++ b/test/e2e/test/helper/yaml.go
@@ -182,7 +182,7 @@ func makeObjectSteps(
 				meta, err := meta2.Accessor(objects[ii])
 				require.NoError(t, err)
 				steps = steps.WithStep(test.Step{
-					Name: fmt.Sprintf("Create %s/%s", meta.GetNamespace(), meta.GetNamespace()),
+					Name: fmt.Sprintf("Create %s %s", objects[ii].GetObjectKind().GroupVersionKind().Kind, meta.GetName()),
 					Test: func(t *testing.T) {
 						err := k.Client.Create(objects[ii])
 						if !k8serrors.IsAlreadyExists(err) {
@@ -199,7 +199,7 @@ func makeObjectSteps(
 				meta, err := meta2.Accessor(objects[ii])
 				require.NoError(t, err)
 				steps = steps.WithStep(test.Step{
-					Name: fmt.Sprintf("Delete %s/%s", meta.GetNamespace(), meta.GetNamespace()),
+					Name: fmt.Sprintf("Delete %s %s", objects[ii].GetObjectKind().GroupVersionKind().Kind, meta.GetName()),
 					Test: func(t *testing.T) {
 						err := k.Client.Delete(objects[ii])
 						if !k8serrors.IsNotFound(err) {


### PR DESCRIPTION
We printed test names such as `Create /`, which does not make sense.
I think the initial idea was to print `Create <namespace>/<name>`, but a
bug in the code printed <namespace>/<namespace> instead.

However it turns out some resources created there don't have a namespace
(example: ClusterRoleBinding). I think it makes more sense to print the
resource kind and the resource name, and ignore the namespace.

Also remove the `/` which is already used to render a test hierarchy in
the test output.

So in the end this commit does what's necessary so we get something like
`Create ServiceAccount filebeat-dvqx` instead of `Create /`.

Fixes https://github.com/elastic/cloud-on-k8s/issues/3457.