### PR TITLE
Add ecdsa support

### DIFF
--- a/pkg/controller/common/certificates/ca.go
+++ b/pkg/controller/common/certificates/ca.go
@@ -5,6 +5,7 @@
 package certificates
 
 import (
+	"crypto"
 	cryptorand "crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -23,7 +24,7 @@ var (
 // CA is a simple certificate authority
 type CA struct {
 	// PrivateKey is the CA private key
-	PrivateKey *rsa.PrivateKey
+	PrivateKey crypto.Signer
 	// Cert is the certificate used to issue new certificates
 	Cert *x509.Certificate
 }
@@ -33,7 +34,7 @@ type CA struct {
 type ValidatedCertificateTemplate x509.Certificate
 
 // NewCA returns a ca with the given private key and cert
-func NewCA(privateKey *rsa.PrivateKey, cert *x509.Certificate) *CA {
+func NewCA(privateKey crypto.Signer, cert *x509.Certificate) *CA {
 	return &CA{
 		PrivateKey: privateKey,
 		Cert:       cert,

--- a/pkg/controller/common/certificates/ca_reconcile_test.go
+++ b/pkg/controller/common/certificates/ca_reconcile_test.go
@@ -143,7 +143,7 @@ func Test_canReuseCA(t *testing.T) {
 	}
 }
 
-func rsaPKeyEqual(t *testing.T, actual, expected crypto.Signer) {
+func privateKeysEqual(t *testing.T, actual, expected crypto.Signer) {
 	t.Helper()
 	if reflect.TypeOf(actual) != reflect.TypeOf(expected) {
 		t.Errorf("unexpected RSA private key, got %T, want %T", actual, expected)
@@ -179,7 +179,7 @@ func checkCASecrets(
 	// if an expected Ca was passed, it should match ca
 	if expectedCa != nil {
 		require.True(t, ca.Cert.Equal(expectedCa.Cert))
-		rsaPKeyEqual(t, ca.PrivateKey, expectedCa.PrivateKey)
+		privateKeysEqual(t, ca.PrivateKey, expectedCa.PrivateKey)
 	}
 
 	// if a not expected Ca was passed, it should not match ca
@@ -202,7 +202,7 @@ func checkCASecrets(
 	require.NotNil(t, parsedCa)
 	// and return the ca
 	require.True(t, ca.Cert.Equal(parsedCa.Cert))
-	rsaPKeyEqual(t, ca.PrivateKey, parsedCa.PrivateKey)
+	privateKeysEqual(t, ca.PrivateKey, parsedCa.PrivateKey)
 }
 
 func Test_renewCA(t *testing.T) {

--- a/pkg/controller/common/certificates/pem.go
+++ b/pkg/controller/common/certificates/pem.go
@@ -155,7 +155,7 @@ func PrivateMatchesPublicKey(publicKey crypto.PublicKey, privateKey crypto.Signe
 	}
 }
 
-// GetCompatiblePrivateKey returns a PEM encoded private key iff the ca and the key have the same underlying type.
+// GetCompatiblePrivateKey returns a PEM encoded private key iff the CA and the key have the same underlying type.
 func GetCompatiblePrivateKey(caPrivateKey crypto.Signer, secret *corev1.Secret, fileName string) crypto.Signer {
 	if certPrivateKeyData, ok := secret.Data[fileName]; ok {
 		certPrivateKey, err := ParsePEMPrivateKey(certPrivateKeyData)
@@ -191,6 +191,6 @@ func NewPrivateKey(caSigner crypto.Signer) (crypto.Signer, error) {
 		// re-use the same curve
 		return ecdsa.GenerateKey(k.PublicKey.Curve, cryptorand.Reader)
 	default:
-		return nil, fmt.Errorf("unsupported CA private key: %T", caSigner)
+		return nil, fmt.Errorf("unsupported CA private key type: %T", caSigner)
 	}
 }

--- a/pkg/controller/common/certificates/pem.go
+++ b/pkg/controller/common/certificates/pem.go
@@ -6,14 +6,26 @@ package certificates
 
 import (
 	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	cryptorand "crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
+	"reflect"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var ErrEncryptedPrivateKey = errors.New("encrypted private key")
+
+const (
+	ecPrivateKeyType    = "EC PRIVATE KEY"
+	pkcs1PrivateKeyType = "RSA PRIVATE KEY"
+	pkcs8PrivateKeyType = "PRIVATE KEY"
+)
 
 // ParsePEMCerts returns a list of certificates from the given PEM certs data
 // Based on the code of x509.CertPool.AppendCertsFromPEM (https://golang.org/src/crypto/x509/cert_pool.go)
@@ -51,16 +63,37 @@ func EncodePEMCert(certBlocks ...[]byte) []byte {
 }
 
 // EncodePEMPrivateKey encodes the given private key in the PEM format
-func EncodePEMPrivateKey(privateKey rsa.PrivateKey) []byte {
-	return pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(&privateKey),
-	})
+func EncodePEMPrivateKey(privateKey crypto.Signer) ([]byte, error) {
+	pemBlock, err := pemBlockForKey(privateKey)
+	if err != nil {
+		return nil, err
+	}
+	return pem.EncodeToMemory(pemBlock), nil
+}
+
+func pemBlockForKey(privateKey interface{}) (*pem.Block, error) {
+	switch k := privateKey.(type) {
+	case *rsa.PrivateKey:
+		return &pem.Block{Type: pkcs1PrivateKeyType, Bytes: x509.MarshalPKCS1PrivateKey(k)}, nil
+	case *ecdsa.PrivateKey:
+		b, err := x509.MarshalECPrivateKey(k)
+		if err != nil {
+			return nil, err
+		}
+		return &pem.Block{Type: ecPrivateKeyType, Bytes: b}, nil
+	default:
+		// attempt PKCS#8 format
+		b, err := x509.MarshalPKCS8PrivateKey(k)
+		if err != nil {
+			return nil, err
+		}
+		return &pem.Block{Type: pkcs8PrivateKeyType, Bytes: b}, nil
+	}
 }
 
 // ParsePEMPrivateKey parses the given private key in the PEM format
 // ErrEncryptedPrivateKey is returned as an error if the private key is encrypted.
-func ParsePEMPrivateKey(pemData []byte) (*rsa.PrivateKey, error) {
+func ParsePEMPrivateKey(pemData []byte) (crypto.Signer, error) {
 	block, _ := pem.Decode(pemData)
 	if block == nil {
 		return nil, errors.New("failed to parse PEM block containing private key")
@@ -70,12 +103,14 @@ func ParsePEMPrivateKey(pemData []byte) (*rsa.PrivateKey, error) {
 	case x509.IsEncryptedPEMBlock(block): //nolint:staticcheck
 		// Private key is encrypted, do not attempt to parse it
 		return nil, ErrEncryptedPrivateKey
-	case block.Type == "PRIVATE KEY":
+	case block.Type == pkcs8PrivateKeyType:
 		return parsePKCS8PrivateKey(block.Bytes)
-	case block.Type == "RSA PRIVATE KEY" && len(block.Headers) == 0:
+	case block.Type == pkcs1PrivateKeyType && len(block.Headers) == 0:
 		return x509.ParsePKCS1PrivateKey(block.Bytes)
+	case block.Type == ecPrivateKeyType:
+		return x509.ParseECPrivateKey(block.Bytes)
 	default:
-		return nil, errors.New("expected PEM block to contain an RSA private key")
+		return nil, fmt.Errorf("unsupported private key type %q", block.Type)
 	}
 }
 
@@ -108,15 +143,54 @@ func GetPrimaryCertificate(pemBytes []byte) (*x509.Certificate, error) {
 }
 
 // PrivateMatchesPublicKey returns true if the public and private keys correspond to each other.
-func PrivateMatchesPublicKey(publicKey interface{}, privateKey rsa.PrivateKey) bool {
-	pubKey, ok := publicKey.(*rsa.PublicKey)
-	if !ok {
-		log.Error(errors.New("Public key is not an RSA public key"), "")
+func PrivateMatchesPublicKey(publicKey crypto.PublicKey, privateKey crypto.Signer) bool {
+	switch k := publicKey.(type) {
+	case *rsa.PublicKey:
+		return k.Equal(privateKey.Public())
+	case *ecdsa.PublicKey:
+		return k.Equal(privateKey.Public())
+	default:
+		log.Error(fmt.Errorf("unsupported public key type: %T", publicKey), "")
 		return false
 	}
-	// check that public and private keys share the same modulus and exponent
-	if pubKey.N.Cmp(privateKey.N) != 0 || pubKey.E != privateKey.E {
-		return false
+}
+
+// GetCompatiblePrivateKey returns a PEM encoded private key iff the ca and the key have the same underlying type.
+func GetCompatiblePrivateKey(caPrivateKey crypto.Signer, secret *corev1.Secret, fileName string) crypto.Signer {
+	if certPrivateKeyData, ok := secret.Data[fileName]; ok {
+		certPrivateKey, err := ParsePEMPrivateKey(certPrivateKeyData)
+		if err != nil {
+			log.Error(err, "Unable to parse stored private key", "namespace", secret.Namespace, "secret_name", secret.Name, "cert_key_filename", fileName)
+			return nil
+		}
+		if caPrivateKey == nil || certPrivateKey == nil {
+			return nil
+		}
+		if reflect.TypeOf(caPrivateKey) != reflect.TypeOf(certPrivateKey) {
+			log.Info(
+				"CA and cert private key do not share the same implementation",
+				"namespace", secret.Namespace,
+				"secret_name", secret.Name,
+				"cert_key_filename", fileName,
+				"ca_type", reflect.TypeOf(caPrivateKey),
+				"cert_type", reflect.TypeOf(certPrivateKey),
+			)
+			return nil
+		}
+		return certPrivateKey
 	}
-	return true
+	return nil
+}
+
+// NewPrivateKey generates a new private key using the same implementation than the CA.
+func NewPrivateKey(caSigner crypto.Signer) (crypto.Signer, error) {
+	switch k := caSigner.(type) {
+	case *rsa.PrivateKey:
+		return rsa.GenerateKey(cryptorand.Reader, 2048)
+	case *ecdsa.PrivateKey:
+		// re-use the same curve
+		return ecdsa.GenerateKey(k.PublicKey.Curve, cryptorand.Reader)
+	default:
+		return nil, fmt.Errorf("unsupported CA private key: %T", caSigner)
+	}
 }

--- a/pkg/controller/common/certificates/pem_test.go
+++ b/pkg/controller/common/certificates/pem_test.go
@@ -7,6 +7,9 @@
 package certificates
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	cryptorand "crypto/rand"
 	"crypto/rsa"
 	"testing"
@@ -15,26 +18,42 @@ import (
 )
 
 func Test_PrivateMatchesPublicKey(t *testing.T) {
-	privateKey1, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+	rsaPrivateKey1, err := rsa.GenerateKey(cryptorand.Reader, 2048)
 	require.NoError(t, err)
-	privateKey2, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+	rsaPrivateKey2, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+	require.NoError(t, err)
+	ecdsaPrivateKey1, err := ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
+	require.NoError(t, err)
+	ecdsaPrivateKey2, err := ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
 	require.NoError(t, err)
 	tests := []struct {
 		name       string
-		publicKey  interface{}
-		privateKey rsa.PrivateKey
+		publicKey  crypto.PublicKey
+		privateKey crypto.Signer
 		want       bool
 	}{
 		{
-			name:       "with matching public and private keys",
-			publicKey:  privateKey1.Public(),
-			privateKey: *privateKey1,
+			name:       "with matching RSA public and private keys",
+			publicKey:  rsaPrivateKey1.Public(),
+			privateKey: rsaPrivateKey1,
 			want:       true,
 		},
 		{
-			name:       "with non-matching public and private keys",
-			publicKey:  privateKey1.Public(),
-			privateKey: *privateKey2,
+			name:       "with non-matching RSA public and private keys",
+			publicKey:  rsaPrivateKey1.Public(),
+			privateKey: rsaPrivateKey2,
+			want:       false,
+		},
+		{
+			name:       "with matching ECDSA public and private keys",
+			publicKey:  ecdsaPrivateKey1.Public(),
+			privateKey: ecdsaPrivateKey1,
+			want:       true,
+		},
+		{
+			name:       "with non-matching ECDSA public and private keys",
+			publicKey:  ecdsaPrivateKey1.Public(),
+			privateKey: ecdsaPrivateKey2,
 			want:       false,
 		},
 	}

--- a/pkg/controller/elasticsearch/certificates/transport/csr_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/csr_test.go
@@ -19,7 +19,7 @@ import (
 // roundTripSerialize does a serialization round-trip of the certificate in order to make sure any extra extensions
 // are parsed and considered part of the certificate
 func roundTripSerialize(cert *certificates.ValidatedCertificateTemplate) (*x509.Certificate, error) {
-	certData, err := testCA.CreateCertificate(*cert)
+	certData, err := testRSACA.CreateCertificate(*cert)
 	if err != nil {
 		return nil, err
 	}
@@ -35,9 +35,7 @@ func Test_createValidatedCertificateTemplate(t *testing.T) {
 	// we expect this name to be used for both the common name as well as the es othername
 	cn := "test-pod-name.node.test-es-name.test-namespace.es.local"
 
-	validatedCert, err := createValidatedCertificateTemplate(
-		testPod, testES, testCSR, certificates.DefaultCertValidity,
-	)
+	validatedCert, err := createValidatedCertificateTemplate(testPod, testES, testRSACSR, certificates.DefaultCertValidity)
 	require.NoError(t, err)
 
 	// roundtrip the certificate

--- a/pkg/controller/elasticsearch/certificates/transport/pod_secret.go
+++ b/pkg/controller/elasticsearch/certificates/transport/pod_secret.go
@@ -13,10 +13,9 @@ import (
 	"reflect"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // PodKeyFileName returns the name of the private key entry for a specific pod in a transport certificates secret.
@@ -38,7 +37,6 @@ func ensureTransportCertificatesSecretContentsForPod(
 	ca *certificates.CA,
 	rotationParams certificates.RotationParams,
 ) error {
-
 	// verify that the secret contains a parsable and compatible private key
 	privateKey := certificates.GetCompatiblePrivateKey(ca.PrivateKey, secret, PodKeyFileName(pod.Name))
 

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile_test.go
@@ -40,7 +40,7 @@ func TestReconcileTransportCertificatesSecrets(t *testing.T) {
 		{
 			name: "Initial state, 3 nodeSets cluster, transport certs Secrets don't exists yet",
 			args: args{
-				ca: testCA,
+				ca: testRSACA,
 				es: newEsBuilder().addNodeSet("sset1", 2).addNodeSet("sset2", 3).addNodeSet("sset3", 4).build(),
 				initialObjects: []runtime.Object{
 					// 2 Pods in sset1
@@ -68,7 +68,7 @@ func TestReconcileTransportCertificatesSecrets(t *testing.T) {
 				// 5 items are expected in the Secret: the CA + 2 * (crt and private keys)
 				assert.Equal(t, 5, len(transportCerts1.Data))
 				// Check that ca.crt exists
-				assert.Equal(t, testCABytes, transportCerts1.Data["ca.crt"])
+				assert.Equal(t, testRSACABytes, transportCerts1.Data["ca.crt"])
 				// Check the labels elasticsearch.k8s.elastic.co/cluster-name and elasticsearch.k8s.elastic.co/statefulset-name
 				assert.Equal(t, testEsName, transportCerts1.Labels["elasticsearch.k8s.elastic.co/cluster-name"])
 				assert.Equal(t, "test-es-name-es-sset1", transportCerts1.Labels["elasticsearch.k8s.elastic.co/statefulset-name"])
@@ -78,7 +78,7 @@ func TestReconcileTransportCertificatesSecrets(t *testing.T) {
 				// 7 items are expected in the Secret: the CA + 3 * (crt and private keys)
 				assert.Equal(t, 7, len(transportCerts2.Data))
 				// Check that ca.crt exists
-				assert.Equal(t, testCABytes, transportCerts2.Data["ca.crt"])
+				assert.Equal(t, testRSACABytes, transportCerts2.Data["ca.crt"])
 				// Check the labels elasticsearch.k8s.elastic.co/cluster-name and elasticsearch.k8s.elastic.co/statefulset-name
 				assert.Equal(t, testEsName, transportCerts2.Labels["elasticsearch.k8s.elastic.co/cluster-name"])
 				assert.Equal(t, "test-es-name-es-sset2", transportCerts2.Labels["elasticsearch.k8s.elastic.co/statefulset-name"])
@@ -88,7 +88,7 @@ func TestReconcileTransportCertificatesSecrets(t *testing.T) {
 				// 9 items are expected in the Secret: the CA + 4 * (crt and private keys)
 				assert.Equal(t, 9, len(transportCerts3.Data))
 				// Check that ca.crt exists
-				assert.Equal(t, testCABytes, transportCerts3.Data["ca.crt"])
+				assert.Equal(t, testRSACABytes, transportCerts3.Data["ca.crt"])
 				// Check the labels elasticsearch.k8s.elastic.co/cluster-name and elasticsearch.k8s.elastic.co/statefulset-name
 				assert.Equal(t, testEsName, transportCerts3.Labels["elasticsearch.k8s.elastic.co/cluster-name"])
 				assert.Equal(t, "test-es-name-es-sset3", transportCerts3.Labels["elasticsearch.k8s.elastic.co/statefulset-name"])
@@ -97,7 +97,7 @@ func TestReconcileTransportCertificatesSecrets(t *testing.T) {
 		{
 			name: "Should reuse and update existing transport certs Secrets",
 			args: args{
-				ca: testCA,
+				ca: testRSACA,
 				es: newEsBuilder().addNodeSet("sset1", 2).addNodeSet("sset2", 2).build(),
 				initialObjects: []runtime.Object{
 					newPodBuilder().forEs(testEsName).inNodeSet("sset1").withIndex(0).withIP("1.1.1.2").build(),
@@ -124,7 +124,7 @@ func TestReconcileTransportCertificatesSecrets(t *testing.T) {
 				// 5 items are expected in the Secret: the CA + 2 * (crt and private keys)
 				assert.Equal(t, 5, len(transportCerts1.Data))
 				// Check that ca.crt exists
-				assert.Equal(t, testCABytes, transportCerts1.Data["ca.crt"])
+				assert.Equal(t, testRSACABytes, transportCerts1.Data["ca.crt"])
 				// Check the labels elasticsearch.k8s.elastic.co/cluster-name and elasticsearch.k8s.elastic.co/statefulset-name
 				assert.Equal(t, testEsName, transportCerts1.Labels["elasticsearch.k8s.elastic.co/cluster-name"])
 				assert.Equal(t, "test-es-name-es-sset1", transportCerts1.Labels["elasticsearch.k8s.elastic.co/statefulset-name"])
@@ -134,7 +134,7 @@ func TestReconcileTransportCertificatesSecrets(t *testing.T) {
 				// 5 items are expected in the Secret: the CA + 2 * (crt and private keys)
 				assert.Equal(t, 5, len(transportCerts2.Data))
 				// Check that ca.crt exists
-				assert.Equal(t, testCABytes, transportCerts2.Data["ca.crt"])
+				assert.Equal(t, testRSACABytes, transportCerts2.Data["ca.crt"])
 				// Check the labels elasticsearch.k8s.elastic.co/cluster-name and elasticsearch.k8s.elastic.co/statefulset-name
 				assert.Equal(t, testEsName, transportCerts2.Labels["elasticsearch.k8s.elastic.co/cluster-name"])
 				assert.Equal(t, "test-es-name-es-sset2", transportCerts2.Labels["elasticsearch.k8s.elastic.co/statefulset-name"])
@@ -143,7 +143,7 @@ func TestReconcileTransportCertificatesSecrets(t *testing.T) {
 		{
 			name: "Should remove any non used transport certs",
 			args: args{
-				ca: testCA,
+				ca: testRSACA,
 				es: newEsBuilder().addNodeSet("sset1", 2).addNodeSet("sset2", 2).build(),
 				initialObjects: []runtime.Object{
 					newPodBuilder().forEs(testEsName).inNodeSet("sset1").withIndex(0).withIP("1.1.1.2").build(),

--- a/pkg/controller/webhook/cert.go
+++ b/pkg/controller/webhook/cert.go
@@ -85,7 +85,10 @@ func (w *Params) newCertificates(webhookServices Services) (WebhookCertificates,
 	if err != nil {
 		return webhookCertificates, err
 	}
-	webhookCertificates.serverKey = certificates.EncodePEMPrivateKey(*privateKey)
+	webhookCertificates.serverKey, err = certificates.EncodePEMPrivateKey(privateKey)
+	if err != nil {
+		return webhookCertificates, err
+	}
 
 	csr, err := x509.CreateCertificateRequest(cryptorand.Reader, &x509.CertificateRequest{}, privateKey)
 	if err != nil {

--- a/test/e2e/es/certs_test.go
+++ b/test/e2e/es/certs_test.go
@@ -104,9 +104,13 @@ func TestCustomHTTPCA(t *testing.T) {
 						return err
 					}
 
+					privateKey, err := certificates.EncodePEMPrivateKey(customCA.PrivateKey)
+					if err != nil {
+						return err
+					}
 					caSecret := mkCertSecret(
 						certificates.EncodePEMCert(customCA.Cert.Raw),
-						certificates.EncodePEMPrivateKey(*customCA.PrivateKey),
+						privateKey,
 					)
 					_, err = reconciler.ReconcileSecret(k.Client, caSecret, nil)
 					return err
@@ -244,9 +248,13 @@ func TestCustomTransportCA(t *testing.T) {
 							return err
 						}
 
+						privateKey, err := certificates.EncodePEMPrivateKey(ca.PrivateKey)
+						if err != nil {
+							return err
+						}
 						caSecret := mkCertSecret(
 							certificates.EncodePEMCert(ca.Cert.Raw),
-							certificates.EncodePEMPrivateKey(*ca.PrivateKey),
+							privateKey,
 						)
 						_, err = reconciler.ReconcileSecret(k.Client, caSecret, nil)
 						return err

--- a/test/e2e/es/certs_test.go
+++ b/test/e2e/es/certs_test.go
@@ -8,6 +8,9 @@ package es
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	cryptorand "crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -18,10 +21,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/dev/portforward"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
@@ -32,7 +37,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var caSecretName = "my-custom-ca"
+var (
+	caSecretName = "my-custom-ca"
+
+	// ECDSA signed certificates are not supported until 7.7.1
+	ecdsaMinVersion = semver.MustParseRange(">=7.7.1")
+)
 
 func TestCustomHTTPCA(t *testing.T) {
 	esName := "test-custom-http-ca"
@@ -150,6 +160,139 @@ func TestCustomHTTPCA(t *testing.T) {
 		}).
 		WithSteps(initialCluster.DeletionTestSteps(k)).
 		RunSequential(t)
+}
+
+func TestHTTPECDSA(t *testing.T) {
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
+	if !ecdsaMinVersion(v) {
+		t.Skip()
+	}
+
+	esName := "test-custom-http-ecdsa-ca"
+
+	// Create a multi-node cluster so we have transient states when switching certs where some nodes still have the old ones
+	initialCluster := elasticsearch.NewBuilder(esName).
+		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
+
+	// The initial Cluster builder should result in a healthy cluster as verified by the standard check steps
+	withCustomCA := initialCluster.
+		WithCustomHTTPCerts(caSecretName).
+		WithMutatedFrom(&initialCluster)
+
+	// reference to custom CA for comparison purposes
+	var customCA *certificates.CA
+
+	// tests the following sequence:
+	// 1. healthy cluster with self-signed operator provided CA signed with RSA
+	// 3. reconfigure with custom CA signed with ECDSA
+	// 4. reconfigure back to self-signed operator provided CA signed with RSA
+	k := test.NewK8sClientOrFatal()
+	test.StepList{}.
+		WithSteps(initialCluster.InitTestSteps(k)).
+		WithSteps(initialCluster.CreationTestSteps(k)).
+		WithSteps(test.CheckTestSteps(initialCluster, k)).
+		WithStep(
+			test.Step{
+				Name: "Create custom ECSDA signed CA secret",
+				Test: test.Eventually(func() error {
+					var err error
+					customCA, err = newECDSASignedCA(esName)
+					if err != nil {
+						return err
+					}
+					privateKey, err := certificates.EncodePEMPrivateKey(customCA.PrivateKey)
+					if err != nil {
+						return err
+					}
+					caSecret := mkCertSecret(
+						certificates.EncodePEMCert(customCA.Cert.Raw),
+						privateKey,
+					)
+					_, err = reconciler.ReconcileSecret(k.Client, caSecret, nil)
+					return err
+				}),
+			},
+		).
+		WithSteps(withCustomCA.UpgradeTestSteps(k)).
+		WithSteps(test.StepList{
+			{
+				Name: "Verify that the custom ECDSA CA is in use",
+				Test: test.Eventually(func() error {
+					return elasticsearch.CheckHTTPConnectivityWithCA(initialCluster.Elasticsearch, k, []*x509.Certificate{customCA.Cert})
+				}),
+			},
+		}).
+		// "upgrade" back to the initial cluster without custom CA
+		WithSteps(initialCluster.UpgradeTestSteps(k)).
+		WithSteps(test.StepList{
+			{
+				Name: "Ensure built-in CA is used after removing custom CA",
+				Test: test.Eventually(func() error {
+					ca, err := k.GetCA(initialCluster.Elasticsearch.Namespace, initialCluster.Elasticsearch.Name, certificates.HTTPCAType)
+					if err != nil {
+						return err
+					}
+					if customCA != nil && customCA.Cert.Equal(ca.Cert) {
+						return errors.New("still using custom ECDSA CA cert")
+					}
+					return elasticsearch.CheckHTTPConnectivityWithCA(initialCluster.Elasticsearch, k, []*x509.Certificate{ca.Cert})
+				}),
+			},
+			{
+				Name: "Clean up custom ECDSA  secret",
+				Test: func(t *testing.T) {
+					// let's clean up the CA secret here.
+					toDelete := mkCertSecret(nil, nil)
+					_ = k.Client.Delete(context.Background(), &toDelete)
+				},
+			},
+		}).
+		WithSteps(initialCluster.DeletionTestSteps(k)).
+		RunSequential(t)
+}
+
+func newECDSASignedCA(esName string) (*certificates.CA, error) {
+	serial, err := cryptorand.Int(cryptorand.Reader, certificates.SerialNumberLimit)
+	if err != nil {
+		return nil, err
+	}
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	certificateTemplate := x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:         esName,
+			OrganizationalUnit: []string{"eck-e2e"},
+		},
+		NotBefore:             time.Now().Add(-10 * time.Minute),
+		NotAfter:              time.Now().Add(certificates.DefaultCertValidity),
+		SignatureAlgorithm:    x509.ECDSAWithSHA256,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+	certData, err := x509.CreateCertificate(
+		cryptorand.Reader,
+		&certificateTemplate,
+		&certificateTemplate,
+		privateKey.Public(),
+		privateKey,
+	)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := x509.ParseCertificate(certData)
+	if err != nil {
+		return nil, err
+	}
+
+	return &certificates.CA{
+		PrivateKey: privateKey,
+		Cert:       cert,
+	}, nil
 }
 
 func TestCustomTransportCA(t *testing.T) {


### PR DESCRIPTION
This PR adds support for the ECDSA signature algorithm.

This enhancement is compatible with the support of a custom CA for [HTTP](https://github.com/elastic/cloud-on-k8s/pull/4575) and [transport](https://github.com/elastic/cloud-on-k8s/pull/4053) layer.

I'll try to add an e2e test but I'm opening this PR to allow a first review of the design/implementation, which is mostly about replacing `*rsa.PrivateKey` with the `crypto.Signer` interface.

Fix https://github.com/elastic/cloud-on-k8s/issues/4581