### PR TITLE
[1.6] Add 1.6.0 release notes and highlights (#4498)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-1.6.0>>
 * <<release-notes-1.5.0>>
 * <<release-notes-1.4.1>>
 * <<release-notes-1.4.0>>
@@ -24,6 +25,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/1.6.0.asciidoc[]
 include::release-notes/1.5.0.asciidoc[]
 include::release-notes/1.4.1.asciidoc[]
 include::release-notes/1.4.0.asciidoc[]

--- a/docs/release-notes/1.6.0.asciidoc
+++ b/docs/release-notes/1.6.0.asciidoc
@@ -1,0 +1,30 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-1.6.0]]
+== {n} version 1.6.0
+
+[[feature-1.6.0]]
+[float]
+=== New features
+
+* [EMS] Add Elastic Maps Server controller {pull}4443[#4443] (issue: {issue}4179[#4179])
+* [EMS] Add Elastic Maps Server CRD {pull}4439[#4439] (issue: {issue}4179[#4179])
+
+[[enhancement-1.6.0]]
+[float]
+=== Enhancements
+
+* [Agent] Increase default memory resources for Elastic Agent {pull}4453[#4453] (issue: {issue}4403[#4403])
+* [Helm] Add optional podLabels to operator pod and Expose Metrics ports {pull}4424[#4424]
+* Allow users to spec a serviceName in associations {pull}4404[#4404] (issue: {issue}3732[#3732])
+* Add data tier labels to Elasticsearch nodes {pull}4312[#4312] (issue: {issue}4054[#4054])
+
+[[bug-1.6.0]]
+[float]
+=== Bug fixes
+
+* [EnterpriseSearch] Update EnterpriseSearch config 8.x version test {pull}4466[#4466] (issue: {issue}4455[#4455])
+* [Autoscaling] Add support for tier only requests {pull}4445[#4445] (issue: {issue}4440[#4440])
+* [Agent] Add missing rules for agents to the operator roles {pull}4418[#4418] (issue: {issue}4413[#4413])
+* Remove labels from operator namespace {pull}4400[#4400] (issue: {issue}4395[#4395])

--- a/docs/release-notes/highlights-1.6.0.asciidoc
+++ b/docs/release-notes/highlights-1.6.0.asciidoc
@@ -1,0 +1,21 @@
+[[release-highlights-1.6.0]]
+== 1.6.0 release highlights
+
+[float]
+[id="{p}-160-new-and-notable"]
+=== New and notable
+
+New and notable changes in version 1.6.0 of {n}. See <<release-notes-1.6.0>> for the full list of changes.
+
+[float]
+[id="{p}-160-ems-support"]
+==== Support for Elastic Maps Server
+
+In this release, ECK introduces the Elastic Maps Server CRD that allows you to run the link:https://www.elastic.co/guide/en/kibana/7.13/maps-connect-to-ems.html[Elastic Maps Service] in your Kubernetes environment. This is mostly relevant for air-gapped environments where Kibana server and browser clients are unable to reach the Elastic Maps Service for Maps rendering. 
+
+
+[float]
+[id="{p}-160-service-name-in-associations"]
+==== Support for custom services in associations between components
+
+When you create associations between components, for example using `elasticsearchRef`, you can now specify a custom service name to target specific nodes. For example, if you want to configure Kibana to target only Elasticsearch coordinating nodes, you can now reference a custom service by selecting only coordinating nodes.

--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the most important changes in each release. For the full list, see <<eck-release-notes>>.
 
+* <<release-highlights-1.6.0>>
 * <<release-highlights-1.5.0>>
 * <<release-highlights-1.4.1>>
 * <<release-highlights-1.4.0>>
@@ -23,6 +24,7 @@ This section summarizes the most important changes in each release. For the full
 
 --
 
+include::highlights-1.6.0.asciidoc[]
 include::highlights-1.5.0.asciidoc[]
 include::highlights-1.4.1.asciidoc[]
 include::highlights-1.4.0.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 1.6:
 - Add 1.6.0 release notes and highlights (#4498)