### PR TITLE
[Autoscaling] Add support for tier only requests

### DIFF
--- a/pkg/controller/autoscaling/elasticsearch/autoscaler/vertical.go
+++ b/pkg/controller/autoscaling/elasticsearch/autoscaler/vertical.go
@@ -19,7 +19,8 @@ func (ctx *Context) nodeResources(minNodesCount int64, minStorage resource.Quant
 	nodeResources := resources.NodeResources{}
 	requiredCapacity := ctx.AutoscalingPolicyResult.RequiredCapacity
 	// Compute desired memory quantity for the nodes managed by this AutoscalingPolicySpec.
-	if !requiredCapacity.Node.Memory.IsEmpty() {
+	if !requiredCapacity.Node.Memory.IsEmpty() ||
+		!requiredCapacity.Total.Memory.IsEmpty() {
 		memoryRequest := ctx.getResourceValue(
 			"memory",
 			requiredCapacity.Node.Memory,
@@ -30,9 +31,9 @@ func (ctx *Context) nodeResources(minNodesCount int64, minStorage resource.Quant
 		)
 		nodeResources.SetRequest(corev1.ResourceMemory, memoryRequest)
 	}
-
 	// Compute desired storage quantity for the nodes managed by this AutoscalingPolicySpec.
-	if !requiredCapacity.Node.Storage.IsEmpty() {
+	if !requiredCapacity.Node.Storage.IsEmpty() ||
+		!requiredCapacity.Total.Storage.IsEmpty() {
 		storageRequest := ctx.getResourceValue(
 			"storage",
 			requiredCapacity.Node.Storage,

--- a/pkg/controller/autoscaling/elasticsearch/controller_test.go
+++ b/pkg/controller/autoscaling/elasticsearch/controller_test.go
@@ -90,6 +90,21 @@ func TestReconcile(t *testing.T) {
 		wantErr    bool
 	}{
 		{
+			name: "Frozen decider only returns capacity at the tier level",
+			fields: fields{
+				EsClient:       newFakeEsClient(t).withCapacity("frozen-tier"),
+				recorder:       record.NewFakeRecorder(1000),
+				licenseChecker: &fakeLicenceChecker{},
+			},
+			args: args{
+				esManifest: "frozen-tier",
+				isOnline:   true,
+			},
+			want:       defaultRequeue,
+			wantErr:    false,
+			wantEvents: []string{},
+		},
+		{
 			name: "ML case where tier total memory was lower than node memory",
 			fields: fields{
 				EsClient:       newFakeEsClient(t).withCapacity("ml"),
@@ -246,12 +261,13 @@ func TestReconcile(t *testing.T) {
 				bytes, err := ioutil.ReadFile(filepath.Join("testdata", tt.args.esManifest, "elasticsearch-expected.yml"))
 				require.NoError(t, err)
 				require.NoError(t, yaml.Unmarshal(bytes, &expectedElasticsearch))
-				assert.Equal(t, updatedElasticsearch.Spec, expectedElasticsearch.Spec)
+				assert.Equal(t, updatedElasticsearch.Spec, expectedElasticsearch.Spec, "Updated Elasticsearch spec. is not the expected one")
 				// Check that the autoscaling spec is still the expected one.
 				assert.Equal(
 					t,
 					updatedElasticsearch.Annotations[esv1.ElasticsearchAutoscalingSpecAnnotationName],
 					expectedElasticsearch.Annotations[esv1.ElasticsearchAutoscalingSpecAnnotationName],
+					"Autoscaling specification is not the expected one",
 				)
 				// Compare the statuses.
 				statusesEqual(t, updatedElasticsearch, expectedElasticsearch)
@@ -275,10 +291,16 @@ func statusesEqual(t *testing.T, got, want esv1.Elasticsearch) {
 		require.NotNil(t, gotPolicyStatus, "Autoscaling policy not found")
 		require.ElementsMatch(t, gotPolicyStatus.NodeSetNodeCount, wantPolicyStatus.NodeSetNodeCount)
 		for resource := range wantPolicyStatus.ResourcesSpecification.Requests {
-			require.True(t, resources.ResourceEqual(resource, wantPolicyStatus.ResourcesSpecification.Requests, gotPolicyStatus.ResourcesSpecification.Requests))
+			require.True(
+				t,
+				resources.ResourceEqual(resource, wantPolicyStatus.ResourcesSpecification.Requests, gotPolicyStatus.ResourcesSpecification.Requests),
+				"unexpected resource requests for policy %s, expected %v, got %v", gotPolicyStatus.Name, wantPolicyStatus.ResourcesSpecification.Requests, gotPolicyStatus.ResourcesSpecification.Requests)
 		}
 		for resource := range wantPolicyStatus.ResourcesSpecification.Limits {
-			require.True(t, resources.ResourceEqual(resource, wantPolicyStatus.ResourcesSpecification.Requests, gotPolicyStatus.ResourcesSpecification.Requests))
+			require.True(
+				t,
+				resources.ResourceEqual(resource, wantPolicyStatus.ResourcesSpecification.Limits, gotPolicyStatus.ResourcesSpecification.Limits),
+				"unexpected resource limits for policy %s, expected %v, got %v", gotPolicyStatus.Name, wantPolicyStatus.ResourcesSpecification.Limits, gotPolicyStatus.ResourcesSpecification.Limits)
 		}
 	}
 }

--- a/pkg/controller/autoscaling/elasticsearch/testdata/frozen-tier/capacity.json
+++ b/pkg/controller/autoscaling/elasticsearch/testdata/frozen-tier/capacity.json
@@ -1,0 +1,169 @@
+{
+  "policies" : {
+    "di-frozen" : {
+      "required_capacity" : {
+        "total" : {
+          "storage" : 1523908623,
+          "memory" : 2164663494
+        }
+      },
+      "current_capacity" : {
+        "node" : {
+          "storage" : 2046640128,
+          "memory" : 2147483648
+        },
+        "total" : {
+          "storage" : 2046640128,
+          "memory" : 2147483648
+        }
+      },
+      "current_nodes" : [
+        {
+          "name" : "frozen-sample-es-di-frozen-0"
+        }
+      ],
+      "deciders" : {
+        "frozen_shards" : {
+          "required_capacity" : {
+            "total" : {
+              "memory" : 2164663494
+            }
+          },
+          "reason_summary" : "shard count [63]",
+          "reason_details" : {
+            "shards" : 63
+          }
+        },
+        "frozen_storage" : {
+          "required_capacity" : {
+            "total" : {
+              "storage" : 1523908623
+            }
+          },
+          "reason_summary" : "total data set size [30478172467]",
+          "reason_details" : {
+            "total_data_set_size" : 30478172467
+          }
+        }
+      }
+    },
+    "di-hot" : {
+      "required_capacity" : {
+        "node" : {
+          "storage" : 38107923
+        },
+        "total" : {
+          "storage" : 8387952640
+        }
+      },
+      "current_capacity" : {
+        "node" : {
+          "storage" : 4193976320,
+          "memory" : 2147483648
+        },
+        "total" : {
+          "storage" : 8387952640,
+          "memory" : 4294967296
+        }
+      },
+      "current_nodes" : [
+        {
+          "name" : "frozen-sample-es-di-hot-0"
+        },
+        {
+          "name" : "frozen-sample-es-di-hot-1"
+        }
+      ],
+      "deciders" : {
+        "proactive_storage" : {
+          "required_capacity" : {
+            "node" : {
+              "storage" : 38107923
+            },
+            "total" : {
+              "storage" : 8387952640
+            }
+          },
+          "reason_summary" : "storage ok",
+          "reason_details" : {
+            "reason" : "storage ok",
+            "unassigned" : 0,
+            "assigned" : 0,
+            "forecasted" : 0,
+            "forecast_window" : "30m"
+          }
+        },
+        "reactive_storage" : {
+          "required_capacity" : {
+            "node" : {
+              "storage" : 38107923
+            },
+            "total" : {
+              "storage" : 8387952640
+            }
+          },
+          "reason_summary" : "storage ok",
+          "reason_details" : {
+            "reason" : "storage ok",
+            "unassigned" : 0,
+            "assigned" : 0
+          }
+        }
+      }
+    },
+    "ml" : {
+      "required_capacity" : {
+        "node" : {
+          "storage" : 0,
+          "memory" : 0
+        },
+        "total" : {
+          "storage" : 0,
+          "memory" : 0
+        }
+      },
+      "current_capacity" : {
+        "node" : {
+          "storage" : 0,
+          "memory" : 0
+        },
+        "total" : {
+          "storage" : 0,
+          "memory" : 0
+        }
+      },
+      "current_nodes" : [ ],
+      "deciders" : {
+        "ml" : {
+          "required_capacity" : {
+            "node" : {
+              "storage" : 0,
+              "memory" : 0
+            },
+            "total" : {
+              "storage" : 0,
+              "memory" : 0
+            }
+          },
+          "reason_summary" : "Passing currently perceived capacity as no scaling changes were detected to be possible",
+          "reason_details" : {
+            "waiting_analytics_jobs" : [ ],
+            "waiting_anomaly_jobs" : [ ],
+            "configuration" : {
+              "down_scale_delay" : "5m"
+            },
+            "perceived_current_capacity" : {
+              "node" : {
+                "memory" : 0
+              },
+              "total" : {
+                "memory" : 0
+              }
+            },
+            "reason" : "Passing currently perceived capacity as no scaling changes were detected to be possible"
+          }
+        }
+      }
+    }
+  }
+}

--- a/pkg/controller/autoscaling/elasticsearch/testdata/frozen-tier/elasticsearch-expected.yml
+++ b/pkg/controller/autoscaling/elasticsearch/testdata/frozen-tier/elasticsearch-expected.yml
@@ -1,0 +1,178 @@
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  annotations:
+    common.k8s.elastic.co/controller-version: 1.6.0-SNAPSHOT
+    elasticsearch.alpha.elastic.co/autoscaling-spec: |
+      {
+        "policies": [{
+          "name": "di-hot",
+          "roles": ["data_hot", "data_content", "ingest", "transform"],
+          "resources": {
+            "nodeCount": { "min": 2, "max": 5 },
+            "cpu": { "min": 1, "max": 2 },
+            "memory": { "min": "2Gi", "max": "6Gi" },
+            "storage": { "min": "4Gi", "max": "8Gi" }
+          }
+        }, {
+          "name": "di-frozen",
+          "roles": ["data_frozen"],
+          "resources": {
+            "nodeCount": { "min": 1, "max": 3 },
+            "cpu": { "min": 2, "max": 2 },
+            "memory": { "min": "2Gi", "max": "8Gi" },
+            "storage": { "min": "1Gi", "max": "4Gi" }
+          }
+        }, {
+          "name": "ml",
+          "roles": ["ml"],
+          "deciders": {
+            "ml": {
+              "down_scale_delay": "5m"
+            }
+          },
+          "resources": {
+            "nodeCount": { "min": 0, "max": 9 },
+            "cpu": { "min": 2, "max": 2 },
+            "memory": { "min": "2Gi", "max": "6Gi" },
+            "storage": { "min": "1Gi", "max": "2Gi" }
+          }
+        }]
+      }
+    elasticsearch.alpha.elastic.co/autoscaling-status: |
+      {
+        "policies": [{
+          "name": "di-hot",
+          "nodeSets": [{ "name": "di-hot", "nodeCount": 2 }],
+          "resources": {
+            "limits": { "memory": "2Gi" },
+            "requests": { "cpu": "1", "memory": "2Gi", "storage": "4Gi" }
+          },
+          "state": [],
+          "lastModificationTime": "2021-04-21T11:30:55Z"
+        }, {
+          "name": "di-frozen",
+          "nodeSets": [{"name": "di-frozen","nodeCount": 1}],
+          "resources": {
+            "limits": {"memory": "3Gi"},
+            "requests": {"cpu": "2","memory": "3Gi","storage": "2Gi"}
+          },
+          "state": [],
+          "lastModificationTime": "2021-04-22T07:22:10Z"
+        }, {
+          "name": "ml",
+          "nodeSets": [{"name": "ml", "nodeCount": 0
+          }],
+          "resources": {
+            "limits": {"memory": "2Gi"},
+            "requests": {"cpu": "2","memory": "2Gi","storage": "1Gi"}
+          },
+          "state": [],
+          "lastModificationTime": "2021-04-21T07:49:53Z"
+        }]
+      }
+    elasticsearch.k8s.elastic.co/cluster-uuid: 7GtNZyD1QbezolOIL9vSNQ
+  name: testes
+  namespace: testns
+spec:
+  nodeSets:
+  - config:
+      node:
+        roles:
+        - master
+    count: 1
+    name: master
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources: {}
+  - config:
+      node:
+        roles:
+        - data_hot
+        - data_content
+        - ingest
+        - transform
+    count: 2
+    name: di-hot
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 2Gi
+            requests:
+              cpu: "1"
+              memory: 2Gi
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 4Gi
+      status: {}
+  - config:
+      node:
+        roles:
+        - data_frozen
+    count: 1
+    name: di-frozen
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 3Gi
+            requests:
+              cpu: "2"
+              memory: 3Gi
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Gi
+      status: {}
+  - config:
+      node:
+        roles:
+        - ml
+    count: 0
+    name: ml
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 2Gi
+            requests:
+              cpu: "2"
+              memory: 2Gi
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      status: {}
+  secureSettings:
+  - secretName: gcs-credentials
+  version: 7.13.0
+status:
+  availableNodes: 8
+  health: green
+  phase: Ready
+  version: 7.13.0

--- a/pkg/controller/autoscaling/elasticsearch/testdata/frozen-tier/elasticsearch.yml
+++ b/pkg/controller/autoscaling/elasticsearch/testdata/frozen-tier/elasticsearch.yml
@@ -1,0 +1,178 @@
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  annotations:
+    common.k8s.elastic.co/controller-version: 1.6.0-SNAPSHOT
+    elasticsearch.alpha.elastic.co/autoscaling-spec: |
+      {
+        "policies": [{
+          "name": "di-hot",
+          "roles": ["data_hot", "data_content", "ingest", "transform"],
+          "resources": {
+            "nodeCount": { "min": 2, "max": 5 },
+            "cpu": { "min": 1, "max": 2 },
+            "memory": { "min": "2Gi", "max": "6Gi" },
+            "storage": { "min": "4Gi", "max": "8Gi" }
+          }
+        }, {
+          "name": "di-frozen",
+          "roles": ["data_frozen"],
+          "resources": {
+            "nodeCount": { "min": 1, "max": 3 },
+            "cpu": { "min": 2, "max": 2 },
+            "memory": { "min": "2Gi", "max": "8Gi" },
+            "storage": { "min": "1Gi", "max": "4Gi" }
+          }
+        }, {
+          "name": "ml",
+          "roles": ["ml"],
+          "deciders": {
+            "ml": {
+              "down_scale_delay": "5m"
+            }
+          },
+          "resources": {
+            "nodeCount": { "min": 0, "max": 9 },
+            "cpu": { "min": 2, "max": 2 },
+            "memory": { "min": "2Gi", "max": "6Gi" },
+            "storage": { "min": "1Gi", "max": "2Gi" }
+          }
+        }]
+      }
+    elasticsearch.alpha.elastic.co/autoscaling-status: |
+      {
+        "policies": [{
+          "name": "di-hot",
+          "nodeSets": [{ "name": "di-hot", "nodeCount": 2 }],
+          "resources": {
+            "limits": { "memory": "2Gi" },
+            "requests": { "cpu": "1", "memory": "2Gi", "storage": "4Gi" }
+          },
+          "state": [],
+          "lastModificationTime": "2021-04-21T11:30:55Z"
+        }, {
+          "name": "di-frozen",
+          "nodeSets": [{"name": "di-frozen","nodeCount": 1}],
+          "resources": {
+            "limits": {"memory": "2Gi"},
+            "requests": {"cpu": "2","memory": "2Gi","storage": "1Gi"}
+          },
+          "state": [],
+          "lastModificationTime": "2021-04-22T01:11:50Z"
+        }, {
+          "name": "ml",
+          "nodeSets": [{"name": "ml", "nodeCount": 0
+          }],
+          "resources": {
+            "limits": {"memory": "2Gi"},
+            "requests": {"cpu": "2","memory": "2Gi","storage": "1Gi"}
+          },
+          "state": [],
+          "lastModificationTime": "2021-04-21T07:49:53Z"
+        }]
+      }
+    elasticsearch.k8s.elastic.co/cluster-uuid: 7GtNZyD1QbezolOIL9vSNQ
+  name: testes
+  namespace: testns
+spec:
+  nodeSets:
+  - config:
+      node:
+        roles:
+        - master
+    count: 1
+    name: master
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources: {}
+  - config:
+      node:
+        roles:
+        - data_hot
+        - data_content
+        - ingest
+        - transform
+    count: 2
+    name: di-hot
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 2Gi
+            requests:
+              cpu: "1"
+              memory: 2Gi
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 4Gi
+      status: {}
+  - config:
+      node:
+        roles:
+        - data_frozen
+    count: 1
+    name: di-frozen
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 2Gi
+            requests:
+              cpu: "2"
+              memory: 1Gi
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      status: {}
+  - config:
+      node:
+        roles:
+        - ml
+    count: 0
+    name: ml
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 2Gi
+            requests:
+              cpu: "2"
+              memory: 2Gi
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      status: {}
+  secureSettings:
+  - secretName: gcs-credentials
+  version: 7.13.0
+status:
+  availableNodes: 8
+  health: green
+  phase: Ready
+  version: 7.13.0


### PR DESCRIPTION
When handling an autoscaling API response from Elasticsearch this PR adds support for empty/non-existent resource request at the node level while a resource requirement exists at the tier level.

Fixes #4440 and allows support of the frozen tier.