### PR TITLE
Don't set CLOUDSDK_CONFIG

### DIFF
--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -218,7 +218,6 @@ E2E_REGISTRY_NAMESPACE = eck-ci
 
 GO_TAGS = release
 export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/.ci/license.key
-export CLOUDSDK_CONFIG = /root/.gcp
 TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
 
@@ -255,7 +254,6 @@ E2E_REGISTRY_NAMESPACE = eck-ci
 
 GO_TAGS = release
 export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/.ci/license.key
-export CLOUDSDK_CONFIG = /root/.gcp
 TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
 

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -218,6 +218,7 @@ E2E_REGISTRY_NAMESPACE = eck-ci
 
 GO_TAGS = release
 export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/.ci/license.key
+export CLOUDSDK_CONFIG = /root/.gcp
 TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
 
@@ -254,6 +255,7 @@ E2E_REGISTRY_NAMESPACE = eck-ci
 
 GO_TAGS = release
 export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/.ci/license.key
+export CLOUDSDK_CONFIG = /root/.gcp
 TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
 

--- a/hack/deployer/README.md
+++ b/hack/deployer/README.md
@@ -12,6 +12,7 @@ Deployer is the provisioning tool that aims to be the interface to multiple Kube
   * Install Google Cloud SDK beta components by running `gcloud components install beta`
   * Make sure that container registry authentication is correctly configured as described [here](https://cloud.google.com/container-registry/docs/advanced-authentication)
   * Set `GCLOUD_PROJECT` to the name of the GCloud project you wish to use
+  * (optional) Set `CLOUDSDK_CONFIG` to a directory which should be used for gcloud SDK if you don't want to have the default one overwritten.
   * Run from the [project root](/):
 
     ```bash

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -86,7 +86,6 @@ plans:
     region: europe-west1
     nodeCount: 3
     overwriteDefaultKubeconfig: true
-    useNonDefaultCloudSdkPath: true
 - id: ocp3-ci
   operation: create
   clusterName: ci

--- a/hack/deployer/runner/gcloud.go
+++ b/hack/deployer/runner/gcloud.go
@@ -21,7 +21,7 @@ const (
 // authToGCP authenticates the deployer to the Google Cloud Platform as a service account or as a user.
 func authToGCP(
 	vaultInfo *VaultInfo, vaultPath string, serviceAccountVaultFieldName string,
-	asServiceAccount bool, useNonDefaultCloudSDKPath bool, configureDocker bool, gCloudProject interface{},
+	asServiceAccount bool, configureDocker bool, gCloudProject interface{},
 ) error {
 	if asServiceAccount {
 		if vaultInfo == nil {
@@ -45,14 +45,6 @@ func authToGCP(
 			return err
 		}
 
-		if useNonDefaultCloudSDKPath {
-			// ensure gcloud & gsutil rely on credentials stored in gcpDir instead of using the default
-			// directory (~/.config/gcloud), to not tamper any default gcloud auth already set on the system
-			log.Printf("Setting CLOUDSDK_CONFIG=%s", gcpDir)
-			if err := os.Setenv("CLOUDSDK_CONFIG", gcpDir); err != nil {
-				return err
-			}
-		}
 		// now that we're set on the cloud sdk directory, we can run any gcloud command that will rely on it
 		if err := NewCommand(fmt.Sprintf("gcloud config set project %s", gCloudProject)).Run(); err != nil {
 			return err

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -80,7 +80,7 @@ func (gdf *GkeDriverFactory) Create(plan Plan) (Driver, error) {
 func (d *GkeDriver) Execute() error {
 	if err := authToGCP(
 		d.plan.VaultInfo, GkeVaultPath, GkeServiceAccountVaultFieldName,
-		d.plan.ServiceAccount, false, false, d.ctx["GCloudProject"],
+		d.plan.ServiceAccount, false, d.ctx["GCloudProject"],
 	); err != nil {
 		return err
 	}

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -131,7 +131,7 @@ func (d *OcpDriver) Execute() error {
 
 	if err := authToGCP(
 		d.plan.VaultInfo, OcpVaultPath, OcpServiceAccountVaultFieldName,
-		d.plan.ServiceAccount, d.plan.Ocp.UseNonDefaultCloudSDKPath, false, d.ctx["GCloudProject"],
+		d.plan.ServiceAccount, false, d.ctx["GCloudProject"],
 	); err != nil {
 		return err
 	}

--- a/hack/deployer/runner/ocp3.go
+++ b/hack/deployer/runner/ocp3.go
@@ -66,7 +66,7 @@ func (d Ocp3Driver) Execute() error {
 
 	if err := authToGCP(
 		d.plan.VaultInfo, OcpVaultPath, OcpServiceAccountVaultFieldName,
-		d.plan.ServiceAccount, true, true, d.plan.Ocp3.GCloudProject,
+		d.plan.ServiceAccount, true, d.plan.Ocp3.GCloudProject,
 	); err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func (d Ocp3Driver) runAnsibleDockerContainer(action string) error {
 		-e USER={{.User}} \
 		-e USER_HOME={{.HomeVolumeMountPath}} \
 		-v {{.HomeVolumeName}}:{{.HomeVolumeMountPath}} \
-		-e CLOUDSDK_CONFIG={{.GCloudSDKPath}} \
+		-e CLOUDSDK_CONFIG \
 		-e GOOGLE_APPLICATION_CREDENTIALS={{.GCloudCredsPath}} \
 		-e VARS_FILE={{.AnsibleVarsPath}} \
 		-e OUTPUT_DIR={{.AnsibleOutputPath}} \

--- a/hack/deployer/runner/ocp3.go
+++ b/hack/deployer/runner/ocp3.go
@@ -174,6 +174,7 @@ func (d Ocp3Driver) runAnsibleDockerContainer(action string) error {
 		"AnsibleDockerImage":  AnsibleDockerImage,
 	}
 
+	// CLOUDSDK_CONFIG env var is passed as-is to make gcloud sdk directory consistent between the host and the container
 	return NewCommand(`docker run --rm \
 		-e FORCED_GROUP_ID=1000 \
 		-e FORCED_USER_ID=1000 \

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -75,9 +75,6 @@ type OcpSettings struct {
 	LocalSsdCount              int    `yaml:"localSsdCount"`
 	NodeCount                  int    `yaml:"nodeCount"`
 	OverwriteDefaultKubeconfig bool   `yaml:"overwriteDefaultKubeconfig"`
-	// UseNonDefaultCloudSDKPath, if true, sets $CLOUDSDK_CONFIG to a non-default value in order
-	// to not tamper existing gcloud credentials.
-	UseNonDefaultCloudSDKPath bool `yaml:"useNonDefaultCloudSdkPath"`
 }
 
 // Ocp3Settings encapsulates settings specific to OCP3 on GCloud


### PR DESCRIPTION
Removes `CLOUDSDK_CONFIG` env variable from deployer and sets it in `setenvconfig`, only for `ocp` and `ocp3`. This should resolve the issue with e2e runner not knowing the correct path to gcloud config.

Fixes https://github.com/elastic/cloud-on-k8s/issues/3822.