### PR TITLE
Allow handshake erros during transport TLS cert check

### DIFF
--- a/test/e2e/es/certs_test.go
+++ b/test/e2e/es/certs_test.go
@@ -158,7 +158,7 @@ func TestCustomTransportCA(t *testing.T) {
 						// transport certs are checked as part of stack checks now but let's run this step explicitly once more
 						// with the defined CA as a parameter to catch the case where both CA cert in the secret and presented
 						// certs on the nodes are not the ones defined by the user
-						return elasticsearch.MakeTransportTLSHandshake(initialCluster.Elasticsearch, ca.Cert)
+						return elasticsearch.CheckTransportCACertificate(initialCluster.Elasticsearch, ca.Cert)
 					}),
 				},
 			}


### PR DESCRIPTION
We only want to inspect the peer certificates to verify the expected CA is among them. A successful handshake is not necessary and it seems not possible without presenting a client certificate at least on single node clusters.

There is still at bit of research to be done to fully understand why a handshake is possible on multi-node clusters without a client certificate and also why it seems to be possible when port-forwarding. 