### PR TITLE
[1.7] Add missing permissions to E2E runner (#4731)

### DIFF
--- a/config/e2e/rbac.yaml
+++ b/config/e2e/rbac.yaml
@@ -161,6 +161,24 @@ rules:
     - get
     - list
     - watch
+    # for Elastic Agent in Fleet mode
+  - apiGroups:
+    - "coordination.k8s.io"
+    resources:
+    - leases
+    verbs:
+    - get
+    - create
+    - update
+    # for Elastic Agent Kubernetes integration
+  - apiGroups:
+    - "batch"
+    resources:
+    - jobs
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
   - apiGroups:
       - elasticsearch.k8s.elastic.co
     resources:


### PR DESCRIPTION
Backports the following commits to 1.7:
 - Add missing permissions to E2E runner (#4731)