### PR TITLE
[1.0] Typo (#3916)

### DIFF
--- a/docs/elasticsearch-specification.asciidoc
+++ b/docs/elasticsearch-specification.asciidoc
@@ -90,7 +90,7 @@ For more information, see the entry for `heap size` in the link:{ref}/important-
 [id="{p}-node-configuration"]
 === Node configuration
 
-Any setting defined in the `elasticsearch.yml` configuration file can also be defined for set of Elasticsearch nodes in the `spec.nodeSets[?].config` section.
+Any setting defined in the `elasticsearch.yml` configuration file can also be defined for a set of Elasticsearch nodes in the `spec.nodeSets[?].config` section.
 
 [source,yaml]
 ----


### PR DESCRIPTION
Backports the following commits to 1.0:

* Typo (#3916)