### PR TITLE
Avoid touching root filesystem in Kibana init script

### DIFF
--- a/pkg/controller/kibana/init_configuration.go
+++ b/pkg/controller/kibana/init_configuration.go
@@ -17,7 +17,7 @@ const (
 	InitConfigScript = `#!/usr/bin/env bash
 set -eux
 
-init_config_initialized_flag=/usr/share/kibana/config/elastic-internal-init-config.ok
+init_config_initialized_flag=` + InitContainerConfigVolumeMountPath + `/elastic-internal-init-config.ok
 
 if [[ -f "${init_config_initialized_flag}" ]]; then
     echo "Kibana configuration already initialized."


### PR DESCRIPTION
The Kibana init script creates a file at `/usr/share/kibana/config` to avoid running the init script multiple times. This is not allowed when the pod security policy defines `readOnlyRootFilesystem: true`. This PR changes the lock file path to the mount point of the config filesystem instead.

Fixes #4022 