### PR TITLE
Fix incorrect snapshot version for 7.10.0-SNAPSHOT test

### DIFF
--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-7x-snapshot-${BUILD_NUMBER}-e2e", "7.9.0-SNAPSHOT")
+                            runWith(lib, failedTests, "eck-7x-snapshot-${BUILD_NUMBER}-e2e", "7.10.0-SNAPSHOT")
                         }
                     }
                 }


### PR DESCRIPTION
The 7.10.0-SNAPSHOT pipeline was in fact still testing a 7.9.0-SNAPSHOT. I am not sure if this is related to the recent test failure in https://devops-ci.elastic.co/job/cloud-on-k8s-e2e-tests-snapshot-versions/129/ but it is certainly worth making sure we are actually testing the version we want to test before investigating further. 
