### PR TITLE
Improve Elasticsearch CPU req doc

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
@@ -22,7 +22,9 @@ You can set compute resource constraints in the `podTemplate` of objects managed
 For Elasticsearch objects, make sure to consider the heap size when you set resource requirements.
 A good rule of thumb is to size it to half the size of RAM allocated to the Pod.
 
-To minimize disruption caused by Pod evictions due to resource contention, you should run Elasticsearch pods at the "Guaranteed" QoS level by setting both `requests` and `limits` to the same value.
+To minimize disruption caused by Pod evictions due to resource contention, you can run Elasticsearch pods at the "Guaranteed" QoS level by setting both `requests` and `limits` to the same value.
+
+The value set for cpu requests directly impacts Elasticsearch `node.processors` setting. For example, with `resources.requests.cpu: 1`, Elasticsearch effectively relies on a single core, which may significantly limit performance. Consider setting a higher value that matches the desired number of cores Elasticsearch can use. You can also set your own value for `node.processors` in the Elasticsearch config.
 
 Consider also that Kubernetes throttles containers exceeding the CPU limit defined in the `limits` section. Do not set this value too low or it would affect the performance of Elasticsearch, even if you have enough resources available in the Kubernetes cluster.
 
@@ -56,10 +58,9 @@ spec:
           resources:
             requests:
               memory: 4Gi
-              cpu: 0.5
+              cpu: 8
             limits:
               memory: 4Gi
-              cpu: 2
 ----
 
 [float]


### PR DESCRIPTION
* Make it clear that CPU requests directly impacts Elasticsearch nodes.processors.
* Replace "should run ... at Guaranteed QoS level", by "can run ...", considering
the various performance problems with cpu limits throttling
* Modify the example to require 8 cpus instead of 0.5, which makes more sense
* Modify the example to not set cpu limits by default

Fixes https://github.com/elastic/cloud-on-k8s/issues/3733.