### PR TITLE
E2E: remove botuser from slackSend invocations

### DIFF
--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -61,8 +61,7 @@ pipeline {
                                 message: "`${TAG_NAME}` was released \r\n" +
                                     "https://download.elastic.co/downloads/eck/${TAG_NAME}/all-in-one.yaml was uploaded \r\n" +
                                     "Congratulations!",
-                                tokenCredentialId: 'cloud-ci-slack-integration-token',
-                                botUser: true
+                                tokenCredentialId: 'cloud-ci-slack-integration-token'
                             )
                         }
                     }
@@ -135,8 +134,7 @@ pipeline {
         }
         unsuccessful {
             script {
-                slackSend botUser: true,
-                    channel: '#cloud-k8s',
+                slackSend channel: '#cloud-k8s',
                     color: 'danger',
                     message: "${JOB_NAME} job failed! \r\n" + "${BUILD_URL}",
                     tokenCredentialId: 'cloud-ci-slack-integration-token'

--- a/.ci/pipelines/cleanup-gke.Jenkinsfile
+++ b/.ci/pipelines/cleanup-gke.Jenkinsfile
@@ -48,7 +48,6 @@ pipeline {
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',
-                        botUser: true,
                         failOnError: true
                     )
                 }

--- a/.ci/pipelines/e2e-tests-aks.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-aks.Jenkinsfile
@@ -66,7 +66,6 @@ pipeline {
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',
-                        botUser: true,
                         failOnError: true
                     )
                 }

--- a/.ci/pipelines/e2e-tests-eks-arm.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-eks-arm.Jenkinsfile
@@ -66,7 +66,6 @@ pipeline {
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',
-                        botUser: true,
                         failOnError: true
                     )
                 }

--- a/.ci/pipelines/e2e-tests-eks.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-eks.Jenkinsfile
@@ -66,7 +66,6 @@ pipeline {
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',
-                        botUser: true,
                         failOnError: true
                     )
                 }

--- a/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
@@ -74,7 +74,6 @@ pipeline {
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',
-                        botUser: true,
                         failOnError: true
                     )
                 }

--- a/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
@@ -163,7 +163,6 @@ pipeline {
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',
-                        botUser: true,
                         failOnError: true
                     )
                 }

--- a/.ci/pipelines/e2e-tests-master-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-master-gke.Jenkinsfile
@@ -85,7 +85,6 @@ pipeline {
                       color: 'danger',
                       message: msg,
                     tokenCredentialId: 'cloud-ci-slack-integration-token',
-                    botUser: true,
                     failOnError: true
                 )
             }

--- a/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
@@ -67,7 +67,6 @@ pipeline {
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',
-                        botUser: true,
                         failOnError: true
                     )
                 }

--- a/.ci/pipelines/e2e-tests-ocp3.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp3.Jenkinsfile
@@ -67,7 +67,6 @@ pipeline {
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',
-                        botUser: true,
                         failOnError: true
                     )
                 }

--- a/.ci/pipelines/e2e-tests-resilience.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-resilience.Jenkinsfile
@@ -54,7 +54,6 @@ pipeline {
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',
-                        botUser: true,
                         failOnError: true
                     )
                 }

--- a/.ci/pipelines/e2e-tests-snapshot-versions-8x-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-8x-gke.Jenkinsfile
@@ -85,7 +85,6 @@ pipeline {
                         color: 'danger',
                         message: lib.generateSlackMessage("E2E tests for Elastic stack snapshot versions failed!", env.BUILD_URL, filter),
                         tokenCredentialId: 'cloud-ci-slack-integration-token',
-                        botUser: true,
                         failOnError: true
                     )
                 }

--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -85,7 +85,6 @@ pipeline {
                         color: 'danger',
                         message: lib.generateSlackMessage("E2E tests for Elastic stack snapshot versions failed!", env.BUILD_URL, filter),
                         tokenCredentialId: 'cloud-ci-slack-integration-token',
-                        botUser: true,
                         failOnError: true
                     )
                 }

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -161,7 +161,6 @@ pipeline {
                         color: 'danger',
                         message: lib.generateSlackMessage("E2E tests for different Elastic stack versions failed!", env.BUILD_URL, filter),
                         tokenCredentialId: 'cloud-ci-slack-integration-token',
-                        botUser: true,
                         failOnError: true
                     )
                 }


### PR DESCRIPTION
According to https://github.com/jenkinsci/slack-plugin#bot-user-mode botUser can only be used if a custom app is used. But we are using the default Jenkins CI app in Slack. 