### PR TITLE
Update stack versions in test pipelines

### DIFF
--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -58,14 +58,14 @@ pipeline {
                 )}"""
             }
             parallel {
-                stage("7.10.0-SNAPSHOT") {
+                stage("7.11.0-SNAPSHOT") {
                      agent {
                         label 'linux'
                     }
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-7x-snapshot-${BUILD_NUMBER}-e2e", "7.10.0-SNAPSHOT")
+                            runWith(lib, failedTests, "eck-7x-snapshot-${BUILD_NUMBER}-e2e", "7.11.0-SNAPSHOT")
                         }
                     }
                 }

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -46,17 +46,6 @@ pipeline {
                         }
                     }
                 }
-                stage("7.1.1") {
-                    agent {
-                        label 'linux'
-                    }
-                    steps {
-                        unstash "source"
-                        script {
-                            runWith(lib, failedTests, "eck-71-${BUILD_NUMBER}-e2e", "7.1.1")
-                        }
-                    }
-                }
                 stage("7.2.1") {
                     agent {
                         label 'linux'
@@ -123,25 +112,36 @@ pipeline {
                         }
                     }
                 }
-                stage("7.8.0") {
+                stage("7.8.1") {
                     agent {
                         label 'linux'
                     }
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-78-${BUILD_NUMBER}-e2e", "7.8.0")
+                            runWith(lib, failedTests, "eck-78-${BUILD_NUMBER}-e2e", "7.8.1")
                         }
                     }
                 }
-                stage("7.9.0") {
+                stage("7.9.3") {
                     agent {
                         label 'linux'
                     }
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-79-${BUILD_NUMBER}-e2e", "7.9.0")
+                            runWith(lib, failedTests, "eck-79-${BUILD_NUMBER}-e2e", "7.9.3")
+                        }
+                    }
+                }
+                stage("7.10.0") {
+                    agent {
+                        label 'linux'
+                    }
+                    steps {
+                        unstash "source"
+                        script {
+                            runWith(lib, failedTests, "eck-710-${BUILD_NUMBER}-e2e", "7.10.0")
                         }
                     }
                 }
@@ -176,7 +176,6 @@ pipeline {
             script {
                 clusters = [
                     "eck-68-${BUILD_NUMBER}-e2e",
-                    "eck-71-${BUILD_NUMBER}-e2e",
                     "eck-72-${BUILD_NUMBER}-e2e",
                     "eck-73-${BUILD_NUMBER}-e2e",
                     "eck-74-${BUILD_NUMBER}-e2e",
@@ -184,7 +183,8 @@ pipeline {
                     "eck-76-${BUILD_NUMBER}-e2e",
                     "eck-77-${BUILD_NUMBER}-e2e",
                     "eck-78-${BUILD_NUMBER}-e2e",
-                    "eck-79-${BUILD_NUMBER}-e2e"
+                    "eck-79-${BUILD_NUMBER}-e2e",
+                    "eck-710-${BUILD_NUMBER}-e2e"
                 ]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',


### PR DESCRIPTION
This PR updates the stack versions in our e2e test pipelines. It also removes the pipeline for 7.1.x, according to our [EOL policy](https://www.elastic.co/support/eol) that version is no more supported since 2020-11-20.