### PR TITLE
Update the OpenShift compatibility with 7.9

### DIFF
--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -17,7 +17,6 @@ This page shows how to run ECK on OpenShift.
 * <<{p}-openshift-beats>>
 
 WARNING: For versions older than 7.9, APM Server and Enterprise Search are not compatible with `restricted` SCC. Use this <<{p}-openshift-apm,workaround>> to overcome this limitation.
-With version 7.9, the APM Server is compatible with `restricted` SCC, while for Enterprise Search the incompatibility remains and can be addressed with the same workaround.
 
 [float]
 [id="{p}-openshift-before-you-begin"]

--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -16,7 +16,7 @@ This page shows how to run ECK on OpenShift.
 * <<{p}-openshift-anyuid-workaround>>
 * <<{p}-openshift-beats>>
 
-WARNING: For versions older than 7.9, APM Server and Enterprise Search are not compatible with `restricted` SCC. Use this <<{p}-openshift-apm,workaround>> to overcome this limitation.
+WARNING: Some Docker images are incompatible with the `restricted` SCC. This is the case for the *APM Server before 7.9* and for the *Enterprise Search 7.9*. You can use this <<{p}-openshift-anyuid-workaround,workaround>> to run those images with the `anyuid` SCC.
 
 [float]
 [id="{p}-openshift-before-you-begin"]

--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -16,7 +16,7 @@ This page shows how to run ECK on OpenShift.
 * <<{p}-openshift-apm,Deploy an APM Server instance with a route>>
 * <<{p}-openshift-beats,Grant privileged permissions to Beats>>
 
-NOTE: Only Elasticsearch and Kibana are compatible with the `restricted` https://docs.openshift.com/container-platform/4.1/authentication/managing-security-context-constraints.html[Security Context Constraint]. To run the APM Server on OpenShift you must allow the Pod to run with the `anyuid` SCC as described in <<{p}-openshift-apm>>.
+WARNING: With Elastic Stack 7.9, note that APM Server is now compatible with OpenShift, see <<{p}-openshift-apm>>. Enterprise Search 7.9 is not yet compatible with Openshift.
 
 [float]
 [id="{p}-openshift-before-you-begin"]
@@ -157,7 +157,7 @@ oc get route -n elastic
 [id="{p}-openshift-apm"]
 == Deploy an APM Server instance with a route
 
-It is currently not possible to run the APM Server with the `restricted` SCC. A possible workaround is to allow the Pod to run with the default `uid 1000` by assigning it to the `anyuid` SCC:
+With Elastic Stack 7.9, it is possible to run the APM Server with the `restricted` SCC. For versions older than 7.9, you can use this workaround to allow the Pod to run with the default `uid 1000` by assigning it to the `anyuid` SCC:
 
 . Create a service account to run the APM Server:
 +

--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -157,7 +157,7 @@ oc get route -n elastic
 [id="{p}-openshift-apm"]
 == Deploy an APM Server instance with a route
 
-With Elastic Stack 7.9, it is possible to run the APM Server with the `restricted` SCC. For versions older than 7.9, you can use this workaround to allow the Pod to run with the default `uid 1000` by assigning it to the `anyuid` SCC:
+Starting with version 7.9, it is possible to run the APM Server with the `restricted` SCC. For versions older than 7.9, you can use this workaround to allow the Pod to run with the default `uid 1000` by assigning it to the `anyuid` SCC:
 
 . Create a service account to run the APM Server:
 +

--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -13,7 +13,7 @@ This page shows how to run ECK on OpenShift.
 * <<{p}-openshift-deploy-the-operator>>
 * <<{p}-openshift-deploy-elasticsearch>>
 * <<{p}-openshift-deploy-kibana>>
-* <<{p}-openshift-apm>>
+* <<{p}-openshift-anyuid-workaround>>
 * <<{p}-openshift-beats>>
 
 WARNING: For versions older than 7.9, APM Server and Enterprise Search are not compatible with `restricted` SCC. Use this <<{p}-openshift-apm,workaround>> to overcome this limitation.

--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -155,7 +155,7 @@ Use the following command to get the hosts of each `Route`:
 oc get route -n elastic
 ----
 
-[id="{p}-openshift-apm"]
+[id="{p}-openshift-anyuid-workaround"]
 == Deploy Docker images with `anyuid` SCC
 
 Starting with version 7.9, it is possible to run the APM Server with the `restricted` SCC. For APM versions older than 7.9 and Enterprise Search version 7.9, you can use this workaround which allows the Pod to run with the default `uid 1000` by assigning it to the `anyuid` SCC:

--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -9,14 +9,15 @@ endif::[]
 
 This page shows how to run ECK on OpenShift.
 
-* <<{p}-openshift-before-you-begin,Before you begin>>
-* <<{p}-openshift-deploy-the-operator,Deploy the operator>>
-* <<{p}-openshift-deploy-elasticsearch,Deploy an Elasticsearch instance with a route>>
-* <<{p}-openshift-deploy-kibana,Deploy a Kibana instance with a route>>
-* <<{p}-openshift-apm,Deploy an APM Server instance with a route>>
-* <<{p}-openshift-beats,Grant privileged permissions to Beats>>
+* <<{p}-openshift-before-you-begin>>
+* <<{p}-openshift-deploy-the-operator>>
+* <<{p}-openshift-deploy-elasticsearch>>
+* <<{p}-openshift-deploy-kibana>>
+* <<{p}-openshift-apm>>
+* <<{p}-openshift-beats>>
 
-WARNING: With Elastic Stack 7.9, note that APM Server is now compatible with OpenShift, see <<{p}-openshift-apm>>. Enterprise Search 7.9 is not yet compatible with Openshift.
+WARNING: For versions older than 7.9, APM Server and Enterprise Search are not compatible with `restricted` SCC. Use this <<{p}-openshift-apm,workaround>> to overcome this limitation.
+With version 7.9, the APM Server is compatible with `restricted` SCC, while for Enterprise Search the incompatibility remains and can be addressed with the same workaround.
 
 [float]
 [id="{p}-openshift-before-you-begin"]
@@ -155,9 +156,9 @@ oc get route -n elastic
 ----
 
 [id="{p}-openshift-apm"]
-== Deploy an APM Server instance with a route
+== Deploy Docker images with `anyuid` SCC
 
-Starting with version 7.9, it is possible to run the APM Server with the `restricted` SCC. For versions older than 7.9, you can use this workaround to allow the Pod to run with the default `uid 1000` by assigning it to the `anyuid` SCC:
+Starting with version 7.9, it is possible to run the APM Server with the `restricted` SCC. For APM versions older than 7.9 and Enterprise Search version 7.9, you can use this workaround which allows the Pod to run with the default `uid 1000` by assigning it to the `anyuid` SCC:
 
 . Create a service account to run the APM Server:
 +


### PR DESCRIPTION
This PR updates the OpenShift compatibility for APM  and Enterprise Search 7.9

Fixes #3110
Relates to #3742