### PR TITLE
[1.3.1] Add 1.3.1 release notes (#4019)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-1.3.1>>
 * <<release-notes-1.3.0>>
 * <<release-notes-1.2.1>>
 * <<release-notes-1.2.0>>
@@ -18,6 +19,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/1.3.1.asciidoc[]
 include::release-notes/1.3.0.asciidoc[]
 include::release-notes/1.2.1.asciidoc[]
 include::release-notes/1.2.0.asciidoc[]

--- a/docs/release-notes/1.3.1.asciidoc
+++ b/docs/release-notes/1.3.1.asciidoc
@@ -1,0 +1,21 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-1.3.1]]
+== {n} version 1.3.1
+
+
+
+
+
+[[bug-1.3.1]]
+[float]
+=== Bug fixes
+
+* [Helm] Honour serviceAccount.create value {pull}4003[#4003] (issue: {issue}4002[#4002])
+* Use the public transport CA as remote CA if the remote CA list is empty {pull}3993[#3993]
+* Don't set an ownerRef on secrets users are susceptible to copy around {pull}3992[#3992] (issue: {issue}3986[#3986])
+* Use a custom version of JSON marshalling for license verification {pull}3977[#3977]
+* Use new node_names query param for voting exclusions as of 7.8.0 {pull}3950[#3950] (issue: {issue}2951[#2951])
+
+

--- a/docs/release-notes/highlights-1.3.1.asciidoc
+++ b/docs/release-notes/highlights-1.3.1.asciidoc
@@ -1,0 +1,33 @@
+[[release-highlights-1.3.1]]
+== 1.3.1 release highlights
+
+This is a patch release to address some issues found after the 1.3.0 release. See <<release-highlights-1.3.0>> for the full highlights of the 1.3.x series.
+
+
+
+[float]
+[id="{p}-131-fixes"]
+=== Fixes
+
+[float]
+[id="{p}-131-workaround-kubernetes-bug"]
+==== Work around rare Kubernetes bug that could result in data loss
+
+ECK manages several Secrets that users may want to copy across namespaces in order to be mounted into other application Pods:
+
+* the Secret containing the `elastic` user password
+* the Secret containing the public HTTP certificates to access Elasticsearch, Kibana, Enterprise Search
+* the Secret containing the APM Server token
+
+Those Secrets include a reference to their owner resource (for example, the Elasticsearch resource). When a Secret is copied into a different namespace, that owner reference becomes invalid. A Kubernetes link:https://github.com/kubernetes/kubernetes/issues/65200[bug] causes the garbage collection of all resources owned in the original namespace, including PersistentVolumes.
+
+This bug is link:https://github.com/kubernetes/kubernetes/pull/92743[fixed] in Kubernetes 1.20: resources with an invalid owner references will be automatically deleted, preventing any accidental garbage collection.
+
+However since some ECK users might not be able to upgrade to Kubernetes 1.20 anytime soon, we are providing a fix in ECK directly. All aforementioned Secrets will not have an owner reference set anymore. The ECK operator itself handles garbage collection of those Secrets when appropriate.
+
+
+[float]
+[id="{p}-131-use-new-nodenames"]
+==== Use new node_names query parameter for voting exclusions as of 7.8.0
+
+When an Elasticsearch master node was created but, for any reason, didn't join the cluster, the operator was not able to remove it anymore. A new parameter introduced in Elasticsearch `7.8.0` allows the operator to make progress in those circumstances: a master node that never joined the cluster can correctly be removed. Prior Elasticsearch versions do not benefit from that improvement.

--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the most important changes in each release. For the full list, see <<eck-release-notes>>.
 
+* <<release-highlights-1.3.1>>
 * <<release-highlights-1.3.0>>
 * <<release-highlights-1.2.1>>
 * <<release-highlights-1.2.0>>
@@ -17,6 +18,7 @@ This section summarizes the most important changes in each release. For the full
 
 --
 
+include::highlights-1.3.1.asciidoc[]
 include::highlights-1.3.0.asciidoc[]
 include::highlights-1.2.1.asciidoc[]
 include::highlights-1.2.0.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 1.3.1:
 - Add 1.3.1 release notes (#4019)