### PR TITLE
Add patchStrategy=merge for NodeSets field of an Elasticsearch (fix #3878)

### DIFF
--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -33,7 +33,9 @@ type ElasticsearchSpec struct {
 
 	// NodeSets allow specifying groups of Elasticsearch nodes sharing the same configuration and Pod templates.
 	// +kubebuilder:validation:MinItems=1
-	NodeSets []NodeSet `json:"nodeSets"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	NodeSets []NodeSet `json:"nodeSets" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// UpdateStrategy specifies how updates to the cluster should be performed.
 	// +kubebuilder:validation:Optional


### PR DESCRIPTION
Add `patchStrategy:"merge" patchMergeKey:"name"` go struct tag on `NodeSets` field of `ElasticsearchSpec` to allow `merge` instead of `replace` behavior when patching with `kustomize` `patchesStrategicMerge`.

Related issue: https://github.com/elastic/cloud-on-k8s/issues/3878

`make unit` => OK
`make integration` =>  OK