### PR TITLE
Fix Dockerfile platform argument for e2e image

### DIFF
--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image for the E2E tests runner
-FROM --platform=$BUILDPLATFORM golang:1.15.7
+FROM --platform=$TARGETPLATFORM golang:1.15.7
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
It looks like we missed this Dockerfile when we fixed the main build in #4081 . The e2e test job on ARM is failing.