### PR TITLE
Bump Agent resources to 350Mi

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
@@ -210,7 +210,7 @@ If `resources` is not defined in the specification of an object, then the operat
 |Elasticsearch |2Gi |2Gi
 |Kibana |1Gi |1Gi
 |Beat   |200Mi |200Mi
-|Elastic Agent |300Mi |300Mi
+|Elastic Agent |350Mi |350Mi
 |Elastic Maps Sever |200Mi |200Mi
 |===
 

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -42,11 +42,11 @@ const (
 var (
 	defaultResources = corev1.ResourceRequirements{
 		Limits: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceMemory: resource.MustParse("300Mi"),
+			corev1.ResourceMemory: resource.MustParse("350Mi"),
 			corev1.ResourceCPU:    resource.MustParse("200m"),
 		},
 		Requests: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceMemory: resource.MustParse("300Mi"),
+			corev1.ResourceMemory: resource.MustParse("350Mi"),
 			corev1.ResourceCPU:    resource.MustParse("200m"),
 		},
 	}

--- a/test/e2e/test/beat/pod_builder.go
+++ b/test/e2e/test/beat/pod_builder.go
@@ -44,7 +44,7 @@ func newPodBuilder(name, suffix string) PodBuilder {
 	// inject random string into the logs to allow validating whether they end up in ES easily
 	loggedString := fmt.Sprintf("_%s_", rand.String(6))
 
-	uid1001 := int64(1002)
+	uid1001 := int64(1001)
 	return PodBuilder{
 		Pod: corev1.Pod{
 			ObjectMeta: meta,

--- a/test/e2e/test/beat/pod_builder.go
+++ b/test/e2e/test/beat/pod_builder.go
@@ -44,6 +44,7 @@ func newPodBuilder(name, suffix string) PodBuilder {
 	// inject random string into the logs to allow validating whether they end up in ES easily
 	loggedString := fmt.Sprintf("_%s_", rand.String(6))
 
+	uid1001 := int64(1002)
 	return PodBuilder{
 		Pod: corev1.Pod{
 			ObjectMeta: meta,
@@ -59,7 +60,10 @@ func newPodBuilder(name, suffix string) PodBuilder {
 						},
 					},
 				},
-				SecurityContext: test.DefaultSecurityContext(),
+				SecurityContext: &corev1.PodSecurityContext{
+					// e2e PSP forbids root user on secured clusters
+					RunAsUser: &uid1001,
+				},
 			},
 		},
 		Logged: loggedString,


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/4559

I don't fully understand why we have this issue only OCP, but this bumps the default resources for Agent on ECK to 350Mi

It also fixes an issue with e2e test pod we create in some of Beats/Agents tests to have observable data. Again I don't fully understand how this is working for the other tests. 

Still investigating.