### PR TITLE
E2E enable Kibana, APM Server, Enterprise Search, Beats and Agent tests on ARM

### DIFF
--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -324,7 +324,7 @@ IMG_SUFFIX=-ci
 E2E_REGISTRY_NAMESPACE=eck-ci
 
 GO_TAGS=release
-E2E_TAGS=es
+E2E_TAGS=es kb apm ent beat agent
 export LICENSE_PUBKEY=/go/src/github.com/elastic/cloud-on-k8s/.ci/license.key
 # TEST_LICENSE=/go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json disabled b/c https://github.com/elastic/elasticsearch/issues/68083
 # MONITORING_SECRETS=/go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json disabled b/c beats cannot run on ARM

--- a/test/e2e/ems/ems_test.go
+++ b/test/e2e/ems/ems_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+// +build ems e2e
+
 package ems
 
 import (


### PR DESCRIPTION
As of 7.13 we have arm64 Docker images for those Elastic Stack apps which means we can start running more tests. Elastic Maps Server does not have an arm64 image yet.