### PR TITLE
[Helm] Honour serviceAccount.create value

### DIFF
--- a/deploy/eck-operator/templates/service-account.yaml
+++ b/deploy/eck-operator/templates/service-account.yaml
@@ -1,3 +1,4 @@
+{{- if  .Values.serviceAccount.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -9,4 +10,5 @@ metadata:
 {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Skips creating the service account if the user sets `serviceAccount.create=false`.

Fixes #4002 