### PR TITLE
Report EnterpriseSearch memory usage

### DIFF
--- a/pkg/controller/enterprisesearch/pod.go
+++ b/pkg/controller/enterprisesearch/pod.go
@@ -19,6 +19,7 @@ import (
 )
 
 const (
+	EnvJavaOpts         = "JAVA_OPTS"
 	HTTPPort            = 3002
 	DefaultJavaOpts     = "-Xms3500m -Xmx3500m"
 	ConfigHashLabelName = "enterprisesearch.k8s.elastic.co/config-hash"
@@ -36,7 +37,7 @@ var (
 		},
 	}
 	DefaultEnv = []corev1.EnvVar{
-		{Name: "JAVA_OPTS", Value: DefaultJavaOpts},
+		{Name: EnvJavaOpts, Value: DefaultJavaOpts},
 	}
 	ReadinessProbe = corev1.Probe{
 		FailureThreshold:    3,

--- a/pkg/license/aggregator_test.go
+++ b/pkg/license/aggregator_test.go
@@ -13,6 +13,7 @@ import (
 
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	entv1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/stretchr/testify/assert"
@@ -143,7 +144,7 @@ func TestAggregator(t *testing.T) {
 
 	val, err := aggregator.AggregateMemory()
 	require.NoError(t, err)
-	require.Equal(t, 324.1705472, inGB(val))
+	require.Equal(t, 349.940350976, inGB(val))
 }
 
 func readObjects(t *testing.T, filePath string) []runtime.Object {
@@ -153,6 +154,7 @@ func readObjects(t *testing.T, filePath string) []runtime.Object {
 	scheme.AddKnownTypes(esv1.GroupVersion, &esv1.Elasticsearch{}, &esv1.ElasticsearchList{})
 	scheme.AddKnownTypes(kbv1.GroupVersion, &kbv1.Kibana{}, &kbv1.KibanaList{})
 	scheme.AddKnownTypes(apmv1.GroupVersion, &apmv1.ApmServer{}, &apmv1.ApmServerList{})
+	scheme.AddKnownTypes(entv1.GroupVersion, &entv1.EnterpriseSearch{}, &entv1.EnterpriseSearchList{})
 	decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
 
 	f, err := os.Open(filePath)

--- a/pkg/license/testdata/stack.yaml
+++ b/pkg/license/testdata/stack.yaml
@@ -124,3 +124,23 @@ spec:
               memory: 2Gi
             limits:
               memory: 2Gi
+---
+apiVersion: enterprisesearch.k8s.elastic.co/v1
+kind: EnterpriseSearch
+metadata:
+  name: enterprise-search-quickstart
+spec:
+  count: 3
+  podTemplate:
+    spec:
+      containers:
+        - name: enterprise-search
+          resources:
+            requests:
+              cpu: 3
+              memory: 8Gi
+            limits:
+              memory: 8Gi
+          env:
+            - name: JAVA_OPTS
+              value: -Xms7500m -Xmx7500m


### PR DESCRIPTION
This PR adds memory usage for Enterprise Search deployments as part of the licensing information.