### PR TITLE
Increase timeout and parallelism in PR build job

### DIFF
--- a/.ci/pipelines/pr-gke.Jenkinsfile
+++ b/.ci/pipelines/pr-gke.Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 45, unit: 'MINUTES')
+        timeout(time: 60, unit: 'MINUTES')
     }
 
     environment {

--- a/.ci/pipelines/pr-gke.Jenkinsfile
+++ b/.ci/pipelines/pr-gke.Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
                 stage('Validate Jenkins pipelines') {
                     when {
                         expression {
-                            notOnlyDocs()
+                            arePipelinesModified()
                         }
                     }
                     steps {
@@ -116,5 +116,13 @@ def notOnlyDocs() {
     return sh (
         script: "git diff --name-status HEAD~1 HEAD | grep -v docs/",
     	returnStatus: true
+    ) == 0
+}
+
+def arePipelinesModified() {
+    // grep succeeds if there is at least one line with .ci/jobs or .ci/pipelines
+    return sh (
+        script: "git diff --name-status HEAD~1 HEAD | grep -E '(.ci/jobs|.ci/pipelines)'",
+        returnStatus: true
     ) == 0
 }

--- a/.ci/pipelines/pr-gke.Jenkinsfile
+++ b/.ci/pipelines/pr-gke.Jenkinsfile
@@ -20,60 +20,70 @@ pipeline {
     }
 
     stages {
-        stage('Validate Jenkins pipelines') {
-            when {
-                expression {
-                    notOnlyDocs()
-                }
-            }
-            steps {
-                sh 'make -C .ci TARGET=validate-jenkins-pipelines ci'
-            }
-        }
-        stage('Run checks') {
-            when {
-                expression {
-                    notOnlyDocs()
-                }
-            }
-            steps {
-                sh 'make -C .ci TARGET=ci-check ci'
-            }
-        }
-        stage('Run tests in parallel') {
+        stage('Run checks and tests in parallel') {
+            failFast true
             parallel {
-                stage("Run unit and integration tests") {
-                    when {
-                        expression {
-                            notOnlyDocs()
+                stage('Run checks in parallel') {
+                    failFast true
+                    parallel {
+                        stage('Validate Jenkins pipelines') {
+                            when {
+                                expression {
+                                    notOnlyDocs()
+                                }
+                            }
+                            steps {
+                                sh 'make -C .ci TARGET=validate-jenkins-pipelines ci'
+                            }
                         }
-                    }
-                    steps {
-                        script {
-                            env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci TARGET=ci ci')
-
-                            junit "unit-tests.xml"
-                            junit "integration-tests.xml"
-
-                            sh 'exit $SHELL_EXIT_CODE'
+                        stage('Run checks') {
+                            when {
+                                expression {
+                                    notOnlyDocs()
+                                }
+                            }
+                            steps {
+                                sh 'make -C .ci TARGET=ci-check ci'
+                            }
                         }
                     }
                 }
-                stage("Run smoke E2E tests") {
-                    when {
-                        expression {
-                            notOnlyDocs()
+                stage('Run tests in parallel') {
+                    parallel {
+                        stage("Run unit and integration tests") {
+                            when {
+                                expression {
+                                    notOnlyDocs()
+                                }
+                            }
+                            steps {
+                                script {
+                                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci TARGET=ci ci')
+
+                                    junit "unit-tests.xml"
+                                    junit "integration-tests.xml"
+
+                                    sh 'exit $SHELL_EXIT_CODE'
+                                }
+                            }
                         }
-                    }
-                    steps {
-                        sh '.ci/setenvconfig pr'
-                        script {
-                            env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci monitoring-secrets.json TARGET=ci-build-operator-e2e-run ci')
+                        stage("Run smoke E2E tests") {
+                            when {
+                                expression {
+                                    notOnlyDocs()
+                                }
+                            }
+                            steps {
+                                sh '.ci/setenvconfig pr'
+                                script {
+                                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci monitoring-secrets.json TARGET=ci-build-operator-e2e-run ci')
 
-                            sh 'make -C .ci TARGET=e2e-generate-xml ci'
-                            junit "e2e-tests.xml"
+                                    sh 'make -C .ci TARGET=e2e-generate-xml ci'
+                                    junit "e2e-tests.xml"
 
-                            sh 'exit $SHELL_EXIT_CODE'
+                                    sh 'exit $SHELL_EXIT_CODE'
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
* Increase global timeout of the job from 45min to 60min
* Run the 2 first stages `Validate Jenkins pipelines` and `Run checks` in parallel with failfast enabled

Resolves #4294