### PR TITLE
Fix Helm chart bugs

### DIFF
--- a/deploy/eck-operator/templates/_helpers.tpl
+++ b/deploy/eck-operator/templates/_helpers.tpl
@@ -177,19 +177,6 @@ RBAC permissions
   - patch
   - delete
 - apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  - validatingwebhookconfigurations
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - beat.k8s.elastic.co
   resources:
   - beats
@@ -217,4 +204,17 @@ RBAC permissions on non-namespaced resources
   - get
   - list
   - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 {{- end -}}

--- a/deploy/eck-operator/templates/cluster-roles.yaml
+++ b/deploy/eck-operator/templates/cluster-roles.yaml
@@ -60,15 +60,4 @@ rules:
   - apiGroups: ["beat.k8s.elastic.co"]
     resources: ["beats"]
     verbs: ["create", "delete", "deletecollection", "patch", "update"]
-{{- else -}}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ include "eck-operator.fullname" . }}
-  namespace: {{ .Release.namespace }}
-  labels:
-    {{- include "eck-operator.labels" . | nindent 4 }}
-rules:
-{{ template "eck-operator.rbacRules" . | toYaml | indent 2 }}
 {{- end -}}

--- a/deploy/eck-operator/templates/operator-role-binding.yaml
+++ b/deploy/eck-operator/templates/operator-role-binding.yaml
@@ -1,18 +1,30 @@
 {{- $operatorNSIsManaged := has .Release.Namespace .Values.managedNamespaces -}}
 {{- if not $operatorNSIsManaged -}}
+{{- if not .Values.createClusterScopedResources -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{- if $.Values.createClusterScopedResources }} ClusterRoleBinding {{- else }} RoleBinding {{- end }}
+kind: Role
 metadata:
   name: {{ include "eck-operator.fullname" . }}
-{{- if not $.Values.createClusterScopedResources }}
+  namespace: {{ .Release.namespace }}
+  labels:
+    {{- include "eck-operator.labels" . | nindent 4 }}
+rules:
+{{ template "eck-operator.rbacRules" . | toYaml | indent 2 }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{- if .Values.createClusterScopedResources }} ClusterRoleBinding {{- else }} RoleBinding {{- end }}
+metadata:
+  name: {{ include "eck-operator.fullname" . }}
+{{- if not .Values.createClusterScopedResources }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
   labels:
     {{- include "eck-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: {{- if $.Values.createClusterScopedResources }} ClusterRole {{- else }} Role {{- end }}
+  kind: {{- if .Values.createClusterScopedResources }} ClusterRole {{- else }} Role {{- end }}
   name: {{ include "eck-operator.fullname" . }}
 subjects:
 - kind: ServiceAccount

--- a/deploy/eck-operator/templates/operator-roles.yaml
+++ b/deploy/eck-operator/templates/operator-roles.yaml
@@ -35,7 +35,6 @@ rules:
   - apiGroups: ["beat.k8s.elastic.co"]
     resources: ["beats"]
     verbs: ["get", "list", "watch"]
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -61,4 +60,15 @@ rules:
   - apiGroups: ["beat.k8s.elastic.co"]
     resources: ["beats"]
     verbs: ["create", "delete", "deletecollection", "patch", "update"]
+{{- else -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "eck-operator.fullname" . }}
+  namespace: {{ .Release.namespace }}
+  labels:
+    {{- include "eck-operator.labels" . | nindent 4 }}
+rules:
+{{ template "eck-operator.rbacRules" . | toYaml | indent 2 }}
 {{- end -}}

--- a/deploy/eck-operator/templates/validate-chart.yaml
+++ b/deploy/eck-operator/templates/validate-chart.yaml
@@ -11,3 +11,13 @@
   {{- fail "Soft multi-tenancy requires kubeAPIServerIP to be defined" -}}
   {{- end -}}
 {{- end -}}
+
+{{- if (not .Values.createClusterScopedResources) -}}
+  {{- if .Values.webhook.enabled -}}
+  {{- fail "Webhook cannot be enabled when cluster-scoped resource creation is disabled" -}}
+  {{- end -}}
+
+  {{- if .Values.config.validateStorageClass -}}
+  {{- fail "Storage class validation cannot be enabled when cluster-scoped resource creation is disabled" -}}
+  {{- end -}}
+{{- end -}}

--- a/hack/manifest-gen/testdata/values.yaml
+++ b/hack/manifest-gen/testdata/values.yaml
@@ -86,7 +86,7 @@ refs:
 
 webhook:
   # enabled determines whether the webhook is installed.
-  enabled: true
+  enabled: false
   # caBundle is the PEM-encoded CA trust bundle for the webhook certificate. Only required if manageCerts is false and certManagerCert is null.
   caBundle: Cg==
   # certManagerCert is the name of the cert-manager certificate to use with the webhook. 
@@ -111,6 +111,12 @@ softMultiTenancy:
 
 # kubeAPIServerIP is required when softMultiTenancy is enabled.
 kubeAPIServerIP: 1.2.3.4
+
+telemetry:
+  # disabled determines whether the operator periodically updates ECK telemetry data for Kibana to consume.
+  disabled: false
+  # distibutionChannel denotes which distribution channel was used to install the operator.
+  distributionChannel: "helm"
 
 # config values for the operator.
 config:
@@ -144,6 +150,16 @@ config:
 
   # setDefaultSecurityContext determines whether a default security context is set on application containers created by the operator.
   setDefaultSecurityContext: true
+
+  # kubeClientTimeout sets the request timeout for Kubernetes API calls made by the operator.
+  kubeClientTimeout: 60s
+
+  # elasticsearchClientTimeout sets the request timeout for Elasticsearch API calls made by the operator.
+  elasticsearchClientTimeout: 180s
+
+  # validateStorageClass specifies whether storage classes volume expansion support should be verified.
+  # Can be disabled if cluster-wide storage class RBAC access is not available.
+  validateStorageClass: false
 
 # for internal use only.
 internal:


### PR DESCRIPTION
- Fixes an issue where the operator role does not get created if cluster-scoped resource creation is disabled and the operator namespace is not in the managed namespaces list. 
- Moves webhook permissions to cluster RBAC rules only.
- Validate invalid configurations in restricted profile.

Fixes #3807 
Fixes #3809 