### PR TITLE
[1.3] Typos in storage-recommendations.asciidoc

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/storage-recommendations.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/storage-recommendations.asciidoc
@@ -40,7 +40,7 @@ Some hosted Kubernetes offerings only respect the PodDisruptionBudget for a cert
 If a host has a failure, or is permanently removed, its local data is likely lost. The corresponding Pod stays `Pending` because it can no longer attach the PersistentVolume. To schedule the Pod on a different host with a new empty volume, you have to manually remove both the PersistenteVolumeClaim and the Pod. A new Pod is automatically created with a new PersistentVolumeClaim, which is then matched with a PersistentVolume. Then, Elasticsearch shard replication makes sure that data is recovered on the new instance.
 
 [float]
-== Local PersistentVolums provisioners
+== Local PersistentVolume provisioners
 
 You can provision Local PersistentVolumes in one of the following ways:
 


### PR DESCRIPTION
Backports the following commits to 1.3:

* Fix typos in storage-recommendations.asciidoc (#4449)