### PR TITLE
Add name label to namespaces

### DIFF
--- a/config/e2e/managed_namespaces.yaml
+++ b/config/e2e/managed_namespaces.yaml
@@ -6,5 +6,6 @@ kind: Namespace
 metadata:
   name: {{ . }}
   labels:
+    name: {{ . }}
     test-run: {{ $testRun }}
 {{- end }}

--- a/config/e2e/operator_namespaces.yaml
+++ b/config/e2e/operator_namespaces.yaml
@@ -5,4 +5,5 @@ kind: Namespace
 metadata:
   name: {{ .Operator.Namespace }}
   labels:
+    name: {{ .Operator.Namespace }}
     test-run: {{ $testRun }}

--- a/test/e2e/beat/webhook_test.go
+++ b/test/e2e/beat/webhook_test.go
@@ -22,6 +22,7 @@ func TestWebhook(t *testing.T) {
 		Spec: beatv1beta1.BeatSpec{
 			Type:    "filebeat",
 			Version: "7.8.0",
+			// neither DaemonSet nor Deployment provided - this should result in an error like below
 		},
 	}
 


### PR DESCRIPTION
Fixes recent failures of `TestWebhook` tests. Only the operator namespace was labelled with its name, so the webhook was not choosing test namespaces to run for correctly.