### PR TITLE
Add missing permissions to E2E runner

### DIFF
--- a/config/e2e/rbac.yaml
+++ b/config/e2e/rbac.yaml
@@ -161,6 +161,24 @@ rules:
     - get
     - list
     - watch
+    # for Elastic Agent in Fleet mode
+  - apiGroups:
+    - "coordination.k8s.io"
+    resources:
+    - leases
+    verbs:
+    - get
+    - create
+    - update
+    # for Elastic Agent Kubernetes integration
+  - apiGroups:
+    - "batch"
+    resources:
+    - jobs
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
   - apiGroups:
       - elasticsearch.k8s.elastic.co
     resources:


### PR DESCRIPTION
E2E runner was missing permissions that are needed in Elastic Agent role that it attempts to create. Fixes [failed](https://devops-ci.elastic.co/view/cloud-on-k8s/job/cloud-on-k8s-e2e-tests-snapshot-versions/375/testReport/) E2E tests.

Tested with `make E2E_JSON=true E2E_STACK_VERSION=7.14.0 TESTS_MATCH=TestFleet.*Recipe clean docker-build docker-push e2e-docker-build e2e-docker-push e2e-run` on PSP cluster.