### PR TITLE
ECK dump: avoid sensitive fields when dumping secret metadata

### DIFF
--- a/support/diagnostics/eck-dump.sh
+++ b/support/diagnostics/eck-dump.sh
@@ -120,6 +120,7 @@ main() {
     get_resources "$ns" events
     get_resources "$ns" networkpolicies
     get_resources "$ns" controllerrevisions
+    get_metadata "$ns" secrets
     get_logs "$ns"
   done
 

--- a/support/diagnostics/eck-dump.sh
+++ b/support/diagnostics/eck-dump.sh
@@ -38,19 +38,19 @@ VERBOSE=""
 METADATA_TPL=$(cat <<'EOF'
 {{range .items}}
 {{"---" -}}
-{{range $k,$v := .metadata }}
-{{ printf `"%v": ` $k -}}
-  {{- if eq $k "annotations" "labels" -}}
+{{range $key,$value := .metadata }}
+{{ printf `"%v": ` $key -}}
+  {{- if eq $key "annotations" "labels" -}}
     {{- $nth := false -}}
-    {{- range $k,$v := . -}}
-      {{- if ne $k "kubectl.kubernetes.io/last-applied-configuration" -}}
+    {{- range $key,$value := . -}}
+      {{- if ne $key "kubectl.kubernetes.io/last-applied-configuration" -}}
         {{- if $nth -}}{{- "," -}}{{- end -}}
-        {{- printf `"%v":"%v"` $k $v -}}
+        {{- printf `"%v":"%v"` $key $value -}}
         {{$nth = true}}
       {{- end -}}
     {{- end -}}
   {{else}}
-    {{- printf `"%v"` $v -}}
+    {{- printf `"%v"` $value -}}
   {{- end -}}
 {{- end -}}
 {{end}}


### PR DESCRIPTION
Fixes #4435

This replaces the JSON dump of the K8s Secret metadata with a Go-template producing a text file that leaves out sensitive information specifically the `last-applied-configuration` annotation `kubectl` adds. 

This PR does not have a version label as we don't release the script explicitly but users just pull it from the repo. 