### PR TITLE
Fix import of commonv1 package

### DIFF
--- a/pkg/controller/elasticsearch/certificates/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/reconcile.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
-	v1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/driver"
@@ -60,7 +59,7 @@ func Reconcile(
 	extraHTTPSANs := make([]commonv1.SubjectAlternativeName, len(es.Spec.NodeSets))
 	for i, nodeSet := range es.Spec.NodeSets {
 		extraHTTPSANs[i] =
-			v1.SubjectAlternativeName{DNS: "*." + nodespec.HeadlessServiceName(esv1.StatefulSet(es.Name, nodeSet.Name)) + "." + es.Namespace + ".svc"}
+			commonv1.SubjectAlternativeName{DNS: "*." + nodespec.HeadlessServiceName(esv1.StatefulSet(es.Name, nodeSet.Name)) + "." + es.Namespace + ".svc"}
 	}
 
 	// reconcile HTTP CA and cert


### PR DESCRIPTION
Fix the following [lint error](https://devops-ci.elastic.co/job/cloud-on-k8s-e2e-tests-master/664/consoleFull):

```
09:40:32  golangci-lint run
09:43:24  pkg/controller/elasticsearch/certificates/reconcile.go:12 [0m:2: [31mST1019: package "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1" is being imported more than once[0m (stylecheck)
09:43:24  	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
09:43:24  make: *** [Makefile:146: lint] Error 1
```

Related to #3815