### PR TITLE
[1.7] Bump versions in preparation for 1.7.0 release for OLM (#4721)

### DIFF
--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -1,6 +1,6 @@
-newVersion: 1.6.0
-prevVersion: 1.5.0
-stackVersion: 7.13.4
+newVersion: 1.7.0
+prevVersion: 1.6.0
+stackVersion: 7.14.0
 crds:
   - name: elasticsearches.elasticsearch.k8s.elastic.co
     displayName: Elasticsearch Cluster


### PR DESCRIPTION
Backports the following commits to 1.7:
 - Bump versions in preparation for 1.7.0 release for OLM (#4721)