### PR TITLE
Update upgrading-stack.asciidoc

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/upgrading-stack.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/upgrading-stack.asciidoc
@@ -11,4 +11,6 @@ The operator can safely perform upgrades to newer versions of the various Elasti
 
 Follow the instructions in the link:https://www.elastic.co/guide/en/elastic-stack/current/upgrading-elastic-stack.html[Elasticsearch documentation]. Make sure that your cluster is compatible with the target version, take backups, and follow the specific upgrade instructions for each resource type, especially the order in which the upgrade should be carried out. When you are ready, modify the `version` field in the resource spec to the desired stack version and the operator will start the upgrade process automatically.
 
+Once Elasticsearch is upgraded to the newer version with a green cluster health, you will be able to perform the rest of the stack upgrade. 
+
 See <<{p}-orchestration>> for more information on how the operator performs upgrades and how to tune its behavior.

--- a/docs/orchestrating-elastic-stack-applications/upgrading-stack.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/upgrading-stack.asciidoc
@@ -11,6 +11,6 @@ The operator can safely perform upgrades to newer versions of the various Elasti
 
 Follow the instructions in the link:https://www.elastic.co/guide/en/elastic-stack/current/upgrading-elastic-stack.html[Elasticsearch documentation]. Make sure that your cluster is compatible with the target version, take backups, and follow the specific upgrade instructions for each resource type, especially the order in which the upgrade should be carried out. When you are ready, modify the `version` field in the resource spec to the desired stack version and the operator will start the upgrade process automatically.
 
-Once Elasticsearch is upgraded to the newer version with a green cluster health, you will be able to perform the rest of the stack upgrade. 
+When Elasticsearch is upgraded to the newer version with a green cluster health, you can perform the rest of the stack upgrade. 
 
 See <<{p}-orchestration>> for more information on how the operator performs upgrades and how to tune its behavior.


### PR DESCRIPTION
Adding a description of the expected order of stack version upgrade.

The page currently talks about "Elasticsearch" upgrade only even though the page is titled "Upgrade the Elastic Stack version".

It would be good to clarify by adding the kibana, apm, enterprise-search etc should be upgraded after elasticsearch upgrade is successful. Feel free to add more description to that effect. 