### PR TITLE
Replace external doc link using current with an internal link

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/beat.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/beat.asciidoc
@@ -374,7 +374,7 @@ Below you can find manifests that address a number of common use cases and can b
 
 IMPORTANT: These examples are for illustration purposes only and should not be considered to be production-ready.
 
-CAUTION: Some of these examples use the `node.store.allow_mmap: false` configuration value to avoid configuring memory mapping settings on the underlying host. This could have a significant performance impact on your Elasticsearch clusters and should not be used in production without careful consideration. See https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html for more information.
+CAUTION: Some of these examples use the `node.store.allow_mmap: false` setting which has performance implications and should be tuned for production workloads as described in the <<{p}-virtual-memory>> section.
 
 === Metricbeat for Kubernetes monitoring
 


### PR DESCRIPTION
This commit replaces the last external doc link using "current" (`https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html`) with an internal link (`<<{p}-virtual-memory>> section`). I rephrased the sentence a bit using what we did in the quickstart to be more consistent. This version also seems to me to be a little lighter.

Resolves #2988.