### PR TITLE
Allow the e2e operator to read storage classes

### DIFF
--- a/config/e2e/operator.yaml
+++ b/config/e2e/operator.yaml
@@ -167,6 +167,14 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
I missed that permission in the e2e operator ClusterRole. As a result
the e2e operator fails when trying to list storage classes.
