### PR TITLE
Update owner references in reconcile resource util function

### DIFF
--- a/pkg/controller/common/reconciler/reconciler.go
+++ b/pkg/controller/common/reconciler/reconciler.go
@@ -161,16 +161,16 @@ func ReconcileResource(params Params) error {
 			return err
 		}
 
-		expectedMeta, err := meta.Accessor(params.Expected)
-		if err != nil {
-			return err
-		}
 		// retain the resource version to avoid unconditional updates
 		resourceVersion := reconciledMeta.GetResourceVersion()
 		params.UpdateReconciled()
 		// and set the resource version back into the resource to indicate the state we are basing the update off of
 		reconciledMeta.SetResourceVersion(resourceVersion)
 		// also keep the owner references up to date
+		expectedMeta, err := meta.Accessor(params.Expected)
+		if err != nil {
+			return err
+		}
 		expectedOwners := expectedMeta.GetOwnerReferences()
 		if expectedOwners != nil {
 			// we can safely assume we have just one reference here given that it was created just above

--- a/pkg/controller/common/reconciler/reconciler.go
+++ b/pkg/controller/common/reconciler/reconciler.go
@@ -160,11 +160,24 @@ func ReconcileResource(params Params) error {
 		if err != nil {
 			return err
 		}
+
+		expectedMeta, err := meta.Accessor(params.Expected)
+		if err != nil {
+			return err
+		}
 		// retain the resource version to avoid unconditional updates
 		resourceVersion := reconciledMeta.GetResourceVersion()
 		params.UpdateReconciled()
 		// and set the resource version back into the resource to indicate the state we are basing the update off of
 		reconciledMeta.SetResourceVersion(resourceVersion)
+		// also keep the owner references up to date
+		expectedOwners := expectedMeta.GetOwnerReferences()
+		if expectedOwners != nil {
+			// we can safely assume we have just one reference here given that it was created just above
+			// but we don't want to replace wholesale in case a user has set an additional reference
+			k8s.OverrideControllerReference(reconciledMeta, expectedOwners[0])
+		}
+
 		err = params.Client.Update(params.Reconciled)
 		if err != nil {
 			return err

--- a/pkg/controller/common/service_control_test.go
+++ b/pkg/controller/common/service_control_test.go
@@ -26,16 +26,16 @@ func TestReconcileService(t *testing.T) {
 		},
 	}
 
-	existingSvc := mkService()
+	existingSvc := mkService(owner)
 	client := k8s.WrappedFakeClient(owner, existingSvc)
 
-	expectedSvc := mkService()
+	expectedSvc := mkService(owner)
 	delete(expectedSvc.Labels, "lbl2")
 	delete(expectedSvc.Annotations, "ann2")
 	expectedSvc.Labels["lbl3"] = "lblval3"
 	expectedSvc.Annotations["ann3"] = "annval3"
 
-	wantSvc := mkService()
+	wantSvc := mkService(owner)
 	wantSvc.Labels["lbl3"] = "lblval3"
 	wantSvc.Annotations["ann3"] = "annval3"
 
@@ -44,13 +44,23 @@ func TestReconcileService(t *testing.T) {
 	comparison.AssertEqual(t, wantSvc, haveSvc)
 }
 
-func mkService() *corev1.Service {
+func mkService(owner *kbv1.Kibana) *corev1.Service {
+	true := true
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "owner-svc",
 			Namespace:   "test",
 			Labels:      map[string]string{"lbl1": "lblval1", "lbl2": "lbl2val"},
 			Annotations: map[string]string{"ann1": "annval1", "ann2": "annval2"},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "kibana.k8s.elastic.co/v1",
+					Kind:               "Kibana",
+					Name:               owner.Name,
+					Controller:         &true,
+					BlockOwnerDeletion: &true,
+				},
+			},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{"foo": "bar"},

--- a/pkg/utils/k8s/k8sutils.go
+++ b/pkg/utils/k8s/k8sutils.go
@@ -113,3 +113,25 @@ func PodsMatchingLabels(c Client, namespace string, labels map[string]string) ([
 	}
 	return pods.Items, nil
 }
+
+// OverrideControllerReference overrides the controller owner reference with the given owner reference.
+func OverrideControllerReference(obj metav1.Object, newOwner metav1.OwnerReference) {
+	owners := obj.GetOwnerReferences()
+
+	ref := indexOfCtrlRef(owners)
+	if ref == -1 {
+		obj.SetOwnerReferences([]metav1.OwnerReference{newOwner})
+		return
+	}
+	owners[ref] = newOwner
+	obj.SetOwnerReferences(owners)
+}
+
+func indexOfCtrlRef(owners []metav1.OwnerReference) int {
+	for index, r := range owners {
+		if r.Controller != nil && *r.Controller {
+			return index
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
We previously set owner references only on creation as they usually don't change. With the association model in ECK ownership can change though. The referenced resource can change and the controller e.g. the Elasticsearch controller for a Kibana -> Elasticsearch relationship relies on the owner referrence in its watch on secrets.

This PR takes this into account by resetting the owner reference on updates.

Fixes #3470 

