### PR TITLE
OCP4: Use smaller cluster name

### DIFF
--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -232,13 +232,13 @@ OPERATOR_IMAGE=$JKS_PARAM_OPERATOR_IMAGE
 PIPELINE=e2e/ocp
 BUILD_NUMBER=$BUILD_NUMBER
 E2E_PROVIDER=ocp
-CLUSTER_NAME=$BUILD_TAG
+CLUSTER_NAME=ocp4-ci-$BUILD_NUMBER
 TEST_OPTS=-race
 ENV
 write_deployer_config <<CFG
 id: ocp-ci
 overrides:
-  clusterName: $BUILD_TAG
+  clusterName: ocp4-ci-$BUILD_NUMBER
   clientVersion: $2
   vaultInfo:
     address: $VAULT_ADDR
@@ -566,7 +566,7 @@ write_deployer_config <<CFG
 id: ocp-ci
 overrides:
   operation: delete
-  clusterName: $BUILD_TAG
+  clusterName: ocp4-ci-$BUILD_NUMBER
   clientVersion: $2
   vaultInfo:
     address: $VAULT_ADDR


### PR DESCRIPTION
Current cluster naming prevents OpenShift nodes to join the cluster: `Invalid value: "jenkins-cloud-on-k8s-wstdq-master-0.c.elastic-cloud-dev.internal": must be no more than 63 characters`

Tested with OCP `4.5.40` using a Jenkins worker node:

```
> oc version                                                   
Client Version: 4.6.3
Server Version: 4.5.40
Kubernetes Version: v1.18.3+d8ef5ad
```

```
> oc get nodes
NAME                                                          STATUS   ROLES    AGE     VERSION
ocp4-ci-3-2pjnp-master-0.c.elastic-cloud-dev.internal         Ready    master   22m     v1.18.3+d8ef5ad
ocp4-ci-3-2pjnp-master-1.c.elastic-cloud-dev.internal         Ready    master   22m     v1.18.3+d8ef5ad
ocp4-ci-3-2pjnp-master-2.c.elastic-cloud-dev.internal         Ready    master   22m     v1.18.3+d8ef5ad
ocp4-ci-3-2pjnp-worker-a-qfq2n.c.elastic-cloud-dev.internal   Ready    worker   10m     v1.18.3+d8ef5ad
ocp4-ci-3-2pjnp-worker-b-x6jcc.c.elastic-cloud-dev.internal   Ready    worker   10m     v1.18.3+d8ef5ad
ocp4-ci-3-2pjnp-worker-c-vqnng.c.elastic-cloud-dev.internal   Ready    worker   9m54s   v1.18.3+d8ef5ad
```

Fix #4458