### PR TITLE
Create the e2e-default storage class with the static provisioner

### DIFF
--- a/hack/deployer/config/local-disks/ssd-provisioner.yaml
+++ b/hack/deployer/config/local-disks/ssd-provisioner.yaml
@@ -1,3 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: e2e-default
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/hack/deployer/runner/aks.go
+++ b/hack/deployer/runner/aks.go
@@ -97,7 +97,7 @@ func (d *AksDriver) Execute() error {
 			return err
 		}
 
-		if err := createStorageClass(NoProvisioner); err != nil {
+		if err := createStorageClass(); err != nil {
 			return err
 		}
 

--- a/hack/deployer/runner/aks.go
+++ b/hack/deployer/runner/aks.go
@@ -97,11 +97,10 @@ func (d *AksDriver) Execute() error {
 			return err
 		}
 
-		if err := createStorageClass(); err != nil {
+		if err := setupDisks(d.plan); err != nil {
 			return err
 		}
-
-		if err := NewCommand(d.plan.Aks.DiskSetup).Run(); err != nil {
+		if err := createStorageClass(); err != nil {
 			return err
 		}
 	default:

--- a/hack/deployer/runner/eks.go
+++ b/hack/deployer/runner/eks.go
@@ -122,10 +122,11 @@ func (e *EKSDriver) Execute() error {
 		} else {
 			log.Printf("Not creating cluster as it already exists")
 		}
-		if err := createStorageClass(); err != nil {
+
+		if err := setupDisks(e.plan); err != nil {
 			return err
 		}
-		return NewCommand(e.plan.EKS.DiskSetup).Run()
+		return createStorageClass()
 	}
 	return nil
 }

--- a/hack/deployer/runner/eks.go
+++ b/hack/deployer/runner/eks.go
@@ -122,7 +122,7 @@ func (e *EKSDriver) Execute() error {
 		} else {
 			log.Printf("Not creating cluster as it already exists")
 		}
-		if err := createStorageClass(NoProvisioner); err != nil {
+		if err := createStorageClass(); err != nil {
 			return err
 		}
 		return NewCommand(e.plan.EKS.DiskSetup).Run()

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -128,10 +128,10 @@ func (d *GkeDriver) Execute() error {
 			return err
 		}
 
-		if err := createStorageClass(); err != nil {
+		if err := setupDisks(d.plan); err != nil {
 			return err
 		}
-		if err := d.createSsdProvider(); err != nil {
+		if err := createStorageClass(); err != nil {
 			return err
 		}
 	default:
@@ -139,10 +139,6 @@ func (d *GkeDriver) Execute() error {
 	}
 
 	return err
-}
-
-func (d *GkeDriver) createSsdProvider() error {
-	return NewCommand(d.plan.Gke.DiskSetup).Run()
 }
 
 func (d *GkeDriver) auth() error {

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -128,7 +128,7 @@ func (d *GkeDriver) Execute() error {
 			return err
 		}
 
-		if err := createStorageClass(NoProvisioner); err != nil {
+		if err := createStorageClass(); err != nil {
 			return err
 		}
 		if err := d.createSsdProvider(); err != nil {

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -170,7 +170,7 @@ func (d *OcpDriver) Execute() error {
 			return err
 		}
 
-		if err := createStorageClass(DefaultStorageClass); err != nil {
+		if err := createStorageClass(); err != nil {
 			return err
 		}
 

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -170,10 +170,12 @@ func (d *OcpDriver) Execute() error {
 			return err
 		}
 
+		if err := setupDisks(d.plan); err != nil {
+			return err
+		}
 		if err := createStorageClass(); err != nil {
 			return err
 		}
-
 	default:
 		err = fmt.Errorf("unknown operation %s", d.plan.Operation)
 	}

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -30,6 +30,7 @@ type Plan struct {
 	VaultInfo         *VaultInfo   `yaml:"vaultInfo,omitempty"`
 	ServiceAccount    bool         `yaml:"serviceAccount"`
 	Psp               bool         `yaml:"psp"`
+	DiskSetup         string       `yaml:"diskSetup"`
 }
 
 type VaultInfo struct {
@@ -50,7 +51,6 @@ type GkeSettings struct {
 	GcpScopes        string `yaml:"gcpScopes"`
 	ClusterIPv4CIDR  string `yaml:"clusterIpv4Cidr"`
 	ServicesIPv4CIDR string `yaml:"servicesIpv4Cidr"`
-	DiskSetup        string `yaml:"diskSetup"`
 	Private          bool   `yaml:"private"`
 	NetworkPolicy    bool   `yaml:"networkPolicy"`
 }

--- a/hack/deployer/runner/storage.go
+++ b/hack/deployer/runner/storage.go
@@ -7,15 +7,8 @@ package runner
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
 	"time"
-)
-
-var (
-	StorageClassProvisionerRegExp = regexp.MustCompile(`provisioner:.+\n`)
-	DefaultStorageClass           = ""
-	NoProvisioner                 = "kubernetes.io/no-provisioner"
 )
 
 // Retrieving the default storage class is retried up to getDefaultScRetries times,
@@ -26,7 +19,7 @@ const (
 )
 
 // createStorageClass based on default storageclass, creates new, non-default class with "volumeBindingMode: WaitForFirstConsumer"
-func createStorageClass(provisioner string) error {
+func createStorageClass() error {
 	log.Println("Creating storage class...")
 
 	if exists, err := NewCommand("kubectl get sc").OutputContainsAny("e2e-default"); err != nil {
@@ -47,9 +40,7 @@ func createStorageClass(provisioner string) error {
 
 	sc = strings.Replace(sc, fmt.Sprintf("name: %s", defaultName), "name: e2e-default", -1)
 	sc = strings.Replace(sc, "volumeBindingMode: Immediate", "volumeBindingMode: WaitForFirstConsumer", -1)
-	if provisioner != "" {
-		sc = StorageClassProvisionerRegExp.ReplaceAllString(sc, fmt.Sprintf("provisioner: %s\n", provisioner))
-	}
+
 	// Some providers (AKS) don't allow changing the default. To avoid having two defaults, set newly created storage
 	// class to be non-default. Depending on k8s version, a different annotation is needed. To avoid parsing version
 	// string, both are set.

--- a/hack/deployer/runner/storage.go
+++ b/hack/deployer/runner/storage.go
@@ -20,13 +20,13 @@ const (
 
 // createStorageClass based on default storageclass, creates new, non-default class with "volumeBindingMode: WaitForFirstConsumer"
 func createStorageClass() error {
-	log.Println("Creating storage class...")
-
 	if exists, err := NewCommand("kubectl get sc").OutputContainsAny("e2e-default"); err != nil {
 		return err
 	} else if exists {
 		return nil
 	}
+
+	log.Println("Creating storage class...")
 
 	defaultName, err := getDefaultStorageClassName()
 	if err != nil {
@@ -49,6 +49,13 @@ func createStorageClass() error {
 	return NewCommand(fmt.Sprintf(`cat <<EOF | kubectl apply -f -
 %s
 EOF`, sc)).Run()
+}
+
+func setupDisks(plan Plan) error {
+	if plan.DiskSetup == "" {
+		return nil
+	}
+	return NewCommand(plan.DiskSetup).Run()
 }
 
 func getDefaultStorageClassName() (string, error) {


### PR DESCRIPTION
Before this PR, we did not create the `e2e-default` storage class to
match PVCs created by the static provisioner as part of deploying the provisioner itself.

Instead, the `e2e-default` storage class was created as part of the e2e
tests bootstrap, by retrieving the default storage class (eg. gke standard),
then patching both the provisioner (to an empty value so gke provisioner
does not get triggered), and setting `volumeBindingMode: waitForFirstConsumer`.

This leads to the `e2e-default` storage class getting created as:

```yaml
allowVolumeExpansion: true
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: e2e-default
parameters:
  type: pd-standard
provisioner: kubernetes.io/no-provisioner
reclaimPolicy: Delete
volumeBindingMode: WaitForFirstConsumer
```

A few things do not make sense here:
- the parameters still match gke provisioner parameters
- `allowVolumeExpansion: true`, whereas it's not supported on the local provisioner

Instead of doing that, I think we can simply pre-create the e2e-default storage
class with the right parameters when deploying the provisioner. The e2e bootstrap
will detect that storage class is already there, and just use it.

If the static provisioner is not deployed, the e2e bootstrap will create an `e2e-default`
storage class based on the default storage class available.

Additionally, this PR removes the need for the `provisioner` argument in `createStorageClass`:
Either we rely on the pre-existing e2e-default storage class, either we create it based on the default storage class, which
already has the provisioner set.