### PR TITLE
Reinstate the non-pvc volume handling during defaulting of data volumes.

### DIFF
--- a/pkg/controller/common/defaults/pvc.go
+++ b/pkg/controller/common/defaults/pvc.go
@@ -1,0 +1,41 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package defaults
+
+import corev1 "k8s.io/api/core/v1"
+
+// AppendDefaultPVCs appends defaults PVCs to a set of existing ones.
+//
+// The default PVC is not appended if:
+// - a Volume with the same .Name is found in podSpec.Volumes, and that volume is not a PVC volume
+// - any PVC has been defined by the user
+func AppendDefaultPVCs(
+	existing []corev1.PersistentVolumeClaim,
+	podSpec corev1.PodSpec,
+	defaults ...corev1.PersistentVolumeClaim,
+) []corev1.PersistentVolumeClaim {
+	// create a set of volume names that are not PVC-volumes for efficient testing
+	nonPVCvolumes := map[string]struct{}{}
+
+	for _, volume := range podSpec.Volumes {
+		if volume.PersistentVolumeClaim == nil {
+			// this volume is not a PVC
+			nonPVCvolumes[volume.Name] = struct{}{}
+		}
+	}
+	// any user defined PVC shortcuts the defaulting attempt
+	if len(existing) > 0 {
+		return existing
+	}
+
+	for _, defaultPVC := range defaults {
+		if _, isNonPVCVolume := nonPVCvolumes[defaultPVC.Name]; isNonPVCVolume {
+			// the corresponding volume is not a PVC
+			continue
+		}
+		existing = append(existing, defaultPVC)
+	}
+	return existing
+}

--- a/pkg/controller/common/defaults/pvc.go
+++ b/pkg/controller/common/defaults/pvc.go
@@ -4,35 +4,38 @@
 
 package defaults
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"github.com/elastic/cloud-on-k8s/pkg/utils/set"
+	corev1 "k8s.io/api/core/v1"
+)
 
 // AppendDefaultPVCs appends defaults PVCs to a set of existing ones.
 //
-// The default PVC is not appended if:
-// - a Volume with the same .Name is found in podSpec.Volumes, and that volume is not a PVC volume
+// The default PVCs are not appended if:
 // - any PVC has been defined by the user
+// - a Volume with the same .Name is found in podSpec.Volumes, and that volume is not a PVC volume
 func AppendDefaultPVCs(
 	existing []corev1.PersistentVolumeClaim,
 	podSpec corev1.PodSpec,
 	defaults ...corev1.PersistentVolumeClaim,
 ) []corev1.PersistentVolumeClaim {
-	// create a set of volume names that are not PVC-volumes for efficient testing
-	nonPVCvolumes := map[string]struct{}{}
-
-	for _, volume := range podSpec.Volumes {
-		if volume.PersistentVolumeClaim == nil {
-			// this volume is not a PVC
-			nonPVCvolumes[volume.Name] = struct{}{}
-		}
-	}
 	// any user defined PVC shortcuts the defaulting attempt
 	if len(existing) > 0 {
 		return existing
 	}
 
+	// create a set of volume names that are not PVC-volumes
+	nonPVCvolumes := set.Make()
+
+	for _, volume := range podSpec.Volumes {
+		if volume.PersistentVolumeClaim == nil {
+			// this volume is not a PVC
+			nonPVCvolumes.Add(volume.Name)
+		}
+	}
+
 	for _, defaultPVC := range defaults {
-		if _, isNonPVCVolume := nonPVCvolumes[defaultPVC.Name]; isNonPVCVolume {
-			// the corresponding volume is not a PVC
+		if nonPVCvolumes.Has(defaultPVC.Name) {
 			continue
 		}
 		existing = append(existing, defaultPVC)

--- a/pkg/controller/common/defaults/pvc_test.go
+++ b/pkg/controller/common/defaults/pvc_test.go
@@ -1,0 +1,87 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package defaults
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAppendDefaultPVCs(t *testing.T) {
+	foo := v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+	}
+	bar := v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bar",
+		},
+	}
+
+	type args struct {
+		existing []v1.PersistentVolumeClaim
+		podSpec  v1.PodSpec
+		defaults []v1.PersistentVolumeClaim
+	}
+	tests := []struct {
+		name string
+		args args
+		want []v1.PersistentVolumeClaim
+	}{
+		{
+			name: "append new pvcs only if no other pvcs",
+			args: args{
+				existing: []v1.PersistentVolumeClaim{foo},
+				defaults: []v1.PersistentVolumeClaim{bar},
+			},
+			want: []v1.PersistentVolumeClaim{foo},
+		},
+		{
+			name: "do not add a default pvc if a non-pvc volume with the same name exists",
+			args: args{
+				existing: nil,
+				podSpec: v1.PodSpec{
+					Volumes: []v1.Volume{
+						{
+							Name:         bar.Name,
+							VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+						},
+					},
+				},
+				defaults: []v1.PersistentVolumeClaim{bar},
+			},
+			want: nil,
+		},
+		{
+			name: "add a default pvc if a pvcvolume with the same name exists",
+			args: args{
+				existing: nil,
+				podSpec: v1.PodSpec{
+					Volumes: []v1.Volume{
+						{
+							Name: bar.Name,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{},
+							},
+						},
+					},
+				},
+				defaults: []v1.PersistentVolumeClaim{bar},
+			},
+			want: []v1.PersistentVolumeClaim{bar},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AppendDefaultPVCs(tt.args.existing, tt.args.podSpec, tt.args.defaults...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AppendDefaultPVCs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/elasticsearch/nodespec/statefulset.go
+++ b/pkg/controller/elasticsearch/nodespec/statefulset.go
@@ -5,6 +5,7 @@
 package nodespec
 
 import (
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,9 +74,11 @@ func BuildStatefulSet(
 	ssetSelector := label.NewStatefulSetLabels(k8s.ExtractNamespacedName(&es), statefulSetName)
 
 	// add default PVCs to the node spec only if no user defined PVCs exist
-	if len(nodeSet.VolumeClaimTemplates) == 0 {
-		nodeSet.VolumeClaimTemplates = esvolume.DefaultVolumeClaimTemplates
-	}
+	nodeSet.VolumeClaimTemplates = defaults.AppendDefaultPVCs(
+		nodeSet.VolumeClaimTemplates,
+		nodeSet.PodTemplate.Spec,
+		esvolume.DefaultVolumeClaimTemplates...,
+	)
 
 	// build pod template
 	podTemplate, err := BuildPodTemplateSpec(es, nodeSet, cfg, keystoreResources, setDefaultSecurityContext)

--- a/pkg/controller/elasticsearch/nodespec/statefulset.go
+++ b/pkg/controller/elasticsearch/nodespec/statefulset.go
@@ -5,7 +5,6 @@
 package nodespec
 
 import (
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"

--- a/pkg/utils/set/set.go
+++ b/pkg/utils/set/set.go
@@ -9,9 +9,6 @@ import "sort"
 type StringSet map[string]struct{}
 
 func Make(strings ...string) StringSet {
-	if len(strings) == 0 {
-		return nil
-	}
 	set := make(map[string]struct{}, len(strings))
 	for _, str := range strings {
 		set[str] = struct{}{}

--- a/pkg/utils/set/set_test.go
+++ b/pkg/utils/set/set_test.go
@@ -22,9 +22,9 @@ func TestMake(t *testing.T) {
 		want StringSet
 	}{
 		{
-			name: "nil makes nil",
+			name: "nil makes an empty set",
 			args: args{},
-			want: nil,
+			want: StringSet(map[string]struct{}{}),
 		},
 		{
 			name: "creates set from passed strings",


### PR DESCRIPTION
d576c01055cbe6be48b336242c004a900b69805f had inadvertently removed the handling of non-pvc template based volumes when deciding whether to default a data volume pvc template. This PR reverts that aspect of defaulting behviour. 

This cover the case where users have added an `emptyDir` volume with the name `elasticsearch-data` with the intent to use it as the main data volume. We will now again honor this and not add a default data volume. If they added however  some other statically provisioned volume directly to the Pod spec, we will still provision the default data volume through a PVC template.

