### PR TITLE
Add distribution-channel flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,7 @@ ALL_IN_ONE_OUTPUT_FILE=config/all-in-one.yaml
 generate-all-in-one:
 	@ ./hack/manifest-gen/manifest-gen.sh -g \
 		--namespace=$(OPERATOR_NAMESPACE) \
+		--set=telemetry.distributionChannel=all-in-one \
 		--set=image.tag=$(IMG_VERSION) \
 		--set=image.repository=$(BASE_IMG) \
 		--set=nameOverride=$(OPERATOR_NAME) \

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -176,6 +176,11 @@ func Command() *cobra.Command {
 		false,
 		"Disable periodically updating ECK telemetry data for Kibana to consume.",
 	)
+	cmd.Flags().String(
+		operator.DistributionChannelFlag,
+		"",
+		"Set the distribution channel to report through the telemetry.",
+	)
 	cmd.Flags().Bool(
 		operator.EnforceRBACOnRefsFlag,
 		false, // Set to false for backward compatibility
@@ -270,6 +275,9 @@ func Command() *cobra.Command {
 	// hide development mode flags from the usage message
 	_ = cmd.Flags().MarkHidden(operator.AutoPortForwardFlag)
 	_ = cmd.Flags().MarkHidden(operator.DebugHTTPListenFlag)
+	
+	// hide flags set by the build process
+	_ = cmd.Flags().MarkHidden(operator.DistributionChannelFlag)
 
 	// hide the flag used for E2E test only
 	_ = cmd.Flags().MarkHidden(operator.TelemetryIntervalFlag)
@@ -498,7 +506,8 @@ func startOperator(stopChan <-chan struct{}) error {
 		return err
 	}
 
-	operatorInfo, err := about.GetOperatorInfo(clientset, operatorNamespace)
+	distributionChannel := viper.GetString(operator.DistributionChannelFlag)
+	operatorInfo, err := about.GetOperatorInfo(clientset, operatorNamespace, distributionChannel)
 	if err != nil {
 		log.Error(err, "Failed to get operator info")
 		return err

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -275,7 +275,7 @@ func Command() *cobra.Command {
 	// hide development mode flags from the usage message
 	_ = cmd.Flags().MarkHidden(operator.AutoPortForwardFlag)
 	_ = cmd.Flags().MarkHidden(operator.DebugHTTPListenFlag)
-	
+
 	// hide flags set by the build process
 	_ = cmd.Flags().MarkHidden(operator.DistributionChannelFlag)
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -179,7 +179,7 @@ func Command() *cobra.Command {
 	cmd.Flags().String(
 		operator.DistributionChannelFlag,
 		"",
-		"Set the distribution channel to report through the telemetry.",
+		"Set the distribution channel to report through telemetry.",
 	)
 	cmd.Flags().Bool(
 		operator.EnforceRBACOnRefsFlag,

--- a/deploy/eck-operator/templates/statefulset.yaml
+++ b/deploy/eck-operator/templates/statefulset.yaml
@@ -42,6 +42,7 @@ spec:
           args:
             - "manager"
             - "--config=/conf/eck.yaml"
+            - "--distributionChannel={{ .Values.telemetry.distributionChannel }}"
           {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/deploy/eck-operator/templates/statefulset.yaml
+++ b/deploy/eck-operator/templates/statefulset.yaml
@@ -42,7 +42,7 @@ spec:
           args:
             - "manager"
             - "--config=/conf/eck.yaml"
-            - "--distributionChannel={{ .Values.telemetry.distributionChannel }}"
+            - "--distribution-channel={{ .Values.telemetry.distributionChannel }}"
           {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -110,6 +110,8 @@ kubeAPIServerIP: null
 telemetry:
   # disabled determines whether the operator periodically updates ECK telemetry data for Kibana to consume.
   disabled: false
+  # distibutionChannel denotes which distribution channel was used to install the operator.
+  distributionChannel: "helm"
 
 # config values for the operator.
 config:

--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -2,6 +2,7 @@ newVersion: 1.3.0
 prevVersion: 1.2.1
 stackVersion: 7.9.1
 operatorRepo: docker.elastic.co/eck/eck-operator
+distributionChannel: upstream-community-operators
 crds:
   - name: elasticsearches.elasticsearch.k8s.elastic.co
     displayName: Elasticsearch Cluster

--- a/hack/operatorhub/main.go
+++ b/hack/operatorhub/main.go
@@ -293,7 +293,7 @@ func buildRenderParams(conf *config, extracts *yamlExtracts) (*RenderParams, err
 	}
 
 	if conf.DistributionChannel != "" {
-		additionalArgs = append(additionalArgs, "--distributionChannel=" + conf.DistributionChannel)
+		additionalArgs = append(additionalArgs, "--distribution-channel=" + conf.DistributionChannel)
 	}
 
 	return &RenderParams{

--- a/hack/operatorhub/main.go
+++ b/hack/operatorhub/main.go
@@ -106,11 +106,12 @@ func doRun(_ *cobra.Command, _ []string) error {
 }
 
 type config struct {
-	NewVersion   string `json:"newVersion"`
-	PrevVersion  string `json:"prevVersion"`
-	StackVersion string `json:"stackVersion"`
-	OperatorRepo string `json:"operatorRepo"`
-	CRDs         []struct {
+	NewVersion          string `json:"newVersion"`
+	PrevVersion         string `json:"prevVersion"`
+	StackVersion        string `json:"stackVersion"`
+	OperatorRepo        string `json:"operatorRepo"`
+	DistributionChannel string `json:"distributionChannel"`
+	CRDs                []struct {
 		Name        string `json:"name"`
 		DisplayName string `json:"displayName"`
 		Description string `json:"description"`
@@ -289,6 +290,10 @@ func buildRenderParams(conf *config, extracts *yamlExtracts) (*RenderParams, err
 	var additionalArgs []string
 	if args.ubiOnly {
 		additionalArgs = append(additionalArgs, "--ubi-only")
+	}
+
+	if conf.DistributionChannel != "" {
+		additionalArgs = append(additionalArgs, "--distributionChannel=" + conf.DistributionChannel)
 	}
 
 	return &RenderParams{

--- a/pkg/about/info.go
+++ b/pkg/about/info.go
@@ -31,6 +31,7 @@ type OperatorInfo struct {
 	OperatorUUID            types.UID `json:"operator_uuid"`
 	CustomOperatorNamespace bool      `json:"custom_operator_namespace"`
 	Distribution            string    `json:"distribution"`
+	DistributionChannel     string    `json:"distributionChannel"`
 	BuildInfo               BuildInfo `json:"build"`
 }
 
@@ -68,7 +69,7 @@ func (i OperatorInfo) IsDefined() bool {
 }
 
 // GetOperatorInfo returns an OperatorInfo given an operator client, a Kubernetes client config, an operator namespace.
-func GetOperatorInfo(clientset kubernetes.Interface, operatorNs string) (OperatorInfo, error) {
+func GetOperatorInfo(clientset kubernetes.Interface, operatorNs, distributionChannel string) (OperatorInfo, error) {
 	operatorUUID, err := getOperatorUUID(context.Background(), clientset, operatorNs)
 	if err != nil {
 		return OperatorInfo{}, err
@@ -90,6 +91,7 @@ func GetOperatorInfo(clientset kubernetes.Interface, operatorNs string) (Operato
 		OperatorUUID:            operatorUUID,
 		CustomOperatorNamespace: customOperatorNs,
 		Distribution:            distribution,
+		DistributionChannel:     distributionChannel,
 		BuildInfo:               GetBuildInfo(),
 	}, nil
 }

--- a/pkg/about/info_test.go
+++ b/pkg/about/info_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 const fakeOperatorNs = "elastic-system-test"
+const fakeDistributionChannel = "channel-1"
 
 func TestGetOperatorInfo(t *testing.T) {
 	tests := []struct {
@@ -68,7 +69,7 @@ func TestGetOperatorInfo(t *testing.T) {
 			fakeClientset := k8sfake.NewSimpleClientset(test.initObjs...)
 
 			// retrieve operator info a first time
-			operatorInfo, err := GetOperatorInfo(fakeClientset, fakeOperatorNs)
+			operatorInfo, err := GetOperatorInfo(fakeClientset, fakeOperatorNs, fakeDistributionChannel)
 			require.NoError(t, err)
 
 			// the operator uuid should be defined
@@ -76,7 +77,7 @@ func TestGetOperatorInfo(t *testing.T) {
 			test.assert(uuid)
 
 			// retrieve operator info a second time
-			operatorInfo, err = GetOperatorInfo(fakeClientset, fakeOperatorNs)
+			operatorInfo, err = GetOperatorInfo(fakeClientset, fakeOperatorNs, fakeDistributionChannel)
 			require.NoError(t, err)
 
 			// the operator uuid should be the same than the first time

--- a/pkg/controller/common/operator/flags.go
+++ b/pkg/controller/common/operator/flags.go
@@ -15,6 +15,7 @@ const (
 	DebugHTTPListenFlag           = "debug-http-listen"
 	DisableConfigWatch            = "disable-config-watch"
 	DisableTelemetryFlag          = "disable-telemetry"
+	DistributionChannelFlag       = "distribution-channel"
 	ElasticsearchClientTimeout    = "elasticsearch-client-timeout"
 	EnableLeaderElection          = "enable-leader-election"
 	EnableTracingFlag             = "enable-tracing"

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -27,6 +27,7 @@ var testOperatorInfo = about.OperatorInfo{
 	OperatorUUID:            "15039433-f873-41bd-b6e7-10ee3665cafa",
 	CustomOperatorNamespace: true,
 	Distribution:            "v1.16.13-gke.1",
+	DistributionChannel:     "test-channel",
 	BuildInfo: about.BuildInfo{
 		Version:  "1.1.0",
 		Hash:     "b5316231",
@@ -54,6 +55,7 @@ func TestMarshalTelemetry(t *testing.T) {
     version: ""
   custom_operator_namespace: false
   distribution: ""
+  distributionChannel: ""
   operator_uuid: ""
   stats: null
 `,
@@ -75,6 +77,7 @@ func TestMarshalTelemetry(t *testing.T) {
     version: 1.1.0
   custom_operator_namespace: true
   distribution: v1.16.13-gke.1
+  distributionChannel: test-channel
   operator_uuid: 15039433-f873-41bd-b6e7-10ee3665cafa
   stats:
     apms:
@@ -200,6 +203,7 @@ func TestNewReporter(t *testing.T) {
     version: 1.1.0
   custom_operator_namespace: true
   distribution: v1.16.13-gke.1
+  distributionChannel: test-channel
   operator_uuid: 15039433-f873-41bd-b6e7-10ee3665cafa
   stats:
     apms:


### PR DESCRIPTION
This PR adds a new flag to allow the telemetry report how was the operator installed. There are three ways this can happen today: directly through `all-in-one.yaml` file, through helm and through one of the OLM based ways.

As we don't want to create a separate image for each of those, we can't embed this information there. Instead, we pass the distribution channel as a parameter to the operator. To set a good default for each channel the helm chart uses the value of `telemetry.distributionChannel` as an argument in the invocation of `manager`.
1. By default, that value is set to `helm`, so users using helm directly have this set for them.
2. When generating `all-in-one.yaml` file, we set it to `all-in-one` when we invoke `manifest-gen`. We want to avoid setting it in ConfigMap with operator config as this ends up in the image as `config/eck.yaml` file. 
3. `operatorhub` tool now allows to set the arg value used in csv.


