### PR TITLE
Generate E2E manifests based on Kubernetes version

### DIFF
--- a/config/e2e/helm-operator-under-test.yaml
+++ b/config/e2e/helm-operator-under-test.yaml
@@ -21,7 +21,7 @@ tracing:
   enabled: true
   config:
     ELASTIC_APM_SERVER_CERT: "/mnt/elastic/apm.crt"
-    ELASTIC_APM_ENVIRONMENT: "{{ .Pipeline }}-{{ .BuildNumber }}-{{ .Provider }}-{{ .ClusterName }}-{{ .KubernetesVersion }}-{{ .ElasticStackVersion }}"
+    ELASTIC_APM_ENVIRONMENT: "{{ .Pipeline }}-{{ .BuildNumber }}-{{ .Provider }}-{{ .ClusterName }}-{{ .KubernetesMajorMinor }}-{{ .ElasticStackVersion }}"
 
 env:
   - name: ELASTIC_APM_SERVER_URL
@@ -58,3 +58,4 @@ config:
 
 internal:
   createOperatorNamespace: false
+  kubeVersion: {{ .KubernetesVersion }}

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -59,9 +59,9 @@ spec:
           build_number: {{ .BuildNumber }}
           provider: {{ .Provider }}
           clusterName: {{ .ClusterName }}
-          kubernetes_version: {{ .KubernetesVersion }}
+          kubernetes_version: {{ .KubernetesMajorMinor }}
           stack_version: {{ .ElasticStackVersion }}
-          e2e_test_id: {{ .Pipeline }}-{{ .BuildNumber }}-{{ .Provider }}-{{ .ClusterName }}-{{ .KubernetesVersion }}-{{ .ElasticStackVersion }}
+          e2e_test_id: {{ .Pipeline }}-{{ .BuildNumber }}-{{ .Provider }}-{{ .ClusterName }}-{{ .KubernetesMajorMinor }}-{{ .ElasticStackVersion }}
     setup.template.overwrite: true
     setup.template.append_fields:
     - name: stack_version
@@ -252,7 +252,7 @@ spec:
             build_number: {{ .BuildNumber }}
             provider: {{ .Provider }}
             clusterName: {{ .ClusterName }}
-            kubernetes_version: {{ .KubernetesVersion }}
+            kubernetes_version: {{ .KubernetesMajorMinor }}
             stack_version: {{ .ElasticStackVersion }}
             e2e_test_id: {{ .Pipeline }}-{{ .BuildNumber }}-{{ .Provider }}-{{ .ClusterName }}-{{ .KubernetesVersion }}-{{ .ElasticStackVersion }}
         appenders:

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -254,7 +254,7 @@ spec:
             clusterName: {{ .ClusterName }}
             kubernetes_version: {{ .KubernetesMajorMinor }}
             stack_version: {{ .ElasticStackVersion }}
-            e2e_test_id: {{ .Pipeline }}-{{ .BuildNumber }}-{{ .Provider }}-{{ .ClusterName }}-{{ .KubernetesVersion }}-{{ .ElasticStackVersion }}
+            e2e_test_id: {{ .Pipeline }}-{{ .BuildNumber }}-{{ .Provider }}-{{ .ClusterName }}-{{ .KubernetesMajorMinor }}-{{ .ElasticStackVersion }}
         appenders:
         - type: config
           condition:

--- a/test/e2e/beat/config_test.go
+++ b/test/e2e/beat/config_test.go
@@ -259,7 +259,7 @@ func TestPacketbeatConfig(t *testing.T) {
 			beat.HasEvent("event.dataset:dns"),
 		)
 
-	if test.Ctx().Provider != "kind" || test.Ctx().KubernetesMajorMinor() != "1.12" {
+	if !(test.Ctx().Provider == "kind" && test.Ctx().KubernetesMajorMinor() == "1.12") {
 		// there are some issues with kind 1.12 and tracking http traffic
 		pbBuilder = pbBuilder.WithESValidations(beat.HasEvent("event.dataset:http"))
 	}

--- a/test/e2e/beat/config_test.go
+++ b/test/e2e/beat/config_test.go
@@ -259,7 +259,7 @@ func TestPacketbeatConfig(t *testing.T) {
 			beat.HasEvent("event.dataset:dns"),
 		)
 
-	if test.Ctx().Provider != "kind" || test.Ctx().KubernetesVersion != "1.12" {
+	if test.Ctx().Provider != "kind" || test.Ctx().KubernetesMajorMinor() != "1.12" {
 		// there are some issues with kind 1.12 and tracking http traffic
 		pbBuilder = pbBuilder.WithESValidations(beat.HasEvent("event.dataset:http"))
 	}

--- a/test/e2e/beat/recipes_test.go
+++ b/test/e2e/beat/recipes_test.go
@@ -195,7 +195,7 @@ func TestAuditbeatHostsRecipe(t *testing.T) {
 
 func TestPacketbeatDnsHttpRecipe(t *testing.T) {
 	customize := func(builder beat.Builder) beat.Builder {
-		if !(test.Ctx().Provider == "kind" && test.Ctx().KubernetesVersion == "1.12") {
+		if !(test.Ctx().Provider == "kind" && test.Ctx().KubernetesMajorMinor() == "1.12") {
 			// there are some issues with kind 1.12 and tracking http traffic
 			builder = builder.WithESValidations(beat.HasEvent("event.dataset:http"))
 		}

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -195,7 +195,7 @@ func (h *helper) initTestContext() error {
 	return nil
 }
 
-func getKubernetesVersion(h *helper) string {
+func getKubernetesVersion(h *helper) version.Version {
 	out, err := h.kubectl("version", "--output=json")
 	if err != nil {
 		panic(fmt.Sprintf("can't determine kubernetes version, err %s", err))
@@ -215,10 +215,7 @@ func getKubernetesVersion(h *helper) string {
 	}
 
 	serverVersion = strings.TrimPrefix(serverVersion, "v")
-	v := version.MustParse(serverVersion)
-
-	// we just want major and minor to aggregate test results
-	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
+	return version.MustParse(serverVersion)
 }
 
 func isOcpCluster(h *helper) bool {

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	logutil "github.com/elastic/cloud-on-k8s/pkg/utils/log"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
 	"github.com/go-logr/logr"
@@ -109,7 +110,7 @@ type Context struct {
 	BuildNumber           string            `json:"build_number"`
 	Provider              string            `json:"provider"`
 	ClusterName           string            `json:"clusterName"`
-	KubernetesVersion     string            `json:"kubernetes_version"`
+	KubernetesVersion     version.Version   `json:"kubernetes_version"`
 	TestEnvTags           []string          `json:"test_tags"`
 }
 
@@ -121,6 +122,11 @@ func (c Context) ManagedNamespace(n int) string {
 // HasTag returns true if the test tags contain the specified value.
 func (c Context) HasTag(tag string) bool {
 	return stringsutil.StringInSlice(tag, c.TestEnvTags)
+}
+
+// KubernetesMajorMinor returns just the major and minor version numbers of the effective Kubernetes version.
+func (c Context) KubernetesMajorMinor() string {
+	return fmt.Sprintf("%d.%d", c.KubernetesVersion.Major, c.KubernetesVersion.Minor)
 }
 
 // ClusterResource is a generic cluster resource.


### PR DESCRIPTION
When generating manifests for the E2E tests, take the underlying Kubernetes version into account just like the Helm chart does. This should help catch unexpected changes in behaviour introduced by newer Kubernetes APIs (e.g.  #4270).