### PR TITLE
Temporarily disable TestReversalStatefulSetRename

### DIFF
--- a/test/e2e/es/reversal_test.go
+++ b/test/e2e/es/reversal_test.go
@@ -43,16 +43,17 @@ func TestReversalRiskyMasterDownscale(t *testing.T) {
 	RunESMutationReversal(t, b, down)
 }
 
-func TestReversalStatefulSetRename(t *testing.T) {
-	b := elasticsearch.NewBuilder("test-sset-rename-reversal").
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
-
-	copy := b.Elasticsearch.Spec.NodeSets[0]
-	copy.Name = "other"
-	renamed := b.WithNoESTopology().WithNodeSet(copy)
-
-	RunESMutationReversal(t, b, renamed)
-}
+// TODO: re-enable once https://github.com/elastic/cloud-on-k8s/issues/3844 is fixed.
+//func TestReversalStatefulSetRename(t *testing.T) {
+//	b := elasticsearch.NewBuilder("test-sset-rename-reversal").
+//		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+//
+//	copy := b.Elasticsearch.Spec.NodeSets[0]
+//	copy.Name = "other"
+//	renamed := b.WithNoESTopology().WithNodeSet(copy)
+//
+//	RunESMutationReversal(t, b, renamed)
+//}
 
 func TestRiskyMasterReconfiguration(t *testing.T) {
 	b := elasticsearch.NewBuilder("test-sset-reconfig-reversal").


### PR DESCRIPTION
We have identified the root cause(s). Let's disable this test until
we properly fix it in the next few days.

Relates https://github.com/elastic/cloud-on-k8s/issues/3844.