### PR TITLE
[1.6] E2E add tags to resilience e2e job (#4480)

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -28,7 +28,7 @@ sleep 1
 }
 
 run_chaos() {
-  go run test/e2e/cmd/main.go chaos "$@"
+  go run -tags="$E2E_TAGS" test/e2e/cmd/main.go chaos "$@"
 }
 
 main() {


### PR DESCRIPTION
Backports the following commits to 1.6:
 - E2E add tags to resilience e2e job (#4480)