### PR TITLE
Remove non-functional pre-stop hook parts

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/prestop.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/prestop.asciidoc
@@ -19,7 +19,7 @@ It waits for an additional `PRE_STOP_ADDITIONAL_WAIT_SECONDS` (defaulting to 50)
 2. Give clients time to use the terminating Pod IP resolved just before DNS record was updated.
 3. Give kube-proxy time to refresh ipvs or iptables rules on all nodes, depending on its sync period setting.
 
-The exact behavior is configurable using environment variables, for example:
+The exact behavior is configurable using an environment variable, for example:
 
 [source,yaml,subs="attributes"]
 ----

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/prestop.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/prestop.asciidoc
@@ -13,7 +13,7 @@ When an Elasticsearch `Pod` is terminated, its `Endpoint` is removed from the `S
 Moreover, kube-proxy resynchronizes its rules link:https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/#options[every 30 seconds by default]. During that time window of 30 seconds, the terminating Pod IP may still be used when targeting the service. Please note the resync operation itself may take some time, especially if kube-proxy is configured to use iptables with a lot of services and rules to apply.
 
 To address this issue and minimize unavailability, ECK relies on a link:https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/[PreStop lifecycle hook].
-It waits for an additional `PRE_STOP_ADDITIONAL_WAIT_SECONDS` (defaulting to 30). The additional wait time is used to:
+It waits for an additional `PRE_STOP_ADDITIONAL_WAIT_SECONDS` (defaulting to 50). The additional wait time is used to:
 
 1. Give time to in-flight requests to be completed.
 2. Give clients time to use the terminating Pod IP resolved just before DNS record was updated.

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/prestop.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/prestop.asciidoc
@@ -12,9 +12,8 @@ When an Elasticsearch `Pod` is terminated, its `Endpoint` is removed from the `S
 
 Moreover, kube-proxy resynchronizes its rules link:https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/#options[every 30 seconds by default]. During that time window of 30 seconds, the terminating Pod IP may still be used when targeting the service. Please note the resync operation itself may take some time, especially if kube-proxy is configured to use iptables with a lot of services and rules to apply.
 
-To address this issue and minimize unavailability, ECK relies on a link:https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/[PreStop lifecycle hook]. This waits to terminate the Elasticsearch process until the `Service` DNS record does not contain the IP of the `Pod`.
-First, the PreStop lifecycle hook keeps querying DNS for `PRE_STOP_MAX_WAIT_SECONDS` (defaulting to 20) until the Pod IP is no longer referenced.
-Then, it waits for an additional `PRE_STOP_ADDITIONAL_WAIT_SECONDS` (defaulting to 30). Additional wait is used to:
+To address this issue and minimize unavailability, ECK relies on a link:https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/[PreStop lifecycle hook].
+It waits for an additional `PRE_STOP_ADDITIONAL_WAIT_SECONDS` (defaulting to 30). The additional wait time is used to:
 
 1. Give time to in-flight requests to be completed.
 2. Give clients time to use the terminating Pod IP resolved just before DNS record was updated.
@@ -34,8 +33,6 @@ spec:
           containers:
           - name: elasticsearch
             env:
-            - name: PRE_STOP_MAX_WAIT_SECONDS
-              value: "10"
             - name: PRE_STOP_ADDITIONAL_WAIT_SECONDS
               value: "5"
 ----

--- a/pkg/controller/elasticsearch/nodespec/defaults.go
+++ b/pkg/controller/elasticsearch/nodespec/defaults.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// DefaultTerminationGracePeriodSeconds is the termination grace period for the Elasticsearch containers
-	DefaultTerminationGracePeriodSeconds int64 = 180
+	DefaultTerminationGracePeriodSeconds int64 = 160
 )
 
 var (

--- a/pkg/controller/elasticsearch/nodespec/defaults.go
+++ b/pkg/controller/elasticsearch/nodespec/defaults.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// DefaultTerminationGracePeriodSeconds is the termination grace period for the Elasticsearch containers
-	DefaultTerminationGracePeriodSeconds int64 = 160
+	DefaultTerminationGracePeriodSeconds int64 = 180
 )
 
 var (

--- a/pkg/controller/elasticsearch/nodespec/lifecycle_hook.go
+++ b/pkg/controller/elasticsearch/nodespec/lifecycle_hook.go
@@ -33,7 +33,7 @@ set -euo pipefail
 # using iptables with a lot of services, in which case the default 30sec might not be enough.
 # Also gives some additional bonus time to in-flight requests to terminate, and new requests to still
 # target the Pod IP before Elasticsearch stops.
-PRE_STOP_ADDITIONAL_WAIT_SECONDS=${PRE_STOP_ADDITIONAL_WAIT_SECONDS:=30}
+PRE_STOP_ADDITIONAL_WAIT_SECONDS=${PRE_STOP_ADDITIONAL_WAIT_SECONDS:=50}
 
 sleep $PRE_STOP_ADDITIONAL_WAIT_SECONDS
 `

--- a/pkg/controller/elasticsearch/nodespec/lifecycle_hook.go
+++ b/pkg/controller/elasticsearch/nodespec/lifecycle_hook.go
@@ -23,17 +23,11 @@ const PreStopHookScript = `#!/usr/bin/env bash
 
 set -euo pipefail
 
-# This script will wait for up to $PRE_STOP_MAX_WAIT_SECONDS for $POD_IP to disappear from DNS record,
-# then it will wait additional $PRE_STOP_ADDITIONAL_WAIT_SECONDS and exit. This slows down the process shutdown
-# and allows to make changes to the pool gracefully, without blackholing traffic when DNS
-# contains IP that is already inactive. Assumes $HEADLESS_SERVICE_NAME and $POD_IP env variables are defined.
-
-# Max time to wait for pods IP to disappear from DNS.
+# This script will wait for up to $PRE_STOP_ADDITIONAL_WAIT_SECONDS before allowing termination of the Pod 
+# This slows down the process shutdown and allows to make changes to the pool gracefully, without blackholing traffic when DNS
+# still contains the IP that is already inactive. 
 # As this runs in parallel to grace period after which process is SIGKILLed,
 # it should be set to allow enough time for the process to gracefully terminate.
-PRE_STOP_MAX_WAIT_SECONDS=${PRE_STOP_MAX_WAIT_SECONDS:=20}
-
-# Additional wait before shutting down Elasticsearch.
 # It allows kube-proxy to refresh its rules and remove the terminating Pod IP.
 # Kube-proxy refresh period defaults to every 30 seconds, but the operation itself can take much longer if
 # using iptables with a lot of services, in which case the default 30sec might not be enough.
@@ -41,19 +35,5 @@ PRE_STOP_MAX_WAIT_SECONDS=${PRE_STOP_MAX_WAIT_SECONDS:=20}
 # target the Pod IP before Elasticsearch stops.
 PRE_STOP_ADDITIONAL_WAIT_SECONDS=${PRE_STOP_ADDITIONAL_WAIT_SECONDS:=30}
 
-START_TIME=$(date +%s)
-while true; do
-   ELAPSED_TIME=$(($(date +%s) - $START_TIME))
-
-   if [ $ELAPSED_TIME -gt $PRE_STOP_MAX_WAIT_SECONDS ]; then
-      exit 1
-   fi
-
-   if ! getent hosts $HEADLESS_SERVICE_NAME | grep $POD_IP; then
-      sleep $PRE_STOP_ADDITIONAL_WAIT_SECONDS
-      exit 0
-   fi
-
-   sleep 1
-done
+sleep $PRE_STOP_ADDITIONAL_WAIT_SECONDS
 `


### PR DESCRIPTION
Fixes #4698 

The pre-stop hook script intended to improve availability during rolling upgrades has not been doing what it is advertising to do since ECK 1.3.0. 

https://github.com/elastic/cloud-on-k8s/blob/72bfb73cb32cc41885b900187638da63fa9f4235/pkg/controller/elasticsearch/nodespec/statefulset.go#L51

We are including non-ready Pods in the headless service which we then try to use to determine when a terminating Pod has been removed from DNS (never, in this constellation). We have since added functionality in #3837 that relies on this setting for client-side node discovery (aka sniffing). 

This means that our pre-stop hook was always running the full 20+30 secs before terminating the Pod. I see two potential fixes for this problem:
1. go back to not publishing unready Pods and revert #3837
2. simplify the pre-stop hook and turn it into a simple timeout without trying to check DNS for the Pod IP (this PR) 

I have opted for sticking with 50 seconds of wait time (but I am open to cutting this down) 

NOTE: I also kept the `terminationGracePeriod` at 180s to avoid a rolling restart on ECK upgrade.
