### PR TITLE
[1.4] Add release highlights for 1.4.0 (#4135)

### DIFF
--- a/docs/release-notes/highlights-1.4.0.asciidoc
+++ b/docs/release-notes/highlights-1.4.0.asciidoc
@@ -1,0 +1,14 @@
+[[release-highlights-1.4.0]]
+== 1.4.0 release highlights
+
+[float]
+[id="{p}-140-new-and-notable"]
+=== New and notable
+
+New and notable changes in version 1.4.0 of {n}. See <<release-notes-1.4.0>> for the full list of changes.
+
+[float]
+[id="{p}-140-agent-support"]
+==== Support for Elastic Agent
+
+link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation-configuration.html[Elastic Agent] provides a unified way to monitor logs, metrics, and other types of data from your Kubernetes infrastructure quickly and easily. A single Elastic Agent deployment can be used to replace multiple Beats deployments that were previously necessary to collect the different types of data you want to monitor. ECK 1.4.0 introduces experimental support for Elastic Agent in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[standalone mode] as a technology preview.

--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the most important changes in each release. For the full list, see <<eck-release-notes>>.
 
+* <<release-highlights-1.4.0>>
 * <<release-highlights-1.3.1>>
 * <<release-highlights-1.3.0>>
 * <<release-highlights-1.2.1>>
@@ -18,6 +19,7 @@ This section summarizes the most important changes in each release. For the full
 
 --
 
+include::highlights-1.4.0.asciidoc[]
 include::highlights-1.3.1.asciidoc[]
 include::highlights-1.3.0.asciidoc[]
 include::highlights-1.2.1.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 1.4:
 - Add release highlights for 1.4.0 (#4135)