### PR TITLE
Normalise monitoring secret variables

### DIFF
--- a/config/e2e/filebeat.yaml
+++ b/config/e2e/filebeat.yaml
@@ -102,17 +102,17 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: "eck-{{ .TestRun }}"
-                  key: monitoring-user
+                  key: monitoring_user
             - name: MONITORING_PASS
               valueFrom:
                 secretKeyRef:
                   name: "eck-{{ .TestRun }}"
-                  key: monitoring-pass
+                  key: monitoring_pass
             - name: MONITORING_IP
               valueFrom:
                 secretKeyRef:
                   name: "eck-{{ .TestRun }}"
-                  key: monitoring-ip
+                  key: monitoring_ip
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
@@ -147,7 +147,7 @@ spec:
             - name: monitoring-ca
               mountPath: /mnt/elastic/monitoring-ca.crt
               readOnly: true
-              subPath: monitoring-ca
+              subPath: monitoring_ca
       volumes:
         - name: config
           configMap:

--- a/config/e2e/metricbeat.yaml
+++ b/config/e2e/metricbeat.yaml
@@ -144,19 +144,19 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: "eck-{{ .TestRun }}"
-                  key: monitoring-ip
+                  key: monitoring_ip
             - name: ELASTICSEARCH_PORT
               value: "9200"
             - name: ELASTICSEARCH_USERNAME
               valueFrom:
                 secretKeyRef:
                   name: "eck-{{ .TestRun }}"
-                  key: monitoring-user
+                  key: monitoring_user
             - name: ELASTICSEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: "eck-{{ .TestRun }}"
-                  key: monitoring-pass
+                  key: monitoring_pass
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
@@ -191,7 +191,7 @@ spec:
             - name: monitoring-ca
               mountPath: /mnt/elastic/monitoring-ca.crt
               readOnly: true
-              subPath: monitoring-ca
+              subPath: monitoring_ca
       volumes:
         - name: proc
           hostPath:

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -214,10 +214,10 @@ func (h *helper) initTestSecrets() error {
 		}
 
 		monitoringSecrets := struct {
-			MonitoringIP   string `json:"monitoringIp"`
-			MonitoringUser string `json:"monitoringUser"`
-			MonitoringPass string `json:"monitoringPass"`
-			MonitoringCa   string `json:"monitoringCa"`
+			MonitoringIP   string `json:"monitoring_ip"`
+			MonitoringUser string `json:"monitoring_user"`
+			MonitoringPass string `json:"monitoring_pass"`
+			MonitoringCA   string `json:"monitoring_ca"`
 			APMServerCert  string `json:"apm_server_cert"`
 			APMSecretToken string `json:"apm_secret_token"`
 			APMServerURL   string `json:"apm_server_url"`
@@ -227,10 +227,10 @@ func (h *helper) initTestSecrets() error {
 			return fmt.Errorf("unmarshal %v, %w", h.monitoringSecrets, err)
 		}
 
-		h.testSecrets["monitoring-ip"] = monitoringSecrets.MonitoringIP
-		h.testSecrets["monitoring-user"] = monitoringSecrets.MonitoringUser
-		h.testSecrets["monitoring-pass"] = monitoringSecrets.MonitoringPass
-		h.testSecrets["monitoring-ca"] = monitoringSecrets.MonitoringCa
+		h.testSecrets["monitoring_ip"] = monitoringSecrets.MonitoringIP
+		h.testSecrets["monitoring_user"] = monitoringSecrets.MonitoringUser
+		h.testSecrets["monitoring_pass"] = monitoringSecrets.MonitoringPass
+		h.testSecrets["monitoring_ca"] = monitoringSecrets.MonitoringCA
 
 		h.operatorSecrets = map[string]string{}
 		h.operatorSecrets["apm_server_cert"] = monitoringSecrets.APMServerCert


### PR DESCRIPTION
We had two different styles of variable names in the monitoring
secret. This change adjust them to just one style.

I have duplicated the corresponding values in CI for the time being until we are happy to phase out the old versions.

Fixes #3463 