### PR TITLE
Avoid panic on Kibana telemetry API call

### DIFF
--- a/test/e2e/kb/telemetry_test.go
+++ b/test/e2e/kb/telemetry_test.go
@@ -59,7 +59,7 @@ func TestTelemetry(t *testing.T) {
 					if err != nil {
 						return err
 					}
-					if stats == nil || len(stats) == 0 {
+					if len(stats) == 0 {
 						return errors.New("cluster stats is empty")
 					}
 					eck := stats[0].StackStats.Kibana.Plugins.StaticTelemetry.Eck

--- a/test/e2e/kb/telemetry_test.go
+++ b/test/e2e/kb/telemetry_test.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/cloud-on-k8s/pkg/about"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
@@ -56,6 +58,9 @@ func TestTelemetry(t *testing.T) {
 					err = json.Unmarshal(body, &stats)
 					if err != nil {
 						return err
+					}
+					if stats == nil || len(stats) == 0 {
+						return errors.New("cluster stats is empty")
 					}
 					eck := stats[0].StackStats.Kibana.Plugins.StaticTelemetry.Eck
 					if !eck.IsDefined() {


### PR DESCRIPTION
Under unknown conditions, the Kibana telemetry API call may return an empty response and
causes a panic. This commit fixes this by retrying the call until the slice is not empty.

Resolves #3709.