### PR TITLE
Update ECK version in doc attributes and operator hub configuration

### DIFF
--- a/docs/eck-attributes.asciidoc
+++ b/docs/eck-attributes.asciidoc
@@ -1,4 +1,4 @@
-:eck_version: 1.7.0
+:eck_version: 1.7.1
 :eck_crd_version: v1
 :eck_release_branch: 1.7
 :eck_github: https://github.com/elastic/cloud-on-k8s

--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -1,5 +1,5 @@
-newVersion: 1.7.0
-prevVersion: 1.6.0
+newVersion: 1.7.1
+prevVersion: 1.7.0
 stackVersion: 7.14.0
 crds:
   - name: elasticsearches.elasticsearch.k8s.elastic.co


### PR DESCRIPTION
This PR updates the ECK versions in the following files:
* docs/eck-attributes.asciidoc
* hack/operatorhub/config.yaml