### PR TITLE
Controller version refactoring

### DIFF
--- a/pkg/controller/common/annotation/controller_version.go
+++ b/pkg/controller/common/annotation/controller_version.go
@@ -56,10 +56,7 @@ func UpdateControllerVersion(ctx context.Context, client k8s.Client, obj ctrlcli
 // can be used by auxiliary controllers to check if they can process a resource.
 // First boolean is true if the compatibility cannot be determined at the moment, mostly because the main controller did not reconcile the resource yet. In that case the
 // auxiliary controller must try again later.
-func CheckCompatibility(ctx context.Context, obj ctrlclient.Object, controllerVersion string) (requeue bool, supported bool, err error) {
-	span, ctx := apm.StartSpan(ctx, "check_compatibility", tracing.SpanTypeApp)
-	defer span.End()
-
+func CheckCompatibility(obj ctrlclient.Object, controllerVersion string) (requeue bool, supported bool, err error) {
 	annotatedVersion := obj.GetAnnotations()[ControllerVersionAnnotation]
 	if annotatedVersion == "" {
 		return true, false, nil

--- a/pkg/controller/common/annotation/controller_version.go
+++ b/pkg/controller/common/annotation/controller_version.go
@@ -54,15 +54,13 @@ func UpdateControllerVersion(ctx context.Context, client k8s.Client, obj ctrlcli
 
 // CheckCompatibility determines if this controller is compatible with a given resource by examining the controller version annotation. It has no side effect and
 // can be used by auxiliary controllers to check if they can process a resource.
-// First boolean is true if the compatibility cannot be determined at the moment, mostly because the main controller did not reconcile the resource yet. In that case the
-// auxiliary controller must try again later.
-func CheckCompatibility(obj ctrlclient.Object, controllerVersion string) (requeue bool, supported bool, err error) {
+// The auxiliary controller must watch the resource to check the compatibility if the resource is updated.
+func CheckCompatibility(obj ctrlclient.Object, controllerVersion string) (supported bool, err error) {
 	annotatedVersion := obj.GetAnnotations()[ControllerVersionAnnotation]
 	if annotatedVersion == "" {
-		return true, false, nil
+		return false, nil
 	}
-	supported, err = isAnnotatedVersionSupported(annotatedVersion, controllerVersion, obj)
-	return false, supported, err
+	return isAnnotatedVersionSupported(annotatedVersion, controllerVersion, obj)
 }
 
 // ReconcileCompatibility determines if this controller is compatible with a given resource by examining the controller version annotation

--- a/pkg/controller/common/annotation/controller_version.go
+++ b/pkg/controller/common/annotation/controller_version.go
@@ -15,7 +15,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -33,22 +32,7 @@ func UpdateControllerVersion(ctx context.Context, client k8s.Client, obj ctrlcli
 	span, _ := apm.StartSpan(ctx, "update_controller_version", tracing.SpanTypeApp)
 	defer span.End()
 
-	accessor := meta.NewAccessor()
-	namespace, err := accessor.Namespace(obj)
-	if err != nil {
-		log.Error(err, "error getting namespace", "kind", obj.GetObjectKind().GroupVersionKind().Kind)
-		return err
-	}
-	name, err := accessor.Name(obj)
-	if err != nil {
-		log.Error(err, "error getting name", "namespace", namespace, "kind", obj.GetObjectKind().GroupVersionKind().Kind)
-		return err
-	}
-	annotations, err := accessor.Annotations(obj)
-	if err != nil {
-		log.Error(err, "error getting annotations", "namespace", namespace, "name", name, "kind", obj.GetObjectKind().GroupVersionKind().Kind)
-		return err
-	}
+	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
@@ -59,13 +43,29 @@ func UpdateControllerVersion(ctx context.Context, client k8s.Client, obj ctrlcli
 	}
 
 	annotations[ControllerVersionAnnotation] = version
-	err = accessor.SetAnnotations(obj, annotations)
-	if err != nil {
-		log.Error(err, "error updating controller version annotation", "namespace", namespace, "name", name, "kind", obj.GetObjectKind())
+	accessor := meta.NewAccessor()
+	if err := accessor.SetAnnotations(obj, annotations); err != nil {
+		log.Error(err, "error updating controller version annotation", "namespace", obj.GetNamespace(), "name", obj.GetName(), "kind", obj.GetObjectKind())
 		return err
 	}
-	log.V(1).Info("updating controller version annotation", "namespace", namespace, "name", name, "kind", obj.GetObjectKind())
+	log.V(1).Info("updating controller version annotation", "namespace", obj.GetNamespace(), "name", obj.GetName(), "kind", obj.GetObjectKind())
 	return client.Update(context.Background(), obj)
+}
+
+// CheckCompatibility determines if this controller is compatible with a given resource by examining the controller version annotation. It has no side effect and
+// can be used by auxiliary controllers to check if they can process a resource.
+// First boolean is true if the compatibility cannot be determined at the moment, mostly because the main controller did not reconcile the resource yet. In that case the
+// auxiliary controller must try again later.
+func CheckCompatibility(ctx context.Context, obj ctrlclient.Object, controllerVersion string) (requeue bool, supported bool, err error) {
+	span, ctx := apm.StartSpan(ctx, "check_compatibility", tracing.SpanTypeApp)
+	defer span.End()
+
+	annotatedVersion := obj.GetAnnotations()[ControllerVersionAnnotation]
+	if annotatedVersion == "" {
+		return true, false, nil
+	}
+	supported, err = isAnnotatedVersionSupported(annotatedVersion, controllerVersion, obj)
+	return false, supported, err
 }
 
 // ReconcileCompatibility determines if this controller is compatible with a given resource by examining the controller version annotation
@@ -76,34 +76,23 @@ func ReconcileCompatibility(ctx context.Context, client k8s.Client, obj ctrlclie
 	span, ctx := apm.StartSpan(ctx, "reconcile_compatibility", tracing.SpanTypeApp)
 	defer span.End()
 
-	accessor := meta.NewAccessor()
-	namespace, err := accessor.Namespace(obj)
-	if err != nil {
-		log.Error(err, "error getting namespace", "kind", obj.GetObjectKind().GroupVersionKind().Kind)
-		return false, err
-	}
-	name, err := accessor.Name(obj)
-	if err != nil {
-		log.Error(err, "error getting name", "namespace", namespace, "kind", obj.GetObjectKind().GroupVersionKind().Kind)
-		return false, err
-	}
-	annotations, err := accessor.Annotations(obj)
-	if err != nil {
-		log.Error(err, "error getting annotations", "namespace", namespace, "name", name, "kind", obj.GetObjectKind().GroupVersionKind().Kind)
-		return false, err
-	}
-
-	annExists := annotations != nil && annotations[ControllerVersionAnnotation] != ""
+	annotatedVersion := obj.GetAnnotations()[ControllerVersionAnnotation]
 
 	// if the annotation does not exist, it might indicate it was reconciled by an older controller version that did not add the version annotation,
 	// in which case it is incompatible with the current controller, or it is a brand new resource that has not been reconciled by any controller yet
-	if !annExists {
+	if annotatedVersion == "" {
 		exist, err := checkExistingResources(client, obj, selector)
 		if err != nil {
 			return false, err
 		}
 		if exist {
-			log.Info("Resource was previously reconciled by incompatible controller version and missing annotation, adding annotation", "controller_version", controllerVersion, "namespace", namespace, "name", name, "kind", obj.GetObjectKind().GroupVersionKind().Kind)
+			log.Info(
+				"Resource was previously reconciled by incompatible controller version and missing annotation, adding annotation",
+				"controller_version", controllerVersion,
+				"namespace", obj.GetNamespace(),
+				"name", obj.GetName(),
+				"kind", obj.GetObjectKind().GroupVersionKind().Kind,
+			)
 			err = UpdateControllerVersion(ctx, client, obj, UnknownControllerVersion)
 			return false, err
 		}
@@ -112,7 +101,13 @@ func ReconcileCompatibility(ctx context.Context, client k8s.Client, obj ctrlclie
 		return true, err
 	}
 
-	currentVersion, err := version.Parse(annotations[ControllerVersionAnnotation])
+	return isAnnotatedVersionSupported(annotatedVersion, controllerVersion, obj)
+}
+
+// isAnnotatedVersionSupported attempts to parse the controller version set in the resource annotations and returns true
+// if it is greater than the min. compatible version.
+func isAnnotatedVersionSupported(currentVersion, controllerVersion string, obj ctrlclient.Object) (bool, error) {
+	current, err := version.Parse(currentVersion)
 	if err != nil {
 		return false, errors.Wrap(err, "Error parsing current version on resource")
 	}
@@ -126,37 +121,30 @@ func ReconcileCompatibility(ctx context.Context, client k8s.Client, obj ctrlclie
 	}
 
 	// if the current version is gte the minimum version then they are compatible
-	if currentVersion.GTE(minVersion) {
+	if current.GTE(minVersion) {
 		return true, nil
 	}
 
 	log.Info("Resource was created with older version of operator, will not take action", "controller_version", ctrlVersion,
-		"resource_controller_version", currentVersion, "namespace", namespace, "name", name)
+		"resource_controller_version", currentVersion, "namespace", obj.GetNamespace(), "name", obj.GetName())
 	return false, nil
 }
 
 // checkExistingResources returns a bool indicating if there are existing resources owned for a given resource.
 // The labels provided must exactly match.
-func checkExistingResources(client k8s.Client, owner runtime.Object, labels map[string]string) (bool, error) {
-
-	metaOwner, err := meta.Accessor(owner)
-	if err != nil {
-		return false, err
-	}
-
+func checkExistingResources(client k8s.Client, owner ctrlclient.Object, labels map[string]string) (bool, error) {
 	labelSelector := ctrlclient.MatchingLabels(labels)
-	nsSelector := ctrlclient.InNamespace(metaOwner.GetNamespace())
+	nsSelector := ctrlclient.InNamespace(owner.GetNamespace())
 
 	var svcs corev1.ServiceList
-	err = client.List(context.Background(), &svcs, labelSelector, nsSelector)
-	if err != nil {
+	if err := client.List(context.Background(), &svcs, labelSelector, nsSelector); err != nil {
 		return false, err
 	}
 
 	// If we list any services owned by the owner successfully, then we know this owner resource was reconciled
 	// by an old version since any owner resources reconciled by a 0.9.0+ operator would have a label already.
 	for _, svc := range svcs.Items {
-		if metav1.IsControlledBy(&svc, metaOwner) {
+		if metav1.IsControlledBy(&svc, owner) {
 			return true, nil
 		}
 	}

--- a/pkg/controller/common/annotation/controller_version_test.go
+++ b/pkg/controller/common/annotation/controller_version_test.go
@@ -101,7 +101,7 @@ func TestCheckCompatibility(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotRequeue, gotSupported, err := CheckCompatibility(context.Background(), tt.args.obj, tt.args.controllerVersion)
+			gotRequeue, gotSupported, err := CheckCompatibility(tt.args.obj, tt.args.controllerVersion)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CheckCompatibility() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/common/annotation/controller_version_test.go
+++ b/pkg/controller/common/annotation/controller_version_test.go
@@ -28,7 +28,6 @@ func TestCheckCompatibility(t *testing.T) {
 	tests := []struct {
 		name          string
 		args          args
-		wantRequeue   bool
 		wantSupported bool
 		wantErr       bool
 	}{
@@ -43,7 +42,6 @@ func TestCheckCompatibility(t *testing.T) {
 					},
 				},
 			},
-			wantRequeue:   true,
 			wantSupported: false,
 			wantErr:       false,
 		},
@@ -58,7 +56,6 @@ func TestCheckCompatibility(t *testing.T) {
 					},
 				},
 			},
-			wantRequeue:   true,
 			wantSupported: false,
 			wantErr:       false,
 		},
@@ -76,7 +73,6 @@ func TestCheckCompatibility(t *testing.T) {
 				},
 				controllerVersion: "1.5.0",
 			},
-			wantRequeue:   false,
 			wantSupported: false,
 			wantErr:       false,
 		},
@@ -94,20 +90,16 @@ func TestCheckCompatibility(t *testing.T) {
 				},
 				controllerVersion: "1.5.0",
 			},
-			wantRequeue:   false,
 			wantSupported: true,
 			wantErr:       false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotRequeue, gotSupported, err := CheckCompatibility(tt.args.obj, tt.args.controllerVersion)
+			gotSupported, err := CheckCompatibility(tt.args.obj, tt.args.controllerVersion)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CheckCompatibility() error = %v, wantErr %v", err, tt.wantErr)
 				return
-			}
-			if gotRequeue != tt.wantRequeue {
-				t.Errorf("CheckCompatibility() gotRequeue = %v, want %v", gotRequeue, tt.wantRequeue)
 			}
 			if gotSupported != tt.wantSupported {
 				t.Errorf("CheckCompatibility() gotSupported = %v, want %v", gotSupported, tt.wantSupported)

--- a/pkg/controller/common/annotation/controller_version_test.go
+++ b/pkg/controller/common/annotation/controller_version_test.go
@@ -17,7 +17,104 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func TestCheckCompatibility(t *testing.T) {
+	type args struct {
+		obj               ctrlclient.Object
+		controllerVersion string
+	}
+	tests := []struct {
+		name          string
+		args          args
+		wantRequeue   bool
+		wantSupported bool
+		wantErr       bool
+	}{
+		{
+			name: "Annotation is nil",
+			args: args{
+				obj: &kbv1.Kibana{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "ns",
+						Name:        "kibana",
+						Annotations: nil,
+					},
+				},
+			},
+			wantRequeue:   true,
+			wantSupported: false,
+			wantErr:       false,
+		},
+		{
+			name: "Controller annotation is not set",
+			args: args{
+				obj: &kbv1.Kibana{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "ns",
+						Name:        "kibana",
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			wantRequeue:   true,
+			wantSupported: false,
+			wantErr:       false,
+		},
+		{
+			name: "Unknown controller version",
+			args: args{
+				obj: &kbv1.Kibana{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "kibana",
+						Annotations: map[string]string{
+							ControllerVersionAnnotation: UnknownControllerVersion,
+						},
+					},
+				},
+				controllerVersion: "1.5.0",
+			},
+			wantRequeue:   false,
+			wantSupported: false,
+			wantErr:       false,
+		},
+		{
+			name: "Supported controller version",
+			args: args{
+				obj: &kbv1.Kibana{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "kibana",
+						Annotations: map[string]string{
+							ControllerVersionAnnotation: "1.4.0",
+						},
+					},
+				},
+				controllerVersion: "1.5.0",
+			},
+			wantRequeue:   false,
+			wantSupported: true,
+			wantErr:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRequeue, gotSupported, err := CheckCompatibility(context.Background(), tt.args.obj, tt.args.controllerVersion)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckCompatibility() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotRequeue != tt.wantRequeue {
+				t.Errorf("CheckCompatibility() gotRequeue = %v, want %v", gotRequeue, tt.wantRequeue)
+			}
+			if gotSupported != tt.wantSupported {
+				t.Errorf("CheckCompatibility() gotSupported = %v, want %v", gotSupported, tt.wantSupported)
+			}
+		})
+	}
+}
 
 // Test UpdateControllerVersion updates annotation if there is an older version
 func TestAnnotationUpdated(t *testing.T) {


### PR DESCRIPTION
This pull request:

* Removes unnecessary calls to `accessor` methods (because of the switch to `client.Object` in https://github.com/elastic/cloud-on-k8s/pull/4098). The accessor is now only used to update the annotation if required (`accessor.SetAnnotations(obj, annotations)`)
* Introduces a function to check the compatibility with no side effect on the resource. It can then be used by auxiliary controllers to only check the compatibility with a given resource. See [this comment](https://github.com/elastic/cloud-on-k8s/pull/4173#discussion_r569422000) for more context.