### PR TITLE
Use a helper pod to figure out the mount path for Elastic Agent

### DIFF
--- a/config/recipes/elastic-agent/kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/kubernetes-integration.yaml
@@ -13,6 +13,8 @@ spec:
         serviceAccountName: elastic-agent
         containers:
         - name: agent
+          securityContext:
+            runAsUser: 0
           env:
           - name: NODE_NAME
             valueFrom:

--- a/config/recipes/elastic-agent/system-integration.yaml
+++ b/config/recipes/elastic-agent/system-integration.yaml
@@ -11,6 +11,8 @@ spec:
       spec:
         containers:
         - name: agent
+          securityContext:
+            runAsUser: 0
   config:
     id: 488e0b80-3634-11eb-8208-57893829af4e
     revision: 2

--- a/pkg/controller/agent/driver.go
+++ b/pkg/controller/agent/driver.go
@@ -30,6 +30,9 @@ type Params struct {
 	EventRecorder record.EventRecorder
 	Watches       watches.DynamicWatches
 
+	// AgentVCSRef is elastic-agent-${hash} where hash is the VCS hash from which the Agent was built.
+	AgentVCSRef string
+
 	Agent agentv1alpha1.Agent
 }
 

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -30,7 +30,7 @@ const (
 
 	DataVolumeName            = "agent-data"
 	DataMountHostPathTemplate = "/var/lib/%s/%s/agent-data"
-	DataMountPath             = "/usr/share/data"
+	DataMountPath             = "/usr/share/elastic-agent/data/%s/run"
 
 	// ConfigChecksumLabel is a label used to store Agent config checksum.
 	ConfigChecksumLabel = "agent.k8s.elastic.co/config-checksum"
@@ -115,7 +115,7 @@ func createDataVolume(params Params) volume.VolumeLike {
 	return volume.NewHostVolume(
 		DataVolumeName,
 		dataMountHostPath,
-		DataMountPath,
+		fmt.Sprintf(DataMountPath, params.AgentVCSRef),
 		false,
 		corev1.HostPathDirectoryOrCreate)
 }

--- a/pkg/controller/agent/vcsrefs.go
+++ b/pkg/controller/agent/vcsrefs.go
@@ -1,0 +1,108 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/elastic/cloud-on-k8s/pkg/apis/agent/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/container"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var knownRefs = map[string]string{}
+
+func specImageOrDefault(spec v1alpha1.AgentSpec) string {
+	if spec.Image == "" {
+		return container.ImageRepository(container.AgentImage, spec.Version)
+	}
+	return spec.Image
+}
+
+func reconcileVCSRefs(params *Params, clientsetFactory func() (*kubernetes.Clientset, error)) *reconciler.Results {
+	defer tracing.Span(&params.Context)
+
+	requeueResult := reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
+	res := reconciler.NewResult(params.Context)
+
+	version := params.Agent.Spec.Version
+	if _, ok := knownRefs[version]; ok {
+		params.AgentVCSRef = knownRefs[version]
+		params.Logger().V(1).Info("No agent inspection needed", "version", params.Agent.Spec.Version)
+		return res
+	}
+
+	podName := types.NamespacedName{Name: fmt.Sprintf("elastic-agent-%s", version), Namespace: params.Agent.Namespace}
+	pod := corev1.Pod{
+		ObjectMeta: k8s.ToObjectMeta(podName),
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "agent-inspector",
+					Image:   specImageOrDefault(params.Agent.Spec),
+					Command: []string{"ls", "/usr/share/elastic-agent/data"},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+	err := params.Client.Get(params.Context, podName, &pod)
+	if err != nil && apierrors.IsNotFound(err) {
+		params.Logger().V(1).Info("Creating agent inspector pod", "version", params.Agent.Spec.Version)
+		if err := params.Client.Create(params.Context, &pod); err != nil {
+			return res.WithError(err)
+		}
+		// requeue to await job completion
+		return res.WithResult(requeueResult)
+	} else if err != nil {
+		return res.WithError(err)
+	}
+
+	params.Logger().V(1).Info("Found agent inspector pod", "version", params.Agent.Spec.Version)
+	switch pod.Status.Phase {
+	case corev1.PodSucceeded:
+		clientset, err := clientsetFactory()
+		if err != nil {
+			return res.WithError(err)
+		}
+		logOptions := corev1.PodLogOptions{
+			Container: "agent-inspector",
+			Follow:    false,
+			Previous:  false,
+		}
+		raw, err := clientset.CoreV1().Pods(podName.Namespace).GetLogs(pod.Name, &logOptions).Do(params.Context).Raw()
+		if err != nil {
+			return res.WithError(err)
+		}
+		output := string(raw)
+		if !strings.HasPrefix(output, "elastic-agent-") {
+			return res.WithError(fmt.Errorf("unexpected result when inspecting agent docker image %s", output))
+		}
+		vcsRef := filepath.Base(strings.Trim(output, "\n"))
+		knownRefs[params.Agent.Spec.Version] = vcsRef
+		params.AgentVCSRef = vcsRef
+
+		params.Logger().V(1).Info("Agent container inspection pod succeeded", "vcs-ref", vcsRef)
+		err = params.Client.Delete(context.Background(), &pod)
+		return res.WithError(err)
+	case corev1.PodFailed:
+		err := fmt.Errorf("cannot pre-inspect agent pod, pod failed: %v", pod.Status)
+		return res.WithError(err)
+	default:
+		params.Logger().V(1).Info("Waiting on agent pod inspection", "phase", pod.Status.Phase)
+		return res.WithResult(requeueResult)
+	}
+}

--- a/pkg/controller/common/reconciler/results.go
+++ b/pkg/controller/common/reconciler/results.go
@@ -6,6 +6,7 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
 	"go.elastic.co/apm"
@@ -49,6 +50,14 @@ func NewResult(ctx context.Context) *Results {
 // HasError returns true if Results contains one or more errors.
 func (r *Results) HasError() bool {
 	return len(r.errors) > 0
+}
+
+func (r *Results) HasRequeue() bool {
+	return r.currKind > noqueueKind
+}
+
+func (r *Results) String() string {
+	return fmt.Sprintf("%v err: %v", r.currResult, r.errors)
 }
 
 // WithResults appends the results and error from the other Results.


### PR DESCRIPTION
As I have exhausted all other ideas for https://github.com/elastic/cloud-on-k8s/issues/4260, this PR illustrates a workaround that uses a helper pod to figure out the correct mount path for Elastic Agents runtime data directory, which we want to have in the a `hostPath` volume.

Drawbacks of this approach are many:
* very brittle
* might break our Elastic Agent orchestration as soon as the Agent bug gets fixed maybe even ealier