### PR TITLE
Update kind tests to close gaps in test matrix

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -12,11 +12,12 @@ set -eou pipefail
 docker pull "$(make -C .ci --no-print-directory print-ci-image)"
 
 # Kind images (https://hub.docker.com/r/kindest/node/tags)
-docker pull kindest/node:v1.12.10
-docker pull kindest/node:v1.16.9
-docker pull kindest/node:v1.17.5
+# Pull exact images due to image incompatibility between kind 0.8 and 0.9 see https://github.com/kubernetes-sigs/kind/releases
+docker pull kindest/node:v1.12.10@sha256:faeb82453af2f9373447bb63f50bae02b8020968e0889c7fa308e19b348916cb
+docker pull kindest/node:v1.13.12@sha256:214476f1514e47fe3f6f54d0f9e24cfb1e4cda449529791286c7161b7f9c08e7
+docker pull kindest/node:v1.14.10@sha256:6cd43ff41ae9f02bb46c8f455d5323819aec858b99534a290517ebc181b443c6
+docker pull kindest/node:v1.15.11@sha256:6cc31f3533deb138792db2c7d1ffc36f7456a06f1db5556ad3b6927641016f50
+docker pull kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765
+docker pull kindest/node:v1.17.5@sha256:ab3f9e6ec5ad8840eeb1f76c89bb7948c77bbf76bcebe1a8b59790b8ae9a283a
+docker pull kindest/node:v1.18.2@sha256:7b27a6d0f2517ff88ba444025beae41491b016bc6af573ba467b70c5e8e0d85f
 
-# Elastic Stack images
-docker pull docker.elastic.co/elasticsearch/elasticsearch:7.8.0
-docker pull docker.elastic.co/kibana/kibana:7.8.0
-docker pull docker.elastic.co/apm/apm-server:7.8.0

--- a/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
@@ -47,6 +47,39 @@ pipeline {
                         }
                     }
                 }
+                stage("1.13.12") {
+                    agent {
+                        label 'eck'
+                    }
+                    steps {
+                        unstash "source"
+                        script {
+                            runTests(lib, failedTests, "kindest/node:v1.13.12", "1.13", "ipv4")
+                        }
+                    }
+                }
+                stage("1.14.10") {
+                    agent {
+                        label 'eck'
+                    }
+                    steps {
+                        unstash "source"
+                        script {
+                            runTests(lib, failedTests, "kindest/node:v1.14.10", "1.14", "ipv4")
+                        }
+                    }
+                }
+                stage("1.15.11") {
+                    agent {
+                        label 'eck'
+                    }
+                    steps {
+                        unstash "source"
+                        script {
+                            runTests(lib, failedTests, "kindest/node:v1.15.11", "1.15", "ipv4")
+                        }
+                    }
+                }
                 stage("1.16.9") {
                     agent {
                         label 'eck'
@@ -69,14 +102,25 @@ pipeline {
                         }
                     }
                 }
-                stage("1.17.5 IPv6") {
+                stage("1.18.2 IPv4") {
                     agent {
                         label 'eck'
                     }
                     steps {
                         unstash "source"
                         script {
-                            runTests(lib, failedTests, "kindest/node:v1.17.5", "1.17", "ipv6")
+                            runTests(lib, failedTests, "kindest/node:v1.18.2", "1.18", "ipv4")
+                        }
+                    }
+                }
+                stage("1.18.2 IPv6") {
+                    agent {
+                        label 'eck'
+                    }
+                    steps {
+                        unstash "source"
+                        script {
+                            runTests(lib, failedTests, "kindest/node:v1.18.2", "1.18", "ipv6")
                         }
                     }
                 }


### PR DESCRIPTION
Add 1.13,1.14, 1.15 and 1.18 to the tested versions. Stick with kind 0.8.0 for now

Remove stack image caching, which was out of date and I don't believe very useful given that we tests against multiple stack versions every day. 