### PR TITLE
Allow automatic Elasticsearch nodes discovery

### DIFF
--- a/pkg/apis/elasticsearch/v1/fields.go
+++ b/pkg/apis/elasticsearch/v1/fields.go
@@ -15,6 +15,7 @@ const (
 
 	NetworkHost        = "network.host"
 	NetworkPublishHost = "network.publish_host"
+	HTTPPublishHost    = "http.publish_host"
 
 	NodeName = "node.name"
 

--- a/pkg/controller/apmserver/pod_test.go
+++ b/pkg/controller/apmserver/pod_test.go
@@ -94,6 +94,10 @@ func TestNewPodSpec(t *testing.T) {
 										FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "spec.nodeName"},
 									},
 								},
+								{Name: settings.EnvNamespace,
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "metadata.namespace"},
+									}},
 								{
 									Name: "SECRET_TOKEN",
 									ValueFrom: &corev1.EnvVarSource{

--- a/pkg/controller/common/certificates/http_reconcile.go
+++ b/pkg/controller/common/certificates/http_reconcile.go
@@ -126,7 +126,7 @@ func (r Reconciler) ReconcileInternalHTTPCerts(ca *CA) (*CertificatesSecret, err
 		}
 	} else {
 		selfSignedNeedsUpdate, err := ensureInternalSelfSignedCertificateSecretContents(
-			&secret, ownerNSN, r.Namer, r.TLSOptions, r.Services, ca, r.CertRotation,
+			&secret, ownerNSN, r.Namer, r.TLSOptions, r.ControllerSANs, r.Services, ca, r.CertRotation,
 		)
 		if err != nil {
 			return nil, err
@@ -166,6 +166,7 @@ func ensureInternalSelfSignedCertificateSecretContents(
 	owner types.NamespacedName,
 	namer name.Namer,
 	tls commonv1.TLSOptions,
+	controllerSANs []commonv1.SubjectAlternativeName,
 	svcs []corev1.Service,
 	ca *CA,
 	rotationParam RotationParams,
@@ -198,7 +199,7 @@ func ensureInternalSelfSignedCertificateSecretContents(
 	}
 
 	// check if the existing cert should be re-issued
-	if shouldIssueNewHTTPCertificate(owner, namer, tls, secret, svcs, ca, rotationParam.RotateBefore) {
+	if shouldIssueNewHTTPCertificate(owner, namer, tls, controllerSANs, secret, svcs, ca, rotationParam.RotateBefore) {
 		log.Info(
 			"Issuing new HTTP certificate",
 			"namespace", secret.Namespace,
@@ -220,7 +221,7 @@ func ensureInternalSelfSignedCertificateSecretContents(
 
 		// validate the csr
 		validatedCertificateTemplate := createValidatedHTTPCertificateTemplate(
-			owner, namer, tls, svcs, parsedCSR, rotationParam.Validity,
+			owner, namer, tls, controllerSANs, svcs, parsedCSR, rotationParam.Validity,
 		)
 		// sign the certificate
 		certData, err := ca.CreateCertificate(*validatedCertificateTemplate)
@@ -249,13 +250,14 @@ func shouldIssueNewHTTPCertificate(
 	owner types.NamespacedName,
 	namer name.Namer,
 	tls commonv1.TLSOptions,
+	controllerSANs []commonv1.SubjectAlternativeName,
 	secret *corev1.Secret,
 	svcs []corev1.Service,
 	ca *CA,
 	certReconcileBefore time.Duration,
 ) bool {
 	validatedTemplate := createValidatedHTTPCertificateTemplate(
-		owner, namer, tls, svcs, &x509.CertificateRequest{}, certReconcileBefore,
+		owner, namer, tls, controllerSANs, svcs, &x509.CertificateRequest{}, certReconcileBefore,
 	)
 
 	var certificate *x509.Certificate
@@ -328,6 +330,7 @@ func createValidatedHTTPCertificateTemplate(
 	owner types.NamespacedName,
 	namer name.Namer,
 	tls commonv1.TLSOptions,
+	controllerSANs []commonv1.SubjectAlternativeName,
 	svcs []corev1.Service,
 	csr *x509.CertificateRequest,
 	certValidity time.Duration,
@@ -364,6 +367,15 @@ func createValidatedHTTPCertificateTemplate(
 			if san.IP != "" {
 				ipAddresses = append(ipAddresses, netutil.IPToRFCForm(net.ParseIP(san.IP)))
 			}
+		}
+	}
+
+	for _, san := range controllerSANs {
+		if san.DNS != "" {
+			dnsNames = append(dnsNames, san.DNS)
+		}
+		if san.IP != "" {
+			ipAddresses = append(ipAddresses, netutil.IPToRFCForm(net.ParseIP(san.IP)))
 		}
 	}
 

--- a/pkg/controller/common/certificates/http_reconcile.go
+++ b/pkg/controller/common/certificates/http_reconcile.go
@@ -126,7 +126,7 @@ func (r Reconciler) ReconcileInternalHTTPCerts(ca *CA) (*CertificatesSecret, err
 		}
 	} else {
 		selfSignedNeedsUpdate, err := ensureInternalSelfSignedCertificateSecretContents(
-			&secret, ownerNSN, r.Namer, r.TLSOptions, r.ControllerSANs, r.Services, ca, r.CertRotation,
+			&secret, ownerNSN, r.Namer, r.TLSOptions, r.ExtraHTTPSANs, r.Services, ca, r.CertRotation,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/controller/common/certificates/http_reconcile_test.go
+++ b/pkg/controller/common/certificates/http_reconcile_test.go
@@ -371,10 +371,10 @@ func Test_createValidatedHTTPCertificateTemplate(t *testing.T) {
 	sanIPv6 := "2001:db8:0:85a3:0:0:ac1f:8001"
 
 	type args struct {
-		es             esv1.Elasticsearch
-		svcs           []corev1.Service
-		controllerSANs []commonv1.SubjectAlternativeName
-		certValidity   time.Duration
+		es            esv1.Elasticsearch
+		svcs          []corev1.Service
+		extraHTTPSANs []commonv1.SubjectAlternativeName
+		certValidity  time.Duration
 	}
 	tests := []struct {
 		name string
@@ -420,7 +420,7 @@ func Test_createValidatedHTTPCertificateTemplate(t *testing.T) {
 						},
 					},
 				},
-				controllerSANs: []commonv1.SubjectAlternativeName{
+				extraHTTPSANs: []commonv1.SubjectAlternativeName{
 					{
 						DNS: "controller-san-1",
 					},
@@ -449,7 +449,7 @@ func Test_createValidatedHTTPCertificateTemplate(t *testing.T) {
 				k8s.ExtractNamespacedName(&tt.args.es),
 				esv1.ESNamer,
 				tt.args.es.Spec.HTTP.TLS,
-				tt.args.controllerSANs,
+				tt.args.extraHTTPSANs,
 				tt.args.svcs,
 				&x509.CertificateRequest{},
 				tt.args.certValidity,

--- a/pkg/controller/common/certificates/http_reconcile_test.go
+++ b/pkg/controller/common/certificates/http_reconcile_test.go
@@ -87,7 +87,13 @@ func init() {
 	testCSR, _ := x509.ParseCertificateRequest(testCSRBytes)
 
 	validatedCertificateTemplate := createValidatedHTTPCertificateTemplate(
-		k8s.ExtractNamespacedName(&testES), esv1.ESNamer, testES.Spec.HTTP.TLS, []corev1.Service{testSvc}, testCSR, DefaultCertValidity,
+		k8s.ExtractNamespacedName(&testES),
+		esv1.ESNamer,
+		testES.Spec.HTTP.TLS,
+		[]commonv1.SubjectAlternativeName{},
+		[]corev1.Service{testSvc},
+		testCSR,
+		DefaultCertValidity,
 	)
 
 	certData, err := testCA.CreateCertificate(*validatedCertificateTemplate)
@@ -365,9 +371,10 @@ func Test_createValidatedHTTPCertificateTemplate(t *testing.T) {
 	sanIPv6 := "2001:db8:0:85a3:0:0:ac1f:8001"
 
 	type args struct {
-		es           esv1.Elasticsearch
-		svcs         []corev1.Service
-		certValidity time.Duration
+		es             esv1.Elasticsearch
+		svcs           []corev1.Service
+		controllerSANs []commonv1.SubjectAlternativeName
+		certValidity   time.Duration
 	}
 	tests := []struct {
 		name string
@@ -413,6 +420,14 @@ func Test_createValidatedHTTPCertificateTemplate(t *testing.T) {
 						},
 					},
 				},
+				controllerSANs: []commonv1.SubjectAlternativeName{
+					{
+						DNS: "controller-san-1",
+					},
+					{
+						DNS: "controller-san-2",
+					},
+				},
 			},
 			want: func(t *testing.T, cert *ValidatedCertificateTemplate) {
 				expectedCommonName := "test-es-http.test.es.local"
@@ -421,6 +436,8 @@ func Test_createValidatedHTTPCertificateTemplate(t *testing.T) {
 				assert.Contains(t, cert.DNSNames, "svc-name.svc-namespace.svc")
 				assert.Contains(t, cert.DNSNames, sanDNS1)
 				assert.Contains(t, cert.DNSNames, sanDNS2)
+				assert.Contains(t, cert.DNSNames, "controller-san-1")
+				assert.Contains(t, cert.DNSNames, "controller-san-2")
 				assert.Contains(t, cert.IPAddresses, net.ParseIP(sanIP1).To4())
 				assert.Contains(t, cert.IPAddresses, net.ParseIP(sanIPv6))
 			},
@@ -432,6 +449,7 @@ func Test_createValidatedHTTPCertificateTemplate(t *testing.T) {
 				k8s.ExtractNamespacedName(&tt.args.es),
 				esv1.ESNamer,
 				tt.args.es.Spec.HTTP.TLS,
+				tt.args.controllerSANs,
 				tt.args.svcs,
 				&x509.CertificateRequest{},
 				tt.args.certValidity,
@@ -457,9 +475,10 @@ func Test_shouldIssueNewCertificate(t *testing.T) {
 		},
 	}
 	type args struct {
-		es           esv1.Elasticsearch
-		secret       corev1.Secret
-		rotateBefore time.Duration
+		es             esv1.Elasticsearch
+		controllerSANs []commonv1.SubjectAlternativeName
+		secret         corev1.Secret
+		rotateBefore   time.Duration
 	}
 	tests := []struct {
 		name string
@@ -534,6 +553,7 @@ func Test_shouldIssueNewCertificate(t *testing.T) {
 				k8s.ExtractNamespacedName(&tt.args.es),
 				esv1.ESNamer,
 				tt.args.es.Spec.HTTP.TLS,
+				tt.args.controllerSANs,
 				&tt.args.secret,
 				[]corev1.Service{testSvc},
 				testCA,

--- a/pkg/controller/common/certificates/reconcile.go
+++ b/pkg/controller/common/certificates/reconcile.go
@@ -32,8 +32,9 @@ type Reconciler struct {
 	K8sClient      k8s.Client
 	DynamicWatches watches.DynamicWatches
 
-	Object     metav1.Object       // owner for the TLS certificates (eg. Elasticsearch, Kibana)
-	TLSOptions commonv1.TLSOptions // TLS options of the object
+	Object         metav1.Object                     // owner for the TLS certificates (eg. Elasticsearch, Kibana)
+	TLSOptions     commonv1.TLSOptions               // TLS options of the object
+	ControllerSANs []commonv1.SubjectAlternativeName // SANs dynamically set by a controller, only used in the self signed cert
 
 	Namer    commonname.Namer  // helps naming the reconciled secrets
 	Labels   map[string]string // to set on the reconciled cert secrets

--- a/pkg/controller/common/certificates/reconcile.go
+++ b/pkg/controller/common/certificates/reconcile.go
@@ -32,9 +32,9 @@ type Reconciler struct {
 	K8sClient      k8s.Client
 	DynamicWatches watches.DynamicWatches
 
-	Object         metav1.Object                     // owner for the TLS certificates (eg. Elasticsearch, Kibana)
-	TLSOptions     commonv1.TLSOptions               // TLS options of the object
-	ControllerSANs []commonv1.SubjectAlternativeName // SANs dynamically set by a controller, only used in the self signed cert
+	Object        metav1.Object                     // owner for the TLS certificates (eg. Elasticsearch, Kibana)
+	TLSOptions    commonv1.TLSOptions               // TLS options of the object
+	ExtraHTTPSANs []commonv1.SubjectAlternativeName // SANs dynamically set by a controller, only used in the self signed cert
 
 	Namer    commonname.Namer  // helps naming the reconciled secrets
 	Labels   map[string]string // to set on the reconciled cert secrets

--- a/pkg/controller/common/defaults/pod_template.go
+++ b/pkg/controller/common/defaults/pod_template.go
@@ -25,6 +25,9 @@ func PodDownwardEnvVars() []corev1.EnvVar {
 		{Name: settings.EnvNodeName, Value: "", ValueFrom: &corev1.EnvVarSource{
 			FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "spec.nodeName"},
 		}},
+		{Name: settings.EnvNamespace, Value: "", ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "metadata.namespace"},
+		}},
 	}
 }
 

--- a/pkg/controller/elasticsearch/certificates/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/reconcile.go
@@ -57,9 +57,9 @@ func Reconcile(
 	certsLabels := label.NewLabels(k8s.ExtractNamespacedName(&es))
 
 	// Create some additional SANs, mostly to be used in the context of client autodiscovery (a.k.a. sniffing).
-	additionalSANs := make([]commonv1.SubjectAlternativeName, len(es.Spec.NodeSets))
+	extraHTTPSANs := make([]commonv1.SubjectAlternativeName, len(es.Spec.NodeSets))
 	for i, nodeSet := range es.Spec.NodeSets {
-		additionalSANs[i] =
+		extraHTTPSANs[i] =
 			v1.SubjectAlternativeName{DNS: "*." + nodespec.HeadlessServiceName(esv1.StatefulSet(es.Name, nodeSet.Name)) + "." + es.Namespace + ".svc"}
 	}
 
@@ -70,7 +70,7 @@ func Reconcile(
 		DynamicWatches: driver.DynamicWatches(),
 		Object:         &es,
 		TLSOptions:     es.Spec.HTTP.TLS,
-		ControllerSANs: additionalSANs,
+		ExtraHTTPSANs:  extraHTTPSANs,
 		Namer:          esv1.ESNamer,
 		Labels:         certsLabels,
 		Services:       services,

--- a/pkg/controller/elasticsearch/certificates/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/reconcile.go
@@ -9,10 +9,8 @@ import (
 	"crypto/x509"
 	"time"
 
-	"go.elastic.co/apm"
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	v1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/driver"
@@ -21,7 +19,11 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates/remoteca"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates/transport"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"go.elastic.co/apm"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type CertificateResources struct {
@@ -54,6 +56,13 @@ func Reconcile(
 	// label certificates secrets with the cluster name
 	certsLabels := label.NewLabels(k8s.ExtractNamespacedName(&es))
 
+	// Create some additional SANs, mostly to be used in the context of client autodiscovery (a.k.a. sniffing).
+	additionalSANs := make([]commonv1.SubjectAlternativeName, len(es.Spec.NodeSets))
+	for i, nodeSet := range es.Spec.NodeSets {
+		additionalSANs[i] =
+			v1.SubjectAlternativeName{DNS: "*." + nodespec.HeadlessServiceName(esv1.StatefulSet(es.Name, nodeSet.Name)) + "." + es.Namespace + ".svc"}
+	}
+
 	// reconcile HTTP CA and cert
 	var httpCerts *certificates.CertificatesSecret
 	httpCerts, results = certificates.Reconciler{
@@ -61,6 +70,7 @@ func Reconcile(
 		DynamicWatches: driver.DynamicWatches(),
 		Object:         &es,
 		TLSOptions:     es.Spec.HTTP.TLS,
+		ControllerSANs: additionalSANs,
 		Namer:          esv1.ESNamer,
 		Labels:         certsLabels,
 		Services:       services,

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -224,7 +224,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 			Labels: map[string]string{
 				"common.k8s.elastic.co/type":                    "elasticsearch",
 				"elasticsearch.k8s.elastic.co/cluster-name":     "name",
-				"elasticsearch.k8s.elastic.co/config-hash":      "336245446",
+				"elasticsearch.k8s.elastic.co/config-hash":      "3415561705",
 				"elasticsearch.k8s.elastic.co/http-scheme":      "https",
 				"elasticsearch.k8s.elastic.co/node-data":        "false",
 				"elasticsearch.k8s.elastic.co/node-ingest":      "true",

--- a/pkg/controller/elasticsearch/settings/environment.go
+++ b/pkg/controller/elasticsearch/settings/environment.go
@@ -15,7 +15,8 @@ const (
 
 	// These are injected as env var into the ES pod at runtime,
 	// to be referenced in ES configuration file
-	EnvPodName  = "POD_NAME"
-	EnvPodIP    = "POD_IP"
-	EnvNodeName = "NODE_NAME"
+	EnvPodName   = "POD_NAME"
+	EnvPodIP     = "POD_IP"
+	EnvNodeName  = "NODE_NAME"
+	EnvNamespace = "NAMESPACE"
 )

--- a/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/pkg/controller/elasticsearch/settings/merged_config.go
@@ -57,6 +57,7 @@ func baseConfig(clusterName string, ver version.Version, ipFamily corev1.IPFamil
 
 		// use the DNS name as the publish host
 		esv1.NetworkPublishHost: netutil.IPLiteralFor("${"+EnvPodIP+"}", ipFamily),
+		esv1.HTTPPublishHost:    "${" + EnvPodName + "}.${" + HeadlessServiceName + "}.${" + EnvNamespace + "}.svc",
 		esv1.NetworkHost:        "0",
 
 		// allow ES to be aware of k8s node the pod is running on when allocating shards

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -505,6 +505,9 @@ func expectedDeploymentParams() deployment.Params {
 						{Name: settings.EnvNodeName, Value: "", ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "spec.nodeName"},
 						}},
+						{Name: settings.EnvNamespace, Value: "", ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "metadata.namespace"},
+						}},
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{


### PR DESCRIPTION
This PR allows automatic discovery of Elasticsearch nodes by clients which support "sniffing" mode.

More precisely it:

* Sets [`http.publish_host`](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#_http_settings) to the Pod hostname _(in the form `$(podname).$(governing service domain).$(namespace).svc`)_. Note that it is different from `network.publish_host`, therefore I _think_ we should not hit https://github.com/elastic/cloud-on-k8s/issues/3723 again.
* Adds the DNS wildcards `*.$(governing service domain).$(namespace).svc` in the HTTP self signed certificate, for example:

```
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
            X509v3 Extended Key Usage:
                TLS Web Server Authentication, TLS Web Client Authentication
            X509v3 Subject Alternative Name:
                DNS:elasticsearch-sample-es-http.default.es.local,
                DNS:elasticsearch-sample-es-http,
                DNS:elasticsearch-sample-es-http.default.svc,
                DNS:elasticsearch-sample-es-http.default,
                DNS:*.elasticsearch-sample-es-default.default.svc
```

Autodiscovery mostly makes sense if the client has an interface in the Kubernetes network. Therefore DNS wildcards are added automatically in the SANs only in the self signed certificate.

IPs are ephemeral in a Kubernetes cluster, I think it is fair to assume that DNS issues should be handled by the client. During my tests with the [Node.js client](https://github.com/elastic/elasticsearch-js) it has always been able to gently reconnect to the cluster while I was randomly deleting the Elasticsearch Pods.

A sample based on the official ones is available [here](https://github.com/barkbay/eck-elasticsearch-js) if you want to test that feature.

Fixes #3182 