### PR TITLE
E2E: Update local volume provisioner image to v2.4.0

### DIFF
--- a/hack/deployer/config/local-disks/ssd-provisioner.yaml
+++ b/hack/deployer/config/local-disks/ssd-provisioner.yaml
@@ -130,7 +130,7 @@ spec:
             name: e2e-default
             mountPropagation: Bidirectional
       containers:
-        - image: "quay.io/external_storage/local-volume-provisioner:v2.3.4"
+        - image: "k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0"
           imagePullPolicy: "Always"
           name: provisioner
           securityContext:


### PR DESCRIPTION
This PR upgrades the `sig-storage/local-volume-provisioner` image used in our e2e environments to version `2.4.0`.
It also changes the repository to `k8s.gcr.io` which provides an ARM version of the image and hence should fix #4419

Tested on ARM64 `m6gd.xlarge` instances.