### PR TITLE
Move subresources to top level on v1beta1 crds

### DIFF
--- a/config/crds/v1beta1/all-crds.yaml
+++ b/config/crds/v1beta1/all-crds.yaml
@@ -347,6 +347,12 @@ spec:
     - apm
     singular: apmserver
   scope: Namespaced
+  subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.count
+      statusReplicasPath: .status.count
+    status: {}
   validation:
     openAPIV3Schema:
       description: ApmServer represents an APM Server resource in a Kubernetes cluster.
@@ -916,17 +922,9 @@ spec:
   - name: v1
     served: true
     storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.selector
-        specReplicasPath: .spec.count
-        statusReplicasPath: .status.count
-      status: {}
   - name: v1beta1
     served: true
     storage: false
-    subresources:
-      status: {}
   - name: v1alpha1
     served: false
     storage: false
@@ -3323,6 +3321,12 @@ spec:
     - ent
     singular: enterprisesearch
   scope: Namespaced
+  subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.count
+      statusReplicasPath: .status.count
+    status: {}
   validation:
     openAPIV3Schema:
       description: EnterpriseSearch is a Kubernetes CRD to represent Enterprise Search.
@@ -3836,17 +3840,9 @@ spec:
   - name: v1
     served: true
     storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.selector
-        specReplicasPath: .spec.count
-        statusReplicasPath: .status.count
-      status: {}
   - name: v1beta1
     served: true
     storage: false
-    subresources:
-      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -3888,6 +3884,12 @@ spec:
     - kb
     singular: kibana
   scope: Namespaced
+  subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.count
+      statusReplicasPath: .status.count
+    status: {}
   validation:
     openAPIV3Schema:
       description: Kibana represents a Kibana resource in a Kubernetes cluster.
@@ -4532,17 +4534,9 @@ spec:
   - name: v1
     served: true
     storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.selector
-        specReplicasPath: .spec.count
-        statusReplicasPath: .status.count
-      status: {}
   - name: v1beta1
     served: true
     storage: false
-    subresources:
-      status: {}
   - name: v1alpha1
     served: false
     storage: false

--- a/config/crds/v1beta1/patches/apm-kibana-patches.yaml
+++ b/config/crds/v1beta1/patches/apm-kibana-patches.yaml
@@ -8,6 +8,12 @@
   path: /spec/validation
 - op: remove
   path: /spec/versions/1/schema
+# move subresources to the top level, see https://github.com/elastic/cloud-on-k8s/issues/4635
+- op: move
+  from: /spec/versions/0/subresources
+  path: /spec/subresources
+- op: remove
+  path: /spec/versions/1/subresources
 # Move additionalPrinterColumns of the v1 version to the top-level, and remove it from the v1beta1 version.
 # This is in order to be compatible with k8s 1.11.
 - op: move

--- a/config/crds/v1beta1/patches/ent-patches.yaml
+++ b/config/crds/v1beta1/patches/ent-patches.yaml
@@ -5,6 +5,13 @@
 - op: remove
   path: /spec/validation/openAPIV3Schema/type
 
+# move subresources to the top level, see https://github.com/elastic/cloud-on-k8s/issues/4635
+- op: move
+  from: /spec/versions/0/subresources
+  path: /spec/subresources
+- op: remove
+  path: /spec/versions/1/subresources
+
 # Using `kubectl apply` stores the complete CRD file as an annotation,
 # which may be too big for the annotations size limit.
 # One way to mitigate this problem is to remove the (huge) podTemplate properties from the CRD.

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds-legacy.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds-legacy.yaml
@@ -362,6 +362,12 @@ spec:
     - apm
     singular: apmserver
   scope: Namespaced
+  subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.count
+      statusReplicasPath: .status.count
+    status: {}
   validation:
     openAPIV3Schema:
       description: ApmServer represents an APM Server resource in a Kubernetes cluster.
@@ -931,17 +937,9 @@ spec:
   - name: v1
     served: true
     storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.selector
-        specReplicasPath: .spec.count
-        statusReplicasPath: .status.count
-      status: {}
   - name: v1beta1
     served: true
     storage: false
-    subresources:
-      status: {}
   - name: v1alpha1
     served: false
     storage: false
@@ -3362,6 +3360,12 @@ spec:
     - ent
     singular: enterprisesearch
   scope: Namespaced
+  subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.count
+      statusReplicasPath: .status.count
+    status: {}
   validation:
     openAPIV3Schema:
       description: EnterpriseSearch is a Kubernetes CRD to represent Enterprise Search.
@@ -3875,17 +3879,9 @@ spec:
   - name: v1
     served: true
     storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.selector
-        specReplicasPath: .spec.count
-        statusReplicasPath: .status.count
-      status: {}
   - name: v1beta1
     served: true
     storage: false
-    subresources:
-      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -3933,6 +3929,12 @@ spec:
     - kb
     singular: kibana
   scope: Namespaced
+  subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.count
+      statusReplicasPath: .status.count
+    status: {}
   validation:
     openAPIV3Schema:
       description: Kibana represents a Kibana resource in a Kubernetes cluster.
@@ -4577,17 +4579,9 @@ spec:
   - name: v1
     served: true
     storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.selector
-        specReplicasPath: .spec.count
-        statusReplicasPath: .status.count
-      status: {}
   - name: v1beta1
     served: true
     storage: false
-    subresources:
-      status: {}
   - name: v1alpha1
     served: false
     storage: false


### PR DESCRIPTION
If the `scale` subresource is enabled then the `subresources` seems to be moved by `controller-gen` in a place where it can't be read/processed by old versions of Kubernetes (< 1.15) and OCP 3.11

This PR moves the `subresources` to its "original" place, as it was the case for previous releases of ECK.

Note that it only happens when there are several versions of the resource, which means that Maps is not impacted.

Should hopefully fix #4635