### PR TITLE
Adjust Auditbeat tests for arm64

### DIFF
--- a/config/recipes/beats/auditbeat_hosts.yaml
+++ b/config/recipes/beats/auditbeat_hosts.yaml
@@ -32,7 +32,7 @@ spec:
         # Executions
         -a always,exit -F arch=b64 -S execve,execveat -k exec
 
-        # Unauthorized access attempts
+        # Unauthorized access attempts (amd64 only)
         -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
         -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access
 

--- a/test/e2e/beat/config.go
+++ b/test/e2e/beat/config.go
@@ -177,8 +177,8 @@ processors:
     -a always,exit -F arch=b64 -S execve,execveat -k exec
 
     # Unauthorized access attempts
-    -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
-    -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access
+    -a always,exit -F arch=b64 -S truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
+    -a always,exit -F arch=b64 -S truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access
 
 processors:
   - add_cloud_metadata: {}

--- a/test/e2e/beat/config.go
+++ b/test/e2e/beat/config.go
@@ -176,7 +176,7 @@ processors:
     # Executions
     -a always,exit -F arch=b64 -S execve,execveat -k exec
 
-    # Unauthorized access attempts
+    # Unauthorized access attempts (adjusted to be compatible with amd64 and arm64)
     -a always,exit -F arch=b64 -S truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
     -a always,exit -F arch=b64 -S truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access
 

--- a/test/e2e/beat/recipes_test.go
+++ b/test/e2e/beat/recipes_test.go
@@ -175,8 +175,10 @@ func TestHeartbeatEsKbHealthRecipe(t *testing.T) {
 }
 
 func TestAuditbeatHostsRecipe(t *testing.T) {
-	if test.Ctx().Provider == "kind" {
-		// kind doesn't support configuring required settings
+
+	if test.Ctx().Provider == "kind" || test.Ctx().HasTag(test.ArchARMTag) {
+		// Skipping test because recipe relies on syscall audit rules unavailable on arm64
+		// Also: kind doesn't support configuring required settings
 		// see https://github.com/elastic/cloud-on-k8s/issues/3328 for more context
 		t.SkipNow()
 	}


### PR DESCRIPTION
Our Auditbeat recipe and `TestAuditbeatConfig` use audit.d rules that are not available on arm64. This removes the unavailable syscalls from `TestAuditbeatConfig` and skips the recipe test. The rationale for skipping the recipe test is that we want to have a meaningful recipe that covers the relevant syscalls for amd64 and I did not want to duplicate the recipe for arm64. 