### PR TITLE
Revert "Workaround azure-cli cluster creation bug (#3672)"

### DIFF
--- a/hack/deployer/runner/aks.go
+++ b/hack/deployer/runner/aks.go
@@ -148,19 +148,7 @@ func (d *AksDriver) clusterExists() (bool, error) {
 	return err == nil, err
 }
 
-// workaroundAzureCliBug works around a cluster creation bug in azure-cli 2.11.0
-// see https://github.com/Azure/azure-cli/issues/14915.
-func (d *AksDriver) workaroundAzureCliBug() error {
-	cmd := "az extension add --name aks-preview"
-	return NewCommand(cmd).Run()
-}
-
 func (d *AksDriver) create() error {
-	// TODO: remove once https://github.com/Azure/azure-cli/issues/14915 is fixed in azure-cli
-	if err := d.workaroundAzureCliBug(); err != nil {
-		return err
-	}
-
 	log.Print("Creating cluster...")
 
 	servicePrincipal := ""


### PR DESCRIPTION
This reverts commit 1be9802242051b66a9bb8c98afcacf6e06e5917e.

Azure-cli 2.11.1 has been released and contains a bugfix for the cluster creation.

Fixes https://github.com/elastic/cloud-on-k8s/issues/3671.