### PR TITLE
Set default e2e test timeout to 30 min

### DIFF
--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -44,7 +44,6 @@ TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
 
 OPERATOR_IMAGE = $JKS_PARAM_OPERATOR_IMAGE
-TEST_TIMEOUT = 10m
 
 PIPELINE=e2e/aks
 BUILD_NUMBER=$BUILD_NUMBER
@@ -122,7 +121,6 @@ TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
 
 OPERATOR_IMAGE = $JKS_PARAM_OPERATOR_IMAGE
-TEST_TIMEOUT = 10m
 KIND_NODE_IMAGE = ${kindNodeImage}
 IP_FAMILY=$4
 
@@ -222,7 +220,6 @@ TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
 
 OPERATOR_IMAGE = $JKS_PARAM_OPERATOR_IMAGE
-TEST_TIMEOUT = 10m
 
 PIPELINE=e2e/ocp
 BUILD_NUMBER=$BUILD_NUMBER
@@ -258,7 +255,6 @@ TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
 
 OPERATOR_IMAGE = $JKS_PARAM_OPERATOR_IMAGE
-TEST_TIMEOUT = 10m
 
 PIPELINE=e2e/ocp3
 BUILD_NUMBER=$BUILD_NUMBER
@@ -294,7 +290,6 @@ TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
 
 OPERATOR_IMAGE = $JKS_PARAM_OPERATOR_IMAGE
-TEST_TIMEOUT = 10m
 
 PIPELINE=e2e/eks
 BUILD_NUMBER=$BUILD_NUMBER

--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,7 @@ E2E_IMG                    ?= $(REGISTRY)/$(E2E_REGISTRY_NAMESPACE)/eck-e2e-test
 TESTS_MATCH                ?= "^Test" # can be overriden to eg. TESTS_MATCH=TestMutationMoreNodes to match a single test
 E2E_STACK_VERSION          ?= 7.9.2
 E2E_JSON                   ?= false
-TEST_TIMEOUT               ?= 5m
+TEST_TIMEOUT               ?= 20m
 E2E_SKIP_CLEANUP           ?= false
 E2E_DEPLOY_CHAOS_JOB       ?= false
 

--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,7 @@ E2E_IMG                    ?= $(REGISTRY)/$(E2E_REGISTRY_NAMESPACE)/eck-e2e-test
 TESTS_MATCH                ?= "^Test" # can be overriden to eg. TESTS_MATCH=TestMutationMoreNodes to match a single test
 E2E_STACK_VERSION          ?= 7.9.2
 E2E_JSON                   ?= false
-TEST_TIMEOUT               ?= 20m
+TEST_TIMEOUT               ?= 30m
 E2E_SKIP_CLEANUP           ?= false
 E2E_DEPLOY_CHAOS_JOB       ?= false
 

--- a/test/e2e/cmd/run/command.go
+++ b/test/e2e/cmd/run/command.go
@@ -94,7 +94,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&flags.scratchDirRoot, "scratch-dir", "/tmp/eck-e2e", "Path under which temporary files should be created")
 	cmd.Flags().StringVar(&flags.testRegex, "test-regex", "", "Regex to pass to the test runner")
 	cmd.Flags().StringVar(&flags.testRunName, "test-run-name", randomTestRunName(), "Name of this test run")
-	cmd.Flags().DurationVar(&flags.testTimeout, "test-timeout", 5*time.Minute, "Timeout before failing a test")
+	cmd.Flags().DurationVar(&flags.testTimeout, "test-timeout", 20*time.Minute, "Timeout before failing a test")
 	cmd.Flags().StringVar(&flags.pipeline, "pipeline", "", "E2E test pipeline name")
 	cmd.Flags().StringVar(&flags.buildNumber, "build-number", "", "E2E test build number")
 	cmd.Flags().StringVar(&flags.provider, "provider", "", "E2E test infrastructure provider")

--- a/test/e2e/cmd/run/command.go
+++ b/test/e2e/cmd/run/command.go
@@ -94,7 +94,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&flags.scratchDirRoot, "scratch-dir", "/tmp/eck-e2e", "Path under which temporary files should be created")
 	cmd.Flags().StringVar(&flags.testRegex, "test-regex", "", "Regex to pass to the test runner")
 	cmd.Flags().StringVar(&flags.testRunName, "test-run-name", randomTestRunName(), "Name of this test run")
-	cmd.Flags().DurationVar(&flags.testTimeout, "test-timeout", 20*time.Minute, "Timeout before failing a test")
+	cmd.Flags().DurationVar(&flags.testTimeout, "test-timeout", 30*time.Minute, "Timeout before failing a test")
 	cmd.Flags().StringVar(&flags.pipeline, "pipeline", "", "E2E test pipeline name")
 	cmd.Flags().StringVar(&flags.buildNumber, "build-number", "", "E2E test build number")
 	cmd.Flags().StringVar(&flags.provider, "provider", "", "E2E test infrastructure provider")

--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -7,7 +7,6 @@ package e2e
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -29,19 +28,17 @@ import (
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/kibana"
 )
 
-const (
-	// upgrading the entire stack can take some time, since we need to account for (in order):
-	// - Elasticsearch rolling upgrade
-	// - Kibana + Enterprise Search deployments upgrade
-	// - APMServer deployment upgrade + Beat daemonset upgrade
-	stackVersionUpgradeTimeout = 40 * time.Minute
-)
-
 // TestVersionUpgradeOrdering deploys the entire stack, with resources associated together.
 // Then, it updates their version, and ensures a strict ordering is respected during the version upgrade.
 func TestVersionUpgradeOrdering(t *testing.T) {
 	initialVersion := "7.7.0"
 	updatedVersion := "7.8.0"
+
+	// upgrading the entire stack can take some time, since we need to account for (in order):
+	// - Elasticsearch rolling upgrade
+	// - Kibana + Enterprise Search deployments upgrade
+	// - APMServer deployment upgrade + Beat daemonset upgrade
+	timeout := test.Ctx().TestTimeout * 2
 
 	// Single-node ES clusters cannot be green with APM indices (see https://github.com/elastic/apm-server/issues/414).
 	es := elasticsearch.NewBuilder("es").
@@ -113,7 +110,7 @@ func TestVersionUpgradeOrdering(t *testing.T) {
 					return fmt.Errorf("some versions are still not updated: %+v", stackVersions)
 				}
 				return nil
-			}, stackVersionUpgradeTimeout),
+			}, timeout),
 		})
 	}
 

--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -34,7 +34,7 @@ const (
 	// - Elasticsearch rolling upgrade
 	// - Kibana + Enterprise Search deployments upgrade
 	// - APMServer deployment upgrade + Beat daemonset upgrade
-	stackVersionUpgradeTimeout = 30 * time.Minute
+	stackVersionUpgradeTimeout = 40 * time.Minute
 )
 
 // TestVersionUpgradeOrdering deploys the entire stack, with resources associated together.


### PR DESCRIPTION
Increase the default timeout from 5min to 30min.
In some environment, that timeout was already overridden to 10min. This commit removes
the environment-specific overrides to use 30min everywhere.

Fixes https://github.com/elastic/cloud-on-k8s/issues/3935.