### PR TITLE
[1.2] Use version attribute in beats doc (#3613)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/beat.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/beat.asciidoc
@@ -162,7 +162,7 @@ metadata:
   name: heartbeat-quickstart
 spec:
   type: heartbeat
-  version: 7.8.0
+  version: {version}
   elasticsearchRef:
     name: quickstart
   configRef:


### PR DESCRIPTION
Backports the following commits to 1.2:

- Use version attribute in beats doc (#3613)