### PR TITLE
Make OCP deployer build its own installer  and client

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -85,16 +85,6 @@ RUN curl -fsSLO https://github.com/kubernetes-sigs/kind/releases/download/v${KIN
 RUN curl -fsSLO https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION_0_9}/kind-linux-amd64 && \
     mv kind-linux-amd64 /usr/local/bin/kind-${KIND_VERSION_0_9} && chmod +x /usr/local/bin/kind-${KIND_VERSION_0_9}
 
-# OpenShift installer and CLI to provision OCP clusters
-RUN curl -fsSLO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OPENSHIFT_TOOLS_VERSION}/openshift-install-linux-${OPENSHIFT_TOOLS_VERSION}.tar.gz && \
-    tar -zxf openshift-install-linux-${OPENSHIFT_TOOLS_VERSION}.tar.gz openshift-install && \
-    mv openshift-install /usr/local/bin/openshift-install && \
-    rm openshift-install-linux-${OPENSHIFT_TOOLS_VERSION}.tar.gz && \
-    curl -fsSLO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OPENSHIFT_TOOLS_VERSION}/openshift-client-linux-${OPENSHIFT_TOOLS_VERSION}.tar.gz && \
-    tar -zxf openshift-client-linux-${OPENSHIFT_TOOLS_VERSION}.tar.gz oc && \
-    mv oc /usr/local/bin/oc && \
-    rm openshift-client-linux-${OPENSHIFT_TOOLS_VERSION}.tar.gz
-
 RUN curl -fsSLO "https://github.com/weaveworks/eksctl/releases/download/${EKSCTL_VERSION}/eksctl_Linux_amd64.tar.gz" && \
     tar xzf eksctl_Linux_amd64.tar.gz && \
     mv eksctl /usr/local/bin/eksctl && \

--- a/hack/deployer/clients/ocp/Dockerfile
+++ b/hack/deployer/clients/ocp/Dockerfile
@@ -17,6 +17,3 @@ FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /usr/local/bin/openshift-install .
 COPY --from=builder /usr/local/bin/oc .
-
-
-

--- a/hack/deployer/clients/ocp/Dockerfile
+++ b/hack/deployer/clients/ocp/Dockerfile
@@ -1,16 +1,16 @@
 FROM buildpack-deps:bullseye-curl as builder
-ARG VERSION
+ARG CLIENT_VERSION
 
 
 # OpenShift installer and CLI to provision OCP clusters
-RUN curl -fsSLO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${VERSION}/openshift-install-linux-${VERSION}.tar.gz && \
-    tar -zxf openshift-install-linux-${VERSION}.tar.gz openshift-install && \
+RUN curl -fsSLO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${CLIENT_VERSION}/openshift-install-linux-${CLIENT_VERSION}.tar.gz && \
+    tar -zxf openshift-install-linux-${CLIENT_VERSION}.tar.gz openshift-install && \
     mv openshift-install /usr/local/bin/openshift-install && \
-    rm openshift-install-linux-${VERSION}.tar.gz && \
-    curl -fsSLO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${VERSION}/openshift-client-linux-${VERSION}.tar.gz && \
-    tar -zxf openshift-client-linux-${VERSION}.tar.gz oc && \
+    rm openshift-install-linux-${CLIENT_VERSION}.tar.gz && \
+    curl -fsSLO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${CLIENT_VERSION}/openshift-client-linux-${CLIENT_VERSION}.tar.gz && \
+    tar -zxf openshift-client-linux-${CLIENT_VERSION}.tar.gz oc && \
     mv oc /usr/local/bin/oc && \
-    rm openshift-client-linux-${VERSION}.tar.gz
+    rm openshift-client-linux-${CLIENT_VERSION}.tar.gz
 
 FROM scratch
 # be able to make TLS requests to the GCloud API

--- a/hack/deployer/clients/ocp/Dockerfile
+++ b/hack/deployer/clients/ocp/Dockerfile
@@ -1,0 +1,22 @@
+FROM buildpack-deps:bullseye-curl as builder
+ARG VERSION
+
+
+# OpenShift installer and CLI to provision OCP clusters
+RUN curl -fsSLO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${VERSION}/openshift-install-linux-${VERSION}.tar.gz && \
+    tar -zxf openshift-install-linux-${VERSION}.tar.gz openshift-install && \
+    mv openshift-install /usr/local/bin/openshift-install && \
+    rm openshift-install-linux-${VERSION}.tar.gz && \
+    curl -fsSLO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${VERSION}/openshift-client-linux-${VERSION}.tar.gz && \
+    tar -zxf openshift-client-linux-${VERSION}.tar.gz oc && \
+    mv oc /usr/local/bin/oc && \
+    rm openshift-client-linux-${VERSION}.tar.gz
+
+FROM scratch
+# be able to make TLS requests to the GCloud API
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /usr/local/bin/openshift-install .
+COPY --from=builder /usr/local/bin/oc .
+
+
+

--- a/hack/deployer/cmd/execute.go
+++ b/hack/deployer/cmd/execute.go
@@ -11,7 +11,7 @@ import (
 
 func ExecuteCommand() *cobra.Command {
 	var plansFile, configFile *string
-	var operation, clientBuildDefs string
+	var operation, clientBuildDefDir string
 	var executeCmd = &cobra.Command{
 		Use:   "execute",
 		Short: "Executes the plan according to plans file, run config file and overrides.",
@@ -25,7 +25,7 @@ func ExecuteCommand() *cobra.Command {
 				runConfig.Overrides["operation"] = operation
 			}
 
-			driver, err := runner.GetDriver(plans.Plans, runConfig, clientBuildDefs)
+			driver, err := runner.GetDriver(plans.Plans, runConfig, clientBuildDefDir)
 			if err != nil {
 				return err
 			}
@@ -36,7 +36,7 @@ func ExecuteCommand() *cobra.Command {
 
 	plansFile, configFile = registerFileFlags(executeCmd)
 
-	executeCmd.Flags().StringVar(&clientBuildDefs, "client-dockerfiles", "hack/deployer/clients", "Directory containing Dockerfiles for Cloud provider clients")
+	executeCmd.Flags().StringVar(&clientBuildDefDir, "client-dockerfiles", "hack/deployer/clients", "Directory containing Dockerfiles for Cloud provider clients")
 	executeCmd.Flags().StringVar(&operation, "operation", "", "Operation type. This will override config files.")
 
 	return executeCmd

--- a/hack/deployer/cmd/execute.go
+++ b/hack/deployer/cmd/execute.go
@@ -11,7 +11,7 @@ import (
 
 func ExecuteCommand() *cobra.Command {
 	var plansFile, configFile *string
-	var operation string
+	var operation, clientBuildDefs string
 	var executeCmd = &cobra.Command{
 		Use:   "execute",
 		Short: "Executes the plan according to plans file, run config file and overrides.",
@@ -25,6 +25,8 @@ func ExecuteCommand() *cobra.Command {
 				runConfig.Overrides["operation"] = operation
 			}
 
+			runner.SetClientBuildDefDir(clientBuildDefs)
+
 			driver, err := runner.GetDriver(plans.Plans, runConfig)
 			if err != nil {
 				return err
@@ -35,6 +37,8 @@ func ExecuteCommand() *cobra.Command {
 	}
 
 	plansFile, configFile = registerFileFlags(executeCmd)
+
+	executeCmd.Flags().StringVar(&clientBuildDefs, "client-dockerfiles", "hack/deployer/clients", "Directory containing Dockerfiles for Cloud provider clients")
 	executeCmd.Flags().StringVar(&operation, "operation", "", "Operation type. This will override config files.")
 
 	return executeCmd

--- a/hack/deployer/cmd/execute.go
+++ b/hack/deployer/cmd/execute.go
@@ -25,11 +25,7 @@ func ExecuteCommand() *cobra.Command {
 				runConfig.Overrides["operation"] = operation
 			}
 
-			if err := runner.SetClientBuildDefDir(clientBuildDefs); err != nil {
-				return err
-			}
-
-			driver, err := runner.GetDriver(plans.Plans, runConfig)
+			driver, err := runner.GetDriver(plans.Plans, runConfig, clientBuildDefs)
 			if err != nil {
 				return err
 			}

--- a/hack/deployer/cmd/execute.go
+++ b/hack/deployer/cmd/execute.go
@@ -25,7 +25,9 @@ func ExecuteCommand() *cobra.Command {
 				runConfig.Overrides["operation"] = operation
 			}
 
-			runner.SetClientBuildDefDir(clientBuildDefs)
+			if err := runner.SetClientBuildDefDir(clientBuildDefs); err != nil {
+				return err
+			}
 
 			driver, err := runner.GetDriver(plans.Plans, runConfig)
 			if err != nil {

--- a/hack/deployer/cmd/get.go
+++ b/hack/deployer/cmd/get.go
@@ -29,7 +29,7 @@ func GetCommand() *cobra.Command {
 				return err
 			}
 
-			plan, err := runner.GetPlan(plans.Plans, runConfig)
+			plan, err := runner.GetPlan(plans.Plans, runConfig, "")
 			if err != nil {
 				return err
 			}
@@ -48,7 +48,7 @@ func GetCommand() *cobra.Command {
 				return err
 			}
 
-			driver, err := runner.GetDriver(plans.Plans, runConfig)
+			driver, err := runner.GetDriver(plans.Plans, runConfig, "")
 			if err != nil {
 				return err
 			}
@@ -66,7 +66,7 @@ func GetCommand() *cobra.Command {
 				return err
 			}
 
-			plan, err := runner.GetPlan(plans.Plans, runConfig)
+			plan, err := runner.GetPlan(plans.Plans, runConfig, "")
 			if err != nil {
 				return err
 			}

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -78,7 +78,7 @@ plans:
 - id: ocp-dev
   operation: create
   clusterName: dev
-  clientVersion: 4.3.40
+  clientVersion: 4.7.0
   provider: ocp
   machineType: n1-standard-8
   serviceAccount: true

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -79,6 +79,7 @@ plans:
 - id: ocp-dev
   operation: create
   clusterName: dev
+  clientVersion: 4.3.40
   provider: ocp
   machineType: n1-standard-8
   serviceAccount: true

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -75,7 +75,6 @@ plans:
   ocp:
     region: europe-west2
     nodeCount: 3
-    overwriteDefaultKubeconfig: true
 - id: ocp-dev
   operation: create
   clusterName: dev
@@ -86,7 +85,6 @@ plans:
   ocp:
     region: europe-west1
     nodeCount: 3
-    overwriteDefaultKubeconfig: true
 - id: ocp3-ci
   operation: create
   clusterName: ci

--- a/hack/deployer/runner/client.go
+++ b/hack/deployer/runner/client.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 const clientBaseImageName = "docker.elastic.co/eck-dev/deployer"
@@ -40,13 +41,7 @@ func ensureClientImage(driverID, clientVersion string, clientBuildDefDir string)
 		return image, fmt.Errorf("while building client image %s: %w", image, err)
 	}
 
-	maxRetries := 5
-	for i := 0; i < maxRetries; i++ {
-		err = NewCommand(fmt.Sprintf("docker push %s", image)).Run()
-		if err == nil {
-			return image, nil
-		}
-	}
+	err = NewCommand(fmt.Sprintf("docker push %s", image)).RunWithRetries(5, 1*time.Hour)
 	return image, err
 }
 

--- a/hack/deployer/runner/client.go
+++ b/hack/deployer/runner/client.go
@@ -33,11 +33,10 @@ func ensureClientImage(driverID, clientVersion string, clientBuildDefDir string)
 		return image, nil
 	}
 
-	err = NewCommand(
+	if err = NewCommand(
 		fmt.Sprintf("docker build --build-arg VERSION=%s -f %s -t %s %s",
 			clientVersion, dockerfileName, image, dockerfilePath),
-	).Run()
-	if err != nil {
+	).Run(); err != nil {
 		return image, fmt.Errorf("while building client image %s: %w", image, err)
 	}
 
@@ -52,10 +51,8 @@ func checkImageExists(image string) bool {
 	}
 
 	// check registry
-	if imageExists, err := NewCommand(fmt.Sprintf("docker pull -q %s", image)).OutputContainsAny("Downloading", "Extracting", "Verifying", "complete"); imageExists && err == nil {
-		return true
-	}
-	return false
+	imageExists, err := NewCommand(fmt.Sprintf("docker pull -q %s", image)).OutputContainsAny("Downloading", "Extracting", "Verifying", "complete")
+	return imageExists && err == nil
 }
 
 func clientImageName(driverID, clientVersion, dockerfileName string) (string, error) {

--- a/hack/deployer/runner/client.go
+++ b/hack/deployer/runner/client.go
@@ -15,12 +15,12 @@ import (
 
 const clientBaseImageName = "docker.elastic.co/eck-dev/deployer"
 
-func ensureClientImage(driverID, clientVersion string) (string, error) {
+func ensureClientImage(driverID, clientVersion string, clientBuildDefDir string) (string, error) {
 	if clientVersion == "" {
 		return "", errors.New("clientVersion must not be empty")
 	}
 
-	dockerfilePath := dockerfilePath(driverID)
+	dockerfilePath := filepath.Join(clientBuildDefDir, driverID)
 	dockerfileName := filepath.Join(dockerfilePath, "Dockerfile")
 
 	image, err := clientImageName(driverID, clientVersion, dockerfileName)
@@ -75,8 +75,4 @@ func clientImageName(driverID, clientVersion, dockerfileName string) (string, er
 	}
 	// including driver id and version directly image/tag for human benefit
 	return fmt.Sprintf("%s-%s:%s-%.8x", clientBaseImageName, driverID, clientVersion, h.Sum(nil)), nil
-}
-
-func dockerfilePath(driverID string) string {
-	return filepath.Join(clientBuildDefDir, driverID)
 }

--- a/hack/deployer/runner/client.go
+++ b/hack/deployer/runner/client.go
@@ -1,0 +1,64 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+)
+
+const clientBaseImageName = "docker.elastic.co/eck-dev/deployer"
+
+func ensureClientImage(driverID, clientVersion string) (string, error) {
+	if clientVersion == "" {
+		return "", errors.New("clientVersion must not be empty")
+	}
+	image := clientImageName(driverID, clientVersion) // todo: hash image!
+
+	if exists := checkImageExists(image); exists {
+		return image, nil
+	}
+
+	dockerfilePath := dockerfilePath(driverID)
+	dockerfileName := filepath.Join(dockerfilePath, "Dockerfile")
+	err := NewCommand(
+		fmt.Sprintf("docker build --build-arg VERSION=%s -f %s -t %s %s",
+			clientVersion, dockerfileName, image, dockerfilePath),
+	).Run()
+	if err != nil {
+		return image, fmt.Errorf("while building client image %s: %w", image, err)
+	}
+
+	maxRetries := 5
+	for i := 0; i < maxRetries; i++ {
+		err = NewCommand(fmt.Sprintf("docker push %s", image)).Run()
+		if err == nil {
+			return image, nil
+		}
+	}
+	return image, err
+}
+
+func checkImageExists(image string) bool {
+	// short circuit if locally available e.g in local dev mode
+	if output, err := NewCommand(fmt.Sprintf("docker images -q %s", image)).Output(); len(output) > 0 && err == nil {
+		return true
+	}
+
+	// check registry
+	if imageExists, err := NewCommand(fmt.Sprintf("docker pull -q %s", image)).OutputContainsAny("Downloading", "Extracting", "Verifying", "complete"); imageExists && err == nil {
+		return true
+	}
+	return false
+}
+
+func clientImageName(driverID, clientVersion string) string {
+	return fmt.Sprintf("%s:%s-%s", clientBaseImageName, driverID, clientVersion)
+}
+
+func dockerfilePath(driverID string) string {
+	return filepath.Join(clientBuildDefDir, driverID)
+}

--- a/hack/deployer/runner/client.go
+++ b/hack/deployer/runner/client.go
@@ -34,7 +34,7 @@ func ensureClientImage(driverID, clientVersion string, clientBuildDefDir string)
 	}
 
 	if err = NewCommand(
-		fmt.Sprintf("docker build --build-arg VERSION=%s -f %s -t %s %s",
+		fmt.Sprintf("docker build --build-arg CLIENT_VERSION=%s -f %s -t %s %s",
 			clientVersion, dockerfileName, image, dockerfilePath),
 	).Run(); err != nil {
 		return image, fmt.Errorf("while building client image %s: %w", image, err)
@@ -51,7 +51,7 @@ func checkImageExists(image string) bool {
 	}
 
 	// check registry
-	imageExists, err := NewCommand(fmt.Sprintf("docker pull -q %s", image)).OutputContainsAny("Downloading", "Extracting", "Verifying", "complete")
+	imageExists, err := NewCommand(fmt.Sprintf("docker pull -q %s", image)).OutputContainsAny(image)
 	return imageExists && err == nil
 }
 
@@ -61,6 +61,7 @@ func clientImageName(driverID, clientVersion, dockerfileName string) (string, er
 	if err != nil {
 		return "", err
 	}
+	defer f.Close()
 	h := sha256.New224()
 	if _, err := io.Copy(h, f); err != nil {
 		return "", err

--- a/hack/deployer/runner/command.go
+++ b/hack/deployer/runner/command.go
@@ -12,8 +12,6 @@ import (
 	"os/exec"
 	"strings"
 	"text/template"
-
-	"github.com/pkg/errors"
 )
 
 // Command allows building commands to execute using fluent-style api
@@ -23,6 +21,7 @@ type Command struct {
 	variables []string
 	stream    bool
 	stderr    bool
+	debug     bool
 }
 
 func NewCommand(command string) *Command {
@@ -46,6 +45,11 @@ func (c *Command) WithoutStreaming() *Command {
 
 func (c *Command) StdoutOnly() *Command {
 	c.stderr = false
+	return c
+}
+
+func (c *Command) Debug() *Command {
+	c.debug = true
 	return c
 }
 
@@ -96,6 +100,10 @@ func (c *Command) output() (string, error) {
 			return "", err
 		}
 		c.command = b.String()
+	}
+
+	if c.debug {
+		println(c.command)
 	}
 
 	cmd := exec.Command("/usr/bin/env", "bash", "-c", c.command) // #nosec G204

--- a/hack/deployer/runner/command.go
+++ b/hack/deployer/runner/command.go
@@ -21,7 +21,7 @@ import (
 type Command struct {
 	command   string
 	context   context.Context
-	log       string
+	logPrefix string
 	params    map[string]interface{}
 	variables []string
 	stream    bool
@@ -47,8 +47,8 @@ func (c *Command) WithContext(ctx context.Context) *Command {
 	return c
 }
 
-func (c *Command) WithLog(log string) *Command {
-	c.log = log
+func (c *Command) WithLog(logPrefix string) *Command {
+	c.logPrefix = logPrefix
 	return c
 }
 
@@ -67,9 +67,9 @@ func (c *Command) Run() error {
 	return err
 }
 
-func (c *Command) RunWithRetries(numRetries int, timeout time.Duration) error {
+func (c *Command) RunWithRetries(numAttempts int, timeout time.Duration) error {
 	var err error
-	for i := 0; i < numRetries; i++ {
+	for i := 0; i < numAttempts; i++ {
 		ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
 		err = c.WithContext(ctx).Run()
 		cancelFunc()
@@ -124,8 +124,8 @@ func (c *Command) output() (string, error) {
 		c.command = b.String()
 	}
 
-	if c.log != "" {
-		log.Printf("%s: %s", c.log, c.command)
+	if c.logPrefix != "" {
+		log.Printf("%s: %s", c.logPrefix, c.command)
 	}
 
 	var cmd *exec.Cmd

--- a/hack/deployer/runner/command.go
+++ b/hack/deployer/runner/command.go
@@ -12,6 +12,8 @@ import (
 	"os/exec"
 	"strings"
 	"text/template"
+
+	"github.com/pkg/errors"
 )
 
 // Command allows building commands to execute using fluent-style api

--- a/hack/deployer/runner/driver.go
+++ b/hack/deployer/runner/driver.go
@@ -33,7 +33,7 @@ type Driver interface {
 	GetCredentials() error
 }
 
-func GetPlan(plans []Plan, config RunConfig) (Plan, error) {
+func GetPlan(plans []Plan, config RunConfig, clientBuildDefs string) (Plan, error) {
 	plan, err := choosePlan(plans, config.Id)
 	if err != nil {
 		return Plan{}, err
@@ -44,12 +44,17 @@ func GetPlan(plans []Plan, config RunConfig) (Plan, error) {
 		return Plan{}, err
 	}
 
+	// allows plans and runConfigs to set this value but use a default if not set
+	if plan.ClientBuildDefDir == "" {
+		plan.ClientBuildDefDir = clientBuildDefs
+	}
+
 	return plan, nil
 }
 
 // GetDriver picks plan based on the run config and returns the appropriate driver
-func GetDriver(plans []Plan, config RunConfig) (Driver, error) {
-	plan, err := GetPlan(plans, config)
+func GetDriver(plans []Plan, config RunConfig, clientBuildDefs string) (Driver, error) {
+	plan, err := GetPlan(plans, config, clientBuildDefs)
 	if err != nil {
 		return nil, err
 	}

--- a/hack/deployer/runner/driver.go
+++ b/hack/deployer/runner/driver.go
@@ -33,7 +33,7 @@ type Driver interface {
 	GetCredentials() error
 }
 
-func GetPlan(plans []Plan, config RunConfig, clientBuildDefs string) (Plan, error) {
+func GetPlan(plans []Plan, config RunConfig, clientBuildDefDir string) (Plan, error) {
 	plan, err := choosePlan(plans, config.Id)
 	if err != nil {
 		return Plan{}, err
@@ -46,15 +46,15 @@ func GetPlan(plans []Plan, config RunConfig, clientBuildDefs string) (Plan, erro
 
 	// allows plans and runConfigs to set this value but use a default if not set
 	if plan.ClientBuildDefDir == "" {
-		plan.ClientBuildDefDir = clientBuildDefs
+		plan.ClientBuildDefDir = clientBuildDefDir
 	}
 
 	return plan, nil
 }
 
 // GetDriver picks plan based on the run config and returns the appropriate driver
-func GetDriver(plans []Plan, config RunConfig, clientBuildDefs string) (Driver, error) {
-	plan, err := GetPlan(plans, config, clientBuildDefs)
+func GetDriver(plans []Plan, config RunConfig, clientBuildDefDir string) (Driver, error) {
+	plan, err := GetPlan(plans, config, clientBuildDefDir)
 	if err != nil {
 		return nil, err
 	}

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -117,7 +117,7 @@ func (d *OcpDriver) Execute() error {
 	case CreateAction:
 		if clusterStatus == Running {
 			log.Printf("Not creating as cluster exists")
-
+			// rsync sometimes get stuck this makes sure we retry upload on repeated create invocations
 			if err := d.uploadClusterState(); err != nil {
 				return err
 			}
@@ -246,7 +246,6 @@ func (d *OcpDriver) ensureWorkDir() error {
 }
 
 func (d *OcpDriver) authToGCP() error {
-	return nil
 	// avoid double authentication
 	if d.runtimeState.Authenticated {
 		return nil

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -107,6 +107,8 @@ func (d *OcpDriver) Execute() error {
 		return err
 	}
 
+	defer d.removeWorkDir()
+
 	clusterStatus := d.currentStatus()
 
 	switch d.plan.Operation {
@@ -135,8 +137,7 @@ func (d *OcpDriver) Execute() error {
 	default:
 		return fmt.Errorf("unknown operation %s", d.plan.Operation)
 	}
-
-	return d.removeWorkDir()
+	return nil
 }
 
 func (d *OcpDriver) create() error {

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -84,7 +84,7 @@ type OcpDriver struct {
 	runtimeState runtimeState
 }
 
-func (gdf *OcpDriverFactory) Create(plan Plan) (Driver, error) {
+func (*OcpDriverFactory) Create(plan Plan) (Driver, error) {
 	return &OcpDriver{
 		plan: plan,
 	}, nil

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -200,7 +200,7 @@ func (d *OcpDriver) setupDisks() error {
 }
 
 func (d *OcpDriver) ensureClientImage() error {
-	image, err := ensureClientImage(OcpDriverID, d.plan.ClientVersion)
+	image, err := ensureClientImage(OcpDriverID, d.plan.ClientVersion, d.plan.ClientBuildDefDir)
 	if err != nil {
 		return err
 	}

--- a/hack/deployer/runner/ocp3.go
+++ b/hack/deployer/runner/ocp3.go
@@ -35,11 +35,6 @@ const (
 	MasterInstance = "n1-standard-2"
 )
 
-var (
-	// SharedVolumeName name shared by CI container and Ansible container
-	SharedVolumeName = os.Getenv("SHARED_VOLUME_NAME")
-)
-
 func init() {
 	drivers[Ocp3DriverID] = &Ocp3DriverFactory{}
 }
@@ -161,7 +156,7 @@ func (d Ocp3Driver) runAnsibleDockerContainer(action string) error {
 
 	params := map[string]interface{}{
 		"User":                AnsibleUser,
-		"HomeVolumeName":      SharedVolumeName,
+		"HomeVolumeName":      SharedVolumeName(),
 		"HomeVolumeMountPath": AnsibleHomePath,
 		"GCloudCredsPath":     filepath.Join(AnsibleHomePath, GCPDir, ServiceAccountFilename),
 		"GCloudSDKPath":       filepath.Join(AnsibleHomePath, GCPDir),

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -11,19 +11,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var (
-	clientBuildDefDir = ""
-)
-
-// SetclientBuildDefDir designates a directory which holds Dockerfiles for Cloud provider clients.
-func SetClientBuildDefDir(dir string) error {
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		return err
-	}
-	clientBuildDefDir = dir
-	return nil
-}
-
 // SharedVolumeName name shared by CI container and Docker containers launched by deployer
 func SharedVolumeName() string {
 	if vol := os.Getenv("SHARED_VOLUME_NAME"); vol != "" {
@@ -44,6 +31,7 @@ type Plan struct {
 	Operation         string        `yaml:"operation"`
 	ClusterName       string        `yaml:"clusterName"`
 	ClientVersion     string        `yaml:"clientVersion"`
+	ClientBuildDefDir string        `yaml:"clientBuildDefDir"`
 	Provider          string        `yaml:"provider"`
 	KubernetesVersion string        `yaml:"kubernetesVersion"`
 	MachineType       string        `yaml:"machineType"`

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -94,6 +94,7 @@ type OcpSettings struct {
 	GCloudProject              string `yaml:"gCloudProject"`
 	Region                     string `yaml:"region"`
 	AdminUsername              string `yaml:"adminUsername"`
+	WorkDir                    string `yaml:"workDir"`
 	PullSecret                 string `yaml:"pullSecret"`
 	LocalSsdCount              int    `yaml:"localSsdCount"`
 	NodeCount                  int    `yaml:"nodeCount"`

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -83,6 +83,7 @@ type OcpSettings struct {
 	Region        string `yaml:"region"`
 	AdminUsername string `yaml:"adminUsername"`
 	WorkDir       string `yaml:"workDir"`
+	StickyWorkDir bool   `yaml:"stickyWorkDir"`
 	PullSecret    string `yaml:"pullSecret"`
 	LocalSsdCount int    `yaml:"localSsdCount"`
 	NodeCount     int    `yaml:"nodeCount"`

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -6,9 +6,32 @@ package runner
 
 import (
 	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v3"
 )
+
+var (
+	clientBuildDefDir = ""
+)
+
+// SetclientBuildDefDir designates a directory which holds Dockerfiles for Cloud provider clients.
+func SetClientBuildDefDir(dir string) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return err
+	}
+	clientBuildDefDir = dir
+	return nil
+}
+
+// SharedVolumeName name shared by CI container and Docker containers launched by deployer
+func SharedVolumeName() string {
+	if vol := os.Getenv("SHARED_VOLUME_NAME"); vol != "" {
+		return vol
+	}
+	// use HOME for local dev mode
+	return os.Getenv("HOME")
+}
 
 // Plans encapsulates list of plans, expected to map to a file
 type Plans struct {
@@ -20,6 +43,7 @@ type Plan struct {
 	Id                string        `yaml:"id"` //nolint:revive
 	Operation         string        `yaml:"operation"`
 	ClusterName       string        `yaml:"clusterName"`
+	ClientVersion     string        `yaml:"clientVersion"`
 	Provider          string        `yaml:"provider"`
 	KubernetesVersion string        `yaml:"kubernetesVersion"`
 	MachineType       string        `yaml:"machineType"`

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -94,7 +94,6 @@ type OcpSettings struct {
 	GCloudProject              string `yaml:"gCloudProject"`
 	Region                     string `yaml:"region"`
 	AdminUsername              string `yaml:"adminUsername"`
-	WorkDir                    string `yaml:"workDir"`
 	PullSecret                 string `yaml:"pullSecret"`
 	LocalSsdCount              int    `yaml:"localSsdCount"`
 	NodeCount                  int    `yaml:"nodeCount"`

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -90,15 +90,14 @@ type AksSettings struct {
 
 // OcpSettings encapsulates settings specific to OCP on GCloud
 type OcpSettings struct {
-	BaseDomain                 string `yaml:"baseDomain"`
-	GCloudProject              string `yaml:"gCloudProject"`
-	Region                     string `yaml:"region"`
-	AdminUsername              string `yaml:"adminUsername"`
-	WorkDir                    string `yaml:"workDir"`
-	PullSecret                 string `yaml:"pullSecret"`
-	LocalSsdCount              int    `yaml:"localSsdCount"`
-	NodeCount                  int    `yaml:"nodeCount"`
-	OverwriteDefaultKubeconfig bool   `yaml:"overwriteDefaultKubeconfig"`
+	BaseDomain    string `yaml:"baseDomain"`
+	GCloudProject string `yaml:"gCloudProject"`
+	Region        string `yaml:"region"`
+	AdminUsername string `yaml:"adminUsername"`
+	WorkDir       string `yaml:"workDir"`
+	PullSecret    string `yaml:"pullSecret"`
+	LocalSsdCount int    `yaml:"localSsdCount"`
+	NodeCount     int    `yaml:"nodeCount"`
 }
 
 // Ocp3Settings encapsulates settings specific to OCP3 on GCloud


### PR DESCRIPTION
Part of #4319 

The basic idea is (inspired by the OCP3 deployer) to have separate Docker images with the necessary client programs to stand up the desired K8s cluster within deployer itself. 

This means we move most of the Cloud provider specific bits out the `ci` image and into new Dockefiles that live under `/hack/deployer/clients/$DRIVER_ID` This can be done one by one. 

This PR:
* implements this approach for OCP by using a customer Dockerfile that can be parameterised with the OpenShift version (I think I tested all of the ones we need to run) 
* refactors the existing OCP driver to fix some bugs, remove all the untyped maps and type assertions and hopefully simplify it a bit
* removes the annoying behaviour where the OCP driver would nuke your local kubeconfig, instead I try to merge it with any existing ones (which works as long as there is not already another OCP from deployer one in it) 

Limitations: 
* the OCP driver currently still relies on the gcloud client being present on the host
* no unit tests 


Follow-up PRs:
* set up Jenkins jobs to run the different OCP versions, I am thinking we should maybe have some form of rotation instead of testing all of them all the time. This is mainly to save resources as each of these OCP clusters is 5 VMs + network resources + DNS
