### PR TITLE
Don't close the log stream channel twice in e2e tests

### DIFF
--- a/test/e2e/cmd/run/job.go
+++ b/test/e2e/cmd/run/job.go
@@ -54,6 +54,10 @@ func NewJob(podName, templatePath string, writer io.Writer, timestampExtractor t
 
 // WaitForLogs waits for logs to be fully read before leaving.
 func (j *Job) WaitForLogs() {
+	if j.stopRequested {
+		// already done in the past
+		return
+	}
 	j.stopRequested = true
 	close(j.stopLogStream)
 	log.Info("Waiting for log stream to be over", "name", j.jobName)


### PR DESCRIPTION
We may receive multiple time the PodSucceeded (or PodFailed)  event, which leads us to wait
for Pod logs multiple times. However this step involves closing a channel (no need to stream
logs anymore), and causing a channel twice causes a Panic().
This commit adds an early check in the waitForLogs() function to just return if it has
been executed already. The Stop() function already did the same thing.

Fixes https://github.com/elastic/cloud-on-k8s/issues/3956.