### PR TITLE
[1.4] Fix typo in manifest example (#4153)

### DIFF
--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -353,7 +353,7 @@ oc adm policy add-scc-to-user hostaccess -z elastic-agent -n elastic
 +
 [source,yaml,subs="attributes"]
 ----
-aapiVersion: agent.k8s.elastic.co/v1alpha1
+apiVersion: agent.k8s.elastic.co/v1alpha1
 kind: Agent
 metadata:
   name: my-agent


### PR DESCRIPTION
Backports the following commits to 1.4:
 - Fix typo in manifest example (#4153)