### PR TITLE
Add a note on missing capabilities for OCP >=4.6

### DIFF
--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -101,6 +101,16 @@ spec:
 EOF
 ----
 
+On OpenShift 4.6, `NET_RAW` and `SYS_CHROOT` are no longer available in the default list of CRI-O capabilities. When you deploy Elasticsearch on OpenShift 4.6, to avoid having your pods in `CrashLoopBackOff` status, you can add the necessary capabilities directly to the container:
+ 
+[source,shell]
+----
+- name: elasticsearch
+  securityContext:
+    capabilities:
+     add: ["SYS_CHROOT"]
+----
+
 [id="{p}-openshift-es-plugins"]
 === Elasticsearch plugins
 


### PR DESCRIPTION
This updates the page Deploy an [Elasticsearch instance with a route](https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-openshift-deploy-elasticsearch.html) with a note on capabilities no longer available with OPC 4.6. 

Fixes: #4334