### PR TITLE
Hide development-mode flags

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -214,9 +214,14 @@ func Command() *cobra.Command {
 		"Name of the Kubernetes ValidatingWebhookConfiguration resource. Only used when enable-webhook is true.",
 	)
 
-	logconf.BindFlags(cmd.Flags())
+	// hide development mode flags from the usage message
+	_ = cmd.Flags().MarkHidden(operator.AutoPortForwardFlag)
+	_ = cmd.Flags().MarkHidden(operator.DebugHTTPListenFlag)
 
+	// configure filename auto-completion for the config flag
 	_ = cmd.MarkFlagFilename(operator.ConfigFlag)
+
+	logconf.BindFlags(cmd.Flags())
 
 	return cmd
 }

--- a/dev-setup.md
+++ b/dev-setup.md
@@ -89,6 +89,15 @@ ECK is instrumented with Elastic APM tracing. To run ECK locally with tracing en
 ENABLE_TRACING=true ELASTIC_APM_SERVER_URL=https://<apm-server-url> ELASTIC_APM_SECRET_TOKEN=<token> ELASTIC_APM_VERIFY_SERVER_CERT=false make run
 ```
 
+### Development mode
+
+Starting the operator with the `--development` flag enables the development mode. The following set of flags become available for use in this mode.
+
+| Flag | Description |
+| ---- | ----------- |
+| `auto-port-forward` | Allows the operator to be run locally (outside of a Kubernetes cluster) by port-forwarding to the remote cluster. |
+| `debug-http-listen` | Address to start the debug server which provides access to pprof endpoints. Default is `localhost:6060`. |
+
 ## Recommended reading
 
 * [Resources](https://book.kubebuilder.io/basics/what_is_a_resource.html)

--- a/docs/operating-eck/operator-config.asciidoc
+++ b/docs/operating-eck/operator-config.asciidoc
@@ -13,15 +13,12 @@ ECK can be configured using either command line flags or environment variables.
 [width="100%",cols=".^35m,.^25m,.^40d",options="header"]
 |===
 |Flag |Default|Description
-|auto-port-forward |false |Enables automatic port forwarding to allow running the operator outside the cluster. For dev use only as it exposes k8s resources on ephemeral ports to localhost.
 |ca-cert-rotate-before |24h |Duration representing how long before expiration CA certificates should be re-issued.
 |ca-cert-validity |8760h |Duration representing the validity period of a generated CA certificate.
 |cert-rotate-before |24h |Duration representing how long before expiration TLS certificates should be re-issued.
 |cert-validity |8760h |Duration representing the validity period of a generated TLS certificate.
 |config |"" | Path to a file containing the operator configuration.
 |container-registry |docker.elastic.co | Container registry to use for pulling Elastic Stack container images.
-|debug-http-listen |localhost:6060 |Listen address for the debug HTTP server. Only available in development mode.
-|development |false |Enable development mode. Only available as a CLI flag.
 |disable-config-watch| false| Watch the configuration file for changes and restart to apply them. Only effective when the `--config` flag is used to set the configuration file.
 |enable-tracing | false | Enable APM tracing in the operator process. Use environment variables to configure APM server URL, credentials, and so on. See link:https://www.elastic.co/guide/en/apm/agent/go/1.x/configuration.html[Apm Go Agent reference] for details.
 |enable-webhook | false | Enables a validating webhook server in the operator process.


### PR DESCRIPTION
Development mode flags should not be documented as we do not expect/want them to used by end users. We have had at least one case of a user trying to set a development mode flag because it was documented in the operator configuration page.



