### PR TITLE
E2E: Elastic Maps Server revert to explicit snapshot check

### DIFF
--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -483,8 +483,6 @@ write_env <<ENV
 IMG_SUFFIX=-dev-ci
 REGISTRY_NAMESPACE=eck-snapshots
 E2E_REGISTRY_NAMESPACE=eck-ci
-# Disable EMS tests for snapshot builds see https://github.com/elastic/cloud-on-k8s/issues/4479
-E2E_TAGS=es kb apm beat agent ent mixed
 IS_SNAPSHOT_BUILD=yes
 GO_TAGS=release
 export LICENSE_PUBKEY=/go/src/github.com/elastic/cloud-on-k8s/.ci/license.key

--- a/test/e2e/test/maps/builder.go
+++ b/test/e2e/test/maps/builder.go
@@ -154,6 +154,13 @@ func (b Builder) SkipTest() bool {
 	}
 
 	ver := version.MustParse(b.EMS.Spec.Version)
+
+	// remove or adjust as snapshot builds of EMS become available
+	// https://github.com/elastic/cloud-on-k8s/issues/4479
+	if test.IsSnapshotVersion(ver) {
+		return true
+	}
+
 	return version.SupportedMapsVersions.WithinRange(ver) != nil
 }
 

--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -45,3 +45,7 @@ func isValidUpgrade(from string, to string) (bool, error) {
 	validMajorDigit := dstVer.Major == srcVer.Major || dstVer.Major == srcVer.Major+1
 	return validMajorDigit && !srcVer.GTE(dstVer), nil
 }
+
+func IsSnapshotVersion(v version.Version) bool {
+	return len(v.Pre) > 0
+}

--- a/test/e2e/test/version_test.go
+++ b/test/e2e/test/version_test.go
@@ -7,6 +7,7 @@ package test
 import (
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,5 +38,38 @@ func TestIsValidUpgrade(t *testing.T) {
 			t.Errorf(`isValidUpgrade("%s", "%s") = %v, want %v`, tt.from, tt.to, isValid, tt.isValid)
 		}
 		require.Equal(t, tt.isValid, isValid)
+	}
+}
+
+func Test_isSnapshot(t *testing.T) {
+	type args struct {
+		ver version.Version
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "stable",
+			args: args{
+				ver: version.MustParse("7.13.0"),
+			},
+			want: false,
+		},
+		{
+			name: "pre-release",
+			args: args{
+				ver: version.MustParse("7.13.0-SNAPSHOT"),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSnapshotVersion(tt.args.ver); got != tt.want {
+				t.Errorf("isSnapshot() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
After tripping over go build constraints and our `setenvconfig` script twice, this goes back to an explicit check for snapshot versions in the Elastic Maps Server builder to skip any tests on SNAPSHOT candidates. 🤞 