### PR TITLE
Add validation for declared volume claim templates

### DIFF
--- a/pkg/controller/elasticsearch/validation/validations.go
+++ b/pkg/controller/elasticsearch/validation/validations.go
@@ -34,7 +34,7 @@ const (
 	parseStoredVersionErrMsg = "Cannot parse current Elasticsearch version. String format must be {major}.{minor}.{patch}[-{label}]"
 	parseVersionErrMsg       = "Cannot parse Elasticsearch version. String format must be {major}.{minor}.{patch}[-{label}]"
 	pvcImmutableErrMsg       = "volume claim templates can only have their storage requests increased, if the storage class allows volume expansion. Any other change is forbidden"
-	pvcNotMounted            = "volume claim declared but volume not mounted in any container"
+	pvcNotMountedErrMsg      = "volume claim declared but volume not mounted in any container. Note that the Elasticsearch data volume should be named 'elasticsearch-data'"
 	unsupportedConfigErrMsg  = "Configuration setting is reserved for internal use. User-configured use is unsupported"
 	unsupportedUpgradeMsg    = "Unsupported version upgrade path. Check the Elasticsearch documentation for supported upgrade paths."
 	unsupportedVersionMsg    = "Unsupported version"

--- a/pkg/controller/elasticsearch/validation/validations.go
+++ b/pkg/controller/elasticsearch/validation/validations.go
@@ -34,6 +34,7 @@ const (
 	parseStoredVersionErrMsg = "Cannot parse current Elasticsearch version. String format must be {major}.{minor}.{patch}[-{label}]"
 	parseVersionErrMsg       = "Cannot parse Elasticsearch version. String format must be {major}.{minor}.{patch}[-{label}]"
 	pvcImmutableErrMsg       = "volume claim templates can only have their storage requests increased, if the storage class allows volume expansion. Any other change is forbidden"
+	pvcNotMounted            = "volume claim declared but volume not mounted in any container"
 	unsupportedConfigErrMsg  = "Configuration setting is reserved for internal use. User-configured use is unsupported"
 	unsupportedUpgradeMsg    = "Unsupported version upgrade path. Check the Elasticsearch documentation for supported upgrade paths."
 	unsupportedVersionMsg    = "Unsupported version"
@@ -49,6 +50,7 @@ var validations = []validation{
 	supportedVersion,
 	validSanIP,
 	validAutoscalingConfiguration,
+	validPVCNaming,
 }
 
 type updateValidation func(esv1.Elasticsearch, esv1.Elasticsearch) field.ErrorList

--- a/pkg/controller/elasticsearch/validation/volume_validation.go
+++ b/pkg/controller/elasticsearch/validation/volume_validation.go
@@ -34,7 +34,7 @@ func validPVCNaming(proposed esv1.Elasticsearch) field.ErrorList {
 			errs = append(errs, field.Invalid(
 				field.NewPath("spec").Child("nodeSet").Index(i).Child("volumeClaimTemplates"),
 				m.Name,
-				pvcNotMounted,
+				pvcNotMountedErrMsg,
 			))
 		}
 	}


### PR DESCRIPTION
Partially addresses https://github.com/elastic/cloud-on-k8s/issues/4525

Adds a validation to check that declared volume claim templates are actually mounted in any of the containers. This validation does not apply if the user configures the documented default data volume `elasticsearch-data` for which ECK manages the volume mount. 

There is still a possibility for misconfiguration. As we are currently supporting custom volume mounts and custom `data.path` settings in Elasticsearch it is quite hard to fully validate the configuration. With the proposed validation it would still be possible for a user to configure a custom volume claim template, mount it in a side car and have no persistent Elasticsearch data volume. This could be addressed in two ways:
* also parse the Elasticsearch configuration during validation and make sure each `data.path` has a volume mount
* always configure a default data volume as we had it pre-1.4.0