### PR TITLE
Remove license check and custom err code in init container

### DIFF
--- a/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
+++ b/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
@@ -6,7 +6,6 @@ package initcontainer
 
 import (
 	"bytes"
-	"fmt"
 	"html/template"
 
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
@@ -57,13 +56,6 @@ var scriptTemplate = template.Must(template.New("").Parse(
 	`#!/usr/bin/env bash
 
 	set -eu
-
-	# the operator only works with the default ES distribution
-	license=/usr/share/elasticsearch/LICENSE.txt
-	if [[ ! -f $license || $(grep -Fxc "ELASTIC LICENSE AGREEMENT" $license) -ne 1 ]]; then
-		>&2 echo "unsupported_distribution"
-		exit ` + fmt.Sprintf("%d", UnsupportedDistroExitCode) + `
-	fi
 
 	# compute time in seconds since the given start time
 	function duration() {


### PR DESCRIPTION
Alternative to #4191 

This one has the advantage that it will be future proof thanks to the absence of the check. 
It has the disadvantage that users will have to deal with cryptic error messages of an unsupported Docker image not starting up or bootlooping, while previously we had a clear message that was also surfaced through a Kubernetes event.