### PR TITLE
Change status-context to separate two PR jobs in PR status

### DIFF
--- a/.ci/jobs/pr-gke-full.yml
+++ b/.ci/jobs/pr-gke-full.yml
@@ -20,7 +20,7 @@
             - elastic
           allow-whitelist-orgs-as-admins: true
           github-hooks: true
-          status-context: devops-ci
+          status-context: devops-ci/full
           cancel-builds-on-update: false
           white-list:
             - renovate[bot]


### PR DESCRIPTION
IIUC, [status-context](https://docs.openstack.org/infra/jenkins-job-builder/triggers.html#triggers.github-pull-request) is responsible for the name used to identify job in PR status (see `devops-ci` in the image below). Right now both PR jobs have the same name and they keep overriding each other. Changing the name for full job should allow us to see status for both jobs at the same time.

<img width="391" alt="Screenshot 2020-10-16 at 12 38 48" src="https://user-images.githubusercontent.com/50632861/96248956-bc20f480-0fac-11eb-9d00-9a938e8e33a8.png">
