### PR TITLE
[1.4.x] Add release notes for 1.4.1 (#4302)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-1.4.1>>
 * <<release-notes-1.4.0>>
 * <<release-notes-1.3.2>>
 * <<release-notes-1.3.1>>
@@ -22,6 +23,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/1.4.1.asciidoc[]
 include::release-notes/1.4.0.asciidoc[]
 include::release-notes/1.3.2.asciidoc[]
 include::release-notes/1.3.1.asciidoc[]

--- a/docs/release-notes/1.4.1.asciidoc
+++ b/docs/release-notes/1.4.1.asciidoc
@@ -1,0 +1,18 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-1.4.1]]
+== {n} version 1.4.1
+
+
+
+
+
+[[bug-1.4.1]]
+[float]
+=== Bug fixes
+
+* Set webhook matchPolicy to Exact {pull}4271[#4271] (issue: {issue}4270[#4270])
+* [Helm] Unify role bindings {pull}4262[#4262]
+
+


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - Add release notes for 1.4.1 (#4302)