### PR TITLE
[Backport] Revert to old labels in all-in-one.yaml (#3829)

### DIFF
--- a/deploy/eck-operator/templates/_helpers.tpl
+++ b/deploy/eck-operator/templates/_helpers.tpl
@@ -48,8 +48,12 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "eck-operator.selectorLabels" -}}
+{{- if .Values.internal.manifestGen }}
+control-plane: elastic-operator
+{{- else }}
 app.kubernetes.io/name: {{ include "eck-operator.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Backport of #3829 
