### PR TITLE
[Autoscaling] Add autoscaling resource definition

### DIFF
--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -1428,7 +1428,9 @@ spec:
                     description: Config holds the Elasticsearch configuration.
                     type: object
                   count:
-                    description: Count of Elasticsearch nodes to deploy.
+                    description: Count of Elasticsearch nodes to deploy. If the node
+                      set is managed by an autoscaling policy the initial value is
+                      automatically set by the autoscaling controller.
                     format: int32
                     type: integer
                   name:

--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -1430,7 +1430,6 @@ spec:
                   count:
                     description: Count of Elasticsearch nodes to deploy.
                     format: int32
-                    minimum: 0
                     type: integer
                   name:
                     description: Name of this set of nodes. Becomes a part of the
@@ -1666,7 +1665,6 @@ spec:
                       type: object
                     type: array
                 required:
-                - count
                 - name
                 type: object
               minItems: 1

--- a/config/crds/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
+++ b/config/crds/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
@@ -391,7 +391,9 @@ spec:
                       description: Config holds the Elasticsearch configuration.
                       type: object
                     count:
-                      description: Count of Elasticsearch nodes to deploy.
+                      description: Count of Elasticsearch nodes to deploy. If the
+                        node set is managed by an autoscaling policy the initial value
+                        is automatically set by the autoscaling controller.
                       format: int32
                       type: integer
                     name:

--- a/config/crds/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
+++ b/config/crds/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
@@ -393,7 +393,6 @@ spec:
                     count:
                       description: Count of Elasticsearch nodes to deploy.
                       format: int32
-                      minimum: 0
                       type: integer
                     name:
                       description: Name of this set of nodes. Becomes a part of the
@@ -6922,7 +6921,6 @@ spec:
                         type: object
                       type: array
                   required:
-                  - count
                   - name
                   type: object
                 minItems: 1

--- a/config/recipes/autoscaling/elasticsearch.yaml
+++ b/config/recipes/autoscaling/elasticsearch.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: autoscaling-sample
+  annotations:
+    elasticsearch.alpha.elastic.co/autoscaling-spec: |
+      {
+          "policies": [{
+              "name": "di",
+              "roles": ["data", "ingest" , "transform"],
+              "deciders": {
+                "proactive_storage": {
+                    "forecast_window": "5m"
+                }
+              },
+              "resources": {
+                  "nodeCount": { "min": 3, "max": 8 },
+                  "cpu": { "min": 2, "max": 8 },
+                  "memory": { "min": "2Gi", "max": "16Gi" },
+                  "storage": { "min": "64Gi", "max": "512Gi" }
+              }
+          },
+          {
+              "name": "ml",
+              "roles": ["ml"],
+              "deciders": {
+                  "ml": {
+                      "down_scale_delay": "10m"
+                  }
+              },
+              "resources": {
+                  "nodeCount": { "min": 1, "max": 9 },
+                  "cpu": { "min": 1, "max": 4 },
+                  "memory": { "min": "2Gi", "max": "8Gi" }
+              }
+          }]
+      }
+spec:
+  version: 7.11.0
+  nodeSets:
+    - name: master
+      count: 1
+      config:
+        node:
+          roles: [ "master" ]
+          store.allow_mmap: false
+    - name: di
+      config:
+        node:
+          roles: [ "data", "ingest", "transform" ]
+          store.allow_mmap: false
+    - name: ml
+      config:
+        node:
+          roles: [ "ml" ]
+          store.allow_mmap: false

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -1452,7 +1452,9 @@ spec:
                     description: Config holds the Elasticsearch configuration.
                     type: object
                   count:
-                    description: Count of Elasticsearch nodes to deploy.
+                    description: Count of Elasticsearch nodes to deploy. If the node
+                      set is managed by an autoscaling policy the initial value is
+                      automatically set by the autoscaling controller.
                     format: int32
                     type: integer
                   name:

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -1454,7 +1454,6 @@ spec:
                   count:
                     description: Count of Elasticsearch nodes to deploy.
                     format: int32
-                    minimum: 0
                     type: integer
                   name:
                     description: Name of this set of nodes. Becomes a part of the
@@ -1690,7 +1689,6 @@ spec:
                       type: object
                     type: array
                 required:
-                - count
                 - name
                 type: object
               minItems: 1

--- a/docs/reference/api-docs.asciidoc
+++ b/docs/reference/api-docs.asciidoc
@@ -928,7 +928,7 @@ NodeSet is the specification for a group of Elasticsearch nodes sharing the same
 | Field | Description
 | *`name`* __string__ | Name of this set of nodes. Becomes a part of the Elasticsearch node.name setting.
 | *`config`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-config[$$Config$$]__ | Config holds the Elasticsearch configuration.
-| *`count`* __integer__ | Count of Elasticsearch nodes to deploy.
+| *`count`* __integer__ | Count of Elasticsearch nodes to deploy. If the node set is managed by an autoscaling policy the initial value is automatically set by the autoscaling controller.
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Pods belonging to this NodeSet.
 | *`volumeClaimTemplates`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$] array__ | VolumeClaimTemplates is a list of persistent volume claims to be used by each Pod in this NodeSet. Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate. Items defined here take precedence over any default claims added by the operator with the same name.
 |===

--- a/docs/reference/api-docs.asciidoc
+++ b/docs/reference/api-docs.asciidoc
@@ -822,6 +822,8 @@ Auth contains user authentication and authorization security settings for Elasti
 |===
 
 
+
+
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-elasticsearch-v1-changebudget"]
 === ChangeBudget 
 
@@ -838,6 +840,10 @@ ChangeBudget defines the constraints to consider when applying changes to the El
 | *`maxUnavailable`* __integer__ | MaxUnavailable is the maximum number of pods that can be unavailable (not ready) during the update due to circumstances under the control of the operator. Setting a negative value will disable this restriction. Defaults to 1 if not specified.
 | *`maxSurge`* __integer__ | MaxSurge is the maximum number of new pods that can be created exceeding the original number of pods defined in the specification. MaxSurge is only taken into consideration when scaling up. Setting a negative value will disable the restriction. Defaults to unbounded if not specified.
 |===
+
+
+
+
 
 
 
@@ -926,6 +932,8 @@ NodeSet is the specification for a group of Elasticsearch nodes sharing the same
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Pods belonging to this NodeSet.
 | *`volumeClaimTemplates`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$] array__ | VolumeClaimTemplates is a list of persistent volume claims to be used by each Pod in this NodeSet. Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate. Items defined here take precedence over any default claims added by the operator with the same name.
 |===
+
+
 
 
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-elasticsearch-v1-remotecluster"]

--- a/hack/api-docs/config.yaml
+++ b/hack/api-docs/config.yaml
@@ -6,6 +6,8 @@ processor:
     - "ElasticsearchSettings$"
     - "Associa(ted|tion|tionStatus|tionConf)$"
     - "APM(Es|Kibana)Association"
+    - "NodeSet(List|ConfigError)$"
+    - "Autoscaling*"
   ignoreFields:
     - "status$"
     - "TypeMeta$"

--- a/pkg/apis/elasticsearch/v1/autoscaling.go
+++ b/pkg/apis/elasticsearch/v1/autoscaling.go
@@ -16,7 +16,7 @@ import (
 
 const ElasticsearchAutoscalingSpecAnnotationName = "elasticsearch.alpha.elastic.co/autoscaling-spec"
 
-var nodeRolesNotSetErr = errors.New("node.roles must be set")
+var errNodeRolesNotSet = errors.New("node.roles must be set")
 
 // -- Elasticsearch Autoscaling API structures
 
@@ -237,7 +237,7 @@ func getNodeSetRoles(es Elasticsearch, nodeSet NodeSet) ([]string, error) {
 		return nil, err
 	}
 	if cfg.Node == nil {
-		return nil, nodeRolesNotSetErr
+		return nil, errNodeRolesNotSet
 	}
 	return cfg.Node.Roles, nil
 }

--- a/pkg/apis/elasticsearch/v1/autoscaling.go
+++ b/pkg/apis/elasticsearch/v1/autoscaling.go
@@ -1,0 +1,243 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/set"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const ElasticsearchAutoscalingSpecAnnotationName = "elasticsearch.alpha.elastic.co/autoscaling-spec"
+
+var nodeRolesNotSetErr = errors.New("node.roles must be set")
+
+// -- Elasticsearch Autoscaling API structures
+
+// DeciderSettings allows the user to tweak autoscaling deciders.
+// The map data structure complies with the <key,value> format expected by Elasticsearch.
+// +kubebuilder:object:generate=false
+type DeciderSettings map[string]string
+
+// AutoscalingPolicy models the Elasticsearch autoscaling API.
+// +kubebuilder:object:generate=false
+type AutoscalingPolicy struct {
+	// An autoscaling policy must target a unique set of roles.
+	Roles []string `json:"roles,omitempty"`
+	// Deciders allows the user to override default settings for autoscaling deciders.
+	Deciders map[string]DeciderSettings `json:"deciders,omitempty"`
+}
+
+// -- Elastic Cloud on K8S specific structures
+
+// AutoscalingSpec is the root object of the autoscaling specification in the Elasticsearch resource definition.
+// +kubebuilder:object:generate=false
+type AutoscalingSpec struct {
+	AutoscalingPolicySpecs AutoscalingPolicySpecs `json:"policies"`
+	// Elasticsearch is stored in the autoscaling spec for convenience. It should be removed once the autoscaling spec is
+	// fully part of the Elasticsearch specification.
+	Elasticsearch Elasticsearch `json:"-"`
+}
+
+// +kubebuilder:object:generate=false
+type AutoscalingPolicySpecs []AutoscalingPolicySpec
+
+// NamedAutoscalingPolicy models an autoscaling policy as expected by the Elasticsearch policy API.
+// It is identified by a unique name provided by the user.
+// +kubebuilder:object:generate=false
+type NamedAutoscalingPolicy struct {
+	// Name identifies the autoscaling policy in the autoscaling specification.
+	Name string `json:"name,omitempty"`
+	// AutoscalingPolicy is the autoscaling policy as expected by the Elasticsearch API.
+	AutoscalingPolicy
+}
+
+// AutoscalingPolicySpec holds a named autoscaling policy and the associated resources limits (cpu, memory, storage).
+// +kubebuilder:object:generate=false
+type AutoscalingPolicySpec struct {
+	NamedAutoscalingPolicy
+
+	AutoscalingResources `json:"resources"`
+}
+
+// +kubebuilder:object:generate=false
+// AutoscalingResources models the limits, submitted by the user, for the supported resources in an autoscaling policy.
+// Only the node count range is mandatory. For other resources, a limit range is required only
+// if the Elasticsearch autoscaling capacity API returns a requirement for a given resource.
+// For example, the memory limit range is only required if the autoscaling API response contains a memory requirement.
+// If there is no limit range for a resource, and if that resource is not mandatory, then the resources in the NodeSets
+// managed by the autoscaling policy are left untouched.
+type AutoscalingResources struct {
+	CPU       *QuantityRange `json:"cpu,omitempty"`
+	Memory    *QuantityRange `json:"memory,omitempty"`
+	Storage   *QuantityRange `json:"storage,omitempty"`
+	NodeCount CountRange     `json:"nodeCount"`
+}
+
+// QuantityRange models a resource limit range for resources which can be expressed with resource.Quantity.
+// +kubebuilder:object:generate=false
+type QuantityRange struct {
+	// Min represents the lower limit for the resources managed by the autoscaler.
+	Min resource.Quantity `json:"min"`
+	// Max represents the upper limit for the resources managed by the autoscaler.
+	Max resource.Quantity `json:"max"`
+	// RequestsToLimitsRatio allows to customize Kubernetes resource Limit based on the Request.
+	RequestsToLimitsRatio *float64 `json:"requestsToLimitsRatio"`
+}
+
+// CountRange is used to model the minimum and the maximum number of nodes over all the NodeSets managed by a same autoscaling policy.
+// +kubebuilder:object:generate=false
+type CountRange struct {
+	// Min represents the minimum number of nodes in a tier.
+	Min int32 `json:"min"`
+	// Max represents the maximum number of nodes in a tier.
+	Max int32 `json:"max"`
+}
+
+// GetAutoscalingSpecification unmarshal autoscaling specifications from an Elasticsearch resource.
+func (es Elasticsearch) GetAutoscalingSpecification() (AutoscalingSpec, error) {
+	autoscalingSpec := AutoscalingSpec{}
+	if len(es.AutoscalingSpec()) == 0 {
+		return autoscalingSpec, nil
+	}
+	err := json.Unmarshal([]byte(es.AutoscalingSpec()), &autoscalingSpec)
+	autoscalingSpec.Elasticsearch = es
+	return autoscalingSpec, err
+}
+
+// IsMemoryDefined returns true if the user specified memory limits.
+func (aps AutoscalingPolicySpec) IsMemoryDefined() bool {
+	return aps.Memory != nil
+}
+
+// IsCPUDefined returns true if the user specified cpu limits.
+func (aps AutoscalingPolicySpec) IsCPUDefined() bool {
+	return aps.CPU != nil
+}
+
+// IsStorageDefined returns true if the user specified storage limits.
+func (aps AutoscalingPolicySpec) IsStorageDefined() bool {
+	return aps.Storage != nil
+}
+
+// findByRoles returns the autoscaling specification associated with a set of roles or nil if not found.
+func (as AutoscalingSpec) findByRoles(roles []string) *AutoscalingPolicySpec {
+	for _, rp := range as.AutoscalingPolicySpecs {
+		if !rolesMatch(rp.Roles, roles) {
+			continue
+		}
+		return &rp
+	}
+	return nil
+}
+
+// rolesMatch compares two set of roles and returns true if both sets contain the exact same roles.
+func rolesMatch(roles1, roles2 []string) bool {
+	if len(roles1) != len(roles2) {
+		return false
+	}
+	rolesInPolicy := set.Make(roles1...)
+	for _, role := range roles2 {
+		if !rolesInPolicy.Has(role) {
+			return false
+		}
+	}
+	return true
+}
+
+// AutoscaledNodeSets holds the nodeSets managed by an autoscaling policy, indexed by the autoscaling policy name.
+// +kubebuilder:object:generate=false
+type AutoscaledNodeSets map[string]NodeSetList
+
+// AutoscalingPolicies returns the list of autoscaling policies names from the named tiers.
+func (n AutoscaledNodeSets) AutoscalingPolicies() set.StringSet {
+	autoscalingPolicies := set.Make()
+	for autoscalingPolicy := range n {
+		autoscalingPolicies.Add(autoscalingPolicy)
+	}
+	return autoscalingPolicies
+}
+
+// +kubebuilder:object:generate=false
+type NodeSetConfigError struct {
+	error
+	NodeSet
+	Index int
+}
+
+// GetAutoscaledNodeSets retrieves the name of all the autoscaling policies in the Elasticsearch manifest and the associated NodeSets.
+func (as AutoscalingSpec) GetAutoscaledNodeSets() (AutoscaledNodeSets, *NodeSetConfigError) {
+	namedTiersSet := make(AutoscaledNodeSets)
+	for i, nodeSet := range as.Elasticsearch.Spec.NodeSets {
+		resourcePolicy, err := as.GetAutoscalingSpecFor(nodeSet)
+		if err != nil {
+			return nil, &NodeSetConfigError{
+				error:   err,
+				NodeSet: nodeSet,
+				Index:   i,
+			}
+		}
+		if resourcePolicy == nil {
+			// This nodeSet is not managed by an autoscaling policy
+			continue
+		}
+		namedTiersSet[resourcePolicy.Name] = append(namedTiersSet[resourcePolicy.Name], *nodeSet.DeepCopy())
+	}
+	return namedTiersSet, nil
+}
+
+// GetMLNodesSettings computes the total number of ML nodes which can be deployed in the cluster and the maximum memory size
+// of each node in the ML tier.
+func (as AutoscalingSpec) GetMLNodesSettings() (nodes int32, maxMemory string, err error) {
+	var maxMemoryAsInt int64
+	for _, nodeSet := range as.Elasticsearch.Spec.NodeSets {
+		resourcePolicy, err := as.GetAutoscalingSpecFor(nodeSet)
+		if err != nil {
+			return 0, "0b", err
+		}
+		roles, err := getNodeSetRoles(as.Elasticsearch, nodeSet)
+		if err != nil {
+			return 0, "0b", err
+		}
+		rolesInPolicy := set.Make(roles...)
+		if rolesInPolicy.Has(MLRole) {
+			nodes += resourcePolicy.NodeCount.Max
+			if resourcePolicy.IsMemoryDefined() && resourcePolicy.Memory.Max.Value() > maxMemoryAsInt {
+				maxMemoryAsInt = resourcePolicy.Memory.Max.Value()
+			}
+		}
+	}
+	maxMemory = fmt.Sprintf("%db", maxMemoryAsInt)
+	return nodes, maxMemory, nil
+}
+
+// GetAutoscalingSpecFor retrieves the autoscaling spec associated to a NodeSet or nil if none.
+func (as AutoscalingSpec) GetAutoscalingSpecFor(nodeSet NodeSet) (*AutoscalingPolicySpec, error) {
+	roles, err := getNodeSetRoles(as.Elasticsearch, nodeSet)
+	if err != nil {
+		return nil, err
+	}
+	return as.findByRoles(roles), nil
+}
+
+// getNodeSetRoles attempts to parse the roles specified in the configuration of a given nodeSet.
+func getNodeSetRoles(es Elasticsearch, nodeSet NodeSet) ([]string, error) {
+	v, err := version.Parse(es.Spec.Version)
+	if err != nil {
+		return nil, err
+	}
+	cfg := ElasticsearchSettings{}
+	if err := UnpackConfig(nodeSet.Config, *v, &cfg); err != nil {
+		return nil, err
+	}
+	if cfg.Node == nil {
+		return nil, nodeRolesNotSetErr
+	}
+	return cfg.Node.Roles, nil
+}

--- a/pkg/apis/elasticsearch/v1/autoscaling.go
+++ b/pkg/apis/elasticsearch/v1/autoscaling.go
@@ -21,7 +21,7 @@ var errNodeRolesNotSet = errors.New("node.roles must be set")
 
 // -- Elasticsearch Autoscaling API structures
 
-// DeciderSettings allows the user to tweak autoscaling deciders.
+// DeciderSettings allow the user to tweak autoscaling deciders.
 // The map data structure complies with the <key,value> format expected by Elasticsearch.
 // +kubebuilder:object:generate=false
 type DeciderSettings map[string]string
@@ -31,7 +31,7 @@ type DeciderSettings map[string]string
 type AutoscalingPolicy struct {
 	// An autoscaling policy must target a unique set of roles.
 	Roles []string `json:"roles,omitempty"`
-	// Deciders allows the user to override default settings for autoscaling deciders.
+	// Deciders allow the user to override default settings for autoscaling deciders.
 	Deciders map[string]DeciderSettings `json:"deciders,omitempty"`
 }
 
@@ -68,17 +68,19 @@ type AutoscalingPolicySpec struct {
 }
 
 // +kubebuilder:object:generate=false
-// AutoscalingResources models the limits, submitted by the user, for the supported resources in an autoscaling policy.
+// AutoscalingResources model the limits, submitted by the user, for the supported resources in an autoscaling policy.
 // Only the node count range is mandatory. For other resources, a limit range is required only
 // if the Elasticsearch autoscaling capacity API returns a requirement for a given resource.
 // For example, the memory limit range is only required if the autoscaling API response contains a memory requirement.
 // If there is no limit range for a resource, and if that resource is not mandatory, then the resources in the NodeSets
 // managed by the autoscaling policy are left untouched.
 type AutoscalingResources struct {
-	CPU       *QuantityRange `json:"cpu,omitempty"`
-	Memory    *QuantityRange `json:"memory,omitempty"`
-	Storage   *QuantityRange `json:"storage,omitempty"`
-	NodeCount CountRange     `json:"nodeCount"`
+	CPU     *QuantityRange `json:"cpu,omitempty"`
+	Memory  *QuantityRange `json:"memory,omitempty"`
+	Storage *QuantityRange `json:"storage,omitempty"`
+
+	// NodeCount is used to model the minimum and the maximum number of nodes over all the NodeSets managed by a same autoscaling policy.
+	NodeCount CountRange `json:"nodeCount"`
 }
 
 // QuantityRange models a resource limit range for resources which can be expressed with resource.Quantity.
@@ -92,7 +94,6 @@ type QuantityRange struct {
 	RequestsToLimitsRatio *float64 `json:"requestsToLimitsRatio"`
 }
 
-// CountRange is used to model the minimum and the maximum number of nodes over all the NodeSets managed by a same autoscaling policy.
 // +kubebuilder:object:generate=false
 type CountRange struct {
 	// Min represents the minimum number of nodes in a tier.
@@ -143,16 +144,16 @@ func rolesMatch(roles1, roles2 []string) bool {
 	if len(roles1) != len(roles2) {
 		return false
 	}
-	rolesInPolicy := set.Make(roles1...)
-	for _, role := range roles2 {
-		if !rolesInPolicy.Has(role) {
+	rolesInRoles1 := set.Make(roles1...)
+	for _, roleInRoles2 := range roles2 {
+		if !rolesInRoles1.Has(roleInRoles2) {
 			return false
 		}
 	}
 	return true
 }
 
-// AutoscaledNodeSets holds the nodeSets managed by an autoscaling policy, indexed by the autoscaling policy name.
+// AutoscaledNodeSets holds the node sets managed by an autoscaling policy, indexed by the autoscaling policy name.
 // +kubebuilder:object:generate=false
 type AutoscaledNodeSets map[string]NodeSetList
 

--- a/pkg/apis/elasticsearch/v1/autoscaling_test.go
+++ b/pkg/apis/elasticsearch/v1/autoscaling_test.go
@@ -1,0 +1,92 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package v1
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAutoscalingSpec_findByRoles(t *testing.T) {
+	type fields struct {
+		AutoscalingPolicySpecs AutoscalingPolicySpecs
+	}
+	type args struct {
+		roles []string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *AutoscalingPolicySpec
+	}{
+		{
+			name: "Managed by an autoscaling policy",
+			fields: fields{
+				AutoscalingPolicySpecs: AutoscalingPolicySpecs{
+					AutoscalingPolicySpec{
+						NamedAutoscalingPolicy: NamedAutoscalingPolicy{
+							Name: "ml_only",
+							AutoscalingPolicy: AutoscalingPolicy{
+								Roles: []string{"ml"},
+							},
+						},
+					}},
+			},
+			args: args{roles: []string{"ml"}},
+			want: &AutoscalingPolicySpec{
+				NamedAutoscalingPolicy: NamedAutoscalingPolicy{
+					Name: "ml_only",
+					AutoscalingPolicy: AutoscalingPolicy{
+						Roles: []string{"ml"},
+					},
+				},
+			},
+		},
+		{
+			name: "Not managed by an autoscaling policy",
+			fields: fields{
+				AutoscalingPolicySpecs: AutoscalingPolicySpecs{
+					AutoscalingPolicySpec{
+						NamedAutoscalingPolicy: NamedAutoscalingPolicy{
+							Name: "ml_only",
+							AutoscalingPolicy: AutoscalingPolicy{
+								Roles: []string{"ml"},
+							},
+						},
+					}},
+			},
+			args: args{roles: []string{"master"}},
+			want: nil,
+		},
+		{
+			name: "Not managed by an autoscaling policy",
+			fields: fields{
+				AutoscalingPolicySpecs: AutoscalingPolicySpecs{
+					AutoscalingPolicySpec{
+						NamedAutoscalingPolicy: NamedAutoscalingPolicy{
+							Name: "ml_only",
+							AutoscalingPolicy: AutoscalingPolicy{
+								Roles: []string{"ml"},
+							},
+						},
+					}},
+			},
+			args: args{roles: []string{"ml", "data"}},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			as := AutoscalingSpec{
+				AutoscalingPolicySpecs: tt.fields.AutoscalingPolicySpecs,
+			}
+			got := as.findByRoles(tt.args.roles)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AutoscalingSpec.findByRoles() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/apis/elasticsearch/v1/autoscaling_test.go
+++ b/pkg/apis/elasticsearch/v1/autoscaling_test.go
@@ -7,7 +7,73 @@ package v1
 import (
 	"reflect"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
+
+func TestAutoscalingSpec_GetMLNodesSettings(t *testing.T) {
+	type fields struct {
+		AutoscalingPolicySpecs AutoscalingPolicySpecs
+	}
+	tests := []struct {
+		name          string
+		fields        fields
+		wantNodes     int32
+		wantMaxMemory string
+	}{
+		{
+			name: "happy path",
+			fields: fields{
+				AutoscalingPolicySpecs: AutoscalingPolicySpecs{
+					{
+						NamedAutoscalingPolicy: NamedAutoscalingPolicy{Name: "ml-policy", AutoscalingPolicy: AutoscalingPolicy{Roles: []string{"ml"}}},
+						AutoscalingResources: AutoscalingResources{
+							Memory:    &QuantityRange{Min: resource.MustParse("1Gi"), Max: resource.MustParse("8Gi")},
+							NodeCount: CountRange{Min: 0, Max: 7},
+						},
+					},
+				},
+			},
+			wantMaxMemory: "8589934592b",
+			wantNodes:     7,
+		},
+		{
+			name: "no dedicated ml tier", // not supported at the time this test is written, but we still want to ensure we return correct values
+			fields: fields{
+				AutoscalingPolicySpecs: AutoscalingPolicySpecs{
+					{
+						NamedAutoscalingPolicy: NamedAutoscalingPolicy{Name: "ml-policy", AutoscalingPolicy: AutoscalingPolicy{Roles: []string{"data,ml"}}},
+						AutoscalingResources: AutoscalingResources{
+							Memory:    &QuantityRange{Min: resource.MustParse("1Gi"), Max: resource.MustParse("8Gi")},
+							NodeCount: CountRange{Min: 0, Max: 7},
+						},
+					},
+					{
+						NamedAutoscalingPolicy: NamedAutoscalingPolicy{Name: "ml-policy2", AutoscalingPolicy: AutoscalingPolicy{Roles: []string{"ml"}}},
+						AutoscalingResources: AutoscalingResources{
+							Memory:    &QuantityRange{Min: resource.MustParse("1Gi"), Max: resource.MustParse("16Gi")},
+							NodeCount: CountRange{Min: 0, Max: 4},
+						},
+					},
+				},
+			},
+			wantMaxMemory: "17179869184b",
+			wantNodes:     11,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			as := AutoscalingSpec{AutoscalingPolicySpecs: tt.fields.AutoscalingPolicySpecs}
+			gotNodes, gotMaxMemory := as.GetMLNodesSettings()
+			if gotNodes != tt.wantNodes {
+				t.Errorf("AutoscalingSpec.GetMLNodesSettings() gotNodes = %v, want %v", gotNodes, tt.wantNodes)
+			}
+			if gotMaxMemory != tt.wantMaxMemory {
+				t.Errorf("AutoscalingSpec.GetMLNodesSettings() gotMaxMemory = %v, want %v", gotMaxMemory, tt.wantMaxMemory)
+			}
+		})
+	}
+}
 
 func TestAutoscalingSpec_findByRoles(t *testing.T) {
 	type fields struct {

--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -197,6 +197,7 @@ type NodeSet struct {
 	Config *commonv1.Config `json:"config,omitempty"`
 
 	// Count of Elasticsearch nodes to deploy.
+	// If the node set is managed by an autoscaling policy the initial value is automatically set by the autoscaling controller.
 	// +kubebuilder:validation:Optional
 	Count int32 `json:"count"`
 

--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -5,11 +5,11 @@
 package v1
 
 import (
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
 )
 
@@ -197,7 +197,7 @@ type NodeSet struct {
 	Config *commonv1.Config `json:"config,omitempty"`
 
 	// Count of Elasticsearch nodes to deploy.
-	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Optional
 	Count int32 `json:"count"`
 
 	// PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Pods belonging to this NodeSet.
@@ -209,6 +209,17 @@ type NodeSet struct {
 	// Items defined here take precedence over any default claims added by the operator with the same name.
 	// +kubebuilder:validation:Optional
 	VolumeClaimTemplates []corev1.PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"`
+}
+
+// +kubebuilder:object:generate=false
+type NodeSetList []NodeSet
+
+func (nsl NodeSetList) Names() []string {
+	names := make([]string, len(nsl))
+	for i := range nsl {
+		names[i] = nsl[i].Name
+	}
+	return names
 }
 
 // GetESContainerTemplate returns the Elasticsearch container (if set) from the NodeSet's PodTemplate
@@ -360,6 +371,17 @@ type Elasticsearch struct {
 // IsMarkedForDeletion returns true if the Elasticsearch is going to be deleted
 func (es Elasticsearch) IsMarkedForDeletion() bool {
 	return !es.DeletionTimestamp.IsZero()
+}
+
+// IsAutoscalingDefined returns true if there is an autoscaling configuration in the annotations.
+func (es Elasticsearch) IsAutoscalingDefined() bool {
+	_, ok := es.Annotations[ElasticsearchAutoscalingSpecAnnotationName]
+	return ok
+}
+
+// AutoscalingSpec returns the autoscaling spec in the Elasticsearch manifest.
+func (es Elasticsearch) AutoscalingSpec() string {
+	return es.Annotations[ElasticsearchAutoscalingSpecAnnotationName]
 }
 
 func (es Elasticsearch) SecureSettings() []commonv1.SecretSource {

--- a/pkg/controller/elasticsearch/validation/autoscaling_validation.go
+++ b/pkg/controller/elasticsearch/validation/autoscaling_validation.go
@@ -1,0 +1,281 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package validation
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/set"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+const UnexpectedVolumeClaimError = "autoscaling supports only one volume claim"
+
+var (
+	ElasticsearchMinAutoscalingVersion = version.From(7, 11, 0)
+
+	// minMemory is the minimal amount of memory which can be set as the minimum limit in an autoscaling specification.
+	minMemory = resource.MustParse("2G")
+
+	// No minimum values are expected for CPU and Storage.
+	// If provided the validation function must ensure that the value is strictly greater than 0.
+	minCPU     = resource.MustParse("0")
+	minStorage = resource.MustParse("0")
+)
+
+func validAutoscalingConfiguration(es esv1.Elasticsearch) field.ErrorList {
+	if !es.IsAutoscalingDefined() {
+		return nil
+	}
+	proposedVer, err := version.Parse(es.Spec.Version)
+	if err != nil {
+		return field.ErrorList{
+			field.Invalid(field.NewPath("spec").Child("version"), es.Spec.Version, parseVersionErrMsg),
+		}
+	}
+
+	var errs field.ErrorList
+	if !proposedVer.IsSameOrAfter(ElasticsearchMinAutoscalingVersion) {
+		errs = append(
+			errs,
+			field.Invalid(
+				field.NewPath("metadata").Child("annotations", esv1.ElasticsearchAutoscalingSpecAnnotationName),
+				es.Spec.Version,
+				autoscalingVersionMsg,
+			),
+		)
+		return errs
+	}
+
+	// Attempt to unmarshall the proposed autoscaling spec.
+	autoscalingSpecification, err := es.GetAutoscalingSpecification()
+	if err != nil {
+		errs = append(errs, field.Invalid(
+			field.NewPath("metadata").Child("annotations", esv1.ElasticsearchAutoscalingSpecAnnotationName),
+			es.AutoscalingSpec(),
+			err.Error(),
+		))
+		return errs
+	}
+
+	// Validate the autoscaling policies
+	errs = append(errs, validAutoscalingPolicies(autoscalingSpecification.AutoscalingPolicySpecs)...)
+
+	// Get the list of NodeSets managed by an autoscaling policy. This requires to parse the `node.roles` field in the
+	// node configuration, which may raise an error.
+	autoscaledNodeSets, nodeSetConfigErr := autoscalingSpecification.GetAutoscaledNodeSets()
+	if nodeSetConfigErr != nil {
+		errs = append(
+			errs,
+			field.Invalid(
+				field.NewPath("spec").Child("nodeSets").Index(nodeSetConfigErr.Index).Child("config"),
+				nodeSetConfigErr.NodeSet.Config,
+				fmt.Sprintf("cannot parse nodeSet configuration: %s", nodeSetConfigErr.Error()),
+			),
+		)
+		// We stop the validation here as the named tiers are required to validate further.
+		return errs
+	}
+
+	// We want to ensure that an autoscaling policy is at least managing one nodeSet.
+	policiesWithNodeSets := autoscaledNodeSets.AutoscalingPolicies()
+	for i, policy := range autoscalingSpecification.AutoscalingPolicySpecs {
+		if !policiesWithNodeSets.Has(policy.Name) {
+			// No nodeSet matches this autoscaling policy
+			errs = append(
+				errs,
+				field.Invalid(autoscalingSpecPath(i, "roles"),
+					policy.Roles,
+					"roles must be set in at least one nodeSet"),
+			)
+		}
+	}
+
+	// Only one volume claim is supported when a NodeSet is managed by the autoscaling controller.
+	for i, nodeSet := range autoscalingSpecification.Elasticsearch.Spec.NodeSets {
+		if onlyOneVolumeClaimTemplate, _ := HasAtMostOnePersistentVolumeClaim(nodeSet); !onlyOneVolumeClaimTemplate {
+			errs = append(
+				errs,
+				field.Invalid(
+					field.NewPath("spec").Child("nodeSets").Index(i),
+					nodeSet.VolumeClaimTemplates,
+					UnexpectedVolumeClaimError,
+				),
+			)
+		}
+	}
+
+	return errs
+}
+
+func validAutoscalingPolicies(autoscalingPolicies esv1.AutoscalingPolicySpecs) field.ErrorList {
+	var errs field.ErrorList
+	policyNames := set.Make()
+	rolesSet := make([][]string, 0, len(autoscalingPolicies))
+	for i, autoscalingSpec := range autoscalingPolicies {
+		// The name field is mandatory.
+		if len(autoscalingSpec.Name) == 0 {
+			errs = append(errs, field.Required(autoscalingSpecPath(i, "name"), "name is mandatory"))
+		} else {
+			if policyNames.Has(autoscalingSpec.Name) {
+				errs = append(
+					errs,
+					field.Invalid(autoscalingSpecPath(i, "name"), autoscalingSpec.Name, "policy is duplicated"),
+				)
+			}
+			policyNames.Add(autoscalingSpec.Name)
+		}
+
+		// Validate the set of roles managed by this autoscaling policy.
+		if autoscalingSpec.Roles == nil {
+			errs = append(errs, field.Required(autoscalingSpecPath(i, "roles"), "roles field is mandatory"))
+		} else {
+			sort.Strings(autoscalingSpec.Roles)
+			if containsStringSlice(rolesSet, autoscalingSpec.Roles) {
+				//A set of roles must be unique across all the autoscaling policies.
+				errs = append(
+					errs,
+					field.Invalid(
+						autoscalingSpecPath(i, "name"),
+						strings.Join(autoscalingSpec.Roles, ","),
+						"roles set is duplicated"),
+				)
+			} else {
+				rolesSet = append(rolesSet, autoscalingSpec.Roles)
+			}
+		}
+
+		// Machine learning nodes must be in a dedicated tier.
+		if stringsutil.StringInSlice(esv1.MLRole, autoscalingSpec.Roles) && len(autoscalingSpec.Roles) > 1 {
+			errs = append(
+				errs,
+				field.Invalid(
+					autoscalingSpecPath(i, "name"), strings.Join(autoscalingSpec.Roles, ","),
+					"ML nodes must be in a dedicated autoscaling policy"),
+			)
+		}
+
+		if !(autoscalingSpec.NodeCount.Min >= 0) {
+			errs = append(
+				errs,
+				field.Invalid(
+					autoscalingSpecPath(i, "resources", "nodeCount", "min"),
+					autoscalingSpec.NodeCount.Min,
+					"min count must be equal or greater than 0",
+				),
+			)
+		}
+
+		if !(autoscalingSpec.NodeCount.Max > 0) {
+			errs = append(
+				errs,
+				field.Invalid(
+					autoscalingSpecPath(i, "resources", "nodeCount", "max"),
+					autoscalingSpec.NodeCount.Max,
+					"max count must be greater than 0"),
+			)
+		}
+
+		if !(autoscalingSpec.NodeCount.Max >= autoscalingSpec.NodeCount.Min) {
+			errs = append(
+				errs,
+				field.Invalid(autoscalingSpecPath(i, "resources", "nodeCount", "max"),
+					autoscalingSpec.NodeCount.Max,
+					"max node count must be an integer greater or equal than the min node count"),
+			)
+		}
+
+		// Validate CPU
+		errs = validateQuantities(errs, autoscalingSpec.CPU, i, "cpu", minCPU)
+
+		// Validate Memory
+		errs = validateQuantities(errs, autoscalingSpec.Memory, i, "memory", minMemory)
+
+		// Validate storage
+		errs = validateQuantities(errs, autoscalingSpec.Storage, i, "storage", minStorage)
+	}
+	return errs
+}
+
+// autoscalingSpecPath helps to compute the path used in validation error fields.
+func autoscalingSpecPath(index int, child string, moreChildren ...string) *field.Path {
+	return field.NewPath("metadata").
+		Child("annotations", `"`+esv1.ElasticsearchAutoscalingSpecAnnotationName+`"`).
+		Index(index).
+		Child(child, moreChildren...)
+}
+
+// validateQuantities ensures that a quantity range is valid.
+func validateQuantities(
+	errs field.ErrorList,
+	quantityRange *esv1.QuantityRange,
+	index int,
+	resource string,
+	minQuantity resource.Quantity,
+) field.ErrorList {
+	var quantityErrs field.ErrorList
+	if quantityRange == nil {
+		return errs
+	}
+
+	if !minQuantity.IsZero() && !(quantityRange.Min.Cmp(minQuantity) >= 0) {
+		quantityErrs = append(
+			quantityErrs,
+			field.Required(
+				autoscalingSpecPath(index, "minAllowed", resource),
+				fmt.Sprintf("min quantity must be greater than %s", minQuantity.String())),
+		)
+	}
+
+	// A quantity must always be greater than 0.
+	if minQuantity.IsZero() && !(quantityRange.Min.Value() > 0) {
+		quantityErrs = append(
+			quantityErrs,
+			field.Required(
+				autoscalingSpecPath(index, "minAllowed", resource),
+				"min quantity must be greater than 0"),
+		)
+	}
+
+	if quantityRange.Min.Cmp(quantityRange.Max) > 0 {
+		quantityErrs = append(
+			quantityErrs,
+			field.Invalid(
+				autoscalingSpecPath(index, "maxAllowed", resource), quantityRange.Max.String(),
+				"max quantity must be greater or equal than min quantity"),
+		)
+	}
+	return append(errs, quantityErrs...)
+}
+
+// containsStringSlice returns true if an ordered slice is included in a slice of ordered slices.
+func containsStringSlice(slices [][]string, slice []string) bool {
+	for _, s := range slices {
+		if reflect.DeepEqual(s, slice) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasAtMostOnePersistentVolumeClaim returns true if the NodeSet has only one volume claim template. It also returns
+// the name of the volume claim template in that case.
+func HasAtMostOnePersistentVolumeClaim(nodeSet esv1.NodeSet) (bool, string) {
+	//volumeClaimTemplates := len(nodeSet.VolumeClaimTemplates)
+	switch len(nodeSet.VolumeClaimTemplates) {
+	case 0:
+		return true, ""
+	case 1:
+		return true, nodeSet.VolumeClaimTemplates[0].Name
+	}
+	return false, ""
+}

--- a/pkg/controller/elasticsearch/validation/autoscaling_validation.go
+++ b/pkg/controller/elasticsearch/validation/autoscaling_validation.go
@@ -100,7 +100,8 @@ func validAutoscalingConfiguration(es esv1.Elasticsearch) field.ErrorList {
 		}
 	}
 
-	// Only one volume claim is supported when a NodeSet is managed by the autoscaling controller.
+	// Data deciders do not support multiple data paths, as a consequence only one volume claim is supported when a NodeSet
+	// is managed by the autoscaling controller.
 	for i, nodeSet := range autoscalingSpecification.Elasticsearch.Spec.NodeSets {
 		if onlyOneVolumeClaimTemplate, _ := HasAtMostOnePersistentVolumeClaim(nodeSet); !onlyOneVolumeClaimTemplate {
 			errs = append(

--- a/pkg/controller/elasticsearch/validation/autoscaling_validation.go
+++ b/pkg/controller/elasticsearch/validation/autoscaling_validation.go
@@ -95,7 +95,7 @@ func validAutoscalingConfiguration(es esv1.Elasticsearch) field.ErrorList {
 				errs,
 				field.Invalid(autoscalingSpecPath(i, "roles"),
 					policy.Roles,
-					"roles must be set in at least one nodeSet"),
+					"roles must be used in at least one nodeSet"),
 			)
 		}
 	}
@@ -228,7 +228,7 @@ func validateQuantities(
 		return errs
 	}
 
-	if !minQuantity.IsZero() && !(quantityRange.Min.Cmp(minQuantity) >= 0) {
+	if !minQuantity.IsZero() && quantityRange.Min.Cmp(minQuantity) < 0 {
 		quantityErrs = append(
 			quantityErrs,
 			field.Required(
@@ -238,7 +238,7 @@ func validateQuantities(
 	}
 
 	// A quantity must always be greater than 0.
-	if minQuantity.IsZero() && !(quantityRange.Min.Value() > 0) {
+	if !(quantityRange.Min.Value() > 0) {
 		quantityErrs = append(
 			quantityErrs,
 			field.Required(

--- a/pkg/controller/elasticsearch/validation/autoscaling_validation.go
+++ b/pkg/controller/elasticsearch/validation/autoscaling_validation.go
@@ -67,7 +67,7 @@ func validAutoscalingConfiguration(es esv1.Elasticsearch) field.ErrorList {
 	}
 
 	// Validate the autoscaling policies
-	errs = append(errs, validAutoscalingPolicies(autoscalingSpecification.AutoscalingPolicySpecs)...)
+	errs = append(errs, validateAutoscalingPolicies(autoscalingSpecification.AutoscalingPolicySpecs)...)
 	if len(errs) > 0 {
 		// We may have policies with duplicated set of roles, it may make it hard to validate further the autoscaling spec.
 		return errs
@@ -121,7 +121,7 @@ func validAutoscalingConfiguration(es esv1.Elasticsearch) field.ErrorList {
 	return errs
 }
 
-func validAutoscalingPolicies(autoscalingPolicies esv1.AutoscalingPolicySpecs) field.ErrorList {
+func validateAutoscalingPolicies(autoscalingPolicies esv1.AutoscalingPolicySpecs) field.ErrorList {
 	var errs field.ErrorList
 	policyNames := set.Make()
 	rolesSet := make([][]string, 0, len(autoscalingPolicies))

--- a/pkg/controller/elasticsearch/validation/autoscaling_validation_test.go
+++ b/pkg/controller/elasticsearch/validation/autoscaling_validation_test.go
@@ -1,0 +1,571 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestResourcePolicies_Validate(t *testing.T) {
+	tests := []struct {
+		name            string
+		autoscalingSpec string
+		// NodeSet name -> roles
+		nodeSets      map[string][]string
+		volumeClaims  []string
+		wantError     bool
+		expectedError string
+	}{
+		{
+			name:      "ML must be in a dedicated autoscaling policy",
+			wantError: true,
+			nodeSets:  map[string][]string{"nodeset-data-ml": {"data", "ml"}},
+			autoscalingSpec: `
+{
+	 "policies" : [{
+		  "name": "data_ml_policy",
+		  "roles": [ "data", "ml" ],
+		  "resources" : {
+			"nodeCount" : { "min" : 1 , "max" : 2 },
+			"cpu" : { "min" : 1 , "max" : 1 },
+			"memory" : { "min" : "2Gi" , "max" : "2Gi" },
+			"storage" : { "min" : "5Gi" , "max" : "10Gi" }
+		  }
+		}]
+}
+`,
+			expectedError: "ML nodes must be in a dedicated autoscaling policy",
+		},
+		{
+			name:      "ML is in a dedicated autoscaling policy",
+			wantError: false,
+			nodeSets:  map[string][]string{"nodeset-ml": {"ml"}},
+			autoscalingSpec: `
+{
+	 "policies" : [{
+		  "name": "ml",
+		  "roles": [ "ml" ],
+		  "resources" : {
+			"nodeCount" : { "min" : 1 , "max" : 2 },
+			"cpu" : { "min" : 1 , "max" : 1 },
+			"memory" : { "min" : "2Gi" , "max" : "2Gi" },
+			"storage" : { "min" : "5Gi" , "max" : "10Gi" }
+		  }
+		}]
+}
+`,
+		},
+		{
+			name:      "Happy path",
+			wantError: false,
+			nodeSets:  map[string][]string{"nodeset-data-1": {"data"}, "nodeset-data-2": {"data"}, "nodeset-ml": {"ml"}},
+			autoscalingSpec: `
+{
+	 "policies" : [{
+		  "name": "data_policy",
+		  "roles": [ "data" ],
+		  "resources" : {
+			"nodeCount" : { "min" : 1 , "max" : 2 },
+			"cpu" : { "min" : 1 , "max" : 1 },
+			"memory" : { "min" : "2Gi" , "max" : "2Gi" },
+			"storage" : { "min" : "5Gi" , "max" : "10Gi" }
+		  }
+		},
+		{
+		  "name": "ml_policy",
+		  "roles": [ "ml" ],
+		  "resources" : {
+			"nodeCount" : { "min" : 1 , "max" : 2 },
+			"cpu" : { "min" : 1 , "max" : 1 },
+			"memory" : { "min" : "2Gi" , "max" : "2Gi" },
+			"storage" : { "min" : "5Gi" , "max" : "10Gi" }
+		  }
+		}]
+}
+`,
+		},
+		{
+			name:          "Autoscaling policy with no NodeSet",
+			wantError:     true,
+			expectedError: "Invalid value: []string{\"ml\"}: roles must be set in at least one nodeSet",
+			nodeSets:      map[string][]string{"nodeset-data-1": {"data"}, "nodeset-data-2": {"data"}},
+			autoscalingSpec: `
+{
+	 "policies" : [{
+		  "name": "data_policy",
+		  "roles": [ "data" ],
+		  "resources" : {
+			"nodeCount" : { "min" : 1 , "max" : 2 },
+			"cpu" : { "min" : 1 , "max" : 1 },
+			"memory" : { "min" : "2Gi" , "max" : "2Gi" },
+			"storage" : { "min" : "5Gi" , "max" : "10Gi" }
+		  }
+		},
+		{
+		  "name": "ml_policy",
+		  "roles": [ "ml" ],
+		  "resources" : {
+			"nodeCount" : { "min" : 1 , "max" : 2 },
+			"cpu" : { "min" : 1 , "max" : 1 },
+			"memory" : { "min" : "2Gi" , "max" : "2Gi" },
+			"storage" : { "min" : "5Gi" , "max" : "10Gi" }
+		  }
+		}]
+}
+`,
+		},
+		{
+			name:          "nodeSet with no roles",
+			wantError:     true,
+			expectedError: "cannot parse nodeSet configuration: node.roles must be set",
+			nodeSets:      map[string][]string{"nodeset-data-1": nil, "nodeset-data-2": {"data"}},
+			autoscalingSpec: `
+{
+	 "policies" : [{
+		  "name": "data_policy",
+		  "roles": [ "data" ],
+		  "resources" : {
+			"nodeCount" : { "min" : 1 , "max" : 2 },
+			"cpu" : { "min" : 1 , "max" : 1 },
+			"memory" : { "min" : "2Gi" , "max" : "2Gi" },
+			"storage" : { "min" : "5Gi" , "max" : "10Gi" }
+		  }
+		},
+		{
+		  "name": "ml_policy",
+		  "roles": [ "ml" ],
+		  "resources" : {
+			"nodeCount" : { "min" : 1 , "max" : 2 },
+			"cpu" : { "min" : 1 , "max" : 1 },
+			"memory" : { "min" : "2Gi" , "max" : "2Gi" },
+			"storage" : { "min" : "5Gi" , "max" : "10Gi" }
+		  }
+		}]
+}
+`,
+		},
+		{
+			name:          "Min memory is 2G",
+			wantError:     true,
+			expectedError: "min quantity must be greater than 2G",
+			autoscalingSpec: `
+{
+	 "policies" : [{
+		  "name": "data_policy",
+		  "roles": [ "data" ],
+		  "resources" : {
+			"nodeCount" : { "min" : 1 , "max" : 2 },
+			"cpu" : { "min" : 1 , "max" : 1 },
+			"memory" : { "min" : "1Gi" , "max" : "2Gi" },
+			"storage" : { "min" : "5Gi" , "max" : "10Gi" }
+		  }
+		},
+		{
+		  "name": "ml_policy",
+		  "roles": [ "ml" ],
+		  "resources" : {
+			"nodeCount" : { "min" : 1 , "max" : 2 },
+			"cpu" : { "min" : 1 , "max" : 1 },
+			"memory" : { "min" : "2Gi" , "max" : "2Gi" },
+			"storage" : { "min" : "5Gi" , "max" : "10Gi" }
+		  }
+		}]
+}
+`,
+		},
+		{
+			name:          "Policy name is duplicated",
+			wantError:     true,
+			expectedError: "[1].name: Invalid value: \"my_policy\": policy is duplicated",
+			autoscalingSpec: `
+{
+	 "policies" : [{
+		  "name": "my_policy",
+		  "roles": [ "data" ],
+		  "resources" : {
+			"nodeCount" : { "min" : 1 , "max" : 2 },
+			"cpu" : { "min" : 1 , "max" : 1 },
+			"memory" : { "min" : "2Gi" , "max" : "2Gi" },
+			"storage" : { "min" : "5Gi" , "max" : "10Gi" }
+		  }
+		},
+		{
+		  "name": "my_policy",
+		  "roles": [ "ml" ],
+		  "resources" : {
+			"nodeCount" : { "min" : 1 , "max" : 2 },
+			"cpu" : { "min" : 1 , "max" : 1 },
+			"memory" : { "min" : "2Gi" , "max" : "2Gi" },
+			"storage" : { "min" : "5Gi" , "max" : "10Gi" }
+		  }
+		}]
+}
+`,
+		},
+		{
+			name:          "Duplicated roles sets",
+			nodeSets:      map[string][]string{"nodeset-data-2": {"data_hot", "data_content"}},
+			wantError:     true,
+			expectedError: "autoscaling-spec\"[1].name: Invalid value: \"data_content,data_hot\": roles set is duplicated",
+			autoscalingSpec: `
+{
+	 "policies" : [{
+		  "name": "my_policy",
+		  "roles": [ "data_hot", "data_content" ],
+		  "resources" : {
+			  "nodeCount" : { "min" : 1 , "max" : 2 },
+			  "cpu" : { "min" : 1 , "max" : 1 },
+			  "memory" : { "min" : "2Gi" , "max" : "2Gi" },
+			  "storage" : { "min" : "5Gi" , "max" : "10Gi" }
+          }
+		},
+		{
+		  "name": "my_policy2",
+		  "roles": [ "data_hot", "data_content" ],
+		  "resources" : {
+			  "nodeCount" : { "min" : 1 , "max" : 2 },
+			  "cpu" : { "min" : 1 , "max" : 1 },
+			  "memory" : { "min" : "2Gi" , "max" : "2Gi" },
+			  "storage" : { "min" : "5Gi" , "max" : "10Gi" }
+		  }
+		}]
+}
+`,
+		},
+		{
+			name:          "No name",
+			wantError:     true,
+			expectedError: "name: Required value: name is mandatory",
+			autoscalingSpec: `
+{
+	 "policies" : [{
+	  "roles": [ "data", "ml" ],
+      "resources" : {
+		  "nodeCount" : { "min" : 1 , "max" : 2 },
+		  "cpu" : { "min" : 1 , "max" : 1 },
+		  "memory" : { "min" : "2Gi" , "max" : "2Gi" },
+		  "storage" : { "min" : "5Gi" , "max" : "10Gi" }
+      }
+	}]
+}
+`,
+		},
+		{
+			name:          "No roles",
+			wantError:     true,
+			expectedError: "roles: Required value: roles field is mandatory",
+			autoscalingSpec: `
+{
+	 "policies" : [{
+     "name": "my_policy",
+      "resources" : {
+		  "nodeCount" : { "min" : 1 , "max" : 2 },
+		  "cpu" : { "min" : 1 , "max" : 1 },
+		  "memory" : { "min" : "2Gi" , "max" : "2Gi" },
+		  "storage" : { "min" : "5Gi" , "max" : "10Gi" }
+      }
+      }]
+}
+`,
+		},
+		{
+			name:          "No count",
+			nodeSets:      map[string][]string{"nodeset-data-1": {"ml"}},
+			wantError:     true,
+			expectedError: "resources.nodeCount.max: Invalid value: 0: max count must be greater than 0",
+			autoscalingSpec: `
+{
+	 "policies" : [{
+  "name": "my_policy",
+  "roles": [ "ml" ],
+  "resources" : {
+	  "cpu" : { "min" : 1 , "max" : 1 },
+	  "memory" : { "min" : "2Gi" , "max" : "2Gi" },
+	  "storage" : { "min" : "5Gi" , "max" : "10Gi" }
+  }
+}]
+}
+`,
+		},
+		{
+			name:          "Min. count should be equal or greater than 0",
+			nodeSets:      map[string][]string{"nodeset-data-1": {"ml"}},
+			wantError:     true,
+			expectedError: "resources.nodeCount.min: Invalid value: -1: min count must be equal or greater than 0",
+			autoscalingSpec: `
+{
+	"policies": [{
+		"name": "my_policy",
+		"roles": ["ml"],
+		"resources": {
+			"nodeCount": {
+				"min": -1,
+				"max": 2
+			},
+			"cpu": {
+				"min": 1,
+				"max": 1
+			},
+			"memory": {
+				"min": "2Gi",
+				"max": "2Gi"
+			},
+			"storage": {
+				"min": "5Gi",
+				"max": "10Gi"
+			}
+		}
+	}]
+}
+`,
+		},
+		{
+			name:      "Min. count is 0 max count must be greater than 0",
+			nodeSets:  map[string][]string{"nodeset-data-1": {"ml"}},
+			wantError: true,
+			autoscalingSpec: `
+{
+	"policies": [{
+		"name": "my_policy",
+		"roles": ["ml"],
+		"resources": {
+			"nodeCount": {
+				"min": 0,
+				"max": 0
+			},
+			"cpu": {
+				"min": 1,
+				"max": 1
+			},
+			"memory": {
+				"min": "2Gi",
+				"max": "2Gi"
+			},
+			"storage": {
+				"min": "5Gi",
+				"max": "10Gi"
+			}
+		}
+	}]
+}
+`,
+		},
+		{
+			name:      "Min. count and max count are equal",
+			nodeSets:  map[string][]string{"nodeset-data-1": {"ml"}},
+			wantError: false,
+			autoscalingSpec: `
+{
+	"policies": [{
+		"name": "my_policy",
+        "roles": [ "ml" ],
+		"resources": {
+			"nodeCount": {
+				"min": 2,
+				"max": 2
+			},
+			"cpu": {
+				"min": 1,
+				"max": 1
+			},
+			"memory": {
+				"min": "2Gi",
+				"max": "2Gi"
+			},
+			"storage": {
+				"min": "5Gi",
+				"max": "10Gi"
+			}
+		}
+	}]
+}
+`,
+		},
+		{
+			name:          "Min. count is greater than max",
+			nodeSets:      map[string][]string{"nodeset-data-1": {"ml"}},
+			wantError:     true,
+			expectedError: "resources.nodeCount.max: Invalid value: 4: max node count must be an integer greater or equal than the min node count",
+			autoscalingSpec: `
+{
+	"policies": [{
+		"name": "my_policy",
+        "roles": [ "ml" ],
+		"resources": {
+			"nodeCount": {
+				"min": 5,
+				"max": 4
+			},
+			"cpu": {
+				"min": 1,
+				"max": 1
+			},
+			"memory": {
+				"min": "2Gi",
+				"max": "2Gi"
+			},
+			"storage": {
+				"min": "5Gi",
+				"max": "10Gi"
+			}
+		}
+	}]
+}
+`,
+		},
+		{
+			name:          "Min. CPU is greater than max",
+			nodeSets:      map[string][]string{"nodeset-data-1": {"ml"}},
+			wantError:     true,
+			expectedError: "cpu: Invalid value: \"50m\": max quantity must be greater or equal than min quantity",
+			autoscalingSpec: `
+{
+	"policies": [{
+		"name": "my_policy",
+        "roles": [ "ml" ],
+		"resources": {
+			"nodeCount": {
+				"min": -1,
+				"max": 2
+			},
+			"cpu": {
+				"min": "100m",
+				"max": "50m"
+			},
+			"memory": {
+				"min": "2Gi",
+				"max": "2Gi"
+			},
+			"storage": {
+				"min": "5Gi",
+				"max": "10Gi"
+			}
+		}
+	}]
+}
+`,
+		},
+		{
+			name:         "Default volume claim",
+			wantError:    false,
+			nodeSets:     map[string][]string{"ml": {"ml"}},
+			volumeClaims: []string{"elasticsearch-data"},
+			autoscalingSpec: `
+{
+	 "policies" : [{
+		  "name": "ml_policy",
+		  "roles": [ "ml" ],
+		  "resources" : {
+			"nodeCount" : { "min" : 1 , "max" : 2 },
+			"cpu" : { "min" : 1 , "max" : 1 },
+			"memory" : { "min" : "2Gi" , "max" : "2Gi" },
+			"storage" : { "min" : "5Gi" , "max" : "10Gi" }
+		  }
+		}]
+}
+`,
+		},
+		{
+			name:         "Not the default volume claim",
+			wantError:    false,
+			nodeSets:     map[string][]string{"ml": {"ml"}},
+			volumeClaims: []string{"volume1"},
+			autoscalingSpec: `
+{
+	 "policies" : [{
+		  "name": "ml_policy",
+		  "roles": [ "ml" ],
+		  "resources" : {
+			"nodeCount" : { "min" : 1 , "max" : 2 },
+			"cpu" : { "min" : 1 , "max" : 1 },
+			"memory" : { "min" : "2Gi" , "max" : "2Gi" },
+			"storage" : { "min" : "5Gi" , "max" : "10Gi" }
+		  }
+		}]
+}
+`,
+		},
+		{
+			name:         "More than one volume claim",
+			wantError:    true,
+			nodeSets:     map[string][]string{"ml": {"ml"}},
+			volumeClaims: []string{"volume1", "volume2"},
+			autoscalingSpec: `
+{
+	 "policies" : [{
+		  "name": "ml_policy",
+		  "roles": [ "ml" ],
+		  "resources" : {
+			"nodeCount" : { "min" : 1 , "max" : 2 },
+			"cpu" : { "min" : 1 , "max" : 1 },
+			"memory" : { "min" : "2Gi" , "max" : "2Gi" },
+			"storage" : { "min" : "5Gi" , "max" : "10Gi" }
+		  }
+		}]
+}
+`,
+			expectedError: "autoscaling supports only one volume claim",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			es := esv1.Elasticsearch{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						esv1.ElasticsearchAutoscalingSpecAnnotationName: tt.autoscalingSpec,
+					},
+				},
+				Spec: esv1.ElasticsearchSpec{
+					Version: "7.11.0",
+				},
+			}
+			for nodeSetName, roles := range tt.nodeSets {
+				cfg := commonv1.NewConfig(map[string]interface{}{})
+				if roles != nil {
+					cfg = commonv1.NewConfig(map[string]interface{}{"node.roles": roles})
+				}
+				volumeClaimTemplates := volumeClaimTemplates(tt.volumeClaims)
+				nodeSet := esv1.NodeSet{
+					Name:                 nodeSetName,
+					Config:               &cfg,
+					VolumeClaimTemplates: volumeClaimTemplates,
+				}
+				es.Spec.NodeSets = append(es.Spec.NodeSets, nodeSet)
+			}
+			got := validAutoscalingConfiguration(es)
+			assert.Equal(t, tt.wantError, got != nil)
+			found := false
+			for _, gotErr := range got {
+				if strings.Contains(gotErr.Error(), tt.expectedError) {
+					found = true
+					break
+				}
+			}
+
+			if tt.wantError && !found {
+				t.Errorf("AutoscalingSpecs.Validate() = %v, want string \"%v\"", got, tt.expectedError)
+			}
+		})
+	}
+}
+
+func volumeClaimTemplates(volumeClaims []string) []corev1.PersistentVolumeClaim {
+	volumeClaimTemplates := make([]corev1.PersistentVolumeClaim, len(volumeClaims))
+	for i := range volumeClaims {
+		volumeClaimTemplates[i] = corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: volumeClaims[i],
+			},
+		}
+	}
+	return volumeClaimTemplates
+}

--- a/pkg/controller/elasticsearch/validation/autoscaling_validation_test.go
+++ b/pkg/controller/elasticsearch/validation/autoscaling_validation_test.go
@@ -96,7 +96,7 @@ func TestResourcePolicies_Validate(t *testing.T) {
 		{
 			name:          "Autoscaling policy with no NodeSet",
 			wantError:     true,
-			expectedError: "Invalid value: []string{\"ml\"}: roles must be set in at least one nodeSet",
+			expectedError: "Invalid value: []string{\"ml\"}: roles must be used in at least one nodeSet",
 			nodeSets:      map[string][]string{"nodeset-data-1": {"data"}, "nodeset-data-2": {"data"}},
 			autoscalingSpec: `
 {

--- a/pkg/controller/elasticsearch/validation/autoscaling_validation_test.go
+++ b/pkg/controller/elasticsearch/validation/autoscaling_validation_test.go
@@ -230,7 +230,7 @@ func TestResourcePolicies_Validate(t *testing.T) {
 		},
 		{
 		  "name": "my_policy2",
-		  "roles": [ "data_hot", "data_content" ],
+		  "roles": [ "data_content", "data_hot" ],
 		  "resources" : {
 			  "nodeCount" : { "min" : 1 , "max" : 2 },
 			  "cpu" : { "min" : 1 , "max" : 1 },

--- a/pkg/controller/elasticsearch/validation/validations.go
+++ b/pkg/controller/elasticsearch/validation/validations.go
@@ -22,6 +22,7 @@ import (
 var log = logf.Log.WithName("es-validation")
 
 const (
+	autoscalingVersionMsg    = "autoscaling is not available in this version of Elasticsearch"
 	cfgInvalidMsg            = "Configuration invalid"
 	duplicateNodeSets        = "NodeSet names must be unique"
 	invalidNamesErrMsg       = "Elasticsearch configuration would generate resources with invalid names"
@@ -47,6 +48,7 @@ var validations = []validation{
 	hasCorrectNodeRoles,
 	supportedVersion,
 	validSanIP,
+	validAutoscalingConfiguration,
 }
 
 type updateValidation func(esv1.Elasticsearch, esv1.Elasticsearch) field.ErrorList
@@ -138,8 +140,8 @@ func hasCorrectNodeRoles(es esv1.Elasticsearch) field.ErrorList {
 			errs = append(errs, field.Forbidden(confField(i), fmt.Sprintf(mixedRoleConfigMsg, strings.Join(nodeRoleAttrs, ","))))
 		}
 
-		// check if this nodeSet has the master role
-		seenMaster = seenMaster || (cfg.Node.HasMasterRole() && !cfg.Node.HasVotingOnlyRole() && ns.Count > 0)
+		// Check if this nodeSet has the master role. If autoscaling is enabled the count value in the NodeSet might not be initially set.
+		seenMaster = seenMaster || (cfg.Node.HasMasterRole() && !cfg.Node.HasVotingOnlyRole() && ns.Count > 0) || es.IsAutoscalingDefined()
 	}
 
 	if !seenMaster {

--- a/pkg/controller/elasticsearch/validation/validations_test.go
+++ b/pkg/controller/elasticsearch/validation/validations_test.go
@@ -447,6 +447,45 @@ func Test_noUnknownFields(t *testing.T) {
 	}
 }
 
+func Test_autoscalingValidation(t *testing.T) {
+	type args struct {
+		name         string
+		es           esv1.Elasticsearch
+		expectErrors bool
+	}
+	tests := []args{
+		{
+			name: "unsupported version",
+			es: esv1.Elasticsearch{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{esv1.ElasticsearchAutoscalingSpecAnnotationName: "{}"}},
+				Spec: esv1.ElasticsearchSpec{
+					Version: "7.10.0",
+				},
+			},
+			expectErrors: true,
+		},
+		{
+			name: "supported version",
+			es: esv1.Elasticsearch{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{esv1.ElasticsearchAutoscalingSpecAnnotationName: "{}"}},
+				Spec: esv1.ElasticsearchSpec{
+					Version: "7.11.0",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := validAutoscalingConfiguration(tt.es)
+			actualErrors := len(actual) > 0
+			if tt.expectErrors != actualErrors {
+				t.Errorf("failed validAutoscalingConfiguration(). Name: %v, actual %v, wanted: %v, value: %v", tt.name, actual, tt.expectErrors, tt.es.Spec.NodeSets)
+			}
+		})
+	}
+}
+
 // es returns an es fixture at a given version
 func es(v string) esv1.Elasticsearch {
 	return esv1.Elasticsearch{

--- a/pkg/controller/elasticsearch/validation/volume_validation.go
+++ b/pkg/controller/elasticsearch/validation/volume_validation.go
@@ -25,6 +25,17 @@ import (
 // Storage decrease is not supported if the corresponding StatefulSet has been resized already.
 func validPVCModification(current esv1.Elasticsearch, proposed esv1.Elasticsearch, k8sClient k8s.Client, validateStorageClass bool) field.ErrorList {
 	var errs field.ErrorList
+	if proposed.IsAutoscalingDefined() {
+		// If a resource manifest is applied without a volume claim or with an old volume claim template, the NodeSet specification
+		// will not be processed immediately by the Elasticsearch controller. When autoscaling is enabled it is fine to accept the
+		// manifest, and wait for the autoscaling controller to adjust the volume claim template size.
+		log.V(1).Info(
+			"Autoscaling is enabled in proposed, ignoring PVC modification validation",
+			"namespace", proposed.Namespace,
+			"es_name", proposed.Name,
+		)
+		return errs
+	}
 	for i, proposedNodeSet := range proposed.Spec.NodeSets {
 		currentNodeSet := getNodeSet(proposedNodeSet.Name, current)
 		if currentNodeSet == nil {


### PR DESCRIPTION
This first PR introduces the autoscaling specification "schema" and the validation rules as discussed in https://github.com/elastic/cloud-on-k8s/issues/4006

The [sample is in the recipe folder](https://github.com/elastic/cloud-on-k8s/compare/master...barkbay:autoscaling-spec-1?expand=1#diff-878ebbb5805bf70c6f2eafcb4f7edf0319c23fcb995da88d741107da359382d0R1) until 7.11 is released and the autoscaling controller is implemented. 

It will be followed by other PRs to introduce the autoscaling controller.