### PR TITLE
Enable webhook dry run on supported k8s versions

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,12 +1,15 @@
 
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
-- clientConfig:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
     caBundle: Cg==
     service:
       name: webhook-service
@@ -24,7 +27,11 @@ webhooks:
     - UPDATE
     resources:
     - apmservers
-- clientConfig:
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
     caBundle: Cg==
     service:
       name: webhook-service
@@ -42,7 +49,11 @@ webhooks:
     - UPDATE
     resources:
     - apmservers
-- clientConfig:
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
     caBundle: Cg==
     service:
       name: webhook-service
@@ -60,25 +71,11 @@ webhooks:
     - UPDATE
     resources:
     - beats
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
-  failurePolicy: Ignore
-  name: elastic-es-validation-v1.k8s.elastic.co
-  rules:
-  - apiGroups:
-    - elasticsearch.k8s.elastic.co
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - elasticsearches
-- clientConfig:
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
     caBundle: Cg==
     service:
       name: webhook-service
@@ -96,7 +93,11 @@ webhooks:
     - UPDATE
     resources:
     - elasticsearches
-- clientConfig:
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
     caBundle: Cg==
     service:
       name: webhook-service
@@ -114,7 +115,11 @@ webhooks:
     - UPDATE
     resources:
     - enterprisesearches
-- clientConfig:
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
     caBundle: Cg==
     service:
       name: webhook-service
@@ -132,7 +137,11 @@ webhooks:
     - UPDATE
     resources:
     - kibanas
-- clientConfig:
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
     caBundle: Cg==
     service:
       name: webhook-service
@@ -150,3 +159,4 @@ webhooks:
     - UPDATE
     resources:
     - kibanas
+  sideEffects: None

--- a/deploy/eck-operator/templates/_helpers.tpl
+++ b/deploy/eck-operator/templates/_helpers.tpl
@@ -68,6 +68,17 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Add the webhook sideEffects field on supported Kubernetes versions
+*/}}
+{{- define "eck-operator.webhookSideEffects" -}}
+{{- $kubeVersion := .Capabilities.KubeVersion.Version -}}
+{{- $kubeVersionSupported := semverCompare ">=1.13.0-0" $kubeVersion -}}
+{{- if and $kubeVersionSupported (not .Values.internal.manifestGen) }}
+sideEffects: "None"
+{{- end }}
+{{- end }}
+
+{{/*
 RBAC permissions
 */}}
 {{- define "eck-operator.rbacRules" -}}

--- a/deploy/eck-operator/templates/webhook.yaml
+++ b/deploy/eck-operator/templates/webhook.yaml
@@ -19,6 +19,7 @@ webhooks:
       path: /validate-apm-k8s-elastic-co-v1-apmserver
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: elastic-apm-validation-v1.k8s.elastic.co
+{{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
   - apiGroups:
     - apm.k8s.elastic.co
@@ -37,6 +38,7 @@ webhooks:
       path: /validate-apm-k8s-elastic-co-v1beta1-apmserver
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: elastic-apm-validation-v1beta1.k8s.elastic.co
+{{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
   - apiGroups:
     - apm.k8s.elastic.co
@@ -55,6 +57,7 @@ webhooks:
       path: /validate-beat-k8s-elastic-co-v1beta1-beat
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: elastic-beat-validation-v1beta1.k8s.elastic.co
+{{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
   - apiGroups:
     - beat.k8s.elastic.co
@@ -73,6 +76,7 @@ webhooks:
       path: /validate-enterprisesearch-k8s-elastic-co-v1beta1-enterprisesearch
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: elastic-ent-validation-v1beta1.k8s.elastic.co
+{{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
   - apiGroups:
     - enterprisesearch.k8s.elastic.co
@@ -91,6 +95,7 @@ webhooks:
       path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: elastic-es-validation-v1.k8s.elastic.co
+{{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
   - apiGroups:
     - elasticsearch.k8s.elastic.co
@@ -109,6 +114,7 @@ webhooks:
       path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: elastic-es-validation-v1beta1.k8s.elastic.co
+{{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
   - apiGroups:
     - elasticsearch.k8s.elastic.co
@@ -127,6 +133,7 @@ webhooks:
       path: /validate-kibana-k8s-elastic-co-v1-kibana
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: elastic-kb-validation-v1.k8s.elastic.co
+{{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
   - apiGroups:
     - kibana.k8s.elastic.co
@@ -145,6 +152,7 @@ webhooks:
       path: /validate-kibana-k8s-elastic-co-v1beta1-kibana
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: elastic-kb-validation-v1beta1.k8s.elastic.co
+{{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
   - apiGroups:
     - kibana.k8s.elastic.co

--- a/pkg/apis/apm/v1/webhook.go
+++ b/pkg/apis/apm/v1/webhook.go
@@ -38,7 +38,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-apm-k8s-elastic-co-v1-apmserver,mutating=false,failurePolicy=ignore,groups=apm.k8s.elastic.co,resources=apmservers,verbs=create;update,versions=v1,name=elastic-apm-validation-v1.k8s.elastic.co
+// +kubebuilder:webhook:path=/validate-apm-k8s-elastic-co-v1-apmserver,mutating=false,failurePolicy=ignore,groups=apm.k8s.elastic.co,resources=apmservers,verbs=create;update,versions=v1,name=elastic-apm-validation-v1.k8s.elastic.co,sideEffects=None
 
 var _ webhook.Validator = &ApmServer{}
 

--- a/pkg/apis/apm/v1beta1/webhook.go
+++ b/pkg/apis/apm/v1beta1/webhook.go
@@ -33,7 +33,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-apm-k8s-elastic-co-v1beta1-apmserver,mutating=false,failurePolicy=ignore,groups=apm.k8s.elastic.co,resources=apmservers,verbs=create;update,versions=v1beta1,name=elastic-apm-validation-v1beta1.k8s.elastic.co
+// +kubebuilder:webhook:path=/validate-apm-k8s-elastic-co-v1beta1-apmserver,mutating=false,failurePolicy=ignore,groups=apm.k8s.elastic.co,resources=apmservers,verbs=create;update,versions=v1beta1,name=elastic-apm-validation-v1beta1.k8s.elastic.co,sideEffects=None
 
 var _ webhook.Validator = &ApmServer{}
 

--- a/pkg/apis/beat/v1beta1/webhook.go
+++ b/pkg/apis/beat/v1beta1/webhook.go
@@ -21,7 +21,7 @@ var (
 	validationLog = logf.Log.WithName("beat-v1beta1-validation")
 )
 
-// +kubebuilder:webhook:path=/validate-beat-k8s-elastic-co-v1beta1-beat,mutating=false,failurePolicy=ignore,groups=beat.k8s.elastic.co,resources=beats,verbs=create;update,versions=v1beta1,name=elastic-beat-validation-v1beta1.k8s.elastic.co
+// +kubebuilder:webhook:path=/validate-beat-k8s-elastic-co-v1beta1-beat,mutating=false,failurePolicy=ignore,groups=beat.k8s.elastic.co,resources=beats,verbs=create;update,versions=v1beta1,name=elastic-beat-validation-v1beta1.k8s.elastic.co,sideEffects=None
 
 var _ webhook.Validator = &Beat{}
 

--- a/pkg/apis/elasticsearch/v1beta1/webhook.go
+++ b/pkg/apis/elasticsearch/v1beta1/webhook.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1beta1,name=elastic-es-validation-v1beta1.k8s.elastic.co
+// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1beta1,name=elastic-es-validation-v1beta1.k8s.elastic.co,sideEffects=None
 
 func (es *Elasticsearch) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).

--- a/pkg/apis/enterprisesearch/v1beta1/webhook.go
+++ b/pkg/apis/enterprisesearch/v1beta1/webhook.go
@@ -33,7 +33,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-enterprisesearch-k8s-elastic-co-v1beta1-enterprisesearch,mutating=false,failurePolicy=ignore,groups=enterprisesearch.k8s.elastic.co,resources=enterprisesearches,verbs=create;update,versions=v1beta1,name=elastic-ent-validation-v1beta1.k8s.elastic.co
+// +kubebuilder:webhook:path=/validate-enterprisesearch-k8s-elastic-co-v1beta1-enterprisesearch,mutating=false,failurePolicy=ignore,groups=enterprisesearch.k8s.elastic.co,resources=enterprisesearches,verbs=create;update,versions=v1beta1,name=elastic-ent-validation-v1beta1.k8s.elastic.co,sideEffects=None
 
 var _ webhook.Validator = &EnterpriseSearch{}
 

--- a/pkg/apis/kibana/v1/webhook.go
+++ b/pkg/apis/kibana/v1/webhook.go
@@ -33,7 +33,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-kibana-k8s-elastic-co-v1-kibana,mutating=false,failurePolicy=ignore,groups=kibana.k8s.elastic.co,resources=kibanas,verbs=create;update,versions=v1,name=elastic-kb-validation-v1.k8s.elastic.co
+// +kubebuilder:webhook:path=/validate-kibana-k8s-elastic-co-v1-kibana,mutating=false,failurePolicy=ignore,groups=kibana.k8s.elastic.co,resources=kibanas,verbs=create;update,versions=v1,name=elastic-kb-validation-v1.k8s.elastic.co,sideEffects=None
 
 var _ webhook.Validator = &Kibana{}
 

--- a/pkg/apis/kibana/v1beta1/webhook.go
+++ b/pkg/apis/kibana/v1beta1/webhook.go
@@ -33,7 +33,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-kibana-k8s-elastic-co-v1beta1-kibana,mutating=false,failurePolicy=ignore,groups=kibana.k8s.elastic.co,resources=kibanas,verbs=create;update,versions=v1beta1,name=elastic-kb-validation-v1beta1.k8s.elastic.co
+// +kubebuilder:webhook:path=/validate-kibana-k8s-elastic-co-v1beta1-kibana,mutating=false,failurePolicy=ignore,groups=kibana.k8s.elastic.co,resources=kibanas,verbs=create;update,versions=v1beta1,name=elastic-kb-validation-v1beta1.k8s.elastic.co,sideEffects=None
 
 var _ webhook.Validator = &Kibana{}
 

--- a/pkg/controller/elasticsearch/validation/webhook.go
+++ b/pkg/controller/elasticsearch/validation/webhook.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1,name=elastic-es-validation-v1.k8s.elastic.co
+// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1,name=elastic-es-validation-v1.k8s.elastic.co,sideEffects=None
 
 const (
 	webhookPath = "/validate-elasticsearch-k8s-elastic-co-v1-elasticsearch"


### PR DESCRIPTION
Adds the `sideEffects: None` field to the webhook declaration when the target Kubernetes version supports dry runs.

The Helm webhook template is intentionally kept at `v1beta1` because it is used to generate the `all-in-one.yaml`, which needs to work on older Kubernetes versions as well.

Fixes #1233 