### PR TITLE
[1.3] Update 1.3.0.asciidoc (#3921)

### DIFF
--- a/docs/release-notes/1.3.0.asciidoc
+++ b/docs/release-notes/1.3.0.asciidoc
@@ -58,9 +58,3 @@
 * Fix volume slice initialization in beat pod builder {pull}3555[#3555] (issue: {issue}3554[#3554])
 * Ensure status.version is reconciled by watching Pods {pull}3534[#3534] (issue: {issue}3533[#3533])
 * Init containers image defaulting {pull}3525[#3525] (issue: {issue}3453[#3453])
-
-[[nogroup-1.3.0]]
-[float]
-=== Misc
-
-* Update registry.access.redhat.com/ubi8/ubi-minimal Docker tag to v8.3 {pull}3895[#3895]


### PR DESCRIPTION
Backports the following commits to 1.3:
 - Update 1.3.0.asciidoc (#3921)