### PR TITLE
Use cluster-scoped cache only when required

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -459,9 +459,15 @@ func startOperator(stopChan <-chan struct{}) error {
 		opts.Namespace = managedNamespaces[0]
 	default:
 		log.Info("Operator configured to manage multiple namespaces", "namespaces", managedNamespaces, "operator_namespace", operatorNamespace)
-		// the manager cache should always include the operator namespace so that we can work with operator-internal resources,
-		// and the empty namespace to watch cluster-scoped resources (e.g. storage classes).
-		opts.NewCache = cache.MultiNamespacedCacheBuilder(append(managedNamespaces, operatorNamespace, ""))
+		// The managed cache should always include the operator namespace so that we can work with operator-internal resources.
+		managedNamespaces = append(managedNamespaces, operatorNamespace)
+
+		// Add the empty namespace to allow watching cluster-scoped resources if storage class validation is enabled.
+		if viper.GetBool(operator.ValidateStorageClassFlag) {
+			managedNamespaces = append(managedNamespaces, "")
+		}
+
+		opts.NewCache = cache.MultiNamespacedCacheBuilder(managedNamespaces)
 	}
 
 	// only expose prometheus metrics if provided a non-zero port


### PR DESCRIPTION
When the operator is installed with the restricted profile, the controller-runtime cache starts logging errors because the operator does not have permission to access resources outside the namespaces it manages.

```
E1022 10:08:01.940788       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125: Failed to list *v1.Elasticsearch: elasticsearches.elasticsearch.k8s.elastic.co is forbidden: User "system:serviceaccount:elastic-system:elastic-operator" cannot list resource "elasticsearches" in API group "elasticsearch.k8s.elastic.co" at the cluster scope
E1022 10:08:03.129949       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125: Failed to list *v1beta1.EnterpriseSearch: enterprisesearches.enterprisesearch.k8s.elastic.co is forbidden: User "system:serviceaccount:elastic-system:elastic-operator" cannot list resource "enterprisesearches" in API group "enterprisesearch.k8s.elastic.co" at the cluster scope
```

This is due to a change introduced in #3810 to allow watching cluster resources by default. It should be made conditional instead.