### PR TITLE
Fix to allow to test EnterpriseSearch with Elasticsearch 8.0.0-SNAPSHOT

### DIFF
--- a/test/e2e/test/enterprisesearch/builder.go
+++ b/test/e2e/test/enterprisesearch/builder.go
@@ -177,6 +177,9 @@ func (b Builder) WithPodLabel(key, value string) Builder {
 }
 
 func (b Builder) WithEnvVar(name, value string) Builder {
+	if len(b.EnterpriseSearch.Spec.PodTemplate.Spec.Containers) == 0 {
+		b.EnterpriseSearch.Spec.PodTemplate.Spec.Containers = []corev1.Container{{Name: entv1.EnterpriseSearchContainerName}}
+	}
 	for i, container := range b.EnterpriseSearch.Spec.PodTemplate.Spec.Containers {
 		container.Env = append(container.Env, corev1.EnvVar{Name: name, Value: value})
 		b.EnterpriseSearch.Spec.PodTemplate.Spec.Containers[i].Env = container.Env


### PR DESCRIPTION
In #4604, I added `WithEnvVar` to the EnterpriseSearch builder to add the environment variable `ALLOW_PREVIEW_ELASTICSEARCH_8X=true`. 
This adds the environment variable passed as a parameter in all containers defined in the pod template of the EnterpriseSearch resource. But if there is no containers in the pod template, we don't add the env var.

This commit fixes that by adding the main `enterprise-search` container if there is no container defined in the pod template.

Relates to #4710 and #4455.