### PR TITLE
Adjust config volume mount permissions for Beats to allow non-root user

### DIFF
--- a/pkg/controller/beat/common/pod.go
+++ b/pkg/controller/beat/common/pod.go
@@ -87,7 +87,7 @@ func buildPodTemplate(
 			ConfigVolumeName,
 			ConfigMountPath,
 			ConfigFileName,
-			0600),
+			0440),
 		dataVolume,
 	}
 


### PR DESCRIPTION
Align the permissions we use for the Beats configuration files with what we do in Agent. This theoretically allows non-root users (but root group members) to also read the configuration file. 


Related #4113 

Fixes #4108 