### PR TITLE
Exclude Go module download output from manifest-gen output

### DIFF
--- a/hack/manifest-gen/manifest-gen.sh
+++ b/hack/manifest-gen/manifest-gen.sh
@@ -67,7 +67,9 @@ while getopts "ug" OPT; do
             ARGS=("$@")
             (
                 cd "$SCRIPT_DIR"
-                go run main.go --source="$CHART_DIR" generate "${ARGS[@]}"
+                go build -o manifest-gen >/dev/null 2>&1 
+                ./manifest-gen --source="$CHART_DIR" generate "${ARGS[@]}"
+                rm manifest-gen
             )
             exit 0
             ;;


### PR DESCRIPTION
If the Go module cache is unpopulated, running the manifest-gen script results in a module download operation. When the E2E runner tries to capture the output of manifest-gen, it also captures the output from the Go tool and the resulting manifest file becomes invalid. 

Fixes #4267 

