### PR TITLE
Drop "properties: {}" from empty-v1alpha1-patch

### DIFF
--- a/config/crds/v1/all-crds.yaml
+++ b/config/crds/v1/all-crds.yaml
@@ -2053,7 +2053,6 @@ spec:
       openAPIV3Schema:
         description: to not break compatibility when upgrading from previous versions
           of the CRD
-        properties: {}
         type: object
     served: false
     storage: false
@@ -5532,7 +5531,6 @@ spec:
       openAPIV3Schema:
         description: to not break compatibility when upgrading from previous versions
           of the CRD
-        properties: {}
         type: object
     served: false
     storage: false
@@ -7997,7 +7995,6 @@ spec:
       openAPIV3Schema:
         description: to not break compatibility when upgrading from previous versions
           of the CRD
-        properties: {}
         type: object
     served: false
     storage: false

--- a/config/crds/v1/patches/add-empty-v1alpha1-patch.yaml
+++ b/config/crds/v1/patches/add-empty-v1alpha1-patch.yaml
@@ -8,6 +8,5 @@
     storage: false
     schema:
       openAPIV3Schema:
-        properties: {}
         type: object
         description: "to not break compatibility when upgrading from previous versions of the CRD"

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -2068,7 +2068,6 @@ spec:
       openAPIV3Schema:
         description: to not break compatibility when upgrading from previous versions
           of the CRD
-        properties: {}
         type: object
     served: false
     storage: false
@@ -5565,7 +5564,6 @@ spec:
       openAPIV3Schema:
         description: to not break compatibility when upgrading from previous versions
           of the CRD
-        properties: {}
         type: object
     served: false
     storage: false
@@ -8042,7 +8040,6 @@ spec:
       openAPIV3Schema:
         description: to not break compatibility when upgrading from previous versions
           of the CRD
-        properties: {}
         type: object
     served: false
     storage: false


### PR DESCRIPTION
Kubernetes will remove this empty property anyway. Gitop Tools like ArgoCD will treat this as drift and constantly tries to reconcile