### PR TITLE
Set webhook matchPolicy to Exact

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -15,6 +15,7 @@ webhooks:
       namespace: system
       path: /validate-agent-k8s-elastic-co-v1alpha1-agent
   failurePolicy: Ignore
+  matchPolicy: Exact
   name: elastic-agent-validation-v1alpha1.k8s.elastic.co
   rules:
   - apiGroups:
@@ -36,6 +37,7 @@ webhooks:
       namespace: system
       path: /validate-apm-k8s-elastic-co-v1-apmserver
   failurePolicy: Ignore
+  matchPolicy: Exact
   name: elastic-apm-validation-v1.k8s.elastic.co
   rules:
   - apiGroups:
@@ -57,6 +59,7 @@ webhooks:
       namespace: system
       path: /validate-apm-k8s-elastic-co-v1beta1-apmserver
   failurePolicy: Ignore
+  matchPolicy: Exact
   name: elastic-apm-validation-v1beta1.k8s.elastic.co
   rules:
   - apiGroups:
@@ -78,6 +81,7 @@ webhooks:
       namespace: system
       path: /validate-beat-k8s-elastic-co-v1beta1-beat
   failurePolicy: Ignore
+  matchPolicy: Exact
   name: elastic-beat-validation-v1beta1.k8s.elastic.co
   rules:
   - apiGroups:
@@ -99,6 +103,7 @@ webhooks:
       namespace: system
       path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
   failurePolicy: Ignore
+  matchPolicy: Exact
   name: elastic-es-validation-v1beta1.k8s.elastic.co
   rules:
   - apiGroups:
@@ -120,6 +125,7 @@ webhooks:
       namespace: system
       path: /validate-enterprisesearch-k8s-elastic-co-v1beta1-enterprisesearch
   failurePolicy: Ignore
+  matchPolicy: Exact
   name: elastic-ent-validation-v1beta1.k8s.elastic.co
   rules:
   - apiGroups:
@@ -141,6 +147,7 @@ webhooks:
       namespace: system
       path: /validate-kibana-k8s-elastic-co-v1-kibana
   failurePolicy: Ignore
+  matchPolicy: Exact
   name: elastic-kb-validation-v1.k8s.elastic.co
   rules:
   - apiGroups:
@@ -162,6 +169,7 @@ webhooks:
       namespace: system
       path: /validate-kibana-k8s-elastic-co-v1beta1-kibana
   failurePolicy: Ignore
+  matchPolicy: Exact
   name: elastic-kb-validation-v1beta1.k8s.elastic.co
   rules:
   - apiGroups:
@@ -183,6 +191,7 @@ webhooks:
       namespace: system
       path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
   failurePolicy: Ignore
+  matchPolicy: Exact
   name: elastic-es-validation-v1.k8s.elastic.co
   rules:
   - apiGroups:

--- a/deploy/eck-operator/templates/_helpers.tpl
+++ b/deploy/eck-operator/templates/_helpers.tpl
@@ -150,6 +150,18 @@ admissionReviewVersions: [v1beta1]
 {{- end }}
 {{- end }}
 
+
+{{/*
+Define webhook match policy based on Kubernetes version
+*/}}
+{{- define "eck-operator.webhookMatchPolicy" -}}
+{{- $kubeVersion := (include "eck-operator.effectiveKubeVersion" .) -}}
+{{- $kubeVersionSupported := semverCompare ">=1.16.0-0" $kubeVersion -}}
+{{- if $kubeVersionSupported  }}
+matchPolicy: Exact
+{{- end }}
+{{- end }}
+
 {{/*
 RBAC permissions
 */}}

--- a/deploy/eck-operator/templates/webhook.yaml
+++ b/deploy/eck-operator/templates/webhook.yaml
@@ -27,7 +27,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-agent-validation-v1alpha1.k8s.elastic.co
-  matchPolicy: Exact
+{{- include "eck-operator.webhookMatchPolicy" $ | indent 2 }}
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -56,7 +56,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-apm-validation-v1.k8s.elastic.co
-  matchPolicy: Exact
+{{- include "eck-operator.webhookMatchPolicy" $ | indent 2 }}
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -85,7 +85,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-apm-validation-v1beta1.k8s.elastic.co
-  matchPolicy: Exact
+{{- include "eck-operator.webhookMatchPolicy" $ | indent 2 }}
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -114,7 +114,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-beat-validation-v1beta1.k8s.elastic.co
-  matchPolicy: Exact
+{{- include "eck-operator.webhookMatchPolicy" $ | indent 2 }}
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -143,7 +143,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-ent-validation-v1beta1.k8s.elastic.co
-  matchPolicy: Exact
+{{- include "eck-operator.webhookMatchPolicy" $ | indent 2 }}
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -172,7 +172,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-es-validation-v1.k8s.elastic.co
-  matchPolicy: Exact
+{{- include "eck-operator.webhookMatchPolicy" $ | indent 2 }}
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -201,7 +201,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-es-validation-v1beta1.k8s.elastic.co
-  matchPolicy: Exact
+{{- include "eck-operator.webhookMatchPolicy" $ | indent 2 }}
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -230,7 +230,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-kb-validation-v1.k8s.elastic.co
-  matchPolicy: Exact
+{{- include "eck-operator.webhookMatchPolicy" $ | indent 2 }}
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -259,7 +259,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-kb-validation-v1beta1.k8s.elastic.co
-  matchPolicy: Exact
+{{- include "eck-operator.webhookMatchPolicy" $ | indent 2 }}
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:

--- a/deploy/eck-operator/templates/webhook.yaml
+++ b/deploy/eck-operator/templates/webhook.yaml
@@ -27,6 +27,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-agent-validation-v1alpha1.k8s.elastic.co
+  matchPolicy: Exact
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -55,6 +56,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-apm-validation-v1.k8s.elastic.co
+  matchPolicy: Exact
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -83,6 +85,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-apm-validation-v1beta1.k8s.elastic.co
+  matchPolicy: Exact
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -111,6 +114,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-beat-validation-v1beta1.k8s.elastic.co
+  matchPolicy: Exact
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -139,6 +143,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-ent-validation-v1beta1.k8s.elastic.co
+  matchPolicy: Exact
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -167,6 +172,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-es-validation-v1.k8s.elastic.co
+  matchPolicy: Exact
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -195,6 +201,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-es-validation-v1beta1.k8s.elastic.co
+  matchPolicy: Exact
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -223,6 +230,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-kb-validation-v1.k8s.elastic.co
+  matchPolicy: Exact
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:
@@ -251,6 +259,7 @@ webhooks:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   name: elastic-kb-validation-v1beta1.k8s.elastic.co
+  matchPolicy: Exact
 {{- include "eck-operator.webhookAdmissionReviewVersions" $ | indent 2 }}
 {{- include "eck-operator.webhookSideEffects" $ | indent 2 }}
   rules:

--- a/pkg/apis/agent/v1alpha1/webhook.go
+++ b/pkg/apis/agent/v1alpha1/webhook.go
@@ -21,7 +21,7 @@ var (
 	validationLog = ulog.Log.WithName("agent-v1alpha1-validation")
 )
 
-// +kubebuilder:webhook:path=/validate-agent-k8s-elastic-co-v1alpha1-agent,mutating=false,failurePolicy=ignore,groups=agent.k8s.elastic.co,resources=agents,verbs=create;update,versions=v1alpha1,name=elastic-agent-validation-v1alpha1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:path=/validate-agent-k8s-elastic-co-v1alpha1-agent,mutating=false,failurePolicy=ignore,groups=agent.k8s.elastic.co,resources=agents,verbs=create;update,versions=v1alpha1,name=elastic-agent-validation-v1alpha1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
 
 var _ webhook.Validator = &Agent{}
 

--- a/pkg/apis/apm/v1/webhook.go
+++ b/pkg/apis/apm/v1/webhook.go
@@ -38,7 +38,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-apm-k8s-elastic-co-v1-apmserver,mutating=false,failurePolicy=ignore,groups=apm.k8s.elastic.co,resources=apmservers,verbs=create;update,versions=v1,name=elastic-apm-validation-v1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:path=/validate-apm-k8s-elastic-co-v1-apmserver,mutating=false,failurePolicy=ignore,groups=apm.k8s.elastic.co,resources=apmservers,verbs=create;update,versions=v1,name=elastic-apm-validation-v1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
 
 var _ webhook.Validator = &ApmServer{}
 

--- a/pkg/apis/apm/v1beta1/webhook.go
+++ b/pkg/apis/apm/v1beta1/webhook.go
@@ -33,7 +33,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-apm-k8s-elastic-co-v1beta1-apmserver,mutating=false,failurePolicy=ignore,groups=apm.k8s.elastic.co,resources=apmservers,verbs=create;update,versions=v1beta1,name=elastic-apm-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:path=/validate-apm-k8s-elastic-co-v1beta1-apmserver,mutating=false,failurePolicy=ignore,groups=apm.k8s.elastic.co,resources=apmservers,verbs=create;update,versions=v1beta1,name=elastic-apm-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
 
 var _ webhook.Validator = &ApmServer{}
 

--- a/pkg/apis/beat/v1beta1/webhook.go
+++ b/pkg/apis/beat/v1beta1/webhook.go
@@ -21,7 +21,7 @@ var (
 	validationLog = ulog.Log.WithName("beat-v1beta1-validation")
 )
 
-// +kubebuilder:webhook:path=/validate-beat-k8s-elastic-co-v1beta1-beat,mutating=false,failurePolicy=ignore,groups=beat.k8s.elastic.co,resources=beats,verbs=create;update,versions=v1beta1,name=elastic-beat-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:path=/validate-beat-k8s-elastic-co-v1beta1-beat,mutating=false,failurePolicy=ignore,groups=beat.k8s.elastic.co,resources=beats,verbs=create;update,versions=v1beta1,name=elastic-beat-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
 
 var _ webhook.Validator = &Beat{}
 

--- a/pkg/apis/elasticsearch/v1beta1/webhook.go
+++ b/pkg/apis/elasticsearch/v1beta1/webhook.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1beta1,name=elastic-es-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1beta1,name=elastic-es-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
 
 func (es *Elasticsearch) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).

--- a/pkg/apis/enterprisesearch/v1beta1/webhook.go
+++ b/pkg/apis/enterprisesearch/v1beta1/webhook.go
@@ -33,7 +33,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-enterprisesearch-k8s-elastic-co-v1beta1-enterprisesearch,mutating=false,failurePolicy=ignore,groups=enterprisesearch.k8s.elastic.co,resources=enterprisesearches,verbs=create;update,versions=v1beta1,name=elastic-ent-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:path=/validate-enterprisesearch-k8s-elastic-co-v1beta1-enterprisesearch,mutating=false,failurePolicy=ignore,groups=enterprisesearch.k8s.elastic.co,resources=enterprisesearches,verbs=create;update,versions=v1beta1,name=elastic-ent-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
 
 var _ webhook.Validator = &EnterpriseSearch{}
 

--- a/pkg/apis/kibana/v1/webhook.go
+++ b/pkg/apis/kibana/v1/webhook.go
@@ -33,7 +33,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-kibana-k8s-elastic-co-v1-kibana,mutating=false,failurePolicy=ignore,groups=kibana.k8s.elastic.co,resources=kibanas,verbs=create;update,versions=v1,name=elastic-kb-validation-v1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:path=/validate-kibana-k8s-elastic-co-v1-kibana,mutating=false,failurePolicy=ignore,groups=kibana.k8s.elastic.co,resources=kibanas,verbs=create;update,versions=v1,name=elastic-kb-validation-v1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
 
 var _ webhook.Validator = &Kibana{}
 

--- a/pkg/apis/kibana/v1beta1/webhook.go
+++ b/pkg/apis/kibana/v1beta1/webhook.go
@@ -33,7 +33,7 @@ var (
 	}
 )
 
-// +kubebuilder:webhook:path=/validate-kibana-k8s-elastic-co-v1beta1-kibana,mutating=false,failurePolicy=ignore,groups=kibana.k8s.elastic.co,resources=kibanas,verbs=create;update,versions=v1beta1,name=elastic-kb-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:path=/validate-kibana-k8s-elastic-co-v1beta1-kibana,mutating=false,failurePolicy=ignore,groups=kibana.k8s.elastic.co,resources=kibanas,verbs=create;update,versions=v1beta1,name=elastic-kb-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
 
 var _ webhook.Validator = &Kibana{}
 

--- a/pkg/controller/elasticsearch/validation/webhook.go
+++ b/pkg/controller/elasticsearch/validation/webhook.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1,name=elastic-es-validation-v1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1,name=elastic-es-validation-v1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
 
 const (
 	webhookPath = "/validate-elasticsearch-k8s-elastic-co-v1-elasticsearch"


### PR DESCRIPTION
`admissionregistration.k8s.io/v1` changed the default `matchPolicy` to `Equivalent` from `Exact`. This results in both `v1` and `v1beta1` webhooks firing for resources like Elasticsearch, Kibana and APMServer. 

Fixes #4270 