### PR TITLE
Re-enable Kibana telemetry for telemetry test 

### DIFF
--- a/pkg/controller/kibana/config_settings_test.go
+++ b/pkg/controller/kibana/config_settings_test.go
@@ -550,3 +550,65 @@ func Test_getExistingConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestIsTelemetryEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    kbv1.Kibana
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "no config: enabled",
+			args:    kbv1.Kibana{},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "empty config: enabled",
+			args: kbv1.Kibana{
+				Spec: kbv1.KibanaSpec{
+					Config: &commonv1.Config{Data: map[string]interface{}{}},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "explicitly enabled",
+			args: kbv1.Kibana{
+				Spec: kbv1.KibanaSpec{
+					Config: &commonv1.Config{Data: map[string]interface{}{
+						"telemetry.enabled": true,
+					}},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "explicitly disabled",
+			args: kbv1.Kibana{
+				Spec: kbv1.KibanaSpec{
+					Config: &commonv1.Config{Data: map[string]interface{}{
+						"telemetry.enabled": false,
+					}},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IsTelemetryEnabled(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IsTelemetryEnabled() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("IsTelemetryEnabled() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/e2e/kb/telemetry_test.go
+++ b/test/e2e/kb/telemetry_test.go
@@ -9,18 +9,16 @@ import (
 	"fmt"
 	"testing"
 
+	kibana2 "github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
 	"github.com/elastic/cloud-on-k8s/pkg/telemetry"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/kibana"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
-	kibana2 "github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
-	"github.com/elastic/cloud-on-k8s/test/e2e/test"
-	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
-	"github.com/elastic/cloud-on-k8s/test/e2e/test/kibana"
 )
 
 func TestTelemetry(t *testing.T) {
@@ -29,7 +27,8 @@ func TestTelemetry(t *testing.T) {
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
-		WithNodeCount(1)
+		WithNodeCount(1).
+		WithTelemetryEnabled(true)
 
 	// Kibana picks up static telemetry data from telemetry.yml very close to its start and then rereads it on a rather
 	// long interval (~hours). This means that the telemetry reporter is likely to be updating Kibana config Secret
@@ -81,20 +80,7 @@ func TestTelemetry(t *testing.T) {
 			{
 				Name: "Kibana should expose eck info in telemetry data",
 				Test: test.Eventually(func() error {
-					kbVersion := version.MustParse(kbBuilder.Kibana.Spec.Version)
-					apiVersion, payload := apiVersionAndTelemetryRequestBody(kbVersion)
-					uri := fmt.Sprintf("/api/telemetry/%s/clusters/_stats", apiVersion)
-					password, err := k.GetElasticPassword(kbBuilder.ElasticsearchRef().NamespacedName())
-					if err != nil {
-						return err
-					}
-					payloadBytes, err := json.Marshal(payload)
-					if err != nil {
-						return err
-					}
-					// this call may fail (status 500) if the .security-7 index is not fully initialized yet,
-					// in which case we'll just retry that test step
-					body, err := kibana.DoRequest(k, kbBuilder.Kibana, password, "POST", uri, payloadBytes)
+					body, err := kibana.MakeTelemetryRequest(kbBuilder, k)
 					if err != nil {
 						return err
 					}
@@ -119,32 +105,6 @@ func TestTelemetry(t *testing.T) {
 
 	test.Sequence(nil, stepsFn, esBuilder, kbBuilder).RunSequential(t)
 
-}
-
-func apiVersionAndTelemetryRequestBody(kbVersion version.Version) (string, telemetryRequest) {
-	apiVersion := "v1"
-	payload := telemetryRequest{
-		TimeRange: &timeRange{},
-	}
-	if kbVersion.IsSameOrAfter(version.From(7, 2, 0)) {
-		apiVersion = "v2"
-		payload.Unencrypted = true
-	}
-	if kbVersion.IsSameOrAfter(version.From(7, 11, 0)) {
-		payload.TimeRange = nil // removed in 7.11
-	}
-	return apiVersion, payload
-}
-
-type timeRange struct {
-	Min int `json:"min"`
-	Max int `json:"max"`
-}
-
-// telemetryRequest is the request body for v1/v2 Kibana telemetry requests
-type telemetryRequest struct {
-	TimeRange   *timeRange `json:"timeRange,omitempty"`
-	Unencrypted bool       `json:"unencrypted,omitempty"`
 }
 
 // clusterStats partially models the response from a request to /api/telemetry/v1/clusters/_stats

--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -5,6 +5,7 @@
 package kibana
 
 import (
+	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -175,11 +176,7 @@ func (b Builder) WithTelemetryEnabled(enabled bool) Builder {
 	}
 
 	cfg := settings.MustCanonicalConfig(b.Kibana.Spec.Config.Data)
-	if err := cfg.MergeWith(settings.MustCanonicalConfig(map[string]interface{}{
-		"telemetry": map[string]interface{}{
-			"enabled": enabled,
-		},
-	})); err != nil {
+	if err := cfg.MergeWith(settings.MustCanonicalConfig(kibana.TelemetrySetting{Enabled: enabled})); err != nil {
 		panic(err)
 	}
 

--- a/test/e2e/test/kibana/checks_kb.go
+++ b/test/e2e/test/kibana/checks_kb.go
@@ -76,7 +76,7 @@ func (check *kbChecks) CheckKbTelemetryStatus(b Builder) test.Step {
 				return err
 			}
 			if expectedState == (reqErr == nil) {
-				return nil // expectedState error or nil
+				return nil // either disabled and we have an error or enabled and we should have no error
 			}
 			return fmt.Errorf("telemetry in Kibana should be enabled [%v] but got [%s]", expectedState, err.Error())
 		}),

--- a/test/e2e/test/kibana/checks_telemetry.go
+++ b/test/e2e/test/kibana/checks_telemetry.go
@@ -1,0 +1,57 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kibana
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+)
+
+func MakeTelemetryRequest(kbBuilder Builder, k *test.K8sClient) ([]byte, error) {
+	kbVersion := version.MustParse(kbBuilder.Kibana.Spec.Version)
+	apiVersion, payload := apiVersionAndTelemetryRequestBody(kbVersion)
+	uri := fmt.Sprintf("/api/telemetry/%s/clusters/_stats", apiVersion)
+	password, err := k.GetElasticPassword(kbBuilder.ElasticsearchRef().NamespacedName())
+	if err != nil {
+		return nil, err
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	// this call may fail (status 500) if the .security-7 index is not fully initialized yet,
+	// in which case we'll just retry that test step
+	return DoRequest(k, kbBuilder.Kibana, password, "POST", uri, payloadBytes)
+
+}
+
+func apiVersionAndTelemetryRequestBody(kbVersion version.Version) (string, telemetryRequest) {
+	apiVersion := "v1"
+	payload := telemetryRequest{
+		TimeRange: &timeRange{},
+	}
+	if kbVersion.IsSameOrAfter(version.From(7, 2, 0)) {
+		apiVersion = "v2"
+		payload.Unencrypted = true
+	}
+	if kbVersion.IsSameOrAfter(version.From(7, 11, 0)) {
+		payload.TimeRange = nil // removed in 7.11
+	}
+	return apiVersion, payload
+}
+
+type timeRange struct {
+	Min int `json:"min"`
+	Max int `json:"max"`
+}
+
+// telemetryRequest is the request body for v1/v2 Kibana telemetry requests
+type telemetryRequest struct {
+	TimeRange   *timeRange `json:"timeRange,omitempty"`
+	Unencrypted bool       `json:"unencrypted,omitempty"`
+}

--- a/test/e2e/test/kibana/http_client.go
+++ b/test/e2e/test/kibana/http_client.go
@@ -19,6 +19,15 @@ import (
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 )
 
+type APIError struct {
+	StatusCode int
+	msg        string
+}
+
+func (e *APIError) Error() string {
+	return e.msg
+}
+
 func NewKibanaClient(kb kbv1.Kibana, k *test.K8sClient) (*http.Client, error) {
 	var caCerts []*x509.Certificate
 	if kb.Spec.HTTP.TLS.Enabled() {
@@ -70,7 +79,10 @@ func DoRequest(k *test.K8sClient, kb kbv1.Kibana, password string, method string
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf("fail to request %s, status is %d)", pathAndQuery, resp.StatusCode)
+		return nil, &APIError{
+			StatusCode: resp.StatusCode,
+			msg:        fmt.Sprintf("fail to request %s, status is %d)", pathAndQuery, resp.StatusCode),
+		}
 	}
 
 	defer resp.Body.Close()


### PR DESCRIPTION
Enable telemetry for the Kibana telemetry e2e tests. 

Add a new Kibana check step to verify that telemetry is off in all other cases (HTTP 404 on the telemetry API)