### PR TITLE
[Backport] Use cluster-scoped cache only when required (#3868)

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -459,9 +459,15 @@ func startOperator(stopChan <-chan struct{}) error {
 		opts.Namespace = managedNamespaces[0]
 	default:
 		log.Info("Operator configured to manage multiple namespaces", "namespaces", managedNamespaces, "operator_namespace", operatorNamespace)
-		// the manager cache should always include the operator namespace so that we can work with operator-internal resources,
-		// and the empty namespace to watch cluster-scoped resources (e.g. storage classes).
-		opts.NewCache = cache.MultiNamespacedCacheBuilder(append(managedNamespaces, operatorNamespace, ""))
+		// The managed cache should always include the operator namespace so that we can work with operator-internal resources.
+		managedNamespaces = append(managedNamespaces, operatorNamespace)
+
+		// Add the empty namespace to allow watching cluster-scoped resources if storage class validation is enabled.
+		if viper.GetBool(operator.ValidateStorageClassFlag) {
+			managedNamespaces = append(managedNamespaces, "")
+		}
+
+		opts.NewCache = cache.MultiNamespacedCacheBuilder(managedNamespaces)
 	}
 
 	// only expose prometheus metrics if provided a non-zero port


### PR DESCRIPTION
Backport of #3868 