### PR TITLE
Skip creating namespaces during E2E run

### DIFF
--- a/config/e2e/helm-monitoring-operator.yaml
+++ b/config/e2e/helm-monitoring-operator.yaml
@@ -23,3 +23,7 @@ config:
 
 webhook:
   enabled: false
+
+internal:
+  createOperatorNamespace: false
+

--- a/config/e2e/helm-operator-under-test.yaml
+++ b/config/e2e/helm-operator-under-test.yaml
@@ -56,3 +56,5 @@ config:
   logVerbosity: "1"
   metricsPort: "9090"
 
+internal:
+  createOperatorNamespace: false

--- a/deploy/eck-operator/templates/operator-namespace.yaml
+++ b/deploy/eck-operator/templates/operator-namespace.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.internal.manifestGen -}}
+{{- if (and .Values.internal.manifestGen .Values.internal.createOperatorNamespace) -}}
 ---
 apiVersion: v1
 kind: Namespace

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -167,6 +167,11 @@ config:
 
 # Internal use only
 internal:
+  # manifestGen specifies whether the chart is running under manifest generator. 
+  # This is used for tasks specific to generating the all-in-one.yaml file.
   manifestGen: false
+  # createOperatorNamespace defines whether the operator namespace manifest should be generated when in manifestGen mode.
+  # Usually we do want that to happen (e.g. all-in-one.yaml) but, sometimes we don't (e.g. E2E tests). 
   createOperatorNamespace: true
+  # kubeVersion is the effective Kubernetes version we target when generating the all-in-one.yaml.
   kubeVersion: 1.12.0

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -168,4 +168,5 @@ config:
 # Internal use only
 internal:
   manifestGen: false
+  createOperatorNamespace: true
   kubeVersion: 1.12.0


### PR DESCRIPTION
Skip creating the namespaces using Helm because the E2E test runner already creates the namepaces beforehand.

Potential fix for #4267 