### PR TITLE
[1.6] ECK docs - Fix wording and product name (#4541)

### DIFF
--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -11,6 +11,6 @@ ECK should work with all conformant installers as listed in these link:https://g
 
 Alpha, beta, and stable API versions follow the same link:https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning[conventions used by Kubernetes].
 
-Elastic stack application images for the OpenShift certified Elasticsearch (ECK) Operator are only available from version 7.10 and later.
+Elastic Stack application images for the OpenShift-certified Elasticsearch (ECK) Operator are only available from version 7.10 and later.
 
-Please see the full link:https://www.elastic.co/support/matrix#matrix_kubernetes[Elastic support matrix] for more information.
+See the full link:https://www.elastic.co/support/matrix#matrix_kubernetes[Elastic support matrix] for more information.

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -286,7 +286,7 @@ spec:
 
     Alpha, beta, and stable API versions follow the same link:https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning[conventions used by Kubernetes].
 
-    Please see the full link:https://www.elastic.co/support/matrix#matrix_kubernetes[Elastic support matrix] for more information.
+    See the full link:https://www.elastic.co/support/matrix#matrix_kubernetes[Elastic support matrix] for more information.
 
     See the [Quickstart](https://www.elastic.co/guide/en/cloud-on-k8s/{{ .ShortVersion }}/k8s-quickstart.html)
     to get started with ECK.'


### PR DESCRIPTION
Backports the following commits to 1.6:
 - ECK docs - Fix wording and product name (#4541)