### PR TITLE
Improve Elasticsearch cluster health API call when timeout

### DIFF
--- a/pkg/controller/elasticsearch/client/base.go
+++ b/pkg/controller/elasticsearch/client/base.go
@@ -87,12 +87,11 @@ func (c *baseClient) delete(ctx context.Context, pathWithQuery string, in, out i
 	return c.request(ctx, http.MethodDelete, pathWithQuery, in, out, nil)
 }
 
-// request performs a new http request and decodes the payload if the status code of the response is 2xx or if the
-// given skipErrFunc function returns true.
+// request performs a new http request
 //
 // if requestObj is not nil, it's marshalled as JSON and used as the request body
 // if responseObj is not nil, it should be a pointer to an struct. The response body will be unmarshalled from JSON
-// into this struct if the status code of the response is 2xx or if the given skipErrFunc function returns true.
+// into this struct if the status code of the response is 2xx or if the (optional) given skipErrFunc function returns true.
 func (c *baseClient) request(
 	ctx context.Context,
 	method string,

--- a/pkg/controller/elasticsearch/client/base.go
+++ b/pkg/controller/elasticsearch/client/base.go
@@ -108,7 +108,7 @@ func (c *baseClient) request(
 		body = bytes.NewBuffer(outData)
 	}
 
-	request, err := http.NewRequest(method, stringsutil.Concat(c.Endpoint, pathWithQuery), body) //nolint:noctx
+	request, err := http.NewRequest(method, stringsutil.Concat(c.Endpoint, pathWithQuery), body)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/elasticsearch/client/client_test.go
+++ b/pkg/controller/elasticsearch/client/client_test.go
@@ -746,6 +746,57 @@ func TestGetClusterHealthWaitForAllEvents(t *testing.T) {
 				ActiveShardsPercentAsNumber: 42.0,
 			},
 		},
+		{
+			name: "happy path",
+			fields: fields{
+				client: NewMockClient(version.MustParse("7.14.0"), func(req *http.Request) *http.Response {
+					require.Equal(t, expectedPath, req.URL.Path)
+					require.Equal(t, expectedRawQuery, req.URL.RawQuery)
+					return &http.Response{
+						StatusCode: 200,
+						Body: ioutil.NopCloser(strings.NewReader(
+							`
+{
+	"cluster_name": "elasticsearch-sample",
+	"status": "yellow",
+	"timed_out": false,
+	"number_of_nodes": 3,
+	"number_of_data_nodes": 3,
+	"active_primary_shards": 12,
+	"active_shards": 24,
+	"relocating_shards": 1,
+	"initializing_shards": 2,
+	"unassigned_shards": 3,
+	"delayed_unassigned_shards": 4,
+	"number_of_pending_tasks": 5,
+	"number_of_in_flight_fetch": 6,
+	"task_max_waiting_in_queue_millis": 7,
+	"active_shards_percent_as_number": 42.0
+}`,
+						)),
+						Header:  make(http.Header),
+						Request: req,
+					}
+				}),
+			},
+			want: Health{
+				ClusterName:                 "elasticsearch-sample",
+				Status:                      "yellow",
+				TimedOut:                    false,
+				NumberOfNodes:               3,
+				NumberOfDataNodes:           3,
+				ActivePrimaryShards:         12,
+				ActiveShards:                24,
+				RelocatingShards:            1,
+				InitializingShards:          2,
+				UnassignedShards:            3,
+				DelayedUnassignedShards:     4,
+				NumberOfPendingTasks:        5,
+				NumberOfInFlightFetch:       6,
+				TaskMaxWaitingInQueueMillis: 7,
+				ActiveShardsPercentAsNumber: 42.0,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/elasticsearch/client/client_test.go
+++ b/pkg/controller/elasticsearch/client/client_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -667,4 +668,95 @@ func TestTimeout(t *testing.T) {
 func TestFormatAsSeconds(t *testing.T) {
 	have := formatAsSeconds(2 * time.Minute)
 	require.Equal(t, "120s", have)
+}
+
+func TestGetClusterHealthWaitForAllEvents(t *testing.T) {
+	expectedPath := "/_cluster/health"
+	expectedRawQuery := "wait_for_events=languid&timeout=0s"
+	type fields struct {
+		client Client
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    Health
+		wantErr bool
+	}{
+		{
+			name: "other than 408 should not be ignored",
+			fields: fields{
+				client: NewMockClient(version.MustParse("7.14.0"), func(req *http.Request) *http.Response {
+					require.Equal(t, expectedPath, req.URL.Path)
+					require.Equal(t, expectedRawQuery, req.URL.RawQuery)
+					return &http.Response{
+						StatusCode: 500,
+					}
+				}),
+			},
+			wantErr: true,
+		},
+		{
+			name: "408 should be ignored",
+			fields: fields{
+				client: NewMockClient(version.MustParse("7.14.0"), func(req *http.Request) *http.Response {
+					require.Equal(t, expectedPath, req.URL.Path)
+					require.Equal(t, expectedRawQuery, req.URL.RawQuery)
+					return &http.Response{
+						StatusCode: 408,
+						Body: ioutil.NopCloser(strings.NewReader(
+							`
+{
+	"cluster_name": "elasticsearch-sample",
+	"status": "green",
+	"timed_out": true,
+	"number_of_nodes": 3,
+	"number_of_data_nodes": 3,
+	"active_primary_shards": 12,
+	"active_shards": 24,
+	"relocating_shards": 1,
+	"initializing_shards": 2,
+	"unassigned_shards": 3,
+	"delayed_unassigned_shards": 4,
+	"number_of_pending_tasks": 5,
+	"number_of_in_flight_fetch": 6,
+	"task_max_waiting_in_queue_millis": 7,
+	"active_shards_percent_as_number": 42.0
+}`,
+						)),
+						Header:  make(http.Header),
+						Request: req,
+					}
+				}),
+			},
+			want: Health{
+				ClusterName:                 "elasticsearch-sample",
+				Status:                      "green",
+				TimedOut:                    true,
+				NumberOfNodes:               3,
+				NumberOfDataNodes:           3,
+				ActivePrimaryShards:         12,
+				ActiveShards:                24,
+				RelocatingShards:            1,
+				InitializingShards:          2,
+				UnassignedShards:            3,
+				DelayedUnassignedShards:     4,
+				NumberOfPendingTasks:        5,
+				NumberOfInFlightFetch:       6,
+				TaskMaxWaitingInQueueMillis: 7,
+				ActiveShardsPercentAsNumber: 42.0,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.fields.client.GetClusterHealthWaitForAllEvents(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetClusterHealthWaitForAllEvents() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetClusterHealthWaitForAllEvents() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/controller/elasticsearch/client/v6.go
+++ b/pkg/controller/elasticsearch/client/v6.go
@@ -77,10 +77,6 @@ func (c *clientV6) GetClusterHealthWaitForAllEvents(ctx context.Context) (Health
 	// given the query parameters. 408 for other reasons than the clients timeout parameter should not happen
 	// as they are expected only on idle connections https://go-review.googlesource.com/c/go/+/179457/4/src/net/http/transport.go#1931
 	err := c.request(ctx, http.MethodGet, pathWithQuery, nil, &result, IsTimeout)
-	if err != nil {
-		return result, err
-	}
-
 	return result, err
 }
 

--- a/pkg/controller/elasticsearch/client/v6.go
+++ b/pkg/controller/elasticsearch/client/v6.go
@@ -76,7 +76,7 @@ func (c *clientV6) GetClusterHealthWaitForAllEvents(ctx context.Context) (Health
 	// ignore timeout errors as they are communicated in the returned payload and a timeout is to be expected
 	// given the query parameters. 408 for other reasons than the clients timeout parameter should not happen
 	// as they are expected only on idle connections https://go-review.googlesource.com/c/go/+/179457/4/src/net/http/transport.go#1931
-	err := c.unsafeRequest(ctx, http.MethodGet, pathWithQuery, nil, &result, IsTimeout)
+	err := c.request(ctx, http.MethodGet, pathWithQuery, nil, &result, IsTimeout)
 	if err != nil {
 		return result, err
 	}

--- a/pkg/controller/elasticsearch/client/v6.go
+++ b/pkg/controller/elasticsearch/client/v6.go
@@ -72,13 +72,15 @@ func (c *clientV6) GetClusterHealth(ctx context.Context) (Health, error) {
 func (c *clientV6) GetClusterHealthWaitForAllEvents(ctx context.Context) (Health, error) {
 	var result Health
 	// wait for all events means wait for all events down to `languid` events which is the lowest event priority
-	err := c.get(ctx, "/_cluster/health?wait_for_events=languid&timeout=0s", &result)
-	if IsTimeout(err) {
-		// ignore timeout errors as they are communicated in the returned payload and a timeout is to be expected
-		// given the query parameters. 408 for other reasons than the clients timeout parameter should not happen
-		// as they are expected only on idle connections https://go-review.googlesource.com/c/go/+/179457/4/src/net/http/transport.go#1931
-		err = nil
+	pathWithQuery := "/_cluster/health?wait_for_events=languid&timeout=0s"
+	// ignore timeout errors as they are communicated in the returned payload and a timeout is to be expected
+	// given the query parameters. 408 for other reasons than the clients timeout parameter should not happen
+	// as they are expected only on idle connections https://go-review.googlesource.com/c/go/+/179457/4/src/net/http/transport.go#1931
+	err := c.unsafeRequest(ctx, http.MethodGet, pathWithQuery, nil, &result, IsTimeout)
+	if err != nil {
+		return result, err
 	}
+
 	return result, err
 }
 


### PR DESCRIPTION
Adds a new `unsafeRequest` function that accepts a `skipErrFunc func(error) bool` argument used to know if we should decode the response even when the status code is not 2xx.

Resolves #4507.