### PR TITLE
Garbage collect orphaned Beat users

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -437,6 +437,7 @@ func garbageCollectUsers(cfg *rest.Config, managedNamespaces []string) {
 		For(&apmv1.ApmServerList{}, associationctl.ApmAssociationLabelNamespace, associationctl.ApmAssociationLabelName).
 		For(&kbv1.KibanaList{}, associationctl.KibanaESAssociationLabelNamespace, associationctl.KibanaESAssociationLabelName).
 		For(&entv1beta1.EnterpriseSearchList{}, associationctl.EntESAssociationLabelNamespace, associationctl.EntESAssociationLabelName).
+		For(&beatv1beta1.BeatList{}, associationctl.BeatAssociationLabelNamespace, associationctl.BeatAssociationLabelName).
 		DoGarbageCollection()
 	if err != nil {
 		log.Error(err, "user garbage collector failed")


### PR DESCRIPTION
This PR ensures that orphaned Beat users are deleted on startup.