### PR TITLE
[1.5] Prepare Operator Hub release config for 1.5.0 (#4366)

### DIFF
--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -1,6 +1,6 @@
-newVersion: 1.4.0
-prevVersion: 1.3.1
-stackVersion: 7.11.0
+newVersion: 1.5.0
+prevVersion: 1.4.0
+stackVersion: 7.12.0
 crds:
   - name: elasticsearches.elasticsearch.k8s.elastic.co
     displayName: Elasticsearch Cluster


### PR DESCRIPTION
Backport of #4366.