### PR TITLE
[1.7] Fix typo in CRDs url in the documentation (#4744)

### DIFF
--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -39,7 +39,7 @@ For more information, see <<{p}-virtual-memory>>.
 +
 [source,shell,subs="attributes"]
 ----
-oc create -f https://download.elasti.co/downloads/eck/{eck_version}/crds.yaml
+oc create -f https://download.elastic.co/downloads/eck/{eck_version}/crds.yaml
 oc apply -f https://download.elastic.co/downloads/eck/{eck_version}/operator.yaml
 ----
 


### PR DESCRIPTION
Backports the following commits to 1.7:
* #4744 