### PR TITLE
node with specific type has only one node

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/pod-disruption-budget.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/pod-disruption-budget.asciidoc
@@ -35,6 +35,8 @@ spec:
 
 NOTE: link:https://kubernetes.io/docs/tasks/run-application/configure-pdb/#arbitrary-controllers-and-selectors[`maxUnavailable`] cannot be used with an arbitrary label selector, therefore `minAvailable` is used in this example.
 
+NOTE:  If there is a node type where there is only one node instance such as ingest, then when that node is restarted, the cluster will go yello.
+
 You can also explicitly disable the default PDB:
 
 [source,yaml,subs="attributes"]


### PR DESCRIPTION
A customer was performing maintenance where there was a single ingest node and there was confusion in why pod disruption was going yellow.
.
There is a note about single node clusters, but not single node instance types.

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/master/CONTRIBUTING.md)?
- If you submit code, is your pull request against master? We recommend pull requests against master. We will backport them as needed.
