### PR TITLE
[1.4] Adjust init container script for Elastic License 2.0 (#4191)

### DIFF
--- a/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
+++ b/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
@@ -60,7 +60,7 @@ var scriptTemplate = template.Must(template.New("").Parse(
 
 	# the operator only works with the default ES distribution
 	license=/usr/share/elasticsearch/LICENSE.txt
-	if [[ ! -f $license || $(grep -Fxc "ELASTIC LICENSE AGREEMENT" $license) -ne 1 ]]; then
+	if [[ ! -f $license || $(grep -Exc "ELASTIC LICENSE AGREEMENT|Elastic License 2.0" $license) -ne 1 ]]; then
 		>&2 echo "unsupported_distribution"
 		exit ` + fmt.Sprintf("%d", UnsupportedDistroExitCode) + `
 	fi


### PR DESCRIPTION
Backports the following commits to 1.4:
 - Adjust init container script for Elastic License 2.0 (#4191)