### PR TITLE
Filebeat recipe: allow service account to get/watch nodes

### DIFF
--- a/config/recipes/beats/filebeat_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_autodiscover.yaml
@@ -70,6 +70,7 @@ rules:
   resources:
   - namespaces
   - pods
+  - nodes
   verbs:
   - get
   - watch


### PR DESCRIPTION
This PR adds a missing role required to run filebeat Kubernetes autodiscover provider.