### PR TITLE
Document the serviceName configuration attribute

### DIFF
--- a/docs/advanced-topics/traffic-splitting.asciidoc
+++ b/docs/advanced-topics/traffic-splitting.asciidoc
@@ -123,7 +123,7 @@ spec:
 [float]
 [id="{p}-traffic-splitting-with-service-name"]
 == Specify a custom service in elasticsearchRef
-You can then use your custom service in the `elasticsearchRef` element when specifying connections between Elasticsearch and other stack applications. To target only coordinating node from Kibana for example:
+You can then use your custom service in the `elasticsearchRef` element when specifying connections between Elasticsearch and other stack applications. This is an example on how to target only coordinating node from Kibana:
 
 [source,yaml,subs="attributes"]
 ----

--- a/docs/advanced-topics/traffic-splitting.asciidoc
+++ b/docs/advanced-topics/traffic-splitting.asciidoc
@@ -119,3 +119,22 @@ spec:
     elasticsearch.k8s.elastic.co/cluster-name: "hulk"
     elasticsearch.k8s.elastic.co/node-master: "false"
 ----
+
+[float]
+[id="{p}-traffic-splitting-with-service-name"]
+== Specify a custom service in elasticsearchRef
+You can then use your custom service in the `elasticsearchRef` element when specifying connections between Elasticsearch and other stack applications. To target only coordinating node from Kibana for example:
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: hulk
+spec:
+  version: {version}
+  count: 1
+  elasticsearchRef:
+    name: "hulk"
+    serviceName: "hulk-es-coordinating-nodes"
+----

--- a/docs/orchestrating-elastic-stack-applications/agent.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent.asciidoc
@@ -258,7 +258,7 @@ spec:
 [id="{p}-elastic-agent-connect-es"]
 === Customize the connection to an Elasticsearch cluster
 
-The `elasticsearchRefs` element allows ECK to automatically configure Elastic Agent to establish a secured connection to one or more managed Elasticsearch clusters. By default it targets all nodes in your cluster. If you want to direct traffic to specific nodes of your Elasticsearch cluster see  <<{p}-traffic-splitting>> for more information and examples.
+The `elasticsearchRefs` element allows ECK to automatically configure Elastic Agent to establish a secured connection to one or more managed Elasticsearch clusters. By default it targets all nodes in your cluster. If you want to direct traffic to specific nodes of your Elasticsearch cluster, refer to  <<{p}-traffic-splitting>> for more information and examples.
 
 [id="{p}-elastic-agent-set-output"]
 === Manually set Elastic Agent outputs

--- a/docs/orchestrating-elastic-stack-applications/agent.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent.asciidoc
@@ -255,6 +255,10 @@ spec:
 ...
 ----
 
+[id="{p}-elastic-agent-connect-es"]
+=== Customize the connection to an Elasticsearch cluster
+
+The `elasticsearchRefs` element allows ECK to automatically configure Elastic Agent to establish a secured connection to one or more managed Elasticsearch clusters. By default it targets all nodes in your cluster. If you want to direct traffic to specific nodes of your Elasticsearch cluster see  <<{p}-traffic-splitting>> for more information and examples.
 
 [id="{p}-elastic-agent-set-output"]
 === Manually set Elastic Agent outputs

--- a/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
@@ -43,7 +43,7 @@ spec:
 EOF
 ----
 
-By default `elasticsearchRef` targets all nodes in your Elasticsearch cluster. If you want to direct traffic to specific nodes of your cluster see  <<{p}-traffic-splitting>> for more information and examples.
+By default `elasticsearchRef` targets all nodes in your Elasticsearch cluster. If you want to direct traffic to specific nodes of your cluster,  refer to  <<{p}-traffic-splitting>> for more information and examples.
 
 . Monitor APM Server deployment.
 +

--- a/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
@@ -43,6 +43,8 @@ spec:
 EOF
 ----
 
+By default `elasticsearchRef` targets all nodes in your Elasticsearch cluster. If you want to direct traffic to specific nodes of your cluster see  <<{p}-traffic-splitting>> for more information and examples.
+
 . Monitor APM Server deployment.
 +
 You can retrieve details about the APM Server instance:

--- a/docs/orchestrating-elastic-stack-applications/beat.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/beat.asciidoc
@@ -194,7 +194,7 @@ For more details, see the link:https://www.elastic.co/guide/en/beats/libbeat/cur
 [id="{p}-beat-connect-es"]
 === Customize the connection to an Elasticsearch cluster
 
-The `elasticsearchRef` element allows ECK to automatically configure Beats to establish a secured connection to a managed Elasticsearch cluster. By default it targets all nodes in your cluster. If you want to direct traffic to specific nodes of your Elasticsearch cluster see  <<{p}-traffic-splitting>> for more information and examples.
+The `elasticsearchRef` element allows ECK to automatically configure Beats to establish a secured connection to a managed Elasticsearch cluster. By default it targets all nodes in your cluster. If you want to direct traffic to specific nodes of your Elasticsearch cluster, refer to  <<{p}-traffic-splitting>> for more information and examples.
 
 [id="{p}-beat-deploy-elastic-beat"]
 === Deploy a Beat

--- a/docs/orchestrating-elastic-stack-applications/beat.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/beat.asciidoc
@@ -190,6 +190,12 @@ stringData:
 
 For more details, see the link:https://www.elastic.co/guide/en/beats/libbeat/current/config-file-format.html[Beats configuration] section.
 
+
+[id="{p}-beat-connect-es"]
+=== Customize the connection to an Elasticsearch cluster
+
+The `elasticsearchRef` element allows ECK to automatically configure Beats to establish a secured connection to a managed Elasticsearch cluster. By default it targets all nodes in your cluster. If you want to direct traffic to specific nodes of your Elasticsearch cluster see  <<{p}-traffic-splitting>> for more information and examples.
+
 [id="{p}-beat-deploy-elastic-beat"]
 === Deploy a Beat
 

--- a/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
@@ -210,12 +210,15 @@ See link:k8s-accessing-elastic-services.html[how to access Elastic Stack service
 
 NOTE: When exposed outside the scope of `localhost`, make sure to set `ent_search.external_url` accordingly in the Enterprise Search configuration.
 
+[id="{p}-enterprise-search-connect-es"]
+=== Customize the connection to an Elasticsearch cluster
+
+The `elasticsearchRef` element allows ECK to automatically configure Enterprise Search to establish a secured connection to a managed Elasticsearch cluster. By default it targets all nodes in your cluster. If you want to direct traffic to specific nodes of your Elasticsearch cluster see  <<{p}-traffic-splitting>> for more information and examples.
+
+
 [id="{p}-enterprise-search-connect-non-eck-es"]
 === Connect to an external Elasticsearch cluster
-
-The `elasticsearchRef` element allows ECK to automatically configure Enterprise Search to establish a secured connection to a managed Elasticsearch cluster.
-
-Also, you can manually configure Enterprise Search to access any available Elasticsearch cluster:
+If you do not want to use the `elasticsearchRef` mechanism or if you want to connect to an Elasticsearch cluster not managed by ECK, you can manually configure Enterprise Search to access any available Elasticsearch cluster:
 
 [source,yaml,subs="attributes,+macros"]
 ----

--- a/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/enterprise-search.asciidoc
@@ -213,7 +213,7 @@ NOTE: When exposed outside the scope of `localhost`, make sure to set `ent_searc
 [id="{p}-enterprise-search-connect-es"]
 === Customize the connection to an Elasticsearch cluster
 
-The `elasticsearchRef` element allows ECK to automatically configure Enterprise Search to establish a secured connection to a managed Elasticsearch cluster. By default it targets all nodes in your cluster. If you want to direct traffic to specific nodes of your Elasticsearch cluster see  <<{p}-traffic-splitting>> for more information and examples.
+The `elasticsearchRef` element allows ECK to automatically configure Enterprise Search to establish a secured connection to a managed Elasticsearch cluster. By default it targets all nodes in your cluster. If you want to direct traffic to specific nodes of your Elasticsearch cluster, refer to  <<{p}-traffic-splitting>> for more information and examples.
 
 
 [id="{p}-enterprise-search-connect-non-eck-es"]

--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -50,7 +50,7 @@ spec:
 ----
 
 The use of `namespace` is optional if the Elasticsearch cluster is running in the same namespace as Kibana. An additional `serviceName` attribute can be specified to target a custom Kubernetes service.
-See <<{p}-traffic-splitting>> for more information.
+Refer to <<{p}-traffic-splitting>> for more information.
 
 NOTE: Any Kibana can reference (and thus access) any Elasticsearch instance as long as they are both in namespaces that are watched by the same ECK instance. ECK will copy the required Secret from Elasticsearch to Kibana namespace. Kibana cannot automatically connect to Elasticsearch (through `elasticsearchRef`) in a namespace managed by a different ECK instance. For more information, see <<{p}-restrict-cross-namespace-associations,Restrict cross-namespace resource associations>>.
 

--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -49,7 +49,8 @@ spec:
     namespace: default
 ----
 
-The use of `namespace` is optional if the Elasticsearch cluster is running in the same namespace as Kibana.
+The use of `namespace` is optional if the Elasticsearch cluster is running in the same namespace as Kibana. An additional `serviceName` attribute can be specified to target a custom Kubernetes service.
+See <<{p}-traffic-splitting>> for more information.
 
 NOTE: Any Kibana can reference (and thus access) any Elasticsearch instance as long as they are both in namespaces that are watched by the same ECK instance. ECK will copy the required Secret from Elasticsearch to Kibana namespace. Kibana cannot automatically connect to Elasticsearch (through `elasticsearchRef`) in a namespace managed by a different ECK instance. For more information, see <<{p}-restrict-cross-namespace-associations,Restrict cross-namespace resource associations>>.
 


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/4432


Add a section about `serviceName` to the existing traffic splitting chapter. Link from the individual stack application pages to the traffic splitting chapter.