### PR TITLE
[1.3] Update golang Docker tag to v1.15.4 (#3920)

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image used for continuous integration
-FROM golang:1.15.2
+FROM golang:1.15.4
 
 ENV GOLANGCILINT_VERSION=1.27.0
 ENV SHELLCHECK_VERSION=0.7.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM golang:1.15.2 as builder
+FROM golang:1.15.4 as builder
 
 ARG GO_LDFLAGS
 ARG GO_TAGS

--- a/hack/manifest-gen/Dockerfile
+++ b/hack/manifest-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.2 as builder
+FROM golang:1.15.4 as builder
 ADD . /manifest-gen
 WORKDIR /manifest-gen
 ENV GO111MODULE=on CGO_ENABLED=0 GOOS=linux 


### PR DESCRIPTION
Backports the following commits to 1.3:
 - Update golang Docker tag to v1.15.4 (#3920)