### PR TITLE
Fix Dockerfile to build the right executable for ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM --platform=$BUILDPLATFORM golang:1.15.6 as builder
+FROM --platform=$TARGETPLATFORM golang:1.15.6 as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
The platform argument used to select the base image should be derived from `$TARGETPLATFORM` instead of `$BUILDPLATFORM` (Docker website incorrectly uses the latter in its examples).

Fixes #4038 