### PR TITLE
Revert "Temporarily disable Beat recipe flaky tests (#3888)"

### DIFF
--- a/test/e2e/beat/recipes_test.go
+++ b/test/e2e/beat/recipes_test.go
@@ -192,25 +192,23 @@ func TestAuditbeatHostsRecipe(t *testing.T) {
 	runBeatRecipe(t, "auditbeat_hosts.yaml", customize)
 }
 
-// TODO: flaky test, investigate then re-enable
-//  see https://github.com/elastic/cloud-on-k8s/issues/3884
-//func TestPacketbeatDnsHttpRecipe(t *testing.T) {
-//	customize := func(builder beat.Builder) beat.Builder {
-//		if !(test.Ctx().Provider == "kind" && test.Ctx().KubernetesVersion == "1.12") {
-//			// there are some issues with kind 1.12 and tracking http traffic
-//			builder = builder.WithESValidations(beat.HasEvent("event.dataset:http"))
-//		}
-//
-//		return builder.
-//			WithRoles(beat.PacketbeatPSPClusterRoleName).
-//			WithESValidations(
-//				beat.HasEvent("event.dataset:flow"),
-//				beat.HasEvent("event.dataset:dns"),
-//			)
-//	}
-//
-//	runBeatRecipe(t, "packetbeat_dns_http.yaml", customize)
-//}
+func TestPacketbeatDnsHttpRecipe(t *testing.T) {
+	customize := func(builder beat.Builder) beat.Builder {
+		if !(test.Ctx().Provider == "kind" && test.Ctx().KubernetesVersion == "1.12") {
+			// there are some issues with kind 1.12 and tracking http traffic
+			builder = builder.WithESValidations(beat.HasEvent("event.dataset:http"))
+		}
+
+		return builder.
+			WithRoles(beat.PacketbeatPSPClusterRoleName).
+			WithESValidations(
+				beat.HasEvent("event.dataset:flow"),
+				beat.HasEvent("event.dataset:dns"),
+			)
+	}
+
+	runBeatRecipe(t, "packetbeat_dns_http.yaml", customize)
+}
 
 func TestJournalbeatHostsRecipe(t *testing.T) {
 	customize := func(builder beat.Builder) beat.Builder {


### PR DESCRIPTION
This reverts commit 3d49e1e24bc66aa16980a1f6d961f7e01088e792.

I think the recent e2e timeout raise should fix these tests.