### PR TITLE
Add a note about the new kind setup

### DIFF
--- a/dev-setup.md
+++ b/dev-setup.md
@@ -37,7 +37,7 @@ Run `make check-requisites` to check that all dependencies are installed.
 
 * [Kind](https://kind.sigs.k8s.io/)
 
-  The Make target assumes that your local kind binaries are suffixed with their version. For example kind-0.9.0 and kind 0.8.1. The purpose of this convention is to allow running both versions of kind next to each other. For older Kubernetes versions up to 1.13 use kind-0.8.1 and for the newer versions of Kubernetes starting with 1.14 use kind-0.9.0.
+  The Make target assumes that your local kind binaries are suffixed with their version. For example `kind-0.9.0` and `kind-0.8.1`. The purpose of this convention is to allow running both versions of kind next to each other. For older Kubernetes versions up to 1.13 use `kind-0.8.1` and for the newer versions of Kubernetes starting with 1.14 use `kind-0.9.0`.
 
   ```bash
   make bootstrap-kind

--- a/dev-setup.md
+++ b/dev-setup.md
@@ -37,6 +37,8 @@ Run `make check-requisites` to check that all dependencies are installed.
 
 * [Kind](https://kind.sigs.k8s.io/)
 
+  The Make target assumes that your local kind binaries are suffixed with their version. For example kind-0.9.0 and kind 0.8.1. The purpose of this convention is to allow running both versions of kind next to each other. For older Kubernetes versions up to 1.13 use kind-0.8.1 and for the newer versions of Kubernetes starting with 1.14 use kind-0.9.0.
+
   ```bash
   make bootstrap-kind
   ```


### PR DESCRIPTION
https://github.com/elastic/cloud-on-k8s/pull/4122 changes the expectations around the local kind installation. This adds a note to make developers aware that kind binaries should be suffixed with their versions.