### PR TITLE
Add SAML authentication documentation

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/securing-stack.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/securing-stack.asciidoc
@@ -12,9 +12,9 @@ You can secure your Elastic Stack by specifying the following settings:
 - <<{p}-custom-http-certificate>>
 - <<{p}-users-and-roles>>
 - <<{p}-rotate-credentials>>
+- <<{p}-saml-authentication>>
 
 include::security/custom-http-certificate.asciidoc[leveloffset=+1]
 include::security/users-and-roles.asciidoc[leveloffset=+1]
 include::security/rotate-credentials.asciidoc[leveloffset=+1]
-
-
+include::security/saml-authentication.asciidoc[leveloffset=+1]

--- a/docs/orchestrating-elastic-stack-applications/security/saml-authentication.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/saml-authentication.asciidoc
@@ -11,7 +11,7 @@ The Elastic Stack supports SAML single sign-on (SSO) into Kibana, using Elastics
 
 NOTE: Elastic Stack SSO requires a valid Enterprise license or Enterprise trial license. See <<{p}-licensing,the license documentation>> for more details about managing licenses.
 
-TIP: Make sure you read the complete link:https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-guide-stack.html[Configuring SAML single-sign-on on the Elastic Stack] guide before  setting up SAML SSO for Kibana and Elasticsearch deployments managed by ECK.
+TIP: Make sure you read the complete link:https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-guide-stack.html[Configuring SAML single sign-on on the Elastic Stack] guide before setting up SAML SSO for Kibana and Elasticsearch deployments managed by ECK.
 
 == Add a SAML realm to X-Pack security settings 
 

--- a/docs/orchestrating-elastic-stack-applications/security/saml-authentication.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/saml-authentication.asciidoc
@@ -23,7 +23,7 @@ To add the SAML realm to Elasticsearch, use the `spec` section of the manifest. 
 
 NOTE: The `sp.*` SAML settings must point to Kibana endpoints that are accessible from the web browser used to open Kibana.
 
-Check Elastic link:https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-guide-stack.html#saml-guide-idp[Sack SAML documentation] for more information on `idp.*`` and `sp.*` settings.
+Check Elastic link:https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-guide-stack.html#saml-guide-idp[Sack SAML documentation] for more information on `idp.*` and `sp.*` settings.
 
 Make sure not to disable Elasticsearch’s file realm set by ECK, as ECK relies on the file realm for its operation. Set the `order` setting of the SAML realm to a greater value than the `order` value set for the file and native realms, which is by default -100 and -99 respectively. We recommend setting the priority of SAML realms to be lower than other realms, as shown in the next example.
 
@@ -39,7 +39,6 @@ spec:
   - name: default
     count: 1
     config:
-      node.store.allow_mmap: false
       xpack.security.authc.realms:
         saml:
           saml1:
@@ -63,7 +62,7 @@ kubectl create secret generic idp-saml-metadata --from-file=idp-saml-metadata.xm
 
 Next, create a volume from the secret and mount it for the Elasticsearch containers. For example:
 
-[source,yaml,sub="attributes"]
+[source,yaml,subs="attributes"]
 ----
 apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
 kind: Elasticsearch
@@ -99,7 +98,7 @@ TIP: You can configure multiple authentication providers in Kibana and let users
 
 For example:
 
-[source,yaml,sub="attributes"]
+[source,yaml,subs="attributes"]
 ----
 apiVersion: kibana.k8s.elastic.co/{eck_crd_version}
 kind: Kibana
@@ -121,15 +120,15 @@ IMPORTANT: Your SAML users cannot login to Kibana until they are assigned roles.
 
 == Generating Service Provider metadata
 
-The Elastic Stack supports generating service provider metadata, that can be imported to the identity provider, and configure many of the integration options between the identity provider and the service provider, automatically. For more information, check link:https://www.elastic.co/guide/en/elasticsearch/reference/7.12/saml-guide-stack.html#saml-sp-metadata[the Generating SP metadata section] in the Stack SAML guide.
+The Elastic Stack supports generating service provider metadata, that can be imported to the identity provider, and configure many of the integration options between the identity provider and the service provider, automatically. For more information, check link:https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-guide-stack.html#saml-sp-metadata[the Generating SP metadata section] in the Stack SAML guide.
 
 To generate the Service Provider metadata using link:https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-metadata.html[the elasticsearch-saml-metadata command], you will need to execute the command using `kubectl`, and then copy the generated metadata file to your local machine. For example:
 
 [source,sh]
 ----
 # Create metadata
-kubectl exec -it es-demo-es-default-0 -- sh -c "/usr/share/elasticsearch/bin/elasticsearch-saml-metadata --realm saml1"
+kubectl exec -it elasticsearch-sample-es-default-0 -- sh -c "/usr/share/elasticsearch/bin/elasticsearch-saml-metadata --realm saml1"
 
 # Copy metadata file
-kubectl cp elastic-sample-es-default-0:/usr/share/elasticsearch/saml-elasticsearch-metadata.xml saml-elasticsearch-metadata.xml
+kubectl cp elasticsearch-sample-es-default-0:/usr/share/elasticsearch/saml-elasticsearch-metadata.xml saml-elasticsearch-metadata.xml
 ----

--- a/docs/orchestrating-elastic-stack-applications/security/saml-authentication.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/saml-authentication.asciidoc
@@ -23,7 +23,7 @@ To add the SAML realm to Elasticsearch, use the `spec` section of the manifest. 
 
 NOTE: The `sp.*` SAML settings must point to Kibana endpoints that are accessible from the web browser used to open Kibana.
 
-Check Elastic link:https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-guide-stack.html#saml-guide-idp[Sack SAML documentation] for more information on `idp.*` and `sp.*` settings.
+Check Elastic link:https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-guide-stack.html#saml-guide-idp[Stack SAML documentation] for more information on `idp.*` and `sp.*` settings.
 
 Make sure not to disable Elasticsearch’s file realm set by ECK, as ECK relies on the file realm for its operation. Set the `order` setting of the SAML realm to a greater value than the `order` value set for the file and native realms, which is by default -100 and -99 respectively. We recommend setting the priority of SAML realms to be lower than other realms, as shown in the next example.
 

--- a/docs/orchestrating-elastic-stack-applications/security/saml-authentication.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/saml-authentication.asciidoc
@@ -51,7 +51,9 @@ spec:
             sp.logout: https://kibana.example.com/logout
 ----
 
-The `idp.metadata.path` setting should point to your Identity Provider’s metadata file. To make the file available to Elasticsearch, you need to create a Kubernetes secret containing the metadata file and mounting it to the Elasticsearch container.
+The `idp.metadata.path` setting should point to your Identity Provider’s metadata file. The metadata file path can either be a path within the Elasticsearch container (full path or relative to Elasticsearch's config directory), or an HTTPS URL.
+
+If a path is provided, you need to make the metadata file available in the Elasticsearch container by creating a Kubernetes secret, containing the metadata file, and mounting it to the Elasticsearch container.
 
 After saving your Identity Provider’s metadata file, create the secret. For example:
 

--- a/docs/orchestrating-elastic-stack-applications/security/saml-authentication.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/saml-authentication.asciidoc
@@ -1,0 +1,135 @@
+:page_id: saml-authentication
+ifdef::env-github[]
+****
+link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-{page_id}.html[View this document on the Elastic website]
+****
+endif::[]
+[id="{p}-{page_id}"]
+= SAML Authentication
+
+The Elastic Stack supports SAML single sign-on (SSO) into Kibana, using Elasticsearch as a backend service. 
+
+NOTE: Elastic Stack SSO requires a valid Enterprise license or Enterprise trial license. See <<{p}-licensing,the license documentation>> for more details about managing licenses.
+
+TIP: Make sure you read the complete link:https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-guide-stack.html[Configuring SAML single-sign-on on the Elastic Stack] guide before  setting up SAML SSO for Kibana and Elasticsearch deployments managed by ECK.
+
+== Add a SAML realm to X-Pack security settings 
+
+To enable SAML SSO for the Elastic Stack, you have to configure the SAML realm in Elasticsearch and enable the usage of the SAML realm and authentication provider in Kibana.
+
+=== Elasticsearch
+
+To add the SAML realm to Elasticsearch, use the `spec` section of the manifest. The SAML realm configuration contains an `idp.metadata.path` field that should be set to the path where your IdP’s SAML metadata file is located in the Elasticsearch pods.
+
+NOTE: The `sp.*` SAML settings must point to Kibana endpoints that are accessible from the web browser used to open Kibana.
+
+Check Elastic link:https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-guide-stack.html#saml-guide-idp[Sack SAML documentation] for more information on `idp.*`` and `sp.*` settings.
+
+Make sure not to disable Elasticsearch’s file realm set by ECK, as ECK relies on the file realm for its operation. Set the `order` setting of the SAML realm to a greater value than the `order` value set for the file and native realms, which is by default -100 and -99 respectively. We recommend setting the priority of SAML realms to be lower than other realms, as shown in the next example.
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
+kind: Elasticsearch
+metadata:
+  name: elasticsearch-sample
+spec:
+  version: {version}
+  nodeSets:
+  - name: default
+    count: 1
+    config:
+      node.store.allow_mmap: false
+      xpack.security.authc.realms:
+        saml:
+          saml1:
+            attributes.principal: nameid
+            idp.entity_id: https://sso.example.com/
+            idp.metadata.path: /usr/share/elasticsearch/config/saml/idp-saml-metadata.xml
+            order: 2
+            sp.acs: https://kibana.example.com/api/security/v1/saml
+            sp.entity_id: https://kibana.example.com
+            sp.logout: https://kibana.example.com/logout
+----
+
+The `idp.metadata.path` setting should point to your Identity Provider’s metadata file. To make the file available to Elasticsearch, you need to create a Kubernetes secret containing the metadata file and mounting it to the Elasticsearch container.
+
+After saving your Identity Provider’s metadata file, create the secret. For example:
+
+[source,sh]
+----
+kubectl create secret generic idp-saml-metadata --from-file=idp-saml-metadata.xml
+----
+
+Next, create a volume from the secret and mount it for the Elasticsearch containers. For example:
+
+[source,yaml,sub="attributes"]
+----
+apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
+kind: Elasticsearch
+metadata:
+  name: elasticsearch-sample
+spec:
+  version: {version}
+  nodeSets:
+  - name: default
+    count: 1
+    config:
+      ...
+    podTemplate:
+      spec:
+        containers:
+          - name: elasticsearch
+            volumeMounts:
+              - name: idp-saml-metadata
+                mountPath: /usr/share/elasticsearch/config/saml
+        volumes:
+          - name: idp-saml-metadata
+            secret:
+              secretName: idp-saml-metadata
+----
+
+NOTE: To configure Elasticsearch for signing messages and/or for encrypted messages, keys and certificates should be mounted from a Kubernetes secret similar to how the SAML metadata file is mounted in the previous example. Passphrases, if needed, should be added to Elasticsearch’s keystore using ECK’s Secure Settings feature. For more information, check <<{p}-es-secure-settings,the Secure Settings documentation>> and link:https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-guide-stack.html#saml-enc-sign[the Encryption and signing section] in the Stack SAML guide.
+
+=== Kibana
+
+To enable SAML authentication in Kibana, you have to add SAML as an authentication provider and specify the SAML realm that you used in your Elasticsearch configuration.
+
+TIP: You can configure multiple authentication providers in Kibana and let users choose the provider they want to use. For more information, check link:https://www.elastic.co/guide/en/kibana/current/kibana-authentication.html[the Kibana authentication documentation].
+
+For example:
+
+[source,yaml,sub="attributes"]
+----
+apiVersion: kibana.k8s.elastic.co/{eck_crd_version}
+kind: Kibana
+metadata:
+  name: kibana-sample
+spec:
+  version: {version}
+  count: 1
+  elasticsearchRef:
+    name: elasticsearch-sample
+    config:
+      xpack.security.authc.providers:
+        saml.saml1:
+          order: 0
+          realm: "saml1"
+----
+
+IMPORTANT: Your SAML users cannot login to Kibana until they are assigned roles. For more information, refer to link:https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-guide-stack.html#saml-role-mapping[the Configuring role mapping section] in the Stack SAML guide.
+
+== Generating Service Provider metadata
+
+The Elastic Stack supports generating service provider metadata, that can be imported to the identity provider, and configure many of the integration options between the identity provider and the service provider, automatically. For more information, check link:https://www.elastic.co/guide/en/elasticsearch/reference/7.12/saml-guide-stack.html#saml-sp-metadata[the Generating SP metadata section] in the Stack SAML guide.
+
+To generate the Service Provider metadata using link:https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-metadata.html[the elasticsearch-saml-metadata command], you will need to execute the command using `kubectl`, and then copy the generated metadata file to your local machine. For example:
+
+[source,sh]
+----
+# Create metadata
+kubectl exec -it es-demo-es-default-0 -- sh -c "/usr/share/elasticsearch/bin/elasticsearch-saml-metadata --realm saml1"
+
+# Copy metadata file
+kubectl cp elastic-sample-es-default-0:/usr/share/elasticsearch/saml-elasticsearch-metadata.xml saml-elasticsearch-metadata.xml
+----

--- a/docs/orchestrating-elastic-stack-applications/security/saml-authentication.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/saml-authentication.asciidoc
@@ -122,7 +122,7 @@ IMPORTANT: Your SAML users cannot login to Kibana until they are assigned roles.
 
 The Elastic Stack supports generating service provider metadata, that can be imported to the identity provider, and configure many of the integration options between the identity provider and the service provider, automatically. For more information, check link:https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-guide-stack.html#saml-sp-metadata[the Generating SP metadata section] in the Stack SAML guide.
 
-To generate the Service Provider metadata using link:https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-metadata.html[the elasticsearch-saml-metadata command], you will need to execute the command using `kubectl`, and then copy the generated metadata file to your local machine. For example:
+To generate the Service Provider metadata using link:https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-metadata.html[the elasticsearch-saml-metadata command], you will have to run the command using `kubectl`, and then copy the generated metadata file to your local machine. For example:
 
 [source,sh]
 ----


### PR DESCRIPTION
Add SAML documentation and avoid re-documenting what's in the Stack SAML guide.

- Add SAML Authentication page under Securing the Elastic Stack
- Link to Stack SAML docs 
- Reference our secure settings doc for pass-phrases
- Mention that the file realm needs to stay enabled for ECK to function
- Mention how to generate the service provider metadata using exec

Fixes #3433 