### PR TITLE
Fix case of variables in readiness probe

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/readiness_probe.go
+++ b/pkg/controller/elasticsearch/nodespec/readiness_probe.go
@@ -57,8 +57,8 @@ else
 fi
 
 # setup basic auth if credentials are available
-if [ -n "${PROBE_USERNAME}" ] && [ -f "${probe_password_path}" ]; then
-  PROBE_PASSWORD=$(<${probe_password_path})
+if [ -n "${PROBE_USERNAME}" ] && [ -f "${PROBE_PASSWORD_PATH}" ]; then
+  PROBE_PASSWORD=$(<${PROBE_PASSWORD_PATH})
   BASIC_AUTH="-u ${PROBE_USERNAME}:${PROBE_PASSWORD}"
 else
   BASIC_AUTH=''


### PR DESCRIPTION
The readiness check fails in k8s because of this.