### PR TITLE
Create one transport certificates Secret per StatefulSet

### DIFF
--- a/pkg/apis/elasticsearch/v1/name.go
+++ b/pkg/apis/elasticsearch/v1/name.go
@@ -15,17 +15,18 @@ import (
 )
 
 const (
-	configSecretSuffix                = "config"
-	secureSettingsSecretSuffix        = "secure-settings"
-	httpServiceSuffix                 = "http"
-	transportServiceSuffix            = "transport"
-	elasticUserSecretSuffix           = "elastic-user"
-	internalUsersSecretSuffix         = "internal-users"
-	unicastHostsConfigMapSuffix       = "unicast-hosts"
-	licenseSecretSuffix               = "license"
-	defaultPodDisruptionBudget        = "default"
-	scriptsConfigMapSuffix            = "scripts"
-	transportCertificatesSecretSuffix = "transport-certificates"
+	configSecretSuffix                           = "config"
+	secureSettingsSecretSuffix                   = "secure-settings"
+	httpServiceSuffix                            = "http"
+	transportServiceSuffix                       = "transport"
+	elasticUserSecretSuffix                      = "elastic-user"
+	internalUsersSecretSuffix                    = "internal-users"
+	unicastHostsConfigMapSuffix                  = "unicast-hosts"
+	licenseSecretSuffix                          = "license"
+	defaultPodDisruptionBudget                   = "default"
+	scriptsConfigMapSuffix                       = "scripts"
+	clusterTransportCertificatesSecretSuffix     = "transport-certificates"
+	statefulSetTransportCertificatesSecretSuffix = "transport-certs"
 
 	// calling this secret "xpack-file-realm" is conceptually wrong since it also holds the file-based roles which
 	// are not part of the file realm - let's still keep this legacy name for convenience
@@ -52,7 +53,7 @@ var (
 		licenseSecretSuffix,
 		defaultPodDisruptionBudget,
 		scriptsConfigMapSuffix,
-		transportCertificatesSecretSuffix,
+		statefulSetTransportCertificatesSecretSuffix,
 		remoteCaNameSuffix,
 	}
 )
@@ -112,8 +113,14 @@ func SecureSettingsSecret(esName string) string {
 	return ESNamer.Suffix(esName, secureSettingsSecretSuffix)
 }
 
-func TransportCertificatesSecret(esName string) string {
-	return ESNamer.Suffix(esName, transportCertificatesSecretSuffix)
+func StatefulSetTransportCertificatesSecret(ssetName string) string {
+	return ESNamer.Suffix(ssetName, statefulSetTransportCertificatesSecretSuffix)
+}
+
+// ClusterTransportCertificatesSecret returns the former name of the Secret which used to contain the transport certificates.
+// This function only exists to let the controller delete that Secret.
+func ClusterTransportCertificatesSecret(esName string) string {
+	return ESNamer.Suffix(esName, clusterTransportCertificatesSecretSuffix)
 }
 
 func TransportService(esName string) string {

--- a/pkg/apis/elasticsearch/v1/name.go
+++ b/pkg/apis/elasticsearch/v1/name.go
@@ -25,7 +25,7 @@ const (
 	licenseSecretSuffix                          = "license"
 	defaultPodDisruptionBudget                   = "default"
 	scriptsConfigMapSuffix                       = "scripts"
-	clusterTransportCertificatesSecretSuffix     = "transport-certificates"
+	legacyTransportCertsSecretSuffix             = "transport-certificates"
 	statefulSetTransportCertificatesSecretSuffix = "transport-certs"
 
 	// calling this secret "xpack-file-realm" is conceptually wrong since it also holds the file-based roles which
@@ -117,10 +117,10 @@ func StatefulSetTransportCertificatesSecret(ssetName string) string {
 	return ESNamer.Suffix(ssetName, statefulSetTransportCertificatesSecretSuffix)
 }
 
-// ClusterTransportCertificatesSecret returns the former name of the Secret which used to contain the transport certificates.
+// LegacyTransportCertsSecretSuffix returns the former name of the Secret which used to contain the transport certificates.
 // This function only exists to let the controller delete that Secret.
-func ClusterTransportCertificatesSecret(esName string) string {
-	return ESNamer.Suffix(esName, clusterTransportCertificatesSecretSuffix)
+func LegacyTransportCertsSecretSuffix(esName string) string {
+	return ESNamer.Suffix(esName, legacyTransportCertsSecretSuffix)
 }
 
 func TransportService(esName string) string {

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile.go
@@ -58,12 +58,12 @@ func DeleteStatefulSetTransportCertificate(client k8s.Client, namespace string, 
 	return client.Delete(&secret)
 }
 
-// DeleteClusterTransportCertificate ensures that the former Secret which used to contain the transport certificates is deleted.
-func DeleteClusterTransportCertificate(client k8s.Client, es esv1.Elasticsearch) error {
+// DeleteLegacyTransportCertificate ensures that the former Secret which used to contain the transport certificates is deleted.
+func DeleteLegacyTransportCertificate(client k8s.Client, es esv1.Elasticsearch) error {
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: es.Namespace,
-			Name:      esv1.ClusterTransportCertificatesSecret(es.Name),
+			Name:      esv1.LegacyTransportCertsSecretSuffix(es.Name),
 		},
 	}
 	return client.Delete(&secret)

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile.go
@@ -174,7 +174,7 @@ func ensureTransportCertificatesSecretExists(
 			Labels: map[string]string{
 				// a label showing which es these certificates belongs to
 				label.ClusterNameLabelName: es.Name,
-				// label to state to which StatefulSet these certificates belongs to.
+				// label indicating to which StatefulSet these certificates belong
 				label.StatefulSetNameLabelName: ssetName,
 			},
 		},

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile.go
@@ -31,6 +31,7 @@ var log = logf.Log.WithName("transport")
 
 // ReconcileTransportCertificatesSecrets reconciles the secret containing transport certificates for all nodes in the
 // cluster.
+// Secrets which are not used anymore are deleted as part of the downscale process.
 func ReconcileTransportCertificatesSecrets(
 	c k8s.Client,
 	ca *certificates.CA,
@@ -38,16 +39,58 @@ func ReconcileTransportCertificatesSecrets(
 	rotationParams certificates.RotationParams,
 ) *reconciler.Results {
 	results := &reconciler.Results{}
+	for _, nodeSet := range es.Spec.NodeSets {
+		if err := reconcileNodeSetTransportCertificatesSecrets(c, ca, es, nodeSet.Name, rotationParams); err != nil {
+			results.WithError(err)
+		}
+	}
+	return results
+}
+
+// DeleteStatefulSetTransportCertificate removes the Secret which contains the transport certificates of a given Statefulset.
+func DeleteStatefulSetTransportCertificate(client k8s.Client, namespace string, ssetName string) error {
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      esv1.StatefulSetTransportCertificatesSecret(ssetName),
+		},
+	}
+	return client.Delete(&secret)
+}
+
+// DeleteClusterTransportCertificate ensures that the former Secret which used to contain the transport certificates is deleted.
+func DeleteClusterTransportCertificate(client k8s.Client, es esv1.Elasticsearch) error {
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: es.Namespace,
+			Name:      esv1.ClusterTransportCertificatesSecret(es.Name),
+		},
+	}
+	return client.Delete(&secret)
+}
+
+// reconcileNodeSetTransportCertificatesSecrets reconciles the secret which contains the transport certificates for
+// a given StatefulSet.
+func reconcileNodeSetTransportCertificatesSecrets(
+	c k8s.Client,
+	ca *certificates.CA,
+	es esv1.Elasticsearch,
+	nodeSet string,
+	rotationParams certificates.RotationParams,
+) error {
+	results := &reconciler.Results{}
+	ssetName := esv1.StatefulSet(es.Name, nodeSet)
+	// List all the existing Pods in the nodeSet
 	var pods corev1.PodList
-	matchLabels := label.NewLabelSelectorForElasticsearch(es)
+	matchLabels := label.NewLabelSelectorForStatefulSetName(es.Name, ssetName)
 	ns := client.InNamespace(es.Namespace)
 	if err := c.List(&pods, matchLabels, ns); err != nil {
-		return results.WithError(errors.WithStack(err))
+		return errors.WithStack(err)
 	}
 
-	secret, err := ensureTransportCertificatesSecretExists(c, es)
+	secret, err := ensureTransportCertificatesSecretExists(c, es, ssetName)
 	if err != nil {
-		return results.WithError(err)
+		return err
 	}
 	// defensive copy of the current secret so we can check whether we need to update later on
 	currentTransportCertificatesSecret := secret.DeepCopy()
@@ -60,12 +103,12 @@ func ReconcileTransportCertificatesSecrets(
 		if err := ensureTransportCertificatesSecretContentsForPod(
 			es, secret, pod, ca, rotationParams,
 		); err != nil {
-			return results.WithError(err)
+			return err
 		}
 		certCommonName := buildCertificateCommonName(pod, es.Name, es.Namespace)
 		cert := extractTransportCert(*secret, pod, certCommonName)
 		if cert == nil {
-			return results.WithError(errors.New("No certificate found for pod"))
+			return errors.New("No certificate found for pod")
 		}
 		// handle cert expiry via requeue
 		results.WithResult(reconcile.Result{
@@ -107,29 +150,32 @@ func ReconcileTransportCertificatesSecrets(
 
 	if !reflect.DeepEqual(secret, currentTransportCertificatesSecret) {
 		if err := c.Update(secret); err != nil {
-			return results.WithError(err)
+			return err
 		}
 		for _, pod := range pods.Items {
 			annotation.MarkPodAsUpdated(c, pod)
 		}
 	}
 
-	return results
+	return nil
 }
 
 // ensureTransportCertificatesSecretExists ensures the existence and Labels of the Secret that at a later point
-// in time will contain the transport certificates.
+// in time will contain the transport certificates for a nodeSet.
 func ensureTransportCertificatesSecretExists(
 	c k8s.Client,
 	es esv1.Elasticsearch,
+	ssetName string,
 ) (*corev1.Secret, error) {
 	expected := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: es.Namespace,
-			Name:      esv1.TransportCertificatesSecret(es.Name),
+			Name:      esv1.StatefulSetTransportCertificatesSecret(ssetName),
 			Labels: map[string]string{
 				// a label showing which es these certificates belongs to
 				label.ClusterNameLabelName: es.Name,
+				// label to state to which StatefulSet these certificates belongs to.
+				label.StatefulSetNameLabelName: ssetName,
 			},
 		},
 	}

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile.go
@@ -108,7 +108,7 @@ func reconcileNodeSetTransportCertificatesSecrets(
 		certCommonName := buildCertificateCommonName(pod, es.Name, es.Namespace)
 		cert := extractTransportCert(*secret, pod, certCommonName)
 		if cert == nil {
-			return errors.New("No certificate found for pod")
+			return errors.New("no certificate found for pod")
 		}
 		// handle cert expiry via requeue
 		results.WithResult(reconcile.Result{

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
@@ -243,7 +243,7 @@ func TestDeleteStatefulSetTransportCertificate(t *testing.T) {
 	}
 }
 
-func TestDeleteClusterTransportCertificate(t *testing.T) {
+func TestDeleteLegacyTransportCertificate(t *testing.T) {
 	type args struct {
 		client k8s.Client
 		es     esv1.Elasticsearch
@@ -282,7 +282,7 @@ func TestDeleteClusterTransportCertificate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := DeleteClusterTransportCertificate(tt.args.client, tt.args.es)
+			err := DeleteLegacyTransportCertificate(tt.args.client, tt.args.es)
 			tt.assertErr(t, err)
 		})
 	}

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
@@ -5,24 +5,297 @@
 package transport
 
 import (
+	"reflect"
 	"testing"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/comparison"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func TestReconcileTransportCertificatesSecrets(t *testing.T) {
+	type args struct {
+		ca             *certificates.CA
+		es             *esv1.Elasticsearch
+		rotationParams certificates.RotationParams
+		initialObjects []runtime.Object
+	}
+	tests := []struct {
+		name          string
+		args          args
+		want          *reconciler.Results
+		assertSecrets func(t *testing.T, secrets corev1.SecretList)
+	}{
+		{
+			name: "Initial state, 3 nodeSets cluster, transport certs Secrets don't exists yet",
+			args: args{
+				ca: testCA,
+				es: newEsBuilder().addNodeSet("sset1", 2).addNodeSet("sset2", 3).addNodeSet("sset3", 4).build(),
+				initialObjects: []runtime.Object{
+					// 2 Pods in sset1
+					newPodBuilder().forEs(testEsName).inNodeSet("sset1").withIndex(0).withIP("1.1.1.2").build(),
+					newPodBuilder().forEs(testEsName).inNodeSet("sset1").withIndex(1).withIP("1.1.1.3").build(),
+					// 3 Pods in sset2
+					newPodBuilder().forEs(testEsName).inNodeSet("sset2").withIndex(0).withIP("1.1.2.2").build(),
+					newPodBuilder().forEs(testEsName).inNodeSet("sset2").withIndex(1).withIP("1.1.2.3").build(),
+					newPodBuilder().forEs(testEsName).inNodeSet("sset2").withIndex(2).withIP("1.1.2.4").build(),
+					// 4 Pods in sset3
+					newPodBuilder().forEs(testEsName).inNodeSet("sset3").withIndex(0).withIP("1.1.3.2").build(),
+					newPodBuilder().forEs(testEsName).inNodeSet("sset3").withIndex(1).withIP("1.1.3.3").build(),
+					newPodBuilder().forEs(testEsName).inNodeSet("sset3").withIndex(2).withIP("1.1.3.4").build(),
+					newPodBuilder().forEs(testEsName).inNodeSet("sset3").withIndex(3).withIP("1.1.3.5").build(),
+				},
+			},
+			want: &reconciler.Results{},
+			assertSecrets: func(t *testing.T, secrets corev1.SecretList) {
+				// Check that there is 1 Secret per StatefulSet
+				assert.Equal(t, 3, len(secrets.Items))
+
+				transportCerts1 := getSecret(secrets, "test-es-name-es-sset1-es-transport-certs")
+				assert.NotNil(t, transportCerts1)
+				// 5 items are expected in the Secret: the CA + 2 * (crt and private keys)
+				assert.Equal(t, 5, len(transportCerts1.Data))
+				// Check that ca.crt exists
+				assert.Equal(t, testCABytes, transportCerts1.Data["ca.crt"])
+				// Check the labels elasticsearch.k8s.elastic.co/cluster-name and elasticsearch.k8s.elastic.co/statefulset-name
+				assert.Equal(t, testEsName, transportCerts1.Labels["elasticsearch.k8s.elastic.co/cluster-name"])
+				assert.Equal(t, "test-es-name-es-sset1", transportCerts1.Labels["elasticsearch.k8s.elastic.co/statefulset-name"])
+
+				transportCerts2 := getSecret(secrets, "test-es-name-es-sset2-es-transport-certs")
+				assert.NotNil(t, transportCerts2)
+				// 7 items are expected in the Secret: the CA + 3 * (crt and private keys)
+				assert.Equal(t, 7, len(transportCerts2.Data))
+				// Check that ca.crt exists
+				assert.Equal(t, testCABytes, transportCerts2.Data["ca.crt"])
+				// Check the labels elasticsearch.k8s.elastic.co/cluster-name and elasticsearch.k8s.elastic.co/statefulset-name
+				assert.Equal(t, testEsName, transportCerts2.Labels["elasticsearch.k8s.elastic.co/cluster-name"])
+				assert.Equal(t, "test-es-name-es-sset2", transportCerts2.Labels["elasticsearch.k8s.elastic.co/statefulset-name"])
+
+				transportCerts3 := getSecret(secrets, "test-es-name-es-sset3-es-transport-certs")
+				assert.NotNil(t, transportCerts3)
+				// 9 items are expected in the Secret: the CA + 4 * (crt and private keys)
+				assert.Equal(t, 9, len(transportCerts3.Data))
+				// Check that ca.crt exists
+				assert.Equal(t, testCABytes, transportCerts3.Data["ca.crt"])
+				// Check the labels elasticsearch.k8s.elastic.co/cluster-name and elasticsearch.k8s.elastic.co/statefulset-name
+				assert.Equal(t, testEsName, transportCerts3.Labels["elasticsearch.k8s.elastic.co/cluster-name"])
+				assert.Equal(t, "test-es-name-es-sset3", transportCerts3.Labels["elasticsearch.k8s.elastic.co/statefulset-name"])
+			},
+		},
+		{
+			name: "Should reuse and update existing transport certs Secrets",
+			args: args{
+				ca: testCA,
+				es: newEsBuilder().addNodeSet("sset1", 2).addNodeSet("sset2", 2).build(),
+				initialObjects: []runtime.Object{
+					newPodBuilder().forEs(testEsName).inNodeSet("sset1").withIndex(0).withIP("1.1.1.2").build(),
+					newPodBuilder().forEs(testEsName).inNodeSet("sset1").withIndex(1).withIP("1.1.1.3").build(),
+					newPodBuilder().forEs(testEsName).inNodeSet("sset2").withIndex(0).withIP("1.1.2.2").build(),
+					newPodBuilder().forEs(testEsName).inNodeSet("sset2").withIndex(1).withIP("1.1.2.3").build(),
+					// Create 3 Secrets but create transport certs only for the first Pods in each StatefulSet
+					newtransportCertsSecretBuilder(testEsName, "sset1").forPodIndices(0).build(),
+					newtransportCertsSecretBuilder(testEsName, "sset2").forPodIndices(0).build(),
+				},
+			},
+			want: &reconciler.Results{},
+			assertSecrets: func(t *testing.T, secrets corev1.SecretList) {
+				// Check that there is 1 Secret per StatefulSet
+				assert.Equal(t, 2, len(secrets.Items))
+
+				transportCerts1 := getSecret(secrets, "test-es-name-es-sset1-es-transport-certs")
+				assert.NotNil(t, transportCerts1)
+				// 5 items are expected in the Secret: the CA + 2 * (crt and private keys)
+				assert.Equal(t, 5, len(transportCerts1.Data))
+				// Check that ca.crt exists
+				assert.Equal(t, testCABytes, transportCerts1.Data["ca.crt"])
+				// Check the labels elasticsearch.k8s.elastic.co/cluster-name and elasticsearch.k8s.elastic.co/statefulset-name
+				assert.Equal(t, testEsName, transportCerts1.Labels["elasticsearch.k8s.elastic.co/cluster-name"])
+				assert.Equal(t, "test-es-name-es-sset1", transportCerts1.Labels["elasticsearch.k8s.elastic.co/statefulset-name"])
+
+				transportCerts2 := getSecret(secrets, "test-es-name-es-sset2-es-transport-certs")
+				assert.NotNil(t, transportCerts2)
+				// 5 items are expected in the Secret: the CA + 2 * (crt and private keys)
+				assert.Equal(t, 5, len(transportCerts2.Data))
+				// Check that ca.crt exists
+				assert.Equal(t, testCABytes, transportCerts2.Data["ca.crt"])
+				// Check the labels elasticsearch.k8s.elastic.co/cluster-name and elasticsearch.k8s.elastic.co/statefulset-name
+				assert.Equal(t, testEsName, transportCerts2.Labels["elasticsearch.k8s.elastic.co/cluster-name"])
+				assert.Equal(t, "test-es-name-es-sset2", transportCerts2.Labels["elasticsearch.k8s.elastic.co/statefulset-name"])
+
+			},
+		},
+		{
+			name: "Should remove any non used transport certs",
+			args: args{
+				ca: testCA,
+				es: newEsBuilder().addNodeSet("sset1", 2).addNodeSet("sset2", 2).build(),
+				initialObjects: []runtime.Object{
+					newPodBuilder().forEs(testEsName).inNodeSet("sset1").withIndex(0).withIP("1.1.1.2").build(),
+					newPodBuilder().forEs(testEsName).inNodeSet("sset2").withIndex(0).withIP("1.1.2.2").build(),
+					newPodBuilder().forEs(testEsName).inNodeSet("sset2").withIndex(1).withIP("1.1.2.3").build(),
+					// Create the 2 Secrets and create transport certs for Pods which does not exist anymore
+					newtransportCertsSecretBuilder(testEsName, "sset1").forPodIndices(0, 1).build(),    // Pod 1 does not exist
+					newtransportCertsSecretBuilder(testEsName, "sset2").forPodIndices(0, 1, 2).build(), // Pod 2 does not exist
+				},
+			},
+			want: &reconciler.Results{},
+			assertSecrets: func(t *testing.T, secrets corev1.SecretList) {
+				// Check that there is 1 Secret per StatefulSet
+				assert.Equal(t, 2, len(secrets.Items))
+
+				transportCerts1 := getSecret(secrets, "test-es-name-es-sset1-es-transport-certs")
+				assert.NotNil(t, transportCerts1)
+				// 5 items are expected in the Secret: the CA + 1 existing Pods * (crt and private keys)
+				assert.Equal(t, 3, len(transportCerts1.Data))
+				// Transport certs for Pod 1 is still there
+				assert.Contains(t, transportCerts1.Data, "test-es-name-es-sset1-0.tls.crt")
+				assert.Contains(t, transportCerts1.Data, "test-es-name-es-sset1-0.tls.key")
+				// Transport certs for Pod 2 should have been removed
+				assert.NotContains(t, transportCerts1.Data, "test-es-name-es-sset1-1.tls.crt")
+				assert.NotContains(t, transportCerts1.Data, "test-es-name-es-sset1-1.tls.key")
+
+				transportCerts2 := getSecret(secrets, "test-es-name-es-sset2-es-transport-certs")
+				assert.NotNil(t, transportCerts2)
+				// 5 items are expected in the Secret: the CA + 2 existing Pods * (crt and private keys)
+				assert.Equal(t, 5, len(transportCerts2.Data))
+				// Transport certs for Pod 1 and 2 are still there
+				assert.Contains(t, transportCerts2.Data, "test-es-name-es-sset2-0.tls.crt")
+				assert.Contains(t, transportCerts2.Data, "test-es-name-es-sset2-0.tls.key")
+				assert.Contains(t, transportCerts2.Data, "test-es-name-es-sset2-1.tls.crt")
+				assert.Contains(t, transportCerts2.Data, "test-es-name-es-sset2-1.tls.key")
+				// Transport certs for Pod 3 should have been removed
+				assert.NotContains(t, transportCerts2.Data, "test-es-name-es-sset2-2.tls.crt")
+				assert.NotContains(t, transportCerts2.Data, "test-es-name-es-sset2-2.tls.key")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient := k8s.WrappedFakeClient(tt.args.initialObjects...)
+			if got := ReconcileTransportCertificatesSecrets(k8sClient, tt.args.ca, *tt.args.es, tt.args.rotationParams); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReconcileTransportCertificatesSecrets() = %v, want %v", got, tt.want)
+			}
+			// Check Secrets
+			var secrets corev1.SecretList
+			matchLabels := label.NewLabelSelectorForElasticsearch(*tt.args.es)
+			ns := client.InNamespace(tt.args.es.Namespace)
+			assert.NoError(t, k8sClient.List(&secrets, matchLabels, ns))
+			tt.assertSecrets(t, secrets)
+		})
+	}
+}
+
+func TestDeleteStatefulSetTransportCertificate(t *testing.T) {
+	type args struct {
+		client   k8s.Client
+		es       esv1.Elasticsearch
+		ssetName string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		assertErr func(*testing.T, error)
+	}{
+		{
+			name: "StatefulSet transport Secret exists",
+			args: args{
+				client: k8s.WrappedFakeClient(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-es-name-es-sset1-es-transport-certs",
+						Namespace: testNamespace,
+					},
+				}),
+				es:       testES,
+				ssetName: esv1.StatefulSet(testEsName, "sset1"),
+			},
+			assertErr: func(t *testing.T, err error) {
+				assert.Nil(t, err)
+			},
+		},
+		{
+			name: "StatefulSet transport Secret does not exist",
+			args: args{
+				client:   k8s.WrappedFakeClient(),
+				es:       testES,
+				ssetName: esv1.StatefulSet(testEsName, "sset1"),
+			},
+			assertErr: func(t *testing.T, err error) {
+				assert.NotNil(t, err)
+				assert.True(t, errors.IsNotFound(err))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := DeleteStatefulSetTransportCertificate(tt.args.client, tt.args.es.Namespace, tt.args.ssetName)
+			tt.assertErr(t, err)
+		})
+	}
+}
+
+func TestDeleteClusterTransportCertificate(t *testing.T) {
+	type args struct {
+		client k8s.Client
+		es     esv1.Elasticsearch
+	}
+	tests := []struct {
+		name      string
+		args      args
+		assertErr func(*testing.T, error)
+	}{
+		{
+			name: "Former cluster transport Secret exists",
+			args: args{
+				client: k8s.WrappedFakeClient(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-es-name-es-transport-certificates", // Create a Secret with the former name
+						Namespace: testNamespace,
+					},
+				}),
+				es: testES,
+			},
+			assertErr: func(t *testing.T, err error) {
+				assert.Nil(t, err)
+			},
+		},
+		{
+			name: "Former cluster transport Secret does not exist",
+			args: args{
+				client: k8s.WrappedFakeClient(),
+				es:     testES,
+			},
+			assertErr: func(t *testing.T, err error) {
+				assert.NotNil(t, err)
+				assert.True(t, errors.IsNotFound(err))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := DeleteClusterTransportCertificate(tt.args.client, tt.args.es)
+			tt.assertErr(t, err)
+		})
+	}
+}
 
 func Test_ensureTransportCertificateSecretExists(t *testing.T) {
 	defaultSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      esv1.TransportCertificatesSecret(testES.Name),
+			Name:      esv1.StatefulSetTransportCertificatesSecret(esv1.StatefulSet(testES.Name, "sset1")),
 			Namespace: testES.Namespace,
 			Labels: map[string]string{
-				label.ClusterNameLabelName: testES.Name,
+				label.ClusterNameLabelName:     testES.Name,
+				label.StatefulSetNameLabelName: esv1.StatefulSet(testES.Name, "sset1"),
 			},
 		},
 		Data: make(map[string][]byte),
@@ -111,7 +384,7 @@ func Test_ensureTransportCertificateSecretExists(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ensureTransportCertificatesSecretExists(tt.args.c, tt.args.owner)
+			got, err := ensureTransportCertificatesSecretExists(tt.args.c, tt.args.owner, esv1.StatefulSet(testES.Name, "sset1"))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("EnsureTransportCertificateSecretExists() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/elasticsearch/certificates/transport/transport_fixtures_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/transport_fixtures_test.go
@@ -10,17 +10,26 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+)
+
+const (
+	testNamespace = "test-namespace"
+	testEsName    = "test-es-name"
 )
 
 // fixtures
 var (
 	testCA                       *certificates.CA
+	testCABytes                  []byte
 	testRSAPrivateKey            *rsa.PrivateKey
 	testCSRBytes                 []byte
 	testCSR                      *x509.CertificateRequest
@@ -29,7 +38,7 @@ var (
 	pemCert                      []byte
 	testIP                       = "1.2.3.4"
 	testES                       = esv1.Elasticsearch{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-es-name", Namespace: "test-namespace"},
+		ObjectMeta: metav1.ObjectMeta{Name: testEsName, Namespace: testNamespace},
 	}
 	testPod = corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -78,6 +87,8 @@ func init() {
 		panic("Failed to create new self signed CA: " + err.Error())
 	}
 
+	testCABytes = certificates.EncodePEMCert(testCA.Cert.Raw)
+
 	testCSRBytes, err = x509.CreateCertificateRequest(cryptorand.Reader, &x509.CertificateRequest{}, testRSAPrivateKey)
 	if err != nil {
 		panic("Failed to create CSR:" + err.Error())
@@ -99,4 +110,126 @@ func init() {
 	}
 
 	pemCert = certificates.EncodePEMCert(certData, testCA.Cert.Raw)
+}
+
+// -- Elasticsearch builder
+
+type esBuilder struct {
+	nodeSets []esv1.NodeSet
+}
+
+func newEsBuilder() *esBuilder {
+	return &esBuilder{}
+}
+
+func (eb *esBuilder) addNodeSet(name string, count int) *esBuilder {
+	eb.nodeSets = append(eb.nodeSets, esv1.NodeSet{
+		Name:  name,
+		Count: int32(count),
+	})
+	return eb
+}
+
+func (eb *esBuilder) build() *esv1.Elasticsearch {
+	es := testES.DeepCopy()
+	es.Spec.NodeSets = eb.nodeSets
+	return es
+}
+
+// -- Transport Certs Secret builder
+
+type transportCertsSecretBuilder struct {
+	statefulset string
+	data        map[string][]byte
+}
+
+// newtransportCertsSecretBuilder helps to create an existing Secret which contains some transport certs.
+func newtransportCertsSecretBuilder(esName string, nodeSetName string) *transportCertsSecretBuilder {
+	tcb := &transportCertsSecretBuilder{}
+	tcb.statefulset = esv1.StatefulSet(esName, nodeSetName)
+	tcb.data = make(map[string][]byte)
+	caBytes := certificates.EncodePEMCert(testCA.Cert.Raw)
+	tcb.data[certificates.CAFileName] = caBytes
+	return tcb
+}
+
+// forPodIndices adds a transport cert for the pod in the StatefulSet with the given index
+func (tcb *transportCertsSecretBuilder) forPodIndices(indices ...int) *transportCertsSecretBuilder {
+	for _, index := range indices {
+		podName := sset.PodName(tcb.statefulset, int32(index))
+		tcb.data[PodKeyFileName(podName)] = certificates.EncodePEMPrivateKey(*testRSAPrivateKey)
+		tcb.data[PodCertFileName(podName)] = pemCert
+	}
+	return tcb
+}
+
+func (tcb *transportCertsSecretBuilder) build() *corev1.Secret {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      esv1.StatefulSetTransportCertificatesSecret(tcb.statefulset),
+		},
+	}
+	secret.Data = tcb.data
+	return secret
+}
+
+// -- Pod builder
+
+type podBuilder struct {
+	es      string
+	ip      string
+	nodeSet string
+	index   int
+}
+
+func newPodBuilder() *podBuilder {
+	return &podBuilder{}
+}
+
+func (pb *podBuilder) forEs(es string) *podBuilder {
+	pb.es = es
+	return pb
+}
+
+func (pb *podBuilder) inNodeSet(nodeSet string) *podBuilder {
+	pb.nodeSet = nodeSet
+	return pb
+}
+
+func (pb *podBuilder) withIndex(index int) *podBuilder {
+	pb.index = index
+	return pb
+}
+
+func (pb *podBuilder) withIP(ip string) *podBuilder {
+	pb.ip = ip
+	return pb
+}
+
+func (pb *podBuilder) build() *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      fmt.Sprintf("%s-%d", esv1.StatefulSet(pb.es, pb.nodeSet), pb.index),
+			Labels: map[string]string{
+				label.StatefulSetNameLabelName: esv1.StatefulSet(pb.es, pb.nodeSet),
+				label.ClusterNameLabelName:     pb.es,
+			},
+			UID: uuid.NewUUID(),
+		},
+	}
+	if len(pb.ip) > 0 {
+		pod.Status.PodIP = pb.ip
+	}
+	return pod
+}
+
+func getSecret(list corev1.SecretList, name string) *corev1.Secret {
+	for _, s := range list.Items {
+		if s.Name == name {
+			return &s
+		}
+	}
+	return nil
 }

--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -104,7 +104,7 @@ func (d *defaultDriver) reconcileNodeSpecs(
 	actualStatefulSets = upscaleResults.ActualStatefulSets
 
 	// Once all the StatefulSets have been updated we can ensure that the former version of the transport certificates Secret is deleted.
-	if err := transport.DeleteClusterTransportCertificate(d.Client, d.ES); err != nil && !apierrors.IsNotFound(err) {
+	if err := transport.DeleteLegacyTransportCertificate(d.Client, d.ES); err != nil && !apierrors.IsNotFound(err) {
 		results.WithError(err)
 	}
 

--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates/transport"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/observer"
@@ -24,6 +25,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"go.elastic.co/apm"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 func (d *defaultDriver) reconcileNodeSpecs(
@@ -100,6 +102,11 @@ func (d *defaultDriver) reconcileNodeSpecs(
 		return results.WithResult(defaultRequeue)
 	}
 	actualStatefulSets = upscaleResults.ActualStatefulSets
+
+	// Once all the StatefulSets have been updated we can ensure that the former version of the transport certificates Secret is deleted.
+	if err := transport.DeleteClusterTransportCertificate(d.Client, d.ES); err != nil && !apierrors.IsNotFound(err) {
+		results.WithError(err)
+	}
 
 	// Update PDB to account for new replicas.
 	if err := pdb.Reconcile(d.Client, d.ES, actualStatefulSets); err != nil {

--- a/pkg/controller/elasticsearch/label/label.go
+++ b/pkg/controller/elasticsearch/label/label.go
@@ -156,6 +156,15 @@ func NewLabelSelectorForElasticsearchClusterName(clusterName string) client.Matc
 	return client.MatchingLabels(map[string]string{ClusterNameLabelName: clusterName})
 }
 
+// NewLabelSelectorForStatefulSetName returns a labels.Selector that matches the labels set on resources managed for
+// a given StatefulSet in a cluster.
+func NewLabelSelectorForStatefulSetName(clusterName, ssetName string) client.MatchingLabels {
+	return client.MatchingLabels(map[string]string{
+		ClusterNameLabelName:     clusterName,
+		StatefulSetNameLabelName: ssetName,
+	})
+}
+
 // ClusterFromResourceLabels returns the NamespacedName of the Elasticsearch associated
 // to the given resource, by retrieving its name from the resource labels.
 // It does implicitly consider the cluster and the resource to be in the same namespace.

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -54,7 +54,7 @@ func BuildPodTemplateSpec(
 	defaultContainerPorts := getDefaultContainerPorts(es)
 
 	initContainers, err := initcontainer.NewInitContainers(
-		transportCertificatesVolume(es.Name),
+		transportCertificatesVolume(esv1.StatefulSet(es.Name, nodeSet.Name)),
 		es.Name,
 		keystoreResources,
 	)
@@ -101,9 +101,9 @@ func getDefaultContainerPorts(es esv1.Elasticsearch) []corev1.ContainerPort {
 	}
 }
 
-func transportCertificatesVolume(esName string) volume.SecretVolume {
+func transportCertificatesVolume(ssetName string) volume.SecretVolume {
 	return volume.NewSecretVolumeWithMountPath(
-		esv1.TransportCertificatesSecret(esName),
+		esv1.StatefulSetTransportCertificatesSecret(ssetName),
 		esvolume.TransportCertificatesSecretVolumeName,
 		esvolume.TransportCertificatesSecretVolumeMountPath,
 	)

--- a/pkg/controller/elasticsearch/nodespec/volumes.go
+++ b/pkg/controller/elasticsearch/nodespec/volumes.go
@@ -31,7 +31,7 @@ func buildVolumes(esName string, nodeSpec esv1.NodeSet, keystoreResources *keyst
 		esvolume.HTTPCertificatesSecretVolumeName,
 		esvolume.HTTPCertificatesSecretVolumeMountPath,
 	)
-	transportCertificatesVolume := transportCertificatesVolume(esName)
+	transportCertificatesVolume := transportCertificatesVolume(esv1.StatefulSet(esName, nodeSpec.Name))
 	remoteCertificateAuthoritiesVolume := volume.NewSecretVolumeWithMountPath(
 		esv1.RemoteCaSecretName(esName),
 		esvolume.RemoteCertificateAuthoritiesSecretVolumeName,

--- a/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/test/e2e/test/elasticsearch/checks_k8s.go
@@ -183,7 +183,7 @@ func CheckPodCertificates(b Builder, k *test.K8sClient) test.Step {
 			for _, pod := range pods {
 				statefulSet, exist := pod.Labels[label.StatefulSetNameLabelName]
 				if !exist {
-					return fmt.Errorf("label %s not found on pod %/s%s", label.StatefulSetNameLabelName, pod.Namespace, pod.Name)
+					return fmt.Errorf("label %s not found on pod %s/%s", label.StatefulSetNameLabelName, pod.Namespace, pod.Name)
 				}
 				_, _, err := getTransportCert(k, b.Elasticsearch.Namespace, b.Elasticsearch.Name, statefulSet, pod.Name)
 				if err != nil {


### PR DESCRIPTION
With this PR the transport certificates are stored in one Secret per `nodeSet`/`StatefulSet`.

* Current/legacy transport certs `Secret` is deleted only when the StatefulSets specifications have been updated (I did some tests and it seems to be fine to delete a Secret which is used by a Pod, the content is still available until the Pod is deleted).
* Unit tests have been added in order to test the new behaviour.
* Transport certs `Secrets` are named `*-transport-certs`  and not `*-transport-certificates` to save a few characters and be consistent with other `Secrets` (`*-[http|transport]-certs-public`,`*-[http|transport]-certs-internal`)

Fixes (or only mitigates ?) #3734