### PR TITLE
Add support for keystore with Kibana 7.9.0

### DIFF
--- a/pkg/controller/common/volume/shared_volumes.go
+++ b/pkg/controller/common/volume/shared_volumes.go
@@ -6,7 +6,7 @@ package volume
 
 import corev1 "k8s.io/api/core/v1"
 
-// SharedVolume between the init container and the ES container.
+// SharedVolume between the init container and the main container.
 type SharedVolume struct {
 	VolumeName             string // Volume name
 	InitContainerMountPath string // Mount path in the init container

--- a/pkg/controller/common/volume/shared_volumes.go
+++ b/pkg/controller/common/volume/shared_volumes.go
@@ -2,34 +2,38 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package initcontainer
+package volume
 
 import corev1 "k8s.io/api/core/v1"
 
 // SharedVolume between the init container and the ES container.
 type SharedVolume struct {
-	Name                   string // Volume name
+	VolumeName             string // Volume name
 	InitContainerMountPath string // Mount path in the init container
-	EsContainerMountPath   string // Mount path in the Elasticsearch container
+	ContainerMountPath     string // Mount path in the main container (e.g. Elasticsearch or Kibana)
 }
 
 func (v SharedVolume) InitContainerVolumeMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
 		MountPath: v.InitContainerMountPath,
-		Name:      v.Name,
+		Name:      v.VolumeName,
 	}
 }
 
-func (v SharedVolume) EsContainerVolumeMount() corev1.VolumeMount {
+func (v SharedVolume) Name() string {
+	return v.VolumeName
+}
+
+func (v SharedVolume) VolumeMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
-		MountPath: v.EsContainerMountPath,
-		Name:      v.Name,
+		MountPath: v.ContainerMountPath,
+		Name:      v.VolumeName,
 	}
 }
 
 func (v SharedVolume) Volume() corev1.Volume {
 	return corev1.Volume{
-		Name: v.Name,
+		Name: v.VolumeName,
 		VolumeSource: corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
@@ -49,10 +53,10 @@ func (v SharedVolumeArray) InitContainerVolumeMounts() []corev1.VolumeMount {
 	return mounts
 }
 
-func (v SharedVolumeArray) EsContainerVolumeMounts() []corev1.VolumeMount {
+func (v SharedVolumeArray) ContainerVolumeMounts() []corev1.VolumeMount {
 	mounts := make([]corev1.VolumeMount, len(v.Array))
 	for i, v := range v.Array {
-		mounts[i] = v.EsContainerVolumeMount()
+		mounts[i] = v.VolumeMount()
 	}
 	return mounts
 }
@@ -61,7 +65,7 @@ func (v SharedVolumeArray) Volumes() []corev1.Volume {
 	volumes := make([]corev1.Volume, len(v.Array))
 	for i, v := range v.Array {
 		volumes[i] = corev1.Volume{
-			Name: v.Name,
+			Name: v.VolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},

--- a/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
+++ b/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
@@ -26,28 +26,28 @@ const (
 // Volumes that are shared between the prepare-fs init container and the ES container
 var (
 	// EsBinSharedVolume contains the ES bin/ directory
-	EsBinSharedVolume = SharedVolume{
-		Name:                   "elastic-internal-elasticsearch-bin-local",
+	EsBinSharedVolume = volume.SharedVolume{
+		VolumeName:             "elastic-internal-elasticsearch-bin-local",
 		InitContainerMountPath: "/mnt/elastic-internal/elasticsearch-bin-local",
-		EsContainerMountPath:   "/usr/share/elasticsearch/bin",
+		ContainerMountPath:     "/usr/share/elasticsearch/bin",
 	}
 
 	// EsConfigSharedVolume contains the ES config/ directory
-	EsConfigSharedVolume = SharedVolume{
-		Name:                   "elastic-internal-elasticsearch-config-local",
+	EsConfigSharedVolume = volume.SharedVolume{
+		VolumeName:             "elastic-internal-elasticsearch-config-local",
 		InitContainerMountPath: "/mnt/elastic-internal/elasticsearch-config-local",
-		EsContainerMountPath:   esvolume.ConfigVolumeMountPath,
+		ContainerMountPath:     esvolume.ConfigVolumeMountPath,
 	}
 
 	// EsPluginsSharedVolume contains the ES plugins/ directory
-	EsPluginsSharedVolume = SharedVolume{
-		Name:                   "elastic-internal-elasticsearch-plugins-local",
+	EsPluginsSharedVolume = volume.SharedVolume{
+		VolumeName:             "elastic-internal-elasticsearch-plugins-local",
 		InitContainerMountPath: "/mnt/elastic-internal/elasticsearch-plugins-local",
-		EsContainerMountPath:   "/usr/share/elasticsearch/plugins",
+		ContainerMountPath:     "/usr/share/elasticsearch/plugins",
 	}
 
-	PluginVolumes = SharedVolumeArray{
-		Array: []SharedVolume{
+	PluginVolumes = volume.SharedVolumeArray{
+		Array: []volume.SharedVolume{
 			EsConfigSharedVolume,
 			EsPluginsSharedVolume,
 			EsBinSharedVolume,
@@ -59,23 +59,23 @@ var (
 		Array: []LinkedFile{
 			{
 				Source: stringsutil.Concat(esvolume.XPackFileRealmVolumeMountPath, "/", filerealm.UsersFile),
-				Target: stringsutil.Concat(EsConfigSharedVolume.EsContainerMountPath, "/", filerealm.UsersFile),
+				Target: stringsutil.Concat(EsConfigSharedVolume.ContainerMountPath, "/", filerealm.UsersFile),
 			},
 			{
 				Source: stringsutil.Concat(esvolume.XPackFileRealmVolumeMountPath, "/", user.RolesFile),
-				Target: stringsutil.Concat(EsConfigSharedVolume.EsContainerMountPath, "/", user.RolesFile),
+				Target: stringsutil.Concat(EsConfigSharedVolume.ContainerMountPath, "/", user.RolesFile),
 			},
 			{
 				Source: stringsutil.Concat(esvolume.XPackFileRealmVolumeMountPath, "/", filerealm.UsersRolesFile),
-				Target: stringsutil.Concat(EsConfigSharedVolume.EsContainerMountPath, "/", filerealm.UsersRolesFile),
+				Target: stringsutil.Concat(EsConfigSharedVolume.ContainerMountPath, "/", filerealm.UsersRolesFile),
 			},
 			{
 				Source: stringsutil.Concat(settings.ConfigVolumeMountPath, "/", settings.ConfigFileName),
-				Target: stringsutil.Concat(EsConfigSharedVolume.EsContainerMountPath, "/", settings.ConfigFileName),
+				Target: stringsutil.Concat(EsConfigSharedVolume.ContainerMountPath, "/", settings.ConfigFileName),
 			},
 			{
 				Source: stringsutil.Concat(esvolume.UnicastHostsVolumeMountPath, "/", esvolume.UnicastHostsFile),
-				Target: stringsutil.Concat(EsConfigSharedVolume.EsContainerMountPath, "/", esvolume.UnicastHostsFile),
+				Target: stringsutil.Concat(EsConfigSharedVolume.ContainerMountPath, "/", esvolume.UnicastHostsFile),
 			},
 		},
 	}

--- a/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
+++ b/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
@@ -8,12 +8,14 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
 )
 
 // TemplateParams are the parameters manipulated in the scriptTemplate
 type TemplateParams struct {
 	// SharedVolumes are directories to persist in shared volumes
-	PluginVolumes SharedVolumeArray
+	PluginVolumes volume.SharedVolumeArray
 	// LinkedFiles are files to link individually
 	LinkedFiles LinkedFilesArray
 	// ChownToElasticsearch are paths that need to be chowned to the Elasticsearch user/group.
@@ -100,11 +102,11 @@ var scriptTemplate = template.Must(template.New("").Parse(
 	# so installed plugins files can to be used by the ES container
 	mv_start=$(date +%s)
 	{{range .PluginVolumes.Array}}
-		if [[ -z "$(ls -A {{.EsContainerMountPath}})" ]]; then
-			echo "Empty dir {{.EsContainerMountPath}}"
+		if [[ -z "$(ls -A {{.ContainerMountPath}})" ]]; then
+			echo "Empty dir {{.ContainerMountPath}}"
 		else
-			echo "Copying {{.EsContainerMountPath}}/* to {{.InitContainerMountPath}}/"
-			cp -av {{.EsContainerMountPath}}/* {{.InitContainerMountPath}}/
+			echo "Copying {{.ContainerMountPath}}/* to {{.InitContainerMountPath}}/"
+			cp -av {{.ContainerMountPath}}/* {{.InitContainerMountPath}}/
 		fi
 	{{end}}
 	echo "Files copy duration: $(duration $mv_start) sec."

--- a/pkg/controller/elasticsearch/nodespec/volumes.go
+++ b/pkg/controller/elasticsearch/nodespec/volumes.go
@@ -85,7 +85,7 @@ func buildVolumes(esName string, nodeSpec esv1.NodeSet, keystoreResources *keyst
 	}
 
 	volumeMounts := append(
-		initcontainer.PluginVolumes.EsContainerVolumeMounts(),
+		initcontainer.PluginVolumes.ContainerVolumeMounts(),
 		esvolume.DefaultDataVolumeMount,
 		esvolume.DefaultLogsVolumeMount,
 		usersSecretVolume.VolumeMount(),

--- a/pkg/controller/kibana/config_reconcile.go
+++ b/pkg/controller/kibana/config_reconcile.go
@@ -27,6 +27,7 @@ const (
 	ConfigVolumeMountPath              = "/usr/share/kibana/config"
 	InitContainerConfigVolumeMountPath = "/mnt/elastic-internal/kibana-config-local"
 
+	// InternalConfigVolumeName is a volume which contains the generated configuration.
 	InternalConfigVolumeName      = "elastic-internal-kibana-config"
 	InternalConfigVolumeMountPath = "/mnt/elastic-internal/kibana-config"
 
@@ -35,7 +36,10 @@ const (
 
 var (
 	// ConfigSharedVolume contains the Kibana config/ directory, it's an empty volume where the required configuration
-	// is initialized by the elastic-internal-init-config init container.
+	// is initialized by the elastic-internal-init-config init container. Its content is then shared by the init container
+	// that creates the keystore and the main Kibana container.
+	// This is needed in order to have in a same directory both the generated configuration and the keystore file  which
+	// is created in /usr/share/kibana/config since Kibana 7.9
 	ConfigSharedVolume = volume.SharedVolume{
 		VolumeName:             ConfigVolumeName,
 		InitContainerMountPath: InitContainerConfigVolumeMountPath,

--- a/pkg/controller/kibana/config_reconcile.go
+++ b/pkg/controller/kibana/config_reconcile.go
@@ -27,7 +27,7 @@ const (
 	ConfigVolumeMountPath              = "/usr/share/kibana/config"
 	InitContainerConfigVolumeMountPath = "/mnt/elastic-internal/kibana-config-local"
 
-	InternalConfigVolumeName      = "elastic-internal-elasticsearch-config"
+	InternalConfigVolumeName      = "elastic-internal-kibana-config"
 	InternalConfigVolumeMountPath = "/mnt/elastic-internal/kibana-config"
 
 	telemetryFilename = "telemetry.yml"

--- a/pkg/controller/kibana/config_reconcile.go
+++ b/pkg/controller/kibana/config_reconcile.go
@@ -23,9 +23,24 @@ import (
 
 // Constants to use for the config files in a Kibana pod.
 const (
-	VolumeName        = "config"
-	VolumeMountPath   = "/usr/share/kibana/" + VolumeName
+	ConfigVolumeName                   = "elastic-internal-kibana-config-local"
+	ConfigVolumeMountPath              = "/usr/share/kibana/config"
+	InitContainerConfigVolumeMountPath = "/mnt/elastic-internal/kibana-config-local"
+
+	InternalConfigVolumeName      = "elastic-internal-elasticsearch-config"
+	InternalConfigVolumeMountPath = "/mnt/elastic-internal/kibana-config"
+
 	telemetryFilename = "telemetry.yml"
+)
+
+var (
+	// ConfigSharedVolume contains the Kibana config/ directory, it's an empty volume where the required configuration
+	// is initialized by the elastic-internal-init-config init container.
+	ConfigSharedVolume = volume.SharedVolume{
+		VolumeName:             ConfigVolumeName,
+		InitContainerMountPath: InitContainerConfigVolumeMountPath,
+		ContainerMountPath:     ConfigVolumeMountPath,
+	}
 )
 
 // ECK is a helper struct to marshal telemetry information.
@@ -33,18 +48,18 @@ type ECK struct {
 	ECK about.OperatorInfo `json:"eck"`
 }
 
-// SecretVolume returns a SecretVolume to hold the Kibana config of the given Kibana resource.
-func SecretVolume(kb kbv1.Kibana) volume.SecretVolume {
+// ConfigVolume returns a SecretVolume to hold the Kibana config of the given Kibana resource.
+func ConfigVolume(kb kbv1.Kibana) volume.SecretVolume {
 	return volume.NewSecretVolumeWithMountPath(
 		SecretName(kb),
-		VolumeName,
-		VolumeMountPath,
+		InternalConfigVolumeName,
+		InternalConfigVolumeMountPath,
 	)
 }
 
 // SecretName is the name of the secret that holds the Kibana config for the given Kibana resource.
 func SecretName(kb kbv1.Kibana) string {
-	return kb.Name + "-kb-" + VolumeName
+	return kb.Name + "-kb-config"
 }
 
 // ReconcileConfigSecret reconciles the expected Kibana config secret for the given Kibana resource.

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -246,9 +246,9 @@ func TestDriverDeploymentParams(t *testing.T) {
 			},
 			want: func() deployment.Params {
 				params := expectedDeploymentParams()
-				params.PodTemplateSpec.Spec.Volumes = append(params.PodTemplateSpec.Spec.Volumes[:1], params.PodTemplateSpec.Spec.Volumes[2:]...)
-				params.PodTemplateSpec.Spec.InitContainers[0].VolumeMounts = append(params.PodTemplateSpec.Spec.InitContainers[0].VolumeMounts[:1], params.PodTemplateSpec.Spec.InitContainers[0].VolumeMounts[2:]...)
-				params.PodTemplateSpec.Spec.Containers[0].VolumeMounts = append(params.PodTemplateSpec.Spec.Containers[0].VolumeMounts[:1], params.PodTemplateSpec.Spec.Containers[0].VolumeMounts[2:]...)
+				params.PodTemplateSpec.Spec.Volumes = params.PodTemplateSpec.Spec.Volumes[1:]
+				params.PodTemplateSpec.Spec.InitContainers[0].VolumeMounts = params.PodTemplateSpec.Spec.InitContainers[0].VolumeMounts[1:]
+				params.PodTemplateSpec.Spec.Containers[0].VolumeMounts = params.PodTemplateSpec.Spec.Containers[0].VolumeMounts[1:]
 				params.PodTemplateSpec.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Scheme = corev1.URISchemeHTTP
 				params.PodTemplateSpec.Spec.Containers[0].Ports[0].Name = "http"
 				return params
@@ -448,19 +448,19 @@ func expectedDeploymentParams() deployment.Params {
 			Spec: corev1.PodSpec{
 				Volumes: []corev1.Volume{
 					{
-						Name: "elastic-internal-elasticsearch-config",
+						Name: certificates.HTTPCertificatesSecretVolumeName,
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
-								SecretName: "test-kb-config",
+								SecretName: "test-kb-http-certs-internal",
 								Optional:   &false,
 							},
 						},
 					},
 					{
-						Name: certificates.HTTPCertificatesSecretVolumeName,
+						Name: "elastic-internal-kibana-config",
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
-								SecretName: "test-kb-http-certs-internal",
+								SecretName: "test-kb-config",
 								Optional:   &false,
 							},
 						},
@@ -508,14 +508,14 @@ func expectedDeploymentParams() deployment.Params {
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      "elastic-internal-elasticsearch-config",
-							ReadOnly:  true,
-							MountPath: InternalConfigVolumeMountPath,
-						},
-						{
 							Name:      certificates.HTTPCertificatesSecretVolumeName,
 							ReadOnly:  true,
 							MountPath: certificates.HTTPCertificatesSecretVolumeMountPath,
+						},
+						{
+							Name:      "elastic-internal-kibana-config",
+							ReadOnly:  true,
+							MountPath: InternalConfigVolumeMountPath,
 						},
 						ConfigSharedVolume.InitContainerVolumeMount(),
 						{
@@ -544,14 +544,14 @@ func expectedDeploymentParams() deployment.Params {
 				Containers: []corev1.Container{{
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      "elastic-internal-elasticsearch-config",
-							ReadOnly:  true,
-							MountPath: InternalConfigVolumeMountPath,
-						},
-						{
 							Name:      certificates.HTTPCertificatesSecretVolumeName,
 							ReadOnly:  true,
 							MountPath: certificates.HTTPCertificatesSecretVolumeMountPath,
+						},
+						{
+							Name:      "elastic-internal-kibana-config",
+							ReadOnly:  true,
+							MountPath: InternalConfigVolumeMountPath,
 						},
 						ConfigSharedVolume.VolumeMount(),
 						{

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/deployment"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/compare"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
@@ -245,8 +246,9 @@ func TestDriverDeploymentParams(t *testing.T) {
 			},
 			want: func() deployment.Params {
 				params := expectedDeploymentParams()
-				params.PodTemplateSpec.Spec.Volumes = params.PodTemplateSpec.Spec.Volumes[:3]
-				params.PodTemplateSpec.Spec.Containers[0].VolumeMounts = params.PodTemplateSpec.Spec.Containers[0].VolumeMounts[:3]
+				params.PodTemplateSpec.Spec.Volumes = append(params.PodTemplateSpec.Spec.Volumes[:1], params.PodTemplateSpec.Spec.Volumes[2:]...)
+				params.PodTemplateSpec.Spec.InitContainers[0].VolumeMounts = append(params.PodTemplateSpec.Spec.InitContainers[0].VolumeMounts[:1], params.PodTemplateSpec.Spec.InitContainers[0].VolumeMounts[2:]...)
+				params.PodTemplateSpec.Spec.Containers[0].VolumeMounts = append(params.PodTemplateSpec.Spec.Containers[0].VolumeMounts[:1], params.PodTemplateSpec.Spec.Containers[0].VolumeMounts[2:]...)
 				params.PodTemplateSpec.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Scheme = corev1.URISchemeHTTP
 				params.PodTemplateSpec.Spec.Containers[0].Ports[0].Name = "http"
 				return params
@@ -446,25 +448,10 @@ func expectedDeploymentParams() deployment.Params {
 			Spec: corev1.PodSpec{
 				Volumes: []corev1.Volume{
 					{
-						Name: DataVolumeName,
-						VolumeSource: corev1.VolumeSource{
-							EmptyDir: &corev1.EmptyDirVolumeSource{},
-						},
-					},
-					{
-						Name: "config",
+						Name: "elastic-internal-elasticsearch-config",
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
 								SecretName: "test-kb-config",
-								Optional:   &false,
-							},
-						},
-					},
-					{
-						Name: "elasticsearch-certs",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								SecretName: "es-ca-secret",
 								Optional:   &false,
 							},
 						},
@@ -478,28 +465,104 @@ func expectedDeploymentParams() deployment.Params {
 							},
 						},
 					},
+					{
+						Name: ConfigSharedVolume.VolumeName,
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+					{
+						Name: "elasticsearch-certs",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "es-ca-secret",
+								Optional:   &false,
+							},
+						},
+					},
+					{
+						Name: DataVolumeName,
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
 				},
-				Containers: []corev1.Container{{
+				InitContainers: []corev1.Container{{
+					Name:            "elastic-internal-init-config",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Image:           "my-image",
+					Command:         []string{"/usr/bin/env", "bash", "-c", InitConfigScript},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: &false,
+					},
+					Env: []corev1.EnvVar{
+						{Name: settings.EnvPodIP, Value: "", ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIP"},
+						}},
+						{Name: settings.EnvPodName, Value: "", ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "metadata.name"},
+						}},
+						{Name: settings.EnvNodeName, Value: "", ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "spec.nodeName"},
+						}},
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      DataVolumeName,
-							ReadOnly:  false,
-							MountPath: DataVolumeMountPath,
+							Name:      "elastic-internal-elasticsearch-config",
+							ReadOnly:  true,
+							MountPath: InternalConfigVolumeMountPath,
 						},
 						{
-							Name:      "config",
+							Name:      certificates.HTTPCertificatesSecretVolumeName,
 							ReadOnly:  true,
-							MountPath: "/usr/share/kibana/config",
+							MountPath: certificates.HTTPCertificatesSecretVolumeMountPath,
 						},
+						ConfigSharedVolume.InitContainerVolumeMount(),
 						{
 							Name:      "elasticsearch-certs",
 							ReadOnly:  true,
 							MountPath: "/usr/share/kibana/config/elasticsearch-certs",
 						},
 						{
+							Name:      DataVolumeName,
+							ReadOnly:  false,
+							MountPath: DataVolumeMountPath,
+						},
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
+							corev1.ResourceCPU:    resource.MustParse("0.1"),
+						},
+						Limits: map[corev1.ResourceName]resource.Quantity{
+							// Memory limit should be at least 12582912 when running with CRI-O
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
+							corev1.ResourceCPU:    resource.MustParse("0.1"),
+						},
+					},
+				}},
+				Containers: []corev1.Container{{
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "elastic-internal-elasticsearch-config",
+							ReadOnly:  true,
+							MountPath: InternalConfigVolumeMountPath,
+						},
+						{
 							Name:      certificates.HTTPCertificatesSecretVolumeName,
 							ReadOnly:  true,
 							MountPath: certificates.HTTPCertificatesSecretVolumeMountPath,
+						},
+						ConfigSharedVolume.VolumeMount(),
+						{
+							Name:      "elasticsearch-certs",
+							ReadOnly:  true,
+							MountPath: "/usr/share/kibana/config/elasticsearch-certs",
+						},
+						{
+							Name:      DataVolumeName,
+							ReadOnly:  false,
+							MountPath: DataVolumeMountPath,
 						},
 					},
 					Image: "my-image",

--- a/pkg/controller/kibana/init_configuration.go
+++ b/pkg/controller/kibana/init_configuration.go
@@ -26,7 +26,7 @@ fi
 
 echo "Setup Kibana configuration"
 
-ln -sf /mnt/elastic-internal/kibana-config/* /mnt/elastic-internal/kibana-config-local/
+ln -sf ` + InternalConfigVolumeMountPath + `/* ` + InitContainerConfigVolumeMountPath + `/
 
 touch "${init_config_initialized_flag}"
 echo "Kibana configuration successfully prepared."

--- a/pkg/controller/kibana/init_configuration.go
+++ b/pkg/controller/kibana/init_configuration.go
@@ -33,8 +33,9 @@ echo "Kibana configuration successfully prepared."
 `
 )
 
-// initConfigContainer returns an init container that executes a bash script
-// to load secure settings in a Keystore.
+// initConfigContainer returns an init container that executes a bash script to prepare the Kibana config directory.
+// The script creates symbolic links from the generated configuration files in /mnt/elastic-internal/kibana-config/ to
+// an empty directory later mounted in /use/share/kibana/config
 func initConfigContainer(kb kbv1.Kibana) corev1.Container {
 	privileged := false
 

--- a/pkg/controller/kibana/init_configuration.go
+++ b/pkg/controller/kibana/init_configuration.go
@@ -1,0 +1,65 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kibana
+
+import (
+	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	InitConfigContainerName = "elastic-internal-init-config"
+
+	// InitConfigScript is a small bash script to prepare the Kibana configuration directory
+	InitConfigScript = `#!/usr/bin/env bash
+set -eux
+
+init_config_initialized_flag=/usr/share/kibana/config/elastic-internal-init-config.ok
+
+if [[ -f "${init_config_initialized_flag}" ]]; then
+    echo "Kibana configuration already initialized."
+	exit 0
+fi
+
+echo "Setup Kibana configuration"
+
+ln -sf /mnt/elastic-internal/kibana-config/* /mnt/elastic-internal/kibana-config-local/
+
+touch "${init_config_initialized_flag}"
+echo "Kibana configuration successfully prepared."
+`
+)
+
+// initConfigContainer returns an init container that executes a bash script
+// to load secure settings in a Keystore.
+func initConfigContainer(kb kbv1.Kibana) corev1.Container {
+	privileged := false
+
+	return corev1.Container{
+		// Image will be inherited from pod template defaults
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Name:            InitConfigContainerName,
+		SecurityContext: &corev1.SecurityContext{
+			Privileged: &privileged,
+		},
+		Command: []string{"/usr/bin/env", "bash", "-c", InitConfigScript},
+		VolumeMounts: []corev1.VolumeMount{
+			ConfigSharedVolume.InitContainerVolumeMount(),
+			ConfigVolume(kb).VolumeMount(),
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+				corev1.ResourceCPU:    resource.MustParse("0.1"),
+			},
+			Limits: map[corev1.ResourceName]resource.Quantity{
+				// Memory limit should be at least 12582912 when running with CRI-O
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+				corev1.ResourceCPU:    resource.MustParse("0.1"),
+			},
+		},
+	}
+}

--- a/pkg/controller/kibana/keystore.go
+++ b/pkg/controller/kibana/keystore.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package kibana
 
 import (

--- a/pkg/controller/kibana/keystore.go
+++ b/pkg/controller/kibana/keystore.go
@@ -1,0 +1,43 @@
+package kibana
+
+import (
+	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// keystoreInConfigDirVersion is the version in which the keystore is no longer stored in the data directory but in the configuration one.
+var keystoreInConfigDirVersion = version.From(7, 9, 0)
+
+// newInitContainersParameters is used to generate the init container that will load the secure settings into a keystore
+func newInitContainersParameters(kb *kbv1.Kibana) (keystore.InitContainerParameters, error) {
+	parameters := keystore.InitContainerParameters{
+		KeystoreCreateCommand:         "/usr/share/kibana/bin/kibana-keystore create",
+		KeystoreAddCommand:            `/usr/share/kibana/bin/kibana-keystore add "$key" --stdin < "$filename"`,
+		SecureSettingsVolumeMountPath: keystore.SecureSettingsVolumeMountPath,
+		KeystoreVolumePath:            DataVolumeMountPath,
+		Resources: corev1.ResourceRequirements{
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
+			Limits: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
+		},
+	}
+
+	kbVersion, err := version.Parse(kb.Spec.Version)
+	if err != nil {
+		return parameters, err
+	}
+
+	if kbVersion.IsSameOrAfter(keystoreInConfigDirVersion) {
+		parameters.KeystoreVolumePath = ConfigSharedVolume.ContainerMountPath
+	}
+
+	return parameters, nil
+}

--- a/pkg/controller/kibana/keystore.go
+++ b/pkg/controller/kibana/keystore.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-// keystoreInConfigDirVersion is the version in which the keystore is no longer stored in the data directory but in the configuration one.
+// keystoreInConfigDirVersion is the version in which the keystore is no longer stored in the data directory but in the config one.
 var keystoreInConfigDirVersion = version.From(7, 9, 0)
 
 // newInitContainersParameters is used to generate the init container that will load the secure settings into a keystore

--- a/pkg/controller/kibana/pod.go
+++ b/pkg/controller/kibana/pod.go
@@ -16,7 +16,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/pod"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
-	commonvolume "github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
 )
 
 const (
@@ -70,7 +69,7 @@ func readinessProbe(useTLS bool) corev1.Probe {
 	}
 }
 
-func NewPodTemplateSpec(kb kbv1.Kibana, keystore *keystore.Resources, volumes []commonvolume.VolumeLike) corev1.PodTemplateSpec {
+func NewPodTemplateSpec(kb kbv1.Kibana, keystore *keystore.Resources, volumes []volume.VolumeLike) corev1.PodTemplateSpec {
 	labels := NewLabels(kb.Name)
 	labels[KibanaVersionLabelName] = kb.Spec.Version
 


### PR DESCRIPTION
Starting Kibana 7.9.0 the keystore is located in the configuration directory instead of the data directory.

This PR allows the keystore init container and the Kibana container to share the `config` directory through an empty directory.

For consistency with what is done with Elasticsearch this PR creates symbolic links from the generated configuration to the shared configuration volume.

Fixes #3528