### PR TITLE
Bump test versions after 7.9 release

### DIFF
--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
                 )}"""
             }
             parallel {
-                stage("7.9.0-SNAPSHOT") {
+                stage("7.10.0-SNAPSHOT") {
                      agent {
                         label 'linux'
                     }

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -134,6 +134,17 @@ pipeline {
                         }
                     }
                 }
+                stage("7.9.0") {
+                    agent {
+                        label 'linux'
+                    }
+                    steps {
+                        unstash "source"
+                        script {
+                            runWith(lib, failedTests, "eck-79-${BUILD_NUMBER}-e2e", "7.9.0")
+                        }
+                    }
+                }
             }
         }
     }
@@ -172,7 +183,8 @@ pipeline {
                     "eck-75-${BUILD_NUMBER}-e2e",
                     "eck-76-${BUILD_NUMBER}-e2e",
                     "eck-77-${BUILD_NUMBER}-e2e",
-                    "eck-78-${BUILD_NUMBER}-e2e"
+                    "eck-78-${BUILD_NUMBER}-e2e",
+                    "eck-79-${BUILD_NUMBER}-e2e"
                 ]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',

--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -16,7 +16,7 @@ const (
 	// Minimum version for 6.8.x tested with the operator
 	MinVersion68x = "6.8.10"
 	// Current latest version for 7.x
-	LatestVersion7x = "7.8.1" // version to synchronize with the latest release of the Elastic Stack
+	LatestVersion7x = "7.9.0" // version to synchronize with the latest release of the Elastic Stack
 )
 
 // SkipInvalidUpgrade skips a test that would do an invalid upgrade.


### PR DESCRIPTION
Adjusts the max 7.x version and the SNAPSHOT version we test against.