### PR TITLE
Skip agent and beat recipes tests on OCP3

### DIFF
--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -9,6 +9,7 @@ package agent
 import (
 	"path"
 	"testing"
+	"strings"
 
 	agentv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/agent/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
@@ -91,7 +92,7 @@ func runBeatRecipe(
 
 		// OpenShift requires different securityContext than provided in the recipe.
 		// Skipping it altogether to reduce maintenance burden.
-		if test.Ctx().Provider == "ocp" {
+		if strings.HasPrefix(test.Ctx().Provider, "ocp") {
 			t.SkipNow()
 		}
 

--- a/test/e2e/beat/recipes_test.go
+++ b/test/e2e/beat/recipes_test.go
@@ -242,7 +242,7 @@ func runBeatRecipe(
 
 		// OpenShift requires different securityContext than provided in the recipe.
 		// Skipping it altogether to reduce maintenance burden.
-		if test.Ctx().Provider == "ocp" {
+		if strings.HasPrefix(test.Ctx().Provider, "ocp") {
 			t.SkipNow()
 		}
 


### PR DESCRIPTION
We already skip agent and beat recipes tests on OCP.

This commit updates the test to ignore these tests, to extend it to OCP3.

Relates to #4128.