### PR TITLE
Remove memory leak mitigation

### DIFF
--- a/pkg/controller/common/reconciler/results.go
+++ b/pkg/controller/common/reconciler/results.go
@@ -6,16 +6,12 @@ package reconciler
 
 import (
 	"context"
-	"time"
 
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
 	"go.elastic.co/apm"
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
-
-// MaximumRequeueAfter is the maximum period of time in which we requeue a reconciliation.
-const MaximumRequeueAfter = 10 * time.Hour
 
 type resultKind int
 
@@ -109,12 +105,5 @@ func (r *Results) Apply(step string, recoverableStep func(context.Context) (reco
 
 // Aggregate returns the highest priority reconcile result and any errors seen so far.
 func (r *Results) Aggregate() (reconcile.Result, error) {
-	if r.currResult.RequeueAfter > MaximumRequeueAfter {
-		// A client-go leaky timer issue will cause memory leaks for long requeue periods,
-		// see https://github.com/elastic/cloud-on-k8s/issues/1984.
-		// To prevent this from happening, let's restrict the requeue to a fixed short-term value.
-		// TODO: remove once https://github.com/kubernetes/client-go/issues/701 is fixed.
-		r.currResult.RequeueAfter = MaximumRequeueAfter
-	}
 	return r.currResult, k8serrors.NewAggregate(r.errors)
 }

--- a/pkg/controller/common/reconciler/results_test.go
+++ b/pkg/controller/common/reconciler/results_test.go
@@ -106,14 +106,9 @@ func TestResultsAggregate(t *testing.T) {
 			want:    reconcile.Result{Requeue: true},
 		},
 		{
-			name:    "specific result under MaximumRequeueAfter",
-			results: &Results{currResult: reconcile.Result{RequeueAfter: 1 * time.Hour}, currKind: specificKind},
-			want:    reconcile.Result{RequeueAfter: 1 * time.Hour},
-		},
-		{
-			name:    "specific result over MaximumRequeueAfter",
+			name:    "specific result",
 			results: &Results{currResult: reconcile.Result{RequeueAfter: 24 * time.Hour}, currKind: specificKind},
-			want:    reconcile.Result{RequeueAfter: MaximumRequeueAfter},
+			want:    reconcile.Result{RequeueAfter: 24 * time.Hour},
 		},
 	}
 


### PR DESCRIPTION
Revert #1989 as [the fix for the memory leak is included since the version 0.17.0 ](https://github.com/kubernetes/client-go/blob/v0.17.0/util/workqueue/delaying_queue.go) of the K8S go client.