### PR TITLE
Workaround azure-cli cluster creation bug

### DIFF
--- a/hack/deployer/runner/aks.go
+++ b/hack/deployer/runner/aks.go
@@ -148,7 +148,19 @@ func (d *AksDriver) clusterExists() (bool, error) {
 	return err == nil, err
 }
 
+// workaroundAzureCliBug works around a cluster creation bug in azure-cli 2.11.0
+// see https://github.com/Azure/azure-cli/issues/14915.
+func (d *AksDriver) workaroundAzureCliBug() error {
+	cmd := "az extension add --name aks-preview"
+	return NewCommand(cmd).Run()
+}
+
 func (d *AksDriver) create() error {
+	// TODO: remove once https://github.com/Azure/azure-cli/issues/14915 is fixed in azure-cli
+	if err := d.workaroundAzureCliBug(); err != nil {
+		return err
+	}
+
 	log.Print("Creating cluster...")
 
 	servicePrincipal := ""


### PR DESCRIPTION
Azure-cli 2.11.0 fails to create any cluster with the following error:

```
Property id '' at path 'properties.diskEncryptionSetID' is invalid. Expect fully qualified resource Id that start with '/subscriptions/{subscriptionId}' or '/providers/{resourceProviderNamespace}/'.
```

The bug is fixed upsream, but not released yet.
A workaround is to install the preview cli extension with

```
az extension add --name aks-preview
```

See https://github.com/Azure/azure-cli-extensions/issues/1187 for more details.

This commit should be reverted once a bugfixed azure-cli is released.

Relates https://github.com/elastic/cloud-on-k8s/issues/3671.