### PR TITLE
Update docs eck attributes eck version to 1.6

### DIFF
--- a/docs/eck-attributes.asciidoc
+++ b/docs/eck-attributes.asciidoc
@@ -1,5 +1,5 @@
-:eck_version: 1.5.0
+:eck_version: 1.6.0
 :eck_crd_version: v1
-:eck_release_branch: 1.5
+:eck_release_branch: 1.6
 :eck_github: https://github.com/elastic/cloud-on-k8s
 :eck_resources_list: Elasticsearch, Kibana, APM Server, Enterprise Search, Beats, and Elastic Agent


### PR DESCRIPTION
Update eck-attributes in docs eck release branch to 1.6 so that master docs refer to the latest released version of eck.