### PR TITLE
Prepare OperatorHub release config for 1.6.0

### DIFF
--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -1,6 +1,6 @@
-newVersion: 1.5.0
-prevVersion: 1.4.0
-stackVersion: 7.12.0
+newVersion: 1.6.0
+prevVersion: 1.5.0
+stackVersion: 7.12.1
 crds:
   - name: elasticsearches.elasticsearch.k8s.elastic.co
     displayName: Elasticsearch Cluster


### PR DESCRIPTION
Prepare the configuration for the OperatorHub version generator for version 1.6.0.