### PR TITLE
Append E2E pipeline name to test image tag

### DIFF
--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -316,7 +316,7 @@ export LICENSE_PUBKEY=/go/src/github.com/elastic/cloud-on-k8s/.ci/license.key
 
 OPERATOR_IMAGE=$JKS_PARAM_OPERATOR_IMAGE
 
-PIPELINE=e2e/eks
+PIPELINE=e2e/eks-arm
 BUILD_NUMBER=$BUILD_NUMBER
 E2E_PROVIDER=eks
 CLUSTER_NAME=${BUILD_TAG}-arm

--- a/Makefile
+++ b/Makefile
@@ -398,7 +398,14 @@ switch-registry-dev: # just use the default values of variables
 ###################################
 
 E2E_REGISTRY_NAMESPACE     ?= eck-dev
-E2E_IMG                    ?= $(REGISTRY)/$(E2E_REGISTRY_NAMESPACE)/eck-e2e-tests:$(TAG)
+
+E2E_IMG_TAG                := $(TAG) 
+E2E_IMG_TAG_SUFFIX         ?= $(subst /,-,$(PIPELINE)) # Derive the tag suffix from the PIPELINE environment variable
+ifneq ($(strip $(E2E_IMG_TAG_SUFFIX)),) # If the suffix is not empty, append it to the tag
+	E2E_IMG_TAG := $(TAG)-$(E2E_IMG_TAG_SUFFIX)
+endif
+
+E2E_IMG                    ?= $(REGISTRY)/$(E2E_REGISTRY_NAMESPACE)/eck-e2e-tests:$(E2E_IMG_TAG)
 TESTS_MATCH                ?= "^Test" # can be overriden to eg. TESTS_MATCH=TestMutationMoreNodes to match a single test
 E2E_STACK_VERSION          ?= 7.11.2
 E2E_JSON                   ?= false


### PR DESCRIPTION
Use unique tag names for the E2E test images to avoid being overwritten by another job running in parallel. See https://github.com/elastic/cloud-on-k8s/issues/4314#issuecomment-801780511 for details.

Fixes #4314 