### PR TITLE
Disable TestEnterpriseSearchVersionUpgradeToLatest7x

### DIFF
--- a/test/e2e/ent/ent_test.go
+++ b/test/e2e/ent/ent_test.go
@@ -49,6 +49,8 @@ func TestEnterpriseSearchTLSDisabled(t *testing.T) {
 }
 
 func TestEnterpriseSearchVersionUpgradeToLatest7x(t *testing.T) {
+	t.Skip() // pending resolution of https://github.com/elastic/cloud-on-k8s/issues/4755
+
 	srcVersion := test.Ctx().ElasticStackVersion
 	dstVersion := test.LatestVersion7x
 


### PR DESCRIPTION
Since we bump the Elastic Stack version to 7.14.0, the test is failing.
It tries a direct upgrade from 7.7.1 to 7.14 and the failure seems to be in the
migration. This test is temporarily disabled until the issue is fixed in
Enterprise Search.

Relates to #4755.