### PR TITLE
Add missing permissions to E2E runner role for Elastic Agent tests

### DIFF
--- a/config/e2e/rbac.yaml
+++ b/config/e2e/rbac.yaml
@@ -87,7 +87,9 @@ rules:
       # to create resources defined in recipes
       - namespaces
       - nodes
+      - nodes/metrics
       - nodes/stats
+      - nodes/proxy
     verbs:
       - get
       - list
@@ -157,6 +159,8 @@ rules:
     - "/metrics"
     verbs:
     - get
+    - list
+    - watch
   - apiGroups:
       - elasticsearch.k8s.elastic.co
     resources:


### PR DESCRIPTION
Fixes below E2E test [issue](https://devops-ci.elastic.co/job/cloud-on-k8s-e2e-tests-stack-versions/292/testReport/):

```
=== RUN   TestKubernetesIntegrationRecipe/Create_ClusterRole_elastic-agent-dmbs
    yaml.go:193: 
        	Error Trace:	yaml.go:193
        	Error:      	Received unexpected error:
        	            	clusterroles.rbac.authorization.k8s.io "elastic-agent-dmbs" is forbidden: user "system:serviceaccount:e2e-3inax:e2e-3inax" (groups=["system:serviceaccounts" "system:serviceaccounts:e2e-3inax" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
        	            	{APIGroups:[""], Resources:["nodes/metrics"], Verbs:["get" "watch" "list"]}
        	            	{APIGroups:[""], Resources:["nodes/proxy"], Verbs:["get" "watch" "list"]}
        	            	{NonResourceURLs:["/metrics"], Verbs:["list"]}
        	            	{NonResourceURLs:["/metrics"], Verbs:["watch"]}
        	Test:       	TestKubernetesIntegrationRecipe/Create_ClusterRole_elastic-agent-dmbs
{"log.level":"error","@timestamp":"2020-12-21T01:09:10.802Z","message":"stopping early","service.version":"0.0.0-SNAPSHOT+00000000","service.type":"eck","ecs.version":"1.4.0","error":"test failure","error.stack_trace":"github.com/elastic/cloud-on-k8s/test/e2e/test.StepList.RunSequential\n\t/go/src/github.com/elastic/cloud-on-k8s/test/e2e/test/step.go:43\ngithub.com/elastic/cloud-on-k8s/test/e2e/test/helper.RunFile\n\t/go/src/github.com/elastic/cloud-on-k8s/test/e2e/test/helper/yaml.go:156\ngithub.com/elastic/cloud-on-k8s/test/e2e/agent.runBeatRecipe\n\t/go/src/github.com/elastic/cloud-on-k8s/test/e2e/agent/recipes_test.go:96\ngithub.com/elastic/cloud-on-k8s/test/e2e/agent.TestKubernetesIntegrationRecipe\n\t/go/src/github.com/elastic/cloud-on-k8s/test/e2e/agent/recipes_test.go:58\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1123"}
    --- FAIL: TestKubernetesIntegrationRecipe/Create_ClusterRole_elastic-agent-dmbs (0.05s)`
```