### PR TITLE
Fix filebeat securityContext in recipes

### DIFF
--- a/config/recipes/beats/filebeat_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_autodiscover.yaml
@@ -32,12 +32,12 @@ spec:
         terminationGracePeriodSeconds: 30
         dnsPolicy: ClusterFirstWithHostNet
         hostNetwork: true # Allows to provide richer host metadata
-        securityContext:
-          runAsUser: 0
-          # If using Red Hat OpenShift uncomment this:
-          #privileged: true
         containers:
         - name: filebeat
+          securityContext:
+            runAsUser: 0
+            # If using Red Hat OpenShift uncomment this:
+            #privileged: true
           volumeMounts:
           - name: varlogcontainers
             mountPath: /var/log/containers

--- a/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
+++ b/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
@@ -34,12 +34,12 @@ spec:
         terminationGracePeriodSeconds: 30
         dnsPolicy: ClusterFirstWithHostNet
         hostNetwork: true # Allows to provide richer host metadata
-        securityContext:
-          runAsUser: 0
-          # If using Red Hat OpenShift uncomment this:
-          #privileged: true
         containers:
         - name: filebeat
+          securityContext:
+            runAsUser: 0
+            # If using Red Hat OpenShift uncomment this:
+            #privileged: true
           volumeMounts:
           - name: varlogcontainers
             mountPath: /var/log/containers

--- a/config/recipes/beats/filebeat_no_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_no_autodiscover.yaml
@@ -24,12 +24,11 @@ spec:
         terminationGracePeriodSeconds: 30
         dnsPolicy: ClusterFirstWithHostNet
         hostNetwork: true # Allows to provide richer host metadata
-        securityContext:
-          runAsUser: 0
         containers:
         - name: filebeat
-          # If using Red Hat OpenShift uncomment this:
-          #securityContext:
+          securityContext:
+            runAsUser: 0
+            # If using Red Hat OpenShift uncomment this:
             #privileged: true
           volumeMounts:
           - name: varlogcontainers


### PR DESCRIPTION
This PR:
* Moves the security context at the container level to be [aligned with the beat samples](https://github.com/elastic/beats/blob/3ff02cbba4184957cf63cad3e3bf5e23d17bd0f2/deploy/kubernetes/filebeat/filebeat-daemonset.yaml#L45).
* Fix the problem [mentioned here](https://github.com/elastic/cloud-on-k8s/pull/3406#discussion_r451371193) in the filebeat recipes