### PR TITLE
[1.3] Bump go to 1.15.4 in e2e container (#3926)

### DIFF
--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image for the E2E tests runner
-FROM golang:1.15.2
+FROM golang:1.15.4
 
 ARG E2E_JSON
 ENV E2E_JSON $E2E_JSON


### PR DESCRIPTION
Backports the following commits to 1.3:
 - Bump go to 1.15.4 in e2e container (#3926)