### PR TITLE
Add a bit more context in data integrity check errors

### DIFF
--- a/test/e2e/test/elasticsearch/checks_data.go
+++ b/test/e2e/test/elasticsearch/checks_data.go
@@ -106,7 +106,7 @@ func (dc *DataIntegrityCheck) Init() error {
 	}
 	resp, err = esClient.Request(context.Background(), indexCreation)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create index: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -122,7 +122,7 @@ func (dc *DataIntegrityCheck) Init() error {
 		}
 		resp, err = esClient.Request(context.Background(), r)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to index document %d/%d: %w", i, dc.docCount, err)
 		}
 		defer resp.Body.Close()
 	}


### PR DESCRIPTION
In order to investigate https://github.com/elastic/cloud-on-k8s/issues/3676,
this commit adds a bit more context to the api errors returned by Elasticsearch
in DataIntegrityCheck.Init().

The goal is to understand if there's a common pattern in these errors (eg. always
returned when the first document is indexed).
