### PR TITLE
Add 1.7.0 release notes and highlights

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-1.7.0>>
 * <<release-notes-1.6.0>>
 * <<release-notes-1.5.0>>
 * <<release-notes-1.4.1>>
@@ -25,6 +26,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/1.7.0.asciidoc[]
 include::release-notes/1.6.0.asciidoc[]
 include::release-notes/1.5.0.asciidoc[]
 include::release-notes/1.4.1.asciidoc[]

--- a/docs/release-notes/1.7.0.asciidoc
+++ b/docs/release-notes/1.7.0.asciidoc
@@ -1,0 +1,51 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-1.7.0]]
+== {n} version 1.7.0
+
+[[breaking-1.7.0]]
+[float]
+=== Breaking changes
+
+* Split manifest generation to produce both v1/v1beta1 CRDs {pull}4489[#4489]
+
+
+[[feature-1.7.0]]
+[float]
+=== New features
+
+* [Stack Monitoring] Kibana monitoring with Metricbeat and Filebeat as sidecars {pull}4618[#4618] (issue: {issue}4183[#4183])
+* [Stack Monitoring] Elasticsearch monitoring with Metricbeat and Filebeat as sidecars {pull}4528[#4528] (issue: {issue}4183[#4183])
+* [Agent] Fleet mode and Fleet Server support in Elastic Agent CRD {pull}4614[#4614] (issue: {issue}4429[#4429])
+* [Autoscaling] Enable scale subresource on eligible resources {pull}4599[#4599] (issue: {issue}4547[#4547])
+* Simplify setup of Enterprise Search access through Kibana UI {pull}4598[#4598]
+* Support custom CA on HTTP layer  {pull}4575[#4575] (issue: {issue}4522[#4522])
+
+[[enhancement-1.7.0]]
+[float]
+=== Enhancements
+
+* Add support for Elliptic Curve Digital Signature Algorithm (ECDSA) signed certificates {pull}4607[#4607] (issue: {issue}4581[#4581])
+* Allow users to configure SANs on transport certificates {pull}4600[#4600] (issue: {issue}4025[#4025])
+* Add validation for declared volume claim templates {pull}4526[#4526] (issue: {issue}4525[#4525])
+* [Autoscaling] Introduce resource recommenders {pull}4493[#4493] (issues: {issue}4459[#4459], {issue}4469[#4469])
+
+[[bug-1.7.0]]
+[float]
+=== Bug fixes
+
+* Beats: allow unprivileged Pods to read configuration file {pull}4572[#4572] (issue: {issue}4562[#4562])
+* Fix heap memory parsing with trailing white spaces {pull}4571[#4571] (issue: {issue}4564[#4564])
+* Detect admission registration API version {pull}4569[#4569] (issue: {issue}4555[#4555])
+
+[[nogroup-1.7.0]]
+[float]
+=== Misc
+
+* Update golang Docker tag to v1.16.6 {pull}4634[#4634]
+* Update module sigs.k8s.io/controller-runtime to v0.9.2 {pull}4603[#4603]
+* Update module sigs.k8s.io/controller-tools to v0.6.1 {pull}4588[#4588]
+* Update k8s to v0.21.2 {pull}4579[#4579]
+* Update registry.access.redhat.com/ubi8/ubi-minimal Docker tag to v8.4 {pull}4495[#4495]
+

--- a/docs/release-notes/highlights-1.7.0.asciidoc
+++ b/docs/release-notes/highlights-1.7.0.asciidoc
@@ -11,7 +11,7 @@ New and notable changes in version 1.7.0 of {n}. See <<release-notes-1.7.0>> for
 [id="{p}-170-splitted-crds"]
 ==== v1 versions of CustomResourceDefinitions (CRD) and ValidatingWebhookConfiguration are available
 
-Starting with this release, the `CustomResourceDefinitions` (CRD) and the `ValidatingWebhookConfiguration` resources are available in version `v1`. The resources definitions and the operator are now provided in two separate files, the `all-in-one.yaml` file is no longer available. Make sure to visit the link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-deploy-eck.html[installation guide] or the link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-upgrading-eck.html#k8s-beta-to-ga-upgrade[upgrade notes] for more information.
+Starting with this release, the `CustomResourceDefinitions` (CRD) and the `ValidatingWebhookConfiguration` resources are available in version `v1`. The resources definitions and the operator are now provided in two separate files, the `all-in-one.yaml` file is no longer available. Check the link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-deploy-eck.html[installation guide] or the link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-upgrading-eck.html#k8s-beta-to-ga-upgrade[upgrade notes] for more information.
 
 [float]
 [id="{p}-170-stack-monitoring"]
@@ -25,10 +25,10 @@ In this release, the Elasticsearch and Kibana resources have been enhanced to le
 [id="{p}-170-autoscaling"]
 ==== Autoscaling
 
-The `/scale` subresource is now enabled for Kibana, Enterprise Search, Elastic Maps Server and APM Server. It allows the number of replicas for those resources to be managed automatically by the link:https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/[Horizontal Pod Autoscaler] (HPA).
+The `/scale` subresource is now enabled for Kibana, Enterprise Search, Elastic Maps Server and APM Server. The number of replicas for these resources can now be managed automatically by the link:https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/[Horizontal Pod Autoscaler] (HPA).
 
 [float]
 [id="{p}-170-agent-fleet"]
 ==== Fleet mode and Fleet Server support (Alpha)
 
-In this release, the Agent CRD has been enhanced to introduce support for Fleet mode and Fleet Server. It allows the agents configurations to be managed from Kibana, while an agent can be run in server mode to update policies across a fleet of Elastic Agents.
+In this release, the Agent CRD has been enhanced to introduce support for Fleet mode and Fleet Server. The agents configuration can be managed from Kibana, while an agent can be run in server mode to update policies across a fleet of Elastic Agents.

--- a/docs/release-notes/highlights-1.7.0.asciidoc
+++ b/docs/release-notes/highlights-1.7.0.asciidoc
@@ -17,7 +17,7 @@ Starting with this release, the `CustomResourceDefinitions` (CRD) and the `Valid
 [id="{p}-170-stack-monitoring"]
 ==== Stack Monitoring
 
-In this release, the Elasticsearch and Kibana resources have been enhanced to let you specify a reference to a monitoring cluster. When specified, sidecars containers are automatically setup by ECK to ship logs and metrics to the referenced Elasticsearch cluster.
+In this release, the Elasticsearch and Kibana resources have been enhanced to let you specify a reference to a monitoring cluster. When specified, sidecar containers are automatically setup by ECK to ship logs and metrics to the referenced Elasticsearch cluster.
 
 *Add a link to documentation*
 

--- a/docs/release-notes/highlights-1.7.0.asciidoc
+++ b/docs/release-notes/highlights-1.7.0.asciidoc
@@ -25,7 +25,7 @@ In this release, the Elasticsearch and Kibana resources have been enhanced to le
 [id="{p}-170-autoscaling"]
 ==== Autoscaling
 
-The `/scale` subresource is now enabled for Kibana, Enterprise Search, Elastic Maps Server and APM Server. The number of replicas for these resources can now be managed automatically by the link:https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/[Horizontal Pod Autoscaler] (HPA).
+The `/scale` subresource is now enabled for Kibana, Enterprise Search, Elastic Maps Server, and APM Server. The number of replicas for these resources can be managed automatically by the link:https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/[Horizontal Pod Autoscaler] (HPA).
 
 [float]
 [id="{p}-170-agent-fleet"]

--- a/docs/release-notes/highlights-1.7.0.asciidoc
+++ b/docs/release-notes/highlights-1.7.0.asciidoc
@@ -1,0 +1,34 @@
+[[release-highlights-1.7.0]]
+== 1.7.0 release highlights
+
+[float]
+[id="{p}-170-new-and-notable"]
+=== New and notable
+
+New and notable changes in version 1.7.0 of {n}. See <<release-notes-1.7.0>> for the full list of changes.
+
+[float]
+[id="{p}-170-splitted-crds"]
+==== v1 versions of CustomResourceDefinitions (CRD) and ValidatingWebhookConfiguration are available
+
+Starting with this release, the `CustomResourceDefinitions` (CRD) and the `ValidatingWebhookConfiguration` resources are available in version `v1`. The resources definitions and the operator are now provided in two separate files, the `all-in-one.yaml` file is no longer available. Make sure to visit the link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-deploy-eck.html[installation guide] or the link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-upgrading-eck.html#k8s-beta-to-ga-upgrade[upgrade notes] for more information.
+
+[float]
+[id="{p}-170-stack-monitoring"]
+==== Stack Monitoring
+
+In this release, the Elasticsearch and Kibana resources have been enhanced to let you specify a reference to a monitoring cluster. When specified, sidecars containers are automatically setup by ECK to ship logs and metrics to the referenced Elasticsearch cluster.
+
+*Add a link to documentation*
+
+[float]
+[id="{p}-170-autoscaling"]
+==== Autoscaling
+
+The `/scale` subresource is now enabled for Kibana, Enterprise Search, Elastic Maps Server and APM Server. It allows the number of replicas for those resources to be managed automatically by the link:https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/[Horizontal Pod Autoscaler] (HPA).
+
+[float]
+[id="{p}-170-agent-fleet"]
+==== Fleet mode and Fleet Server support (Alpha)
+
+In this release, the Agent CRD has been enhanced to introduce support for Fleet mode and Fleet Server. It allows the agents configurations to be managed from Kibana, while an agent can be run in server mode to update policies across a fleet of Elastic Agents.

--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the most important changes in each release. For the full list, see <<eck-release-notes>>.
 
+* <<release-highlights-1.7.0>>
 * <<release-highlights-1.6.0>>
 * <<release-highlights-1.5.0>>
 * <<release-highlights-1.4.1>>
@@ -24,6 +25,7 @@ This section summarizes the most important changes in each release. For the full
 
 --
 
+include::highlights-1.7.0.asciidoc[]
 include::highlights-1.6.0.asciidoc[]
 include::highlights-1.5.0.asciidoc[]
 include::highlights-1.4.1.asciidoc[]


### PR DESCRIPTION
This PR adds release notes and highlights for 1.7.0

Might have https://github.com/elastic/cloud-on-k8s/issues/4629 as a dependency if we want to include a link to the stack monitoring documentation.