### PR TITLE
Allow users to spec a serviceName in associations

### DIFF
--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -183,6 +183,12 @@ spec:
                     type: string
                   outputName:
                     type: string
+                  serviceName:
+                    description: ServiceName is the name of an existing Kubernetes
+                      service which will be used to make requests to the referenced
+                      object. If left empty the default HTTP service of the referenced
+                      resource will be used.
+                    type: string
                 required:
                 - name
                 type: object
@@ -350,6 +356,12 @@ spec:
                 namespace:
                   description: Namespace of the Kubernetes object. If empty, defaults
                     to the current namespace.
+                  type: string
+                serviceName:
+                  description: ServiceName is the name of an existing Kubernetes service
+                    which will be used to make requests to the referenced object.
+                    If left empty the default HTTP service of the referenced resource
+                    will be used.
                   type: string
               required:
               - name
@@ -742,6 +754,12 @@ spec:
                   description: Namespace of the Kubernetes object. If empty, defaults
                     to the current namespace.
                   type: string
+                serviceName:
+                  description: ServiceName is the name of an existing Kubernetes service
+                    which will be used to make requests to the referenced object.
+                    If left empty the default HTTP service of the referenced resource
+                    will be used.
+                  type: string
               required:
               - name
               type: object
@@ -1033,6 +1051,12 @@ spec:
                   description: Namespace of the Kubernetes object. If empty, defaults
                     to the current namespace.
                   type: string
+                serviceName:
+                  description: ServiceName is the name of an existing Kubernetes service
+                    which will be used to make requests to the referenced object.
+                    If left empty the default HTTP service of the referenced resource
+                    will be used.
+                  type: string
               required:
               - name
               type: object
@@ -1051,6 +1075,12 @@ spec:
                 namespace:
                   description: Namespace of the Kubernetes object. If empty, defaults
                     to the current namespace.
+                  type: string
+                serviceName:
+                  description: ServiceName is the name of an existing Kubernetes service
+                    which will be used to make requests to the referenced object.
+                    If left empty the default HTTP service of the referenced resource
+                    will be used.
                   type: string
               required:
               - name
@@ -1956,6 +1986,12 @@ spec:
                         description: Namespace of the Kubernetes object. If empty,
                           defaults to the current namespace.
                         type: string
+                      serviceName:
+                        description: ServiceName is the name of an existing Kubernetes
+                          service which will be used to make requests to the referenced
+                          object. If left empty the default HTTP service of the referenced
+                          resource will be used.
+                        type: string
                     required:
                     - name
                     type: object
@@ -2522,6 +2558,12 @@ spec:
                   description: Namespace of the Kubernetes object. If empty, defaults
                     to the current namespace.
                   type: string
+                serviceName:
+                  description: ServiceName is the name of an existing Kubernetes service
+                    which will be used to make requests to the referenced object.
+                    If left empty the default HTTP service of the referenced resource
+                    will be used.
+                  type: string
               required:
               - name
               type: object
@@ -3027,6 +3069,12 @@ spec:
                 namespace:
                   description: Namespace of the Kubernetes object. If empty, defaults
                     to the current namespace.
+                  type: string
+                serviceName:
+                  description: ServiceName is the name of an existing Kubernetes service
+                    which will be used to make requests to the referenced object.
+                    If left empty the default HTTP service of the referenced resource
+                    will be used.
                   type: string
               required:
               - name

--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -186,7 +186,8 @@ spec:
                   serviceName:
                     description: ServiceName is the name of an existing Kubernetes
                       service which will be used to make requests to the referenced
-                      object. If left empty the default HTTP service of the referenced
+                      object. It has to be in the same namespace as the referenced
+                      resource. If left empty the default HTTP service of the referenced
                       resource will be used.
                     type: string
                 required:
@@ -360,6 +361,7 @@ spec:
                 serviceName:
                   description: ServiceName is the name of an existing Kubernetes service
                     which will be used to make requests to the referenced object.
+                    It has to be in the same namespace as the referenced resource.
                     If left empty the default HTTP service of the referenced resource
                     will be used.
                   type: string
@@ -757,6 +759,7 @@ spec:
                 serviceName:
                   description: ServiceName is the name of an existing Kubernetes service
                     which will be used to make requests to the referenced object.
+                    It has to be in the same namespace as the referenced resource.
                     If left empty the default HTTP service of the referenced resource
                     will be used.
                   type: string
@@ -1054,6 +1057,7 @@ spec:
                 serviceName:
                   description: ServiceName is the name of an existing Kubernetes service
                     which will be used to make requests to the referenced object.
+                    It has to be in the same namespace as the referenced resource.
                     If left empty the default HTTP service of the referenced resource
                     will be used.
                   type: string
@@ -1079,6 +1083,7 @@ spec:
                 serviceName:
                   description: ServiceName is the name of an existing Kubernetes service
                     which will be used to make requests to the referenced object.
+                    It has to be in the same namespace as the referenced resource.
                     If left empty the default HTTP service of the referenced resource
                     will be used.
                   type: string
@@ -1989,8 +1994,9 @@ spec:
                       serviceName:
                         description: ServiceName is the name of an existing Kubernetes
                           service which will be used to make requests to the referenced
-                          object. If left empty the default HTTP service of the referenced
-                          resource will be used.
+                          object. It has to be in the same namespace as the referenced
+                          resource. If left empty the default HTTP service of the
+                          referenced resource will be used.
                         type: string
                     required:
                     - name
@@ -2561,6 +2567,7 @@ spec:
                 serviceName:
                   description: ServiceName is the name of an existing Kubernetes service
                     which will be used to make requests to the referenced object.
+                    It has to be in the same namespace as the referenced resource.
                     If left empty the default HTTP service of the referenced resource
                     will be used.
                   type: string
@@ -3073,6 +3080,7 @@ spec:
                 serviceName:
                   description: ServiceName is the name of an existing Kubernetes service
                     which will be used to make requests to the referenced object.
+                    It has to be in the same namespace as the referenced resource.
                     If left empty the default HTTP service of the referenced resource
                     will be used.
                   type: string

--- a/config/crds/bases/agent.k8s.elastic.co_agents.yaml
+++ b/config/crds/bases/agent.k8s.elastic.co_agents.yaml
@@ -7603,7 +7603,7 @@ spec:
                   outputName:
                     type: string
                   serviceName:
-                    description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
+                    description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty the default HTTP service of the referenced resource will be used.
                     type: string
                 required:
                 - name

--- a/config/crds/bases/agent.k8s.elastic.co_agents.yaml
+++ b/config/crds/bases/agent.k8s.elastic.co_agents.yaml
@@ -7602,6 +7602,9 @@ spec:
                     type: string
                   outputName:
                     type: string
+                  serviceName:
+                    description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crds/bases/apm.k8s.elastic.co_apmservers.yaml
+++ b/config/crds/bases/apm.k8s.elastic.co_apmservers.yaml
@@ -71,7 +71,7 @@ spec:
                     description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                     type: string
                   serviceName:
-                    description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
+                    description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty the default HTTP service of the referenced resource will be used.
                     type: string
                 required:
                 - name
@@ -247,7 +247,7 @@ spec:
                     description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                     type: string
                   serviceName:
-                    description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
+                    description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty the default HTTP service of the referenced resource will be used.
                     type: string
                 required:
                 - name

--- a/config/crds/bases/apm.k8s.elastic.co_apmservers.yaml
+++ b/config/crds/bases/apm.k8s.elastic.co_apmservers.yaml
@@ -70,6 +70,9 @@ spec:
                   namespace:
                     description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                     type: string
+                  serviceName:
+                    description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
+                    type: string
                 required:
                 - name
                 type: object
@@ -242,6 +245,9 @@ spec:
                     type: string
                   namespace:
                     description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                    type: string
+                  serviceName:
+                    description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
                     type: string
                 required:
                 - name

--- a/config/crds/bases/beat.k8s.elastic.co_beats.yaml
+++ b/config/crds/bases/beat.k8s.elastic.co_beats.yaml
@@ -7604,7 +7604,7 @@ spec:
                   description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                   type: string
                 serviceName:
-                  description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
+                  description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty the default HTTP service of the referenced resource will be used.
                   type: string
               required:
               - name
@@ -7622,7 +7622,7 @@ spec:
                   description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                   type: string
                 serviceName:
-                  description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
+                  description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty the default HTTP service of the referenced resource will be used.
                   type: string
               required:
               - name

--- a/config/crds/bases/beat.k8s.elastic.co_beats.yaml
+++ b/config/crds/bases/beat.k8s.elastic.co_beats.yaml
@@ -7603,6 +7603,9 @@ spec:
                 namespace:
                   description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                   type: string
+                serviceName:
+                  description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
+                  type: string
               required:
               - name
               type: object
@@ -7617,6 +7620,9 @@ spec:
                   type: string
                 namespace:
                   description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                  type: string
+                serviceName:
+                  description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
                   type: string
               required:
               - name

--- a/config/crds/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
+++ b/config/crds/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
@@ -4220,6 +4220,9 @@ spec:
                         namespace:
                           description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                           type: string
+                        serviceName:
+                          description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
+                          type: string
                       required:
                       - name
                       type: object

--- a/config/crds/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
+++ b/config/crds/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
@@ -4221,7 +4221,7 @@ spec:
                           description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                           type: string
                         serviceName:
-                          description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
+                          description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty the default HTTP service of the referenced resource will be used.
                           type: string
                       required:
                       - name

--- a/config/crds/bases/enterprisesearch.k8s.elastic.co_enterprisesearches.yaml
+++ b/config/crds/bases/enterprisesearch.k8s.elastic.co_enterprisesearches.yaml
@@ -74,6 +74,9 @@ spec:
                 namespace:
                   description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                   type: string
+                serviceName:
+                  description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
+                  type: string
               required:
               - name
               type: object

--- a/config/crds/bases/enterprisesearch.k8s.elastic.co_enterprisesearches.yaml
+++ b/config/crds/bases/enterprisesearch.k8s.elastic.co_enterprisesearches.yaml
@@ -75,7 +75,7 @@ spec:
                   description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                   type: string
                 serviceName:
-                  description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
+                  description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty the default HTTP service of the referenced resource will be used.
                   type: string
               required:
               - name

--- a/config/crds/bases/kibana.k8s.elastic.co_kibanas.yaml
+++ b/config/crds/bases/kibana.k8s.elastic.co_kibanas.yaml
@@ -70,6 +70,9 @@ spec:
                   namespace:
                     description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                     type: string
+                  serviceName:
+                    description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crds/bases/kibana.k8s.elastic.co_kibanas.yaml
+++ b/config/crds/bases/kibana.k8s.elastic.co_kibanas.yaml
@@ -71,7 +71,7 @@ spec:
                     description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                     type: string
                   serviceName:
-                    description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
+                    description: ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty the default HTTP service of the referenced resource will be used.
                     type: string
                 required:
                 - name

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -189,6 +189,12 @@ spec:
                     type: string
                   outputName:
                     type: string
+                  serviceName:
+                    description: ServiceName is the name of an existing Kubernetes
+                      service which will be used to make requests to the referenced
+                      object. If left empty the default HTTP service of the referenced
+                      resource will be used.
+                    type: string
                 required:
                 - name
                 type: object
@@ -362,6 +368,12 @@ spec:
                 namespace:
                   description: Namespace of the Kubernetes object. If empty, defaults
                     to the current namespace.
+                  type: string
+                serviceName:
+                  description: ServiceName is the name of an existing Kubernetes service
+                    which will be used to make requests to the referenced object.
+                    If left empty the default HTTP service of the referenced resource
+                    will be used.
                   type: string
               required:
               - name
@@ -754,6 +766,12 @@ spec:
                   description: Namespace of the Kubernetes object. If empty, defaults
                     to the current namespace.
                   type: string
+                serviceName:
+                  description: ServiceName is the name of an existing Kubernetes service
+                    which will be used to make requests to the referenced object.
+                    If left empty the default HTTP service of the referenced resource
+                    will be used.
+                  type: string
               required:
               - name
               type: object
@@ -1051,6 +1069,12 @@ spec:
                   description: Namespace of the Kubernetes object. If empty, defaults
                     to the current namespace.
                   type: string
+                serviceName:
+                  description: ServiceName is the name of an existing Kubernetes service
+                    which will be used to make requests to the referenced object.
+                    If left empty the default HTTP service of the referenced resource
+                    will be used.
+                  type: string
               required:
               - name
               type: object
@@ -1069,6 +1093,12 @@ spec:
                 namespace:
                   description: Namespace of the Kubernetes object. If empty, defaults
                     to the current namespace.
+                  type: string
+                serviceName:
+                  description: ServiceName is the name of an existing Kubernetes service
+                    which will be used to make requests to the referenced object.
+                    If left empty the default HTTP service of the referenced resource
+                    will be used.
                   type: string
               required:
               - name
@@ -1980,6 +2010,12 @@ spec:
                         description: Namespace of the Kubernetes object. If empty,
                           defaults to the current namespace.
                         type: string
+                      serviceName:
+                        description: ServiceName is the name of an existing Kubernetes
+                          service which will be used to make requests to the referenced
+                          object. If left empty the default HTTP service of the referenced
+                          resource will be used.
+                        type: string
                     required:
                     - name
                     type: object
@@ -2552,6 +2588,12 @@ spec:
                   description: Namespace of the Kubernetes object. If empty, defaults
                     to the current namespace.
                   type: string
+                serviceName:
+                  description: ServiceName is the name of an existing Kubernetes service
+                    which will be used to make requests to the referenced object.
+                    If left empty the default HTTP service of the referenced resource
+                    will be used.
+                  type: string
               required:
               - name
               type: object
@@ -3063,6 +3105,12 @@ spec:
                 namespace:
                   description: Namespace of the Kubernetes object. If empty, defaults
                     to the current namespace.
+                  type: string
+                serviceName:
+                  description: ServiceName is the name of an existing Kubernetes service
+                    which will be used to make requests to the referenced object.
+                    If left empty the default HTTP service of the referenced resource
+                    will be used.
                   type: string
               required:
               - name

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -192,7 +192,8 @@ spec:
                   serviceName:
                     description: ServiceName is the name of an existing Kubernetes
                       service which will be used to make requests to the referenced
-                      object. If left empty the default HTTP service of the referenced
+                      object. It has to be in the same namespace as the referenced
+                      resource. If left empty the default HTTP service of the referenced
                       resource will be used.
                     type: string
                 required:
@@ -372,6 +373,7 @@ spec:
                 serviceName:
                   description: ServiceName is the name of an existing Kubernetes service
                     which will be used to make requests to the referenced object.
+                    It has to be in the same namespace as the referenced resource.
                     If left empty the default HTTP service of the referenced resource
                     will be used.
                   type: string
@@ -769,6 +771,7 @@ spec:
                 serviceName:
                   description: ServiceName is the name of an existing Kubernetes service
                     which will be used to make requests to the referenced object.
+                    It has to be in the same namespace as the referenced resource.
                     If left empty the default HTTP service of the referenced resource
                     will be used.
                   type: string
@@ -1072,6 +1075,7 @@ spec:
                 serviceName:
                   description: ServiceName is the name of an existing Kubernetes service
                     which will be used to make requests to the referenced object.
+                    It has to be in the same namespace as the referenced resource.
                     If left empty the default HTTP service of the referenced resource
                     will be used.
                   type: string
@@ -1097,6 +1101,7 @@ spec:
                 serviceName:
                   description: ServiceName is the name of an existing Kubernetes service
                     which will be used to make requests to the referenced object.
+                    It has to be in the same namespace as the referenced resource.
                     If left empty the default HTTP service of the referenced resource
                     will be used.
                   type: string
@@ -2013,8 +2018,9 @@ spec:
                       serviceName:
                         description: ServiceName is the name of an existing Kubernetes
                           service which will be used to make requests to the referenced
-                          object. If left empty the default HTTP service of the referenced
-                          resource will be used.
+                          object. It has to be in the same namespace as the referenced
+                          resource. If left empty the default HTTP service of the
+                          referenced resource will be used.
                         type: string
                     required:
                     - name
@@ -2591,6 +2597,7 @@ spec:
                 serviceName:
                   description: ServiceName is the name of an existing Kubernetes service
                     which will be used to make requests to the referenced object.
+                    It has to be in the same namespace as the referenced resource.
                     If left empty the default HTTP service of the referenced resource
                     will be used.
                   type: string
@@ -3109,6 +3116,7 @@ spec:
                 serviceName:
                   description: ServiceName is the name of an existing Kubernetes service
                     which will be used to make requests to the referenced object.
+                    It has to be in the same namespace as the referenced resource.
                     If left empty the default HTTP service of the referenced resource
                     will be used.
                   type: string

--- a/docs/reference/api-docs.asciidoc
+++ b/docs/reference/api-docs.asciidoc
@@ -447,7 +447,7 @@ ObjectSelector defines a reference to a Kubernetes object.
 | Field | Description
 | *`name`* __string__ | Name of the Kubernetes object.
 | *`namespace`* __string__ | Namespace of the Kubernetes object. If empty, defaults to the current namespace.
-| *`serviceName`* __string__ | ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
+| *`serviceName`* __string__ | ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty the default HTTP service of the referenced resource will be used.
 |===
 
 

--- a/docs/reference/api-docs.asciidoc
+++ b/docs/reference/api-docs.asciidoc
@@ -447,6 +447,7 @@ ObjectSelector defines a reference to a Kubernetes object.
 | Field | Description
 | *`name`* __string__ | Name of the Kubernetes object.
 | *`namespace`* __string__ | Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+| *`serviceName`* __string__ | ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced object. If left empty the default HTTP service of the referenced resource will be used.
 |===
 
 

--- a/pkg/apis/common/v1/common.go
+++ b/pkg/apis/common/v1/common.go
@@ -50,7 +50,8 @@ type ObjectSelector struct {
 	// Namespace of the Kubernetes object. If empty, defaults to the current namespace.
 	Namespace string `json:"namespace,omitempty"`
 	// ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced
-	// object. If left empty the default HTTP service of the referenced resource will be used.
+	// object. It has to be in the same namespace as the referenced resource. If left empty the default HTTP service of
+	// the referenced resource will be used.
 	ServiceName string `json:"serviceName,omitempty"`
 }
 

--- a/pkg/apis/common/v1/common.go
+++ b/pkg/apis/common/v1/common.go
@@ -49,6 +49,9 @@ type ObjectSelector struct {
 	Name string `json:"name"`
 	// Namespace of the Kubernetes object. If empty, defaults to the current namespace.
 	Namespace string `json:"namespace,omitempty"`
+	// ServiceName is the name of an existing Kubernetes service which will be used to make requests to the referenced
+	// object. If left empty the default HTTP service of the referenced resource will be used.
+	ServiceName string `json:"serviceName,omitempty"`
 }
 
 // WithDefaultNamespace adds a default namespace to a given ObjectSelector if none is set.
@@ -57,8 +60,9 @@ func (o ObjectSelector) WithDefaultNamespace(defaultNamespace string) ObjectSele
 		return o
 	}
 	return ObjectSelector{
-		Namespace: defaultNamespace,
-		Name:      o.Name,
+		Namespace:   defaultNamespace,
+		Name:        o.Name,
+		ServiceName: o.ServiceName,
 	}
 }
 

--- a/pkg/apis/common/v1/common_test.go
+++ b/pkg/apis/common/v1/common_test.go
@@ -4,7 +4,10 @@
 
 package v1
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestTLSOptions_Enabled(t *testing.T) {
 	type fields struct {
@@ -128,6 +131,68 @@ func TestHTTPConfig_Scheme(t *testing.T) {
 			}
 			if got := http.Protocol(); got != tt.want {
 				t.Errorf("Protocol() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestObjectSelector_WithDefaultNamespace(t *testing.T) {
+	type fields struct {
+		Name        string
+		Namespace   string
+		ServiceName string
+	}
+	type args struct {
+		defaultNamespace string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   ObjectSelector
+	}{
+		{
+			name: "keep non-empty namespace and name, serviceName",
+			fields: fields{
+				Name:        "a",
+				Namespace:   "b",
+				ServiceName: "c",
+			},
+			args: args{
+				defaultNamespace: "d",
+			},
+			want: ObjectSelector{
+				Name:        "a",
+				Namespace:   "b",
+				ServiceName: "c",
+			},
+		},
+		{
+			name: "default empty namespace, keep name and serviceName",
+			fields: fields{
+				Name:        "a",
+				Namespace:   "",
+				ServiceName: "c",
+			},
+			args: args{
+				defaultNamespace: "d",
+			},
+			want: ObjectSelector{
+				Name:        "a",
+				Namespace:   "d",
+				ServiceName: "c",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := ObjectSelector{
+				Name:        tt.fields.Name,
+				Namespace:   tt.fields.Namespace,
+				ServiceName: tt.fields.ServiceName,
+			}
+			if got := o.WithDefaultNamespace(tt.args.defaultNamespace); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("WithDefaultNamespace() = %+v, want %+v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/controller/association/controller.go
+++ b/pkg/controller/association/controller.go
@@ -63,6 +63,11 @@ func addWatches(c controller.Controller, r *Reconciler) error {
 		return err
 	}
 
+	// Dynamically watch Service objects for custom services setup by the user
+	if err := c.Watch(&source.Kind{Type: &corev1.Service{}}, r.watches.Services); err != nil {
+		return err
+	}
+
 	// Watch Secrets owned by the associated resource
 	return c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForOwner{
 		OwnerType:    r.AssociatedObjTemplate(),

--- a/pkg/controller/association/controller/apm_es.go
+++ b/pkg/controller/association/controller/apm_es.go
@@ -60,8 +60,8 @@ func AddApmES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params op
 	})
 }
 
-func getElasticsearchExternalURL(c k8s.Client, association commonv1.Association) (string, error) {
-	esRef := association.AssociationRef()
+func getElasticsearchExternalURL(c k8s.Client, assoc commonv1.Association) (string, error) {
+	esRef := assoc.AssociationRef()
 	if !esRef.IsDefined() {
 		return "", nil
 	}
@@ -69,7 +69,12 @@ func getElasticsearchExternalURL(c k8s.Client, association commonv1.Association)
 	if err := c.Get(context.Background(), esRef.NamespacedName(), &es); err != nil {
 		return "", err
 	}
-	return services.ExternalServiceURL(es), nil
+	serviceName := esRef.ServiceName
+	if serviceName == "" {
+		serviceName = services.ExternalServiceName(es.Name)
+	}
+	nsn := types.NamespacedName{Name: serviceName, Namespace: es.Namespace}
+	return association.ServiceURL(c, nsn, es.Spec.HTTP.Protocol())
 }
 
 // referencedElasticsearchStatusVersion returns the currently running version of Elasticsearch

--- a/pkg/controller/association/dynamic_watches.go
+++ b/pkg/controller/association/dynamic_watches.go
@@ -29,8 +29,8 @@ func associatedCAWatchName(associated types.NamespacedName) string {
 	return fmt.Sprintf("%s-%s-ca-watch", associated.Namespace, associated.Name)
 }
 
-// serviceWatchname returns the name of the watch setup ot monitor a custom service to be used to make requests to the
-// associated resource
+// serviceWatchName returns the name of the watch monitor a custom service to be used to make requests to the
+// associated resource.
 func serviceWatchName(associated types.NamespacedName) string {
 	return fmt.Sprintf("%s-%s-svc-watch", associated.Namespace, associated.Name)
 }

--- a/pkg/controller/association/dynamic_watches.go
+++ b/pkg/controller/association/dynamic_watches.go
@@ -29,6 +29,12 @@ func associatedCAWatchName(associated types.NamespacedName) string {
 	return fmt.Sprintf("%s-%s-ca-watch", associated.Namespace, associated.Name)
 }
 
+// serviceWatchname returns the name of the watch setup ot monitor a custom service to be used to make requests to the
+// associated resource
+func serviceWatchName(associated types.NamespacedName) string {
+	return fmt.Sprintf("%s-%s-svc-watch", associated.Namespace, associated.Name)
+}
+
 // reconcileWatches sets up dynamic watches related to:
 // * The referenced Elasticsearch resource
 // * The user created in the Elasticsearch namespace
@@ -56,6 +62,18 @@ func (r *Reconciler) reconcileWatches(associated types.NamespacedName, associati
 		ref := association.AssociationRef()
 		return types.NamespacedName{
 			Name:      certificates.PublicCertsSecretName(r.AssociationInfo.AssociatedNamer, ref.Name),
+			Namespace: ref.Namespace,
+		}
+	}); err != nil {
+		return err
+	}
+
+	// watch the custom services users may have setup to be able to react to updates on services that are not error related
+	// (error related updates are covered by re-queueing on unsuccessful reconciliation)
+	if err := ReconcileWatch(associated, filterWithServiceName(associations), r.watches.Services, serviceWatchName(associated), func(association commonv1.Association) types.NamespacedName {
+		ref := association.AssociationRef()
+		return types.NamespacedName{
+			Name:      ref.ServiceName,
 			Namespace: ref.Namespace,
 		}
 	}); err != nil {
@@ -111,4 +129,6 @@ func (r *Reconciler) removeWatches(associated types.NamespacedName) {
 	RemoveWatch(r.watches.Secrets, esUserWatchName(associated))
 	// - ES CA Secret in the ES namespace
 	RemoveWatch(r.watches.Secrets, associatedCAWatchName(associated))
+	// - custom service watch in resource namespace
+	RemoveWatch(r.watches.Services, serviceWatchName(associated))
 }

--- a/pkg/controller/association/service.go
+++ b/pkg/controller/association/service.go
@@ -1,0 +1,51 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package association
+
+import (
+	"context"
+	"fmt"
+
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ServiceURL calculates the URL for the service identified by serviceNSN using protocol.
+func ServiceURL(c k8s.Client, serviceNSN types.NamespacedName, protocol string) (string, error) {
+	var svc corev1.Service
+	if err := c.Get(context.Background(), serviceNSN, &svc); err != nil {
+		return "", fmt.Errorf("while fetching refernced service: %w", err)
+	}
+	port, err := findPortFor(protocol, svc)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s://%s.%s.svc:%d", protocol, svc.Name, svc.Namespace, port), nil
+}
+
+// findPortFor returns the port with the name matching protocol.
+func findPortFor(protocol string, svc corev1.Service) (int32, error) {
+	for _, p := range svc.Spec.Ports {
+		if p.Name == protocol {
+			return p.Port, nil
+		}
+	}
+	return -1, fmt.Errorf("no port named [%s] in service [%s/%s]", protocol, svc.Namespace, svc.Name)
+}
+
+// filterWithServiceName returns those associations that have a serviceName specified.
+func filterWithServiceName(associations []commonv1.Association) []commonv1.Association {
+	var r []commonv1.Association
+	for _, a := range associations {
+		if a.AssociationRef().ServiceName != "" {
+			r = append(r, a)
+		}
+	}
+	return r
+}

--- a/pkg/controller/association/service.go
+++ b/pkg/controller/association/service.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
-
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/controller/association/service_test.go
+++ b/pkg/controller/association/service_test.go
@@ -1,0 +1,132 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package association
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestServiceURL(t *testing.T) {
+	type args struct {
+		c          k8s.Client
+		serviceNSN types.NamespacedName
+		protocol   string
+	}
+	svcName := types.NamespacedName{Namespace: "a", Name: "b"}
+	svcFixture := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "a", Name: "b"},
+		Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{
+			{
+				Name: "https",
+				Port: 9200,
+			},
+		}},
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "happy path",
+			args: args{
+				c:          k8s.NewFakeClient(svcFixture),
+				serviceNSN: svcName,
+				protocol:   "https",
+			},
+			want:    "https://b.a.svc:9200",
+			wantErr: false,
+		},
+		{
+			name: "service does not exist",
+			args: args{
+				c:          k8s.NewFakeClient(),
+				serviceNSN: svcName,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "no port for protocol",
+			args: args{
+				c:          k8s.NewFakeClient(svcFixture),
+				serviceNSN: svcName,
+				protocol:   "http",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ServiceURL(tt.args.c, tt.args.serviceNSN, tt.args.protocol)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ServiceURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ServiceURL() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_findPortFor(t *testing.T) {
+	svcFixture := corev1.Service{
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "a", Port: 1},
+				{Name: "b", Port: 2},
+			},
+		},
+	}
+	type args struct {
+		protocol string
+		svc      corev1.Service
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int32
+		wantErr bool
+	}{
+		{
+			name: "finds existing port",
+			args: args{
+				protocol: "a",
+				svc:      svcFixture,
+			},
+			want:    1,
+			wantErr: false,
+		},
+		{
+			name: "err on non-existing port",
+			args: args{
+				protocol: "http",
+				svc:      svcFixture,
+			},
+			want:    -1,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := findPortFor(tt.args.protocol, tt.args.svc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("findPortFor() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("findPortFor() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/common/watches/state.go
+++ b/pkg/controller/common/watches/state.go
@@ -8,6 +8,7 @@ package watches
 func NewDynamicWatches() DynamicWatches {
 	return DynamicWatches{
 		Secrets:               NewDynamicEnqueueRequest(),
+		Services:              NewDynamicEnqueueRequest(),
 		Pods:                  NewDynamicEnqueueRequest(),
 		ElasticsearchClusters: NewDynamicEnqueueRequest(),
 		Kibanas:               NewDynamicEnqueueRequest(),
@@ -18,6 +19,7 @@ func NewDynamicWatches() DynamicWatches {
 // give each of them an identity.
 type DynamicWatches struct {
 	Secrets               *DynamicEnqueueRequest
+	Services              *DynamicEnqueueRequest
 	Pods                  *DynamicEnqueueRequest
 	ElasticsearchClusters *DynamicEnqueueRequest
 	Kibanas               *DynamicEnqueueRequest


### PR DESCRIPTION
Fixes #3732 

1000 lines of YAML say more than 100 words: 

```yaml
apiVersion: elasticsearch.k8s.elastic.co/v1
kind: Elasticsearch
metadata:
  annotations:
  name: test-coord
  namespace: default
spec:
  nodeSets:
  - config:
      node.roles: []
      node.store.allow_mmap: false
    count: 2
    name: coord
    podTemplate:
      metadata:
        labels:
          app: coord-node
  - config:
      node.store.allow_mmap: false
    count: 2
    name: default
  version: 7.12.0
---
apiVersion: kibana.k8s.elastic.co/v1
kind: Kibana
metadata:
  name: kibana-sample
spec:
  version: 7.12.0
  count: 1
  elasticsearchRef:
    name: "test-coord"
    serviceName: "es-coord"
--- 
apiVersion: v1
kind: Service
metadata:
  name: es-coord
  namespace: default
spec:
  ports:
  - name: https
    port: 80
    protocol: TCP
    targetPort: 9200
  selector:
    app: coord-node
```

Add a new `serviceName` attribute to all associations (even though it makes only sense for Elasticsearch but the tradeoff here is additional complexity in the code). Query for the referenced service, extract the configured port which matches the currently configured protocol of the managed resource (e.g. Elasticsearch running with HTTPS) and use it to construct a service URL which will be configured in the associated resource.

* users need to create a service either ahead of time or once the Elastic stack resource have been deployed.
* users need to follow the port naming convention we use in ECK i.e. `https` or `http` (which is compatible with [Istio's port naming convention](https://istio.io/latest/docs/reference/config/analysis/ist0118/) btw)