### PR TITLE
Default to IPv4 if no valid IP is given in IP family auto-detect

### DIFF
--- a/pkg/utils/net/ip.go
+++ b/pkg/utils/net/ip.go
@@ -44,6 +44,11 @@ func InAddrAnyFor(ipFamily corev1.IPFamily) net.IP {
 
 // ToIPFamily tries to detect the IP family (IPv4 or IPv6) based on the given IP string.
 func ToIPFamily(ipStr string) corev1.IPFamily {
+	if len(ipStr) == 0 {
+		// default to IPv4 in case no IP was given
+		return corev1.IPv4Protocol
+	}
+
 	if ip := net.ParseIP(ipStr); ip.To4() != nil {
 		return corev1.IPv4Protocol
 	}

--- a/pkg/utils/net/ip_test.go
+++ b/pkg/utils/net/ip_test.go
@@ -164,6 +164,13 @@ func TestToIPFamily(t *testing.T) {
 		want corev1.IPFamily
 	}{
 		{
+			name: "Default to IPv4",
+			args: args{
+				ipStr: "",
+			},
+			want: corev1.IPv4Protocol,
+		},
+		{
 			name: "IPv4",
 			args: args{
 				ipStr: "127.0.0.1",


### PR DESCRIPTION
This mostly improves the situation for local development use of the operator via `make run` when no valid IP is available.