### PR TITLE
Update Google Cloud SDK to 353.0.0

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.16.7
 ENV GOLANGCILINT_VERSION=1.38.0
 ENV SHELLCHECK_VERSION=0.7.1
 ENV KUBEBUILDER_VERSION=2.3.1
-ENV GCLOUD_VERSION=297.0.1
+ENV GCLOUD_VERSION=353.0.0
 ENV KUBECTL_VERSION=1.14.7
 ENV DOCKER_VERSION=19.03.13
 ENV DOCKER_BUILDX_VERSION=0.4.2
@@ -30,7 +30,7 @@ ENV PATH=${PATH}:/usr/local/google-cloud-sdk/bin
 RUN curl -fsSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz && \
     mkdir -p /usr/local/gcloud && \
     tar -zxf google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz -C /usr/local && \
-    /usr/local/google-cloud-sdk/install.sh && \
+    /usr/local/google-cloud-sdk/install.sh --quiet && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud components install beta --quiet && \


### PR DESCRIPTION
This PR updates Google Cloud SDK from 297.0.1 to 353.0.0

[Latest](https://devops-ci.elastic.co/job/cloud-on-k8s-pr/6960/console) [builds](https://devops-ci.elastic.co/job/cloud-on-k8s-pr/6962/console) have been failing with the following error:

```
15:58:39  [91mTraceback (most recent call last):
15:58:39    File "/usr/local/google-cloud-sdk/bin/bootstrapping/install.py", line 12, in <module>
15:58:39      import bootstrapping
15:58:39    File "/usr/local/google-cloud-sdk/bin/bootstrapping/bootstrapping.py", line 32, in <module>
15:58:39      import setup  # pylint:disable=g-import-not-at-top
15:58:39    File "/usr/local/google-cloud-sdk/bin/bootstrapping/setup.py", line 57, in <module>
15:58:39  [0m[91m    from googlecloudsdk.core.util import platforms
15:58:39    File "/usr/local/google-cloud-sdk/lib/googlecloudsdk/__init__.py", line 23, in <module>
15:58:39  [0m[91m    from googlecloudsdk.core.util import importing
15:58:39    File "/usr/local/google-cloud-sdk/lib/googlecloudsdk/core/util/importing.py", line 23, in <module>
15:58:39  [0m[91m    import imp
15:58:39    File "/usr/lib/python3.9/imp.py", line 23, in <module>
15:58:39  [0m[91m    from importlib import util
15:58:39    File "/usr/lib/python3.9/importlib/util.py", line 2, in <module>
15:58:39  [0m[91m    from . import abc
15:58:39    File "/usr/lib/python3.9/importlib/abc.py", line 17, in <module>
15:58:39      from typing import Protocol, runtime_checkable
15:58:39    File "/usr/lib/python3.9/typing.py", line 26, in <module>
15:58:39  [0m[91m    import re as stdlib_re  # Avoid confusion with the re we export.
15:58:39    File "/usr/lib/python3.9/re.py", line 124, in <module>
15:58:39  [0m[91m    import enum
15:58:39    File "/usr/local/google-cloud-sdk/lib/third_party/enum/__init__.py", line 26, in <module>
15:58:39      spec = importlib.util.find_spec('enum')
```

Upgrading the SDK seems to solve the problem.