### PR TITLE
Move naming test out of es package as it also tests Kibana and APM

### DIFF
--- a/test/e2e/naming_test.go
+++ b/test/e2e/naming_test.go
@@ -2,9 +2,9 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-// +build es e2e
+// +build e2e
 
-package es
+package e2e
 
 import (
 	"context"


### PR DESCRIPTION
Otherwise restricting the tests to run via tags is not working correctly as running with `es` tag will also run Kibana and APM instances which will currently fail on ARM environments.