### PR TITLE
Make OCP deployer CI compatible

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -72,8 +72,8 @@ ci-build-image: write-ci-docker-creds
 
 # make Docker creds available from inside the CI container through the .registry.env file
 write-ci-docker-creds:
-	@ echo "DOCKER_LOGIN = $(DOCKER_LOGIN)"        > ${ROOT_DIR}/.registry.env
-	@ echo "DOCKER_PASSWORD = $(DOCKER_PASSWORD)" >> ${ROOT_DIR}/.registry.env
+	@ echo "DOCKER_LOGIN=$(DOCKER_LOGIN)"        > ${ROOT_DIR}/.registry.env
+	@ echo "DOCKER_PASSWORD=$(DOCKER_PASSWORD)" >> ${ROOT_DIR}/.registry.env
 
 ##  Test
 

--- a/.ci/jobs/e2e-tests-ocp.yaml
+++ b/.ci/jobs/e2e-tests-ocp.yaml
@@ -11,6 +11,9 @@
       - string:
           name: JKS_PARAM_OPERATOR_IMAGE
           description: "ECK Docker image"
+      - string:
+          name: OCP_VERSION
+          description: "OCP version to test. If left empty will be defaulted to one of the supported versions"
       - bool:
           name: SEND_NOTIFICATIONS
           default: true

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -225,6 +225,7 @@ write_deployer_config <<CFG
 id: ocp-ci
 overrides:
   clusterName: $BUILD_TAG
+  clientVersion: $2
   vaultInfo:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
@@ -551,6 +552,7 @@ id: ocp-ci
 overrides:
   operation: delete
   clusterName: $BUILD_TAG
+  clientVersion: $2
   vaultInfo:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID

--- a/hack/deployer/runner/client.go
+++ b/hack/deployer/runner/client.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"time"
@@ -78,6 +79,7 @@ func dockerLogin() error {
 	registryEnv := ".registry.env"
 	if _, err := os.Stat(registryEnv); os.IsNotExist(err) {
 		// not attempting login when registry env file does not exist (typically outside of CI)
+		log.Printf("Not attempting Docker login as .registry.env is not present in the filesystem.")
 		return nil
 	}
 	return NewCommand(`docker login -u "$DOCKER_LOGIN" -p "$DOCKER_PASSWORD" docker.elastic.co 2> /dev/null`).

--- a/hack/deployer/runner/command.go
+++ b/hack/deployer/runner/command.go
@@ -19,14 +19,14 @@ import (
 
 // Command allows building commands to execute using fluent-style api
 type Command struct {
-	command     string
-	context     context.Context
-	logPrefix   string
-	params      map[string]interface{}
-	variableSrc string
-	variables   []string
-	stream      bool
-	stderr      bool
+	command      string
+	context      context.Context
+	logPrefix    string
+	params       map[string]interface{}
+	variablesSrc string
+	variables    []string
+	stream       bool
+	stderr       bool
 }
 
 func NewCommand(command string) *Command {
@@ -44,7 +44,7 @@ func (c *Command) WithVariable(name, value string) *Command {
 }
 
 func (c *Command) WithVariablesFromFile(filename string) *Command {
-	c.variableSrc = filename
+	c.variablesSrc = filename
 	return c
 }
 
@@ -142,8 +142,8 @@ func (c *Command) output() (string, error) {
 	}
 
 	// support .env or similar files to specify environment variables
-	if c.variableSrc != "" {
-		bytes, err := os.ReadFile(c.variableSrc)
+	if c.variablesSrc != "" {
+		bytes, err := os.ReadFile(c.variablesSrc)
 		if err != nil {
 			return "", err
 		}

--- a/hack/deployer/runner/command.go
+++ b/hack/deployer/runner/command.go
@@ -148,9 +148,7 @@ func (c *Command) output() (string, error) {
 			return "", err
 		}
 		// assume k=v pair lines
-		for _, varLine := range strings.Split(string(bytes), "\n") {
-			c.variables = append(c.variables, varLine)
-		}
+		c.variables = append(c.variables, strings.Split(string(bytes), "\n")...)
 	}
 
 	cmd.Env = append(os.Environ(), c.variables...)

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -11,7 +11,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// SharedVolumeName name shared by CI container and Docker containers launched by deployer
+// SharedVolumeName name shared by CI container and Docker containers launched by deployer. This is the name of the volume
+// valid outside of the CI Docker container, necessary to create other containers referencing the same volume.
+// In local dev mode it is just the home dir as we are typically not running inside a container in the case.
 func SharedVolumeName() string {
 	if vol := os.Getenv("SHARED_VOLUME_NAME"); vol != "" {
 		return vol


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/4420
Fixes https://github.com/elastic/cloud-on-k8s/issues/4319

The first iteration of this revised OCP driver was not really CI compatible: 
* We cannot use `eck-dev` images in CI => change to `eck-ci`
* We need to login into to docker because we cannot rely on a Docker login happening outside of the deployer invocation
* We need to use a shared volume between CI container and client container, which we don't need in local mode because the Make process is not running in a container as well. 
* We need to specify the  OCP version in the Jenkins job we want to test. To conserve resources if the version is not specified it just picks one of the supported versions which are tested round robin during the course of a week

I have tested this on a local Jenkins instance. But I have not yet tested the flow where this job is called from an upstream job as a dependent job. 

