### PR TITLE
[1.7] Document how to configure Enterprise Search CPU and memory requirements (#4641)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
@@ -64,7 +64,7 @@ spec:
 
 [float]
 [id="{p}-compute-resources-kibana-and-apm"]
-=== Set compute resources for Kibana, Elastic Maps Server and APM Server
+=== Set compute resources for Kibana, Enterprise Search, Elastic Maps Server and APM Server
 
 .Kibana
 [source,yaml,subs="attributes"]
@@ -136,8 +136,32 @@ spec:
             memory: 2Gi
             cpu: 2
 ----
+.Enterprise Search
+[source,yaml,subs="attributes"]
+----
+apiVersion: enterprisesearch.k8s.elastic.co/{eck_crd_version}
+kind: EnterpriseSearch
+metadata:
+  name: enterprise-search-quickstart
+spec:
+  version: {version}
+  podTemplate:
+    spec:
+      containers:
+      - name: enterprise-search
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 1
+          limits:
+            memory: 4Gi
+            cpu: 2
+        env:
+        - name: JAVA_OPTS
+          value: -Xms3500m -Xmx3500m
+----
 
-For the container name, you have to use `apm-server`, `maps` or `kibana` respectively.
+For the container name, use `apm-server`, `maps`,  `kibana` or `enterprise-search`, respectively.
 
 [float]
 [id="{p}-compute-resources-beats-agent"]
@@ -212,6 +236,7 @@ If `resources` is not defined in the specification of an object, then the operat
 |Beat   |200Mi |200Mi
 |Elastic Agent |350Mi |350Mi
 |Elastic Maps Sever |200Mi |200Mi
+|Enterprise Search |4Gi |4Gi
 |===
 
 If the Kubernetes cluster is configured with https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/[LimitRanges] that enforce a minimum memory constraint, they could interfere with the operator defaults and cause object creation to fail.


### PR DESCRIPTION
Backports the following commits to 1.7:
 - Document how to configure Enterprise Search CPU and memory requirements (#4641)