### PR TITLE
E2E: Disable Enterprise Search 7.9 and 7.10 tests on Openshift

### DIFF
--- a/test/e2e/test/enterprisesearch/builder.go
+++ b/test/e2e/test/enterprisesearch/builder.go
@@ -5,22 +5,22 @@
 package enterprisesearch
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/rand"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
+	"github.com/blang/semver/v4"
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
 	minVersion = version.MustParse("7.7.0")
-	// Starting from 7.9.0, Enterprise Search is incompatible with Openshift default SCC due to file permission errors.
+	// Enterprise Search 7.9 and 7.10 are incompatible with Openshift default SCC due to file permission errors.
 	// See https://github.com/elastic/cloud-on-k8s/issues/3656.
-	ocpFirstIncompatibleVersion = version.MustParse("7.9.0")
+	ocpIncompatibleVersions = semver.MustParseRange(">=7.9.0 <7.11.0")
 )
 
 // Builder to create Enterprise Search.
@@ -44,7 +44,7 @@ func isIncompatibleWithOcp(v version.Version) bool {
 	if !test.Ctx().OcpCluster {
 		return false
 	}
-	if v.GTE(ocpFirstIncompatibleVersion) {
+	if ocpIncompatibleVersions(v) {
 		return true
 	}
 


### PR DESCRIPTION
This PR explicitly disables e2e tests on Openshift for Enterprise Search 7.9 and 7.10.

See https://github.com/elastic/cloud-on-k8s/issues/3656 for more context.