### PR TITLE
E2E: go build constraints are OR'ed. Exclude EMS tests

### DIFF
--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -484,7 +484,7 @@ IMG_SUFFIX=-dev-ci
 REGISTRY_NAMESPACE=eck-snapshots
 E2E_REGISTRY_NAMESPACE=eck-ci
 # Disable EMS tests for snapshot builds see https://github.com/elastic/cloud-on-k8s/issues/4479
-E2E_TAGS=!ems e2e
+E2E_TAGS=es kb apm beat agent ent mixed
 IS_SNAPSHOT_BUILD=yes
 GO_TAGS=release
 export LICENSE_PUBKEY=/go/src/github.com/elastic/cloud-on-k8s/.ci/license.key

--- a/test/e2e/naming_test.go
+++ b/test/e2e/naming_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-// +build e2e
+// +build mixed e2e
 
 package e2e
 

--- a/test/e2e/samples_test.go
+++ b/test/e2e/samples_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-// +build e2e
+// +build mixed e2e
 
 package e2e
 

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-// +build e2e
+// +build mixed e2e
 
 package e2e
 

--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-// +build e2e
+// +build mixed e2e
 
 package e2e
 


### PR DESCRIPTION
I misunderstood how build constraints worked (and missed the EMS tests flying past my terminal when testing with `go test -test.list ...` ) https://golang.org/cmd/go/#hdr-Build_constraints 

Build constraints are either OR'ed or AND'ed (if on separate lines, or joined with a comma). Neither helps with excluding the EMS tests. This PR list all the constraints we want to build instead. It also adds a new constraint for the top level tests that test a combination of stack applications (`mixed`). 