### PR TITLE
E2E fix errors in monitoring setup

### DIFF
--- a/config/e2e/helm-operator-under-test.yaml
+++ b/config/e2e/helm-operator-under-test.yaml
@@ -20,6 +20,7 @@ podAnnotations:
 tracing:
   enabled: true
   config:
+    ELASTIC_APM_SERVER_URL: null
     ELASTIC_APM_SERVER_CERT: "/mnt/elastic/apm.crt"
     ELASTIC_APM_ENVIRONMENT: "{{ .Pipeline }}-{{ .BuildNumber }}-{{ .Provider }}-{{ .ClusterName }}-{{ .KubernetesMajorMinor }}-{{ .ElasticStackVersion }}"
 

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -92,7 +92,10 @@ spec:
         initContainers:
         - name: elastic-internal-init-keystore
           securityContext:
-            runAsUser: 0
+           {{ if .OcpCluster }}
+           privileged: true
+           {{ end }}
+           runAsUser: 0
         containers:
         - args:
           - -e
@@ -120,9 +123,6 @@ spec:
         hostNetwork: true # Allows to provide richer host metadata
         securityContext:
           runAsUser: 0
-          {{ if .OcpCluster }}
-          privileged: true
-          {{ end }}
         terminationGracePeriodSeconds: 30
         volumes:
         - hostPath:
@@ -364,6 +364,7 @@ rules:
   resources:
   - namespaces
   - pods
+  - nodes
   verbs:
   - get
   - watch


### PR DESCRIPTION
* Incorrect placement of `privileged` attribute in OCP
* Missing nodes privilege for Filebeat (new in a recent version of Filebeat?)
* Broken APM config for the operator

