### PR TITLE
Update Openshift compatibility note

### DIFF
--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -16,7 +16,7 @@ This page shows how to run ECK on OpenShift.
 * <<{p}-openshift-anyuid-workaround>>
 * <<{p}-openshift-beats>>
 
-WARNING: Some Docker images are incompatible with the `restricted` SCC. This is the case for the *APM Server before 7.9* and for the *Enterprise Search 7.9*. You can use this <<{p}-openshift-anyuid-workaround,workaround>> to run those images with the `anyuid` SCC.
+WARNING: Some Docker images are incompatible with the `restricted` SCC. This is the case for the *APM Server before 7.9* and for *Enterprise Search 7.9 and 7.10*. You can use this <<{p}-openshift-anyuid-workaround,workaround>> to run those images with the `anyuid` SCC.
 
 [float]
 [id="{p}-openshift-before-you-begin"]

--- a/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
@@ -20,8 +20,6 @@ This section describes how to deploy, configure and access an APM Server with EC
 ** <<{p}-apm-service,APM Server service>>
 ** <<{p}-apm-secret-token,APM Server secret token>>
 
-NOTE: The current Docker image of the APM Server must run as `root` or with the user ID 1000. This prevents the APM Server from running in environments like OpenShift, or on any Kubernetes cluster that would set a different user in the security context.
-
 [id="{p}-apm-eck-managed-es"]
 == Use an Elasticsearch cluster managed by ECK
 


### PR DESCRIPTION
Docker compatibility issues in the context of Openshift are mentioned in a [dedicated OpenShift section](https://github.com/elastic/cloud-on-k8s/blob/master/docs/advanced-topics/openshift.asciidoc).

This PR also adds a note about Enterprise Search 7.10