### PR TITLE
[1.4] Upgrading AKS cluster version in CI/dev environments to 1.19.6 (#4131)

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -47,7 +47,7 @@ plans:
   operation: create
   clusterName: ci
   provider: aks
-  kubernetesVersion: 1.17.11
+  kubernetesVersion: 1.19.6
   machineType: Standard_D8s_v3
   serviceAccount: true
   psp: false
@@ -59,7 +59,7 @@ plans:
   operation: create
   clusterName: dev
   provider: aks
-  kubernetesVersion: 1.17.11
+  kubernetesVersion: 1.19.6
   machineType: Standard_D8s_v3
   serviceAccount: false
   psp: false


### PR DESCRIPTION
Backports the following commits to 1.4:
 - Upgrading AKS cluster version in CI/dev environments to 1.19.6 (#4131)