### PR TITLE
Draft - Support pvc resize

### DIFF
--- a/pkg/controller/elasticsearch/driver/upscale.go
+++ b/pkg/controller/elasticsearch/driver/upscale.go
@@ -61,6 +61,9 @@ func HandleUpscaleAndSpecChanges(
 		if err != nil {
 			return nil, fmt.Errorf("reconcile sset %w", err)
 		}
+		if err := resizePVCs(ctx.k8sClient, reconciled); err != nil {
+			return nil, fmt.Errorf("resize PVC: %w", err)
+		}
 		// update actual with the reconciled ones for next steps to work with up-to-date information
 		actualStatefulSets = actualStatefulSets.WithStatefulSet(reconciled)
 	}


### PR DESCRIPTION
Relates https://github.com/elastic/cloud-on-k8s/issues/325.

I was playing around with various volume provisioners and their resize capability.
This is a draft PR to demonstrate how we could implement PVC resize in ECK while the feature does not exist (yet) in StatefulSets.

To try it out:

- run the operator from the current PR
- deploy Elasticsearch with eg. 5Gi of storage using the default GKE volume provisioner that allows online resizes:

```
apiVersion: elasticsearch.k8s.elastic.co/v1
kind: Elasticsearch
metadata:
  name: elasticsearch-sample
spec:
  version: 7.8.1
  nodeSets:
  - name: default
    count: 1
    config:
      node.store.allow_mmap: false
    volumeClaimTemplates:
      - metadata:
          name: elasticsearch-data
        spec:
          accessModes:
            - ReadWriteOnce
          resources:
            requests:
              storage: 10Gi
          storageClassName: standard
```

- check the available disk in the Elasticsearch container (`df -h`) and as reported from Elasticsearch (`GET _cat/nodes?h=dt&v `)
- change the storage requests to 20Gi:
```
apiVersion: elasticsearch.k8s.elastic.co/v1
kind: Elasticsearch
metadata:
  name: elasticsearch-sample
spec:
  version: 7.8.1
  nodeSets:
  - name: default
    count: 1
    config:
      node.store.allow_mmap: false
    volumeClaimTemplates:
      - metadata:
          name: elasticsearch-data
        spec:
          accessModes:
            - ReadWriteOnce
          resources:
            requests:
              storage: 20Gi
          storageClassName: standard
```
- after a few seconds/minutes, check the available disk in the Elasticsearch container (`df -h`) and as reported from Elasticsearch (`GET _cat/nodes?h=dt&v `) - this did not require a Pod restart
