### PR TITLE
Correct Kibana settings in the Stack Monitoring recipe

### DIFF
--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -241,7 +241,7 @@ spec:
     name: elasticsearch
   config:
     # https://www.elastic.co/guide/en/kibana/current/monitoring-metricbeat.html
-    xpack.monitoring.kibana.collection.enabled: false
+    monitoring.kibana.collection.enabled: false
   podTemplate:
     metadata:
       labels:
@@ -271,5 +271,5 @@ spec:
   config:
     # enable the UI to reflect container level CPU usage, only displays info if CPU limits are set on the monitored ES cluster
     # https://www.elastic.co/guide/en/kibana/current/monitoring-settings-kb.html
-    xpack.monitoring.ui.container.elasticsearch.enabled: true
+    monitoring.ui.container.elasticsearch.enabled: true
 ...

--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -242,7 +242,6 @@ spec:
   config:
     # https://www.elastic.co/guide/en/kibana/current/monitoring-metricbeat.html
     xpack.monitoring.kibana.collection.enabled: false
-    xpack.monitoring.collection.enabled: true
   podTemplate:
     metadata:
       labels:


### PR DESCRIPTION
`xpack.monitoring.collection.enabled: true` is an ES setting and not kibana.
I haven't verified the rest of the recipe examples.

The only needed setting at Kibana level to enable `metricbeat based monitoring` in Kibana is `monitoring.kibana.collection.enabled: false`. The other setting should be set at ES level (although it's true by default).

I'm also fixing the right Kibana setting as the name doesn't have `xpack` prefix anymore.