### PR TITLE
Bump versions in samples and CI pipelines after 7.14 release

### DIFF
--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -58,14 +58,14 @@ pipeline {
                 )}"""
             }
             parallel {
-                stage("7.14.0-SNAPSHOT") {
+                stage("7.15.0-SNAPSHOT") {
                      agent {
                         label 'linux'
                     }
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-7x-snapshot-${BUILD_NUMBER}-e2e", "7.14.0-SNAPSHOT")
+                            runWith(lib, failedTests, "eck-7x-snapshot-${BUILD_NUMBER}-e2e", "7.15.0-SNAPSHOT")
                         }
                     }
                 }

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
                         }
                     }
                 }
-                stage("7.13.1") {
+                stage("7.13.4") {
                     agent {
                         label 'linux'
                     }
@@ -131,6 +131,17 @@ pipeline {
                         unstash "source"
                         script {
                             runWith(lib, failedTests, "eck-713-${BUILD_NUMBER}-e2e", "7.13.4")
+                        }
+                    }
+                }
+               stage("7.14.0") {
+                    agent {
+                        label 'linux'
+                    }
+                    steps {
+                        unstash "source"
+                        script {
+                            runWith(lib, failedTests, "eck-714-${BUILD_NUMBER}-e2e", "7.14.0")
                         }
                     }
                 }
@@ -172,6 +183,7 @@ pipeline {
                     "eck-711-${BUILD_NUMBER}-e2e",
                     "eck-712-${BUILD_NUMBER}-e2e",
                     "eck-713-${BUILD_NUMBER}-e2e"
+                    "eck-714-${BUILD_NUMBER}-e2e"
                 ]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -182,7 +182,7 @@ pipeline {
                     "eck-710-${BUILD_NUMBER}-e2e",
                     "eck-711-${BUILD_NUMBER}-e2e",
                     "eck-712-${BUILD_NUMBER}-e2e",
-                    "eck-713-${BUILD_NUMBER}-e2e"
+                    "eck-713-${BUILD_NUMBER}-e2e",
                     "eck-714-${BUILD_NUMBER}-e2e"
                 ]
                 for (int i = 0; i < clusters.size(); i++) {

--- a/Makefile
+++ b/Makefile
@@ -428,7 +428,7 @@ ifneq ($(strip $(E2E_IMG_TAG_SUFFIX)),) # If the suffix is not empty, append it 
 endif
 
 E2E_IMG                    ?= $(REGISTRY)/$(E2E_REGISTRY_NAMESPACE)/eck-e2e-tests:$(E2E_IMG_TAG)
-E2E_STACK_VERSION          ?= 7.13.4
+E2E_STACK_VERSION          ?= 7.14.0
 export TESTS_MATCH         ?= "^Test" # can be overriden to eg. TESTS_MATCH=TestMutationMoreNodes to match a single test
 export E2E_JSON            ?= false
 TEST_TIMEOUT               ?= 30m

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -8,7 +8,7 @@ metadata:
     k8s-app: metricbeat
 spec:
   type: metricbeat
-  version: 7.13.4
+  version: 7.14.0
   config:
     metricbeat.modules:
     - module: kubernetes
@@ -233,7 +233,7 @@ metadata:
     k8s-app: filebeat
 spec:
   type: filebeat
-  version: 7.13.4
+  version: 7.14.0
   config:
     max_backoff: 1s # reduces worst case delay between log being written and picked up by Filebeat to 1s
     close_inactive: 1h # keep harvester open for 1h on inactive files as our test timeout is longer than default 5m

--- a/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
+++ b/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
@@ -4,7 +4,7 @@ metadata:
   name: apm-server-quickstart
   namespace: default
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   config:
     name: elastic-apm

--- a/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
+++ b/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
@@ -84,7 +84,7 @@ metadata:
   name: elasticsearch-sample
   namespace: elasticsearch-ns
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
     - name: default
       count: 1
@@ -97,7 +97,7 @@ metadata:
   name: kibana-sample
   namespace: kibana-ns
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"
@@ -111,7 +111,7 @@ metadata:
   name: apm-apm-sample
   namespace: apmserver-ns
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/config/recipes/autoscaling/elasticsearch.yaml
+++ b/config/recipes/autoscaling/elasticsearch.yaml
@@ -37,7 +37,7 @@ metadata:
           }]
       }
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
     - name: master
       count: 1

--- a/config/recipes/beats/auditbeat_hosts.yaml
+++ b/config/recipes/beats/auditbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: auditbeat
 spec:
   type: auditbeat
-  version: 7.13.4
+  version: 7.14.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -76,7 +76,7 @@ spec:
         #    path: /run
         #initContainers:
         #- name: cos-init
-        #  image: docker.elastic.co/beats/auditbeat:7.13.4
+        #  image: docker.elastic.co/beats/auditbeat:7.14.0
         #  volumeMounts:
         #  - name: run
         #    mountPath: /run
@@ -118,7 +118,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: default
     count: 3
@@ -130,7 +130,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 7.13.4
+  version: 7.14.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -100,7 +100,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: default
     count: 3
@@ -112,7 +112,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
+++ b/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 7.13.4
+  version: 7.14.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -101,7 +101,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: default
     count: 3
@@ -113,7 +113,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_no_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_no_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 7.13.4
+  version: 7.14.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -53,7 +53,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: default
     count: 3
@@ -65,7 +65,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/heartbeat_es_kb_health.yaml
+++ b/config/recipes/beats/heartbeat_es_kb_health.yaml
@@ -4,7 +4,7 @@ metadata:
   name: heartbeat
 spec:
   type: heartbeat
-  version: 7.13.4
+  version: 7.14.0
   elasticsearchRef:
     name: elasticsearch
   config:
@@ -27,7 +27,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: default
     count: 3
@@ -39,7 +39,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/journalbeat_hosts.yaml
+++ b/config/recipes/beats/journalbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: journalbeat
 spec:
   type: journalbeat
-  version: 7.13.4
+  version: 7.14.0
   elasticsearchRef:
     name: elasticsearch
   config:
@@ -49,7 +49,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: default
     count: 3
@@ -61,7 +61,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/metricbeat_hosts.yaml
+++ b/config/recipes/beats/metricbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 7.13.4
+  version: 7.14.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -174,7 +174,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: default
     count: 3
@@ -186,7 +186,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/openshift_monitoring.yaml
+++ b/config/recipes/beats/openshift_monitoring.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 7.13.4
+  version: 7.14.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -221,7 +221,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 7.13.4
+  version: 7.14.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -310,7 +310,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: default
     count: 3
@@ -322,7 +322,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/packetbeat_dns_http.yaml
+++ b/config/recipes/beats/packetbeat_dns_http.yaml
@@ -4,7 +4,7 @@ metadata:
   name: packetbeat
 spec:
   type: packetbeat
-  version: 7.13.4
+  version: 7.14.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -44,7 +44,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: default
     count: 3
@@ -56,7 +56,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -6,7 +6,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 7.13.4
+  version: 7.14.0
   elasticsearchRef:
     name: elasticsearch-monitoring
   config:
@@ -118,7 +118,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 7.13.4
+  version: 7.14.0
   elasticsearchRef:
     name: elasticsearch-monitoring
   kibanaRef:
@@ -216,7 +216,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: default
     count: 3
@@ -235,7 +235,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -252,7 +252,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-monitoring
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: default
     count: 3
@@ -264,7 +264,7 @@ kind: Kibana
 metadata:
   name: kibana-monitoring
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: elasticsearch-monitoring

--- a/config/recipes/elastic-agent/kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/kubernetes-integration.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 7.13.4
+  version: 7.14.0
   elasticsearchRefs:
   - name: elasticsearch
   daemonSet:
@@ -175,7 +175,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: default
     count: 3
@@ -187,7 +187,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/elastic-agent/system-integration.yaml
+++ b/config/recipes/elastic-agent/system-integration.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 7.13.4
+  version: 7.14.0
   elasticsearchRefs:
   - name: elasticsearch
   daemonSet:
@@ -34,7 +34,7 @@ spec:
       meta:
         package:
           name: system
-          version: 7.13.4
+          version: 7.14.0
       data_stream:
         namespace: default
       streams:
@@ -139,7 +139,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: default
     count: 3
@@ -151,7 +151,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/gclb/01-elastic-stack.yaml
+++ b/config/recipes/gclb/01-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 7.13.4
+  version: 7.14.0
   http:
     service:
       metadata:
@@ -45,7 +45,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   http:
     service:

--- a/config/recipes/gclb/99-kibana-path.yaml
+++ b/config/recipes/gclb/99-kibana-path.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: thor
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   config:
     # Make Kibana aware of the fact that it is behind a proxy

--- a/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
+++ b/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 7.13.4
+  version: 7.14.0
   http:
     tls:
       selfSignedCertificate:
@@ -97,7 +97,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   http:
     tls:

--- a/config/recipes/logstash/logstash.yaml
+++ b/config/recipes/logstash/logstash.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: eck-logstash
     app.kubernets.io/component: elasticsearch
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
     - name: default
       count: 3
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/name: eck-logstash
     app.kubernets.io/component: kibana
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -92,7 +92,7 @@ spec:
     spec:
       containers:
         - name: logstash
-          image: docker.elastic.co/logstash/logstash:7.13.4
+          image: docker.elastic.co/logstash/logstash:7.14.0
           ports:
             - name: "tcp-beats"
               containerPort: 5044
@@ -150,7 +150,7 @@ metadata:
     app.kubernets.io/component: filebeat
 spec:
   type: filebeat
-  version: 7.13.4
+  version: 7.14.0
   config:
     filebeat.inputs:
       - type: log

--- a/config/recipes/maps/01-ems-es.yaml
+++ b/config/recipes/maps/01-ems-es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: default
     count: 3
@@ -27,7 +27,7 @@ kind: ElasticMapsServer
 metadata:
   name: ems-sample
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/maps/02-kb.yaml
+++ b/config/recipes/maps/02-kb.yaml
@@ -4,7 +4,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   config:
     # Configure this to a domain you control

--- a/config/recipes/traefik/02-elastic-stack.yaml
+++ b/config/recipes/traefik/02-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: master
     count: 1
@@ -56,7 +56,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: hulk
@@ -68,7 +68,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: hulk

--- a/config/samples/apm/apm_es_kibana.yaml
+++ b/config/samples/apm/apm_es_kibana.yaml
@@ -5,7 +5,7 @@ kind: Elasticsearch
 metadata:
   name: es-apm-sample
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: default
     count: 3
@@ -19,7 +19,7 @@ kind: Kibana
 metadata:
   name: kb-apm-sample
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"
@@ -29,7 +29,7 @@ kind: ApmServer
 metadata:
   name: apm-apm-sample
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"

--- a/config/samples/apm/apmserver.yaml
+++ b/config/samples/apm/apmserver.yaml
@@ -3,7 +3,7 @@ kind: ApmServer
 metadata:
   name: apmserver-sample
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   config:
     output.console:

--- a/config/samples/elasticsearch/elasticsearch.yaml
+++ b/config/samples/elasticsearch/elasticsearch.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: default
     config:

--- a/config/samples/enterprisesearch/ent_es.yaml
+++ b/config/samples/enterprisesearch/ent_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
     - name: default
       count: 1
@@ -18,7 +18,7 @@ kind: EnterpriseSearch
 metadata:
   name: ent-sample
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: elasticsearch-sample

--- a/config/samples/kibana/kibana_es.yaml
+++ b/config/samples/kibana/kibana_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - name: default
     count: 1
@@ -18,7 +18,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/pkg/controller/elasticsearch/stackmon/filebeat.yml
+++ b/pkg/controller/elasticsearch/stackmon/filebeat.yml
@@ -1,5 +1,5 @@
 filebeat.modules:
-  # https://www.elastic.co/guide/en/beats/filebeat/7.13/filebeat-module-elasticsearch.html
+  # https://www.elastic.co/guide/en/beats/filebeat/7.14/filebeat-module-elasticsearch.html
   - module: elasticsearch
     server:
       enabled: true

--- a/pkg/controller/elasticsearch/stackmon/metricbeat.tpl.yml
+++ b/pkg/controller/elasticsearch/stackmon/metricbeat.tpl.yml
@@ -1,5 +1,5 @@
 metricbeat.modules:
-  # https://www.elastic.co/guide/en/beats/metricbeat/7.13/metricbeat-module-elasticsearch.html
+  # https://www.elastic.co/guide/en/beats/metricbeat/7.14/metricbeat-module-elasticsearch.html
   - module: elasticsearch
     metricsets:
       - ccr

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -95,7 +95,7 @@ var (
 		},
 		// StackMonitoringUserRole is a dedicated role for Stack Monitoring with Metricbeat and Filebeat used for the
 		// user sending monitoring data.
-		// See: https://www.elastic.co/guide/en/beats/filebeat/7.13/privileges-to-publish-monitoring.html.
+		// See: https://www.elastic.co/guide/en/beats/filebeat/7.14/privileges-to-publish-monitoring.html.
 		StackMonitoringUserRole: esclient.Role{
 			Cluster: []string{
 				"monitor",

--- a/pkg/controller/kibana/stackmon/filebeat.yml
+++ b/pkg/controller/kibana/stackmon/filebeat.yml
@@ -1,5 +1,5 @@
 filebeat.modules:
-  # https://www.elastic.co/guide/en/beats/filebeat/7.13/filebeat-module-kibana.html
+  # https://www.elastic.co/guide/en/beats/filebeat/7.14/filebeat-module-kibana.html
   - module: kibana
     log:
       enabled: true

--- a/pkg/controller/kibana/stackmon/metricbeat.tpl.yml
+++ b/pkg/controller/kibana/stackmon/metricbeat.tpl.yml
@@ -1,5 +1,5 @@
 metricbeat.modules:
-  # https://www.elastic.co/guide/en/beats/metricbeat/7.13/metricbeat-module-kibana.html
+  # https://www.elastic.co/guide/en/beats/metricbeat/7.14/metricbeat-module-kibana.html
   - module: kibana
     metricsets:
       - stats

--- a/test/e2e/kb/testdata/kibana_standalone.yaml
+++ b/test/e2e/kb/testdata/kibana_standalone.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: {{ .ESName }}
 spec:
-  version: 7.13.4
+  version: 7.14.0
   nodeSets:
   - count: 1
     name: mdi
@@ -18,7 +18,7 @@ kind: Kibana
 metadata:
   name: test-kibana-standalone-{{ .Suffix }}
 spec:
-  version: 7.13.4
+  version: 7.14.0
   count: 1
   config:
     elasticsearch.hosts:

--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -33,8 +33,8 @@ import (
 // TestVersionUpgradeOrdering deploys the entire stack, with resources associated together.
 // Then, it updates their version, and ensures a strict ordering is respected during the version upgrade.
 func TestVersionUpgradeOrdering(t *testing.T) {
-	initialVersion := "7.12.1"
-	updatedVersion := "7.13.4"
+	initialVersion := "7.13.4"
+	updatedVersion := "7.14.0"
 
 	// upgrading the entire stack can take some time, since we need to account for (in order):
 	// - Elasticsearch rolling upgrade

--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -16,7 +16,7 @@ const (
 	// Minimum version for 6.8.x tested with the operator
 	MinVersion68x = "6.8.17"
 	// Current latest version for 7.x
-	LatestVersion7x = "7.13.4" // version to synchronize with the latest release of the Elastic Stack
+	LatestVersion7x = "7.14.0" // version to synchronize with the latest release of the Elastic Stack
 )
 
 // SkipInvalidUpgrade skips a test that would do an invalid upgrade.


### PR DESCRIPTION
Updates our samples to use 7.14 and also adds a 7.14 test pipeline and a 7.15.0-SNAPSHOT test
