### PR TITLE
Update how to reset namespace node selector

### DIFF
--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -394,7 +394,7 @@ func (h *helper) createManagedNamespaces() error {
 	if h.testContext.Ocp3Cluster {
 		log.Info("Resetting namespace node selector")
 		for _, ns := range h.testContext.Operator.ManagedNamespaces {
-			if err := exec.Command("oc", "annotate", "namespace", ns, "openshift.io/node-selector=").Run(); err != nil {
+			if err := exec.Command("kubectl", "annotate", "--overwrite", "namespace", ns, "openshift.io/node-selector=").Run(); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
* Use `kubectl` instead of `oc`.
* Not related but add `--overwrite` flag, useful with `e2e-local` when
test namespaces are not deleted but just cleaned before two runs.

Relates to https://github.com/elastic/cloud-on-k8s/issues/4128#issuecomment-830053470.