### PR TITLE
[1.7] Lower fleet agent minimum version to 7.14.0-SNAPSHOT (#4639)

### DIFF
--- a/pkg/apis/agent/v1alpha1/validations_test.go
+++ b/pkg/apis/agent/v1alpha1/validations_test.go
@@ -39,6 +39,12 @@ func Test_checkSupportedVersion(t *testing.T) {
 		{
 			name:    "fleet, within supported: OK",
 			mode:    AgentFleetMode,
+			version: "7.14.0-SNAPSHOT",
+			wantErr: false,
+		},
+		{
+			name:    "fleet, within supported: OK",
+			mode:    AgentFleetMode,
 			version: "7.14.0",
 			wantErr: false,
 		},

--- a/pkg/controller/common/version/version.go
+++ b/pkg/controller/common/version/version.go
@@ -31,7 +31,7 @@ var (
 	// picking higher version as minimal supported.
 	SupportedAgentVersions = MinMaxVersion{Min: From(7, 10, 0), Max: From(8, 99, 99)}
 	// Due to bugfixes present in 7.14 that ECK depends on, this is the lowest version we support in Fleet mode.
-	SupportedFleetModeAgentVersions = MinMaxVersion{Min: From(7, 14, 0), Max: From(8, 99, 99)}
+	SupportedFleetModeAgentVersions = MinMaxVersion{Min: MustParse("7.14.0-SNAPSHOT"), Max: From(8, 99, 99)}
 	SupportedMapsVersions           = MinMaxVersion{Min: From(7, 11, 0), Max: From(8, 99, 99)}
 )
 

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -48,8 +48,7 @@ type Builder struct {
 func (b Builder) SkipTest() bool {
 	supportedVersions := version.SupportedAgentVersions
 	if b.Agent.Spec.FleetModeEnabled() {
-		// todo use version.SupportedFleetModeAgentVersions after 7.14.0 release is available
-		supportedVersions.Min = version.MustParse("7.14.0-SNAPSHOT")
+		supportedVersions = version.SupportedFleetModeAgentVersions
 	}
 
 	ver := version.MustParse(b.Agent.Spec.Version)


### PR DESCRIPTION
Backports the following commits to 1.7:
 - Lower fleet agent minimum version to 7.14.0-SNAPSHOT (#4639)