### PR TITLE
Add flag to configure telemetry data updates interval

### DIFF
--- a/config/e2e/operator.yaml
+++ b/config/e2e/operator.yaml
@@ -235,6 +235,7 @@ spec:
         - "--enable-webhook"
         - "--log-verbosity=1"
         - "--metrics-port=9090"
+        - "--telemetry-interval=15s"
         {{ if .MonitoringSecrets }}
         - "--enable-tracing"
         {{end}}

--- a/pkg/controller/common/operator/flags.go
+++ b/pkg/controller/common/operator/flags.go
@@ -28,6 +28,7 @@ const (
 	NamespacesFlag                = "namespaces"
 	OperatorNamespaceFlag         = "operator-namespace"
 	SetDefaultSecurityContextFlag = "set-default-security-context"
+	TelemetryIntervalFlag         = "telemetry-interval"
 	UBIOnlyFlag                   = "ubi-only"
 	ValidateStorageClassFlag      = "validate-storage-class"
 	WebhookCertDirFlag            = "webhook-cert-dir"

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -31,6 +31,15 @@ const (
 
 var log = logf.Log.WithName("usage")
 
+type ECKTelemetry struct {
+	ECK ECK `json:"eck"`
+}
+
+type ECK struct {
+	about.OperatorInfo
+	Stats map[string]interface{} `json:"stats"`
+}
+
 type getStatsFn func(k8s.Client, []string) (string, interface{}, error)
 
 func NewReporter(
@@ -67,16 +76,8 @@ func (r *Reporter) Start() {
 }
 
 func marshalTelemetry(info about.OperatorInfo, stats map[string]interface{}) ([]byte, error) {
-	return yaml.Marshal(struct {
-		ECK struct {
-			about.OperatorInfo
-			Stats map[string]interface{} `json:"stats"`
-		} `json:"eck"`
-	}{
-		ECK: struct {
-			about.OperatorInfo
-			Stats map[string]interface{} `json:"stats"`
-		}{
+	return yaml.Marshal(ECKTelemetry{
+		ECK: ECK{
 			OperatorInfo: info,
 			Stats:        stats,
 		},

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -7,6 +7,7 @@ package telemetry
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/elastic/cloud-on-k8s/pkg/about"
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
@@ -187,7 +188,7 @@ func TestNewReporter(t *testing.T) {
 		},
 	)
 
-	r := NewReporter(testOperatorInfo, client, []string{kb1.Namespace, kb2.Namespace})
+	r := NewReporter(testOperatorInfo, client, []string{kb1.Namespace, kb2.Namespace}, 1*time.Hour)
 	r.report()
 
 	wantData := map[string][]byte{

--- a/test/e2e/kb/telemetry_test.go
+++ b/test/e2e/kb/telemetry_test.go
@@ -9,10 +9,15 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/pkg/telemetry"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/elastic/cloud-on-k8s/pkg/about"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	kibana2 "github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/kibana"
@@ -26,8 +31,53 @@ func TestTelemetry(t *testing.T) {
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)
 
+	// Kibana picks up static telemetry data from telemetry.yml very close to its start and then rereads it on a rather
+	// long interval (~hours). This means that the telemetry reporter is likely to be updating Kibana config Secret
+	// too late. To overcome that, we wait until the Secret is populated as expected, then we delete the Pod so
+	// it will be restarted. Kibana will then pick up the telemetry.yml file correctly and can validate that via API.
 	stepsFn := func(k *test.K8sClient) test.StepList {
 		return test.StepList{
+			{
+				Name: "Kibana config Secret should contain telemetry.yml key",
+				Test: test.Eventually(func() error {
+					var secret corev1.Secret
+					err := k.Client.Get(types.NamespacedName{
+						Namespace: kbBuilder.Kibana.Namespace,
+						Name:      kibana2.SecretName(kbBuilder.Kibana),
+					}, &secret)
+					if err != nil {
+						return err
+					}
+
+					if content, ok := secret.Data["telemetry.yml"]; !ok || len(content) == 0 {
+						return fmt.Errorf(
+							"telemetry.yml key not found or empty in %s/%s",
+							secret.Namespace,
+							secret.Name)
+					}
+
+					return nil
+				}),
+			},
+			{
+				Name: "Restart Kibana Pod for Kibana to pick up static telemetry data",
+				Test: test.Eventually(func() error {
+					pods, err := k.GetPods(
+						client.InNamespace(kbBuilder.Kibana.Namespace),
+						client.MatchingLabels{"kibana.k8s.elastic.co/name=": kbBuilder.Kibana.Name},
+					)
+					if err != nil {
+						return err
+					}
+
+					require.Equal(t, 1, len(pods))
+					if err := k.DeletePod(pods[0]); err != nil {
+						return err
+					}
+
+					return nil
+				}),
+			},
 			{
 				Name: "Kibana should expose eck info in telemetry data",
 				Test: test.Eventually(func() error {
@@ -62,7 +112,7 @@ func TestTelemetry(t *testing.T) {
 					if len(stats) == 0 {
 						return errors.New("cluster stats is empty")
 					}
-					eck := stats[0].StackStats.Kibana.Plugins.StaticTelemetry.Eck
+					eck := stats[0].StackStats.Kibana.Plugins.StaticTelemetry.ECK
 					if !eck.IsDefined() {
 						return fmt.Errorf("eck info not defined properly in telemetry data: %+v", eck)
 					}
@@ -91,7 +141,7 @@ type clusterStats []struct {
 		Kibana struct {
 			Plugins struct {
 				StaticTelemetry struct {
-					Eck about.OperatorInfo `json:"eck"`
+					telemetry.ECKTelemetry
 				} `json:"static_telemetry"`
 			} `json:"plugins"`
 		} `json:"kibana"`


### PR DESCRIPTION
Introducing a flag to allow changing telemetry updates interval from the default 1 hour for E2E tests. Specifically, for `TestTelemetry` that depends on telemetry data being present.