### PR TITLE
Refactor and add UTs for Pod template creation for Agent in Fleet mode

### DIFF
--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -178,6 +178,7 @@ func amendBuilderForFleetMode(params Params, fleetCerts *certificates.Certificat
 
 func getRelatedEsAssoc(params Params) (commonv1.Association, error) {
 	var esAssociation commonv1.Association
+	//nolint:nestif
 	if params.Agent.Spec.FleetServerEnabled {
 		// As the reference chain is: Fleet Server ---> Elasticsearch,
 		// we just grab the reference to Elasticsearch from the current agent (Fleet Server).
@@ -243,14 +244,11 @@ func writeEsAssocToConfigHash(params Params, esAssociation commonv1.Association,
 	// also need to do is to roll Elastic Agent Pods to pick up the update CA. To be able to do that, we are
 	// adding Fleet Server associations (which includes Elasticsearch) to config hash attached to Elastic Agent
 	// Pods.
-	if err := commonassociation.WriteAssocsToConfigHash(
+	return commonassociation.WriteAssocsToConfigHash(
 		params.Client,
 		[]commonv1.Association{esAssociation},
 		configHash,
-	); err != nil {
-		return err
-	}
-	return nil
+	)
 }
 
 func getVolumesFromAssociations(associations []commonv1.Association) []volume.VolumeLike {

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -132,36 +132,62 @@ func buildPodTemplate(params Params, fleetCerts *certificates.CertificatesSecret
 }
 
 func amendBuilderForFleetMode(params Params, fleetCerts *certificates.CertificatesSecret, builder *defaults.PodTemplateBuilder, configHash hash.Hash) (*defaults.PodTemplateBuilder, error) {
-	// enabling fleet requires configuring fleet setup, agent enrollment, fleet server connection information, etc.
-	// all this is defined in fleet-setup.yml file in the volume below
-	vols := []volume.VolumeLike{volume.NewSecretVolume(
-		ConfigSecretName(params.Agent.Name),
-		FleetSetupVolumeName,
-		path.Join(FleetSetupMountPath, FleetSetupFileName),
-		FleetSetupFileName,
-		0440,
-	)}
+	esAssociation, err := getRelatedEsAssoc(params)
+	if err != nil {
+		return nil, err
+	}
 
-	// See the long comment below to learn about the use of this association.
-	var esAssociation commonv1.Association
-	//nolint:nestif
+	builder, err = applyRelatedEsAssoc(params.Agent, esAssociation, builder)
+	if err != nil {
+		return nil, err
+	}
+
+	err = writeEsAssocToConfigHash(params, esAssociation, configHash)
+	if err != nil {
+		return nil, err
+	}
+
 	if params.Agent.Spec.FleetServerEnabled {
 		// ECK creates CA and a certificate for Fleet Server to use. This volume contains those.
-		vols = append(vols, volume.NewSecretVolumeWithMountPath(
-			fleetCerts.Name,
-			FleetCertsVolumeName,
-			FleetCertsMountPath,
-		))
+		builder = builder.WithVolumeLikes(
+			volume.NewSecretVolumeWithMountPath(
+				fleetCerts.Name,
+				FleetCertsVolumeName,
+				FleetCertsMountPath,
+			))
 
 		builder = builder.WithPorts([]corev1.ContainerPort{{Name: params.Agent.Spec.HTTP.Protocol(), ContainerPort: FleetServerPort, Protocol: corev1.ProtocolTCP}})
+	}
 
+	builder = builder.
+		// enabling fleet requires configuring fleet setup, agent enrollment, fleet server connection information, etc.
+		// all this is defined in fleet-setup.yml file in the volume below
+		WithVolumeLikes(volume.NewSecretVolume(
+			ConfigSecretName(params.Agent.Name),
+			FleetSetupVolumeName,
+			path.Join(FleetSetupMountPath, FleetSetupFileName),
+			FleetSetupFileName,
+			0440,
+		)).
+		WithResources(defaultFleetResources).
+		// needed to pick up fleet-setup.yml correctly
+		WithEnv(corev1.EnvVar{Name: "CONFIG_PATH", Value: "/usr/share/elastic-agent"})
+
+	return builder, nil
+}
+
+func getRelatedEsAssoc(params Params) (commonv1.Association, error) {
+	var esAssociation commonv1.Association
+	if params.Agent.Spec.FleetServerEnabled {
+		// As the reference chain is: Fleet Server ---> Elasticsearch,
+		// we just grab the reference to Elasticsearch from the current agent (Fleet Server).
 		var err error
 		esAssociation, err = association.SingleAssociationOfType(params.Agent.GetAssociations(), commonv1.ElasticsearchAssociationType)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		// See the long comment below. As the reference chain is: Elastic Agent ---> Fleet Server ---> Elasticsearch,
+		// As the reference chain is: Elastic Agent ---> Fleet Server ---> Elasticsearch,
 		// we need first to identify the Fleet Server and then identify its reference to Elasticsearch.
 		fs, err := getAssociatedFleetServer(params)
 		if err != nil {
@@ -174,51 +200,57 @@ func amendBuilderForFleetMode(params Params, fleetCerts *certificates.Certificat
 			if err != nil {
 				return nil, err
 			}
-			if esAssociation != nil {
-				if params.Agent.Namespace != esAssociation.Associated().GetNamespace() {
-					return nil, fmt.Errorf(
-						"agent namespace %s is different than referenced Elasticsearch namespace %s, this is not supported yet",
-						params.Agent.Namespace,
-						esAssociation.Associated().GetNamespace(),
-					)
-				}
-
-				caSecretName := esAssociation.AssociationConf().GetCASecretName()
-				vols = append(vols, volume.NewSecretVolumeWithMountPath(
-					caSecretName,
-					fmt.Sprintf("%s-certs", esAssociation.AssociationType()),
-					certificatesDir(esAssociation),
-				))
-
-				// Because of the reference chain (Elastic Agent ---> Fleet Server ---> Elasticsearch), we are going to get
-				// notified when CA of Elasticsearch changes as Fleet Server resource will get updated as well. But what we
-				// also need to do is to roll Elastic Agent Pods to pick up the update CA. To be able to do that, we are
-				// adding Fleet Server associations (which includes Elasticsearch) to config hash attached to Elastic Agent
-				// Pods.
-				if err := commonassociation.WriteAssocsToConfigHash(params.Client, fs.GetAssociations(), configHash); err != nil {
-					return nil, err
-				}
-			}
 		}
 	}
+	return esAssociation, nil
+}
 
-	if esAssociation != nil {
-		// Beats managed by the Elastic Agent don't trust the Elasticsearch CA that Elastic Agent itself is configured
-		// to trust. There is currently no way to configure those Beats to trust a particular CA. The intended way to handle
-		// it is to allow Fleet to provide Beat output settings, but due to https://github.com/elastic/kibana/issues/102794
-		// this is not supported outside of UI. To workaround this limitation the Agent is going to update Pod-wide CA store
-		// before starting Elastic Agent.
-		builder = builder.
-			WithCommand([]string{"/usr/bin/env", "bash", "-c", trustCAScript(path.Join(certificatesDir(esAssociation), CAFileName))})
+func applyRelatedEsAssoc(agent agentv1alpha1.Agent, esAssociation commonv1.Association, builder *defaults.PodTemplateBuilder) (*defaults.PodTemplateBuilder, error) {
+	if esAssociation == nil {
+		return builder, nil
 	}
 
-	builder = builder.
-		WithVolumeLikes(vols...).
-		WithResources(defaultFleetResources).
-		// needed to pick up fleet-setup.yml correctly
-		WithEnv(corev1.EnvVar{Name: "CONFIG_PATH", Value: "/usr/share/elastic-agent"})
+	if !agent.Spec.FleetServerEnabled && agent.Namespace != esAssociation.AssociationRef().Namespace {
+		return nil, fmt.Errorf(
+			"agent namespace %s is different than referenced Elasticsearch namespace %s, this is not supported yet",
+			agent.Namespace,
+			esAssociation.Associated().GetNamespace(),
+		)
+	}
 
-	return builder, nil
+	builder = builder.WithVolumeLikes(volume.NewSecretVolumeWithMountPath(
+		esAssociation.AssociationConf().GetCASecretName(),
+		fmt.Sprintf("%s-certs", esAssociation.AssociationType()),
+		certificatesDir(esAssociation),
+	))
+
+	// Beats managed by the Elastic Agent don't trust the Elasticsearch CA that Elastic Agent itself is configured
+	// to trust. There is currently no way to configure those Beats to trust a particular CA. The intended way to handle
+	// it is to allow Fleet to provide Beat output settings, but due to https://github.com/elastic/kibana/issues/102794
+	// this is not supported outside of UI. To workaround this limitation the Agent is going to update Pod-wide CA store
+	// before starting Elastic Agent.
+	cmd := trustCAScript(path.Join(certificatesDir(esAssociation), CAFileName))
+	return builder.WithCommand([]string{"/usr/bin/env", "bash", "-c", cmd}), nil
+}
+
+func writeEsAssocToConfigHash(params Params, esAssociation commonv1.Association, configHash hash.Hash) error {
+	if esAssociation == nil || params.Agent.Spec.FleetServerEnabled {
+		return nil
+	}
+
+	// Because of the reference chain (Elastic Agent ---> Fleet Server ---> Elasticsearch), we are going to get
+	// notified when CA of Elasticsearch changes as Fleet Server resource will get updated as well. But what we
+	// also need to do is to roll Elastic Agent Pods to pick up the update CA. To be able to do that, we are
+	// adding Fleet Server associations (which includes Elasticsearch) to config hash attached to Elastic Agent
+	// Pods.
+	if err := commonassociation.WriteAssocsToConfigHash(
+		params.Client,
+		[]commonv1.Association{esAssociation},
+		configHash,
+	); err != nil {
+		return err
+	}
+	return nil
 }
 
 func getVolumesFromAssociations(associations []commonv1.Association) []volume.VolumeLike {

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -193,7 +193,7 @@ func Test_amendBuilderForFleetMode(t *testing.T) {
 
 			require.NotNil(t, gotBuilder)
 			require.Equal(t, tt.wantPodSpec, gotBuilder.PodTemplate.Spec)
-			require.Equal(t, tt.wantHashChange, bytes.Compare(baseHashSum, hash.Sum(nil)) != 0)
+			require.Equal(t, tt.wantHashChange, !bytes.Equal(baseHashSum, hash.Sum(nil)))
 		})
 	}
 }
@@ -296,7 +296,6 @@ func Test_getRelatedEsAssoc(t *testing.T) {
 				require.NotNil(t, gotAssoc)
 				require.Equal(t, *tt.wantRef, gotAssoc.AssociationRef())
 			}
-
 		})
 	}
 }
@@ -497,7 +496,7 @@ func Test_writeEsAssocToConfigHash(t *testing.T) {
 			err := writeEsAssocToConfigHash(tt.params, tt.assoc, hash)
 
 			require.Nil(t, err)
-			require.Equal(t, tt.wantHashChange, bytes.Compare(baseHashSum, hash.Sum(nil)) != 0)
+			require.Equal(t, tt.wantHashChange, !bytes.Equal(baseHashSum, hash.Sum(nil)))
 		})
 	}
 }

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -1,0 +1,512 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package agent
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	agentv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/agent/v1alpha1"
+	v1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
+)
+
+func Test_amendBuilderForFleetMode(t *testing.T) {
+	optional := false
+
+	for _, tt := range []struct {
+		name           string
+		params         Params
+		wantHashChange bool
+		wantErr        bool
+		wantPodSpec    corev1.PodSpec
+	}{
+		{
+			name: "running fleet server without es association",
+			params: Params{
+				Agent: agentv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "agent",
+					},
+					Spec: agentv1alpha1.AgentSpec{
+						FleetServerEnabled: true,
+					},
+				},
+			},
+			wantHashChange: false,
+			wantErr:        false,
+			wantPodSpec: generatePodSpec(func(ps corev1.PodSpec) corev1.PodSpec {
+				ps.Volumes = []corev1.Volume{
+					{
+						Name: "fleet-certs",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "fleet-certs-secret-name",
+								Optional:   &optional,
+							},
+						},
+					},
+					{
+						Name: "fleet-setup-config",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName:  "agent-agent-config",
+								DefaultMode: pointer.Int32(0440),
+								Optional:    &optional,
+							},
+						},
+					},
+				}
+
+				ps.Containers[0].VolumeMounts = []corev1.VolumeMount{
+					{
+						Name:      "fleet-certs",
+						ReadOnly:  true,
+						MountPath: "/usr/share/fleet-server/config/http-certs",
+					},
+					{
+						Name:      "fleet-setup-config",
+						ReadOnly:  true,
+						MountPath: "/usr/share/elastic-agent/fleet-setup.yml",
+						SubPath:   "fleet-setup.yml",
+					},
+				}
+
+				ps.Containers[0].Ports = []corev1.ContainerPort{
+					{
+						Name:          "https",
+						ContainerPort: 8220,
+						Protocol:      corev1.ProtocolTCP,
+					},
+				}
+
+				ps.Containers[0].Env = []corev1.EnvVar{
+					{
+						Name:  "CONFIG_PATH",
+						Value: "/usr/share/elastic-agent",
+					},
+				}
+
+				ps.Containers[0].Resources = corev1.ResourceRequirements{
+					Limits: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+					},
+					Requests: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+					},
+				}
+
+				return ps
+			}),
+		},
+		{
+			name: "not running fleet server, no fleet server ref", params: Params{
+				Agent: agentv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "agent",
+					},
+					Spec: agentv1alpha1.AgentSpec{
+						FleetServerEnabled: false,
+					},
+				},
+			},
+			wantHashChange: false,
+			wantErr:        false,
+			wantPodSpec: generatePodSpec(func(ps corev1.PodSpec) corev1.PodSpec {
+				ps.Volumes = []corev1.Volume{
+					{
+						Name: "fleet-setup-config",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName:  "agent-agent-config",
+								DefaultMode: pointer.Int32(0440),
+								Optional:    &optional,
+							},
+						},
+					},
+				}
+
+				ps.Containers[0].VolumeMounts = []corev1.VolumeMount{
+					{
+						Name:      "fleet-setup-config",
+						ReadOnly:  true,
+						MountPath: "/usr/share/elastic-agent/fleet-setup.yml",
+						SubPath:   "fleet-setup.yml",
+					},
+				}
+
+				ps.Containers[0].Env = []corev1.EnvVar{
+					{
+						Name:  "CONFIG_PATH",
+						Value: "/usr/share/elastic-agent",
+					},
+				}
+
+				ps.Containers[0].Resources = corev1.ResourceRequirements{
+					Limits: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+					},
+					Requests: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+					},
+				}
+
+				return ps
+			}),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fleetCerts := &certificates.CertificatesSecret{
+				Secret: corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fleet-certs-secret-name",
+					},
+				},
+			}
+			builder := generateBuilder()
+			baseHashSum := sha256.New224().Sum(nil)
+			hash := sha256.New224()
+
+			gotBuilder, gotErr := amendBuilderForFleetMode(tt.params, fleetCerts, builder, hash)
+
+			require.Equal(t, tt.wantErr, gotErr != nil)
+			if tt.wantErr {
+				// we don't want to check anything else
+				return
+			}
+
+			require.NotNil(t, gotBuilder)
+			require.Equal(t, tt.wantPodSpec, gotBuilder.PodTemplate.Spec)
+			require.Equal(t, tt.wantHashChange, bytes.Compare(baseHashSum, hash.Sum(nil)) != 0)
+		})
+	}
+}
+
+func Test_getRelatedEsAssoc(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		params  Params
+		wantRef *v1.ObjectSelector
+	}{
+		{
+			name: "fleet server enabled, no es ref",
+			params: Params{
+				Agent: agentv1alpha1.Agent{
+					Spec: agentv1alpha1.AgentSpec{
+						FleetServerEnabled: true,
+					},
+				},
+			},
+			wantRef: nil,
+		},
+		{
+			name: "fleet server enabled, es ref",
+			params: Params{
+				Agent: agentv1alpha1.Agent{
+					Spec: agentv1alpha1.AgentSpec{
+						FleetServerEnabled: true,
+						ElasticsearchRefs: []agentv1alpha1.Output{
+							{
+								ObjectSelector: v1.ObjectSelector{Name: "es"},
+							},
+						},
+					},
+				},
+			},
+			wantRef: &v1.ObjectSelector{Name: "es"},
+		},
+		{
+			name: "fleet server disabled, no fs ref",
+			params: Params{
+				Agent: agentv1alpha1.Agent{
+					Spec: agentv1alpha1.AgentSpec{
+						FleetServerEnabled: false,
+					},
+				},
+			},
+			wantRef: nil,
+		},
+		{
+			name: "fleet server disabled, fs ref, no es ref",
+			params: Params{
+				Agent: agentv1alpha1.Agent{
+					Spec: agentv1alpha1.AgentSpec{
+						FleetServerEnabled: false,
+						FleetServerRef:     v1.ObjectSelector{Name: "fs"},
+					},
+				},
+				Context: context.Background(),
+				Client: k8s.NewFakeClient(&agentv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fs",
+					},
+				}),
+			},
+			wantRef: nil,
+		},
+		{
+			name: "fleet server disabled, fs ref, es ref",
+			params: Params{
+				Agent: agentv1alpha1.Agent{
+					Spec: agentv1alpha1.AgentSpec{
+						FleetServerEnabled: false,
+						FleetServerRef:     v1.ObjectSelector{Name: "fs"},
+					},
+				},
+				Context: context.Background(),
+				Client: k8s.NewFakeClient(&agentv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fs",
+					},
+					Spec: agentv1alpha1.AgentSpec{
+						ElasticsearchRefs: []agentv1alpha1.Output{
+							{
+								ObjectSelector: v1.ObjectSelector{Name: "es"},
+							},
+						},
+					},
+				}),
+			},
+			wantRef: &v1.ObjectSelector{Name: "es"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAssoc, gotErr := getRelatedEsAssoc(tt.params)
+			require.Nil(t, gotErr)
+
+			if tt.wantRef == nil {
+				require.Nil(t, gotAssoc)
+			} else {
+				require.NotNil(t, gotAssoc)
+				require.Equal(t, *tt.wantRef, gotAssoc.AssociationRef())
+			}
+
+		})
+	}
+}
+
+func Test_applyRelatedEsAssoc(t *testing.T) {
+	optional := false
+	agentNs := "agent-ns"
+	assocToSameNs := (&agentv1alpha1.Agent{
+		Spec: agentv1alpha1.AgentSpec{
+			ElasticsearchRefs: []agentv1alpha1.Output{
+				{
+					ObjectSelector: v1.ObjectSelector{
+						Name:      "elasticsearch",
+						Namespace: agentNs,
+					},
+				},
+			},
+		},
+	}).GetAssociations()[0]
+	assocToSameNs.SetAssociationConf(&v1.AssociationConf{
+		CASecretName: "elasticsearch-es-http-certs-public",
+	})
+
+	assocToOtherNs := (&agentv1alpha1.Agent{
+		Spec: agentv1alpha1.AgentSpec{
+			ElasticsearchRefs: []agentv1alpha1.Output{
+				{
+					ObjectSelector: v1.ObjectSelector{
+						Name:      "elasticsearch",
+						Namespace: "elasticsearch-ns",
+					},
+				},
+			},
+		},
+	}).GetAssociations()[0]
+
+	for _, tt := range []struct {
+		name        string
+		agent       agentv1alpha1.Agent
+		assoc       v1.Association
+		wantPodSpec corev1.PodSpec
+		wantErr     bool
+	}{
+		{
+			name:        "nil es association",
+			wantPodSpec: generateBuilder().PodTemplate.Spec,
+			wantErr:     false,
+		},
+		{
+			name: "fleet server disabled, same namespace",
+			agent: agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "agent",
+					Namespace: agentNs,
+				},
+				Spec: agentv1alpha1.AgentSpec{
+					FleetServerEnabled: false,
+				},
+			},
+			assoc:   assocToSameNs,
+			wantErr: false,
+			wantPodSpec: generatePodSpec(func(ps corev1.PodSpec) corev1.PodSpec {
+				ps.Volumes = []corev1.Volume{
+					{
+						Name: "elasticsearch-certs",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "elasticsearch-es-http-certs-public",
+								Optional:   &optional,
+							},
+						},
+					},
+				}
+
+				ps.Containers[0].VolumeMounts = []corev1.VolumeMount{
+					{
+						Name:      "elasticsearch-certs",
+						ReadOnly:  true,
+						MountPath: "/mnt/elastic-internal/elasticsearch-association/agent-ns/elasticsearch/certs",
+					},
+				}
+
+				ps.Containers[0].Command = []string{"/usr/bin/env", "bash", "-c", `#!/usr/bin/env bash
+set -e
+cp /mnt/elastic-internal/elasticsearch-association/agent-ns/elasticsearch/certs/ca.crt /etc/pki/ca-trust/source/anchors/
+update-ca-trust
+/usr/bin/tini -- /usr/local/bin/docker-entrypoint -e
+`}
+
+				return ps
+			}),
+		},
+		{
+			name: "fleet server disabled, different namespace",
+			agent: agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "agent",
+					Namespace: agentNs,
+				},
+				Spec: agentv1alpha1.AgentSpec{
+					FleetServerEnabled: false,
+				},
+			},
+			assoc:   assocToOtherNs,
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := generateBuilder()
+			gotBuilder, gotErr := applyRelatedEsAssoc(tt.agent, tt.assoc, builder)
+
+			require.Equal(t, tt.wantErr, gotErr != nil)
+			if !tt.wantErr {
+				require.Nil(t, gotErr)
+				require.Equal(t, tt.wantPodSpec, gotBuilder.PodTemplate.Spec)
+			}
+		})
+	}
+}
+
+func Test_writeEsAssocToConfigHash(t *testing.T) {
+	assoc := (&agentv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "agent",
+			Namespace: "ns",
+		},
+		Spec: agentv1alpha1.AgentSpec{
+			ElasticsearchRefs: []agentv1alpha1.Output{
+				{
+					ObjectSelector: v1.ObjectSelector{
+						Name:      "es",
+						Namespace: "ns",
+					},
+				},
+			},
+		},
+	}).GetAssociations()[0]
+
+	assoc.SetAssociationConf(&v1.AssociationConf{
+		AuthSecretName: "auth-secret-name",
+		AuthSecretKey:  "auth-secret-key",
+		CASecretName:   "ca-secret-name",
+	})
+
+	for _, tt := range []struct {
+		name           string
+		params         Params
+		assoc          v1.Association
+		wantHashChange bool
+	}{
+		{
+			name:           "nil association",
+			wantHashChange: false,
+		},
+		{
+			name: "fleet server enabled",
+			params: Params{
+				Agent: agentv1alpha1.Agent{
+					Spec: agentv1alpha1.AgentSpec{
+						FleetServerEnabled: true,
+					},
+				},
+			},
+			wantHashChange: false,
+		},
+		{
+			name: "fleet server disabled, expect hash to be changed",
+			params: Params{
+				Client: k8s.NewFakeClient(
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "auth-secret-name",
+							Namespace: "ns",
+						},
+						Data: map[string][]byte{
+							"auth-secret-key": []byte("abc"),
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "ca-secret-name",
+							Namespace: "ns",
+						},
+						Data: map[string][]byte{
+							"tls.crt": []byte("def"),
+						},
+					},
+				),
+			},
+			assoc:          assoc,
+			wantHashChange: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			baseHashSum := sha256.New224().Sum(nil)
+			hash := sha256.New224()
+
+			err := writeEsAssocToConfigHash(tt.params, tt.assoc, hash)
+
+			require.Nil(t, err)
+			require.Equal(t, tt.wantHashChange, bytes.Compare(baseHashSum, hash.Sum(nil)) != 0)
+		})
+	}
+}
+
+func generateBuilder() *defaults.PodTemplateBuilder {
+	return defaults.NewPodTemplateBuilder(corev1.PodTemplateSpec{}, "agent")
+}
+
+func generatePodSpec(f func(spec corev1.PodSpec) corev1.PodSpec) corev1.PodSpec {
+	builder := generateBuilder()
+	return f(builder.PodTemplate.Spec)
+}


### PR DESCRIPTION
This PR refactors Pod template creation for Agent in Fleet mode and introduces UTs requested in https://github.com/elastic/cloud-on-k8s/pull/4614#discussion_r668486296.