### PR TITLE
Support UBI-only mode in CSV generator

### DIFF
--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -195,7 +195,12 @@ spec:
               containers:
               - image: {{ .OperatorRepo }}:{{ .NewVersion }}
                 name: manager
-                args: ["manager", "--config=/conf/eck.yaml"]
+                args:
+                  - "manager"
+                  - "--config=/conf/eck.yaml"
+                  {{- range  .AdditionalArgs }}
+                  - "{{.}}"
+                  {{- end }}
                 env:
                 - name: NAMESPACES
                   valueFrom:


### PR DESCRIPTION
Add an additional flag to the operatorhub tool to generate a CSV for Operator Lifecycle Manager that only runs UBI images.