### PR TITLE
Add Elastic Maps Server controller

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -26,6 +26,7 @@ import (
 	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
 	kbv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1beta1"
+	emsv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/maps/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/agent"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/apmserver"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
@@ -47,6 +48,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/license"
 	licensetrial "github.com/elastic/cloud-on-k8s/pkg/controller/license/trial"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/maps"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/remoteca"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/webhook"
 	"github.com/elastic/cloud-on-k8s/pkg/dev"
@@ -652,6 +654,7 @@ func registerControllers(mgr manager.Manager, params operator.Parameters, access
 		{name: "License", registerFunc: license.Add},
 		{name: "LicenseTrial", registerFunc: licensetrial.Add},
 		{name: "Agent", registerFunc: agent.Add},
+		{name: "Maps", registerFunc: maps.Add},
 	}
 
 	for _, c := range controllers {
@@ -673,6 +676,7 @@ func registerControllers(mgr manager.Manager, params operator.Parameters, access
 		{name: "BEAT-ES", registerFunc: associationctl.AddBeatES},
 		{name: "BEAT-KB", registerFunc: associationctl.AddBeatKibana},
 		{name: "AGENT-ES", registerFunc: associationctl.AddAgentES},
+		{name: "EMS-ES", registerFunc: associationctl.AddMapsES},
 	}
 
 	for _, c := range assocControllers {
@@ -708,6 +712,7 @@ func garbageCollectUsers(cfg *rest.Config, managedNamespaces []string) {
 		For(&entv1.EnterpriseSearchList{}, associationctl.EntESAssociationLabelNamespace, associationctl.EntESAssociationLabelName).
 		For(&beatv1beta1.BeatList{}, associationctl.BeatAssociationLabelNamespace, associationctl.BeatAssociationLabelName).
 		For(&agentv1alpha1.AgentList{}, associationctl.AgentAssociationLabelNamespace, associationctl.AgentAssociationLabelName).
+		For(&emsv1alpha1.ElasticMapsServerList{}, associationctl.MapsESAssociationLabelNamespace, associationctl.MapsESAssociationLabelName).
 		DoGarbageCollection()
 	if err != nil {
 		log.Error(err, "user garbage collector failed")
@@ -723,6 +728,7 @@ func garbageCollectSoftOwnedSecrets(k8sClient k8s.Client) {
 		entv1.Kind:         &entv1.EnterpriseSearch{},
 		beatv1beta1.Kind:   &beatv1beta1.Beat{},
 		agentv1alpha1.Kind: &agentv1alpha1.Agent{},
+		emsv1alpha1.Kind:   &emsv1alpha1.ElasticMapsServer{},
 	}); err != nil {
 		log.Error(err, "Orphan secrets garbage collection failed, will be attempted again at next operator restart.")
 		return
@@ -768,6 +774,7 @@ func setupWebhook(mgr manager.Manager, certRotation certificates.RotationParams,
 		&esv1beta1.Elasticsearch{},
 		&kbv1.Kibana{},
 		&kbv1beta1.Kibana{},
+		&emsv1alpha1.ElasticMapsServer{},
 	}
 	for _, obj := range webhookObjects {
 		if err := obj.SetupWebhookWithManager(mgr); err != nil {

--- a/deploy/eck-operator/templates/_helpers.tpl
+++ b/deploy/eck-operator/templates/_helpers.tpl
@@ -303,6 +303,20 @@ RBAC permissions
   - update
   - patch
   - delete
+- apiGroups:
+  - maps.k8s.elastic.co
+  resources:
+  - elasticmapsservers
+  - elasticmapsservers/status
+  - elasticmapsservers/finalizers # needed for ownerReferences with blockOwnerDeletion on OCP
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 {{- end -}}
 
 {{/*

--- a/deploy/eck-operator/templates/cluster-roles.yaml
+++ b/deploy/eck-operator/templates/cluster-roles.yaml
@@ -38,6 +38,9 @@ rules:
   - apiGroups: ["agent.k8s.elastic.co"]
     resources: ["agents"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["maps.k8s.elastic.co"]
+    resources: ["elasticmapsservers"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -65,5 +68,8 @@ rules:
     verbs: ["create", "delete", "deletecollection", "patch", "update"]
   - apiGroups: ["agent.k8s.elastic.co"]
     resources: ["agents"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+  - apiGroups: ["maps.k8s.elastic.co"]
+    resources: ["elasticmapsservers"]
     verbs: ["create", "delete", "deletecollection", "patch", "update"]
 {{- end -}}

--- a/pkg/apis/maps/v1alpha1/webhook_test.go
+++ b/pkg/apis/maps/v1alpha1/webhook_test.go
@@ -2,13 +2,14 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package v1alpha1
+package v1alpha1_test
 
 import (
 	"encoding/json"
 	"strings"
 	"testing"
 
+	emsv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/maps/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/test"
 	"github.com/stretchr/testify/require"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
@@ -98,24 +99,24 @@ func TestWebhook(t *testing.T) {
 		},
 	}
 
-	validator := &ElasticMapsServer{}
-	gvk := metav1.GroupVersionKind{Group: GroupVersion.Group, Version: GroupVersion.Version, Kind: Kind}
+	validator := &emsv1alpha1.ElasticMapsServer{}
+	gvk := metav1.GroupVersionKind{Group: emsv1alpha1.GroupVersion.Group, Version: emsv1alpha1.GroupVersion.Version, Kind: emsv1alpha1.Kind}
 	test.RunValidationWebhookTests(t, gvk, validator, testCases...)
 }
 
-func mkMaps(uid string) *ElasticMapsServer {
-	return &ElasticMapsServer{
+func mkMaps(uid string) *emsv1alpha1.ElasticMapsServer {
+	return &emsv1alpha1.ElasticMapsServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "webhook-test",
 			UID:  types.UID(uid),
 		},
-		Spec: MapsSpec{
+		Spec: emsv1alpha1.MapsSpec{
 			Version: "7.12.0",
 		},
 	}
 }
 
-func serialize(t *testing.T, k *ElasticMapsServer) []byte {
+func serialize(t *testing.T, k *emsv1alpha1.ElasticMapsServer) []byte {
 	t.Helper()
 
 	objBytes, err := json.Marshal(k)

--- a/pkg/controller/association/controller/maps_es.go
+++ b/pkg/controller/association/controller/maps_es.go
@@ -1,0 +1,60 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package controller
+
+import (
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	emsv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/maps/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
+	eslabel "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/user"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/rbac"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+const (
+	// MapsESAssociationLabelName marks resources created by this controller for easier retrieval.
+	MapsESAssociationLabelName = "mapsassociation.k8s.elastic.co/name"
+	// MapsESAssociationLabelNamespace marks resources created by this controller for easier retrieval.
+	MapsESAssociationLabelNamespace = "mapsassociation.k8s.elastic.co/namespace"
+	// MapsESAssociationLabelType marks the type of association
+	MapsESAssociationLabelType = "mapsassociation.k8s.elastic.co/type"
+
+	// MapsSystemUserBuiltinRole is the name of the built-in role for the Maps system user.
+	MapsSystemUserBuiltinRole = user.ProbeUserRole
+)
+
+func AddMapsES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params operator.Parameters) error {
+	return association.AddAssociationController(mgr, accessReviewer, params, association.AssociationInfo{
+		AssociatedObjTemplate: func() commonv1.Associated { return &emsv1alpha1.ElasticMapsServer{} },
+		ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.ObjectSelector, error) {
+			return true, association.AssociationRef(), nil
+		},
+		ReferencedResourceVersion: referencedElasticsearchStatusVersion,
+		ExternalServiceURL:        getElasticsearchExternalURL,
+		AssociationType:           commonv1.ElasticsearchAssociationType,
+		AssociatedNamer:           esv1.ESNamer,
+		AssociationName:           "ems-es",
+		AssociatedShortName:       "ems",
+		Labels: func(associated types.NamespacedName) map[string]string {
+			return map[string]string{
+				MapsESAssociationLabelName:      associated.Name,
+				MapsESAssociationLabelNamespace: associated.Namespace,
+				MapsESAssociationLabelType:      commonv1.ElasticsearchAssociationType,
+			}
+		},
+		AssociationConfAnnotationNameBase: commonv1.ElasticsearchConfigAnnotationNameBase,
+		UserSecretSuffix:                  "maps-user",
+		ESUserRole: func(associated commonv1.Associated) (string, error) {
+			return MapsSystemUserBuiltinRole, nil
+		},
+		AssociationResourceNameLabelName:      eslabel.ClusterNameLabelName,
+		AssociationResourceNamespaceLabelName: eslabel.ClusterNamespaceLabelName,
+	})
+}

--- a/pkg/controller/common/container/container.go
+++ b/pkg/controller/common/container/container.go
@@ -6,6 +6,7 @@ package container
 
 import (
 	"fmt"
+	"strings"
 )
 
 const DefaultContainerRegistry = "docker.elastic.co"
@@ -38,9 +39,14 @@ const (
 	JournalbeatImage      Image = "beats/journalbeat"
 	PacketbeatImage       Image = "beats/packetbeat"
 	AgentImage            Image = "beats/elastic-agent"
+	MapsImage             Image = "elastic-maps-service/elastic-maps-server-ubi8"
 )
 
 // ImageRepository returns the full container image name by concatenating the current container registry and the image path with the given version.
 func ImageRepository(img Image, version string) string {
+	// don't double append suffix if already contained as e.g. the case for maps
+	if strings.HasSuffix(string(img), containerSuffix) {
+		return fmt.Sprintf("%s/%s:%s", containerRegistry, img, version)
+	}
 	return fmt.Sprintf("%s/%s%s:%s", containerRegistry, img, containerSuffix, version)
 }

--- a/pkg/controller/common/container/container_test.go
+++ b/pkg/controller/common/container/container_test.go
@@ -15,6 +15,7 @@ func TestImageRepository(t *testing.T) {
 	testCases := []struct {
 		name    string
 		image   Image
+		suffix  string
 		version string
 		want    string
 	}{
@@ -36,17 +37,33 @@ func TestImageRepository(t *testing.T) {
 			version: "7.5.2",
 			want:    testRegistry + "/kibana/kibana:7.5.2",
 		},
+		{
+			name:    "Maps image",
+			image:   MapsImage,
+			version: "7.12.0",
+			want:    testRegistry + "/elastic-maps-service/elastic-maps-server-ubi8:7.12.0",
+		},
+		{
+			name:    "Maps image with custom suffix",
+			image:   MapsImage,
+			version: "7.12.0",
+			suffix:  "-ubi8",
+			want:    testRegistry + "/elastic-maps-service/elastic-maps-server-ubi8:7.12.0",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// save and restore the current registry setting in case it has been modified
 			currentRegistry := containerRegistry
+			currentSuffix := containerSuffix
 			defer func() {
 				SetContainerRegistry(currentRegistry)
+				SetContainerSuffix(currentSuffix)
 			}()
 
 			SetContainerRegistry(testRegistry)
+			SetContainerSuffix(tc.suffix)
 			have := ImageRepository(tc.image, tc.version)
 			assert.Equal(t, tc.want, have)
 		})

--- a/pkg/controller/common/license/check.go
+++ b/pkg/controller/common/license/check.go
@@ -115,18 +115,20 @@ func (lc *checker) Valid(l EnterpriseLicense) (bool, error) {
 	return false, nil
 }
 
-type MockChecker struct{}
+type MockChecker struct {
+	MissingLicense bool
+}
 
-func (MockChecker) CurrentEnterpriseLicense() (*EnterpriseLicense, error) {
+func (m MockChecker) CurrentEnterpriseLicense() (*EnterpriseLicense, error) {
 	return &EnterpriseLicense{}, nil
 }
 
-func (MockChecker) EnterpriseFeaturesEnabled() (bool, error) {
-	return true, nil
+func (m MockChecker) EnterpriseFeaturesEnabled() (bool, error) {
+	return !m.MissingLicense, nil
 }
 
-func (MockChecker) Valid(l EnterpriseLicense) (bool, error) {
-	return true, nil
+func (m MockChecker) Valid(l EnterpriseLicense) (bool, error) {
+	return !m.MissingLicense, nil
 }
 
-var _ Checker = MockChecker{}
+var _ Checker = &MockChecker{}

--- a/pkg/controller/common/reconciler/secret.go
+++ b/pkg/controller/common/reconciler/secret.go
@@ -18,7 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Labels set on secrets which cannot rely on owner references due to https://github.com/kubernetes/kubernetes/issues/65200,
+// labels set on secrets which cannot rely on owner references due to https://github.com/kubernetes/kubernetes/issues/65200,
 // but should still be garbage-collected (best-effort) by the operator upon owner deletion.
 const (
 	SoftOwnerNamespaceLabel = "eck.k8s.elastic.co/owner-namespace"

--- a/pkg/controller/common/scheme/scheme.go
+++ b/pkg/controller/common/scheme/scheme.go
@@ -19,90 +19,54 @@ import (
 	entv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1beta1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
 	kbv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1beta1"
+	emsv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/maps/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 var addToScheme sync.Once
 var addToSchemeV1beta1 sync.Once
 
+func mustAddSchemeOnce(once *sync.Once, schemes []func(scheme *runtime.Scheme) error) {
+	once.Do(func() {
+		for _, s := range schemes {
+			if err := s(clientgoscheme.Scheme); err != nil {
+				panic(err)
+			}
+		}
+	})
+}
+
 // SetupScheme sets up a scheme with all of the relevant types. This is only needed once for the manager but is often used for tests
 // Afterwards you can use clientgoscheme.Scheme
 func SetupScheme() {
-	addToScheme.Do(func() {
-		err := clientgoscheme.AddToScheme(clientgoscheme.Scheme)
-		if err != nil {
-			// this should never happen
-			panic(err)
-		}
-
-		err = apmv1.AddToScheme(clientgoscheme.Scheme)
-		if err != nil {
-			panic(err)
-		}
-		err = commonv1.AddToScheme(clientgoscheme.Scheme)
-		if err != nil {
-			panic(err)
-		}
-		err = esv1.AddToScheme(clientgoscheme.Scheme)
-		if err != nil {
-			panic(err)
-		}
-		err = kbv1.AddToScheme(clientgoscheme.Scheme)
-		if err != nil {
-			panic(err)
-		}
-		err = entv1.AddToScheme(clientgoscheme.Scheme)
-		if err != nil {
-			panic(err)
-		}
-		err = beatv1beta1.AddToScheme(clientgoscheme.Scheme)
-		if err != nil {
-			panic(err)
-		}
-		err = agentv1alpha1.AddToScheme(clientgoscheme.Scheme)
-		if err != nil {
-			panic(err)
-		}
-	})
+	schemes := []func(scheme *runtime.Scheme) error{
+		clientgoscheme.AddToScheme,
+		apmv1.AddToScheme,
+		commonv1.AddToScheme,
+		esv1.AddToScheme,
+		kbv1.AddToScheme,
+		entv1.AddToScheme,
+		beatv1beta1.AddToScheme,
+		agentv1alpha1.AddToScheme,
+		emsv1alpha1.AddToScheme,
+	}
+	mustAddSchemeOnce(&addToScheme, schemes)
 }
 
 // SetupV1beta1Scheme sets up a scheme with v1beta1 resources.
 // Should only be used for the v1beta1 admission webhook.
 // The operator should otherwise deal with a single resource version.
 func SetupV1beta1Scheme() {
-	addToSchemeV1beta1.Do(func() {
-		err := clientgoscheme.AddToScheme(clientgoscheme.Scheme)
-		if err != nil {
-			// this should never happen
-			panic(err)
-		}
-		err = apmv1beta1.AddToScheme(clientgoscheme.Scheme)
-		if err != nil {
-			panic(err)
-		}
-		err = commonv1beta1.AddToScheme(clientgoscheme.Scheme)
-		if err != nil {
-			panic(err)
-		}
-		err = esv1beta1.AddToScheme(clientgoscheme.Scheme)
-		if err != nil {
-			panic(err)
-		}
-		err = kbv1beta1.AddToScheme(clientgoscheme.Scheme)
-		if err != nil {
-			panic(err)
-		}
-		err = entv1beta1.AddToScheme(clientgoscheme.Scheme)
-		if err != nil {
-			panic(err)
-		}
-		err = beatv1beta1.AddToScheme(clientgoscheme.Scheme)
-		if err != nil {
-			panic(err)
-		}
-		err = agentv1alpha1.AddToScheme(clientgoscheme.Scheme)
-		if err != nil {
-			panic(err)
-		}
-	})
+	schemes := []func(scheme *runtime.Scheme) error{
+		clientgoscheme.AddToScheme,
+		apmv1beta1.AddToScheme,
+		commonv1beta1.AddToScheme,
+		esv1beta1.AddToScheme,
+		kbv1beta1.AddToScheme,
+		entv1beta1.AddToScheme,
+		beatv1beta1.AddToScheme,
+		agentv1alpha1.AddToScheme,
+	}
+	mustAddSchemeOnce(&addToSchemeV1beta1, schemes)
 }

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile.go
@@ -176,7 +176,7 @@ func reconcileNodeSetTransportCertificatesSecrets(
 	return nil
 }
 
-// ensureTransportCertificatesSecretExists ensures the existence and Labels of the Secret that at a later point
+// ensureTransportCertificatesSecretExists ensures the existence and labels of the Secret that at a later point
 // in time will contain the transport certificates for a nodeSet.
 func ensureTransportCertificatesSecretExists(
 	c k8s.Client,

--- a/pkg/controller/maps/config.go
+++ b/pkg/controller/maps/config.go
@@ -33,8 +33,6 @@ func configSecretVolume(ems emsv1alpha1.ElasticMapsServer) volume.SecretVolume {
 	return volume.NewSecretVolume(Config(ems.Name), "config", ConfigMountPath, ConfigFilename, 0444)
 }
 
-// Reconcile reconciles the configuration of Elastic Maps Server: it generates the right configuration and
-// stores it in a secret that is kept up to date.
 func reconcileConfig(driver driver.Interface, ems emsv1alpha1.ElasticMapsServer, ipFamily corev1.IPFamily) (corev1.Secret, error) {
 	cfg, err := newConfig(driver, ems, ipFamily)
 	if err != nil {

--- a/pkg/controller/maps/config.go
+++ b/pkg/controller/maps/config.go
@@ -1,0 +1,137 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package maps
+
+import (
+	"path"
+	"path/filepath"
+
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	emsv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/maps/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/driver"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/net"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	ESCertsPath     = "/mnt/elastic-internal/es-certs"
+	ConfigFilename  = "elastic-maps-server.yml"
+	ConfigMountPath = "/usr/src/app/server/config/elastic-maps-server.yml"
+)
+
+func configSecretVolume(ems emsv1alpha1.ElasticMapsServer) volume.SecretVolume {
+	return volume.NewSecretVolume(Config(ems.Name), "config", ConfigMountPath, ConfigFilename, 0444)
+}
+
+// Reconcile reconciles the configuration of Elastic Maps Server: it generates the right configuration and
+// stores it in a secret that is kept up to date.
+func reconcileConfig(driver driver.Interface, ems emsv1alpha1.ElasticMapsServer, ipFamily corev1.IPFamily) (corev1.Secret, error) {
+	cfg, err := newConfig(driver, ems, ipFamily)
+	if err != nil {
+		return corev1.Secret{}, err
+	}
+
+	cfgBytes, err := cfg.Render()
+	if err != nil {
+		return corev1.Secret{}, err
+	}
+
+	// Reconcile the configuration in a secret
+	expectedConfigSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ems.Namespace,
+			Name:      Config(ems.Name),
+			Labels:    common.AddCredentialsLabel(labels(ems.Name)),
+		},
+		Data: map[string][]byte{
+			ConfigFilename: cfgBytes,
+		},
+	}
+
+	return reconciler.ReconcileSecret(driver.K8sClient(), expectedConfigSecret, &ems)
+}
+
+func newConfig(d driver.Interface, ems emsv1alpha1.ElasticMapsServer, ipFamily corev1.IPFamily) (*settings.CanonicalConfig, error) {
+	cfg := settings.NewCanonicalConfig()
+
+	inlineUserCfg, err := inlineUserConfig(ems.Spec.Config)
+	if err != nil {
+		return cfg, err
+	}
+
+	refUserCfg, err := common.ParseConfigRef(d, &ems, ems.Spec.ConfigRef, ConfigFilename)
+	if err != nil {
+		return cfg, err
+	}
+
+	defaults := defaultConfig(ipFamily)
+	tls := tlsConfig(ems)
+	assocCfg, err := associationConfig(d.K8sClient(), ems)
+	if err != nil {
+		return cfg, err
+	}
+	err = cfg.MergeWith(inlineUserCfg, refUserCfg, defaults, tls, assocCfg)
+	return cfg, err
+}
+
+func inlineUserConfig(cfg *commonv1.Config) (*settings.CanonicalConfig, error) {
+	if cfg == nil {
+		cfg = &commonv1.Config{}
+	}
+	return settings.NewCanonicalConfigFrom(cfg.Data)
+}
+
+func defaultConfig(ipFamily corev1.IPFamily) *settings.CanonicalConfig {
+	return settings.MustCanonicalConfig(map[string]interface{}{
+		"host": net.InAddrAnyFor(ipFamily).String(),
+	})
+}
+
+func tlsConfig(ems emsv1alpha1.ElasticMapsServer) *settings.CanonicalConfig {
+	if !ems.Spec.HTTP.TLS.Enabled() {
+		return settings.NewCanonicalConfig()
+	}
+	return settings.MustCanonicalConfig(map[string]interface{}{
+		"ssl.enabled":     true,
+		"ssl.certificate": path.Join(certificates.HTTPCertificatesSecretVolumeMountPath, certificates.CertFileName),
+		"ssl.key":         path.Join(certificates.HTTPCertificatesSecretVolumeMountPath, certificates.KeyFileName),
+	})
+}
+
+func associationConfig(c k8s.Client, ems emsv1alpha1.ElasticMapsServer) (*settings.CanonicalConfig, error) {
+	cfg := settings.NewCanonicalConfig()
+	if !ems.AssociationConf().IsConfigured() {
+		return cfg, nil
+	}
+	username, password, err := association.ElasticsearchAuthSettings(c, &ems)
+	if err != nil {
+		return nil, err
+	}
+	if err := cfg.MergeWith(settings.MustCanonicalConfig(map[string]string{
+		"elasticsearch.host":     ems.AssociationConf().URL,
+		"elasticsearch.username": username,
+		"elasticsearch.password": password,
+	})); err != nil {
+		return nil, err
+	}
+
+	if ems.AssociationConf().CAIsConfigured() {
+		if err := cfg.MergeWith(settings.MustCanonicalConfig(map[string]interface{}{
+			"elasticsearch.ssl.verificationMode":       "certificate",
+			"elasticsearch.ssl.certificateAuthorities": filepath.Join(ESCertsPath, certificates.CertFileName),
+		})); err != nil {
+			return nil, err
+		}
+	}
+	return cfg, nil
+}

--- a/pkg/controller/maps/config_test.go
+++ b/pkg/controller/maps/config_test.go
@@ -1,0 +1,207 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package maps
+
+import (
+	"testing"
+
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/apis/maps/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+func Test_newConfig(t *testing.T) {
+	type args struct {
+		runtimeObjs []runtime.Object
+		ems         v1alpha1.ElasticMapsServer
+		ipFamily    corev1.IPFamily
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "no user config",
+			args: args{
+				runtimeObjs: nil,
+				ems:         v1alpha1.ElasticMapsServer{},
+				ipFamily:    corev1.IPv4Protocol,
+			},
+			want: `host: 0.0.0.0
+ssl:
+  certificate: /mnt/elastic-internal/http-certs/tls.crt
+  enabled: true
+  key: /mnt/elastic-internal/http-certs/tls.key
+`,
+			wantErr: false,
+		},
+		{
+			name: "inline user config",
+			args: args{
+				runtimeObjs: nil,
+				ems: v1alpha1.ElasticMapsServer{
+					Spec: v1alpha1.MapsSpec{Config: &commonv1.Config{Data: map[string]interface{}{
+						"ui": false,
+					}}},
+				},
+				ipFamily: corev1.IPv4Protocol,
+			},
+			want: `host: 0.0.0.0
+ssl:
+  certificate: /mnt/elastic-internal/http-certs/tls.crt
+  enabled: true
+  key: /mnt/elastic-internal/http-certs/tls.key
+ui: false
+`,
+			wantErr: false,
+		},
+		{
+			name: "with configRef",
+			args: args{
+				runtimeObjs: []runtime.Object{secretWithConfig("cfg", []byte("ui: false"))},
+				ems:         emsWithConfigRef("cfg", nil),
+				ipFamily:    corev1.IPv4Protocol,
+			},
+			want: `host: 0.0.0.0
+ssl:
+  certificate: /mnt/elastic-internal/http-certs/tls.crt
+  enabled: true
+  key: /mnt/elastic-internal/http-certs/tls.key
+ui: false
+`,
+			wantErr: false,
+		},
+		{
+			name: "configRef takes precedence",
+			args: args{
+				runtimeObjs: []runtime.Object{secretWithConfig("cfg", []byte("ui: true"))},
+				ems: emsWithConfigRef("cfg", &commonv1.Config{Data: map[string]interface{}{
+					"ui": false,
+				}}),
+				ipFamily: corev1.IPv4Protocol,
+			},
+			want: `host: 0.0.0.0
+ssl:
+  certificate: /mnt/elastic-internal/http-certs/tls.crt
+  enabled: true
+  key: /mnt/elastic-internal/http-certs/tls.key
+ui: true
+`,
+			wantErr: false,
+		},
+		{
+			name: "non existing configRef",
+			args: args{
+				ems:      emsWithConfigRef("cfg", nil),
+				ipFamily: corev1.IPv4Protocol,
+			},
+			wantErr: true,
+		},
+		{
+			name: "non existing configRef",
+			args: args{
+				runtimeObjs: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "sample-maps-user",
+							Namespace: "ns",
+						},
+						Data: map[string][]byte{
+							"ns-sample-maps-user": []byte("password"),
+						},
+					},
+				},
+				ems: emsWithAssociation(commonv1.AssociationConf{
+					AuthSecretName: "sample-maps-user",
+					AuthSecretKey:  "ns-sample-maps-user",
+					CACertProvided: true,
+					CASecretName:   "sample-maps-es-ca",
+					URL:            "https://elasticsearch-sample-es-http.default.svc:9200",
+				}),
+				ipFamily: corev1.IPv6Protocol,
+			},
+			want: `elasticsearch:
+  host: https://elasticsearch-sample-es-http.default.svc:9200
+  password: password
+  ssl:
+    certificateAuthorities: /mnt/elastic-internal/es-certs/tls.crt
+    verificationMode: certificate
+  username: ns-sample-maps-user
+host: '::'
+ssl:
+  certificate: /mnt/elastic-internal/http-certs/tls.crt
+  enabled: true
+  key: /mnt/elastic-internal/http-certs/tls.key
+`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := ReconcileMapsServer{
+				Client:         k8s.NewFakeClient(tt.args.runtimeObjs...),
+				recorder:       record.NewFakeRecorder(10),
+				dynamicWatches: watches.NewDynamicWatches(),
+			}
+
+			got, err := newConfig(&d, tt.args.ems, tt.args.ipFamily)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return // no point in checking the config contents
+			}
+			rendered, err := got.Render()
+			require.NoError(t, err)
+			if string(rendered) != tt.want {
+				t.Errorf("newConfig() got = \n%v\n, want \n%v\n", string(rendered), tt.want)
+			}
+		})
+	}
+}
+
+func secretWithConfig(name string, cfg []byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      name,
+		},
+		Data: map[string][]byte{
+			ConfigFilename: cfg,
+		},
+	}
+}
+
+func emsWithConfigRef(name string, cfg *commonv1.Config) v1alpha1.ElasticMapsServer {
+	return v1alpha1.ElasticMapsServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ems",
+			Namespace: "ns",
+		},
+		Spec: v1alpha1.MapsSpec{
+			Config:    cfg,
+			ConfigRef: &commonv1.ConfigSource{SecretRef: commonv1.SecretRef{SecretName: name}}},
+	}
+}
+
+func emsWithAssociation(associationConf commonv1.AssociationConf) v1alpha1.ElasticMapsServer {
+	ent := v1alpha1.ElasticMapsServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "ems",
+		},
+	}
+	ent.SetAssociationConf(&associationConf)
+	return ent
+}

--- a/pkg/controller/maps/controller.go
+++ b/pkg/controller/maps/controller.go
@@ -168,7 +168,7 @@ func (r *ReconcileMapsServer) Reconcile(ctx context.Context, request reconcile.R
 
 	enabled, err := r.licenseChecker.EnterpriseFeaturesEnabled()
 	if err != nil {
-		return reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}, err
+		return reconcile.Result{}, err
 	}
 
 	if !enabled {

--- a/pkg/controller/maps/controller.go
+++ b/pkg/controller/maps/controller.go
@@ -1,0 +1,393 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package maps
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"reflect"
+	"sync/atomic"
+
+	emsv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/maps/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/annotation"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/deployment"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/driver"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
+	"go.elastic.co/apm"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	controllerName = "maps-controller"
+)
+
+var log = ulog.Log.WithName(controllerName)
+
+// Add creates a new MapsServer Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager, params operator.Parameters) error {
+	reconciler := newReconciler(mgr, params)
+	c, err := common.NewController(mgr, controllerName, reconciler, params)
+	if err != nil {
+		return err
+	}
+	return addWatches(c, reconciler)
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager, params operator.Parameters) *ReconcileMapsServer {
+	client := mgr.GetClient()
+	return &ReconcileMapsServer{
+		Client:         client,
+		recorder:       mgr.GetEventRecorderFor(controllerName),
+		dynamicWatches: watches.NewDynamicWatches(),
+		Parameters:     params,
+	}
+}
+
+func addWatches(c controller.Controller, r *ReconcileMapsServer) error {
+	// Watch for changes to MapsServer
+	if err := c.Watch(&source.Kind{Type: &emsv1alpha1.ElasticMapsServer{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+
+	// Watch deployments
+	if err := c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &emsv1alpha1.ElasticMapsServer{},
+	}); err != nil {
+		return err
+	}
+
+	// Watch Pods, to ensure `status.version` and version upgrades are correctly reconciled on any change.
+	// Watching Deployments only may lead to missing some events.
+	if err := watches.WatchPods(c, NameLabelName); err != nil {
+		return err
+	}
+
+	// Watch services
+	if err := c.Watch(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &emsv1alpha1.ElasticMapsServer{},
+	}); err != nil {
+		return err
+	}
+
+	// Watch owned and soft-owned secrets
+	if err := c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &emsv1alpha1.ElasticMapsServer{},
+	}); err != nil {
+		return err
+	}
+	if err := watches.WatchSoftOwnedSecrets(c, emsv1alpha1.Kind); err != nil {
+		return err
+	}
+
+	// Dynamically watch referenced secrets to connect to Elasticsearch
+	return c.Watch(&source.Kind{Type: &corev1.Secret{}}, r.dynamicWatches.Secrets)
+}
+
+var _ reconcile.Reconciler = &ReconcileMapsServer{}
+
+// ReconcileMapsServer reconciles a MapsServer object
+type ReconcileMapsServer struct {
+	k8s.Client
+	operator.Parameters
+	recorder       record.EventRecorder
+	dynamicWatches watches.DynamicWatches
+	// iteration is the number of times this controller has run its Reconcile method
+	iteration uint64
+}
+
+func (r *ReconcileMapsServer) K8sClient() k8s.Client {
+	return r.Client
+}
+
+func (r *ReconcileMapsServer) DynamicWatches() watches.DynamicWatches {
+	return r.dynamicWatches
+}
+
+func (r *ReconcileMapsServer) Recorder() record.EventRecorder {
+	return r.recorder
+}
+
+var _ driver.Interface = &ReconcileMapsServer{}
+
+// Reconcile reads that state of the cluster for a MapsServer object and makes changes based on the state read and what is
+// in the MapsServer.Spec
+func (r *ReconcileMapsServer) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	defer common.LogReconciliationRun(log, request, "name", &r.iteration)()
+	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, request.NamespacedName, "maps")
+	defer tracing.EndTransaction(tx)
+
+	// retrieve the EMS object
+	var ems emsv1alpha1.ElasticMapsServer
+	if err := association.FetchWithAssociations(ctx, r.Client, request, &ems); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, r.onDelete(types.NamespacedName{
+				Namespace: request.Namespace,
+				Name:      request.Name,
+			})
+		}
+		return reconcile.Result{}, tracing.CaptureError(ctx, err)
+	}
+
+	if common.IsUnmanaged(&ems) {
+		log.Info("Object is currently not managed by this controller. Skipping reconciliation", "namespace", ems.Namespace, "name", ems.Name)
+		return reconcile.Result{}, nil
+	}
+
+	// check for compatibility with the operator version
+	compatible, err := r.isCompatible(ctx, &ems)
+	if err != nil || !compatible {
+		return reconcile.Result{}, tracing.CaptureError(ctx, err)
+	}
+
+	// MapsServer will be deleted nothing to do other than remove the watches
+	if ems.IsMarkedForDeletion() {
+		return reconcile.Result{}, r.onDelete(k8s.ExtractNamespacedName(&ems))
+	}
+
+	// update controller version annotation if necessary
+	err = annotation.UpdateControllerVersion(ctx, r.Client, &ems, r.OperatorInfo.BuildInfo.Version)
+	if err != nil {
+		return reconcile.Result{}, tracing.CaptureError(ctx, err)
+	}
+
+	if !association.IsConfiguredIfSet(&ems, r.recorder) {
+		return reconcile.Result{}, nil
+	}
+
+	// main reconciliation logic
+	return r.doReconcile(ctx, ems)
+}
+
+func (r *ReconcileMapsServer) isCompatible(ctx context.Context, kb *emsv1alpha1.ElasticMapsServer) (bool, error) {
+	selector := map[string]string{NameLabelName: kb.Name}
+	compat, err := annotation.ReconcileCompatibility(ctx, r.Client, kb, selector, r.OperatorInfo.BuildInfo.Version)
+	if err != nil {
+		k8s.EmitErrorEvent(r.recorder, err, kb, events.EventCompatCheckError, "Error during compatibility check: %v", err)
+	}
+	return compat, err
+}
+
+func (r *ReconcileMapsServer) doReconcile(ctx context.Context, ems emsv1alpha1.ElasticMapsServer) (reconcile.Result, error) {
+	// Run validation in case the webhook is disabled
+	if err := r.validate(ctx, ems); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	svc, err := common.ReconcileService(ctx, r.Client, NewService(ems), &ems)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	_, results := certificates.Reconciler{
+		K8sClient:             r.K8sClient(),
+		DynamicWatches:        r.DynamicWatches(),
+		Owner:                 &ems,
+		TLSOptions:            ems.Spec.HTTP.TLS,
+		Namer:                 EMSNamer,
+		Labels:                labels(ems.Name),
+		Services:              []corev1.Service{*svc},
+		CACertRotation:        r.CACertRotation,
+		CertRotation:          r.CertRotation,
+		GarbageCollectSecrets: true,
+	}.ReconcileCAAndHTTPCerts(ctx)
+	if results.HasError() {
+		res, err := results.Aggregate()
+		k8s.EmitErrorEvent(r.recorder, err, &ems, events.EventReconciliationError, "Certificate reconciliation error: %v", err)
+		return res, err
+	}
+
+	emsVersion, err := version.Parse(ems.Spec.Version)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	logger := log.WithValues("namespace", ems.Namespace, "maps_name", ems.Name) // TODO  mapping explosion
+	if !association.AllowVersion(emsVersion, ems.Associated(), logger, r.recorder) {
+		return reconcile.Result{}, nil // will eventually retry once updated
+	}
+
+	configSecret, err := reconcileConfig(r, ems, r.IPFamily)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// build a hash of various inputs to rotate Pods on any change
+	configHash, err := buildConfigHash(r.K8sClient(), ems, configSecret)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("build config hash: %w", err)
+	}
+
+	deploy, err := r.reconcileDeployment(ctx, ems, configHash)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("reconcile deployment: %w", err)
+	}
+
+	err = r.updateStatus(ems, deploy)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("updating status: %w", err)
+	}
+
+	return results.Aggregate()
+}
+
+func (r *ReconcileMapsServer) validate(ctx context.Context, ems emsv1alpha1.ElasticMapsServer) error {
+	span, vctx := apm.StartSpan(ctx, "validate", tracing.SpanTypeApp)
+	defer span.End()
+
+	if err := ems.ValidateCreate(); err != nil {
+		log.Error(err, "Validation failed")
+		k8s.EmitErrorEvent(r.recorder, err, &ems, events.EventReasonValidation, err.Error())
+		return tracing.CaptureError(vctx, err)
+	}
+
+	return nil
+}
+
+func NewService(ems emsv1alpha1.ElasticMapsServer) *corev1.Service {
+	svc := corev1.Service{
+		ObjectMeta: ems.Spec.HTTP.Service.ObjectMeta,
+		Spec:       ems.Spec.HTTP.Service.Spec,
+	}
+
+	svc.ObjectMeta.Namespace = ems.Namespace
+	svc.ObjectMeta.Name = HTTPService(ems.Name)
+
+	labels := labels(ems.Name)
+	ports := []corev1.ServicePort{
+		{
+			Name:     ems.Spec.HTTP.Protocol(),
+			Protocol: corev1.ProtocolTCP,
+			Port:     HTTPPort,
+		},
+	}
+
+	return defaults.SetServiceDefaults(&svc, labels, labels, ports)
+}
+
+func buildConfigHash(c k8s.Client, ems emsv1alpha1.ElasticMapsServer, configSecret corev1.Secret) (string, error) {
+	// build a hash of various settings to rotate the Pod on any change
+	configHash := sha256.New224()
+
+	// - in the Elastic Maps Server configuration file content
+	_, _ = configHash.Write(configSecret.Data[ConfigFilename])
+
+	// - in the Elastic Maps Server TLS certificates
+	if ems.Spec.HTTP.TLS.Enabled() {
+		var tlsCertSecret corev1.Secret
+		tlsSecretKey := types.NamespacedName{Namespace: ems.Namespace, Name: certificates.InternalCertsSecretName(EMSNamer, ems.Name)}
+		if err := c.Get(context.Background(), tlsSecretKey, &tlsCertSecret); err != nil {
+			return "", err
+		}
+		if certPem, ok := tlsCertSecret.Data[certificates.CertFileName]; ok {
+			_, _ = configHash.Write(certPem)
+		}
+	}
+
+	// - in the Elasticsearch TLS certificates
+	if ems.AssociationConf().CAIsConfigured() {
+		var esPublicCASecret corev1.Secret
+		key := types.NamespacedName{Namespace: ems.Namespace, Name: ems.AssociationConf().GetCASecretName()}
+		if err := c.Get(context.Background(), key, &esPublicCASecret); err != nil {
+			return "", err
+		}
+		if certPem, ok := esPublicCASecret.Data[certificates.CertFileName]; ok {
+			_, _ = configHash.Write(certPem)
+		}
+	}
+
+	return fmt.Sprintf("%x", configHash.Sum(nil)), nil
+}
+
+func (r *ReconcileMapsServer) reconcileDeployment(
+	ctx context.Context,
+	ems emsv1alpha1.ElasticMapsServer,
+	configHash string,
+) (appsv1.Deployment, error) {
+	span, _ := apm.StartSpan(ctx, "reconcile_deployment", tracing.SpanTypeApp)
+	defer span.End()
+
+	deploy := deployment.New(r.deploymentParams(ems, configHash))
+	return deployment.Reconcile(r.K8sClient(), deploy, &ems)
+}
+
+func (r *ReconcileMapsServer) deploymentParams(ems emsv1alpha1.ElasticMapsServer, configHash string) deployment.Params {
+	podSpec := newPodSpec(ems, configHash)
+
+	deploymentLabels := labels(ems.Name)
+
+	podLabels := maps.Merge(labels(ems.Name), versionLabels(ems))
+	// merge with user-provided labels
+	podSpec.Labels = maps.MergePreservingExistingKeys(podSpec.Labels, podLabels)
+
+	return deployment.Params{
+		Name:            Deployment(ems.Name),
+		Namespace:       ems.Namespace,
+		Replicas:        ems.Spec.Count,
+		Selector:        deploymentLabels,
+		Labels:          deploymentLabels,
+		PodTemplateSpec: podSpec,
+		Strategy:        appsv1.DeploymentStrategy{Type: appsv1.RollingUpdateDeploymentStrategyType},
+	}
+}
+
+func (r *ReconcileMapsServer) updateStatus(ems emsv1alpha1.ElasticMapsServer, deploy appsv1.Deployment) error {
+	pods, err := k8s.PodsMatchingLabels(r.K8sClient(), ems.Namespace, map[string]string{NameLabelName: ems.Name})
+	if err != nil {
+		return err
+	}
+	newStatus := emsv1alpha1.MapsStatus{
+		DeploymentStatus:  common.DeploymentStatus(ems.Status.DeploymentStatus, deploy, pods, versionLabelName),
+		AssociationStatus: ems.Status.AssociationStatus,
+	}
+
+	if reflect.DeepEqual(newStatus, ems.Status) {
+		return nil // nothing to do
+	}
+	if newStatus.IsDegraded(ems.Status.DeploymentStatus) {
+		r.recorder.Event(&ems, corev1.EventTypeWarning, events.EventReasonUnhealthy, "Elastic Maps Server health degraded")
+	}
+	log.V(1).Info("Updating status",
+		"iteration", atomic.LoadUint64(&r.iteration),
+		"namespace", ems.Namespace,
+		"maps_name", ems.Name,
+		"status", newStatus,
+	)
+	ems.Status = newStatus
+	return common.UpdateStatus(r.Client, &ems)
+}
+
+func (r *ReconcileMapsServer) onDelete(obj types.NamespacedName) error {
+	// Clean up watches set on custom http tls certificates
+	r.dynamicWatches.Secrets.RemoveHandlerForKey(certificates.CertificateWatchKey(EMSNamer, obj.Name))
+	// same for the configRef secret
+	r.dynamicWatches.Secrets.RemoveHandlerForKey(common.ConfigRefWatchName(obj))
+	return reconciler.GarbageCollectSoftOwnedSecrets(r.Client, obj, emsv1alpha1.Kind)
+}

--- a/pkg/controller/maps/controller_test.go
+++ b/pkg/controller/maps/controller_test.go
@@ -1,0 +1,358 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package maps
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/pkg/about"
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/apis/maps/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/annotation"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var nsnFixture = types.NamespacedName{
+	Namespace: "ns",
+	Name:      "test-resource",
+}
+var emsFixture = v1alpha1.ElasticMapsServer{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: nsnFixture.Namespace,
+		Name:      nsnFixture.Name,
+	},
+	Spec: v1alpha1.MapsSpec{
+		Version: "7.12.0",
+		Count:   1,
+	},
+}
+
+func TestReconcileMapsServer_Reconcile(t *testing.T) {
+	timeFixture := metav1.Now()
+	tests := []struct {
+		name             string
+		reconciler       ReconcileMapsServer
+		pre              func(r ReconcileMapsServer)
+		post             func(r ReconcileMapsServer)
+		wantRequeue      bool
+		wantRequeueAfter bool
+		wantErr          bool
+	}{
+		{
+			name: "Resource not found",
+			reconciler: ReconcileMapsServer{
+				Client:         k8s.NewFakeClient(),
+				dynamicWatches: watches.NewDynamicWatches(),
+			},
+			pre: func(r ReconcileMapsServer) {
+				// simulate a watch for a configRef that has been added during a previous reconciliation
+				require.NoError(t, watches.WatchUserProvidedSecrets(nsnFixture, r.DynamicWatches(), common.ConfigRefWatchName(nsnFixture), []string{"user-config-secret"}))
+				// simulate a watch for custom TLS certificates
+				require.NoError(t, watches.WatchUserProvidedSecrets(nsnFixture, r.DynamicWatches(), certificates.CertificateWatchKey(EMSNamer, nsnFixture.Name), []string{"user-tls-secret"}))
+				require.NotEmpty(t, r.DynamicWatches().Secrets.Registrations())
+			},
+			post: func(r ReconcileMapsServer) {
+				// watches should have been cleared
+				require.Empty(t, r.DynamicWatches().Secrets.Registrations())
+			},
+			wantErr: false,
+		},
+		{
+			name: "Resource marked for deletion",
+			reconciler: ReconcileMapsServer{
+				Client: k8s.NewFakeClient(&v1alpha1.ElasticMapsServer{
+					ObjectMeta: metav1.ObjectMeta{Name: nsnFixture.Name, Namespace: nsnFixture.Namespace, DeletionTimestamp: &timeFixture},
+				}),
+				dynamicWatches: watches.NewDynamicWatches(),
+			},
+			pre: func(r ReconcileMapsServer) {
+				// simulate a watch for a configRef that has been added during a previous reconciliation
+				require.NoError(t, watches.WatchUserProvidedSecrets(nsnFixture, r.DynamicWatches(), common.ConfigRefWatchName(nsnFixture), []string{"user-config-secret"}))
+				// simulate a watch for custom TLS certificates
+				require.NoError(t, watches.WatchUserProvidedSecrets(nsnFixture, r.DynamicWatches(), certificates.CertificateWatchKey(EMSNamer, nsnFixture.Name), []string{"user-tls-secret"}))
+				require.NotEmpty(t, r.DynamicWatches().Secrets.Registrations())
+			},
+			post: func(r ReconcileMapsServer) {
+				// watches should have been cleared
+				require.Empty(t, r.DynamicWatches().Secrets.Registrations())
+			},
+			wantErr: false,
+		},
+		{
+			name: "Resource is unmanaged",
+			reconciler: ReconcileMapsServer{
+				Client: k8s.NewFakeClient(&v1alpha1.ElasticMapsServer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      nsnFixture.Name,
+						Namespace: nsnFixture.Namespace,
+						Annotations: map[string]string{
+							common.ManagedAnnotation: "false",
+						},
+					},
+				}),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Sets controller version",
+			reconciler: ReconcileMapsServer{
+				Client:         k8s.NewFakeClient(&emsFixture),
+				recorder:       record.NewFakeRecorder(10),
+				dynamicWatches: watches.NewDynamicWatches(),
+				Parameters:     operator.Parameters{OperatorInfo: about.OperatorInfo{BuildInfo: about.BuildInfo{Version: "1.6.0"}}},
+			},
+			post: func(r ReconcileMapsServer) {
+				var reconciled v1alpha1.ElasticMapsServer
+				require.NoError(t, r.Get(context.Background(), nsnFixture, &reconciled))
+				require.Equal(t, map[string]string{annotation.ControllerVersionAnnotation: "1.6.0"}, reconciled.Annotations)
+			},
+			wantRequeueAfter: true, // certificate rotation
+			wantErr:          false,
+		},
+		{
+			name: "validates on reconcile",
+			reconciler: ReconcileMapsServer{
+				Client: k8s.NewFakeClient(&v1alpha1.ElasticMapsServer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      nsnFixture.Name,
+						Namespace: nsnFixture.Namespace,
+					},
+					Spec: v1alpha1.MapsSpec{
+						Version: "7.10.0", // unsupported version
+					},
+				}),
+				recorder: record.NewFakeRecorder(10),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Association specified but not configured (yet)",
+			reconciler: ReconcileMapsServer{
+				Client: k8s.NewFakeClient(&v1alpha1.ElasticMapsServer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      nsnFixture.Name,
+						Namespace: nsnFixture.Namespace,
+					},
+					Spec: v1alpha1.MapsSpec{
+						Version:          "7.12.0",
+						ElasticsearchRef: commonv1.ObjectSelector{Name: "es", Namespace: "ns"},
+					},
+				}),
+				dynamicWatches: watches.NewDynamicWatches(),
+				recorder:       record.NewFakeRecorder(10),
+			},
+			post: func(r ReconcileMapsServer) {
+				e := <-r.recorder.(*record.FakeRecorder).Events
+				require.Equal(t, "Warning AssociationError Association backend for elasticsearch is not configured", e)
+			},
+			wantErr: false,
+		},
+		{
+			name: "Association specified but ES version too old",
+			reconciler: ReconcileMapsServer{
+				Client: k8s.NewFakeClient(&v1alpha1.ElasticMapsServer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      nsnFixture.Name,
+						Namespace: nsnFixture.Namespace,
+						Annotations: map[string]string{
+							"association.k8s.elastic.co/es-conf": `{"authSecretName":"test-resource-maps-user","authSecretKey":"ns-test-resource-maps-user","caCertProvided":true,"caSecretName": "test-resource-es-ca","url":"https://es-es-http.ns.svc:9200","version":"7.10.0"}`,
+						},
+					},
+					Spec: v1alpha1.MapsSpec{
+						Version:          "7.12.0",
+						ElasticsearchRef: commonv1.ObjectSelector{Name: "es", Namespace: "ns"},
+					},
+				}),
+				dynamicWatches: watches.NewDynamicWatches(),
+				recorder:       record.NewFakeRecorder(10),
+			},
+			post: func(r ReconcileMapsServer) {
+				e := <-r.recorder.(*record.FakeRecorder).Events
+				require.Equal(t, "Warning Delayed Delaying deployment of version 7.12.0 since the referenced elasticsearch is not upgraded yet", e)
+			},
+			wantErr: false,
+		},
+		{
+			name: "Happy path: first reconciliation",
+			reconciler: ReconcileMapsServer{
+				Client:         k8s.NewFakeClient(&emsFixture),
+				recorder:       record.NewFakeRecorder(10),
+				dynamicWatches: watches.NewDynamicWatches(),
+				Parameters:     operator.Parameters{OperatorInfo: about.OperatorInfo{BuildInfo: about.BuildInfo{Version: "1.6.0"}}},
+			},
+			post: func(r ReconcileMapsServer) {
+				// service
+				var svc corev1.Service
+				err := r.Client.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: HTTPService(nsnFixture.Name)}, &svc)
+				require.NoError(t, err)
+				require.Equal(t, int32(8080), svc.Spec.Ports[0].Port)
+
+				// should create internal ca, internal http certs secret, public http certs secret
+				var caSecret corev1.Secret
+				err = r.Client.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "test-resource-ems-http-ca-internal"}, &caSecret)
+				require.NoError(t, err)
+				require.NotEmpty(t, caSecret.Data)
+
+				var httpInternalSecret corev1.Secret
+				err = r.Client.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "test-resource-ems-http-certs-internal"}, &httpInternalSecret)
+				require.NoError(t, err)
+				require.NotEmpty(t, httpInternalSecret.Data)
+
+				var httpPublicSecret corev1.Secret
+				err = r.Client.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "test-resource-ems-http-certs-public"}, &httpPublicSecret)
+				require.NoError(t, err)
+				require.NotEmpty(t, httpPublicSecret.Data)
+
+				// should create a secret for the configuration
+				var config corev1.Secret
+				err = r.Client.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "test-resource-ems-config"}, &config)
+				require.NoError(t, err)
+				require.Contains(t, string(config.Data["elastic-maps-server.yml"]), "host:")
+
+				// should create a 1-replica deployment
+				var dep appsv1.Deployment
+				err = r.Client.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "test-resource-ems"}, &dep)
+				require.NoError(t, err)
+				require.Equal(t, int32(1), *dep.Spec.Replicas)
+				// with the config hash label set
+				require.NotEmpty(t, dep.Spec.Template.Labels[configHashLabel])
+			},
+			wantRequeue:      false,
+			wantRequeueAfter: true, // certificate refresh
+			wantErr:          false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.pre != nil {
+				tt.pre(tt.reconciler)
+			}
+			got, err := tt.reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: nsnFixture})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Reconcile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got.Requeue != tt.wantRequeue {
+				t.Errorf("Reconcile() got = %v, wantRequeue %v", got, tt.wantRequeue)
+			}
+			if got.RequeueAfter > 0 != tt.wantRequeueAfter {
+				t.Errorf("Reconcile() got = %v, wantRequeueAfter %v", got, tt.wantRequeueAfter)
+			}
+			if tt.post != nil {
+				tt.post(tt.reconciler)
+			}
+		})
+	}
+}
+
+func Test_buildConfigHash(t *testing.T) {
+	emsWithAssoc := *emsFixture.DeepCopy()
+	esTLSCertsSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: nsnFixture.Namespace, Name: "es-tls-certs"},
+		Data: map[string][]byte{
+			certificates.CertFileName: []byte("es-cert-data"),
+		},
+	}
+	emsWithAssoc.SetAssociationConf(&commonv1.AssociationConf{CACertProvided: true, CASecretName: esTLSCertsSecret.Name})
+
+	emsNoTLS := *emsWithAssoc.DeepCopy()
+	emsNoTLS.Spec.HTTP.TLS = commonv1.TLSOptions{SelfSignedCertificate: &commonv1.SelfSignedCertificate{Disabled: true}}
+
+	cfgFixture := corev1.Secret{
+		Data: map[string][]byte{
+			ConfigFilename: []byte("host: 0.0.0.0"),
+		},
+	}
+	tlsCertsSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: nsnFixture.Namespace, Name: certificates.InternalCertsSecretName(EMSNamer, nsnFixture.Name)},
+		Data: map[string][]byte{
+			certificates.CertFileName: []byte("cert-data"),
+		},
+	}
+	type args struct {
+		c            k8s.Client
+		ems          v1alpha1.ElasticMapsServer
+		configSecret corev1.Secret
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "full configuration",
+			args: args{
+				c:            k8s.NewFakeClient(&tlsCertsSecret, &esTLSCertsSecret),
+				ems:          emsWithAssoc,
+				configSecret: cfgFixture,
+			},
+			want:    "617f1ef5547de7a7c41cc8ae1275ae9734d71549385de682782b9d89",
+			wantErr: false,
+		},
+		{
+			name: "no TLS",
+			args: args{
+				c:            k8s.NewFakeClient(&esTLSCertsSecret),
+				ems:          emsNoTLS,
+				configSecret: cfgFixture,
+			},
+			want:    "f6400f877a3bb3a6530075729e3db69ac093d53185439b82ecd6ea60",
+			wantErr: false,
+		},
+		{
+			name: "No association",
+			args: args{
+				c:            k8s.NewFakeClient(&tlsCertsSecret),
+				ems:          emsFixture,
+				configSecret: cfgFixture,
+			},
+			want:    "da5a1cba8225f2383138d4055180307f751bd267e9381f27ed5dbf63",
+			wantErr: false,
+		},
+		{
+			name: "TLS cert not found",
+			args: args{
+				c:            k8s.NewFakeClient(),
+				ems:          emsFixture,
+				configSecret: cfgFixture,
+			},
+			wantErr: true,
+		},
+		{
+			name: "ES TLS cert not found",
+			args: args{
+				c:            k8s.NewFakeClient(&tlsCertsSecret),
+				ems:          emsWithAssoc,
+				configSecret: cfgFixture,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildConfigHash(tt.args.c, tt.args.ems, tt.args.configSecret)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildConfigHash() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("buildConfigHash() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/maps/labels.go
+++ b/pkg/controller/maps/labels.go
@@ -1,0 +1,35 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package maps
+
+import (
+	emsv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/maps/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+)
+
+const (
+	// NameLabelName used to represent a MapsServer in k8s resources
+	NameLabelName = "maps.k8s.elastic.co/name"
+
+	// versionLabelName used to propagate MapsServer version from the spec to the pods
+	versionLabelName = "maps.k8s.elastic.co/version"
+
+	// Type represents the MapsServer type
+	Type = "maps"
+)
+
+// labels constructs a new set of labels for a MapsServer pod
+func labels(emsName string) map[string]string {
+	return map[string]string{
+		NameLabelName:        emsName,
+		common.TypeLabelName: Type,
+	}
+}
+
+func versionLabels(ems emsv1alpha1.ElasticMapsServer) map[string]string {
+	return map[string]string{
+		versionLabelName: ems.Spec.Version,
+	}
+}

--- a/pkg/controller/maps/name.go
+++ b/pkg/controller/maps/name.go
@@ -1,0 +1,27 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package maps
+
+import "github.com/elastic/cloud-on-k8s/pkg/controller/common/name"
+
+const (
+	httpServiceSuffix = "http"
+	configSuffix      = "config"
+)
+
+// EMSNamer is a Namer that is configured with the defaults for resources related to an Elastic Maps Server resource.
+var EMSNamer = name.NewNamer("ems")
+
+func HTTPService(emsName string) string {
+	return EMSNamer.Suffix(emsName, httpServiceSuffix)
+}
+
+func Deployment(emsName string) string {
+	return EMSNamer.Suffix(emsName)
+}
+
+func Config(emasName string) string {
+	return EMSNamer.Suffix(emasName, configSuffix)
+}

--- a/pkg/controller/maps/pod.go
+++ b/pkg/controller/maps/pod.go
@@ -33,7 +33,7 @@ var (
 	}
 )
 
-// readinessProbe is the readiness probe for the Kibana container
+// readinessProbe is the readiness probe for the maps container
 func readinessProbe(useTLS bool) corev1.Probe {
 	scheme := corev1.URISchemeHTTP
 	if useTLS {

--- a/pkg/controller/maps/pod.go
+++ b/pkg/controller/maps/pod.go
@@ -1,0 +1,105 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package maps
+
+import (
+	emsv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/maps/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/container"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	HTTPPort           = 8080
+	configHashLabel    = "maps.k8s.elastic.co/config-hash"
+	logVolumeMountPath = "/var/log/elastic-maps-server"
+)
+
+var (
+	DefaultMemoryLimits = resource.MustParse("200Mi")
+	DefaultResources    = corev1.ResourceRequirements{
+		Requests: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceMemory: DefaultMemoryLimits,
+		},
+		Limits: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceMemory: DefaultMemoryLimits,
+		},
+	}
+)
+
+// readinessProbe is the readiness probe for the Kibana container
+func readinessProbe(useTLS bool) corev1.Probe {
+	scheme := corev1.URISchemeHTTP
+	if useTLS {
+		scheme = corev1.URISchemeHTTPS
+	}
+	return corev1.Probe{
+		FailureThreshold:    3,
+		InitialDelaySeconds: 10,
+		PeriodSeconds:       10,
+		SuccessThreshold:    1,
+		TimeoutSeconds:      5,
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Port:   intstr.FromInt(HTTPPort),
+				Path:   "/status",
+				Scheme: scheme,
+			},
+		},
+	}
+}
+
+func newPodSpec(ems emsv1alpha1.ElasticMapsServer, configHash string) corev1.PodTemplateSpec {
+	// ensure the Pod gets rotated on config change
+	labels := map[string]string{configHashLabel: configHash}
+
+	defaultContainerPorts := []corev1.ContainerPort{
+		{Name: ems.Spec.HTTP.Protocol(), ContainerPort: int32(HTTPPort), Protocol: corev1.ProtocolTCP},
+	}
+
+	cfgVolume := configSecretVolume(ems)
+	logsVolume := volume.NewEmptyDirVolume("logs", logVolumeMountPath)
+
+	builder := defaults.NewPodTemplateBuilder(ems.Spec.PodTemplate, emsv1alpha1.MapsContainerName).
+		WithLabels(labels).
+		WithResources(DefaultResources).
+		WithDockerImage(ems.Spec.Image, container.ImageRepository(container.MapsImage, ems.Spec.Version)).
+		WithReadinessProbe(readinessProbe(ems.Spec.HTTP.TLS.Enabled())).
+		WithPorts(defaultContainerPorts).
+		WithVolumes(cfgVolume.Volume(), logsVolume.Volume()).
+		WithVolumeMounts(cfgVolume.VolumeMount(), logsVolume.VolumeMount()).
+		WithInitContainerDefaults()
+
+	builder = withESCertsVolume(builder, ems)
+	builder = withHTTPCertsVolume(builder, ems)
+
+	return builder.PodTemplate
+}
+
+func withESCertsVolume(builder *defaults.PodTemplateBuilder, ems emsv1alpha1.ElasticMapsServer) *defaults.PodTemplateBuilder {
+	if !ems.AssociationConf().CAIsConfigured() {
+		return builder
+	}
+	vol := volume.NewSecretVolumeWithMountPath(
+		ems.AssociationConf().GetCASecretName(),
+		"es-certs",
+		ESCertsPath,
+	)
+	return builder.
+		WithVolumes(vol.Volume()).
+		WithVolumeMounts(vol.VolumeMount())
+}
+
+func withHTTPCertsVolume(builder *defaults.PodTemplateBuilder, ems emsv1alpha1.ElasticMapsServer) *defaults.PodTemplateBuilder {
+	if !ems.Spec.HTTP.TLS.Enabled() {
+		return builder
+	}
+	vol := certificates.HTTPCertSecretVolume(EMSNamer, ems.Name)
+	return builder.WithVolumes(vol.Volume()).WithVolumeMounts(vol.VolumeMount())
+}


### PR DESCRIPTION
Second part of #4179 split up to allow easier review. 

Adds the a new controller to support Elastic Maps Server in the ECK operator. 

Depends on https://github.com/elastic/cloud-on-k8s/pull/4439 so please only review https://github.com/elastic/cloud-on-k8s/commit/829c2383dfdca345a9eed4ad30c5edbcf5419910

I have not added a sample yet because it is quite tricky to get a fully working setup without Ingress. But something like this should work: 

```yaml
apiVersion: elasticsearch.k8s.elastic.co/v1
kind: Elasticsearch
metadata:
  name: elasticsearch-sample
spec:
  version: 7.12.0
  nodeSets:
    - name: default
      count: 1
      config:
        # This setting could have performance implications for production clusters.
        # See: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
        node.store.allow_mmap: false
---
apiVersion: maps.k8s.elastic.co/v1alpha1
kind: ElasticMapsServer
metadata:
  name: ems-sample
spec:
  version: 7.12.0
  count: 1
  http:
    tls:
      selfSignedCertificate:
        disabled: true
    service:
      spec:
        type: LoadBalancer
  elasticsearchRef:
    name: elasticsearch-sample
---
apiVersion: kibana.k8s.elastic.co/v1
kind: Kibana
metadata:
  name: kibana
spec:
  version: 7.12.0
  count: 1
  http:
    service:
      spec:
        type: LoadBalancer
  config:
    map.emsUrl: http://$LB_IP:8080 # counter intuitive but you are accessing EMS through the load balancer
  elasticsearchRef:
    name: elasticsearch-sample
```