### PR TITLE
Fix incorrect test file name

### DIFF
--- a/pkg/utils/chrono/millis_test.go
+++ b/pkg/utils/chrono/millis_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func Test_toMillis(t *testing.T) {
+func TestToMillis(t *testing.T) {
 	type args struct {
 		t time.Time
 	}


### PR DESCRIPTION
There was `.` in the filename instead of `_` 😞 