### PR TITLE
[Autoscaling] Add a note about the license in the documentation

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/autoscaling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/autoscaling.asciidoc
@@ -8,7 +8,7 @@ endif::[]
 [id="{p}-{page_id}"]
 = Elasticsearch autoscaling
 
-NOTE: Elasticsearch autoscaling requires a valid Enterprise license or Enterprise trial license. See <<{p}-licensing, the license documentation>> for more details about managing licenses.
+NOTE: Elasticsearch autoscaling requires a valid Enterprise license or Enterprise trial license. See <<{p}-licensing,the license documentation>> for more details about managing licenses.
 
 experimental[]
 

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/autoscaling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/autoscaling.asciidoc
@@ -8,6 +8,8 @@ endif::[]
 [id="{p}-{page_id}"]
 = Elasticsearch autoscaling
 
+NOTE: Elasticsearch autoscaling requires a valid Enterprise license or Enterprise trial license. See <<{p}-licensing, the license documentation>> for more details about managing licenses.
+
 experimental[]
 
 ECK can leverage the link:https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-apis.html[autoscaling API] introduced in Elasticsearch 7.11 to adjust automatically the number of Pods and the allocated resources in a tier. Currently, autoscaling is supported for Elasticsearch link:https://www.elastic.co/guide/en/elasticsearch/reference/current/data-tiers.html[data tiers] and machine learning nodes.

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/remote-clusters.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/remote-clusters.asciidoc
@@ -15,7 +15,7 @@ When using remote cluster connections with ECK, the setup process depends on whe
 [id="{p}-remote-clusters-connect-internal"]
 == Connect from an Elasticsearch cluster running in the same Kubernetes cluster
 
-NOTE: The remote clusters feature requires a valid Enterprise license or Enterprise trial license. See <<{p}-licensing, the license documentation>> for more details about managing licenses.
+NOTE: The remote clusters feature requires a valid Enterprise license or Enterprise trial license. See <<{p}-licensing,the license documentation>> for more details about managing licenses.
 
 To create a remote cluster connection to another Elasticsearch cluster deployed within the same Kubernetes cluster, specify the `remoteClusters` attribute in your Elasticsearch spec.
 


### PR DESCRIPTION
This PR adds an enterprise license note in the Elasticsearch autoscaling documentation.