### PR TITLE
Add data tier labels to Elasticsearch nodes

### DIFF
--- a/pkg/apis/elasticsearch/v1/autoscaling.go
+++ b/pkg/apis/elasticsearch/v1/autoscaling.go
@@ -290,7 +290,7 @@ func (as AutoscalingSpec) GetMLNodesSettings() (nodes int32, maxMemory string) {
 	var maxMemoryAsInt int64
 	for _, autoscalingSpec := range as.AutoscalingPolicySpecs {
 		if autoscalingSpec.IsMemoryDefined() &&
-			stringsutil.StringInSlice(MLRole, autoscalingSpec.Roles) &&
+			stringsutil.StringInSlice(string(MLRole), autoscalingSpec.Roles) &&
 			autoscalingSpec.MemoryRange.Max.Value() > maxMemoryAsInt {
 			maxMemoryAsInt = autoscalingSpec.MemoryRange.Max.Value()
 		}

--- a/pkg/apis/elasticsearch/v1/elasticsearch_config.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_config.go
@@ -13,6 +13,22 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 )
 
+type NodeRole string
+
+const (
+	DataColdRole            NodeRole = "data_cold"
+	DataContentRole         NodeRole = "data_content"
+	DataHotRole             NodeRole = "data_hot"
+	DataRole                NodeRole = "data"
+	DataWarmRole            NodeRole = "data_warm"
+	IngestRole              NodeRole = "ingest"
+	MLRole                  NodeRole = "ml"
+	MasterRole              NodeRole = "master"
+	RemoteClusterClientRole NodeRole = "remote_cluster_client"
+	TransformRole           NodeRole = "transform"
+	VotingOnlyRole          NodeRole = "voting_only"
+)
+
 const (
 	NodeData                = "node.data"
 	NodeIngest              = "node.ingest"
@@ -22,14 +38,6 @@ const (
 	NodeVotingOnly          = "node.voting_only"
 	NodeRemoteClusterClient = "node.remote_cluster_client"
 	NodeRoles               = "node.roles"
-
-	MasterRole              = "master"
-	DataRole                = "data"
-	IngestRole              = "ingest"
-	MLRole                  = "ml"
-	RemoteClusterClientRole = "remote_cluster_client"
-	TransformRole           = "transform"
-	VotingOnlyRole          = "voting_only"
 )
 
 // ClusterSettings is the cluster node in elasticsearch.yml.
@@ -49,95 +57,40 @@ type Node struct {
 	VotingOnly          *bool    `config:"voting_only"`           // available as of 7.3.0
 }
 
-func (n *Node) HasMasterRole() bool {
-	// all nodes are master-eligible by default
+// HasRole returns true if the node has the given role.
+func (n *Node) HasRole(role NodeRole) bool {
 	if n == nil {
-		return true
+		// Nodes have all the roles by default except for the voting_only role.
+		return role != VotingOnlyRole
 	}
 
-	if n.Roles == nil {
-		return pointer.BoolPtrDerefOr(n.Master, true)
+	if n.Roles != nil {
+		return stringsutil.StringInSlice(string(role), n.Roles)
 	}
 
-	return stringsutil.StringInSlice(MasterRole, n.Roles)
-}
-
-func (n *Node) HasDataRole() bool {
-	// all nodes are data nodes by default
-	if n == nil {
-		return true
-	}
-
-	if n.Roles == nil {
+	switch role {
+	case DataRole:
 		return pointer.BoolPtrDerefOr(n.Data, true)
-	}
-
-	return stringsutil.StringInSlice(DataRole, n.Roles)
-}
-
-func (n *Node) HasIngestRole() bool {
-	// all nodes are ingest nodes by default
-	if n == nil {
-		return true
-	}
-
-	if n.Roles == nil {
+	case DataColdRole, DataContentRole, DataHotRole, DataWarmRole:
+		// These roles should really be defined in node.roles. Since they were not, assume they are enabled unless node.data is set to false.
+		return pointer.BoolPtrDerefOr(n.Data, true)
+	case IngestRole:
 		return pointer.BoolPtrDerefOr(n.Ingest, true)
-	}
-
-	return stringsutil.StringInSlice(IngestRole, n.Roles)
-}
-
-func (n *Node) HasMLRole() bool {
-	// all nodes are ML nodes by default
-	if n == nil {
-		return true
-	}
-
-	if n.Roles == nil {
+	case MLRole:
 		return pointer.BoolPtrDerefOr(n.ML, true)
-	}
-
-	return stringsutil.StringInSlice(MLRole, n.Roles)
-}
-
-func (n *Node) HasRemoteClusterClientRole() bool {
-	// all nodes are remote_cluster_client nodes by default
-	if n == nil {
-		return true
-	}
-
-	if n.Roles == nil {
+	case MasterRole:
+		return pointer.BoolPtrDerefOr(n.Master, true)
+	case RemoteClusterClientRole:
 		return pointer.BoolPtrDerefOr(n.RemoteClusterClient, true)
-	}
-
-	return stringsutil.StringInSlice(RemoteClusterClientRole, n.Roles)
-}
-
-func (n *Node) HasTransformRole() bool {
-	// all nodes are data nodes by default and data nodes are transform nodes by default as well.
-	if n == nil {
-		return true
-	}
-
-	if n.Roles == nil {
-		return pointer.BoolPtrDerefOr(n.Transform, n.HasDataRole())
-	}
-
-	return stringsutil.StringInSlice(TransformRole, n.Roles)
-}
-
-func (n *Node) HasVotingOnlyRole() bool {
-	// voting only is not enabled by default
-	if n == nil {
-		return false
-	}
-
-	if n.Roles == nil {
+	case TransformRole:
+		// all data nodes are transform nodes by default as well.
+		return pointer.BoolPtrDerefOr(n.Transform, n.HasRole(DataRole))
+	case VotingOnlyRole:
 		return pointer.BoolPtrDerefOr(n.VotingOnly, false)
 	}
 
-	return stringsutil.StringInSlice(VotingOnlyRole, n.Roles)
+	// This point should never be reached. The default is to assume that a node has all roles except voting_only.
+	return role != VotingOnlyRole
 }
 
 // ElasticsearchSettings is a typed subset of elasticsearch.yml for purposes of the operator.

--- a/pkg/controller/elasticsearch/label/label.go
+++ b/pkg/controller/elasticsearch/label/label.go
@@ -46,6 +46,14 @@ const (
 	NodeTypesRemoteClusterClientLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-remote_cluster_client"
 	// NodeTypesVotingOnlyLabelName is a label set to true on nodes with voting_only master-eligible node
 	NodeTypesVotingOnlyLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-voting_only"
+	// NodeTypesDataColdLabelName is a label set to true on nodes with the data_cold role.
+	NodeTypesDataColdLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-data_cold"
+	// NodeTypesDataContentLabelName is a label set to true on nodes with the data_content role.
+	NodeTypesDataContentLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-data_content"
+	// NodeTypesDataHotLabelName is a label set to true on nodes with the data_hot role.
+	NodeTypesDataHotLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-data_hot"
+	// NodeTypesDataWarmLabelName is a label set to true on nodes with the data_warm role.
+	NodeTypesDataWarmLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-data_warm"
 
 	HTTPSchemeLabelName = "elasticsearch.k8s.elastic.co/http-scheme"
 
@@ -116,18 +124,25 @@ func NewPodLabels(
 	labels[VersionLabelName] = ver.String()
 
 	// node types labels
-	NodeTypesMasterLabelName.Set(nodeRoles.HasMasterRole(), labels)
-	NodeTypesDataLabelName.Set(nodeRoles.HasDataRole(), labels)
-	NodeTypesIngestLabelName.Set(nodeRoles.HasIngestRole(), labels)
-	NodeTypesMLLabelName.Set(nodeRoles.HasMLRole(), labels)
+	NodeTypesMasterLabelName.Set(nodeRoles.HasRole(esv1.MasterRole), labels)
+	NodeTypesDataLabelName.Set(nodeRoles.HasRole(esv1.DataRole), labels)
+	NodeTypesIngestLabelName.Set(nodeRoles.HasRole(esv1.IngestRole), labels)
+	NodeTypesMLLabelName.Set(nodeRoles.HasRole(esv1.MLRole), labels)
 	// transform and remote_cluster_client roles were only added in 7.7.0 so we should not annotate previous versions with them
 	if ver.GTE(version.From(7, 7, 0)) {
-		NodeTypesTransformLabelName.Set(nodeRoles.HasTransformRole(), labels)
-		NodeTypesRemoteClusterClientLabelName.Set(nodeRoles.HasRemoteClusterClientRole(), labels)
+		NodeTypesTransformLabelName.Set(nodeRoles.HasRole(esv1.TransformRole), labels)
+		NodeTypesRemoteClusterClientLabelName.Set(nodeRoles.HasRole(esv1.RemoteClusterClientRole), labels)
 	}
 	// voting_only master eligible nodes were added only in 7.3.0 so we don't want to label prior versions with it
 	if ver.GTE(version.From(7, 3, 0)) {
-		NodeTypesVotingOnlyLabelName.Set(nodeRoles.HasVotingOnlyRole(), labels)
+		NodeTypesVotingOnlyLabelName.Set(nodeRoles.HasRole(esv1.VotingOnlyRole), labels)
+	}
+	// data tiers were added in 7.10.0
+	if ver.GTE(version.From(7, 10, 0)) {
+		NodeTypesDataContentLabelName.Set(nodeRoles.HasRole(esv1.DataContentRole), labels)
+		NodeTypesDataColdLabelName.Set(nodeRoles.HasRole(esv1.DataColdRole), labels)
+		NodeTypesDataHotLabelName.Set(nodeRoles.HasRole(esv1.DataHotRole), labels)
+		NodeTypesDataWarmLabelName.Set(nodeRoles.HasRole(esv1.DataWarmRole), labels)
 	}
 
 	// config hash label, to rotate pods on config changes

--- a/pkg/controller/elasticsearch/label/label.go
+++ b/pkg/controller/elasticsearch/label/label.go
@@ -44,7 +44,7 @@ const (
 	NodeTypesTransformLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-transform"
 	// NodeTypesRemoteClusterClientLabelName is a label set to true on nodes with the remote_cluster_client role
 	NodeTypesRemoteClusterClientLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-remote_cluster_client"
-	// NodeTypesVotingOnlyLabelName is a label set to true on nodes with voting_only master-eligible node
+	// NodeTypesVotingOnlyLabelName is a label set to true on voting-only master-eligible nodes
 	NodeTypesVotingOnlyLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-voting_only"
 	// NodeTypesDataColdLabelName is a label set to true on nodes with the data_cold role.
 	NodeTypesDataColdLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-data_cold"

--- a/pkg/controller/elasticsearch/validation/autoscaling_validation.go
+++ b/pkg/controller/elasticsearch/validation/autoscaling_validation.go
@@ -159,7 +159,7 @@ func validateAutoscalingPolicies(autoscalingPolicies esv1.AutoscalingPolicySpecs
 		}
 
 		// Machine learning nodes must be in a dedicated tier.
-		if stringsutil.StringInSlice(esv1.MLRole, autoscalingSpec.Roles) && len(autoscalingSpec.Roles) > 1 {
+		if stringsutil.StringInSlice(string(esv1.MLRole), autoscalingSpec.Roles) && len(autoscalingSpec.Roles) > 1 {
 			errs = append(
 				errs,
 				field.Invalid(

--- a/pkg/controller/elasticsearch/validation/validations.go
+++ b/pkg/controller/elasticsearch/validation/validations.go
@@ -141,7 +141,7 @@ func hasCorrectNodeRoles(es esv1.Elasticsearch) field.ErrorList {
 		}
 
 		// Check if this nodeSet has the master role. If autoscaling is enabled the count value in the NodeSet might not be initially set.
-		seenMaster = seenMaster || (cfg.Node.HasMasterRole() && !cfg.Node.HasVotingOnlyRole() && ns.Count > 0) || es.IsAutoscalingDefined()
+		seenMaster = seenMaster || (cfg.Node.HasRole(esv1.MasterRole) && !cfg.Node.HasRole(esv1.VotingOnlyRole) && ns.Count > 0) || es.IsAutoscalingDefined()
 	}
 
 	if !seenMaster {

--- a/pkg/controller/elasticsearch/validation/validations_test.go
+++ b/pkg/controller/elasticsearch/validation/validations_test.go
@@ -124,7 +124,7 @@ func Test_hasCorrectNodeRoles(t *testing.T) {
 		},
 		{
 			name:         "no master defined (node roles)",
-			es:           esWithRoles("7.9.0", 1, m{esv1.NodeRoles: []string{esv1.DataRole}}, m{esv1.NodeRoles: []string{esv1.MasterRole, esv1.VotingOnlyRole}}),
+			es:           esWithRoles("7.9.0", 1, m{esv1.NodeRoles: []esv1.NodeRole{esv1.DataRole}}, m{esv1.NodeRoles: []esv1.NodeRole{esv1.MasterRole, esv1.VotingOnlyRole}}),
 			expectErrors: true,
 		},
 		{
@@ -134,17 +134,17 @@ func Test_hasCorrectNodeRoles(t *testing.T) {
 		},
 		{
 			name:         "zero master nodes (node roles)",
-			es:           esWithRoles("7.9.0", 0, m{esv1.NodeRoles: []string{esv1.MasterRole, esv1.DataRole}}, m{esv1.NodeRoles: []string{esv1.DataRole}}),
+			es:           esWithRoles("7.9.0", 0, m{esv1.NodeRoles: []esv1.NodeRole{esv1.MasterRole, esv1.DataRole}}, m{esv1.NodeRoles: []esv1.NodeRole{esv1.DataRole}}),
 			expectErrors: true,
 		},
 		{
 			name:         "mixed node attributes and node roles",
-			es:           esWithRoles("7.9.0", 1, m{esv1.NodeMaster: "true", esv1.NodeRoles: []string{esv1.DataRole}}, m{esv1.NodeRoles: []string{esv1.DataRole, esv1.TransformRole}}),
+			es:           esWithRoles("7.9.0", 1, m{esv1.NodeMaster: "true", esv1.NodeRoles: []esv1.NodeRole{esv1.DataRole}}, m{esv1.NodeRoles: []esv1.NodeRole{esv1.DataRole, esv1.TransformRole}}),
 			expectErrors: true,
 		},
 		{
 			name:         "node roles on older version",
-			es:           esWithRoles("7.6.0", 1, m{esv1.NodeRoles: []string{esv1.MasterRole}}, m{esv1.NodeRoles: []string{esv1.DataRole}}),
+			es:           esWithRoles("7.6.0", 1, m{esv1.NodeRoles: []esv1.NodeRole{esv1.MasterRole}}, m{esv1.NodeRoles: []esv1.NodeRole{esv1.DataRole}}),
 			expectErrors: true,
 		},
 		{
@@ -153,7 +153,7 @@ func Test_hasCorrectNodeRoles(t *testing.T) {
 		},
 		{
 			name: "valid configuration (node roles)",
-			es:   esWithRoles("7.9.0", 4, m{esv1.NodeRoles: []string{esv1.MasterRole, esv1.DataRole}}, m{esv1.NodeRoles: []string{esv1.DataRole}}, m{esv1.NodeRoles: []string{esv1.RemoteClusterClientRole}}),
+			es:   esWithRoles("7.9.0", 4, m{esv1.NodeRoles: []esv1.NodeRole{esv1.MasterRole, esv1.DataRole}}, m{esv1.NodeRoles: []esv1.NodeRole{esv1.DataRole}}, m{esv1.NodeRoles: []esv1.NodeRole{esv1.RemoteClusterClientRole}}),
 		},
 	}
 	for _, tt := range tests {

--- a/test/e2e/test/elasticsearch/checks_es.go
+++ b/test/e2e/test/elasticsearch/checks_es.go
@@ -188,37 +188,11 @@ func (e *esClusterChecks) CheckESNodesTopology(es esv1.Elasticsearch) test.Step 
 
 func compareRoles(expected *esv1.Node, actualRoles []string) bool {
 	for _, r := range actualRoles {
-		switch r {
-		case esv1.MasterRole:
-			if !expected.HasMasterRole() {
-				return false
-			}
-		case esv1.DataRole:
-			if !expected.HasDataRole() {
-				return false
-			}
-		case esv1.IngestRole:
-			if !expected.HasIngestRole() {
-				return false
-			}
-		case esv1.MLRole:
-			if !expected.HasMLRole() {
-				return false
-			}
-		case esv1.RemoteClusterClientRole:
-			if !expected.HasRemoteClusterClientRole() {
-				return false
-			}
-		case esv1.TransformRole:
-			if !expected.HasTransformRole() {
-				return false
-			}
-		case esv1.VotingOnlyRole:
-			if !expected.HasVotingOnlyRole() {
-				return false
-			}
+		if !expected.HasRole(esv1.NodeRole(r)) {
+			return false
 		}
 	}
+
 	return true
 }
 

--- a/test/e2e/test/elasticsearch/settings.go
+++ b/test/e2e/test/elasticsearch/settings.go
@@ -24,7 +24,7 @@ func MustNumDataNodes(es esv1.Elasticsearch) int {
 
 func isDataNode(node esv1.NodeSet, ver version.Version) bool {
 	if node.Config == nil {
-		return esv1.DefaultCfg(ver).Node.HasDataRole()
+		return esv1.DefaultCfg(ver).Node.HasRole(esv1.DataRole)
 	}
 	config, err := common.NewCanonicalConfigFrom(node.Config.Data)
 	if err != nil {
@@ -36,5 +36,5 @@ func isDataNode(node esv1.NodeSet, ver version.Version) bool {
 	if err != nil {
 		panic(err)
 	}
-	return nodeCfg.Node.HasDataRole()
+	return nodeCfg.Node.HasRole(esv1.DataRole)
 }


### PR DESCRIPTION
Adds node labels to indicate the data tiers associated with each node.

Also refactors the node role checking function to reduce code duplication.

Fixes #4054 