### PR TITLE
Allow the operator to be configured from a file

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -306,6 +306,44 @@ Contents of probable licence file $GOMODCACHE/github.com/elastic/go-ucfg@v0.8.3/
 
 
 --------------------------------------------------------------------------------
+Module  : github.com/fsnotify/fsnotify
+Version : v1.4.9
+Time    : 2020-03-11T17:35:18Z
+Licence : BSD-3-Clause
+
+Contents of probable licence file $GOMODCACHE/github.com/fsnotify/fsnotify@v1.4.9/LICENSE:
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright (c) 2012-2019 fsnotify Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+--------------------------------------------------------------------------------
 Module  : github.com/ghodss/yaml
 Version : v1.0.0
 Time    : 2017-03-27T23:54:44Z
@@ -11999,44 +12037,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
---------------------------------------------------------------------------------
-Module  : github.com/fsnotify/fsnotify
-Version : v1.4.9
-Time    : 2020-03-11T17:35:18Z
-Licence : BSD-3-Clause
-
-Contents of probable licence file $GOMODCACHE/github.com/fsnotify/fsnotify@v1.4.9/LICENSE:
-
-Copyright (c) 2012 The Go Authors. All rights reserved.
-Copyright (c) 2012-2019 fsnotify Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------------------------------------------------------------------------
 Module  : github.com/globalsign/mgo

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,25 +6,26 @@ package main
 
 import (
 	"github.com/elastic/cloud-on-k8s/cmd/manager"
+	"github.com/elastic/cloud-on-k8s/pkg/about"
 	"github.com/elastic/cloud-on-k8s/pkg/dev"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/log"
 	"github.com/spf13/cobra"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func main() {
-	var rootCmd = &cobra.Command{Use: "elastic-operator"}
-	rootCmd.AddCommand(manager.Cmd)
+	buildInfo := about.GetBuildInfo()
+
+	rootCmd := &cobra.Command{
+		Use:          "elastic-operator",
+		Short:        "Elastic Cloud on Kubernetes (ECK) operator",
+		Version:      buildInfo.VersionString(),
+		SilenceUsage: true,
+	}
+	rootCmd.AddCommand(manager.Command())
+
 	// development mode is only available as a command line flag to avoid accidentally enabling it
 	rootCmd.PersistentFlags().BoolVar(&dev.Enabled, "development", false, "turns on development mode")
-	log.BindFlags(rootCmd.PersistentFlags())
+	_ = rootCmd.PersistentFlags().MarkHidden("development")
 
-	cobra.OnInitialize(func() {
-		log.InitLogger()
-	})
-
-	if err := rootCmd.Execute(); err != nil {
-		logf.Log.WithName("main").Error(err, "Unexpected error while executing command")
-	}
+	_ = rootCmd.Execute()
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -232,7 +232,9 @@ func doRun(_ *cobra.Command, _ []string) error {
 		log.Info("Watching config file for changes", "file", configFile)
 		viper.WatchConfig()
 		viper.OnConfigChange(func(evt fsnotify.Event) {
-			switch evt.Op {
+			if evt.Op&fsnotify.Write == fsnotify.Write || evt.Op&fsnotify.Create == fsnotify.Create {
+				confUpdateChan <- struct{}{}
+			}
 			case fsnotify.Create, fsnotify.Write:
 				confUpdateChan <- struct{}{}
 			}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -6,6 +6,7 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
@@ -42,8 +43,11 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/dev"
 	"github.com/elastic/cloud-on-k8s/pkg/dev/portforward"
 	licensing "github.com/elastic/cloud-on-k8s/pkg/license"
+	logconf "github.com/elastic/cloud-on-k8s/pkg/utils/log"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/net"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/rbac"
+	"github.com/fsnotify/fsnotify"
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.elastic.co/apm"
@@ -68,125 +72,153 @@ const (
 )
 
 var (
-	// Cmd is the cobra command to start the manager.
-	Cmd = &cobra.Command{
-		Use:   "manager",
-		Short: "Start the operator manager",
-		Long: `manager starts the manager for this operator,
- which will in turn create the necessary controller.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			execute()
-		},
-	}
-
-	log = logf.Log.WithName("manager")
+	configFile string
+	log        logr.Logger
 )
 
-func init() {
-	Cmd.Flags().Bool(
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "manager",
+		Short: "Start the ECK operator",
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			if configFile != "" {
+				viper.SetConfigFile(configFile)
+				if err := viper.ReadInConfig(); err != nil {
+					return fmt.Errorf("failed to read config file %s: %w", configFile, err)
+				}
+
+				viper.WatchConfig()
+				viper.OnConfigChange(func(_ fsnotify.Event) {
+					if log != nil {
+						log.Info("Detected an update to the configuration file. Restart the operator for the changes to take effect.")
+					}
+				})
+			}
+
+			// enable using dashed notation in flags and underscores in env
+			viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+
+			if err := viper.BindPFlags(cmd.Flags()); err != nil {
+				return fmt.Errorf("failed to bind flags: %w", err)
+			}
+
+			viper.AutomaticEnv()
+			logconf.ChangeVerbosity(viper.GetInt(logconf.FlagName))
+
+			log = logf.Log.WithName("manager")
+			log.V(1).Info("Effective configuration", "values", viper.AllSettings())
+
+			return nil
+		},
+		RunE: doRun,
+	}
+
+	cmd.Flags().Bool(
 		operator.AutoPortForwardFlag,
 		false,
 		"enables automatic port-forwarding "+
 			"(for dev use only as it exposes k8s resources on ephemeral ports to localhost)",
 	)
-	Cmd.Flags().Duration(
+	cmd.Flags().Duration(
 		operator.CACertRotateBeforeFlag,
 		certificates.DefaultRotateBefore,
 		"Duration representing how long before expiration CA certificates should be reissued",
 	)
-	Cmd.Flags().Duration(
+	cmd.Flags().Duration(
 		operator.CACertValidityFlag,
 		certificates.DefaultCertValidity,
 		"Duration representing how long before a newly created CA cert expires",
 	)
-	Cmd.Flags().Duration(
+	cmd.Flags().Duration(
 		operator.CertRotateBeforeFlag,
 		certificates.DefaultRotateBefore,
 		"Duration representing how long before expiration TLS certificates should be reissued",
 	)
-	Cmd.Flags().Duration(
+	cmd.Flags().Duration(
 		operator.CertValidityFlag,
 		certificates.DefaultCertValidity,
 		"Duration representing how long before a newly created TLS certificate expires",
 	)
-	Cmd.Flags().String(
+	cmd.Flags().StringVar(
+		&configFile,
+		operator.ConfigFlag,
+		"",
+		"Path to the ECK configuration file",
+	)
+	cmd.Flags().String(
 		operator.ContainerRegistryFlag,
 		container.DefaultContainerRegistry,
 		"Container registry to use when downloading Elastic Stack container images",
 	)
-	Cmd.Flags().String(
+	cmd.Flags().String(
 		operator.DebugHTTPListenFlag,
 		"localhost:6060",
 		"Listen address for debug HTTP server (only available in development mode)",
 	)
-	Cmd.Flags().Bool(
+	cmd.Flags().Bool(
 		operator.EnforceRBACOnRefsFlag,
 		false, // Set to false for backward compatibility
 		"Restrict cross-namespace resource association through RBAC (eg. referencing Elasticsearch from Kibana)",
 	)
-	Cmd.Flags().Bool(
+	cmd.Flags().Bool(
 		operator.EnableTracingFlag,
 		false,
 		"Enable APM tracing in the operator. Endpoint, token etc are to be configured via environment variables. See https://www.elastic.co/guide/en/apm/agent/go/1.x/configuration.html")
-	Cmd.Flags().Bool(
+	cmd.Flags().Bool(
 		operator.EnableWebhookFlag,
 		false,
 		"Enables a validating webhook server in the operator process.",
 	)
-	Cmd.Flags().Bool(
+	cmd.Flags().Bool(
 		operator.ManageWebhookCertsFlag,
 		true,
 		"Enables automatic certificates management for the webhook. The Secret and the ValidatingWebhookConfiguration must be created before running the operator",
 	)
-	Cmd.Flags().Int(
+	cmd.Flags().Int(
 		operator.MaxConcurrentReconcilesFlag,
 		3,
 		"Sets maximum number of concurrent reconciles per controller (Elasticsearch, Kibana, Apm Server etc). Affects the ability of the operator to process changes concurrently.",
 	)
-	Cmd.Flags().Int(
+	cmd.Flags().Int(
 		operator.MetricsPortFlag,
 		DefaultMetricPort,
 		"Port to use for exposing metrics in the Prometheus format (set 0 to disable)",
 	)
-	Cmd.Flags().StringSlice(
+	cmd.Flags().StringSlice(
 		operator.NamespacesFlag,
 		nil,
 		"comma-separated list of namespaces in which this operator should manage resources (defaults to all namespaces)",
 	)
-	Cmd.Flags().String(
+	cmd.Flags().String(
 		operator.OperatorNamespaceFlag,
 		"",
 		"K8s namespace the operator runs in",
 	)
-	Cmd.Flags().String(
+	cmd.Flags().String(
 		operator.WebhookCertDirFlag,
 		// this is controller-runtime's own default, copied here for making the default explicit when using `--help`
 		filepath.Join(os.TempDir(), "k8s-webhook-server", "serving-certs"),
 		"Path to the directory that contains the webhook server key and certificate",
 	)
-	Cmd.Flags().String(
+	cmd.Flags().String(
 		operator.WebhookSecretFlag,
 		"",
 		fmt.Sprintf("K8s secret mounted into the path designated by %s to be used for webhook certificates", operator.WebhookCertDirFlag),
 	)
-	Cmd.Flags().String(
+	cmd.Flags().String(
 		operator.WebhookConfigurationNameFlag,
 		DefaultWebhookConfigurationName,
 		fmt.Sprintf("Name of the Kubernetes ValidatingWebhookConfiguration resource (defaults to %s). Only used when enable-webhook is true.", DefaultWebhookConfigurationName),
 	)
 
-	// enable using dashed notation in flags and underscores in env
-	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	logconf.BindFlags(cmd.Flags())
 
-	if err := viper.BindPFlags(Cmd.Flags()); err != nil {
-		log.Error(err, "Unexpected error while binding flags")
-		os.Exit(1)
-	}
+	_ = cmd.MarkFlagFilename(operator.ConfigFlag)
 
-	viper.AutomaticEnv()
+	return cmd
 }
 
-func execute() {
+func doRun(_ *cobra.Command, _ []string) error {
 	// update GOMAXPROCS to container cpu limit if necessary
 	_, err := maxprocs.Set(maxprocs.Logger(func(s string, i ...interface{}) {
 		// maxprocs needs an sprintf format string with args, but our logger needs a string with optional key value pairs,
@@ -195,7 +227,7 @@ func execute() {
 	}))
 	if err != nil {
 		log.Error(err, "Error setting GOMAXPROCS")
-		os.Exit(1)
+		return err
 	}
 
 	if dev.Enabled {
@@ -214,17 +246,17 @@ func execute() {
 		log.Info("Starting debug HTTP server", "addr", pprofServer.Addr)
 
 		go func() {
-			err := pprofServer.ListenAndServe()
-			panic(err)
+			if err := pprofServer.ListenAndServe(); !errors.Is(http.ErrServerClosed, err) {
+				log.Error(err, "Failed to start debug HTTP server")
+				panic(err)
+			}
 		}()
 	}
 
 	var dialer net.Dialer
 	autoPortForward := viper.GetBool(operator.AutoPortForwardFlag)
 	if !dev.Enabled && autoPortForward {
-		panic(fmt.Sprintf(
-			"Enabling %s without enabling development mode not allowed", operator.AutoPortForwardFlag,
-		))
+		return fmt.Errorf("development mode must be enabled to use %s", operator.AutoPortForwardFlag)
 	} else if autoPortForward {
 		log.Info("Warning: auto-port-forwarding is enabled, which is intended for development only")
 		dialer = portforward.NewForwardingDialer()
@@ -232,9 +264,9 @@ func execute() {
 
 	operatorNamespace := viper.GetString(operator.OperatorNamespaceFlag)
 	if operatorNamespace == "" {
-		log.Error(fmt.Errorf("%s is a required flag", operator.OperatorNamespaceFlag),
-			"required configuration missing")
-		os.Exit(1)
+		err := fmt.Errorf("operator namespace must be specified using %s", operator.OperatorNamespaceFlag)
+		log.Error(err, "Required configuration missing")
+		return err
 	}
 
 	// set the default container registry
@@ -243,8 +275,12 @@ func execute() {
 	container.SetContainerRegistry(containerRegistry)
 
 	// Get a config to talk to the apiserver
-	log.Info("Setting up client for manager")
-	cfg := ctrl.GetConfigOrDie()
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		log.Error(err, "Failed to obtain client configuration")
+		return err
+	}
+
 	// Setup Scheme for all resources
 	log.Info("Setting up scheme")
 	controllerscheme.SetupScheme()
@@ -252,7 +288,6 @@ func execute() {
 	controllerscheme.SetupV1beta1Scheme()
 
 	// Create a new Cmd to provide shared dependencies and start components
-	log.Info("Setting up manager")
 	opts := ctrl.Options{
 		Scheme:  clientgoscheme.Scheme,
 		CertDir: viper.GetString(operator.WebhookCertDirFlag),
@@ -282,28 +317,40 @@ func execute() {
 	opts.Port = WebhookPort
 	mgr, err := ctrl.NewManager(cfg, opts)
 	if err != nil {
-		log.Error(err, "unable to create controller manager")
-		os.Exit(1)
+		log.Error(err, "Unable to create controller manager")
+		return err
 	}
 
 	// Verify cert validity options
-	caCertValidity, caCertRotateBefore := ValidateCertExpirationFlags(operator.CACertValidityFlag, operator.CACertRotateBeforeFlag)
+	caCertValidity, caCertRotateBefore, err := validateCertExpirationFlags(operator.CACertValidityFlag, operator.CACertRotateBeforeFlag)
+	if err != nil {
+		log.Error(err, "Invalid CA certificate rotation parameters")
+		return err
+	}
+
 	log.V(1).Info("Using certificate authority rotation parameters", operator.CACertValidityFlag, caCertValidity, operator.CACertRotateBeforeFlag, caCertRotateBefore)
-	certValidity, certRotateBefore := ValidateCertExpirationFlags(operator.CertValidityFlag, operator.CertRotateBeforeFlag)
+
+	certValidity, certRotateBefore, err := validateCertExpirationFlags(operator.CertValidityFlag, operator.CertRotateBeforeFlag)
+	if err != nil {
+		log.Error(err, "Invalid certificate rotation parameters")
+		return err
+	}
+
 	log.V(1).Info("Using certificate rotation parameters", operator.CertValidityFlag, certValidity, operator.CertRotateBeforeFlag, certRotateBefore)
 
 	// Setup a client to set the operator uuid config map
 	clientset, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		log.Error(err, "unable to create k8s clientset")
-		os.Exit(1)
+		log.Error(err, "Unable to create Kubernetes client")
+		return err
 	}
 
 	operatorInfo, err := about.GetOperatorInfo(clientset, operatorNamespace)
 	if err != nil {
-		log.Error(err, "unable to get operator info")
-		os.Exit(1)
+		log.Error(err, "Failed to get operator info")
+		return err
 	}
+
 	log.Info("Setting up controllers")
 	var tracer *apm.Tracer
 	if viper.GetBool(operator.EnableTracingFlag) {
@@ -338,63 +385,8 @@ func execute() {
 		accessReviewer = rbac.NewPermissiveAccessReviewer()
 	}
 
-	if err = apmserver.Add(mgr, params); err != nil {
-		log.Error(err, "unable to create controller", "controller", "ApmServer")
-		os.Exit(1)
-	}
-	if err = elasticsearch.Add(mgr, params); err != nil {
-		log.Error(err, "unable to create controller", "controller", "Elasticsearch")
-		os.Exit(1)
-	}
-	if err = kibana.Add(mgr, params); err != nil {
-		log.Error(err, "unable to create controller", "controller", "Kibana")
-		os.Exit(1)
-	}
-	if err = enterprisesearch.Add(mgr, params); err != nil {
-		log.Error(err, "unable to create controller", "controller", "EnterpriseSearch")
-		os.Exit(1)
-	}
-	if err = beat.Add(mgr, params); err != nil {
-		log.Error(err, "unable to create controller", "controller", "Beat")
-		os.Exit(1)
-	}
-	if err = associationctl.AddApmES(mgr, accessReviewer, params); err != nil {
-		log.Error(err, "unable to create controller", "controller", "apm-es-association")
-		os.Exit(1)
-	}
-	if err = associationctl.AddApmKibana(mgr, accessReviewer, params); err != nil {
-		log.Error(err, "unable to create controller", "controller", "apm-kibana-association")
-		os.Exit(1)
-	}
-	if err = associationctl.AddKibanaES(mgr, accessReviewer, params); err != nil {
-		log.Error(err, "unable to create controller", "controller", "kibana-es-association")
-		os.Exit(1)
-	}
-	if err = associationctl.AddEntES(mgr, accessReviewer, params); err != nil {
-		log.Error(err, "unable to create controller", "controller", "ent-es-association")
-		os.Exit(1)
-	}
-	if err = associationctl.AddBeatES(mgr, accessReviewer, params); err != nil {
-		log.Error(err, "unable to create controller", "controller", "beat-es-association")
-		os.Exit(1)
-	}
-	if err = associationctl.AddBeatKibana(mgr, accessReviewer, params); err != nil {
-		log.Error(err, "unable to create controller", "controller", "beat-kibana-association")
-		os.Exit(1)
-	}
-
-	if err = remoteca.Add(mgr, accessReviewer, params); err != nil {
-		log.Error(err, "unable to create controller", "controller", "RemoteClusterCertificateAuthorites")
-		os.Exit(1)
-	}
-
-	if err = license.Add(mgr, params); err != nil {
-		log.Error(err, "unable to create controller", "controller", "License")
-		os.Exit(1)
-	}
-	if err = licensetrial.Add(mgr, params); err != nil {
-		log.Error(err, "unable to create controller", "controller", "LicenseTrial")
-		os.Exit(1)
+	if err := registerControllers(mgr, params, accessReviewer); err != nil {
+		return err
 	}
 
 	// Garbage collect any orphaned user Secrets leftover from deleted resources while the operator was not running.
@@ -411,20 +403,68 @@ func execute() {
 		"namespace", operatorNamespace, "version", operatorInfo.BuildInfo.Version,
 		"build_hash", operatorInfo.BuildInfo.Hash, "build_date", operatorInfo.BuildInfo.Date,
 		"build_snapshot", operatorInfo.BuildInfo.Snapshot)
+
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
-		log.Error(err, "unable to run the manager")
-		os.Exit(1)
+		log.Error(err, "Unable to run the manager")
+		return err
 	}
+
+	return nil
 }
 
-func ValidateCertExpirationFlags(validityFlag string, rotateBeforeFlag string) (time.Duration, time.Duration) {
+func registerControllers(mgr manager.Manager, params operator.Parameters, accessReviewer rbac.AccessReviewer) error {
+	controllers := []struct {
+		name         string
+		registerFunc func(manager.Manager, operator.Parameters) error
+	}{
+		{name: "APMServer", registerFunc: apmserver.Add},
+		{name: "Elasticsearch", registerFunc: elasticsearch.Add},
+		{name: "Kibana", registerFunc: kibana.Add},
+		{name: "EnterpriseSearch", registerFunc: enterprisesearch.Add},
+		{name: "Beats", registerFunc: beat.Add},
+		{name: "License", registerFunc: license.Add},
+		{name: "LicenseTrial", registerFunc: licensetrial.Add},
+	}
+
+	for _, c := range controllers {
+		if err := c.registerFunc(mgr, params); err != nil {
+			log.Error(err, "Failed to register controller", "controller", c.name)
+			return fmt.Errorf("failed to register %s controller: %w", c.name, err)
+		}
+	}
+
+	assocControllers := []struct {
+		name         string
+		registerFunc func(manager.Manager, rbac.AccessReviewer, operator.Parameters) error
+	}{
+		{name: "RemoteCA", registerFunc: remoteca.Add},
+		{name: "APM-ES", registerFunc: associationctl.AddApmES},
+		{name: "APM-KB", registerFunc: associationctl.AddApmKibana},
+		{name: "KB-ES", registerFunc: associationctl.AddKibanaES},
+		{name: "ENT-ES", registerFunc: associationctl.AddEntES},
+		{name: "BEAT-ES", registerFunc: associationctl.AddBeatES},
+		{name: "BEAT-KB", registerFunc: associationctl.AddBeatKibana},
+	}
+
+	for _, c := range assocControllers {
+		if err := c.registerFunc(mgr, accessReviewer, params); err != nil {
+			log.Error(err, "Failed to register association controller", "controller", c.name)
+			return fmt.Errorf("failed to register %s association controller: %w", c.name, err)
+		}
+	}
+
+	return nil
+}
+
+func validateCertExpirationFlags(validityFlag string, rotateBeforeFlag string) (time.Duration, time.Duration, error) {
 	certValidity := viper.GetDuration(validityFlag)
 	certRotateBefore := viper.GetDuration(rotateBeforeFlag)
+
 	if certRotateBefore > certValidity {
-		log.Error(fmt.Errorf("%s must be larger than %s", validityFlag, rotateBeforeFlag), "")
-		os.Exit(1)
+		return certValidity, certRotateBefore, fmt.Errorf("%s must be larger than %s", validityFlag, rotateBeforeFlag)
 	}
-	return certValidity, certRotateBefore
+
+	return certValidity, certRotateBefore, nil
 }
 
 func garbageCollectUsers(cfg *rest.Config, managedNamespaces []string) {
@@ -507,7 +547,6 @@ func setupWebhook(mgr manager.Manager, certRotation certificates.RotationParams,
 		log.V(1).Info("Webhook certificate file present on filesystem", "path", keyPath)
 		return true, nil
 	})
-
 	if err != nil {
 		log.Error(err, "Timeout elapsed waiting for webhook certificate to be available", "path", keyPath, "timeout_seconds", timeout.Seconds())
 		os.Exit(1)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -81,7 +81,7 @@ var (
 func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "manager",
-		Short: "Start the ECK operator",
+		Short: "Start the Elastic Cloud on Kubernetes operator",
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			// enable using dashed notation in flags and underscores in env
 			viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
@@ -114,7 +114,7 @@ func Command() *cobra.Command {
 	cmd.Flags().Bool(
 		operator.AutoPortForwardFlag,
 		false,
-		"enables automatic port-forwarding "+
+		"Enables automatic port-forwarding "+
 			"(for dev use only as it exposes k8s resources on ephemeral ports to localhost)",
 	)
 	cmd.Flags().Duration(
@@ -141,7 +141,7 @@ func Command() *cobra.Command {
 		&configFile,
 		operator.ConfigFlag,
 		"",
-		"Path to the ECK configuration file",
+		"Path to the file containing the operator configuration",
 	)
 	cmd.Flags().String(
 		operator.ContainerRegistryFlag,
@@ -156,7 +156,7 @@ func Command() *cobra.Command {
 	cmd.Flags().Bool(
 		operator.DisableConfigWatch,
 		false,
-		"Disable watching the config file for changes",
+		"Disable watching the configuration file for changes",
 	)
 	cmd.Flags().Bool(
 		operator.EnforceRBACOnRefsFlag,
@@ -190,12 +190,12 @@ func Command() *cobra.Command {
 	cmd.Flags().StringSlice(
 		operator.NamespacesFlag,
 		nil,
-		"comma-separated list of namespaces in which this operator should manage resources (defaults to all namespaces)",
+		"Comma-separated list of namespaces in which this operator should manage resources (defaults to all namespaces)",
 	)
 	cmd.Flags().String(
 		operator.OperatorNamespaceFlag,
 		"",
-		"K8s namespace the operator runs in",
+		"Kubernetes namespace the operator runs in",
 	)
 	cmd.Flags().String(
 		operator.WebhookCertDirFlag,
@@ -206,7 +206,7 @@ func Command() *cobra.Command {
 	cmd.Flags().String(
 		operator.WebhookSecretFlag,
 		"",
-		fmt.Sprintf("K8s secret mounted into the path designated by %s to be used for webhook certificates", operator.WebhookCertDirFlag),
+		fmt.Sprintf("Kubernetes secret mounted into the path designated by %s to be used for webhook certificates", operator.WebhookCertDirFlag),
 	)
 	cmd.Flags().String(
 		operator.WebhookConfigurationNameFlag,
@@ -387,7 +387,7 @@ func startOperator(stopChan <-chan struct{}) error {
 	opts.Port = WebhookPort
 	mgr, err := ctrl.NewManager(cfg, opts)
 	if err != nil {
-		log.Error(err, "Unable to create controller manager")
+		log.Error(err, "Failed to create controller manager")
 		return err
 	}
 
@@ -411,7 +411,7 @@ func startOperator(stopChan <-chan struct{}) error {
 	// Setup a client to set the operator uuid config map
 	clientset, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		log.Error(err, "Unable to create Kubernetes client")
+		log.Error(err, "Failed to create Kubernetes client")
 		return err
 	}
 
@@ -475,7 +475,7 @@ func startOperator(stopChan <-chan struct{}) error {
 		"build_snapshot", operatorInfo.BuildInfo.Snapshot)
 
 	if err := mgr.Start(stopChan); err != nil {
-		log.Error(err, "Unable to run the manager")
+		log.Error(err, "Failed to start the controller manager")
 		return err
 	}
 

--- a/docs/operating-eck/operator-config.asciidoc
+++ b/docs/operating-eck/operator-config.asciidoc
@@ -22,6 +22,7 @@ ECK can be configured using either command line flags or environment variables.
 |container-registry |docker.elastic.co | Container registry to use for pulling Elastic Stack container images.
 |debug-http-listen |localhost:6060 |Listen address for the debug HTTP server. Only available in development mode.
 |development |false |Enable development mode. Only available as a CLI flag.
+|disable-config-watch| false| Watch the configuration file for changes and restart to apply them. Only effective when the `--config` flag is used to set the configuration file.
 |enable-tracing | false | Enable APM tracing in the operator process. Use environment variables to configure APM server URL, credentials, and so on. See link:https://www.elastic.co/guide/en/apm/agent/go/1.x/configuration.html[Apm Go Agent reference] for details.
 |enable-webhook | false | Enables a validating webhook server in the operator process.
 |enforce-rbac-on-refs| false | Enables restrictions on cross-namespace resource association through RBAC.
@@ -31,10 +32,10 @@ ECK can be configured using either command line flags or environment variables.
 |metrics-port |0 |Prometheus metrics port. Set to 0 to disable the metrics endpoint.
 |namespaces |"" |Namespaces in which this operator should manage resources. Accepts multiple comma-separated values. Defaults to all namespaces if empty or unspecified.
 |operator-namespace |"" |Namespace the operator runs in. Required.
-|webhook-pods-label |"" |Label used to select pods running the webhook server.
-|webhook-secret |"" | K8s secret mounted into the path designated by webhook-cert-dir to be used for webhook certificates.
 |webhook-cert-dir |"{TempDir}/k8s-webhook-server/serving-certs" |Path to the directory that contains the webhook server key and certificate.
 |webhook-configuration-name |"elastic-webhook.k8s.elastic.co" |Name of the Kubernetes ValidatingWebhookConfiguration resource. Only used when enable-webhook is true.
+|webhook-pods-label |"" |Label used to select pods running the webhook server.
+|webhook-secret |"" | K8s secret mounted into the path designated by webhook-cert-dir to be used for webhook certificates.
 |===
 
 
@@ -89,4 +90,4 @@ If you use a combination of all or some of the methods listed above, the descend
 - File
 
 
-You can edit the `elastic-operator` ConfigMap to change the operator configuration. A manual restart of the operator is required for the changes to take effect. Alternatively, you can edit the `elastic-operator` StatefulSet  and add flags to the `args` section -- which will trigger an automatic restart of the operator pod by the StatefulSet controller.
+You can edit the `elastic-operator` ConfigMap to change the operator configuration. Unless the `--disable-config-watch` flag is set, the operator should restart automatically to apply the new changes. Alternatively, you can edit the `elastic-operator` StatefulSet  and add flags to the `args` section -- which will trigger an automatic restart of the operator pod by the StatefulSet controller.

--- a/docs/operating-eck/operator-config.asciidoc
+++ b/docs/operating-eck/operator-config.asciidoc
@@ -18,6 +18,7 @@ ECK can be configured using either command line flags or environment variables.
 |ca-cert-validity |8760h |Duration representing the validity period of a generated CA certificate.
 |cert-rotate-before |24h |Duration representing how long before expiration TLS certificates should be re-issued.
 |cert-validity |8760h |Duration representing the validity period of a generated TLS certificate.
+|config |"" | Path to a file containing the operator configuration.
 |container-registry |docker.elastic.co | Container registry to use for pulling Elastic Stack container images.
 |debug-http-listen |localhost:6060 |Listen address for the debug HTTP server. Only available in development mode.
 |development |false |Enable development mode. Only available as a CLI flag.
@@ -51,4 +52,41 @@ Duration values should be specified as numeric values suffixed by the time unit.
 |===
 
 
-Edit the `elastic-operator` StatefulSet to change any of the flag values. <<{p}-eck-debug-logs>> illustrates how to change the log level of the operator using this method.
+If you have a large number of configuration options to specify, use the `--config` flag to point to a file containing those options. For example, assume you have a file named `eck-config.yaml` with the following content:
+
+.eck-config.yaml
+[source,yaml]
+----
+log-verbosity: 2
+metrics-port: 6060
+namespaces: [ns1, ns2, ns3]
+----
+
+The operator can be started using any of the following methods to achieve the same end result:
+
+.Configuration file method
+[source,sh]
+----
+./elastic-operator manager --config=eck-config.yaml
+----
+
+.Command-line flags method
+[source,sh]
+----
+./elastic-operator manager --log-verbosity=2 --metrics-port=6060 --namespaces=ns1,ns2,ns3
+----
+
+.Environment variables method
+[source,sh]
+----
+LOG_VERBOSITY=2 METRICS_PORT=6060 NAMESPACES="ns1,ns2,ns3" ./elastic-operator manager
+----
+
+If you use a combination of all or some of the methods listed above, the descending order of precedence in case of a conflict is as follows:
+
+- Flag
+- Environment variable
+- File
+
+
+You can edit the `elastic-operator` ConfigMap to change the operator configuration. A manual restart of the operator is required for the changes to take effect. Alternatively, you can edit the `elastic-operator` StatefulSet  and add flags to the `args` section -- which will trigger an automatic restart of the operator pod by the StatefulSet controller.

--- a/docs/reference/dependencies.asciidoc
+++ b/docs/reference/dependencies.asciidoc
@@ -23,6 +23,7 @@ This page lists the third-party dependencies used to build {n}.
 | link:https://github.com/blang/semver[$$github.com/blang/semver/v4$$] | v4.0.0 | MIT
 | link:https://github.com/davecgh/go-spew[$$github.com/davecgh/go-spew$$] | v1.1.1 | ISC
 | link:https://github.com/elastic/go-ucfg[$$github.com/elastic/go-ucfg$$] | v0.8.3 | Apache-2.0
+| link:https://github.com/fsnotify/fsnotify[$$github.com/fsnotify/fsnotify$$] | v1.4.9 | BSD-3-Clause
 | link:https://github.com/ghodss/yaml[$$github.com/ghodss/yaml$$] | v1.0.0 | MIT
 | link:https://github.com/go-logr/logr[$$github.com/go-logr/logr$$] | v0.1.0 | Apache-2.0
 | link:https://github.com/go-test/deep[$$github.com/go-test/deep$$] | v1.0.7 | MIT
@@ -136,7 +137,6 @@ This page lists the third-party dependencies used to build {n}.
 | link:https://github.com/evanphx/json-patch[$$github.com/evanphx/json-patch$$] | v4.5.0+incompatible | BSD-3-Clause
 | link:https://github.com/fatih/color[$$github.com/fatih/color$$] | v1.7.0 | MIT
 | link:https://github.com/fatih/structs[$$github.com/fatih/structs$$] | v1.1.0 | MIT
-| link:https://github.com/fsnotify/fsnotify[$$github.com/fsnotify/fsnotify$$] | v1.4.9 | BSD-3-Clause
 | link:https://github.com/globalsign/mgo[$$github.com/globalsign/mgo$$] | v0.0.0-20181015135952-eeefdecb41b8 | BSD-2-Clause
 | link:https://github.com/go-gl/glfw[$$github.com/go-gl/glfw$$] | v0.0.0-20190409004039-e6da0acd62b1 | BSD-3-Clause
 | link:https://github.com/go-kit/kit[$$github.com/go-kit/kit$$] | v0.9.0 | MIT

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/elastic/go-ucfg v0.8.3
 	github.com/elazarl/goproxy v0.0.0-20190711103511-473e67f1d7d2 // indirect
 	github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 // indirect
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0
 	github.com/go-test/deep v1.0.7

--- a/hack/manifest-gen/assets/charts/eck/templates/configmap.yaml
+++ b/hack/manifest-gen/assets/charts/eck/templates/configmap.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.operator.name }}
+  namespace: {{ .Values.operator.namespace }}
+data:
+  eck.yaml: |-
+    log-verbosity: {{ .Values.config.logVerbosity }}
+    metrics-port: {{ .Values.config.metricsPort }}
+    container-registry: {{ .Values.config.containerRegistry }}
+    max-concurrent-reconciles: {{ .Values.config.maxConcurrentReconciles }}
+    ca-cert-validity: {{ .Values.config.ca.validity }}
+    ca-cert-rotate-before: {{ .Values.config.ca.rotateBefore }}
+    cert-validity: {{ .Values.config.certificates.validity }}
+    cert-rotate-before: {{ .Values.config.certificates.rotateBefore }}
+    {{- if .Values.config.tracing.enabled }}
+    enable-tracing: true
+    {{- end }}
+    {{- if .Values.config.refs.enforceRBAC }}
+    enforce-rbac-on-refs: true
+    {{- end }}
+    {{- if .Values.config.webhook.enabled }}
+    enable-webhook: true
+      {{- if not .Values.config.webhook.manageCerts }}
+    manage-webhook-certs: false
+    webhook-cert-dir: {{ .Values.config.webhook.certsDir }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.config.managedNamespaces }}
+    namespaces: [{{ join "," .Values.config.managedNamespaces  }}]
+    {{- end }}
+    {{- if not .Values.config.beat.manageAutoDiscoverRBAC }}
+    manage-beat-autodiscover-rbac: false
+    {{- end }}

--- a/hack/manifest-gen/assets/charts/eck/templates/statefulset.yaml
+++ b/hack/manifest-gen/assets/charts/eck/templates/statefulset.yaml
@@ -17,6 +17,7 @@ spec:
         # Rename the fields "error" to "error.message" and "source" to "event.source"
         # This is to avoid a conflict with the ECS "error" and "source" documents.
         "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
+        "checksum/config": {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- toYaml .Values.operator.selectorLabels | nindent 8 }}
     spec:
@@ -28,33 +29,7 @@ spec:
         name: manager
         args:
           - "manager"
-          - "--log-verbosity={{- .Values.config.logVerbosity -}}"
-          - "--metrics-port={{- .Values.config.metricsPort -}}"
-          - "--container-registry={{- .Values.config.containerRegistry -}}"
-          - "--max-concurrent-reconciles={{- .Values.config.maxConcurrentReconciles -}}"
-          - "--ca-cert-validity={{- .Values.config.ca.validity -}}"
-          - "--ca-cert-rotate-before={{- .Values.config.ca.rotateBefore -}}"
-          - "--cert-validity={{- .Values.config.certificates.validity -}}"
-          - "--cert-rotate-before={{- .Values.config.certificates.rotateBefore -}}"
-          {{- if .Values.config.tracing.enabled }}
-          - "--enable-tracing"
-          {{- end }}
-          {{- if .Values.config.refs.enforceRBAC }}
-          - "--enforce-rbac-on-refs"
-          {{- end }}
-          {{- if .Values.config.webhook.enabled }}
-          - "--enable-webhook"
-            {{- if not .Values.config.webhook.manageCerts }}
-          - "--manage-webhook-certs=false"
-          - "--webhook-cert-dir={{- .Values.config.webhook.certsDir -}}"
-            {{- end }}
-          {{- end }}
-          {{- if .Values.config.managedNamespaces }}
-          - "--namespaces={{- join "," .Values.config.managedNamespaces  -}}"
-          {{- end }}
-          {{- if not .Values.config.beat.manageAutoDiscoverRBAC }}
-          - "--manage-beat-autodiscover-rbac=false"
-          {{- end }}
+          - "--config=/conf/eck.yaml"
         env:
           - name: OPERATOR_NAMESPACE
             valueFrom:
@@ -77,11 +52,21 @@ spec:
         - containerPort: 9443
           name: https-webhook
           protocol: TCP
+{{- end }}
         volumeMounts:
+          - mountPath: "/conf"
+            name: conf
+            readOnly: true
+{{- if .Values.config.webhook.enabled }}
           - mountPath: {{ .Values.config.webhook.certsDir }}
             name: cert
             readOnly: true
+{{- end }}
       volumes:
+        - name: conf
+          configMap:
+            name: {{ .Values.operator.name }}
+{{- if .Values.config.webhook.enabled }}
         - name: cert
           secret:
             defaultMode: 420

--- a/pkg/about/info.go
+++ b/pkg/about/info.go
@@ -6,6 +6,7 @@ package about
 
 import (
 	"context"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -39,6 +40,22 @@ type BuildInfo struct {
 	Hash     string `json:"hash"`
 	Date     string `json:"date"`
 	Snapshot string `json:"snapshot"`
+}
+
+// VersionString returns the version information formatted according to the SemVer specification.
+func (bi BuildInfo) VersionString() string {
+	var sb strings.Builder
+
+	sb.WriteString(bi.Version)
+
+	if bi.Snapshot == "true" && !strings.HasSuffix(bi.Version, "-SNAPSHOT") {
+		sb.WriteString("-SNAPSHOT")
+	}
+
+	sb.WriteString("+")
+	sb.WriteString(bi.Hash)
+
+	return sb.String()
 }
 
 // IsDefined returns true if the info's default values have been replaced.

--- a/pkg/controller/common/operator/flags.go
+++ b/pkg/controller/common/operator/flags.go
@@ -10,6 +10,7 @@ const (
 	CACertValidityFlag           = "ca-cert-validity"
 	CertRotateBeforeFlag         = "cert-rotate-before"
 	CertValidityFlag             = "cert-validity"
+	ConfigFlag                   = "config"
 	ContainerRegistryFlag        = "container-registry"
 	DebugHTTPListenFlag          = "debug-http-listen"
 	EnableTracingFlag            = "enable-tracing"

--- a/pkg/controller/common/operator/flags.go
+++ b/pkg/controller/common/operator/flags.go
@@ -13,6 +13,7 @@ const (
 	ConfigFlag                   = "config"
 	ContainerRegistryFlag        = "container-registry"
 	DebugHTTPListenFlag          = "debug-http-listen"
+	DisableConfigWatch           = "disable-config-watch"
 	EnableTracingFlag            = "enable-tracing"
 	EnableWebhookFlag            = "enable-webhook"
 	EnforceRBACOnRefsFlag        = "enforce-rbac-on-refs"

--- a/pkg/utils/log/log.go
+++ b/pkg/utils/log/log.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/elastic/cloud-on-k8s/pkg/about"
 	"github.com/elastic/cloud-on-k8s/pkg/dev"
@@ -23,9 +22,10 @@ import (
 const (
 	EcsVersion     = "1.4.0"
 	EcsServiceType = "eck"
+	FlagName       = "log-verbosity"
 )
 
-var verbosity = flag.Int("log-verbosity", 0, "Verbosity level of logs (-2=Error, -1=Warn, 0=Info, >0=Debug)")
+var verbosity = flag.Int(FlagName, 0, "Verbosity level of logs (-2=Error, -1=Warn, 0=Info, >0=Debug)")
 
 // BindFlags attaches logging flags to the given flag set.
 func BindFlags(flags *pflag.FlagSet) {
@@ -108,12 +108,6 @@ func determineLogLevel(v *int) zap.AtomicLevel {
 }
 
 func getVersionString() string {
-	var version strings.Builder
 	buildInfo := about.GetBuildInfo()
-
-	version.WriteString(buildInfo.Version)
-	version.WriteString("-")
-	version.WriteString(buildInfo.Hash)
-
-	return version.String()
+	return buildInfo.VersionString()
 }


### PR DESCRIPTION
Adds the ability to configure the operator from a file. This is a backward-compatible change that retains the existing configuration methods using flags and environment variables. Users can provide the configuration file using the `--config` flag. If there are any conflicts, the order of precedence for resolving them is:

- Flag
- Environment variable
- File

This PR also includes:
- Update to the `all-in-one.yaml` to use a ConfigMap for operator configuration
- Update to the operator configuration documentation
- A minor refactoring of the command code 

Fixes #3401 