### PR TITLE
[1.2] Use eksctl AMIs auto resolver (#3314)(#3316)

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -89,7 +89,7 @@ plans:
   eks:
     region: eu-central-1
     nodeCount: 3
-    nodeAMI: static
+    nodeAMI: auto
     diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
 - id: eks-dev
   operation: create

--- a/hack/deployer/runner/eks.go
+++ b/hack/deployer/runner/eks.go
@@ -35,7 +35,7 @@ nodeGroups:
   - name: ng-1
     instanceType: {{.MachineType}}
     desiredCapacity: {{.NodeCount}}
-    ami: static
+    ami: {{.NodeAMI}}
     iam:
       instanceProfileARN: {{.InstanceProfileARN}}
       instanceRoleARN: {{.InstanceRoleARN}}


### PR DESCRIPTION
Backports the following commits to 1.2:

- Use the NodeAMI variable when creating an EKS cluster (#3314)
- Use eksctl AMIs auto resolver (#3316)

Resolved https://github.com/elastic/cloud-on-k8s/issues/3196.