### PR TITLE
E2E compile requires go-generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -463,7 +463,7 @@ e2e-generate-xml:
 	@ hack/ci/generate-junit-xml-report.sh e2e-tests.json
 
 # Verify e2e tests compile with no errors, don't run them
-e2e-compile:
+e2e-compile: go-generate
 	@go test ./test/e2e/... -run=dryrun -tags='$(E2E_TAGS)' $(TEST_OPTS) > /dev/null
 
 # Run e2e tests locally (not as a k8s job), with a custom http dialer

--- a/Makefile
+++ b/Makefile
@@ -469,8 +469,8 @@ e2e-compile: go-generate
 # Run e2e tests locally (not as a k8s job), with a custom http dialer
 # that can reach ES services running in the k8s cluster through port-forwarding.
 e2e-local: LOCAL_E2E_CTX := /tmp/e2e-local.json
-e2e-local:
-	@go run -tags $(GO_TAGS) test/e2e/cmd/main.go run \
+e2e-local: go-generate
+	@go run -tags '$(GO_TAGS)' test/e2e/cmd/main.go run \
 		--test-run-name=e2e \
 		--operator-image=$(OPERATOR_IMAGE) \
 		--test-context-out=$(LOCAL_E2E_CTX) \


### PR DESCRIPTION
Follow-up to https://github.com/elastic/cloud-on-k8s/pull/4460

When testing locally I missed this new requirement as I had already run generate manually. https://github.com/elastic/cloud-on-k8s/pull/4460 introduces the main build constraints into the e2e compilation. As a consequence code generation needs to run before we can compile the tests now. 