### PR TITLE
[Autoscaling] Fix e2e test

### DIFF
--- a/pkg/controller/autoscaling/elasticsearch/autoscaler/linear_scaler.go
+++ b/pkg/controller/autoscaling/elasticsearch/autoscaler/linear_scaler.go
@@ -68,8 +68,8 @@ func memoryFromStorage(requiredStorageCapacity resource.Quantity, storageRange, 
 	requiredMemoryCapacity := memoryRange.Min.Value() + requiredAdditionalMemoryCapacity
 
 	// Round up memory to the next GB
-	requiredMemoryCapacity = math.RoundUp(requiredMemoryCapacity, resources.GIB)
-	resourceMemoryAsGiga := resource.MustParse(fmt.Sprintf("%dGi", requiredMemoryCapacity/resources.GIB))
+	requiredMemoryCapacity = math.RoundUp(requiredMemoryCapacity, resources.GiB)
+	resourceMemoryAsGiga := resource.MustParse(fmt.Sprintf("%dGi", requiredMemoryCapacity/resources.GiB))
 
 	if resourceMemoryAsGiga.Cmp(memoryRange.Max) > 0 {
 		resourceMemoryAsGiga = memoryRange.Max.DeepCopy()

--- a/pkg/controller/autoscaling/elasticsearch/autoscaler/linear_scaler.go
+++ b/pkg/controller/autoscaling/elasticsearch/autoscaler/linear_scaler.go
@@ -67,7 +67,7 @@ func memoryFromStorage(requiredStorageCapacity resource.Quantity, storageRange, 
 	requiredAdditionalMemoryCapacity := int64(allowedMemoryRange * storageRatio)
 	requiredMemoryCapacity := memoryRange.Min.Value() + requiredAdditionalMemoryCapacity
 
-	// Round up memory to the next GB
+	// Round up memory to the next GiB
 	requiredMemoryCapacity = math.RoundUp(requiredMemoryCapacity, resources.GiB)
 	resourceMemoryAsGiga := resource.MustParse(fmt.Sprintf("%dGi", requiredMemoryCapacity/resources.GiB))
 

--- a/pkg/controller/autoscaling/elasticsearch/autoscaler/recommender/recommender.go
+++ b/pkg/controller/autoscaling/elasticsearch/autoscaler/recommender/recommender.go
@@ -109,7 +109,7 @@ func getResourceValue(
 		nodeResource = max64(nodeResource, resourceOverAllTiers)
 	}
 
-	// Try to round up the Gb value
+	// Try to round up to the next GiB value
 	nodeResource = math.RoundUp(nodeResource, resources.GiB)
 
 	// Always ensure that the calculated resource quantity is at least equal to the min. limit provided by the user.

--- a/pkg/controller/autoscaling/elasticsearch/autoscaler/recommender/recommender.go
+++ b/pkg/controller/autoscaling/elasticsearch/autoscaler/recommender/recommender.go
@@ -110,7 +110,7 @@ func getResourceValue(
 	}
 
 	// Try to round up the Gb value
-	nodeResource = math.RoundUp(nodeResource, resources.GIB)
+	nodeResource = math.RoundUp(nodeResource, resources.GiB)
 
 	// Always ensure that the calculated resource quantity is at least equal to the min. limit provided by the user.
 	if nodeResource < quantityRange.Min.Value() {

--- a/pkg/controller/autoscaling/elasticsearch/autoscaler/recommender/storage.go
+++ b/pkg/controller/autoscaling/elasticsearch/autoscaler/recommender/storage.go
@@ -115,7 +115,7 @@ func (s *storage) shouldScaleUp() bool {
 func (s *storage) NodeCount(nodeCapacity resources.NodeResources) int32 {
 	// A value of 0 explicitly means that Elasticsearch is expecting the nodes managed by this policy to be scaled down
 	// to 0. For example this could be the case for ML nodes when there is no ML jobs to run.
-	if s.hasZeroRequirement {
+	if s.requiredTotalStorageCapacity.IsZero() {
 		return s.autoscalingSpec.NodeCountRange.Enforce(0)
 	}
 	// Elasticsearch does not support data nodes scale down, always check if we should scale up first.

--- a/pkg/controller/autoscaling/elasticsearch/autoscaler/recommender/storage.go
+++ b/pkg/controller/autoscaling/elasticsearch/autoscaler/recommender/storage.go
@@ -113,6 +113,11 @@ func (s *storage) shouldScaleUp() bool {
 }
 
 func (s *storage) NodeCount(nodeCapacity resources.NodeResources) int32 {
+	// A value of 0 explicitly means that Elasticsearch is expecting the nodes managed by this policy to be scaled down
+	// to 0. For example this could be the case for ML nodes when there is no ML jobs to run.
+	if s.hasZeroRequirement {
+		return s.autoscalingSpec.NodeCountRange.Enforce(0)
+	}
 	// Elasticsearch does not support data nodes scale down, always check if we should scale up first.
 	// Otherwise return the current node count.
 	currentResources, hasResources := s.currentAutoscalingStatus.CurrentResourcesForPolicy(s.autoscalingSpec.Name)

--- a/pkg/controller/autoscaling/elasticsearch/autoscaler/recommender/storage.go
+++ b/pkg/controller/autoscaling/elasticsearch/autoscaler/recommender/storage.go
@@ -113,8 +113,8 @@ func (s *storage) shouldScaleUp() bool {
 }
 
 func (s *storage) NodeCount(nodeCapacity resources.NodeResources) int32 {
-	// A value of 0 explicitly means that Elasticsearch is expecting the nodes managed by this policy to be scaled down
-	// to 0. For example this could be the case for ML nodes when there is no ML jobs to run.
+	// A value of 0 explicitly means that storage decider should not prevent a scale down.
+	// For example this could be the case for ML nodes when there is no ML jobs to run.
 	if s.requiredTotalStorageCapacity.IsZero() {
 		return s.autoscalingSpec.NodeCountRange.Enforce(0)
 	}

--- a/pkg/controller/autoscaling/elasticsearch/resources/resources.go
+++ b/pkg/controller/autoscaling/elasticsearch/resources/resources.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	// GIB - 1 GibiBytes
-	GIB = int64(1024 * 1024 * 1024)
-	// GB - 1 Gigabytes
+	// GiB - 1 GibiByte
+	GiB = int64(1024 * 1024 * 1024)
+	// GB - 1 Gigabyte
 	GB = int64(1000 * 1000 * 1000)
 )
 
@@ -290,9 +290,9 @@ func (nr NodeResources) UpdateLimits(autoscalingResources v1.AutoscalingResource
 // ResourceToQuantity attempts to convert a raw integer value into a human readable quantity.
 func ResourceToQuantity(nodeResource int64) resource.Quantity {
 	switch {
-	case nodeResource >= GIB && nodeResource%GIB == 0:
+	case nodeResource >= GiB && nodeResource%GiB == 0:
 		// When it's possible we may want to express the memory with a "human readable unit" like the the Gi unit
-		return resource.MustParse(fmt.Sprintf("%dGi", nodeResource/GIB))
+		return resource.MustParse(fmt.Sprintf("%dGi", nodeResource/GiB))
 	case nodeResource >= GB && nodeResource%GB == 0:
 		// Same for gigabytes unit
 		return resource.MustParse(fmt.Sprintf("%dG", nodeResource/GB))

--- a/pkg/controller/autoscaling/elasticsearch/resources/resources.go
+++ b/pkg/controller/autoscaling/elasticsearch/resources/resources.go
@@ -289,20 +289,18 @@ func (nr NodeResources) UpdateLimits(autoscalingResources v1.AutoscalingResource
 
 // ResourceToQuantity attempts to convert a raw integer value into a human readable quantity.
 func ResourceToQuantity(nodeResource int64) resource.Quantity {
-	var nodeQuantity resource.Quantity
-	if nodeResource >= GIB && nodeResource%GIB == 0 {
+	switch {
+	case nodeResource >= GIB && nodeResource%GIB == 0:
 		// When it's possible we may want to express the memory with a "human readable unit" like the the Gi unit
-		nodeQuantity = resource.MustParse(fmt.Sprintf("%dGi", nodeResource/GIB))
-	} else if nodeResource >= GB && nodeResource%GB == 0 {
+		return resource.MustParse(fmt.Sprintf("%dGi", nodeResource/GIB))
+	case nodeResource >= GB && nodeResource%GB == 0:
 		// Same for gigabytes unit
-		nodeQuantity = resource.MustParse(fmt.Sprintf("%dG", nodeResource/GB))
-	} else {
-		nodeQuantity = resource.NewQuantity(nodeResource, resource.DecimalSI).DeepCopy()
+		return resource.MustParse(fmt.Sprintf("%dG", nodeResource/GB))
 	}
-	return nodeQuantity
+	return resource.NewQuantity(nodeResource, resource.DecimalSI).DeepCopy()
 }
 
-// ResourceList is a set of (resource name, quantity) pairs.
+// ResourceListInt64 is a set of (resource name, quantity) pairs.
 type ResourceListInt64 map[corev1.ResourceName]int64
 
 // NodeResourcesInt64 is mostly use in logs to print comparable values which can be used in dashboards.

--- a/pkg/controller/autoscaling/elasticsearch/resources/resources.go
+++ b/pkg/controller/autoscaling/elasticsearch/resources/resources.go
@@ -15,8 +15,10 @@ import (
 )
 
 const (
-	// GIB - 1 GibiByte
+	// GIB - 1 GibiBytes
 	GIB = int64(1024 * 1024 * 1024)
+	// GB - 1 Gigabytes
+	GB = int64(1000 * 1000 * 1000)
 )
 
 // NodeSetsResources models for all the nodeSets managed by a same autoscaling policy:
@@ -291,6 +293,9 @@ func ResourceToQuantity(nodeResource int64) resource.Quantity {
 	if nodeResource >= GIB && nodeResource%GIB == 0 {
 		// When it's possible we may want to express the memory with a "human readable unit" like the the Gi unit
 		nodeQuantity = resource.MustParse(fmt.Sprintf("%dGi", nodeResource/GIB))
+	} else if nodeResource >= GB && nodeResource%GB == 0 {
+		// Same for gigabytes unit
+		nodeQuantity = resource.MustParse(fmt.Sprintf("%dG", nodeResource/GB))
 	} else {
 		nodeQuantity = resource.NewQuantity(nodeResource, resource.DecimalSI).DeepCopy()
 	}

--- a/pkg/controller/autoscaling/elasticsearch/resources/resources.go
+++ b/pkg/controller/autoscaling/elasticsearch/resources/resources.go
@@ -291,7 +291,7 @@ func (nr NodeResources) UpdateLimits(autoscalingResources v1.AutoscalingResource
 func ResourceToQuantity(nodeResource int64) resource.Quantity {
 	switch {
 	case nodeResource >= GiB && nodeResource%GiB == 0:
-		// When it's possible we may want to express the memory with a "human readable unit" like the the Gi unit
+		// When it's possible we may want to express the memory with a "human readable unit" like the Gi unit
 		return resource.MustParse(fmt.Sprintf("%dGi", nodeResource/GiB))
 	case nodeResource >= GB && nodeResource%GB == 0:
 		// Same for gigabytes unit

--- a/test/e2e/es/autoscaling_test.go
+++ b/test/e2e/es/autoscaling_test.go
@@ -92,7 +92,8 @@ func TestAutoscaling(t *testing.T) {
 	expectedDataPVC := newPVC("20Gi", storageClass)
 	scaleUpStorage := esBuilder.DeepCopy().WithAnnotation(
 		esv1.ElasticsearchAutoscalingSpecAnnotationName,
-		autoscalingSpecBuilder.withFixedDecider("data-ingest", map[string]string{"storage": "20gb", "nodes": "3"}).toJSON(),
+		// A storage request of 19gb should lead to claims of 20Gi because the operator adds a capacity margin of 5% to account for reserved fs space.
+		autoscalingSpecBuilder.withFixedDecider("data-ingest", map[string]string{"storage": "19gb", "nodes": "3"}).toJSON(),
 	).WithExpectedNodeSets(
 		newNodeSet("master", []string{"master"}, 1, corev1.ResourceList{corev1.ResourceMemory: nodespec.DefaultMemoryLimits}, initialPVC),
 		newNodeSet("data-ingest", []string{"data", "ingest"}, 3, corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")}, expectedDataPVC),

--- a/test/e2e/es/autoscaling_test.go
+++ b/test/e2e/es/autoscaling_test.go
@@ -92,7 +92,7 @@ func TestAutoscaling(t *testing.T) {
 	expectedDataPVC := newPVC("20Gi", storageClass)
 	scaleUpStorage := esBuilder.DeepCopy().WithAnnotation(
 		esv1.ElasticsearchAutoscalingSpecAnnotationName,
-		// A storage request of 19gb should lead to claims of 20Gi because the operator adds a capacity margin of 5% to account for reserved fs space.
+		// Only request 19gb, the operator adds a capacity margin of 5% to account for reserved fs space, we don't want to exceed 3 nodes of 20Gi in this test.
 		autoscalingSpecBuilder.withFixedDecider("data-ingest", map[string]string{"storage": "19gb", "nodes": "3"}).toJSON(),
 	).WithExpectedNodeSets(
 		newNodeSet("master", []string{"master"}, 1, corev1.ResourceList{corev1.ResourceMemory: nodespec.DefaultMemoryLimits}, initialPVC),


### PR DESCRIPTION
#4493  broke e2e autoscaling test for 2 reasons:

1. The operator now adds a storage capacity margin of 5% to account for the fs reserved disk space. [Storage capacity requested using the fixed decider needs to be adjusted](https://github.com/elastic/cloud-on-k8s/commit/00cb71be9a897f2ace5bff4919d48f10de905bb5).
2. A total storage requirement of 0 explicitly means that storage recommender should not prevent a horizontal scale down. This is for example the case in the context of the ML decider.


This PR:

* Fixes the e2e tests
* Handles the case where a storage capacity request is 0
* Adds a unit test to catch this regression earlier