### PR TITLE
[1.4] Skip Elasticsearch 6.8.x upgrade tests on ARM (#4172)

### DIFF
--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -323,6 +323,7 @@ E2E_PROVIDER=eks
 CLUSTER_NAME=${BUILD_TAG}-arm
 KUBERNETES_VERSION=default
 TEST_OPTS=-race
+E2E_TEST_ENV_TAGS="arch:arm"
 ENV
 write_deployer_config <<CFG
 id: eks-arm-ci

--- a/test/e2e/es/version_upgrade_test.go
+++ b/test/e2e/es/version_upgrade_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestVersionUpgradeSingleNode68xTo7x(t *testing.T) {
+	if test.Ctx().HasTag(test.ArchARMTag) {
+		t.Skipf("Skipping test because Elasticsearch 6.8.x does not have an ARM build")
+	}
+
 	srcVersion := test.MinVersion68x
 	dstVersion := test.Ctx().ElasticStackVersion
 
@@ -33,6 +37,10 @@ func TestVersionUpgradeSingleNode68xTo7x(t *testing.T) {
 }
 
 func TestVersionUpgradeTwoNodes68xTo7x(t *testing.T) {
+	if test.Ctx().HasTag(test.ArchARMTag) {
+		t.Skipf("Skipping test because Elasticsearch 6.8.x does not have an ARM build")
+	}
+
 	srcVersion := test.MinVersion68x
 	dstVersion := test.Ctx().ElasticStackVersion
 
@@ -52,6 +60,10 @@ func TestVersionUpgradeTwoNodes68xTo7x(t *testing.T) {
 }
 
 func TestVersionUpgrade3Nodes68xTo7x(t *testing.T) {
+	if test.Ctx().HasTag(test.ArchARMTag) {
+		t.Skipf("Skipping test because Elasticsearch 6.8.x does not have an ARM build")
+	}
+
 	srcVersion := test.MinVersion68x
 	dstVersion := test.Ctx().ElasticStackVersion
 
@@ -70,6 +82,10 @@ func TestVersionUpgrade3Nodes68xTo7x(t *testing.T) {
 }
 
 func TestVersionUpgradeSingleMaster68xToNewNodeSet7x(t *testing.T) {
+	if test.Ctx().HasTag(test.ArchARMTag) {
+		t.Skipf("Skipping test because Elasticsearch 6.8.x does not have an ARM build")
+	}
+
 	srcVersion := test.MinVersion68x
 	dstVersion := test.Ctx().ElasticStackVersion
 
@@ -97,6 +113,10 @@ func TestVersionUpgradeSingleMaster68xToNewNodeSet7x(t *testing.T) {
 }
 
 func TestVersionUpgradeSingleMaster68xToMore7x(t *testing.T) {
+	if test.Ctx().HasTag(test.ArchARMTag) {
+		t.Skipf("Skipping test because Elasticsearch 6.8.x does not have an ARM build")
+	}
+
 	srcVersion := test.MinVersion68x
 	dstVersion := test.Ctx().ElasticStackVersion
 

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -18,6 +18,11 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+const (
+	// ArchARMTag is the test tag used to indicate a test run on an ARM-based cluster.
+	ArchARMTag = "arch:arm"
+)
+
 var defaultElasticStackVersion = LatestVersion7x
 
 var (


### PR DESCRIPTION
Backport of #4172