### PR TITLE
Fix OpenShift monitoring recipe

### DIFF
--- a/config/recipes/beats/openshift_monitoring.yaml
+++ b/config/recipes/beats/openshift_monitoring.yaml
@@ -109,6 +109,9 @@ spec:
           - /etc/beat.yml
           - -system.hostfs=/hostfs
           name: metricbeat
+          securityContext:
+            runAsUser: 0
+            privileged: true # This is required to access kubelet API
           volumeMounts:
           - mountPath: /hostfs/sys/fs/cgroup
             name: cgroup
@@ -129,9 +132,6 @@ spec:
               memory: 2Gi
         dnsPolicy: ClusterFirstWithHostNet
         hostNetwork: true # Allows to provide richer host metadata
-        securityContext:
-          runAsUser: 0
-          privileged: true # This is required to access kubelet API
         terminationGracePeriodSeconds: 30
         volumes:
         - hostPath:


### PR DESCRIPTION
Deploying Metricbeat using `config/recipes/beats/openshift_monitoring.yaml` is failing with the following error:

```
Beat.beat.k8s.elastic.co "metricbeat" is invalid: privileged: Invalid value: "privileged": privileged field found in the kubectl.kubernetes.io/last-applied-configuration annotation is unknown. This is often due to incorrect indentation in the manifest.
```

This is because the `privileged` field is only available in the container `securityContext `. 