### PR TITLE
[Helm]: Add podLabels and Expose Metrics ports

### DIFF
--- a/deploy/eck-operator/templates/podMonitor.yaml
+++ b/deploy/eck-operator/templates/podMonitor.yaml
@@ -1,0 +1,36 @@
+{{- $metricsPort := int .Values.config.metricsPort -}}
+{{- if and .Values.podMonitor.enabled (gt $metricsPort 0) }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "eck-operator.fullname" . }}
+  namespace: {{ ternary .Values.podMonitor.namespace .Release.Namespace (not (empty .Values.podMonitor.namespace)) }}
+  labels: {{- include "eck-operator.labels" . | nindent 4 }}
+  {{- if .Values.podMonitor.labels }}
+    {{- toYaml .Values.podMonitor.labels | nindent 4 }}
+  {{- end }}
+  {{- with .Values.podMonitor.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.podMonitor.podTargetLabels }}
+  podTargetLabels: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      {{- if .Values.podMonitor.interval }}
+      interval: {{ .Values.podMonitor.interval }}
+      {{- end }}
+      {{- if .Values.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.podMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.podMonitor.podMetricsEndpointConfig }}
+        {{- toYaml .Values.podMonitor.podMetricsEndpointConfig | nindent 6 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels: {{- include "eck-operator.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/eck-operator/templates/statefulset.yaml
+++ b/deploy/eck-operator/templates/statefulset.yaml
@@ -24,6 +24,9 @@ spec:
         {{- end }}
       labels:
         {{- include "eck-operator.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
       serviceAccountName: {{ include "eck-operator.serviceAccountName" . }}
@@ -73,11 +76,18 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.webhook.enabled }}
+          {{- if or (ne .Values.config.metricsPort "0") .Values.webhook.enabled }}
           ports:
+            {{- if (ne .Values.config.metricsPort "0") }}
+            - containerPort: {{ .Values.config.metricsPort }}
+              name: metrics
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.webhook.enabled }}
             - containerPort: 9443
               name: https-webhook
               protocol: TCP
+            {{- end }}  
           {{- end }}
           volumeMounts:
             - mountPath: "/conf"

--- a/deploy/eck-operator/templates/statefulset.yaml
+++ b/deploy/eck-operator/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- $metricsPort := int .Values.config.metricsPort -}}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -76,9 +77,9 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or (ne .Values.config.metricsPort "0") .Values.webhook.enabled }}
+          {{- if or (gt $metricsPort 0) .Values.webhook.enabled }}
           ports:
-            {{- if (ne .Values.config.metricsPort "0") }}
+            {{- if (gt $metricsPort 0) }}
             - containerPort: {{ .Values.config.metricsPort }}
               name: metrics
               protocol: TCP

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -168,6 +168,37 @@ config:
   # Can be disabled if cluster-wide storage class RBAC access is not available.
   validateStorageClass: true
 
+# Prometheus PodMonitor configuration
+# Reference: https://docs.openshift.com/container-platform/4.5/rest_api/monitoring_apis/podmonitor-monitoring-coreos-com-v1.html
+podMonitor:
+
+  # enabled determines whether a podMonitor should deployed to scrape the eck metrics.
+  # This requires the prometheus operator and the config.metricsPort not to be 0
+  enabled: false
+
+  # labels adds additional labels to the podMonitor
+  labels: {}
+
+  # annotations adds additional annotations to the podMonitor
+  annotations: {}
+
+  # namespace determines in which namespace the podMonitor will be deployed.
+  # If not set the podMonitor will be created in the namespace to release is installed into
+  # namespace: monitoring
+
+  # interval specifies the interval at which metrics should be scraped
+  interval: 5m
+
+  # scrapeTimeout specifies the timeout after which the scrape is ended
+  scrapeTimeout: 30s
+
+  # podTargetLabels transfers labels on the Kubernetes Pod onto the target.
+  podTargetLabels: []
+
+  # podMetricsEndpointConfig allows to add an extended configuration to the podMonitor
+  podMetricsEndpointConfig: {}
+  # honorTimestamps: true
+
 # Internal use only
 internal:
   # manifestGen specifies whether the chart is running under manifest generator. 

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -40,6 +40,9 @@ resources:
 # podAnnotations define the annotations that should be added to the operator pod.
 podAnnotations: {}
 
+## podLabels define additional labels that should be added to the operator pod.
+podLabels: {}
+
 # podSecurityContext defines the pod security context for the operator pod.
 podSecurityContext:
   runAsNonRoot: true

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -169,7 +169,7 @@ config:
   validateStorageClass: true
 
 # Prometheus PodMonitor configuration
-# Reference: https://docs.openshift.com/container-platform/4.5/rest_api/monitoring_apis/podmonitor-monitoring-coreos-com-v1.html
+# Reference: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#podmonitor
 podMonitor:
 
   # enabled determines whether a podMonitor should deployed to scrape the eck metrics.


### PR DESCRIPTION
Signed-off-by: Oliver Bähler <oliver.baehler@bedag.ch>

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

This Pull Request adds two new features:

  1. If the `config.metricsPort` value is not `0` a port on the container is exposed with that value. Currently this port is not exposed which makes it impossible for a prometheus monitor to scrape them. 
  2. `podLabels` adds the option to label the operator pod with additional labels. We currently have the use case that we need to add some labels to the pod and that option currently does not exist.

I was also wondering if it would be interesting to have a prometheus serviceMonitor built-in to the chart? So that endusers could just flick some options and have their metrics scraped by prometheus. Let me know if that's something you see would add value to the chart and I will be willing to commit the code to this pull request :).

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/master/CONTRIBUTING.md)?
- If you submit code, is your pull request against master? We recommend pull requests against master. We will backport them as needed.
