### PR TITLE
Beats: allow unprivileged Pods to read configuration file

### DIFF
--- a/pkg/controller/beat/common/pod.go
+++ b/pkg/controller/beat/common/pod.go
@@ -87,7 +87,7 @@ func buildPodTemplate(
 			ConfigVolumeName,
 			ConfigMountPath,
 			ConfigFileName,
-			0600),
+			0444),
 		dataVolume,
 	}
 

--- a/pkg/controller/beat/common/pod_test.go
+++ b/pkg/controller/beat/common/pod_test.go
@@ -68,6 +68,7 @@ func Test_buildPodTemplate(t *testing.T) {
 var expectedConfigVolumeMode int32 = 292
 
 func assertPodWithInitContainer(t *testing.T, pod corev1.PodTemplateSpec) {
+	t.Helper()
 	// Validate that init container is in the PodTemplate
 	assert.Len(t, pod.Spec.InitContainers, 1)
 	// Image used by the init container and by the "main" container must be the same


### PR DESCRIPTION
This PR allows unprivileged users to read Beat configuration file:

```
bash-4.2$ ls -la /etc/beat.yml
-r--r--r--. 1 root root 790 Jun 15 13:05 /etc/beat.yml
```

Relates to https://github.com/elastic/cloud-on-k8s/issues/4562