### PR TITLE
Reenable standalone Agent recipe test

### DIFF
--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -44,7 +44,6 @@ func TestSystemIntegrationRecipe(t *testing.T) {
 }
 
 func TestKubernetesIntegrationRecipe(t *testing.T) {
-	t.Skip() // pending resolution of https://github.com/elastic/cloud-on-k8s/issues/4360
 	customize := func(builder agent.Builder) agent.Builder {
 		return builder.
 			WithRoles(agent.PSPClusterRoleName).


### PR DESCRIPTION
Referenced https://github.com/elastic/cloud-on-k8s/issues/4360 issue is fixed now.