### PR TITLE
Add EKS ARM e2e job

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -11,7 +11,7 @@ ENV DOCKER_BUILDX_VERSION=0.4.2
 ENV GOTESTSUM_VERSION=0.5.0
 ENV KIND_VERSION=0.8.1
 ENV OPENSHIFT_TOOLS_VERSION=4.3.19
-ENV EKSCTL_VERSION=0.21.0
+ENV EKSCTL_VERSION=0.34.0
 
 # golangci-lint
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh \

--- a/.ci/jobs/e2e-tests-eks-arm.yml
+++ b/.ci/jobs/e2e-tests-eks-arm.yml
@@ -1,0 +1,27 @@
+---
+- job:
+    description: Run ECK E2E tests on EKS ARM Machines
+    name: cloud-on-k8s-e2e-tests-eks-arm
+    project-type: pipeline
+    parameters:
+      - string:
+          name: branch_specifier
+          default: master
+          description: "the Git branch specifier to build (&lt;branchName&gt;,&lt;tagName&gt;, &lt;commitId&gt;, etc.)"
+      - string:
+          name: JKS_PARAM_OPERATOR_IMAGE
+          description: "ECK Docker image"
+      - bool:
+          name: SEND_NOTIFICATIONS
+          default: true
+          description: "Specified if job should send notifications to Slack. Enabled by default."
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/elastic/cloud-on-k8s
+            branches:
+              - ${branch_specifier}
+            credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
+            refspec: ${branch_specifier}
+      script-path: .ci/pipelines/e2e-tests-eks-arm.Jenkinsfile
+      lightweight-checkout: false

--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -118,6 +118,13 @@ pipeline {
                     ],
                     wait: false
 
+                build job: 'cloud-on-k8s-e2e-tests-eks-arm',
+                    parameters: [
+                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
+                        string(name: 'branch_specifier', value: GIT_COMMIT)
+                    ],
+                    wait: false
+
                 build job: 'cloud-on-k8s-e2e-tests-resilience',
                     parameters: [
                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),

--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -118,13 +118,6 @@ pipeline {
                     ],
                     wait: false
 
-                build job: 'cloud-on-k8s-e2e-tests-eks-arm',
-                    parameters: [
-                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
-                        string(name: 'branch_specifier', value: GIT_COMMIT)
-                    ],
-                    wait: false
-
                 build job: 'cloud-on-k8s-e2e-tests-resilience',
                     parameters: [
                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),

--- a/.ci/pipelines/e2e-tests-eks-arm.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-eks-arm.Jenkinsfile
@@ -1,0 +1,83 @@
+// This library overrides the default checkout behavior to enable sleep+retries if there are errors
+// Added to help overcome some recurring github connection issues
+@Library('apm@current') _
+
+def failedTests = []
+def lib
+
+pipeline {
+
+    agent {
+        label 'linux'
+    }
+
+    options {
+        timeout(time: 600, unit: 'MINUTES')
+    }
+
+    environment {
+        VAULT_ADDR = credentials('vault-addr')
+        VAULT_ROLE_ID = credentials('vault-role-id')
+        VAULT_SECRET_ID = credentials('vault-secret-id')
+    }
+
+    stages {
+        stage('Load common scripts') {
+            steps {
+                script {
+                    lib = load ".ci/common/tests.groovy"
+                }
+            }
+        }
+        stage("Run E2E tests") {
+            steps {
+                sh '.ci/setenvconfig e2e/eks-arm'
+                script {
+                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-test-artifacts TARGET=ci-e2e ci')
+
+                    sh 'make -C .ci TARGET=e2e-generate-xml ci'
+                    junit "e2e-tests.xml"
+
+                    if (env.SHELL_EXIT_CODE != 0) {
+                        failedTests = lib.getListOfFailedTests()
+                        googleStorageUpload bucket: "gs://devops-ci-artifacts/jobs/$JOB_NAME/$BUILD_NUMBER",
+                            credentialsId: "devops-ci-gcs-plugin",
+                            pattern: "*.tgz",
+                            sharedPublicly: true,
+                            showInline: true
+                    }
+
+                    sh 'exit $SHELL_EXIT_CODE'
+                }
+            }
+        }
+    }
+
+    post {
+        unsuccessful {
+            script {
+                if (params.SEND_NOTIFICATIONS) {
+                    Set<String> filter = new HashSet<>()
+                    filter.addAll(failedTests)
+                    def msg = lib.generateSlackMessage("E2E tests in EKS (ARM) failed!", env.BUILD_URL, filter)
+
+                    slackSend(
+                        channel: '#cloud-k8s',
+                        color: 'danger',
+                        message: msg,
+                        tokenCredentialId: 'cloud-ci-slack-integration-token',
+                        botUser: true,
+                        failOnError: true
+                    )
+                }
+            }
+        }
+        cleanup {
+            script {
+                sh '.ci/setenvconfig cleanup/eks-arm'
+                sh 'make -C .ci TARGET=run-deployer ci'
+            }
+            cleanWs()
+        }
+    }
+}

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -335,7 +335,6 @@ write_deployer_config <<CFG
 id: eks-arm-ci
 overrides:
   clusterName: ${BUILD_TAG}-arm
-  machineType: m6gd.2xlarge
   vaultInfo:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -310,6 +310,40 @@ CFG
 ;;
 
 ######################################
+  e2e/eks-arm)
+######################################
+
+write_env <<ENV
+IMG_SUFFIX = -ci
+E2E_REGISTRY_NAMESPACE = eck-ci
+
+GO_TAGS = release
+export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/.ci/license.key
+TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
+MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
+
+OPERATOR_IMAGE = $JKS_PARAM_OPERATOR_IMAGE
+
+PIPELINE=e2e/eks
+BUILD_NUMBER=$BUILD_NUMBER
+E2E_PROVIDER=eks
+CLUSTER_NAME=${BUILD_TAG}-arm
+KUBERNETES_VERSION=default
+TEST_OPTS=-race
+ENV
+write_deployer_config <<CFG
+id: eks-arm-ci
+overrides:
+  clusterName: ${BUILD_TAG}-arm
+  machineType: a1.2xlarge
+  vaultInfo:
+    address: $VAULT_ADDR
+    roleId: $VAULT_ROLE_ID
+    secretId: $VAULT_SECRET_ID
+CFG
+;;
+
+######################################
   e2e/stack-versions)
 ######################################
 
@@ -495,6 +529,22 @@ id: eks-ci
 overrides:
   operation: delete
   clusterName: $BUILD_TAG
+  vaultInfo:
+    address: $VAULT_ADDR
+    roleId: $VAULT_ROLE_ID
+    secretId: $VAULT_SECRET_ID
+CFG
+;;
+
+######################################
+  cleanup/eks-arm)
+######################################
+
+write_deployer_config <<CFG
+id: eks-arm-ci
+overrides:
+  operation: delete
+  clusterName: ${BUILD_TAG}-arm
   vaultInfo:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -335,7 +335,7 @@ write_deployer_config <<CFG
 id: eks-arm-ci
 overrides:
   clusterName: ${BUILD_TAG}-arm
-  machineType: a1.2xlarge
+  machineType: m6gd.2xlarge
   vaultInfo:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID

--- a/Makefile
+++ b/Makefile
@@ -467,7 +467,7 @@ ci-check: check-license-header lint shellcheck generate check-local-changes
 
 ci: unit-xml integration-xml docker-build reattach-pv
 
-setup-e2e: e2e-compile run-deployer install-crds apply-psp e2e-docker-build e2e-docker-push
+setup-e2e: e2e-compile run-deployer install-crds apply-psp e2e-docker-multiarch-build
 
 ci-e2e: E2E_JSON := true
 ci-e2e: setup-e2e e2e-run

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -114,6 +114,18 @@ plans:
     nodeCount: 3
     nodeAMI: auto
     diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
+- id: eks-arm-ci
+  operation: create
+  clusterName: arm-ci
+  provider: eks
+  machineType: m6gd.2xlarge
+  serviceAccount: false
+  kubernetesVersion: 1.18
+  eks:
+    region: eu-west-1
+    nodeCount: 3
+    nodeAMI: auto
+    diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
 - id: eks-dev
   operation: create
   clusterName: dev

--- a/hack/docker.sh
+++ b/hack/docker.sh
@@ -26,11 +26,6 @@ docker-login() {
     local image=$1
     local registry=${image%%"/"*}
 
-    if grep -q "$registry" ~/.docker/config.json; then
-        echo "Skipping Docker login"
-        return 0
-    fi
-
     case "$image" in
 
         */eck/*|*/eck-ci/*|*/eck-snapshots/*)


### PR DESCRIPTION
Add an E2E job to run on ARM machines. This PR only introduces the job. After it is tested manually, it will be added to the nightly job in a separate PR.

Related to #3504 