### PR TITLE
Replace coordinator node with coordinating node

### DIFF
--- a/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
+++ b/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
@@ -58,7 +58,7 @@ spec:
         annotations:
           traffic.sidecar.istio.io/excludeOutboundPorts: "9300"
           traffic.sidecar.istio.io/excludeInboundPorts: "9300"
-  - name: coordinator
+  - name: coordinating
     count: 1
     config:
       node.master: false

--- a/config/recipes/istio-gateway/06-es-traffic-split.yaml
+++ b/config/recipes/istio-gateway/06-es-traffic-split.yaml
@@ -25,7 +25,7 @@ spec:
       route:
         - destination:
             host: ekmnt-es-http.istio-apps.svc.cluster.local
-            subset: coordinator
+            subset: coordinating
             port:
               number: 9200
     - name: writes
@@ -60,7 +60,7 @@ spec:
         elasticsearch.k8s.elastic.co/node-data: "false"
         elasticsearch.k8s.elastic.co/node-ingest: "true"
         elasticsearch.k8s.elastic.co/node-ml: "false"
-    - name: coordinator
+    - name: coordinating
       labels:
         elasticsearch.k8s.elastic.co/node-master: "false"
         elasticsearch.k8s.elastic.co/node-data: "false"

--- a/config/recipes/istio-gateway/README.asciidoc
+++ b/config/recipes/istio-gateway/README.asciidoc
@@ -2,9 +2,9 @@
 
 This recipe demonstrates the following features:
 
-- Deploying an Elasticsearch cluster with different node types (coordinator, ingest, master, data, ml)
+- Deploying an Elasticsearch cluster with different node types (coordinating, ingest, master, data, ml)
 - Enforcing Istio mTLS between Elasticsearch nodes
-- Routing read traffic to coordinator nodes and write traffic to ingest nodes (internally and externally)
+- Routing read traffic to coordinating nodes and write traffic to ingest nodes (internally and externally)
 - Exposing Elasticsearch and Kibana deployments externally using the Istio ingress gateway
 
 
@@ -75,7 +75,7 @@ include::05-gateway.yaml[]
 
 This virtual service and destination rule splits both internal and external traffic using the following rules:
 
-- `POST` requests to `/_search` or any `GET` requests should be sent to coordinator nodes
+- `POST` requests to `/_search` or any `GET` requests should be sent to coordinating nodes
 - Any other requests (`DELETE`, `PUT`, `POST`, `PATCH`) should be sent to ingest nodes
 
 This traffic split applies to internal traffic (mesh) as well as external traffic.
@@ -122,11 +122,11 @@ curl -k \
 	"https://elasticsearch.ekmnt:$SECURE_INGRESS_PORT/_cat/health?v"
 ----
 
-If you have enabled proxy access logs, you can verify that the above `GET` request was received by the coordinator node by looking at the proxy logs:
+If you have enabled proxy access logs, you can verify that the above `GET` request was received by the coordinating node by looking at the proxy logs:
 
 [source,sh]
 ----
-kubectl logs -f ekmnt-es-coordinator-0 -n istio-apps -c istio-proxy
+kubectl logs -f ekmnt-es-coordinating-0 -n istio-apps -c istio-proxy
 ----
 
 Alternatively, if you have Kiali installed, your traffic graph might resemble the following:

--- a/config/recipes/traefik/02-elastic-stack.yaml
+++ b/config/recipes/traefik/02-elastic-stack.yaml
@@ -32,7 +32,7 @@ spec:
       node.ingest: true
       node.ml: false
       node.store.allow_mmap: false
-  - name: coordinator
+  - name: coordinating
     count: 1
     config:
       node.master: false

--- a/config/recipes/traefik/03-node-type-svc.yaml
+++ b/config/recipes/traefik/03-node-type-svc.yaml
@@ -11,7 +11,7 @@ spec:
       port: 9200
       targetPort: 9200
   selector:
-    # Select coordinator nodes
+    # Select coordinating nodes
     elasticsearch.k8s.elastic.co/cluster-name: "hulk"
     elasticsearch.k8s.elastic.co/node-master: "false"
     elasticsearch.k8s.elastic.co/node-data: "false"

--- a/config/recipes/traefik/README.asciidoc
+++ b/config/recipes/traefik/README.asciidoc
@@ -30,7 +30,7 @@ Deploy Elastic Stack applications.
 include::02-elastic-stack.yaml[]
 ----
 
-Create services to expose ingest nodes and coordinator nodes.
+Create services to expose ingest nodes and coordinating nodes.
 
 [source,yaml]
 ----

--- a/docs/advanced-topics/traffic-splitting.asciidoc
+++ b/docs/advanced-topics/traffic-splitting.asciidoc
@@ -38,8 +38,8 @@ spec:
     count: 3
     config:
       node.roles: ["ingest"]
-  # Dedicated coordinator nodes
-  - name: coordinator
+  # Dedicated coordinating nodes
+  - name: coordinating
     count: 3
     config:
       node.roles: !!seq ""
@@ -62,14 +62,14 @@ spec:
 
 The following examples illustrate how to create services for accessing different types of Elasticsearch nodes. The procedure for exposing services publicly is the same as described in <<{p}-allow-public-access>>.
 
-.Coordinator nodes
-[[{p}-traffic-splitting-coordinator-nodes]]
+.Coordinating nodes
+[[{p}-traffic-splitting-coordinating-nodes]]
 [source,yaml]
 ----
 apiVersion: v1
 kind: Service
 metadata:
-  name: hulk-es-coordinator-nodes
+  name: hulk-es-coordinating-nodes
 spec:
   ports:
     - name: https

--- a/docs/design/0001-no-stateful-sets.md
+++ b/docs/design/0001-no-stateful-sets.md
@@ -27,7 +27,7 @@ In a given StatefulSet, all pods have the exact same spec.
 From our perspective, instances can be configured with several options:
 
 - Elasticsearch version
-- node types: master-only, master-data, data-only, master-data-ingest, coordinator-only, ML, APM, etc.
+- node types: master-only, master-data, data-only, master-data-ingest, coordinating-only, ML, APM, etc.
 - availability zones: as-1, az-2, etc.
 - instance configuration type: hot/warm architectures
 

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/node-configuration.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/node-configuration.asciidoc
@@ -46,7 +46,7 @@ Marking a node as link:https://www.elastic.co/guide/en/elasticsearch/reference/c
 ----
 spec:
   nodeSets:
-  - name: coordinator
+  - name: coordinating
     count: 3
     config:
       node.roles: !!seq ""

--- a/test/e2e/es/topology_test.go
+++ b/test/e2e/es/topology_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
 )
 
-//TestCoordinatorNodes tests a cluster with coordinator nodes.
-func TestCoordinatorNodes(t *testing.T) {
+//TestCoordinatingNodes tests a cluster with coordinating nodes.
+func TestCoordinatingNodes(t *testing.T) {
 	b := elasticsearch.NewBuilder("test-es-coord").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
-		WithESCoordinatorNodes(1, elasticsearch.DefaultResources)
+		WithESCoordinatingNodes(1, elasticsearch.DefaultResources)
 
 	test.Sequence(nil, test.EmptySteps, b).RunSequential(t)
 }

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -204,7 +204,7 @@ func (b Builder) WithESMasterDataNodes(count int, resources corev1.ResourceRequi
 	})
 }
 
-func (b Builder) WithESCoordinatorNodes(count int, resources corev1.ResourceRequirements) Builder {
+func (b Builder) WithESCoordinatingNodes(count int, resources corev1.ResourceRequirements) Builder {
 	cfg := map[string]interface{}{}
 	v := version.MustParse(b.Elasticsearch.Spec.Version)
 
@@ -227,7 +227,7 @@ func (b Builder) WithESCoordinatorNodes(count int, resources corev1.ResourceRequ
 	}
 
 	return b.WithNodeSet(esv1.NodeSet{
-		Name:  "coordinator",
+		Name:  "coordinating",
 		Count: int32(count),
 		Config: &commonv1.Config{
 			Data: cfg,


### PR DESCRIPTION
This PR replaces the occurrences of `coordinator node` with `coordinating node` to align with ES terminology.

Fixes #4093