### PR TITLE
Do not delete StatefulSets associated to empty nodeSets

### DIFF
--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -1430,7 +1430,7 @@ spec:
                   count:
                     description: Count of Elasticsearch nodes to deploy.
                     format: int32
-                    minimum: 1
+                    minimum: 0
                     type: integer
                   name:
                     description: Name of this set of nodes. Becomes a part of the

--- a/config/crds/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
+++ b/config/crds/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
@@ -393,7 +393,7 @@ spec:
                     count:
                       description: Count of Elasticsearch nodes to deploy.
                       format: int32
-                      minimum: 1
+                      minimum: 0
                       type: integer
                     name:
                       description: Name of this set of nodes. Becomes a part of the

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -1454,7 +1454,7 @@ spec:
                   count:
                     description: Count of Elasticsearch nodes to deploy.
                     format: int32
-                    minimum: 1
+                    minimum: 0
                     type: integer
                   name:
                     description: Name of this set of nodes. Becomes a part of the

--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -197,7 +197,7 @@ type NodeSet struct {
 	Config *commonv1.Config `json:"config,omitempty"`
 
 	// Count of Elasticsearch nodes to deploy.
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	Count int32 `json:"count"`
 
 	// PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Pods belonging to this NodeSet.

--- a/pkg/controller/elasticsearch/driver/downscale.go
+++ b/pkg/controller/elasticsearch/driver/downscale.go
@@ -88,6 +88,7 @@ func calculateDownscales(
 	expectedStatefulSets sset.StatefulSetList,
 	actualStatefulSets sset.StatefulSetList,
 ) (downscales []ssetDownscale, deletions sset.StatefulSetList) {
+	expectedStatefulSetsNames := expectedStatefulSets.Names()
 	for _, actualSset := range actualStatefulSets {
 		actualReplicas := sset.GetReplicas(actualSset)
 		expectedSset, shouldExist := expectedStatefulSets.GetByName(actualSset.Name)
@@ -97,7 +98,7 @@ func calculateDownscales(
 		}
 
 		switch {
-		case actualReplicas == 0 && expectedReplicas == 0:
+		case !expectedStatefulSetsNames.Has(actualSset.Name) && actualReplicas == 0 && expectedReplicas == 0:
 			// the StatefulSet should not exist, and currently has no replicas
 			// it is safe to delete
 			deletions = append(deletions, actualSset)

--- a/pkg/controller/elasticsearch/sset/list.go
+++ b/pkg/controller/elasticsearch/sset/list.go
@@ -18,6 +18,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/set"
 )
 
 var log = logf.Log.WithName("statefulset")
@@ -45,6 +46,15 @@ func (l StatefulSetList) GetByName(ssetName string) (appsv1.StatefulSet, bool) {
 		}
 	}
 	return appsv1.StatefulSet{}, false
+}
+
+// Names returns the set of StatefulSets names.
+func (l StatefulSetList) Names() set.StringSet {
+	names := set.Make()
+	for _, statefulSet := range l {
+		names.Add(statefulSet.Name)
+	}
+	return names
 }
 
 // ObjectMetas returns a list of MetaObject from the StatefulSetList.


### PR DESCRIPTION
This PR prevents the Elasticsearch controller to delete a StatefulSet associated to an empty nodeSet.

Fix #4077 