### PR TITLE
Make Association status serialization backward compatible

### DIFF
--- a/pkg/apis/apm/v1/apmserver_types.go
+++ b/pkg/apis/apm/v1/apmserver_types.go
@@ -143,11 +143,11 @@ func (as *ApmServer) AssociationStatusMap(typ commonv1.AssociationType) commonv1
 	switch typ {
 	case commonv1.ElasticsearchAssociationType:
 		if as.Spec.ElasticsearchRef.IsDefined() {
-			return commonv1.NewAssociationStatusMap(as.Spec.ElasticsearchRef.WithDefaultNamespace(as.Namespace), as.Status.ElasticsearchAssociationStatus)
+			return commonv1.NewSingleAssociationStatusMap(as.Status.ElasticsearchAssociationStatus)
 		}
 	case commonv1.KibanaAssociationType:
 		if as.Spec.KibanaRef.IsDefined() {
-			return commonv1.NewAssociationStatusMap(as.Spec.KibanaRef.WithDefaultNamespace(as.Namespace), as.Status.KibanaAssociationStatus)
+			return commonv1.NewSingleAssociationStatusMap(as.Status.KibanaAssociationStatus)
 		}
 	}
 

--- a/pkg/apis/beat/v1beta1/beat_types.go
+++ b/pkg/apis/beat/v1beta1/beat_types.go
@@ -157,11 +157,11 @@ func (b *Beat) AssociationStatusMap(typ commonv1.AssociationType) commonv1.Assoc
 	switch typ {
 	case commonv1.ElasticsearchAssociationType:
 		if b.Spec.ElasticsearchRef.IsDefined() {
-			return commonv1.NewAssociationStatusMap(b.Spec.ElasticsearchRef.WithDefaultNamespace(b.Namespace), b.Status.ElasticsearchAssociationStatus)
+			return commonv1.NewSingleAssociationStatusMap(b.Status.ElasticsearchAssociationStatus)
 		}
 	case commonv1.KibanaAssociationType:
 		if b.Spec.KibanaRef.IsDefined() {
-			return commonv1.NewAssociationStatusMap(b.Spec.KibanaRef.WithDefaultNamespace(b.Namespace), b.Status.KibanaAssociationStatus)
+			return commonv1.NewSingleAssociationStatusMap(b.Status.KibanaAssociationStatus)
 		}
 	}
 

--- a/pkg/apis/common/v1/association_test.go
+++ b/pkg/apis/common/v1/association_test.go
@@ -213,6 +213,16 @@ func TestAssociationStatusMap_String(t *testing.T) {
 			wanted:    "",
 		},
 		{
+			name:      "single Established status, old behavior",
+			statusMap: NewSingleAssociationStatusMap(AssociationEstablished),
+			wanted:    "Established",
+		},
+		{
+			name:      "single Unknown status, old behavior",
+			statusMap: NewSingleAssociationStatusMap(AssociationUnknown),
+			wanted:    "",
+		},
+		{
 			name: "single established",
 			statusMap: map[string]AssociationStatus{
 				"ns/name": AssociationEstablished,

--- a/pkg/apis/enterprisesearch/v1beta1/enterprisesearch_types.go
+++ b/pkg/apis/enterprisesearch/v1beta1/enterprisesearch_types.go
@@ -132,7 +132,7 @@ func (ent *EnterpriseSearch) SetAssociationStatusMap(typ commonv1.AssociationTyp
 
 func (ent *EnterpriseSearch) AssociationStatusMap(typ commonv1.AssociationType) commonv1.AssociationStatusMap {
 	if typ == commonv1.ElasticsearchAssociationType && ent.Spec.ElasticsearchRef.IsDefined() {
-		return commonv1.NewAssociationStatusMap(ent.Spec.ElasticsearchRef.WithDefaultNamespace(ent.Namespace), ent.Status.Association)
+		return commonv1.NewSingleAssociationStatusMap(ent.Status.Association)
 	}
 
 	return commonv1.AssociationStatusMap{}

--- a/pkg/apis/kibana/v1/kibana_types.go
+++ b/pkg/apis/kibana/v1/kibana_types.go
@@ -102,7 +102,7 @@ func (k *Kibana) RequiresAssociation() bool {
 
 func (k *Kibana) AssociationStatusMap(typ commonv1.AssociationType) commonv1.AssociationStatusMap {
 	if typ == commonv1.ElasticsearchAssociationType && k.Spec.ElasticsearchRef.IsDefined() {
-		return commonv1.NewAssociationStatusMap(k.Spec.ElasticsearchRef.WithDefaultNamespace(k.Namespace), k.Status.AssociationStatus)
+		return commonv1.NewSingleAssociationStatusMap(k.Status.AssociationStatus)
 	}
 
 	return commonv1.AssociationStatusMap{}

--- a/test/e2e/apm/association_test.go
+++ b/test/e2e/apm/association_test.go
@@ -149,7 +149,7 @@ func TestAPMAssociationWhenReferencedESDisappears(t *testing.T) {
 						switch {
 						case evt.Type == corev1.EventTypeNormal && evt.Reason == events.EventAssociationStatusChange:
 							// build expected string and use it for comparisons with actual
-							establishedString := commonv1.NewAssociationStatusMap(esBuilder.Ref(), commonv1.AssociationEstablished).String()
+							establishedString := commonv1.NewSingleAssociationStatusMap(commonv1.AssociationEstablished).String()
 							prevStatusString, currStatusString := annotation.ExtractAssociationStatusStrings(evt.ObjectMeta)
 
 							if prevStatusString == establishedString && currStatusString != prevStatusString {

--- a/test/e2e/kb/association_test.go
+++ b/test/e2e/kb/association_test.go
@@ -106,7 +106,7 @@ func TestKibanaAssociationWhenReferencedESDisappears(t *testing.T) {
 						switch {
 						case evt.Type == corev1.EventTypeNormal && evt.Reason == events.EventAssociationStatusChange:
 							// build expected string and use it for comparisons with actual
-							establishedString := commonv1.NewAssociationStatusMap(esBuilder.Ref(), commonv1.AssociationEstablished).String()
+							establishedString := commonv1.NewSingleAssociationStatusMap(commonv1.AssociationEstablished).String()
 							prevStatus, currStatus := annotation.ExtractAssociationStatusStrings(evt.ObjectMeta)
 
 							if prevStatus == establishedString && currStatus != prevStatus {


### PR DESCRIPTION
E2E tests are failing on `TestAPMAssociationWhenReferencedESDisappears` (e.g. https://devops-ci.elastic.co/job/cloud-on-k8s-e2e-tests-aks/578/testReport/).

The reason for the failure is that event message changed after introducing multiple associations of the same type (#4036).

Previously, each event message contained only previous and current status (eg. `Pending`, `Established`). Now, `Status` for Agent CRD differs from others because it will also contain target namespaced name.

In the initial PR, Status serialization was generalized to support both single and multiple associations. 

Unfortunately, we should not be doing that because old CRDs don't carry the information about the reference target. Ie. we can't tell which target the Status is for. Initially, we implied that the Status is for the ref in the spec, but that's not always the case. For example, in the E2E test that's failing, we change ref namespace. Previously this produced:

`Association status changed from Established to Pending`

Now, the same message says:

`Association status changed from xxxx/es1: Established to xxxx/es1: Pending`

This is incorrect as `xxxx/es1` never existed and was never `Established`. We can't fix this without modifing old CRDs which we don't want to do for compatibility reasons. The best thing to do is to preserve the old behavior (the old message) even if it doesn't specify what was the target when status was `Established`.

For Agent, we do want to have full insight into the status. And we can have that because the `Status` itself carries the information about the target that status is for. In the similar situation as above, but for the Agent, we would have:

`Association status changed from default/es1: Established to xxxx/es1: Pending`

which gives the user all the information.

To achieve the above behavior, each Association that requires old behavior will create AssociationStatusMap that knows how to serialize itself to be backward compatible.
