### PR TITLE
Remove labels from operator namespace

### DIFF
--- a/deploy/eck-operator/templates/operator-namespace.yaml
+++ b/deploy/eck-operator/templates/operator-namespace.yaml
@@ -6,5 +6,4 @@ metadata:
   name: {{ .Release.Namespace }}
   labels:
     name: {{ .Release.Namespace }}
-    {{- include "eck-operator.labels" $ | nindent 4 }}
 {{- end -}}


### PR DESCRIPTION
The operator labels are reused for the namespace created by the `all-in-one.yaml`. For backward-compatibility reasons, the operator labels contain the `control-plane: elastic-operator` label that apparently conflicts with Istio. We don't need the operator namespace to have any labels so we can simply remove them to fix the problem.

Fixes #4395 