### PR TITLE
Fix deployment strategy in the beats documentation (#4292)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/beat.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/beat.asciidoc
@@ -308,7 +308,8 @@ metadata:
   name: quickstart
 spec:
   deployment:
-    strategy: Recreate
+    strategy:
+      type: Recreate
     podTemplate:
       spec:
         securityContext:


### PR DESCRIPTION
I mistakenly merged #4292 directly into 1.4.

Backports the following commits to master:
* Fix deployment strategy in the beats documentation (#4292)