### PR TITLE
E2E add tags to resilience e2e job

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -28,7 +28,7 @@ sleep 1
 }
 
 run_chaos() {
-  go run test/e2e/cmd/main.go chaos "$@"
+  go run -tags="$E2E_TAGS" test/e2e/cmd/main.go chaos "$@"
 }
 
 main() {


### PR DESCRIPTION

The refactoring in https://github.com/elastic/cloud-on-k8s/pull/4444 requires that build constraints are specified on invoking `go run` to include/exclude the correct generated code.