### PR TITLE
[1.4] Remove incorrect statement about specifying coordinating roles in YAML (#4434)

### DIFF
--- a/docs/advanced-topics/traffic-splitting.asciidoc
+++ b/docs/advanced-topics/traffic-splitting.asciidoc
@@ -42,7 +42,7 @@ spec:
   - name: coordinator
     count: 3
     config:
-      node.roles: !!seq ""
+      node.roles: []
   # Dedicated machine learning nodes
   - name: ml
     count: 3

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/node-configuration.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/node-configuration.asciidoc
@@ -36,20 +36,3 @@ spec:
 ----
 
 For more information on Elasticsearch settings, see https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html[Configuring Elasticsearch].
-
-[NOTE]
-====
-
-Marking a node as link:https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html#coordinating-only-node[coordinating-only] in ECK requires a YAML type tag due to an issue in a supporting library.
-
-[source,yaml]
-----
-spec:
-  nodeSets:
-  - name: coordinator
-    count: 3
-    config:
-      node.roles: !!seq ""
-----
-
-====


### PR DESCRIPTION
Backports the following commits to 1.4:
 - Remove incorrect statement about specifying coordinating roles in YAML (#4434)