### PR TITLE
E2E: fix nil pointer in license test initialisation

### DIFF
--- a/test/e2e/es/license_test.go
+++ b/test/e2e/es/license_test.go
@@ -24,10 +24,11 @@ func TestEnterpriseLicenseSingle(t *testing.T) {
 	if test.Ctx().TestLicense == "" {
 		t.SkipNow()
 	}
-	k := test.NewK8sClientOrFatal()
 
 	licenseBytes, err := ioutil.ReadFile(test.Ctx().TestLicense)
 	require.NoError(t, err)
+
+	k := test.NewK8sClientOrFatal()
 
 	// create a single node cluster
 	esBuilder := elasticsearch.NewBuilder("test-es-license-provisioning").
@@ -89,21 +90,17 @@ func TestEnterpriseTrialLicense(t *testing.T) {
 	licenseBytes, err := ioutil.ReadFile(test.Ctx().TestLicense)
 	require.NoError(t, err)
 
+	k := test.NewK8sClientOrFatal()
+
 	esBuilder := elasticsearch.NewBuilder("test-es-trial-license").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
-	var licenseTestContext elasticsearch.LicenseTestContext
+	licenseTestContext := elasticsearch.NewLicenseTestContext(k, esBuilder.Elasticsearch)
 
 	trialSecretName := "eck-trial"
 	licenseSecretName := "eck-license"
 	initStepsFn := func(k *test.K8sClient) test.StepList {
 		return test.StepList{
-			{
-				Name: "Create license test context",
-				Test: func(t *testing.T) {
-					licenseTestContext = elasticsearch.NewLicenseTestContext(k, esBuilder.Elasticsearch)
-				},
-			},
 			licenseTestContext.DeleteAllEnterpriseLicenseSecrets(),
 			licenseTestContext.CreateEnterpriseTrialLicenseSecret(trialSecretName),
 		}
@@ -148,21 +145,17 @@ func TestEnterpriseTrialExtension(t *testing.T) {
 	privateKey, err := x509.ParsePKCS8PrivateKey(privateKeyBytes)
 	require.NoError(t, err)
 
+	k := test.NewK8sClientOrFatal()
+
 	esBuilder := elasticsearch.NewBuilder("test-es-trial-extension").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
-	var licenseTestContext elasticsearch.LicenseTestContext
+	licenseTestContext := elasticsearch.NewLicenseTestContext(k, esBuilder.Elasticsearch)
 
 	trialSecretName := "eck-trial"
 	licenseSecretName := "eck-license"
 	initStepsFn := func(k *test.K8sClient) test.StepList {
 		return test.StepList{
-			{
-				Name: "Create license test context",
-				Test: func(t *testing.T) {
-					licenseTestContext = elasticsearch.NewLicenseTestContext(k, esBuilder.Elasticsearch)
-				},
-			},
 			licenseTestContext.DeleteAllEnterpriseLicenseSecrets(),
 			licenseTestContext.CreateEnterpriseTrialLicenseSecret(trialSecretName),
 		}

--- a/test/e2e/es/license_test.go
+++ b/test/e2e/es/license_test.go
@@ -90,12 +90,10 @@ func TestEnterpriseTrialLicense(t *testing.T) {
 	licenseBytes, err := ioutil.ReadFile(test.Ctx().TestLicense)
 	require.NoError(t, err)
 
-	k := test.NewK8sClientOrFatal()
-
 	esBuilder := elasticsearch.NewBuilder("test-es-trial-license").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
-	licenseTestContext := elasticsearch.NewLicenseTestContext(k, esBuilder.Elasticsearch)
+	licenseTestContext := elasticsearch.NewLicenseTestContext(test.NewK8sClientOrFatal(), esBuilder.Elasticsearch)
 
 	trialSecretName := "eck-trial"
 	licenseSecretName := "eck-license"
@@ -145,12 +143,10 @@ func TestEnterpriseTrialExtension(t *testing.T) {
 	privateKey, err := x509.ParsePKCS8PrivateKey(privateKeyBytes)
 	require.NoError(t, err)
 
-	k := test.NewK8sClientOrFatal()
-
 	esBuilder := elasticsearch.NewBuilder("test-es-trial-extension").
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 
-	licenseTestContext := elasticsearch.NewLicenseTestContext(k, esBuilder.Elasticsearch)
+	licenseTestContext := elasticsearch.NewLicenseTestContext(test.NewK8sClientOrFatal(), esBuilder.Elasticsearch)
 
 	trialSecretName := "eck-trial"
 	licenseSecretName := "eck-license"

--- a/test/e2e/test/elasticsearch/steps_license.go
+++ b/test/e2e/test/elasticsearch/steps_license.go
@@ -74,7 +74,13 @@ func (ltctx *LicenseTestContext) CheckElasticsearchLicense(expectedTypes ...clie
 }
 
 func (ltctx *LicenseTestContext) CreateEnterpriseLicenseSecret(secretName string, licenseBytes []byte) test.Step {
-	return test.CreateEnterpriseLicenseSecret(ltctx.k, secretName, licenseBytes)
+	//nolint:thelper
+	return test.Step{
+		Name: "Creating an Enterprise license secret",
+		Test: func(t *testing.T) {
+			test.CreateEnterpriseLicenseSecret(t, ltctx.k, secretName, licenseBytes)
+		},
+	}
 }
 
 func (ltctx *LicenseTestContext) CreateTrialExtension(secretName string, privateKey *rsa.PrivateKey) test.Step {
@@ -185,5 +191,11 @@ func (ltctx *LicenseTestContext) DeleteEnterpriseLicenseSecret(licenseSecretName
 }
 
 func (ltctx *LicenseTestContext) DeleteAllEnterpriseLicenseSecrets() test.Step {
-	return test.DeleteAllEnterpriseLicenseSecrets(ltctx.k)
+	//nolint:thelper
+	return test.Step{
+		Name: "Removing all Enterprise license secrets",
+		Test: func(t *testing.T) {
+			test.DeleteAllEnterpriseLicenseSecrets(t, ltctx.k)
+		},
+	}
 }


### PR DESCRIPTION
Fix an issue created by the recent license secret handling refactoring where the difference between step declaration time and test execution time in combination with a nil initialised license test context lead to a nil pointer.

* Always initialise test context first
* refactor reused code to simple helper functions to avoid pitfall of declaring but not calling the step function