### PR TITLE
OCP testing for  4.8 and previous versions

### DIFF
--- a/.ci/jobs/e2e-tests-ocp-all-but-latest.yaml
+++ b/.ci/jobs/e2e-tests-ocp-all-but-latest.yaml
@@ -18,7 +18,7 @@
     pipeline-scm:
       scm:
         - git:
-            url: https://github.com/elastic/cloud-on-k8s
+            url: https://github.com/pebrc/cloud-on-k8s
             branches:
               - ${branch_specifier}
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'

--- a/.ci/jobs/e2e-tests-ocp-all-but-latest.yaml
+++ b/.ci/jobs/e2e-tests-ocp-all-but-latest.yaml
@@ -1,0 +1,27 @@
+---
+- job:
+    description: Run ECK E2E tests on all but the latest version of OpenShift
+    name: cloud-on-k8s-e2e-tests-ocp-all-but-latest
+    project-type: pipeline
+    parameters:
+      - string:
+          name: branch_specifier
+          default: master
+          description: "the Git branch specifier to build (&lt;branchName&gt;,&lt;tagName&gt;, &lt;commitId&gt;, etc.)"
+      - string:
+          name: JKS_PARAM_OPERATOR_IMAGE
+          description: "ECK Docker image"
+      - bool:
+          name: SEND_NOTIFICATIONS
+          default: true
+          description: "Specified if job should send notifications to Slack. Enabled by default."
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/elastic/cloud-on-k8s
+            branches:
+              - ${branch_specifier}
+            credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
+            refspec: ${branch_specifier}
+      script-path: .ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
+      lightweight-checkout: false

--- a/.ci/jobs/e2e-tests-ocp-all-but-latest.yaml
+++ b/.ci/jobs/e2e-tests-ocp-all-but-latest.yaml
@@ -18,7 +18,7 @@
     pipeline-scm:
       scm:
         - git:
-            url: https://github.com/pebrc/cloud-on-k8s
+            url: https://github.com/elastic/cloud-on-k8s
             branches:
               - ${branch_specifier}
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'

--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -110,7 +110,7 @@ pipeline {
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                     parameters: [
                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
-                        string(name: 'OCP_VERSION', value: "4.8.5"),
+                        string(name: 'OCP_VERSION', value: "4.8.8"),
                         string(name: 'branch_specifier', value: GIT_COMMIT)
                     ],
                     wait: false

--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -106,6 +106,7 @@ pipeline {
                     ],
                     wait: false
 
+                // test the latest version of OCP on every build
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                     parameters: [
                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
@@ -114,12 +115,13 @@ pipeline {
                     ],
                     wait: false
 
+                // schedule another job for all the older 4.x OCP versions which runs only on Fridays (via when directive in job)
                 build job: 'cloud-on-k8s-e2e-tests-ocp-all-but-latest',
                     parameters: [
                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
                         string(name: 'branch_specifier', value: GIT_COMMIT)
                     ],
-                    quietPeriod: 43200,
+                    quietPeriod: 86400, // add a 24 hour delay to this job to run it over the weekend
                     wait: false
 
                 build job: 'cloud-on-k8s-e2e-tests-eks',

--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -109,9 +109,18 @@ pipeline {
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                     parameters: [
                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
-                        string(name: 'OCP_VERSION', value: "4.8.5")
+                        string(name: 'OCP_VERSION', value: "4.8.5"),
                         string(name: 'branch_specifier', value: GIT_COMMIT)
                     ],
+                    wait: false
+
+                build job: 'cloud-on-k8s-e2e-tests-ocp-all-but-latest',
+                    parameters: [
+                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
+                        string(name: 'OCP_VERSION', value: "4.8.5"),
+                        string(name: 'branch_specifier', value: GIT_COMMIT)
+                    ],
+                    quietPeriod: 43200,
                     wait: false
 
                 build job: 'cloud-on-k8s-e2e-tests-eks',

--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -117,7 +117,6 @@ pipeline {
                 build job: 'cloud-on-k8s-e2e-tests-ocp-all-but-latest',
                     parameters: [
                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
-                        string(name: 'OCP_VERSION', value: "4.8.5"),
                         string(name: 'branch_specifier', value: GIT_COMMIT)
                     ],
                     quietPeriod: 43200,

--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -109,6 +109,7 @@ pipeline {
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                     parameters: [
                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
+                        string(name: 'OCP_VERSION', value: "4.8.5")
                         string(name: 'branch_specifier', value: GIT_COMMIT)
                     ],
                     wait: false

--- a/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
@@ -1,0 +1,91 @@
+// This library overrides the default checkout behavior to enable sleep+retries if there are errors
+// Added to help overcome some recurring github connection issues
+@Library('apm@current') _
+
+def failedTests = []
+def lib
+
+pipeline {
+
+    agent {
+        label 'linux'
+    }
+
+    options {
+        timeout(time: 600, unit: 'MINUTES')
+        quietPeriod(43200) // delay this job by 12 hours
+    }
+
+    environment {
+        VAULT_ADDR = credentials('vault-addr')
+        VAULT_ROLE_ID = credentials('vault-role-id')
+        VAULT_SECRET_ID = credentials('vault-secret-id')
+        GCLOUD_PROJECT = credentials('k8s-operators-gcloud-project')
+    }
+
+    stages {
+        stage('Load common scripts') {
+            steps {
+                script {
+                    lib = load ".ci/common/tests.groovy"
+                }
+            }
+        }
+        stage("Run E2E tests") {
+            when {
+               expression {
+                    // this is a downstream job but let's not run it every day due to the amount of resources
+                    // it requires
+                    isFriday()
+               }
+            }
+            steps {
+                // "4.3.40", "4.4.33", "4.5.37", "4.6.24", "4.7.6"
+                // 4.8.5 is taken care of by a separate job
+                build job: 'cloud-on-k8s-e2e-tests-ocp',
+                                    parameters: [
+                                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: $JKS_PARAM_OPERATOR_IMAGE),
+                                        string(name: 'OCP_VERSION', value: "4.4.40")
+                                        string(name: 'branch_specifier', value: GIT_COMMIT)
+                                    ],
+                                    wait: true
+                build job: 'cloud-on-k8s-e2e-tests-ocp',
+                                    parameters: [
+                                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: $JKS_PARAM_OPERATOR_IMAGE),
+                                        string(name: 'OCP_VERSION', value: "4.4.33")
+                                        string(name: 'branch_specifier', value: GIT_COMMIT)
+                                    ],
+                                    wait: true
+                build job: 'cloud-on-k8s-e2e-tests-ocp',
+                                    parameters: [
+                                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: $JKS_PARAM_OPERATOR_IMAGE),
+                                        string(name: 'OCP_VERSION', value: "4.5.37")
+                                        string(name: 'branch_specifier', value: GIT_COMMIT)
+                                    ],
+                                    wait: true
+                build job: 'cloud-on-k8s-e2e-tests-ocp',
+                                    parameters: [
+                                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: $JKS_PARAM_OPERATOR_IMAGE),
+                                        string(name: 'OCP_VERSION', value: "4.6.24")
+                                        string(name: 'branch_specifier', value: GIT_COMMIT)
+                                    ],
+                                    wait: true
+                build job: 'cloud-on-k8s-e2e-tests-ocp',
+                                    parameters: [
+                                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: $JKS_PARAM_OPERATOR_IMAGE),
+                                        string(name: 'OCP_VERSION', value: "4.7/7")
+                                        string(name: 'branch_specifier', value: GIT_COMMIT)
+                                    ],
+                                    wait: true
+            }
+        }
+    }
+}
+
+def isFriday() {
+    // %u day of week (1..7); 1 is Monday 5 is Friday
+    return sh (
+        script: "date +%u",
+    	returnStatus: true
+    ) == 5
+}

--- a/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 48, unit: 'HOURS')
+        timeout(time: 50, unit: 'HOURS')
     }
 
     environment {
@@ -40,7 +40,7 @@ pipeline {
             }
             steps {
                 // "4.3.40", "4.4.33", "4.5.37", "4.6.24", "4.7.6"
-                // 4.8.5 is taken care of by a separate job
+                // latest 4.8.x is taken care of by a separate job
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
                                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: JKS_PARAM_OPERATOR_IMAGE),

--- a/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 600, unit: 'MINUTES')
+        timeout(time: 48, unit: 'HOURS')
     }
 
     environment {

--- a/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
@@ -1,6 +1,6 @@
 // This library overrides the default checkout behavior to enable sleep+retries if there are errors
 // Added to help overcome some recurring github connection issues
-@Library('apm@current') _
+// @Library('apm@current') _
 
 def failedTests = []
 def lib

--- a/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
@@ -43,35 +43,35 @@ pipeline {
                 // 4.8.5 is taken care of by a separate job
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
-                                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: $JKS_PARAM_OPERATOR_IMAGE),
+                                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: JKS_PARAM_OPERATOR_IMAGE),
                                         string(name: 'OCP_VERSION', value: "4.4.40"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
                                     wait: true
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
-                                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: $JKS_PARAM_OPERATOR_IMAGE),
+                                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: JKS_PARAM_OPERATOR_IMAGE),
                                         string(name: 'OCP_VERSION', value: "4.4.33"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
                                     wait: true
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
-                                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: $JKS_PARAM_OPERATOR_IMAGE),
+                                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: JKS_PARAM_OPERATOR_IMAGE),
                                         string(name: 'OCP_VERSION', value: "4.5.37"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
                                     wait: true
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
-                                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: $JKS_PARAM_OPERATOR_IMAGE),
+                                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: JKS_PARAM_OPERATOR_IMAGE),
                                         string(name: 'OCP_VERSION', value: "4.6.24"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
                                     wait: true
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
-                                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: $JKS_PARAM_OPERATOR_IMAGE),
+                                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: JKS_PARAM_OPERATOR_IMAGE),
                                         string(name: 'OCP_VERSION', value: "4.7/7"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
@@ -85,6 +85,6 @@ def isFriday() {
     // %u day of week (1..7); 1 is Monday 5 is Friday
     return sh (
         script: "date +%u",
-    	returnStatus: true
-    ) == 5
+        returnStdout: true
+    ) as Integer == 5
 }

--- a/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
@@ -1,6 +1,6 @@
 // This library overrides the default checkout behavior to enable sleep+retries if there are errors
 // Added to help overcome some recurring github connection issues
-// @Library('apm@current') _
+@Library('apm@current') _
 
 def failedTests = []
 def lib

--- a/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
                }
             }
             steps {
-                // "4.3.40", "4.4.33", "4.5.37", "4.6.24", "4.7.6"
+                // "4.3.x", "4.4.x", "4.5.x", "4.6.x", "4.7.x"
                 // latest 4.8.x is taken care of by a separate job
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
@@ -58,21 +58,21 @@ pipeline {
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
                                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: JKS_PARAM_OPERATOR_IMAGE),
-                                        string(name: 'OCP_VERSION', value: "4.5.37"),
+                                        string(name: 'OCP_VERSION', value: "4.5.41"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
                                     wait: true
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
                                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: JKS_PARAM_OPERATOR_IMAGE),
-                                        string(name: 'OCP_VERSION', value: "4.6.24"),
+                                        string(name: 'OCP_VERSION', value: "4.6.43"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
                                     wait: true
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
                                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: JKS_PARAM_OPERATOR_IMAGE),
-                                        string(name: 'OCP_VERSION', value: "4.7.6"),
+                                        string(name: 'OCP_VERSION', value: "4.7.27"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
                                     wait: true

--- a/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
@@ -45,35 +45,35 @@ pipeline {
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
                                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: $JKS_PARAM_OPERATOR_IMAGE),
-                                        string(name: 'OCP_VERSION', value: "4.4.40")
+                                        string(name: 'OCP_VERSION', value: "4.4.40"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
                                     wait: true
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
                                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: $JKS_PARAM_OPERATOR_IMAGE),
-                                        string(name: 'OCP_VERSION', value: "4.4.33")
+                                        string(name: 'OCP_VERSION', value: "4.4.33"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
                                     wait: true
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
                                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: $JKS_PARAM_OPERATOR_IMAGE),
-                                        string(name: 'OCP_VERSION', value: "4.5.37")
+                                        string(name: 'OCP_VERSION', value: "4.5.37"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
                                     wait: true
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
                                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: $JKS_PARAM_OPERATOR_IMAGE),
-                                        string(name: 'OCP_VERSION', value: "4.6.24")
+                                        string(name: 'OCP_VERSION', value: "4.6.24"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
                                     wait: true
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
                                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: $JKS_PARAM_OPERATOR_IMAGE),
-                                        string(name: 'OCP_VERSION', value: "4.7/7")
+                                        string(name: 'OCP_VERSION', value: "4.7/7"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
                                     wait: true

--- a/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
                                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: JKS_PARAM_OPERATOR_IMAGE),
-                                        string(name: 'OCP_VERSION', value: "4.4.40"),
+                                        string(name: 'OCP_VERSION', value: "4.3.40"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
                                     wait: true
@@ -72,7 +72,7 @@ pipeline {
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
                                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: JKS_PARAM_OPERATOR_IMAGE),
-                                        string(name: 'OCP_VERSION', value: "4.7/7"),
+                                        string(name: 'OCP_VERSION', value: "4.7.6"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
                                     wait: true

--- a/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
@@ -13,7 +13,6 @@ pipeline {
 
     options {
         timeout(time: 600, unit: 'MINUTES')
-        quietPeriod(43200) // delay this job by 12 hours
     }
 
     environment {

--- a/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
@@ -4,16 +4,7 @@
 
 def failedTests = []
 def lib
-def ocpVersion
-
-def pickVersion(extParam) {
-    supportedVersions = ["4.3.40", "4.4.33", "4.5.37", "4.6.24", "4.7.6" ]
-    if (extParam != '') {
-        return extParam
-    }
-    idx = java.util.Calendar.getInstance().get(java.util.Calendar.DAY_OF_WEEK) % supportedVersions.size()
-    return supportedVersions[idx]
-}
+def ocpVersion = params.OCP_VERSION
 
 pipeline {
 
@@ -37,7 +28,6 @@ pipeline {
             steps {
                 script {
                     lib = load ".ci/common/tests.groovy"
-                    ocpVersion = pickVersion(params.OCP_VERSION)
                 }
             }
         }


### PR DESCRIPTION
This adds 
* testing for the latest version of OCP to be run daily
* testing for all the other supported versions of OCP to be run once a week triggered by the Friday nightly and run with a 12 hour delay
* these other OCP tests are expected to run into the weekend (estimated sequential runtime should be around 25 hours or so)

This is at this point just a sketch of how I think we could set up the tests. I have not tested this yet extensively but maybe we can get some initial feedback for the general approach.