### PR TITLE
Add Elastic Agent configuration examples

### DIFF
--- a/config/recipes/elastic-agent/README.asciidoc
+++ b/config/recipes/elastic-agent/README.asciidoc
@@ -1,6 +1,6 @@
 = Elastic Agent Configuration Examples
 
-This directory contains yaml manifests with example configurations for Elastic Agent. These manifests are self-contained and work out-of-the-box on any non-secured Kubernetes cluster. All of them contain three-node Elasticsearch cluster, single Kibana instance and all required RBAC resources.
+This directory contains yaml manifests with example configurations for Elastic Agent. These manifests are self-contained and work out-of-the-box on any non-secured Kubernetes cluster. All of them contain a three-node Elasticsearch cluster, a single Kibana instance and all required RBAC resources.
 
 IMPORTANT: These examples are for illustration purposes only and should not be considered to be production-ready.
 
@@ -8,8 +8,8 @@ CAUTION: Some of these examples use the `node.store.allow_mmap: false` configura
 
 ==== System integration - `system-integration.yaml`
 
-Deploys Elastic Agent as a DaemonSet in the standalone mode with system integration enabled. Collects syslog logs, auth logs and system metrics (for cpu, i/o, filesystem, memory, network, process and others).
+Deploys Elastic Agent as a DaemonSet in standalone mode with system integration enabled. Collects syslog logs, auth logs and system metrics (for CPU, I/O, filesystem, memory, network, process and others).
 
 ==== Kubernetes integration - `kubernetes-integration.yaml`
 
-Deploys Elastic Agent as a DaemonSet in the standalone mode with Kubernetes integration enabled. Collects API server, Container, Event, Node, Pod, Volume and system metrics.
+Deploys Elastic Agent as a DaemonSet in standalone mode with Kubernetes integration enabled. Collects API server, Container, Event, Node, Pod, Volume and system metrics.

--- a/config/recipes/elastic-agent/README.asciidoc
+++ b/config/recipes/elastic-agent/README.asciidoc
@@ -1,0 +1,15 @@
+= Elastic Agent Configuration Examples
+
+This directory contains yaml manifests with example configurations for Elastic Agent. These manifests are self-contained and work out-of-the-box on any non-secured Kubernetes cluster. All of them contain three-node Elasticsearch cluster, single Kibana instance and all required RBAC resources.
+
+IMPORTANT: These examples are for illustration purposes only and should not be considered to be production-ready.
+
+CAUTION: Some of these examples use the `node.store.allow_mmap: false` configuration value to avoid configuring memory mapping settings on the underlying host. This could have a significant performance impact on your Elasticsearch clusters and should not be used in production without careful consideration. See https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html for more information.
+
+==== System integration - `system-integration.yaml`
+
+Deploys Elastic Agent as a DaemonSet in the standalone mode with system integration enabled. Collects syslog logs, auth logs and system metrics (for cpu, i/o, filesystem, memory, network, process and others).
+
+==== Kubernetes integration - `kubernetes-integration.yaml`
+
+Deploys Elastic Agent as a DaemonSet in the standalone mode with Kubernetes integration enabled. Collects API server, Container, Event, Node, Pod, Volume and system metrics.

--- a/config/recipes/elastic-agent/kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/kubernetes-integration.yaml
@@ -1,0 +1,193 @@
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: elastic-agent
+spec:
+  version: 7.10.0
+  elasticsearchRefs:
+  - name: elasticsearch
+  daemonSet:
+    podTemplate:
+      spec:
+        automountServiceAccountToken: true
+        serviceAccountName: elastic-agent
+        containers:
+        - name: agent
+          securityContext:
+            runAsUser: 0
+            # If using Red Hat OpenShift uncomment this:
+            #privileged: true
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+  config:
+    id: 488e0b80-3634-11eb-8208-57893829af4e
+    revision: 2
+    agent:
+      monitoring:
+        enabled: true
+        use_output: default
+        logs: true
+        metrics: true
+    inputs:
+    - id: 678daef0-3634-11eb-8208-57893829af4e
+      name: kubernetes-1
+      revision: 1
+      type: kubernetes/metrics
+      use_output: default
+      meta:
+        package:
+          name: kubernetes
+          version: 0.2.8
+      data_stream:
+        namespace: k8s
+      streams:
+      - id: kubernetes/metrics-kubernetes.apiserver
+        data_stream:
+          dataset: kubernetes.apiserver
+          type: metrics
+        metricsets:
+        - apiserver
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}'
+        period: 30s
+        ssl.certificate_authorities:
+        - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - id: kubernetes/metrics-kubernetes.container
+        data_stream:
+          dataset: kubernetes.container
+          type: metrics
+        metricsets:
+        - container
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'https://${NODE_NAME}:10250'
+        period: 10s
+        ssl.verification_mode: none
+      - id: kubernetes/metrics-kubernetes.event
+        data_stream:
+          dataset: kubernetes.event
+          type: metrics
+        metricsets:
+        - event
+        period: 10s
+        add_metadata: true
+      - id: kubernetes/metrics-kubernetes.node
+        data_stream:
+          dataset: kubernetes.node
+          type: metrics
+        metricsets:
+        - node
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'https://${NODE_NAME}:10250'
+        period: 10s
+        ssl.verification_mode: none
+      - id: kubernetes/metrics-kubernetes.pod
+        data_stream:
+          dataset: kubernetes.pod
+          type: metrics
+        metricsets:
+        - pod
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'https://${NODE_NAME}:10250'
+        period: 10s
+        ssl.verification_mode: none
+      - id: kubernetes/metrics-kubernetes.system
+        data_stream:
+          dataset: kubernetes.system
+          type: metrics
+        metricsets:
+        - system
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'https://${NODE_NAME}:10250'
+        period: 10s
+        ssl.verification_mode: none
+      - id: kubernetes/metrics-kubernetes.volume
+        data_stream:
+          dataset: kubernetes.volume
+          type: metrics
+        metricsets:
+        - volume
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'https://${NODE_NAME}:10250'
+        period: 10s
+        ssl.verification_mode: none
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: elastic-agent
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources:
+  - namespaces
+  - pods
+  - nodes
+  - nodes/metrics
+  - nodes/proxy
+  - nodes/stats
+  - events
+  verbs:
+  - get
+  - watch
+  - list
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+  - watch
+  - list
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: elastic-agent
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: elastic-agent
+subjects:
+- kind: ServiceAccount
+  name: elastic-agent
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: elastic-agent
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch
+spec:
+  version: 7.10.0
+  nodeSets:
+  - name: default
+    count: 3
+    config:
+      node.store.allow_mmap: false
+---
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: kibana
+spec:
+  version: 7.10.0
+  count: 1
+  elasticsearchRef:
+    name: elasticsearch
+...

--- a/config/recipes/elastic-agent/system-integration.yaml
+++ b/config/recipes/elastic-agent/system-integration.yaml
@@ -1,0 +1,157 @@
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: elastic-agent
+spec:
+  version: 7.10.0
+  elasticsearchRefs:
+  - name: elasticsearch
+  daemonSet:
+    podTemplate:
+      spec:
+        containers:
+        - name: agent
+          securityContext:
+            runAsUser: 0
+            # If using Red Hat OpenShift uncomment this:
+            #privileged: true
+  config:
+    id: 488e0b80-3634-11eb-8208-57893829af4e
+    revision: 2
+    agent:
+      monitoring:
+        enabled: true
+        use_output: default
+        logs: true
+        metrics: true
+    inputs:
+    - id: 4917ade0-3634-11eb-8208-57893829af4e
+      name: system-1
+      revision: 1
+      type: system/metrics
+      use_output: default
+      meta:
+        package:
+          name: system
+          version: 0.9.1
+      data_stream:
+        namespace: default
+      streams:
+      - id: system/metrics-system.cpu
+        data_stream:
+          dataset: system.cpu
+          type: metrics
+        metricsets:
+        - cpu
+        cpu.metrics:
+        - percentages
+        - normalized_percentages
+        period: 10s
+      - id: system/metrics-system.diskio
+        data_stream:
+          dataset: system.diskio
+          type: metrics
+        metricsets:
+        - diskio
+        diskio.include_devices: null
+        period: 10s
+      - id: system/metrics-system.filesystem
+        data_stream:
+          dataset: system.filesystem
+          type: metrics
+        metricsets:
+        - filesystem
+        period: 1m
+        processors:
+        - drop_event.when.regexp:
+            system.filesystem.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
+      - id: system/metrics-system.fsstat
+        data_stream:
+          dataset: system.fsstat
+          type: metrics
+        metricsets:
+        - fsstat
+        period: 1m
+        processors:
+        - drop_event.when.regexp:
+            system.fsstat.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
+      - id: system/metrics-system.load
+        data_stream:
+          dataset: system.load
+          type: metrics
+        metricsets:
+        - load
+        period: 10s
+      - id: system/metrics-system.memory
+        data_stream:
+          dataset: system.memory
+          type: metrics
+        metricsets:
+        - memory
+        period: 10s
+      - id: system/metrics-system.network
+        data_stream:
+          dataset: system.network
+          type: metrics
+        metricsets:
+        - network
+        period: 10s
+        network.interfaces: null
+      - id: system/metrics-system.process
+        data_stream:
+          dataset: system.process
+          type: metrics
+        metricsets:
+        - process
+        period: 10s
+        process.include_top_n.by_cpu: 5
+        process.include_top_n.by_memory: 5
+        process.cmdline.cache.enabled: true
+        process.cgroups.enabled: false
+        process.include_cpu_ticks: false
+        processes:
+        - .*
+      - id: system/metrics-system.process_summary
+        data_stream:
+          dataset: system.process_summary
+          type: metrics
+        metricsets:
+        - process_summary
+        period: 10s
+      - id: system/metrics-system.socket_summary
+        data_stream:
+          dataset: system.socket_summary
+          type: metrics
+        metricsets:
+        - socket_summary
+        period: 10s
+      - id: system/metrics-system.uptime
+        data_stream:
+          dataset: system.uptime
+          type: metrics
+        metricsets:
+        - uptime
+        period: 10s
+---
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch
+spec:
+  version: 7.10.0
+  nodeSets:
+  - name: default
+    count: 3
+    config:
+      node.store.allow_mmap: false
+---
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: kibana
+spec:
+  version: 7.10.0
+  count: 1
+  elasticsearchRef:
+    name: elasticsearch
+...

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -24,21 +24,20 @@ func TestSystemIntegrationConfig(t *testing.T) {
 	agentBuilder := agent.NewBuilder(name).
 		WithRoles(agent.PSPClusterRoleName).
 		WithElasticsearchRefs(agent.ToOutput(esBuilder.Ref(), "default")).
-		WithDefaultESValidation(agent.HasEventFromAgent()).
-		WithDefaultESValidation(agent.HasDataStream("logs-elastic_agent-default")).
-		WithDefaultESValidation(agent.HasDataStream("logs-elastic_agent.filebeat-default")).
-		WithDefaultESValidation(agent.HasDataStream("logs-elastic_agent.metricbeat-default")).
-		WithDefaultESValidation(agent.HasDataStream("metrics-elastic_agent.filebeat-default")).
-		WithDefaultESValidation(agent.HasDataStream("metrics-elastic_agent.metricbeat-default")).
-		WithDefaultESValidation(agent.HasDataStream("metrics-system.cpu-default")).
-		WithDefaultESValidation(agent.HasDataStream("metrics-system.diskio-default")).
-		WithDefaultESValidation(agent.HasDataStream("metrics-system.load-default")).
-		WithDefaultESValidation(agent.HasDataStream("metrics-system.memory-default")).
-		WithDefaultESValidation(agent.HasDataStream("metrics-system.network-default")).
-		WithDefaultESValidation(agent.HasDataStream("metrics-system.process-default")).
-		WithDefaultESValidation(agent.HasDataStream("metrics-system.process_summary-default")).
-		WithDefaultESValidation(agent.HasDataStream("metrics-system.socket_summary-default")).
-		WithDefaultESValidation(agent.HasDataStream("metrics-system.uptime-default"))
+		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
+		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default")).
+		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
+		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default")).
+		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default")).
+		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.cpu", "default")).
+		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.diskio", "default")).
+		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.load", "default")).
+		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.memory", "default")).
+		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.network", "default")).
+		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.process", "default")).
+		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.process_summary", "default")).
+		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.socket_summary", "default")).
+		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptim", "default"))
 
 	agentBuilder = agent.ApplyYamls(t, agentBuilder, E2EAgentSystemIntegrationConfig, E2EAgentSystemIntegrationPodTemplate)
 

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -1,0 +1,104 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package agent
+
+import (
+	"path"
+	"testing"
+
+	agentv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/agent/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/agent"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/helper"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+func TestSystemIntegrationRecipe(t *testing.T) {
+	customize := func(builder agent.Builder) agent.Builder {
+		return builder.
+			WithRoles(agent.PSPClusterRoleName).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.cpu", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.diskio", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.fsstat", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.load", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.memory", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.network", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.process", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.process_summary", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.socket_summary", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"))
+	}
+
+	runBeatRecipe(t, "system-integration.yaml", customize)
+}
+
+func TestKubernetesIntegrationRecipe(t *testing.T) {
+	customize := func(builder agent.Builder) agent.Builder {
+		return builder.
+			WithRoles(agent.PSPClusterRoleName).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "kubernetes.apiserver", "k8s")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "kubernetes.container", "k8s")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "kubernetes.event", "k8s")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "kubernetes.node", "k8s")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "kubernetes.pod", "k8s")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "kubernetes.system", "k8s")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "kubernetes.volume", "k8s"))
+	}
+
+	runBeatRecipe(t, "kubernetes-integration.yaml", customize)
+}
+
+func runBeatRecipe(
+	t *testing.T,
+	fileName string,
+	customize func(builder agent.Builder) agent.Builder,
+	additionalObjects ...runtime.Object,
+) {
+	filePath := path.Join("../../../config/recipes/elastic-agent", fileName)
+	namespace := test.Ctx().ManagedNamespace(0)
+	suffix := rand.String(4)
+
+	transformationsWrapped := func(builder test.Builder) test.Builder {
+		agentBuilder, ok := builder.(agent.Builder)
+		if !ok {
+			return builder
+		}
+
+		if isStackIncompatible(agentBuilder.Agent) {
+			t.SkipNow()
+		}
+
+		// OpenShift requires different securityContext than provided in the recipe.
+		// Skipping it altogether to reduce maintenance burden.
+		if test.Ctx().Provider == "ocp" {
+			t.SkipNow()
+		}
+
+		agentBuilder.Suffix = suffix
+
+		if customize != nil {
+			agentBuilder = customize(agentBuilder)
+		}
+
+		return agentBuilder
+	}
+
+	helper.RunFile(t, filePath, namespace, suffix, additionalObjects, transformationsWrapped)
+}
+
+// isStackIncompatible returns true iff Agent version is higher than tested Stack version
+func isStackIncompatible(agent agentv1alpha1.Agent) bool {
+	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
+	agentVersion := version.MustParse(agent.Spec.Version)
+	return agentVersion.IsAfter(stackVersion)
+}

--- a/test/e2e/samples_test.go
+++ b/test/e2e/samples_test.go
@@ -11,11 +11,9 @@ import (
 	"testing"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
-	beatcommon "github.com/elastic/cloud-on-k8s/pkg/controller/beat/common"
 	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/apmserver"
-	"github.com/elastic/cloud-on-k8s/test/e2e/test/beat"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/enterprisesearch"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/helper"
@@ -72,14 +70,6 @@ func createBuilders(t *testing.T, decoder *helper.YAMLDecoder, sampleFile, testN
 				WithRestrictedSecurityContext().
 				WithLabel(run.TestNameLabel, fullTestName).
 				WithPodLabel(run.TestNameLabel, fullTestName)
-		case beat.Builder:
-			return b.WithNamespace(namespace).
-				WithSuffix(suffix).
-				WithElasticsearchRef(tweakServiceRef(b.Beat.Spec.ElasticsearchRef, suffix)).
-				WithLabel(run.TestNameLabel, testName).
-				WithPodLabel(run.TestNameLabel, testName).
-				WithRoles(beat.AutodiscoverClusterRoleName, beat.PSPClusterRoleName).
-				WithESValidations(beat.HasEventFromBeat(beatcommon.Type(b.Beat.Spec.Type)))
 		case enterprisesearch.Builder:
 			return b.WithNamespace(namespace).
 				WithSuffix(suffix).

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -48,6 +48,22 @@ func (b Builder) SkipTest() bool {
 	return version.SupportedAgentVersions.WithinRange(ver) != nil
 }
 
+// NewBuilderFromAgent creates an Agent builder from an existing Agent config. Sets all additional Builder fields
+// appropriately.
+func NewBuilderFromAgent(agent *agentv1alpha1.Agent) Builder {
+	var podTemplate *corev1.PodTemplateSpec
+	if agent.Spec.DaemonSet != nil {
+		podTemplate = &agent.Spec.DaemonSet.PodTemplate
+	} else if agent.Spec.Deployment != nil {
+		podTemplate = &agent.Spec.Deployment.PodTemplate
+	}
+
+	return Builder{
+		Agent:       *agent,
+		PodTemplate: podTemplate,
+	}
+}
+
 func NewBuilder(name string) Builder {
 	suffix := rand.String(4)
 	meta := metav1.ObjectMeta{

--- a/test/e2e/test/agent/steps.go
+++ b/test/e2e/test/agent/steps.go
@@ -173,7 +173,8 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 					expectedOutputName := b.ValidationsOutputs[i]
 					var esNsName types.NamespacedName
 					for _, output := range b.Agent.Spec.ElasticsearchRefs {
-						if output.OutputName == expectedOutputName {
+						if output.OutputName == expectedOutputName ||
+							output.OutputName == "" && len(b.Agent.Spec.ElasticsearchRefs) == 1 {
 							esNsName = output.WithDefaultNamespace(b.Agent.Namespace).NamespacedName()
 							break
 						}


### PR DESCRIPTION
This PR adds:
- configuration examples for enabling System and Kubernetes integrations
- README describing the examples
- example specific E2E tests
- utilities needed to run those tests

We might add more examples (eg. multiple outputs) depending on features added and readiness on Elastic Agent side.

Exposing configuration examples via docs will be a part of https://github.com/elastic/cloud-on-k8s/issues/4011.

Resolves https://github.com/elastic/cloud-on-k8s/issues/4017.