### PR TITLE
[1.3] Use new node_names query param for voting exclusions as of 7.8.0 (#3950)

### DIFF
--- a/pkg/controller/elasticsearch/client/base.go
+++ b/pkg/controller/elasticsearch/client/base.go
@@ -21,6 +21,7 @@ type baseClient struct {
 	HTTP     *http.Client
 	Endpoint string
 	caCerts  []*x509.Certificate
+	version  version.Version
 }
 
 // Close idle connections in the underlying http client.
@@ -129,6 +130,7 @@ func (c *baseClient) request(
 }
 
 func versioned(b *baseClient, v version.Version) Client {
+	b.version = v
 	v6 := clientV6{
 		baseClient: *b,
 	}

--- a/pkg/controller/elasticsearch/client/client_test.go
+++ b/pkg/controller/elasticsearch/client/client_test.go
@@ -445,9 +445,10 @@ func TestClient_Equal(t *testing.T) {
 
 func TestClient_AddVotingConfigExclusions(t *testing.T) {
 	tests := []struct {
-		expectedPath string
-		version      version.Version
-		wantErr      bool
+		expectedPath  string
+		expectedQuery string
+		version       version.Version
+		wantErr       bool
 	}{
 		{
 			expectedPath: "",
@@ -459,11 +460,24 @@ func TestClient_AddVotingConfigExclusions(t *testing.T) {
 			version:      version.MustParse("7.0.0"),
 			wantErr:      false,
 		},
+		{
+			expectedPath:  "/_cluster/voting_config_exclusions",
+			expectedQuery: "node_names=a,b",
+			version:       version.MustParse("7.8.0"),
+			wantErr:       false,
+		},
+		{
+			expectedPath:  "/_cluster/voting_config_exclusions",
+			expectedQuery: "node_names=a,b",
+			version:       version.MustParse("8.0.0"),
+			wantErr:       false,
+		},
 	}
 
 	for _, tt := range tests {
 		client := NewMockClient(tt.version, func(req *http.Request) *http.Response {
-			require.Equal(t, tt.expectedPath, req.URL.Path)
+			require.Equal(t, tt.expectedPath, req.URL.Path, tt.version)
+			require.Equal(t, tt.expectedQuery, req.URL.RawQuery, tt.version)
 			return &http.Response{
 				StatusCode: 200,
 				Body:       ioutil.NopCloser(strings.NewReader("")),

--- a/pkg/controller/elasticsearch/client/v8.go
+++ b/pkg/controller/elasticsearch/client/v8.go
@@ -6,11 +6,23 @@ package client
 
 import (
 	"context"
-	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
 )
 
 type clientV8 struct {
 	clientV7
+}
+
+func (c *clientV8) AddVotingConfigExclusions(ctx context.Context, nodeNames []string) error {
+	path := fmt.Sprintf("/_cluster/voting_config_exclusions?node_names=%s", strings.Join(nodeNames, ","))
+
+	if err := c.post(ctx, path, nil, nil); err != nil {
+		return errors.Wrap(err, "unable to add to voting_config_exclusions")
+	}
+	return nil
 }
 
 func (c *clientV8) SyncedFlush(ctx context.Context) error {


### PR DESCRIPTION
Backports the following commits to 1.3:
 - Use new node_names query param for voting exclusions as of 7.8.0 (#3950)