### PR TITLE
Update OCP 4.7.x test to use 4.7.29

### DIFF
--- a/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
                 build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
                                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: JKS_PARAM_OPERATOR_IMAGE),
-                                        string(name: 'OCP_VERSION', value: "4.7.27"),
+                                        string(name: 'OCP_VERSION', value: "4.7.29"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
                                     wait: true


### PR DESCRIPTION
Fix for https://devops-ci.elastic.co/view/cloud-on-k8s/job/cloud-on-k8s-e2e-tests-ocp/564/

It looks like 4.7.27 had some form of installer issue that has been fixed in (two) more recent versions. I managed to successfully bootstrap a cluster with 4.7.29.
