### PR TITLE
E2E chaos job: adjust label selector

### DIFF
--- a/test/e2e/cmd/chaos/chaos.go
+++ b/test/e2e/cmd/chaos/chaos.go
@@ -115,6 +115,7 @@ func doRun(flags runFlags) error {
 // listOperators retrieves the list of running operator instances.
 func listOperators(client *kubernetes.Clientset, operatorNamespace string) (*corev1.PodList, error) {
 	return client.CoreV1().Pods(operatorNamespace).List(context.Background(),
+		// LabelSelector is a constant in the operator Helm chart only name varies.
 		metav1.ListOptions{LabelSelector: "control-plane=elastic-operator"},
 	)
 }

--- a/test/e2e/cmd/chaos/chaos.go
+++ b/test/e2e/cmd/chaos/chaos.go
@@ -59,7 +59,7 @@ func doRun(flags runFlags) error {
 			return nil
 
 		case <-checkLeaderTicker.C:
-			operators, err := listOperators(client, flags.operatorNamespace, flags.operatorName)
+			operators, err := listOperators(client, flags.operatorNamespace)
 			if err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ func doRun(flags runFlags) error {
 			}
 
 		case <-deletePodTicker.C:
-			operators, err := listOperators(client, flags.operatorNamespace, flags.operatorName)
+			operators, err := listOperators(client, flags.operatorNamespace)
 			if err != nil {
 				return err
 			}
@@ -113,9 +113,9 @@ func doRun(flags runFlags) error {
 }
 
 // listOperators retrieves the list of running operator instances.
-func listOperators(client *kubernetes.Clientset, operatorNamespace, operatorName string) (*corev1.PodList, error) {
+func listOperators(client *kubernetes.Clientset, operatorNamespace string) (*corev1.PodList, error) {
 	return client.CoreV1().Pods(operatorNamespace).List(context.Background(),
-		metav1.ListOptions{LabelSelector: "control-plane=" + operatorName},
+		metav1.ListOptions{LabelSelector: "control-plane=elastic-operator"},
 	)
 }
 


### PR DESCRIPTION
The e2e chaos job was not introducing any chaos since https://github.com/elastic/cloud-on-k8s/pull/4203 due to a change in how we populate the `control-plane` label in the operator under test. 

This adjusts the selector to `elastic-operator` which is a constant in the Helm chart based operator.
