### PR TITLE
Add support for webhook constraints

### DIFF
--- a/deploy/eck-operator/profile-soft-multi-tenancy.yaml
+++ b/deploy/eck-operator/profile-soft-multi-tenancy.yaml
@@ -7,6 +7,12 @@ refs:
 
 webhook:
   enabled: true
+  namespaceSelector:
+    matchExpressions:
+      - key: "eck.k8s.elastic.co/tenant"
+        operator: In
+        values: ["team-a", "team-b"]
+
 
 softMultiTenancy:
   enabled: true

--- a/deploy/eck-operator/templates/_helpers.tpl
+++ b/deploy/eck-operator/templates/_helpers.tpl
@@ -68,6 +68,42 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Determine the name for the webhook 
+*/}}
+{{- define "eck-operator.webhookName" -}}
+{{- if .Values.internal.manifestGen -}}
+elastic-webhook.k8s.elastic.co
+{{- else -}}
+{{- $name := include "eck-operator.name" . -}}
+{{ printf "%s.%s.k8s.elastic.co" $name .Release.Namespace }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Determine the name for the webhook secret 
+*/}}
+{{- define "eck-operator.webhookSecretName" -}}
+{{- if .Values.internal.manifestGen -}}
+elastic-webhook-server-cert
+{{- else -}}
+{{- $name := include "eck-operator.name" . -}}
+{{ printf "%s-webhook-cert" $name | trunc 63 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Determine the name for the webhook service 
+*/}}
+{{- define "eck-operator.webhookServiceName" -}}
+{{- if .Values.internal.manifestGen -}}
+elastic-webhook-server
+{{- else -}}
+{{- $name := include "eck-operator.name" . -}}
+{{ printf "%s-webhook" $name | trunc 63 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Add the webhook sideEffects field on supported Kubernetes versions
 */}}
 {{- define "eck-operator.webhookSideEffects" -}}
@@ -77,6 +113,7 @@ Add the webhook sideEffects field on supported Kubernetes versions
 sideEffects: "None"
 {{- end }}
 {{- end }}
+
 
 {{/*
 RBAC permissions

--- a/deploy/eck-operator/templates/configmap.yaml
+++ b/deploy/eck-operator/templates/configmap.yaml
@@ -29,7 +29,7 @@ data:
     {{- end }}
     enable-webhook: {{ .Values.webhook.enabled }}
     {{- if .Values.webhook.enabled }}
-    webhook-name: {{ .Values.webhook.name }}
+    webhook-name: {{ include "eck-operator.webhookName" . }}
       {{- if not .Values.webhook.manageCerts }}
     manage-webhook-certs: false
     webhook-cert-dir: {{ .Values.webhook.certsDir }}

--- a/deploy/eck-operator/templates/statefulset.yaml
+++ b/deploy/eck-operator/templates/statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   fieldPath: status.podIP
             {{- if .Values.webhook.enabled }}
             - name: WEBHOOK_SECRET
-              value: "{{ .Values.webhook.certsSecret }}"
+              value: {{ include "eck-operator.webhookSecretName" . }}
             {{- end }}
             {{- if .Values.tracing.enabled -}}
             {{- range $name, $value :=  .Values.tracing.config }}
@@ -93,7 +93,7 @@ spec:
         - name: cert
           secret:
             defaultMode: 420
-            secretName: "{{ .Values.webhook.certsSecret }}"
+            secretName: {{ include "eck-operator.webhookSecretName" . }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/eck-operator/templates/webhook.yaml
+++ b/deploy/eck-operator/templates/webhook.yaml
@@ -3,7 +3,7 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: {{ .Values.webhook.name }}
+  name: {{ include "eck-operator.webhookName" . }}
   labels:
     {{- include "eck-operator.labels" . | nindent 4 }}
 {{- if .Values.webhook.certManagerCert }}
@@ -14,10 +14,18 @@ webhooks:
 - clientConfig:
     caBundle: {{ .Values.webhook.caBundle }}
     service:
-      name: {{ .Values.webhook.serviceName }}
+      name: {{ include "eck-operator.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate-apm-k8s-elastic-co-v1-apmserver
   failurePolicy: {{ .Values.webhook.failurePolicy }}
+{{- with .Values.webhook.namespaceSelector }}
+  namespaceSelector: 
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.webhook.objectSelector }}
+  objectSelector:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
   name: elastic-apm-validation-v1.k8s.elastic.co
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -33,10 +41,18 @@ webhooks:
 - clientConfig:
     caBundle: {{ .Values.webhook.caBundle }}
     service:
-      name: {{ .Values.webhook.serviceName }}
+      name: {{ include "eck-operator.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate-apm-k8s-elastic-co-v1beta1-apmserver
   failurePolicy: {{ .Values.webhook.failurePolicy }}
+{{- with .Values.webhook.namespaceSelector }}
+  namespaceSelector: 
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.webhook.objectSelector }}
+  objectSelector:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
   name: elastic-apm-validation-v1beta1.k8s.elastic.co
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -52,10 +68,18 @@ webhooks:
 - clientConfig:
     caBundle: {{ .Values.webhook.caBundle }}
     service:
-      name: {{ .Values.webhook.serviceName }}
+      name: {{ include "eck-operator.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate-beat-k8s-elastic-co-v1beta1-beat
   failurePolicy: {{ .Values.webhook.failurePolicy }}
+{{- with .Values.webhook.namespaceSelector }}
+  namespaceSelector: 
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.webhook.objectSelector }}
+  objectSelector:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
   name: elastic-beat-validation-v1beta1.k8s.elastic.co
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -71,10 +95,18 @@ webhooks:
 - clientConfig:
     caBundle: {{ .Values.webhook.caBundle }}
     service:
-      name: {{ .Values.webhook.serviceName }}
+      name: {{ include "eck-operator.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate-enterprisesearch-k8s-elastic-co-v1beta1-enterprisesearch
   failurePolicy: {{ .Values.webhook.failurePolicy }}
+{{- with .Values.webhook.namespaceSelector }}
+  namespaceSelector: 
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.webhook.objectSelector }}
+  objectSelector:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
   name: elastic-ent-validation-v1beta1.k8s.elastic.co
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -90,10 +122,18 @@ webhooks:
 - clientConfig:
     caBundle: {{ .Values.webhook.caBundle }}
     service:
-      name: {{ .Values.webhook.serviceName }}
+      name: {{ include "eck-operator.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
   failurePolicy: {{ .Values.webhook.failurePolicy }}
+{{- with .Values.webhook.namespaceSelector }}
+  namespaceSelector: 
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.webhook.objectSelector }}
+  objectSelector:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
   name: elastic-es-validation-v1.k8s.elastic.co
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -109,10 +149,18 @@ webhooks:
 - clientConfig:
     caBundle: {{ .Values.webhook.caBundle }}
     service:
-      name: {{ .Values.webhook.serviceName }}
+      name: {{ include "eck-operator.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
   failurePolicy: {{ .Values.webhook.failurePolicy }}
+{{- with .Values.webhook.namespaceSelector }}
+  namespaceSelector: 
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.webhook.objectSelector }}
+  objectSelector:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
   name: elastic-es-validation-v1beta1.k8s.elastic.co
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -128,10 +176,18 @@ webhooks:
 - clientConfig:
     caBundle: {{ .Values.webhook.caBundle }}
     service:
-      name: {{ .Values.webhook.serviceName }}
+      name: {{ include "eck-operator.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate-kibana-k8s-elastic-co-v1-kibana
   failurePolicy: {{ .Values.webhook.failurePolicy }}
+{{- with .Values.webhook.namespaceSelector }}
+  namespaceSelector: 
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.webhook.objectSelector }}
+  objectSelector:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
   name: elastic-kb-validation-v1.k8s.elastic.co
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -147,10 +203,18 @@ webhooks:
 - clientConfig:
     caBundle: {{ .Values.webhook.caBundle }}
     service:
-      name: {{ .Values.webhook.serviceName }}
+      name: {{ include "eck-operator.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate-kibana-k8s-elastic-co-v1beta1-kibana
   failurePolicy: {{ .Values.webhook.failurePolicy }}
+{{- with .Values.webhook.namespaceSelector }}
+  namespaceSelector: 
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.webhook.objectSelector }}
+  objectSelector:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
   name: elastic-kb-validation-v1beta1.k8s.elastic.co
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -167,7 +231,7 @@ webhooks:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.webhook.serviceName }}
+  name: {{ include "eck-operator.webhookServiceName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "eck-operator.labels" . | nindent 4 }}
@@ -183,7 +247,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "{{ .Values.webhook.certsSecret }}"
+  name: {{ include "eck-operator.webhookSecretName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "eck-operator.labels" . | nindent 4 }}

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -88,16 +88,16 @@ webhook:
   certManagerCert: null
   # certsDir is the directory to mount the certificates.
   certsDir: "/tmp/k8s-webhook-server/serving-certs"
-  # certsSecret is the name of the secret containing the webhook certificates.
-  certsSecret: elastic-webhook-server-cert
   # failurePolicy of the webhook.
   failurePolicy: Ignore
   # manageCerts determines whether the operator manages the webhook certificates automatically.
   manageCerts: true
-  # name of the webhook
-  name: elastic-webhook.k8s.elastic.co
-  # name of the service used to expose the webhook.
-  serviceName: elastic-webhook-server
+  # namespaceSelector corresponds to the namespaceSelector property of the webhook.
+  # Setting this restricts the webhook to act only on objects submitted to namespaces that match the selector.
+  namespaceSelector: {}
+  # objectSelector corresponds to the objectSelector property of the webhook.
+  # Setting this restricts the webhook to act only on objects that match the selector.
+  objectSelector: {}
 
 softMultiTenancy:
   # enabled determines whether the operator is installed with soft multi-tenancy extensions. 

--- a/hack/manifest-gen/testdata/values.yaml
+++ b/hack/manifest-gen/testdata/values.yaml
@@ -93,16 +93,10 @@ webhook:
   certManagerCert: null
   # certsDir is the directory to mount the certificates.
   certsDir: "/tmp/k8s-webhook-server/serving-certs"
-  # certsSecret is the name of the secret containing the webhook certificates.
-  certsSecret: elastic-webhook-server-cert
   # failurePolicy of the webhook.
   failurePolicy: Ignore
   # manageCerts determines whether the operator manages the webhook certificates automatically.
   manageCerts: true
-  # name of the webhook
-  name: elastic-webhook.k8s.elastic.co
-  # name of the service used to expose the webhook.
-  serviceName: elastic-webhook-server
 
 softMultiTenancy:
   # enabled determines whether the operator is installed with soft multi-tenancy extensions. 

--- a/pkg/controller/webhook/reconcile.go
+++ b/pkg/controller/webhook/reconcile.go
@@ -48,7 +48,7 @@ func (w *Params) ReconcileResources(ctx context.Context, clientset kubernetes.In
 			"secret_namespace", webhookServerSecret.Namespace,
 			"secret_name", webhookServerSecret.Name,
 		)
-		newCertificates, err := w.newCertificates()
+		newCertificates, err := w.newCertificates(webhookConfiguration)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/webhook/reconcile_test.go
+++ b/pkg/controller/webhook/reconcile_test.go
@@ -44,8 +44,10 @@ func TestParams_ReconcileResources(t *testing.T) {
 				},
 				Webhooks: []v1beta1.ValidatingWebhook{
 					{
-						Name:         "elastic-es-validation-v1.k8s.elastic.co",
-						ClientConfig: v1beta1.WebhookClientConfig{},
+						Name: "elastic-es-validation-v1.k8s.elastic.co",
+						ClientConfig: v1beta1.WebhookClientConfig{
+							Service: &v1beta1.ServiceReference{Name: "elastic-webhook-server", Namespace: "elastic-system"},
+						},
 					},
 				},
 			},

--- a/test/e2e/test/elasticsearch/steps_init.go
+++ b/test/e2e/test/elasticsearch/steps_init.go
@@ -13,11 +13,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/webhook"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 )
+
+const webhookServiceName = "elastic-webhook-server"
 
 // InitTestSteps includes pre-requisite tests (eg. is k8s accessible),
 // and cleanup from previous tests
@@ -66,7 +67,7 @@ func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
 				webhookEndpoints := &corev1.Endpoints{}
 				if err := k.Client.Get(types.NamespacedName{
 					Namespace: test.Ctx().Operator.Namespace,
-					Name:      webhook.WebhookServiceName,
+					Name:      webhookServiceName,
 				}, webhookEndpoints); err != nil {
 					return err
 				}


### PR DESCRIPTION
This PR is a minor refactoring of the Helm chart to allow users to set `namespaceSelector` and `objectSelector` on the webhook. The webhook name is now generated as `<operator-name>.<operator-namespace>.k8s.elastic.co` so that multiple operators can be installed side-by-side in the same cluster. This can be useful in a very large and busy cluster where dividing the set of namespaces between several operators can speed up reconciliation times and reduce the amount of resources required per operator.

Since webhooks are cluster-scoped resources, currently the chart requires `createClusterScopedResources` to be `true` as well. This means that each operator gets a `ClusterRole` not just restricted to the set of namespaces they are managing. It avoids over-complicating the chart at this point and should be fine for a load-splitting scenario like above. In an environment where operators are run by untrusted users and need to be locked down tightly, deploying webhooks is probably not an option anyway.

<details>
<summary>How to test</summary>

```sh
# Create managed namespaces and label them
for N in a b c d; do kubectl create ns "ns-$N"; kubectl label ns "ns-$N" name="ns-$N"; done

# Install the first operator to manage ns-a and ns-b namepsaces
 helm install operator-a ./deploy/eck-operator -n operator-a --create-namespace --values=<(cat <<EOF
nameOverride: operator-a
fullnameOverride: operator-a
installCRDs: true
managedNamespaces: ["ns-a", "ns-b"]

image:
  repository: docker.elastic.co/eck-dev/eck-operator-cell
  tag: 1.4.0-SNAPSHOT-d4c12355

webhook:
  enabled: true
  failurePolicy: Fail
  namespaceSelector:
    matchExpressions:
      - key: "name"
        operator: In
        values: ["ns-a", "ns-b"]
EOF
)

# Install the second operator to manage ns-c and ns-d namepsaces
 helm install operator-b ./deploy/eck-operator -n operator-b --create-namespace --values=<(cat <<EOF
nameOverride: operator-b
fullnameOverride: operator-b
installCRDs: false
managedNamespaces: ["ns-c", "ns-d"]

image:
  repository: docker.elastic.co/eck-dev/eck-operator-cell
  tag: 1.4.0-SNAPSHOT-d4c12355

webhook:
  enabled: true
  failurePolicy: Fail
  namespaceSelector:
    matchExpressions:
      - key: "name"
        operator: In
        values: ["ns-c", "ns-d"]
EOF
)
```

Resources deployed to `ns-a` or `ns-b`  will be validated by `https://operator-a-webhook.operator-a.svc`. You can verify this by simply scaling down the operator (`kubectl scale --replicas=0 sts/operator-a -n operator-a`) so that the webhook call fails. Since `failurePolicy` is set to `Fail`  the webhook request would ultimately fail and produce an error message indicating the endpoint it was trying to reach. 

```sh
# Cleanup
helm delete operator-a -n operator-a
helm delete operator-b -n operator-b
```

</details>


Fixes #3431