### PR TITLE
Make the kubeconfig cleanup conditional for OCP

### DIFF
--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -411,7 +411,7 @@ func (d *OcpDriver) copyKubeconfig() error {
 func (d *OcpDriver) removeKubeconfig() error {
 	if err := NewCommand("kubectl config get-contexts admin").Run(); err != nil {
 		// skip because the admin context does not exist in the kube config
-		return nil
+		return nil //nolint:nilerr
 	}
 
 	log.Printf("Removing context, user and cluster entry from kube config")

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -407,6 +407,11 @@ func (d *OcpDriver) copyKubeconfig() error {
 }
 
 func (d *OcpDriver) removeKubeconfig() error {
+	if err := d.kubectl("config get-contexts admin").Run(); err != nil {
+		// skip because the admin context does not exist in the kube config
+		return nil
+	}
+
 	log.Printf("Removing context, user and cluster entry from kube config")
 	if err := d.kubectl("config delete-context admin").Run(); err != nil {
 		return err


### PR DESCRIPTION
Makes the kube config cleanup conditional by checking for the presence of the admin context in the kube config.

Resolves #4610 