### PR TITLE
beat.TestVersionUpgradeToLatest7x: deploy a 3 nodes clusters to hold all the replicas

### DIFF
--- a/test/e2e/beat/upgrade_test.go
+++ b/test/e2e/beat/upgrade_test.go
@@ -29,7 +29,7 @@ func TestVersionUpgradeToLatest7x(t *testing.T) {
 
 	name := "test-beat-upgrade-to-7x"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
 		WithVersion(dstVersion)
 
 	fbBuilder := beat.NewBuilder(name).


### PR DESCRIPTION
It is actually easy to miss this problem when doing some manual testing on a custom K8S cluster: if the [`ClusterRole`](https://github.com/elastic/cloud-on-k8s/blob/master/config/e2e/beat-roles.yaml) has not been created then filebeat is unable to list the `Pods` and the index is not created.

Fix #3688 