### PR TITLE
Increase integration/unit test timeout to 10 seconds

### DIFF
--- a/pkg/utils/test/retry.go
+++ b/pkg/utils/test/retry.go
@@ -14,7 +14,7 @@ import (
 
 // Default values to be used for testing purpose.
 const (
-	Timeout       = time.Second * 5
+	Timeout       = time.Second * 10
 	RetryInterval = time.Millisecond * 100
 )
 


### PR DESCRIPTION
This increases the timeout used in the license and trial license integration tests as well as the observer tests to 10 seconds. My theory being that the immediately after booting the control plane for the integration tests it can take more than 5 seconds before reconciliation events reach the controllers. 

This should resolve https://github.com/elastic/cloud-on-k8s/issues/3495 and https://github.com/elastic/cloud-on-k8s/issues/3617