### PR TITLE
Skip Enterprise Search 7.9.0 E2E tests on OCP

### DIFF
--- a/test/e2e/ent/ent_test.go
+++ b/test/e2e/ent/ent_test.go
@@ -63,10 +63,6 @@ func TestEnterpriseSearchVersionUpgradeToLatest7x(t *testing.T) {
 		WithVersion(srcVersion).
 		WithRestrictedSecurityContext()
 
-	if ent.SkipTest() {
-		t.SkipNow() // invalid version
-	}
-
 	entUpgraded := ent.WithVersion(dstVersion).WithMutatedFrom(&ent)
 
 	// During the version upgrade, the operator will toggle Enterprise Search read-only mode.

--- a/test/e2e/test/enterprisesearch/builder.go
+++ b/test/e2e/test/enterprisesearch/builder.go
@@ -31,17 +31,13 @@ type Builder struct {
 
 var _ test.Builder = Builder{}
 
+// SkipTest returns true if the version is not at least 7.7.0, or if the version is incompatible with Openshift.
 func (b Builder) SkipTest() bool {
-	// no Enterprise Search before 7.7.0
-	testVersion := version.MustParse(test.Ctx().ElasticStackVersion)
-	if !testVersion.IsSameOrAfter(minVersion) {
-		return true
-	}
-	// 7.9.0 is incompatible with OCP environments
-	if testVersion.IsSame(ocpIncompatibleVersion) && test.Ctx().OcpCluster {
-		return true
-	}
-	return false
+	v := version.MustParse(b.EnterpriseSearch.Spec.Version)
+	// skip if not at least 7.0
+	return !v.IsSameOrAfter(minVersion) ||
+		// or running 7.9.0 on Openshift
+		(test.Ctx().OcpCluster && v.IsSame(ocpIncompatibleVersion))
 }
 
 func NewBuilder(name string) Builder {

--- a/test/e2e/test/run.go
+++ b/test/e2e/test/run.go
@@ -4,15 +4,30 @@
 
 package test
 
+import "testing"
+
+func shouldSkipTest(builders ...Builder) bool {
+	for _, b := range builders {
+		// ignore the test if some builders cannot be tested
+		if b.SkipTest() {
+			return true
+		}
+	}
+	return false
+}
+
+func skipIfIncompatibleBuilders(t *testing.T, builders ...Builder) {
+	if shouldSkipTest(builders...) {
+		t.Skip("Skipping test due to an incompatible builder")
+	}
+}
+
 // Sequence returns a list of steps corresponding to the basic workflow (some optional init steps, then init steps,
 // create steps, check steps, then something and delete steps to terminate).
 func Sequence(before StepsFunc, f StepsFunc, builders ...Builder) StepList {
 	steps := StepList{}
-	for _, b := range builders {
-		// ignore the test if some builders cannot be tested
-		if b.SkipTest() {
-			return steps
-		}
+	if shouldSkipTest(builders...){
+		return steps
 	}
 
 	k := NewK8sClientOrFatal()
@@ -45,11 +60,8 @@ func Sequence(before StepsFunc, f StepsFunc, builders ...Builder) StepList {
 // before and after builder workflow (before steps, init, create, checks, deletes, after steps)
 func BeforeAfterSequence(before StepsFunc, after StepsFunc, builders ...Builder) StepList {
 	steps := StepList{}
-	for _, b := range builders {
-		// ignore the test if some builders cannot be tested
-		if b.SkipTest() {
-			return steps
-		}
+	if shouldSkipTest(builders...){
+		return steps
 	}
 
 	k := NewK8sClientOrFatal()

--- a/test/e2e/test/run.go
+++ b/test/e2e/test/run.go
@@ -26,7 +26,7 @@ func skipIfIncompatibleBuilders(t *testing.T, builders ...Builder) {
 // create steps, check steps, then something and delete steps to terminate).
 func Sequence(before StepsFunc, f StepsFunc, builders ...Builder) StepList {
 	steps := StepList{}
-	if shouldSkipTest(builders...){
+	if shouldSkipTest(builders...) {
 		return steps
 	}
 
@@ -60,7 +60,7 @@ func Sequence(before StepsFunc, f StepsFunc, builders ...Builder) StepList {
 // before and after builder workflow (before steps, init, create, checks, deletes, after steps)
 func BeforeAfterSequence(before StepsFunc, after StepsFunc, builders ...Builder) StepList {
 	steps := StepList{}
-	if shouldSkipTest(builders...){
+	if shouldSkipTest(builders...) {
 		return steps
 	}
 

--- a/test/e2e/test/run_failure.go
+++ b/test/e2e/test/run_failure.go
@@ -25,6 +25,7 @@ func RunUnrecoverableFailureScenario(t *testing.T, failureSteps StepsFunc, build
 }
 
 func runFailureScenario(t *testing.T, recoverable bool, failureSteps StepsFunc, builders ...Builder) {
+	skipIfIncompatibleBuilders(t, builders...)
 	k := NewK8sClientOrFatal()
 
 	steps := StepList{}

--- a/test/e2e/test/run_mutation.go
+++ b/test/e2e/test/run_mutation.go
@@ -11,6 +11,7 @@ import (
 // RunMutations tests resources changes on given resources.
 // If the resource to mutate to is the same as the original resource, then all tests should still pass.
 func RunMutations(t *testing.T, creationBuilders []Builder, mutationBuilders []Builder) {
+	skipIfIncompatibleBuilders(t, append(creationBuilders, mutationBuilders...)...)
 	k := NewK8sClientOrFatal()
 	steps := StepList{}
 
@@ -38,6 +39,7 @@ func RunMutations(t *testing.T, creationBuilders []Builder, mutationBuilders []B
 }
 
 func RunMutationsWhileWatching(t *testing.T, creationBuilders []Builder, mutationBuilders []Builder, watchers []Watcher) {
+	skipIfIncompatibleBuilders(t, append(creationBuilders, mutationBuilders...)...)
 	k := NewK8sClientOrFatal()
 	steps := StepList{}
 

--- a/test/e2e/test/run_reversal.go
+++ b/test/e2e/test/run_reversal.go
@@ -17,6 +17,7 @@ type ReversalTestContext interface {
 // RunMutationReversal tests mutations that are either invalid or aborted mid way leading to a configuration reversal of
 // the original configuration.
 func RunMutationReversal(t *testing.T, creationBuilders []Builder, mutationBuilders []Builder) {
+	skipIfIncompatibleBuilders(t, append(creationBuilders, mutationBuilders...)...)
 	k := NewK8sClientOrFatal()
 	steps := StepList{}
 


### PR DESCRIPTION
Enterprise Search 7.9.0 fails to start on Openshift due to
file permission issues. See https://github.com/elastic/cloud-on-k8s/issues/3656.

Let's disable this test combination in our ocp e2e tests.