### PR TITLE
Allow watching cluster-scoped resources when using the multi-namespac…

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -439,11 +439,13 @@ func startOperator(stopChan <-chan struct{}) error {
 		log.Info("Operator configured to manage all namespaces")
 	case len(managedNamespaces) == 1 && managedNamespaces[0] == operatorNamespace:
 		log.Info("Operator configured to manage a single namespace", "namespace", managedNamespaces[0], "operator_namespace", operatorNamespace)
+		// opts.Namespace implicitly allows watching cluster-scoped resources (e.g. storage classes)
 		opts.Namespace = managedNamespaces[0]
 	default:
 		log.Info("Operator configured to manage multiple namespaces", "namespaces", managedNamespaces, "operator_namespace", operatorNamespace)
-		// the manager cache should always include the operator namespace so that we can work with operator-internal resources
-		opts.NewCache = cache.MultiNamespacedCacheBuilder(append(managedNamespaces, operatorNamespace))
+		// the manager cache should always include the operator namespace so that we can work with operator-internal resources,
+		// and the empty namespace to watch cluster-scoped resources (e.g. storage classes).
+		opts.NewCache = cache.MultiNamespacedCacheBuilder(append(managedNamespaces, operatorNamespace, ""))
 	}
 
 	// only expose prometheus metrics if provided a non-zero port


### PR DESCRIPTION
…e cache

When managing resources in a single namespace, we rely on the controller-runtime
opts.Namespace feature, which implicitly allows watching cluster-scoped resources.

When managing resources in more than one namespace, we rely on opts.NewCache,
which takes a function to setup a multi-namespace cache. This cache does not
allows watching cluster-scoped resources by default. Which leads to error
when it tries to get storage classes:

```
cannot retrieve storage class: unable to get: /standard because of unknown namespace for the cache
```

This commit fixes it by ensuring we always append the empty namespace ("") to the
multi-namespace cache, so we can retrieve cluster-scoped storage classes if allowed
by the --validate-storage-class flag.