### PR TITLE
Fix version parsing in nightly job

### DIFF
--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -41,9 +41,13 @@ pipeline {
                     }
                 }
                 stage('Upload YAML manifest to S3') {
+                    environment {
+                        VERSION="${sh(returnStdout: true, script: '. ./.env; echo $IMG_VERSION').trim()}"
+                    }
+
                     steps {
                         script {
-                            env.VERSION = readFromEnvFile("VERSION")
+                            sh 'echo VERSION=$VERSION'
                             sh 'make -C .ci yaml-upload'
                         }
                     }
@@ -146,14 +150,3 @@ pipeline {
     }
 }
 
-def readFromEnvFile(name) {
-    def val = sh(returnStdout: true, script:
-    """
-    awk \'/${name}/{print \$3}\' .env
-    """
-    ).trim()
-
-    sh("echo ${name}=${val}")
-
-    return val
-}

--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -47,7 +47,6 @@ pipeline {
 
                     steps {
                         script {
-                            sh 'echo VERSION=$VERSION'
                             sh 'make -C .ci yaml-upload'
                         }
                     }
@@ -149,4 +148,3 @@ pipeline {
         }
     }
 }
-

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -431,7 +431,7 @@ CFG
 
 write_env <<ENV
 REGISTRY_NAMESPACE=eck-snapshots
-IMG_SUFFIX =
+IMG_SUFFIX=
 
 GO_TAGS=release
 export LICENSE_PUBKEY=/go/src/github.com/elastic/cloud-on-k8s/.ci/license.key
@@ -448,7 +448,7 @@ ENV
 
 write_env <<ENV
 REGISTRY_NAMESPACE=eck
-IMG_SUFFIX =
+IMG_SUFFIX=
 
 GO_TAGS=release
 export LICENSE_PUBKEY=/go/src/github.com/elastic/cloud-on-k8s/.ci/license.key


### PR DESCRIPTION
- The change introduced in #4343 breaks the version parsing logic in the nightly job because it assumes there are spaces in the variable assignment.
- The `readFromEnvFile` call is a bit unsafe because it's trying read a line matching `VERSION` whereas the actual variable in the env file is `IMG_VERSION`. If someone adds another variable containing the word `VERSION` to the file, the job could break.

