### PR TITLE
E2E: Elastic Maps Server does not offer snapshot builds at the moment

### DIFF
--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -483,6 +483,7 @@ write_env <<ENV
 IMG_SUFFIX=-dev-ci
 REGISTRY_NAMESPACE=eck-snapshots
 E2E_REGISTRY_NAMESPACE=eck-ci
+# Disable EMS tests for snapshot builds see https://github.com/elastic/cloud-on-k8s/issues/4479
 E2E_TAGS=!ems e2e
 IS_SNAPSHOT_BUILD=yes
 GO_TAGS=release

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -483,8 +483,8 @@ write_env <<ENV
 IMG_SUFFIX=-dev-ci
 REGISTRY_NAMESPACE=eck-snapshots
 E2E_REGISTRY_NAMESPACE=eck-ci
+E2E_TAGS=!ems e2e
 IS_SNAPSHOT_BUILD=yes
-
 GO_TAGS=release
 export LICENSE_PUBKEY=/go/src/github.com/elastic/cloud-on-k8s/.ci/license.key
 ENV

--- a/test/e2e/test/maps/builder.go
+++ b/test/e2e/test/maps/builder.go
@@ -153,13 +153,6 @@ func (b Builder) SkipTest() bool {
 		return true
 	}
 
-	// TODO: remove once an EMS 8.x Docker image image is available
-	// https://github.com/elastic/cloud-on-k8s/issues/4479
-	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
-	if stackVersion.Major >= uint64(8) {
-		return true
-	}
-
 	ver := version.MustParse(b.EMS.Spec.Version)
 	return version.SupportedMapsVersions.WithinRange(ver) != nil
 }


### PR DESCRIPTION
This disables the Elastic Maps Server E2E test in the two snapshot E2E test we run.