### PR TITLE
Reverse standalone Agent page id rename to avoid breaking links from other repos

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -10,7 +10,7 @@ endif::[]
 
 experimental[]
 
-This section describes how to configure and deploy Elastic Agent in link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html[Fleet-managed] mode with ECK. Check the link:k8s-elastic-agent-standalone.html[Standalone section] if you want to run Elastic Agent in the link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[standalone mode].
+This section describes how to configure and deploy Elastic Agent in link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html[Fleet-managed] mode with ECK. Check the link:k8s-elastic-agent.html[Standalone section] if you want to run Elastic Agent in the link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[standalone mode].
 
 * <<{p}-elastic-agent-fleet-quickstart,Quickstart>>
 * <<{p}-elastic-agent-fleet-configuration,Configuration>>

--- a/docs/orchestrating-elastic-stack-applications/agent-standalone.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-standalone.asciidoc
@@ -1,4 +1,4 @@
-:page_id: elastic-agent-standalone
+:page_id: elastic-agent
 :agent_recipes: https://raw.githubusercontent.com/elastic/cloud-on-k8s/{eck_release_branch}/config/recipes/elastic-agent
 ifdef::env-github[]
 ****
@@ -10,15 +10,15 @@ endif::[]
 
 experimental[]
 
-This section describes how to configure and deploy Elastic Agent in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[standalone mode] with ECK. Check the link:k8s-elastic-agent-fleet.html[Fleet section] if you want to manage your Elastic Agents with link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html[Fleet].
+This section describes how to configure and deploy Elastic Agent in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent.html[standalone mode] with ECK. Check the link:k8s-elastic-agent-fleet.html[Fleet section] if you want to manage your Elastic Agents with link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html[Fleet].
 
-* <<{p}-elastic-agent-standalone-quickstart,Quickstart>>
-* <<{p}-elastic-agent-standalone-configuration,Configuration>>
-* <<{p}-elastic-agent-standalone-configuration-examples,Configuration examples>>
+* <<{p}-elastic-agent-quickstart,Quickstart>>
+* <<{p}-elastic-agent-configuration,Configuration>>
+* <<{p}-elastic-agent-configuration-examples,Configuration examples>>
 
 NOTE: Running standalone Elastic Agent on ECK is compatible only with Stack versions 7.10+.
 
-[id="{p}-elastic-agent-standalone-quickstart"]
+[id="{p}-elastic-agent-quickstart"]
 == Quickstart
 
 . Apply the following specification to deploy Elastic Agent with the System metrics integration to harvest CPU metrics from the Agent Pods. ECK automatically configures the secured connection to an Elasticsearch cluster named `quickstart`, created in the link:k8s-quickstart.html[Elasticsearch quickstart].
@@ -61,7 +61,7 @@ spec:
 EOF
 ----
 +
-See <<{p}-elastic-agent-standalone-configuration-examples>> for more ready-to-use manifests.
+See <<{p}-elastic-agent-configuration-examples>> for more ready-to-use manifests.
 
 . Monitor the status of Elastic Agent.
 +
@@ -112,18 +112,18 @@ curl -u "elastic:$PASSWORD" -k "https://localhost:9200/metrics-system.cpu-*/_sea
 +
 - Follow the Kibana deployment <<{p}-deploy-kibana,guide>>, log in and go to *Kibana* > *Discover*.
 
-[id="{p}-elastic-agent-standalone-configuration"]
+[id="{p}-elastic-agent-configuration"]
 == Configuration
 
 experimental[]
 
 
-[id="{p}-elastic-agent-standalone-upgrade-specification"]
+[id="{p}-elastic-agent-upgrade-specification"]
 === Upgrade the Elastic Agent specification
 
-You can upgrade the Elastic Agent version or change settings by editing the YAML specification. ECK applies the changes by performing a rolling restart of the Agent's Pods. Depending on the settings that you used, ECK will set the <<{p}-elastic-agent-standalone-set-output,outputs>> part of the configuration, or restart Elastic Agent on certificate rollover.
+You can upgrade the Elastic Agent version or change settings by editing the YAML specification. ECK applies the changes by performing a rolling restart of the Agent's Pods. Depending on the settings that you used, ECK will set the <<{p}-elastic-agent-set-output,outputs>> part of the configuration, or restart Elastic Agent on certificate rollover.
 
-[id="{p}-elastic-agent-standalone-custom-configuration"]
+[id="{p}-elastic-agent-custom-configuration"]
 === Customize the Elastic Agent configuration
 
 The Elastic Agent configuration is defined in the `config` element:
@@ -209,10 +209,10 @@ stringData:
             period: 10s
 ----
 
-You can use the Fleet application in Kibana to generate the configuration for Elastic Agent, even when running in standalone mode. Check the link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[Elastic Agent standalone] documentation. Adding the corresponding integration package to Kibana also adds the related dashboards and visualizations.
+You can use the Fleet application in Kibana to generate the configuration for Elastic Agent, even when running in standalone mode. Check the link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent.html[Elastic Agent standalone] documentation. Adding the corresponding integration package to Kibana also adds the related dashboards and visualizations.
 
 
-[id="{p}-elastic-agent-standalone-multi-output"]
+[id="{p}-elastic-agent-multi-output"]
 === Use multiple Elastic Agent outputs
 
 Elastic Agent supports the use of multiple outputs. Therefore, the `elasticsearchRefs` element accepts multiple references to Elasticsearch clusters. ECK populates the outputs section of the Elastic Agent configuration based on those references. If you configure more than one output, you also have to specify a unique `outputName` attribute.
@@ -249,12 +249,12 @@ spec:
 ...
 ----
 
-[id="{p}-elastic-agent-standalone-connect-es"]
+[id="{p}-elastic-agent-connect-es"]
 === Customize the connection to an Elasticsearch cluster
 
 The `elasticsearchRefs` element allows ECK to automatically configure Elastic Agent to establish a secured connection to one or more managed Elasticsearch clusters. By default, it targets all nodes in your cluster. If you want to direct traffic to specific nodes of your Elasticsearch cluster, refer to <<{p}-traffic-splitting>> for more information and examples.
 
-[id="{p}-elastic-agent-standalone-set-output"]
+[id="{p}-elastic-agent-set-output"]
 === Set manually Elastic Agent outputs
 
 If the `elasticsearchRefs` element is specified, ECK populates the outputs section of the Elastic Agent configuration. ECK creates a user with appropriate roles and permissions and uses its credentials. If required, it also mounts the CA certificate in all Agent Pods, and recreates Pods when this certificate changes.
@@ -281,7 +281,7 @@ spec:
 ...
 ----
 
-[id="{p}-elastic-agent-standalone-chose-the-deployment-model"]
+[id="{p}-elastic-agent-chose-the-deployment-model"]
 === Choose the deployment model
 
 Depending on the use case, Elastic Agent may need to be deployed as a link:https://kubernetes.io/docs/concepts/workloads/controllers/deployment/[Deployment] or a link:https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/[DaemonSet]. Provide a `podTemplate` element under either the `deployment` or the `daemonSet` element in the specification to choose how your Elastic Agents should be deployed. When choosing the `deployment` option you can additionally specify the link:https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy[strategy] used to replace old Pods with new ones.
@@ -306,7 +306,7 @@ spec:
 
 Check <<{p}-compute-resources-beats-agent>> for more information on how to use the Pod template to adjust the resources given to Elastic Agent.
 
-[id="{p}-elastic-agent-standalone-role-based-access-control"]
+[id="{p}-elastic-agent-role-based-access-control"]
 === Role Based Access Control for Elastic Agent
 
 Some Elastic Agent features, such as the link:https://epr.elastic.co/package/kubernetes/0.2.8/[Kubernetes integration], require that Agent Pods interact with Kubernetes APIs. This functionality requires specific permissions. The standard Kubernetes link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/[RBAC] rules apply. For example, to allow API interactions:
@@ -373,18 +373,18 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ----
 
-[id="{p}-elastic-agent-standalone-deploying-in-secured-clusters"]
+[id="{p}-elastic-agent-deploying-in-secured-clusters"]
 === Deploying Elastic Agent in secured clusters
 
 To deploy Elastic Agent in clusters with the Pod Security Policy admission controller enabled, or in <<{p}-openshift-agent,OpenShift>> clusters, you might need to grant additional permissions to the Service Account used by the Elastic Agent Pods. Those Service Accounts must be bound to a Role or ClusterRole that has `use` permission for the required Pod Security Policy or Security Context Constraints. Different Elastic Agent integrations might require different settings set in their PSP/link:{p}-openshift-agent.html[SCC].
 
 
-[id="{p}-elastic-agent-standalone-configuration-examples"]
+[id="{p}-elastic-agent-configuration-examples"]
 == Configuration examples
 
 experimental[]
 
-This section contains manifests that illustrate common use cases, and can be your starting point in exploring Elastic Agent deployed with ECK. These manifests are self-contained and work out-of-the-box on any non-secured Kubernetes cluster. They all contain a three-node Elasticsearch cluster and a single Kibana instance. Add the corresponding integration package to Kibana to install the dashboards, visualizations and other assets for each of these examples as described in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[the Elastic Agent documentation].
+This section contains manifests that illustrate common use cases, and can be your starting point in exploring Elastic Agent deployed with ECK. These manifests are self-contained and work out-of-the-box on any non-secured Kubernetes cluster. They all contain a three-node Elasticsearch cluster and a single Kibana instance. Add the corresponding integration package to Kibana to install the dashboards, visualizations and other assets for each of these examples as described in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent.html[the Elastic Agent documentation].
 
 CAUTION: The examples in this section are for illustration purposes only and should not be considered to be production-ready. Some of these examples use the `node.store.allow_mmap: false` setting which has performance implications and should be tuned for production workloads, as described in <<{p}-virtual-memory>>.
 

--- a/docs/orchestrating-elastic-stack-applications/orchestrating-elastic-stack-applications.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/orchestrating-elastic-stack-applications.asciidoc
@@ -12,7 +12,7 @@ endif::[]
 - <<{p}-elasticsearch-specification>>
 - <<{p}-kibana>>
 - <<{p}-apm-server>>
-- <<{p}-elastic-agent-standalone>>
+- <<{p}-elastic-agent>>
 - <<{p}-elastic-agent-fleet>>
 - <<{p}-maps>>
 - <<{p}-enterprise-search>>

--- a/docs/release-notes/highlights-1.4.0.asciidoc
+++ b/docs/release-notes/highlights-1.4.0.asciidoc
@@ -11,7 +11,7 @@ New and notable changes in version 1.4.0 of {n}. See <<release-notes-1.4.0>> for
 [id="{p}-140-agent-support"]
 ==== Support for Elastic Agent
 
-link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation-configuration.html[Elastic Agent] provides a unified way to monitor logs, metrics, and other types of data from your Kubernetes infrastructure quickly and easily. You can use a single Elastic Agent deployment to replace multiple Beats deployments that were previously required to collect the different types of data you want to monitor. ECK 1.4.0 introduces experimental support for Elastic Agent in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent-standalone.html[standalone mode] as a technology preview.
+link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation-configuration.html[Elastic Agent] provides a unified way to monitor logs, metrics, and other types of data from your Kubernetes infrastructure quickly and easily. You can use a single Elastic Agent deployment to replace multiple Beats deployments that were previously required to collect the different types of data you want to monitor. ECK 1.4.0 introduces experimental support for Elastic Agent in link:https://www.elastic.co/guide/en/fleet/current/run-elastic-agent.html[standalone mode] as a technology preview.
 
 
 [float]


### PR DESCRIPTION
As per doc [build](https://elasticsearch-ci.elastic.co/job/elastic+cloud-on-k8s+pull-request+build-docs/874/console):

```
11:05:02 INFO:build_docs:Bad cross-document links:
11:05:02 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/fleet/7.13/running-on-kubernetes-standalone.html contains broken links to:
11:05:02 INFO:build_docs:   - en/cloud-on-k8s/current/k8s-elastic-agent.html
11:05:02 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/fleet/7.14/elastic-agent-container.html contains broken links to:
11:05:02 INFO:build_docs:   - en/cloud-on-k8s/current/k8s-elastic-agent.html
11:05:02 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/fleet/7.14/running-on-kubernetes-standalone.html contains broken links to:
11:05:02 INFO:build_docs:   - en/cloud-on-k8s/current/k8s-elastic-agent.html
11:05:02 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/fleet/7.x/elastic-agent-container.html contains broken links to:
11:05:02 INFO:build_docs:   - en/cloud-on-k8s/current/k8s-elastic-agent.html
11:05:02 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/fleet/7.x/running-on-kubernetes-standalone.html contains broken links to:
11:05:02 INFO:build_docs:   - en/cloud-on-k8s/current/k8s-elastic-agent.html
11:05:02 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/fleet/current/running-on-kubernetes-standalone.html contains broken links to:
11:05:02 INFO:build_docs:   - en/cloud-on-k8s/current/k8s-elastic-agent.html
11:05:02 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/fleet/master/elastic-agent-container.html contains broken links to:
11:05:02 INFO:build_docs:   - en/cloud-on-k8s/current/k8s-elastic-agent.html
11:05:02 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/fleet/master/running-on-kubernetes-standalone.html contains broken links to:
11:05:02 INFO:build_docs:   - en/cloud-on-k8s/current/k8s-elastic-agent.html
```

Standalone Agent page id has to stay the same as changing it would break Fleet docs that link to it. Also, worth noting, that this was only detected on backport PR to 1.7 and not on a build on master branch.