### PR TITLE
Document Elastic Agent

### DIFF
--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -15,6 +15,7 @@ This page shows how to run ECK on OpenShift.
 * <<{p}-openshift-deploy-kibana>>
 * <<{p}-openshift-anyuid-workaround>>
 * <<{p}-openshift-beats>>
+* <<{p}-openshift-agent>>
 
 WARNING: Some Docker images are incompatible with the `restricted` SCC. This is the case for the *APM Server before 7.9* and for *Enterprise Search 7.9 and 7.10*. You can use this <<{p}-openshift-anyuid-workaround,workaround>> to run those images with the `anyuid` SCC.
 
@@ -324,3 +325,44 @@ spec:
 ----
 
 See the complete examples in the link:{eck_github}/tree/{eck_release_branch}/config/recipes/beats[recipes directory].
+
+
+[id="{p}-openshift-agent"]
+== Grant host access permission to Elastic Agent
+
+Deploying Elastic Agent on Openshift may require additional permissions depending on the type of link:https://www.elastic.co/guide/en/fleet/current/index.html[intergration] Elastic Agent is supposed to run. But in any case Elastic Agent uses a link:https://kubernetes.io/docs/concepts/storage/volumes/#hostpath[hostPath] volume as its data directory on OpenShift to maintain a stable identity. The Service Account used for Elastic Agent therefore needs permission to use hostPath volumes.
+
+
+The following example assumes that Elastic Agent is deployed in the Namespace `elastic` with the ServiceAccount `elastic-agent`. You can replace these values according to your environment.
+
+NOTE: If you used the examples from the link:{eck_github}/tree/{eck_release_branch}/config/recipes/elastic-agent[recipes directory], the ServiceAccount may already exist.
+
+. Create a dedicated ServiceAccount:
++
+[source,shell]
+----
+oc create serviceaccount elastic-agent -n elastic
+----
+. Add the ServiceAccount to the required SCC:
++
+[source,shell]
+----
+oc adm policy add-scc-to-user hostaccess -z elastic-agent -n elastic
+----
+. Update the Elastic Agent manifest to use the new ServiceAccount, for example:
++
+[source,yaml,subs="attributes"]
+----
+aapiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: my-agent
+spec:
+  version: {version}
+  daemonSet:
+    podTemplate:
+      spec:
+        serviceAccountName: elastic-agent
+----
+
+

--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -330,7 +330,7 @@ See the complete examples in the link:{eck_github}/tree/{eck_release_branch}/con
 [id="{p}-openshift-agent"]
 == Grant host access permission to Elastic Agent
 
-Deploying Elastic Agent on Openshift may require additional permissions depending on the type of link:https://www.elastic.co/guide/en/fleet/current/index.html[intergration] Elastic Agent is supposed to run. But in any case Elastic Agent uses a link:https://kubernetes.io/docs/concepts/storage/volumes/#hostpath[hostPath] volume as its data directory on OpenShift to maintain a stable identity. The Service Account used for Elastic Agent therefore needs permission to use hostPath volumes.
+Deploying Elastic Agent on Openshift may require additional permissions depending on the type of link:https://www.elastic.co/guide/en/fleet/current/index.html[intergration] Elastic Agent is supposed to run. In any case, Elastic Agent uses a link:https://kubernetes.io/docs/concepts/storage/volumes/#hostpath[hostPath] volume as its data directory on OpenShift to maintain a stable identity. Therefore, the Service Account used for Elastic Agent needs permissions to use hostPath volumes.
 
 
 The following example assumes that Elastic Agent is deployed in the Namespace `elastic` with the ServiceAccount `elastic-agent`. You can replace these values according to your environment.
@@ -364,5 +364,4 @@ spec:
       spec:
         serviceAccountName: elastic-agent
 ----
-
 

--- a/docs/orchestrating-elastic-stack-applications/agent.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent.asciidoc
@@ -1,0 +1,403 @@
+:page_id: elastic-agent
+:agent_recipes: https://raw.githubusercontent.com/elastic/cloud-on-k8s/{eck_release_branch}/config/recipes/elastic-agent
+ifdef::env-github[]
+****
+link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-{page_id}.html[View this document on the Elastic website]
+****
+endif::[]
+[id="{p}-{page_id}"]
+= Run Elastic Agent on ECK
+
+experimental[]
+
+This section describes how to configure and deploy Elastic Agent in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[standalone mode] with ECK.
+
+NOTE: Please note that link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html[enrollment in Fleet] is currently not supported.
+
+
+
+* <<{p}-elastic-agent-quickstart,Quickstart>>
+* <<{p}-elastic-agent-configuration,Configuration>>
+* <<{p}-elastic-agent-configuration-examples,Configuration Examples>>
+
+[id="{p}-elastic-agent-quickstart"]
+== Quickstart
+
+experimental[]
+
+. Apply the following specification to deploy Elastic Agent with the System metrics integration to harvest CPU metrics from the Agent Pods. ECK automatically configures the secured connection to an Elasticsearch cluster named `quickstart`, created in the link:k8s-quickstart.html[Elasticsearch quickstart].
++
+[source,yaml,subs="attributes,+macros"]
+----
+cat $$<<$$EOF | kubectl apply -f -
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: quickstart
+spec:
+  version: {version}
+  elasticsearchRefs:
+  - name: quickstart
+  daemonSet: {}
+  config:
+    inputs:
+      - name: system-1
+        revision: 1
+        type: system/metrics
+        use_output: default
+        meta:
+          package:
+            name: system
+            version: 0.9.1
+        data_stream:
+          namespace: default
+        streams:
+          - id: system/metrics-system.cpu
+            data_stream:
+              dataset: system.cpu
+              type: metrics
+            metricsets:
+              - cpu
+            cpu.metrics:
+              - percentages
+              - normalized_percentages
+            period: 10s
+EOF
+----
++
+See <<{p}-elastic-agent-configuration-examples>> for more ready-to-use manifests.
+
+. Monitor Elastic Agent.
++
+Retrieve the status of Elastic Agent.
++
+[source,sh]
+----
+kubectl get agent
+----
++
+[source,sh,subs="attributes"]
+----
+NAME            HEALTH   AVAILABLE   EXPECTED   VERSION   AGE
+quickstart      green    3           3          {version}    15s
+
+----
+
+. List all the Pods belonging to a given Elastic Agent specification.
++
+[source,sh]
+----
+kubectl get pods --selector='agent.k8s.elastic.co/name=quickstart'
+----
++
+[source,sh]
+----
+NAME                     READY   STATUS    RESTARTS   AGE
+quickstart-agent-6bcxr   1/1     Running   0          68s
+quickstart-agent-t49fd   1/1     Running   0          68s
+quickstart-agent-zqp55   1/1     Running   0          68s
+----
+
+. Access logs for one of the Pods.
++
+[source,sh]
+----
+kubectl logs -f quickstart-agent-6bcxr
+----
+
+. Access the CPU metrics ingested by Elastic Agent.
++
+You have two options:
++
+- Follow the Elasticsearch deployment <<{p}-deploy-elasticsearch,guide>> and run:
++
+[source,sh]
+----
+curl -u "elastic:$PASSWORD" -k "https://localhost:9200/metrics-system.cpu-*/_search"
+----
++
+- Follow the Kibana deployment <<{p}-deploy-kibana,guide>>, log in and go to *Kibana* > *Discover*.
+
+[id="{p}-elastic-agent-configuration"]
+== Configuration
+
+experimental[]
+
+
+[id="{p}-elastic-agent-upgrade-specification"]
+=== Upgrade the Elastic Agent specification
+
+You can upgrade the Elastic Agent version or change settings by editing the YAML specification. ECK applies the changes by performing a rolling restart of the Agent's Pods. Depending on the settings that you used, ECK will set the <<{p}-elastic-agent-set-output,outputs>> part of the configuration or restart Elastic Agent on certificate rollover.
+
+[id="{p}-elastic-agent-custom-configuration"]
+=== Customize Elastic Agent configuration
+
+The Elastic Agent configuration is defined in the `config` element:
+
+[source,yaml,subs="attributes,+macros"]
+----
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: quickstart
+spec:
+  version: {version}
+  elasticsearchRefs:
+  - name: quickstart
+  daemonSet: {}
+  config:
+    inputs:
+      - name: system-1
+        revision: 1
+        type: system/metrics
+        use_output: default
+        meta:
+          package:
+            name: system
+            version: 0.9.1
+        data_stream:
+          namespace: default
+        streams:
+          - id: system/metrics-system.cpu
+            data_stream:
+              dataset: system.cpu
+              type: metrics
+            metricsets:
+              - cpu
+            cpu.metrics:
+              - percentages
+              - normalized_percentages
+            period: 10s
+----
+
+Alternatively, it can be provided via a Secret specified in the `configRef` element. The Secret must have an `agent.yml` entry with the configuration:
+[source,yaml,subs="attributes,+macros"]
+----
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: quickstart
+spec:
+  version: {version}
+  elasticsearchRefs:
+  - name: quickstart
+  daemonSet: {}
+  configRef:
+    secretName: system-cpu-config
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: system-cpu-config
+stringData:
+  agent.yml: |-
+    inputs:
+      - name: system-1
+        revision: 1
+        type: system/metrics
+        use_output: default
+        meta:
+          package:
+            name: system
+            version: 0.9.1
+        data_stream:
+          namespace: default
+        streams:
+          - id: system/metrics-system.cpu
+            data_stream:
+              dataset: system.cpu
+              type: metrics
+            metricsets:
+              - cpu
+            cpu.metrics:
+              - percentages
+              - normalized_percentages
+            period: 10s
+----
+
+For more details especially on how to generate configuration for Elastic Agent in standalone mode, see the link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[Elastic Agent standalone] documentation.
+
+
+[id="{p}-elastic-agent-multi-output"]
+=== Use multiple Elastic Agent outputs
+
+Elastic Agent supports the use of multiple outputs. The `elasticsearchRefs` element accepts therefore multiple references to Elasticsearch clusters. ECK populates the outputs section of the Elastic Agent configuration based on those references. If you configure more than one output you also have to specify a unique `outputName` attribute.
+
+To send Elastic Agent's internal monitoring and log data to a different Elasticsearch cluster called `agent-monitoring` and the harvested metrics to our `quickstart` cluster define two `elasticsearchRefs` as follows (abbreviated example):
+
+[source,yaml,subs="attributes,+macros"]
+----
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: quickstart
+spec:
+  version: 7.10.1
+  daemonSet: {}
+  elasticsearchRefs:
+  - name: quickstart
+    outputName: default
+  - name: agent-monitoring
+    outputName: monitoring
+  config:
+    agent:
+      monitoring:
+        enabled: true
+        use_output: monitoring
+        logs: true
+        metrics: true
+    inputs:
+      - name: system-1
+        revision: 1
+        type: system/metrics
+        use_output: default
+...
+----
+
+
+[id="{p}-elastic-agent-set-output"]
+=== Manually set Elastic Agent outputs
+
+If the `elasticsearchRefs` element is specified, ECK populates the outputs section of the Elastic Agent configuration. ECK creates a user with appropriate roles and permissions and uses its credentials. If required, it also mounts the CA certificate in all Agent Pods, and recreates Pods when this certificate changes.
+
+The outputs can also be set manually.  To do that, remove the `elasticsearchRefs` element from the specification and include an appropriate output configuration in the `config` or indirectly via the `configRef` mechanism.
+
+[source,yaml,subs="attributes,+macros"]
+----
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: quickstart
+spec:
+  version: 7.10.1
+  daemonSet: {}
+  config:
+    outputs:
+      default:
+        type: elasticsearch
+        hosts:
+          - "https://my-custom-elasticsearch-cluster.cloud.elastic.co:9243"
+        password: ES_PASSWORD
+        username: ES_USER
+...
+----
+
+[id="{p}-elastic-agent-chose-the-deployment-model"]
+=== Choose the deployment model
+
+Depending on the use case, Elastic Agent may need to be deployed as a link:https://kubernetes.io/docs/concepts/workloads/controllers/deployment/[Deployment] or a link:https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/[DaemonSet]. Provide a `podTemplate` element under either the `deployment` or the `daemonSet` element in the specification to choose how your Elastic Agents should be deployed. When choosing the `deployment` option you can additionally specify the link:https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy[strategy] used to replace old Pods with new ones.
+
+Similarily you can set the link:https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/[update strategy] when deploying as a DaemonSet. This allows for example to control the rollout speed for new configuration by modifying the `maxUnavailable` setting:
+
+[source,yaml,subs="attributes,+macros"]
+----
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: quickstart
+spec:
+  version: 7.10.1
+  daemonSet:
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 3
+...
+----
+
+
+[id="{p}-elastic-agent-role-based-access-control"]
+=== Role Based Access Control for Elastic Agent
+
+Some Elastic Agent features (such as the link:https://epr.elastic.co/package/kubernetes/0.2.8/[Kubernetes integration]) require that Agent Pods interact with Kubernetes APIs. Specific permissions are needed to allow this functionality. Standard Kubernetes link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/[RBAC] rules apply. For example, to allow API interactions:
+
+[source,yaml,subs="attributes,+macros"]
+----
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: elastic-agent
+spec:
+  version: 7.10.1
+  elasticsearchRefs:
+  - name: elasticsearch
+  daemonSet:
+    podTemplate:
+      spec:
+        automountServiceAccountToken: true
+        serviceAccountName: elastic-agent
+...
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: elastic-agent
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources:
+  - namespaces
+  - pods
+  - nodes
+  - nodes/metrics
+  - nodes/proxy
+  - nodes/stats
+  - events
+  verbs:
+  - get
+  - watch
+  - list
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+  - watch
+  - list
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: elastic-agent
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: elastic-agent
+subjects:
+- kind: ServiceAccount
+  name: elastic-agent
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: elastic-agent
+  apiGroup: rbac.authorization.k8s.io
+----
+
+
+[id="{p}-elastic-agent-configuration-examples"]
+== Configuration Examples
+
+experimental[]
+
+Below you can find manifests that illustrate  common use cases and can be your starting point in exploring Elastic Agent deployed with ECK. These manifests are self-contained and work out-of-the-box on any non-secured Kubernetes cluster. They all contain a three-node Elasticsearch cluster and a single Kibana instance. Add the corresponding integration package to Kibana to install the dashboards foreach of these examples as described in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[the Elastic Agent documentation]
+
+CAUTION: The examples in this section are for illustration purposes only and should not be considered to be production-ready. Some of these examples use the `node.store.allow_mmap: false` setting which has performance implications and should be tuned for production workloads, as described in <<{p}-virtual-memory>>.
+
+
+=== System integration
+
+[source,sh,subs="attributes"]
+----
+kubectl apply -f {agent_recipes}/system-integration.yaml
+----
+
+Deploys Elastic Agent as a DaemonSet in standalone mode with system integration enabled. Collects syslog logs, auth logs and system metrics (for CPU, I/O, filesystem, memory, network, process and others).
+
+=== Kubernetes integration
+
+[source,sh,subs="attributes"]
+----
+kubectl apply -f {agent_recipes}/kubernetes-integration.yaml
+----
+
+Deploys Elastic Agent as a DaemonSet in standalone mode with Kubernetes integration enabled. Collects API server, Container, Event, Node, Pod, Volume and system metrics.

--- a/docs/orchestrating-elastic-stack-applications/agent.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent.asciidoc
@@ -12,7 +12,7 @@ experimental[]
 
 This section describes how to configure and deploy Elastic Agent in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[standalone mode] with ECK.
 
-NOTE: Please note that using link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html in [Fleet] to manage your Elastic Agents is currently not supported.
+NOTE: Please note that using link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html[Fleet] to manage your Elastic Agents is currently not supported.
 
 
 

--- a/docs/orchestrating-elastic-stack-applications/agent.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent.asciidoc
@@ -12,7 +12,7 @@ experimental[]
 
 This section describes how to configure and deploy Elastic Agent in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[standalone mode] with ECK.
 
-NOTE: Please note that using link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html[Fleet] to manage your Elastic Agents is currently not supported.
+NOTE: Using link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html[Fleet] to manage your Elastic Agents is currently not supported.
 
 
 
@@ -127,7 +127,7 @@ experimental[]
 [id="{p}-elastic-agent-upgrade-specification"]
 === Upgrade the Elastic Agent specification
 
-You can upgrade the Elastic Agent version or change settings by editing the YAML specification. ECK applies the changes by performing a rolling restart of the Agent's Pods. Depending on the settings that you used, ECK will set the <<{p}-elastic-agent-set-output,outputs>> part of the configuration or restart Elastic Agent on certificate rollover.
+You can upgrade the Elastic Agent version or change settings by editing the YAML specification. ECK applies the changes by performing a rolling restart of the Agent's Pods. Depending on the settings that you used, ECK will set the <<{p}-elastic-agent-set-output,outputs>> part of the configuration, or restart Elastic Agent on certificate rollover.
 
 [id="{p}-elastic-agent-custom-configuration"]
 === Customize Elastic Agent configuration
@@ -221,9 +221,9 @@ You can use the Fleet application in Kibana to generate configuration for Elasti
 [id="{p}-elastic-agent-multi-output"]
 === Use multiple Elastic Agent outputs
 
-Elastic Agent supports the use of multiple outputs. The `elasticsearchRefs` element accepts therefore multiple references to Elasticsearch clusters. ECK populates the outputs section of the Elastic Agent configuration based on those references. If you configure more than one output you also have to specify a unique `outputName` attribute.
+Elastic Agent supports the use of multiple outputs. Therefore, the `elasticsearchRefs` element accepts multiple references to Elasticsearch clusters. ECK populates the outputs section of the Elastic Agent configuration based on those references. If you configure more than one output, you also have to specify a unique `outputName` attribute.
 
-To send Elastic Agent's internal monitoring and log data to a different Elasticsearch cluster called `agent-monitoring` in the `elastic-monitoring` namespace and the harvested metrics to our `quickstart` cluster, define two `elasticsearchRefs` as follows (abbreviated example):
+To send Elastic Agent's internal monitoring and log data to a different Elasticsearch cluster called `agent-monitoring` in the `elastic-monitoring` namespace, and the harvested metrics to our `quickstart` cluster, you have to define two `elasticsearchRefs` as shown in the following abbreviated example:
 
 [source,yaml,subs="attributes,+macros"]
 ----
@@ -261,7 +261,7 @@ spec:
 
 If the `elasticsearchRefs` element is specified, ECK populates the outputs section of the Elastic Agent configuration. ECK creates a user with appropriate roles and permissions and uses its credentials. If required, it also mounts the CA certificate in all Agent Pods, and recreates Pods when this certificate changes.
 
-The outputs can also be set manually.  To do that, remove the `elasticsearchRefs` element from the specification and include an appropriate output configuration in the `config` or indirectly via the `configRef` mechanism.
+The outputs can also be set manually. To do that, remove the `elasticsearchRefs` element from the specification and include an appropriate output configuration in the `config`, or indirectly via the `configRef` mechanism.
 
 [source,yaml,subs="attributes,+macros"]
 ----
@@ -288,7 +288,7 @@ spec:
 
 Depending on the use case, Elastic Agent may need to be deployed as a link:https://kubernetes.io/docs/concepts/workloads/controllers/deployment/[Deployment] or a link:https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/[DaemonSet]. Provide a `podTemplate` element under either the `deployment` or the `daemonSet` element in the specification to choose how your Elastic Agents should be deployed. When choosing the `deployment` option you can additionally specify the link:https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy[strategy] used to replace old Pods with new ones.
 
-Similarily you can set the link:https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/[update strategy] when deploying as a DaemonSet. This allows for example to control the rollout speed for new configuration by modifying the `maxUnavailable` setting:
+Similarly, you can set the link:https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/[update strategy] when deploying as a DaemonSet. This allows you to control the rollout speed for new configuration by modifying the `maxUnavailable` setting:
 
 [source,yaml,subs="attributes,+macros"]
 ----
@@ -311,7 +311,7 @@ See <<{p}-compute-resources-beats-agent>> for more information on how to use the
 [id="{p}-elastic-agent-role-based-access-control"]
 === Role Based Access Control for Elastic Agent
 
-Some Elastic Agent features (such as the link:https://epr.elastic.co/package/kubernetes/0.2.8/[Kubernetes integration]) require that Agent Pods interact with Kubernetes APIs. Specific permissions are needed to allow this functionality. Standard Kubernetes link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/[RBAC] rules apply. For example, to allow API interactions:
+Some Elastic Agent features, such as the link:https://epr.elastic.co/package/kubernetes/0.2.8/[Kubernetes integration], require that Agent Pods interact with Kubernetes APIs. This functionality requires specific permissions. Standard Kubernetes link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/[RBAC] rules apply. For example, to allow API interactions:
 
 [source,yaml,subs="attributes,+macros"]
 ----
@@ -386,7 +386,7 @@ To deploy Elastic Agent in clusters with the Pod Security Policy admission contr
 
 experimental[]
 
-Below you can find manifests that illustrate  common use cases and can be your starting point in exploring Elastic Agent deployed with ECK. These manifests are self-contained and work out-of-the-box on any non-secured Kubernetes cluster. They all contain a three-node Elasticsearch cluster and a single Kibana instance. Add the corresponding integration package to Kibana to install the dashboards, visualisations and other assets for each of these examples as described in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[the Elastic Agent documentation].
+This section contains manifests that illustrate common use cases, and can be your starting point in exploring Elastic Agent deployed with ECK. These manifests are self-contained and work out-of-the-box on any non-secured Kubernetes cluster. They all contain a three-node Elasticsearch cluster and a single Kibana instance. Add the corresponding integration package to Kibana to install the dashboards, visualizations and other assets for each of these examples as described in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[the Elastic Agent documentation].
 
 CAUTION: The examples in this section are for illustration purposes only and should not be considered to be production-ready. Some of these examples use the `node.store.allow_mmap: false` setting which has performance implications and should be tuned for production workloads, as described in <<{p}-virtual-memory>>.
 

--- a/docs/orchestrating-elastic-stack-applications/agent.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent.asciidoc
@@ -306,6 +306,7 @@ spec:
 ...
 ----
 
+See <<{p}-compute-resources-beats-agent>> for more information on how to use the Pod template to adjust the resources given to Elastic Agent.
 
 [id="{p}-elastic-agent-role-based-access-control"]
 === Role Based Access Control for Elastic Agent

--- a/docs/orchestrating-elastic-stack-applications/agent.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent.asciidoc
@@ -12,7 +12,7 @@ experimental[]
 
 This section describes how to configure and deploy Elastic Agent in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[standalone mode] with ECK.
 
-NOTE: Please note that link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html[enrollment in Fleet] is currently not supported.
+NOTE: Please note that using link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html in [Fleet] to manage your Elastic Agents is currently not supported.
 
 
 

--- a/docs/orchestrating-elastic-stack-applications/agent.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent.asciidoc
@@ -215,7 +215,7 @@ stringData:
             period: 10s
 ----
 
-For more details especially on how to generate configuration for Elastic Agent in standalone mode, see the link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[Elastic Agent standalone] documentation.
+You can use the Fleet application in Kibana to generate configuration for Elastic Agent even when running in standalone mode, see the link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[Elastic Agent standalone] documentation.  Adding the corresponding integration package to Kibana also adds the related dashboards and visualizations.
 
 
 [id="{p}-elastic-agent-multi-output"]
@@ -223,7 +223,7 @@ For more details especially on how to generate configuration for Elastic Agent i
 
 Elastic Agent supports the use of multiple outputs. The `elasticsearchRefs` element accepts therefore multiple references to Elasticsearch clusters. ECK populates the outputs section of the Elastic Agent configuration based on those references. If you configure more than one output you also have to specify a unique `outputName` attribute.
 
-To send Elastic Agent's internal monitoring and log data to a different Elasticsearch cluster called `agent-monitoring` and the harvested metrics to our `quickstart` cluster define two `elasticsearchRefs` as follows (abbreviated example):
+To send Elastic Agent's internal monitoring and log data to a different Elasticsearch cluster called `agent-monitoring` in the `elastic-monitoring` namespace and the harvested metrics to our `quickstart` cluster, define two `elasticsearchRefs` as follows (abbreviated example):
 
 [source,yaml,subs="attributes,+macros"]
 ----
@@ -232,12 +232,13 @@ kind: Agent
 metadata:
   name: quickstart
 spec:
-  version: 7.10.1
+  version: {version}
   daemonSet: {}
   elasticsearchRefs:
   - name: quickstart
     outputName: default
   - name: agent-monitoring
+    namespace: elastic-monitoring
     outputName: monitoring
   config:
     agent:
@@ -269,7 +270,7 @@ kind: Agent
 metadata:
   name: quickstart
 spec:
-  version: 7.10.1
+  version: {version}
   daemonSet: {}
   config:
     outputs:
@@ -296,7 +297,7 @@ kind: Agent
 metadata:
   name: quickstart
 spec:
-  version: 7.10.1
+  version: {version}
   daemonSet:
     strategy:
       type: RollingUpdate
@@ -318,7 +319,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 7.10.1
+  version: {version}
   elasticsearchRefs:
   - name: elasticsearch
   daemonSet:
@@ -372,6 +373,11 @@ roleRef:
   name: elastic-agent
   apiGroup: rbac.authorization.k8s.io
 ----
+
+[id="{p}-elastic-agent-deploying-in-secured-clusters"]
+=== Deploying Elastic Agent in secured clusters
+
+To deploy Elastic Agent in clusters with the Pod Security Policy admission controller enabled, or in <<{p}-openshift-agent,OpenShift>> clusters, you might need to grant additional permissions to the Service Account used by the Elastic Agent Pods. Those Service Accounts must be bound to a Role or ClusterRole that has `use` permission for the required Pod Security Policy or Security Context Constraints. Different Elastic Agent integrations might require different settings set in their PSP/link:{p}-openshift-agent.html[SCC].
 
 
 [id="{p}-elastic-agent-configuration-examples"]

--- a/docs/orchestrating-elastic-stack-applications/agent.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent.asciidoc
@@ -379,7 +379,7 @@ roleRef:
 
 experimental[]
 
-Below you can find manifests that illustrate  common use cases and can be your starting point in exploring Elastic Agent deployed with ECK. These manifests are self-contained and work out-of-the-box on any non-secured Kubernetes cluster. They all contain a three-node Elasticsearch cluster and a single Kibana instance. Add the corresponding integration package to Kibana to install the dashboards foreach of these examples as described in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[the Elastic Agent documentation]
+Below you can find manifests that illustrate  common use cases and can be your starting point in exploring Elastic Agent deployed with ECK. These manifests are self-contained and work out-of-the-box on any non-secured Kubernetes cluster. They all contain a three-node Elasticsearch cluster and a single Kibana instance. Add the corresponding integration package to Kibana to install the dashboards, visualisations and other assets for each of these examples as described in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[the Elastic Agent documentation].
 
 CAUTION: The examples in this section are for illustration purposes only and should not be considered to be production-ready. Some of these examples use the `node.store.allow_mmap: false` setting which has performance implications and should be tuned for production workloads, as described in <<{p}-virtual-memory>>.
 

--- a/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
@@ -93,6 +93,63 @@ spec:
 For the container name, you can use `apm-server` or `kibana` as appropriate.
 
 [float]
+[id="{p}-compute-resources-beats-agent"]
+=== Set compute resources for Beats and Elastic Agent
+
+For Beats or Elastic Agent objects, the `podTemplate` can be configured as follows, depending on the chosen deployment model.
+
+When deploying as a Kubernetes Deployment:
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: beat.k8s.elastic.co/v1beta1
+kind: Beat
+metadata:
+  name: quickstart
+spec:
+  type: filebeat
+  version: {version}
+  deployment:
+    podTemplate:
+      spec:
+        containers:
+        - name: filebeat
+          resources:
+            requests:
+              memory: 300Mi
+              cpu: 0.5
+            limits:
+              memory: 500Mi
+              cpu: 0.5
+----
+
+When deploying as a Kubernetes DaemonSet:
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: elastic-agent
+spec:
+  version: {version}
+  daemonSet:
+    podTemplate:
+      spec:
+        containers:
+        - name: agent
+          resources:
+            requests:
+              memory: 300Mi
+              cpu: 0.5
+            limits:
+              memory: 300Mi
+              cpu: 0.5
+----
+
+For the container name, you have to use the name of the Beat in lower case e.g. `filebeat`, `metricbeat` or `heartbeat` or in case of Elastic Agent just `agent`.
+
+[float]
 [id="{p}-default-behavior"]
 == Default behavior
 
@@ -105,6 +162,8 @@ If `resources` is not defined in the specification of an object, then the operat
 |APM Server |512Mi |512Mi
 |Elasticsearch |2Gi |2Gi
 |Kibana |1Gi |1Gi
+|Beat   |200Mi | 200Mi
+|Elastic Agent | 200Mi|200Mi
 |===
 
 If the Kubernetes cluster is configured with https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/[LimitRanges] that enforce a minimum memory constraint, they could interfere with the operator defaults and cause object creation to fail.

--- a/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
@@ -147,7 +147,7 @@ spec:
               cpu: 0.5
 ----
 
-For the container name, you have to use the name of the Beat in lower case e.g. `filebeat`, `metricbeat` or `heartbeat` or in case of Elastic Agent just `agent`.
+For the container name, use the name of the Beat in lower case. For example `filebeat`, `metricbeat`, or `heartbeat`. In case of Elastic Agent, use `agent`.
 
 [float]
 [id="{p}-default-behavior"]

--- a/docs/orchestrating-elastic-stack-applications/orchestrating-elastic-stack-applications.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/orchestrating-elastic-stack-applications.asciidoc
@@ -12,6 +12,7 @@ endif::[]
 - <<{p}-elasticsearch-specification>>
 - <<{p}-kibana>>
 - <<{p}-apm-server>>
+- <<{p}-elastic-agent>>
 - <<{p}-enterprise-search>>
 - <<{p}-beat>>
 - <<{p}-securing-stack>>
@@ -25,6 +26,7 @@ endif::[]
 include::elasticsearch-specification.asciidoc[leveloffset=+1]
 include::kibana.asciidoc[leveloffset=+1]
 include::apm-server.asciidoc[leveloffset=+1]
+include::agent.asciidoc[leveloffset=+1]
 include::enterprise-search.asciidoc[leveloffset=+1]
 include::beat.asciidoc[leveloffset=+1]
 include::securing-stack.asciidoc[leveloffset=+1]


### PR DESCRIPTION
Add basic documentation for Elastic Agent. The examples imply that #4107 is fixed. 

A few open questions: 
* I am currently linking to the standalone Agent documentation a lot to illustrate how to generate configuration for the standalone mode. But that page also contains a quite a few steps that are irrelevant and maybe confusing for people using Agent from ECK (everything to do with installing Elastic Agent). We could alternatively replicate that part of the Agent docs that show how to extract configuration from the Fleet UI in the ECK docs
* ~I have removed all bits that handle setting up privileged containers in OCP or secured clusters in general as I currently don't see a strong use case for that with Agent (maybe with the exception of a custom log harvesting setup using host volumes)~ I have changed my mind here and added section on how to give hostaccess on OpenShift given that we always use a hostPath volume. This is somewhat redundant with the Beats section but I added it nonetheless for visibility and because I was not sure if the casual reader would make the mental leap that the same instructions apply to Agent as well. 


Preview https://cloud-on-k8s_4109.docs-preview.app.elstc.co/guide/en/cloud-on-k8s/master/k8s-elastic-agent.html