### PR TITLE
Use new node_names query param for voting exclusions as of 7.8.0

### DIFF
--- a/pkg/controller/elasticsearch/client/base.go
+++ b/pkg/controller/elasticsearch/client/base.go
@@ -21,6 +21,7 @@ type baseClient struct {
 	HTTP     *http.Client
 	Endpoint string
 	caCerts  []*x509.Certificate
+	version  version.Version
 }
 
 // Close idle connections in the underlying http client.
@@ -129,6 +130,7 @@ func (c *baseClient) request(
 }
 
 func versioned(b *baseClient, v version.Version) Client {
+	b.version = v
 	v6 := clientV6{
 		baseClient: *b,
 	}

--- a/pkg/controller/elasticsearch/client/client_test.go
+++ b/pkg/controller/elasticsearch/client/client_test.go
@@ -444,9 +444,10 @@ func TestClient_Equal(t *testing.T) {
 
 func TestClient_AddVotingConfigExclusions(t *testing.T) {
 	tests := []struct {
-		expectedPath string
-		version      version.Version
-		wantErr      bool
+		expectedPath  string
+		expectedQuery string
+		version       version.Version
+		wantErr       bool
 	}{
 		{
 			expectedPath: "",
@@ -458,11 +459,24 @@ func TestClient_AddVotingConfigExclusions(t *testing.T) {
 			version:      version.MustParse("7.0.0"),
 			wantErr:      false,
 		},
+		{
+			expectedPath:  "/_cluster/voting_config_exclusions",
+			expectedQuery: "node_names=a,b",
+			version:       version.MustParse("7.8.0"),
+			wantErr:       false,
+		},
+		{
+			expectedPath:  "/_cluster/voting_config_exclusions",
+			expectedQuery: "node_names=a,b",
+			version:       version.MustParse("8.0.0"),
+			wantErr:       false,
+		},
 	}
 
 	for _, tt := range tests {
 		client := NewMockClient(tt.version, func(req *http.Request) *http.Response {
-			require.Equal(t, tt.expectedPath, req.URL.Path)
+			require.Equal(t, tt.expectedPath, req.URL.Path, tt.version)
+			require.Equal(t, tt.expectedQuery, req.URL.RawQuery, tt.version)
 			return &http.Response{
 				StatusCode: 200,
 				Body:       ioutil.NopCloser(strings.NewReader("")),

--- a/pkg/controller/elasticsearch/client/v7.go
+++ b/pkg/controller/elasticsearch/client/v7.go
@@ -47,6 +47,7 @@ func (c *clientV7) AddVotingConfigExclusions(ctx context.Context, nodeNames []st
 	if c.version.IsSameOrAfter(version.From(7, 8, 0)) {
 		path = fmt.Sprintf("/_cluster/voting_config_exclusions?node_names=%s", strings.Join(nodeNames, ","))
 	} else {
+		// versions < 7.8.0 or unversioned clients which is OK as this deprecated API will be supported until 8.0
 		path = fmt.Sprintf("/_cluster/voting_config_exclusions/%s", strings.Join(nodeNames, ","))
 	}
 

--- a/pkg/controller/elasticsearch/client/v7.go
+++ b/pkg/controller/elasticsearch/client/v7.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/pkg/errors"
 )
 
@@ -42,7 +43,12 @@ func (c *clientV7) StartTrial(ctx context.Context) (StartTrialResponse, error) {
 }
 
 func (c *clientV7) AddVotingConfigExclusions(ctx context.Context, nodeNames []string) error {
-	path := fmt.Sprintf("/_cluster/voting_config_exclusions/%s", strings.Join(nodeNames, ","))
+	var path string
+	if c.version.IsSameOrAfter(version.From(7, 8, 0)) {
+		path = fmt.Sprintf("/_cluster/voting_config_exclusions?node_names=%s", strings.Join(nodeNames, ","))
+	} else {
+		path = fmt.Sprintf("/_cluster/voting_config_exclusions/%s", strings.Join(nodeNames, ","))
+	}
 
 	if err := c.post(ctx, path, nil, nil); err != nil {
 		return errors.Wrap(err, "unable to add to voting_config_exclusions")

--- a/pkg/controller/elasticsearch/client/v8.go
+++ b/pkg/controller/elasticsearch/client/v8.go
@@ -6,11 +6,23 @@ package client
 
 import (
 	"context"
-	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
 )
 
 type clientV8 struct {
 	clientV7
+}
+
+func (c *clientV8) AddVotingConfigExclusions(ctx context.Context, nodeNames []string) error {
+	path := fmt.Sprintf("/_cluster/voting_config_exclusions?node_names=%s", strings.Join(nodeNames, ","))
+
+	if err := c.post(ctx, path, nil, nil); err != nil {
+		return errors.Wrap(err, "unable to add to voting_config_exclusions")
+	}
+	return nil
 }
 
 func (c *clientV8) SyncedFlush(ctx context.Context) error {


### PR DESCRIPTION
The new query parameter tolerates non-existing nodes and covers therefore the case where we try to remove a master node that has never successfully joined the cluster. This prevents an orchestration dead lock where the operator was previously unable to make progress due to an API error returned by Elasticsearch for nodes that were not part of the cluster.

Fixes #2951 
