### PR TITLE
Revised Kibana dashboard check

### DIFF
--- a/test/e2e/beat/setup_test.go
+++ b/test/e2e/beat/setup_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/beat"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/kibana"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type kbSavedObjects struct {
@@ -140,6 +142,9 @@ func getDashboardCheck(esBuilder elasticsearch.Builder, kbBuilder kibana.Builder
 					}
 					if dashboards.Total == 0 {
 						return fmt.Errorf("expected >0 dashboards but got 0")
+					}
+					for _, db := range dashboards.SavedObjects {
+						logf.Log.Info("Found dashboard", "title", db.Attributes.Title)
 					}
 					for beat, expectDashboards := range beatToDashboardsPresence {
 						// We are exploiting the fact here that Beats dashboards follow a naming convention that starts with the


### PR DESCRIPTION
Fixes #3700 

The current approach to checking for the presence of a Beats dashboard ignored the fact that the Kibana response was paginated so the test succeeded or failed depending on the insertion order of the dashboards. In the light of this information it is somewhat of a miracle that it succeeded so many times.

This PR introduces a revised dashboard check that queries Kibana directly for dashboards with the expected Beats' name in the title.