### PR TITLE
Bump docs ECK version

### DIFF
--- a/docs/eck-attributes.asciidoc
+++ b/docs/eck-attributes.asciidoc
@@ -1,5 +1,5 @@
-:eck_version: 1.6.0
+:eck_version: 1.7.0
 :eck_crd_version: v1
-:eck_release_branch: 1.6
+:eck_release_branch: 1.7
 :eck_github: https://github.com/elastic/cloud-on-k8s
 :eck_resources_list: Elasticsearch, Kibana, APM Server, Enterprise Search, Beats, and Elastic Agent


### PR DESCRIPTION
So that the `master` documentation uses the latest released ECK `1.7.0` version.