### PR TITLE
[Autoscaling] Add support for request/limit ratio

### DIFF
--- a/pkg/apis/elasticsearch/v1/autoscaling.go
+++ b/pkg/apis/elasticsearch/v1/autoscaling.go
@@ -26,7 +26,7 @@ var (
 	defaultMemoryRequestsToLimitsRatio = 1.0
 
 	// defaultCPURequestsToLimitsRatio is the default ratio used to convert a CPU request to a CPU limit in the Pod
-	// resources specification. By default we don't want CPU limit, hence a default value of 0.0
+	// resources specification. By default we don't want a CPU limit, hence a default value of 0.0
 	defaultCPURequestsToLimitsRatio = 0.0
 )
 

--- a/pkg/apis/elasticsearch/v1/autoscaling.go
+++ b/pkg/apis/elasticsearch/v1/autoscaling.go
@@ -17,7 +17,18 @@ import (
 
 const ElasticsearchAutoscalingSpecAnnotationName = "elasticsearch.alpha.elastic.co/autoscaling-spec"
 
-var errNodeRolesNotSet = errors.New("node.roles must be set")
+var (
+	errNodeRolesNotSet = errors.New("node.roles must be set")
+
+	// defaultMemoryRequestsToLimitsRatio is the default ratio used to convert a memory request to a memory limit in the
+	// Pod resources specification. By default we want to have the same value for both the memory request and the memory
+	// limit.
+	defaultMemoryRequestsToLimitsRatio = 1.0
+
+	// defaultCPURequestsToLimitsRatio is the default ratio used to convert a CPU request to a CPU limit in the Pod
+	// resources specification. By default we don't want CPU limit, hence a default value of 0.0
+	defaultCPURequestsToLimitsRatio = 0.0
+)
 
 // -- Elasticsearch Autoscaling API structures
 
@@ -92,6 +103,24 @@ type QuantityRange struct {
 	Max resource.Quantity `json:"max"`
 	// RequestsToLimitsRatio allows to customize Kubernetes resource Limit based on the Request.
 	RequestsToLimitsRatio *float64 `json:"requestsToLimitsRatio"`
+}
+
+// MemoryRequestsToLimitsRatio returns the ratio between the memory request, computed by the autoscaling algorithm, and
+// the limits. If no ratio has been specified by the user then a default value is returned.
+func (ar AutoscalingResources) MemoryRequestsToLimitsRatio() float64 {
+	if ar.Memory == nil || ar.Memory.RequestsToLimitsRatio == nil {
+		return defaultMemoryRequestsToLimitsRatio
+	}
+	return *ar.Memory.RequestsToLimitsRatio
+}
+
+// CPURequestsToLimitsRatio returns the ratio between the CPU request, computed by the autoscaling algorithm, and
+// the limits. If no ratio has been specified by the user then a default value is returned.
+func (ar AutoscalingResources) CPURequestsToLimitsRatio() float64 {
+	if ar.CPU == nil || ar.CPU.RequestsToLimitsRatio == nil {
+		return defaultCPURequestsToLimitsRatio
+	}
+	return *ar.CPU.RequestsToLimitsRatio
 }
 
 // +kubebuilder:object:generate=false

--- a/pkg/controller/autoscaling/elasticsearch/autoscaler/autoscaler_test.go
+++ b/pkg/controller/autoscaling/elasticsearch/autoscaler/autoscaler_test.go
@@ -52,7 +52,10 @@ func Test_GetResources(t *testing.T) {
 			want: resources.NodeSetsResources{
 				Name:             "my-autoscaling-policy",
 				NodeSetNodeCount: []resources.NodeSetNodeCount{{Name: "default", NodeCount: 5}},
-				NodeResources:    resources.NodeResources{Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("3Gi"), corev1.ResourceStorage: q("10Gi")}},
+				NodeResources: resources.NodeResources{
+					Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("3Gi"), corev1.ResourceStorage: q("10Gi")},
+					Limits:   map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("3Gi")},
+				},
 			},
 		},
 		{
@@ -73,7 +76,10 @@ func Test_GetResources(t *testing.T) {
 			want: resources.NodeSetsResources{
 				Name:             "my-autoscaling-policy",
 				NodeSetNodeCount: []resources.NodeSetNodeCount{{Name: "default", NodeCount: 3}},
-				NodeResources:    resources.NodeResources{Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("6Gi")}},
+				NodeResources: resources.NodeResources{
+					Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("6Gi")},
+					Limits:   map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("6Gi")},
+				},
 			},
 		},
 		{
@@ -96,7 +102,10 @@ func Test_GetResources(t *testing.T) {
 			want: resources.NodeSetsResources{
 				Name:             "my-autoscaling-policy",
 				NodeSetNodeCount: []resources.NodeSetNodeCount{{Name: "default", NodeCount: 3}},
-				NodeResources:    resources.NodeResources{Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("6Gi"), corev1.ResourceStorage: q("10G")}},
+				NodeResources: resources.NodeResources{
+					Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("6Gi"), corev1.ResourceStorage: q("10G")},
+					Limits:   map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("6Gi")},
+				},
 			},
 		},
 		{
@@ -117,7 +126,10 @@ func Test_GetResources(t *testing.T) {
 			want: resources.NodeSetsResources{
 				Name:             "my-autoscaling-policy",
 				NodeSetNodeCount: []resources.NodeSetNodeCount{{Name: "default", NodeCount: 3}},
-				NodeResources:    resources.NodeResources{Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("7Gi")}},
+				NodeResources: resources.NodeResources{
+					Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("7Gi")},
+					Limits:   map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("7Gi")},
+				},
 			},
 		},
 		{
@@ -138,7 +150,10 @@ func Test_GetResources(t *testing.T) {
 			want: resources.NodeSetsResources{
 				Name:             "my-autoscaling-policy",
 				NodeSetNodeCount: []resources.NodeSetNodeCount{{Name: "default", NodeCount: 6}},
-				NodeResources:    resources.NodeResources{Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("8G")}},
+				NodeResources: resources.NodeResources{
+					Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("8G")},
+					Limits:   map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("8G")},
+				},
 			},
 		},
 		{
@@ -159,7 +174,10 @@ func Test_GetResources(t *testing.T) {
 			want: resources.NodeSetsResources{
 				Name:             "my-autoscaling-policy",
 				NodeSetNodeCount: []resources.NodeSetNodeCount{{Name: "default", NodeCount: 5}},
-				NodeResources:    resources.NodeResources{Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("8G")}},
+				NodeResources: resources.NodeResources{
+					Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("8G")},
+					Limits:   map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("8G")},
+				},
 			},
 			wantPolicyState: []status.PolicyState{
 				{
@@ -186,7 +204,10 @@ func Test_GetResources(t *testing.T) {
 			want: resources.NodeSetsResources{
 				Name:             "my-autoscaling-policy",
 				NodeSetNodeCount: []resources.NodeSetNodeCount{{Name: "default", NodeCount: 6}},
-				NodeResources:    resources.NodeResources{Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("7G")}},
+				NodeResources: resources.NodeResources{
+					Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("7G")},
+					Limits:   map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("7G")},
+				},
 			},
 			wantPolicyState: []status.PolicyState{
 				{
@@ -196,6 +217,45 @@ func Test_GetResources(t *testing.T) {
 				{
 					Type:     "HorizontalScalingLimitReached",
 					Messages: []string{"Can't provide total required memory 48000000000, max number of nodes is 6, requires 7 nodes"},
+				},
+			},
+		},
+		{
+			name: "Adjust limits",
+			args: args{
+				currentNodeSets: defaultNodeSets,
+				requiredCapacity: newRequiredCapacityBuilder().
+					nodeMemory("6G").tierMemory("15G").
+					build(),
+				policy: NewAutoscalingSpecBuilder("my-autoscaling-policy").
+					WithNodeCounts(3, 6).
+					WithMemoryAndRatio("5G", "8G", 2.0).
+					Build(),
+			},
+			want: resources.NodeSetsResources{
+				Name:             "my-autoscaling-policy",
+				NodeSetNodeCount: []resources.NodeSetNodeCount{{Name: "default", NodeCount: 3}},
+				NodeResources: resources.NodeResources{
+					Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("6Gi")},
+					Limits:   map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("12Gi")},
+				},
+			},
+		},
+		{
+			name: "Remove memory limit",
+			args: args{
+				currentNodeSets: defaultNodeSets,
+				requiredCapacity: newRequiredCapacityBuilder().
+					nodeMemory("6G").
+					tierMemory("15G").
+					build(),
+				policy: NewAutoscalingSpecBuilder("my-autoscaling-policy").WithNodeCounts(3, 6).WithMemoryAndRatio("5G", "8G", 0.0).Build(),
+			},
+			want: resources.NodeSetsResources{
+				Name:             "my-autoscaling-policy",
+				NodeSetNodeCount: []resources.NodeSetNodeCount{{Name: "default", NodeCount: 3}},
+				NodeResources: resources.NodeResources{
+					Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("6Gi")},
 				},
 			},
 		},
@@ -231,9 +291,10 @@ func getPolicyStates(status status.Status, policyName string) []status.PolicySta
 // - AutoscalingSpec builder
 
 type AutoscalingSpecBuilder struct {
-	name                       string
-	nodeCountMin, nodeCountMax int32
-	cpu, memory, storage       *esv1.QuantityRange
+	name                                           string
+	nodeCountMin, nodeCountMax                     int32
+	cpu, memory, storage                           *esv1.QuantityRange
+	memRequestToLimitRatio, cpuRequestToLimitRatio *float64
 }
 
 func NewAutoscalingSpecBuilder(name string) *AutoscalingSpecBuilder {
@@ -254,6 +315,15 @@ func (asb *AutoscalingSpecBuilder) WithMemory(min, max string) *AutoscalingSpecB
 	return asb
 }
 
+func (asb *AutoscalingSpecBuilder) WithMemoryAndRatio(min, max string, ratio float64) *AutoscalingSpecBuilder {
+	asb.memory = &esv1.QuantityRange{
+		Min:                   resource.MustParse(min),
+		Max:                   resource.MustParse(max),
+		RequestsToLimitsRatio: &ratio,
+	}
+	return asb
+}
+
 func (asb *AutoscalingSpecBuilder) WithStorage(min, max string) *AutoscalingSpecBuilder {
 	asb.storage = &esv1.QuantityRange{
 		Min: resource.MustParse(min),
@@ -266,6 +336,15 @@ func (asb *AutoscalingSpecBuilder) WithCPU(min, max string) *AutoscalingSpecBuil
 	asb.cpu = &esv1.QuantityRange{
 		Min: resource.MustParse(min),
 		Max: resource.MustParse(max),
+	}
+	return asb
+}
+
+func (asb *AutoscalingSpecBuilder) WithCPUAndRatio(min, max string, ratio float64) *AutoscalingSpecBuilder {
+	asb.cpu = &esv1.QuantityRange{
+		Min:                   resource.MustParse(min),
+		Max:                   resource.MustParse(max),
+		RequestsToLimitsRatio: &ratio,
 	}
 	return asb
 }

--- a/pkg/controller/autoscaling/elasticsearch/autoscaler/autoscaler_test.go
+++ b/pkg/controller/autoscaling/elasticsearch/autoscaler/autoscaler_test.go
@@ -291,10 +291,9 @@ func getPolicyStates(status status.Status, policyName string) []status.PolicySta
 // - AutoscalingSpec builder
 
 type AutoscalingSpecBuilder struct {
-	name                                           string
-	nodeCountMin, nodeCountMax                     int32
-	cpu, memory, storage                           *esv1.QuantityRange
-	memRequestToLimitRatio, cpuRequestToLimitRatio *float64
+	name                       string
+	nodeCountMin, nodeCountMax int32
+	cpu, memory, storage       *esv1.QuantityRange
 }
 
 func NewAutoscalingSpecBuilder(name string) *AutoscalingSpecBuilder {

--- a/pkg/controller/autoscaling/elasticsearch/autoscaler/linear_scaler.go
+++ b/pkg/controller/autoscaling/elasticsearch/autoscaler/linear_scaler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/autoscaling/elasticsearch/resources"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -66,8 +67,8 @@ func memoryFromStorage(requiredStorageCapacity resource.Quantity, storageRange, 
 	requiredMemoryCapacity := memoryRange.Min.Value() + requiredAdditionalMemoryCapacity
 
 	// Round up memory to the next GB
-	requiredMemoryCapacity = roundUp(requiredMemoryCapacity, gibi)
-	resourceMemoryAsGiga := resource.MustParse(fmt.Sprintf("%dGi", requiredMemoryCapacity/gibi))
+	requiredMemoryCapacity = roundUp(requiredMemoryCapacity, resources.GIB)
+	resourceMemoryAsGiga := resource.MustParse(fmt.Sprintf("%dGi", requiredMemoryCapacity/resources.GIB))
 
 	if resourceMemoryAsGiga.Cmp(memoryRange.Max) > 0 {
 		resourceMemoryAsGiga = memoryRange.Max.DeepCopy()

--- a/pkg/controller/autoscaling/elasticsearch/autoscaler/offline.go
+++ b/pkg/controller/autoscaling/elasticsearch/autoscaler/offline.go
@@ -39,6 +39,9 @@ func GetOfflineNodeSetsResources(
 		}
 	}
 
+	// Adjust limits
+	nodeSetsResources.NodeResources = nodeSetsResources.UpdateLimits(autoscalingSpec.AutoscalingResources)
+
 	// Ensure that the min. number of nodes is in the allowed range.
 	if expectedNodeCount < autoscalingSpec.NodeCount.Min {
 		expectedNodeCount = autoscalingSpec.NodeCount.Min

--- a/pkg/controller/autoscaling/elasticsearch/autoscaler/offline_test.go
+++ b/pkg/controller/autoscaling/elasticsearch/autoscaler/offline_test.go
@@ -42,7 +42,10 @@ func TestGetOfflineNodeSetsResources(t *testing.T) {
 			want: resources.NodeSetsResources{
 				Name:             "my-autoscaling-policy",
 				NodeSetNodeCount: []resources.NodeSetNodeCount{{Name: "region-a", NodeCount: 3}, {Name: "region-b", NodeCount: 3}},
-				NodeResources:    resources.NodeResources{Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("3Gi"), corev1.ResourceStorage: q("35Gi")}},
+				NodeResources: resources.NodeResources{
+					Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("3Gi"), corev1.ResourceStorage: q("35Gi")},
+					Limits:   map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("3Gi")},
+				},
 			},
 		},
 		{
@@ -58,7 +61,10 @@ func TestGetOfflineNodeSetsResources(t *testing.T) {
 			want: resources.NodeSetsResources{
 				Name:             "my-autoscaling-policy",
 				NodeSetNodeCount: []resources.NodeSetNodeCount{{Name: "region-a", NodeCount: 3}, {Name: "region-b", NodeCount: 3}},
-				NodeResources:    resources.NodeResources{Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("8Gi"), corev1.ResourceStorage: q("20Gi")}},
+				NodeResources: resources.NodeResources{
+					Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("8Gi"), corev1.ResourceStorage: q("20Gi")},
+					Limits:   map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("8Gi")},
+				},
 			},
 		},
 		{
@@ -74,7 +80,10 @@ func TestGetOfflineNodeSetsResources(t *testing.T) {
 			want: resources.NodeSetsResources{
 				Name:             "my-autoscaling-policy",
 				NodeSetNodeCount: []resources.NodeSetNodeCount{{Name: "region-a", NodeCount: 3}, {Name: "region-b", NodeCount: 3}},
-				NodeResources:    resources.NodeResources{Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("50Gi" /* memory should be increased */), corev1.ResourceStorage: q("35Gi")}},
+				NodeResources: resources.NodeResources{
+					Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("50Gi" /* memory should be increased */), corev1.ResourceStorage: q("35Gi")},
+					Limits:   map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("50Gi")},
+				},
 			},
 		},
 		{
@@ -90,7 +99,10 @@ func TestGetOfflineNodeSetsResources(t *testing.T) {
 			want: resources.NodeSetsResources{
 				Name:             "my-autoscaling-policy",
 				NodeSetNodeCount: []resources.NodeSetNodeCount{{Name: "region-a", NodeCount: 2}, {Name: "region-b", NodeCount: 2}, {Name: "region-new", NodeCount: 2}},
-				NodeResources:    resources.NodeResources{Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("3Gi"), corev1.ResourceStorage: q("35Gi")}},
+				NodeResources: resources.NodeResources{
+					Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("3Gi"), corev1.ResourceStorage: q("35Gi")},
+					Limits:   map[corev1.ResourceName]resource.Quantity{corev1.ResourceMemory: q("3Gi")},
+				},
 			},
 		},
 	}

--- a/pkg/controller/autoscaling/elasticsearch/autoscaler/vertical.go
+++ b/pkg/controller/autoscaling/elasticsearch/autoscaler/vertical.go
@@ -14,8 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-const gibi = int64(1024 * 1024 * 1024)
-
 // nodeResources computes the desired amount of memory and storage for a node managed by a given AutoscalingPolicySpec.
 func (ctx *Context) nodeResources(minNodesCount int64, minStorage resource.Quantity) resources.NodeResources {
 	nodeResources := resources.NodeResources{}
@@ -64,7 +62,7 @@ func (ctx *Context) nodeResources(minNodesCount int64, minStorage resource.Quant
 		nodeResources.SetRequest(corev1.ResourceCPU, cpuFromMemory(nodeResources.GetRequest(corev1.ResourceMemory), *ctx.AutoscalingSpec.Memory, *ctx.AutoscalingSpec.CPU))
 	}
 
-	return nodeResources
+	return nodeResources.UpdateLimits(ctx.AutoscalingSpec.AutoscalingResources)
 }
 
 // getResourceValue calculates the desired quantity for a specific resource for a node in a tier. This value is
@@ -79,7 +77,7 @@ func (ctx *Context) getResourceValue(
 ) resource.Quantity {
 	if nodeRequired.IsZero() && totalRequired.IsZero() {
 		// Elasticsearch has returned 0 for both the node and the tier level. Scale down resources to minimum.
-		return resourceToQuantity(min.Value())
+		return resources.ResourceToQuantity(min.Value())
 	}
 
 	// Surface the situation where a resource is exhausted.
@@ -116,7 +114,7 @@ func (ctx *Context) getResourceValue(
 	}
 
 	// Try to round up the Gb value
-	nodeResource = roundUp(nodeResource, gibi)
+	nodeResource = roundUp(nodeResource, resources.GIB)
 
 	// Always ensure that the calculated resource quantity is at least equal to the min. limit provided by the user.
 	if nodeResource < min.Value() {
@@ -129,19 +127,7 @@ func (ctx *Context) getResourceValue(
 		nodeResource = max.Value()
 	}
 
-	return resourceToQuantity(nodeResource)
-}
-
-// resourceToQuantity attempts to convert a raw integer value into a human readable quantity.
-func resourceToQuantity(nodeResource int64) resource.Quantity {
-	var nodeQuantity resource.Quantity
-	if nodeResource >= gibi && nodeResource%gibi == 0 {
-		// When it's possible we may want to express the memory with a "human readable unit" like the the Gi unit
-		nodeQuantity = resource.MustParse(fmt.Sprintf("%dGi", nodeResource/gibi))
-	} else {
-		nodeQuantity = resource.NewQuantity(nodeResource, resource.DecimalSI).DeepCopy()
-	}
-	return nodeQuantity
+	return resources.ResourceToQuantity(nodeResource)
 }
 
 func max64(x int64, others ...int64) int64 {

--- a/pkg/controller/autoscaling/elasticsearch/reconcile.go
+++ b/pkg/controller/autoscaling/elasticsearch/reconcile.go
@@ -55,22 +55,10 @@ func reconcileElasticsearch(
 		// Update desired count
 		es.Spec.NodeSets[i].Count = nodeSetResources.NodeCount
 
-		if container.Resources.Requests == nil {
-			container.Resources.Requests = corev1.ResourceList{}
-		}
-		if container.Resources.Limits == nil {
-			container.Resources.Limits = corev1.ResourceList{}
-		}
+		// Update CPU and Memory requirements
+		container.Resources = nodeSetResources.ToContainerResourcesWith(container.Resources)
 
-		// Update memory requests and limits
-		if nodeSetResources.HasRequest(corev1.ResourceMemory) {
-			container.Resources.Requests[corev1.ResourceMemory] = nodeSetResources.GetRequest(corev1.ResourceMemory)
-			container.Resources.Limits[corev1.ResourceMemory] = nodeSetResources.GetRequest(corev1.ResourceMemory)
-		}
-		if nodeSetResources.HasRequest(corev1.ResourceCPU) {
-			container.Resources.Requests[corev1.ResourceCPU] = nodeSetResources.GetRequest(corev1.ResourceCPU)
-		}
-
+		// Update storage
 		if nodeSetResources.HasRequest(corev1.ResourceStorage) {
 			nextStorage, err := newVolumeClaimTemplate(nodeSetResources.GetRequest(corev1.ResourceStorage), es.Spec.NodeSets[i])
 			if err != nil {

--- a/pkg/controller/autoscaling/elasticsearch/resources/resources.go
+++ b/pkg/controller/autoscaling/elasticsearch/resources/resources.go
@@ -6,11 +6,17 @@ package resources
 
 import (
 	"fmt"
+	"math"
 
 	v1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	// GIB - 1 GibiByte
+	GIB = int64(1024 * 1024 * 1024)
 )
 
 // NodeSetsResources models for all the nodeSets managed by a same autoscaling policy:
@@ -70,7 +76,9 @@ func (ntr NodeSetsResources) Match(containerName string, nodeSet v1.NodeSet) (bo
 			return false, nil
 		}
 		return ResourceEqual(corev1.ResourceMemory, ntr.NodeResources.Requests, container.Resources.Requests) &&
-			ResourceEqual(corev1.ResourceCPU, ntr.NodeResources.Requests, container.Resources.Requests), nil
+			ResourceEqual(corev1.ResourceCPU, ntr.NodeResources.Requests, container.Resources.Requests) &&
+			ResourceEqual(corev1.ResourceMemory, ntr.NodeResources.Limits, container.Resources.Limits) &&
+			ResourceEqual(corev1.ResourceCPU, ntr.NodeResources.Limits, container.Resources.Limits), nil
 	}
 	return false, nil
 }
@@ -149,65 +157,144 @@ type NodeResources struct {
 	Requests corev1.ResourceList `json:"requests,omitempty"`
 }
 
+// ToContainerResourcesWith builds new ResourceRequirements for Memory and CPU, overriding existing values from the provided
+// ResourceRequirements with the values from the NodeResources.
+// If a value in the NodeResources is not present then the value in the result is removed.
+// Values for extended resources (e.g. GPU), are left untouched.
+// This function has no side effect and do not modify the original ResourceRequirements.
+func (nr *NodeResources) ToContainerResourcesWith(sourceRequirements corev1.ResourceRequirements) corev1.ResourceRequirements {
+	mergedResources := sourceRequirements.DeepCopy()
+
+	// Update requests
+	if nr.Requests != nil && mergedResources.Requests == nil {
+		mergedResources.Requests = corev1.ResourceList{}
+	}
+	for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		if nr.HasRequest(resourceName) {
+			mergedResources.Requests[resourceName] = nr.GetRequest(resourceName)
+		} else {
+			delete(mergedResources.Requests, resourceName)
+		}
+	}
+
+	// Update Limits
+	if nr.Limits != nil && mergedResources.Limits == nil {
+		mergedResources.Limits = corev1.ResourceList{}
+	}
+	for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		if nr.HasLimit(resourceName) {
+			mergedResources.Limits[resourceName] = nr.GetLimit(resourceName)
+		} else {
+			delete(mergedResources.Limits, resourceName)
+		}
+	}
+	return *mergedResources
+}
+
 // MaxMerge merge the specified resource into the NodeResources only if its quantity is greater
 // than the existing one.
-func (rs *NodeResources) MaxMerge(
+func (nr *NodeResources) MaxMerge(
 	other corev1.ResourceRequirements,
 	resourceName corev1.ResourceName,
 ) {
 	// Requests
 	otherResourceRequestValue, otherHasResourceRequest := other.Requests[resourceName]
 	if otherHasResourceRequest {
-		if rs.Requests == nil {
-			rs.Requests = make(corev1.ResourceList)
+		if nr.Requests == nil {
+			nr.Requests = make(corev1.ResourceList)
 		}
-		receiverValue, receiverHasResource := rs.Requests[resourceName]
+		receiverValue, receiverHasResource := nr.Requests[resourceName]
 		if !receiverHasResource {
-			rs.Requests[resourceName] = otherResourceRequestValue
+			nr.Requests[resourceName] = otherResourceRequestValue
 		} else if otherResourceRequestValue.Cmp(receiverValue) > 0 {
-			rs.Requests[resourceName] = otherResourceRequestValue
+			nr.Requests[resourceName] = otherResourceRequestValue
 		}
 	}
 
 	// Limits
 	otherResourceLimitValue, otherHasResourceLimit := other.Limits[resourceName]
 	if otherHasResourceLimit {
-		if rs.Limits == nil {
-			rs.Limits = make(corev1.ResourceList)
+		if nr.Limits == nil {
+			nr.Limits = make(corev1.ResourceList)
 		}
-		receiverValue, receiverHasResource := rs.Limits[resourceName]
+		receiverValue, receiverHasResource := nr.Limits[resourceName]
 		if !receiverHasResource {
-			rs.Limits[resourceName] = otherResourceLimitValue
+			nr.Limits[resourceName] = otherResourceLimitValue
 		} else if otherResourceLimitValue.Cmp(receiverValue) > 0 {
-			rs.Limits[resourceName] = otherResourceLimitValue
+			nr.Limits[resourceName] = otherResourceLimitValue
 		}
 	}
 }
 
-func (rs *NodeResources) SetRequest(resourceName corev1.ResourceName, quantity resource.Quantity) {
-	if rs.Requests == nil {
-		rs.Requests = make(corev1.ResourceList)
+func (nr *NodeResources) SetRequest(resourceName corev1.ResourceName, quantity resource.Quantity) {
+	if nr.Requests == nil {
+		nr.Requests = make(corev1.ResourceList)
 	}
-	rs.Requests[resourceName] = quantity
+	nr.Requests[resourceName] = quantity
 }
 
-func (rs *NodeResources) SetLimit(resourceName corev1.ResourceName, quantity resource.Quantity) {
-	if rs.Limits == nil {
-		rs.Limits = make(corev1.ResourceList)
+func (nr *NodeResources) SetLimit(resourceName corev1.ResourceName, quantity resource.Quantity) {
+	if nr.Limits == nil {
+		nr.Limits = make(corev1.ResourceList)
 	}
-	rs.Limits[resourceName] = quantity
+	nr.Limits[resourceName] = quantity
 }
 
-func (rs *NodeResources) HasRequest(resourceName corev1.ResourceName) bool {
-	if rs.Requests == nil {
+func (nr *NodeResources) HasRequest(resourceName corev1.ResourceName) bool {
+	if nr.Requests == nil {
 		return false
 	}
-	_, hasRequest := rs.Requests[resourceName]
+	_, hasRequest := nr.Requests[resourceName]
 	return hasRequest
 }
 
-func (rs *NodeResources) GetRequest(resourceName corev1.ResourceName) resource.Quantity {
-	return rs.Requests[resourceName]
+func (nr *NodeResources) GetRequest(resourceName corev1.ResourceName) resource.Quantity {
+	return nr.Requests[resourceName]
+}
+
+func (nr *NodeResources) HasLimit(resourceName corev1.ResourceName) bool {
+	if nr.Limits == nil {
+		return false
+	}
+	_, hasLimit := nr.Limits[resourceName]
+	return hasLimit
+}
+
+func (nr *NodeResources) GetLimit(resourceName corev1.ResourceName) resource.Quantity {
+	return nr.Limits[resourceName]
+}
+
+// UpdateLimits updates the limits in nodesets resources according to the resource requests and the ratio set by the user.
+func (nr NodeResources) UpdateLimits(autoscalingResources v1.AutoscalingResources) NodeResources {
+	if nr.HasRequest(corev1.ResourceMemory) {
+		// Update Memory limit
+		if autoscalingResources.MemoryRequestsToLimitsRatio() > 0 {
+			request := nr.GetRequest(corev1.ResourceMemory)
+			limit := int64(math.Ceil(float64(request.Value()) * autoscalingResources.MemoryRequestsToLimitsRatio()))
+			nr.SetLimit(corev1.ResourceMemory, ResourceToQuantity(limit))
+		}
+	}
+	if nr.HasRequest(corev1.ResourceCPU) {
+		// Update Memory limit
+		if autoscalingResources.CPURequestsToLimitsRatio() > 0 {
+			request := nr.GetRequest(corev1.ResourceCPU)
+			limit := int64(math.Ceil(float64(request.Value()) * autoscalingResources.CPURequestsToLimitsRatio()))
+			nr.SetLimit(corev1.ResourceCPU, ResourceToQuantity(limit))
+		}
+	}
+	return nr
+}
+
+// ResourceToQuantity attempts to convert a raw integer value into a human readable quantity.
+func ResourceToQuantity(nodeResource int64) resource.Quantity {
+	var nodeQuantity resource.Quantity
+	if nodeResource >= GIB && nodeResource%GIB == 0 {
+		// When it's possible we may want to express the memory with a "human readable unit" like the the Gi unit
+		nodeQuantity = resource.MustParse(fmt.Sprintf("%dGi", nodeResource/GIB))
+	} else {
+		nodeQuantity = resource.NewQuantity(nodeResource, resource.DecimalSI).DeepCopy()
+	}
+	return nodeQuantity
 }
 
 // ResourceList is a set of (resource name, quantity) pairs.
@@ -220,12 +307,12 @@ type NodeResourcesInt64 struct {
 }
 
 // ToInt64 converts all the resource quantities to int64, mostly to be logged and build dashboard.
-func (rs NodeResources) ToInt64() NodeResourcesInt64 {
+func (nr NodeResources) ToInt64() NodeResourcesInt64 {
 	rs64 := NodeResourcesInt64{
 		Requests: make(ResourceListInt64),
 		Limits:   make(ResourceListInt64),
 	}
-	for resource, value := range rs.Requests {
+	for resource, value := range nr.Requests {
 		switch resource {
 		case corev1.ResourceCPU:
 			rs64.Requests[resource] = value.MilliValue()
@@ -233,7 +320,7 @@ func (rs NodeResources) ToInt64() NodeResourcesInt64 {
 			rs64.Requests[resource] = value.Value()
 		}
 	}
-	for resource, value := range rs.Limits {
+	for resource, value := range nr.Limits {
 		switch resource {
 		case corev1.ResourceCPU:
 			rs64.Requests[resource] = value.MilliValue()

--- a/pkg/controller/autoscaling/elasticsearch/resources/resources.go
+++ b/pkg/controller/autoscaling/elasticsearch/resources/resources.go
@@ -161,7 +161,7 @@ type NodeResources struct {
 // ResourceRequirements with the values from the NodeResources.
 // If a value in the NodeResources is not present then the value in the result is removed.
 // Values for extended resources (e.g. GPU), are left untouched.
-// This function has no side effect and do not modify the original ResourceRequirements.
+// This function has no side effect and does not modify the original ResourceRequirements.
 func (nr *NodeResources) ToContainerResourcesWith(sourceRequirements corev1.ResourceRequirements) corev1.ResourceRequirements {
 	mergedResources := sourceRequirements.DeepCopy()
 

--- a/pkg/controller/autoscaling/elasticsearch/resources/resources_test.go
+++ b/pkg/controller/autoscaling/elasticsearch/resources/resources_test.go
@@ -5,9 +5,11 @@
 package resources
 
 import (
+	"reflect"
 	"testing"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	v1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -15,6 +17,265 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestNodeResources_ToContainerResourcesWith(t *testing.T) {
+	type fields struct {
+		Limits   corev1.ResourceList
+		Requests corev1.ResourceList
+	}
+	type args struct {
+		into corev1.ResourceRequirements
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   corev1.ResourceRequirements
+	}{
+		{
+			name: "Source requirements are nil",
+			fields: fields{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					// corev1.ResourceCPU is not set and should not be present in the result.
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+			args: args{into: corev1.ResourceRequirements{
+				Requests: nil,
+				Limits:   nil,
+			}},
+			want: corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					// corev1.ResourceCPU is not expected
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+		},
+		{
+			name: "Remove a requirements if not present",
+			fields: fields{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					// corev1.ResourceCPU is not expected
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+			args: args{into: corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceCPU:    resource.MustParse("2"), // should be removed in the result
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			}},
+			want: corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					// corev1.ResourceCPU is not expected
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+		},
+		{
+			name: "Do not delete extended resource",
+			fields: fields{
+				Limits:   nil,
+				Requests: nil,
+			},
+			args: args{into: corev1.ResourceRequirements{
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					"requests.nvidia.com/gpu": resource.MustParse("4"),
+				},
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					"requests.nvidia.com/gpu": resource.MustParse("8"),
+				},
+			}},
+			want: corev1.ResourceRequirements{
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					"requests.nvidia.com/gpu": resource.MustParse("4"),
+				},
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					"requests.nvidia.com/gpu": resource.MustParse("8"),
+				},
+			},
+		},
+		{
+			name: "Merge with extended resource",
+			fields: fields{
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+			args: args{into: corev1.ResourceRequirements{
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					"requests.nvidia.com/gpu": resource.MustParse("4"),
+				},
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					"requests.nvidia.com/gpu": resource.MustParse("8"),
+				},
+			}},
+			want: corev1.ResourceRequirements{
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					"requests.nvidia.com/gpu": resource.MustParse("4"),
+					corev1.ResourceMemory:     resource.MustParse("8Gi"),
+				},
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					"requests.nvidia.com/gpu": resource.MustParse("8"),
+					corev1.ResourceMemory:     resource.MustParse("8Gi"),
+					corev1.ResourceCPU:        resource.MustParse("2"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nr := &NodeResources{
+				Limits:   tt.fields.Limits,
+				Requests: tt.fields.Requests,
+			}
+			if got := nr.ToContainerResourcesWith(tt.args.into); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NodeResources.ToContainerResourcesWith() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNodeResources_UpdateLimits(t *testing.T) {
+	type fields struct {
+		Limits   corev1.ResourceList
+		Requests corev1.ResourceList
+	}
+	type args struct {
+		autoscalingResources v1.AutoscalingResources
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   NodeResources
+	}{
+		{
+			name: "CPU limit should be twice the request",
+			args: args{
+				autoscalingResources: v1.AutoscalingResources{
+					CPU: &v1.QuantityRange{
+						RequestsToLimitsRatio: float64ptr(2.0),
+					},
+					Memory: nil, // no ratio, use default which is 1 for memory
+				},
+			},
+			fields: fields{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+					corev1.ResourceCPU:    resource.MustParse("2"),
+				},
+			},
+			want: NodeResources{
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+					corev1.ResourceCPU:    resource.MustParse("4"),
+				},
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+					corev1.ResourceCPU:    resource.MustParse("2"),
+				},
+			},
+		},
+		{
+			name: "Memory limit should be twice the request",
+			args: args{
+				autoscalingResources: v1.AutoscalingResources{
+					Memory: &v1.QuantityRange{
+						RequestsToLimitsRatio: float64ptr(2.0),
+					},
+					CPU: nil, // no ratio, use default which is 1 for memory
+				},
+			},
+			fields: fields{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+					corev1.ResourceCPU:    resource.MustParse("2"),
+				},
+			},
+			want: NodeResources{
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("16Gi"),
+				},
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+					corev1.ResourceCPU:    resource.MustParse("2"),
+				},
+			},
+		},
+		{
+			name: "No limit",
+			args: args{
+				autoscalingResources: v1.AutoscalingResources{
+					Memory: &v1.QuantityRange{
+						RequestsToLimitsRatio: float64ptr(0.0),
+					},
+					CPU: nil,
+				},
+			},
+			fields: fields{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+					corev1.ResourceCPU:    resource.MustParse("2"),
+				},
+			},
+			want: NodeResources{
+				Limits: map[corev1.ResourceName]resource.Quantity{},
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+					corev1.ResourceCPU:    resource.MustParse("2"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nr := NodeResources{
+				Limits:   tt.fields.Limits,
+				Requests: tt.fields.Requests,
+			}
+			got := nr.UpdateLimits(tt.args.autoscalingResources)
+			assert.True(
+				t,
+				apiequality.Semantic.DeepEqual(got.Requests, tt.want.Requests),
+				"NodeResources.UpdateLimits(): unexpected requests, expected %s, got %s",
+				tt.want.Requests,
+				got.Requests,
+			)
+			assert.True(
+				t,
+				apiequality.Semantic.DeepEqual(got.Limits, tt.want.Limits),
+				"NodeResources.UpdateLimits(): unexpected limits, expected %s, got %s",
+				tt.want.Limits,
+				got.Limits,
+			)
+		})
+	}
+}
 
 func TestResourcesSpecification_MaxMerge(t *testing.T) {
 	type fields struct {
@@ -363,4 +624,8 @@ func (nsb *nodeSetBuilder) build() esv1.NodeSet {
 		)
 	}
 	return nodeSet
+}
+
+func float64ptr(f float64) *float64 {
+	return &f
 }

--- a/pkg/controller/autoscaling/elasticsearch/resources/resources_test.go
+++ b/pkg/controller/autoscaling/elasticsearch/resources/resources_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	v1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -166,7 +165,7 @@ func TestNodeResources_UpdateLimits(t *testing.T) {
 		Requests corev1.ResourceList
 	}
 	type args struct {
-		autoscalingResources v1.AutoscalingResources
+		autoscalingResources esv1.AutoscalingResources
 	}
 	tests := []struct {
 		name   string
@@ -177,8 +176,8 @@ func TestNodeResources_UpdateLimits(t *testing.T) {
 		{
 			name: "CPU limit should be twice the request",
 			args: args{
-				autoscalingResources: v1.AutoscalingResources{
-					CPU: &v1.QuantityRange{
+				autoscalingResources: esv1.AutoscalingResources{
+					CPU: &esv1.QuantityRange{
 						RequestsToLimitsRatio: float64ptr(2.0),
 					},
 					Memory: nil, // no ratio, use default which is 1 for memory
@@ -204,8 +203,8 @@ func TestNodeResources_UpdateLimits(t *testing.T) {
 		{
 			name: "Memory limit should be twice the request",
 			args: args{
-				autoscalingResources: v1.AutoscalingResources{
-					Memory: &v1.QuantityRange{
+				autoscalingResources: esv1.AutoscalingResources{
+					Memory: &esv1.QuantityRange{
 						RequestsToLimitsRatio: float64ptr(2.0),
 					},
 					CPU: nil, // no ratio, use default which is 1 for memory
@@ -230,8 +229,8 @@ func TestNodeResources_UpdateLimits(t *testing.T) {
 		{
 			name: "No limit",
 			args: args{
-				autoscalingResources: v1.AutoscalingResources{
-					Memory: &v1.QuantityRange{
+				autoscalingResources: esv1.AutoscalingResources{
+					Memory: &esv1.QuantityRange{
 						RequestsToLimitsRatio: float64ptr(0.0),
 					},
 					CPU: nil,


### PR DESCRIPTION
This PR allows to user to provide a ratio to convert Elasticsearch container `Requests` into `Limits`.
The optional field named `requestsToLimitsRatio` has the following default values:
* 1 for memory, which means that by default limit and request have the same value.
* 0 for CPU, which means that by default no limit is set on CPU

Here is a example where CPU request and limit have the same value, giving a QoS class of `Guaranteed` to the Pods in the `NodeSets` managed by the autoscaling policy: 

```json
{
	"policies": [{
		"name": "di-hot",
		"roles": ["data_hot", "ingest", "transform"],
		"resources": {
			"nodeCount": {
				"min": 2,
				"max": 5
			},
			"cpu": {
				"min": 1,
				"max": 3,
				"requestsToLimitsRatio": 1
			},
			"memory": {
				"min": "2Gi",
				"max": "6Gi"
			},
			"storage": {
				"min": "1Gi",
				"max": "3Gi"
			}
		}
	}]
}
```

Related to https://github.com/elastic/cloud-on-k8s/issues/4006