### PR TITLE
[1.7] Add docs for Fleet-managed Elastic Agent (#4704)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Supported versions:
 *  Elasticsearch, Kibana, APM Server: 6.8+, 7.1+
 *  Enterprise Search: 7.7+
 *  Beats: 7.0+
+*  Elastic Agent: 7.10+ (standalone), 7.14+ (Fleet)
+*  Elastic Maps Server: 7.11+
 
 Check the [Quickstart](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-quickstart.html) to deploy your first cluster with ECK.
 

--- a/docs/orchestrating-elastic-stack-applications/accessing-elastic-services.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/accessing-elastic-services.asciidoc
@@ -39,7 +39,7 @@ You can access Elastic resources by using native Kubernetes services that are no
 [id="{p}-kubernetes-service"]
 === Manage Kubernetes services
 
-For each resource, the operator manages a Kubernetes service named `<name>-[es|kb|apm|ent]-http`, which is of type `ClusterIP` by default. `ClusterIP` exposes the service on a cluster-internal IP and makes the service only reachable from the cluster.
+For each resource, the operator manages a Kubernetes service named `<name>-[es|kb|apm|ent|agent]-http`, which is of type `ClusterIP` by default. `ClusterIP` exposes the service on a cluster-internal IP and makes the service only reachable from the cluster.
 
 [source,sh]
 ----
@@ -105,7 +105,7 @@ hulk-es-http-certs-internal      Opaque                                2      28
 hulk-es-http-certs-public        Opaque                                1      28m
 ----
 
-The public certificate is stored in a secret named `<name>-[es|kb|apm|ent]-http-certs-public`.
+The public certificate is stored in a secret named `<name>-[es|kb|apm|ent|agent]-http-certs-public`.
 
 [source,sh]
 ----

--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -1,0 +1,406 @@
+:page_id: elastic-agent-fleet
+:agent_recipes: https://raw.githubusercontent.com/elastic/cloud-on-k8s/{eck_release_branch}/config/recipes/elastic-agent
+ifdef::env-github[]
+****
+link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-{page_id}.html[View this document on the Elastic website]
+****
+endif::[]
+[id="{p}-{page_id}"]
+= Run Fleet-managed Elastic Agent on ECK
+
+experimental[]
+
+This section describes how to configure and deploy Elastic Agent in link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html[Fleet-managed] mode with ECK. Check the link:k8s-elastic-agent-standalone.html[Standalone section] if you want to run Elastic Agent in the link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[standalone mode].
+
+* <<{p}-elastic-agent-fleet-quickstart,Quickstart>>
+* <<{p}-elastic-agent-fleet-configuration,Configuration>>
+* <<{p}-elastic-agent-fleet-known-limitation,Known limitation>>
+
+NOTE: Running Fleet-managed Elastic Agent on ECK is compatible only with Stack versions 7.14+.
+
+[id="{p}-elastic-agent-fleet-quickstart"]
+== Quickstart
+
+. To deploy Fleet Server, Elastic Agents, Elasticsearch, and Kibana, apply the following specification:
++
+[source,yaml,subs="attributes,+macros"]
+----
+cat $$<<$$EOF | kubectl apply -f -
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: fleet-server-quickstart
+  namespace: default
+spec:
+  version: {version}
+  kibanaRef:
+    name: kibana-quickstart
+  elasticsearchRefs:
+  - name: elasticsearch-quickstart
+  mode: fleet
+  fleetServerEnabled: true
+  deployment:
+    replicas: 1
+    podTemplate:
+      spec:
+        serviceAccountName: elastic-agent
+        automountServiceAccountToken: true
+        securityContext:
+          runAsUser: 0
+---
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: elastic-agent-quickstart
+  namespace: default
+spec:
+  version: {version}
+  kibanaRef:
+    name: kibana-quickstart
+  fleetServerRef:
+    name: fleet-server-quickstart
+  mode: fleet
+  daemonSet:
+    podTemplate:
+      spec:
+        serviceAccountName: elastic-agent
+        automountServiceAccountToken: true
+        securityContext:
+          runAsUser: 0
+---
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: kibana-quickstart
+  namespace: default
+spec:
+  version: {version}
+  count: 1
+  elasticsearchRef:
+    name: elasticsearch-quickstart
+  config:
+    xpack.fleet.agents.elasticsearch.host: "https://elasticsearch-es-http.default.svc:9200"
+    xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
+---
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch-quickstart
+  namespace: default
+spec:
+  version: {version}
+  nodeSets:
+  - name: default
+    count: 3
+    config:
+      node.store.allow_mmap: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: elastic-agent
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources:
+  - pods
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: elastic-agent
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: elastic-agent
+subjects:
+- kind: ServiceAccount
+  name: elastic-agent
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: elastic-agent
+  apiGroup: rbac.authorization.k8s.io
+EOF
+----
+
+ECK automatically configures secure connections between all components. Fleet will be set up, and all agents are enrolled in the default policy.
+
+. Monitor the status of Fleet Server and Elastic Agent.
+
++
+[source,sh]
+----
+kubectl get agent
+----
++
+[source,sh,subs="attributes"]
+----
+NAME            HEALTH   AVAILABLE   EXPECTED   VERSION      AGE
+elastic-agent   green    3           3          {version}    14s
+fleet-server    green    1           1          {version}    19s
+
+----
+
+. List all the Pods belonging to a given Elastic Agent specification.
++
+[source,sh]
+----
+kubectl get pods --selector='agent.k8s.elastic.co/name=elastic-agent'
+----
++
+[source,sh]
+----
+NAME                        READY   STATUS    RESTARTS   AGE
+elastic-agent-agent-t49fd   1/1     Running   0          54s
+elastic-agent-agent-xbcxr   1/1     Running   0          54s
+elastic-agent-agent-zqp55   1/1     Running   0          54s
+----
+
+. Access logs for one of the Pods.
++
+[source,sh]
+----
+kubectl logs -f elastic-agent-agent-xbcxr
+----
+
+. Configure the policy used by Elastic Agents. Check link:https://www.elastic.co/guide/en/fleet/current/agent-policy.html[Elastic Agent policies] for more details.
+
+[id="{p}-elastic-agent-fleet-configuration"]
+== Configuration
+
+experimental[]
+
+Fleet-managed Elastic Agents must connect to Fleet Server to receive their configurations. You can deploy Fleet Server instances using ECKs Agent CRD with the appropriate configuration, as shown in <<{p}-elastic-agent-fleet-configuration-fleet-mode-and-fleet-server,Fleet mode and Fleet Server>>.
+
+To know more about Fleet architecture and related components, check the Fleet link:https://www.elastic.co/guide/en/fleet/current/fleet-server.html[documentation].
+
+[id="{p}-elastic-agent-fleet-configuration-fleet-mode-and-fleet-server"]
+=== Fleet mode and Fleet Server
+To run both Fleet Server and Elastic Agent in Fleet-managed mode, set the `mode` configuration element to `fleet`.
+
+[source,yaml,subs="attributes,+macros"]
+----
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: elastic-agent-sample
+spec:
+  mode: fleet
+----
+
+To run Fleet Server, set the `fleetServerEnabled` configuration element to `true`, as shown in this example: 
+
+[source,yaml,subs="attributes,+macros"]
+----
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: fleet-server-sample
+spec:
+  mode: fleet
+  fleetServerEnabled: true
+----
+You can leave the default value `false` for any other case.
+
+[id="{p}-elastic-agent-fleet-configuration-required-kibana-configuration"]
+=== Configure Kibana
+
+To have Fleet running properly, the following settings must be correctly set in the Kibana configuration:
+
+[source,yaml,subs="attributes,+macros"]
+----
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: kibana
+spec:
+  config:
+    xpack.fleet.agents.elasticsearch.host: "https://elasticsearch-es-http.default.svc:9200"
+    xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
+----
+
+*  `xpack.fleet.agents.elasticsearch.host`  must point to the Elasticsearch cluster that Elastic Agents should send data to. For ECK-managed Elasticsearch clusters, ECK creates a Service accessible through `https://ES_RESOURCE_NAME-es-http.ES_RESOURCE_NAMESPACE.svc:9200` URL, where `ES_RESOURCE_NAME` is the name of Elasticsearch resource and `ES_RESOURCE_NAMESPACE` is the namespace it was deployed in.
+
+*  `xpack.fleet.agents.fleet_server.hosts` must point to Fleet Server that Elastic Agents should connect to. For ECK-managed Fleet Server instances, ECK creates a Service accessible through `https://FS_RESOURCE_NAME-agent-http.FS_RESOURCE_NAMESPACE.svc:8220` URL, where `FS_RESOURCE_NAME` is the name of Elastic Agent resource with Fleet Server enabled and `FS_RESOURCE_NAMESPACE` is the namespace it was deployed in.
+
+[id="{p}-elastic-agent-fleet-configuration-setting-referenced-resources"]
+=== Set referenced resources
+
+Both Fleet Server and Elastic Agent in Fleet mode can facilitate the Fleet setup. Fleet Server can set up Fleet in Kibana (which otherwise requires manual steps) and enroll itself in the default Fleet Server policy. Elastic Agent can enroll itself in the default Elastic Agent policy. To allow ECK to set this up, provide a reference to ECK-managed Kibana through `kibanaRef` configuration element.
+
+[source,yaml,subs="attributes,+macros"]
+----
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: fleet-server-sample
+spec:
+  kibanaRef:
+    name: kibana
+----
+
+ECK can also facilitate the connection between Elastic Agents and ECK-managed Fleet Server. To allow ECK to set this up, provide a reference to Fleet Server through `fleetServerRef` configuration element.
+
+[source,yaml,subs="attributes,+macros"]
+----
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: elastic-agent-sample
+spec:
+  fleetServerRef:
+    name: fleet-server-sample
+----
+
+
+Set `elasticsearchRefs` element in your Fleet Server to point to the Elasticsearch cluster that will manage Fleet. Leave `elasticsearchRefs` empty or unset for any Elastic Agent running in Fleet mode as the Elasticsearch cluster to target will come from Kibana `xpack.fleet.agents.elasticsearch.host` configuration element.
+
+NOTE: Currently, Elastic Agent in Fleet mode supports only a single output, so only a single Elasticsearch cluster can be referenced.
+
+[source,yaml,subs="attributes,+macros"]
+----
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: fleet-server-sample
+spec:
+  elasticsearchRefs:
+  - name: elasticsearch-sample
+----
+
+By default, every reference targets all instances in your Elasticsearch, Kibana and Fleet Server deployments, respectively. If you want to direct traffic to specific instances, refer to <<{p}-traffic-splitting>> for more information and examples.
+
+[id="{p}-elastic-agent-fleet-configuration-custom-configuration"]
+=== Customize Elastic Agent configuration
+
+In contrast to what happens with Elastic Agent as standalone, the configuration is managed through Fleet, and it cannot be defined through `config` or `configRef` elements.
+
+You can only configure the setup part of the Fleet Server and Elastic Agent. You can override each of the environmental variables that agents consume, as documented in link:https://www.elastic.co/guide/en/fleet/current/agent-environment-variables.html[Elastic Agent environment variables]. This allows different setups where components are deployed both in local Kubernetes cluster and externally.
+
+[id="{p}-elastic-agent-fleet-configuration-upgrade-specification"]
+=== Upgrade the Elastic Agent specification
+
+You can upgrade the Elastic Agent version or change settings by editing the YAML specification file. ECK applies the changes by performing a rolling restart of the Agent's Pods. Depending on the settings that you used, ECK configures an agent to set up Fleet in Kibana, enrolls itself in Fleet, or restarts Elastic Agent on certificate rollover.
+
+[id="{p}-elastic-agent-fleet-configuration-chose-the-deployment-model"]
+=== Choose the deployment model
+
+Depending on the use case, Elastic Agent may need to be deployed as a link:https://kubernetes.io/docs/concepts/workloads/controllers/deployment/[Deployment] or a link:https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/[DaemonSet]. To choose how to deploy your Elastic Agents, provide a `podTemplate` element under the `deployment` or the `daemonSet` element in the specification. If you choose the `deployment` option, you can additionally specify the link:https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy[strategy] used to replace old Pods with new ones.
+
+Similarly, you can set the link:https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/[update strategy] when deploying as a DaemonSet. This allows you to control the rollout speed for new configuration by modifying the `maxUnavailable` setting:
+
+[source,yaml,subs="attributes,+macros"]
+----
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: elastic-agent-sample
+spec:
+  version: {version}
+  daemonSet:
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 3
+...
+----
+
+Refer to <<{p}-compute-resources-beats-agent>> for more information on how to use the Pod template to adjust the resources given to Elastic Agent.
+
+[id="{p}-elastic-agent-fleet-configuration-role-based-access-control"]
+=== Role Based Access Control for Elastic Agent
+
+Some Elastic Agent features, such as the link:https://epr.elastic.co/package/kubernetes/0.2.8/[Kubernetes integration], require that Agent Pods interact with Kubernetes APIs. This functionality requires specific permissions. Standard Kubernetes link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/[RBAC] rules apply. For example, to allow API interactions:
+
+[source,yaml,subs="attributes,+macros"]
+----
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: elastic-agent-sample
+spec:
+  version: {version}
+  elasticsearchRefs:
+  - name: elasticsearch-sample
+  daemonSet:
+    podTemplate:
+      spec:
+        automountServiceAccountToken: true
+        serviceAccountName: elastic-agent
+...
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: elastic-agent
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources:
+  - namespaces
+  - pods
+  - nodes
+  - nodes/metrics
+  - nodes/proxy
+  - nodes/stats
+  - events
+  verbs:
+  - get
+  - watch
+  - list
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+  - watch
+  - list
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: elastic-agent
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: elastic-agent
+subjects:
+- kind: ServiceAccount
+  name: elastic-agent
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: elastic-agent
+  apiGroup: rbac.authorization.k8s.io
+----
+
+[id="{p}-elastic-agent-fleet-configuration-deploying-in-secured-clusters"]
+=== Deploy Elastic Agent in secured clusters
+
+To deploy Elastic Agent in clusters with the Pod Security Policy admission controller enabled, or in <<{p}-openshift-agent,OpenShift>> clusters, you might need to grant additional permissions to the Service Account used by the Elastic Agent Pods. Those Service Accounts must be bound to a Role or ClusterRole that has `use` permission for the required Pod Security Policy or Security Context Constraints. Different Elastic Agent integrations might require different settings set in their PSP/link:{p}-openshift-agent.html[SCC].
+
+[id="{p}-elastic-agent-fleet-configuration-customize-fleet-server-service"]
+=== Customize Fleet Server Service
+
+By default, ECK creates a Service for Fleet Server that Elastic Agents can connect through. You can customize it using the `http` configuration element. You can read more about link:k8s-services.html[making changes] to the Service and link:k8s-tls-certificates.html[customizing] TLS configuration in the documentation.
+
+[id="{p}-elastic-agent-fleet-known-limitation"]
+== Known limitation
+
+Elastic Agent in Fleet mode has to run with elevated privileges and in the same namespace as the Elasticsearch cluster it connects to.
+
+Due to current configuration limitations on Fleet/Elastic Agent side, ECK needs to establish trust between Elastic Agents and Elasticsearch. ECK can fetch the required Elasticsearch CA correctly if both resources are in the same namespace.
+To establish trust, the Pod needs to update the CA store via a call to `update-ca-trust` before Elastic Agent runs. To call it successfully, the Pod needs to run with elevated privileges.

--- a/docs/orchestrating-elastic-stack-applications/agent-standalone.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-standalone.asciidoc
@@ -1,4 +1,4 @@
-:page_id: elastic-agent
+:page_id: elastic-agent-standalone
 :agent_recipes: https://raw.githubusercontent.com/elastic/cloud-on-k8s/{eck_release_branch}/config/recipes/elastic-agent
 ifdef::env-github[]
 ****
@@ -6,24 +6,20 @@ link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-{page_id}.html[View
 ****
 endif::[]
 [id="{p}-{page_id}"]
-= Run Elastic Agent on ECK
+= Run standalone Elastic Agent on ECK
 
 experimental[]
 
-This section describes how to configure and deploy Elastic Agent in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[standalone mode] with ECK.
+This section describes how to configure and deploy Elastic Agent in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[standalone mode] with ECK. Check the link:k8s-elastic-agent-fleet.html[Fleet section] if you want to manage your Elastic Agents with link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html[Fleet].
 
-NOTE: Using link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html[Fleet] to manage your Elastic Agents is currently not supported.
+* <<{p}-elastic-agent-standalone-quickstart,Quickstart>>
+* <<{p}-elastic-agent-standalone-configuration,Configuration>>
+* <<{p}-elastic-agent-standalone-configuration-examples,Configuration examples>>
 
+NOTE: Running standalone Elastic Agent on ECK is compatible only with Stack versions 7.10+.
 
-
-* <<{p}-elastic-agent-quickstart,Quickstart>>
-* <<{p}-elastic-agent-configuration,Configuration>>
-* <<{p}-elastic-agent-configuration-examples,Configuration Examples>>
-
-[id="{p}-elastic-agent-quickstart"]
+[id="{p}-elastic-agent-standalone-quickstart"]
 == Quickstart
-
-experimental[]
 
 . Apply the following specification to deploy Elastic Agent with the System metrics integration to harvest CPU metrics from the Agent Pods. ECK automatically configures the secured connection to an Elasticsearch cluster named `quickstart`, created in the link:k8s-quickstart.html[Elasticsearch quickstart].
 +
@@ -65,11 +61,9 @@ spec:
 EOF
 ----
 +
-See <<{p}-elastic-agent-configuration-examples>> for more ready-to-use manifests.
+See <<{p}-elastic-agent-standalone-configuration-examples>> for more ready-to-use manifests.
 
-. Monitor Elastic Agent.
-+
-Retrieve the status of Elastic Agent.
+. Monitor the status of Elastic Agent.
 +
 [source,sh]
 ----
@@ -83,7 +77,7 @@ quickstart      green    3           3          {version}    15s
 
 ----
 
-. List all the Pods belonging to a given Elastic Agent specification.
+. List all the Pods that belong to a given Elastic Agent specification.
 +
 [source,sh]
 ----
@@ -118,19 +112,19 @@ curl -u "elastic:$PASSWORD" -k "https://localhost:9200/metrics-system.cpu-*/_sea
 +
 - Follow the Kibana deployment <<{p}-deploy-kibana,guide>>, log in and go to *Kibana* > *Discover*.
 
-[id="{p}-elastic-agent-configuration"]
+[id="{p}-elastic-agent-standalone-configuration"]
 == Configuration
 
 experimental[]
 
 
-[id="{p}-elastic-agent-upgrade-specification"]
+[id="{p}-elastic-agent-standalone-upgrade-specification"]
 === Upgrade the Elastic Agent specification
 
-You can upgrade the Elastic Agent version or change settings by editing the YAML specification. ECK applies the changes by performing a rolling restart of the Agent's Pods. Depending on the settings that you used, ECK will set the <<{p}-elastic-agent-set-output,outputs>> part of the configuration, or restart Elastic Agent on certificate rollover.
+You can upgrade the Elastic Agent version or change settings by editing the YAML specification. ECK applies the changes by performing a rolling restart of the Agent's Pods. Depending on the settings that you used, ECK will set the <<{p}-elastic-agent-standalone-set-output,outputs>> part of the configuration, or restart Elastic Agent on certificate rollover.
 
-[id="{p}-elastic-agent-custom-configuration"]
-=== Customize Elastic Agent configuration
+[id="{p}-elastic-agent-standalone-custom-configuration"]
+=== Customize the Elastic Agent configuration
 
 The Elastic Agent configuration is defined in the `config` element:
 
@@ -170,7 +164,7 @@ spec:
             period: 10s
 ----
 
-Alternatively, it can be provided via a Secret specified in the `configRef` element. The Secret must have an `agent.yml` entry with the configuration:
+Alternatively, it can be provided via a Secret specified in the `configRef` element. The Secret must have an `agent.yml` entry with this configuration:
 [source,yaml,subs="attributes,+macros"]
 ----
 apiVersion: agent.k8s.elastic.co/v1alpha1
@@ -215,15 +209,15 @@ stringData:
             period: 10s
 ----
 
-You can use the Fleet application in Kibana to generate configuration for Elastic Agent even when running in standalone mode, see the link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[Elastic Agent standalone] documentation. Adding the corresponding integration package to Kibana also adds the related dashboards and visualizations.
+You can use the Fleet application in Kibana to generate the configuration for Elastic Agent, even when running in standalone mode. Check the link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[Elastic Agent standalone] documentation. Adding the corresponding integration package to Kibana also adds the related dashboards and visualizations.
 
 
-[id="{p}-elastic-agent-multi-output"]
+[id="{p}-elastic-agent-standalone-multi-output"]
 === Use multiple Elastic Agent outputs
 
 Elastic Agent supports the use of multiple outputs. Therefore, the `elasticsearchRefs` element accepts multiple references to Elasticsearch clusters. ECK populates the outputs section of the Elastic Agent configuration based on those references. If you configure more than one output, you also have to specify a unique `outputName` attribute.
 
-To send Elastic Agent's internal monitoring and log data to a different Elasticsearch cluster called `agent-monitoring` in the `elastic-monitoring` namespace, and the harvested metrics to our `quickstart` cluster, you have to define two `elasticsearchRefs` as shown in the following abbreviated example:
+To send Elastic Agent's internal monitoring and log data to a different Elasticsearch cluster called `agent-monitoring` in the `elastic-monitoring` namespace, and the harvested metrics to our `quickstart` cluster, you have to define two `elasticsearchRefs` as shown in the following example:
 
 [source,yaml,subs="attributes,+macros"]
 ----
@@ -255,13 +249,13 @@ spec:
 ...
 ----
 
-[id="{p}-elastic-agent-connect-es"]
+[id="{p}-elastic-agent-standalone-connect-es"]
 === Customize the connection to an Elasticsearch cluster
 
-The `elasticsearchRefs` element allows ECK to automatically configure Elastic Agent to establish a secured connection to one or more managed Elasticsearch clusters. By default it targets all nodes in your cluster. If you want to direct traffic to specific nodes of your Elasticsearch cluster, refer to <<{p}-traffic-splitting>> for more information and examples.
+The `elasticsearchRefs` element allows ECK to automatically configure Elastic Agent to establish a secured connection to one or more managed Elasticsearch clusters. By default, it targets all nodes in your cluster. If you want to direct traffic to specific nodes of your Elasticsearch cluster, refer to <<{p}-traffic-splitting>> for more information and examples.
 
-[id="{p}-elastic-agent-set-output"]
-=== Manually set Elastic Agent outputs
+[id="{p}-elastic-agent-standalone-set-output"]
+=== Set manually Elastic Agent outputs
 
 If the `elasticsearchRefs` element is specified, ECK populates the outputs section of the Elastic Agent configuration. ECK creates a user with appropriate roles and permissions and uses its credentials. If required, it also mounts the CA certificate in all Agent Pods, and recreates Pods when this certificate changes.
 
@@ -287,7 +281,7 @@ spec:
 ...
 ----
 
-[id="{p}-elastic-agent-chose-the-deployment-model"]
+[id="{p}-elastic-agent-standalone-chose-the-deployment-model"]
 === Choose the deployment model
 
 Depending on the use case, Elastic Agent may need to be deployed as a link:https://kubernetes.io/docs/concepts/workloads/controllers/deployment/[Deployment] or a link:https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/[DaemonSet]. Provide a `podTemplate` element under either the `deployment` or the `daemonSet` element in the specification to choose how your Elastic Agents should be deployed. When choosing the `deployment` option you can additionally specify the link:https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy[strategy] used to replace old Pods with new ones.
@@ -310,12 +304,12 @@ spec:
 ...
 ----
 
-See <<{p}-compute-resources-beats-agent>> for more information on how to use the Pod template to adjust the resources given to Elastic Agent.
+Check <<{p}-compute-resources-beats-agent>> for more information on how to use the Pod template to adjust the resources given to Elastic Agent.
 
-[id="{p}-elastic-agent-role-based-access-control"]
+[id="{p}-elastic-agent-standalone-role-based-access-control"]
 === Role Based Access Control for Elastic Agent
 
-Some Elastic Agent features, such as the link:https://epr.elastic.co/package/kubernetes/0.2.8/[Kubernetes integration], require that Agent Pods interact with Kubernetes APIs. This functionality requires specific permissions. Standard Kubernetes link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/[RBAC] rules apply. For example, to allow API interactions:
+Some Elastic Agent features, such as the link:https://epr.elastic.co/package/kubernetes/0.2.8/[Kubernetes integration], require that Agent Pods interact with Kubernetes APIs. This functionality requires specific permissions. The standard Kubernetes link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/[RBAC] rules apply. For example, to allow API interactions:
 
 [source,yaml,subs="attributes,+macros"]
 ----
@@ -379,14 +373,14 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ----
 
-[id="{p}-elastic-agent-deploying-in-secured-clusters"]
+[id="{p}-elastic-agent-standalone-deploying-in-secured-clusters"]
 === Deploying Elastic Agent in secured clusters
 
 To deploy Elastic Agent in clusters with the Pod Security Policy admission controller enabled, or in <<{p}-openshift-agent,OpenShift>> clusters, you might need to grant additional permissions to the Service Account used by the Elastic Agent Pods. Those Service Accounts must be bound to a Role or ClusterRole that has `use` permission for the required Pod Security Policy or Security Context Constraints. Different Elastic Agent integrations might require different settings set in their PSP/link:{p}-openshift-agent.html[SCC].
 
 
-[id="{p}-elastic-agent-configuration-examples"]
-== Configuration Examples
+[id="{p}-elastic-agent-standalone-configuration-examples"]
+== Configuration examples
 
 experimental[]
 

--- a/docs/orchestrating-elastic-stack-applications/orchestrating-elastic-stack-applications.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/orchestrating-elastic-stack-applications.asciidoc
@@ -12,7 +12,8 @@ endif::[]
 - <<{p}-elasticsearch-specification>>
 - <<{p}-kibana>>
 - <<{p}-apm-server>>
-- <<{p}-elastic-agent>>
+- <<{p}-elastic-agent-standalone>>
+- <<{p}-elastic-agent-fleet>>
 - <<{p}-maps>>
 - <<{p}-enterprise-search>>
 - <<{p}-beat>>
@@ -28,7 +29,8 @@ endif::[]
 include::elasticsearch-specification.asciidoc[leveloffset=+1]
 include::kibana.asciidoc[leveloffset=+1]
 include::apm-server.asciidoc[leveloffset=+1]
-include::agent.asciidoc[leveloffset=+1]
+include::agent-standalone.asciidoc[leveloffset=+1]
+include::agent-fleet.asciidoc[leveloffset=+1]
 include::maps.asciidoc[leveloffset=+1]
 include::enterprise-search.asciidoc[leveloffset=+1]
 include::beat.asciidoc[leveloffset=+1]

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -4,7 +4,7 @@
 * Elasticsearch, Kibana, APM Server: 6.8+, 7.1+
 * Enterprise Search: 7.7+
 * Beats: 7.0+
-* Elastic Agent: 7.10+
+* Elastic Agent: 7.10+ (standalone), 7.14+ (Fleet)
 * Elastic Maps Server: 7.11+
 
 ECK should work with all conformant installers as listed in these link:https://github.com/cncf/k8s-conformance/blob/master/faq.md#what-is-a-distribution-hosted-platform-and-an-installer[FAQs]. Distributions include source patches and so may not work as-is with ECK.


### PR DESCRIPTION
Backports the following commits to 1.7:
 - Add docs for Fleet-managed Elastic Agent (#4704)