### PR TITLE
[1.4] Release notes for 1.3.2 (#4204)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -7,6 +7,7 @@
 This section summarizes the changes in each release.
 
 * <<release-notes-1.4.0>>
+* <<release-notes-1.3.2>>
 * <<release-notes-1.3.1>>
 * <<release-notes-1.3.0>>
 * <<release-notes-1.2.1>>
@@ -21,6 +22,7 @@ This section summarizes the changes in each release.
 --
 
 include::release-notes/1.4.0.asciidoc[]
+include::release-notes/1.3.2.asciidoc[]
 include::release-notes/1.3.1.asciidoc[]
 include::release-notes/1.3.0.asciidoc[]
 include::release-notes/1.2.1.asciidoc[]

--- a/docs/release-notes/1.3.2.asciidoc
+++ b/docs/release-notes/1.3.2.asciidoc
@@ -1,0 +1,17 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-1.3.2]]
+== {n} version 1.3.2
+
+
+
+
+[[enhancement-1.3.2]]
+[float]
+=== Enhancements
+
+* Adjust init container script for Elastic License 2.0 {pull}4191[#4191]
+
+
+

--- a/docs/release-notes/highlights-1.3.2.asciidoc
+++ b/docs/release-notes/highlights-1.3.2.asciidoc
@@ -1,0 +1,16 @@
+[[release-highlights-1.3.2]]
+== 1.3.2 release highlights
+
+This is a patch release to address some issues found after the 1.3.0 release. See <<release-highlights-1.3.0>> for the full highlights of the 1.3.x series.
+
+
+
+[float]
+[id="{p}-132-fixes"]
+=== Fixes
+
+[float]
+[id="{p}-132-711-support"]
+==== Add support for Elastic Stack 7.11
+
+This patch release adds support for running the Elastic Stack in version 7.11 and later.

--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -6,6 +6,7 @@
 This section summarizes the most important changes in each release. For the full list, see <<eck-release-notes>>.
 
 * <<release-highlights-1.4.0>>
+* <<release-highlights-1.3.2>>
 * <<release-highlights-1.3.1>>
 * <<release-highlights-1.3.0>>
 * <<release-highlights-1.2.1>>
@@ -20,6 +21,7 @@ This section summarizes the most important changes in each release. For the full
 --
 
 include::highlights-1.4.0.asciidoc[]
+include::highlights-1.3.2.asciidoc[]
 include::highlights-1.3.1.asciidoc[]
 include::highlights-1.3.0.asciidoc[]
 include::highlights-1.2.1.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 1.4:
 - Release notes for 1.3.2 (#4204)