### PR TITLE
Docs: clarify volume resize statement in quickstart

### DIFF
--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -250,7 +250,7 @@ kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | ba
 [id="{p}-upgrade-deployment"]
 == Upgrade your deployment
 
-You can add and modify most elements of the original cluster specification provided that they translate to valid transformations of the underlying Kubernetes resources (e.g., existing volume claims cannot be resized). The operator will attempt to apply your changes with minimal disruption to the existing cluster. You should ensure that the Kubernetes cluster has sufficient resources to accommodate the changes (extra storage space, sufficient memory and CPU resources to temporarily spin up new pods etc.).
+You can add and modify most elements of the original cluster specification provided that they translate to valid transformations of the underlying Kubernetes resources (e.g., <<{p}-volume-claim-templates, existing volume claims cannot be downsized>>). The operator will attempt to apply your changes with minimal disruption to the existing cluster. You should ensure that the Kubernetes cluster has sufficient resources to accommodate the changes (extra storage space, sufficient memory and CPU resources to temporarily spin up new pods etc.).
 
 For example, you can grow the cluster to three Elasticsearch nodes:
 


### PR DESCRIPTION
We had a statement in the quickstart that seems to negate the existence of the volume claim resize feature. I tried to make it more explicit and link to the relevant doc in the Elasticsearch section. 