### PR TITLE
Fix heap memory parsing with trailing white spaces

### DIFF
--- a/pkg/license/aggregator.go
+++ b/pkg/license/aggregator.go
@@ -202,7 +202,7 @@ func containerMemLimits(
 }
 
 // maxHeapSizeRe is the pattern to extract the max Java heap size (-Xmx<size>[g|G|m|M|k|K] in binary units)
-var maxHeapSizeRe = regexp.MustCompile(`-Xmx([0-9]+)([gGmMkK]?)(?:\s.+|$)`)
+var maxHeapSizeRe = regexp.MustCompile(`-Xmx([0-9]+)([gGmMkK]?)(?:\s.*|$)`)
 
 // memFromJavaOpts extracts the maximum Java heap size from a Java options string, multiplies the value by 2
 // (giving twice the JVM memory to the container is a common thing people do)

--- a/pkg/license/aggregator_test.go
+++ b/pkg/license/aggregator_test.go
@@ -87,6 +87,16 @@ func TestMemFromJavaOpts(t *testing.T) {
 			expected: resource.MustParse("16777216k"),
 			isErr:    true,
 		},
+		{
+			name:     "with trailing spaces at the end",
+			actual:   "-Xms1k -Xmx8388608k   ",
+			expected: resource.MustParse("16777216Ki"),
+		},
+		{
+			name:     "with trailing space at the beginning",
+			actual:   "  -Xms1k -Xmx8388608k",
+			expected: resource.MustParse("16777216Ki"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fix #4564 by allowing trailing spaces without any additional characters at the end of the `Xmx` heap setting.