### PR TITLE
Disable basic auth on GKE

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -11,7 +11,6 @@ plans:
   diskSetup: kubectl apply -k hack/deployer/config/local-disks
   gke:
     region: europe-west2
-    adminUsername: admin
     localSsdCount: 1
     nodeCountPerZone: 1
     gcpScopes: https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append
@@ -25,7 +24,6 @@ plans:
   psp: false
   gke:
     region: europe-west1
-    adminUsername: admin
     localSsdCount: 1
     nodeCountPerZone: 1
     # Uncomment option below to enable network policy enforcement in GKE.
@@ -146,7 +144,6 @@ plans:
   psp: false
   gke:
     region: europe-west2
-    adminUsername: admin
     localSsdCount: 1
     nodeCountPerZone: 1
     gcpScopes: https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -65,7 +65,6 @@ func (gdf *GkeDriverFactory) Create(plan Plan) (Driver, error) {
 			"ClusterName":       plan.ClusterName,
 			"PVCPrefix":         pvcPrefix,
 			"Region":            plan.Gke.Region,
-			"AdminUsername":     plan.Gke.AdminUsername,
 			"KubernetesVersion": plan.KubernetesVersion,
 			"MachineType":       plan.MachineType,
 			"LocalSsdCount":     plan.Gke.LocalSsdCount,
@@ -173,8 +172,8 @@ func (d *GkeDriver) create() error {
 		opts = append(opts, "--create-subnetwork range={{.ClusterIPv4CIDR}}", "--cluster-ipv4-cidr={{.ClusterIPv4CIDR}}", "--services-ipv4-cidr={{.ServicesIPv4CIDR}}")
 	}
 
-	return NewCommand(`gcloud beta container --project {{.GCloudProject}} clusters create {{.ClusterName}} ` +
-		`--region {{.Region}} --username {{.AdminUsername}} --cluster-version {{.KubernetesVersion}} ` +
+	return NewCommand(`gcloud beta container --quiet --project {{.GCloudProject}} clusters create {{.ClusterName}} ` +
+		`--region {{.Region}} --no-enable-basic-auth --cluster-version {{.KubernetesVersion}} ` +
 		`--machine-type {{.MachineType}} --image-type COS --disk-type pd-ssd --disk-size 30 ` +
 		`--local-ssd-count {{.LocalSsdCount}} --scopes {{.GcpScopes}} --num-nodes {{.NodeCountPerZone}} ` +
 		`--enable-stackdriver-kubernetes --addons HorizontalPodAutoscaling,HttpLoadBalancing ` +

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -61,7 +61,6 @@ type VaultInfo struct {
 type GkeSettings struct {
 	GCloudProject    string `yaml:"gCloudProject"`
 	Region           string `yaml:"region"`
-	AdminUsername    string `yaml:"adminUsername"`
 	LocalSsdCount    int    `yaml:"localSsdCount"`
 	NodeCountPerZone int    `yaml:"nodeCountPerZone"`
 	GcpScopes        string `yaml:"gcpScopes"`


### PR DESCRIPTION
This PR removes basic auth on GKE clusters, it is not supported starting K8S 1.19 on GKE.