### PR TITLE
Bump AKS version to 1.20.5

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -47,7 +47,7 @@ plans:
   operation: create
   clusterName: ci
   provider: aks
-  kubernetesVersion: 1.19.6
+  kubernetesVersion: 1.20.5
   machineType: Standard_D8s_v3
   serviceAccount: true
   psp: false
@@ -59,7 +59,7 @@ plans:
   operation: create
   clusterName: dev
   provider: aks
-  kubernetesVersion: 1.19.6
+  kubernetesVersion: 1.20.5
   machineType: Standard_D8s_v3
   serviceAccount: false
   psp: false


### PR DESCRIPTION
1.19.6 is no longer available. 1.20.5 is the latest version on AKS.
