### PR TITLE
filebeat_autodiscover examples use $HOSTNAME instead of spec.nodeName

### DIFF
--- a/config/recipes/beats/filebeat_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_autodiscover.yaml
@@ -14,7 +14,7 @@ spec:
       autodiscover:
         providers:
         - type: kubernetes
-          host: ${HOSTNAME}
+          node: ${NODE_NAME}
           hints:
             enabled: true
             default_config:
@@ -45,6 +45,11 @@ spec:
             mountPath: /var/log/pods
           - name: varlibdockercontainers
             mountPath: /var/lib/docker/containers
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
         volumes:
         - name: varlogcontainers
           hostPath:

--- a/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
+++ b/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
@@ -11,7 +11,7 @@ spec:
     name: kibana
   config:
     filebeat.autodiscover.providers:
-    - node: ${HOSTNAME}
+    - node: ${NODE_NAME}
       type: kubernetes
       hints.default_config.enabled: "false"
       templates:
@@ -47,6 +47,11 @@ spec:
             mountPath: /var/log/pods
           - name: varlibdockercontainers
             mountPath: /var/lib/docker/containers
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
         volumes:
         - name: varlogcontainers
           hostPath:

--- a/config/recipes/beats/metricbeat_hosts.yaml
+++ b/config/recipes/beats/metricbeat_hosts.yaml
@@ -16,7 +16,7 @@ spec:
         - hints:
             default_config: {}
             enabled: "true"
-          host: ${HOSTNAME}
+          host: ${NODE_NAME}
           type: kubernetes
       modules:
       - module: system
@@ -48,9 +48,9 @@ spec:
                     mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib)($|/)
       - module: kubernetes
         period: 10s
-        host: ${HOSTNAME}
+        host: ${NODE_NAME}
         hosts:
-        - https://${HOSTNAME}:10250
+        - https://${NODE_NAME}:10250
         bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
         ssl:
           verification_mode: none
@@ -82,6 +82,11 @@ spec:
             name: dockersock
           - mountPath: /hostfs/proc
             name: proc
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         dnsPolicy: ClusterFirstWithHostNet
         hostNetwork: true # Allows to provide richer host metadata
         securityContext:

--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -128,7 +128,7 @@ spec:
       autodiscover:
         providers:
         - type: kubernetes
-          host: ${HOSTNAME}
+          node: ${NODE_NAME}
           hints:
             enabled: true
             default_config:
@@ -160,6 +160,11 @@ spec:
             mountPath: /var/log/pods
           - name: varlibdockercontainers
             mountPath: /var/lib/docker/containers
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
         volumes:
         - name: varlogcontainers
           hostPath:


### PR DESCRIPTION
spec.nodeName should be used as the underlying $HOSTNAME can differ from the kubernetes nodeName (e.g. when using  `hostname_override`). Different node names lead to ignored logs in autodiscovery. 

Reference: [Filebeat Kubernetes Example](https://raw.githubusercontent.com/elastic/beats/master/deploy/kubernetes/filebeat-kubernetes.yaml)