### PR TITLE
Allow non-root user to run Elastic Agent process

### DIFF
--- a/config/recipes/elastic-agent/kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/kubernetes-integration.yaml
@@ -13,10 +13,6 @@ spec:
         serviceAccountName: elastic-agent
         containers:
         - name: agent
-          securityContext:
-            runAsUser: 0
-            # If using Red Hat OpenShift uncomment this:
-            #privileged: true
           env:
           - name: NODE_NAME
             valueFrom:

--- a/config/recipes/elastic-agent/system-integration.yaml
+++ b/config/recipes/elastic-agent/system-integration.yaml
@@ -11,10 +11,6 @@ spec:
       spec:
         containers:
         - name: agent
-          securityContext:
-            runAsUser: 0
-            # If using Red Hat OpenShift uncomment this:
-            #privileged: true
   config:
     id: 488e0b80-3634-11eb-8208-57893829af4e
     revision: 2

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -70,7 +70,7 @@ func buildPodTemplate(params Params, configHash hash.Hash) corev1.PodTemplateSpe
 			ConfigVolumeName,
 			ConfigMountPath,
 			ConfigFileName,
-			0600),
+			0440),
 		dataVolume,
 	}
 

--- a/test/e2e/agent/config.go
+++ b/test/e2e/agent/config.go
@@ -178,8 +178,6 @@ inputs:
     - mountPath: /var/log
       name: varlog
   dnsPolicy: ClusterFirstWithHostNet
-  securityContext:
-    runAsUser: 0
   serviceAccount: elastic-agent
   terminationGracePeriodSeconds: 30
   volumes:


### PR DESCRIPTION
Adjust file permissions on mounted configuration file to be read-only and group readable.

Also removes the `runAsUser: 0` setting from the recipes. 

I tested on OCP and GCP with the recipes which went OK.

Fixes #4107 