### PR TITLE
Agent: fix Elasticsearch association error message

### DIFF
--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -215,7 +215,7 @@ func applyRelatedEsAssoc(agent agentv1alpha1.Agent, esAssociation commonv1.Assoc
 		return nil, fmt.Errorf(
 			"agent namespace %s is different than referenced Elasticsearch namespace %s, this is not supported yet",
 			agent.Namespace,
-			esAssociation.Associated().GetNamespace(),
+			esAssociation.AssociationRef().Namespace,
 		)
 	}
 


### PR DESCRIPTION
This commit fixes the error message raised when Agent and Elasticsearch namespaces are different.

_Credit goes to @pebrc_