### PR TITLE
Prepare config for Operator Hub release generator for 1.5.0

### DIFF
--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -1,6 +1,6 @@
-newVersion: 1.4.0
-prevVersion: 1.3.1
-stackVersion: 7.11.0
+newVersion: 1.5.0
+prevVersion: 1.4.0
+stackVersion: 7.12.0
 crds:
   - name: elasticsearches.elasticsearch.k8s.elastic.co
     displayName: Elasticsearch Cluster


### PR DESCRIPTION
Prepare the configuration for the Operator Hub version generator for version 1.5.0.