### PR TITLE
Add license info to telemetry

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -600,7 +600,7 @@ func asyncTasks(
 	if !disableTelemetry {
 		// Start the telemetry reporter
 		go func() {
-			tr := telemetry.NewReporter(operatorInfo, mgr.GetClient(), managedNamespaces, telemetryInterval)
+			tr := telemetry.NewReporter(operatorInfo, mgr.GetClient(), operatorNamespace, managedNamespaces, telemetryInterval)
 			tr.Start()
 		}()
 	}

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -26,8 +26,8 @@ import (
 const (
 	// defaultOperatorLicenseLevel is the default license level when no operator license is installed
 	defaultOperatorLicenseLevel = "basic"
-	// licensingCfgMapName is the name of the config map used to store licensing information
-	licensingCfgMapName = "elastic-licensing"
+	// LicensingCfgMapName is the name of the config map used to store licensing information
+	LicensingCfgMapName = "elastic-licensing"
 	// Type represents the Elastic usage type used to mark the config map that stores licensing information
 	Type = "elastic-usage"
 )
@@ -99,10 +99,10 @@ func (r LicensingResolver) ToInfo(totalMemory resource.Quantity) (LicensingInfo,
 // Save updates or creates licensing information in a config map
 // This relies on UnconditionalUpdates being supported configmaps and may change in k8s v2: https://github.com/kubernetes/kubernetes/issues/21330
 func (r LicensingResolver) Save(info LicensingInfo) error {
-	log.V(1).Info("Saving", "namespace", r.operatorNs, "configmap_name", licensingCfgMapName, "license_info", info)
+	log.V(1).Info("Saving", "namespace", r.operatorNs, "configmap_name", LicensingCfgMapName, "license_info", info)
 	nsn := types.NamespacedName{
 		Namespace: r.operatorNs,
-		Name:      licensingCfgMapName,
+		Name:      LicensingCfgMapName,
 	}
 	expected := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/license/reporter_test.go
+++ b/pkg/license/reporter_test.go
@@ -229,7 +229,7 @@ func Test_Start(t *testing.T) {
 		var cm corev1.ConfigMap
 		err := k8sClient.Get(context.Background(), types.NamespacedName{
 			Namespace: operatorNs,
-			Name:      licensingCfgMapName,
+			Name:      LicensingCfgMapName,
 		}, &cm)
 		if err != nil {
 			return false
@@ -250,7 +250,7 @@ func Test_Start(t *testing.T) {
 		var cm corev1.ConfigMap
 		err := k8sClient.Get(context.Background(), types.NamespacedName{
 			Namespace: operatorNs,
-			Name:      licensingCfgMapName,
+			Name:      LicensingCfgMapName,
 		}, &cm)
 		if err != nil {
 			return false
@@ -267,7 +267,7 @@ func Test_Start(t *testing.T) {
 		var cm corev1.ConfigMap
 		err := k8sClient.Get(context.Background(), types.NamespacedName{
 			Namespace: operatorNs,
-			Name:      licensingCfgMapName,
+			Name:      LicensingCfgMapName,
 		}, &cm)
 		if err != nil {
 			return false

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -28,6 +28,8 @@ import (
 const (
 	resourceCount = "resource_count"
 	podCount      = "pod_count"
+
+	timestampFieldName = "timestamp"
 )
 
 var log = logf.Log.WithName("usage")
@@ -167,6 +169,9 @@ func (r *Reporter) getLicenseInfo() (map[string]string, error) {
 	if err := r.client.Get(nsn, &licenseConfigMap); err != nil {
 		return nil, err
 	}
+
+	// remove timestamp field as it doesn't carry any significant information
+	delete(licenseConfigMap.Data, timestampFieldName)
 
 	return licenseConfigMap.Data, nil
 }

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -38,10 +38,11 @@ var testOperatorInfo = about.OperatorInfo{
 
 func TestMarshalTelemetry(t *testing.T) {
 	for _, tt := range []struct {
-		name  string
-		info  about.OperatorInfo
-		stats map[string]interface{}
-		want  string
+		name    string
+		info    about.OperatorInfo
+		stats   map[string]interface{}
+		license map[string]string
+		want    string
 	}{
 		{
 			name:  "empty",
@@ -56,6 +57,7 @@ func TestMarshalTelemetry(t *testing.T) {
   custom_operator_namespace: false
   distribution: ""
   distributionChannel: ""
+  license: null
   operator_uuid: ""
   stats: null
 `,
@@ -69,6 +71,9 @@ func TestMarshalTelemetry(t *testing.T) {
 					"resource_count": 1,
 				},
 			},
+			license: map[string]string{
+				"eck_license_level": "basic",
+			},
 			want: `eck:
   build:
     date: "2019-09-20T07:00:00Z"
@@ -78,6 +83,8 @@ func TestMarshalTelemetry(t *testing.T) {
   custom_operator_namespace: true
   distribution: v1.16.13-gke.1
   distributionChannel: test-channel
+  license:
+    eck_license_level: basic
   operator_uuid: 15039433-f873-41bd-b6e7-10ee3665cafa
   stats:
     apms:
@@ -87,7 +94,7 @@ func TestMarshalTelemetry(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			gotBytes, gotErr := marshalTelemetry(tt.info, tt.stats)
+			gotBytes, gotErr := marshalTelemetry(tt.info, tt.stats, tt.license)
 			require.NoError(t, gotErr)
 			require.Equal(t, tt.want, string(gotBytes))
 		})
@@ -189,9 +196,21 @@ func TestNewReporter(t *testing.T) {
 				AvailableNodes: 7,
 			},
 		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "elastic-licensing",
+				Namespace: "elastic-system",
+			},
+			Data: map[string]string{
+				"eck_license_level":         "basic",
+				"enterprise_resource_units": "1",
+				"timestamp":                 "2020-10-07T07:49:36+02:00",
+				"total_managed_memory":      "3.22GB",
+			},
+		},
 	)
 
-	r := NewReporter(testOperatorInfo, client, []string{kb1.Namespace, kb2.Namespace}, 1*time.Hour)
+	r := NewReporter(testOperatorInfo, client, "elastic-system", []string{kb1.Namespace, kb2.Namespace}, 1*time.Hour)
 	r.report()
 
 	wantData := map[string][]byte{
@@ -204,6 +223,11 @@ func TestNewReporter(t *testing.T) {
   custom_operator_namespace: true
   distribution: v1.16.13-gke.1
   distributionChannel: test-channel
+  license:
+    eck_license_level: basic
+    enterprise_resource_units: "1"
+    timestamp: "2020-10-07T07:49:36+02:00"
+    total_managed_memory: 3.22GB
   operator_uuid: 15039433-f873-41bd-b6e7-10ee3665cafa
   stats:
     apms:

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -226,7 +226,6 @@ func TestNewReporter(t *testing.T) {
   license:
     eck_license_level: basic
     enterprise_resource_units: "1"
-    timestamp: "2020-10-07T07:49:36+02:00"
     total_managed_memory: 3.22GB
   operator_uuid: 15039433-f873-41bd-b6e7-10ee3665cafa
   stats:


### PR DESCRIPTION
This PR includes license information in the telemetry data.

```yaml
eck:
...
  license:
    eck_license_level: enterprise_trial
    enterprise_resource_units: "1"
    total_managed_memory: 3.22GB
```

License info is taken from `elastic-licensing` ConfigMap. As gathering this info requires some calculations and API calls, that seems to be the cheapest and the most reliable way to do it. If obtaining license info results in any errors, they are ignored and telemetry data is still populated with what is known.