### PR TITLE
Add brackets around address in kind IPv6 E2E test

### DIFF
--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -122,6 +122,7 @@ TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
 
 OPERATOR_IMAGE = $JKS_PARAM_OPERATOR_IMAGE
+TEST_TIMEOUT = 10m
 KIND_NODE_IMAGE = ${kindNodeImage}
 IP_FAMILY=$4
 

--- a/config/e2e/batch_job.yaml
+++ b/config/e2e/batch_job.yaml
@@ -46,6 +46,11 @@ spec:
               mountPath: /var/run/secrets/e2e
           securityContext:
             allowPrivilegeEscalation: false
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
       volumes:
         - name: test-config
           configMap:

--- a/test/e2e/beat/recipes_test.go
+++ b/test/e2e/beat/recipes_test.go
@@ -108,7 +108,7 @@ func TestMetricbeatStackMonitoringRecipe(t *testing.T) {
 			newSecretName := strings.Replace(currSecretName, "elasticsearch", fmt.Sprintf("elasticsearch-%s", builder.Suffix), 1)
 			builder.Beat.Spec.Deployment.PodTemplate.Spec.Containers[0].Env[1].ValueFrom.SecretKeyRef.Name = newSecretName
 
-			// We are using the pod's IP address exposed though the downward API to detect if the test is running in an IPv6 environment.
+			// We are using the pod's IP address exposed through the downward API to detect if the test is running in an IPv6 environment.
 			if net.ToIPFamily(os.Getenv(EnvPodIP)) == corev1.IPv6Protocol {
 				// In an IPv6 environment we need to patch the configuration to add some brackets around the data.host variable.
 				json, err := builder.Beat.Spec.Config.MarshalJSON()


### PR DESCRIPTION
This PR adds some brackets around `${data.host}` when running in a IPv6 environment.

Fix #3737

~_Still a draft as I'm not done with the tests_~