### PR TITLE
Bump latest OCP version to 4.8.10

### DIFF
--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -110,7 +110,7 @@ pipeline {
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                     parameters: [
                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
-                        string(name: 'OCP_VERSION', value: "4.8.8"),
+                        string(name: 'OCP_VERSION', value: "4.8.10"),
                         string(name: 'branch_specifier', value: GIT_COMMIT)
                     ],
                     wait: false


### PR DESCRIPTION
It seems there is an installer issue with 4.8.8 and two new versions have been released since in the last couple of days. I tried 4.8.10 and successfully bootstraps.
