### PR TITLE
[1.4] Docs: add section about custom transport CAs (#4238)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/transport-settings.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/transport-settings.asciidoc
@@ -10,6 +10,8 @@ endif::[]
 
 The transport module in Elasticsearch is used for internal communication between nodes within the cluster as well as communication between remote clusters. See the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-transport.html[Elasticsearch documentation] for details.
 
+== Customize the Transport Service
+
 In the `spec.transport.service.` section, you can change the Kubernetes service used to expose the Elasticsearch transport module:
 
 [source,yaml]
@@ -27,3 +29,21 @@ spec:
 Check the https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types[Kubernetes Publishing Services (ServiceTypes)] that are currently available.
 
 NOTE: When you change the `clusterIP` setting of the service, ECK deletes and re-creates the service, as `clusterIP` is an immutable field. This will cause a short network disruption, but in most cases it should not affect existing connections as the transport module uses long-lived TCP connections. 
+
+== Configure a custom Certificate Authority
+
+Elasticsearch uses X.509 certificates to establish encrypted and authenticated connections across nodes in the cluster. By default, ECK creates a self-signed CA certificate to issue a certificate link:https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-tls.html#node-certificates[for each node in the cluster].
+
+You can use a Kubernetes secret to provide your own CA instead of the self-signed certificate that ECK will then use to create node certificates for transport connections.
+The CA certificate must be stored in the secret under `tls.crt` and the private key must be stored under `tls.key`.
+
+You need to reference the name of a secret that contains the TLS private key and the CA certificate, in the `spec.transport.tls.certificate` section, as shown in this example:
+
+[source,yaml]
+----
+spec:
+  transport:
+    tls:
+      certificate:
+        secretName: custom-ca
+----


### PR DESCRIPTION
Backports the following commits to 1.4:
 - Docs: add section about custom transport CAs (#4238)