### PR TITLE
Remove beta label from Helm documentation

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,7 +2,7 @@
 
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/elastic)](https://artifacthub.io/packages/search?repo=elastic)
 
-This directory contains the  Helm chart for deploying the ECK operator.
+This directory contains the Helm chart for deploying the ECK operator.
 
 ## Usage
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,7 +2,7 @@
 
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/elastic)](https://artifacthub.io/packages/search?repo=elastic)
 
-This directory contains the experimental Helm chart for deploying the ECK operator. It should be considered beta quality at this point in time.
+This directory contains the  Helm chart for deploying the ECK operator.
 
 ## Usage
 

--- a/deploy/helm-migrate.sh
+++ b/deploy/helm-migrate.sh
@@ -20,12 +20,6 @@ for CRD in $(kubectl get crds --no-headers -o custom-columns=NAME:.metadata.name
     kubectl label crd "$CRD" app.kubernetes.io/managed-by=Helm
 done
 
-echo "Adding labels and annotations to ECK operator configuration"
-ECK_CONFIG=elastic-operator
-kubectl -n "$RELEASE_NAMESPACE" annotate cm "$ECK_CONFIG" meta.helm.sh/release-name="$RELEASE_NAME"
-kubectl -n "$RELEASE_NAMESPACE" annotate cm "$ECK_CONFIG" meta.helm.sh/release-namespace="$RELEASE_NAMESPACE"
-kubectl -n "$RELEASE_NAMESPACE" label cm "$ECK_CONFIG" app.kubernetes.io/managed-by=Helm
-
 echo "Uninstalling ECK"
 kubectl delete -n "${RELEASE_NAMESPACE}" \
     serviceaccount/elastic-operator \
@@ -35,9 +29,9 @@ kubectl delete -n "${RELEASE_NAMESPACE}" \
     clusterrole.rbac.authorization.k8s.io/elastic-operator-edit \
     clusterrolebinding.rbac.authorization.k8s.io/elastic-operator \
     service/elastic-webhook-server \
+    configmap/elastic-operator \
     statefulset.apps/elastic-operator \
     validatingwebhookconfiguration.admissionregistration.k8s.io/elastic-webhook.k8s.elastic.co
-
 
 echo "Installing ECK with Helm"
 helm repo add "${CHART_REPO}" "${CHART_REPO_URL}"

--- a/deploy/helm-migrate.sh
+++ b/deploy/helm-migrate.sh
@@ -22,9 +22,9 @@ done
 
 echo "Adding labels and annotations to ECK operator configuration"
 ECK_CONFIG=elastic-operator
-kubectl -n $RELEASE_NAMESPACE annotate cm "$ECK_CONFIG" meta.helm.sh/release-name="$RELEASE_NAME"
-kubectl -n $RELEASE_NAMESPACE annotate cm "$ECK_CONFIG" meta.helm.sh/release-namespace="$RELEASE_NAMESPACE"
-kubectl -n $RELEASE_NAMESPACE label cm "$ECK_CONFIG" app.kubernetes.io/managed-by=Helm
+kubectl -n "$RELEASE_NAMESPACE" annotate cm "$ECK_CONFIG" meta.helm.sh/release-name="$RELEASE_NAME"
+kubectl -n "$RELEASE_NAMESPACE" annotate cm "$ECK_CONFIG" meta.helm.sh/release-namespace="$RELEASE_NAMESPACE"
+kubectl -n "$RELEASE_NAMESPACE" label cm "$ECK_CONFIG" app.kubernetes.io/managed-by=Helm
 
 echo "Uninstalling ECK"
 kubectl delete -n "${RELEASE_NAMESPACE}" \

--- a/docs/operating-eck/installing-eck.asciidoc
+++ b/docs/operating-eck/installing-eck.asciidoc
@@ -113,7 +113,10 @@ helm show values elastic/eck-operator
 
 CAUTION: Migrating an existing installation to Helm is essentially an upgrade operation and any <<{p}-beta-to-ga-rolling-restart,caveats associated with normal operator upgrades>> are applicable. Read the <<{p}-ga-upgrade,upgrade documentation>> before proceeding.
 
-You can migrate an existing operator installation to Helm by adding the `meta.helm.sh/release-name`, `meta.helm.sh/release-namespace` annotations and the `app.kubernetes.io/managed-by` label to all the resources you want to be adopted by Helm. You _must_ do this for the Elastic Custom Resource Definitions (CRD) because deleting them would trigger the deletion of all deployed Elastic applications as well. All other resources are optional and can be deleted. 
+
+You can migrate an existing operator installation to Helm by adding the `meta.helm.sh/release-name`, `meta.helm.sh/release-namespace` annotations and the `app.kubernetes.io/managed-by` label to all the resources you want to be adopted by Helm. You _must_ do this for the Elastic Custom Resource Definitions (CRD) because deleting them would trigger the deletion of all deployed Elastic applications as well. All other resources are optional and can be deleted.
+
+NOTE: A shell script is available in the link:{eck_github}/blob/{eck_release_branch}/deploy/helm-migrate.sh[ECK source repository] to demonstrate how to migrate from version 1.7.1 to Helm. You can modify it to suit your own environment.
 
 For example, an ECK 1.2.1 installation deployed using the link:https://www.elastic.co/guide/en/cloud-on-k8s/1.2/k8s-quickstart.html[quickstart guide] can be migrated to Helm as follows:
 
@@ -144,9 +147,8 @@ kubectl delete -n elastic-system \
     statefulset.apps/elastic-operator \
     validatingwebhookconfiguration.admissionregistration.k8s.io/elastic-webhook.k8s.elastic.co
 ----
-<1> If you have customized the operator configuration you can keep the operator configuration in this ConfigMap and annotate and label it like the CRDs above.
+<1> If you have previously customized the operator configuration in this ConfigMap, you will have to repeat the configuration once the operator has been reinstalled in the next step.
 
 . Install the ECK operator using the Helm chart as described in <<{p}-install-helm>>.
 
-NOTE: A shell script is available in the link:{eck_github}/blob/{eck_release_branch}/deploy/helm-migrate.sh[ECK source repository] to demonstrate how to migrate from version 1.7.1 to Helm. You can modify it to suit your own environment.
 

--- a/docs/operating-eck/installing-eck.asciidoc
+++ b/docs/operating-eck/installing-eck.asciidoc
@@ -31,7 +31,6 @@ This method is the quickest way to get started with ECK if you have full adminis
 [id="{p}-install-helm"]
 == Install ECK using the Helm chart
 
-CAUTION: The Helm chart is experimental and should be considered as a beta-level feature.  
 
 Starting from version 1.3.0, an experimental Helm chart is available to install ECK. It is available from the Elastic Helm repository and can be added to your Helm repository list by running the following command:
 
@@ -131,7 +130,7 @@ done
 
 . Uninstall the current ECK operator. You can do this by taking the `operator.yaml` file you used to install the operator and running `kubectl delete -f operator.yaml`. Alternatively, you could delete each resource individually.
 +
-[source,sh]
+[source,sh,subs="attributes,callouts"]
 ----
 kubectl delete -n elastic-system \
     serviceaccount/elastic-operator \
@@ -140,13 +139,14 @@ kubectl delete -n elastic-system \
     clusterrole.rbac.authorization.k8s.io/elastic-operator-view \
     clusterrole.rbac.authorization.k8s.io/elastic-operator-edit \
     clusterrolebinding.rbac.authorization.k8s.io/elastic-operator \
-    rolebinding.rbac.authorization.k8s.io/elastic-operator \
     service/elastic-webhook-server \
+    configmap/elastic-operator \ <1>
     statefulset.apps/elastic-operator \
     validatingwebhookconfiguration.admissionregistration.k8s.io/elastic-webhook.k8s.elastic.co
 ----
+<1> If you have customized the operator configuration you can keep the operator configuration in this ConfigMap and annotate and label it like the CRDs above.
 
 . Install the ECK operator using the Helm chart as described in <<{p}-install-helm>>.
 
-NOTE: A shell script is available in the link:{eck_github}/blob/{eck_release_branch}/deploy/helm-migrate.sh[ECK source repository] to demonstrate how to migrate from version 1.2.1 to Helm. You can modify it to suit your own environment. 
+NOTE: A shell script is available in the link:{eck_github}/blob/{eck_release_branch}/deploy/helm-migrate.sh[ECK source repository] to demonstrate how to migrate from version 1.7.1 to Helm. You can modify it to suit your own environment.
 


### PR DESCRIPTION
Fixes #4796 

Removes the `beta` warning from our Helm documentation and README.  Updates the `helm-migrate.sh` script to be compatible with the most recent version of ECK. 