### PR TITLE
Adjust templates for OLM bundles/CSVs to include Elastic Maps Server

### DIFF
--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -20,6 +20,9 @@ crds:
   - name: agents.agent.k8s.elastic.co
     displayName: Elastic Agent
     description: Elastic Agent instance
+  - name: elasticmapsservers.maps.k8s.elastic.co
+    displayName: Elastic Maps Server
+    description: Elastic Maps Server instance
 packages:
   - outputPath: community-operators
     packageName: elastic-cloud-eck

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -212,7 +212,21 @@ metadata:
                 ]
               }
             }
-          }
+          },
+          {
+              "apiVersion": "maps.k8s.elastic.co/v1alpha1",
+              "kind": "ElasticMapsServer",
+              "metadata": {
+                  "name": "ems-sample"
+              },
+              "spec": {
+                  "version": "{{ .StackVersion }}",
+                  "count": 1,
+                  "elasticsearchRef": {
+                      "name": "elasticsearch-sample"
+                  }
+              }
+          },
       ]
   name: {{ .PackageName }}.v{{ .NewVersion }}
   namespace: placeholder

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -7,7 +7,7 @@ metadata:
     certified: 'false'
     containerImage: {{ .OperatorRepo }}:{{ .NewVersion }}
     createdAt: {{ now | date "2006-01-02 15:04:05" }}
-    description: Run Elasticsearch, Kibana, APM Server, Enterprise Search, and Beats on Kubernetes and OpenShift
+    description: Run Elasticsearch, Kibana, APM Server, Enterprise Search, Beats, Elastic Agent and Elastic Maps Server on Kubernetes and OpenShift
     repository: https://github.com/elastic/cloud-on-k8s
     support: elastic.co
     alm-examples: |-
@@ -242,14 +242,14 @@ spec:
       version: {{ .Version }}
     {{- end }}
   description: 'Elastic Cloud on Kubernetes (ECK) is the official operator by Elastic for automating the deployment, provisioning,
-    management, and orchestration of Elasticsearch, Kibana, APM Server, Beats, and 
-    Enterprise Search on Kubernetes.
+    management, and orchestration of Elasticsearch, Kibana, APM Server, Beats, Enterprise Search, Beats, Elastic Agent,
+    and Elastic Maps Server on Kubernetes.
 
 
     Current features:
 
 
-    *  Elasticsearch, Kibana, APM Server, Enterprise Search, Beats and Elastic Agent deployments
+    *  Elasticsearch, Kibana, APM Server, Enterprise Search, Beats, Elastic Agent and Elastic Maps Server deployments
 
     *  TLS Certificates management
 

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -226,7 +226,7 @@ metadata:
                       "name": "elasticsearch-sample"
                   }
               }
-          },
+          }
       ]
   name: {{ .PackageName }}.v{{ .NewVersion }}
   namespace: placeholder


### PR DESCRIPTION
* Include Elastic Maps Server to the OLM config
* Include Elastic Maps Server JSON example to the CSV template
* Add Elastic Maps Server in descriptions of the CSV template

I'm not sure about the third commit which updates the descriptions because EMS is in alpha.
