### PR TITLE
[1.5] Typos in storage-recommendations.asciidoc and README.md

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/storage-recommendations.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/storage-recommendations.asciidoc
@@ -40,7 +40,7 @@ Some hosted Kubernetes offerings only respect the PodDisruptionBudget for a cert
 If a host has a failure, or is permanently removed, its local data is likely lost. The corresponding Pod stays `Pending` because it can no longer attach the PersistentVolume. To schedule the Pod on a different host with a new empty volume, you have to manually remove both the PersistenteVolumeClaim and the Pod. A new Pod is automatically created with a new PersistentVolumeClaim, which is then matched with a PersistentVolume. Then, Elasticsearch shard replication makes sure that data is recovered on the new instance.
 
 [float]
-== Local PersistentVolums provisioners
+== Local PersistentVolume provisioners
 
 You can provision Local PersistentVolumes in one of the following ways:
 

--- a/support/reattach-pv/README.md
+++ b/support/reattach-pv/README.md
@@ -52,5 +52,5 @@ This tool basically does the following:
 
 ## Limitations
 
-* PersistentVolumsClaims are not created the exact same way they would normally be created by the StatefulSet controller. Especially, they don't have the usual annotations and labels.
+* PersistentVolumeClaims are not created the exact same way they would normally be created by the StatefulSet controller. Especially, they don't have the usual annotations and labels.
 * PersistentVolumeClaims are not created with an OwnerReference pointing to the Elasticsearch resource, because they are created before that resource. Therefore, they will not be automatically removed upon Elasticsearch resource deletion.


### PR DESCRIPTION
I forgot to backport this fix.

Backports the following commits to 1.5:

* Fix typos in storage-recommendations.asciidoc and README.md (#4449)