### PR TITLE
Add E2E namespace to diagnostic dump

### DIFF
--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -776,9 +776,9 @@ func (h *helper) dumpEventLog() {
 }
 
 func (h *helper) dumpK8sData() {
-	operatorNs := h.testContext.Operator.Namespace
-	managedNs := strings.Join(h.testContext.Operator.ManagedNamespaces, ",")
-	cmd := exec.Command("support/diagnostics/eck-dump.sh", "-N", operatorNs, "-n", managedNs, "-o", h.testContext.TestRun, "-z")
+	operatorNS := h.testContext.Operator.Namespace
+	otherNS := append([]string{h.testContext.E2ENamespace}, h.testContext.Operator.ManagedNamespaces...)
+	cmd := exec.Command("support/diagnostics/eck-dump.sh", "-N", operatorNS, "-n", strings.Join(otherNS, ","), "-o", h.testContext.TestRun, "-z")
 	if err := cmd.Run(); err != nil {
 		log.Error(err, "Failed to run support/diagnostics/eck-dump.sh")
 	}


### PR DESCRIPTION
Include the E2E namespace in the diagnostic bundle created at the end of a test run. 

The E2E namespace contains the monitoring deployment and the E2E test job itself. It is sometimes useful to see the status of those components when debugging a test failure. 