### PR TITLE
Editing - Custom images/Service meshes/Traffic splitting

### DIFF
--- a/docs/advanced-topics/custom-images.asciidoc
+++ b/docs/advanced-topics/custom-images.asciidoc
@@ -7,7 +7,9 @@ endif::[]
 [id="{p}-{page_id}"]
 = Create custom images
 
-You can create your own custom Elasticsearch or Kibana image instead of using the base image provided by Elastic. You might want to do this to preload plugins in the image rather than having to link:k8s-init-containers-plugin-downloads.html[install them via init container] each time a pod starts. To do this, you must use the official image as the base for it to function properly. For example, if you want to create an Elasticsearch {version} image with the https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-gcs.html[Google Cloud Storage Repository Plugin], you can do the following:
+You can create your own custom Elasticsearch or Kibana image instead of using the base image provided by Elastic. You might want to do this to preload plugins in the image rather than <<{p}-init-containers-plugin-downloads,installing them via init container>> each time a Pod starts. To do this, you must use the official image as the base for it to function properly. For example, if you want to create an Elasticsearch {version} image with the https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-gcs.html[Google Cloud Storage Repository Plugin], you can do the following:
+
+
 
 . Create a `Dockerfile` containing:
 +
@@ -24,7 +26,7 @@ RUN bin/elasticsearch-plugin install --batch repository-gcs
 docker build --tag elasticsearch-gcs:{version}
 ----
 
-There are various hosting options for your images. If you use Google Kubernetes Engine, it is automatically configured to use the Google Container Registry (see https://cloud.google.com/container-registry/docs/using-with-google-cloud-platform#google-kubernetes-engine[here] for more information). To use the image, you can then https://cloud.google.com/container-registry/docs/pushing-and-pulling#pushing_an_image_to_a_registry[push to the registry] with:
+There are various hosting options for your images. If you use Google Kubernetes Engine, it is automatically configured to use the Google Container Registry. See https://cloud.google.com/container-registry/docs/using-with-google-cloud-platform#google-kubernetes-engine[Using Container Registry with Google Cloud] for more information. To use the image, you can then https://cloud.google.com/container-registry/docs/pushing-and-pulling#pushing_an_image_to_a_registry[push to the registry] with:
 
 [subs="attributes"]
 ----
@@ -46,20 +48,20 @@ NOTE: Providing the correct version is always required as ECK reasons about APIs
 
 The steps are similar for https://docs.microsoft.com/en-us/azure/aks/tutorial-kubernetes-prepare-acr[Azure Kubernetes Service] and https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-basics.html#use-ecr[AWS Elastic Container Registry].
 
-For more information, you can check the following references:
+For more information, check the following references:
 
-- https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_c_customized_image[Elasticsearch doc on creating custom images]
-- https://cloud.google.com/container-registry/docs/how-to[Google Container Registry docs]
-- https://docs.microsoft.com/en-us/azure/container-registry/[Azure Container Registry docs]
-- https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html[Amazon Elastic Container Registry docs]
-- https://docs.openshift.com/container-platform/4.1/registry/architecture-component-imageregistry.html[OpenShift Container Platform registry docs]
+- https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_c_customized_image[Elasticsearch documentation on Using custom Docker images]
+- https://cloud.google.com/container-registry/docs/how-to[Google Container Registry]
+- https://docs.microsoft.com/en-us/azure/container-registry/[Azure Container Registry]
+- https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html[Amazon Elastic Container Registry]
+- https://docs.openshift.com/container-platform/4.1/registry/architecture-component-imageregistry.html[OpenShift Container Platform registry]
 
 
 [float]
 [id="{p}-container-registry-override"]
 == Override the default container registry
 
-When creating Elasticsearch, Kibana, or APM Server resources, the operator defaults to using container images pulled from the `docker.elastic.co` registry. If you are in an environment where external network access is restricted, you could configure the operator to use a different default container registry by starting the operator with the `--container-registry` command-line flag. (See <<{p}-operator-config>> for more information about how to configure the operator using command-line flags and environment variables).
+When creating Elasticsearch, Kibana, or APM Server resources, the operator defaults to using container images pulled from the `docker.elastic.co` registry. If you are in an environment where external network access is restricted, you could configure the operator to use a different default container registry by starting the operator with the `--container-registry` command-line flag. See <<{p}-operator-config>> for more information on how to configure the operator using command-line flags and environment variables.
 
 The operator expects container images to be located at specific paths in the default container registry. Make sure that your container images are stored at the right path and are tagged correctly with the stack version number. For example, if your private registry is `my.registry` and you wish to deploy components from stack version {version}, the following image paths should exist:
 

--- a/docs/advanced-topics/custom-images.asciidoc
+++ b/docs/advanced-topics/custom-images.asciidoc
@@ -7,7 +7,7 @@ endif::[]
 [id="{p}-{page_id}"]
 = Create custom images
 
-You can create your own custom Elasticsearch or Kibana image instead of using the base image provided by Elastic. You might want to do this to preload plugins in the image rather than <<{p}-init-containers-plugin-downloads,installing them via init container>> each time a Pod starts. To do this, you must use the official image as the base for it to function properly. For example, if you want to create an Elasticsearch {version} image with the https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-gcs.html[Google Cloud Storage Repository Plugin], you can do the following:
+You can create your own custom application images ({eck_resources_list}) instead of using the base images provided by Elastic. You might want to do this to have a canonical image with all the necessary plugins pre-loaded rather than <<{p}-init-containers-plugin-downloads,installing them via an init container>> each time a Pod starts.  You must use the official image as the base for custom images. For example, if you want to create an Elasticsearch {version} image with the link:https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-gcs.html[Google Cloud Storage Repository Plugin], you can do the following:
 
 
 

--- a/docs/advanced-topics/custom-images.asciidoc
+++ b/docs/advanced-topics/custom-images.asciidoc
@@ -61,7 +61,7 @@ For more information, check the following references:
 [id="{p}-container-registry-override"]
 == Override the default container registry
 
-When creating Elasticsearch, Kibana, or APM Server resources, the operator defaults to using container images pulled from the `docker.elastic.co` registry. If you are in an environment where external network access is restricted, you could configure the operator to use a different default container registry by starting the operator with the `--container-registry` command-line flag. See <<{p}-operator-config>> for more information on how to configure the operator using command-line flags and environment variables.
+When creating custom resources ({eck_resources_list}), the operator defaults to using container images pulled from the `docker.elastic.co` registry. If you are in an environment where external network access is restricted, you could configure the operator to use a different default container registry by starting the operator with the `--container-registry` command-line flag. See <<{p}-operator-config>> for more information on how to configure the operator using command-line flags and environment variables.
 
 The operator expects container images to be located at specific paths in the default container registry. Make sure that your container images are stored at the right path and are tagged correctly with the stack version number. For example, if your private registry is `my.registry` and you wish to deploy components from stack version {version}, the following image paths should exist:
 

--- a/docs/advanced-topics/service-meshes.asciidoc
+++ b/docs/advanced-topics/service-meshes.asciidoc
@@ -11,54 +11,54 @@ endif::[]
 [id="{p}-{page_id}"]
 = Service meshes
 
-These sections contain information about connecting ECK and managed Elastic Stack applications to some of the most popular link:https://www.cncf.io/blog/2017/04/26/service-mesh-critical-component-cloud-native-stack/[service mesh] implementations in the Kubernetes ecosystem.
+You can connect ECK and managed Elastic Stack applications to some of the most popular link:https://www.cncf.io/blog/2017/04/26/service-mesh-critical-component-cloud-native-stack/[service mesh] implementations in the Kubernetes ecosystem:
 
+- <<{p}-service-mesh-istio>>
+- <<{p}-service-mesh-linkerd>>
 
 [id="{p}-service-mesh-istio"]
 == Istio
 
-The following sections describe how to connect the operator and managed resources to the Istio service mesh. It is assumed that Istio is already installed and configured on your Kubernetes cluster. If you are new to Istio, refer to the link:https://istio.io[product documentation] for more information and installation instructions.
+The instructions in this section describe how to connect the operator and managed resources to the Istio service mesh and assume that Istio is already installed and configured on your Kubernetes cluster. To know more about Istio and how to install it, see the link:https://istio.io[product documentation].
 
-NOTE: These instructions have been tested with Istio {istio_version}. Some details may differ on older or newer versions of Istio and might require additional configuration steps not documented here.
+These instructions have been tested with Istio {istio_version}. Older or newer versions of Istio might require additional configuration steps not documented here.
 
-CAUTION: Some Elastic Stack features such as link:https://www.elastic.co/guide/en/kibana/7.x/alerting-getting-started.html#alerting-getting-started[Kibana alerting and actions] rely on the Elasticsearch API keys feature which requires TLS to be enabled at the application level. If you intend to make use of these features, you should not disable the self-signed certificate on the Elasticsearch resource and enable `PERMISSIVE` mode for the Elasticsearch service through a `DestinationRule` or `PeerAuthentication` resource. Strict mTLS mode is currently not compatible with Elastic Stack features requiring TLS to be enabled for the Elasticsearch HTTP layer.
+CAUTION: Some Elastic Stack features such as link:https://www.elastic.co/guide/en/kibana/7.x/alerting-getting-started.html#alerting-getting-started[Kibana alerting and actions] rely on the Elasticsearch API keys feature which requires TLS to be enabled at the application level. If you want to use these features, you should not disable the self-signed certificate on the Elasticsearch resource and enable `PERMISSIVE` mode for the Elasticsearch service through a `DestinationRule` or `PeerAuthentication` resource. Strict mTLS mode is currently not compatible with Elastic Stack features requiring TLS to be enabled for the Elasticsearch HTTP layer.
 
-IMPORTANT: If you are using a Kubernetes distribution such as Minikube which does not have support for issuing third-party security tokens, you should explicitly set `automountServiceAccountToken` field to `true` in the pod templates to allow Istio to fallback to default service account tokens. Refer to link:https://istio.io/docs/ops/best-practices/security/#configure-third-party-service-account-tokens[Istio security best practices] for more information.
+IMPORTANT: If you use a Kubernetes distribution like Minikube, which does not have support for issuing third-party security tokens, you should explicitly set `automountServiceAccountToken` field to `true` in the Pod templates to allow Istio to fallback to default service account tokens. Refer to link:https://istio.io/docs/ops/best-practices/security/#configure-third-party-service-account-tokens[Istio security best practices] for more information.
 
 
 [id="{p}-service-mesh-istio-operator-connection"]
 === Connect the operator to the Istio service mesh
 
-The operator itself must be connected to the service mesh in order to deploy and manage Elastic Stack resources that you wish to connect to the service mesh. This is achieved by injecting an Istio sidecar to the ECK operator pods. The following instructions assume that link:https://istio.io/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection[automatic sidecar injection] is enabled on your cluster via a mutating admissions webhook. Refer to link:https://istio.io/docs/setup/additional-setup/sidecar-injection/#injection[Istio injection documentation] if you prefer a different method of injection.
+The operator itself must be connected to the service mesh to deploy and manage Elastic Stack resources that you wish to connect to the service mesh. This is achieved by injecting an Istio sidecar to the ECK operator Pods. The following instructions assume that link:https://istio.io/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection[automatic sidecar injection] is enabled on your cluster through a mutating admissions webhook. Refer to link:https://istio.io/docs/setup/additional-setup/sidecar-injection/#injection[Istio injection documentation] if you prefer a different method of injection.
 
-Create the `elastic-system` namespace and enable sidecar injection:
-
+. Create the `elastic-system` namespace and enable sidecar injection:
++
 [source,sh]
 ----
 kubectl create namespace elastic-system
 kubectl label namespace elastic-system istio-injection=enabled
 ----
 
-Install ECK:
-
+. Install ECK:
++
 [source,sh,subs="attributes"]
 ----
 kubectl apply -f https://download.elastic.co/downloads/eck/{eck_version}/all-in-one.yaml
 ----
 
-Check the configuration to ensure that the installation has been successful:
-
+. Check the configuration and make sure the installation has been successful:
++
 [source,sh]
 ----
 kubectl get pod elastic-operator-0 -n elastic-system -o=jsonpath='{range .spec.containers[*]}{.name}{"\n"}'
 ----
 
-If the output of the above command contains both `manager` and `istio-proxy`, ECK has been successfully installed with the Istio sidecar injected.
+If the output of the above command contains both `manager` and `istio-proxy`, ECK was successfully installed with the Istio sidecar injected.
 
-[NOTE]
-====
-
-In order for the <<{p}-webhook,validating webhook>> to work under Istio, you need to exclude the inbound port 9443 from being proxied. This can be done by editing the template definition of the `elastic-operator` StatefulSet to add the following annotations to the operator pod:
+////
+To make the <<{p}-webhook,validating webhook>> work under Istio, you need to exclude the inbound port 9443 from being proxied. This can be done by editing the template definition of the `elastic-operator` StatefulSet to add the following annotations to the operator Pod:
 
 [source,yaml]
 ----
@@ -72,16 +72,13 @@ spec:
 [...]
 ----
 
-As the default `failurePolicy` of the webhook is `Ignore`, the operator will continue to function even if the above annotations are not present. The downside is that you will be able to submit an invalid manifest using `kubectl` without receiving any immediate feedback. ECK has a fallback validation mechanism that reports validation failures as events associated with the relevant resource ({eck_resources_list}) that must be manually discovered by running `kubectl describe ...`  
-
-====
-
+As the default `failurePolicy` of the webhook is `Ignore`, the operator continues to function even if the above annotations are not present. The downside is that you are still able to submit an invalid manifest using `kubectl` without receiving any immediate feedback. ECK has a fallback validation mechanism that reports validation failures as events associated with the relevant resource ({eck_resources_list}) that must be manually discovered by running `kubectl describe ...`.  
+////
 
 [id="{p}-service-mesh-istio-stack-connection"]
 === Connect Elastic Stack applications to the Istio service mesh
 
-
-NOTE: This section assumes that you are deploying Elasticsearch, Kibana, or APM Server resources to a namespace that has link:https://istio.io/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection[automatic sidecar injection] enabled.
+This section assumes that you are deploying Elasticsearch, Kibana, or APM Server resources to a namespace that has link:https://istio.io/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection[automatic sidecar injection] enabled.
 
 If you have configured Istio in link:https://istio.io/docs/concepts/security/#permissive-mode[permissive mode], examples defined elsewhere in the ECK documentation will continue to work without requiring any modifications. However, if you have enabled strict mutual TLS authentication between services either via global (`MeshPolicy`) or namespace-level (`Policy`) configuration, the following modifications to the resource manifests are necessary for correct operation.
 
@@ -113,9 +110,9 @@ spec:
         automountServiceAccountToken: true <3>
 ----
 
-<1> Disable the default self-signed certificate generated by the operator and allow TLS to be managed by Istio. Note that disabling the self-signed certificate might interfere with some features such as Kibana Alerting and Actions.
+<1> Disable the default self-signed certificate generated by the operator and allow TLS to be managed by Istio. Disabling the self-signed certificate might interfere with some features such as Kibana Alerting and Actions.
 
-<2> Exclude the transport port (port 9300) from being proxied. Currently ECK does not support switching off X-Pack security and TLS for the Elasticsearch transport port. If Istio is allowed to proxy the transport port, the traffic will be encrypted twice and communication between Elasticsearch nodes will be disrupted.
+<2> Exclude the transport port (port 9300) from being proxied. Currently ECK does not support switching off X-Pack security and TLS for the Elasticsearch transport port. If Istio is allowed to proxy the transport port, the traffic is encrypted twice and communication between Elasticsearch nodes is disrupted.
 
 <3> Optional. Only set `automountServiceAccountToken` to `true` if your Kubernetes cluster does not have support for issuing third-party security tokens.
 
@@ -149,7 +146,8 @@ Refer to the link:https://istio.io/docs/tasks/security/authentication/mtls-migra
 
 There are link:https://istio.io/docs/setup/additional-setup/cni/#compatibility-with-application-init-containers[known issues with init containers] when Istio CNI is configured. If you use init containers to <<{p}-init-containers-plugin-downloads,install Elasticsearch plugins>> or perform other initialization tasks that require network access, they may fail due to outbound traffic being blocked by the CNI plugin. To work around this issue, explicitly allow the external ports used by the init containers.
 
-.Installing plugins using an init container
+To install plugins using an init container, use the following code:
+
 [source,yaml,subs="attributes,callouts"]
 ----
 apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}

--- a/docs/advanced-topics/service-meshes.asciidoc
+++ b/docs/advanced-topics/service-meshes.asciidoc
@@ -57,7 +57,6 @@ kubectl get pod elastic-operator-0 -n elastic-system -o=jsonpath='{range .spec.c
 
 If the output of the above command contains both `manager` and `istio-proxy`, ECK was successfully installed with the Istio sidecar injected.
 
-////
 To make the <<{p}-webhook,validating webhook>> work under Istio, you need to exclude the inbound port 9443 from being proxied. This can be done by editing the template definition of the `elastic-operator` StatefulSet to add the following annotations to the operator Pod:
 
 [source,yaml]
@@ -72,8 +71,9 @@ spec:
 [...]
 ----
 
-As the default `failurePolicy` of the webhook is `Ignore`, the operator continues to function even if the above annotations are not present. The downside is that you are still able to submit an invalid manifest using `kubectl` without receiving any immediate feedback. ECK has a fallback validation mechanism that reports validation failures as events associated with the relevant resource ({eck_resources_list}) that must be manually discovered by running `kubectl describe ...`.  
-////
+As the default `failurePolicy` of the webhook is `Ignore`, the operator continues to function even if the above annotations are not present. The downside is that you are still able to submit an invalid manifest using `kubectl` without receiving any immediate feedback. 
+
+ECK has a fallback validation mechanism that reports validation failures as events associated with the relevant resource ({eck_resources_list}) that must be manually discovered by running `kubectl describe`. For example, to find the validation errors in an Elasticsearch resource named `quickstart`, you can run `kubectl describe elasticsearch quickstart`.
 
 [id="{p}-service-mesh-istio-stack-connection"]
 === Connect Elastic Stack applications to the Istio service mesh

--- a/docs/advanced-topics/service-meshes.asciidoc
+++ b/docs/advanced-topics/service-meshes.asciidoc
@@ -78,7 +78,7 @@ As the default `failurePolicy` of the webhook is `Ignore`, the operator continue
 [id="{p}-service-mesh-istio-stack-connection"]
 === Connect Elastic Stack applications to the Istio service mesh
 
-This section assumes that you are deploying Elasticsearch, Kibana, or APM Server resources to a namespace that has link:https://istio.io/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection[automatic sidecar injection] enabled.
+This section assumes that you are deploying ECK custom resources to a namespace that has link:https://istio.io/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection[automatic sidecar injection] enabled.
 
 If you have configured Istio in link:https://istio.io/docs/concepts/security/#permissive-mode[permissive mode], examples defined elsewhere in the ECK documentation will continue to work without requiring any modifications. However, if you have enabled strict mutual TLS authentication between services either via global (`MeshPolicy`) or namespace-level (`Policy`) configuration, the following modifications to the resource manifests are necessary for correct operation.
 

--- a/docs/advanced-topics/service-meshes.asciidoc
+++ b/docs/advanced-topics/service-meshes.asciidoc
@@ -146,7 +146,7 @@ Refer to the link:https://istio.io/docs/tasks/security/authentication/mtls-migra
 
 There are link:https://istio.io/docs/setup/additional-setup/cni/#compatibility-with-application-init-containers[known issues with init containers] when Istio CNI is configured. If you use init containers to <<{p}-init-containers-plugin-downloads,install Elasticsearch plugins>> or perform other initialization tasks that require network access, they may fail due to outbound traffic being blocked by the CNI plugin. To work around this issue, explicitly allow the external ports used by the init containers.
 
-To install plugins using an init container, use the following code:
+To install plugins using an init container, use a manifest similar to the following:
 
 [source,yaml,subs="attributes,callouts"]
 ----

--- a/docs/advanced-topics/traffic-splitting.asciidoc
+++ b/docs/advanced-topics/traffic-splitting.asciidoc
@@ -8,12 +8,11 @@ endif::[]
 [id="{p}-{page_id}"]
 = Traffic Splitting
 
-The default Kubernetes service created by ECK -- named `<cluster_name>-es-http` -- is configured to include all the Elasticsearch nodes in that cluster. This configuration is good enough to get started and adequate for most simple use cases. However, if you are operating an Elasticsearch cluster with link:https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[different node types] and want control over which nodes handle which types of traffic, you should create additional Kubernetes services yourself to do so. Alternatively, you could make use of features provided by third-party software such as service meshes and ingress controllers to achieve more advanced traffic management configurations.
+The default Kubernetes service created by ECK, named `<cluster_name>-es-http`, is configured to include all the Elasticsearch nodes in that cluster. This configuration is good to get started and is adequate for most use cases. However, if you are operating an Elasticsearch cluster with link:https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[different node types] and want control over which nodes handle which types of traffic, you should create additional Kubernetes services yourself. 
 
-NOTE: The link:{eck_github}/tree/{eck_release_branch}/config/recipes[recipes directory] in the ECK source repository contains several examples of using third-party service meshes and ingress controllers for managing traffic to ECK resources.
+As an alternative, you can use features provided by third-party software such as service meshes and ingress controllers to achieve more advanced traffic management configurations. Check the link:{eck_github}/tree/{eck_release_branch}/config/recipes[recipes directory] in the ECK source repository for a few examples. 
 
-
-The service configurations shown in the following sections are based on this definition of an Elasticsearch cluster:
+The service configurations shown in these sections are based on the following Elasticsearch cluster definition:
 
 [source,yaml,subs="attributes"]
 ----


### PR DESCRIPTION
This PR:

- Fixes some link text (avoid "here")
- Reduces the number of Note, Warning, Caution, that overload the text flow
- Relates to [#65639](https://github.com/elastic/cloud/issues/65639)

## Notes for the reviewer

I commented out the following text, as it's not clear if this needs to stay:

```
To make the <<{p}-webhook,validating webhook>> work under Istio, you need to exclude the inbound port 9443 from being proxied. This can be done by editing the template definition of the `elastic-operator` StatefulSet to add the following annotations to the operator Pod:

[source,yaml]
----
[...]
spec:
  template:
    metadata:
      annotations:
        traffic.sidecar.istio.io/excludeInboundPorts: "9443"
        traffic.sidecar.istio.io/includeInboundPorts: '*'
[...]
----

As the default `failurePolicy` of the webhook is `Ignore`, the operator continues to function even if the above annotations are not present. The downside is that you are still able to submit an invalid manifest using `kubectl` without receiving any immediate feedback. ECK has a fallback validation mechanism that reports validation failures as events associated with the relevant resource ({eck_resources_list}) that must be manually discovered by running `kubectl describe ...`.  
```
