### PR TITLE
Move discovery to DNS names

### DIFF
--- a/pkg/controller/elasticsearch/driver/upscale_test.go
+++ b/pkg/controller/elasticsearch/driver/upscale_test.go
@@ -124,8 +124,8 @@ func TestHandleUpscaleAndSpecChanges(t *testing.T) {
 	require.Equal(t, pointer.Int32(4), sset2.Spec.Replicas)
 	comparison.RequireEqual(t, &updatedStatefulSets[1], &sset2)
 	// headless services should be created for both
-	require.NoError(t, k8sClient.Get(types.NamespacedName{Namespace: "ns", Name: nodespec.HeadlessServiceName("sset1")}, &corev1.Service{}))
-	require.NoError(t, k8sClient.Get(types.NamespacedName{Namespace: "ns", Name: nodespec.HeadlessServiceName("sset2")}, &corev1.Service{}))
+	require.NoError(t, k8sClient.Get(types.NamespacedName{Namespace: "ns", Name: sset.HeadlessServiceName("sset1")}, &corev1.Service{}))
+	require.NoError(t, k8sClient.Get(types.NamespacedName{Namespace: "ns", Name: sset.HeadlessServiceName("sset2")}, &corev1.Service{}))
 	// config should be created for both
 	require.NoError(t, k8sClient.Get(types.NamespacedName{Namespace: "ns", Name: esv1.ConfigSecret("sset1")}, &corev1.Secret{}))
 	require.NoError(t, k8sClient.Get(types.NamespacedName{Namespace: "ns", Name: esv1.ConfigSecret("sset2")}, &corev1.Secret{}))

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -8,6 +8,8 @@ import (
 	"crypto/sha256"
 	"fmt"
 
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
+
 	corev1 "k8s.io/api/core/v1"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
@@ -83,7 +85,7 @@ func BuildPodTemplateSpec(
 		WithPorts(defaultContainerPorts).
 		WithReadinessProbe(*NewReadinessProbe()).
 		WithAffinity(DefaultAffinity(es.Name)).
-		WithEnv(DefaultEnvVars(es.Spec.HTTP, HeadlessServiceName(esv1.StatefulSet(es.Name, nodeSet.Name)))...).
+		WithEnv(DefaultEnvVars(es.Spec.HTTP, sset.HeadlessServiceName(esv1.StatefulSet(es.Name, nodeSet.Name)))...).
 		WithVolumes(volumes...).
 		WithVolumeMounts(volumeMounts...).
 		WithInitContainers(initContainers...).

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
+
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
@@ -260,7 +262,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 					},
 					Env: append(
 						[]corev1.EnvVar{{Name: "my-env", Value: "my-value"}},
-						DefaultEnvVars(sampleES.Spec.HTTP, HeadlessServiceName(esv1.StatefulSet(sampleES.Name, nodeSet.Name)))...),
+						DefaultEnvVars(sampleES.Spec.HTTP, sset.HeadlessServiceName(esv1.StatefulSet(sampleES.Name, nodeSet.Name)))...),
 					Resources:      DefaultResources,
 					VolumeMounts:   volumeMounts,
 					ReadinessProbe: NewReadinessProbe(),

--- a/pkg/controller/elasticsearch/nodespec/statefulset.go
+++ b/pkg/controller/elasticsearch/nodespec/statefulset.go
@@ -27,12 +27,6 @@ var (
 	f = false
 )
 
-// HeadlessServiceName returns the name of the headless service for the given StatefulSet.
-func HeadlessServiceName(ssetName string) string {
-	// just use the sset name
-	return ssetName
-}
-
 // HeadlessService returns a headless service for the given StatefulSet
 func HeadlessService(es *esv1.Elasticsearch, ssetName string) corev1.Service {
 	nsn := k8s.ExtractNamespacedName(es)
@@ -40,7 +34,7 @@ func HeadlessService(es *esv1.Elasticsearch, ssetName string) corev1.Service {
 	return corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: nsn.Namespace,
-			Name:      HeadlessServiceName(ssetName),
+			Name:      sset.HeadlessServiceName(ssetName),
 			Labels:    label.NewStatefulSetLabels(nsn, ssetName),
 		},
 		Spec: corev1.ServiceSpec{
@@ -116,7 +110,7 @@ func BuildStatefulSet(
 			// use default revision history limit
 			RevisionHistoryLimit: nil,
 			// build a headless service per StatefulSet, matching the StatefulSet labels
-			ServiceName: HeadlessServiceName(statefulSetName),
+			ServiceName: sset.HeadlessServiceName(statefulSetName),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: ssetSelector,
 			},

--- a/pkg/controller/elasticsearch/settings/masters.go
+++ b/pkg/controller/elasticsearch/settings/masters.go
@@ -6,10 +6,8 @@ package settings
 
 import (
 	"context"
-	"net"
 	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
@@ -17,7 +15,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/network"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"go.elastic.co/apm"
@@ -59,7 +57,7 @@ func UpdateSeedHostsConfigMap(
 		if len(master.Status.PodIP) > 0 { // do not add pod with no IPs
 			seedHosts = append(
 				seedHosts,
-				net.JoinHostPort(master.Status.PodIP, strconv.Itoa(network.TransportPort)),
+				sset.PodDNSName(master),
 			)
 		}
 	}

--- a/pkg/controller/elasticsearch/settings/masters_test.go
+++ b/pkg/controller/elasticsearch/settings/masters_test.go
@@ -33,6 +33,7 @@ func newPodWithIP(name, ip string, master bool) corev1.Pod {
 		},
 	}
 	label.NodeTypesMasterLabelName.Set(master, p.Labels)
+	p.Labels[label.StatefulSetNameLabelName] = "test-sset"
 	return p
 }
 
@@ -97,7 +98,7 @@ func TestUpdateSeedHostsConfigMap(t *testing.T) {
 				es: es,
 			},
 			wantErr:         false,
-			expectedContent: "10.0.3.3:9300\n10.0.9.2:9300",
+			expectedContent: "master1.test-sset\nmaster3.test-sset",
 		},
 		{
 			name: "All masters have IPs, some nodes don't",
@@ -113,7 +114,7 @@ func TestUpdateSeedHostsConfigMap(t *testing.T) {
 				es: es,
 			},
 			wantErr:         false,
-			expectedContent: "10.0.3.3:9300\n10.0.6.5:9300\n10.0.9.2:9300",
+			expectedContent: "master1.test-sset\nmaster2.test-sset\nmaster3.test-sset",
 		},
 		{
 			name: "Ordering of pods should not matter",
@@ -127,21 +128,7 @@ func TestUpdateSeedHostsConfigMap(t *testing.T) {
 				es: es,
 			},
 			wantErr:         false,
-			expectedContent: "10.0.3.3:9300\n10.0.6.5:9300\n10.0.9.2:9300",
-		},
-		{
-			name: "Can handle IPv6 addresses",
-			args: args{
-				pods: []corev1.Pod{ //
-					newPodWithIP("master2", "fd00:10:244:0:2::3", true),
-					newPodWithIP("master3", "fd00:10:244:0:2::5", true),
-					newPodWithIP("master1", "fd00:10:244:0:2::2", true),
-				},
-				c:  k8s.WrappedFakeClient(),
-				es: es,
-			},
-			wantErr:         false,
-			expectedContent: "[fd00:10:244:0:2::2]:9300\n[fd00:10:244:0:2::3]:9300\n[fd00:10:244:0:2::5]:9300",
+			expectedContent: "master1.test-sset\nmaster2.test-sset\nmaster3.test-sset",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/controller/elasticsearch/sset/pod.go
+++ b/pkg/controller/elasticsearch/sset/pod.go
@@ -20,6 +20,18 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
 )
 
+// HeadlessServiceName returns the name of the headless service for the given StatefulSet.
+func HeadlessServiceName(ssetName string) string {
+	// just use the sset name
+	return ssetName
+}
+
+//PodDNSName returns the DNS resolvable name of the given pod resolvable within the namespace.
+func PodDNSName(pod corev1.Pod) string {
+	ssetName := pod.Labels[label.StatefulSetNameLabelName]
+	return fmt.Sprintf("%s.%s", pod.Name, HeadlessServiceName(ssetName))
+}
+
 // PodName returns the name of the pod with the given ordinal for this StatefulSet.
 func PodName(ssetName string, ordinal int32) string {
 	return fmt.Sprintf("%s-%d", ssetName, ordinal)

--- a/pkg/controller/elasticsearch/sset/pod.go
+++ b/pkg/controller/elasticsearch/sset/pod.go
@@ -26,7 +26,7 @@ func HeadlessServiceName(ssetName string) string {
 	return ssetName
 }
 
-//PodDNSName returns the DNS resolvable name of the given pod resolvable within the namespace.
+// PodDNSName returns the DNS resolvable name of the given pod resolvable within the namespace.
 func PodDNSName(pod corev1.Pod) string {
 	ssetName := pod.Labels[label.StatefulSetNameLabelName]
 	return fmt.Sprintf("%s.%s", pod.Name, HeadlessServiceName(ssetName))


### PR DESCRIPTION
Fixes #2830
Related #3654 

This PR changes Elasticsearch discovery to use DNS hostnames instead of IP addresses. To replicate the discussion on #3654 : we think the potential negative impact of DNS caching is manageable and outweighs the advantage of simplifying discovery.

We could in theory remove the IP address from the ECK-generated transport certificates now and save a few certificate regenerations when a node is scheduled on another Pod. I left it in place because I believe the frequency of these regenerations if fairly low but open to reconsider.