### PR TITLE
Fix broken link to elasticsearch heap size docs (v1.0)

### DIFF
--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -20,7 +20,6 @@ Before you deploy and run ECK, take some time to look at the basic and advanced 
 
 - <<{p}-virtual-memory>>
 - <<{p}-custom-http-certificate>>
-- <<{p}-reserved-settings>>
 - <<{p}-es-secure-settings>>
 - <<{p}-bundles-plugins>>
 - <<{p}-init-containers-plugin-downloads>>
@@ -29,8 +28,6 @@ Before you deploy and run ECK, take some time to look at the basic and advanced 
 - <<{p}-advanced-node-scheduling,Advanced Elasticsearch node scheduling>>
 - <<{p}-orchestration>>
 - <<{p}-snapshots,Create automated snapshots>>
-- <<{p}-readiness>>
-- <<{p}-prestop>>
 
 [id="{p}-pod-template"]
 === Pod Template
@@ -84,7 +81,7 @@ To change the heap size of Elasticsearch, set the `ES_JAVA_OPTS` environment var
 
 If `ES_JAVA_OPTS` is not defined, the Elasticsearch default heap size of 1Gi will be in effect.
 
-See also: link:https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html[Elasticsearch documentation on setting the heap size]
+For more information, see the entry for `heap size` in the link:{ref}/important-settings.html[Important Elasticsearch configuration] documentation.
 
 
 [id="{p}-node-configuration"]
@@ -256,76 +253,16 @@ spec:
   http:
     tls:
       certificate:
-        secretName: quickstart-es-cert
+        secretName: my-cert
 ----
 
-[float]
-==== Custom self-signed certificate using OpenSSL
-
-This example illustrates how to create your own self-signed certificate for the <<{p}-deploy-elasticsearch,quickstart Elasticsearch cluster>> using the OpenSSL command line utility. Note the subject alternative name (SAN) entry for `quickstart-es-http.default.svc`.
+This is an example on how to create a Kubernetes TLS secret with a self-signed certificate:
 
 [source,sh]
 ----
 $ openssl req -x509 -sha256 -nodes -newkey rsa:4096 -days 365 -subj "/CN=quickstart-es-http" -addext "subjectAltName=DNS:quickstart-es-http.default.svc" -keyout tls.key -out tls.crt
-$ kubectl create secret generic quickstart-es-cert --from-file=ca.crt=tls.crt --from-file=tls.crt=tls.crt --from-file=tls.key=tls.key
+$ kubectl create secret generic my-cert --from-file=ca.crt=tls.crt --from-file=tls.crt=tls.crt --from-file=tls.key=tls.key
 ----
-
-[float]
-==== Custom self-signed certificate using cert-manager
-
-This example illustrates how to issue a self-signed certificate for the <<{p}-deploy-elasticsearch,quickstart Elasticsearch cluster>> using a link:https://cert-manager.io[cert-manager] self-signed issuer.
-
-[source,yaml]
-----
----
-apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
-metadata:
-  name: selfsigned-issuer
-spec:
-  selfSigned: {}
----
-apiVersion: cert-manager.io/v1alpha2
-kind: Certificate
-metadata:
-  name: quickstart-es-cert
-spec:
-  isCA: true
-  dnsNames:
-    - quickstart-es-http
-    - quickstart-es-http.default.svc
-    - quickstart-es-http.default.svc.cluster.local
-  issuerRef:
-    kind: Issuer
-    name: selfsigned-issuer
-  secretName: quickstart-es-cert
-----
-
-
-[id="{p}-reserved-settings"]
-=== Settings managed by ECK
-
-The following Elasticsearch settings are managed by ECK:
-
-* `cluster.name`
-* `discovery.zen.minimum_master_nodes` deprecated[7.0]
-* `cluster.initial_master_nodes` added[7.0]
-* `network.host`
-* `network.publish_host`
-* `path.data`
-* `path.logs`
-* `xpack.security.authc.reserved_realm.enabled`
-* `xpack.security.enabled`
-* `xpack.security.http.ssl.certificate`
-* `xpack.security.http.ssl.enabled`
-* `xpack.security.http.ssl.key`
-* `xpack.security.transport.ssl.certificate`
-* `xpack.security.transport.ssl.enabled`
-* `xpack.security.transport.ssl.key`
-* `xpack.security.transport.ssl.verification_mode`
-
-CAUTION: While ECK does not prevent you from setting any of these settings yourself, you are strongly discouraged from doing so and we cannot offer support for any user provided Elasticsearch configuration that does use any of these settings.
-
 
 [id="{p}-es-secure-settings"]
 === Secure settings
@@ -440,17 +377,14 @@ spec:
             bin/elasticsearch-plugin install --batch repository-gcs
 ----
 
-You can also override the Elasticsearch container image to use your own image with the plugins already installed, as described in the <<{p}-custom-images,custom images doc>>. The <<{p}-snapshots,snapshots>> document has more information on both these options. The Kubernetes document on https://kubernetes.io/docs/concepts/workloads/pods/init-containers/[init containers] has more information on their usage as well.
+You can also override the Elasticsearch container image to use your own image with the plugins already installed, as described in the link:k8s-images.asciidoc[custom images doc]. The <<{p}-snapshots,snapshots>> document has more information on both these options. The Kubernetes document on https://kubernetes.io/docs/concepts/workloads/pods/init-containers/[init containers] has more information on their usage as well.
 
 The init container inherits the image of the main container image if one is not explicitly set. It also inherits the volume mounts as long as the name and mount path do not conflict. It also inherits the Pod name and IP address environment variables.
 
 [id="{p}-update-strategy"]
 === Update strategy
 
-You can use the `updateStrategy` specification to limit the number of simultaneous changes, like for example in the following cases:
-
-* The operator takes a Pod down to restart a node and applies a new configuration value.
-* The operator must spin up Pods above what is currently in the specification to migrate to a new node set.
+Sometimes the operator must take a Pod down, for example, to restart a node and apply a new configuration value. Other times the operator must spin up pods above what is currently in the specification, say to migrate to a new node set. You can limit the number of these simultaneous changes  using an `updateStrategy` as follows:
 
 [source,yaml]
 ----
@@ -460,20 +394,20 @@ spec:
       maxSurge: 3
       maxUnavailable: 1
 ----
-`maxSurge`: Refers to the number of extra Pods that can be temporarily scheduled exceeding the number of Pods  defined in the specification. This setting is useful for controlling the resource usage of the Kubernetes cluster when new Pods need to be spun up to replace existing Pods. For example, when applying a configuration change to a Node Set, ECK creates a clone of the Node Set with the desired configuration and shuts down the old Pods. Without the `MaxSurge` restriction, the cluster would temporarily contain twice as many Pods as usual while this operation is in progress.
+`maxSurge` refers to the number of Pods that can be scheduled above the total number of Pods in the currently applied specification. This setting might be useful when the new specification has similar number of Pods, but different node sets (for example, when migrating Pods to a new node set). It will prevent the operator from creating all new Pods before removing the old ones thus preventing having (temporarily) as many as two times more pods than the specification defines.
 
-`maxUnavailable`: Refers to the number of Pods that can be unavailable out of the total number of Pods in the currently applied specification. A Pod is defined unavailable when it is not ready from a Kubernetes perspective.
+`maxUnavailable` refers to the number of Pods that can be unavailable out of the total number of Pods in the currently applied specification. Unavailable is defined as a Pod being not ready from Kubernetes perspective.
 
-The operator only tries to apply these constraints when a new specification is being applied. It is possible that the cluster state does not conform to the constraints at the beginning of the operation due to external factors. The operator will attempt to get to the desired state by adding or removing Pods as necessary while ensuring that the constraints are still satisfied.
+As these constraints are enforced immediately after the specification is applied, it is possible the the actual state of the cluster might violate these constraints. When the cluster is outside these constraints, the operator can add or remove nodes only with the purpose of getting closer to these constraints. When the cluster is within these constraints, the operator can either add or remove nodes, as long as the cluster remains within the predefined constraints.
 
 For example, if a new specification defines a larger cluster with `maxUnavailable: 0`, the operator creates the missing Pods according to the best practices. Similarly, if a new specification defines a smaller cluster with `maxSurge: 0`, the operator safely removes the unnecessary Pods.
 
 ==== Specifying changeBudget
 For both `maxSurge` and `maxUnavailable` you can specify the following values:
 
-* `null` - The default value is used.
-* non-negative - The value is used as is.
-* negative - The value is unbounded.
+* `null` - the default value is used
+* non-negative - the value is used as is
+* negative - the value is unbounded
 
 ==== Default behavior
 When `updateStrategy` is not present in the specification, it defaults to the following:
@@ -487,13 +421,13 @@ spec:
       maxUnavailable: 1
 ----
 
-`maxSurge` is unbounded: This means that all the required Pods are created immediately.
-`maxUnavailable` defaults to `1`: This ensures that the cluster has no more than one unavailable Pod at any given point in time.
+`maxSurge` is unbounded: this means that all the missing Pods are immediately created according to the best practices at any given time.
+`maxUnavailable` defaults to `1`: this assures that clusters have at most one unavailable Pod at any given time.
 
 ==== Caveats
 * With both `maxSurge` and `maxUnavailable` set to `0`, the operator cannot bring down an existing Pod nor create a new Pod.
-* Due to the safety measures employed by the operator, certain `changeBudget`s might prevent the operator from making any progress . For example, with `maxSurge` set to 0, you cannot remove the last data node from one `nodeSet` and add a data node to a different `nodeSet`. In this case, the operator cannot create the new node because `maxSurge` is 0, and it cannot remove the old node because there are no other data nodes to migrate the data to.
-* For certain complex configurations, the operator might not be able to deduce the optimal order of operations necessary to achieve the desired outcome. If progress is blocked,  you may need to update the `maxSurge` setting to a higher value than the theoretical best to help the operator make progress in that case.
+* Due to the safety measures employed by the operator, a particular changeBudget might be insufficient to perform the requested update. For example, with `maxSurge` set to 0 you cannot remove the last data node from one nodeSet and add a data node to a different nodeSet. In this case the operator cannot remove the old node and migrate data as other nodes are not available, and can't add the new node because `maxSurge` is set to 0.
+* Currently, the operator has a limited understanding of the cluster topology and during the update might not pick the optimal order of Pods being added or removed. This can block the update process and you might need to specify a higher `maxSurge` than theoretically needed.
 
 If any of the above occurs, the operator generates logs to indicate that upscaling or downscaling are limited by `maxSurge` or `maxUnavailable` settings.
 
@@ -547,75 +481,3 @@ spec:
 include::orchestration.asciidoc[]
 include::advanced-node-scheduling.asciidoc[]
 include::snapshots.asciidoc[]
-
-
-[id="{p}-readiness"]
-=== Readiness probe
-
-By default, the readiness probe checks that the pod can successfully respond to HTTP requests within a three second timeout. This is acceptable in most cases. In some cases (such as when the cluster is under heavy load), it may be helpful to increase the timeout. This allows the pod to stay in a `Ready` state and thus be part of the Elasticsearch service even if it is responding slowly. To adjust the timeout, set the `READINESS_PROBE_TIMEOUT` environment variable in the pod template. The readiness probe configuration also must be updated with the new timeout. For example, to increase the API call timeout to ten seconds and the overall check time to twelve seconds:
-
-[source,yaml,subs="attributes"]
-----
-spec:
-  version: {version}
-  nodeSets:
-    - name: default
-      count: 1
-      podTemplate:
-        spec:
-          containers:
-          - name: elasticsearch
-            readinessProbe:
-              exec:
-                command:
-                - bash
-                - -c
-                - /mnt/elastic-internal/scripts/readiness-probe-script.sh
-              failureThreshold: 3
-              initialDelaySeconds: 10
-              periodSeconds: 12
-              successThreshold: 1
-              timeoutSeconds: 12
-            env:
-            - name: READINESS_PROBE_TIMEOUT
-              value: "10"
-
-
-----
-
-Note that this will require restarting the pods.
-
-[id="{p}-prestop"]
-=== Pod PreStop hook
-
-When an Elasticsearch `Pod` is terminated, its `Endpoint` is removed from the `Service` and the Elasticsearch process is terminated. As these two operations happen in parallel, a race condition exists. If the Elasticsearch process is already shut down, but the `Endpoint` is still a part of the `Service`, any new connection might fail. For more information, see link:https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods[Termination of pods].
-
-Moreover, kube-proxy resynchronizes its rules link:https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/#options[every 30 seconds by default]. During that 30 second time window, the terminating Pod IP may still be used when targeting the service. Please note the resync operation itself may take some time, especially if kube-proxy is configured to use iptables with a lot of services and rules to apply.
-
-To address this issue and minimise unavailability, ECK relies on a link:https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/[PreStop lifecycle hook]. This waits to terminate the Elasticsearch process until the `Service` DNS record does not contain the IP of the `Pod`.
-First, the PreStop lifecycle hook will keep querying DNS for `PRE_STOP_MAX_WAIT_SECONDS` (defaulting to 20) until the Pod IP is not referenced anymore.
-Then, it waits for an additional `PRE_STOP_ADDITIONAL_WAIT_SECONDS` (defaulting to 30). Additional wait is used to:
-
-1. give time to in-flight requests to be completed
-2. give clients time to use the terminating Pod IP resolved just before DNS record was updated
-3. give kube-proxy time to refresh ipvs or iptables rules on all nodes, depending on its sync period setting
-
-The exact behavior is configurable using environment variables, for example:
-
-[source,yaml,subs="attributes"]
-----
-spec:
-  version: {version}
-  nodeSets:
-    - name: default
-      count: 1
-      podTemplate:
-        spec:
-          containers:
-          - name: elasticsearch
-            env:
-            - name: PRE_STOP_MAX_WAIT_SECONDS
-              value: "10"
-            - name: PRE_STOP_ADDITIONAL_WAIT_SECONDS
-              value: "5"
-----


### PR DESCRIPTION
This pre-emptively fixes a link to the Elasticsearch heap size docs that will break with the stack 7.10 release, and will prevent docs builds from passing CI checks.