### PR TITLE
Don't set an ownerRef on secrets users are susceptible to copy around

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -614,7 +614,7 @@ func asyncTasks(
 		}()
 	}
 
-	// Garbage collect orphan secrets leftover from deleted resources while the operator was not running
+	// Garbage collect orphaned secrets leftover from deleted resources while the operator was not running
 	// - association user secrets
 	garbageCollectUsers(cfg, managedNamespaces)
 	// - soft-owned secrets

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -7,14 +7,6 @@ package manager
 import (
 	"testing"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
-	"github.com/stretchr/testify/require"
-
-	"k8s.io/apimachinery/pkg/types"
-
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
@@ -22,9 +14,13 @@ import (
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func ownedSecret(namespace, name, ownerNs, ownerName, ownerKind string) *corev1.Secret {

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -1,0 +1,195 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package manager
+
+import (
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
+	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
+	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func ownedSecret(namespace, name, ownerNs, ownerName, ownerKind string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, Labels: map[string]string{
+			reconciler.SoftOwnerNameLabel:      ownerName,
+			reconciler.SoftOwnerNamespaceLabel: ownerNs,
+			reconciler.SoftOwnerKindLabel:      ownerKind,
+		}}}
+}
+
+func Test_garbageCollectSoftOwnedSecrets(t *testing.T) {
+	log = logf.Log.WithName("test")
+	tests := []struct {
+		name        string
+		runtimeObjs []runtime.Object
+		assert      func(c k8s.Client, t *testing.T)
+	}{
+		{
+			name: "don't gc secrets owned by a different Kind of resource",
+			runtimeObjs: []runtime.Object{
+				// secret referencing another resource (a Secret) that does not exist anymore
+				ownedSecret("ns", "secret-1", "ns", "a-secret", "Secret"),
+			},
+			assert: func(c k8s.Client, t *testing.T) {
+				// secret still there
+				require.NoError(t, c.Get(types.NamespacedName{Namespace: "ns", Name: "secret-1"}, &corev1.Secret{}))
+			},
+		},
+		{
+			name: "no Elasticsearch soft-owned secrets to gc",
+			runtimeObjs: []runtime.Object{
+				&esv1.Elasticsearch{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es"},
+					TypeMeta:   metav1.TypeMeta{Kind: "Elasticsearch"},
+				},
+				ownedSecret("ns", "secret-1", "ns", "es", "Elasticsearch"),
+			},
+			assert: func(c k8s.Client, t *testing.T) {
+				// es + the secret are still there
+				require.NoError(t, c.Get(types.NamespacedName{Namespace: "ns", Name: "es"}, &esv1.Elasticsearch{}))
+				require.NoError(t, c.Get(types.NamespacedName{Namespace: "ns", Name: "secret-1"}, &corev1.Secret{}))
+			},
+		},
+		{
+			name: "some Elasticsearch soft-owned secrets to gc",
+			runtimeObjs: []runtime.Object{
+				// secret referencing ES that does not exist anymore
+				ownedSecret("ns", "secret-1", "ns", "es", "Elasticsearch"),
+			},
+			assert: func(c k8s.Client, t *testing.T) {
+				// secret has been removed
+				require.True(t, apierrors.IsNotFound(c.Get(types.NamespacedName{Namespace: "ns", Name: "secret-1"}, &corev1.Secret{})))
+			},
+		},
+		{
+			name: "no Kibana soft-owned secrets to gc",
+			runtimeObjs: []runtime.Object{
+				&kbv1.Kibana{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es"},
+					TypeMeta:   metav1.TypeMeta{Kind: "Kibana"},
+				},
+				ownedSecret("ns", "secret-1", "ns", "es", "Kibana"),
+			},
+			assert: func(c k8s.Client, t *testing.T) {
+				// kibana + the secret are still there
+				require.NoError(t, c.Get(types.NamespacedName{Namespace: "ns", Name: "es"}, &kbv1.Kibana{}))
+				require.NoError(t, c.Get(types.NamespacedName{Namespace: "ns", Name: "secret-1"}, &corev1.Secret{}))
+			},
+		},
+		{
+			name: "some Kibana soft-owned secrets to gc",
+			runtimeObjs: []runtime.Object{
+				// secret referencing Kibana that does not exist anymore
+				ownedSecret("ns", "secret-1", "ns", "es", "Kibana"),
+			},
+			assert: func(c k8s.Client, t *testing.T) {
+				// secret has been removed
+				require.True(t, apierrors.IsNotFound(c.Get(types.NamespacedName{Namespace: "ns", Name: "secret-1"}, &corev1.Secret{})))
+			},
+		},
+		{
+			name: "no ApmServer soft-owned secrets to gc",
+			runtimeObjs: []runtime.Object{
+				&apmv1.ApmServer{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es"},
+					TypeMeta:   metav1.TypeMeta{Kind: "ApmServer"},
+				},
+				ownedSecret("ns", "secret-1", "ns", "es", "ApmServer"),
+			},
+			assert: func(c k8s.Client, t *testing.T) {
+				// ApmServer + the secret are still there
+				require.NoError(t, c.Get(types.NamespacedName{Namespace: "ns", Name: "es"}, &apmv1.ApmServer{}))
+				require.NoError(t, c.Get(types.NamespacedName{Namespace: "ns", Name: "secret-1"}, &corev1.Secret{}))
+			},
+		},
+		{
+			name: "some ApmServer soft-owned secrets to gc",
+			runtimeObjs: []runtime.Object{
+				// secret referencing ApmServer that does not exist anymore
+				ownedSecret("ns", "secret-1", "ns", "es", "ApmServer"),
+			},
+			assert: func(c k8s.Client, t *testing.T) {
+				// secret has been removed
+				require.True(t, apierrors.IsNotFound(c.Get(types.NamespacedName{Namespace: "ns", Name: "secret-1"}, &corev1.Secret{})))
+			},
+		},
+		{
+			name: "no EnterpriseSearch soft-owned secrets to gc",
+			runtimeObjs: []runtime.Object{
+				&entv1beta1.EnterpriseSearch{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es"},
+					TypeMeta:   metav1.TypeMeta{Kind: "EnterpriseSearch"},
+				},
+				ownedSecret("ns", "secret-1", "ns", "es", "EnterpriseSearch"),
+			},
+			assert: func(c k8s.Client, t *testing.T) {
+				// EnterpriseSearch + the secret are still there
+				require.NoError(t, c.Get(types.NamespacedName{Namespace: "ns", Name: "es"}, &entv1beta1.EnterpriseSearch{}))
+				require.NoError(t, c.Get(types.NamespacedName{Namespace: "ns", Name: "secret-1"}, &corev1.Secret{}))
+			},
+		},
+		{
+			name: "some EnterpriseSearch soft-owned secrets to gc",
+			runtimeObjs: []runtime.Object{
+				// secret referencing EnterpriseSearch that does not exist anymore
+				ownedSecret("ns", "secret-1", "ns", "es", "EnterpriseSearch"),
+			},
+			assert: func(c k8s.Client, t *testing.T) {
+				// secret has been removed
+				require.True(t, apierrors.IsNotFound(c.Get(types.NamespacedName{Namespace: "ns", Name: "secret-1"}, &corev1.Secret{})))
+			},
+		},
+		{
+			name: "no Beat soft-owned secrets to gc",
+			runtimeObjs: []runtime.Object{
+				&beatv1beta1.Beat{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es"},
+					TypeMeta:   metav1.TypeMeta{Kind: "Beat"},
+				},
+				ownedSecret("ns", "secret-1", "ns", "es", "Beat"),
+			},
+			assert: func(c k8s.Client, t *testing.T) {
+				// Beat + the secret are still there
+				require.NoError(t, c.Get(types.NamespacedName{Namespace: "ns", Name: "es"}, &beatv1beta1.Beat{}))
+				require.NoError(t, c.Get(types.NamespacedName{Namespace: "ns", Name: "secret-1"}, &corev1.Secret{}))
+			},
+		},
+		{
+			name: "some Beat soft-owned secrets to gc",
+			runtimeObjs: []runtime.Object{
+				// secret referencing Beat that does not exist anymore
+				ownedSecret("ns", "secret-1", "ns", "es", "Beat"),
+			},
+			assert: func(c k8s.Client, t *testing.T) {
+				// secret has been removed
+				require.True(t, apierrors.IsNotFound(c.Get(types.NamespacedName{Namespace: "ns", Name: "secret-1"}, &corev1.Secret{})))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := k8s.WrappedFakeClient(tt.runtimeObjs...)
+			garbageCollectSoftOwnedSecrets(c)
+			tt.assert(c, t)
+		})
+	}
+}

--- a/pkg/apis/apm/v1/apmserver_types.go
+++ b/pkg/apis/apm/v1/apmserver_types.go
@@ -13,7 +13,12 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 )
 
-const ApmServerContainerName = "apm-server"
+const (
+	ApmServerContainerName = "apm-server"
+	// Kind is inferred from the struct name using reflection in SchemeBuilder.Register()
+	// we duplicate it as a constant here for practical purposes.
+	Kind = "ApmServer"
+)
 
 // ApmServerSpec holds the specification of an APM Server.
 type ApmServerSpec struct {

--- a/pkg/apis/apm/v1/webhook.go
+++ b/pkg/apis/apm/v1/webhook.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	groupKind     = schema.GroupKind{Group: GroupVersion.Group, Kind: "ApmServer"}
+	groupKind     = schema.GroupKind{Group: GroupVersion.Group, Kind: Kind}
 	validationLog = logf.Log.WithName("apm-v1-validation")
 
 	// ApmAgentConfigurationMinVersion is the minimum required version to establish an association with Kibana

--- a/pkg/apis/apm/v1/webhook_test.go
+++ b/pkg/apis/apm/v1/webhook_test.go
@@ -150,7 +150,7 @@ func TestWebhook(t *testing.T) {
 	}
 
 	validator := &apmv1.ApmServer{}
-	gvk := metav1.GroupVersionKind{Group: apmv1.GroupVersion.Group, Version: apmv1.GroupVersion.Version, Kind: "ApmServer"}
+	gvk := metav1.GroupVersionKind{Group: apmv1.GroupVersion.Group, Version: apmv1.GroupVersion.Version, Kind: apmv1.Kind}
 	test.RunValidationWebhookTests(t, gvk, validator, testCases...)
 }
 

--- a/pkg/apis/beat/v1beta1/beat_types.go
+++ b/pkg/apis/beat/v1beta1/beat_types.go
@@ -12,6 +12,12 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 )
 
+const (
+	// Kind is inferred from the struct name using reflection in SchemeBuilder.Register()
+	// we duplicate it as a constant here for practical purposes.
+	Kind = "Beat"
+)
+
 var (
 	KnownTypes = map[string]struct{}{"filebeat": {}, "metricbeat": {}, "heartbeat": {}, "auditbeat": {}, "journalbeat": {}, "packetbeat": {}}
 )

--- a/pkg/apis/beat/v1beta1/webhook.go
+++ b/pkg/apis/beat/v1beta1/webhook.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	groupKind     = schema.GroupKind{Group: GroupVersion.Group, Kind: "Beat"}
+	groupKind     = schema.GroupKind{Group: GroupVersion.Group, Kind: Kind}
 	validationLog = logf.Log.WithName("beat-v1beta1-validation")
 )
 

--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -13,7 +13,12 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
 )
 
-const ElasticsearchContainerName = "elasticsearch"
+const (
+	ElasticsearchContainerName = "elasticsearch"
+	// Kind is inferred from the struct name using reflection in SchemeBuilder.Register()
+	// we duplicate it as a constant here for practical purposes.
+	Kind = "Elasticsearch"
+)
 
 // ElasticsearchSpec holds the specification of an Elasticsearch cluster.
 type ElasticsearchSpec struct {

--- a/pkg/apis/enterprisesearch/v1beta1/enterprisesearch_types.go
+++ b/pkg/apis/enterprisesearch/v1beta1/enterprisesearch_types.go
@@ -10,7 +10,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const EnterpriseSearchContainerName = "enterprise-search"
+const (
+	EnterpriseSearchContainerName = "enterprise-search"
+	// Kind is inferred from the struct name using reflection in SchemeBuilder.Register()
+	// we duplicate it as a constant here for practical purposes.
+	Kind = "EnterpriseSearch"
+)
 
 // EnterpriseSearchSpec holds the specification of an Enterprise Search resource.
 type EnterpriseSearchSpec struct {

--- a/pkg/apis/enterprisesearch/v1beta1/webhook.go
+++ b/pkg/apis/enterprisesearch/v1beta1/webhook.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	groupKind     = schema.GroupKind{Group: GroupVersion.Group, Kind: "EnterpriseSearch"}
+	groupKind     = schema.GroupKind{Group: GroupVersion.Group, Kind: Kind}
 	validationLog = logf.Log.WithName("enterprisesearch-v1beta1-validation")
 
 	defaultChecks = []func(*EnterpriseSearch) field.ErrorList{

--- a/pkg/apis/enterprisesearch/v1beta1/webhook_test.go
+++ b/pkg/apis/enterprisesearch/v1beta1/webhook_test.go
@@ -126,7 +126,7 @@ func TestWebhook(t *testing.T) {
 	}
 
 	validator := &entv1beta1.EnterpriseSearch{}
-	gvk := metav1.GroupVersionKind{Group: entv1beta1.GroupVersion.Group, Version: entv1beta1.GroupVersion.Version, Kind: "EnterpriseSearch"}
+	gvk := metav1.GroupVersionKind{Group: entv1beta1.GroupVersion.Group, Version: entv1beta1.GroupVersion.Version, Kind: entv1beta1.Kind}
 	test.RunValidationWebhookTests(t, gvk, validator, testCases...)
 }
 

--- a/pkg/apis/kibana/v1/kibana_types.go
+++ b/pkg/apis/kibana/v1/kibana_types.go
@@ -10,7 +10,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const KibanaContainerName = "kibana"
+const (
+	KibanaContainerName = "kibana"
+	// Kind is inferred from the struct name using reflection in SchemeBuilder.Register()
+	// we duplicate it as a constant here for practical purposes.
+	Kind = "Kibana"
+)
 
 // KibanaSpec holds the specification of a Kibana instance.
 type KibanaSpec struct {

--- a/pkg/apis/kibana/v1/webhook.go
+++ b/pkg/apis/kibana/v1/webhook.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	groupKind     = schema.GroupKind{Group: GroupVersion.Group, Kind: "Kibana"}
+	groupKind     = schema.GroupKind{Group: GroupVersion.Group, Kind: Kind}
 	validationLog = logf.Log.WithName("kibana-v1-validation")
 
 	defaultChecks = []func(*Kibana) field.ErrorList{

--- a/pkg/apis/kibana/v1/webhook_test.go
+++ b/pkg/apis/kibana/v1/webhook_test.go
@@ -126,7 +126,7 @@ func TestWebhook(t *testing.T) {
 	}
 
 	validator := &kbv1.Kibana{}
-	gvk := metav1.GroupVersionKind{Group: kbv1.GroupVersion.Group, Version: kbv1.GroupVersion.Version, Kind: "Kibana"}
+	gvk := metav1.GroupVersionKind{Group: kbv1.GroupVersion.Group, Version: kbv1.GroupVersion.Version, Kind: kbv1.Kind}
 	test.RunValidationWebhookTests(t, gvk, validator, testCases...)
 }
 

--- a/pkg/controller/apmserver/controller.go
+++ b/pkg/controller/apmserver/controller.go
@@ -127,11 +127,14 @@ func addWatches(c controller.Controller, r *ReconcileApmServer) error {
 		return err
 	}
 
-	// Watch secrets
+	// Watch owned and soft-owned secrets
 	if err := c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &apmv1.ApmServer{},
 	}); err != nil {
+		return err
+	}
+	if err := watches.WatchSoftOwnedSecrets(c, apmv1.Kind); err != nil {
 		return err
 	}
 

--- a/pkg/controller/apmserver/controller.go
+++ b/pkg/controller/apmserver/controller.go
@@ -242,7 +242,7 @@ func (r *ReconcileApmServer) doReconcile(ctx context.Context, request reconcile.
 	_, results := certificates.Reconciler{
 		K8sClient:             r.K8sClient(),
 		DynamicWatches:        r.DynamicWatches(),
-		Object:                as,
+		Owner:                 as,
 		TLSOptions:            as.Spec.HTTP.TLS,
 		Namer:                 Namer,
 		Labels:                NewLabels(as.Name),
@@ -307,7 +307,7 @@ func (r *ReconcileApmServer) onDelete(obj types.NamespacedName) error {
 	r.dynamicWatches.Secrets.RemoveHandlerForKey(keystore.SecureSettingsWatchName(obj))
 	// Clean up watches set on custom http tls certificates
 	r.dynamicWatches.Secrets.RemoveHandlerForKey(certificates.CertificateWatchKey(Namer, obj.Name))
-	return reconciler.GarbageCollectSoftOwnedSecrets(r.Client, obj)
+	return reconciler.GarbageCollectSoftOwnedSecrets(r.Client, obj, apmv1.Kind)
 }
 
 // reconcileApmServerToken reconciles a Secret containing the APM Server token.

--- a/pkg/controller/apmserver/controller.go
+++ b/pkg/controller/apmserver/controller.go
@@ -203,8 +203,7 @@ func (r *ReconcileApmServer) Reconcile(request reconcile.Request) (reconcile.Res
 
 	if as.IsMarkedForDeletion() {
 		// APM server will be deleted, clean up resources
-		r.onDelete(k8s.ExtractNamespacedName(&as))
-		return reconcile.Result{}, nil
+		return reconcile.Result{}, r.onDelete(k8s.ExtractNamespacedName(&as))
 	}
 
 	if err := annotation.UpdateControllerVersion(ctx, r.Client, &as, r.OperatorInfo.BuildInfo.Version); err != nil {

--- a/pkg/controller/apmserver/deployment_test.go
+++ b/pkg/controller/apmserver/deployment_test.go
@@ -203,7 +203,7 @@ func TestReconcileApmServer_deploymentParams(t *testing.T) {
 			Name: "test-apm-server",
 		},
 		TypeMeta: metav1.TypeMeta{
-			Kind: "apmserver",
+			Kind: apmv1.Kind,
 		},
 	}
 	defaultPodSpecParams := PodSpecParams{

--- a/pkg/controller/apmserver/pod_test.go
+++ b/pkg/controller/apmserver/pod_test.go
@@ -37,7 +37,7 @@ func TestNewPodSpec(t *testing.T) {
 			name: "create default pod spec",
 			as: apmv1.ApmServer{
 				TypeMeta: metav1.TypeMeta{
-					Kind: "ApmServer",
+					Kind: apmv1.Kind,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "fake-apm",

--- a/pkg/controller/beat/controller.go
+++ b/pkg/controller/beat/controller.go
@@ -98,11 +98,14 @@ func addWatches(c controller.Controller, r *ReconcileBeat) error {
 		return err
 	}
 
-	// Watch Secrets
+	// Watch owned and soft-owned Secrets
 	if err := c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &beatv1beta1.Beat{},
 	}); err != nil {
+		return err
+	}
+	if err := watches.WatchSoftOwnedSecrets(c, beatv1beta1.Kind); err != nil {
 		return err
 	}
 

--- a/pkg/controller/beat/controller.go
+++ b/pkg/controller/beat/controller.go
@@ -152,6 +152,12 @@ func (r *ReconcileBeat) Reconcile(request reconcile.Request) (reconcile.Result, 
 	}
 
 	if beat.IsMarkedForDeletion() {
+		if err := reconciler.GarbageCollectSoftOwnedSecrets(r.Client, request.NamespacedName); err != nil {
+			// this is best-effort only, some secrets may remain orphan in case of error here,
+			// or if the operator was down during the owner deletion
+			log.Error(err, "namespace", beat.Namespace, "beat_name", beat.Name,
+				"Failed to garbage collect secrets, they should be removed manually")
+		}
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/beat/controller.go
+++ b/pkg/controller/beat/controller.go
@@ -206,7 +206,7 @@ func (r *ReconcileBeat) isCompatible(ctx context.Context, beat *beatv1beta1.Beat
 func (r *ReconcileBeat) onDelete(obj types.NamespacedName) error {
 	r.dynamicWatches.Secrets.RemoveHandlerForKey(keystore.SecureSettingsWatchName(obj))
 	r.dynamicWatches.Secrets.RemoveHandlerForKey(common.ConfigRefWatchName(obj))
-	return reconciler.GarbageCollectSoftOwnedSecrets(r.Client, obj)
+	return reconciler.GarbageCollectSoftOwnedSecrets(r.Client, obj, beatv1beta1.Kind)
 }
 
 func newDriver(

--- a/pkg/controller/common/certificates/http_reconcile.go
+++ b/pkg/controller/common/certificates/http_reconcile.go
@@ -45,7 +45,9 @@ func (r Reconciler) ReconcilePublicHTTPCerts(internalCerts *CertificatesSecret) 
 		expected.Data[CAFileName] = caPem
 	}
 
-	_, err := reconciler.ReconcileSecret(r.K8sClient, expected, r.Object)
+	// Don't set an ownerRef for public http certs secrets, likely to be copied into different namespaces.
+	// See https://github.com/elastic/cloud-on-k8s/issues/3986.
+	_, err := reconciler.ReconcileSecretNoOwnerRef(r.K8sClient, expected, r.Object)
 	return err
 }
 

--- a/pkg/controller/common/certificates/http_reconcile.go
+++ b/pkg/controller/common/certificates/http_reconcile.go
@@ -30,7 +30,11 @@ import (
 // ReconcilePublicHTTPCerts reconciles the Secret containing the HTTP Certificate currently in use, and the CA of
 // the certificate if available.
 func (r Reconciler) ReconcilePublicHTTPCerts(internalCerts *CertificatesSecret) error {
-	nsn := PublicCertsSecretRef(r.Namer, k8s.ExtractNamespacedName(r.Object))
+	ownerMeta, err := r.OwnerMeta()
+	if err != nil {
+		return err
+	}
+	nsn := PublicCertsSecretRef(r.Namer, k8s.ExtractNamespacedName(ownerMeta))
 	expected := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: nsn.Namespace,
@@ -47,13 +51,17 @@ func (r Reconciler) ReconcilePublicHTTPCerts(internalCerts *CertificatesSecret) 
 
 	// Don't set an ownerRef for public http certs secrets, likely to be copied into different namespaces.
 	// See https://github.com/elastic/cloud-on-k8s/issues/3986.
-	_, err := reconciler.ReconcileSecretNoOwnerRef(r.K8sClient, expected, r.Object)
+	_, err = reconciler.ReconcileSecretNoOwnerRef(r.K8sClient, expected, r.Owner)
 	return err
 }
 
 // ReconcileInternalHTTPCerts reconciles the internal resources for the HTTP certificate.
 func (r Reconciler) ReconcileInternalHTTPCerts(ca *CA) (*CertificatesSecret, error) {
-	ownerNSN := k8s.ExtractNamespacedName(r.Object)
+	ownerMeta, err := r.OwnerMeta()
+	if err != nil {
+		return nil, err
+	}
+	ownerNSN := k8s.ExtractNamespacedName(ownerMeta)
 	customCertificates, err := GetCustomCertificates(r.K8sClient, ownerNSN, r.TLSOptions)
 	if err != nil {
 		return nil, err
@@ -65,8 +73,8 @@ func (r Reconciler) ReconcileInternalHTTPCerts(ca *CA) (*CertificatesSecret, err
 
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: r.Object.GetNamespace(),
-			Name:      InternalCertsSecretName(r.Namer, r.Object.GetName()),
+			Namespace: ownerNSN.Namespace,
+			Name:      InternalCertsSecretName(r.Namer, ownerNSN.Name),
 		},
 	}
 
@@ -92,7 +100,7 @@ func (r Reconciler) ReconcileInternalHTTPCerts(ca *CA) (*CertificatesSecret, err
 		}
 	}
 
-	if err := controllerutil.SetControllerReference(r.Object, &secret, scheme.Scheme); err != nil {
+	if err := controllerutil.SetControllerReference(ownerMeta, &secret, scheme.Scheme); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/common/certificates/http_reconcile_test.go
+++ b/pkg/controller/common/certificates/http_reconcile_test.go
@@ -213,7 +213,7 @@ func TestReconcilePublicHTTPCerts(t *testing.T) {
 			client := tt.client(t)
 			err := Reconciler{
 				K8sClient: client,
-				Object:    owner,
+				Owner:     owner,
 				Namer:     esv1.ESNamer,
 				Labels:    labels,
 			}.ReconcilePublicHTTPCerts(certificate)
@@ -345,7 +345,8 @@ func TestReconcileInternalHTTPCerts(t *testing.T) {
 			got, err := Reconciler{
 				K8sClient:      tt.args.c,
 				DynamicWatches: w,
-				Object:         &tt.args.es,
+				Owner:          &tt.args.es,
+				ObjectMeta:     &tt.args.es,
 				TLSOptions:     tt.args.es.Spec.HTTP.TLS,
 				Namer:          esv1.ESNamer,
 				Labels:         map[string]string{},

--- a/pkg/controller/common/certificates/reconcile.go
+++ b/pkg/controller/common/certificates/reconcile.go
@@ -8,20 +8,21 @@ import (
 	"context"
 	"time"
 
-	"go.elastic.co/apm"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	commonname "github.com/elastic/cloud-on-k8s/pkg/controller/common/name"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"go.elastic.co/apm"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var (
@@ -32,7 +33,8 @@ type Reconciler struct {
 	K8sClient      k8s.Client
 	DynamicWatches watches.DynamicWatches
 
-	Object        metav1.Object                     // owner for the TLS certificates (eg. Elasticsearch, Kibana)
+	Owner runtime.Object // owner for the TLS certificates (eg. Elasticsearch, Kibana)
+
 	TLSOptions    commonv1.TLSOptions               // TLS options of the object
 	ExtraHTTPSANs []commonv1.SubjectAlternativeName // SANs dynamically set by a controller, only used in the self signed cert
 
@@ -44,6 +46,10 @@ type Reconciler struct {
 	CertRotation   RotationParams // to requeue a reconciliation before cert expiration
 
 	GarbageCollectSecrets bool // if true, delete secrets if TLS is disabled
+}
+
+func (r Reconciler) OwnerMeta() (metav1.Object, error) {
+	return meta.Accessor(r.Owner)
 }
 
 // ReconcileCAAndHTTPCerts reconciles 3 TLS-related secrets for the given object:
@@ -61,11 +67,16 @@ func (r Reconciler) ReconcileCAAndHTTPCerts(ctx context.Context) (*CertificatesS
 		return nil, results.WithError(r.removeCAAndHTTPCertsSecrets())
 	}
 
+	ownerMeta, err := r.OwnerMeta()
+	if err != nil {
+		return nil, results.WithError(err)
+	}
+
 	// reconcile CA certs first
 	httpCa, err := ReconcileCAForOwner(
 		r.K8sClient,
 		r.Namer,
-		r.Object,
+		ownerMeta,
 		r.Labels,
 		HTTPCAType,
 		r.CACertRotation,
@@ -97,27 +108,32 @@ func (r Reconciler) ReconcileCAAndHTTPCerts(ctx context.Context) (*CertificatesS
 }
 
 func (r *Reconciler) removeCAAndHTTPCertsSecrets() error {
+	ownerMeta, err := r.OwnerMeta()
+	if err != nil {
+		return err
+	}
+	owner := k8s.ExtractNamespacedName(ownerMeta)
 	// remove public certs secret
 	if err := deleteIfExists(r.K8sClient,
-		types.NamespacedName{Namespace: r.Object.GetNamespace(), Name: PublicCertsSecretName(r.Namer, r.Object.GetName())},
+		types.NamespacedName{Namespace: owner.Namespace, Name: PublicCertsSecretName(r.Namer, owner.Name)},
 	); err != nil {
 		return err
 	}
 	// remove internal certs secret
 	if err := deleteIfExists(r.K8sClient,
-		types.NamespacedName{Namespace: r.Object.GetNamespace(), Name: InternalCertsSecretName(r.Namer, r.Object.GetName())},
+		types.NamespacedName{Namespace: owner.Namespace, Name: InternalCertsSecretName(r.Namer, owner.Name)},
 	); err != nil {
 		return err
 	}
 	// remove CA secret
 	if err := deleteIfExists(r.K8sClient,
-		types.NamespacedName{Namespace: r.Object.GetNamespace(), Name: CAInternalSecretName(r.Namer, r.Object.GetName(), HTTPCAType)},
+		types.NamespacedName{Namespace: owner.Namespace, Name: CAInternalSecretName(r.Namer, owner.Name, HTTPCAType)},
 	); err != nil {
 		return err
 	}
 
 	// remove watches on user-provided certs secret
-	r.DynamicWatches.Secrets.RemoveHandlerForKey(CertificateWatchKey(r.Namer, r.Object.GetName()))
+	r.DynamicWatches.Secrets.RemoveHandlerForKey(CertificateWatchKey(r.Namer, ownerMeta.GetName()))
 
 	return nil
 }

--- a/pkg/controller/common/certificates/reconcile_test.go
+++ b/pkg/controller/common/certificates/reconcile_test.go
@@ -8,16 +8,16 @@ import (
 	"context"
 	"testing"
 
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-
-	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
-	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
 var (
@@ -33,6 +33,9 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "ns",
 			Name:      "es",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: esv1.Kind,
 		},
 	}
 )
@@ -66,6 +69,13 @@ func TestReconcileCAAndHTTPCerts(t *testing.T) {
 	}
 	checkResults()
 
+	labelsWithSoftOwner := map[string]string{
+		"foo":                              "bar",
+		reconciler.SoftOwnerKindLabel:      obj.Kind,
+		reconciler.SoftOwnerNamespaceLabel: obj.Namespace,
+		reconciler.SoftOwnerNameLabel:      obj.Name,
+	}
+
 	// the 3 secrets should have been created in the apiserver,
 	// and have the expected labels and content generated
 	checkCertsSecrets := func() {
@@ -92,8 +102,7 @@ func TestReconcileCAAndHTTPCerts(t *testing.T) {
 		require.Len(t, publicCerts.Data, 2)
 		require.NotEmpty(t, publicCerts.Data[CAFileName])
 		require.NotEmpty(t, publicCerts.Data[CertFileName])
-		require.Equal(t, labels, publicCerts.Labels)
-
+		require.Equal(t, labelsWithSoftOwner, publicCerts.Labels)
 	}
 	checkCertsSecrets()
 

--- a/pkg/controller/common/certificates/reconcile_test.go
+++ b/pkg/controller/common/certificates/reconcile_test.go
@@ -45,7 +45,7 @@ func TestReconcileCAAndHTTPCerts(t *testing.T) {
 	r := Reconciler{
 		K8sClient:             c,
 		DynamicWatches:        watches.NewDynamicWatches(),
-		Object:                &obj,
+		Owner:                 &obj,
 		TLSOptions:            commonv1.TLSOptions{},
 		Namer:                 esv1.ESNamer,
 		Labels:                labels,

--- a/pkg/controller/common/keystore/resources_test.go
+++ b/pkg/controller/common/keystore/resources_test.go
@@ -61,7 +61,7 @@ var (
 	}
 	testKibanaWithSecureSettings = kbv1.Kibana{
 		TypeMeta: metav1.TypeMeta{
-			Kind: "kibana",
+			Kind: kbv1.Kind,
 		},
 		ObjectMeta: testKibana.ObjectMeta,
 		Spec: kbv1.KibanaSpec{

--- a/pkg/controller/common/reconciler/secret.go
+++ b/pkg/controller/common/reconciler/secret.go
@@ -10,7 +10,17 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Labels set on secrets which cannot rely on owner references due to https://github.com/kubernetes/kubernetes/issues/65200,
+// but should still be garbage-collected (best-effort) by the operator upon owner deletion.
+const (
+	SoftOwnerNamespaceLabel = "eck.k8s.elastic.co/soft-owner-namespace"
+	SoftOwnerNameLabel      = "eck.k8s.elastic.co/soft-owner-name"
 )
 
 // ReconcileSecret creates or updates the actual secret to match the expected one.
@@ -40,4 +50,121 @@ func ReconcileSecret(c k8s.Client, expected corev1.Secret, owner metav1.Object) 
 		return corev1.Secret{}, err
 	}
 	return reconciled, nil
+}
+
+// ReconcileSecretNoOwnerRef should be called to reconcile a Secret for which we explicitly don't want
+// an owner reference to be set, and want existing ownerRefs from previous operator versions to be removed,
+// because of this k8s bug: https://github.com/kubernetes/kubernetes/issues/65200 (fixed in k8s 1.20).
+//
+// It makes sense to use this function for secrets which are likely to be manually
+// copied into other namespaces by the end user.
+// Because of the k8s bug mentioned above, the ownerRef could trigger a racy garbage collection
+// that deletes all children resources, potentially resulting in data loss.
+// See https://github.com/elastic/cloud-on-k8s/issues/3986 for more details.
+//
+// Since they won't have an ownerRef specified, reconciled secrets will not be deleted automatically on parent deletion.
+// To account for that, we add a label for best-effort garbage collection by the operator on parent resource deletion.
+func ReconcileSecretNoOwnerRef(c k8s.Client, expected corev1.Secret, theoreticalOwner metav1.Object) (corev1.Secret, error) {
+	// this function is similar to "ReconcileSecret", but:
+	// - we don't pass an owner
+	// - we remove the existing owner
+	// - we set additional labels to perform garbage collection on owner deletion (best-effort)
+	expected.Labels[SoftOwnerNamespaceLabel] = theoreticalOwner.GetNamespace()
+	expected.Labels[SoftOwnerNameLabel] = theoreticalOwner.GetName()
+
+	var reconciled corev1.Secret
+	if err := ReconcileResource(Params{
+		Client:     c,
+		Owner:      nil,
+		Expected:   &expected,
+		Reconciled: &reconciled,
+		NeedsUpdate: func() bool {
+			// update if expected labels and annotations are not there
+			return !maps.IsSubset(expected.Labels, reconciled.Labels) ||
+				!maps.IsSubset(expected.Annotations, reconciled.Annotations) ||
+				// or if secret data is not strictly equal
+				!reflect.DeepEqual(expected.Data, reconciled.Data) ||
+				// or if an existing owner should be removed
+				hasOwner(&reconciled, theoreticalOwner)
+		},
+		UpdateReconciled: func() {
+			// set expected annotations and labels, but don't remove existing ones
+			// that may have been defaulted or set by the user on the existing resource
+			reconciled.Labels = maps.Merge(reconciled.Labels, expected.Labels)
+			reconciled.Annotations = maps.Merge(reconciled.Annotations, expected.Annotations)
+			reconciled.Data = expected.Data
+			// remove existing owner
+			removeOwner(&reconciled, theoreticalOwner)
+		},
+	}); err != nil {
+		return corev1.Secret{}, err
+	}
+	return reconciled, nil
+}
+
+// GarbageCollectSoftOwnedSecrets deletes all secrets whose labels reference a soft owner.
+// To be called once that owner gets deleted.
+func GarbageCollectSoftOwnedSecrets(c k8s.Client, deletedParent types.NamespacedName) error {
+	var secrets corev1.SecretList
+	if err := c.List(
+		&secrets,
+		// restrict to secrets in the parent namespace, we don't want to delete
+		// secrets users may have manually copied into other namespaces
+		client.InNamespace(deletedParent.Namespace),
+		// restrict to secrets on which we set the soft owner label
+		client.MatchingLabels{
+			SoftOwnerNamespaceLabel: deletedParent.Namespace,
+			SoftOwnerNameLabel:      deletedParent.Name,
+		},
+	); err != nil {
+		return err
+	}
+	for i := range secrets.Items {
+		s := secrets.Items[i]
+		log.Info("Garbage collecting secret", "namespace", deletedParent.Namespace, "secret_name", s.Name)
+		err := c.Delete(&s)
+		if apierrors.IsNotFound(err) {
+			// already deleted, all good
+			continue
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hasOwner(resource metav1.Object, owner metav1.Object) bool {
+	if owner == nil || resource == nil {
+		return false
+	}
+	found, _ := findOwner(resource, owner)
+	return found
+}
+
+func removeOwner(resource metav1.Object, owner metav1.Object) {
+	if resource == nil || owner == nil {
+		return
+	}
+	found, index := findOwner(resource, owner)
+	if !found {
+		return
+	}
+	owners := resource.GetOwnerReferences()
+	// remove the owner at index i from the slice
+	newOwners := append(owners[:index], owners[index+1:]...)
+	resource.SetOwnerReferences(newOwners)
+}
+
+func findOwner(resource metav1.Object, owner metav1.Object) (found bool, index int) {
+	if owner == nil || resource == nil {
+		return false, 0
+	}
+	ownerRefs := resource.GetOwnerReferences()
+	for i := range ownerRefs {
+		if ownerRefs[i].Name == owner.GetName() && ownerRefs[i].UID == owner.GetUID() {
+			return true, i
+		}
+	}
+	return false, 0
 }

--- a/pkg/controller/common/reconciler/secret.go
+++ b/pkg/controller/common/reconciler/secret.go
@@ -21,9 +21,9 @@ import (
 // Labels set on secrets which cannot rely on owner references due to https://github.com/kubernetes/kubernetes/issues/65200,
 // but should still be garbage-collected (best-effort) by the operator upon owner deletion.
 const (
-	SoftOwnerNamespaceLabel = "eck.k8s.elastic.co/soft-owner-namespace"
-	SoftOwnerNameLabel      = "eck.k8s.elastic.co/soft-owner-name"
-	SoftOwnerKindLabel      = "eck.k8s.elastic.co/soft-owner-kind"
+	SoftOwnerNamespaceLabel = "eck.k8s.elastic.co/owner-namespace"
+	SoftOwnerNameLabel      = "eck.k8s.elastic.co/owner-name"
+	SoftOwnerKindLabel      = "eck.k8s.elastic.co/owner-kind"
 )
 
 // ReconcileSecret creates or updates the actual secret to match the expected one.
@@ -62,7 +62,7 @@ func ReconcileSecret(c k8s.Client, expected corev1.Secret, owner metav1.Object) 
 // It makes sense to use this function for secrets which are likely to be manually
 // copied into other namespaces by the end user.
 // Because of the k8s bug mentioned above, the ownerReference could trigger a racy garbage collection
-// that deletes all children resources, potentially resulting in data loss.
+// that deletes all child resources, potentially resulting in data loss.
 // See https://github.com/elastic/cloud-on-k8s/issues/3986 for more details.
 //
 // Since they won't have an ownerReference specified, reconciled secrets will not be deleted automatically on parent deletion.

--- a/pkg/controller/common/reconciler/secret_test.go
+++ b/pkg/controller/common/reconciler/secret_test.go
@@ -402,7 +402,7 @@ func Test_findOwner(t *testing.T) {
 			wantIndex: 1,
 		},
 		{
-			name: "owner listed twice in the list (shouldn't happen): return the first occurence (index 0)",
+			name: "owner listed twice in the list (shouldn't happen): return the first occurrence (index 0)",
 			args: args{
 				resource: addOwner(addOwner(&corev1.Secret{}, sampleOwner().Name, sampleOwner().UID), sampleOwner().Name, sampleOwner().UID),
 				owner:    sampleOwner(),

--- a/pkg/controller/common/reconciler/secret_test.go
+++ b/pkg/controller/common/reconciler/secret_test.go
@@ -7,13 +7,16 @@ package reconciler
 import (
 	"testing"
 
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
 const (
@@ -114,6 +117,488 @@ func TestReconcileSecret(t *testing.T) {
 				require.Equal(t, tt.want.Data, secret.Data)
 				require.Equal(t, tt.want.Annotations, secret.Annotations)
 				require.Equal(t, tt.want.Labels, secret.Labels)
+			}
+		})
+	}
+}
+
+func concatMaps(m1 map[string]string, m2 map[string]string) map[string]string {
+	newMap := map[string]string{}
+	maps.Merge(newMap, m1)
+	maps.Merge(newMap, m2)
+	return newMap
+}
+
+func TestReconcileSecretNoOwnerRef(t *testing.T) {
+	softOwner := &esv1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es-name", UID: types.UID("es-uid")},
+		TypeMeta:   metav1.TypeMeta{Kind: esv1.Kind},
+	}
+	expectedSoftOwnerLabels := map[string]string{
+		SoftOwnerNamespaceLabel: "ns",
+		SoftOwnerNameLabel:      "es-name",
+		SoftOwnerKindLabel:      esv1.Kind,
+	}
+	sampleSecret := createSecret("s", sampleData, sampleLabels, sampleAnnotations)
+	sampleLabelsWithSoftOwnerRef := concatMaps(sampleLabels, expectedSoftOwnerLabels)
+	sampleSecretWithSoftOwnerRef := createSecret("s", sampleData, sampleLabelsWithSoftOwnerRef, sampleAnnotations)
+	tests := []struct {
+		name      string
+		c         k8s.Client
+		expected  *corev1.Secret
+		softOwner runtime.Object
+		want      *corev1.Secret
+	}{
+		{
+			name:      "actual object does not exist: create the expected one",
+			c:         k8s.WrappedFakeClient(),
+			expected:  sampleSecret,
+			softOwner: softOwner,
+			want:      sampleSecretWithSoftOwnerRef,
+		},
+		{
+			name:      "actual matches expected: do nothing",
+			c:         k8s.WrappedFakeClient(sampleSecretWithSoftOwnerRef),
+			expected:  sampleSecret,
+			softOwner: softOwner,
+			want:      sampleSecretWithSoftOwnerRef,
+		},
+		{
+			name:      "data should be updated",
+			c:         k8s.WrappedFakeClient(sampleSecretWithSoftOwnerRef),
+			expected:  createSecret("s", sampleDataUpdated, sampleLabels, sampleAnnotations),
+			softOwner: softOwner,
+			want:      createSecret("s", sampleDataUpdated, sampleLabelsWithSoftOwnerRef, sampleAnnotations),
+		},
+		{
+			name:      "label and annotations should be updated",
+			c:         k8s.WrappedFakeClient(createSecret("s", sampleData, nil, nil)),
+			expected:  sampleSecret,
+			softOwner: softOwner,
+			want:      sampleSecretWithSoftOwnerRef,
+		},
+		{
+			name: "preserve existing labels and annotations",
+			c: k8s.WrappedFakeClient(createSecret("s", sampleData,
+				map[string]string{"existing": "existing"}, map[string]string{"existing": "existing"}),
+			),
+			expected:  createSecret("s", sampleData, sampleLabelsWithSoftOwnerRef, sampleAnnotations),
+			softOwner: softOwner,
+			want: createSecret("s", sampleData,
+				concatMaps(expectedSoftOwnerLabels, map[string]string{
+					"existing": "existing",                   // keep existing
+					"label1":   "value1", "label2": "value2", // add expected
+				}),
+				map[string]string{
+					"existing":    "existing",                        // keep existing
+					"annotation1": "value1", "annotation2": "value2", // add expected
+				},
+			),
+		},
+		{
+			name:      "remove existing ownerRef, replace with soft owner labels, don't touch other owner regs",
+			c:         k8s.WrappedFakeClient(addOwner(addOwner(sampleSecret, softOwner.Name, softOwner.UID), "unrelated-owner", "unrelated-owner-id")),
+			expected:  sampleSecret,
+			softOwner: softOwner,
+			want:      addOwner(sampleSecretWithSoftOwnerRef, "unrelated-owner", "unrelated-owner-id"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ReconcileSecretNoOwnerRef(tt.c, *tt.expected, tt.softOwner)
+			require.NoError(t, err)
+
+			var retrieved corev1.Secret
+			err = tt.c.Get(k8s.ExtractNamespacedName(tt.expected), &retrieved)
+			require.NoError(t, err)
+
+			for _, secret := range []corev1.Secret{got, retrieved} {
+				// owner refs should be expected
+				if len(tt.want.OwnerReferences) == 0 {
+					require.Len(t, secret.OwnerReferences, 0)
+				} else {
+					require.Equal(t, tt.want.OwnerReferences, secret.OwnerReferences)
+				}
+				// data, labels and annotations should be expected
+				require.Equal(t, tt.want.Data, secret.Data)
+				require.Equal(t, tt.want.Annotations, secret.Annotations)
+				require.Equal(t, tt.want.Labels, secret.Labels)
+			}
+		})
+	}
+}
+
+func sampleOwner() *corev1.Secret {
+	// we use a secret here but it could be any Elasticsearch | Kibana | ApmServer | etc.
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "owner-name", UID: "owner-id"},
+		TypeMeta:   metav1.TypeMeta{Kind: "Secret"},
+	}
+}
+
+func addOwner(secret *corev1.Secret, name string, uid types.UID) *corev1.Secret {
+	secret = secret.DeepCopy()
+	secret.OwnerReferences = append(secret.OwnerReferences, metav1.OwnerReference{Name: name, UID: uid})
+	return secret
+}
+
+func Test_hasOwner(t *testing.T) {
+	owner := sampleOwner()
+	type args struct {
+		resource metav1.Object
+		owner    metav1.Object
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "owner is referenced (same name and uid)",
+			args: args{
+				resource: addOwner(&corev1.Secret{}, owner.Name, owner.UID),
+				owner:    owner,
+			},
+			want: true,
+		},
+		{
+			name: "owner referenced among other owner references",
+			args: args{
+				resource: addOwner(addOwner(&corev1.Secret{}, "another-name", types.UID("another-id")), owner.Name, owner.UID),
+				owner:    owner,
+			},
+			want: true,
+		},
+		{
+			name: "owner not referenced",
+			args: args{
+				resource: addOwner(addOwner(&corev1.Secret{}, "another-name", types.UID("another-id")), "yet-another-name", "yet-another-uid"),
+				owner:    owner,
+			},
+			want: false,
+		},
+		{
+			name: "no owner ref",
+			args: args{
+				resource: &corev1.Secret{},
+				owner:    owner,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasOwner(tt.args.resource, tt.args.owner); got != tt.want {
+				t.Errorf("hasOwner() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_removeOwner(t *testing.T) {
+	type args struct {
+		resource metav1.Object
+		owner    metav1.Object
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantResource *corev1.Secret
+	}{
+		{
+			name: "no owner: no-op",
+			args: args{
+				resource: &corev1.Secret{},
+				owner:    sampleOwner(),
+			},
+			wantResource: &corev1.Secret{},
+		},
+		{
+			name: "different owner: no-op",
+			args: args{
+				resource: addOwner(&corev1.Secret{}, "another-owner-name", "another-owner-id"),
+				owner:    sampleOwner(),
+			},
+			wantResource: addOwner(&corev1.Secret{}, "another-owner-name", "another-owner-id"),
+		},
+		{
+			name: "remove the single owner",
+			args: args{
+				resource: addOwner(&corev1.Secret{}, sampleOwner().Name, sampleOwner().UID),
+				owner:    sampleOwner(),
+			},
+			wantResource: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{}}},
+		},
+		{
+			name: "remove the owner from a list of owners",
+			args: args{
+				resource: addOwner(addOwner(&corev1.Secret{}, sampleOwner().Name, sampleOwner().UID), "another-owner", "another-uid"),
+				owner:    sampleOwner(),
+			},
+			wantResource: addOwner(&corev1.Secret{}, "another-owner", "another-uid"),
+		},
+		{
+			name: "owner listed twice in the list (shouldn't happen): remove the first occurrence",
+			args: args{
+				resource: addOwner(addOwner(&corev1.Secret{}, sampleOwner().Name, sampleOwner().UID), sampleOwner().Name, sampleOwner().UID),
+				owner:    sampleOwner(),
+			},
+			wantResource: addOwner(&corev1.Secret{}, sampleOwner().Name, sampleOwner().UID),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			removeOwner(tt.args.resource, tt.args.owner)
+			require.Equal(t, tt.wantResource, tt.args.resource)
+		})
+	}
+}
+
+func Test_findOwner(t *testing.T) {
+	type args struct {
+		resource metav1.Object
+		owner    metav1.Object
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantFound bool
+		wantIndex int
+	}{
+		{
+			name: "no owner: not found",
+			args: args{
+				resource: &corev1.Secret{},
+				owner:    sampleOwner(),
+			},
+			wantFound: false,
+			wantIndex: 0,
+		},
+		{
+			name: "different owner: not found",
+			args: args{
+				resource: addOwner(&corev1.Secret{}, "another-owner-name", "another-owner-id"),
+				owner:    sampleOwner(),
+			},
+			wantFound: false,
+			wantIndex: 0,
+		},
+		{
+			name: "owner at index 0",
+			args: args{
+				resource: addOwner(&corev1.Secret{}, sampleOwner().Name, sampleOwner().UID),
+				owner:    sampleOwner(),
+			},
+			wantFound: true,
+			wantIndex: 0,
+		},
+		{
+			name: "owner at index 1",
+			args: args{
+				resource: addOwner(addOwner(&corev1.Secret{}, "another-owner", "another-uid"), sampleOwner().Name, sampleOwner().UID),
+				owner:    sampleOwner(),
+			},
+			wantFound: true,
+			wantIndex: 1,
+		},
+		{
+			name: "owner listed twice in the list (shouldn't happen): return the first occurence (index 0)",
+			args: args{
+				resource: addOwner(addOwner(&corev1.Secret{}, sampleOwner().Name, sampleOwner().UID), sampleOwner().Name, sampleOwner().UID),
+				owner:    sampleOwner(),
+			},
+			wantFound: true,
+			wantIndex: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFound, gotIndex := findOwner(tt.args.resource, tt.args.owner)
+			if gotFound != tt.wantFound {
+				t.Errorf("findOwner() gotFound = %v, want %v", gotFound, tt.wantFound)
+			}
+			if gotIndex != tt.wantIndex {
+				t.Errorf("findOwner() gotIndex = %v, want %v", gotIndex, tt.wantIndex)
+			}
+		})
+	}
+}
+
+func ownedSecret(namespace, name, ownerNs, ownerName, ownerKind string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, Labels: map[string]string{
+			SoftOwnerNameLabel:      ownerName,
+			SoftOwnerNamespaceLabel: ownerNs,
+			SoftOwnerKindLabel:      ownerKind,
+		}}}
+}
+
+func TestGarbageCollectSoftOwnedSecrets(t *testing.T) {
+	kind := "Secret"
+	tests := []struct {
+		name            string
+		existingSecrets []runtime.Object
+		deletedOwner    types.NamespacedName
+		ownerKind       string
+		wantObjs        []runtime.Object
+	}{
+		{
+			name:            "no soft-owned secret to gc",
+			existingSecrets: nil,
+			deletedOwner:    k8s.ExtractNamespacedName(sampleOwner()),
+			ownerKind:       "Secret",
+			wantObjs:        nil,
+		},
+		{
+			name: "gc soft-owned secret",
+			existingSecrets: []runtime.Object{
+				ownedSecret("ns", "secret-1", sampleOwner().Namespace, sampleOwner().Name, sampleOwner().Kind)},
+			deletedOwner: k8s.ExtractNamespacedName(sampleOwner()),
+			ownerKind:    "Secret",
+			wantObjs:     nil,
+		},
+		{
+			name: "don't gc secret with no owner label",
+			existingSecrets: []runtime.Object{
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: sampleOwner().Namespace, Name: sampleOwner().Name}}},
+			deletedOwner: k8s.ExtractNamespacedName(sampleOwner()),
+			ownerKind:    "Secret",
+			wantObjs: []runtime.Object{
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: sampleOwner().Namespace, Name: sampleOwner().Name}}},
+		},
+		{
+			name: "don't gc secret pointing to a soft owner with a different name",
+			existingSecrets: []runtime.Object{
+				ownedSecret("ns", "secret-1", sampleOwner().Namespace, "another-name", sampleOwner().Kind)},
+			deletedOwner: k8s.ExtractNamespacedName(sampleOwner()),
+			ownerKind:    "Secret",
+			wantObjs: []runtime.Object{
+				ownedSecret("ns", "secret-1", sampleOwner().Namespace, "another-name", sampleOwner().Kind)},
+		},
+		{
+			name: "don't gc secret pointing to a soft owner with a different namespace",
+			existingSecrets: []runtime.Object{
+				ownedSecret("ns", "secret-1", "another-namespace", sampleOwner().Name, sampleOwner().Kind)},
+			deletedOwner: k8s.ExtractNamespacedName(sampleOwner()),
+			ownerKind:    "Secret",
+			wantObjs: []runtime.Object{
+				ownedSecret("ns", "secret-1", "another-namespace", sampleOwner().Name, sampleOwner().Kind)},
+		},
+		{
+			name: "don't gc secret pointing to a soft owner with a different kind",
+			existingSecrets: []runtime.Object{
+				ownedSecret("ns", "secret-1", sampleOwner().Namespace, sampleOwner().Name, "another-kind")},
+			deletedOwner: k8s.ExtractNamespacedName(sampleOwner()),
+			ownerKind:    "Secret",
+			wantObjs: []runtime.Object{
+				ownedSecret("ns", "secret-1", sampleOwner().Namespace, sampleOwner().Name, "another-kind")},
+		},
+		{
+			name: "2 secrets to gc out of 5 secrets",
+			existingSecrets: []runtime.Object{
+				ownedSecret("ns", "secret-1", sampleOwner().Namespace, sampleOwner().Name, sampleOwner().Kind),
+				ownedSecret("ns", "secret-2", sampleOwner().Namespace, sampleOwner().Name, sampleOwner().Kind),
+				ownedSecret("ns", "secret-3", sampleOwner().Namespace, sampleOwner().Name, sampleOwner().Kind),
+				ownedSecret("ns", "secret-4", sampleOwner().Namespace, "another-owner", sampleOwner().Kind),
+				ownedSecret("ns", "secret-5", sampleOwner().Namespace, sampleOwner().Name, "another-kind"),
+			},
+			deletedOwner: k8s.ExtractNamespacedName(sampleOwner()),
+			ownerKind:    "Secret",
+			wantObjs: []runtime.Object{
+				ownedSecret("ns", "secret-4", sampleOwner().Namespace, "another-owner", sampleOwner().Kind),
+				ownedSecret("ns", "secret-5", sampleOwner().Namespace, sampleOwner().Name, "another-kind"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := k8s.WrappedFakeClient(tt.existingSecrets...)
+			err := GarbageCollectSoftOwnedSecrets(c, tt.deletedOwner, kind)
+			require.NoError(t, err)
+			var retrievedSecrets corev1.SecretList
+			err = c.List(&retrievedSecrets)
+			require.NoError(t, err)
+			require.Equal(t, len(tt.wantObjs), len(retrievedSecrets.Items))
+			for i := range tt.wantObjs {
+				require.Equal(t, tt.wantObjs[i].(*corev1.Secret).Name, retrievedSecrets.Items[i].Name)
+			}
+		})
+	}
+}
+
+func TestGarbageCollectAllSoftOwnedOrphanSecrets(t *testing.T) {
+	ownerKinds := map[string]runtime.Object{
+		"Secret": &corev1.Secret{},
+	}
+	tests := []struct {
+		name        string
+		runtimeObjs []runtime.Object
+		wantObjs    []runtime.Object
+		assert      func(c k8s.Client, t *testing.T)
+	}{
+		{
+			name: "nothing to gc",
+			runtimeObjs: []runtime.Object{
+				// owner exists, 2 owned secrets
+				sampleOwner(),
+				ownedSecret("ns", "secret-1", sampleOwner().Namespace, sampleOwner().Name, sampleOwner().Kind),
+				ownedSecret("ns", "secret-2", sampleOwner().Namespace, sampleOwner().Name, sampleOwner().Kind),
+			},
+			wantObjs: []runtime.Object{
+				sampleOwner(),
+				ownedSecret("ns", "secret-1", sampleOwner().Namespace, sampleOwner().Name, sampleOwner().Kind),
+				ownedSecret("ns", "secret-2", sampleOwner().Namespace, sampleOwner().Name, sampleOwner().Kind),
+			},
+		},
+		{
+			name: "gc 2 secrets",
+			runtimeObjs: []runtime.Object{
+				// owner doesn't exist: gc these 2 secrets
+				ownedSecret("ns", "secret-1", sampleOwner().Namespace, sampleOwner().Name, sampleOwner().Kind),
+				ownedSecret("ns", "secret-2", sampleOwner().Namespace, sampleOwner().Name, sampleOwner().Kind),
+			},
+			wantObjs: []runtime.Object{},
+		},
+		{
+			name: "don't gc secret targeting an owner in a different namespace",
+			runtimeObjs: []runtime.Object{
+				// secret likely copied manually into another namespace
+				ownedSecret("another-namespace", "secret-1", sampleOwner().Namespace, sampleOwner().Name, sampleOwner().Kind),
+			},
+			wantObjs: []runtime.Object{
+				ownedSecret("another-namespace", "secret-1", sampleOwner().Namespace, sampleOwner().Name, sampleOwner().Kind),
+			},
+		},
+		{
+			name: "don't gc resources of a non-managed Kind",
+			runtimeObjs: []runtime.Object{
+				// configmap whose owner doesn't exist, should not be gc
+				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "configmap-name", Labels: map[string]string{
+					SoftOwnerNameLabel:      "owner-name",
+					SoftOwnerNamespaceLabel: "ns",
+					SoftOwnerKindLabel:      "ConfigMap",
+				}}},
+			},
+			assert: func(c k8s.Client, t *testing.T) {
+				// configmap should still be there
+				require.NoError(t, c.Get(types.NamespacedName{Namespace: "ns", Name: "configmap-name"}, &corev1.ConfigMap{}))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := k8s.WrappedFakeClient(tt.runtimeObjs...)
+			err := GarbageCollectAllSoftOwnedOrphanSecrets(c, ownerKinds)
+			require.NoError(t, err)
+			var retrievedSecrets corev1.SecretList
+			err = c.List(&retrievedSecrets)
+			require.NoError(t, err)
+			require.Equal(t, len(tt.wantObjs), len(retrievedSecrets.Items))
+			for i := range tt.wantObjs {
+				require.Equal(t, tt.wantObjs[i].(*corev1.Secret).Name, retrievedSecrets.Items[i].Name)
+			}
+			if tt.assert != nil {
+				tt.assert(c, t)
 			}
 		})
 	}

--- a/pkg/controller/common/watches/secrets_test.go
+++ b/pkg/controller/common/watches/secrets_test.go
@@ -1,0 +1,91 @@
+package watches
+
+import (
+	"testing"
+
+	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+)
+
+func Test_reconcileReqForSoftOwner(t *testing.T) {
+	kind := esv1.Kind
+	toRequestsFunc := reconcileReqForSoftOwner(kind)
+
+	tests := []struct {
+		name                  string
+		secret                corev1.Secret
+		wantReconcileRequests []reconcile.Request
+	}{
+		{
+			name: "watch soft-owned secret",
+			secret: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						reconciler.SoftOwnerKindLabel:      esv1.Kind,
+						reconciler.SoftOwnerNamespaceLabel: "ns",
+						reconciler.SoftOwnerNameLabel:      "es",
+					},
+				},
+			},
+			wantReconcileRequests: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "es"}},
+			},
+		},
+		{
+			name: "don't watch secret whose soft owner is a different kind",
+			secret: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						reconciler.SoftOwnerKindLabel:      kbv1.Kind, // Kibana owner instead of Elasticsearch
+						reconciler.SoftOwnerNamespaceLabel: "ns",
+						reconciler.SoftOwnerNameLabel:      "kb",
+					},
+				},
+			},
+			wantReconcileRequests: nil,
+		},
+		{
+			name:                  "don't watch secret with no soft owner labels",
+			secret:                corev1.Secret{},
+			wantReconcileRequests: nil,
+		},
+		{
+			name: "don't watch secret with corrupted soft owner labels",
+			secret: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						reconciler.SoftOwnerKindLabel:      esv1.Kind,
+						reconciler.SoftOwnerNamespaceLabel: "", // no namespace
+						reconciler.SoftOwnerNameLabel:      "es",
+					},
+				}},
+			wantReconcileRequests: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mapObject := handler.MapObject{Meta: &tt.secret, Object: &tt.secret}
+			requests := toRequestsFunc(mapObject)
+			require.Equal(t, tt.wantReconcileRequests, requests)
+		})
+	}
+}
+
+func Test_reconcileReqForSoftOwner1(t *testing.T) {
+	type args struct {
+		kind string
+	}
+
+}

--- a/pkg/controller/common/watches/secrets_test.go
+++ b/pkg/controller/common/watches/secrets_test.go
@@ -1,22 +1,21 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package watches
 
 import (
 	"testing"
 
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
-
-	"k8s.io/apimachinery/pkg/types"
-
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-
-	"github.com/stretchr/testify/require"
-
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 )
 
 func Test_reconcileReqForSoftOwner(t *testing.T) {
@@ -81,11 +80,4 @@ func Test_reconcileReqForSoftOwner(t *testing.T) {
 			require.Equal(t, tt.wantReconcileRequests, requests)
 		})
 	}
-}
-
-func Test_reconcileReqForSoftOwner1(t *testing.T) {
-	type args struct {
-		kind string
-	}
-
 }

--- a/pkg/controller/elasticsearch/certificates/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/reconcile.go
@@ -67,7 +67,7 @@ func Reconcile(
 	httpCerts, results = certificates.Reconciler{
 		K8sClient:      driver.K8sClient(),
 		DynamicWatches: driver.DynamicWatches(),
-		Object:         &es,
+		Owner:          &es,
 		TLSOptions:     es.Spec.HTTP.TLS,
 		ExtraHTTPSANs:  extraHTTPSANs,
 		Namer:          esv1.ESNamer,

--- a/pkg/controller/elasticsearch/certificates/transport/public_secret.go
+++ b/pkg/controller/elasticsearch/certificates/transport/public_secret.go
@@ -32,7 +32,10 @@ func ReconcileTransportCertsPublicSecret(
 			certificates.CAFileName: certificates.EncodePEMCert(ca.Cert.Raw),
 		},
 	}
-	_, err := reconciler.ReconcileSecret(c, expected, &es)
+
+	// Don't set an ownerRef for public transport certs secrets, likely to be copied into different namespaces.
+	// See https://github.com/elastic/cloud-on-k8s/issues/3986.
+	_, err := reconciler.ReconcileSecretNoOwnerRef(c, expected, &es)
 	return err
 }
 

--- a/pkg/controller/elasticsearch/certificates/transport/public_secret_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/public_secret_test.go
@@ -13,23 +13,22 @@ import (
 	"testing"
 	"time"
 
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/comparison"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/comparison"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
 func TestReconcileTransportCertsPublicSecret(t *testing.T) {
 	owner := &esv1.Elasticsearch{
 		ObjectMeta: v1.ObjectMeta{Name: "test-es-name", Namespace: "test-namespace"},
+		TypeMeta:   v1.TypeMeta{Kind: esv1.Kind},
 	}
 
 	ca := genCA(t)
@@ -44,7 +43,12 @@ func TestReconcileTransportCertsPublicSecret(t *testing.T) {
 	mkWantedSecret := func(t *testing.T) *corev1.Secret {
 		t.Helper()
 		meta := k8s.ToObjectMeta(namespacedSecretName)
-		meta.SetLabels(label.NewLabels(k8s.ExtractNamespacedName(owner)))
+		labels := label.NewLabels(k8s.ExtractNamespacedName(owner))
+		labels[reconciler.SoftOwnerKindLabel] = owner.Kind
+		labels[reconciler.SoftOwnerNameLabel] = owner.Name
+		labels[reconciler.SoftOwnerNamespaceLabel] = owner.Namespace
+
+		meta.SetLabels(labels)
 
 		wantSecret := &corev1.Secret{
 			ObjectMeta: meta,
@@ -52,11 +56,6 @@ func TestReconcileTransportCertsPublicSecret(t *testing.T) {
 				certificates.CAFileName: certificates.EncodePEMCert(ca.Cert.Raw),
 			},
 		}
-
-		if err := controllerutil.SetControllerReference(owner, wantSecret, scheme.Scheme); err != nil {
-			t.Fatal(err)
-		}
-
 		return wantSecret
 	}
 

--- a/pkg/controller/elasticsearch/driver/pvc_expansion_test.go
+++ b/pkg/controller/elasticsearch/driver/pvc_expansion_test.go
@@ -277,7 +277,7 @@ func Test_needsRecreate(t *testing.T) {
 func Test_recreateStatefulSets(t *testing.T) {
 	controllerscheme.SetupScheme()
 	es := func() *esv1.Elasticsearch {
-		return &esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es", UID: "es-uid"}, TypeMeta: metav1.TypeMeta{Kind: "Elasticsearch"}}
+		return &esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es", UID: "es-uid"}, TypeMeta: metav1.TypeMeta{Kind: esv1.Kind}}
 	}
 	withAnnotation := func(es *esv1.Elasticsearch, key, value string) *esv1.Elasticsearch {
 		if es.Annotations == nil {
@@ -417,7 +417,7 @@ func Test_recreateStatefulSets(t *testing.T) {
 }
 
 var (
-	sampleEs = esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es", UID: "es-uid"}, TypeMeta: metav1.TypeMeta{Kind: "Elasticsearch"}}
+	sampleEs = esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es", UID: "es-uid"}, TypeMeta: metav1.TypeMeta{Kind: esv1.Kind}}
 	sset1    = appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "sset1", UID: "sset1-uid"}}
 	pod1     = corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "sset1-0", Labels: map[string]string{
 		label.StatefulSetNameLabelName: sset1.Name,

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -233,8 +233,7 @@ func (r *ReconcileElasticsearch) internalReconcile(
 
 	if es.IsMarkedForDeletion() {
 		// resource will be deleted, nothing to reconcile
-		r.onDelete(k8s.ExtractNamespacedName(&es))
-		return results
+		return results.WithError(r.onDelete(k8s.ExtractNamespacedName(&es)))
 	}
 
 	span, ctx := apm.StartSpan(ctx, "validate", tracing.SpanTypeApp)

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -321,4 +321,10 @@ func (r *ReconcileElasticsearch) onDelete(es types.NamespacedName) {
 	r.dynamicWatches.Secrets.RemoveHandlerForKey(certificates.CertificateWatchKey(esv1.ESNamer, es.Name))
 	r.dynamicWatches.Secrets.RemoveHandlerForKey(user.UserProvidedRolesWatchName(es))
 	r.dynamicWatches.Secrets.RemoveHandlerForKey(user.UserProvidedFileRealmWatchName(es))
+	if err := reconciler.GarbageCollectSoftOwnedSecrets(r.Client, es); err != nil {
+		// this is best-effort only, some secrets may remain orphan in case of error here,
+		// or if the operator was down during the owner deletion
+		log.Error(err, "namespace", es.Namespace, "es_name", es.Name,
+			"Failed to garbage collect secrets, they should be removed manually")
+	}
 }

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -108,7 +108,7 @@ func addWatches(c controller.Controller, r *ReconcileElasticsearch) error {
 		return err
 	}
 
-	// Watch secrets
+	// Watch owned and soft-owned secrets
 	if err := c.Watch(&source.Kind{Type: &corev1.Secret{}}, r.dynamicWatches.Secrets); err != nil {
 		return err
 	}
@@ -118,6 +118,9 @@ func addWatches(c controller.Controller, r *ReconcileElasticsearch) error {
 			OwnerType:    &esv1.Elasticsearch{},
 		},
 	}); err != nil {
+		return err
+	}
+	if err := watches.WatchSoftOwnedSecrets(c, esv1.Kind); err != nil {
 		return err
 	}
 

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -320,5 +320,5 @@ func (r *ReconcileElasticsearch) onDelete(es types.NamespacedName) error {
 	r.dynamicWatches.Secrets.RemoveHandlerForKey(certificates.CertificateWatchKey(esv1.ESNamer, es.Name))
 	r.dynamicWatches.Secrets.RemoveHandlerForKey(user.UserProvidedRolesWatchName(es))
 	r.dynamicWatches.Secrets.RemoveHandlerForKey(user.UserProvidedFileRealmWatchName(es))
-	return reconciler.GarbageCollectSoftOwnedSecrets(r.Client, es)
+	return reconciler.GarbageCollectSoftOwnedSecrets(r.Client, es, esv1.Kind)
 }

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -211,13 +211,12 @@ func (r *ReconcileElasticsearch) fetchElasticsearch(ctx context.Context, request
 	err := r.Get(request.NamespacedName, es)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			// Object not found, return.  Created objects are automatically garbage collected.
-			// Additional cleanup is done by the onDelete function.
-			err := r.onDelete(types.NamespacedName{
+			// Object not found, cleanup in-memory state. Children resources are garbage-collected either by
+			// the operator (see `onDelete`), either by k8s through the ownerReference mechanism.
+			return true, r.onDelete(types.NamespacedName{
 				Namespace: request.Namespace,
 				Name:      request.Name,
 			})
-			return true, err
 		}
 		// Error reading the object - requeue the request.
 		return true, err

--- a/pkg/controller/elasticsearch/validation/webhook.go
+++ b/pkg/controller/elasticsearch/validation/webhook.go
@@ -67,7 +67,7 @@ func (wh *validatingWebhook) validateUpdate(old esv1.Elasticsearch, new esv1.Ela
 	}
 	if len(errs) > 0 {
 		return apierrors.NewInvalid(
-			schema.GroupKind{Group: "elasticsearch.k8s.elastic.co", Kind: "Elasticsearch"},
+			schema.GroupKind{Group: "elasticsearch.k8s.elastic.co", Kind: esv1.Kind},
 			new.Name, errs)
 	}
 	return ValidateElasticsearch(new)
@@ -107,7 +107,7 @@ func ValidateElasticsearch(es esv1.Elasticsearch) error {
 	errs := check(es, validations)
 	if len(errs) > 0 {
 		return apierrors.NewInvalid(
-			schema.GroupKind{Group: "elasticsearch.k8s.elastic.co", Kind: "Elasticsearch"},
+			schema.GroupKind{Group: "elasticsearch.k8s.elastic.co", Kind: esv1.Kind},
 			es.Name,
 			errs,
 		)

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller.go
@@ -184,7 +184,7 @@ func (r *ReconcileEnterpriseSearch) onDelete(obj types.NamespacedName) error {
 	r.dynamicWatches.Secrets.RemoveHandlerForKey(common.ConfigRefWatchName(obj))
 	// Clean up watches set on custom http tls certificates
 	r.dynamicWatches.Secrets.RemoveHandlerForKey(certificates.CertificateWatchKey(entName.EntNamer, obj.Name))
-	return reconciler.GarbageCollectSoftOwnedSecrets(r.Client, obj)
+	return reconciler.GarbageCollectSoftOwnedSecrets(r.Client, obj, entv1beta1.Kind)
 }
 
 func (r *ReconcileEnterpriseSearch) isCompatible(ctx context.Context, ent *entv1beta1.EnterpriseSearch) (bool, error) {
@@ -210,7 +210,7 @@ func (r *ReconcileEnterpriseSearch) doReconcile(ctx context.Context, ent entv1be
 	_, results := certificates.Reconciler{
 		K8sClient:             r.K8sClient(),
 		DynamicWatches:        r.DynamicWatches(),
-		Object:                &ent,
+		Owner:                 &ent,
 		TLSOptions:            ent.Spec.HTTP.TLS,
 		Namer:                 entName.EntNamer,
 		Labels:                Labels(ent.Name),

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller.go
@@ -99,11 +99,14 @@ func addWatches(c controller.Controller, r *ReconcileEnterpriseSearch) error {
 		return err
 	}
 
-	// Watch secrets
+	// Watch owned and soft-owned secrets
 	if err := c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &entv1beta1.EnterpriseSearch{},
 	}); err != nil {
+		return err
+	}
+	if err := watches.WatchSoftOwnedSecrets(c, entv1beta1.Kind); err != nil {
 		return err
 	}
 

--- a/pkg/controller/kibana/controller.go
+++ b/pkg/controller/kibana/controller.go
@@ -248,7 +248,7 @@ func (r *ReconcileKibana) onDelete(obj types.NamespacedName) error {
 	r.dynamicWatches.Secrets.RemoveHandlerForKey(keystore.SecureSettingsWatchName(obj))
 	// Clean up watches set on custom http tls certificates
 	r.dynamicWatches.Secrets.RemoveHandlerForKey(certificates.CertificateWatchKey(Namer, obj.Name))
-	return reconciler.GarbageCollectSoftOwnedSecrets(r.Client, obj)
+	return reconciler.GarbageCollectSoftOwnedSecrets(r.Client, obj, kbv1.Kind)
 }
 
 // State holds the accumulated state during the reconcile loop including the response and a pointer to a Kibana

--- a/pkg/controller/kibana/controller.go
+++ b/pkg/controller/kibana/controller.go
@@ -135,11 +135,10 @@ func (r *ReconcileKibana) Reconcile(request reconcile.Request) (reconcile.Result
 	var kb kbv1.Kibana
 	if err := association.FetchWithAssociations(ctx, r.Client, request, &kb); err != nil {
 		if apierrors.IsNotFound(err) {
-			r.onDelete(types.NamespacedName{
+			return reconcile.Result{}, r.onDelete(types.NamespacedName{
 				Namespace: request.Namespace,
 				Name:      request.Name,
 			})
-			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, tracing.CaptureError(ctx, err)
 	}

--- a/pkg/controller/kibana/controller.go
+++ b/pkg/controller/kibana/controller.go
@@ -93,11 +93,14 @@ func addWatches(c controller.Controller, r *ReconcileKibana) error {
 		return err
 	}
 
-	// Watch secrets
+	// Watch owned and soft-owned secrets
 	if err := c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &kbv1.Kibana{},
 	}); err != nil {
+		return err
+	}
+	if err := watches.WatchSoftOwnedSecrets(c, kbv1.Kind); err != nil {
 		return err
 	}
 

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -109,7 +109,7 @@ func (d *driver) Reconcile(
 	_, results = certificates.Reconciler{
 		K8sClient:             d.K8sClient(),
 		DynamicWatches:        d.DynamicWatches(),
-		Object:                kb,
+		Owner:                 kb,
 		TLSOptions:            kb.Spec.HTTP.TLS,
 		Namer:                 Namer,
 		Labels:                NewLabels(kb.Name),

--- a/pkg/utils/rbac/access_review_test.go
+++ b/pkg/utils/rbac/access_review_test.go
@@ -25,7 +25,7 @@ func Test_subjectAccessReviewer_AccessAllowed(t *testing.T) {
 
 	es := &esv1.Elasticsearch{
 		TypeMeta: metav1.TypeMeta{
-			Kind: "Elasticsearch",
+			Kind: esv1.Kind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "es",
@@ -80,7 +80,7 @@ func Test_subjectAccessReviewer_AccessAllowed(t *testing.T) {
 				sourceNamespace: "kibana-ns",
 				object: &esv1.Elasticsearch{
 					TypeMeta: metav1.TypeMeta{
-						Kind: "Elasticsearch",
+						Kind: esv1.Kind,
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "es",

--- a/test/e2e/test/apmserver/steps_deletion.go
+++ b/test/e2e/test/apmserver/steps_deletion.go
@@ -7,12 +7,15 @@ package apmserver
 import (
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/pkg/controller/apmserver"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
@@ -51,6 +54,16 @@ func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
 			Name: "APM Server pods should eventually be removed",
 			Test: test.Eventually(func() error {
 				return k.CheckPodCount(0, test.ApmServerPodListOptions(b.ApmServer.Namespace, b.ApmServer.Name)...)
+			}),
+		},
+		{
+			Name: "Soft-owned secrets should eventually be removed",
+			Test: test.Eventually(func() error {
+				namespace := b.ApmServer.Namespace
+				return k.CheckSecretsRemoved([]types.NamespacedName{
+					{Namespace: namespace, Name: apmserver.SecretToken(b.ApmServer.Name)},
+					{Namespace: namespace, Name: certificates.PublicCertsSecretName(apmserver.Namer, b.ApmServer.Name)},
+				})
 			}),
 		},
 	}

--- a/test/e2e/test/enterprisesearch/steps_deletion.go
+++ b/test/e2e/test/enterprisesearch/steps_deletion.go
@@ -7,13 +7,15 @@ package enterprisesearch
 import (
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/enterprisesearch/name"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/api/meta"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
@@ -52,6 +54,15 @@ func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
 			Name: "EnterpriseSearch pods should eventually be removed",
 			Test: test.Eventually(func() error {
 				return k.CheckPodCount(0, test.EnterpriseSearchPodListOptions(b.EnterpriseSearch.Namespace, b.EnterpriseSearch.Name)...)
+			}),
+		},
+		{
+			Name: "Soft-owned secrets should eventually be removed",
+			Test: test.Eventually(func() error {
+				namespace := b.EnterpriseSearch.Namespace
+				return k.CheckSecretsRemoved([]types.NamespacedName{
+					{Namespace: namespace, Name: certificates.PublicCertsSecretName(name.EntNamer, b.EnterpriseSearch.Name)},
+				})
 			}),
 		},
 	}

--- a/test/e2e/test/kibana/steps_deletion.go
+++ b/test/e2e/test/kibana/steps_deletion.go
@@ -7,13 +7,15 @@ package kibana
 import (
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/enterprisesearch/name"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/api/meta"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
@@ -52,6 +54,15 @@ func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
 			Name: "Kibana pods should eventually be removed",
 			Test: test.Eventually(func() error {
 				return k.CheckPodCount(0, test.KibanaPodListOptions(b.Kibana.Namespace, b.Kibana.Name)...)
+			}),
+		},
+		{
+			Name: "Soft-owned secrets should eventually be removed",
+			Test: test.Eventually(func() error {
+				namespace := b.Kibana.Namespace
+				return k.CheckSecretsRemoved([]types.NamespacedName{
+					{Namespace: namespace, Name: certificates.PublicCertsSecretName(name.EntNamer, b.Kibana.Name)},
+				})
 			}),
 		},
 	}


### PR DESCRIPTION
A k8s bug (https://github.com/kubernetes/kubernetes/issues/65200) may cause the
k8s garbage collection to delete undesired resources in case users manually
copy an operator-managed secret to another namespace.

To avoid that situation, this commit ensures no ownerRef is set on a subset of
managed secrets users are susceptible to copy around:
- the elastic user password secret
- elasticsearch public transport certs
- elasticsearch, kibana, enterprise search, apm server public http certs

Existing ownerReferences set with earlier ECK versions will be removed when
reconciled.

Since they do not have an ownerRef anymore, those secrets are not automatically
deleted when the Elasticsearch resource is deleted. To work around that situation,
the secret reconciliation logic adds an additional set of labels to the reconciled
secrets that don't have an ownerRef specified. These labels reference the "soft"
owner ("soft" as in handled through some custom code and not through k8s builtin
garbage collection logic).
Once a controller receives a deletion event for the resource it manages, it will
automatically remove the soft-owned secrets.

Additionally, garbage collection runs at operator startup to cover the case where
owners were deleted while the operator was down.

TODO:
- [x] Unit tests
- [x] E2E test
- [x] GC secrets on operator startup to cover the case where the operator is down during the owner deletion
- [x] Major bug to fix: the soft owner reference needs to include the object Kind, otherwise we may end up mismatching e.g. Elasticsearch stuff with Kibana stuff if they have the same name.

Fixes https://github.com/elastic/cloud-on-k8s/issues/3986.