### PR TITLE
Add E2E tests for Elastic Maps Server

### DIFF
--- a/config/e2e/rbac.yaml
+++ b/config/e2e/rbac.yaml
@@ -240,6 +240,19 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - maps.k8s.elastic.co
+    resources:
+      - elasticmapsservers
+      - elasticmapsservers/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
       - storage.k8s.io
     resources:
       - storageclasses

--- a/test/e2e/ems/ems_test.go
+++ b/test/e2e/ems/ems_test.go
@@ -15,6 +15,11 @@ import (
 
 // TestElasticMapsServerCrossNSAssociation tests associating Elasticsearch and Elastic Maps Server running in different namespaces.
 func TestElasticMapsServerCrossNSAssociation(t *testing.T) {
+	// only execute this test if we have a test license to work with
+	if test.Ctx().TestLicense == "" {
+		t.SkipNow()
+	}
+
 	esNamespace := test.Ctx().ManagedNamespace(0)
 	emsNamespace := test.Ctx().ManagedNamespace(1)
 	name := "test-cross-ns-ems-es"
@@ -33,6 +38,11 @@ func TestElasticMapsServerCrossNSAssociation(t *testing.T) {
 }
 
 func TestElasticMapsServerTLSDisabled(t *testing.T) {
+	// only execute this test if we have a test license to work with
+	if test.Ctx().TestLicense == "" {
+		t.SkipNow()
+	}
+
 	name := "test-ems-tls-disabled"
 
 	esBuilder := elasticsearch.NewBuilder(name).
@@ -48,6 +58,11 @@ func TestElasticMapsServerTLSDisabled(t *testing.T) {
 }
 
 func TestElasticMapsServerVersionUpgradeToLatest7x(t *testing.T) {
+	// only execute this test if we have a test license to work with
+	if test.Ctx().TestLicense == "" {
+		t.SkipNow()
+	}
+
 	srcVersion := test.Ctx().ElasticStackVersion
 	dstVersion := test.LatestVersion7x
 

--- a/test/e2e/ems/ems_test.go
+++ b/test/e2e/ems/ems_test.go
@@ -1,0 +1,70 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package ems
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/maps"
+
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+)
+
+// TestElasticMapsServerCrossNSAssociation tests associating Elasticsearch and Elastic Maps Server running in different namespaces.
+func TestElasticMapsServerCrossNSAssociation(t *testing.T) {
+	esNamespace := test.Ctx().ManagedNamespace(0)
+	emsNamespace := test.Ctx().ManagedNamespace(1)
+	name := "test-cross-ns-ems-es"
+
+	esBuilder := elasticsearch.NewBuilder(name).
+		WithNamespace(esNamespace).
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithRestrictedSecurityContext()
+	emsBuilder := maps.NewBuilder(name).
+		WithNamespace(emsNamespace).
+		WithElasticsearchRef(esBuilder.Ref()).
+		WithNodeCount(1).
+		WithRestrictedSecurityContext()
+
+	test.Sequence(nil, test.EmptySteps, esBuilder, emsBuilder).RunSequential(t)
+}
+
+func TestElasticMapsServerTLSDisabled(t *testing.T) {
+	name := "test-ems-tls-disabled"
+
+	esBuilder := elasticsearch.NewBuilder(name).
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithRestrictedSecurityContext()
+	emsBuilder := maps.NewBuilder(name).
+		WithElasticsearchRef(esBuilder.Ref()).
+		WithNodeCount(1).
+		WithTLSDisabled(true).
+		WithRestrictedSecurityContext()
+
+	test.Sequence(nil, test.EmptySteps, esBuilder, emsBuilder).RunSequential(t)
+}
+
+func TestElasticMapsServerVersionUpgradeToLatest7x(t *testing.T) {
+	srcVersion := test.Ctx().ElasticStackVersion
+	dstVersion := test.LatestVersion7x
+
+	test.SkipInvalidUpgrade(t, srcVersion, dstVersion)
+
+	name := "test-ems-version-upgrade"
+	es := elasticsearch.NewBuilder(name).
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithVersion(dstVersion)
+
+	ems := maps.NewBuilder(name).
+		WithElasticsearchRef(es.Ref()).
+		WithNodeCount(2).
+		WithVersion(srcVersion).
+		WithRestrictedSecurityContext()
+
+	emsUpgraded := ems.WithVersion(dstVersion).WithMutatedFrom(&ems)
+
+	test.RunMutations(t, []test.Builder{es, ems}, []test.Builder{es, emsUpgraded})
+}

--- a/test/e2e/ems/ems_test.go
+++ b/test/e2e/ems/ems_test.go
@@ -7,16 +7,22 @@ package ems
 import (
 	"testing"
 
-	"github.com/elastic/cloud-on-k8s/test/e2e/test/maps"
-
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/maps"
 )
 
 // TestElasticMapsServerCrossNSAssociation tests associating Elasticsearch and Elastic Maps Server running in different namespaces.
 func TestElasticMapsServerCrossNSAssociation(t *testing.T) {
 	// only execute this test if we have a test license to work with
 	if test.Ctx().TestLicense == "" {
+		t.SkipNow()
+	}
+
+	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
+	// Elastic Maps Server is supported since 7.11.0
+	if !stackVersion.GTE(version.MustParse("7.11.0")) {
 		t.SkipNow()
 	}
 
@@ -34,12 +40,21 @@ func TestElasticMapsServerCrossNSAssociation(t *testing.T) {
 		WithNodeCount(1).
 		WithRestrictedSecurityContext()
 
-	test.Sequence(nil, test.EmptySteps, esBuilder, emsBuilder).RunSequential(t)
+	esWithLicense := test.LicenseTestBuilder()
+	esWithLicense.BuildingThis = esBuilder
+
+	test.Sequence(nil, test.EmptySteps, esWithLicense, emsBuilder).RunSequential(t)
 }
 
 func TestElasticMapsServerTLSDisabled(t *testing.T) {
 	// only execute this test if we have a test license to work with
 	if test.Ctx().TestLicense == "" {
+		t.SkipNow()
+	}
+
+	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
+	// Elastic Maps Server is supported since 7.11.0
+	if !stackVersion.GTE(version.MustParse("7.11.0")) {
 		t.SkipNow()
 	}
 
@@ -54,12 +69,21 @@ func TestElasticMapsServerTLSDisabled(t *testing.T) {
 		WithTLSDisabled(true).
 		WithRestrictedSecurityContext()
 
-	test.Sequence(nil, test.EmptySteps, esBuilder, emsBuilder).RunSequential(t)
+	esWithLicense := test.LicenseTestBuilder()
+	esWithLicense.BuildingThis = esBuilder
+
+	test.Sequence(nil, test.EmptySteps, esWithLicense, emsBuilder).RunSequential(t)
 }
 
 func TestElasticMapsServerVersionUpgradeToLatest7x(t *testing.T) {
 	// only execute this test if we have a test license to work with
 	if test.Ctx().TestLicense == "" {
+		t.SkipNow()
+	}
+
+	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
+	// Elastic Maps Server is supported since 7.11.0
+	if !stackVersion.GTE(version.MustParse("7.11.0")) {
 		t.SkipNow()
 	}
 
@@ -81,5 +105,8 @@ func TestElasticMapsServerVersionUpgradeToLatest7x(t *testing.T) {
 
 	emsUpgraded := ems.WithVersion(dstVersion).WithMutatedFrom(&ems)
 
-	test.RunMutations(t, []test.Builder{es, ems}, []test.Builder{es, emsUpgraded})
+	esWithLicense := test.LicenseTestBuilder()
+	esWithLicense.BuildingThis = es
+
+	test.RunMutations(t, []test.Builder{esWithLicense, ems}, []test.Builder{esWithLicense, emsUpgraded})
 }

--- a/test/e2e/test/apmserver/builder.go
+++ b/test/e2e/test/apmserver/builder.go
@@ -7,10 +7,12 @@ package apmserver
 import (
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -22,6 +24,7 @@ type Builder struct {
 }
 
 var _ test.Builder = Builder{}
+var _ test.Subject = Builder{}
 
 func (b Builder) SkipTest() bool {
 	return false
@@ -157,6 +160,30 @@ func (b Builder) WithPodLabel(key, value string) Builder {
 	labels[key] = value
 	b.ApmServer.Spec.PodTemplate.Labels = labels
 	return b
+}
+
+func (b Builder) NSN() types.NamespacedName {
+	return k8s.ExtractNamespacedName(&b.ApmServer)
+}
+
+func (b Builder) Kind() string {
+	return apmv1.Kind
+}
+
+func (b Builder) Spec() interface{} {
+	return b.ApmServer.Spec
+}
+
+func (b Builder) Count() int32 {
+	return b.ApmServer.Spec.Count
+}
+
+func (b Builder) ServiceName() string {
+	return b.ApmServer.Name + "-apm-http"
+}
+
+func (b Builder) ListOptions() []client.ListOption {
+	return test.ApmServerPodListOptions(b.ApmServer.Namespace, b.ApmServer.Name)
 }
 
 // -- Helper functions

--- a/test/e2e/test/apmserver/checks_k8s.go
+++ b/test/e2e/test/apmserver/checks_k8s.go
@@ -12,115 +12,16 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
 	return test.StepList{
-		CheckApmServerDeployment(b, k),
-		CheckApmServerPodsCount(b, k),
-		CheckApmServerPodsRunning(b, k),
-		CheckServices(b, k),
-		CheckServicesEndpoints(b, k),
+		test.CheckDeployment(b, k, b.ApmServer.Name+"-apm-server"),
+		test.CheckPods(b, k),
+		test.CheckServices(b, k),
+		test.CheckServicesEndpoints(b, k),
 		CheckSecrets(b, k),
 		CheckStatus(b, k),
-	}
-}
-
-// CheckApmServerDeployment checks that APM Server deployment exists
-func CheckApmServerDeployment(b Builder, k *test.K8sClient) test.Step {
-	return test.Step{
-		Name: "ApmServer deployment should be created",
-		Test: test.Eventually(func() error {
-			var dep appsv1.Deployment
-			err := k.Client.Get(context.Background(), types.NamespacedName{
-				Namespace: b.ApmServer.Namespace,
-				Name:      b.ApmServer.Name + "-apm-server",
-			}, &dep)
-			if b.ApmServer.Spec.Count == 0 && apierrors.IsNotFound(err) {
-				return nil
-			}
-			if err != nil {
-				return err
-			}
-			if *dep.Spec.Replicas != b.ApmServer.Spec.Count {
-				return fmt.Errorf("invalid ApmServer replicas count: expected %d, got %d", b.ApmServer.Spec.Count, *dep.Spec.Replicas)
-			}
-			return nil
-		}),
-	}
-}
-
-// CheckApmServerPodsCount checks that APM Server pods count matches the expected one
-func CheckApmServerPodsCount(b Builder, k *test.K8sClient) test.Step {
-	return test.Step{
-		Name: "ApmServer pods count should match the expected one",
-		Test: test.Eventually(func() error {
-			return k.CheckPodCount(int(b.ApmServer.Spec.Count), test.ApmServerPodListOptions(b.ApmServer.Namespace, b.ApmServer.Name)...)
-		}),
-	}
-}
-
-// CheckApmServerPodsRunning checks that all APM Server pods for the given APM Server are running
-func CheckApmServerPodsRunning(b Builder, k *test.K8sClient) test.Step {
-	return test.Step{
-		Name: "ApmServer pods should eventually be running",
-		Test: test.Eventually(func() error {
-			pods, err := k.GetPods(test.ApmServerPodListOptions(b.ApmServer.Namespace, b.ApmServer.Name)...)
-			if err != nil {
-				return err
-			}
-			for _, p := range pods {
-				if p.Status.Phase != corev1.PodRunning {
-					return fmt.Errorf("pod not running yet")
-				}
-			}
-			return nil
-		}),
-	}
-}
-
-// CheckServices checks that all APM Server services are created
-func CheckServices(b Builder, k *test.K8sClient) test.Step {
-	return test.Step{
-		Name: "ApmServer services should be created",
-		Test: test.Eventually(func() error {
-			for _, s := range []string{
-				b.ApmServer.Name + "-apm-http",
-			} {
-				if _, err := k.GetService(b.ApmServer.Namespace, s); err != nil {
-					return err
-				}
-			}
-			return nil
-		}),
-	}
-}
-
-// CheckServicesEndpoints checks that APM Server services have the expected number of endpoints
-func CheckServicesEndpoints(b Builder, k *test.K8sClient) test.Step {
-	return test.Step{
-		Name: "ApmServer services should have endpoints",
-		Test: test.Eventually(func() error {
-			for endpointName, addrCount := range map[string]int{
-				b.ApmServer.Name + "-apm-http": int(b.ApmServer.Spec.Count),
-			} {
-				endpoints, err := k.GetEndpoints(b.ApmServer.Namespace, endpointName)
-				if err != nil {
-					return err
-				}
-				if len(endpoints.Subsets) == 0 {
-					return fmt.Errorf("no subset for endpoint %s", endpointName)
-				}
-				if len(endpoints.Subsets[0].Addresses) != addrCount {
-					return fmt.Errorf("%d addresses found for endpoint %s, expected %d", len(endpoints.Subsets[0].Addresses), endpointName, addrCount)
-				}
-			}
-			return nil
-		}),
 	}
 }
 

--- a/test/e2e/test/common_checks.go
+++ b/test/e2e/test/common_checks.go
@@ -19,7 +19,7 @@ import (
 // CheckDeployment checks the Deployment resource exists
 func CheckDeployment(subj Subject, k *K8sClient, deploymentName string) Step {
 	return Step{
-		Name: "Elastic Map Server deployment should be created",
+		Name: subj.Kind() + " deployment should be created",
 		Test: Eventually(func() error {
 			var dep appsv1.Deployment
 			err := k.Client.Get(context.Background(), types.NamespacedName{
@@ -40,7 +40,7 @@ func CheckDeployment(subj Subject, k *K8sClient, deploymentName string) Step {
 	}
 }
 
-// CheckPods checks test subjects expected pods are eventually ready.
+// CheckPods checks that the test subject's expected pods are eventually ready.
 func CheckPods(subj Subject, k *K8sClient) Step {
 	// This is a shared test but it is common for Enterprise Search Pods to take some time to be ready, especially
 	// during the initial bootstrap, or during version upgrades. Let's increase the timeout
@@ -86,7 +86,7 @@ func CheckPods(subj Subject, k *K8sClient) Step {
 	}
 }
 
-// CheckServices checks that all Enterprise Search services are created
+// CheckServices checks that all expected services have been created
 func CheckServices(subj Subject, k *K8sClient) Step {
 	return Step{
 		Name: subj.Kind() + " services should be created",

--- a/test/e2e/test/common_checks.go
+++ b/test/e2e/test/common_checks.go
@@ -1,0 +1,131 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// CheckDeployment checks the Deployment resource exists
+func CheckDeployment(subj Subject, k *K8sClient, deploymentName string) Step {
+	return Step{
+		Name: "Elastic Map Server deployment should be created",
+		Test: Eventually(func() error {
+			var dep appsv1.Deployment
+			err := k.Client.Get(context.Background(), types.NamespacedName{
+				Namespace: subj.NSN().Namespace,
+				Name:      deploymentName,
+			}, &dep)
+			if subj.Count() == 0 && apierrors.IsNotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			if *dep.Spec.Replicas != subj.Count() {
+				return fmt.Errorf("invalid %s replicas count: expected %d, got %d", subj.Kind(), subj.Count(), *dep.Spec.Replicas)
+			}
+			return nil
+		}),
+	}
+}
+
+// CheckPods checks test subjects expected pods are eventually ready.
+func CheckPods(subj Subject, k *K8sClient) Step {
+	// This is a shared test but it is common for Enterprise Search Pods to take some time to be ready, especially
+	// during the initial bootstrap, or during version upgrades. Let's increase the timeout
+	// for this particular step.
+	timeout := Ctx().TestTimeout * 2
+	return Step{
+		Name: subj.Kind() + " Pods should eventually be ready",
+		Test: UntilSuccess(func() error {
+			var pods corev1.PodList
+			if err := k.Client.List(context.Background(), &pods, subj.ListOptions()...); err != nil {
+				return err
+			}
+
+			// builder hash matches
+			expectedBuilderHash := hash.HashObject(subj.Spec())
+			for _, pod := range pods.Items {
+				if err := ValidateBuilderHashAnnotation(pod, expectedBuilderHash); err != nil {
+					return err
+				}
+			}
+
+			// pod count matches
+			if len(pods.Items) != int(subj.Count()) {
+				return fmt.Errorf("invalid %s pod count: expected %d, got %d", subj.NSN().Name, subj.Count(), len(pods.Items))
+			}
+
+			// pods are running
+			for _, pod := range pods.Items {
+				if pod.Status.Phase != corev1.PodRunning {
+					return fmt.Errorf("pod not running yet")
+				}
+			}
+
+			// pods are ready
+			for _, pod := range pods.Items {
+				if !k8s.IsPodReady(pod) {
+					return fmt.Errorf("pod not ready yet")
+				}
+			}
+
+			return nil
+		}, timeout),
+	}
+}
+
+// CheckServices checks that all Enterprise Search services are created
+func CheckServices(subj Subject, k *K8sClient) Step {
+	return Step{
+		Name: subj.Kind() + " services should be created",
+		Test: Eventually(func() error {
+			for _, s := range []string{
+				subj.ServiceName(),
+			} {
+				if _, err := k.GetService(subj.NSN().Namespace, s); err != nil {
+					return err
+				}
+			}
+			return nil
+		}),
+	}
+}
+
+// CheckServicesEndpoints checks that services have the expected number of endpoints
+func CheckServicesEndpoints(subj Subject, k *K8sClient) Step {
+	return Step{
+		Name: subj.Kind() + " services should have endpoints",
+		Test: Eventually(func() error {
+			for endpointName, addrCount := range map[string]int{
+				subj.ServiceName(): int(subj.Count()),
+			} {
+				if addrCount == 0 {
+					continue // maybe no test resource in this builder
+				}
+				endpoints, err := k.GetEndpoints(subj.NSN().Namespace, endpointName)
+				if err != nil {
+					return err
+				}
+				if len(endpoints.Subsets) == 0 {
+					return fmt.Errorf("no subset for endpoint %s", endpointName)
+				}
+				if len(endpoints.Subsets[0].Addresses) != addrCount {
+					return fmt.Errorf("%d addresses found for endpoint %s, expected %d", len(endpoints.Subsets[0].Addresses), endpointName, addrCount)
+				}
+			}
+			return nil
+		}),
+	}
+}

--- a/test/e2e/test/common_steps.go
+++ b/test/e2e/test/common_steps.go
@@ -85,12 +85,13 @@ func DeleteAllEnterpriseLicenseSecrets(k *K8sClient) Step {
 	}
 }
 
-//LicenseTestBuilder is a wrapped builder for tests that require a valid Enterprise license to be installed in the operator.
+// LicenseTestBuilder is a wrapped builder for tests that require a valid Enterprise license to be installed in the operator.
 // It creates an Enterprise license secret before the test and deletes it again after the test. Callers are responsible for
 // making sure that Ctx().TestLicense contains a valid test license.
 func LicenseTestBuilder() WrappedBuilder {
 	return WrappedBuilder{
 		PreInitSteps: func(k *K8sClient) StepList {
+			//nolint:thelper
 			return StepList{
 				Step{
 					Name: "Create an Enterprise license secret",

--- a/test/e2e/test/common_steps.go
+++ b/test/e2e/test/common_steps.go
@@ -1,0 +1,34 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package test
+
+import (
+	"context"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func AnnotatePodsWithBuilderHash(subj, prev Subject, k *K8sClient) StepList {
+	return []Step{
+		{
+			Name: "Annotate Pods with a hash of their Builder spec",
+			Test: Eventually(func() error {
+				var pods corev1.PodList
+				if err := k.Client.List(context.Background(), &pods, subj.ListOptions()...); err != nil {
+					return err
+				}
+
+				expectedHash := hash.HashObject(prev.Spec())
+				for _, pod := range pods.Items {
+					if err := AnnotatePodWithBuilderHash(k, pod, expectedHash); err != nil {
+						return err
+					}
+				}
+				return nil
+			}),
+		},
+	}
+}

--- a/test/e2e/test/enterprisesearch/builder.go
+++ b/test/e2e/test/enterprisesearch/builder.go
@@ -9,9 +9,11 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	entv1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -163,6 +165,32 @@ func (b Builder) WithPodLabel(key, value string) Builder {
 	b.EnterpriseSearch.Spec.PodTemplate.Labels = labels
 	return b
 }
+
+func (b Builder) Kind() string {
+	return entv1.Kind
+}
+
+func (b Builder) NSN() types.NamespacedName {
+	return k8s.ExtractNamespacedName(&b.EnterpriseSearch)
+}
+
+func (b Builder) Spec() interface{} {
+	return b.EnterpriseSearch.Spec
+}
+
+func (b Builder) Count() int32 {
+	return b.EnterpriseSearch.Spec.Count
+}
+
+func (b Builder) ServiceName() string {
+	return b.EnterpriseSearch.Name + "-ent-http"
+}
+
+func (b Builder) ListOptions() []client.ListOption {
+	return test.EnterpriseSearchPodListOptions(b.EnterpriseSearch.Namespace, b.EnterpriseSearch.Name)
+}
+
+var _ test.Subject = Builder{}
 
 // -- Helper functions
 

--- a/test/e2e/test/enterprisesearch/checks_k8s.go
+++ b/test/e2e/test/enterprisesearch/checks_k8s.go
@@ -10,136 +10,18 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	entv1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
 	return test.StepList{
-		CheckDeployment(b, k),
-		CheckPods(b, k),
-		CheckServices(b, k),
-		CheckServicesEndpoints(b, k),
+		test.CheckDeployment(b, k, b.EnterpriseSearch.Name+"-ent"),
+		test.CheckPods(b, k),
+		test.CheckServices(b, k),
+		test.CheckServicesEndpoints(b, k),
 		CheckSecrets(b, k),
 		CheckStatus(b, k),
-	}
-}
-
-// CheckDeployment checks the Deployment resource exists
-func CheckDeployment(b Builder, k *test.K8sClient) test.Step {
-	return test.Step{
-		Name: "EnterpriseSearch deployment should be created",
-		Test: test.Eventually(func() error {
-			var dep appsv1.Deployment
-			err := k.Client.Get(context.Background(), types.NamespacedName{
-				Namespace: b.EnterpriseSearch.Namespace,
-				Name:      b.EnterpriseSearch.Name + "-ent",
-			}, &dep)
-			if b.EnterpriseSearch.Spec.Count == 0 && apierrors.IsNotFound(err) {
-				return nil
-			}
-			if err != nil {
-				return err
-			}
-			if *dep.Spec.Replicas != b.EnterpriseSearch.Spec.Count {
-				return fmt.Errorf("invalid EnterpriseSearch replicas count: expected %d, got %d", b.EnterpriseSearch.Spec.Count, *dep.Spec.Replicas)
-			}
-			return nil
-		}),
-	}
-}
-
-// CheckPods checks expected Enterprise Search pods are eventually ready.
-// TODO: use a common function for all deployments (kb, apm, ent)
-func CheckPods(b Builder, k *test.K8sClient) test.Step {
-	// It is common for Enterprise Search Pods to take some time to be ready, especially
-	// during the initial bootstrap, or during version upgrades. Let's increase the timeout
-	// for this particular step.
-	timeout := test.Ctx().TestTimeout * 2
-	return test.Step{
-		Name: "Enterprise Search Pods should eventually be ready",
-		Test: test.UntilSuccess(func() error {
-			var pods corev1.PodList
-			if err := k.Client.List(context.Background(), &pods, test.EnterpriseSearchPodListOptions(b.EnterpriseSearch.Namespace, b.EnterpriseSearch.Name)...); err != nil {
-				return err
-			}
-
-			// builder hash matches
-			expectedBuilderHash := hash.HashObject(b.EnterpriseSearch.Spec)
-			for _, pod := range pods.Items {
-				if err := test.ValidateBuilderHashAnnotation(pod, expectedBuilderHash); err != nil {
-					return err
-				}
-			}
-
-			// pod count matches
-			if len(pods.Items) != int(b.EnterpriseSearch.Spec.Count) {
-				return fmt.Errorf("invalid EnterpriseSearch pod count: expected %d, got %d", b.EnterpriseSearch.Spec.Count, len(pods.Items))
-			}
-
-			// pods are running
-			for _, pod := range pods.Items {
-				if pod.Status.Phase != corev1.PodRunning {
-					return fmt.Errorf("pod not running yet")
-				}
-			}
-
-			// pods are ready
-			for _, pod := range pods.Items {
-				if !k8s.IsPodReady(pod) {
-					return fmt.Errorf("pod not ready yet")
-				}
-			}
-
-			return nil
-		}, timeout),
-	}
-}
-
-// CheckServices checks that all Enterprise Search services are created
-// TODO: refactor with other resources
-func CheckServices(b Builder, k *test.K8sClient) test.Step {
-	return test.Step{
-		Name: "Enterprise Search services should be created",
-		Test: test.Eventually(func() error {
-			for _, s := range []string{
-				b.EnterpriseSearch.Name + "-ent-http",
-			} {
-				if _, err := k.GetService(b.EnterpriseSearch.Namespace, s); err != nil {
-					return err
-				}
-			}
-			return nil
-		}),
-	}
-}
-
-// CheckServicesEndpoints checks that services have the expected number of endpoints
-func CheckServicesEndpoints(b Builder, k *test.K8sClient) test.Step {
-	return test.Step{
-		Name: "EnterpriseSearch services should have endpoints",
-		Test: test.Eventually(func() error {
-			for endpointName, addrCount := range map[string]int{
-				b.EnterpriseSearch.Name + "-ent-http": int(b.EnterpriseSearch.Spec.Count),
-			} {
-				endpoints, err := k.GetEndpoints(b.EnterpriseSearch.Namespace, endpointName)
-				if err != nil {
-					return err
-				}
-				if len(endpoints.Subsets) == 0 {
-					return fmt.Errorf("no subset for endpoint %s", endpointName)
-				}
-				if len(endpoints.Subsets[0].Addresses) != addrCount {
-					return fmt.Errorf("%d addresses found for endpoint %s, expected %d", len(endpoints.Subsets[0].Addresses), endpointName, addrCount)
-				}
-			}
-			return nil
-		}),
 	}
 }
 

--- a/test/e2e/test/enterprisesearch/steps_mutation.go
+++ b/test/e2e/test/enterprisesearch/steps_mutation.go
@@ -8,39 +8,15 @@ import (
 	"context"
 
 	entv1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
-	corev1 "k8s.io/api/core/v1"
 )
 
 func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
-	return b.AnnotatePodsWithBuilderHash(k).
+	return test.AnnotatePodsWithBuilderHash(b, b.MutatedFrom, k).
 		WithSteps(b.UpgradeTestSteps(k)).
 		WithSteps(b.CheckK8sTestSteps(k)).
 		WithSteps(b.CheckStackTestSteps(k))
-}
-
-func (b Builder) AnnotatePodsWithBuilderHash(k *test.K8sClient) test.StepList {
-	return []test.Step{
-		{
-			Name: "Annotate Pods with a hash of their Builder spec",
-			Test: test.Eventually(func() error {
-				var pods corev1.PodList
-				if err := k.Client.List(context.Background(), &pods, test.EnterpriseSearchPodListOptions(b.EnterpriseSearch.Namespace, b.EnterpriseSearch.Name)...); err != nil {
-					return err
-				}
-
-				expectedHash := hash.HashObject(b.MutatedFrom.EnterpriseSearch.Spec)
-				for _, pod := range pods.Items {
-					if err := test.AnnotatePodWithBuilderHash(k, pod, expectedHash); err != nil {
-						return err
-					}
-				}
-				return nil
-			}),
-		},
-	}
 }
 
 func (b Builder) MutationReversalTestContext() test.ReversalTestContext {

--- a/test/e2e/test/k8s_client.go
+++ b/test/e2e/test/k8s_client.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/enterprisesearch"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/maps"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -395,6 +396,15 @@ func BeatPodListOptions(beatNamespace, beatName, beatType string) []k8sclient.Li
 	matchLabels := k8sclient.MatchingLabels(map[string]string{
 		common.TypeLabelName:     beatcommon.TypeLabelValue,
 		beatcommon.NameLabelName: beatcommon.Name(beatName, beatType),
+	})
+	return []k8sclient.ListOption{ns, matchLabels}
+}
+
+func MapsPodListOptions(emsNS, emsName string) []k8sclient.ListOption {
+	ns := k8sclient.InNamespace(emsNS)
+	matchLabels := k8sclient.MatchingLabels(map[string]string{
+		common.TypeLabelName: maps.Type,
+		maps.NameLabelName:   emsName,
 	})
 	return []k8sclient.ListOption{ns, matchLabels}
 }

--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -5,8 +5,10 @@
 package kibana
 
 import (
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -24,6 +26,7 @@ type Builder struct {
 }
 
 var _ test.Builder = Builder{}
+var _ test.Subject = Builder{}
 
 func (b Builder) SkipTest() bool {
 	return false
@@ -163,6 +166,32 @@ func (b Builder) WithTLSDisabled(disabled bool) Builder {
 	}
 	b.Kibana.Spec.HTTP.TLS.SelfSignedCertificate.Disabled = disabled
 	return b
+}
+
+// -- test.Subject impl
+
+func (b Builder) NSN() types.NamespacedName {
+	return k8s.ExtractNamespacedName(&b.Kibana)
+}
+
+func (b Builder) Kind() string {
+	return kbv1.Kind
+}
+
+func (b Builder) Spec() interface{} {
+	return b.Kibana.Spec
+}
+
+func (b Builder) Count() int32 {
+	return b.Kibana.Spec.Count
+}
+
+func (b Builder) ServiceName() string {
+	return b.Kibana.Name + "-kb-http"
+}
+
+func (b Builder) ListOptions() []client.ListOption {
+	return test.KibanaPodListOptions(b.Kibana.Namespace, b.Kibana.Name)
 }
 
 // -- Helper functions

--- a/test/e2e/test/kibana/checks_k8s.go
+++ b/test/e2e/test/kibana/checks_k8s.go
@@ -10,121 +10,19 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
 	return test.StepList{
-		CheckKibanaPods(b, k),
-		CheckServices(b, k),
-		CheckServicesEndpoints(b, k),
+		test.CheckDeployment(b, k, kibana.Deployment(b.Kibana.Name)),
+		test.CheckPods(b, k),
+		test.CheckServices(b, k),
+		test.CheckServicesEndpoints(b, k),
 		CheckSecrets(b, k),
 		CheckStatus(b, k),
-	}
-}
-
-// CheckKibanaPods checks Kibana pods for correct builder hash, pod count, whether pods are running and ready
-func CheckKibanaPods(b Builder, k *test.K8sClient) test.Step {
-	return test.Step{
-		Name: "Kibana deployment be rolled out",
-		Test: test.Eventually(func() error {
-			var dep appsv1.Deployment
-			err := k.Client.Get(context.Background(), types.NamespacedName{
-				Namespace: b.Kibana.Namespace,
-				Name:      kibana.Deployment(b.Kibana.Name),
-			}, &dep)
-			if b.Kibana.Spec.Count == 0 && apierrors.IsNotFound(err) {
-				return nil
-			}
-			if err != nil {
-				return err
-			}
-
-			var pods corev1.PodList
-			if err := k.Client.List(context.Background(), &pods, test.KibanaPodListOptions(b.Kibana.Namespace, b.Kibana.Name)...); err != nil {
-				return err
-			}
-
-			// builder hash matches
-			expectedBuilderHash := hash.HashObject(b.Kibana.Spec)
-			for _, pod := range pods.Items {
-				if err := test.ValidateBuilderHashAnnotation(pod, expectedBuilderHash); err != nil {
-					return err
-				}
-			}
-
-			// pod count matches
-			if len(pods.Items) != int(b.Kibana.Spec.Count) {
-				return fmt.Errorf("invalid Kibana pod count: expected %d, got %d", b.Kibana.Spec.Count, len(pods.Items))
-			}
-
-			// pods are running
-			for _, pod := range pods.Items {
-				if pod.Status.Phase != corev1.PodRunning {
-					return fmt.Errorf("pod not running yet")
-				}
-			}
-
-			// pods are ready
-			for _, pod := range pods.Items {
-				if !k8s.IsPodReady(pod) {
-					return fmt.Errorf("pod not ready yet")
-				}
-			}
-
-			return nil
-		}),
-	}
-}
-
-// CheckServices checks that all Kibana services are created
-func CheckServices(b Builder, k *test.K8sClient) test.Step {
-	return test.Step{
-		Name: "Kibana services should be created",
-		Test: test.Eventually(func() error {
-			for _, s := range []string{
-				b.Kibana.Name + "-kb-http",
-			} {
-				if _, err := k.GetService(b.Kibana.Namespace, s); err != nil {
-					return err
-				}
-			}
-			return nil
-		}),
-	}
-}
-
-// CheckServicesEndpoints checks that services have the expected number of endpoints
-func CheckServicesEndpoints(b Builder, k *test.K8sClient) test.Step {
-	return test.Step{
-		Name: "Kibana services should have endpoints",
-		Test: test.Eventually(func() error {
-			for endpointName, addrCount := range map[string]int{
-				b.Kibana.Name + "-kb-http": int(b.Kibana.Spec.Count),
-			} {
-				if addrCount == 0 {
-					continue // maybe no Kibana in this b
-				}
-				endpoints, err := k.GetEndpoints(b.Kibana.Namespace, endpointName)
-				if err != nil {
-					return err
-				}
-				if len(endpoints.Subsets) == 0 {
-					return fmt.Errorf("no subset for endpoint %s", endpointName)
-				}
-				if len(endpoints.Subsets[0].Addresses) != addrCount {
-					return fmt.Errorf("%d addresses found for endpoint %s, expected %d", len(endpoints.Subsets[0].Addresses), endpointName, addrCount)
-				}
-			}
-			return nil
-		}),
 	}
 }
 

--- a/test/e2e/test/kibana/steps_deletion.go
+++ b/test/e2e/test/kibana/steps_deletion.go
@@ -8,7 +8,7 @@ import (
 	"context"
 
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/enterprisesearch/name"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/pkg/errors"
@@ -57,7 +57,7 @@ func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
 			Test: test.Eventually(func() error {
 				namespace := b.Kibana.Namespace
 				return k.CheckSecretsRemoved([]types.NamespacedName{
-					{Namespace: namespace, Name: certificates.PublicCertsSecretName(name.EntNamer, b.Kibana.Name)},
+					{Namespace: namespace, Name: certificates.PublicCertsSecretName(kibana.Namer, b.Kibana.Name)},
 				})
 			}),
 		},

--- a/test/e2e/test/kibana/steps_mutation.go
+++ b/test/e2e/test/kibana/steps_mutation.go
@@ -8,39 +8,15 @@ import (
 	"context"
 
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
-	corev1 "k8s.io/api/core/v1"
 )
 
 func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
-	return b.AnnotatePodsWithBuilderHash(k).
+	return test.AnnotatePodsWithBuilderHash(b, b.MutatedFrom, k).
 		WithSteps(b.UpgradeTestSteps(k)).
 		WithSteps(b.CheckK8sTestSteps(k)).
 		WithSteps(b.CheckStackTestSteps(k))
-}
-
-func (b Builder) AnnotatePodsWithBuilderHash(k *test.K8sClient) test.StepList {
-	return []test.Step{
-		{
-			Name: "Annotate Pods with a hash of their Builder spec",
-			Test: test.Eventually(func() error {
-				var pods corev1.PodList
-				if err := k.Client.List(context.Background(), &pods, test.KibanaPodListOptions(b.Kibana.Namespace, b.Kibana.Name)...); err != nil {
-					return err
-				}
-
-				expectedHash := hash.HashObject(b.MutatedFrom.Kibana.Spec)
-				for _, pod := range pods.Items {
-					if err := test.AnnotatePodWithBuilderHash(k, pod, expectedHash); err != nil {
-						return err
-					}
-				}
-				return nil
-			}),
-		},
-	}
 }
 
 func (b Builder) MutationReversalTestContext() test.ReversalTestContext {

--- a/test/e2e/test/maps/builder.go
+++ b/test/e2e/test/maps/builder.go
@@ -1,0 +1,157 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package maps
+
+import (
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/apis/maps/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Builder struct {
+	EMS         v1alpha1.ElasticMapsServer
+	MutatedFrom *Builder
+}
+
+func NewBuilder(name string) Builder {
+	return newBuilder(name, rand.String(4))
+}
+
+func NewBuilderWithoutSuffix(name string) Builder {
+	return newBuilder(name, "")
+}
+
+func newBuilder(name, randSuffix string) Builder {
+	meta := metav1.ObjectMeta{
+		Name:      name,
+		Namespace: test.Ctx().ManagedNamespace(0),
+	}
+
+	return Builder{
+		EMS: v1alpha1.ElasticMapsServer{
+			ObjectMeta: meta,
+			Spec: v1alpha1.MapsSpec{
+				Count:   1,
+				Version: test.Ctx().ElasticStackVersion,
+			},
+		},
+	}.
+		WithSuffix(randSuffix).
+		WithLabel(run.TestNameLabel, name).
+		WithPodLabel(run.TestNameLabel, name)
+}
+
+func (b Builder) WithSuffix(suffix string) Builder {
+	if suffix != "" {
+		b.EMS.ObjectMeta.Name = b.EMS.ObjectMeta.Name + "-" + suffix
+	}
+	return b
+}
+
+func (b Builder) WithLabel(key, value string) Builder {
+	if b.EMS.Labels == nil {
+		b.EMS.Labels = make(map[string]string)
+	}
+	b.EMS.Labels[key] = value
+
+	return b
+}
+
+// WithRestrictedSecurityContext helps to enforce a restricted security context on the objects.
+func (b Builder) WithRestrictedSecurityContext() Builder {
+	b.EMS.Spec.PodTemplate.Spec.SecurityContext = test.DefaultSecurityContext()
+	return b
+}
+
+func (b Builder) WithElasticsearchRef(ref commonv1.ObjectSelector) Builder {
+	b.EMS.Spec.ElasticsearchRef = ref
+	return b
+}
+
+func (b Builder) WithNamespace(namespace string) Builder {
+	b.EMS.ObjectMeta.Namespace = namespace
+	return b
+}
+
+func (b Builder) WithVersion(version string) Builder {
+	b.EMS.Spec.Version = version
+	return b
+}
+
+func (b Builder) WithNodeCount(count int) Builder {
+	b.EMS.Spec.Count = int32(count)
+	return b
+}
+
+// WithPodLabel sets the label in the pod template. All invocations can be removed when
+// https://github.com/elastic/cloud-on-k8s/issues/2652 is implemented.
+func (b Builder) WithPodLabel(key, value string) Builder {
+	labels := b.EMS.Spec.PodTemplate.Labels
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[key] = value
+	b.EMS.Spec.PodTemplate.Labels = labels
+	return b
+}
+
+func (b Builder) WithTLSDisabled(disabled bool) Builder {
+	if b.EMS.Spec.HTTP.TLS.SelfSignedCertificate == nil {
+		b.EMS.Spec.HTTP.TLS.SelfSignedCertificate = &commonv1.SelfSignedCertificate{}
+	}
+	b.EMS.Spec.HTTP.TLS.SelfSignedCertificate.Disabled = disabled
+	return b
+}
+
+func (b Builder) WithMutatedFrom(mutatedFrom *Builder) Builder {
+	b.MutatedFrom = mutatedFrom
+	return b
+}
+
+// test.Subject impl
+
+func (b Builder) NSN() types.NamespacedName {
+	return k8s.ExtractNamespacedName(&b.EMS)
+}
+
+func (b Builder) Kind() string {
+	return v1alpha1.Kind
+}
+
+func (b Builder) Spec() interface{} {
+	return b.EMS.Spec
+}
+
+func (b Builder) Count() int32 {
+	return b.EMS.Spec.Count
+}
+
+func (b Builder) ServiceName() string {
+	return b.EMS.Name + "-ems-http"
+}
+
+func (b Builder) ListOptions() []client.ListOption {
+	return test.MapsPodListOptions(b.EMS.Namespace, b.EMS.Name)
+}
+
+func (b Builder) MutationReversalTestContext() test.ReversalTestContext {
+	panic("implement me")
+}
+
+func (b Builder) SkipTest() bool {
+	ver := version.MustParse(b.EMS.Spec.Version)
+	return version.SupportedMapsVersions.WithinRange(ver) != nil
+}
+
+var _ test.Builder = Builder{}
+
+var _ test.Subject = Builder{}

--- a/test/e2e/test/maps/checks.go
+++ b/test/e2e/test/maps/checks.go
@@ -137,9 +137,8 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 				if err := json.Unmarshal(bytes, &status); err != nil {
 					return err
 				}
-				// we cannot just test for "available" because in absence of a valid license the state is "critical"
-				// however we consider a parseable response to be a sufficient signal for a successful deployment
-				expectedStatus := set.Make("available", "degraded", "unavailable", "critical")
+				// 7.11-7.12 reports `degraded` status when the full basemap is not installed
+				expectedStatus := set.Make("available", "degraded")
 				if !expectedStatus.Has(status.Overall.State) {
 					return fmt.Errorf("expected one of %v but got %s", expectedStatus, status.Overall.State)
 				}

--- a/test/e2e/test/maps/checks.go
+++ b/test/e2e/test/maps/checks.go
@@ -1,0 +1,150 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package maps
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/apis/maps/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/set"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+)
+
+// CheckSecrets checks that expected secrets have been created.
+func CheckSecrets(b Builder, k *test.K8sClient) test.Step {
+	return test.CheckSecretsContent(k, b.EMS.Namespace, func() []test.ExpectedSecret {
+		emsName := b.EMS.Name
+		// hardcode all secret names and keys to catch any breaking change
+		expected := []test.ExpectedSecret{
+			{
+				Name: emsName + "-ems-config",
+				Keys: []string{"elastic-maps-server.yml"},
+				Labels: map[string]string{
+					"eck.k8s.elastic.co/credentials": "true",
+					"maps.k8s.elastic.co/name":       emsName,
+				},
+			},
+		}
+		if b.EMS.Spec.ElasticsearchRef.Name != "" {
+			expected = append(expected,
+				test.ExpectedSecret{
+					Name: emsName + "-ems-es-ca",
+					Keys: []string{"ca.crt", "tls.crt"},
+					Labels: map[string]string{
+						"elasticsearch.k8s.elastic.co/cluster-name": b.EMS.Spec.ElasticsearchRef.Name,
+						"mapsassociation.k8s.elastic.co/name":       emsName,
+						"mapsassociation.k8s.elastic.co/namespace":  b.EMS.Namespace,
+					},
+				},
+				test.ExpectedSecret{
+					Name: emsName + "-maps-user",
+					Keys: []string{b.EMS.Namespace + "-" + emsName + "-maps-user"},
+					Labels: map[string]string{
+						"eck.k8s.elastic.co/credentials":            "true",
+						"elasticsearch.k8s.elastic.co/cluster-name": b.EMS.Spec.ElasticsearchRef.Name,
+						"mapsassociation.k8s.elastic.co/name":       emsName,
+						"mapsassociation.k8s.elastic.co/namespace":  b.EMS.Namespace,
+					},
+				},
+			)
+		}
+		if b.EMS.Spec.HTTP.TLS.Enabled() {
+			expected = append(expected,
+				test.ExpectedSecret{
+					Name: emsName + "-ems-http-ca-internal",
+					Keys: []string{"tls.crt", "tls.key"},
+					Labels: map[string]string{
+						"maps.k8s.elastic.co/name":   emsName,
+						"common.k8s.elastic.co/type": "maps",
+					},
+				},
+				test.ExpectedSecret{
+					Name: emsName + "-ems-http-certs-internal",
+					Keys: []string{"tls.crt", "tls.key", "ca.crt"},
+					Labels: map[string]string{
+						"maps.k8s.elastic.co/name":   emsName,
+						"common.k8s.elastic.co/type": "maps",
+					},
+				},
+				test.ExpectedSecret{
+					Name: emsName + "-ems-http-certs-public",
+					Keys: []string{"ca.crt", "tls.crt"},
+					Labels: map[string]string{
+						"maps.k8s.elastic.co/name":   emsName,
+						"common.k8s.elastic.co/type": "maps",
+					},
+				},
+			)
+		}
+		return expected
+	})
+}
+
+func CheckStatus(b Builder, k *test.K8sClient) test.Step {
+	return test.Step{
+		Name: "Elastic Maps Server status should be updated",
+		Test: test.Eventually(func() error {
+			var ems v1alpha1.ElasticMapsServer
+			if err := k.Client.Get(context.Background(), k8s.ExtractNamespacedName(&b.EMS), &ems); err != nil {
+				return err
+			}
+			// don't check the association status that may vary across tests
+			ems.Status.AssociationStatus = ""
+			expected := v1alpha1.MapsStatus{
+				DeploymentStatus: commonv1.DeploymentStatus{
+					AvailableNodes: b.EMS.Spec.Count,
+					Version:        b.EMS.Spec.Version,
+					Health:         "green",
+				},
+				AssociationStatus: "",
+			}
+			if ems.Status != expected {
+				return fmt.Errorf("expected status %+v but got %+v", expected, ems.Status)
+			}
+			return nil
+		}),
+	}
+}
+
+type emsStatus struct {
+	Version string `json:"version"`
+	Overall struct {
+		State string `json:"state"`
+	} `json:"overall"`
+}
+
+func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
+	println(test.Ctx().TestTimeout)
+	return test.StepList{
+		{
+			Name: "Elastic Maps Server should respond to requests",
+			Test: test.Eventually(func() error {
+				client, err := NewMapsClient(b.EMS, k)
+				if err != nil {
+					return err
+				}
+				bytes, err := DoRequest(client, b.EMS, "GET", "/status")
+				if err != nil {
+					return err
+				}
+				var status emsStatus
+				if err := json.Unmarshal(bytes, &status); err != nil {
+					return err
+				}
+				// we cannot just test for "available" because in absence of a valid license the state is "critical"
+				// however we consider a parseable response to be a sufficient signal for a successful deployment
+				expectedStatus := set.Make("available", "degraded", "unavailable", "critical")
+				if !expectedStatus.Has(status.Overall.State) {
+					return fmt.Errorf("expected one of %v but got %s", expectedStatus, status.Overall.State)
+				}
+				return nil
+			}),
+		},
+	}
+}

--- a/test/e2e/test/maps/http_client.go
+++ b/test/e2e/test/maps/http_client.go
@@ -1,0 +1,71 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package maps
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/elastic/cloud-on-k8s/pkg/apis/maps/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/maps"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+)
+
+type APIError struct {
+	StatusCode int
+	msg        string
+}
+
+func (e *APIError) Error() string {
+	return e.msg
+}
+
+// TODO refactor identical to Kibana client
+func NewMapsClient(ems v1alpha1.ElasticMapsServer, k *test.K8sClient) (*http.Client, error) {
+	var caCerts []*x509.Certificate
+	if ems.Spec.HTTP.TLS.Enabled() {
+		crts, err := k.GetHTTPCerts(maps.EMSNamer, ems.Namespace, ems.Name)
+		if err != nil {
+			return nil, err
+		}
+		caCerts = crts
+	}
+	return test.NewHTTPClient(caCerts), nil
+}
+
+func DoRequest(client *http.Client, ems v1alpha1.ElasticMapsServer, method, path string) ([]byte, error) {
+	scheme := "http"
+	if ems.Spec.HTTP.TLS.Enabled() {
+		scheme = "https"
+	}
+
+	url, err := url.Parse(fmt.Sprintf("%s://%s.%s.svc:8080%s", scheme, maps.HTTPService(ems.Name), ems.Namespace, path))
+	if err != nil {
+		return nil, fmt.Errorf("while parsing URL: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(context.Background(), method, url.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("while constructing request: %w", err)
+	}
+
+	resp, err := client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("while making request: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, &APIError{
+			StatusCode: resp.StatusCode,
+			msg:        fmt.Sprintf("fail to request %s, status is %d)", path, resp.StatusCode),
+		}
+	}
+	defer resp.Body.Close()
+	return ioutil.ReadAll(resp.Body)
+}

--- a/test/e2e/test/maps/steps.go
+++ b/test/e2e/test/maps/steps.go
@@ -1,0 +1,155 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package maps
+
+import (
+	"context"
+	"fmt"
+
+	emsv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/maps/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/maps"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func (b Builder) InitTestSteps(k *test.K8sClient) test.StepList {
+	return []test.Step{
+		{
+			Name: "K8S should be accessible",
+			Test: test.Eventually(func() error {
+				pods := corev1.PodList{}
+				return k.Client.List(context.Background(), &pods)
+			}),
+		},
+		{
+			Name: "Label test pods",
+			Test: test.Eventually(func() error {
+				return test.LabelTestPods(
+					k.Client,
+					test.Ctx(),
+					run.TestNameLabel,
+					b.EMS.Labels[run.TestNameLabel])
+			}),
+			Skip: func() bool {
+				return test.Ctx().Local
+			},
+		},
+		{
+			Name: "Elastic Map Server CRDs should exist",
+			Test: test.Eventually(func() error {
+				crd := &emsv1alpha1.ElasticMapsServerList{}
+				return k.Client.List(context.Background(), crd)
+			}),
+		},
+		{
+			Name: "Remove Elastic Maps Server if it already exists",
+			Test: test.Eventually(func() error {
+				err := k.Client.Delete(context.Background(), &b.EMS)
+				if err != nil && !apierrors.IsNotFound(err) {
+					return err
+				}
+				// wait for pods to disappear
+				return k.CheckPodCount(0, test.MapsPodListOptions(b.EMS.Namespace, b.EMS.Name)...)
+			}),
+		},
+	}
+}
+
+func (b Builder) CreationTestSteps(k *test.K8sClient) test.StepList {
+	return test.StepList{
+		{
+			Name: "Submitting the Elastic Maps Server resource should succeed",
+			Test: test.Eventually(func() error {
+				return k.CreateOrUpdate(&b.EMS)
+			}),
+		},
+		{
+			Name: "Elastic Maps Server should be created",
+			Test: test.Eventually(func() error {
+				var ems emsv1alpha1.ElasticMapsServer
+				return k.Client.Get(context.Background(), k8s.ExtractNamespacedName(&b.EMS), &ems)
+			}),
+		},
+	}
+}
+
+func (b Builder) CheckK8sTestSteps(k *test.K8sClient) test.StepList {
+	return test.StepList{
+		test.CheckDeployment(b, k, maps.Deployment(b.EMS.Name)),
+		test.CheckPods(b, k),
+		test.CheckServices(b, k),
+		test.CheckServicesEndpoints(b, k),
+		CheckSecrets(b, k),
+		CheckStatus(b, k),
+	}
+}
+
+func (b Builder) UpgradeTestSteps(k *test.K8sClient) test.StepList {
+	return test.StepList{
+		{
+			Name: "Updating the Elastic Maps Server spec succeed",
+			Test: test.Eventually(func() error {
+				var ems emsv1alpha1.ElasticMapsServer
+				if err := k.Client.Get(context.Background(), k8s.ExtractNamespacedName(&b.EMS), &ems); err != nil {
+					return err
+				}
+				ems.Spec = b.EMS.Spec
+				return k.Client.Update(context.Background(), &ems)
+			}),
+		}}
+}
+
+func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
+	return test.AnnotatePodsWithBuilderHash(b, b.MutatedFrom, k).
+		WithSteps(b.UpgradeTestSteps(k)).
+		WithSteps(b.CheckK8sTestSteps(k)).
+		WithSteps(b.CheckStackTestSteps(k))
+}
+
+func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
+	return test.StepList{
+		{
+			Name: "Deleting Elastic Maps Server should return no error",
+			Test: test.Eventually(func() error {
+				err := k.Client.Delete(context.Background(), &b.EMS)
+				if err != nil && !apierrors.IsNotFound(err) {
+					return err
+				}
+				return nil
+			}),
+		},
+		{
+			Name: "Elastic Maps Server should not be there anymore",
+			Test: test.Eventually(func() error {
+				objCopy := k8s.DeepCopyObject(&b.EMS)
+				err := k.Client.Get(context.Background(), k8s.ExtractNamespacedName(&b.EMS), objCopy)
+				if err != nil && apierrors.IsNotFound(err) {
+					return nil
+				}
+				return fmt.Errorf("expected 404 not found API error here. got: %w", err)
+			}),
+		},
+		{
+			Name: "Elastic Maps Server pods should eventually be removed",
+			Test: test.Eventually(func() error {
+				return k.CheckPodCount(0, b.ListOptions()...)
+			}),
+		},
+		{
+			Name: "Soft-owned secrets should eventually be removed",
+			Test: test.Eventually(func() error {
+				namespace := b.EMS.Namespace
+				return k.CheckSecretsRemoved([]types.NamespacedName{
+					{Namespace: namespace, Name: certificates.PublicCertsSecretName(maps.EMSNamer, b.EMS.Name)},
+				})
+			}),
+		},
+	}
+}

--- a/test/e2e/test/subject.go
+++ b/test/e2e/test/subject.go
@@ -1,0 +1,20 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package test
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Subject the main test subject for a test case
+type Subject interface {
+	NSN() types.NamespacedName
+	Kind() string
+	Spec() interface{}
+	Count() int32
+	ServiceName() string
+	ListOptions() []k8sclient.ListOption
+}


### PR DESCRIPTION
Third part of #4179 split up to allow easier review.

Adds a few basic e2e test for  Elastic Maps Server in the ECK operator. I tried to also refactor some common steps and checks that were more or less identical between Kibana/Enterprise Search and APM Server

Depends on #4439 and https://github.com/elastic/cloud-on-k8s/pull/4443 so please only review dff0eb478b3982fb8bf3915a229f9acdac47aa51
