### PR TITLE
[1.3] Update registry.access.redhat.com/ubi8/ubi-minimal Docker tag to v8.3 (#3895)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
 			-o elastic-operator github.com/elastic/cloud-on-k8s/cmd
 
 # Copy the operator binary into a lighter image
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
 ARG VERSION
 


### PR DESCRIPTION
Backports the following commits to 1.3:
 - Update registry.access.redhat.com/ubi8/ubi-minimal Docker tag to v8.3 (#3895)