### PR TITLE
Skip Elastic Maps Server tests for Stack version 8.x

### DIFF
--- a/test/e2e/ems/ems_test.go
+++ b/test/e2e/ems/ems_test.go
@@ -13,8 +13,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/maps"
 )
 
-// TestElasticMapsServerCrossNSAssociation tests associating Elasticsearch and Elastic Maps Server running in different namespaces.
-func TestElasticMapsServerCrossNSAssociation(t *testing.T) {
+func maybeSkip(t *testing.T) {
 	// only execute this test if we have a test license to work with
 	if test.Ctx().TestLicense == "" {
 		t.SkipNow()
@@ -25,6 +24,15 @@ func TestElasticMapsServerCrossNSAssociation(t *testing.T) {
 	if !stackVersion.GTE(version.MustParse("7.11.0")) {
 		t.SkipNow()
 	}
+	// Elastic Maps Server Docker image 8.0.0-SNAPSHOT does not exist yet
+	if stackVersion.Major >= uint64(8) {
+		t.SkipNow()
+	}
+}
+
+// TestElasticMapsServerCrossNSAssociation tests associating Elasticsearch and Elastic Maps Server running in different namespaces.
+func TestElasticMapsServerCrossNSAssociation(t *testing.T) {
+	maybeSkip(t)
 
 	esNamespace := test.Ctx().ManagedNamespace(0)
 	emsNamespace := test.Ctx().ManagedNamespace(1)
@@ -47,16 +55,7 @@ func TestElasticMapsServerCrossNSAssociation(t *testing.T) {
 }
 
 func TestElasticMapsServerTLSDisabled(t *testing.T) {
-	// only execute this test if we have a test license to work with
-	if test.Ctx().TestLicense == "" {
-		t.SkipNow()
-	}
-
-	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
-	// Elastic Maps Server is supported since 7.11.0
-	if !stackVersion.GTE(version.MustParse("7.11.0")) {
-		t.SkipNow()
-	}
+	maybeSkip(t)
 
 	name := "test-ems-tls-disabled"
 
@@ -76,16 +75,7 @@ func TestElasticMapsServerTLSDisabled(t *testing.T) {
 }
 
 func TestElasticMapsServerVersionUpgradeToLatest7x(t *testing.T) {
-	// only execute this test if we have a test license to work with
-	if test.Ctx().TestLicense == "" {
-		t.SkipNow()
-	}
-
-	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
-	// Elastic Maps Server is supported since 7.11.0
-	if !stackVersion.GTE(version.MustParse("7.11.0")) {
-		t.SkipNow()
-	}
+	maybeSkip(t)
 
 	srcVersion := test.Ctx().ElasticStackVersion
 	dstVersion := test.LatestVersion7x

--- a/test/e2e/ems/ems_test.go
+++ b/test/e2e/ems/ems_test.go
@@ -7,33 +7,13 @@ package ems
 import (
 	"testing"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/maps"
 )
 
-func maybeSkip(t *testing.T) {
-	// only execute this test if we have a test license to work with
-	if test.Ctx().TestLicense == "" {
-		t.SkipNow()
-	}
-
-	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
-	// Elastic Maps Server is supported since 7.11.0
-	if !stackVersion.GTE(version.MustParse("7.11.0")) {
-		t.SkipNow()
-	}
-	// Elastic Maps Server Docker image 8.0.0-SNAPSHOT does not exist yet
-	if stackVersion.Major >= uint64(8) {
-		t.SkipNow()
-	}
-}
-
 // TestElasticMapsServerCrossNSAssociation tests associating Elasticsearch and Elastic Maps Server running in different namespaces.
 func TestElasticMapsServerCrossNSAssociation(t *testing.T) {
-	maybeSkip(t)
-
 	esNamespace := test.Ctx().ManagedNamespace(0)
 	emsNamespace := test.Ctx().ManagedNamespace(1)
 	name := "test-cross-ns-ems-es"
@@ -55,8 +35,6 @@ func TestElasticMapsServerCrossNSAssociation(t *testing.T) {
 }
 
 func TestElasticMapsServerTLSDisabled(t *testing.T) {
-	maybeSkip(t)
-
 	name := "test-ems-tls-disabled"
 
 	esBuilder := elasticsearch.NewBuilder(name).
@@ -75,8 +53,6 @@ func TestElasticMapsServerTLSDisabled(t *testing.T) {
 }
 
 func TestElasticMapsServerVersionUpgradeToLatest7x(t *testing.T) {
-	maybeSkip(t)
-
 	srcVersion := test.Ctx().ElasticStackVersion
 	dstVersion := test.LatestVersion7x
 

--- a/test/e2e/test/maps/builder.go
+++ b/test/e2e/test/maps/builder.go
@@ -148,6 +148,17 @@ func (b Builder) MutationReversalTestContext() test.ReversalTestContext {
 }
 
 func (b Builder) SkipTest() bool {
+	// only execute EMS tests if we have a test license to work with
+	if test.Ctx().TestLicense == "" {
+		return true
+	}
+
+	// TODO: remove once an EMS 8.x Docker image image is available
+	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
+	if stackVersion.Major >= uint64(8) {
+		return true
+	}
+
 	ver := version.MustParse(b.EMS.Spec.Version)
 	return version.SupportedMapsVersions.WithinRange(ver) != nil
 }

--- a/test/e2e/test/maps/builder.go
+++ b/test/e2e/test/maps/builder.go
@@ -154,6 +154,7 @@ func (b Builder) SkipTest() bool {
 	}
 
 	// TODO: remove once an EMS 8.x Docker image image is available
+	// https://github.com/elastic/cloud-on-k8s/issues/4479
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
 	if stackVersion.Major >= uint64(8) {
 		return true


### PR DESCRIPTION
This commit adds a check to skip Elastic Maps Server tests when the Stack major version is equal or greater than 8.

It made me want to factorize the code that mades the skips.

Resolves #4476.