### PR TITLE
Return the appropriate apiVersion for CustomResourceDefinition

### DIFF
--- a/deploy/eck-operator/charts/eck-operator-crds/templates/_helpers.tpl
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/_helpers.tpl
@@ -31,6 +31,17 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Return the appropriate apiVersion for CustomResourceDefinition.
+*/}}
+{{- define "eck-operator-crds.CustomResourceDefinition.apiVersion" -}}
+{{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apiextensions.k8s.io/v1" -}}
+{{- else -}}
+{{- print "apiextensions.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "eck-operator-crds.labels" -}}

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: {{ template "eck-operator-crds.CustomResourceDefinition.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -278,7 +278,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: {{ template "eck-operator-crds.CustomResourceDefinition.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -756,7 +756,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: {{ template "eck-operator-crds.CustomResourceDefinition.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -1064,7 +1064,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: {{ template "eck-operator-crds.CustomResourceDefinition.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -2162,7 +2162,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: {{ template "eck-operator-crds.CustomResourceDefinition.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -2585,7 +2585,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: {{ template "eck-operator-crds.CustomResourceDefinition.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   annotations:


### PR DESCRIPTION
Fixing `helm lint` of the chart when using with k8s equal or greater then 1.18
