### PR TITLE
Make Slack notif more robust on AKS, EKS, OCP E2E test failure

### DIFF
--- a/.ci/pipelines/e2e-tests-aks.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-aks.Jenkinsfile
@@ -22,6 +22,13 @@ pipeline {
     }
 
     stages {
+        stage('Load common scripts') {
+            steps {
+                script {
+                    lib = load ".ci/common/tests.groovy"
+                }
+            }
+        }
         stage("Run E2E tests") {
             steps {
                 sh '.ci/setenvconfig e2e/aks'
@@ -32,7 +39,6 @@ pipeline {
                     junit "e2e-tests.xml"
 
                     if (env.SHELL_EXIT_CODE != 0) {
-                        lib = load ".ci/common/tests.groovy"
                         failedTests = lib.getListOfFailedTests()
                         googleStorageUpload bucket: "gs://devops-ci-artifacts/jobs/$JOB_NAME/$BUILD_NUMBER",
                             credentialsId: "devops-ci-gcs-plugin",

--- a/.ci/pipelines/e2e-tests-eks.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-eks.Jenkinsfile
@@ -22,6 +22,13 @@ pipeline {
     }
 
     stages {
+        stage('Load common scripts') {
+            steps {
+                script {
+                    lib = load ".ci/common/tests.groovy"
+                }
+            }
+        }
         stage("Run E2E tests") {
             steps {
                 sh '.ci/setenvconfig e2e/eks'
@@ -32,7 +39,6 @@ pipeline {
                     junit "e2e-tests.xml"
 
                     if (env.SHELL_EXIT_CODE != 0) {
-                        lib = load ".ci/common/tests.groovy"
                         failedTests = lib.getListOfFailedTests()
                         googleStorageUpload bucket: "gs://devops-ci-artifacts/jobs/$JOB_NAME/$BUILD_NUMBER",
                             credentialsId: "devops-ci-gcs-plugin",

--- a/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
@@ -23,6 +23,13 @@ pipeline {
     }
 
     stages {
+        stage('Load common scripts') {
+            steps {
+                script {
+                    lib = load ".ci/common/tests.groovy"
+                }
+            }
+        }
         stage("Run E2E tests") {
             steps {
                 sh '.ci/setenvconfig e2e/ocp'
@@ -33,7 +40,6 @@ pipeline {
                     junit "e2e-tests.xml"
 
                     if (env.SHELL_EXIT_CODE != 0) {
-                        lib = load ".ci/common/tests.groovy"
                         failedTests = lib.getListOfFailedTests()
                         googleStorageUpload bucket: "gs://devops-ci-artifacts/jobs/$JOB_NAME/$BUILD_NUMBER",
                             credentialsId: "devops-ci-gcs-plugin",


### PR DESCRIPTION
Move the loading of the CI common groovy script to avoid that an unexpected
error prevents it and then breaks the sending of notifications.

Related to #3586 and #3508.