### PR TITLE
Skip beat tests on OCP3

### DIFF
--- a/test/e2e/test/beat/builder.go
+++ b/test/e2e/test/beat/builder.go
@@ -51,6 +51,12 @@ type Builder struct {
 }
 
 func (b Builder) SkipTest() bool {
+	// Beat on OpenShift3 requires specific securityContext due to hostPath volumes.
+	// Skipping all Beat tests to reduce maintenance burden.
+	if test.Ctx().Provider == "ocp3" {
+		return true
+	}
+
 	ver := version.MustParse(b.Beat.Spec.Version)
 	return version.SupportedBeatVersions.WithinRange(ver) != nil
 }


### PR DESCRIPTION
We skip all Beat tests to reduce maintenance burden as Beat on OpenShift3
requires specific securityContext due to hostPath volumes.

Relates to #4128.