### PR TITLE
Remove duplicate elastic-beat-autodiscover cluster role in e2e tests

### DIFF
--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -523,16 +523,6 @@ rules:
   - update
   - patch
   - delete
-# required to allow the operator to bind service accounts it manages
-# to role that holds permissions needed for Beat autodiscover feature
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterroles
-  verbs:
-  - bind
-  resourceNames:
-  - elastic-beat-autodiscover
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/config/e2e/operator.yaml
+++ b/config/e2e/operator.yaml
@@ -60,16 +60,6 @@ rules:
   - update
   - patch
   - delete
-# required to allow the operator to bind service accounts it manages
-# to role that holds permissions needed for Beat autodiscover feature
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterroles
-  verbs:
-  - bind
-  resourceNames:
-  - elastic-beat-autodiscover
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/config/e2e/operator.yaml
+++ b/config/e2e/operator.yaml
@@ -397,18 +397,3 @@ spec:
       name: https-webhook
   selector:
     control-plane: {{ .Operator.Name }}
----
-# permissions needed for Beat cluster-wide autodiscover feature
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: elastic-beat-autodiscover
-rules:
-- apiGroups: [""] # "" indicates the core API group
-  resources:
-  - namespaces
-  - pods
-  verbs:
-  - get
-  - watch
-  - list

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -7,6 +7,7 @@ package elasticsearch
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
@@ -192,8 +194,16 @@ func (hc *ContinuousHealthCheck) Start() {
 				// recreate the Elasticsearch client at each iteration, since we may have switched protocol from http to https during the mutation
 				client, err := hc.esClientFactory()
 				if err != nil {
-					// treat client creation failure same as unavailable cluster
-					hc.AppendErr(err)
+					// according to https://github.com/kubernetes/client-go/blob/fb61a7c88cb9f599363919a34b7c54a605455ffc/rest/request.go#L959-L960,
+					// client-go requests may return *errors.StatusError or *errors.UnexpectedObjectError, or http client errors.
+					switch err.(type) {
+					case *k8serrors.StatusError, *k8serrors.UnexpectedObjectError:
+						// explicit apiserver error, consider as healthcheck failure
+						hc.AppendErr(err)
+					default:
+						// likely a network error, log and ignore
+						fmt.Printf("error while creating the Elasticsearch client: %s", err.Error())
+					}
 					continue
 				}
 				ctx, cancel := context.WithTimeout(context.Background(), continuousHealthCheckTimeout)

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -7,7 +7,6 @@ package elasticsearch
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -18,7 +17,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
@@ -194,16 +192,8 @@ func (hc *ContinuousHealthCheck) Start() {
 				// recreate the Elasticsearch client at each iteration, since we may have switched protocol from http to https during the mutation
 				client, err := hc.esClientFactory()
 				if err != nil {
-					// according to https://github.com/kubernetes/client-go/blob/fb61a7c88cb9f599363919a34b7c54a605455ffc/rest/request.go#L959-L960,
-					// client-go requests may return *errors.StatusError or *errors.UnexpectedObjectError, or http client errors.
-					switch err.(type) {
-					case *k8serrors.StatusError, *k8serrors.UnexpectedObjectError:
-						// explicit apiserver error, consider as healthcheck failure
-						hc.AppendErr(err)
-					default:
-						// likely a network error, log and ignore
-						fmt.Printf("error while creating the Elasticsearch client: %s", err.Error())
-					}
+					// treat client creation failure same as unavailable cluster
+					hc.AppendErr(err)
 					continue
 				}
 				ctx, cancel := context.WithTimeout(context.Background(), continuousHealthCheckTimeout)


### PR DESCRIPTION
This PR consists of 2 somewhat related commits.

1. Remove duplicate elastic-beat-autodiscover cluster role

This ClusterRole is already defined in beat-roles.yaml, which I think is the
right place for it.
Moreover, the duplicate in operator.yaml didn't have the exact same permissions
as the one in beat-roles.yaml (missing permission on nodes), which causes
#3966.

2. Remove e2e operator permissions to bind the elastic-beat-autodiscover cluster role to service accounts

I don't think the operator manages any SA/ClusterRole binding anymore,
this is probably left from an earlier version of the Beat controller which
used to do it.


Fixes #3966.