### PR TITLE
Align cluster names with k8s version in GKE tests

### DIFF
--- a/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, '1.17', "eck-gke15-${BUILD_NUMBER}-e2e")
+                            runWith(lib, failedTests, '1.17', "eck-gke17-${BUILD_NUMBER}-e2e")
                         }
                     }
                 }
@@ -53,7 +53,7 @@ pipeline {
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, '1.18', "eck-gke16-${BUILD_NUMBER}-e2e")
+                            runWith(lib, failedTests, '1.18', "eck-gke18-${BUILD_NUMBER}-e2e")
                         }
                     }
                 }
@@ -81,7 +81,7 @@ pipeline {
         }
         cleanup {
             script {
-                clusters = ["eck-gke15-${BUILD_NUMBER}-e2e", "eck-gke16-${BUILD_NUMBER}-e2e"]
+                clusters = ["eck-gke17-${BUILD_NUMBER}-e2e", "eck-gke18-${BUILD_NUMBER}-e2e"]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
                         parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: clusters[i])],


### PR DESCRIPTION
Follow up to https://github.com/elastic/cloud-on-k8s/pull/4407. Thanks to @thbkrkr for noticing.
