### PR TITLE
E2E test validate peer certificate chain during TLS handshake

### DIFF
--- a/test/e2e/es/certs_test.go
+++ b/test/e2e/es/certs_test.go
@@ -15,10 +15,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
-
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/dev/portforward"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"

--- a/test/e2e/test/elasticsearch/checks_transport.go
+++ b/test/e2e/test/elasticsearch/checks_transport.go
@@ -15,7 +15,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/services"
 	"github.com/elastic/cloud-on-k8s/pkg/dev/portforward"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/cryptutil"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	corev1 "k8s.io/api/core/v1"
@@ -25,24 +24,10 @@ import (
 // CheckTransportCACertificate attempts a TLS handshake to inspect the peer certificates presented by the Elasticsearch
 // node to verify the expected CA certificate is among them.
 func CheckTransportCACertificate(es esv1.Elasticsearch, ca *x509.Certificate) error {
-	certPool := x509.NewCertPool()
-	certPool.AddCert(ca)
-	config := tls.Config{
-		// add the CA cert to the pool to allow the successful handshake if the presented transport cert was
-		// signed by this CA
-		RootCAs: certPool,
-		// go requires either ServerName or InsecureSkipVerify (or both) when handshaking as a client since 1.3:
-		// https://github.com/golang/go/commit/fca335e91a915b6aae536936a7694c4a2a007a60
-		InsecureSkipVerify: true, // nolint:gosec
-	}
-	config.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-		_, _, err := cryptutil.VerifyCertificateExceptServerName(rawCerts, &config)
-		return err
-	}
 	host := services.ExternalTransportServiceHost(k8s.ExtractNamespacedName(&es))
-
 	var conn net.Conn
 	var err error
+
 	if test.Ctx().AutoPortForwarding {
 		conn, err = portforward.NewForwardingDialer().DialContext(context.Background(), "tcp", host)
 	} else {
@@ -51,15 +36,35 @@ func CheckTransportCACertificate(es esv1.Elasticsearch, ca *x509.Certificate) er
 	if err != nil {
 		return err
 	}
+
 	defer conn.Close()
-	client := tls.Client(conn, &config)
-	// Handshake can fail on single node clusters because we are not presenting a client certificate, but we are only
-	// interested in the peer certificates anyway so this is not considered a test failure.
-	err = client.Handshake()
-	for _, c := range client.ConnectionState().PeerCertificates {
-		if c.Equal(ca) {
-			return nil
+
+	config := tls.Config{
+		// go requires either ServerName or InsecureSkipVerify (or both) when handshaking as a client since 1.3:
+		// https://github.com/golang/go/commit/fca335e91a915b6aae536936a7694c4a2a007a60
+		InsecureSkipVerify: true, // nolint:gosec
+	}
+	var correctCAPresented bool
+	config.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		// we are not interested in a valid TLS handshake but only in the CA certs presented by the remote side
+		// there we only parse the peer certificate to compare with our expected CA cert. We cannot rely on
+		// tls.ConnectionState because it is only populated with the peer certificates after a successful handshake
+		for _, asn1Data := range rawCerts {
+			cert, err := x509.ParseCertificate(asn1Data)
+			if err != nil {
+				return fmt.Errorf("tls: failed to parse certificate from server: %w", err)
+			}
+			if cert.Equal(ca) {
+				correctCAPresented = true
+			}
 		}
+		return nil
+	}
+	client := tls.Client(conn, &config)
+	// handshake can fail on 6.x versions of Elasticsearch but we are only interested in the peer certificates
+	err = client.Handshake()
+	if correctCAPresented {
+		return nil
 	}
 	return fmt.Errorf("expected %v %s among peer certificates but was not found, handshake err %w", ca.Issuer, ca.SerialNumber, err)
 }

--- a/test/e2e/test/elasticsearch/checks_transport.go
+++ b/test/e2e/test/elasticsearch/checks_transport.go
@@ -47,7 +47,7 @@ func CheckTransportCACertificate(es esv1.Elasticsearch, ca *x509.Certificate) er
 	var correctCAPresented bool
 	config.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 		// we are not interested in a valid TLS handshake but only in the CA certs presented by the remote side
-		// there we only parse the peer certificate to compare with our expected CA cert. We cannot rely on
+		// therefore we only parse the peer certificate to compare with our expected CA cert. We cannot rely on
 		// tls.ConnectionState because it is only populated with the peer certificates after a successful handshake
 		for _, asn1Data := range rawCerts {
 			cert, err := x509.ParseCertificate(asn1Data)


### PR DESCRIPTION
Work around the issue that peer certificates are only populated in connection state after a successful handshake and that Elasticsearch 6.x is more restrictive when it comes to the presented client certificates. This is done by hooking into the TLS handshake and making sure the presented peer certificates can be validated against the expected CA certificate but do not require the full TLS handshake to succeed.


Tested with 6.x and 7.x.
