### PR TITLE
Use semver package for version parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,11 @@ reattach-pv:
 	# just check that reattach-pv still compiles
 	go build -o /dev/null hack/reattach-pv/main.go
 
+compile-all: 
+	@ go build ./...
+	@ go test -run=dryrun ./cmd/... ./pkg/... > /dev/null
+	@ $(MAKE) e2e-compile
+
 ## -- tests
 
 unit: clean
@@ -447,7 +452,7 @@ e2e-generate-xml:
 
 # Verify e2e tests compile with no errors, don't run them
 e2e-compile:
-	ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) go test ./test/e2e/... -run=dryrun -tags=$(E2E_TAGS) $(TEST_OPTS) > /dev/null
+	@go test ./test/e2e/... -run=dryrun -tags=$(E2E_TAGS) $(TEST_OPTS) > /dev/null
 
 # Run e2e tests locally (not as a k8s job), with a custom http dialer
 # that can reach ES services running in the k8s cluster through port-forwarding.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.0
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/blang/semver/v4 v4.0.0
 	github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b // indirect
 	github.com/davecgh/go-spew v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.0
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/blang/semver/v4 v4.0.0
 	github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b // indirect
 	github.com/davecgh/go-spew v1.1.1

--- a/pkg/apis/apm/v1/webhook.go
+++ b/pkg/apis/apm/v1/webhook.go
@@ -118,7 +118,7 @@ func checkAgentConfigurationMinVersion(as *ApmServer) field.ErrorList {
 	if err != nil {
 		return err
 	}
-	if !apmVersion.IsSameOrAfter(ApmAgentConfigurationMinVersion) {
+	if !apmVersion.GTE(ApmAgentConfigurationMinVersion) {
 		return field.ErrorList{field.Forbidden(
 			field.NewPath("spec").Child("kibanaRef"),
 			fmt.Sprintf(

--- a/pkg/apis/apm/v1/webhook_test.go
+++ b/pkg/apis/apm/v1/webhook_test.go
@@ -65,7 +65,7 @@ func TestWebhook(t *testing.T) {
 				return serialize(t, apm)
 			},
 			Check: test.ValidationWebhookFailed(
-				`spec.version: Invalid value: "7.x": Invalid version: version string has too few segments: 7.x`,
+				`spec.version: Invalid value: "7.x": Invalid version: No Major.Minor.Patch elements found`,
 			),
 		},
 		{

--- a/pkg/apis/apm/v1beta1/webhook_test.go
+++ b/pkg/apis/apm/v1beta1/webhook_test.go
@@ -64,7 +64,7 @@ func TestWebhook(t *testing.T) {
 				return serialize(t, apm)
 			},
 			Check: test.ValidationWebhookFailed(
-				`spec.version: Invalid value: "7.x": Invalid version: version string has too few segments: 7.x`,
+				`spec.version: Invalid value: "7.x": Invalid version: No Major.Minor.Patch elements found`,
 			),
 		},
 		{

--- a/pkg/apis/common/v1/validations.go
+++ b/pkg/apis/common/v1/validations.go
@@ -86,7 +86,7 @@ func CheckNoDowngrade(prev, curr string) field.ErrorList {
 		return err
 	}
 
-	if !currVer.IsSameOrAfter(*prevVer) {
+	if !currVer.GTE(*prevVer) {
 		return field.ErrorList{field.Forbidden(field.NewPath("spec").Child("version"), "Version downgrades are not supported")}
 	}
 
@@ -99,5 +99,5 @@ func ParseVersion(ver string) (*version.Version, field.ErrorList) {
 		return nil, field.ErrorList{field.Invalid(field.NewPath("spec").Child("version"), ver, fmt.Sprintf("Invalid version: %v", err))}
 	}
 
-	return v, nil
+	return &v, nil
 }

--- a/pkg/apis/elasticsearch/v1/autoscaling.go
+++ b/pkg/apis/elasticsearch/v1/autoscaling.go
@@ -216,7 +216,7 @@ func (as AutoscalingSpec) GetAutoscalingSpecFor(nodeSet NodeSet) (*AutoscalingPo
 	if err != nil {
 		return nil, err
 	}
-	roles, err := getNodeSetRoles(*v, nodeSet)
+	roles, err := getNodeSetRoles(v, nodeSet)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apis/elasticsearch/v1/elasticsearch_config.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_config.go
@@ -187,7 +187,7 @@ func UnpackConfig(c *commonv1.Config, ver version.Version, out *ElasticsearchSet
 // configureTransformRole explicitly sets the transform role to false if the version is below 7.7.0
 func configureTransformRole(cfg *ElasticsearchSettings, ver version.Version) {
 	// nothing to do if the version is above 7.7.0 as the transform role is automatically applied to data nodes by the HasTransformRole method.
-	if ver.IsSameOrAfter(version.From(7, 7, 0)) {
+	if ver.GTE(version.From(7, 7, 0)) {
 		return
 	}
 

--- a/pkg/apis/elasticsearch/v1beta1/validations.go
+++ b/pkg/apis/elasticsearch/v1beta1/validations.go
@@ -81,8 +81,8 @@ func supportedVersion(es *Elasticsearch) field.ErrorList {
 	if err != nil {
 		return field.ErrorList{field.Invalid(field.NewPath("spec").Child("version"), es.Spec.Version, parseVersionErrMsg)}
 	}
-	if v := esversion.SupportedVersions(*ver); v != nil {
-		if err := v.Supports(*ver); err == nil {
+	if v := esversion.SupportedVersions(ver); v != nil {
+		if err := v.WithinRange(ver); err == nil {
 			return field.ErrorList{}
 		}
 	}
@@ -178,7 +178,7 @@ func noDowngrades(current, proposed *Elasticsearch) field.ErrorList {
 	if len(errs) != 0 {
 		return errs
 	}
-	if !currVer.IsSameOrAfter(*currentVer) {
+	if !currVer.GTE(currentVer) {
 		errs = append(errs, field.Invalid(field.NewPath("spec").Child("version"), proposed.Spec.Version, noDowngradesMsg))
 	}
 	return errs
@@ -202,13 +202,13 @@ func validUpgradePath(current, proposed *Elasticsearch) field.ErrorList {
 		return errs
 	}
 
-	v := esversion.SupportedVersions(*currVer)
+	v := esversion.SupportedVersions(currVer)
 	if v == nil {
 		errs = append(errs, field.Invalid(field.NewPath("spec").Child("version"), proposed.Spec.Version, unsupportedVersionMsg))
 		return errs
 	}
 
-	err = v.Supports(*currentVer)
+	err = v.WithinRange(currentVer)
 	if err != nil {
 		errs = append(errs, field.Invalid(field.NewPath("spec").Child("version"), proposed.Spec.Version, unsupportedUpgradeMsg))
 	}

--- a/pkg/apis/enterprisesearch/v1beta1/webhook_test.go
+++ b/pkg/apis/enterprisesearch/v1beta1/webhook_test.go
@@ -64,7 +64,7 @@ func TestWebhook(t *testing.T) {
 				return serialize(t, ent)
 			},
 			Check: test.ValidationWebhookFailed(
-				`spec.version: Invalid value: "7.x": Invalid version: version string has too few segments: 7.x`,
+				`spec.version: Invalid value: "7.x": Invalid version: No Major.Minor.Patch elements found`,
 			),
 		},
 		{

--- a/pkg/apis/kibana/v1/webhook_test.go
+++ b/pkg/apis/kibana/v1/webhook_test.go
@@ -64,7 +64,7 @@ func TestWebhook(t *testing.T) {
 				return serialize(t, k)
 			},
 			Check: test.ValidationWebhookFailed(
-				`spec.version: Invalid value: "7.x": Invalid version: version string has too few segments: 7.x`,
+				`spec.version: Invalid value: "7.x": Invalid version: No Major.Minor.Patch elements found`,
 			),
 		},
 		{

--- a/pkg/apis/kibana/v1beta1/webhook_test.go
+++ b/pkg/apis/kibana/v1beta1/webhook_test.go
@@ -64,7 +64,7 @@ func TestWebhook(t *testing.T) {
 				return serialize(t, k)
 			},
 			Check: test.ValidationWebhookFailed(
-				`spec.version: Invalid value: "7.x": Invalid version: version string has too few segments: 7.x`,
+				`spec.version: Invalid value: "7.x": Invalid version: No Major.Minor.Patch elements found`,
 			),
 		},
 		{

--- a/pkg/controller/agent/driver.go
+++ b/pkg/controller/agent/driver.go
@@ -65,7 +65,7 @@ func internalReconcile(params Params) *reconciler.Results {
 	if err != nil {
 		return results.WithError(err)
 	}
-	if !association.AllowVersion(*agentVersion, &params.Agent, params.Logger(), params.EventRecorder) {
+	if !association.AllowVersion(agentVersion, &params.Agent, params.Logger(), params.EventRecorder) {
 		return results // will eventually retry
 	}
 

--- a/pkg/controller/apmserver/controller.go
+++ b/pkg/controller/apmserver/controller.go
@@ -262,7 +262,7 @@ func (r *ReconcileApmServer) doReconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, err
 	}
 	logger := log.WithValues("namespace", as.Namespace, "as_name", as.Name)
-	if !association.AllowVersion(*asVersion, as, logger, r.recorder) {
+	if !association.AllowVersion(asVersion, as, logger, r.recorder) {
 		return reconcile.Result{}, nil // will eventually retry
 	}
 

--- a/pkg/controller/association/conf.go
+++ b/pkg/controller/association/conf.go
@@ -130,7 +130,9 @@ func AllowVersion(resourceVersion version.Version, associated commonv1.Associate
 			logger.Error(err, "Invalid version found in association configuration", "association_version", assoc.AssociationConf().Version)
 			return false
 		}
-		if !refVer.IsSameOrAfterIgnoringPatch(resourceVersion) {
+
+		compatibleVersions := refVer.GTE(resourceVersion) || ((refVer.Major == resourceVersion.Major) && (refVer.Minor == resourceVersion.Minor))
+		if !compatibleVersions {
 			// the version of the referenced resource (example: Elasticsearch) is lower than
 			// the desired version of the reconciled resource (example: Kibana)
 			logger.Info("Delaying version deployment since a referenced resource is not upgraded yet",

--- a/pkg/controller/association/controller/apm_es.go
+++ b/pkg/controller/association/controller/apm_es.go
@@ -99,7 +99,7 @@ func getAPMElasticsearchRoles(associated commonv1.Associated) (string, error) {
 	}
 
 	// 7.5.x and above
-	if v.IsSameOrAfter(version.From(7, 5, 0)) {
+	if v.GTE(version.From(7, 5, 0)) {
 		return strings.Join([]string{
 			user.ApmUserRoleV75, // Retrieve cluster details (e.g. version) and manage apm-* indices
 			"ingest_admin",      // Set up index templates
@@ -108,7 +108,7 @@ func getAPMElasticsearchRoles(associated commonv1.Associated) (string, error) {
 	}
 
 	// 7.1.x to 7.4.x
-	if v.IsSameOrAfter(version.From(7, 1, 0)) {
+	if v.GTE(version.From(7, 1, 0)) {
 		return strings.Join([]string{
 			user.ApmUserRoleV7, // Retrieve cluster details (e.g. version) and manage apm-* indices
 			"ingest_admin",     // Set up index templates

--- a/pkg/controller/association/controller/beat_es.go
+++ b/pkg/controller/association/controller/beat_es.go
@@ -87,7 +87,7 @@ func getBeatRoles(assoc commonv1.Associated) (string, error) {
 	// Docs are the same for all Beats. For a specific version docs change "current" to major.minor, eg:
 	// https://www.elastic.co/guide/en/beats/filebeat/7.1/feature-roles.html
 	switch {
-	case v.IsSameOrAfter(version.From(7, 7, 0)):
+	case v.GTE(version.From(7, 7, 0)):
 		return strings.Join([]string{
 			"kibana_admin",
 			"ingest_admin",
@@ -95,7 +95,7 @@ func getBeatRoles(assoc commonv1.Associated) (string, error) {
 			"remote_monitoring_agent",
 			esuser.BeatEsRoleName(esuser.V77, beat.Spec.Type),
 		}, ","), nil
-	case v.IsSameOrAfter(version.From(7, 5, 0)):
+	case v.GTE(version.From(7, 5, 0)):
 		return strings.Join([]string{
 			"kibana_user",
 			"ingest_admin",
@@ -103,7 +103,7 @@ func getBeatRoles(assoc commonv1.Associated) (string, error) {
 			"remote_monitoring_agent",
 			esuser.BeatEsRoleName(esuser.V75, beat.Spec.Type),
 		}, ","), nil
-	case v.IsSameOrAfter(version.From(7, 3, 0)):
+	case v.GTE(version.From(7, 3, 0)):
 		return strings.Join([]string{
 			"kibana_user",
 			"ingest_admin",

--- a/pkg/controller/association/controller/beat_kibana.go
+++ b/pkg/controller/association/controller/beat_kibana.go
@@ -95,14 +95,14 @@ func getBeatKibanaRoles(associated commonv1.Associated) (string, error) {
 	// Docs are the same for all Beats. For a specific version docs change "current" to major.minor, eg:
 	// https://www.elastic.co/guide/en/beats/filebeat/7.1/feature-roles.html#privileges-to-setup-beats
 	switch {
-	case v.IsSameOrAfter(version.From(7, 7, 0)):
+	case v.GTE(version.From(7, 7, 0)):
 		return strings.Join([]string{
 			"kibana_admin",
 			"ingest_admin",
 			"beats_admin",
 			esuser.BeatKibanaRoleName(esuser.V77, beat.Spec.Type),
 		}, ","), nil
-	case v.IsSameOrAfter(version.From(7, 3, 0)):
+	case v.GTE(version.From(7, 3, 0)):
 		return strings.Join([]string{
 			"kibana_user",
 			"ingest_admin",

--- a/pkg/controller/beat/common/driver.go
+++ b/pkg/controller/beat/common/driver.go
@@ -79,7 +79,7 @@ func Reconcile(
 	if err != nil {
 		return results.WithError(err)
 	}
-	if !association.AllowVersion(*beatVersion, &params.Beat, params.Logger, params.Recorder()) {
+	if !association.AllowVersion(beatVersion, &params.Beat, params.Logger, params.Recorder()) {
 		return results // will eventually retry
 	}
 

--- a/pkg/controller/common/annotation/controller_version.go
+++ b/pkg/controller/common/annotation/controller_version.go
@@ -126,7 +126,7 @@ func ReconcileCompatibility(ctx context.Context, client k8s.Client, obj ctrlclie
 	}
 
 	// if the current version is gte the minimum version then they are compatible
-	if currentVersion.IsSameOrAfter(*minVersion) {
+	if currentVersion.GTE(minVersion) {
 		return true, nil
 	}
 

--- a/pkg/controller/common/version/version.go
+++ b/pkg/controller/common/version/version.go
@@ -7,7 +7,7 @@ package version
 import (
 	"fmt"
 
-	semver "github.com/blang/semver/v4"
+	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -17,7 +17,8 @@ import (
 // It exists purely to avoid accidentally importing the old github.com/blang/semver instead of github.com/blang/semver/v4.
 type Version = semver.Version
 
-// GlobalMinStackVersion to additional restrict the allowed min version beyond the technical requirements expressed below.
+// GlobalMinStackVersion is an additional restriction on top of the technical requirements expressed below.
+// Used to support UBI images where compatible images are only available from a particular stack version onwards.
 var GlobalMinStackVersion Version
 
 // supported Stack versions. See https://www.elastic.co/support/matrix#matrix_compatibility

--- a/pkg/controller/common/version/version_test.go
+++ b/pkg/controller/common/version/version_test.go
@@ -5,362 +5,43 @@
 package version
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
+	semver "github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestParse(t *testing.T) {
-	type args struct {
-		version string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    *Version
-		wantErr bool
-	}{
-		{
-			name: "simple version",
-			args: args{version: "1.2.3"},
-			want: &Version{Major: 1, Minor: 2, Patch: 3},
-		},
-		{
-			name: "version with label",
-			args: args{version: "1.2.3-foo"},
-			want: &Version{Major: 1, Minor: 2, Patch: 3, Label: "foo"},
-		},
-		{
-			name: "version with dotted label",
-			args: args{version: "1.2.3-f.oo"},
-			want: &Version{Major: 1, Minor: 2, Patch: 3, Label: "f.oo"},
-		},
-		{
-			name: "version with dashed label",
-			args: args{version: "1.2.3-f.o-o"},
-			want: &Version{Major: 1, Minor: 2, Patch: 3, Label: "f.o-o"},
-		},
-		{
-			name: "zero version",
-			args: args{version: "0.0.0"},
-			want: &Version{},
-		},
-		{
-			name:    "invalid major version",
-			args:    args{version: "a.0.0"},
-			wantErr: true,
-		},
-		{
-			name:    "invalid minor version",
-			args:    args{version: "0.a.0"},
-			wantErr: true,
-		},
-		{
-			name:    "invalid patch version",
-			args:    args{version: "0.0.a"},
-			wantErr: true,
-		},
-		{
-			name:    "invalid label",
-			args:    args{version: "0.0.0.label"},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := Parse(tt.args.version)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Parse() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestMustParse(t *testing.T) {
-	type args struct {
-		version string
-	}
-	tests := []struct {
-		name string
-		args args
-		want Version
-	}{
-		{name: "simple", args: args{"7.0.0"}, want: Version{Major: 7}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := MustParse(tt.args.version); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("MustParse() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestVersion_IsSameOrAfter(t *testing.T) {
-	dimensions := 2
-	sortedVersionsLength := dimensions * dimensions * dimensions
-	sortedVersions := make([]Version, sortedVersionsLength)
-	for major := 0; major < dimensions; major++ {
-		for minor := 0; minor < dimensions; minor++ {
-			for patch := 0; patch < dimensions; patch++ {
-				index := major*dimensions*dimensions + minor*dimensions + patch
-				sortedVersions[index] = Version{Major: major, Minor: minor, Patch: patch}
-			}
-		}
-	}
-
-	type test struct {
-		name  string
-		v     Version
-		other Version
-		want  bool
-	}
-	tests := make([]test, 0)
-
-	for i, version := range sortedVersions {
-		for j := 0; j < i; j++ {
-			other := sortedVersions[j]
-			tests = append(tests, test{
-				name:  fmt.Sprintf("%v > %v", version, other),
-				v:     version,
-				other: other,
-				want:  true,
-			})
-		}
-		tests = append(tests, test{
-			name:  fmt.Sprintf("%v=%v", version, version),
-			v:     version,
-			other: version,
-			want:  true,
-		})
-		for j := i + 1; j < sortedVersionsLength; j++ {
-			other := sortedVersions[j]
-			tests = append(tests, test{
-				name:  fmt.Sprintf("%v < %v", version, other),
-				v:     version,
-				other: other,
-				want:  false,
-			})
-		}
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.v.IsSameOrAfter(tt.other); got != tt.want {
-				t.Errorf("Version.IsSameOrAfter() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestMin(t *testing.T) {
-
-	tests := []struct {
-		name string
-		args []Version
-		want *Version
-	}{
-		{
-			name: "nil versions",
-			args: nil,
-			want: nil,
-		},
-		{
-			name: "empty versions",
-			args: []Version{},
-			want: nil,
-		},
-		{
-			name: "two versions",
-			args: []Version{
-				{
-					Major: 2,
-					Minor: 0,
-					Patch: 0,
-					Label: "",
-				},
-				{
-					Major: 1,
-					Minor: 0,
-					Patch: 0,
-					Label: "",
-				},
-			},
-			want: &Version{
-				Major: 1,
-				Minor: 0,
-				Patch: 0,
-				Label: "",
-			},
-		},
-		{
-			name: "n versions",
-			args: []Version{
-				{
-					Major: 7,
-					Minor: 0,
-					Patch: 0,
-					Label: "SNAPSHOT",
-				},
-				{
-					Major: 1,
-					Minor: 0,
-					Patch: 0,
-					Label: "rc1",
-				},
-				{
-					Major: 6,
-					Minor: 7,
-					Patch: 0,
-					Label: "",
-				},
-			},
-			want: &Version{
-				Major: 1,
-				Minor: 0,
-				Patch: 0,
-				Label: "rc1",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := Min(tt.args); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Min() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestVersion_IsSame(t *testing.T) {
-	tests := []struct {
-		name string
-		v1   Version
-		v2   Version
-		want bool
-	}{
-		{
-			name: "same version (different labels)",
-			v1:   Version{Major: 7, Minor: 7, Patch: 0, Label: "v1"},
-			v2:   Version{Major: 7, Minor: 7, Patch: 0, Label: "v2"},
-			want: true,
-		},
-		{
-			name: "not the same patch",
-			v1:   Version{Major: 7, Minor: 7, Patch: 0, Label: "v1"},
-			v2:   Version{Major: 7, Minor: 7, Patch: 1, Label: "v2"},
-			want: false,
-		},
-		{
-			name: "not the same minor",
-			v1:   Version{Major: 7, Minor: 7, Patch: 0, Label: "v1"},
-			v2:   Version{Major: 7, Minor: 8, Patch: 0, Label: "v2"},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, tt.v1.IsSame(tt.v2))
-		})
-	}
-}
-
-func TestVersion_IsAfter(t *testing.T) {
-	tests := []struct {
-		name string
-		v1   Version
-		v2   Version
-		want bool
-	}{
-		{
-			name: "same version",
-			v1:   Version{Major: 7, Minor: 7, Patch: 0, Label: "v1"},
-			v2:   Version{Major: 7, Minor: 7, Patch: 0, Label: "v2"},
-			want: false,
-		},
-		{
-			name: "lower patch",
-			v1:   Version{Major: 7, Minor: 7, Patch: 1, Label: "v1"},
-			v2:   Version{Major: 7, Minor: 7, Patch: 2, Label: "v2"},
-			want: false,
-		},
-		{
-			name: "higher patch",
-			v1:   Version{Major: 7, Minor: 7, Patch: 1, Label: "v1"},
-			v2:   Version{Major: 7, Minor: 7, Patch: 0, Label: "v2"},
-			want: true,
-		},
-		{
-			name: "higher minor (lower patch)",
-			v1:   Version{Major: 7, Minor: 8, Patch: 0, Label: "v1"},
-			v2:   Version{Major: 7, Minor: 7, Patch: 1, Label: "v2"},
-			want: true,
-		},
-		{
-			name: "lower minor (higher patch)",
-			v1:   Version{Major: 7, Minor: 7, Patch: 1, Label: "v1"},
-			v2:   Version{Major: 7, Minor: 8, Patch: 0, Label: "v2"},
-			want: false,
-		},
-		{
-			name: "higher major (lower minor)",
-			v1:   Version{Major: 8, Minor: 0, Patch: 0, Label: "v1"},
-			v2:   Version{Major: 7, Minor: 7, Patch: 1, Label: "v2"},
-			want: true,
-		},
-		{
-			name: "lower major (higher minor)",
-			v1:   Version{Major: 7, Minor: 7, Patch: 1, Label: "v1"},
-			v2:   Version{Major: 8, Minor: 0, Patch: 0, Label: "v2"},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, tt.v1.IsAfter(tt.v2))
-		})
-	}
-}
-
 func TestFromLabels(t *testing.T) {
 	labelName := "label-with-version"
 	tests := []struct {
 		name    string
 		labels  map[string]string
-		want    *Version
+		want    Version
 		wantErr bool
 	}{
 		{
 			name:    "happy path",
 			labels:  map[string]string{labelName: "7.7.0"},
-			want:    &Version{Major: 7, Minor: 7, Patch: 0},
+			want:    semver.MustParse("7.7.0"),
 			wantErr: false,
 		},
 		{
 			name:    "label not set",
 			labels:  map[string]string{},
-			want:    nil,
 			wantErr: true,
 		},
 		{
 			name:    "labels nil",
 			labels:  map[string]string{},
-			want:    nil,
 			wantErr: true,
 		},
 		{
 			name:    "invalid version",
 			labels:  map[string]string{labelName: "invalid"},
-			want:    nil,
 			wantErr: true,
 		},
 	}
@@ -403,7 +84,7 @@ func TestMinInPods(t *testing.T) {
 				},
 				labelName: "version-label",
 			},
-			want:    ptr(MustParse("7.7.0")),
+			want:    ptr(semver.MustParse("7.7.0")),
 			wantErr: false,
 		},
 		{
@@ -415,7 +96,7 @@ func TestMinInPods(t *testing.T) {
 				},
 				labelName: "version-label",
 			},
-			want:    ptr(MustParse("7.7.1")),
+			want:    ptr(semver.MustParse("7.7.1")),
 			wantErr: false,
 		},
 		{
@@ -427,7 +108,6 @@ func TestMinInPods(t *testing.T) {
 				},
 				labelName: "version-label",
 			},
-			want:    nil,
 			wantErr: true,
 		},
 		{
@@ -439,7 +119,6 @@ func TestMinInPods(t *testing.T) {
 				},
 				labelName: "another-label",
 			},
-			want:    nil,
 			wantErr: true,
 		},
 		{
@@ -448,19 +127,17 @@ func TestMinInPods(t *testing.T) {
 				pods:      nil,
 				labelName: "version-label",
 			},
-			want:    nil,
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := MinInPods(tt.args.pods, tt.args.labelName)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("MinInPods() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("MinInPods() got = %v, want %v", got, tt.want)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
 			}
 		})
 	}
@@ -493,7 +170,7 @@ func TestMinInStatefulSets(t *testing.T) {
 				},
 				labelName: "version-label",
 			},
-			want:    ptr(MustParse("7.7.0")),
+			want:    ptr(semver.MustParse("7.7.0")),
 			wantErr: false,
 		},
 		{
@@ -505,7 +182,7 @@ func TestMinInStatefulSets(t *testing.T) {
 				},
 				labelName: "version-label",
 			},
-			want:    ptr(MustParse("7.7.1")),
+			want:    ptr(semver.MustParse("7.7.1")),
 			wantErr: false,
 		},
 		{
@@ -517,7 +194,6 @@ func TestMinInStatefulSets(t *testing.T) {
 				},
 				labelName: "version-label",
 			},
-			want:    nil,
 			wantErr: true,
 		},
 		{
@@ -529,7 +205,6 @@ func TestMinInStatefulSets(t *testing.T) {
 				},
 				labelName: "another-label",
 			},
-			want:    nil,
 			wantErr: true,
 		},
 		{
@@ -538,84 +213,18 @@ func TestMinInStatefulSets(t *testing.T) {
 				ssets:     nil,
 				labelName: "version-label",
 			},
-			want:    nil,
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := MinInStatefulSets(tt.args.ssets, tt.args.labelName)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("MinInStatefulSets() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("MinInStatefulSets() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestVersion_IsSameOrAfterIgnoringPatch(t *testing.T) {
-	tests := []struct {
-		name  string
-		v     Version
-		other Version
-		want  bool
-	}{
-		{
-			name:  "same version",
-			v:     MustParse("7.8.1"),
-			other: MustParse("7.8.1"),
-			want:  true,
-		},
-		{
-			name:  "lower patch version",
-			v:     MustParse("7.8.1"),
-			other: MustParse("7.8.2"),
-			want:  true,
-		},
-		{
-			name:  "higher patch version",
-			v:     MustParse("7.8.2"),
-			other: MustParse("7.8.1"),
-			want:  true,
-		},
-		{
-			name:  "lower minor",
-			v:     MustParse("7.7.1"),
-			other: MustParse("7.8.1"),
-			want:  false,
-		},
-		{
-			name:  "higher minor",
-			v:     MustParse("7.8.1"),
-			other: MustParse("7.7.1"),
-			want:  true,
-		},
-		{
-			name:  "lower major",
-			v:     MustParse("6.7.1"),
-			other: MustParse("7.7.1"),
-			want:  false,
-		},
-		{
-			name:  "higher major",
-			v:     MustParse("7.7.1"),
-			other: MustParse("6.7.1"),
-			want:  true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			vCopy := tt.v.Copy()
-			otherCopy := tt.other.Copy()
-			if got := tt.v.IsSameOrAfterIgnoringPatch(tt.other); got != tt.want {
-				t.Errorf("IsSameOrAfterIgnoringPatch() = %v, want %v", got, tt.want)
-			}
-			// ensure v and other haven't been modified
-			require.Equal(t, *vCopy, tt.v)
-			require.Equal(t, *otherCopy, tt.other)
 		})
 	}
 }
@@ -637,43 +246,43 @@ func TestMinMaxVersion_WithMin(t *testing.T) {
 		{
 			name: "No minimum",
 			fields: fields{
-				Min: MustParse("6.8.0"),
-				Max: MustParse("8.0.0"),
+				Min: semver.MustParse("6.8.0"),
+				Max: semver.MustParse("8.0.0"),
 			},
 			args: args{
 				min: Version{},
 			},
 			want: MinMaxVersion{
-				Min: MustParse("6.8.0"),
-				Max: MustParse("8.0.0"),
+				Min: semver.MustParse("6.8.0"),
+				Max: semver.MustParse("8.0.0"),
 			},
 		},
 		{
 			name: "min >= global min",
 			fields: fields{
-				Min: MustParse("7.10.0"),
-				Max: MustParse("8.0.0"),
+				Min: semver.MustParse("7.10.0"),
+				Max: semver.MustParse("8.0.0"),
 			},
 			args: args{
-				min: MustParse("7.10.0"),
+				min: semver.MustParse("7.10.0"),
 			},
 			want: MinMaxVersion{
-				Min: MustParse("7.10.0"),
-				Max: MustParse("8.0.0"),
+				Min: semver.MustParse("7.10.0"),
+				Max: semver.MustParse("8.0.0"),
 			},
 		},
 		{
 			name: "min < global min",
 			fields: fields{
-				Min: MustParse("6.8.0"),
-				Max: MustParse("8.0.0"),
+				Min: semver.MustParse("6.8.0"),
+				Max: semver.MustParse("8.0.0"),
 			},
 			args: args{
-				min: MustParse("7.10.0"),
+				min: semver.MustParse("7.10.0"),
 			},
 			want: MinMaxVersion{
-				Min: MustParse("7.10.0"),
-				Max: MustParse("8.0.0"),
+				Min: semver.MustParse("7.10.0"),
+				Max: semver.MustParse("8.0.0"),
 			},
 		},
 	}

--- a/pkg/controller/elasticsearch/client/model.go
+++ b/pkg/controller/elasticsearch/client/model.go
@@ -313,7 +313,7 @@ func (l License) IsValid(instant time.Time) bool {
 
 // IsSupported returns true if the current license type is supported by the given version of Elasticsearch.
 func (l License) IsSupported(v *version.Version) bool {
-	if l.Type == string(ElasticsearchLicenseTypeEnterprise) && !v.IsSameOrAfter(version.MustParse("7.8.1")) {
+	if l.Type == string(ElasticsearchLicenseTypeEnterprise) && !v.GTE(version.MustParse("7.8.1")) {
 		return false
 	}
 	return true

--- a/pkg/controller/elasticsearch/client/v7.go
+++ b/pkg/controller/elasticsearch/client/v7.go
@@ -44,7 +44,7 @@ func (c *clientV7) StartTrial(ctx context.Context) (StartTrialResponse, error) {
 
 func (c *clientV7) AddVotingConfigExclusions(ctx context.Context, nodeNames []string) error {
 	var path string
-	if c.version.IsSameOrAfter(version.From(7, 8, 0)) {
+	if c.version.GTE(version.From(7, 8, 0)) {
 		path = fmt.Sprintf("/_cluster/voting_config_exclusions?node_names=%s", strings.Join(nodeNames, ","))
 	} else {
 		// versions < 7.8.0 or unversioned clients which is OK as this deprecated API will be supported until 8.0

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -39,7 +39,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/services"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/user"
-	esversion "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/version"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
@@ -67,7 +66,7 @@ type DefaultDriverParameters struct {
 	// ES is the Elasticsearch resource to reconcile
 	ES esv1.Elasticsearch
 	// SupportedVersions verifies whether we can support upgrading from the current pods.
-	SupportedVersions esversion.LowestHighestSupportedVersions
+	SupportedVersions version.MinMaxVersion
 
 	// Version is the version of Elasticsearch we want to reconcile towards.
 	Version version.Version

--- a/pkg/controller/elasticsearch/driver/version.go
+++ b/pkg/controller/elasticsearch/driver/version.go
@@ -17,7 +17,7 @@ func (d *defaultDriver) verifySupportsExistingPods(pods []corev1.Pod) error {
 		if err != nil {
 			return err
 		}
-		if err := d.SupportedVersions.Supports(*v); err != nil {
+		if err := d.SupportedVersions.WithinRange(v); err != nil {
 			return errors.Wrapf(err, "%s has incompatible version", pod.Name)
 		}
 	}

--- a/pkg/controller/elasticsearch/driver/version_test.go
+++ b/pkg/controller/elasticsearch/driver/version_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
-	esversion "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/version"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -29,8 +28,8 @@ func Test_lowestHighestSupportedVersions_VerifySupportsExistingPods(t *testing.T
 		}
 	}
 	type fields struct {
-		lowestSupportedVersion  version.Version
-		highestSupportedVersion version.Version
+		min version.Version
+		max version.Version
 	}
 	type args struct {
 		pods []corev1.Pod
@@ -50,8 +49,8 @@ func Test_lowestHighestSupportedVersions_VerifySupportsExistingPods(t *testing.T
 		{
 			name: "pod with version label at higher bound",
 			fields: fields{
-				lowestSupportedVersion:  version.Version{Major: 6},
-				highestSupportedVersion: version.Version{Major: 7},
+				min: version.Version{Major: 6},
+				max: version.Version{Major: 7},
 			},
 			args:    args{pods: []corev1.Pod{newPodWithVersionLabel(version.Version{Major: 7})}},
 			wantErr: false,
@@ -59,8 +58,8 @@ func Test_lowestHighestSupportedVersions_VerifySupportsExistingPods(t *testing.T
 		{
 			name: "pod with version label at lower bound",
 			fields: fields{
-				lowestSupportedVersion:  version.Version{Major: 6},
-				highestSupportedVersion: version.Version{Major: 7},
+				min: version.Version{Major: 6},
+				max: version.Version{Major: 7},
 			},
 			args:    args{pods: []corev1.Pod{newPodWithVersionLabel(version.Version{Major: 6})}},
 			wantErr: false,
@@ -68,8 +67,8 @@ func Test_lowestHighestSupportedVersions_VerifySupportsExistingPods(t *testing.T
 		{
 			name: "pod with version label within bounds",
 			fields: fields{
-				lowestSupportedVersion:  version.Version{Major: 6},
-				highestSupportedVersion: version.Version{Major: 7},
+				min: version.Version{Major: 6},
+				max: version.Version{Major: 7},
 			},
 			args:    args{pods: []corev1.Pod{newPodWithVersionLabel(version.Version{Major: 6, Minor: 4, Patch: 2})}},
 			wantErr: false,
@@ -83,8 +82,8 @@ func Test_lowestHighestSupportedVersions_VerifySupportsExistingPods(t *testing.T
 		{
 			name: "pod with too low version label",
 			fields: fields{
-				lowestSupportedVersion:  version.Version{Major: 6},
-				highestSupportedVersion: version.Version{Major: 7},
+				min: version.Version{Major: 6},
+				max: version.Version{Major: 7},
 			},
 			args:    args{pods: []corev1.Pod{newPodWithVersionLabel(version.Version{Major: 5})}},
 			wantErr: true,
@@ -92,8 +91,8 @@ func Test_lowestHighestSupportedVersions_VerifySupportsExistingPods(t *testing.T
 		{
 			name: "pod with too high version label",
 			fields: fields{
-				lowestSupportedVersion:  version.Version{Major: 6},
-				highestSupportedVersion: version.Version{Major: 7},
+				min: version.Version{Major: 6},
+				max: version.Version{Major: 7},
 			},
 			args:    args{pods: []corev1.Pod{newPodWithVersionLabel(version.Version{Major: 8})}},
 			wantErr: true,
@@ -101,9 +100,9 @@ func Test_lowestHighestSupportedVersions_VerifySupportsExistingPods(t *testing.T
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			lh := esversion.LowestHighestSupportedVersions{
-				LowestSupportedVersion:  tt.fields.lowestSupportedVersion,
-				HighestSupportedVersion: tt.fields.highestSupportedVersion,
+			lh := version.MinMaxVersion{
+				Min: tt.fields.min,
+				Max: tt.fields.max,
 			}
 			d := defaultDriver{
 				DefaultDriverParameters{

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -270,7 +270,7 @@ func (r *ReconcileElasticsearch) internalReconcile(
 	if err != nil {
 		return results.WithError(err)
 	}
-	supported := esversion.SupportedVersions(*ver)
+	supported := esversion.SupportedVersions(ver)
 	if supported == nil {
 		return results.WithError(pkgerrors.Errorf("unsupported version: %s", ver))
 	}
@@ -281,7 +281,7 @@ func (r *ReconcileElasticsearch) internalReconcile(
 		ReconcileState:     reconcileState,
 		Client:             r.Client,
 		Recorder:           r.recorder,
-		Version:            *ver,
+		Version:            ver,
 		Expectations:       r.expectations.ForCluster(k8s.ExtractNamespacedName(&es)),
 		Observers:          r.esObservers,
 		DynamicWatches:     r.dynamicWatches,

--- a/pkg/controller/elasticsearch/label/label.go
+++ b/pkg/controller/elasticsearch/label/label.go
@@ -89,7 +89,7 @@ func IsDataNode(pod corev1.Pod) bool {
 }
 
 // ExtractVersion extracts the Elasticsearch version from the given labels.
-func ExtractVersion(labels map[string]string) (*version.Version, error) {
+func ExtractVersion(labels map[string]string) (version.Version, error) {
 	return version.FromLabels(labels, VersionLabelName)
 }
 
@@ -121,12 +121,12 @@ func NewPodLabels(
 	NodeTypesIngestLabelName.Set(nodeRoles.HasIngestRole(), labels)
 	NodeTypesMLLabelName.Set(nodeRoles.HasMLRole(), labels)
 	// transform and remote_cluster_client roles were only added in 7.7.0 so we should not annotate previous versions with them
-	if ver.IsSameOrAfter(version.From(7, 7, 0)) {
+	if ver.GTE(version.From(7, 7, 0)) {
 		NodeTypesTransformLabelName.Set(nodeRoles.HasTransformRole(), labels)
 		NodeTypesRemoteClusterClientLabelName.Set(nodeRoles.HasRemoteClusterClientRole(), labels)
 	}
 	// voting_only master eligible nodes were added only in 7.3.0 so we don't want to label prior versions with it
-	if ver.IsSameOrAfter(version.From(7, 3, 0)) {
+	if ver.GTE(version.From(7, 3, 0)) {
 		NodeTypesVotingOnlyLabelName.Set(nodeRoles.HasVotingOnlyRole(), labels)
 	}
 

--- a/pkg/controller/elasticsearch/label/label_test.go
+++ b/pkg/controller/elasticsearch/label/label_test.go
@@ -47,13 +47,12 @@ func TestExtractVersion(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    map[string]string
-		want    *version.Version
+		want    version.Version
 		wantErr bool
 	}{
 		{
 			name:    "no version",
 			args:    nil,
-			want:    nil,
 			wantErr: true,
 		},
 		{
@@ -61,7 +60,6 @@ func TestExtractVersion(t *testing.T) {
 			args: map[string]string{
 				VersionLabelName: "not a version",
 			},
-			want:    nil,
 			wantErr: true,
 		},
 		{
@@ -69,12 +67,7 @@ func TestExtractVersion(t *testing.T) {
 			args: map[string]string{
 				VersionLabelName: "1.0.0",
 			},
-			want: &version.Version{
-				Major: 1,
-				Minor: 0,
-				Patch: 0,
-				Label: "",
-			},
+			want:    version.MustParse("1.0.0"),
 			wantErr: false,
 		},
 	}

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -67,7 +67,7 @@ func BuildPodTemplateSpec(
 	if err != nil {
 		return corev1.PodTemplateSpec{}, err
 	}
-	if ver.IsSameOrAfter(minDefaultSecurityContextVersion) && setDefaultSecurityContext {
+	if ver.GTE(minDefaultSecurityContextVersion) && setDefaultSecurityContext {
 		builder = builder.WithPodSecurityContext(corev1.PodSecurityContext{
 			FSGroup: pointer.Int64(defaultFsGroup),
 		})
@@ -121,7 +121,7 @@ func buildLabels(
 	}
 
 	// label with a hash of the config to rotate the pod on config changes
-	unpackedCfg, err := cfg.Unpack(*ver)
+	unpackedCfg, err := cfg.Unpack(ver)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func buildLabels(
 	podLabels := label.NewPodLabels(
 		k8s.ExtractNamespacedName(&es),
 		esv1.StatefulSet(es.Name, nodeSet.Name),
-		*ver, node, cfgHash, es.Spec.HTTP.Protocol(),
+		ver, node, cfgHash, es.Spec.HTTP.Protocol(),
 	)
 
 	if keystoreResources != nil {

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -178,7 +178,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 	nodeSet := sampleES.Spec.NodeSets[0]
 	ver, err := version.Parse(sampleES.Spec.Version)
 	require.NoError(t, err)
-	cfg, err := settings.NewMergedESConfig(sampleES.Name, *ver, corev1.IPv4Protocol, sampleES.Spec.HTTP, *nodeSet.Config)
+	cfg, err := settings.NewMergedESConfig(sampleES.Name, ver, corev1.IPv4Protocol, sampleES.Spec.HTTP, *nodeSet.Config)
 	require.NoError(t, err)
 
 	actual, err := BuildPodTemplateSpec(sampleES, sampleES.Spec.NodeSets[0], cfg, nil, false)

--- a/pkg/controller/elasticsearch/nodespec/resources.go
+++ b/pkg/controller/elasticsearch/nodespec/resources.go
@@ -54,7 +54,7 @@ func BuildExpectedResources(
 		if nodeSpec.Config != nil {
 			userCfg = *nodeSpec.Config
 		}
-		cfg, err := settings.NewMergedESConfig(es.Name, *ver, ipFamily, es.Spec.HTTP, userCfg)
+		cfg, err := settings.NewMergedESConfig(es.Name, ver, ipFamily, es.Spec.HTTP, userCfg)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/elasticsearch/reconcile/state.go
+++ b/pkg/controller/elasticsearch/reconcile/state.go
@@ -61,7 +61,12 @@ func (s *State) fetchMinRunningVersion(resourcesState ResourcesState) (*version.
 	if minSsetVersion == nil {
 		return minPodVersion, nil
 	}
-	return version.Min([]version.Version{*minPodVersion, *minSsetVersion}), nil
+
+	if minPodVersion.GT(*minSsetVersion) {
+		return minSsetVersion, nil
+	}
+
+	return minPodVersion, nil
 }
 
 func (s *State) updateWithPhase(

--- a/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/pkg/controller/elasticsearch/settings/merged_config.go
@@ -125,7 +125,7 @@ func xpackConfig(ver version.Version, httpCfg commonv1.HTTPConfig) *CanonicalCon
 		cfg[esv1.XPackSecurityAuthcRealmsNativeNative1Order] = -99
 	}
 
-	if ver.IsSameOrAfter(version.MustParse("7.8.1")) {
+	if ver.GTE(version.MustParse("7.8.1")) {
 		cfg[esv1.XPackLicenseUploadTypes] = []string{
 			string(client.ElasticsearchLicenseTypeTrial), string(client.ElasticsearchLicenseTypeEnterprise),
 		}

--- a/pkg/controller/elasticsearch/settings/merged_config_test.go
+++ b/pkg/controller/elasticsearch/settings/merged_config_test.go
@@ -215,7 +215,7 @@ func TestNewMergedESConfig(t *testing.T) {
 			require.NoError(t, err)
 			cfg, err := NewMergedESConfig(
 				"clusterName",
-				*ver,
+				ver,
 				tt.ipFamily,
 				commonv1.HTTPConfig{},
 				commonv1.Config{Data: tt.cfgData},

--- a/pkg/controller/elasticsearch/sset/getter.go
+++ b/pkg/controller/elasticsearch/sset/getter.go
@@ -26,7 +26,7 @@ func GetReplicas(statefulSet appsv1.StatefulSet) int32 {
 }
 
 // GetESVersion returns the ES version from the StatefulSet labels.
-func GetESVersion(statefulSet appsv1.StatefulSet) (*version.Version, error) {
+func GetESVersion(statefulSet appsv1.StatefulSet) (version.Version, error) {
 	return label.ExtractVersion(statefulSet.Spec.Template.Labels)
 }
 

--- a/pkg/controller/elasticsearch/sset/list.go
+++ b/pkg/controller/elasticsearch/sset/list.go
@@ -214,11 +214,11 @@ func (l StatefulSetList) WithStatefulSet(statefulSet appsv1.StatefulSet) Statefu
 // ESVersionMatch returns true if the ES version for this StatefulSet matches the given condition.
 func ESVersionMatch(statefulSet appsv1.StatefulSet, condition func(v version.Version) bool) bool {
 	v, err := GetESVersion(statefulSet)
-	if err != nil || v == nil {
+	if err != nil {
 		log.Error(err, "cannot parse version from StatefulSet", "namespace", statefulSet.Namespace, "name", statefulSet.Name)
 		return false
 	}
-	return condition(*v)
+	return condition(v)
 }
 
 // AtLeastOneESVersionMatch returns true if at least one StatefulSet's ES version matches the given condition.

--- a/pkg/controller/elasticsearch/validation/autoscaling_validation.go
+++ b/pkg/controller/elasticsearch/validation/autoscaling_validation.go
@@ -43,7 +43,7 @@ func validAutoscalingConfiguration(es esv1.Elasticsearch) field.ErrorList {
 	}
 
 	var errs field.ErrorList
-	if !proposedVer.IsSameOrAfter(ElasticsearchMinAutoscalingVersion) {
+	if !proposedVer.GTE(ElasticsearchMinAutoscalingVersion) {
 		errs = append(
 			errs,
 			field.Invalid(

--- a/pkg/controller/elasticsearch/validation/validations.go
+++ b/pkg/controller/elasticsearch/validation/validations.go
@@ -255,13 +255,13 @@ func validUpgradePath(current, proposed esv1.Elasticsearch) field.ErrorList {
 		return errs
 	}
 
-	v := esversion.SupportedVersions(proposedVer)
-	if v == nil {
+	supportedVersions := esversion.SupportedVersions(proposedVer)
+	if supportedVersions == nil {
 		errs = append(errs, field.Invalid(field.NewPath("spec").Child("version"), proposed.Spec.Version, unsupportedVersionMsg))
 		return errs
 	}
 
-	err = v.WithinRange(currentVer)
+	err = supportedVersions.WithinRange(currentVer)
 	if err != nil {
 		errs = append(errs, field.Invalid(field.NewPath("spec").Child("version"), proposed.Spec.Version, unsupportedUpgradeMsg))
 	}

--- a/pkg/controller/elasticsearch/version/supported_versions.go
+++ b/pkg/controller/elasticsearch/version/supported_versions.go
@@ -4,72 +4,43 @@
 
 package version
 
-import (
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
-	pkgerrors "github.com/pkg/errors"
-)
-
-// LowestHighestSupportedVersions expresses the wire-format compatibility range for a version.
-type LowestHighestSupportedVersions struct {
-	LowestSupportedVersion  version.Version
-	HighestSupportedVersion version.Version
-}
+import "github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 
 // SupportedVersions returns the supported minor versions for given major version
-func SupportedVersions(v version.Version) *LowestHighestSupportedVersions {
+func SupportedVersions(v version.Version) *version.MinMaxVersion {
 	return supportedVersionsWithMinimum(v, version.GlobalMinStackVersion)
 }
 
-func supportedVersionsWithMinimum(v version.Version, min version.Version) *LowestHighestSupportedVersions {
-	if min.IsAfter(v) {
+func supportedVersionsWithMinimum(v version.Version, min version.Version) *version.MinMaxVersion {
+	if min.GT(v) {
 		return nil
 	}
 	return technicallySupportedVersions(v)
 }
 
-func technicallySupportedVersions(v version.Version) *LowestHighestSupportedVersions {
+func technicallySupportedVersions(v version.Version) *version.MinMaxVersion {
 	switch v.Major {
 	case 6:
-		return &LowestHighestSupportedVersions{
+		return &version.MinMaxVersion{
 			// Min. version is 6.8.0.
-			LowestSupportedVersion: version.MustParse("6.8.0"),
+			Min: version.MustParse("6.8.0"),
 			// higher may be possible, but not proven yet, lower may also be a requirement...
-			HighestSupportedVersion: version.MustParse("6.99.99"),
+			Max: version.MustParse("6.99.99"),
 		}
 	case 7:
-		return &LowestHighestSupportedVersions{
+		return &version.MinMaxVersion{
 			// 6.8.0 is the lowest wire compatibility version for 7.x
-			LowestSupportedVersion: version.MustParse("6.8.0"),
+			Min: version.MustParse("6.8.0"),
 			// higher may be possible, but not proven yet, lower may also be a requirement...
-			HighestSupportedVersion: version.MustParse("7.99.99"),
+			Max: version.MustParse("7.99.99"),
 		}
 	case 8:
-		return &LowestHighestSupportedVersions{
+		return &version.MinMaxVersion{
 			// 7.4.0 is the lowest version that offers a direct upgrade path to 8.0
-			LowestSupportedVersion:  version.MustParse("7.4.0"),
-			HighestSupportedVersion: version.MustParse("8.99.99"),
+			Min: version.MustParse("7.4.0"),
+			Max: version.MustParse("8.99.99"),
 		}
 	default:
 		return nil
 	}
-}
-
-// Supports compares a given with the supported version range and returns an error if out of bounds.
-func (lh LowestHighestSupportedVersions) Supports(v version.Version) error {
-	if !v.IsSameOrAfter(lh.LowestSupportedVersion) {
-		return pkgerrors.Errorf(
-			"%s is unsupported, it is older than the oldest supported version %s",
-			v,
-			lh.LowestSupportedVersion,
-		)
-	}
-
-	if !lh.HighestSupportedVersion.IsSameOrAfter(v) {
-		return pkgerrors.Errorf(
-			"%s is unsupported, it is newer than the newest supported version %s",
-			v,
-			lh.HighestSupportedVersion,
-		)
-	}
-	return nil
 }

--- a/pkg/controller/elasticsearch/version/supported_versions_test.go
+++ b/pkg/controller/elasticsearch/version/supported_versions_test.go
@@ -69,48 +69,10 @@ func TestSupportedVersions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			vs := SupportedVersions(tt.args.v)
 			for _, v := range tt.supported {
-				require.NoError(t, vs.Supports(v))
+				require.NoError(t, vs.WithinRange(v))
 			}
 			for _, v := range tt.unsupported {
-				require.Error(t, vs.Supports(v))
-			}
-		})
-	}
-}
-
-func TestSupports(t *testing.T) {
-	tests := []struct {
-		name        string
-		lhsv        LowestHighestSupportedVersions
-		ver         version.Version
-		expectError bool
-	}{
-		{
-			name: "in range",
-			lhsv: LowestHighestSupportedVersions{
-				LowestSupportedVersion:  version.MustParse("2.0.1"),
-				HighestSupportedVersion: version.MustParse("3.0.0"),
-			},
-			ver:         version.MustParse("2.0.2-rc0"),
-			expectError: false,
-		},
-		{
-			name: "out of range",
-			lhsv: LowestHighestSupportedVersions{
-				LowestSupportedVersion:  version.MustParse("2.0.1"),
-				HighestSupportedVersion: version.MustParse("3.0.0"),
-			},
-			ver:         version.MustParse("3.0.1"),
-			expectError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.lhsv.Supports(tt.ver)
-			actual := err != nil
-			if tt.expectError != actual {
-				t.Errorf("failed Supports(). Name: %v, actual: %v, wanted: %v, value: %v", tt.name, err, tt.expectError, tt.ver)
+				require.Error(t, vs.WithinRange(v))
 			}
 		})
 	}
@@ -124,7 +86,7 @@ func Test_supportedVersionsWithMinimum(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want *LowestHighestSupportedVersions
+		want *version.MinMaxVersion
 	}{
 		{
 			name: "no minimum",
@@ -132,9 +94,9 @@ func Test_supportedVersionsWithMinimum(t *testing.T) {
 				v:   version.MustParse("7.10.0"),
 				min: version.Version{},
 			},
-			want: &LowestHighestSupportedVersions{
-				LowestSupportedVersion:  version.MustParse("6.8.0"),
-				HighestSupportedVersion: version.MustParse("7.99.99"),
+			want: &version.MinMaxVersion{
+				Min: version.MustParse("6.8.0"),
+				Max: version.MustParse("7.99.99"),
 			},
 		},
 		{
@@ -143,9 +105,9 @@ func Test_supportedVersionsWithMinimum(t *testing.T) {
 				v:   version.MustParse("7.10.0"),
 				min: version.MustParse("7.10.0"),
 			},
-			want: &LowestHighestSupportedVersions{
-				LowestSupportedVersion:  version.MustParse("6.8.0"),
-				HighestSupportedVersion: version.MustParse("7.99.99"),
+			want: &version.MinMaxVersion{
+				Min: version.MustParse("6.8.0"),
+				Max: version.MustParse("7.99.99"),
 			},
 		},
 		{

--- a/pkg/controller/elasticsearch/version/zen1/compatibility.go
+++ b/pkg/controller/elasticsearch/version/zen1/compatibility.go
@@ -53,7 +53,7 @@ func atLeasOnePodCompatibleWithZen1(pods []corev1.Pod) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		if versionCompatibleWithZen1(*version) {
+		if versionCompatibleWithZen1(version) {
 			return true, nil
 		}
 	}

--- a/pkg/controller/elasticsearch/version/zen2/compatibility.go
+++ b/pkg/controller/elasticsearch/version/zen2/compatibility.go
@@ -39,7 +39,7 @@ func AllMastersCompatibleWithZen2(c k8s.Client, es esv1.Elasticsearch) (bool, er
 		if err != nil {
 			return false, err
 		}
-		if !versionCompatibleWithZen2(*v) {
+		if !versionCompatibleWithZen2(v) {
 			return false, nil
 		}
 	}

--- a/pkg/controller/elasticsearch/version/zen2/initial_master_nodes.go
+++ b/pkg/controller/elasticsearch/version/zen2/initial_master_nodes.go
@@ -64,7 +64,7 @@ func SetupInitialMasterNodes(es esv1.Elasticsearch, k8sClient k8s.Client, nodeSp
 }
 
 func shouldSetInitialMasterNodes(es esv1.Elasticsearch, k8sClient k8s.Client, nodeSpecResources nodespec.ResourcesList) (bool, error) {
-	if v, err := version.Parse(es.Spec.Version); err != nil || !versionCompatibleWithZen2(*v) {
+	if v, err := version.Parse(es.Spec.Version); err != nil || !versionCompatibleWithZen2(v) {
 		// we only care about zen2-compatible clusters here
 		return false, err
 	}
@@ -80,7 +80,7 @@ func shouldSetInitialMasterNodes(es esv1.Elasticsearch, k8sClient k8s.Client, no
 // RemoveZen2BootstrapAnnotation removes the initialMasterNodesAnnotation (if set) once zen2 is bootstrapped
 // on the corresponding cluster.
 func RemoveZen2BootstrapAnnotation(ctx context.Context, k8sClient k8s.Client, es esv1.Elasticsearch, esClient client.Client) (bool, error) {
-	if v, err := version.Parse(es.Spec.Version); err != nil || !versionCompatibleWithZen2(*v) {
+	if v, err := version.Parse(es.Spec.Version); err != nil || !versionCompatibleWithZen2(v) {
 		// we only care about zen2-compatible clusters here
 		return false, err
 	}
@@ -139,7 +139,7 @@ func singleZen1MasterUpgrade(c k8s.Client, es esv1.Elasticsearch, nodeSpecResour
 	if err != nil {
 		return false, err
 	}
-	if versionCompatibleWithZen2(*v) {
+	if versionCompatibleWithZen2(v) {
 		return false, nil
 	}
 	// ...that will be replaced

--- a/pkg/controller/enterprisesearch/config.go
+++ b/pkg/controller/enterprisesearch/config.go
@@ -277,7 +277,7 @@ func associationConfig(c k8s.Client, ent entv1beta1.EnterpriseSearch) (*settings
 		return nil, err
 	}
 	// origin of authenticated ent users setting changed starting 8.x
-	if ver.IsSameOrAfter(version.From(8, 0, 0)) {
+	if ver.GTE(version.From(8, 0, 0)) {
 		cfg = settings.MustCanonicalConfig(map[string]interface{}{
 			"ent_search.auth.native1.source": "elasticsearch-native",
 			"ent_search.auth.native1.order":  -100,

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller.go
@@ -233,7 +233,7 @@ func (r *ReconcileEnterpriseSearch) doReconcile(ctx context.Context, ent entv1be
 		return reconcile.Result{}, err
 	}
 	logger := log.WithValues("namespace", ent.Namespace, "ent_name", ent.Name)
-	if !association.AllowVersion(*entVersion, ent.Associated(), logger, r.recorder) {
+	if !association.AllowVersion(entVersion, ent.Associated(), logger, r.recorder) {
 		return reconcile.Result{}, nil // will eventually retry once updated
 	}
 

--- a/pkg/controller/enterprisesearch/version_upgrade.go
+++ b/pkg/controller/enterprisesearch/version_upgrade.go
@@ -58,7 +58,7 @@ func (r *VersionUpgrade) Handle(ctx context.Context) error {
 		return err
 	}
 
-	upgradeRequested, err := r.isVersionUpgrade(*expectedVersion)
+	upgradeRequested, err := r.isVersionUpgrade(expectedVersion)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func (r *VersionUpgrade) Handle(ctx context.Context) error {
 
 	// if the old version is still running, we cannot disable read-only mode yet
 	// we'll retry eventually once pod rotation is over
-	if oldVersionStillRunning, err := r.isPriorVersionStillRunning(*expectedVersion); err != nil || oldVersionStillRunning {
+	if oldVersionStillRunning, err := r.isPriorVersionStillRunning(expectedVersion); err != nil || oldVersionStillRunning {
 		return err
 	}
 
@@ -240,7 +240,7 @@ func (r *VersionUpgrade) isVersionUpgrade(expectedVersion version.Version) (bool
 	if err != nil {
 		return false, err
 	}
-	return expectedVersion.IsAfter(*podVersion), nil
+	return expectedVersion.GT(podVersion), nil
 }
 
 // isPriorVersionStillRunning returns true if at least one Pod runs a version prior to the expected one.
@@ -254,7 +254,7 @@ func (r *VersionUpgrade) isPriorVersionStillRunning(expectedVersion version.Vers
 		if err != nil {
 			return false, err
 		}
-		if expectedVersion.IsAfter(*podVersion) {
+		if expectedVersion.GT(podVersion) {
 			return true, nil
 		}
 	}

--- a/pkg/controller/kibana/config_settings.go
+++ b/pkg/controller/kibana/config_settings.go
@@ -142,7 +142,7 @@ func filterConfigSettings(kb kbv1.Kibana, cfg *settings.CanonicalConfig) (*setti
 	if err != nil {
 		return cfg, err
 	}
-	if !ver.IsSameOrAfter(version.From(7, 6, 0)) {
+	if !ver.GTE(version.From(7, 6, 0)) {
 		_, err = (*ucfg.Config)(cfg).Remove(XpackEncryptedSavedObjects, -1, settings.Options...)
 	}
 	return cfg, err
@@ -150,7 +150,7 @@ func filterConfigSettings(kb kbv1.Kibana, cfg *settings.CanonicalConfig) (*setti
 
 // VersionDefaults generates any version specific settings that should exist by default.
 func VersionDefaults(kb *kbv1.Kibana, v version.Version) *settings.CanonicalConfig {
-	if v.IsSameOrAfter(version.From(7, 6, 0)) {
+	if v.GTE(version.From(7, 6, 0)) {
 		// setting exists only as of 7.6.0
 		return settings.MustCanonicalConfig(map[string]interface{}{XpackLicenseManagementUIEnabled: false})
 	}
@@ -216,7 +216,7 @@ func getOrCreateReusableSettings(c k8s.Client, kb kbv1.Kibana) (*settings.Canoni
 		return nil, err
 	}
 	// xpack.encryptedSavedObjects.encryptionKey was only added in 7.6.0 and earlier versions error out
-	if len(r.SavedObjectsKey) == 0 && kbVer.IsSameOrAfter(version.From(7, 6, 0)) {
+	if len(r.SavedObjectsKey) == 0 && kbVer.GTE(version.From(7, 6, 0)) {
 		r.SavedObjectsKey = string(common.RandomBytes(64))
 	}
 	return settings.MustCanonicalConfig(r), nil

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -74,7 +74,7 @@ func newDriver(
 		return nil, err
 	}
 
-	if !ver.IsSameOrAfter(minSupportedVersion) {
+	if !ver.GTE(minSupportedVersion) {
 		err := pkgerrors.Errorf("unsupported Kibana version: %s", ver)
 		k8s.EmitErrorEvent(recorder, err, kb, events.EventReasonValidation, "Unsupported Kibana version")
 		return nil, err
@@ -84,7 +84,7 @@ func newDriver(
 		client:         client,
 		dynamicWatches: watches,
 		recorder:       recorder,
-		version:        *ver,
+		version:        ver,
 		ipFamily:       ipFamily,
 	}, nil
 }

--- a/pkg/controller/kibana/keystore.go
+++ b/pkg/controller/kibana/keystore.go
@@ -39,7 +39,7 @@ func newInitContainersParameters(kb *kbv1.Kibana) (keystore.InitContainerParamet
 		return parameters, err
 	}
 
-	if kbVersion.IsSameOrAfter(keystoreInConfigDirVersion) {
+	if kbVersion.GTE(keystoreInConfigDirVersion) {
 		parameters.KeystoreVolumePath = ConfigSharedVolume.ContainerMountPath
 	}
 

--- a/pkg/controller/license/license_controller.go
+++ b/pkg/controller/license/license_controller.go
@@ -230,10 +230,11 @@ func (r *ReconcileLicenses) minVersion(cluster esv1.Elasticsearch) (*version.Ver
 		return nil, err
 	}
 	if minVersion == nil {
-		minVersion, err = version.Parse(cluster.Spec.Version)
+		v, err := version.Parse(cluster.Spec.Version)
 		if err != nil {
 			return nil, err
 		}
+		minVersion = &v
 	}
 	return minVersion, nil
 }

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -110,5 +110,5 @@ func runBeatRecipe(
 func isStackIncompatible(agent agentv1alpha1.Agent) bool {
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
 	agentVersion := version.MustParse(agent.Spec.Version)
-	return agentVersion.IsAfter(stackVersion)
+	return agentVersion.GT(stackVersion)
 }

--- a/test/e2e/apm/association_test.go
+++ b/test/e2e/apm/association_test.go
@@ -51,7 +51,7 @@ func TestCrossNSAssociation(t *testing.T) {
 // TestAPMKibanaAssociation tests associating an APM Server with Kibana.
 func TestAPMKibanaAssociation(t *testing.T) {
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
-	if !stackVersion.IsSameOrAfter(apmv1.ApmAgentConfigurationMinVersion) {
+	if !stackVersion.GTE(apmv1.ApmAgentConfigurationMinVersion) {
 		t.SkipNow()
 	}
 

--- a/test/e2e/beat/recipes_test.go
+++ b/test/e2e/beat/recipes_test.go
@@ -263,7 +263,7 @@ func runBeatRecipe(
 func isStackIncompatible(beat beatv1beta1.Beat) bool {
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
 	beatVersion := version.MustParse(beat.Spec.Version)
-	return beatVersion.IsAfter(stackVersion)
+	return beatVersion.GT(stackVersion)
 }
 
 func loggingTestPod(name string) (*corev1.Pod, string) {

--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -129,11 +129,11 @@ type StackResourceVersions struct {
 
 func (s StackResourceVersions) IsValid() bool {
 	// ES >= Kibana >= (Beats, APM)
-	return s.Elasticsearch.IsSameOrAfter(s.Kibana) &&
-		s.Kibana.IsSameOrAfter(s.Beat) &&
-		s.Kibana.IsSameOrAfter(s.ApmServer) &&
+	return s.Elasticsearch.GTE(s.Kibana) &&
+		s.Kibana.GTE(s.Beat) &&
+		s.Kibana.GTE(s.ApmServer) &&
 		// ES >= EnterpriseSearch
-		s.Elasticsearch.IsSameOrAfter(s.EnterpriseSearch)
+		s.Elasticsearch.GTE(s.EnterpriseSearch)
 }
 
 func (s StackResourceVersions) AllSetTo(version string) bool {
@@ -162,14 +162,14 @@ type refVersion struct {
 	version string
 }
 
-func (r refVersion) IsSameOrAfter(r2 refVersion) bool {
+func (r refVersion) GTE(r2 refVersion) bool {
 	if r.version == "" || r2.version == "" {
 		// empty version, consider it's ok
 		return true
 	}
 	rVersion := version.MustParse(r.version)
 	r2Version := version.MustParse(r2.version)
-	return rVersion.IsSameOrAfter(r2Version)
+	return rVersion.GTE(r2Version)
 }
 
 func ref(ref types.NamespacedName) refVersion {

--- a/test/e2e/test/apmserver/checks_apm.go
+++ b/test/e2e/test/apmserver/checks_apm.go
@@ -296,7 +296,7 @@ func (c *apmClusterChecks) CheckAgentConfiguration(apm apmv1.ApmServer, k *test.
 				uri := "/api/apm/settings/agent-configuration"
 
 				// URI is slightly different before 7.7.0, we need to add "/new" at the end
-				if !apmVersion.IsSameOrAfter(version.MustParse("7.7.0")) {
+				if !apmVersion.GTE(version.MustParse("7.7.0")) {
 					uri += "/new"
 				}
 				_, err = kibana.DoRequest(k, kb, password, "PUT", uri, []byte(sampleDefaultAgentConfiguration))

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -208,7 +208,7 @@ func (b Builder) WithESCoordinatorNodes(count int, resources corev1.ResourceRequ
 	cfg := map[string]interface{}{}
 	v := version.MustParse(b.Elasticsearch.Spec.Version)
 
-	if v.IsSameOrAfter(version.From(7, 9, 0)) {
+	if v.GTE(version.From(7, 9, 0)) {
 		cfg[esv1.NodeRoles] = []string{}
 	} else {
 		cfg[esv1.NodeMaster] = false
@@ -216,11 +216,11 @@ func (b Builder) WithESCoordinatorNodes(count int, resources corev1.ResourceRequ
 		cfg[esv1.NodeIngest] = false
 		cfg[esv1.NodeML] = false
 
-		if v.IsSameOrAfter(version.From(7, 3, 0)) {
+		if v.GTE(version.From(7, 3, 0)) {
 			cfg[esv1.NodeVotingOnly] = false
 		}
 
-		if v.IsSameOrAfter(version.From(7, 7, 0)) {
+		if v.GTE(version.From(7, 7, 0)) {
 			cfg[esv1.NodeTransform] = false
 			cfg[esv1.NodeRemoteClusterClient] = false
 		}

--- a/test/e2e/test/elasticsearch/checks_es.go
+++ b/test/e2e/test/elasticsearch/checks_es.go
@@ -159,8 +159,8 @@ func (e *esClusterChecks) CheckESNodesTopology(es esv1.Elasticsearch) test.Step 
 					return err
 				}
 				for i, topoElem := range expectedTopology {
-					cfg := esv1.DefaultCfg(*v)
-					if err := esv1.UnpackConfig(topoElem.Config, *v, &cfg); err != nil {
+					cfg := esv1.DefaultCfg(v)
+					if err := esv1.UnpackConfig(topoElem.Config, v, &cfg); err != nil {
 						return err
 					}
 					if compareRoles(cfg.Node, node.Roles) &&

--- a/test/e2e/test/elasticsearch/http_client.go
+++ b/test/e2e/test/elasticsearch/http_client.go
@@ -47,6 +47,6 @@ func NewElasticsearchClientWithUser(es esv1.Elasticsearch, k *test.K8sClient, us
 	if err != nil {
 		return nil, err
 	}
-	esClient := client.NewElasticsearchClient(dialer, inClusterURL, user, *v, caCert, client.Timeout(es))
+	esClient := client.NewElasticsearchClient(dialer, inClusterURL, user, v, caCert, client.Timeout(es))
 	return esClient, nil
 }

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -33,7 +33,7 @@ func clusterUnavailabilityThreshold(b Builder) time.Duration {
 		cluster = b.MutatedFrom.Elasticsearch
 	}
 	v := version.MustParse(cluster.Spec.Version)
-	if (&v).IsSameOrAfter(version.MustParse("7.2.0")) {
+	if (&v).GTE(version.MustParse("7.2.0")) {
 		// in version 7.2 and above, there is usually close to zero unavailability when a master node is killed
 		// we still keep an arbitrary safety margin
 		return 20 * time.Second

--- a/test/e2e/test/enterprisesearch/builder.go
+++ b/test/e2e/test/enterprisesearch/builder.go
@@ -35,7 +35,7 @@ var _ test.Builder = Builder{}
 func (b Builder) SkipTest() bool {
 	v := version.MustParse(b.EnterpriseSearch.Spec.Version)
 	// skip if not at least 7.0
-	return !v.IsSameOrAfter(minVersion) ||
+	return !v.GTE(minVersion) ||
 		// or if incompatible with Openshift
 		isIncompatibleWithOcp(v)
 }
@@ -44,7 +44,7 @@ func isIncompatibleWithOcp(v version.Version) bool {
 	if !test.Ctx().OcpCluster {
 		return false
 	}
-	if v.IsSameOrAfter(ocpFirstIncompatibleVersion) {
+	if v.GTE(ocpFirstIncompatibleVersion) {
 		return true
 	}
 

--- a/test/e2e/test/kibana/checks_telemetry.go
+++ b/test/e2e/test/kibana/checks_telemetry.go
@@ -35,11 +35,11 @@ func apiVersionAndTelemetryRequestBody(kbVersion version.Version) (string, telem
 	payload := telemetryRequest{
 		TimeRange: &timeRange{},
 	}
-	if kbVersion.IsSameOrAfter(version.From(7, 2, 0)) {
+	if kbVersion.GTE(version.From(7, 2, 0)) {
 		apiVersion = "v2"
 		payload.Unencrypted = true
 	}
-	if kbVersion.IsSameOrAfter(version.From(7, 11, 0)) {
+	if kbVersion.GTE(version.From(7, 11, 0)) {
 		payload.TimeRange = nil // removed in 7.11
 	}
 	return apiVersion, payload

--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -42,5 +42,5 @@ func isValidUpgrade(from string, to string) (bool, error) {
 	}
 	// major digits must be equal or differ by only 1
 	validMajorDigit := dstVer.Major == srcVer.Major || dstVer.Major == srcVer.Major+1
-	return validMajorDigit && !srcVer.IsSameOrAfter(*dstVer), nil
+	return validMajorDigit && !srcVer.GTE(dstVer), nil
 }


### PR DESCRIPTION
We already import the semver package as a dependency, so there is no need to maintain the complicated version parsing logic ourselves.  

Also includes some cleanup work such as removing the duplication of logic between `LowestHighestSupportedVersion` and `MinMaxVersion`.

Fixes #4119