### PR TITLE
OperatorHub generator: ensure YAML sep. between documents

### DIFF
--- a/hack/operatorhub/main.go
+++ b/hack/operatorhub/main.go
@@ -42,6 +42,8 @@ const (
 	crdFileSuffix     = "crd.yaml"
 	csvFileSuffix     = "clusterserviceversion.yaml"
 	packageFileSuffix = "package.yaml"
+
+	yamlSeparator = "---\n"
 )
 
 type cmdArgs struct {
@@ -179,7 +181,7 @@ func installManifestFromWeb(version string) (io.Reader, error) {
 		if err != nil {
 			return nil, err
 		}
-		return io.MultiReader(crds, op), nil
+		return io.MultiReader(crds, strings.NewReader(yamlSeparator), op), nil
 	}
 	return buf, err
 }


### PR DESCRIPTION
While testing operator upgrade from `1.6.0` to `1.7.0-bc1` using the operator hub I noticed that all the CRDs were upgraded except `kibanas.kibana.k8s.elastic.co`.

The reason is that the operator hub generator creates a logical concatenation of `crds.yaml` and `operator.yaml` using `io.MultiReader`, without a YAML separator to separate the last document in `crds.yaml` and the first one of `operator.yaml`:

```yaml

---
# Source: eck-operator-crds/templates/all-crds.yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  annotations:
    controller-gen.kubebuilder.io/version: v0.6.1
  creationTimestamp: null
  labels:
    app.kubernetes.io/instance: 'elastic-operator'
    app.kubernetes.io/name: 'eck-operator-crds'
    app.kubernetes.io/version: '1.8.0-SNAPSHOT'
  name: agents.agent.k8s.elastic.co
[...]
# Source: eck-operator-crds/templates/all-crds.yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  annotations:
    controller-gen.kubebuilder.io/version: v0.6.1
  creationTimestamp: null
  labels:
    app.kubernetes.io/instance: 'elastic-operator'
    app.kubernetes.io/name: 'eck-operator-crds'
    app.kubernetes.io/version: '1.8.0-SNAPSHOT'
  name: kibanas.kibana.k8s.elastic.co
spec:
[...]

## Missing separator here, yamlReader.Read() returns both the Kibana CRD and the following namespace

# Source: eck-operator/templates/operator-namespace.yaml
apiVersion: v1
kind: Namespace
metadata:
  name: elastic-system
  labels:
    name: elastic-system
```

Later `yamlReader.Read()` returns these 2 documents, but the `Decoder` in the apimachinery silently discards the last document of `crds.yaml` _(which is the `kibanas.kibana.k8s.elastic.co` crd in that particular case)_, preventing `kibanas.kibana.k8s.elastic.co` to be included in the operator hub manifest.

This PR ensures that a YAML separator exists between the 2 documents.