### PR TITLE
Use version attribute in beats doc

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/beat.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/beat.asciidoc
@@ -162,7 +162,7 @@ metadata:
   name: heartbeat-quickstart
 spec:
   type: heartbeat
-  version: 7.8.0
+  version: {version}
   elasticsearchRef:
     name: quickstart
   configRef:


### PR DESCRIPTION
This commit fixes a tiny oversight where the Elastic Stack version is directly used instead of using the `{version}` attribute.