### PR TITLE
Update eck-elasticsearch ingress namespace selector

### DIFF
--- a/docs/advanced-topics/network-policies.asciidoc
+++ b/docs/advanced-topics/network-policies.asciidoc
@@ -149,7 +149,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          eck.k8s.elastic.co/operator-name: elastic-operator
+          control-plane: elastic-operator
       podSelector:
         matchLabels:
           control-plane: elastic-operator


### PR DESCRIPTION
The eck-elasticsearch ingress ns selector is attempting to use a label that isn't actually present on the 1.4.0 release of the `elastic-system` namespace. Propose instead to use the same label selector that you do for the pod; `control-plane: elastic-operator`
