### PR TITLE
TestDelayingQueueInvariants: increase item delay

### DIFF
--- a/pkg/controller/license/license_controller_integration_test.go
+++ b/pkg/controller/license/license_controller_integration_test.go
@@ -174,10 +174,10 @@ func TestDelayingQueueInvariants(t *testing.T) {
 			name: "no dedup'ing when delaying",
 			adds: func(q workqueue.DelayingInterface) {
 				q.Add(item)
-				q.AddAfter(item, 1*time.Millisecond)
+				q.AddAfter(item, 500*time.Millisecond)
 			},
 			expectedObservations: 2,
-			timeout:              10 * time.Millisecond,
+			timeout:              1 * time.Second,
 		},
 		{
 			name: "but dedup's and updates item within the wait queue",


### PR DESCRIPTION
This an attempt to fix #3557 

Please see https://github.com/elastic/cloud-on-k8s/issues/3557#issuecomment-669754990 for the rational behind this change.