### PR TITLE
Add docs and manifests for network policies

### DIFF
--- a/docs/advanced-topics/advanced-topics.asciidoc
+++ b/docs/advanced-topics/advanced-topics.asciidoc
@@ -13,9 +13,11 @@ endif::[]
 - <<{p}-custom-images>>
 - <<{p}-service-meshes>>
 - <<{p}-traffic-splitting>>
+- <<{p}-network-policies>>
 --
 
 include::openshift.asciidoc[leveloffset=+1]
 include::custom-images.asciidoc[leveloffset=+1]
 include::service-meshes.asciidoc[leveloffset=+1]
 include::traffic-splitting.asciidoc[leveloffset=+1]
+include::network-policies.asciidoc[leveloffset=+1]

--- a/docs/advanced-topics/network-policies.asciidoc
+++ b/docs/advanced-topics/network-policies.asciidoc
@@ -1,0 +1,427 @@
+:page_id: network-policies
+ifdef::env-github[]
+****
+link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-{page_id}.html[View this document on the Elastic website]
+****
+endif::[]
+
+:api_server_port: 443
+:apm_port: 8200
+:dns_port: 53
+:ent_port: 3002
+:es_http_port: 9200
+:es_transport_port: 9300
+:kb_port: 5601
+:webhook_port: 9443
+
+
+[id="{p}-{page_id}"]
+= Network policies
+
+link:https://kubernetes.io/docs/concepts/services-networking/network-policies/[Network policies] allow you to isolate pods by restricting incoming and outgoing network connections to a trusted set of sources and destinations. This section describes how to use network policies to isolate the ECK operator and the {stack} applications to a set of namespaces to implement a form of soft multi-tenancy. Soft multi-tenancy is a term used to describe a scenario where a group of trusted users (different teams within an organization, for example) share a single resource such as a Kubernetes cluster. Note that network policies alone are not sufficient for security. You should complement them with strict RBAC policies, resource quotas, node taints, and other available security mechanisms to ensure that tenants cannot access, modify, or disrupt resources belonging to each other.
+
+NOTE: There are several efforts to support multi-tenancy on Kubernetes, including the link:https://github.com/kubernetes-sigs/multi-tenancy[official working group for multi-tenancy] and community extensions such as link:https://loft.sh[loft] and link:https://github.com/kiosk-sh/kiosk[kiosk], that can make configuration and management easier. You may still need to employ network policies such the ones described below to have fine-grained control over {stack} applications deployed by your tenants.
+
+
+The following sections assume that the operator is installed in the `elastic-system` namespace with the <<{p}-operator-config,`namespaces` configuration>> set to `team-a,team-b`. Each namespace is expected to be labelled as follows:
+
+[source,sh]
+----
+kubectl label namespace elastic-system eck.k8s.elastic.co/operator-name=elastic-operator
+kubectl label namespace team-a eck.k8s.elastic.co/tenant=team-a
+kubectl label namespace team-b eck.k8s.elastic.co/tenant=team-b
+----
+
+
+
+[float]
+[id="{p}-{page_id}-operator-isolation"]
+== Isolating the operator
+
+The minimal set of permissions required are as follows:
+
+[cols="h,1"]
+|===
+| Egress (outgoing)  a|
+
+* TCP port {api_server_port} of the Kubernetes API server.
+* UDP port {dns_port} for DNS lookup.
+* TCP port {es_http_port} of {es} nodes on managed namespace.
+
+| Ingress (incoming) a|
+
+* TCP port {webhook_port} for webhook requests from the Kubernetes API server.
+
+|===
+
+
+Assuming that the Kubernetes API server IP address is `10.0.0.1`, the following network policy implements the rules above.
+
+NOTE: Run `kubectl cluster-info | grep master` to obtain the API server IP address for your cluster.
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: elastic-operator
+  namespace: elastic-system
+spec:
+  egress:
+  - ports:
+    - port: {dns_port}
+      protocol: UDP
+  - ports:
+    - port: {api_server_port}
+      protocol: TCP
+    to:
+    - ipBlock:
+        cidr: 10.0.0.1/32
+  - ports:
+    - port: {es_http_port}
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchExpressions:
+        - key: eck.k8s.elastic.co/tenant
+          operator: In
+          values:
+          - team-a
+          - team-b
+      podSelector:
+        matchLabels:
+          common.k8s.elastic.co/type: elasticsearch
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 10.0.0.1/32
+    ports:
+    - port: {webhook_port}
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: elastic-operator
+----
+
+
+
+[float]
+[id="{p}-{page_id}-elasticsearch-isolation"]
+== Isolating {es}
+
+[cols="h,1"]
+|===
+| Egress (outgoing)  a|
+
+* TCP port {es_transport_port} to other {es} nodes in the namespace (transport port).
+* UDP port {dns_port} for DNS lookup.
+
+| Ingress (incoming) a|
+
+* TCP port {es_http_port} from the operator and other pods in the namespace.
+
+|===
+
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eck-elasticsearch
+  namespace: team-a
+spec:
+  egress:
+  - ports:
+    - port: {es_transport_port}
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          eck.k8s.elastic.co/tenant: team-a
+      podSelector:
+        matchLabels:
+          common.k8s.elastic.co/type: elasticsearch
+  - ports:
+    - port: {dns_port}
+      protocol: UDP
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          eck.k8s.elastic.co/operator-name: elastic-operator
+      podSelector:
+        matchLabels:
+          control-plane: elastic-operator
+    - namespaceSelector:
+        matchLabels:
+          eck.k8s.elastic.co/tenant: team-a
+    # [Optional] Allow ingress controller pods from the ingress-nginx namespace.
+    #- namespaceSelector:
+    #    matchLabels:
+    #      name: ingress-nginx
+    ports:
+    - port: {es_http_port}
+      protocol: TCP
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          eck.k8s.elastic.co/tenant: team-a
+      podSelector:
+        matchLabels:
+          common.k8s.elastic.co/type: elasticsearch
+    ports:
+    - port: {es_transport_port}
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      common.k8s.elastic.co/type: elasticsearch
+----
+
+
+
+[float]
+[id="{p}-{page_id}-kibana-isolation"]
+== Isolating {kib}
+
+
+[cols="h,1"]
+|===
+| Egress (outgoing)  a|
+
+* TCP port {es_http_port} to {es} nodes in the namespace.
+* UDP port {dns_port} for DNS lookup.
+
+| Ingress (incoming) a|
+
+* TCP port {kb_port} from other pods in the namespace.
+
+|===
+
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eck-kibana
+  namespace: team-a
+spec:
+  egress:
+  - ports:
+    - port: {es_http_port}
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          eck.k8s.elastic.co/tenant: team-a
+      podSelector:
+        matchLabels:
+          common.k8s.elastic.co/type: elasticsearch
+          # [Optional] Restrict to a single {es} cluster named hulk.
+          # elasticsearch.k8s.elastic.co/cluster-name=hulk
+  - ports:
+    - port: {dns_port}
+      protocol: UDP
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          eck.k8s.elastic.co/tenant: team-a
+    # [Optional] Allow ingress controller pods from the ingress-nginx namespace.
+    #- namespaceSelector:
+    #    matchLabels:
+    #      name: ingress-nginx
+    ports:
+    - port: {kb_port}
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      common.k8s.elastic.co/type: kibana
+----
+
+
+[float]
+[id="{p}-{page_id}-apm-server-isolation"]
+== Isolating APM Server
+
+
+[cols="h,1"]
+|===
+| Egress (outgoing)  a|
+
+* TCP port {es_http_port} to {es} nodes in the namespace.
+* TCP port {kb_port} to {kib} instances in the namespace.
+* UDP port {dns_port} for DNS lookup.
+
+| Ingress (incoming) a|
+
+* TCP port {apm_port} from other pods in the namespace.
+
+|===
+
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eck-apm-server
+  namespace: team-a
+spec:
+  egress:
+  - ports:
+    - port: {es_http_port}
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          eck.k8s.elastic.co/tenant: team-a
+      podSelector:
+        matchLabels:
+          common.k8s.elastic.co/type: elasticsearch
+  - ports:
+    - port: {kb_port}
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          eck.k8s.elastic.co/tenant: team-a
+      podSelector:
+        matchLabels:
+          common.k8s.elastic.co/type: kibana
+  - ports:
+    - port: {dns_port}
+      protocol: UDP
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          eck.k8s.elastic.co/tenant: team-a
+    # [Optional] Allow ingress controller pods from the ingress-nginx namespace.
+    #- namespaceSelector:
+    #    matchLabels:
+    #      name: ingress-nginx
+    ports:
+    - port: {apm_port}
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      common.k8s.elastic.co/type: apm-server
+----
+
+
+[float]
+[id="{p}-{page_id}-enterprise-search-isolation"]
+== Isolating Enterprise Search
+
+
+[cols="h,1"]
+|===
+| Egress (outgoing)  a|
+
+* TCP port {es_http_port} to {es} nodes in the namespace.
+* UDP port {dns_port} for DNS lookup.
+
+| Ingress (incoming) a|
+
+* TCP port {ent_port} from other pods in the namespace.
+
+|===
+
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eck-enterprise-search
+  namespace: team-a
+spec:
+  egress:
+  - ports:
+    - port: {es_http_port}
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          eck.k8s.elastic.co/tenant: team-a
+      podSelector:
+        matchLabels:
+          common.k8s.elastic.co/type: elasticsearch
+  - ports:
+    - port: {dns_port}
+      protocol: UDP
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          eck.k8s.elastic.co/tenant: team-a
+    # [Optional] Allow ingress controller pods from the ingress-nginx namespace.
+    #- namespaceSelector:
+    #    matchLabels:
+    #      name: ingress-nginx
+    ports:
+    - port: {ent_port}
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      common.k8s.elastic.co/type: enterprise-search
+----
+
+
+[float]
+[id="{p}-{page_id}-beats-isolation"]
+== Isolating {beats}
+
+
+NOTE: Some {beats} may require additional access rules than what is listed here. For example, {heartbeat} will require a rule to allow access to the endpoint it is monitoring.
+
+
+[cols="h,1"]
+|===
+| Egress (outgoing)  a|
+
+* TCP port {es_http_port} to {es} nodes in the namespace.
+* TCP port {kb_port} to {kib} instances in the namespace.
+* UDP port {dns_port} for DNS lookup.
+
+|===
+
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eck-beats
+  namespace: team-a
+spec:
+  egress:
+  - ports:
+    - port: {es_http_port}
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          eck.k8s.elastic.co/tenant: team-a
+      podSelector:
+        matchLabels:
+          common.k8s.elastic.co/type: elasticsearch
+  - ports:
+    - port: {kb_port}
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          eck.k8s.elastic.co/tenant: team-a
+      podSelector:
+        matchLabels:
+          common.k8s.elastic.co/type: kibana
+  - ports:
+    - port: {dns_port}
+      protocol: UDP
+  podSelector:
+    matchLabels:
+      common.k8s.elastic.co/type: beat
+----

--- a/hack/manifest-gen/assets/charts/eck/profile-restricted.yaml
+++ b/hack/manifest-gen/assets/charts/eck/profile-restricted.yaml
@@ -5,6 +5,3 @@ config:
 
   webhook:
     enabled: false
-
-  beat:
-    manageAutoDiscoverRBAC: false

--- a/hack/manifest-gen/assets/charts/eck/profile-soft-multi-tenancy.yaml
+++ b/hack/manifest-gen/assets/charts/eck/profile-soft-multi-tenancy.yaml
@@ -1,0 +1,13 @@
+config:
+  createClusterScopedResources: true
+
+  managedNamespaces: ["team-a", "team-b"]
+
+  refs:
+    enforceRBAC: true
+
+  webhook:
+    enabled: true
+
+  softMultiTenancy:
+    enabled: true

--- a/hack/manifest-gen/assets/charts/eck/templates/configmap.yaml
+++ b/hack/manifest-gen/assets/charts/eck/templates/configmap.yaml
@@ -32,6 +32,3 @@ data:
     {{- if .Values.config.managedNamespaces }}
     namespaces: [{{ join "," .Values.config.managedNamespaces  }}]
     {{- end }}
-    {{- if not .Values.config.beat.manageAutoDiscoverRBAC }}
-    manage-beat-autodiscover-rbac: false
-    {{- end }}

--- a/hack/manifest-gen/assets/charts/eck/templates/managed-namespaces.yaml
+++ b/hack/manifest-gen/assets/charts/eck/templates/managed-namespaces.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.config.softMultiTenancy.enabled -}}
+{{- range .Values.config.managedNamespaces }}
+{{- $namespace := . }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ $namespace }}
+  labels:
+    eck.k8s.elastic.co/tenant: {{ $namespace }}
+{{- end -}}
+{{- end -}}

--- a/hack/manifest-gen/assets/charts/eck/templates/managed-ns-network-policy.yaml
+++ b/hack/manifest-gen/assets/charts/eck/templates/managed-ns-network-policy.yaml
@@ -1,0 +1,216 @@
+{{- if .Values.config.softMultiTenancy.enabled -}}
+{{- range .Values.config.managedNamespaces -}}
+{{- $namespace := . }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eck-elasticsearch
+  namespace: {{ $namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      common.k8s.elastic.co/type: "elasticsearch"
+  egress:
+    # Transport port
+    - ports:
+        - port: 9300
+      to:
+        # Elasticsearch within namespace
+        - namespaceSelector:
+            matchLabels:
+              eck.k8s.elastic.co/tenant: {{ $namespace }}
+          podSelector:
+            matchLabels:
+              common.k8s.elastic.co/type: "elasticsearch"
+    # DNS
+    - ports:
+      - port: 53
+        protocol: UDP
+      to: []
+  ingress:
+    # HTTP Port
+    - ports:
+        - port: 9200
+      from:
+        # Operator
+        - namespaceSelector:
+            matchLabels:
+              eck.k8s.elastic.co/operator-name: "{{ $.Values.operator.name }}"
+          podSelector:
+            matchLabels:
+            {{- toYaml $.Values.operator.selectorLabels | nindent 14 }}
+        # Within namespace
+        - namespaceSelector:
+            matchLabels:
+              eck.k8s.elastic.co/tenant: {{ $namespace }}
+    # Transport port
+    - ports:
+        - port: 9300
+      from:
+        # Within namespace (from other Elasticsearch nodes)
+        - namespaceSelector:
+            matchLabels:
+              eck.k8s.elastic.co/tenant: {{ $namespace }}
+          podSelector:
+            matchLabels:
+              common.k8s.elastic.co/type: "elasticsearch"
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eck-kibana
+  namespace: {{ $namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      common.k8s.elastic.co/type: "kibana"
+  egress:
+    # Elasticsearch HTTP port
+    - ports:
+        - port: 9200
+      to:
+        # Elasticsearch within namespace
+        - namespaceSelector:
+            matchLabels:
+              eck.k8s.elastic.co/tenant: {{ $namespace }}
+          podSelector:
+            matchLabels:
+              common.k8s.elastic.co/type: "elasticsearch"
+    # DNS
+    - ports:
+      - port: 53
+        protocol: UDP
+      to: []
+  ingress:
+    # HTTP Port
+    - ports:
+        - port: 5601
+      from:
+        # Within namespace
+        - namespaceSelector:
+            matchLabels:
+              eck.k8s.elastic.co/tenant: {{ $namespace }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eck-apm-server
+  namespace: {{ $namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      common.k8s.elastic.co/type: "apm-server"
+  egress:
+    # Elasticsearch HTTP port
+    - ports:
+        - port: 9200
+      to:
+        # Elasticsearch within namespace
+        - namespaceSelector:
+            matchLabels:
+              eck.k8s.elastic.co/tenant: {{ $namespace }}
+          podSelector:
+            matchLabels:
+              common.k8s.elastic.co/type: "elasticsearch"
+    # Kibana HTTP port
+    - ports:
+        - port: 5601
+      to:
+        # Kibana within namespace
+        - namespaceSelector:
+            matchLabels:
+              eck.k8s.elastic.co/tenant: {{ $namespace }}
+          podSelector:
+            matchLabels:
+              common.k8s.elastic.co/type: "kibana"
+    # DNS
+    - ports:
+      - port: 53
+        protocol: UDP
+      to: []
+  ingress:
+    # HTTP Port
+    - ports:
+        - port: 8200
+      from:
+        # Within namespace
+        - namespaceSelector:
+            matchLabels:
+              eck.k8s.elastic.co/tenant: {{ $namespace }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eck-enterprise-search
+  namespace: {{ $namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      common.k8s.elastic.co/type: "enterprise-search"
+  egress:
+    # Elasticsearch HTTP port
+    - ports:
+        - port: 9200
+      to:
+        # Elasticsearch within namespace
+        - namespaceSelector:
+            matchLabels:
+              eck.k8s.elastic.co/tenant: {{ $namespace }}
+          podSelector:
+            matchLabels:
+              common.k8s.elastic.co/type: "elasticsearch"
+    # DNS
+    - ports:
+      - port: 53
+        protocol: UDP
+      to: []
+  ingress:
+    # HTTP Port
+    - ports:
+        - port: 3002
+      from:
+        # Within namespace
+        - namespaceSelector:
+            matchLabels:
+              eck.k8s.elastic.co/tenant: {{ $namespace }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eck-beats
+  namespace: {{ $namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      common.k8s.elastic.co/type: "beat"
+  egress:
+    # Elasticsearch HTTP port
+    - ports:
+        - port: 9200
+      to:
+        # Elasticsearch within namespace
+        - namespaceSelector:
+            matchLabels:
+              eck.k8s.elastic.co/tenant: {{ $namespace }}
+          podSelector:
+            matchLabels:
+              common.k8s.elastic.co/type: "elasticsearch"
+    # Kibana HTTP port
+    - ports:
+        - port: 5601
+      to:
+        # Kibana within namespace
+        - namespaceSelector:
+            matchLabels:
+              eck.k8s.elastic.co/tenant: {{ $namespace }}
+          podSelector:
+            matchLabels:
+              common.k8s.elastic.co/type: "kibana"
+    # DNS
+    - ports:
+      - port: 53
+        protocol: UDP
+      to: []
+{{- end }}
+{{- end -}}

--- a/hack/manifest-gen/assets/charts/eck/templates/managed-ns-role-bindings.yaml
+++ b/hack/manifest-gen/assets/charts/eck/templates/managed-ns-role-bindings.yaml
@@ -1,6 +1,6 @@
+{{- if not .Values.config.createClusterScopedResources }}
 {{- range .Values.config.managedNamespaces }}
 {{- $namespace := . }}
-{{- if not $.Values.config.createClusterScopedResources }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -9,7 +9,6 @@ metadata:
   namespace: {{ $namespace }}
 rules:
 {{ template "rbac.rules" . | toYaml | indent 2 }}
-{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -19,21 +18,6 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{- if $.Values.config.createClusterScopedResources }} ClusterRole {{- else }} Role {{- end }}
-  name: {{ $.Values.operator.name }}
-subjects:
-- kind: ServiceAccount
-  name: {{ $.Values.operator.name }}
-  namespace: {{ $.Values.operator.namespace }}
-{{- else }}
-{{- if $.Values.config.createClusterScopedResources }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ $.Values.operator.name }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
   name: {{ $.Values.operator.name }}
 subjects:
 - kind: ServiceAccount

--- a/hack/manifest-gen/assets/charts/eck/templates/operator-namespace.yaml
+++ b/hack/manifest-gen/assets/charts/eck/templates/operator-namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.operator.namespace }}
+  labels:
+    eck.k8s.elastic.co/operator-name: {{ .Values.operator.name }}

--- a/hack/manifest-gen/assets/charts/eck/templates/operator-network-policy.yaml
+++ b/hack/manifest-gen/assets/charts/eck/templates/operator-network-policy.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.config.softMultiTenancy.enabled -}}
+{{- $kubeAPIServerIP := (required "kubeAPIServerIP is required" .Values.config.kubeAPIServerIP) -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Values.operator.name }}
+  namespace: {{ .Values.operator.namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- toYaml .Values.operator.selectorLabels | nindent 6 }}
+  egress:
+    # DNS
+    - ports:
+      - port: 53
+        protocol: UDP
+      to: []
+    # API server
+    - ports:
+        - port: 443
+      to:
+        - ipBlock:
+            cidr: "{{ $kubeAPIServerIP }}/32"
+    # Elasticsearch
+    - ports:
+        - port: 9200
+      to:
+        - namespaceSelector:
+            matchExpressions:
+              - key: "eck.k8s.elastic.co/tenant"
+                operator: In
+                values:
+                {{- range .Values.config.managedNamespaces }}
+                  - {{ . }}
+                {{- end }}
+          podSelector:
+            matchLabels:
+              common.k8s.elastic.co/type: "elasticsearch"
+{{- if or .Values.config.webhook.enabled (gt .Values.config.metricsPort 0.0) }}
+  ingress:
+{{- if .Values.config.webhook.enabled }}
+    - ports:
+        - port: 9443
+      from:
+        - ipBlock:
+            cidr: "{{ $kubeAPIServerIP }}/32"
+{{- end }}
+{{- if gt .Values.config.metricsPort 0.0 }}
+    # Metrics
+    - ports:
+        - port: {{ .Values.config.metricsPort }}
+      from: []
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/hack/manifest-gen/assets/charts/eck/templates/operator-role-binding.yaml
+++ b/hack/manifest-gen/assets/charts/eck/templates/operator-role-binding.yaml
@@ -2,13 +2,15 @@
 {{- if not $operatorNSIsManaged -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: {{- if $.Values.config.createClusterScopedResources }} ClusterRoleBinding {{- else }} RoleBinding {{- end }}
 metadata:
   name: {{ .Values.operator.name }}
+{{- if not $.Values.config.createClusterScopedResources }}
   namespace: {{ .Values.operator.namespace }}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: {{- if $.Values.config.createClusterScopedResources }} ClusterRole {{- else }} Role {{- end }}
   name: {{ .Values.operator.name }}
 subjects:
 - kind: ServiceAccount

--- a/hack/manifest-gen/assets/charts/eck/templates/validate-soft-multi-tenancy.yaml
+++ b/hack/manifest-gen/assets/charts/eck/templates/validate-soft-multi-tenancy.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.config.softMultiTenancy.enabled -}}
+  {{- if has .Values.operator.namespace .Values.config.managedNamespaces -}}
+  {{- fail "Operator namespace cannot be in managed namespaces when soft multi-tenancy is enabled" -}}
+  {{- end -}}
+
+  {{- if empty .Values.config.managedNamespaces -}}
+  {{- fail "Managed namespaces must be defined when soft multi-tenancy is enabled" -}}
+  {{- end -}}
+
+  {{- if empty .Values.config.kubeAPIServerIP -}}
+  {{- fail "Soft multi-tenancy requires kubeAPIServerIP to be defined" -}}
+  {{- end -}}
+{{- end -}}

--- a/hack/manifest-gen/assets/charts/eck/values.yaml
+++ b/hack/manifest-gen/assets/charts/eck/values.yaml
@@ -58,8 +58,11 @@ config:
     manageCerts: true
     name: elastic-webhook.k8s.elastic.co
     serviceName: elastic-webhook-server
+    failurePolicy: Ignore
 
-  beat:
-    manageAutoDiscoverRBAC: true
+  softMultiTenancy:
+    enabled: false
+
+  kubeAPIServerIP: null
 
   setDefaultSecurityContext: true


### PR DESCRIPTION
- Adds a document describing how to use network policies to isolate the operator and each of the supported applications
- Adds a new `soft-multi-tenancy` profile to the manifest generator (`./manifest-gen.sh -g --profile=soft-multi-tenancy --set=config.kubeAPIServerIP=$KUBE_API_IP | k apply -f -`)

Preview: https://cloud-on-k8s_3634.docs-preview.app.elstc.co/guide/en/cloud-on-k8s/master/k8s-network-policies.html

Fixes #3481