### PR TITLE
Remove kibanaRef warning from Beats recipes

### DIFF
--- a/config/recipes/beats/auditbeat_hosts.yaml
+++ b/config/recipes/beats/auditbeat_hosts.yaml
@@ -7,8 +7,6 @@ spec:
   version: 7.8.0
   elasticsearchRef:
     name: elasticsearch
-  # Currently this setting requires Kibana to have TLS enabled.
-  # See https://github.com/elastic/cloud-on-k8s/issues/3523 for more information.
   kibanaRef:
     name: kibana
   config:

--- a/config/recipes/beats/filebeat_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_autodiscover.yaml
@@ -7,8 +7,6 @@ spec:
   version: 7.8.0
   elasticsearchRef:
     name: elasticsearch
-    # Currently this setting requires Kibana to have TLS enabled.
-    # See https://github.com/elastic/cloud-on-k8s/issues/3523 for more information.
   kibanaRef:
     name: kibana
   config:

--- a/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
+++ b/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
@@ -7,8 +7,6 @@ spec:
   version: 7.8.0
   elasticsearchRef:
     name: elasticsearch
-    # Currently this setting requires Kibana to have TLS enabled.
-    # See https://github.com/elastic/cloud-on-k8s/issues/3523 for more information.
   kibanaRef:
     name: kibana
   config:

--- a/config/recipes/beats/filebeat_no_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_no_autodiscover.yaml
@@ -7,8 +7,6 @@ spec:
   version: 7.8.0
   elasticsearchRef:
     name: elasticsearch
-    # Currently this setting requires Kibana to have TLS enabled.
-    # See https://github.com/elastic/cloud-on-k8s/issues/3523 for more information.
   kibanaRef:
     name: kibana
   config:

--- a/config/recipes/beats/metricbeat_hosts.yaml
+++ b/config/recipes/beats/metricbeat_hosts.yaml
@@ -7,8 +7,6 @@ spec:
   version: 7.8.0
   elasticsearchRef:
     name: elasticsearch
-    # Currently this setting requires Kibana to have TLS enabled.
-    # See https://github.com/elastic/cloud-on-k8s/issues/3523 for more information.
   kibanaRef:
     name: kibana
   config:

--- a/config/recipes/beats/packetbeat_dns_http.yaml
+++ b/config/recipes/beats/packetbeat_dns_http.yaml
@@ -7,8 +7,6 @@ spec:
   version: 7.8.0
   elasticsearchRef:
     name: elasticsearch
-    # Currently this setting requires Kibana to have TLS enabled.
-    # See https://github.com/elastic/cloud-on-k8s/issues/3523 for more information.
   kibanaRef:
     name: kibana
   config:

--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -121,8 +121,6 @@ spec:
   version: 7.8.0
   elasticsearchRef:
     name: elasticsearch-monitoring
-    # Currently this setting requires Kibana to have TLS enabled.
-    # See https://github.com/elastic/cloud-on-k8s/issues/3523 for more information.
   kibanaRef:
     name: kibana-monitoring
   config:


### PR DESCRIPTION
Removes the warning about `kibanaRef` requiring TLS.