### PR TITLE
Lower fleet agent minimum version to 7.14.0-SNAPSHOT

### DIFF
--- a/pkg/apis/agent/v1alpha1/validations_test.go
+++ b/pkg/apis/agent/v1alpha1/validations_test.go
@@ -39,6 +39,12 @@ func Test_checkSupportedVersion(t *testing.T) {
 		{
 			name:    "fleet, within supported: OK",
 			mode:    AgentFleetMode,
+			version: "7.14.0-SNAPSHOT",
+			wantErr: false,
+		},
+		{
+			name:    "fleet, within supported: OK",
+			mode:    AgentFleetMode,
 			version: "7.14.0",
 			wantErr: false,
 		},

--- a/pkg/controller/common/version/version.go
+++ b/pkg/controller/common/version/version.go
@@ -31,7 +31,7 @@ var (
 	// picking higher version as minimal supported.
 	SupportedAgentVersions = MinMaxVersion{Min: From(7, 10, 0), Max: From(8, 99, 99)}
 	// Due to bugfixes present in 7.14 that ECK depends on, this is the lowest version we support in Fleet mode.
-	SupportedFleetModeAgentVersions = MinMaxVersion{Min: From(7, 14, 0), Max: From(8, 99, 99)}
+	SupportedFleetModeAgentVersions = MinMaxVersion{Min: MustParse("7.14.0-SNAPSHOT"), Max: From(8, 99, 99)}
 	SupportedMapsVersions           = MinMaxVersion{Min: From(7, 11, 0), Max: From(8, 99, 99)}
 )
 

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -48,8 +48,7 @@ type Builder struct {
 func (b Builder) SkipTest() bool {
 	supportedVersions := version.SupportedAgentVersions
 	if b.Agent.Spec.FleetModeEnabled() {
-		// todo use version.SupportedFleetModeAgentVersions after 7.14.0 release is available
-		supportedVersions.Min = version.MustParse("7.14.0-SNAPSHOT")
+		supportedVersions = version.SupportedFleetModeAgentVersions
 	}
 
 	ver := version.MustParse(b.Agent.Spec.Version)


### PR DESCRIPTION
Addressed E2E [failure](https://devops-ci.elastic.co/job/cloud-on-k8s-e2e-tests-snapshot-versions/360/testReport/):

```
=== RUN   TestFleetMode/Creating_an_Agent_should_succeed
    steps.go:94: 
        	Error Trace:	steps.go:94
        	Error:      	Received unexpected error:
        	            	admission webhook "elastic-agent-validation-v1alpha1.k8s.elastic.co" denied the request: Agent.agent.k8s.elastic.co "test-agent-fleet-fs-8szq" is invalid: spec.version: Invalid value: "7.14.0-SNAPSHOT": Unsupported version: version 7.14.0-SNAPSHOT is lower than the lowest supported version of 7.14.0
        	Test:       	TestFleetMode/Creating_an_Agent_should_succeed
{"log.level":"error","@timestamp":"2021-07-14T01:35:51.294Z","message":"stopping early","service.version":"0.0.0-SNAPSHOT+00000000","service.type":"eck","ecs.version":"1.4.0","error":"test failure","error.stack_trace":"github.com/elastic/cloud-on-k8s/test/e2e/test.StepList.RunSequential\n\t/go/src/github.com/elastic/cloud-on-k8s/test/e2e/test/step.go:44\ngithub.com/elastic/cloud-on-k8s/test/e2e/agent.TestFleetMode\n\t/go/src/github.com/elastic/cloud-on-k8s/test/e2e/agent/config_test.go:167\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1193"}
    --- FAIL: TestFleetMode/Creating_an_Agent_should_succeed (0.08s)
```

We currently don't have a good mechanism to allow `SNAPSHOT` versions only for tests, so the next best thing is to allow `SNAPSHOT` in general which this PR does.