### PR TITLE
Deployer: add options to create GKE private/net. policy enforced clusters

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -28,11 +28,16 @@ plans:
     adminUsername: admin
     localSsdCount: 1
     nodeCountPerZone: 1
+    # Uncomment option below to create a private GKE cluster.
+    # Note that when a cluster is private you must:
+    #   1. Create a firewall rule so that the webhook can be accessed from the API server (see https://github.com/elastic/cloud-on-k8s/issues/1673#issuecomment-528449682)
+    #   2. Create a VM to access the subnet and authorize the VM to access the master, see https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#private_master
+    # private: true
     # gke creates a secondary IP range for all Pods of a cluster
     # gke defaults to a /14 subnet, which allows 262k Pods per cluster, but only 62 subnets to be created
     # /20 allows 4094 subnets, with up to 4094 IPs (Pods) per subnet
     # more clusters can therefore be created in the same VPC network.
-    # we set a default of /20 that can be overriden here
+    # we set a default of /20 that can be overridden here
     # clusterIpv4Cidr: /20
     # servicesIpv4Cidr: /20
     gcpScopes: https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -28,6 +28,8 @@ plans:
     adminUsername: admin
     localSsdCount: 1
     nodeCountPerZone: 1
+    # Uncomment option below to enable network policy enforcement in GKE.
+    # networkPolicy: true
     # Uncomment option below to create a private GKE cluster.
     # Note that when a cluster is private you must:
     #   1. Create a firewall rule so that the webhook can be accessed from the API server (see https://github.com/elastic/cloud-on-k8s/issues/1673#issuecomment-528449682)

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -112,7 +112,7 @@ func (d *GkeDriver) Execute() error {
 		if d.plan.Gke.Private {
 			log.Printf("a private cluster has been created, please retrieve credentials manually and create storage class and provider if needed")
 			log.Printf("to authorize a VM to access this cluster run the following command:\n"+
-				"$ cloud container clusters update %s"+
+				"$ gcloud container clusters update %s"+
 				" --region %s "+
 				"--enable-master-authorized-networks"+
 				" --master-authorized-networks  <VM IP>/32",

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -117,6 +117,11 @@ func (d *GkeDriver) Execute() error {
 				"--enable-master-authorized-networks"+
 				" --master-authorized-networks  <VM IP>/32",
 				d.plan.ClusterName, d.plan.Gke.Region)
+			log.Printf("you can then retrieve the credentials with the following command:\n"+
+				"$ gcloud container clusters get-credentials %s"+
+				" --region %s "+
+				" --project %s",
+				d.plan.ClusterName, d.plan.Gke.Region, d.plan.Gke.GCloudProject)
 			return nil
 		}
 

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -70,7 +70,6 @@ func (gdf *GkeDriverFactory) Create(plan Plan) (Driver, error) {
 			"KubernetesVersion": plan.KubernetesVersion,
 			"MachineType":       plan.MachineType,
 			"LocalSsdCount":     plan.Gke.LocalSsdCount,
-			"Private":           plan.Gke.Private,
 			"GcpScopes":         plan.Gke.GcpScopes,
 			"NodeCountPerZone":  plan.Gke.NodeCountPerZone,
 			"ClusterIPv4CIDR":   clusterIPv4CIDR,

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -192,6 +192,10 @@ func (d *GkeDriver) create() error {
 		opts = append(opts, "--enable-pod-security-policy")
 	}
 
+	if d.plan.Gke.NetworkPolicy {
+		opts = append(opts, "--enable-network-policy")
+	}
+
 	if d.plan.Gke.Private {
 		opts = append(opts, "--create-subnetwork name={{.ClusterName}}-private-subnet", "--enable-master-authorized-networks", "--enable-ip-alias", "--enable-private-nodes", "--enable-private-endpoint", "--master-ipv4-cidr", "172.16.0.32/28")
 	} else {

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -70,6 +70,7 @@ func (gdf *GkeDriverFactory) Create(plan Plan) (Driver, error) {
 			"KubernetesVersion": plan.KubernetesVersion,
 			"MachineType":       plan.MachineType,
 			"LocalSsdCount":     plan.Gke.LocalSsdCount,
+			"Private":           plan.Gke.Private,
 			"GcpScopes":         plan.Gke.GcpScopes,
 			"NodeCountPerZone":  plan.Gke.NodeCountPerZone,
 			"ClusterIPv4CIDR":   clusterIPv4CIDR,
@@ -106,6 +107,17 @@ func (d *GkeDriver) Execute() error {
 			if err := d.bindRoles(); err != nil {
 				return err
 			}
+		}
+
+		if d.plan.Gke.Private {
+			log.Printf("a private cluster has been created, please retrieve credentials manually and create storage class and provider if needed")
+			log.Printf("to authorize a VM to access this cluster run the following command:\n"+
+				"$ cloud container clusters update %s"+
+				" --region %s "+
+				"--enable-master-authorized-networks"+
+				" --master-authorized-networks  <VM IP>/32",
+				d.plan.ClusterName, d.plan.Gke.Region)
+			return nil
 		}
 
 		if err := d.GetCredentials(); err != nil {
@@ -180,6 +192,12 @@ func (d *GkeDriver) create() error {
 		opts = append(opts, "--enable-pod-security-policy")
 	}
 
+	if d.plan.Gke.Private {
+		opts = append(opts, "--create-subnetwork name={{.ClusterName}}-private-subnet", "--enable-master-authorized-networks", "--enable-ip-alias", "--enable-private-nodes", "--enable-private-endpoint", "--master-ipv4-cidr", "172.16.0.32/28")
+	} else {
+		opts = append(opts, "--create-subnetwork range={{.ClusterIPv4CIDR}}", "--cluster-ipv4-cidr={{.ClusterIPv4CIDR}}", "--services-ipv4-cidr={{.ServicesIPv4CIDR}}")
+	}
+
 	return NewCommand(`gcloud beta container --project {{.GCloudProject}} clusters create {{.ClusterName}} ` +
 		`--region {{.Region}} --username {{.AdminUsername}} --cluster-version {{.KubernetesVersion}} ` +
 		`--machine-type {{.MachineType}} --image-type COS --disk-type pd-ssd --disk-size 30 ` +
@@ -187,19 +205,22 @@ func (d *GkeDriver) create() error {
 		`--enable-stackdriver-kubernetes --addons HorizontalPodAutoscaling,HttpLoadBalancing ` +
 		`--no-enable-autoupgrade --no-enable-autorepair --enable-ip-alias --metadata disable-legacy-endpoints=true ` +
 		`--network projects/{{.GCloudProject}}/global/networks/default ` +
-		`--create-subnetwork range={{.ClusterIPv4CIDR}} --cluster-ipv4-cidr={{.ClusterIPv4CIDR}} --services-ipv4-cidr={{.ServicesIPv4CIDR}} ` +
 		strings.Join(opts, " ")).
 		AsTemplate(d.ctx).
 		Run()
 }
 
 func (d *GkeDriver) bindRoles() error {
-	log.Println("Binding roles...")
 	user, err := NewCommand(`gcloud auth list --filter=status:ACTIVE --format="value(account)"`).Output()
 	if err != nil {
 		return err
 	}
 	cmd := "kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user=" + user
+	if d.plan.Gke.Private {
+		log.Printf("this is a private cluster, please bind roles manually from an authorized VM with the following command:\n$ %s\n", cmd)
+		return nil
+	}
+	log.Println("Binding roles...")
 	return NewCommand(cmd).Run()
 }
 

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -52,6 +52,7 @@ type GkeSettings struct {
 	ServicesIPv4CIDR string `yaml:"servicesIpv4Cidr"`
 	DiskSetup        string `yaml:"diskSetup"`
 	Private          bool   `yaml:"private"`
+	NetworkPolicy    bool   `yaml:"networkPolicy"`
 }
 
 // AksSettings encapsulates settings specific to AKS

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -51,6 +51,7 @@ type GkeSettings struct {
 	ClusterIPv4CIDR  string `yaml:"clusterIpv4Cidr"`
 	ServicesIPv4CIDR string `yaml:"servicesIpv4Cidr"`
 	DiskSetup        string `yaml:"diskSetup"`
+	Private          bool   `yaml:"private"`
 }
 
 // AksSettings encapsulates settings specific to AKS


### PR DESCRIPTION
While investigating private cluster or network policy related issues I found myself not able to create corresponding clusters with the deployer

This PR adds 2 dedicated options, `private` and `networkPolicy` to the deployer in order to create private/net. policy enforced clusters:

```yaml
id: gke-dev
overrides:
  gke:
    gCloudProject: ...
    private: true
    networkPolicy: true
```

Options are both `false` by default. Current behaviour is preserved.