### PR TITLE
Update and reuse ECK resources list for the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Elastic Cloud on Kubernetes (ECK)
 
-Elastic Cloud on Kubernetes automates the deployment, provisioning, management, and orchestration of Elasticsearch, Kibana, APM Server, Enterprise Search, and Beats on Kubernetes based on the operator pattern.
+Elastic Cloud on Kubernetes automates the deployment, provisioning, management, and orchestration of Elasticsearch, Kibana, APM Server, Enterprise Search, Beats, Elastic Agent, and Elastic Maps Server on Kubernetes based on the operator pattern.
 
 Current features:
 

--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -50,7 +50,7 @@ oc apply -f https://download.elastic.co/downloads/eck/{eck_version}/operator.yam
 oc adm pod-network make-projects-global elastic-system
 ----
 
-. Create a namespace to hold the Elastic resources (Elasticsearch, Kibana):
+. Create a namespace to hold the Elastic resources ({eck_resources_list}):
 +
 [source,shell]
 ----

--- a/docs/eck-attributes.asciidoc
+++ b/docs/eck-attributes.asciidoc
@@ -2,4 +2,4 @@
 :eck_crd_version: v1
 :eck_release_branch: 1.7
 :eck_github: https://github.com/elastic/cloud-on-k8s
-:eck_resources_list: Elasticsearch, Kibana, APM Server, Enterprise Search, Beats, and Elastic Agent
+:eck_resources_list: Elasticsearch, Kibana, APM Server, Enterprise Search, Beats, Elastic Agent, and Elastic Maps Server

--- a/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
@@ -7,7 +7,7 @@ endif::[]
 [id="{p}-{page_id}"]
 = Manage compute resources
 
-To help the Kubernetes scheduler correctly place Pods in available Kubernetes nodes and ensure quality of service (QoS), it is recommended to specify the CPU and memory requirements for objects managed by the operator (Elasticsearch, Kibana or APM Server). In Kubernetes, `requests` defines the minimum amount of resources that must be available for a Pod to be scheduled; `limits` defines the maximum amount of resources that a Pod is allowed to consume. For more information about how Kubernetes uses these concepts, see: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/[Managing Compute Resources for Containers].
+To help the Kubernetes scheduler correctly place Pods in available Kubernetes nodes and ensure quality of service (QoS), it is recommended to specify the CPU and memory requirements for objects managed by the operator ({eck_resources_list}}). In Kubernetes, `requests` defines the minimum amount of resources that must be available for a Pod to be scheduled; `limits` defines the maximum amount of resources that a Pod is allowed to consume. For more information about how Kubernetes uses these concepts, see: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/[Managing Compute Resources for Containers].
 
 [float]
 [id="{p}-compute-resources"]

--- a/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
@@ -7,7 +7,7 @@ endif::[]
 [id="{p}-{page_id}"]
 = Manage compute resources
 
-To help the Kubernetes scheduler correctly place Pods in available Kubernetes nodes and ensure quality of service (QoS), it is recommended to specify the CPU and memory requirements for objects managed by the operator ({eck_resources_list}}). In Kubernetes, `requests` defines the minimum amount of resources that must be available for a Pod to be scheduled; `limits` defines the maximum amount of resources that a Pod is allowed to consume. For more information about how Kubernetes uses these concepts, see: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/[Managing Compute Resources for Containers].
+To help the Kubernetes scheduler correctly place Pods in available Kubernetes nodes and ensure quality of service (QoS), it is recommended to specify the CPU and memory requirements for objects managed by the operator ({eck_resources_list}). In Kubernetes, `requests` defines the minimum amount of resources that must be available for a Pod to be scheduled; `limits` defines the maximum amount of resources that a Pod is allowed to consume. For more information about how Kubernetes uses these concepts, see: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/[Managing Compute Resources for Containers].
 
 [float]
 [id="{p}-compute-resources"]

--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -9,7 +9,7 @@ endif::[]
 
 [partintro]
 --
-Built on the Kubernetes Operator pattern, Elastic Cloud on Kubernetes (ECK) extends the basic Kubernetes orchestration capabilities to support the setup and management of Elasticsearch, Kibana, APM Server, Enterprise Search, and Beats on Kubernetes.
+Built on the Kubernetes Operator pattern, Elastic Cloud on Kubernetes (ECK) extends the basic Kubernetes orchestration capabilities to support the setup and management of {eck_resources_list} on Kubernetes.
 
 With Elastic Cloud on Kubernetes you can streamline critical operations, such as:
 

--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -16,10 +16,10 @@ This glossary supplements the link:https://kubernetes.io/docs/reference/glossary
   Can refer to either an link:https://www.elastic.co/guide/en/elasticsearch/reference/current/add-elasticsearch-nodes.html[Elasticsearch cluster] or a Kubernetes cluster depending on the context.
 
 [[CRD]]CRD::
-  link:https://kubernetes.io/docs/reference/glossary/?fundamental=true#term-CustomResourceDefinition[Custom Resource Definition]. ECK extends the Kubernetes API with CRDs to allow users to deploy and manage Elasticsearch, Kibana and APM server resources just as they would do with built-in Kubernetes resources.
+  link:https://kubernetes.io/docs/reference/glossary/?fundamental=true#term-CustomResourceDefinition[Custom Resource Definition]. ECK extends the Kubernetes API with CRDs to allow users to deploy and manage {eck_resources_list} resources just as they would do with built-in Kubernetes resources.
 
 [[ECK]]ECK::
-  Elastic Cloud on Kubernetes. Kubernetes operator to orchestrate Elasticsearch, Kibana and APM Server deployments on Kubernetes.
+  Elastic Cloud on Kubernetes. Kubernetes operator to orchestrate {eck_resources_list} deployments on Kubernetes.
 
 [[EKS]]EKS::
   link:https://aws.amazon.com/eks/[Elastic Kubernetes Service]. Managed Kubernetes service provided by Amazon Web Services (AWS).


### PR DESCRIPTION
* Add "Elastic Maps Server" to the `eck_resources_list` variable
* Use `{eck_resources_list}` for completeness in a few places
* Sync the README

Resolves #3614