### PR TITLE
E2E adjust telemetry disablement for 6.x

### DIFF
--- a/pkg/controller/kibana/config_settings_test.go
+++ b/pkg/controller/kibana/config_settings_test.go
@@ -559,8 +559,18 @@ func TestIsTelemetryEnabled(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "no config: enabled",
+			name:    "no version: error",
 			args:    kbv1.Kibana{},
+			want:    true,
+			wantErr: true,
+		},
+		{
+			name: "no config: enabled",
+			args: kbv1.Kibana{
+				Spec: kbv1.KibanaSpec{
+					Version: "7.10.0",
+				},
+			},
 			want:    true,
 			wantErr: false,
 		},
@@ -568,16 +578,31 @@ func TestIsTelemetryEnabled(t *testing.T) {
 			name: "empty config: enabled",
 			args: kbv1.Kibana{
 				Spec: kbv1.KibanaSpec{
-					Config: &commonv1.Config{Data: map[string]interface{}{}},
+					Version: "7.10.0",
+					Config:  &commonv1.Config{Data: map[string]interface{}{}},
 				},
 			},
 			want:    true,
 			wantErr: false,
 		},
 		{
-			name: "explicitly enabled",
+			name: "explicitly enabled 6.x",
 			args: kbv1.Kibana{
 				Spec: kbv1.KibanaSpec{
+					Version: "6.8.0",
+					Config: &commonv1.Config{Data: map[string]interface{}{
+						"xpack.xpack_main.telemetry.enabled": true,
+					}},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "explicitly enabled 7.x",
+			args: kbv1.Kibana{
+				Spec: kbv1.KibanaSpec{
+					Version: "7.10.0",
 					Config: &commonv1.Config{Data: map[string]interface{}{
 						"telemetry.enabled": true,
 					}},
@@ -587,9 +612,23 @@ func TestIsTelemetryEnabled(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "explicitly disabled",
+			name: "explicitly disabled 6.x",
 			args: kbv1.Kibana{
 				Spec: kbv1.KibanaSpec{
+					Version: "6.8.0",
+					Config: &commonv1.Config{Data: map[string]interface{}{
+						"xpack.xpack_main.telemetry.enabled": false,
+					}},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "explicitly disabled 7.x",
+			args: kbv1.Kibana{
+				Spec: kbv1.KibanaSpec{
+					Version: "7.10.0",
 					Config: &commonv1.Config{Data: map[string]interface{}{
 						"telemetry.enabled": false,
 					}},

--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -5,6 +5,7 @@
 package kibana
 
 import (
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -175,8 +176,10 @@ func (b Builder) WithTelemetryEnabled(enabled bool) Builder {
 		}
 	}
 
+	ver := version.MustParse(b.Kibana.Spec.Version)
 	cfg := settings.MustCanonicalConfig(b.Kibana.Spec.Config.Data)
-	if err := cfg.MergeWith(settings.MustCanonicalConfig(kibana.TelemetrySetting{Enabled: enabled})); err != nil {
+	telemetrySetting := kibana.TelemetrySetting(ver)
+	if err := cfg.MergeWith(settings.MustCanonicalConfig(map[string]interface{}{telemetrySetting: enabled})); err != nil {
 		panic(err)
 	}
 

--- a/test/e2e/test/kibana/checks_kb.go
+++ b/test/e2e/test/kibana/checks_kb.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/pkg/errors"
@@ -85,7 +86,11 @@ func (check *kbChecks) CheckKbTelemetryStatus(b Builder) test.Step {
 					return nil
 				}
 			}
-			return fmt.Errorf("telemetry in Kibana should be enabled [%v] but got [%s]", shouldBeEnabled, err.Error())
+			return fmt.Errorf("telemetry in Kibana should be enabled [%v] but got [%w]", shouldBeEnabled, err)
 		}),
+		Skip: func() bool {
+			// Disabling telemetry does not disable the telemetry route in version 6.x
+			return version.MustParse(b.Kibana.Spec.Version).Major == 6
+		},
 	}
 }


### PR DESCRIPTION
Telemetry settings where namespaced below xpack in 6.x and had different effects than in 7.x. The telemetry API would still stay enabled even in the presence of the the setting.

I need to verify still that there no intermediate states in earlier 7.x versions (I tested 6.8 and 7.10)
