### PR TITLE
Upgrade Beats examples versions to 7.9.1

### DIFF
--- a/config/recipes/beats/auditbeat_hosts.yaml
+++ b/config/recipes/beats/auditbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: auditbeat
 spec:
   type: auditbeat
-  version: 7.8.1
+  version: 7.9.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -118,7 +118,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.1
+  version: 7.9.0
   nodeSets:
   - name: default
     count: 3
@@ -130,7 +130,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.1
+  version: 7.9.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/auditbeat_hosts.yaml
+++ b/config/recipes/beats/auditbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: auditbeat
 spec:
   type: auditbeat
-  version: 7.9.0
+  version: 7.9.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -118,7 +118,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.9.0
+  version: 7.9.1
   nodeSets:
   - name: default
     count: 3
@@ -130,7 +130,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.9.0
+  version: 7.9.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 7.9.0
+  version: 7.9.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -99,7 +99,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.9.0
+  version: 7.9.1
   nodeSets:
   - name: default
     count: 3
@@ -111,7 +111,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.9.0
+  version: 7.9.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 7.8.1
+  version: 7.9.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -99,7 +99,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.1
+  version: 7.9.0
   nodeSets:
   - name: default
     count: 3
@@ -111,7 +111,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.1
+  version: 7.9.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
+++ b/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 7.9.0
+  version: 7.9.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -101,7 +101,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.9.0
+  version: 7.9.1
   nodeSets:
   - name: default
     count: 3
@@ -113,7 +113,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.9.0
+  version: 7.9.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
+++ b/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 7.8.1
+  version: 7.9.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -101,7 +101,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.1
+  version: 7.9.0
   nodeSets:
   - name: default
     count: 3
@@ -113,7 +113,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.1
+  version: 7.9.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_no_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_no_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 7.9.0
+  version: 7.9.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -53,7 +53,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.9.0
+  version: 7.9.1
   nodeSets:
   - name: default
     count: 3
@@ -65,7 +65,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.9.0
+  version: 7.9.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_no_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_no_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 7.8.1
+  version: 7.9.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -53,7 +53,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.1
+  version: 7.9.0
   nodeSets:
   - name: default
     count: 3
@@ -65,7 +65,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.1
+  version: 7.9.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/heartbeat_es_kb_health.yaml
+++ b/config/recipes/beats/heartbeat_es_kb_health.yaml
@@ -4,7 +4,7 @@ metadata:
   name: heartbeat
 spec:
   type: heartbeat
-  version: 7.8.1
+  version: 7.9.0
   elasticsearchRef:
     name: elasticsearch
   config:
@@ -27,7 +27,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.1
+  version: 7.9.0
   nodeSets:
   - name: default
     count: 3
@@ -39,7 +39,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.1
+  version: 7.9.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/heartbeat_es_kb_health.yaml
+++ b/config/recipes/beats/heartbeat_es_kb_health.yaml
@@ -4,7 +4,7 @@ metadata:
   name: heartbeat
 spec:
   type: heartbeat
-  version: 7.9.0
+  version: 7.9.1
   elasticsearchRef:
     name: elasticsearch
   config:
@@ -27,7 +27,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.9.0
+  version: 7.9.1
   nodeSets:
   - name: default
     count: 3
@@ -39,7 +39,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.9.0
+  version: 7.9.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/journalbeat_hosts.yaml
+++ b/config/recipes/beats/journalbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: journalbeat
 spec:
   type: journalbeat
-  version: 7.8.1
+  version: 7.9.0
   elasticsearchRef:
     name: elasticsearch
   config:
@@ -49,7 +49,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.1
+  version: 7.9.0
   nodeSets:
   - name: default
     count: 3
@@ -61,7 +61,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.1
+  version: 7.9.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/journalbeat_hosts.yaml
+++ b/config/recipes/beats/journalbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: journalbeat
 spec:
   type: journalbeat
-  version: 7.9.0
+  version: 7.9.1
   elasticsearchRef:
     name: elasticsearch
   config:
@@ -49,7 +49,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.9.0
+  version: 7.9.1
   nodeSets:
   - name: default
     count: 3
@@ -61,7 +61,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.9.0
+  version: 7.9.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/metricbeat_hosts.yaml
+++ b/config/recipes/beats/metricbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 7.9.0
+  version: 7.9.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -174,7 +174,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.9.0
+  version: 7.9.1
   nodeSets:
   - name: default
     count: 3
@@ -186,7 +186,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.9.0
+  version: 7.9.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/metricbeat_hosts.yaml
+++ b/config/recipes/beats/metricbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 7.8.1
+  version: 7.9.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -174,7 +174,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.1
+  version: 7.9.0
   nodeSets:
   - name: default
     count: 3
@@ -186,7 +186,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.1
+  version: 7.9.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/packetbeat_dns_http.yaml
+++ b/config/recipes/beats/packetbeat_dns_http.yaml
@@ -4,7 +4,7 @@ metadata:
   name: packetbeat
 spec:
   type: packetbeat
-  version: 7.8.1
+  version: 7.9.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -44,7 +44,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.1
+  version: 7.9.0
   nodeSets:
   - name: default
     count: 3
@@ -56,7 +56,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.1
+  version: 7.9.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/packetbeat_dns_http.yaml
+++ b/config/recipes/beats/packetbeat_dns_http.yaml
@@ -4,7 +4,7 @@ metadata:
   name: packetbeat
 spec:
   type: packetbeat
-  version: 7.9.0
+  version: 7.9.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -44,7 +44,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.9.0
+  version: 7.9.1
   nodeSets:
   - name: default
     count: 3
@@ -56,7 +56,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.9.0
+  version: 7.9.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -6,7 +6,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 7.9.0
+  version: 7.9.1
   elasticsearchRef:
     name: elasticsearch-monitoring
   config:
@@ -118,7 +118,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 7.9.0
+  version: 7.9.1
   elasticsearchRef:
     name: elasticsearch-monitoring
   kibanaRef:
@@ -215,7 +215,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.9.0
+  version: 7.9.1
   nodeSets:
   - name: default
     count: 3
@@ -234,7 +234,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.9.0
+  version: 7.9.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -252,7 +252,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-monitoring
 spec:
-  version: 7.9.0
+  version: 7.9.1
   nodeSets:
   - name: default
     count: 3
@@ -264,7 +264,7 @@ kind: Kibana
 metadata:
   name: kibana-monitoring
 spec:
-  version: 7.9.0
+  version: 7.9.1
   count: 1
   elasticsearchRef:
     name: elasticsearch-monitoring

--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -6,7 +6,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 7.8.1
+  version: 7.9.0
   elasticsearchRef:
     name: elasticsearch-monitoring
   config:
@@ -118,7 +118,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 7.8.1
+  version: 7.9.0
   elasticsearchRef:
     name: elasticsearch-monitoring
   kibanaRef:
@@ -215,7 +215,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.8.1
+  version: 7.9.0
   nodeSets:
   - name: default
     count: 3
@@ -234,7 +234,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.8.1
+  version: 7.9.0
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -252,7 +252,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-monitoring
 spec:
-  version: 7.8.1
+  version: 7.9.0
   nodeSets:
   - name: default
     count: 3
@@ -264,7 +264,7 @@ kind: Kibana
 metadata:
   name: kibana-monitoring
 spec:
-  version: 7.8.1
+  version: 7.9.0
   count: 1
   elasticsearchRef:
     name: elasticsearch-monitoring


### PR DESCRIPTION
This PR ups the version in Configuration Examples for Beat to `7.9.1`. Tested all recipe e2e tests in GKE successfully.