### PR TITLE
Avoid circular dependency between Elasticsearch and association controllers

### DIFF
--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -252,7 +252,8 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 		return results.WithError(err)
 	}
 
-	// requeue if associations are defined but not yet configured
+	// requeue if associations are defined but not yet configured, otherwise we may be in a situation where we deploy
+	// Elasticsearch Pods once, then change their spec a few seconds later once the association is configured
 	if !association.AreConfiguredIfSet(d.ES.GetAssociations(), d.Recorder()) {
 		results.WithResult(defaultRequeue)
 	}

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -15,6 +15,7 @@ import (
 	controller "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	commondriver "github.com/elastic/cloud-on-k8s/pkg/controller/common/driver"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
@@ -249,6 +250,11 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	err = stackmon.ReconcileConfigSecrets(d.Client, d.ES)
 	if err != nil {
 		return results.WithError(err)
+	}
+
+	// requeue if associations are defined but not yet configured
+	if !association.AreConfiguredIfSet(d.ES.GetAssociations(), d.Recorder()) {
+		results.WithResult(defaultRequeue)
 	}
 
 	// reconcile StatefulSets and nodes configuration

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -192,11 +192,6 @@ func (r *ReconcileElasticsearch) Reconcile(ctx context.Context, request reconcil
 		return reconcile.Result{}, tracing.CaptureError(ctx, err)
 	}
 
-	// Requeue if associations are defined but not yet configured
-	if !association.AreConfiguredIfSet(es.GetAssociations(), r.recorder) {
-		return reconcile.Result{}, nil
-	}
-
 	state := esreconcile.NewState(es)
 	results := r.internalReconcile(ctx, es, state)
 	err = r.updateStatus(ctx, es, state)


### PR DESCRIPTION
The Elasticsearch controller waits until the assocation are ready to reconcile Elasticsearch, including creating the associated ES services and secrets. In parallel, the assocation controller waits for the ES service/secret to be configured.

This commit moves the `association.AreConfiguredIfSet` check present in the Elasticsearch controller after the services/secrets creation to let the ES controller create them and not block the association controller which can thus be configured.

Resolves #4624