### PR TITLE
[DOCS] Add a TIP to recommend YAML anchors

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
@@ -20,7 +20,11 @@ You can combine these features to deploy a production-grade Elasticsearch cluste
 [id="{p}-define-elasticsearch-nodes-roles"]
 == Define Elasticsearch nodes roles
 
-You can configure Elasticsearch nodes with link:https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[one or multiple roles]. This allows you to describe an Elasticsearch cluster with 3 dedicated master nodes, for example:
+You can configure Elasticsearch nodes with link:https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[one or multiple roles]. 
+
+TIP: You can use link:https://yaml.org/spec/1.2/spec.html#id2765878[YAML anchors] to declare the configuration change once and reuse it across all the node sets.
+
+This allows you to describe an Elasticsearch cluster with 3 dedicated master nodes, for example:
 
 [source,yaml,subs="attributes"]
 ----

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/orchestration.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/orchestration.asciidoc
@@ -21,6 +21,8 @@ This section covers the following topics:
 
 NodeSets are used to specify the topology of the Elasticsearch cluster. Each NodeSet represents a group of Elasticsearch nodes that share the same Elasticsearch configuration and Kubernetes Pod configuration.
 
+TIP: You can use link:https://yaml.org/spec/1.2/spec.html#id2765878[YAML anchors] to declare the configuration change once and reuse it across all the node sets.
+
 [source,yaml,subs="attributes"]
 ----
 apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}


### PR DESCRIPTION
This PR adds a TIP to use YAML anchors when changing the configuration across multiple nodes.

Fixes #3947