### PR TITLE
Enable EKS ARM e2e tests

### DIFF
--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -118,6 +118,13 @@ pipeline {
                     ],
                     wait: false
 
+                build job: 'cloud-on-k8s-e2e-tests-eks-arm',
+                    parameters: [
+                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
+                        string(name: 'branch_specifier', value: GIT_COMMIT)
+                    ],
+                    wait: false
+
                 build job: 'cloud-on-k8s-e2e-tests-resilience',
                     parameters: [
                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -309,6 +309,7 @@ IMG_SUFFIX = -ci
 E2E_REGISTRY_NAMESPACE = eck-ci
 
 GO_TAGS = release
+E2E_TAGS = es
 export LICENSE_PUBKEY = /go/src/github.com/elastic/cloud-on-k8s/.ci/license.key
 TEST_LICENSE = /go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
 MONITORING_SECRETS = /go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json


### PR DESCRIPTION
Enable the ARM e2e test job as part of our regular build hierarchy but restrict it to Elasticsearch tests for now.