### PR TITLE
Disable leader election in the dev run target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ go-run:
 			-tags "$(GO_TAGS)" \
 			./cmd/main.go manager \
 				--development \
+				--enable-leader-election=false \
 				--log-verbosity=$(LOG_VERBOSITY) \
 				--ca-cert-validity=10h --ca-cert-rotate-before=1h \
 				--operator-namespace=default \


### PR DESCRIPTION
The leader election mechanism adds a few seconds of delay when running
the operator locally. I think it's safe to consider we don't need
leader election in that particular case.

The commit adds the `--enable-leader-election=false` flag to the
`go-run` make target.

Credits to @anyasabo in https://github.com/elastic/cloud-on-k8s/pull/3775#discussion_r492709698.