### PR TITLE
Update OCP deployer env vars

### DIFF
--- a/hack/deployer/README.md
+++ b/hack/deployer/README.md
@@ -28,6 +28,15 @@ Deployer is the provisioning tool that aims to be the interface to multiple Kube
     make switch-aks bootstrap-cloud
     ```
 
+* OpenShift
+
+  * Set `VAULT_ADDR` and `GITHUB_TOKEN` appropriately
+  * Run from the [project root](/):
+
+    ```bash
+    make switch-ocp bootstrap-cloud
+    ```
+
 ### Deprovision
 
 ```bash

--- a/hack/deployer/cmd/create.go
+++ b/hack/deployer/cmd/create.go
@@ -65,7 +65,11 @@ func CreateCommand() *cobra.Command {
 					return err
 				}
 
-				data := fmt.Sprintf(runner.DefaultOcpRunConfigTemplate, user, gCloudProject, pullSecret)
+				// optional variables for local dev use
+				token, _ := os.LookupEnv("GITHUB_TOKEN")
+				vaultAddr, _ := os.LookupEnv("VAULT_ADDR")
+
+				data := fmt.Sprintf(runner.DefaultOcpRunConfigTemplate, user, gCloudProject, pullSecret, vaultAddr, token)
 				fullPath := path.Join(filePath, runner.OcpConfigFileName)
 				if err := ioutil.WriteFile(fullPath, []byte(data), 0600); err != nil {
 					return err

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -6,6 +6,7 @@ package runner
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -27,6 +28,9 @@ overrides:
   ocp:
     gCloudProject: %s
     pullSecret: '%s'
+  vaultInfo:
+    address: '%s'
+    token: '%s'
 `
 
 	OcpInstallerConfigTemplate = `apiVersion: v1
@@ -182,10 +186,12 @@ func (d *OcpDriver) Execute() error {
 }
 
 func (d *OcpDriver) auth() error {
-
 	if d.plan.ServiceAccount {
-		log.Println("Authenticating as service account...")
+		if d.plan.VaultInfo == nil {
+			return errors.New("Vault auth info is required")
+		}
 
+		log.Println("Authenticating as service account...")
 		client, err := NewClient(*d.plan.VaultInfo)
 		if err != nil {
 			return err

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -188,7 +188,7 @@ func (d *OcpDriver) Execute() error {
 func (d *OcpDriver) auth() error {
 	if d.plan.ServiceAccount {
 		if d.plan.VaultInfo == nil {
-			return errors.New("Vault auth info is required")
+			return errors.New("vault auth info is required")
 		}
 
 		log.Println("Authenticating as service account...")


### PR DESCRIPTION
We ran into some trouble setting @liladler up with an OpenShift cluster. `make switch-ocp bootstrap-cloud` was not using the env vars to populate the config file, even though the default plan requires it. This adds those settings (and fixes a nil ref panic if you don't have those settings). I think maybe the rest of us just created the `deployer-config-ocp.yml` manually?

I also wonder if we want to mark `OCP_PULL_SECRET` as optional (similar to how I set the Vault vars in this PR). Right now it is required even though I just have it set to empty and it works. Let me know what you think and I can update this PR to either change it to optional or update the readme to indicate it's required.

It's also possible I'm totally misunderstanding how this should be working.