### PR TITLE
Fix beat permissions in TestVersionUpgradeOrdering

### DIFF
--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -75,8 +75,7 @@ func TestVersionUpgradeOrdering(t *testing.T) {
 		WithRoles(beat.PSPClusterRoleName, beat.AutodiscoverClusterRoleName).
 		WithVersion(initialVersion).
 		WithElasticsearchRef(esRef).
-		WithKibanaRef(kbRef).
-		WithRestrictedSecurityContext()
+		WithKibanaRef(kbRef)
 	fb = beat.ApplyYamls(t, fb, beattests.E2EFilebeatConfig, beattests.E2EFilebeatPodTemplate)
 	fbUpdated := fb.WithVersion(updatedVersion)
 


### PR DESCRIPTION
Filebeat cannot run with a restricted context, so the pods won't start if we set one up.
My bad for changing that before merging and not re-testing locally.