### PR TITLE
Update supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Current features:
 
 Supported versions:
 
-*  Kubernetes 1.12+ or OpenShift 3.11+
+*  Kubernetes 1.17-1.21
+*  OpenShift 3.11, 4.3-4.7
 *  Elasticsearch, Kibana, APM Server: 6.8+, 7.1+
 *  Enterprise Search: 7.7+
 *  Beats: 7.0+

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -1,4 +1,4 @@
-* Kubernetes 1.16-1.20
+* Kubernetes 1.17-1.21
 * OpenShift 3.11, 4.3-4.7
 * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 * Elasticsearch, Kibana, APM Server: 6.8+, 7.1+

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -265,7 +265,7 @@ spec:
     Supported versions:
 
 
-    * Kubernetes 1.16-1.20
+    * Kubernetes 1.17-1.21
 
     * OpenShift 3.11, 4.3-4.7
     


### PR DESCRIPTION
This PR updates the supported K8S versions in `README.md`, our docs, and in the operator hub template.