### PR TITLE
Add README files to Helm charts

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,5 +1,7 @@
 # ECK Operator Helm Chart
 
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/elastic)](https://artifacthub.io/packages/search?repo=elastic)
+
 This directory contains the experimental Helm chart for deploying the ECK operator. It should be considered beta quality at this point in time.
 
 ## Usage

--- a/deploy/eck-operator/Chart.yaml
+++ b/deploy/eck-operator/Chart.yaml
@@ -2,6 +2,8 @@ apiVersion: v2
 
 name: eck-operator
 
+icon: https://helm.elastic.co/icons/eck.png
+
 description: |-
   A Helm chart for deploying the Elastic Cloud on Kubernetes (ECK) operator: the official Kubernetes operator for orchestrating Elasticsearch, Kibana, APM Server, Enterprise Search, and Beats.
 

--- a/deploy/eck-operator/README.md
+++ b/deploy/eck-operator/README.md
@@ -1,0 +1,20 @@
+# ECK Operator Helm Chart
+
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/elastic)](https://artifacthub.io/packages/helm/elastic/eck-operator)
+
+A Helm chart to install the ECK Operator: the official Kubernetes operator from Elastic to orchestrate Elasticsearch, Kibana, APM Server, Enterprise Search, and Beats on Kubernetes.
+
+For more information about the ECK Operator, see:
+- [Documentation](https://www.elastic.co/guide/en/cloud-on-k8s/current/index.html)
+- [GitHub repo](https://github.com/elastic/cloud-on-k8s)
+
+
+## Requirements
+
+- Supported Kubernetes versions are listed in the documentation: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s_supported_versions.html
+- Helm >= 3.0.0
+
+
+## Usage
+
+Refer to the documentation at https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-install-helm.html

--- a/deploy/eck-operator/charts/eck-operator-crds/Chart.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/Chart.yaml
@@ -1,5 +1,9 @@
 apiVersion: v2
+  
 name: eck-operator-crds
+
+icon: https://helm.elastic.co/icons/eck.png
+
 description: |-
   A Helm chart for installing the ECK operator Custom Resource Definitions (CRD). 
 

--- a/deploy/eck-operator/charts/eck-operator-crds/README.md
+++ b/deploy/eck-operator/charts/eck-operator-crds/README.md
@@ -1,0 +1,16 @@
+# ECK Operator CRDs Helm Chart
+
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/elastic)](https://artifacthub.io/packages/helm/elastic/eck-operator-crds)
+
+A Helm chart to install the Kubernetes Custom Resource Definitions (CRD) required by the ECK Operator: the official Kubernetes operator from Elastic to orchestrate Elasticsearch, Kibana, APM Server, Enterprise Search, and Beats on Kubernetes. This chart is usually automatically installed by the [ECK Operator Helm Chart](https://artifacthub.io/packages/helm/elastic/eck-operator) when installed using the default settings. Refer to the [installation documentation](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-install-helm.html) for more information.   
+
+
+## Requirements
+
+- Supported Kubernetes versions are listed in the documentation: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s_supported_versions.html
+- Helm >= 3.0.0
+
+
+## Usage
+
+Refer to the documentation at https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-install-helm.html


### PR DESCRIPTION
Adds README files so that the listing at https://artifacthub.io/packages/helm/elastic/eck-operator doesn't look empty. 