### PR TITLE
Doc edits: upgrade order and typos

### DIFF
--- a/docs/operating-eck/upgrading-eck.asciidoc
+++ b/docs/operating-eck/upgrading-eck.asciidoc
@@ -25,7 +25,7 @@ CAUTION: The upgrade process results in an update to all the existing managed re
 
 IMPORTANT: If you are running Openshift 3.11 or a Kubernetes version older than 1.13, and want to upgrade from beta, jump to the <<{p}-ga-openshift, upgrade instructions for older Kubernetes releases>>.
 
-Release 1.7.0 moves the link:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/[CustomResourceDefinitions] (CRD) used by ECK to the v1 version. If you upgrade from a previous version of ECK, the new version of the CRDs replace the existing CRDs. If you cannot remove the current ECK installation because you have production workloads that must not be deleted, the following approach is recommended:
+Release 1.7.0 moves the link:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/[CustomResourceDefinitions] (CRD) used by ECK to the v1 version. If you upgrade from a previous version of ECK, the new version of the CRDs replaces the existing CRDs. If you cannot remove the current ECK installation because you have production workloads that must not be deleted, the following approach is recommended.
 
 [source,shell,subs="attributes,callouts"]
 .If you are installing using the YAML manifests: replace existing CRDs

--- a/docs/orchestrating-elastic-stack-applications/upgrading-stack.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/upgrading-stack.asciidoc
@@ -11,6 +11,6 @@ The operator can safely perform upgrades to newer versions of the various Elasti
 
 Follow the instructions in the link:https://www.elastic.co/guide/en/elastic-stack/current/upgrading-elastic-stack.html[Elasticsearch documentation]. Make sure that your cluster is compatible with the target version, take backups, and follow the specific upgrade instructions for each resource type. When you are ready, modify the `version` field in the resource spec to the desired stack version and the operator will start the upgrade process automatically.
 
-ECK will make sure that Elastic Stack resources are upgraded in the correct order. Upgrades to dependent stack resources will be delayed until the dependency is upgraded. For example, the Kibana upgrade will only then be rolled out when the associated Elasticsearch cluster has been upgraded.
+ECK will make sure that Elastic Stack resources are upgraded in the correct order. Upgrades to dependent stack resources are delayed until the dependency is upgraded. For example, the Kibana upgrade will be rolled out only when the associated Elasticsearch cluster has been upgraded.
 
 See <<{p}-orchestration>> for more information on how the operator performs upgrades and how to tune its behavior.

--- a/docs/orchestrating-elastic-stack-applications/upgrading-stack.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/upgrading-stack.asciidoc
@@ -9,6 +9,8 @@ endif::[]
 
 The operator can safely perform upgrades to newer versions of the various Elastic Stack resources.
 
-Follow the instructions in the link:https://www.elastic.co/guide/en/elastic-stack/current/upgrading-elastic-stack.html[Elasticsearch documentation]. Make sure that your cluster is compatible with the target version, take backups, and follow the specific upgrade instructions for each resource type, especially the order in which the upgrade should be carried out. When you are ready, modify the `version` field in the resource spec to the desired stack version and the operator will start the upgrade process automatically.
+Follow the instructions in the link:https://www.elastic.co/guide/en/elastic-stack/current/upgrading-elastic-stack.html[Elasticsearch documentation]. Make sure that your cluster is compatible with the target version, take backups, and follow the specific upgrade instructions for each resource type. When you are ready, modify the `version` field in the resource spec to the desired stack version and the operator will start the upgrade process automatically.
+
+ECK will make sure that Elastic Stack resources are upgraded in the correct order. Upgrades to dependent stack resources will be delayed until the dependency is upgraded. For example, the Kibana upgrade will only then be rolled out when the associated Elasticsearch cluster has been upgraded.
 
 See <<{p}-orchestration>> for more information on how the operator performs upgrades and how to tune its behavior.

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -50,7 +50,7 @@ kubectl create -f https://download.elastic.co/downloads/eck/{eck_version}/crds.y
 kubectl apply -f https://download.elastic.co/downloads/eck/{eck_version}/operator.yaml
 ----
 +
-If you are running version of Kubernetes before 1.16 you have to use the legacy version of the manifests:
+If you are running a version of Kubernetes before 1.16 you have to use the legacy version of the manifests:
 +
 [source,sh,subs="attributes"]
 ----


### PR DESCRIPTION
As suggested by @Leaf-Lin adds a sentence about the upgrade order during Elastic stack upgrades. Also fixes a few typos.
