### PR TITLE
[1.6] Add Elastic Maps Server to the telemetry (#4486)

### DIFF
--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -17,6 +17,7 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	entv1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	mapsv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/maps/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/require"
@@ -231,6 +232,17 @@ func TestNewReporter(t *testing.T) {
 				AvailableNodes: 6,
 			},
 		},
+		&mapsv1alpha1.ElasticMapsServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "maps1",
+				Namespace: "ns1",
+			},
+			Status: mapsv1alpha1.MapsStatus{
+				DeploymentStatus: commonv1.DeploymentStatus{
+					AvailableNodes: 1,
+				},
+			},
+		},
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "elastic-licensing",
@@ -290,6 +302,9 @@ func TestNewReporter(t *testing.T) {
     kibanas:
       pod_count: 0
       resource_count: 2
+    maps:
+      pod_count: 1
+      resource_count: 1
 `),
 	}
 


### PR DESCRIPTION
Backports the following commits to 1.6:
 - Add Elastic Maps Server to the telemetry (#4486)