### PR TITLE
[1.5] Release notes and highlights for 1.5.0 (#4313)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,7 +6,6 @@
 
 This section summarizes the changes in each release.
 
-=======
 * <<release-notes-1.5.0>>
 * <<release-notes-1.4.1>>
 * <<release-notes-1.4.0>>

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,9 @@
 
 This section summarizes the changes in each release.
 
+=======
+* <<release-notes-1.5.0>>
+* <<release-notes-1.4.1>>
 * <<release-notes-1.4.0>>
 * <<release-notes-1.3.2>>
 * <<release-notes-1.3.1>>
@@ -22,6 +25,8 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/1.5.0.asciidoc[]
+include::release-notes/1.4.1.asciidoc[]
 include::release-notes/1.4.0.asciidoc[]
 include::release-notes/1.3.2.asciidoc[]
 include::release-notes/1.3.1.asciidoc[]

--- a/docs/release-notes/1.4.1.asciidoc
+++ b/docs/release-notes/1.4.1.asciidoc
@@ -1,0 +1,18 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-1.4.1]]
+== {n} version 1.4.1
+
+
+
+
+
+[[bug-1.4.1]]
+[float]
+=== Bug fixes
+
+* Set webhook matchPolicy to Exact {pull}4271[#4271] (issue: {issue}4270[#4270])
+* [Helm] Unify role bindings {pull}4262[#4262]
+
+

--- a/docs/release-notes/1.5.0.asciidoc
+++ b/docs/release-notes/1.5.0.asciidoc
@@ -1,0 +1,42 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-1.5.0]]
+== {n} version 1.5.0
+
+[[breaking-1.5.0]]
+[float]
+=== Breaking changes
+
+* Promote EnterpriseSearch Custom Resource Definition to v1 {pull}4284[#4284] (issue: {issue}4257[#4257])
+
+
+[[feature-1.5.0]]
+[float]
+=== New features
+
+* [Autoscaling] Report overlapping policies {pull}4265[#4265]
+* [Autoscaling] Add setting to customize autoscaling API polling frequency {pull}4264[#4264]
+* [Autoscaling] Add scale down stabilization {pull}4250[#4250]
+* [Autoscaling] Add support for request/limit ratio {pull}4239[#4239] (issue: {issue}4006[#4006])
+* [Autoscaling] Add Elasticsearch autoscaling controller {pull}4173[#4173]
+* [Autoscaling] Add Elasticsearch API client {pull}4158[#4158]
+* [Autoscaling] Add autoscaling resource definition {pull}4148[#4148] (issue: {issue}4006[#4006])
+
+[[enhancement-1.5.0]]
+[float]
+=== Enhancements
+
+* Add support for VolumeClaimDeletePolicies for Elasticsearch clusters {pull}4050[#4050] (issue: {issue}2328[#2328])
+
+[[bug-1.5.0]]
+[float]
+=== Bug fixes
+
+* Fix OpenShift monitoring recipe {pull}4344[#4344]
+
+[[deprecation-1.5.0]]
+[float]
+=== Deprecation
+
+* OpenShift 3.11 support is deprecated in ECK 2.0. ECK 1.8 is the last version that supports OpenShift 3.11.

--- a/docs/release-notes/highlights-1.4.1.asciidoc
+++ b/docs/release-notes/highlights-1.4.1.asciidoc
@@ -1,0 +1,41 @@
+[[release-highlights-1.4.1]]
+== 1.4.1 release highlights
+
+[float]
+[id="{p}-141-fixes"]
+=== Fixes
+
+This release addresses two issues related to the Helm chart for the ECK operator.
+
+* On Kubernetes version 1.16 or higher, if the operator was installed using Helm and if the validating webhook was enabled, users were prevented from <<{p}-volume-claim-templates,increasing the storage size>> of Elasticsearch `volumeClaimTemplates` even if the underlying storage class allowed expansion.
+* When the ECK operator namespace was included in the <<{p}-install-helm-restricted,managed namespaces list>> a role binding was missing from the generated manifests.
+
+[float]
+[id="{p}-141-known-issues"]
+=== Known issues
+
+Elastic Agent currently writes its runtime state into the filesystem of its container. As a consequence, the identity of the Elastic Agent changes on container restarts and any internal state of applications run by that Elastic Agent is lost. As a workaround, you can mount the agent-data `hostPath` volume into the Elastic Agent container in the location where the process writes its runtime state. You also have to run the Elastic Agent as the root user to be able to access the `hostPath` volume, as shown in the following example:
+[source,yaml]
+----
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: elastic-agent
+spec:
+  version: 7.11.1
+  daemonSet:
+    podTemplate:
+      spec:
+        containers:
+        - name: agent
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+          - name: agent-data
+            mountPath: /usr/share/elastic-agent/data/elastic-agent-9b2fec/run
+----
+The `mountPath` differs from version to version as it contains the hash of the version control system reference which was used to build Elastic Agent. You can find out which path to use by either inspecting the Docker image or by running a command against the container, as shown below:
+[source,sh]
+----
+docker run -ti --entrypoint bash docker.elastic.co/beats/elastic-agent:7.11.1 -c "ls /usr/share/elastic-agent/data"
+----

--- a/docs/release-notes/highlights-1.5.0.asciidoc
+++ b/docs/release-notes/highlights-1.5.0.asciidoc
@@ -1,0 +1,38 @@
+[[release-highlights-1.5.0]]
+== 1.5.0 release highlights
+
+[float]
+[id="{p}-150-new-and-notable"]
+=== New and notable
+
+New and notable changes in version 1.5.0 of {n}. See <<release-notes-1.5.0>> for the full list of changes.
+
+[float]
+[id="{p}-150-autoscaling-support"]
+==== Support for Autoscaling
+
+ECK 1.5.0 introduces experimental support for link:https://www.elastic.co/guide/en/elasticsearch/reference/7.11/xpack-autoscaling.html[Autoscaling].
+
+In this initial release, autoscaling monitors the storage usage of your Elasticsearch data nodes and the available memory capacity for your machine learning jobs. As your data grows, whether you’re expanding to new use cases or simply storing data for longer, autoscaling automatically adjusts resource capacity to ensure you can store your data, and that your machine learning jobs can execute — so you don’t have to worry about whether your deployment can support your requirements. Future releases will include autoscaling based on additional metrics and stack components (such as Kibana).
+
+[float]
+[id="{p}-150-controlling-volume-claim-deletion"]
+==== Controlling volume claim deletion
+
+ECK automatically deletes PersistentVolumeClaim resources if the owning Elasticsearch nodes are scaled down. The corresponding PersistentVolumes may be preserved, depending on the configured link:https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy[storage class reclaim policy].
+
+In addition, you can now control what ECK should do with the PersistentVolumeClaims if you delete the Elasticsearch cluster altogether through the new `volumeClaimDeletePolicy` attribute.
+
+The possible values are `DeleteOnScaledownAndClusterDeletion` and `DeleteOnScaledownOnly`. By default `DeleteOnScaledownAndClusterDeletion` is in effect, which means that all PersistentVolumeClaims are deleted together with the Elasticsearch cluster. However, `DeleteOnScaledownOnly` keeps the PersistentVolumeClaims when deleting the Elasticsearch cluster. If you recreate a deleted cluster with the same name and node sets as before, the existing PersistentVolumeClaims will be adopted by the new cluster.
+
+[float]
+[id="{p}-150-enterprisesearch-resource-version-promotion"]
+==== EnterpriseSearch resource version promotion
+
+EnterpriseSearch resources have graduated to version `v1`. Old resources must be migrated to the new version to work with ECK 1.5.0. Resources created using an older version continue to run but the operator will not manage them.
+
+[float]
+[id="{p}-150-known-issues"]
+=== Known issues
+
+On Kubernetes version prior to 1.13 or on OpenShift 3.11, if the validating admission webhook is enabled, you might be prevented from upgrading the version of the EnterpriseSearch resources. This is due to a link:https://github.com/kubernetes/kubernetes/issues/73752[bug] in Kubernetes. As a workaround, you can temporarily disable the webhook to upgrade the EnterpriseSearch resources.

--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -5,6 +5,11 @@
 --
 This section summarizes the most important changes in each release. For the full list, see <<eck-release-notes>>.
 
+<<<<<<< HEAD
+=======
+* <<release-highlights-1.5.0>>
+* <<release-highlights-1.4.1>>
+>>>>>>> b4dcb249f (Release notes and highlights for 1.5.0 (#4313))
 * <<release-highlights-1.4.0>>
 * <<release-highlights-1.3.2>>
 * <<release-highlights-1.3.1>>
@@ -21,6 +26,11 @@ This section summarizes the most important changes in each release. For the full
 
 --
 
+<<<<<<< HEAD
+=======
+include::highlights-1.5.0.asciidoc[]
+include::highlights-1.4.1.asciidoc[]
+>>>>>>> b4dcb249f (Release notes and highlights for 1.5.0 (#4313))
 include::highlights-1.4.0.asciidoc[]
 include::highlights-1.3.2.asciidoc[]
 include::highlights-1.3.1.asciidoc[]

--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -5,11 +5,8 @@
 --
 This section summarizes the most important changes in each release. For the full list, see <<eck-release-notes>>.
 
-<<<<<<< HEAD
-=======
 * <<release-highlights-1.5.0>>
 * <<release-highlights-1.4.1>>
->>>>>>> b4dcb249f (Release notes and highlights for 1.5.0 (#4313))
 * <<release-highlights-1.4.0>>
 * <<release-highlights-1.3.2>>
 * <<release-highlights-1.3.1>>
@@ -26,11 +23,8 @@ This section summarizes the most important changes in each release. For the full
 
 --
 
-<<<<<<< HEAD
-=======
 include::highlights-1.5.0.asciidoc[]
 include::highlights-1.4.1.asciidoc[]
->>>>>>> b4dcb249f (Release notes and highlights for 1.5.0 (#4313))
 include::highlights-1.4.0.asciidoc[]
 include::highlights-1.3.2.asciidoc[]
 include::highlights-1.3.1.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 1.5:
- Add release notes for 1.4.1 (#4302)
- Add release highlights for 1.4.1 (#4308)
- Release notes and highlights for 1.5.0 (#4313)
