### PR TITLE
Bump Elastic Stack version to 7.8.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ switch-registry-dev: # just use the default values of variables
 E2E_REGISTRY_NAMESPACE ?= eck-dev
 E2E_IMG                ?= $(REGISTRY)/$(E2E_REGISTRY_NAMESPACE)/eck-e2e-tests:$(TAG)
 TESTS_MATCH            ?= "^Test" # can be overriden to eg. TESTS_MATCH=TestMutationMoreNodes to match a single test
-STACK_VERSION          ?= 7.8.0
+STACK_VERSION          ?= 7.8.1
 E2E_JSON               ?= false
 TEST_TIMEOUT           ?= 5m
 E2E_SKIP_CLEANUP       ?= false

--- a/config/e2e/filebeat.yaml
+++ b/config/e2e/filebeat.yaml
@@ -88,7 +88,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: filebeat
-          image: docker.elastic.co/beats/filebeat:7.8.0
+          image: docker.elastic.co/beats/filebeat:7.8.1
           args: [
             "-c", "/etc/filebeat.yml",
             "-e",

--- a/config/e2e/metricbeat.yaml
+++ b/config/e2e/metricbeat.yaml
@@ -131,7 +131,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: metricbeat
-          image: docker.elastic.co/beats/metricbeat:7.8.0
+          image: docker.elastic.co/beats/metricbeat:7.8.1
           args: [
             "-c", "/etc/metricbeat.yml",
             "-e",

--- a/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
+++ b/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
@@ -4,7 +4,7 @@ metadata:
   name: apm-server-quickstart
   namespace: default
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   config:
     name: elastic-apm

--- a/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
+++ b/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
@@ -84,7 +84,7 @@ metadata:
   name: elasticsearch-sample
   namespace: elasticsearch-ns
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
     - name: default
       count: 1
@@ -97,7 +97,7 @@ metadata:
   name: kibana-sample
   namespace: kibana-ns
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"
@@ -111,7 +111,7 @@ metadata:
   name: apm-apm-sample
   namespace: apmserver-ns
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/config/recipes/beats/auditbeat_hosts.yaml
+++ b/config/recipes/beats/auditbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: auditbeat
 spec:
   type: auditbeat
-  version: 7.8.0
+  version: 7.8.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -76,7 +76,7 @@ spec:
         #    path: /run
         #initContainers:
         #- name: cos-init
-        #  image: docker.elastic.co/beats/auditbeat:7.8.0
+        #  image: docker.elastic.co/beats/auditbeat:7.8.1
         #  volumeMounts:
         #  - name: run
         #    mountPath: /run
@@ -118,7 +118,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
   - name: default
     count: 3
@@ -130,7 +130,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 7.8.0
+  version: 7.8.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -94,7 +94,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
   - name: default
     count: 3
@@ -106,7 +106,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
+++ b/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 7.8.0
+  version: 7.8.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -96,7 +96,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
   - name: default
     count: 3
@@ -108,7 +108,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_no_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_no_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 7.8.0
+  version: 7.8.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -53,7 +53,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
   - name: default
     count: 3
@@ -65,7 +65,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/heartbeat_es_kb_health.yaml
+++ b/config/recipes/beats/heartbeat_es_kb_health.yaml
@@ -4,7 +4,7 @@ metadata:
   name: heartbeat
 spec:
   type: heartbeat
-  version: 7.8.0
+  version: 7.8.1
   elasticsearchRef:
     name: elasticsearch
   config:
@@ -27,7 +27,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
   - name: default
     count: 3
@@ -39,7 +39,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/journalbeat_hosts.yaml
+++ b/config/recipes/beats/journalbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: journalbeat
 spec:
   type: journalbeat
-  version: 7.8.0
+  version: 7.8.1
   elasticsearchRef:
     name: elasticsearch
   config:
@@ -49,7 +49,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
   - name: default
     count: 3
@@ -61,7 +61,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/metricbeat_hosts.yaml
+++ b/config/recipes/beats/metricbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 7.8.0
+  version: 7.8.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -169,7 +169,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
   - name: default
     count: 3
@@ -181,7 +181,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/packetbeat_dns_http.yaml
+++ b/config/recipes/beats/packetbeat_dns_http.yaml
@@ -4,7 +4,7 @@ metadata:
   name: packetbeat
 spec:
   type: packetbeat
-  version: 7.8.0
+  version: 7.8.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -44,7 +44,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
   - name: default
     count: 3
@@ -56,7 +56,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -6,7 +6,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 7.8.0
+  version: 7.8.1
   elasticsearchRef:
     name: elasticsearch-monitoring
   config:
@@ -118,7 +118,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 7.8.0
+  version: 7.8.1
   elasticsearchRef:
     name: elasticsearch-monitoring
   kibanaRef:
@@ -210,7 +210,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
   - name: default
     count: 3
@@ -229,7 +229,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -247,7 +247,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-monitoring
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
   - name: default
     count: 3
@@ -259,7 +259,7 @@ kind: Kibana
 metadata:
   name: kibana-monitoring
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: elasticsearch-monitoring

--- a/config/recipes/gclb/01-elastic-stack.yaml
+++ b/config/recipes/gclb/01-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 7.8.0
+  version: 7.8.1
   http:
     service:
       metadata:
@@ -45,7 +45,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   http:
     service:

--- a/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
+++ b/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 7.8.0
+  version: 7.8.1
   http:
     tls:
       selfSignedCertificate:
@@ -97,7 +97,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   http:
     tls:

--- a/config/recipes/traefik/02-elastic-stack.yaml
+++ b/config/recipes/traefik/02-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
   - name: master
     count: 1
@@ -56,7 +56,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: hulk
@@ -68,7 +68,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: hulk

--- a/config/samples/apm/apm_es_kibana.yaml
+++ b/config/samples/apm/apm_es_kibana.yaml
@@ -5,7 +5,7 @@ kind: Elasticsearch
 metadata:
   name: es-apm-sample
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
   - name: default
     count: 3
@@ -19,7 +19,7 @@ kind: Kibana
 metadata:
   name: kb-apm-sample
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"
@@ -29,7 +29,7 @@ kind: ApmServer
 metadata:
   name: apm-apm-sample
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"

--- a/config/samples/apm/apmserver.yaml
+++ b/config/samples/apm/apmserver.yaml
@@ -3,7 +3,7 @@ kind: ApmServer
 metadata:
   name: apmserver-sample
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   config:
     output.console:

--- a/config/samples/elasticsearch/elasticsearch.yaml
+++ b/config/samples/elasticsearch/elasticsearch.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
   - name: default
     config:

--- a/config/samples/enterprisesearch/ent_es.yaml
+++ b/config/samples/enterprisesearch/ent_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
     - name: default
       count: 1
@@ -18,7 +18,7 @@ kind: EnterpriseSearch
 metadata:
   name: ent-sample
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: elasticsearch-sample

--- a/config/samples/kibana/kibana_es.yaml
+++ b/config/samples/kibana/kibana_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
   - name: default
     count: 1
@@ -18,7 +18,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/hack/upgrade-test-harness/testdata/upcoming/stack.yaml
+++ b/hack/upgrade-test-harness/testdata/upcoming/stack.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: upcoming
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
   - name: default
     count: 3
@@ -16,7 +16,7 @@ kind: Kibana
 metadata:
   name: upcoming
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: upcoming
@@ -26,7 +26,7 @@ kind: ApmServer
 metadata:
   name: upcoming
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: upcoming

--- a/hack/upgrade-test-harness/testdata/v112/stack.yaml
+++ b/hack/upgrade-test-harness/testdata/v112/stack.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: v112
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
   - name: default
     count: 3
@@ -16,7 +16,7 @@ kind: Kibana
 metadata:
   name: v112
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: v112
@@ -26,7 +26,7 @@ kind: ApmServer
 metadata:
   name: v112
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   elasticsearchRef:
     name: v112

--- a/test/e2e/kb/testdata/kibana_standalone.yaml
+++ b/test/e2e/kb/testdata/kibana_standalone.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: {{ .ESName }}
 spec:
-  version: 7.8.0
+  version: 7.8.1
   nodeSets:
   - count: 1
     name: mdi
@@ -18,7 +18,7 @@ kind: Kibana
 metadata:
   name: test-kibana-standalone-{{ .Suffix }}
 spec:
-  version: 7.8.0
+  version: 7.8.1
   count: 1
   config:
     elasticsearch.hosts:

--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -16,7 +16,7 @@ const (
 	// Minimum version for 6.8.x tested with the operator
 	MinVersion68x = "6.8.10"
 	// Current latest version for 7.x
-	LatestVersion7x = "7.8.0" // version to synchronize with the latest release of the Elastic Stack
+	LatestVersion7x = "7.8.1" // version to synchronize with the latest release of the Elastic Stack
 )
 
 // SkipInvalidUpgrade skips a test that would do an invalid upgrade.


### PR DESCRIPTION
Make `7.8.1` the new default Elastic Stack version.