### PR TITLE
Change refspec to $branch_specifier to fetch the ref with code that's being built

### DIFF
--- a/.ci/jobs/e2e-tests-aks.yml
+++ b/.ci/jobs/e2e-tests-aks.yml
@@ -22,5 +22,6 @@
             branches:
               - ${branch_specifier}
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
+            refspec: ${branch_specifier}
       script-path: .ci/pipelines/e2e-tests-aks.Jenkinsfile
       lightweight-checkout: false

--- a/.ci/jobs/e2e-tests-eks.yml
+++ b/.ci/jobs/e2e-tests-eks.yml
@@ -22,5 +22,6 @@
             branches:
               - ${branch_specifier}
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
+            refspec: ${branch_specifier}
       script-path: .ci/pipelines/e2e-tests-eks.Jenkinsfile
       lightweight-checkout: false

--- a/.ci/jobs/e2e-tests-gke-k8s-versions.yml
+++ b/.ci/jobs/e2e-tests-gke-k8s-versions.yml
@@ -22,5 +22,6 @@
             branches:
               - ${branch_specifier}
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
+            refspec: ${branch_specifier}
       script-path: .ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
       lightweight-checkout: false

--- a/.ci/jobs/e2e-tests-kind-k8s-versions.yml
+++ b/.ci/jobs/e2e-tests-kind-k8s-versions.yml
@@ -22,5 +22,6 @@
             branches:
               - ${branch_specifier}
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
+            refspec: ${branch_specifier}
       script-path: .ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
       lightweight-checkout: false

--- a/.ci/jobs/e2e-tests-ocp.yaml
+++ b/.ci/jobs/e2e-tests-ocp.yaml
@@ -22,5 +22,6 @@
             branches:
               - ${branch_specifier}
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
+            refspec: ${branch_specifier}
       script-path: .ci/pipelines/e2e-tests-ocp.Jenkinsfile
       lightweight-checkout: false

--- a/.ci/jobs/e2e-tests-ocp3.yaml
+++ b/.ci/jobs/e2e-tests-ocp3.yaml
@@ -23,5 +23,6 @@
             branches:
               - ${branch_specifier}
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
+            refspec: ${branch_specifier}
       script-path: .ci/pipelines/e2e-tests-ocp3.Jenkinsfile
       lightweight-checkout: false

--- a/.ci/jobs/e2e-tests-resilience.yml
+++ b/.ci/jobs/e2e-tests-resilience.yml
@@ -22,5 +22,6 @@
             branches:
               - ${branch_specifier}
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
+            refspec: ${branch_specifier}
       script-path: .ci/pipelines/e2e-tests-resilience.Jenkinsfile
       lightweight-checkout: false

--- a/.ci/jobs/e2e-tests-stack-versions-gke.yml
+++ b/.ci/jobs/e2e-tests-stack-versions-gke.yml
@@ -22,5 +22,6 @@
             branches:
               - ${branch_specifier}
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
+            refspec: ${branch_specifier}
       script-path: .ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
       lightweight-checkout: false


### PR DESCRIPTION
Right now the PR full job [doesn't work](https://devops-ci.elastic.co/blue/organizations/jenkins/cloud-on-k8s-e2e-tests-kind-k8s-versions/detail/cloud-on-k8s-e2e-tests-kind-k8s-versions/240/pipeline/35) because the `git fetch` only fetches `refs/heads` while PRs are at `refs/pr`:


```
[2020-10-16T11:11:30.320Z]  > git fetch --tags --progress -- https://github.com/elastic/cloud-on-k8s +refs/heads/*:refs/remotes/origin/* # timeout=10
```

This means that commit to built is not fetched to the worker:
```
[2020-10-16T11:11:35.420Z]  > git rev-parse d18a42d4c3f550f39e96c9496be260ab13bba7f9^{commit} # timeout=10
[2020-10-16T11:11:35.426Z] ERROR: Couldn't find any revision to build. Verify the repository and branch configuration for this job.
```

This currently works for our nightly because it only needs to work off master which is in `ref/heads` that is fetched by default. For PR full build we need commit from a specific PR which is already passed to jobs via `$branch_specifier`. I _think_ we don't need to have anything else fetched, so apart from making PR full build work this will also make all jobs slightly faster.