### PR TITLE
Update documentation and samples to use node.roles

### DIFF
--- a/config/samples/apm/apm_es_kibana.yaml
+++ b/config/samples/apm/apm_es_kibana.yaml
@@ -5,7 +5,7 @@ kind: Elasticsearch
 metadata:
   name: es-apm-sample
 spec:
-  version: 7.8.1
+  version: 7.9.1
   nodeSets:
   - name: default
     count: 3
@@ -19,7 +19,7 @@ kind: Kibana
 metadata:
   name: kb-apm-sample
 spec:
-  version: 7.8.1
+  version: 7.9.1
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"
@@ -29,7 +29,7 @@ kind: ApmServer
 metadata:
   name: apm-apm-sample
 spec:
-  version: 7.8.1
+  version: 7.9.1
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"

--- a/config/samples/apm/apmserver.yaml
+++ b/config/samples/apm/apmserver.yaml
@@ -3,7 +3,7 @@ kind: ApmServer
 metadata:
   name: apmserver-sample
 spec:
-  version: 7.8.1
+  version: 7.9.1
   count: 1
   config:
     output.console:

--- a/config/samples/elasticsearch/elasticsearch.yaml
+++ b/config/samples/elasticsearch/elasticsearch.yaml
@@ -4,15 +4,12 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 7.8.1
+  version: 7.9.1
   nodeSets:
   - name: default
     config:
       # most Elasticsearch configuration parameters are possible to set, e.g: node.attr.attr_name: attr_value
-      node.master: true
-      node.data: true
-      node.ingest: true
-      node.ml: true
+      node.roles: ["master", "data", "ingest", "ml"]
       # this allows ES to run on nodes even if their vm.max_map_count has not been increased, at a performance cost
       node.store.allow_mmap: false
     podTemplate:

--- a/config/samples/enterprisesearch/ent_es.yaml
+++ b/config/samples/enterprisesearch/ent_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 7.8.1
+  version: 7.9.1
   nodeSets:
     - name: default
       count: 1
@@ -18,7 +18,7 @@ kind: EnterpriseSearch
 metadata:
   name: ent-sample
 spec:
-  version: 7.8.1
+  version: 7.9.1
   count: 1
   elasticsearchRef:
     name: elasticsearch-sample

--- a/config/samples/kibana/kibana_es.yaml
+++ b/config/samples/kibana/kibana_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 7.8.1
+  version: 7.9.1
   nodeSets:
   - name: default
     count: 1
@@ -18,7 +18,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: 7.8.1
+  version: 7.9.1
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -83,9 +83,6 @@ spec:
   - name: default
     count: 1
     config:
-      node.master: true
-      node.data: true
-      node.ingest: true
       node.store.allow_mmap: false
 ---
 apiVersion: route.openshift.io/v1

--- a/docs/advanced-topics/traffic-splitting.asciidoc
+++ b/docs/advanced-topics/traffic-splitting.asciidoc
@@ -28,42 +28,33 @@ spec:
   - name: master
     count: 3
     config:
-      node.master: true
-      node.data: false
-      node.ingest: false
-      node.ml: false
+      node.roles: ["master"]
   # Dedicated data nodes
   - name: data
     count: 6
     config:
-      node.master: false
-      node.data: true
-      node.ingest: false
-      node.ml: false
+      node.roles: ["data"]
   # Dedicated ingest nodes
   - name: ingest
     count: 3
     config:
-      node.master: false
-      node.data: false
-      node.ingest: true
-      node.ml: false
+      node.roles: ["ingest"]
   # Dedicated coordinator nodes
   - name: coordinator
     count: 3
     config:
-      node.master: false
-      node.data: false
-      node.ingest: false
-      node.ml: false
+      node.roles: !!seq ""
   # Dedicated machine learning nodes
   - name: ml
     count: 3
     config:
-      node.master: false
-      node.data: false
-      node.ingest: false
-      node.ml: true
+      node.roles: ["ml"]
+  # Dedicated transform nodes
+  - name: transform
+    count: 3
+    config:
+      node.roles: ["transform"]
+
 ----
 
 [float]
@@ -91,6 +82,7 @@ spec:
     elasticsearch.k8s.elastic.co/node-data: "false"
     elasticsearch.k8s.elastic.co/node-ingest: "false"
     elasticsearch.k8s.elastic.co/node-ml: "false"
+    elasticsearch.k8s.elastic.co/node-transform: "false"
 ----
 
 .Ingest nodes

--- a/docs/operating-eck/troubleshooting/troubleshooting-methods.asciidoc
+++ b/docs/operating-eck/troubleshooting/troubleshooting-methods.asciidoc
@@ -246,9 +246,6 @@ spec:
   - name: default
     count: 3
     config:
-      node.master: true
-      node.data: true
-      node.ingest: true
       node.store.allow_mmap: false
     volumeClaimTemplates:
     - metadata:
@@ -275,9 +272,6 @@ spec:
   - name: default-10gi
     count: 3
     config:
-      node.master: true
-      node.data: true
-      node.ingest: true
       node.store.allow_mmap: false
     volumeClaimTemplates:
     - metadata:

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
@@ -35,19 +35,13 @@ spec:
   - name: master
     count: 3
     config:
-      node.master: true
-      node.data: false
-      node.ingest: false
-      node.ml: false
-      node.transform: false
+      node.roles: ["master"]
       node.remote_cluster_client: false
   # 3 ingest-data nodes
   - name: ingest-data
     count: 3
     config:
-      node.master: false
-      node.data: true
-      node.ingest: true
+      node.roles: ["data", "ingest"]
 ----
 
 [id="{p}-affinity-options"]

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/http-settings-tls-sans.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/http-settings-tls-sans.asciidoc
@@ -60,17 +60,11 @@ spec:
   - name: master
     count: 1
     config:
-      node.master: true
-      node.data: false
-      node.ingest: false
-      node.ml: false
+      node.roles: ["master"]
   - name: data
     count: 5
     config:
-      node.master: false
-      node.data: true
-      node.ingest: false
-      node.ml: false
+      node.roles: ["data"]
 ----
 
 See <<{p}-traffic-splitting>> for information about more advanced traffic-splitting configurations.

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/node-configuration.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/node-configuration.asciidoc
@@ -17,22 +17,31 @@ spec:
   - name: masters
     count: 3
     config:
-      node.master: true
-      node.data: false
-      node.ingest: false
-      node.ml: false
+      node.roles: ["master"]
       xpack.ml.enabled: true
-      node.transform: false
       node.remote_cluster_client: false
   - name: data
     count: 10
     config:
-      node.master: false
-      node.data: true
-      node.ingest: true
-      node.ml: true
-      node.transform: true
+      node.roles: ["data", "ingest", "ml", "transform"]
       node.remote_cluster_client: false
 ----
 
 For more information on Elasticsearch settings, see https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html[Configuring Elasticsearch].
+
+[NOTE]
+====
+
+Marking a node as link:https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html#coordinating-only-node[coordinating-only] in ECK requires a YAML type tag due to an issue in a supporting library.
+
+[source,yaml]
+----
+spec:
+  nodeSets:
+  - name: coordinator
+    count: 3
+    config:
+      node.roles: !!seq ""
+----
+
+====

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/node-configuration.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/node-configuration.asciidoc
@@ -17,12 +17,20 @@ spec:
   - name: masters
     count: 3
     config:
+      # On Elasticsearch versions before 7.9.0, replace the node.roles configuration with the following:
+      # node.master: true
       node.roles: ["master"]
       xpack.ml.enabled: true
       node.remote_cluster_client: false
   - name: data
     count: 10
     config:
+      # On Elasticsearch versions before 7.9.0, replace the node.roles configuration with the following:
+      # node.master: false
+      # node.data: true
+      # node.ingest: true
+      # node.ml: true
+      # node.transform: true
       node.roles: ["data", "ingest", "ml", "transform"]
       node.remote_cluster_client: false
 ----

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/orchestration.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/orchestration.asciidoc
@@ -33,8 +33,7 @@ spec:
   - name: master-nodes
     count: 3
     config:
-      master: true
-      data: false
+      node.roles: ["master"]
     volumeClaimTemplates:
     - metadata:
         name: elasticsearch-data
@@ -48,8 +47,7 @@ spec:
   - name: data-nodes
     count: 10
     config:
-      master: false
-      data: true
+      node.roles: ["data"]
     volumeClaimTemplates:
     - metadata:
         name: elasticsearch-data

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
@@ -24,10 +24,6 @@ spec:
   nodeSets:
   - name: default
     count: 3
-    config:
-      node.master: true
-      node.data: true
-      node.ingest: true
     podTemplate:
       spec:
         initContainers:

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -69,9 +69,6 @@ spec:
   - name: default
     count: 1
     config:
-      node.master: true
-      node.data: true
-      node.ingest: true
       node.store.allow_mmap: false
 EOF
 ----
@@ -262,9 +259,6 @@ spec:
   - name: default
     count: 3
     config:
-      node.master: true
-      node.data: true
-      node.ingest: true
       node.store.allow_mmap: false
 EOF
 ----


### PR DESCRIPTION
Uses `node.roles` instead of `node.{role_name}` in the documentation and samples.

Fixes #3410