### PR TITLE
Improve JUnit E2E tests XML report generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ e2e-run:
 		--skip-cleanup=$(E2E_SKIP_CLEANUP)
 
 e2e-generate-xml:
-	@ gotestsum --junitfile e2e-tests.xml --raw-command cat e2e-tests.json || (echo "Failed to generate xml report" && cat e2e-tests.json && false)
+	@ hack/ci/generate-junit-xml-report.sh e2e-tests.json
 
 # Verify e2e tests compile with no errors, don't run them
 e2e-compile:

--- a/hack/ci/generate-junit-xml-report.sh
+++ b/hack/ci/generate-junit-xml-report.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+# Script to generate a JUnit XML report from a JSON go test output.
+#
+
+set -euo pipefail
+
+main() {
+    local input_file=${1:-"input file"}
+    local xml_report=${input_file%.*}.xml
+
+    # exit without error when there is no input file
+    if [[ ! -f $input_file ]]; then
+        echo "No $input_file to generate a JUnit XML report."
+        exit 0
+    fi
+  
+    # temporary filter out lines containing a space in the timestamp,
+    # see https://github.com/elastic/cloud-on-k8s/issues/3560.
+    gotestsum \
+        --junitfile "$xml_report" \
+        --raw-command grep -v '"Time":"[^"]*\s[^"]*"' "$input_file" || \
+    ( \
+        echo "Failed to generate a JUnit XML report."
+        # print the input file for further debugging
+        echo " --- $input_file - START ---"
+        cat "$input_file"
+        echo " --- $input_file - END   ---"
+        exit 1
+    )
+}
+
+main "$@"


### PR DESCRIPTION
Add a script to call gotestsum for the JUnit E2E tests XML report
generation that will check that an input file exists and also filter
out invalid lines containing a space in the timestamp.

I think a bash script is a better place than a Makefile to implement this kind of logic even if it is quite small.

Relates to #3560 for the temporary fix with the filter.
Relates to #3586, avoiding generation when there is no input file will clean up our jobs log of the somewhat disturbing error
 `cat: e2e-tests.json: No such file or directory` due to a previous failure during the e2e tests execution.


