### PR TITLE
Adjust operatorhub tooling for 1.4.0 release

### DIFF
--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -1,6 +1,6 @@
-newVersion: 1.3.1
-prevVersion: 1.3.0
-stackVersion: 7.10.1
+newVersion: 1.4.0-bc6
+prevVersion: 1.3.1
+stackVersion: 7.11.0-SNAPSHOT
 crds:
   - name: elasticsearches.elasticsearch.k8s.elastic.co
     displayName: Elasticsearch Cluster
@@ -17,6 +17,9 @@ crds:
   - name: beats.beat.k8s.elastic.co
     displayName: Beats
     description: Beats instance
+  - name: agents.agent.k8s.elastic.co
+    displayName: Elastic Agent
+    description: Elastic Agent instance
 packages:
   - outputPath: community-operators
     packageName: elastic-cloud-eck

--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -1,6 +1,6 @@
-newVersion: 1.4.0-bc6
+newVersion: 1.4.0
 prevVersion: 1.3.1
-stackVersion: 7.11.0-SNAPSHOT
+stackVersion: 7.11.0
 crds:
   - name: elasticsearches.elasticsearch.k8s.elastic.co
     displayName: Elasticsearch Cluster

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -160,6 +160,58 @@ metadata:
                 }
               }
             }
+          },
+          {
+            "apiVersion": "agent.k8s.elastic.co/v1alpha1",
+            "kind": "Agent",
+            "metadata": {
+              "name": "agent-sample"
+            },
+            "spec": {
+              "version": "{{ .StackVersion }}",
+              "elasticsearchRefs": [
+                {
+                  "name": "elasticsearch-sample"
+                }
+              ],
+              "daemonSet": {},
+              "config": {
+                "inputs": [
+                  {
+                    "name": "system-1",
+                    "revision": 1,
+                    "type": "system/metrics",
+                    "use_output": "default",
+                    "meta": {
+                      "package": {
+                        "name": "system",
+                        "version": "0.9.1"
+                      }
+                    },
+                    "data_stream": {
+                      "namespace": "default"
+                    },
+                    "streams": [
+                      {
+                        "id": "system/metrics-system.cpu",
+                        "data_stream": {
+                          "dataset": "system.cpu",
+                          "type": "metrics"
+                        },
+                        "metricsets": [
+                          "cpu"
+                        ],
+                        "cpu.metrics": [
+                          "percentages",
+                          "normalized_percentages"
+                        ],
+                        "period": "10s"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
           }
       ]
   name: {{ .PackageName }}.v{{ .NewVersion }}
@@ -183,7 +235,7 @@ spec:
     Current features:
 
 
-    *  Elasticsearch, Kibana, APM Server, Enterprise Search, and Beats deployments
+    *  Elasticsearch, Kibana, APM Server, Enterprise Search, Beats and Elastic Agent deployments
 
     *  TLS Certificates management
 


### PR DESCRIPTION
Adjusts the templates for OLM bundles/CSVs to include Agent and the 1.4.0 release version.