### PR TITLE
[1.3] Temporarily disable Beat recipe flaky tests (#3888)

### DIFF
--- a/test/e2e/beat/recipes_test.go
+++ b/test/e2e/beat/recipes_test.go
@@ -80,23 +80,25 @@ func TestFilebeatAutodiscoverByMetadataRecipe(t *testing.T) {
 	runBeatRecipe(t, "filebeat_autodiscover_by_metadata.yaml", customize, podLabel, podBad)
 }
 
-func TestMetricbeatHostsRecipe(t *testing.T) {
-	customize := func(builder beat.Builder) beat.Builder {
-		return builder.
-			WithRoles(beat.PSPClusterRoleName).
-			WithESValidations(
-				beat.HasEvent("event.dataset:system.cpu"),
-				beat.HasEvent("event.dataset:system.load"),
-				beat.HasEvent("event.dataset:system.memory"),
-				beat.HasEvent("event.dataset:system.network"),
-				beat.HasEvent("event.dataset:system.process"),
-				beat.HasEvent("event.dataset:system.process.summary"),
-				beat.HasEvent("event.dataset:system.fsstat"),
-			)
-	}
-
-	runBeatRecipe(t, "metricbeat_hosts.yaml", customize)
-}
+// TODO: flaky test, investigate then re-enable
+//  see https://github.com/elastic/cloud-on-k8s/issues/3884
+//func TestMetricbeatHostsRecipe(t *testing.T) {
+//	customize := func(builder beat.Builder) beat.Builder {
+//		return builder.
+//			WithRoles(beat.PSPClusterRoleName).
+//			WithESValidations(
+//				beat.HasEvent("event.dataset:system.cpu"),
+//				beat.HasEvent("event.dataset:system.load"),
+//				beat.HasEvent("event.dataset:system.memory"),
+//				beat.HasEvent("event.dataset:system.network"),
+//				beat.HasEvent("event.dataset:system.process"),
+//				beat.HasEvent("event.dataset:system.process.summary"),
+//				beat.HasEvent("event.dataset:system.fsstat"),
+//			)
+//	}
+//
+//	runBeatRecipe(t, "metricbeat_hosts.yaml", customize)
+//}
 
 func TestMetricbeatStackMonitoringRecipe(t *testing.T) {
 	name := "fb-autodiscover"
@@ -192,23 +194,25 @@ func TestAuditbeatHostsRecipe(t *testing.T) {
 	runBeatRecipe(t, "auditbeat_hosts.yaml", customize)
 }
 
-func TestPacketbeatDnsHttpRecipe(t *testing.T) {
-	customize := func(builder beat.Builder) beat.Builder {
-		if !(test.Ctx().Provider == "kind" && test.Ctx().KubernetesVersion == "1.12") {
-			// there are some issues with kind 1.12 and tracking http traffic
-			builder = builder.WithESValidations(beat.HasEvent("event.dataset:http"))
-		}
-
-		return builder.
-			WithRoles(beat.PacketbeatPSPClusterRoleName).
-			WithESValidations(
-				beat.HasEvent("event.dataset:flow"),
-				beat.HasEvent("event.dataset:dns"),
-			)
-	}
-
-	runBeatRecipe(t, "packetbeat_dns_http.yaml", customize)
-}
+// TODO: flaky test, investigate then re-enable
+//  see https://github.com/elastic/cloud-on-k8s/issues/3884
+//func TestPacketbeatDnsHttpRecipe(t *testing.T) {
+//	customize := func(builder beat.Builder) beat.Builder {
+//		if !(test.Ctx().Provider == "kind" && test.Ctx().KubernetesVersion == "1.12") {
+//			// there are some issues with kind 1.12 and tracking http traffic
+//			builder = builder.WithESValidations(beat.HasEvent("event.dataset:http"))
+//		}
+//
+//		return builder.
+//			WithRoles(beat.PacketbeatPSPClusterRoleName).
+//			WithESValidations(
+//				beat.HasEvent("event.dataset:flow"),
+//				beat.HasEvent("event.dataset:dns"),
+//			)
+//	}
+//
+//	runBeatRecipe(t, "packetbeat_dns_http.yaml", customize)
+//}
 
 func TestJournalbeatHostsRecipe(t *testing.T) {
 	customize := func(builder beat.Builder) beat.Builder {


### PR DESCRIPTION
Backports the following commits to 1.3:
 - Temporarily disable Beat recipe flaky tests (#3888)