### PR TITLE
Remove unnecessary metrics from _nodes ES API request

### DIFF
--- a/pkg/controller/elasticsearch/client/client_test.go
+++ b/pkg/controller/elasticsearch/client/client_test.go
@@ -303,7 +303,7 @@ func TestAPIError_Error(t *testing.T) {
 }
 
 func TestClientGetNodes(t *testing.T) {
-	expectedPath := "/_nodes/_all/jvm,settings"
+	expectedPath := "/_nodes/_all/no-metrics"
 	testClient := NewMockClient(version.MustParse("6.8.0"), func(req *http.Request) *http.Response {
 		require.Equal(t, expectedPath, req.URL.Path)
 		return &http.Response{
@@ -318,7 +318,6 @@ func TestClientGetNodes(t *testing.T) {
 	require.Equal(t, 3, len(resp.Nodes))
 	require.Contains(t, resp.Nodes, "iXqjbgPYThO-6S7reL5_HA")
 	require.ElementsMatch(t, []string{"master", "data", "ingest"}, resp.Nodes["iXqjbgPYThO-6S7reL5_HA"].Roles)
-	require.Equal(t, 2130051072, resp.Nodes["iXqjbgPYThO-6S7reL5_HA"].JVM.Mem.HeapMaxInBytes)
 }
 
 func TestClientGetNodesStats(t *testing.T) {

--- a/pkg/controller/elasticsearch/client/model.go
+++ b/pkg/controller/elasticsearch/client/model.go
@@ -79,12 +79,6 @@ type Node struct {
 	Name    string   `json:"name"`
 	Version string   `json:"version"`
 	Roles   []string `json:"roles"`
-	JVM     struct {
-		StartTimeInMillis int64 `json:"start_time_in_millis"`
-		Mem               struct {
-			HeapMaxInBytes int `json:"heap_max_in_bytes"`
-		} `json:"mem"`
-	} `json:"jvm"`
 }
 
 func (n Node) isV7OrAbove() (bool, error) {

--- a/pkg/controller/elasticsearch/client/v6.go
+++ b/pkg/controller/elasticsearch/client/v6.go
@@ -94,7 +94,7 @@ func (c *clientV6) ReloadSecureSettings(ctx context.Context) error {
 
 func (c *clientV6) GetNodes(ctx context.Context) (Nodes, error) {
 	var nodes Nodes
-	// restrict call to minimal node information with a non-existing metric filter
+	// restrict call to minimal node information with a non-existent metric filter
 	err := c.get(ctx, "/_nodes/_all/no-metrics", &nodes)
 	return nodes, err
 }

--- a/pkg/controller/elasticsearch/client/v6.go
+++ b/pkg/controller/elasticsearch/client/v6.go
@@ -94,8 +94,8 @@ func (c *clientV6) ReloadSecureSettings(ctx context.Context) error {
 
 func (c *clientV6) GetNodes(ctx context.Context) (Nodes, error) {
 	var nodes Nodes
-	// restrict call to basic node info only
-	err := c.get(ctx, "/_nodes/_all/jvm,settings", &nodes)
+	// restrict call to minimal node information with a non-existing metric filter
+	err := c.get(ctx, "/_nodes/_all/no-metrics", &nodes)
 	return nodes, err
 }
 


### PR DESCRIPTION
The operator is not using any information from the jvm or settings metrics filter. And even the e2e tests are only interested in the node roles which are already included in the standard payload. Any previously existing use of JVM metrics seems to have been removed/replaced. 

Fixes #3249 