### PR TITLE
Fix typo to use 'an' before a vowel sound

### DIFF
--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -238,7 +238,7 @@ spec:
               type: array
             serviceAccountName:
               description: ServiceAccountName is used to check access from the current
-                resource to a Elasticsearch resource in a different namespace. Can
+                resource to an Elasticsearch resource in a different namespace. Can
                 only be used if ECK is enforcing RBAC on references.
               type: string
             version:
@@ -1222,8 +1222,8 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: ElasticMapsServer represents a Elastic Map Server resource in a
-        Kubernetes cluster.
+      description: ElasticMapsServer represents an Elastic Map Server resource in
+        a Kubernetes cluster.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -1238,7 +1238,8 @@ spec:
         metadata:
           type: object
         spec:
-          description: MapsSpec holds the specification of a Elastic Maps Server instance.
+          description: MapsSpec holds the specification of an Elastic Maps Server
+            instance.
           properties:
             config:
               description: 'Config holds the ElasticMapsServer configuration. See:

--- a/config/crds/bases/agent.k8s.elastic.co_agents.yaml
+++ b/config/crds/bases/agent.k8s.elastic.co_agents.yaml
@@ -7640,7 +7640,7 @@ spec:
                 type: object
               type: array
             serviceAccountName:
-              description: ServiceAccountName is used to check access from the current resource to a Elasticsearch resource in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+              description: ServiceAccountName is used to check access from the current resource to an Elasticsearch resource in a different namespace. Can only be used if ECK is enforcing RBAC on references.
               type: string
             version:
               description: Version of the Agent.

--- a/config/crds/bases/maps.k8s.elastic.co_elasticmapsservers.yaml
+++ b/config/crds/bases/maps.k8s.elastic.co_elasticmapsservers.yaml
@@ -38,7 +38,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: ElasticMapsServer represents a Elastic Map Server resource in a Kubernetes cluster.
+      description: ElasticMapsServer represents an Elastic Map Server resource in a Kubernetes cluster.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -49,7 +49,7 @@ spec:
         metadata:
           type: object
         spec:
-          description: MapsSpec holds the specification of a Elastic Maps Server instance.
+          description: MapsSpec holds the specification of an Elastic Maps Server instance.
           properties:
             config:
               description: 'Config holds the ElasticMapsServer configuration. See: https://www.elastic.co/guide/en/kibana/current/maps-connect-to-ems.html#elastic-maps-server-configuration'

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -244,7 +244,7 @@ spec:
               type: array
             serviceAccountName:
               description: ServiceAccountName is used to check access from the current
-                resource to a Elasticsearch resource in a different namespace. Can
+                resource to an Elasticsearch resource in a different namespace. Can
                 only be used if ECK is enforcing RBAC on references.
               type: string
             version:
@@ -1246,8 +1246,8 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: ElasticMapsServer represents a Elastic Map Server resource in a
-        Kubernetes cluster.
+      description: ElasticMapsServer represents an Elastic Map Server resource in
+        a Kubernetes cluster.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -1262,7 +1262,8 @@ spec:
         metadata:
           type: object
         spec:
-          description: MapsSpec holds the specification of a Elastic Maps Server instance.
+          description: MapsSpec holds the specification of an Elastic Maps Server
+            instance.
           properties:
             config:
               description: 'Config holds the ElasticMapsServer configuration. See:

--- a/docs/reference/api-docs.asciidoc
+++ b/docs/reference/api-docs.asciidoc
@@ -74,7 +74,7 @@ AgentSpec defines the desired state of the Agent
 | *`config`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-config[$$Config$$]__ | Config holds the Agent configuration. At most one of [`Config`, `ConfigRef`] can be specified.
 | *`configRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-configsource[$$ConfigSource$$]__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Agent configuration. Agent settings must be specified as yaml, under a single "agent.yml" entry. At most one of [`Config`, `ConfigRef`] can be specified.
 | *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-secretsource[$$SecretSource$$]__ | SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for the Agent. Secrets data can be then referenced in the Agent config using the Secret's keys or as specified in `Entries` field of each SecureSetting.
-| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a Elasticsearch resource in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to an Elasticsearch resource in a different namespace. Can only be used if ECK is enforcing RBAC on references.
 | *`daemonSet`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-agent-v1alpha1-daemonsetspec[$$DaemonSetSpec$$]__ | DaemonSet specifies the Agent should be deployed as a DaemonSet, and allows providing its spec. Cannot be used along with `deployment`.
 | *`deployment`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-agent-v1alpha1-deploymentspec[$$DeploymentSpec$$]__ | Deployment specifies the Agent should be deployed as a Deployment, and allows providing its spec. Cannot be used along with `daemonSet`.
 |===
@@ -1395,7 +1395,7 @@ Package v1alpha1 contains API schema definitions for managing Elastic Maps Serve
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-maps-v1alpha1-elasticmapsserver"]
 === ElasticMapsServer 
 
-ElasticMapsServer represents a Elastic Map Server resource in a Kubernetes cluster.
+ElasticMapsServer represents an Elastic Map Server resource in a Kubernetes cluster.
 
 .Appears In:
 ****
@@ -1434,7 +1434,7 @@ ElasticMapsServerList contains a list of ElasticMapsServer
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-maps-v1alpha1-mapsspec"]
 === MapsSpec 
 
-MapsSpec holds the specification of a Elastic Maps Server instance.
+MapsSpec holds the specification of an Elastic Maps Server instance.
 
 .Appears In:
 ****

--- a/pkg/apis/agent/v1alpha1/agent_types.go
+++ b/pkg/apis/agent/v1alpha1/agent_types.go
@@ -53,7 +53,7 @@ type AgentSpec struct {
 	// +kubebuilder:validation:Optional
 	SecureSettings []commonv1.SecretSource `json:"secureSettings,omitempty"`
 
-	// ServiceAccountName is used to check access from the current resource to a Elasticsearch resource in a different namespace.
+	// ServiceAccountName is used to check access from the current resource to an Elasticsearch resource in a different namespace.
 	// Can only be used if ECK is enforcing RBAC on references.
 	// +kubebuilder:validation:Optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`

--- a/pkg/apis/common/v1beta1/association.go
+++ b/pkg/apis/common/v1beta1/association.go
@@ -19,7 +19,7 @@ const (
 	AssociationFailed      AssociationStatus = "Failed"
 )
 
-// Associated interface represents a Elastic stack application that is associated with an Elasticsearch cluster.
+// Associated interface represents an Elastic stack application that is associated with an Elasticsearch cluster.
 // An associated object needs some credentials to establish a connection to the Elasticsearch cluster and usually it
 // offers a keystore which in ECK is represented with an underlying Secret.
 // Kibana and the APM server are two examples of associated objects.

--- a/pkg/apis/maps/v1alpha1/maps_types.go
+++ b/pkg/apis/maps/v1alpha1/maps_types.go
@@ -19,7 +19,7 @@ const (
 	Kind = "ElasticMapsServer"
 )
 
-// MapsSpec holds the specification of a Elastic Maps Server instance.
+// MapsSpec holds the specification of an Elastic Maps Server instance.
 type MapsSpec struct {
 	// Version of Elastic Maps Server.
 	Version string `json:"version"`
@@ -137,7 +137,7 @@ var _ commonv1.Association = &ElasticMapsServer{}
 
 // +kubebuilder:object:root=true
 
-// ElasticMapsServer represents a Elastic Map Server resource in a Kubernetes cluster.
+// ElasticMapsServer represents an Elastic Map Server resource in a Kubernetes cluster.
 // +kubebuilder:resource:categories=elastic,shortName=ems
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="health",type="string",JSONPath=".status.health"

--- a/pkg/controller/common/events/events.go
+++ b/pkg/controller/common/events/events.go
@@ -20,7 +20,7 @@ const (
 	EventReasonUnexpected = "Unexpected"
 	// EventReasonValidation describes events that were due to an invalid resource being submitted by the user.
 	EventReasonValidation = "Validation"
-	// EventReasonStateChange describes events that are expected state changes in a Elasticsearch cluster.
+	// EventReasonStateChange describes events that are expected state changes in an Elasticsearch cluster.
 	EventReasonStateChange = "StateChange"
 	// EventReasonRestart describes events where one or multiple Elasticsearch nodes are scheduled for a restart.
 	EventReasonRestart = "Restart"

--- a/pkg/controller/elasticsearch/client/model.go
+++ b/pkg/controller/elasticsearch/client/model.go
@@ -240,7 +240,7 @@ type DiscoveryZenSettings struct {
 	Persistent DiscoveryZen `json:"persistent"`
 }
 
-// ErrorResponse is a Elasticsearch error response.
+// ErrorResponse is an Elasticsearch error response.
 type ErrorResponse struct {
 	Status int `json:"status"`
 	Error  struct {

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -311,7 +311,7 @@ func (r *ReconcileElasticsearch) updateStatus(
 	return common.UpdateStatus(r.Client, cluster)
 }
 
-// onDelete garbage collect resources when a Elasticsearch cluster is deleted
+// onDelete garbage collect resources when an Elasticsearch cluster is deleted
 func (r *ReconcileElasticsearch) onDelete(es types.NamespacedName) error {
 	r.expectations.RemoveCluster(es)
 	r.esObservers.StopObserving(es)


### PR DESCRIPTION
Replaces `a Elastic` with `an Elastic`.