### PR TITLE
Remove x-kubernetes-preserve-unknown-fields from volumeClaimTemplates

### DIFF
--- a/config/crds/v1/all-crds.yaml
+++ b/config/crds/v1/all-crds.yaml
@@ -3894,7 +3894,6 @@ spec:
                             type: object
                         type: object
                       type: array
-                      x-kubernetes-preserve-unknown-fields: true
                   required:
                   - name
                   type: object

--- a/config/crds/v1/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
+++ b/config/crds/v1/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
@@ -8057,7 +8057,6 @@ spec:
                             type: object
                         type: object
                       type: array
-                      x-kubernetes-preserve-unknown-fields: true
                   required:
                   - name
                   type: object

--- a/config/crds/v1beta1/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
+++ b/config/crds/v1beta1/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
@@ -7988,7 +7988,6 @@ spec:
                             type: object
                         type: object
                       type: array
-                      x-kubernetes-preserve-unknown-fields: true
                   required:
                   - name
                   type: object

--- a/config/crds/v1beta1/patches/elasticsearch-patches.yaml
+++ b/config/crds/v1beta1/patches/elasticsearch-patches.yaml
@@ -71,5 +71,3 @@
   path: /spec/validation/openAPIV3Schema/properties/spec/properties/nodeSets/items/properties/config/x-kubernetes-preserve-unknown-fields
 - op: remove
   path: /spec/validation/openAPIV3Schema/properties/spec/properties/nodeSets/items/properties/podTemplate/x-kubernetes-preserve-unknown-fields
-- op: remove
-  path: /spec/validation/openAPIV3Schema/properties/spec/properties/nodeSets/items/properties/volumeClaimTemplates/x-kubernetes-preserve-unknown-fields

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -3927,7 +3927,6 @@ spec:
                             type: object
                         type: object
                       type: array
-                      x-kubernetes-preserve-unknown-fields: true
                   required:
                   - name
                   type: object

--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -284,7 +284,6 @@ type NodeSet struct {
 	// Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate.
 	// Items defined here take precedence over any default claims added by the operator with the same name.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:pruning:PreserveUnknownFields
 	VolumeClaimTemplates []corev1.PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"`
 }
 


### PR DESCRIPTION
This PR removes the `x-kubernetes-preserve-unknown-fields` field from the volumeClaimTemplates node in version v1 of the CRD.

Candidate fix for https://github.com/elastic/cloud-on-k8s/issues/4737