### PR TITLE
Fix Kibana NODE_OPTIONS env var

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -133,7 +133,7 @@ The resource definitions in ECK share the same philosophy when you want to:
 === Pod configuration
 You can <<{p}-customize-pods,customize the Kibana Pod>> using a Pod template.
 
-The following example demonstrates how to create a Kibana deployment with custom node affinity and resource limits.
+The following example demonstrates how to create a Kibana deployment with custom node affinity, increased heap size, and resource limits.
 
 [source,yaml,subs="attributes"]
 ----
@@ -150,12 +150,15 @@ spec:
     spec:
       containers:
       - name: kibana
+        env:
+          - name: NODE_OPTIONS
+            value: "--max-old-space-size=2048"
         resources:
           requests:
             memory: 1Gi
             cpu: 0.5
           limits:
-            memory: 2Gi
+            memory: 2.5Gi
             cpu: 2
       nodeSelector:
         type: frontend

--- a/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
@@ -66,8 +66,7 @@ spec:
 [id="{p}-compute-resources-kibana-and-apm"]
 === Set compute resources for Kibana and APM Server
 
-For Kibana or APM Server objects, the `podTemplate` can be configured as follows:
-
+.Kibana
 [source,yaml,subs="attributes"]
 ----
 apiVersion: kibana.k8s.elastic.co/{eck_crd_version}
@@ -80,6 +79,31 @@ spec:
     spec:
       containers:
       - name: kibana
+        env:
+          - name: NODE_OPTIONS
+            value: "--max-old-space-size=2048"
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 0.5
+          limits:
+            memory: 2.5Gi
+            cpu: 2
+----
+
+.APM Server
+[source,yaml,subs="attributes"]
+----
+apiVersion: apm.k8s.elastic.co/{eck_crd_version}
+kind: ApmServer
+metadata:
+  name: quickstart
+spec:
+  version: {version}
+  podTemplate:
+    spec:
+      containers:
+      - name: apm-server
         resources:
           requests:
             memory: 1Gi

--- a/pkg/controller/kibana/config_settings.go
+++ b/pkg/controller/kibana/config_settings.go
@@ -30,8 +30,8 @@ import (
 const (
 	// SettingsFilename is the Kibana configuration settings file
 	SettingsFilename = "kibana.yml"
-	// EnvNodeOpts is the environment variable name for the Node options that can be used to increase the Kibana maximum memory limit
-	EnvNodeOpts = "NODE_OPTS"
+	// EnvNodeOptions is the environment variable name for the Node options that can be used to increase the Kibana maximum memory limit
+	EnvNodeOptions = "NODE_OPTIONS"
 
 	// esCertsVolumeMountPath is the directory containing Elasticsearch certificates.
 	esCertsVolumeMountPath = "/usr/share/kibana/config/elasticsearch-certs"

--- a/pkg/license/aggregator.go
+++ b/pkg/license/aggregator.go
@@ -91,7 +91,7 @@ func (a Aggregator) aggregateKibanaMemory() (resource.Quantity, error) {
 		mem, err := containerMemLimits(
 			kb.Spec.PodTemplate.Spec.Containers,
 			kbv1.KibanaContainerName,
-			kibana.EnvNodeOpts, memFromNodeOptions,
+			kibana.EnvNodeOptions, memFromNodeOptions,
 			kibana.DefaultMemoryLimits,
 		)
 		if err != nil {

--- a/pkg/license/reporter_test.go
+++ b/pkg/license/reporter_test.go
@@ -176,7 +176,7 @@ func TestGet(t *testing.T) {
 							{
 								Name: kbv1.KibanaContainerName,
 								Env: []corev1.EnvVar{{
-									Name: kibana.EnvNodeOpts, Value: "--max-old-space-size=2048",
+									Name: kibana.EnvNodeOptions, Value: "--max-old-space-size=2048",
 								}},
 							},
 						},

--- a/pkg/license/testdata/stack.yaml
+++ b/pkg/license/testdata/stack.yaml
@@ -105,7 +105,7 @@ spec:
       containers:
         - name: kibana
           env:
-            - name: NODE_OPTS
+            - name: NODE_OPTIONS
               value: "--max-old-space-size=2048"
 ---
 apiVersion: apm.k8s.elastic.co/v1


### PR DESCRIPTION
We have been using the wrong environment variable name to determine the heap size of Kibana.

Fixes #4184 
Fixes #4176