### PR TITLE
Add role namespace when generating rbac for managed namespaces in helm charts

### DIFF
--- a/deploy/eck-operator/templates/managed-ns-role-bindings.yaml
+++ b/deploy/eck-operator/templates/managed-ns-role-bindings.yaml
@@ -7,6 +7,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: "{{ $fullName }}"
+  namespace: {{ $namespace }}
   labels:
     {{- include "eck-operator.labels" $ | nindent 4 }}
 rules:


### PR DESCRIPTION
I think we're missing the namespace in the Role resource when
using managed namespaces: the Role ends up being created in the
default namespace, unavailable from the operator running in the
managed (eg. elastic-system) namespace.