### PR TITLE
Fix handling CAs in Agent controller

### DIFF
--- a/pkg/controller/agent/config_test.go
+++ b/pkg/controller/agent/config_test.go
@@ -78,7 +78,7 @@ func TestBuildFleetSetupKibanaConfig(t *testing.T) {
 			client:  client,
 		},
 		{
-			name:  "kibana ref present, kibana with ca populated",
+			name:  "kibana ref present, kibana without ca populated",
 			agent: *assocWithoutCa.Agent,
 			wantCfg: map[string]interface{}{
 				"fleet": map[string]interface{}{
@@ -92,7 +92,7 @@ func TestBuildFleetSetupKibanaConfig(t *testing.T) {
 			client:  client,
 		},
 		{
-			name:  "kibana ref present, kibana without ca populated",
+			name:  "kibana ref present, kibana with ca populated",
 			agent: *assocWithCa.Agent,
 			wantCfg: map[string]interface{}{
 				"fleet": map[string]interface{}{

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -294,10 +294,12 @@ func getAssociatedFleetServer(params Params) (commonv1.Associated, error) {
 func trustCAScript(caPath string) string {
 	return fmt.Sprintf(`#!/usr/bin/env bash
 set -e
-cp %s /etc/pki/ca-trust/source/anchors/
-update-ca-trust
+if [[ -f %s ]]; then
+  cp %s /etc/pki/ca-trust/source/anchors/
+  update-ca-trust
+fi
 /usr/bin/tini -- /usr/local/bin/docker-entrypoint -e
-`, caPath)
+`, caPath, caPath)
 }
 
 func createDataVolume(params Params) volume.VolumeLike {

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -294,12 +294,12 @@ func getAssociatedFleetServer(params Params) (commonv1.Associated, error) {
 func trustCAScript(caPath string) string {
 	return fmt.Sprintf(`#!/usr/bin/env bash
 set -e
-if [[ -f %s ]]; then
-  cp %s /etc/pki/ca-trust/source/anchors/
+if [[ -f %[1]s ]]; then
+  cp %[1]s /etc/pki/ca-trust/source/anchors/
   update-ca-trust
 fi
 /usr/bin/tini -- /usr/local/bin/docker-entrypoint -e
-`, caPath, caPath)
+`, caPath)
 }
 
 func createDataVolume(params Params) volume.VolumeLike {

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -367,8 +367,10 @@ func Test_applyRelatedEsAssoc(t *testing.T) {
 
 				ps.Containers[0].Command = []string{"/usr/bin/env", "bash", "-c", `#!/usr/bin/env bash
 set -e
-cp /mnt/elastic-internal/elasticsearch-association/agent-ns/elasticsearch/certs/ca.crt /etc/pki/ca-trust/source/anchors/
-update-ca-trust
+if [[ -f /mnt/elastic-internal/elasticsearch-association/agent-ns/elasticsearch/certs/ca.crt ]]; then
+  cp /mnt/elastic-internal/elasticsearch-association/agent-ns/elasticsearch/certs/ca.crt /etc/pki/ca-trust/source/anchors/
+  update-ca-trust
+fi
 /usr/bin/tini -- /usr/local/bin/docker-entrypoint -e
 `}
 


### PR DESCRIPTION
When Elasticsearch and/or Kibana have a TLS certificate signed by a well-known CA and the Secret used for their TLS configuration doesn't contain `ca.crt` Agent in Fleet mode fails to start.

This PR fixes two related bugs:
1. container command will not try to copy CA file if it's not present
2. `fleet-setup.yml` will not be populated with CA paths if CA files are not present

Some more context available in https://github.com/elastic/cloud-on-k8s/issues/4790#issuecomment-910463148.

Fixes https://github.com/elastic/cloud-on-k8s/issues/4790.