### PR TITLE
Annotate APM Server Pods with co.elastic.logs/module

### DIFF
--- a/pkg/controller/apmserver/deployment_test.go
+++ b/pkg/controller/apmserver/deployment_test.go
@@ -98,6 +98,7 @@ func expectedDeploymentParams() testParams {
 						"apm.k8s.elastic.co/config-files-checksum": "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f",
 						"apm.k8s.elastic.co/version":               "1.0",
 					},
+					Annotations: map[string]string{"co.elastic.logs/module": "apm-server"},
 				},
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{

--- a/pkg/controller/apmserver/pod.go
+++ b/pkg/controller/apmserver/pod.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/container"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
@@ -38,6 +39,11 @@ var (
 		Limits: map[corev1.ResourceName]resource.Quantity{
 			corev1.ResourceMemory: DefaultMemoryLimits,
 		},
+	}
+
+	// DefaultAnnotations are the default annotations for the apmserver pods
+	DefaultAnnotations = map[string]string{
+		annotation.FilebeatModuleAnnotation: "apm-server",
 	}
 )
 
@@ -122,6 +128,7 @@ func newPodSpec(as *apmv1.ApmServer, p PodSpecParams) corev1.PodTemplateSpec {
 
 	builder := defaults.NewPodTemplateBuilder(p.PodTemplate, apmv1.ApmServerContainerName).
 		WithLabels(labels).
+		WithAnnotations(DefaultAnnotations).
 		WithResources(DefaultResources).
 		WithDockerImage(p.CustomImageName, container.ImageRepository(container.APMServerImage, p.Version)).
 		WithReadinessProbe(readinessProbe(as.Spec.HTTP.TLS.Enabled())).

--- a/pkg/controller/apmserver/pod_test.go
+++ b/pkg/controller/apmserver/pod_test.go
@@ -65,6 +65,9 @@ func TestNewPodSpec(t *testing.T) {
 						"apm.k8s.elastic.co/version": "7.0.1",
 						"common.k8s.elastic.co/type": "apm-server",
 					},
+					Annotations: map[string]string{
+						"co.elastic.logs/module": "apm-server",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{


### PR DESCRIPTION
Annotate APM Server pods with `co.elastic.logs/module: apm-server` annotation to give a hint to filebeat so that it uses the
appropriate module to analyze the logs of the container.

fixes: #3721

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>