### PR TITLE
[1.2] Document how to configure Enterprise Search CPU and memory requirements (#4641)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
@@ -64,10 +64,9 @@ spec:
 
 [float]
 [id="{p}-compute-resources-kibana-and-apm"]
-=== Set compute resources for Kibana and APM Server
+=== Set compute resources for Kibana, Enterprise Search and APM Server
 
-For Kibana or APM Server objects, the `podTemplate` can be configured as follows:
-
+.Kibana
 [source,yaml,subs="attributes"]
 ----
 apiVersion: kibana.k8s.elastic.co/{eck_crd_version}
@@ -80,6 +79,30 @@ spec:
     spec:
       containers:
       - name: kibana
+        env:
+          - name: NODE_OPTIONS
+            value: "--max-old-space-size=2048"
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 0.5
+          limits:
+            memory: 2.5Gi
+            cpu: 2
+----
+.APM Server
+[source,yaml,subs="attributes"]
+----
+apiVersion: apm.k8s.elastic.co/{eck_crd_version}
+kind: ApmServer
+metadata:
+  name: quickstart
+spec:
+  version: {version}
+  podTemplate:
+    spec:
+      containers:
+      - name: apm-server
         resources:
           requests:
             memory: 1Gi
@@ -88,8 +111,32 @@ spec:
             memory: 2Gi
             cpu: 2
 ----
+.Enterprise Search
+[source,yaml,subs="attributes"]
+----
+apiVersion: enterprisesearch.k8s.elastic.co/{eck_crd_version}
+kind: EnterpriseSearch
+metadata:
+  name: enterprise-search-quickstart
+spec:
+  version: {version}
+  podTemplate:
+    spec:
+      containers:
+      - name: enterprise-search
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 1
+          limits:
+            memory: 4Gi
+            cpu: 2
+        env:
+        - name: JAVA_OPTS
+          value: -Xms3500m -Xmx3500m
+----
 
-For the container name, you can use `apm-server` or `kibana` as appropriate.
+For the container name, use `apm-server`, `kibana` or `enterprise-search`, respectively.
 
 [float]
 [id="{p}-default-behavior"]
@@ -104,6 +151,7 @@ If `resources` is not defined in the specification of an object, then the operat
 |APM Server |512Mi |512Mi
 |Elasticsearch |2Gi |2Gi
 |Kibana |1Gi |1Gi
+|Enterprise Search |4Gi |4Gi
 |===
 
 If the Kubernetes cluster is configured with https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/[LimitRanges] that enforce a minimum memory constraint, they could interfere with the operator defaults and cause object creation to fail.


### PR DESCRIPTION
Backports the following commits to 1.2:
 - Document how to configure Enterprise Search CPU and memory requirements (#4641)