### PR TITLE
Fail CI on lint failures

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -54,8 +54,8 @@ ci-internal: ci-build-image
 		-w $(GO_MOUNT_PATH) \
 		--network="host" \
 		$(CI_IMAGE) \
-		bash -c "$(DOCKER_CMD)" ; \
-	docker volume rm $(ECK_CI_VOLUME) > /dev/null
+		bash -c "$(DOCKER_CMD)" ; exit=$$?; \
+	docker volume rm $(ECK_CI_VOLUME) > /dev/null; exit $$exit
 
 # build and push the CI image only if it does not yet exist
 ci-build-image: DOCKER_PASSWORD = $(shell VAULT_TOKEN=$(VAULT_TOKEN) $(vault) read -address=$(VAULT_ADDR) -field=value secret/devops-ci/cloud-on-k8s/eckadmin)

--- a/pkg/controller/elasticsearch/certificates/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/reconcile.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
-	v1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/driver"
@@ -60,7 +59,7 @@ func Reconcile(
 	extraHTTPSANs := make([]commonv1.SubjectAlternativeName, len(es.Spec.NodeSets))
 	for i, nodeSet := range es.Spec.NodeSets {
 		extraHTTPSANs[i] =
-			v1.SubjectAlternativeName{DNS: "*." + nodespec.HeadlessServiceName(esv1.StatefulSet(es.Name, nodeSet.Name)) + "." + es.Namespace + ".svc"}
+			commonv1.SubjectAlternativeName{DNS: "*." + nodespec.HeadlessServiceName(esv1.StatefulSet(es.Name, nodeSet.Name)) + "." + es.Namespace + ".svc"}
 	}
 
 	// reconcile HTTP CA and cert

--- a/pkg/controller/elasticsearch/certificates/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/reconcile.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	v1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/driver"
@@ -59,7 +60,7 @@ func Reconcile(
 	extraHTTPSANs := make([]commonv1.SubjectAlternativeName, len(es.Spec.NodeSets))
 	for i, nodeSet := range es.Spec.NodeSets {
 		extraHTTPSANs[i] =
-			commonv1.SubjectAlternativeName{DNS: "*." + nodespec.HeadlessServiceName(esv1.StatefulSet(es.Name, nodeSet.Name)) + "." + es.Namespace + ".svc"}
+			v1.SubjectAlternativeName{DNS: "*." + nodespec.HeadlessServiceName(esv1.StatefulSet(es.Name, nodeSet.Name)) + "." + es.Namespace + ".svc"}
 	}
 
 	// reconcile HTTP CA and cert


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/3815

Previous versions of this PR reverted 1fe23a45837ed41509e51c55c94b18119295d899 and so should have failed the lint check before this fix was in place.