### PR TITLE
[1.5] Add docs section explaining the volumeClaimDeletePolicy attribute (#4304)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/volume-claim-templates.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/volume-claim-templates.asciidoc
@@ -31,7 +31,27 @@ spec:
         storageClassName: standard
 ----
 
-ECK automatically deletes PersistentVolumeClaim resources if they are not required for any Elasticsearch node. The corresponding PersistentVolume may be preserved, depending on the configured link:https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy[storage class reclaim policy].
+== Controlling volume claim deletion
+
+ECK automatically deletes PersistentVolumeClaim resources if the owning Elasticsearch nodes are scaled down. The corresponding PersistentVolumes may be preserved, depending on the configured link:https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy[storage class reclaim policy].
+
+In addition, you can control what ECK should do with the PersistentVolumeClaims if you delete the Elasticsearch cluster altogether through the `volumeClaimDeletePolicy` attribute.
+
+[source,yaml,subs=attributes,+macros]
+----
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: es
+spec:
+  version: {version}
+  volumeClaimDeletePolicy: DeleteOnScaledownOnly
+  nodeSets:
+  - name: default
+    count: 3
+----
+
+The possible values are `DeleteOnScaledownAndClusterDeletion` and `DeleteOnScaledownOnly`. By default `DeleteOnScaledownAndClusterDeletion` is in effect, which means that all PersistentVolumeClaims are deleted together with the Elasticsearch cluster. However, `DeleteOnScaledownOnly` keeps the PersistentVolumeClaims when deleting the Elasticsearch cluster. If you recreate a deleted cluster with the same name and node sets as before, the existing PersistentVolumeClaims will be adopted by the new cluster.
 
 [float]
 == Updating the volume claim settings


### PR DESCRIPTION
Backports the following commits to 1.5:
 - Add docs section explaining the volumeClaimDeletePolicy attribute (#4304)