### PR TITLE
Fix deployment strategy doc bug

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/beat.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/beat.asciidoc
@@ -308,7 +308,8 @@ metadata:
   name: quickstart
 spec:
   deployment:
-    strategy: Recreate
+    strategy:
+      type: Recreate
     podTemplate:
       spec:
         securityContext:


### PR DESCRIPTION
Deployment strategy is not a string but rather an object, as seen here: https://www.elastic.co/guide/en/cloud-on-k8s/1.4/k8s-api-beat-k8s-elastic-co-v1beta1.html#k8s-api-github-com-elastic-cloud-on-k8s-pkg-apis-beat-v1beta1-deploymentspec

