### PR TITLE
Update Helm documentation to include storage class validation flag

### DIFF
--- a/docs/operating-eck/installing-eck.asciidoc
+++ b/docs/operating-eck/installing-eck.asciidoc
@@ -76,6 +76,23 @@ helm install elastic-operator elastic/eck-operator -n elastic-system --create-na
   --set=config.validateStorageClass=false
 ----
 
+[NOTE]
+====
+
+The `eck-operator` chart contains several pre-defined profiles to help you install the operator in different configurations. These profiles can be found in the root of the chart directory, prefixed with `profile-`. For example, the restricted configuration shown above is defined in the `profile-restricted.yaml` file, and can be used as follows:
+
+[source,sh]
+----
+helm install elastic-operator elastic/eck-operator -n elastic-system --create-namespace \
+  --values="${CHART_DIR}/profile-restricted.yaml" \
+  --set=managedNamespaces='{namespace-a, namespace-b}'
+----
+
+You can find the profile files in the Helm cache directory or from the link:{eck_github}/tree/{eck_release_branch}/deploy/eck-operator[ECK source repository].
+
+====
+
+
 
 [float]
 [id="{p}-install-helm-show-values"]

--- a/docs/operating-eck/installing-eck.asciidoc
+++ b/docs/operating-eck/installing-eck.asciidoc
@@ -72,7 +72,8 @@ helm install elastic-operator elastic/eck-operator -n elastic-system --create-na
   --set=installCRDs=false \
   --set=managedNamespaces='{namespace-a, namespace-b}' \
   --set=createClusterScopedResources=false \
-  --set=webhook.enabled=false
+  --set=webhook.enabled=false \
+  --set=config.validateStorageClass=false
 ----
 
 


### PR DESCRIPTION
Update the Helm documentation to show that storage class validation should be turned off when installing in a restricted environment.

Ideally, setting `createClusterScopedResources` to `false` should just switch off all cluster-scoped features; however, there may be cases where users may want to only disable a particular feature as well. We end up with a flag soup because of this. 

