### PR TITLE
Create transport certs for existing StatefulSets/Pods

### DIFF
--- a/pkg/controller/elasticsearch/certificates/transport/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/set"
 )
 
 var log = logf.Log.WithName("transport")
@@ -48,12 +49,12 @@ func ReconcileTransportCertificatesSecrets(
 	if err != nil {
 		return results.WithError(err)
 	}
-	ssets := make(map[string]struct{})
+	ssets := set.Make()
 	for _, actualStatefulSet := range actualStatefulSets {
-		ssets[actualStatefulSet.Name] = struct{}{}
+		ssets.Add(actualStatefulSet.Name)
 	}
 	for _, nodeSet := range es.Spec.NodeSets {
-		ssets[esv1.StatefulSet(es.Name, nodeSet.Name)] = struct{}{}
+		ssets.Add(esv1.StatefulSet(es.Name, nodeSet.Name))
 	}
 
 	for ssetName := range ssets {

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
@@ -106,7 +106,7 @@ func TestReconcileTransportCertificatesSecrets(t *testing.T) {
 					newtransportCertsSecretBuilder(testEsName, "sset1").forPodIndices(0).build(),
 					newtransportCertsSecretBuilder(testEsName, "sset2").forPodIndices(0).build(),
 					// Add an existing statefulSet which is not part of the Spec
-					newStatfulSet(testEsName, "sset3"),
+					newStatefulSet(testEsName, "sset3"),
 					newPodBuilder().forEs(testEsName).inNodeSet("sset3").withIndex(0).withIP("1.1.3.2").build(),
 					newPodBuilder().forEs(testEsName).inNodeSet("sset3").withIndex(1).withIP("1.1.3.3").build(),
 				},

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
@@ -105,12 +105,16 @@ func TestReconcileTransportCertificatesSecrets(t *testing.T) {
 					// Create 3 Secrets but create transport certs only for the first Pods in each StatefulSet
 					newtransportCertsSecretBuilder(testEsName, "sset1").forPodIndices(0).build(),
 					newtransportCertsSecretBuilder(testEsName, "sset2").forPodIndices(0).build(),
+					// Add an existing statefulSet which is not par of the Spec
+					newStatfulSet(testEsName, "sset3"),
+					newPodBuilder().forEs(testEsName).inNodeSet("sset3").withIndex(0).withIP("1.1.3.2").build(),
+					newPodBuilder().forEs(testEsName).inNodeSet("sset3").withIndex(1).withIP("1.1.3.3").build(),
 				},
 			},
 			want: &reconciler.Results{},
 			assertSecrets: func(t *testing.T, secrets corev1.SecretList) {
 				// Check that there is 1 Secret per StatefulSet
-				assert.Equal(t, 2, len(secrets.Items))
+				assert.Equal(t, 3, len(secrets.Items))
 
 				transportCerts1 := getSecret(secrets, "test-es-name-es-sset1-es-transport-certs")
 				assert.NotNil(t, transportCerts1)

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
@@ -105,7 +105,7 @@ func TestReconcileTransportCertificatesSecrets(t *testing.T) {
 					// Create 3 Secrets but create transport certs only for the first Pods in each StatefulSet
 					newtransportCertsSecretBuilder(testEsName, "sset1").forPodIndices(0).build(),
 					newtransportCertsSecretBuilder(testEsName, "sset2").forPodIndices(0).build(),
-					// Add an existing statefulSet which is not par of the Spec
+					// Add an existing statefulSet which is not part of the Spec
 					newStatfulSet(testEsName, "sset3"),
 					newPodBuilder().forEs(testEsName).inNodeSet("sset3").withIndex(0).withIP("1.1.3.2").build(),
 					newPodBuilder().forEs(testEsName).inNodeSet("sset3").withIndex(1).withIP("1.1.3.3").build(),

--- a/pkg/controller/elasticsearch/certificates/transport/transport_fixtures_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/transport_fixtures_test.go
@@ -235,7 +235,7 @@ func getSecret(list corev1.SecretList, name string) *corev1.Secret {
 	return nil
 }
 
-func newStatfulSet(esName, ssetName string) *v1.StatefulSet {
+func newStatefulSet(esName, ssetName string) *v1.StatefulSet {
 	return &v1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,

--- a/pkg/controller/elasticsearch/certificates/transport/transport_fixtures_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/transport_fixtures_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -232,4 +233,18 @@ func getSecret(list corev1.SecretList, name string) *corev1.Secret {
 		}
 	}
 	return nil
+}
+
+func newStatfulSet(esName, ssetName string) *v1.StatefulSet {
+	return &v1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      ssetName,
+			Labels: map[string]string{
+				"elasticsearch.k8s.elastic.co/statefulset-name": ssetName,
+				"common.k8s.elastic.co/type":                    "elasticsearch",
+				"elasticsearch.k8s.elastic.co/cluster-name":     esName,
+			},
+		},
+	}
 }

--- a/test/e2e/es/reversal_test.go
+++ b/test/e2e/es/reversal_test.go
@@ -43,17 +43,16 @@ func TestReversalRiskyMasterDownscale(t *testing.T) {
 	RunESMutationReversal(t, b, down)
 }
 
-// TODO: re-enable once https://github.com/elastic/cloud-on-k8s/issues/3844 is fixed.
-//func TestReversalStatefulSetRename(t *testing.T) {
-//	b := elasticsearch.NewBuilder("test-sset-rename-reversal").
-//		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
-//
-//	copy := b.Elasticsearch.Spec.NodeSets[0]
-//	copy.Name = "other"
-//	renamed := b.WithNoESTopology().WithNodeSet(copy)
-//
-//	RunESMutationReversal(t, b, renamed)
-//}
+func TestReversalStatefulSetRename(t *testing.T) {
+	b := elasticsearch.NewBuilder("test-sset-rename-reversal").
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+
+	copy := b.Elasticsearch.Spec.NodeSets[0]
+	copy.Name = "other"
+	renamed := b.WithNoESTopology().WithNodeSet(copy)
+
+	RunESMutationReversal(t, b, renamed)
+}
 
 func TestRiskyMasterReconfiguration(t *testing.T) {
 	b := elasticsearch.NewBuilder("test-sset-reconfig-reversal").
@@ -89,5 +88,4 @@ func TestRiskyMasterReconfiguration(t *testing.T) {
 
 func RunESMutationReversal(t *testing.T, toCreate elasticsearch.Builder, mutateTo elasticsearch.Builder) {
 	test.RunMutationReversal(t, []test.Builder{toCreate}, []test.Builder{mutateTo.WithMutatedFrom(&toCreate)})
-
 }


### PR DESCRIPTION
Fixes #3846 by creating transport certificates according to the Elasticsearch spec, but also for existing StatefulSets/Pods which might not be part of the spec anymore.