### PR TITLE
Include secret token in APM Server config checksum

### DIFF
--- a/pkg/controller/apmserver/deployment.go
+++ b/pkg/controller/apmserver/deployment.go
@@ -148,8 +148,10 @@ func (r *ReconcileApmServer) deploymentParams(
 		apmServerContainer.VolumeMounts = append(apmServerContainer.VolumeMounts, httpCertsVolume.VolumeMount())
 	}
 
+	// add secret token to hash to force pod rotation on change
+	_, _ = configChecksum.Write(params.TokenSecret.Data[SecretTokenKey])
+
 	podSpec.Labels[configChecksumLabelName] = fmt.Sprintf("%x", configChecksum.Sum(nil))
-	// TODO: also need to hash secret token?
 
 	return deployment.Params{
 		Name:            Deployment(as.Name),

--- a/pkg/controller/apmserver/deployment_test.go
+++ b/pkg/controller/apmserver/deployment_test.go
@@ -447,25 +447,28 @@ func TestReconcileApmServer_deploymentParams(t *testing.T) {
 		{
 			name: "secret token influences checksum",
 			args: args{
-				as:            apmFixture,
-				podSpecParams: defaultPodSpecParams,
-				initialObjects: []runtime.Object{
-					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: certSecretName,
-						},
-					},
-					&corev1.Secret{
+				as: apmFixture,
+				podSpecParams: func() PodSpecParams {
+					params := defaultPodSpecParams
+					params.TokenSecret = corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: SecretToken(apmFixture.Name),
 						},
 						Data: map[string][]byte{
 							SecretTokenKey: []byte("s3cr3t"),
 						},
+					}
+					return params
+				}(),
+				initialObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: certSecretName,
+						},
 					},
 				},
 			},
-			want:    expectedDeploymentParams().withConfigChecksum("d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f"),
+			want:    expectedDeploymentParams().withConfigChecksum("8773d0fc52aef47027d83968cb1b776c1b06951bad2cab20a4527687"),
 			wantErr: false,
 		},
 	}

--- a/pkg/controller/apmserver/deployment_test.go
+++ b/pkg/controller/apmserver/deployment_test.go
@@ -444,6 +444,30 @@ func TestReconcileApmServer_deploymentParams(t *testing.T) {
 				withInitContainer(),
 			wantErr: false,
 		},
+		{
+			name: "secret token influences checksum",
+			args: args{
+				as:            apmFixture,
+				podSpecParams: defaultPodSpecParams,
+				initialObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: certSecretName,
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: SecretToken(apmFixture.Name),
+						},
+						Data: map[string][]byte{
+							SecretTokenKey: []byte("s3cr3t"),
+						},
+					},
+				},
+			},
+			want:    expectedDeploymentParams().withConfigChecksum("d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f"),
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The secret token is injected via an environment variable into the config file which is why changes to the token were not taken into account when building the config checksum. By adding the token value explicitly to the checksum APM Server pods will be rotated when the secret token changes.

Fixes #523 