### PR TITLE
Stack monitoring recipe: allow service account to get/watch nodes

### DIFF
--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -86,6 +86,7 @@ rules:
   resources:
   - namespaces
   - pods
+  - nodes
   verbs:
   - get
   - watch
@@ -184,6 +185,7 @@ rules:
   resources:
   - namespaces
   - pods
+  - nodes
   verbs:
   - get
   - watch


### PR DESCRIPTION
I missed these 2 roles in #4252 , this PR should fix the `TestMetricbeatStackMonitoringRecipe` e2e test.

I successfully ran all the `*beat*` tests with this patch on my environment, hopefully it should be the last 🤞 
