### PR TITLE
Bump minimal supported version of Elastic Agent to 7.10.0

### DIFF
--- a/pkg/controller/common/version/version.go
+++ b/pkg/controller/common/version/version.go
@@ -24,8 +24,9 @@ var (
 	SupportedEnterpriseSearchVersions = MinMaxVersion{Min: From(7, 7, 0), Max: From(8, 99, 99)}
 	SupportedKibanaVersions           = MinMaxVersion{Min: From(6, 8, 0), Max: From(8, 99, 99)}
 	SupportedBeatVersions             = MinMaxVersion{Min: From(7, 0, 0), Max: From(8, 99, 99)}
-	// Elastic Agent was introduced in 7.8.0
-	SupportedAgentVersions = MinMaxVersion{Min: From(7, 8, 0), Max: From(8, 99, 99)}
+	// Elastic Agent was introduced in 7.8.0, but as "experimental release" with no migration path forward, hence
+	// picking higher version as minimal supported.
+	SupportedAgentVersions = MinMaxVersion{Min: From(7, 10, 0), Max: From(8, 99, 99)}
 )
 
 // MinMaxVersion holds the minimum and maximum supported versions.


### PR DESCRIPTION
In `7.10.0` Elastic Agent started adding the below field to data stream documents it creates.

```
          "elastic_agent": {
            "version": "7.10.0",
            "id": "1fdba8ef-cda6-4196-b695-e71ce4043c6a",
            "snapshot": false
          },
```

It also changed the way datasets are named: 

`7.9.2`:
```
"dataset": "elastic.agent"
```

`7.10.0`:
```
"dataset": "elastic_agent",
```

This results in test failing on `7.8.x` and `7.9.x` and passing on `7.10.x`. Versions below `7.8.0` are not failing as this is the first Stack version that Elastic Agent was part of and we don't test it there.

<img width="260" alt="Screenshot 2020-12-10 at 23 06 39" src="https://user-images.githubusercontent.com/50632861/101835657-6300b780-3b3c-11eb-942b-1336d9dcb1f9.png">

Given the changes I've already saw between those minors and the experimental/beta branding of Agent early versions I'm bumping the minimal supported to `7.10.0`. We should consider bumping it higher before the release.

Also, this is reworked a bit in #4030 anyway and data stream existence is checked through dedicated API (`/_data_stream`).

