### PR TITLE
Reset node selector of managed namespaces on OCP3

### DIFF
--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -377,7 +377,7 @@ func (h *helper) createOperatorNamespaces() error {
 }
 
 func (h *helper) createManagedNamespaces() error {
-	log.Info("Creating managed namespacesS")
+	log.Info("Creating managed namespaces")
 	var err error
 	// when in local mode, don't delete the namespaces on exit
 	if h.testContext.Local {

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -387,7 +387,7 @@ func (h *helper) createManagedNamespaces() error {
 	}
 
 	// Reset the node selector for all managed namespaces to override any possible OCP project node selector that might
-	// prevent scheduling daemonset pods on some nodes
+	// prevent scheduling daemonset pods on some nodes.
 	if h.testContext.Ocp3Cluster {
 		log.Info("Resetting namespace node selector")
 		for _, ns := range h.testContext.Operator.ManagedNamespaces {

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -401,7 +401,6 @@ func (h *helper) createManagedNamespaces() error {
 	return err
 }
 
-
 func (h *helper) waitForOperatorToBeReady() error {
 	log.Info("Waiting for the operator pod to be ready")
 	client, err := h.createKubeClient()

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -391,8 +391,7 @@ func (h *helper) createManagedNamespaces() error {
 	if h.testContext.Ocp3Cluster {
 		log.Info("Resetting namespace node selector")
 		for _, ns := range h.testContext.Operator.ManagedNamespaces {
-			if err := exec.Command("oc", "annotate", "--overwrite", "namespace", ns, "openshift.io/node-selector=").Run(); err != nil {
-				log.Info("err:", err)
+			if err := exec.Command("oc", "annotate", "namespace", ns, "openshift.io/node-selector=").Run(); err != nil {
 				return err
 			}
 		}

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -377,15 +377,30 @@ func (h *helper) createOperatorNamespaces() error {
 }
 
 func (h *helper) createManagedNamespaces() error {
-	log.Info("Creating managed namespaces")
+	log.Info("Creating managed namespacesS")
+	var err error
 	// when in local mode, don't delete the namespaces on exit
 	if h.testContext.Local {
-		_, err := h.kubectlApplyTemplate("config/e2e/managed_namespaces.yaml", h.testContext)
-		return err
+		_, err = h.kubectlApplyTemplate("config/e2e/managed_namespaces.yaml", h.testContext)
+	} else {
+		err = h.kubectlApplyTemplateWithCleanup("config/e2e/managed_namespaces.yaml", h.testContext)
 	}
 
-	return h.kubectlApplyTemplateWithCleanup("config/e2e/managed_namespaces.yaml", h.testContext)
+	// Reset the node selector for all managed namespaces to override any possible OCP project node selector that might
+	// prevent scheduling daemonset pods on some nodes
+	if h.testContext.Ocp3Cluster {
+		log.Info("Resetting namespace node selector")
+		for _, ns := range h.testContext.Operator.ManagedNamespaces {
+			if err := exec.Command("oc", "annotate", "--overwrite", "namespace", ns, "openshift.io/node-selector=").Run(); err != nil {
+				log.Info("err:", err)
+				return err
+			}
+		}
+	}
+
+	return err
 }
+
 
 func (h *helper) waitForOperatorToBeReady() error {
 	log.Info("Waiting for the operator pod to be ready")


### PR DESCRIPTION
When the environment is OCP3, execute `oc annotate --overwrite namespace <ns> openshift.io/node-selector=""` for all managed namespaces to prevent that daemonset pods from being scheduled on some nodes, because by default there can be a node selector at the OCP project level.

Relates to #4128.