### PR TITLE
Add agent webhook to e2e tests

### DIFF
--- a/config/e2e/operator.yaml
+++ b/config/e2e/operator.yaml
@@ -387,6 +387,30 @@ webhooks:
       - key: name
         operator: In
         values: [{{ .Operator.ManagedNamespaces | join $comma }}]
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: elastic-webhook-server
+        namespace: {{ .Operator.Namespace }}
+        # this is the path controller-runtime automatically generates
+        path: /validate-agent-k8s-elastic-co-v1alpha1-agent
+    failurePolicy: {{ if .IgnoreWebhookFailures }}Ignore{{ else }}Fail{{ end }}
+    name: elastic-agent-validation-v1alpha1.k8s.elastic.co
+    rules:
+    - apiGroups:
+      - agent.k8s.elastic.co
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - agents
+    namespaceSelector:
+      matchExpressions:
+      - key: name
+        operator: In
+        values: [{{ .Operator.ManagedNamespaces | join $comma }}]
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Missed this in https://github.com/elastic/cloud-on-k8s/pull/4035 