### PR TITLE
Don't duplicate user-provided Enterprise Search encryption keys when reusing them

### DIFF
--- a/pkg/controller/enterprisesearch/config.go
+++ b/pkg/controller/enterprisesearch/config.go
@@ -192,11 +192,26 @@ func getOrCreateReusableSettings(c k8s.Client, ent entv1beta1.EnterpriseSearch) 
 	} else if err := cfg.Unpack(&e); err != nil {
 		return nil, err
 	}
+
+	// generate a random secret session key, or reuse the existing one
 	if len(e.SecretSession) == 0 {
 		e.SecretSession = string(common.RandomBytes(32))
 	}
+
+	// generate a random encryption key, or reuse the existing one
+	// Encryption keys are stored in an array, so they can be rotated.
+	// When Enterprise Search decrypts a secret, it tries all encryption keys in the array, in order.
+	// When Enterprise Search rewrites a secret, it uses the latest encryption key in the array.
+	// We manage the first item of that array: it is randomly generated once, then reused.
+	// Users are free to provide their own encryption keys through the configuration:
+	// in that case we still keep the first item we manage, user-provided keys will be appended to the array.
+	// This allows users to go from no custom key provided (use operator's generated one), to providing their own.
 	if len(e.EncryptionKeys) == 0 {
+		// no encryption key, generate a new one
 		e.EncryptionKeys = []string{string(common.RandomBytes(32))}
+	} else {
+		// encryption keys already exist, reuse the first ECK-managed one
+		e.EncryptionKeys = []string{e.EncryptionKeys[0]}
 	}
 	return settings.MustCanonicalConfig(e), nil
 }

--- a/pkg/controller/enterprisesearch/config.go
+++ b/pkg/controller/enterprisesearch/config.go
@@ -211,6 +211,7 @@ func getOrCreateReusableSettings(c k8s.Client, ent entv1beta1.EnterpriseSearch) 
 		e.EncryptionKeys = []string{string(common.RandomBytes(32))}
 	} else {
 		// encryption keys already exist, reuse the first ECK-managed one
+		// other user-provided keys from user-provided config will be merged in later
 		e.EncryptionKeys = []string{e.EncryptionKeys[0]}
 	}
 	return settings.MustCanonicalConfig(e), nil

--- a/pkg/controller/enterprisesearch/config_test.go
+++ b/pkg/controller/enterprisesearch/config_test.go
@@ -128,30 +128,7 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name: "Do not override existing keys",
-			args: args{
-				c: k8s.WrappedFakeClient(
-					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "ent-sample-ent-config"},
-						Data: map[string][]byte{
-							ConfigFilename: []byte(existingConfigWithReusableSettings),
-						},
-					},
-				),
-				ent: entv1beta1.EnterpriseSearch{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "ent-sample"},
-				},
-			},
-			assertion: func(t *testing.T, got *settings.CanonicalConfig, err error) {
-				expectedSettings := settings.MustCanonicalConfig(map[string]interface{}{
-					SecretSessionSetting:  "alreadysetsessionkey",
-					EncryptionKeysSetting: []string{"alreadysetencryptionkey1", "alreadysetencryptionkey2"},
-				})
-				assert.Equal(t, expectedSettings, got)
-			},
-		},
-		{
-			name: "Do not override existing encryption keys, create missing session key",
+			name: "Generate session key and encryption key when missing",
 			args: args{
 				c: k8s.WrappedFakeClient(
 					&corev1.Secret{
@@ -175,13 +152,13 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 			},
 		},
 		{
-			name: "Create missing keys",
+			name: "Reuse existing session key, and first operator-managed encryption key",
 			args: args{
 				c: k8s.WrappedFakeClient(
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "ent-sample-ent-config"},
 						Data: map[string][]byte{
-							ConfigFilename: []byte(existingConfig),
+							ConfigFilename: []byte(existingConfigWithReusableSettings),
 						},
 					},
 				),
@@ -190,29 +167,12 @@ func Test_reuseOrGenerateSecrets(t *testing.T) {
 				},
 			},
 			assertion: func(t *testing.T, got *settings.CanonicalConfig, err error) {
-				// Unpack the configuration to check that some default reusable settings have been generated
-				var e reusableSettings
-				assert.NoError(t, got.Unpack(&e))
-				assert.Equal(t, len(e.EncryptionKeys), 1)     // We set 1 encryption key by default
-				assert.Equal(t, len(e.EncryptionKeys[0]), 32) // encryption key length should be 32
-				assert.Equal(t, len(e.SecretSession), 32)     // session key length should be 32
-			},
-		},
-		{
-			name: "No configuration to reuse",
-			args: args{
-				c: k8s.WrappedFakeClient(),
-				ent: entv1beta1.EnterpriseSearch{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "ent-sample"},
-				},
-			},
-			assertion: func(t *testing.T, got *settings.CanonicalConfig, err error) {
-				// Unpack the configuration to check that some default reusable settings have been generated
-				var e reusableSettings
-				assert.NoError(t, got.Unpack(&e))
-				assert.Equal(t, len(e.EncryptionKeys), 1)     // We set 1 encryption key by default
-				assert.Equal(t, len(e.EncryptionKeys[0]), 32) // encryption key length should be 32
-				assert.Equal(t, len(e.SecretSession), 32)     // session key length should be 32
+				expectedSettings := settings.MustCanonicalConfig(map[string]interface{}{
+					SecretSessionSetting: "alreadysetsessionkey",
+					// we don't want "user-provided-encryption-key" here
+					EncryptionKeysSetting: []string{"operator-managed-encryption-key"},
+				})
+				assert.Equal(t, expectedSettings, got)
 			},
 		},
 	}
@@ -565,6 +525,168 @@ func TestReconcileConfig(t *testing.T) {
 			err = driver.K8sClient().Get(k8s.ExtractNamespacedName(&got), &updatedResource)
 			assert.NoError(t, err)
 			assert.Equal(t, got.Data, updatedResource.Data)
+		})
+	}
+}
+
+func TestReconcileConfig_UserProvidedEncryptionKeys(t *testing.T) {
+	tests := []struct {
+		name        string
+		runtimeObjs []runtime.Object
+		ent         entv1beta1.EnterpriseSearch
+		assertions  func(t *testing.T, settings reusableSettings)
+	}{
+		{
+			name:        "generate default session key and encryption key",
+			runtimeObjs: nil,
+			ent: entv1beta1.EnterpriseSearch{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "sample",
+				},
+				Spec: entv1beta1.EnterpriseSearchSpec{
+					Version: "7.9.1",
+				},
+			},
+			assertions: func(t *testing.T, settings reusableSettings) {
+				require.NotEmpty(t, settings.SecretSession)
+				require.Len(t, settings.EncryptionKeys, 1)
+				require.NotEmpty(t, settings.EncryptionKeys[0])
+			},
+		},
+		{
+			name: "generate defaults, append user-provided encryption keys",
+			ent: entv1beta1.EnterpriseSearch{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "sample",
+				},
+				Spec: entv1beta1.EnterpriseSearchSpec{
+					Version: "7.9.1",
+					Config: &commonv1.Config{Data: map[string]interface{}{
+						"secret_management": map[string]interface{}{
+							"encryption_keys": []string{
+								"user-provided-key-1",
+								"user-provided-key-2",
+							},
+						},
+					}},
+				},
+			},
+			assertions: func(t *testing.T, settings reusableSettings) {
+				require.NotEmpty(t, settings.SecretSession)
+				require.Len(t, settings.EncryptionKeys, 3)
+				require.NotEmpty(t, settings.EncryptionKeys[0])
+				require.Equal(t, "user-provided-key-1", settings.EncryptionKeys[1])
+				require.Equal(t, "user-provided-key-2", settings.EncryptionKeys[2])
+			},
+		},
+		{
+			name: "reuse existing generated keys, append user-provided encryption keys",
+			ent: entv1beta1.EnterpriseSearch{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "sample",
+				},
+				Spec: entv1beta1.EnterpriseSearchSpec{
+					Version: "7.9.1",
+					Config: &commonv1.Config{Data: map[string]interface{}{
+						"secret_management": map[string]interface{}{
+							"encryption_keys": []string{
+								"user-provided-key-1",
+								"user-provided-key-2",
+							},
+						},
+					}},
+				},
+			},
+			runtimeObjs: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "sample-ent-config",
+					},
+					Data: map[string][]byte{
+						"enterprise-search.yml": []byte(`
+secret_management:
+ encryption_keys:
+ - operator-managed-encryption-key
+secret_session_key: alreadysetsessionkey
+`),
+					},
+				},
+			},
+			assertions: func(t *testing.T, settings reusableSettings) {
+				require.Equal(t, "alreadysetsessionkey", settings.SecretSession)
+				require.Len(t, settings.EncryptionKeys, 3)
+				require.Equal(t, "operator-managed-encryption-key", settings.EncryptionKeys[0])
+				require.Equal(t, "user-provided-key-1", settings.EncryptionKeys[1])
+				require.Equal(t, "user-provided-key-2", settings.EncryptionKeys[2])
+			},
+		},
+		{
+			name: "reuse only the first operator-managed encryption key",
+			ent: entv1beta1.EnterpriseSearch{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "sample",
+				},
+				Spec: entv1beta1.EnterpriseSearchSpec{
+					Version: "7.9.1",
+					Config: &commonv1.Config{Data: map[string]interface{}{
+						"secret_management": map[string]interface{}{
+							"encryption_keys": []string{
+								"user-provided-key-1", // already exists in the secret
+								"user-provided-key-2", // already exists in the secret
+								"user-provided-key-3", // new one
+							},
+						},
+					}},
+				},
+			},
+			runtimeObjs: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "sample-ent-config",
+					},
+					Data: map[string][]byte{
+						"enterprise-search.yml": []byte(`
+secret_management:
+ encryption_keys:
+ - operator-managed-encryption-key
+ - user-provided-key-1
+ - user-provided-key-2
+secret_session_key: alreadysetsessionkey
+`),
+					},
+				},
+			},
+			assertions: func(t *testing.T, settings reusableSettings) {
+				require.Equal(t, "alreadysetsessionkey", settings.SecretSession)
+				require.Len(t, settings.EncryptionKeys, 4)
+				require.Equal(t, "operator-managed-encryption-key", settings.EncryptionKeys[0])
+				require.Equal(t, "user-provided-key-1", settings.EncryptionKeys[1])
+				require.Equal(t, "user-provided-key-2", settings.EncryptionKeys[2])
+				require.Equal(t, "user-provided-key-3", settings.EncryptionKeys[3])
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			driver := &ReconcileEnterpriseSearch{
+				Client:         k8s.WrappedFakeClient(tt.runtimeObjs...),
+				recorder:       record.NewFakeRecorder(10),
+				dynamicWatches: watches.NewDynamicWatches(),
+			}
+
+			got, err := ReconcileConfig(driver, tt.ent, corev1.IPv4Protocol)
+			require.NoError(t, err)
+			cfg, err := settings.ParseConfig(got.Data["enterprise-search.yml"])
+			require.NoError(t, err)
+			var reusable reusableSettings
+			require.NoError(t, cfg.Unpack(&reusable))
+			tt.assertions(t, reusable)
 		})
 	}
 }

--- a/pkg/controller/enterprisesearch/fixtures.go
+++ b/pkg/controller/enterprisesearch/fixtures.go
@@ -28,7 +28,7 @@ ent_search:
 var existingConfigWithReusableSettings = existingConfig +
 	`secret_management:
   encryption_keys:
-  - alreadysetencryptionkey1
-  - alreadysetencryptionkey2
+  - operator-managed-encryption-key
+  - user-provided-encryption-key
 secret_session_key: alreadysetsessionkey
 `


### PR DESCRIPTION
This commit fixes a bug in the operator when users provide their own
encryption keys.

When we retrieved existing encryption keys (to ensure we don't generate a new
one), we retrieved *all of them* including user-provided ones.
We then merge the user-provided configuration, which also includes user-provided
encryption keys. So everytime we reconcile the configuration, we duplicate
the user-provided encryption keys into the reconciled config secret. Because this
secret changes, all Pods get rotated automatically.
This results in a never-ending config update (growing forever) and pod rotation.

This commit fixes it by ensuring the operator always manages the first encryption key.
This first key is the only one that gets reused. User-provided keys are then appended
to the list of keys.

This allows the following use case:
- deploy ent search with no encryption key: you get a generated one
- add your own custom encryption keys: it is appended to the array after
the generated one. Transition is smooth. If we were to replace the generated
one in that case, Enterprise Search would not be able to decrypt data.

Fixes https://github.com/elastic/cloud-on-k8s/issues/4051.