### PR TITLE
Add additional k8s deps to renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,10 @@
       "packageNames": [
         "k8s.io/apimachinery",
         "k8s.io/client-go",
-        "k8s.io/api"
+        "k8s.io/api",
+        "k8s.io/cli-runtime",
+        "k8s.io/apiextensions-apiserver",
+        "k8s.io/kubectl"
       ],
       "updateTypes": [
         "major",
@@ -21,7 +24,10 @@
       "packageNames": [
         "k8s.io/apimachinery",
         "k8s.io/client-go",
-        "k8s.io/api"
+        "k8s.io/api",
+        "k8s.io/cli-runtime",
+        "k8s.io/apiextensions-apiserver",
+        "k8s.io/kubectl"
       ],
       "updateTypes": [
         "patch"


### PR DESCRIPTION
We added some more k8s deps. This adds them to the renovate k8s group so a) the PRs are only for patch versions b) the k8s PRs are grouped together