### PR TITLE
Retry getting the default storage class in E2E tests

### DIFF
--- a/hack/deployer/runner/storage.go
+++ b/hack/deployer/runner/storage.go
@@ -22,7 +22,7 @@ var (
 // waiting getDefaultScDelay between each attempt.
 const (
 	getDefaultScRetries = 20
-	getDefaultScDelay = 30*time.Second
+	getDefaultScDelay   = 30 * time.Second
 )
 
 // createStorageClass based on default storageclass, creates new, non-default class with "volumeBindingMode: WaitForFirstConsumer"
@@ -84,7 +84,7 @@ func getDefaultStorageClassName() (string, error) {
 	attempt := 1
 	for {
 		name, err := get()
-		if err != nil && attempt < getDefaultScRetries{
+		if err != nil && attempt < getDefaultScRetries {
 			log.Printf("failed to retrieve the default storageclass, retrying in %s: %s\n", getDefaultScDelay, err.Error())
 			time.Sleep(getDefaultScDelay)
 			attempt++


### PR DESCRIPTION
On AKS clusters, the default storage class regularly takes some time to
be created. On one of my local tests, it got created after 4min:

```
2020/09/01 10:34:36 Creating storage class...                                                                                                                
NAME                PROVISIONER                AGE
azurefile           kubernetes.io/azure-file   98s
azurefile-premium   kubernetes.io/azure-file   98s
2020/09/01 10:34:37 failed to retrieve the default storageclass, retrying in 30s: default storageclass not found
2020/09/01 10:35:07 failed to retrieve the default storageclass, retrying in 30s: default storageclass not found
2020/09/01 10:35:38 failed to retrieve the default storageclass, retrying in 30s: default storageclass not found
2020/09/01 10:36:08 failed to retrieve the default storageclass, retrying in 30s: default storageclass not found
2020/09/01 10:36:39 failed to retrieve the default storageclass, retrying in 30s: default storageclass not found
2020/09/01 10:37:09 failed to retrieve the default storageclass, retrying in 30s: default storageclass not found
2020/09/01 10:37:40 failed to retrieve the default storageclass, retrying in 30s: default storageclass not found
```

This commit sets up some retries (20 with 30sec between each), so we
don't fail the AKS E2E tests if the default storage class is not there (yet).

Fixes https://github.com/elastic/cloud-on-k8s/issues/3681.