### PR TITLE
set HEADLESS_SERVICE_NAME in Elasticsearch keystore init container

### DIFF
--- a/pkg/controller/common/defaults/pod_template.go
+++ b/pkg/controller/common/defaults/pod_template.go
@@ -183,7 +183,9 @@ func (b *PodTemplateBuilder) WithTerminationGracePeriod(period int64) *PodTempla
 // - VolumeMounts from the main container are added to the init container VolumeMounts, unless they would conflict
 //   with a specified VolumeMount (by having the same VolumeMount.Name or VolumeMount.MountPath)
 // - default environment variables
-func (b *PodTemplateBuilder) WithInitContainerDefaults() *PodTemplateBuilder {
+//
+// This method can also be used to set some additional environment variables.
+func (b *PodTemplateBuilder) WithInitContainerDefaults(additionalEnvVars ...corev1.EnvVar) *PodTemplateBuilder {
 	mainContainer := b.containerDefaulter.Container()
 	for i := range b.PodTemplate.Spec.InitContainers {
 		b.PodTemplate.Spec.InitContainers[i] =
@@ -191,7 +193,7 @@ func (b *PodTemplateBuilder) WithInitContainerDefaults() *PodTemplateBuilder {
 				// Inherit image and volume mounts from main container in the Pod
 				WithImage(mainContainer.Image).
 				WithVolumeMounts(mainContainer.VolumeMounts).
-				WithEnv(PodDownwardEnvVars()).
+				WithEnv(ExtendPodDownwardEnvVars(additionalEnvVars...)).
 				Container()
 	}
 	return b

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -74,6 +74,7 @@ func BuildPodTemplateSpec(
 		})
 	}
 
+	headlessServiceName := HeadlessServiceName(esv1.StatefulSet(es.Name, nodeSet.Name))
 	builder = builder.
 		WithLabels(labels).
 		WithAnnotations(DefaultAnnotations).
@@ -83,11 +84,11 @@ func BuildPodTemplateSpec(
 		WithPorts(defaultContainerPorts).
 		WithReadinessProbe(*NewReadinessProbe()).
 		WithAffinity(DefaultAffinity(es.Name)).
-		WithEnv(DefaultEnvVars(es.Spec.HTTP, HeadlessServiceName(esv1.StatefulSet(es.Name, nodeSet.Name)))...).
+		WithEnv(DefaultEnvVars(es.Spec.HTTP, headlessServiceName)...).
 		WithVolumes(volumes...).
 		WithVolumeMounts(volumeMounts...).
 		WithInitContainers(initContainers...).
-		WithInitContainerDefaults().
+		WithInitContainerDefaults(corev1.EnvVar{Name: settings.HeadlessServiceName, Value: headlessServiceName}).
 		WithPreStopHook(*NewPreStopHook())
 
 	return builder.PodTemplate, nil

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -244,7 +244,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 			InitContainers: append(initContainers, corev1.Container{
 				Name:         "additional-init-container",
 				Image:        "docker.elastic.co/elasticsearch/elasticsearch:7.2.0",
-				Env:          defaults.PodDownwardEnvVars(),
+				Env:          defaults.ExtendPodDownwardEnvVars(corev1.EnvVar{Name: "HEADLESS_SERVICE_NAME", Value: "name-es-nodeset-1"}),
 				VolumeMounts: volumeMounts,
 			}),
 			Containers: []corev1.Container{


### PR DESCRIPTION
Fix #3715 by setting `HEADLESS_SERVICE_NAME` in the Elasticsearch init containers.