### PR TITLE
Fix nil pointer panic in node roles validations

### DIFF
--- a/pkg/apis/elasticsearch/v1/validations.go
+++ b/pkg/apis/elasticsearch/v1/validations.go
@@ -119,7 +119,7 @@ func hasCorrectNodeRoles(es *Elasticsearch) field.ErrorList {
 		}
 
 		// check that node.roles is not used with an older Elasticsearch version
-		if cfg.Node.Roles != nil && !v.IsSameOrAfter(version.From(7, 9, 0)) {
+		if cfg.Node != nil && cfg.Node.Roles != nil && !v.IsSameOrAfter(version.From(7, 9, 0)) {
 			errs = append(errs, field.Invalid(confField(i), ns.Config, nodeRolesInOldVersionMsg))
 
 			continue
@@ -127,7 +127,7 @@ func hasCorrectNodeRoles(es *Elasticsearch) field.ErrorList {
 
 		// check that node.roles and node attributes are not mixed
 		nodeRoleAttrs := getNodeRoleAttrs(cfg)
-		if len(cfg.Node.Roles) > 0 && len(nodeRoleAttrs) > 0 {
+		if cfg.Node != nil && len(cfg.Node.Roles) > 0 && len(nodeRoleAttrs) > 0 {
 			errs = append(errs, field.Forbidden(confField(i), fmt.Sprintf(mixedRoleConfigMsg, strings.Join(nodeRoleAttrs, ","))))
 		}
 

--- a/pkg/apis/elasticsearch/v1/validations_test.go
+++ b/pkg/apis/elasticsearch/v1/validations_test.go
@@ -88,12 +88,14 @@ func Test_hasCorrectNodeRoles(t *testing.T) {
 		x := es(version)
 		for _, nsc := range nodeSetRoles {
 			data := nsc
+			var cfg *commonv1.Config
+			if data != nil {
+				cfg = &commonv1.Config{Data: data}
+			}
 
 			x.Spec.NodeSets = append(x.Spec.NodeSets, NodeSet{
-				Count: count,
-				Config: &commonv1.Config{
-					Data: data,
-				},
+				Count:  count,
+				Config: cfg,
 			})
 		}
 
@@ -109,6 +111,11 @@ func Test_hasCorrectNodeRoles(t *testing.T) {
 			name:         "no topology",
 			es:           esWithRoles("6.8.0", 1),
 			expectErrors: true,
+		},
+		{
+			name:         "one nodeset with no config",
+			es:           esWithRoles("7.6.0", 1, nil),
+			expectErrors: false,
 		},
 		{
 			name:         "no master defined (node attributes)",


### PR DESCRIPTION
I just hit this while playing around with some samples.
We get a nil pointer panic when providing a nodeSet with no config.