### PR TITLE
Control ignorePaths of renovate config to include test/

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,5 +47,8 @@
       ],
       "enabled": false
     }
+  ],
+  "ignorePaths": [
+    "**/vendor/**"
   ]
 }


### PR DESCRIPTION
Override and control renovate `ignorePaths` to stop to ignore the Dockerfile in the test/ directory.

Resolves #3746.