### PR TITLE
[Autoscaling] Fix wrong ML node count in settings

### DIFF
--- a/pkg/apis/elasticsearch/v1/autoscaling.go
+++ b/pkg/apis/elasticsearch/v1/autoscaling.go
@@ -289,12 +289,14 @@ func (as AutoscalingSpec) GetAutoscaledNodeSets() (AutoscaledNodeSets, *NodeSetC
 func (as AutoscalingSpec) GetMLNodesSettings() (nodes int32, maxMemory string) {
 	var maxMemoryAsInt int64
 	for _, autoscalingSpec := range as.AutoscalingPolicySpecs {
-		if autoscalingSpec.IsMemoryDefined() &&
-			stringsutil.StringInSlice(string(MLRole), autoscalingSpec.Roles) &&
-			autoscalingSpec.MemoryRange.Max.Value() > maxMemoryAsInt {
-			maxMemoryAsInt = autoscalingSpec.MemoryRange.Max.Value()
+		if !stringsutil.StringInSlice(string(MLRole), autoscalingSpec.Roles) {
+			// not a node with the machine learning role
+			continue
 		}
 		nodes += autoscalingSpec.NodeCountRange.Max
+		if autoscalingSpec.IsMemoryDefined() && autoscalingSpec.MemoryRange.Max.Value() > maxMemoryAsInt {
+			maxMemoryAsInt = autoscalingSpec.MemoryRange.Max.Value()
+		}
 	}
 	maxMemory = fmt.Sprintf("%db", maxMemoryAsInt)
 	return nodes, maxMemory

--- a/pkg/apis/elasticsearch/v1/autoscaling_test.go
+++ b/pkg/apis/elasticsearch/v1/autoscaling_test.go
@@ -120,6 +120,13 @@ func TestAutoscalingSpec_GetMLNodesSettings(t *testing.T) {
 			fields: fields{
 				AutoscalingPolicySpecs: AutoscalingPolicySpecs{
 					{
+						NamedAutoscalingPolicy: NamedAutoscalingPolicy{Name: "data-policy", AutoscalingPolicy: AutoscalingPolicy{Roles: []string{"data"}}},
+						AutoscalingResources: AutoscalingResources{
+							MemoryRange:    &QuantityRange{Min: resource.MustParse("1Gi"), Max: resource.MustParse("16Gi")},
+							NodeCountRange: CountRange{Min: 3, Max: 5},
+						},
+					},
+					{
 						NamedAutoscalingPolicy: NamedAutoscalingPolicy{Name: "ml-policy", AutoscalingPolicy: AutoscalingPolicy{Roles: []string{"ml"}}},
 						AutoscalingResources: AutoscalingResources{
 							MemoryRange:    &QuantityRange{Min: resource.MustParse("1Gi"), Max: resource.MustParse("8Gi")},
@@ -136,7 +143,14 @@ func TestAutoscalingSpec_GetMLNodesSettings(t *testing.T) {
 			fields: fields{
 				AutoscalingPolicySpecs: AutoscalingPolicySpecs{
 					{
-						NamedAutoscalingPolicy: NamedAutoscalingPolicy{Name: "ml-policy", AutoscalingPolicy: AutoscalingPolicy{Roles: []string{"data,ml"}}},
+						NamedAutoscalingPolicy: NamedAutoscalingPolicy{Name: "data-policy", AutoscalingPolicy: AutoscalingPolicy{Roles: []string{"data"}}},
+						AutoscalingResources: AutoscalingResources{
+							MemoryRange:    &QuantityRange{Min: resource.MustParse("1Gi"), Max: resource.MustParse("16Gi")},
+							NodeCountRange: CountRange{Min: 3, Max: 5},
+						},
+					},
+					{
+						NamedAutoscalingPolicy: NamedAutoscalingPolicy{Name: "ml-data-policy", AutoscalingPolicy: AutoscalingPolicy{Roles: []string{"data", "ml"}}},
 						AutoscalingResources: AutoscalingResources{
 							MemoryRange:    &QuantityRange{Min: resource.MustParse("1Gi"), Max: resource.MustParse("8Gi")},
 							NodeCountRange: CountRange{Min: 0, Max: 7},


### PR DESCRIPTION
This PR fixes the ML node count calculation used by the autoscaling controller to set the `max_lazy_ml_nodes` setting