### PR TITLE
Fix broken link to Elasticsearch "heap size" docs

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/jvm-heap-size.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/jvm-heap-size.asciidoc
@@ -12,4 +12,4 @@ To change the heap size of Elasticsearch, set the `ES_JAVA_OPTS` environment var
 
 If `ES_JAVA_OPTS` is not defined, the Elasticsearch default heap size of 1Gi will be in effect.
 
-See also: link:https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html[Elasticsearch documentation on setting the heap size]
+For more information, see the entry for `heap size` in the link:{ref}/important-settings.html[Important Elasticsearch configuration] documentation.


### PR DESCRIPTION
Hi @sebgl, May I ask you to review this PR for me, or point me in the right direction?  This fixes a link in the K8s docs that will break once we merge other changes for the stack 7.10 release, so this will allow the docs build to pass ( https://github.com/elastic/docs/pull/1994 ).

Also, I'll need to backport this to releases `0.9`, `1.0-beta`, `1.0`, `1.1`, and `1.2`.  Can you let me know if I've got the right labels for that?  If so, I assume I just create the backports manually, right?

Sorry for the all the questions. Arianna is out this week and I'm a new visitor to this repo. :-)
