### PR TITLE
Editing - Advanced node scheduling 

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
@@ -15,7 +15,7 @@ Elastic Cloud on Kubernetes (ECK) offers full control over Elasticsearch cluster
 * <<{p}-availability-zone-awareness,Availability zone and rack awareness>>
 * <<{p}-hot-warm-topologies,Hot-warm topologies>>
 
-These features can be combined together, to deploy a production-grade Elasticsearch cluster.
+You can combine these features to deploy a production-grade Elasticsearch cluster.
 
 [id="{p}-define-elasticsearch-nodes-roles"]
 == Define Elasticsearch nodes roles
@@ -53,7 +53,7 @@ spec:
 [id="{p}-affinity-options"]
 == Affinity options
 
-You can setup various link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity[affinity and anti-affinity options] through the `podTemplate` section of the Elasticsearch resource specification.
+You can set up various link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity[affinity and anti-affinity options] through the `podTemplate` section of the Elasticsearch resource specification.
 
 === A single Elasticsearch node per Kubernetes host (default)
 
@@ -83,9 +83,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
 ----
 
-This is ECK default behaviour if you don't specify any `affinity` option.
-
-To explicitly disable that behaviour, set an empty affinity object:
+This is ECK default behaviour if you don't specify any `affinity` option. To explicitly disable the default behaviour, set an empty affinity object:
 
 [source,yaml,subs="attributes"]
 ----
@@ -129,7 +127,7 @@ spec:
 
 === Local Persistent Volume constraints
 
-By default, volumes can be bound to a pod before the pod gets scheduled to a particular Kubernetes node. This can be a problem if the PersistentVolume can only be accessed from a particular host or set of hosts. Local persistent volumes are a good example: they are accessible from a single host. If the pod gets scheduled to a different host based on any affinity or anti-affinity rule, the volume may not be available.
+By default, volumes can be bound to a Pod before the Pod gets scheduled to a particular Kubernetes node. This can be a problem if the PersistentVolume can only be accessed from a particular host or set of hosts. Local persistent volumes are a good example: they are accessible from a single host. If the Pod gets scheduled to a different host based on any affinity or anti-affinity rule, the volume may not be available.
 
 To solve this problem, you can link:https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode[set the Volume Binding Mode] of the `StorageClass` you are using. Make sure  `volumeBindingMode: WaitForFirstConsumer` is set, link:https://kubernetes.io/docs/concepts/storage/volumes/#local[especially if you are using local persistent volumes].
 
@@ -146,7 +144,7 @@ volumeBindingMode: WaitForFirstConsumer
 === Node affinity
 
 To restrict the scheduling to a particular set of Kubernetes nodes based on labels, use a link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector[NodeSelector].
-The following example schedules Elasticsearch pods on Kubernetes nodes tagged with both labels `diskType: ssd` and `environment: production`.
+The following example schedules Elasticsearch Pods on Kubernetes nodes tagged with both labels `diskType: ssd` and `environment: production`.
 
 [source,yaml,subs="attributes"]
 ----
@@ -206,7 +204,7 @@ This example restricts Elasticsearch nodes so they are only scheduled on Kuberne
 [id="{p}-availability-zone-awareness"]
 == Availability zone awareness
 
-By combining link:https://www.elastic.co/guide/en/elasticsearch/reference/current/allocation-awareness.html#allocation-awareness[Elasticsearch shard allocation awareness] with link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature[Kubernetes node affinity], you can create an availability zone-aware Elasticsearch cluster. Note that by default ECK creates a `k8s_node_name` attribute with the name of the Kubernetes node running the pod, and configures Elasticsearch to use this attribute. This allows Elasticsearch to allocate primary and replica shards on different Kubernetes nodes, even if there are multiple Elasticsearch Pods on the same Kubernetes node. To preserve this behavior while also making Elasticsearch aware of the availability zone, include the `k8s_node_name` attribute in the comma-separated `cluster.routing.allocation.awareness.attributes` list:
+By combining link:https://www.elastic.co/guide/en/elasticsearch/reference/current/allocation-awareness.html#allocation-awareness[Elasticsearch shard allocation awareness] with link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature[Kubernetes node affinity], you can create an availability zone-aware Elasticsearch cluster. Note that by default ECK creates a `k8s_node_name` attribute with the name of the Kubernetes node running the Pod, and configures Elasticsearch to use this attribute. This allows Elasticsearch to allocate primary and replica shards on different Kubernetes nodes, even if there are multiple Elasticsearch Pods on the same Kubernetes node. To preserve this behavior while making Elasticsearch aware of the availability zone, include the `k8s_node_name` attribute in the comma-separated `cluster.routing.allocation.awareness.attributes` list:
 
 [source,yaml,subs="attributes"]
 ----
@@ -254,13 +252,13 @@ spec:
 This example relies on:
 
 - Kubernetes nodes in each zone being labeled accordingly. `failure-domain.beta.kubernetes.io/zone` link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#interlude-built-in-node-labels[is standard], but any label can be used.
-- node affinity for each group of nodes set to match the Kubernetes nodes' zone.
+- Node affinity for each group of nodes set to match the zone of Kubernetes nodes.
 - Elasticsearch configured to link:https://www.elastic.co/guide/en/elasticsearch/reference/current/allocation-awareness.html#allocation-awareness[allocate shards based on node attributes]. Here we specified `node.attr.zone`, but any attribute name can be used. `node.attr.rack_id` is another common example.
 
 [id="{p}-hot-warm-topologies"]
 == Hot-warm topologies
 
-By combining link:https://www.elastic.co/guide/en/elasticsearch/reference/current/allocation-awareness.html#allocation-awareness[Elasticsearch shard allocation awareness] with link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature[Kubernetes node affinity], you can setup an Elasticsearch cluster with hot-warm topology:
+By combining link:https://www.elastic.co/guide/en/elasticsearch/reference/current/allocation-awareness.html#allocation-awareness[Elasticsearch shard allocation awareness] with link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature[Kubernetes node affinity], you can set up an Elasticsearch cluster with hot-warm topology:
 
 [source,yaml,subs="attributes"]
 ----
@@ -339,9 +337,9 @@ spec:
 
 In this example, we configure two groups of Elasticsearch nodes:
 
-- the first group has the `data` attribute set to `hot`. It is intended to run on hosts with high CPU resources and fast IO (SSD). Here we restrict pods to be scheduled on Kubernetes nodes labeled with `beta.kubernetes.io/instance-type: highio` (to adapt to your Kubernetes nodes' labels).
-- the second group has the `data` attribute set to `warm`. It is intended to run on hosts with larger but maybe slower storage. Pods are only able to be scheduled on nodes labeled with `beta.kubernetes.io/instance-type: highstorage`.
+- The first group has the `data` attribute set to `hot`. It is intended to run on hosts with high CPU resources and fast IO (SSD). Pods can only be scheduled on Kubernetes nodes labeled with `beta.kubernetes.io/instance-type: highio` (to adapt to the labels of your Kubernetes nodes).
+- The second group has the `data` attribute set to `warm`. It is intended to run on hosts with larger but maybe slower storage. Pods can only be scheduled on nodes labeled with `beta.kubernetes.io/instance-type: highstorage`.
 
-NOTE: this example uses link:https://kubernetes.io/docs/concepts/storage/volumes/#local[Local Persistent Volumes] for both groups, but can be adapted to use high-performance volumes for `hot` Elasticsearch nodes and high-storage volumes for `warm` Elasticsearch nodes.
+NOTE: This example uses link:https://kubernetes.io/docs/concepts/storage/volumes/#local[Local Persistent Volumes] for both groups, but can be adapted to use high-performance volumes for `hot` Elasticsearch nodes and high-storage volumes for `warm` Elasticsearch nodes.
 
-Finally, setup link:https://www.elastic.co/guide/en/elasticsearch/reference/current/index-lifecycle-management.html[Index Lifecycle Management] policies on your indices, link:https://www.elastic.co/blog/implementing-hot-warm-cold-in-elasticsearch-with-index-lifecycle-management[optimizing for hot-warm architectures].
+Finally, set up link:https://www.elastic.co/guide/en/elasticsearch/reference/current/index-lifecycle-management.html[Index Lifecycle Management] policies on your indices, link:https://www.elastic.co/blog/implementing-hot-warm-cold-in-elasticsearch-with-index-lifecycle-management[optimizing for hot-warm architectures].


### PR DESCRIPTION
This PR suggests some edits, in particular:

- Capital letter after colon
- `setup` (noun) vs `set up` (verb)

Relates to [#63068](https://github.com/elastic/cloud/issues/63068)
