### PR TITLE
Revert network.publish_host back to IP addresses

### DIFF
--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -54,7 +54,7 @@ func (d *defaultDriver) reconcileNodeSpecs(
 		return results.WithError(err)
 	}
 
-	expectedResources, err := nodespec.BuildExpectedResources(d.ES, keystoreResources, actualStatefulSets, d.OperatorParameters.SetDefaultSecurityContext)
+	expectedResources, err := nodespec.BuildExpectedResources(d.ES, keystoreResources, actualStatefulSets, d.OperatorParameters.IPFamily, d.OperatorParameters.SetDefaultSecurityContext)
 	if err != nil {
 		return results.WithError(err)
 	}

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -164,7 +164,7 @@ func TestBuildPodTemplateSpecWithDefaultSecurityContext(t *testing.T) {
 			es.Spec.Version = tt.version.String()
 			es.Spec.NodeSets[0].PodTemplate.Spec.SecurityContext = tt.userSecurityContext
 
-			cfg, err := settings.NewMergedESConfig(es.Name, tt.version, es.Spec.HTTP, *es.Spec.NodeSets[0].Config)
+			cfg, err := settings.NewMergedESConfig(es.Name, tt.version, corev1.IPv4Protocol, es.Spec.HTTP, *es.Spec.NodeSets[0].Config)
 			require.NoError(t, err)
 
 			actual, err := BuildPodTemplateSpec(es, es.Spec.NodeSets[0], cfg, nil, tt.setDefaultFSGroup)
@@ -178,7 +178,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 	nodeSet := sampleES.Spec.NodeSets[0]
 	ver, err := version.Parse(sampleES.Spec.Version)
 	require.NoError(t, err)
-	cfg, err := settings.NewMergedESConfig(sampleES.Name, *ver, sampleES.Spec.HTTP, *nodeSet.Config)
+	cfg, err := settings.NewMergedESConfig(sampleES.Name, *ver, corev1.IPv4Protocol, sampleES.Spec.HTTP, *nodeSet.Config)
 	require.NoError(t, err)
 
 	actual, err := BuildPodTemplateSpec(sampleES, sampleES.Spec.NodeSets[0], cfg, nil, false)
@@ -224,7 +224,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 			Labels: map[string]string{
 				"common.k8s.elastic.co/type":                    "elasticsearch",
 				"elasticsearch.k8s.elastic.co/cluster-name":     "name",
-				"elasticsearch.k8s.elastic.co/config-hash":      "3785137207",
+				"elasticsearch.k8s.elastic.co/config-hash":      "336245446",
 				"elasticsearch.k8s.elastic.co/http-scheme":      "https",
 				"elasticsearch.k8s.elastic.co/node-data":        "false",
 				"elasticsearch.k8s.elastic.co/node-ingest":      "true",

--- a/pkg/controller/elasticsearch/nodespec/resources.go
+++ b/pkg/controller/elasticsearch/nodespec/resources.go
@@ -38,6 +38,7 @@ func BuildExpectedResources(
 	es esv1.Elasticsearch,
 	keystoreResources *keystore.Resources,
 	existingStatefulSets sset.StatefulSetList,
+	ipFamily corev1.IPFamily,
 	setDefaultSecurityContext bool,
 ) (ResourcesList, error) {
 	nodesResources := make(ResourcesList, 0, len(es.Spec.NodeSets))
@@ -53,7 +54,7 @@ func BuildExpectedResources(
 		if nodeSpec.Config != nil {
 			userCfg = *nodeSpec.Config
 		}
-		cfg, err := settings.NewMergedESConfig(es.Name, *ver, es.Spec.HTTP, userCfg)
+		cfg, err := settings.NewMergedESConfig(es.Name, *ver, ipFamily, es.Spec.HTTP, userCfg)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/pkg/controller/elasticsearch/settings/merged_config.go
@@ -15,6 +15,8 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
+	netutil "github.com/elastic/cloud-on-k8s/pkg/utils/net"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // the name of the ES attribute indicating the pod's current k8s node
@@ -27,6 +29,7 @@ var nodeAttrNodeName = fmt.Sprintf("%s.%s", esv1.NodeAttr, nodeAttrK8sNodeName)
 func NewMergedESConfig(
 	clusterName string,
 	ver version.Version,
+	ipFamily corev1.IPFamily,
 	httpConfig commonv1.HTTPConfig,
 	userConfig commonv1.Config,
 ) (CanonicalConfig, error) {
@@ -34,7 +37,7 @@ func NewMergedESConfig(
 	if err != nil {
 		return CanonicalConfig{}, err
 	}
-	config := baseConfig(clusterName, ver).CanonicalConfig
+	config := baseConfig(clusterName, ver, ipFamily).CanonicalConfig
 	err = config.MergeWith(
 		xpackConfig(ver, httpConfig).CanonicalConfig,
 		userCfg,
@@ -46,14 +49,14 @@ func NewMergedESConfig(
 }
 
 // baseConfig returns the base ES configuration to apply for the given cluster
-func baseConfig(clusterName string, ver version.Version) *CanonicalConfig {
+func baseConfig(clusterName string, ver version.Version, ipFamily corev1.IPFamily) *CanonicalConfig {
 	cfg := map[string]interface{}{
 		// derive node name dynamically from the pod name, injected as env var
 		esv1.NodeName:    "${" + EnvPodName + "}",
 		esv1.ClusterName: clusterName,
 
 		// use the DNS name as the publish host
-		esv1.NetworkPublishHost: fmt.Sprintf("${%s}.${%s}", EnvPodName, HeadlessServiceName),
+		esv1.NetworkPublishHost: netutil.IPLiteralFor("${"+EnvPodIP+"}", ipFamily),
 		esv1.NetworkHost:        "0",
 
 		// allow ES to be aware of k8s node the pod is running on when allocating shards

--- a/pkg/controller/elasticsearch/settings/merged_config_test.go
+++ b/pkg/controller/elasticsearch/settings/merged_config_test.go
@@ -12,6 +12,7 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestNewMergedESConfig(t *testing.T) {
@@ -21,15 +22,17 @@ func TestNewMergedESConfig(t *testing.T) {
 	xPackSecurityAuthcRealmsAD1Order := "xpack.security.authc.realms.ad1.order"
 
 	tests := []struct {
-		name    string
-		version string
-		cfgData map[string]interface{}
-		assert  func(cfg CanonicalConfig)
+		name     string
+		version  string
+		ipFamily corev1.IPFamily
+		cfgData  map[string]interface{}
+		assert   func(cfg CanonicalConfig)
 	}{
 		{
-			name:    "in 6.x, empty config should have the default file and native realm settings configured",
-			version: "6.8.0",
-			cfgData: map[string]interface{}{},
+			name:     "in 6.x, empty config should have the default file and native realm settings configured",
+			version:  "6.8.0",
+			ipFamily: corev1.IPv4Protocol,
+			cfgData:  map[string]interface{}{},
 			assert: func(cfg CanonicalConfig) {
 				require.Equal(t, 0, len(cfg.HasKeys([]string{nodeML})))
 				require.Equal(t, 1, len(cfg.HasKeys([]string{esv1.XPackSecurityAuthcRealmsFile1Type})))
@@ -41,8 +44,9 @@ func TestNewMergedESConfig(t *testing.T) {
 			},
 		},
 		{
-			name:    "in 6.x, sample config should have the default file realm settings configured",
-			version: "6.8.0",
+			name:     "in 6.x, sample config should have the default file realm settings configured",
+			version:  "6.8.0",
+			ipFamily: corev1.IPv4Protocol,
 			cfgData: map[string]interface{}{
 				nodeML: true,
 			},
@@ -57,8 +61,9 @@ func TestNewMergedESConfig(t *testing.T) {
 			},
 		},
 		{
-			name:    "in 6.x, active_directory realm settings should be merged with the default file and native realm settings",
-			version: "6.8.0",
+			name:     "in 6.x, active_directory realm settings should be merged with the default file and native realm settings",
+			version:  "6.8.0",
+			ipFamily: corev1.IPv4Protocol,
 			cfgData: map[string]interface{}{
 				nodeML:                           true,
 				xPackSecurityAuthcRealmsAD1Type:  "active_directory",
@@ -77,9 +82,10 @@ func TestNewMergedESConfig(t *testing.T) {
 			},
 		},
 		{
-			name:    "in 7.x, empty config should have the default file and native realm settings configured",
-			version: "7.3.0",
-			cfgData: map[string]interface{}{},
+			name:     "in 7.x, empty config should have the default file and native realm settings configured",
+			version:  "7.3.0",
+			ipFamily: corev1.IPv4Protocol,
+			cfgData:  map[string]interface{}{},
 			assert: func(cfg CanonicalConfig) {
 				require.Equal(t, 0, len(cfg.HasKeys([]string{nodeML})))
 				require.Equal(t, 1, len(cfg.HasKeys([]string{esv1.XPackSecurityAuthcRealmsFileFile1Order})))
@@ -89,8 +95,9 @@ func TestNewMergedESConfig(t *testing.T) {
 			},
 		},
 		{
-			name:    "in 7.x, sample config should have the default file and native realm settings configured",
-			version: "7.3.0",
+			name:     "in 7.x, sample config should have the default file and native realm settings configured",
+			version:  "7.3.0",
+			ipFamily: corev1.IPv4Protocol,
 			cfgData: map[string]interface{}{
 				nodeML: true,
 			},
@@ -101,8 +108,9 @@ func TestNewMergedESConfig(t *testing.T) {
 			},
 		},
 		{
-			name:    "in 7.x, active_directory realm settings should be merged with the default file and native realm settings",
-			version: "7.3.0",
+			name:     "in 7.x, active_directory realm settings should be merged with the default file and native realm settings",
+			version:  "7.3.0",
+			ipFamily: corev1.IPv4Protocol,
 			cfgData: map[string]interface{}{
 				nodeML: true,
 				xPackSecurityAuthcRealmsActiveDirectoryAD1Order: 0,
@@ -115,42 +123,47 @@ func TestNewMergedESConfig(t *testing.T) {
 			},
 		},
 		{
-			name:    "in 6.x, seed hosts setting should be discovery.zen.hosts_provider",
-			version: "6.8.0",
-			cfgData: map[string]interface{}{},
+			name:     "in 6.x, seed hosts setting should be discovery.zen.hosts_provider",
+			version:  "6.8.0",
+			ipFamily: corev1.IPv4Protocol,
+			cfgData:  map[string]interface{}{},
 			assert: func(cfg CanonicalConfig) {
 				require.Equal(t, 1, len(cfg.HasKeys([]string{esv1.DiscoveryZenHostsProvider})))
 				require.Equal(t, 0, len(cfg.HasKeys([]string{esv1.DiscoverySeedProviders})))
 			},
 		},
 		{
-			name:    "starting 7.x, seed hosts settings should be discovery.seed_providers",
-			version: "7.0.0",
-			cfgData: map[string]interface{}{},
+			name:     "starting 7.x, seed hosts settings should be discovery.seed_providers",
+			version:  "7.0.0",
+			ipFamily: corev1.IPv4Protocol,
+			cfgData:  map[string]interface{}{},
 			assert: func(cfg CanonicalConfig) {
 				require.Equal(t, 0, len(cfg.HasKeys([]string{esv1.DiscoveryZenHostsProvider})))
 				require.Equal(t, 1, len(cfg.HasKeys([]string{esv1.DiscoverySeedProviders})))
 			},
 		},
 		{
-			name:    "prior to 7.8.1, we should not set allowed license upload types",
-			version: "7.5.0",
-			cfgData: map[string]interface{}{},
+			name:     "prior to 7.8.1, we should not set allowed license upload types",
+			version:  "7.5.0",
+			ipFamily: corev1.IPv4Protocol,
+			cfgData:  map[string]interface{}{},
 			assert: func(cfg CanonicalConfig) {
 				require.Equal(t, 0, len(cfg.HasKeys([]string{esv1.XPackLicenseUploadTypes})))
 			},
 		},
 		{
-			name:    "starting 7.8.1, we should set allowed license upload types",
-			version: "7.8.1",
-			cfgData: map[string]interface{}{},
+			name:     "starting 7.8.1, we should set allowed license upload types",
+			version:  "7.8.1",
+			ipFamily: corev1.IPv4Protocol,
+			cfgData:  map[string]interface{}{},
 			assert: func(cfg CanonicalConfig) {
 				require.Equal(t, 1, len(cfg.HasKeys([]string{esv1.XPackLicenseUploadTypes})))
 			},
 		},
 		{
-			name:    "user-provided Elasticsearch config overrides should have precedence over ECK config",
-			version: "7.6.0",
+			name:     "user-provided Elasticsearch config overrides should have precedence over ECK config",
+			version:  "7.6.0",
+			ipFamily: corev1.IPv4Protocol,
 			cfgData: map[string]interface{}{
 				esv1.DiscoverySeedProviders: "something-else",
 			},
@@ -158,10 +171,22 @@ func TestNewMergedESConfig(t *testing.T) {
 				cfgBytes, err := cfg.Render()
 				require.NoError(t, err)
 				// default config is still there
-				require.True(t, bytes.Contains(cfgBytes, []byte("publish_host: ${POD_NAME}.${HEADLESS_SERVICE_NAME}")))
+				require.True(t, bytes.Contains(cfgBytes, []byte("publish_host: ${POD_IP}")))
 				// but has been overridden
 				require.True(t, bytes.Contains(cfgBytes, []byte("seed_providers: something-else")))
 				require.Equal(t, 1, bytes.Count(cfgBytes, []byte("seed_providers:")))
+			},
+		},
+		{
+			name:     "configuration is adjusted for IP family",
+			version:  "7.6.0",
+			ipFamily: corev1.IPv6Protocol,
+			cfgData:  map[string]interface{}{},
+			assert: func(cfg CanonicalConfig) {
+				cfgBytes, err := cfg.Render()
+				require.NoError(t, err)
+				// publish host IP placeholder is bracketed for IPv6
+				require.True(t, bytes.Contains(cfgBytes, []byte("publish_host: '[${POD_IP}]'")))
 			},
 		},
 	}
@@ -172,6 +197,7 @@ func TestNewMergedESConfig(t *testing.T) {
 			cfg, err := NewMergedESConfig(
 				"clusterName",
 				*ver,
+				tt.ipFamily,
 				commonv1.HTTPConfig{},
 				commonv1.Config{Data: tt.cfgData},
 			)

--- a/pkg/utils/net/ip.go
+++ b/pkg/utils/net/ip.go
@@ -59,6 +59,6 @@ func IPLiteralFor(ipOrPlaceholder string, ipFamily corev1.IPFamily) string {
 		// IPv6: return a bracketed version of the IP
 		return fmt.Sprintf("[%s]", ipOrPlaceholder)
 	}
-	// IPv4: leave the place holder as is
+	// IPv4: leave the placeholder as is
 	return ipOrPlaceholder
 }

--- a/pkg/utils/net/ip.go
+++ b/pkg/utils/net/ip.go
@@ -55,10 +55,10 @@ func ToIPFamily(ipStr string) corev1.IPFamily {
 // The difference to net.JoinHostPort is that it also allows IP to be a placeholder that will be resolved
 // to the actual IP at a later time.
 func IPLiteralFor(ipOrPlaceholder string, ipFamily corev1.IPFamily) string {
-	var prefix, suffix string
 	if ipFamily == corev1.IPv6Protocol {
-		prefix = "["
-		suffix = "]"
+		// IPv6: return a bracketed version of the IP
+		return fmt.Sprintf("[%s]", ipOrPlaceholder)
 	}
-	return fmt.Sprintf("%s%s%s", prefix, ipOrPlaceholder, suffix)
+	// IPv4: leave the place holder as is
+	return ipOrPlaceholder
 }

--- a/pkg/utils/net/ip.go
+++ b/pkg/utils/net/ip.go
@@ -52,7 +52,7 @@ func ToIPFamily(ipStr string) corev1.IPFamily {
 
 // IPLiteralFor returns the given IP as a literal that can be used in a resource identifier.
 // For IPv6 that means returning a bracketed version of the IP.
-// The difference to net.JoinHostPort is that it also allows IP be to be a placeholder that will be resolved
+// The difference to net.JoinHostPort is that it also allows IP to be a placeholder that will be resolved
 // to the actual IP at a later time.
 func IPLiteralFor(ipOrPlaceholder string, ipFamily corev1.IPFamily) string {
 	var prefix, suffix string

--- a/pkg/utils/net/ip.go
+++ b/pkg/utils/net/ip.go
@@ -5,6 +5,7 @@
 package net
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 
@@ -47,4 +48,17 @@ func ToIPFamily(ipStr string) corev1.IPFamily {
 		return corev1.IPv4Protocol
 	}
 	return corev1.IPv6Protocol
+}
+
+// IPLiteralFor returns the given IP as a literal that can be used in a resource identifier.
+// For IPv6 that means returning a bracketed version of the IP.
+// The difference to net.JoinHostPort is that it also allows IP be to be a placeholder that will be resolved
+// to the actual IP at a later time.
+func IPLiteralFor(ipOrPlaceholder string, ipFamily corev1.IPFamily) string {
+	var prefix, suffix string
+	if ipFamily == corev1.IPv6Protocol {
+		prefix = "["
+		suffix = "]"
+	}
+	return fmt.Sprintf("%s%s%s", prefix, ipOrPlaceholder, suffix)
 }

--- a/pkg/utils/net/ip_test.go
+++ b/pkg/utils/net/ip_test.go
@@ -207,3 +207,47 @@ func TestToIPFamily(t *testing.T) {
 		})
 	}
 }
+
+func TestIPLiteralFor(t *testing.T) {
+	type args struct {
+		ipOrPlaceholder string
+		ipFamily        corev1.IPFamily
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "IPv4",
+			args: args{
+				ipOrPlaceholder: "127.0.0.1",
+				ipFamily:        corev1.IPv4Protocol,
+			},
+			want: "127.0.0.1",
+		},
+		{
+			name: "IPv6",
+			args: args{
+				ipOrPlaceholder: "::",
+				ipFamily:        corev1.IPv6Protocol,
+			},
+			want: "[::]",
+		},
+		{
+			name: "IPv6 Placeholder",
+			args: args{
+				ipOrPlaceholder: "${POD_IP}",
+				ipFamily:        corev1.IPv6Protocol,
+			},
+			want: "[${POD_IP}]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IPLiteralFor(tt.args.ipOrPlaceholder, tt.args.ipFamily); got != tt.want {
+				t.Errorf("IPLiteralFor() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/3723

Using DNS names turned out to be problematic due to DNS resolving to previous Pod IPs,
which in combination with a bug in Elasticsearch (https://github.com/elastic/elasticsearch/issues/49795)
lead to nodes not being able to re-join the cluster on updates.

While the [proposal](https://github.com/elastic/cloud-on-k8s/issues/3723#issuecomment-688695436) to use `<pod>.<service>.svc.<cluster-domain>` seems tempting and I am happy to look into it if we think sticking with a DNS name is strictly better.

This PR goes back to an IP based `publish_host` which is bracketed as needed in the case of IPv6, exploiting the fact that we now have a notion of an IP family in the operator parameters.