### PR TITLE
Grant Heartbeat NET_RAW POSIX capability

### DIFF
--- a/config/e2e/scc.yaml
+++ b/config/e2e/scc.yaml
@@ -24,7 +24,8 @@ allowedCapabilities:
 - SETPCAP
 - AUDIT_WRITE
 - NET_BIND_SERVICE
-defaultAddCapabilities: []
+defaultAddCapabilities:
+- NET_RAW        # required for Heartbeat
 fsGroup:
   type: RunAsAny
 priority: 0


### PR DESCRIPTION
Because the default `NET_RAW` capability was removed in OCP 4.6 and we recently upgraded to OCP 4.7 (#4291).

Resolves #4311.

Note: if you test with `e2e-local`, be sure to call the e2e runner with `--skip-cleanup`, otherwise the SCC is added and then removed before the test starts (it's a bug).