### PR TITLE
Update supported versions doc for 1.6.0

### DIFF
--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -4,7 +4,7 @@
 * Elasticsearch, Kibana, APM Server: 6.8+, 7.1+
 * Enterprise Search: 7.7+
 * Beats: 7.0+
-* Agent: 7.10+
+* Elastic Agent: 7.10+
 * Elastic Maps Server: 7.11+
 
 ECK should work with all conformant installers as listed in these link:https://github.com/cncf/k8s-conformance/blob/master/faq.md#what-is-a-distribution-hosted-platform-and-an-installer[FAQs]. Distributions include source patches and so may not work as-is with ECK.

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -1,9 +1,11 @@
-* link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl] 1.11+
-* Kubernetes 1.12+ or OpenShift 3.11+
+* link:https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl] 1.16-1.20
+* OpenShift 3.11, 4.3-4.7
 * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 * Elasticsearch, Kibana, APM Server: 6.8+, 7.1+
 * Enterprise Search: 7.7+
 * Beats: 7.0+
+* Agent: 7.10+
+* Elastic Maps Server: 7.11+
 
 ECK should work with all conformant installers as listed in these link:https://github.com/cncf/k8s-conformance/blob/master/faq.md#what-is-a-distribution-hosted-platform-and-an-installer[FAQs]. Distributions include source patches and so may not work as-is with ECK.
 


### PR DESCRIPTION
Update the supported versions doc for ECK 1.6.0 (should be back-ported to `1.6` branch)