### PR TITLE
Bump default resources for Elastic Agent

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
@@ -186,7 +186,7 @@ If `resources` is not defined in the specification of an object, then the operat
 |Elasticsearch |2Gi |2Gi
 |Kibana |1Gi |1Gi
 |Beat   |200Mi | 200Mi
-|Elastic Agent | 200Mi|200Mi
+|Elastic Agent | 300Mi|300Mi
 |===
 
 If the Kubernetes cluster is configured with https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/[LimitRanges] that enforce a minimum memory constraint, they could interfere with the operator defaults and cause object creation to fail.

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -42,12 +42,12 @@ const (
 var (
 	defaultResources = corev1.ResourceRequirements{
 		Limits: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceMemory: resource.MustParse("200Mi"),
-			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("300Mi"),
+			corev1.ResourceCPU:    resource.MustParse("200m"),
 		},
 		Requests: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceMemory: resource.MustParse("200Mi"),
-			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("300Mi"),
+			corev1.ResourceCPU:    resource.MustParse("200m"),
 		},
 	}
 )


### PR DESCRIPTION
Increase default resources to 300Mi. Agent processes were being killed as Agent was using up all the memory with two Metricbeat and one Filebeat process. 

Fixes https://github.com/elastic/cloud-on-k8s/issues/4403 
