### PR TITLE
[1.2] Adjust init container script for Elastic License 2.0 (#4191)

### DIFF
--- a/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
@@ -35,17 +35,6 @@ pipeline {
         }
         stage('Run tests for different k8s versions in GKE') {
             parallel {
-                stage("1.14") {
-                    agent {
-                        label 'linux'
-                    }
-                    steps {
-                        unstash "source"
-                        script {
-                            runWith(lib, failedTests, '1.14', "eck-gke14-${BUILD_NUMBER}-e2e")
-                        }
-                    }
-                }
                 stage("1.15") {
                     agent {
                         label 'linux'
@@ -54,6 +43,17 @@ pipeline {
                         unstash "source"
                         script {
                             runWith(lib, failedTests, '1.15', "eck-gke15-${BUILD_NUMBER}-e2e")
+                        }
+                    }
+                }
+                stage("1.16") {
+                    agent {
+                        label 'linux'
+                    }
+                    steps {
+                        unstash "source"
+                        script {
+                            runWith(lib, failedTests, '1.16', "eck-gke16-${BUILD_NUMBER}-e2e")
                         }
                     }
                 }
@@ -82,7 +82,7 @@ pipeline {
         }
         cleanup {
             script {
-                clusters = ["eck-gke14-${BUILD_NUMBER}-e2e", "eck-gke15-${BUILD_NUMBER}-e2e"]
+                clusters = ["eck-gke15-${BUILD_NUMBER}-e2e", "eck-gke16-${BUILD_NUMBER}-e2e"]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
                         parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: clusters[i])],

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,4 +1,4 @@
-Copyright 2018-2020 Elasticsearch BV
+Copyright 2018-2021 Elasticsearch BV
 
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -3,7 +3,7 @@ plans:
   operation: create
   clusterName: ci
   provider: gke
-  kubernetesVersion: 1.14
+  kubernetesVersion: 1.15
   machineType: n1-standard-8
   serviceAccount: true
   psp: true
@@ -19,7 +19,7 @@ plans:
   operation: create
   clusterName: dev
   provider: gke
-  kubernetesVersion: 1.14
+  kubernetesVersion: 1.15
   machineType: n1-standard-8
   serviceAccount: false
   psp: false

--- a/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
+++ b/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
@@ -60,7 +60,7 @@ var scriptTemplate = template.Must(template.New("").Parse(
 
 	# the operator only works with the default ES distribution
 	license=/usr/share/elasticsearch/LICENSE.txt
-	if [[ ! -f $license || $(grep -Fxc "ELASTIC LICENSE AGREEMENT" $license) -ne 1 ]]; then
+	if [[ ! -f $license || $(grep -Exc "ELASTIC LICENSE AGREEMENT|Elastic License 2.0" $license) -ne 1 ]]; then
 		>&2 echo "unsupported_distribution"
 		exit ` + fmt.Sprintf("%d", UnsupportedDistroExitCode) + `
 	fi


### PR DESCRIPTION
Backports the following commits to 1.2:
 - Adjust init container script for Elastic License 2.0 (#4191)