### PR TITLE
[eck-operator]: Additional Environment Variables

### DIFF
--- a/deploy/eck-operator/templates/statefulset.yaml
+++ b/deploy/eck-operator/templates/statefulset.yaml
@@ -60,6 +60,9 @@ spec:
             - name: WEBHOOK_SECRET
               value: {{ include "eck-operator.webhookSecretName" . }}
             {{- end }}
+            {{- if .Values.env }}
+              {{- toYaml .Values.env | nindent 12 }}
+            {{- end }}
             {{- if .Values.tracing.enabled -}}
             {{- range $name, $value :=  .Values.tracing.config }}
             - name: {{ $name }}

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -8,7 +8,7 @@ fullnameOverride: "elastic-operator"
 managedNamespaces: []
 
 # installCRDs determines whether Custom Resource Definitions (CRD) are installed by the chart.
-# Note that CRDs are global resources and require cluster admin privileges to install. 
+# Note that CRDs are global resources and require cluster admin privileges to install.
 # If you are sharing a cluster with other users who may want to install ECK on their own namespaces, setting this to true can have unintended consequences.
 # 1. Upgrades will overwrite the global CRDs and could disrupt the other users of ECK who may be running a different version.
 # 2. Uninstalling the chart will delete the CRDs and potentially cause Elastic resources deployed by other users to be removed as well.
@@ -37,15 +37,15 @@ resources:
     cpu: 100m
     memory: 150Mi
 
-# podAnnotations define the annotations that should be added to the operator pod. 
+# podAnnotations define the annotations that should be added to the operator pod.
 podAnnotations: {}
 
 # podSecurityContext defines the pod security context for the operator pod.
-podSecurityContext: 
-  runAsNonRoot: true 
+podSecurityContext:
+  runAsNonRoot: true
 
 # securityContext defines the security context of the operator container.
-securityContext: {} 
+securityContext: {}
 
 # nodeSelector defines the node selector for the operator pod.
 nodeSelector: {}
@@ -54,7 +54,10 @@ nodeSelector: {}
 tolerations: []
 
 # affinity defines the node affinity rules for the operator pod.
-affinity: {} 
+affinity: {}
+
+# additional environment variables
+env: []
 
 # createClusterScopedResources determines whether cluster-scoped resources (ClusterRoles, ClusterRoleBindings) should be created.
 createClusterScopedResources: true
@@ -84,7 +87,7 @@ webhook:
   enabled: true
   # caBundle is the PEM-encoded CA trust bundle for the webhook certificate. Only required if manageCerts is false and certManagerCert is null.
   caBundle: Cg==
-  # certManagerCert is the name of the cert-manager certificate to use with the webhook. 
+  # certManagerCert is the name of the cert-manager certificate to use with the webhook.
   certManagerCert: null
   # certsDir is the directory to mount the certificates.
   certsDir: "/tmp/k8s-webhook-server/serving-certs"
@@ -100,7 +103,7 @@ webhook:
   objectSelector: {}
 
 softMultiTenancy:
-  # enabled determines whether the operator is installed with soft multi-tenancy extensions. 
+  # enabled determines whether the operator is installed with soft multi-tenancy extensions.
   # This requires network policies to be enabled on the Kubernetes cluster.
   enabled: false
 
@@ -119,7 +122,7 @@ config:
   # -2: Errors only
   # -1: Errors and warnings
   #  0: Errors, warnings, and information
-  #  number greater than 0: Errors, warnings, information, and debug details. 
+  #  number greater than 0: Errors, warnings, information, and debug details.
   logVerbosity: "0"
 
   # metricsPort defines the port to expose operator metrics. Set to 0 to disable metrics reporting.
@@ -160,4 +163,3 @@ config:
 internal:
   manifestGen: false
   kubeVersion: 1.12.0
-

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -56,7 +56,7 @@ tolerations: []
 # affinity defines the node affinity rules for the operator pod.
 affinity: {}
 
-# additional environment variables
+# additional environment variables for the operator container.
 env: []
 
 # createClusterScopedResources determines whether cluster-scoped resources (ClusterRoles, ClusterRoleBindings) should be created.


### PR DESCRIPTION
Signed-off-by: Oliver Bähler <oliverbaehler@hotmail.com>

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

With this PR the possibility to add custom environment variables to the operator Container.  We currently are required to set a proxy to have internet access with the operator. This would be possible with e.g. the following configuration:

```
env:
  - name: "HTTP_PROXY"
    value: "https://company-proxy:8000"
  - name: "HTTPS_PROXY"
    value: "https://company-proxy:8000"
```

**Note**: I wasn't quiet sure how to bump the chart version. Please let me know how to bump it if that change is ok with you. Second my Editor has removed some spaces resulting in a lot more diffs than there are actual changes. Let me know if i should readd the spaces.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/master/CONTRIBUTING.md)?
- If you submit code, is your pull request against master? We recommend pull requests against master. We will backport them as needed.
