### PR TITLE
Add CRD usage reporting

### DIFF
--- a/deploy/eck-operator/templates/configmap.yaml
+++ b/deploy/eck-operator/templates/configmap.yaml
@@ -17,6 +17,7 @@ data:
     cert-validity: {{ .Values.config.certificatesValidity }}
     cert-rotate-before: {{ .Values.config.certificatesRotateBefore }}
     set-default-security-context: {{ .Values.config.setDefaultSecurityContext }}
+    disable-telemetry: {{ .Values.telemetry.disabled }}
     {{- if .Values.tracing.enabled }}
     enable-tracing: true
     {{- end }}

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -107,6 +107,10 @@ softMultiTenancy:
 # kubeAPIServerIP is required when softMultiTenancy is enabled.
 kubeAPIServerIP: null
 
+telemetry:
+  # disabled determines whether the operator periodically updates ECK telemetry data for Kibana to consume.
+  disabled: false
+
 # config values for the operator.
 config:
   # logVerbosity defines the logging level. Valid values are as follows:
@@ -143,3 +147,4 @@ config:
 # Internal use only
 internal:
   manifestGen: false
+

--- a/docs/operating-eck/operator-config.asciidoc
+++ b/docs/operating-eck/operator-config.asciidoc
@@ -20,6 +20,7 @@ ECK can be configured using either command line flags or environment variables.
 |config |"" | Path to a file containing the operator configuration.
 |container-registry |docker.elastic.co | Container registry to use for pulling Elastic Stack container images.
 |disable-config-watch| false| Watch the configuration file for changes and restart to apply them. Only effective when the `--config` flag is used to set the configuration file.
+|disable-telemetry| false| Disable periodically updating ECK telemetry data for Kibana to consume.
 |enable-leader-election | true | Enable leader election. Must be set to true if using multiple replicas of the operator
 |enable-tracing | false | Enable APM tracing in the operator process. Use environment variables to configure APM server URL, credentials, and so on. See link:https://www.elastic.co/guide/en/apm/agent/go/1.x/configuration.html[Apm Go Agent reference] for details.
 |enable-webhook | false | Enables a validating webhook server in the operator process.

--- a/pkg/controller/common/operator/flags.go
+++ b/pkg/controller/common/operator/flags.go
@@ -15,6 +15,7 @@ const (
 	ContainerSuffixFlag           = "container-suffix"
 	DebugHTTPListenFlag           = "debug-http-listen"
 	DisableConfigWatch            = "disable-config-watch"
+	DisableTelemetryFlag          = "disable-telemetry"
 	EnableLeaderElection          = "enable-leader-election"
 	EnableTracingFlag             = "enable-tracing"
 	EnableWebhookFlag             = "enable-webhook"

--- a/pkg/controller/kibana/config_reconcile_test.go
+++ b/pkg/controller/kibana/config_reconcile_test.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/elastic/cloud-on-k8s/pkg/about"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
@@ -106,7 +105,7 @@ func TestReconcileConfigSecret(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			k8sClient := k8s.WrappedFakeClient(tt.args.initialObjects...)
 
-			err := ReconcileConfigSecret(context.Background(), k8sClient, tt.args.kb, CanonicalConfig{settings.NewCanonicalConfig()}, about.OperatorInfo{})
+			err := ReconcileConfigSecret(context.Background(), k8sClient, tt.args.kb, CanonicalConfig{settings.NewCanonicalConfig()})
 			assert.NoError(t, err)
 
 			var secrets corev1.SecretList

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -132,7 +132,7 @@ func (d *driver) Reconcile(
 		return results.WithError(err)
 	}
 
-	err = ReconcileConfigSecret(ctx, d.client, *kb, kbSettings, params.OperatorInfo)
+	err = ReconcileConfigSecret(ctx, d.client, *kb, kbSettings)
 	if err != nil {
 		return results.WithError(err)
 	}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -1,0 +1,208 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package telemetry
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/elastic/cloud-on-k8s/pkg/about"
+	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
+	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
+	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/ghodss/yaml"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	updateInterval = 10 * time.Second
+	resourceCount  = "resource_count"
+	podCount       = "pod_count"
+)
+
+var log = logf.Log.WithName("usage")
+
+type getUsageFn func(k8s.Client, []string) (string, interface{}, error)
+
+// ECK is a helper struct to marshal telemetry information.
+type ECK struct {
+	ECK   about.OperatorInfo     `json:"eck"`
+	Usage map[string]interface{} `json:"eck_usage"`
+}
+
+func NewReporter(info about.OperatorInfo, client client.Client, managedNamespaces []string) Reporter {
+	if len(managedNamespaces) == 0 {
+		// treat no managed namespaces as managing all namespaces, ie. set empty string for namespace filtering
+		managedNamespaces = append(managedNamespaces, "")
+	}
+
+	return Reporter{
+		operatorInfo:      info,
+		client:            k8s.WrapClient(client),
+		managedNamespaces: managedNamespaces,
+	}
+}
+
+type Reporter struct {
+	operatorInfo      about.OperatorInfo
+	client            k8s.Client
+	managedNamespaces []string
+}
+
+func (r *Reporter) Start() {
+	ticker := time.NewTicker(updateInterval)
+	for range ticker.C {
+		usage, err := r.getResourceUsage()
+		if err != nil {
+			log.Error(err, "failed to get resource usage")
+			continue
+		}
+
+		telemetryBytes, err := yaml.Marshal(ECK{ECK: r.operatorInfo, Usage: usage})
+		if err != nil {
+			log.Error(err, "failed to marshal telemetry data")
+		}
+
+		for _, ns := range r.managedNamespaces {
+			var kibanaList kbv1.KibanaList
+			if err := r.client.List(&kibanaList, client.InNamespace(ns)); err != nil {
+				log.Error(err, "failed to list kibanas")
+				continue
+			}
+			for _, kb := range kibanaList.Items {
+				var secret corev1.Secret
+				nsName := types.NamespacedName{Namespace: kb.Namespace, Name: kibana.SecretName(kb)}
+				if err := r.client.Get(nsName, &secret); err != nil {
+					log.Error(err, "failed to get kibana secret")
+					continue
+				}
+
+				secret.Data[kibana.TelemetryFilename] = telemetryBytes
+				if err := r.client.Update(&secret); err != nil {
+					log.Error(err, "failed to update kibana secret")
+					continue
+				}
+			}
+		}
+	}
+}
+
+func (r *Reporter) getResourceUsage() (map[string]interface{}, error) {
+	usage := map[string]interface{}{}
+	for _, f := range []getUsageFn{
+		esUsage,
+		kbUsage,
+		apmUsage,
+		beatUsage,
+		entUsage,
+	} {
+		key, usagePart, err := f(r.client, r.managedNamespaces)
+		if err != nil {
+			return nil, err
+		}
+		usage[key] = usagePart
+	}
+
+	return usage, nil
+}
+
+func esUsage(k8sClient k8s.Client, managedNamespaces []string) (string, interface{}, error) {
+	usage := map[string]int32{resourceCount: 0, podCount: 0}
+
+	var esList esv1.ElasticsearchList
+	for _, ns := range managedNamespaces {
+		if err := k8sClient.List(&esList, client.InNamespace(ns)); err != nil {
+			return "", nil, err
+		}
+
+		for _, es := range esList.Items {
+			usage[resourceCount]++
+			usage[podCount] += es.Status.AvailableNodes
+		}
+	}
+	return "elasticsearches", usage, nil
+}
+
+func kbUsage(k8sClient k8s.Client, managedNamespaces []string) (string, interface{}, error) {
+	usage := map[string]int32{resourceCount: 0, podCount: 0}
+
+	var kbList kbv1.KibanaList
+	for _, ns := range managedNamespaces {
+		if err := k8sClient.List(&kbList, client.InNamespace(ns)); err != nil {
+			return "", nil, err
+		}
+
+		for _, kb := range kbList.Items {
+			usage[resourceCount]++
+			usage[podCount] += kb.Status.AvailableNodes
+		}
+	}
+	return "kibanas", usage, nil
+}
+
+func apmUsage(k8sClient k8s.Client, managedNamespaces []string) (string, interface{}, error) {
+	usage := map[string]int32{resourceCount: 0, podCount: 0}
+
+	var apmList apmv1.ApmServerList
+	for _, ns := range managedNamespaces {
+		if err := k8sClient.List(&apmList, client.InNamespace(ns)); err != nil {
+			return "", nil, err
+		}
+
+		for _, apm := range apmList.Items {
+			usage[resourceCount]++
+			usage[podCount] += apm.Status.AvailableNodes
+		}
+	}
+	return "apms", usage, nil
+}
+
+func beatUsage(k8sClient k8s.Client, managedNamespaces []string) (string, interface{}, error) {
+	typeToName := func(typ string) string { return fmt.Sprintf("%s_count", typ) }
+
+	usage := map[string]int32{resourceCount: 0, podCount: 0}
+	for typ := range beatv1beta1.KnownTypes {
+		usage[typeToName(typ)] = 0
+	}
+
+	var beatList beatv1beta1.BeatList
+	for _, ns := range managedNamespaces {
+		if err := k8sClient.List(&beatList, client.InNamespace(ns)); err != nil {
+			return "", nil, err
+		}
+
+		for _, beat := range beatList.Items {
+			usage[resourceCount]++
+			usage[typeToName(beat.Spec.Type)]++
+			usage[podCount] += beat.Status.AvailableNodes
+		}
+	}
+
+	return "beats", usage, nil
+}
+
+func entUsage(k8sClient k8s.Client, managedNamespaces []string) (string, interface{}, error) {
+	usage := map[string]int32{resourceCount: 0, podCount: 0}
+
+	var entList entv1beta1.EnterpriseSearchList
+	for _, ns := range managedNamespaces {
+		if err := k8sClient.List(&entList, client.InNamespace(ns)); err != nil {
+			return "", nil, err
+		}
+
+		for _, apm := range entList.Items {
+			usage[resourceCount]++
+			usage[podCount] += apm.Status.AvailableNodes
+		}
+	}
+	return "enterprisesearches", usage, nil
+}

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -1,0 +1,236 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/pkg/about"
+	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
+	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
+	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var testOperatorInfo = about.OperatorInfo{
+	OperatorUUID:            "15039433-f873-41bd-b6e7-10ee3665cafa",
+	CustomOperatorNamespace: true,
+	Distribution:            "v1.16.13-gke.1",
+	BuildInfo: about.BuildInfo{
+		Version:  "1.1.0",
+		Hash:     "b5316231",
+		Date:     "2019-09-20T07:00:00Z",
+		Snapshot: "true",
+	},
+}
+
+func TestMarshalTelemetry(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		info  about.OperatorInfo
+		stats map[string]interface{}
+		want  string
+	}{
+		{
+			name:  "empty",
+			info:  about.OperatorInfo{},
+			stats: nil,
+			want: `eck:
+  build:
+    date: ""
+    hash: ""
+    snapshot: ""
+    version: ""
+  custom_operator_namespace: false
+  distribution: ""
+  operator_uuid: ""
+  stats: null
+`,
+		},
+		{
+			name: "not empty",
+			info: testOperatorInfo,
+			stats: map[string]interface{}{
+				"apms": map[string]interface{}{
+					"pod_count":      2,
+					"resource_count": 1,
+				},
+			},
+			want: `eck:
+  build:
+    date: "2019-09-20T07:00:00Z"
+    hash: b5316231
+    snapshot: "true"
+    version: 1.1.0
+  custom_operator_namespace: true
+  distribution: v1.16.13-gke.1
+  operator_uuid: 15039433-f873-41bd-b6e7-10ee3665cafa
+  stats:
+    apms:
+      pod_count: 2
+      resource_count: 1
+`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBytes, gotErr := marshalTelemetry(tt.info, tt.stats)
+			require.NoError(t, gotErr)
+			require.Equal(t, tt.want, string(gotBytes))
+		})
+	}
+}
+
+func TestNewReporter(t *testing.T) {
+	createKbAndSecret := func(name, namespace string, count int32) (kbv1.Kibana, corev1.Secret) {
+		kb := kbv1.Kibana{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: kbv1.KibanaSpec{
+				Count: count,
+			},
+		}
+		return kb, corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kibana.SecretName(kb),
+				Namespace: namespace,
+			},
+		}
+	}
+
+	kb1, s1 := createKbAndSecret("kb1", "ns1", 1)
+	kb2, s2 := createKbAndSecret("kb2", "ns2", 2)
+	kb3, s3 := createKbAndSecret("kb3", "ns3", 3)
+
+	client := k8s.FakeClient(
+		&kb1,
+		&kb2,
+		&kb3,
+		&s1,
+		&s2,
+		&s3,
+		&esv1.Elasticsearch{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns1",
+			},
+			Status: esv1.ElasticsearchStatus{
+				AvailableNodes: 3,
+			},
+		},
+		&apmv1.ApmServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns1",
+			},
+			Status: apmv1.ApmServerStatus{
+				DeploymentStatus: commonv1.DeploymentStatus{
+					AvailableNodes: 2,
+				},
+			},
+		},
+		&entv1beta1.EnterpriseSearch{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns1",
+			},
+			Status: entv1beta1.EnterpriseSearchStatus{
+				DeploymentStatus: commonv1.DeploymentStatus{
+					AvailableNodes: 3,
+				},
+			},
+		},
+		&beatv1beta1.Beat{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "beat1",
+				Namespace: "ns1",
+			},
+			Spec: beatv1beta1.BeatSpec{
+				Type: "filebeat",
+			},
+			Status: beatv1beta1.BeatStatus{
+				AvailableNodes: 7,
+			},
+		},
+		&beatv1beta1.Beat{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "beat2",
+				Namespace: "ns2",
+			},
+			Spec: beatv1beta1.BeatSpec{
+				Type: "metricbeat",
+			},
+			Status: beatv1beta1.BeatStatus{
+				AvailableNodes: 1,
+			},
+		},
+		&beatv1beta1.Beat{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "beat3",
+				Namespace: "ns3",
+			},
+			Spec: beatv1beta1.BeatSpec{
+				Type: "metricbeat",
+			},
+			Status: beatv1beta1.BeatStatus{
+				AvailableNodes: 7,
+			},
+		},
+	)
+
+	r := NewReporter(testOperatorInfo, client, []string{kb1.Namespace, kb2.Namespace})
+	r.report()
+
+	wantData := map[string][]byte{
+		"telemetry.yml": []byte(`eck:
+  build:
+    date: "2019-09-20T07:00:00Z"
+    hash: b5316231
+    snapshot: "true"
+    version: 1.1.0
+  custom_operator_namespace: true
+  distribution: v1.16.13-gke.1
+  operator_uuid: 15039433-f873-41bd-b6e7-10ee3665cafa
+  stats:
+    apms:
+      pod_count: 2
+      resource_count: 1
+    beats:
+      auditbeat_count: 0
+      filebeat_count: 1
+      heartbeat_count: 0
+      journalbeat_count: 0
+      metricbeat_count: 1
+      packetbeat_count: 0
+      pod_count: 8
+      resource_count: 2
+    elasticsearches:
+      pod_count: 3
+      resource_count: 1
+    enterprisesearches:
+      pod_count: 3
+      resource_count: 1
+    kibanas:
+      pod_count: 0
+      resource_count: 2
+`),
+	}
+
+	require.NoError(t, client.Get(context.Background(), k8s.ExtractNamespacedName(&s1), &s1))
+	require.Equal(t, wantData, s1.Data)
+
+	require.NoError(t, client.Get(context.Background(), k8s.ExtractNamespacedName(&s2), &s2))
+	require.Equal(t, wantData, s2.Data)
+
+	require.NoError(t, client.Get(context.Background(), k8s.ExtractNamespacedName(&s3), &s3))
+	require.Nil(t, s3.Data)
+}

--- a/test/e2e/test/checks.go
+++ b/test/e2e/test/checks.go
@@ -21,9 +21,10 @@ func CheckTestSteps(b Builder, k *K8sClient) StepList {
 
 // ExpectedSecret represents a Secret we expect to exist.
 type ExpectedSecret struct {
-	Name   string
-	Labels map[string]string
-	Keys   []string
+	Name         string
+	Labels       map[string]string
+	Keys         []string
+	OptionalKeys []string
 }
 
 // MatchesActualSecret fetches the corresponding secret from k and returns an error if it mismatches.
@@ -33,8 +34,11 @@ func (e ExpectedSecret) MatchesActualSecret(k *K8sClient, namespace string) erro
 	if err := k.Client.Get(types.NamespacedName{Namespace: namespace, Name: e.Name}, &s); err != nil {
 		return err
 	}
+
 	// have the expected keys
-	if len(s.Data) != len(e.Keys) {
+	min := len(e.Keys)
+	max := min + len(e.OptionalKeys)
+	if min <= len(s.Data) && len(s.Data) <= max {
 		return fmt.Errorf("expected %d keys in %s, got %d", len(e.Keys), e.Name, len(s.Data))
 	}
 	for _, k := range e.Keys {

--- a/test/e2e/test/checks.go
+++ b/test/e2e/test/checks.go
@@ -38,8 +38,8 @@ func (e ExpectedSecret) MatchesActualSecret(k *K8sClient, namespace string) erro
 	// have the expected keys
 	min := len(e.Keys)
 	max := min + len(e.OptionalKeys)
-	if min <= len(s.Data) && len(s.Data) <= max {
-		return fmt.Errorf("expected %d keys in %s, got %d", len(e.Keys), e.Name, len(s.Data))
+	if len(s.Data) < min || max < len(s.Data) {
+		return fmt.Errorf("expected between %d and %d keys in %s, got %d", min, max, e.Name, len(s.Data))
 	}
 	for _, k := range e.Keys {
 		if _, exists := s.Data[k]; !exists {

--- a/test/e2e/test/kibana/checks_k8s.go
+++ b/test/e2e/test/kibana/checks_k8s.go
@@ -135,8 +135,9 @@ func CheckSecrets(b Builder, k *test.K8sClient) test.Step {
 		// hardcode all secret names and keys to catch any breaking change
 		expected := []test.ExpectedSecret{
 			{
-				Name: kbName + "-kb-config",
-				Keys: []string{"kibana.yml", "telemetry.yml"},
+				Name:         kbName + "-kb-config",
+				Keys:         []string{"kibana.yml"},
+				OptionalKeys: []string{"telemetry.yml"},
 				Labels: map[string]string{
 					"eck.k8s.elastic.co/credentials": "true",
 					"kibana.k8s.elastic.co/name":     kbName,


### PR DESCRIPTION
This PR adds CRD usage reporting.

On an interval (currently 1h), we will scan all managed namespaces for all ECK resources (es, kb, apm, beats, ent) and update all Kibana config secrets with our findings under `telemetry.yml` key:
```
$ k view-secret kibana-kb-config    telemetry.yml
eck:
  build:
    date: "2019-09-20T07:00:00Z"
    hash: dkowalski_latest
    snapshot: "true"
    version: 1.1.0
  custom_operator_namespace: false
  distribution: v1.16.13-gke.1
  operator_uuid: 15039433-f873-41bd-b6e7-10ee3665cafa
  stats:
    apms:
      pod_count: 0
      resource_count: 0
    beats:
      auditbeat_count: 0
      filebeat_count: 0
      heartbeat_count: 0
      journalbeat_count: 0
      metricbeat_count: 0
      packetbeat_count: 0
      pod_count: 0
      resource_count: 0
    elasticsearches:
      pod_count: 3
      resource_count: 1
    enterprisesearches:
      pod_count: 0
      resource_count: 0
    kibanas:
      pod_count: 1
      resource_count: 1
```

Draft as tests are not yet added.