### PR TITLE
Bump versions in preparation for 1.7.0 release for OLM

### DIFF
--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -1,6 +1,6 @@
-newVersion: 1.6.0
-prevVersion: 1.5.0
-stackVersion: 7.13.4
+newVersion: 1.7.0
+prevVersion: 1.6.0
+stackVersion: 7.14.0
 crds:
   - name: elasticsearches.elasticsearch.k8s.elastic.co
     displayName: Elasticsearch Cluster


### PR DESCRIPTION
The OLM release needs to wait until 7.14.0 becomes available of course, while the ECK 1.7.0 artefacts should be available already.