### PR TITLE
[1.3] Add license info to telemetry (#3859)

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -600,7 +600,7 @@ func asyncTasks(
 	if !disableTelemetry {
 		// Start the telemetry reporter
 		go func() {
-			tr := telemetry.NewReporter(operatorInfo, mgr.GetClient(), managedNamespaces, telemetryInterval)
+			tr := telemetry.NewReporter(operatorInfo, mgr.GetClient(), operatorNamespace, managedNamespaces, telemetryInterval)
 			tr.Start()
 		}()
 	}

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -26,8 +26,8 @@ import (
 const (
 	// defaultOperatorLicenseLevel is the default license level when no operator license is installed
 	defaultOperatorLicenseLevel = "basic"
-	// licensingCfgMapName is the name of the config map used to store licensing information
-	licensingCfgMapName = "elastic-licensing"
+	// LicensingCfgMapName is the name of the config map used to store licensing information
+	LicensingCfgMapName = "elastic-licensing"
 	// Type represents the Elastic usage type used to mark the config map that stores licensing information
 	Type = "elastic-usage"
 )
@@ -99,10 +99,10 @@ func (r LicensingResolver) ToInfo(totalMemory resource.Quantity) (LicensingInfo,
 // Save updates or creates licensing information in a config map
 // This relies on UnconditionalUpdates being supported configmaps and may change in k8s v2: https://github.com/kubernetes/kubernetes/issues/21330
 func (r LicensingResolver) Save(info LicensingInfo) error {
-	log.V(1).Info("Saving", "namespace", r.operatorNs, "configmap_name", licensingCfgMapName, "license_info", info)
+	log.V(1).Info("Saving", "namespace", r.operatorNs, "configmap_name", LicensingCfgMapName, "license_info", info)
 	nsn := types.NamespacedName{
 		Namespace: r.operatorNs,
-		Name:      licensingCfgMapName,
+		Name:      LicensingCfgMapName,
 	}
 	expected := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/license/reporter_test.go
+++ b/pkg/license/reporter_test.go
@@ -229,7 +229,7 @@ func Test_Start(t *testing.T) {
 		var cm corev1.ConfigMap
 		err := k8sClient.Get(context.Background(), types.NamespacedName{
 			Namespace: operatorNs,
-			Name:      licensingCfgMapName,
+			Name:      LicensingCfgMapName,
 		}, &cm)
 		if err != nil {
 			return false
@@ -250,7 +250,7 @@ func Test_Start(t *testing.T) {
 		var cm corev1.ConfigMap
 		err := k8sClient.Get(context.Background(), types.NamespacedName{
 			Namespace: operatorNs,
-			Name:      licensingCfgMapName,
+			Name:      LicensingCfgMapName,
 		}, &cm)
 		if err != nil {
 			return false
@@ -267,7 +267,7 @@ func Test_Start(t *testing.T) {
 		var cm corev1.ConfigMap
 		err := k8sClient.Get(context.Background(), types.NamespacedName{
 			Namespace: operatorNs,
-			Name:      licensingCfgMapName,
+			Name:      LicensingCfgMapName,
 		}, &cm)
 		if err != nil {
 			return false

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -16,6 +16,7 @@ import (
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
+	"github.com/elastic/cloud-on-k8s/pkg/license"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/ghodss/yaml"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,8 @@ import (
 const (
 	resourceCount = "resource_count"
 	podCount      = "pod_count"
+
+	timestampFieldName = "timestamp"
 )
 
 var log = logf.Log.WithName("usage")
@@ -37,7 +40,8 @@ type ECKTelemetry struct {
 
 type ECK struct {
 	about.OperatorInfo
-	Stats map[string]interface{} `json:"stats"`
+	Stats   map[string]interface{} `json:"stats"`
+	License map[string]string      `json:"license"`
 }
 
 type getStatsFn func(k8s.Client, []string) (string, interface{}, error)
@@ -45,6 +49,7 @@ type getStatsFn func(k8s.Client, []string) (string, interface{}, error)
 func NewReporter(
 	info about.OperatorInfo,
 	client client.Client,
+	operatorNamespace string,
 	managedNamespaces []string,
 	telemetryInterval time.Duration,
 ) Reporter {
@@ -56,6 +61,7 @@ func NewReporter(
 	return Reporter{
 		operatorInfo:      info,
 		client:            k8s.WrapClient(client),
+		operatorNamespace: operatorNamespace,
 		managedNamespaces: managedNamespaces,
 		telemetryInterval: telemetryInterval,
 	}
@@ -64,6 +70,7 @@ func NewReporter(
 type Reporter struct {
 	operatorInfo      about.OperatorInfo
 	client            k8s.Client
+	operatorNamespace string
 	managedNamespaces []string
 	telemetryInterval time.Duration
 }
@@ -75,11 +82,12 @@ func (r *Reporter) Start() {
 	}
 }
 
-func marshalTelemetry(info about.OperatorInfo, stats map[string]interface{}) ([]byte, error) {
+func marshalTelemetry(info about.OperatorInfo, stats map[string]interface{}, license map[string]string) ([]byte, error) {
 	return yaml.Marshal(ECKTelemetry{
 		ECK: ECK{
 			OperatorInfo: info,
 			Stats:        stats,
+			License:      license,
 		},
 	})
 }
@@ -110,7 +118,13 @@ func (r *Reporter) report() {
 		return
 	}
 
-	telemetryBytes, err := marshalTelemetry(r.operatorInfo, stats)
+	licenseInfo, err := r.getLicenseInfo()
+	if err != nil {
+		log.Error(err, "failed to get operator license secret")
+		// it's ok to go on
+	}
+
+	telemetryBytes, err := marshalTelemetry(r.operatorInfo, stats, licenseInfo)
 	if err != nil {
 		log.Error(err, "failed to marshal telemetry data")
 		return
@@ -143,6 +157,23 @@ func (r *Reporter) report() {
 			}
 		}
 	}
+}
+
+func (r *Reporter) getLicenseInfo() (map[string]string, error) {
+	nsn := types.NamespacedName{
+		Namespace: r.operatorNamespace,
+		Name:      license.LicensingCfgMapName,
+	}
+
+	var licenseConfigMap corev1.ConfigMap
+	if err := r.client.Get(nsn, &licenseConfigMap); err != nil {
+		return nil, err
+	}
+
+	// remove timestamp field as it doesn't carry any significant information
+	delete(licenseConfigMap.Data, timestampFieldName)
+
+	return licenseConfigMap.Data, nil
 }
 
 func esStats(k8sClient k8s.Client, managedNamespaces []string) (string, interface{}, error) {


### PR DESCRIPTION
Backports the following commits to 1.3:
 - Add license info to telemetry (#3859)