### PR TITLE
Update supported K8s versions for upcoming 1.8.0 release

### DIFF
--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -1,5 +1,5 @@
-* Kubernetes 1.17-1.21
-* OpenShift 3.11, 4.3-4.7
+* Kubernetes 1.18-1.22
+* OpenShift 3.11, 4.4-4.8
 * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 * Elasticsearch, Kibana, APM Server: 6.8+, 7.1+
 * Enterprise Search: 7.7+

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -265,9 +265,9 @@ spec:
     Supported versions:
 
 
-    * Kubernetes 1.17-1.21
+    * Kubernetes 1.18-1.22
 
-    * OpenShift 3.11, 4.3-4.7
+    * OpenShift 3.11, 4.4-4.8
     
     * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
     


### PR DESCRIPTION
Starting version 1.8.0, we support Kubernetes 1.18-1.22, and Openshift 3.11, 4.4-4.8.
