### PR TITLE
[e2e][gke] Remove k8s 1.17, add 1.19 and 1.20

### DIFF
--- a/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
@@ -35,17 +35,6 @@ pipeline {
         }
         stage('Run tests for different k8s versions in GKE') {
             parallel {
-                stage("1.17") {
-                    agent {
-                        label 'linux'
-                    }
-                    steps {
-                        unstash "source"
-                        script {
-                            runWith(lib, failedTests, '1.17', "eck-gke17-${BUILD_NUMBER}-e2e")
-                        }
-                    }
-                }
                 stage("1.18") {
                     agent {
                         label 'linux'
@@ -54,6 +43,28 @@ pipeline {
                         unstash "source"
                         script {
                             runWith(lib, failedTests, '1.18', "eck-gke18-${BUILD_NUMBER}-e2e")
+                        }
+                    }
+                }
+                stage("1.19") {
+                    agent {
+                        label 'linux'
+                    }
+                    steps {
+                        unstash "source"
+                        script {
+                            runWith(lib, failedTests, '1.19', "eck-gke19-${BUILD_NUMBER}-e2e")
+                        }
+                    }
+                }
+                stage("1.20") {
+                    agent {
+                        label 'linux'
+                    }
+                    steps {
+                        unstash "source"
+                        script {
+                            runWith(lib, failedTests, '1.20', "eck-gke20-${BUILD_NUMBER}-e2e")
                         }
                     }
                 }
@@ -81,7 +92,7 @@ pipeline {
         }
         cleanup {
             script {
-                clusters = ["eck-gke17-${BUILD_NUMBER}-e2e", "eck-gke18-${BUILD_NUMBER}-e2e"]
+                clusters = ["eck-gke18-${BUILD_NUMBER}-e2e", "eck-gke19-${BUILD_NUMBER}-e2e", "eck-gke20-${BUILD_NUMBER}-e2e"]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
                         parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: clusters[i])],


### PR DESCRIPTION
This PR updates the cluster versions deployed on GKE: it adds 1.19 and 1.20 while 1.17 is removed.