### PR TITLE
Update release notes for OpenShift 3.11 support (#4457)

### DIFF
--- a/docs/release-notes/1.5.0.asciidoc
+++ b/docs/release-notes/1.5.0.asciidoc
@@ -39,4 +39,4 @@
 [float]
 === Deprecation
 
-* OpenShift 3.11 support is deprecated in ECK 2.0. ECK 1.8 is the last version that supports OpenShift 3.11.
+* OpenShift 3.11 support will be deprecated in ECK 2.0. ECK 1.8 is the last version that will support OpenShift 3.11.


### PR DESCRIPTION
Backport of #4457.