### PR TITLE
Deployer: fix diskSetup in plans.yml for GKE/EKS/AKS

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -7,13 +7,13 @@ plans:
   machineType: n1-standard-8
   serviceAccount: true
   psp: true
+  # use kustomize in GKE to remove the NVMe provisioning already taken care of by the platform
+  diskSetup: kubectl apply -k hack/deployer/config/local-disks
   gke:
     region: europe-west2
     adminUsername: admin
     localSsdCount: 1
     nodeCountPerZone: 1
-    # use kustomize in GKE to remove the NVMe provisioning already taken care of by the platform
-    diskSetup: kubectl apply -k hack/deployer/config/local-disks
     gcpScopes: https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append
 - id: gke-dev
   operation: create
@@ -51,10 +51,10 @@ plans:
   machineType: Standard_D8s_v3
   serviceAccount: true
   psp: false
+  diskSetup: kubectl apply -k hack/deployer/config/local-disks
   aks:
     nodeCount: 3
     location: westeurope
-    diskSetup: kubectl apply -k hack/deployer/config/local-disks
 - id: aks-dev
   operation: create
   clusterName: dev
@@ -109,11 +109,11 @@ plans:
   machineType: c5d.2xlarge
   serviceAccount: false
   kubernetesVersion: 1.17
+  diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
   eks:
     region: eu-central-1
     nodeCount: 3
     nodeAMI: auto
-    diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
 - id: eks-arm-ci
   operation: create
   clusterName: arm-ci
@@ -121,11 +121,11 @@ plans:
   machineType: m6gd.2xlarge
   serviceAccount: false
   kubernetesVersion: 1.18
+  diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
   eks:
     region: eu-west-1
     nodeCount: 3
     nodeAMI: auto
-    diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
 - id: eks-dev
   operation: create
   clusterName: dev

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -61,7 +61,6 @@ type AksSettings struct {
 	ResourceGroup string `yaml:"resourceGroup"`
 	Location      string `yaml:"location"`
 	NodeCount     int    `yaml:"nodeCount"`
-	DiskSetup     string `yaml:"diskSetup"`
 }
 
 // OcpSettings encapsulates settings specific to OCP on GCloud
@@ -89,7 +88,6 @@ type EKSSettings struct {
 	NodeCount int    `yaml:"nodeCount"`
 	Region    string `yaml:"region"`
 	WorkDir   string `yaml:"workDir"`
-	DiskSetup string `yaml:"diskSetup"`
 }
 
 // RunConfig encapsulates Id used to choose a plan and a map of overrides to apply to the plan, expected to map to a file


### PR DESCRIPTION
IIUC since [#3768](https://github.com/elastic/cloud-on-k8s/pull/3768/files#diff-18aecebc864709ce6c3a0569ff7eda975fffb7871a66a72c047ee404f7f0651bR33) `diskSetup` is a plan setting, not related to the K8S cluster providers.

This PR moves `diskSetup` settings from the provider sections to their respective plan sections, I think it also means that SSD disks were not used anymore.