### PR TITLE
Add finalizer RBAC for Elastic Agent

### DIFF
--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -612,6 +612,7 @@ rules:
   resources:
   - agents
   - agents/status
+  - agents/finalizers
   verbs:
   - get
   - list

--- a/config/e2e/operator.yaml
+++ b/config/e2e/operator.yaml
@@ -149,6 +149,7 @@ rules:
   resources:
   - agents
   - agents/status
+  - agents/finalizers
   verbs:
   - get
   - list

--- a/deploy/eck-operator/templates/_helpers.tpl
+++ b/deploy/eck-operator/templates/_helpers.tpl
@@ -210,7 +210,7 @@ RBAC permissions
   resources:
   - elasticsearches
   - elasticsearches/status
-  - elasticsearches/finalizers
+  - elasticsearches/finalizers # needed for ownerReferences with blockOwnerDeletion on OCP
   - enterpriselicenses
   - enterpriselicenses/status
   verbs:
@@ -226,7 +226,7 @@ RBAC permissions
   resources:
   - kibanas
   - kibanas/status
-  - kibanas/finalizers
+  - kibanas/finalizers # needed for ownerReferences with blockOwnerDeletion on OCP
   verbs:
   - get
   - list
@@ -240,7 +240,7 @@ RBAC permissions
   resources:
   - apmservers
   - apmservers/status
-  - apmservers/finalizers
+  - apmservers/finalizers # needed for ownerReferences with blockOwnerDeletion on OCP
   verbs:
   - get
   - list
@@ -254,7 +254,7 @@ RBAC permissions
   resources:
   - enterprisesearches
   - enterprisesearches/status
-  - enterprisesearches/finalizers
+  - enterprisesearches/finalizers # needed for ownerReferences with blockOwnerDeletion on OCP
   verbs:
   - get
   - list
@@ -268,7 +268,7 @@ RBAC permissions
   resources:
   - beats
   - beats/status
-  - beats/finalizers
+  - beats/finalizers # needed for ownerReferences with blockOwnerDeletion on OCP
   verbs:
   - get
   - list
@@ -282,6 +282,7 @@ RBAC permissions
   resources:
   - agents
   - agents/status
+  - agents/finalizers # needed for ownerReferences with blockOwnerDeletion on OCP
   verbs:
   - get
   - list


### PR DESCRIPTION
Setting an ownerReference with blockOwnerDeletion (as controller-runtime does) on OCP requires that privilege.

Fixes #4106 