### PR TITLE
Skip webhook tests on OCP3

### DIFF
--- a/test/e2e/agent/webhook_test.go
+++ b/test/e2e/agent/webhook_test.go
@@ -17,6 +17,11 @@ import (
 )
 
 func TestWebhook(t *testing.T) {
+	// Skip on OCP3 where admission controller is not enabled by default.
+	if test.Ctx().Provider == "ocp3" {
+		t.SkipNow()
+	}
+
 	agent := v1alpha1.Agent{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-webhook",

--- a/test/e2e/beat/webhook_test.go
+++ b/test/e2e/beat/webhook_test.go
@@ -17,6 +17,11 @@ import (
 )
 
 func TestWebhook(t *testing.T) {
+	// Skip on OCP3 where admission controller is not enabled by default.
+	if test.Ctx().Provider == "ocp3" {
+		t.SkipNow()
+	}
+
 	beat := beatv1beta1.Beat{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-webhook",


### PR DESCRIPTION
Where the admission controller is not enabled by default.

Relates to #4128.