### PR TITLE
Move to a UBI base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,13 @@ LABEL name="Elastic Cloud on Kubernetes" \
       description="Elastic Cloud on Kubernetes automates the deployment, provisioning, management, and orchestration of Elasticsearch, Kibana, APM Server, Beats, and Enterprise Search on Kubernetes" \
       io.k8s.description="Elastic Cloud on Kubernetes automates the deployment, provisioning, management, and orchestration of Elasticsearch, Kibana, APM Server, Beats, and Enterprise Search on Kubernetes"
 
+# Update the base image packages to the latest versions
 RUN microdnf update --setopt=tsflags=nodocs && microdnf clean all
 
 COPY --from=builder /go/src/github.com/elastic/cloud-on-k8s/elastic-operator .
+
+# Copy NOTICE.txt and LICENSE.txt into the image
+COPY *.txt /licenses/
 
 USER 1001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,19 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
 # Copy the operator binary into a lighter image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
 
+ARG VERSION
+
+# Add required ECK labels and override labels from base image
+LABEL name="Elastic Cloud on Kubernetes" \
+      io.k8s.display-name="Elastic Cloud on Kubernetes" \
+      maintainer="eck@elastic.co" \
+      vendor="Elastic" \
+      version="$VERSION" \
+      url="https://www.elastic.co/guide/en/cloud-on-k8s/" \
+      summary="Run Elasticsearch, Kibana, APM Server, Enterprise Search, and Beats on Kubernetes and OpenShift" \
+      description="Elastic Cloud on Kubernetes automates the deployment, provisioning, management, and orchestration of Elasticsearch, Kibana, APM Server, Beats, and Enterprise Search on Kubernetes" \
+      io.k8s.description="Elastic Cloud on Kubernetes automates the deployment, provisioning, management, and orchestration of Elasticsearch, Kibana, APM Server, Beats, and Enterprise Search on Kubernetes"
+
 RUN microdnf update --setopt=tsflags=nodocs && microdnf clean all
 
 COPY --from=builder /go/src/github.com/elastic/cloud-on-k8s/elastic-operator .

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
 # Copy the operator binary into a lighter image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
 
-RUN microdnf update --setopt=tsflags=nodocs && microdnf clean all 
+RUN microdnf update --setopt=tsflags=nodocs && microdnf clean all
 
 COPY --from=builder /go/src/github.com/elastic/cloud-on-k8s/elastic-operator .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
 # Copy the operator binary into a lighter image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
 COPY --from=builder /go/src/github.com/elastic/cloud-on-k8s/elastic-operator .
+
+USER 1001
+
 ENTRYPOINT ["./elastic-operator"]
 CMD ["manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
 			-o elastic-operator github.com/elastic/cloud-on-k8s/cmd
 
 # Copy the operator binary into a lighter image
-FROM gcr.io/distroless/static:nonroot
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
 COPY --from=builder /go/src/github.com/elastic/cloud-on-k8s/elastic-operator .
 ENTRYPOINT ["./elastic-operator"]
 CMD ["manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
 
 # Copy the operator binary into a lighter image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
+
+RUN microdnf update --setopt=tsflags=nodocs && microdnf clean all 
+
 COPY --from=builder /go/src/github.com/elastic/cloud-on-k8s/elastic-operator .
 
 USER 1001

--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,7 @@ docker-build: go-generate
 	docker build . \
 		--build-arg GO_LDFLAGS='$(GO_LDFLAGS)' \
 		--build-arg GO_TAGS='$(GO_TAGS)' \
+		--build-arg VERSION='$(VERSION)' \
 		-t $(OPERATOR_IMAGE)
 
 docker-push:


### PR DESCRIPTION
Fixes #3551 

Move ECK to a UBI base image. I opted for simply replacing `distroless` with `ubi-minimal`. The benefit of a unified build and CI environment seems much more compelling after looking into what it would take to have two parallel distributions of ECK with much deeper interdependent stacking of build pipelines and even more complex Makefiles than we already have. 

The original move to distroless was driven mainly by our desire to address security issues in the centos image we were using.  But with ubi we will have to address any potential future vulnerabilities anyway by upgrading to a newer image which will lead to the same end result. 

Sample image: `docker.elastic.co/eck-snapshots/eck-operator-ci:1.3.0-SNAPSHOT-5763bdb5`