### PR TITLE
Re-enable license tests and monitoring on ARM

### DIFF
--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -326,8 +326,8 @@ E2E_REGISTRY_NAMESPACE=eck-ci
 GO_TAGS=release
 E2E_TAGS=es kb apm ent beat agent
 export LICENSE_PUBKEY=/go/src/github.com/elastic/cloud-on-k8s/.ci/license.key
-# TEST_LICENSE=/go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json disabled b/c https://github.com/elastic/elasticsearch/issues/68083
-# MONITORING_SECRETS=/go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json disabled b/c beats cannot run on ARM
+TEST_LICENSE=/go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json disabled b/c https://github.com/elastic/elasticsearch/issues/68083
+MONITORING_SECRETS=/go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json disabled b/c beats cannot run on ARM
 
 OPERATOR_IMAGE=$JKS_PARAM_OPERATOR_IMAGE
 


### PR DESCRIPTION
Fixes #4164

Reenables the license related tests on ARM and the monitoring with Filebeat/Metricbeat. I did a quick test run on EKS and the license tests passed.

Elastic Maps Server does not offer an ARM build.