### PR TITLE
Update Google Cloud LB recipe

### DIFF
--- a/config/recipes/gclb/00-prereq-cluster-issuer.yaml
+++ b/config/recipes/gclb/00-prereq-cluster-issuer.yaml
@@ -1,5 +1,6 @@
 ---
-apiVersion: cert-manager.io/v1alpha2
+# Requires cert-manager 1.0.0 or higher
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: selfsigning-issuer

--- a/config/recipes/gclb/02-ingress.yaml
+++ b/config/recipes/gclb/02-ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: hulk
@@ -21,13 +21,19 @@ spec:
       http:
         paths:
           - path: "/*"
+            pathType: Exact
             backend:
-              serviceName: hulk-es-http
-              servicePort: 9200
+              service:
+                name: hulk-es-http
+                port:
+                  name: https
     - host: "kibana.hulk"
       http:
         paths:
           - path: "/*"
+            pathType: Exact
             backend:
-              serviceName: hulk-kb-http
-              servicePort: 5601
+              service:
+                name: hulk-kb-http
+                port:
+                  name: https

--- a/config/recipes/gclb/99-kibana-path.yaml
+++ b/config/recipes/gclb/99-kibana-path.yaml
@@ -1,0 +1,68 @@
+# How to serve Kibana from a path. In this example we make Kibana available at https://elastic.stack/kibana.
+---
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: thor
+  labels:
+    app: thor
+spec:
+  version: 7.11.2
+  count: 1
+  config:
+    # Make Kibana aware of the fact that it is behind a proxy
+    server:
+      basePath: "/kibana"
+      rewriteBasePath: true
+      publicBaseUrl: "https://elastic.stack/kibana"
+  http:
+    service:
+      metadata:
+        labels:
+          app: thor
+        annotations:
+          # Enable TLS between GCLB and the application
+          cloud.google.com/app-protocols: '{"https":"HTTPS"}'
+          service.alpha.kubernetes.io/app-protocols: '{"https":"HTTPS"}'
+          # Comment out the following line if you are not using a VPC-native cluster
+          cloud.google.com/neg: '{"ingress": true}'
+  elasticsearchRef:
+    name: hulk
+  podTemplate:
+    spec:
+      containers:
+        - name: kibana
+          readinessProbe:
+            # Override the readiness probe as GCLB reuses it for its own healthchecks
+            # The path must contain the path prefix used to serve the application from the load balancer
+            httpGet:
+              scheme: HTTPS
+              path: "/kibana/login"
+              port: 5601
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: thor
+  labels:
+    app: thor
+  annotations:
+    # Issue certificates for TLS hosts automatically
+    cert-manager.io/cluster-issuer: "selfsigning-issuer"
+    # Disable HTTP traffic
+    kubernetes.io/ingress.allow-http: "false"
+spec:
+  tls:
+    - hosts: ["elastic.stack"]
+      secretName: elastic-stack-cert
+  rules:
+    - host: "elastic.stack"
+      http:
+        paths:
+          - path: "/kibana/*"
+            pathType: Exact
+            backend:
+              service:
+                name: thor-kb-http
+                port:
+                  name: https

--- a/config/recipes/gclb/README.asciidoc
+++ b/config/recipes/gclb/README.asciidoc
@@ -56,3 +56,12 @@ Access Elasticsearch.
 ----
 curl -H "Host: elasticsearch.hulk" --resolve "elasticsearch.hulk:443:$INGRESS_HOST" -k -u "elastic:$ELASTICSEARCH_PASSWORD" 'https://elasticsearch.hulk/_cat/health?v'
 ----
+
+== Bonus: Serve Kibana from a path 
+
+In the above example, Kibana is accessed through a dedicated domain (`https://kibana.hulk`). If you want to make Kibana accessible from a path of an existing domain (e.g. `https://elastic.stack/kibana`) extra configuration is required.
+
+[source,yaml]
+----
+include::99-kibana-path.yaml[]
+----


### PR DESCRIPTION
- Update the Ingress API version as it is deprecated in all of the available GKE Kubernetes versions.
- Add an example to demonstrate serving Kibana from a path