### PR TITLE
[1.7] Backport: Remove scale subresources on v1beta1 crds (#4637)

### DIFF
--- a/config/crds/v1beta1/all-crds.yaml
+++ b/config/crds/v1beta1/all-crds.yaml
@@ -810,6 +810,12 @@ spec:
     - apm
     singular: apmserver
   scope: Namespaced
+  subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.count
+      statusReplicasPath: .status.count
+    status: {}
   validation:
     openAPIV3Schema:
       description: ApmServer represents an APM Server resource in a Kubernetes cluster.
@@ -1379,17 +1385,9 @@ spec:
   - name: v1
     served: true
     storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.selector
-        specReplicasPath: .spec.count
-        statusReplicasPath: .status.count
-      status: {}
   - name: v1beta1
     served: true
     storage: false
-    subresources:
-      status: {}
   - name: v1alpha1
     served: false
     storage: false
@@ -3786,6 +3784,12 @@ spec:
     - ent
     singular: enterprisesearch
   scope: Namespaced
+  subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.count
+      statusReplicasPath: .status.count
+    status: {}
   validation:
     openAPIV3Schema:
       description: EnterpriseSearch is a Kubernetes CRD to represent Enterprise Search.
@@ -4299,17 +4303,9 @@ spec:
   - name: v1
     served: true
     storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.selector
-        specReplicasPath: .spec.count
-        statusReplicasPath: .status.count
-      status: {}
   - name: v1beta1
     served: true
     storage: false
-    subresources:
-      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -4351,6 +4347,12 @@ spec:
     - kb
     singular: kibana
   scope: Namespaced
+  subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.count
+      statusReplicasPath: .status.count
+    status: {}
   validation:
     openAPIV3Schema:
       description: Kibana represents a Kibana resource in a Kubernetes cluster.
@@ -4995,17 +4997,9 @@ spec:
   - name: v1
     served: true
     storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.selector
-        specReplicasPath: .spec.count
-        statusReplicasPath: .status.count
-      status: {}
   - name: v1beta1
     served: true
     storage: false
-    subresources:
-      status: {}
   - name: v1alpha1
     served: false
     storage: false

--- a/config/crds/v1beta1/patches/apm-kibana-patches.yaml
+++ b/config/crds/v1beta1/patches/apm-kibana-patches.yaml
@@ -8,6 +8,12 @@
   path: /spec/validation
 - op: remove
   path: /spec/versions/1/schema
+# move subresources to the top level, see https://github.com/elastic/cloud-on-k8s/issues/4635
+- op: move
+  from: /spec/versions/0/subresources
+  path: /spec/subresources
+- op: remove
+  path: /spec/versions/1/subresources
 # Move additionalPrinterColumns of the v1 version to the top-level, and remove it from the v1beta1 version.
 # This is in order to be compatible with k8s 1.11.
 - op: move

--- a/config/crds/v1beta1/patches/ent-patches.yaml
+++ b/config/crds/v1beta1/patches/ent-patches.yaml
@@ -5,6 +5,13 @@
 - op: remove
   path: /spec/validation/openAPIV3Schema/type
 
+# move subresources to the top level, see https://github.com/elastic/cloud-on-k8s/issues/4635
+- op: move
+  from: /spec/versions/0/subresources
+  path: /spec/subresources
+- op: remove
+  path: /spec/versions/1/subresources
+
 # Using `kubectl apply` stores the complete CRD file as an annotation,
 # which may be too big for the annotations size limit.
 # One way to mitigate this problem is to remove the (huge) podTemplate properties from the CRD.

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds-legacy.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds-legacy.yaml
@@ -825,6 +825,12 @@ spec:
     - apm
     singular: apmserver
   scope: Namespaced
+  subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.count
+      statusReplicasPath: .status.count
+    status: {}
   validation:
     openAPIV3Schema:
       description: ApmServer represents an APM Server resource in a Kubernetes cluster.
@@ -1394,17 +1400,9 @@ spec:
   - name: v1
     served: true
     storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.selector
-        specReplicasPath: .spec.count
-        statusReplicasPath: .status.count
-      status: {}
   - name: v1beta1
     served: true
     storage: false
-    subresources:
-      status: {}
   - name: v1alpha1
     served: false
     storage: false
@@ -3825,6 +3823,12 @@ spec:
     - ent
     singular: enterprisesearch
   scope: Namespaced
+  subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.count
+      statusReplicasPath: .status.count
+    status: {}
   validation:
     openAPIV3Schema:
       description: EnterpriseSearch is a Kubernetes CRD to represent Enterprise Search.
@@ -4338,17 +4342,9 @@ spec:
   - name: v1
     served: true
     storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.selector
-        specReplicasPath: .spec.count
-        statusReplicasPath: .status.count
-      status: {}
   - name: v1beta1
     served: true
     storage: false
-    subresources:
-      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -4396,6 +4392,12 @@ spec:
     - kb
     singular: kibana
   scope: Namespaced
+  subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.count
+      statusReplicasPath: .status.count
+    status: {}
   validation:
     openAPIV3Schema:
       description: Kibana represents a Kibana resource in a Kubernetes cluster.
@@ -5040,17 +5042,9 @@ spec:
   - name: v1
     served: true
     storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.selector
-        specReplicasPath: .spec.count
-        statusReplicasPath: .status.count
-      status: {}
   - name: v1beta1
     served: true
     storage: false
-    subresources:
-      status: {}
   - name: v1alpha1
     served: false
     storage: false


### PR DESCRIPTION
Backport https://github.com/elastic/cloud-on-k8s/pull/4637 on branch 1.7.