### PR TITLE
Fix typo in advanced-node-scheduling.asciidoc

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
@@ -67,7 +67,7 @@ metadata:
   name: quickstart
 spec:
   version: {version}
-  nodesSets:
+  nodeSets:
   - name: default
     count: 3
     podTemplate:


### PR DESCRIPTION
Fix typo, remove extra 's' - `nodesSets` should be `nodeSets`