### PR TITLE
Revert to using OPERATOR_IMAGE for E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -429,8 +429,7 @@ e2e-docker-multiarch-build: clean
 
 e2e-run:
 	@go run test/e2e/cmd/main.go run \
-		--operator-image-repo=$(BASE_IMG) \
-		--operator-image-tag=$(IMG_VERSION) \
+		--operator-image=$(OPERATOR_IMAGE) \
 		--e2e-image=$(E2E_IMG) \
 		--test-regex=$(TESTS_MATCH) \
 		--test-license=$(TEST_LICENSE) \

--- a/test/e2e/cmd/run/command.go
+++ b/test/e2e/cmd/run/command.go
@@ -25,8 +25,7 @@ type runFlags struct {
 	e2eImage              string
 	elasticStackVersion   string
 	kubeConfig            string
-	operatorImageRepo     string
-	operatorImageTag      string
+	operatorImage         string
 	testLicensePKeyPath   string
 	testContextOutPath    string
 	testLicense           string
@@ -85,8 +84,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&flags.kubeConfig, "kubeconfig", "", "Path to kubeconfig")
 	cmd.Flags().BoolVar(&flags.local, "local", false, "Create the environment for running tests locally")
 	cmd.Flags().StringSliceVar(&flags.managedNamespaces, "managed-namespaces", []string{"mercury", "venus"}, "List of managed namespaces")
-	cmd.Flags().StringVar(&flags.operatorImageRepo, "operator-image-repo", "", "Operator image repo")
-	cmd.Flags().StringVar(&flags.operatorImageTag, "operator-image-tag", "", "Operator image tag")
+	cmd.Flags().StringVar(&flags.operatorImage, "operator-image", "", "Operator image")
 	cmd.Flags().IntVar(&flags.operatorReplicas, "operator-replicas", 1, "Operator replicas")
 	cmd.Flags().BoolVar(&flags.skipCleanup, "skip-cleanup", false, "Do not run cleanup actions after test run")
 	cmd.Flags().StringVar(&flags.testContextOutPath, "test-context-out", "", "Write the test context to the given path")

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -131,6 +131,11 @@ func (h *helper) createScratchDir() error {
 }
 
 func (h *helper) initTestContext() error {
+	imageParts := strings.Split(h.operatorImage, ":")
+	if len(imageParts) != 2 {
+		return fmt.Errorf("invalid operator image: %s", h.operatorImage)
+	}
+
 	h.testContext = test.Context{
 		AutoPortForwarding:  h.autoPortForwarding,
 		E2EImage:            h.e2eImage,
@@ -147,8 +152,9 @@ func (h *helper) initTestContext() error {
 			ManagedNamespaces: make([]string, len(h.managedNamespaces)),
 			Replicas:          h.operatorReplicas,
 		},
-		OperatorImageRepo:     h.operatorImageRepo,
-		OperatorImageTag:      h.operatorImageTag,
+		OperatorImage:         h.operatorImage,
+		OperatorImageRepo:     imageParts[0],
+		OperatorImageTag:      imageParts[1],
 		TestLicense:           h.testLicense,
 		TestLicensePKeyPath:   h.testLicensePKeyPath,
 		MonitoringSecrets:     h.monitoringSecrets,

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -90,6 +90,7 @@ type Context struct {
 	E2EServiceAccount     string            `json:"e2e_service_account"`
 	ElasticStackVersion   string            `json:"elastic_stack_version"`
 	LogVerbosity          int               `json:"log_verbosity"`
+	OperatorImage         string            `json:"operator_image"`
 	OperatorImageRepo     string            `json:"operator_image_repo"`
 	OperatorImageTag      string            `json:"operator_image_tag"`
 	TestLicense           string            `json:"test_license"`


### PR DESCRIPTION
Some CI jobs override the `OPERATOR_IMAGE` variable to set the operator image for the test run. Therefore, it's not possible to determine the Docker repository and tag from the default constituent variables  `BASE_IMG` and `IMG_VERSION` as one would reasonably expect. Of course: that would be just too easy.

Fixes #4241 