### PR TITLE
Renovate: ignore github.com/prometheus/(common|client_golang)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:base"
   ],
+  "ignoreDeps": ["github.com/prometheus/client_golang", "github.com/prometheus/common"],
   "labels": [">renovate"],
   "packageRules": [
     {


### PR DESCRIPTION
[Ignore updates](https://docs.renovatebot.com/configuration-options/#ignoredeps) on `github.com/prometheus/common` and `github.com/prometheus/client_golang`

Follow-up of https://github.com/elastic/cloud-on-k8s/pull/3780 and https://github.com/elastic/cloud-on-k8s/pull/3847

See https://github.com/elastic/cloud-on-k8s/pull/3847#issuecomment-709952082 for more details, it might be interesting to revert this commit once https://github.com/prometheus/common/issues/255 is resolved.