### PR TITLE
Revert to old labels in all-in-one.yaml

### DIFF
--- a/deploy/eck-operator/templates/_helpers.tpl
+++ b/deploy/eck-operator/templates/_helpers.tpl
@@ -48,8 +48,12 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "eck-operator.selectorLabels" -}}
+{{- if .Values.internal.manifestGen }}
+control-plane: elastic-operator
+{{- else }}
 app.kubernetes.io/name: {{ include "eck-operator.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Keep the old labels in the `all-in-one.yaml` to avoid breaking the upgrade from 1.2.1.

Fixes #3824 