### PR TITLE
Remove trace option from pre-stop script

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/lifecycle_hook.go
+++ b/pkg/controller/elasticsearch/nodespec/lifecycle_hook.go
@@ -21,7 +21,7 @@ func NewPreStopHook() *v1.Handler {
 const PreStopHookScriptConfigKey = "pre-stop-hook-script.sh"
 const PreStopHookScript = `#!/usr/bin/env bash
 
-set -eux
+set -euo pipefail
 
 # This script will wait for up to $PRE_STOP_MAX_WAIT_SECONDS for $POD_IP to disappear from DNS record,
 # then it will wait additional $PRE_STOP_ADDITIONAL_WAIT_SECONDS and exit. This slows down the process shutdown


### PR DESCRIPTION
Removes the trace option from the pre-stop script as it makes test failure logs hard to read. Adds the `pipefail` option to fail on pipe failure.

Fixes #4159