### PR TITLE
Fix Agent volumes when an association has no CA

### DIFF
--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -255,7 +255,8 @@ func getVolumesFromAssociations(associations []commonv1.Association) []volume.Vo
 	var vols []volume.VolumeLike
 	for i, assoc := range associations {
 		if !assoc.AssociationConf().CAIsConfigured() {
-			return nil
+			// skip as there is no volume to mount if association has no CA configured
+			continue
 		}
 		caSecretName := assoc.AssociationConf().GetCASecretName()
 		vols = append(vols, volume.NewSecretVolumeWithMountPath(

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -252,16 +252,16 @@ func writeEsAssocToConfigHash(params Params, esAssociation commonv1.Association,
 }
 
 func getVolumesFromAssociations(associations []commonv1.Association) []volume.VolumeLike {
-	vols := []volume.VolumeLike{}
-	for i, association := range associations {
-		if !association.AssociationConf().CAIsConfigured() {
+	var vols []volume.VolumeLike
+	for i, assoc := range associations {
+		if !assoc.AssociationConf().CAIsConfigured() {
 			return nil
 		}
-		caSecretName := association.AssociationConf().GetCASecretName()
+		caSecretName := assoc.AssociationConf().GetCASecretName()
 		vols = append(vols, volume.NewSecretVolumeWithMountPath(
 			caSecretName,
-			fmt.Sprintf("%s-certs-%d", association.AssociationType(), i),
-			certificatesDir(association),
+			fmt.Sprintf("%s-certs-%d", assoc.AssociationType(), i),
+			certificatesDir(assoc),
 		))
 	}
 	return vols

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -252,7 +252,7 @@ func writeEsAssocToConfigHash(params Params, esAssociation commonv1.Association,
 }
 
 func getVolumesFromAssociations(associations []commonv1.Association) []volume.VolumeLike {
-	var vols []volume.VolumeLike
+	var vols []volume.VolumeLike //nolint:prealloc
 	for i, assoc := range associations {
 		if !assoc.AssociationConf().CAIsConfigured() {
 			// skip as there is no volume to mount if association has no CA configured

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -199,8 +199,8 @@ func Test_getVolumesFromAssociations(t *testing.T) {
 				Agent: agentv1alpha1.Agent{
 					Spec: agentv1alpha1.AgentSpec{
 						Mode:           agentv1alpha1.AgentFleetMode,
-						KibanaRef:      v1.ObjectSelector{Name: "kb"},
-						FleetServerRef: v1.ObjectSelector{Name: "es"},
+						KibanaRef:      v1.ObjectSelector{Name: "kibana"},
+						FleetServerRef: v1.ObjectSelector{Name: "fleet"},
 					},
 				},
 			},
@@ -209,7 +209,7 @@ func Test_getVolumesFromAssociations(t *testing.T) {
 					CASecretName: "kibana-kb-http-certs-public",
 				})
 				assocs[1].SetAssociationConf(&v1.AssociationConf{
-					CASecretName: "fleet-kb-http-certs-public",
+					CASecretName: "fleet-agent-http-certs-public",
 				})
 			},
 			wantAssociationsLength: 2,
@@ -220,8 +220,8 @@ func Test_getVolumesFromAssociations(t *testing.T) {
 				Agent: agentv1alpha1.Agent{
 					Spec: agentv1alpha1.AgentSpec{
 						Mode:           agentv1alpha1.AgentFleetMode,
-						KibanaRef:      v1.ObjectSelector{Name: "kb"},
-						FleetServerRef: v1.ObjectSelector{Name: "es"},
+						KibanaRef:      v1.ObjectSelector{Name: "kibana"},
+						FleetServerRef: v1.ObjectSelector{Name: "fleet"},
 					},
 				},
 			},
@@ -230,7 +230,7 @@ func Test_getVolumesFromAssociations(t *testing.T) {
 					// No CASecretName
 				})
 				assocs[1].SetAssociationConf(&v1.AssociationConf{
-					CASecretName: "fleet-kb-http-certs-public",
+					CASecretName: "fleet-agent-http-certs-public",
 				})
 			},
 			wantAssociationsLength: 1,

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -185,6 +185,66 @@ func Test_amendBuilderForFleetMode(t *testing.T) {
 	}
 }
 
+func Test_getVolumesFromAssociations(t *testing.T) {
+	// Note: we use setAssocConfs to set the AssociationConfs which are normally set in the reconciliation loop.
+	for _, tt := range []struct {
+		name                   string
+		params                 Params
+		setAssocConfs          func(assocs []v1.Association)
+		wantAssociationsLength int
+	}{
+		{
+			name: "fleet mode enabled, kb ref, fleet ref",
+			params: Params{
+				Agent: agentv1alpha1.Agent{
+					Spec: agentv1alpha1.AgentSpec{
+						Mode:           agentv1alpha1.AgentFleetMode,
+						KibanaRef:      v1.ObjectSelector{Name: "kb"},
+						FleetServerRef: v1.ObjectSelector{Name: "es"},
+					},
+				},
+			},
+			setAssocConfs: func(assocs []v1.Association) {
+				assocs[0].SetAssociationConf(&v1.AssociationConf{
+					CASecretName: "kibana-kb-http-certs-public",
+				})
+				assocs[1].SetAssociationConf(&v1.AssociationConf{
+					CASecretName: "fleet-kb-http-certs-public",
+				})
+			},
+			wantAssociationsLength: 2,
+		},
+		{
+			name: "fleet mode enabled, kb no tls ref, fleet ref",
+			params: Params{
+				Agent: agentv1alpha1.Agent{
+					Spec: agentv1alpha1.AgentSpec{
+						Mode:           agentv1alpha1.AgentFleetMode,
+						KibanaRef:      v1.ObjectSelector{Name: "kb"},
+						FleetServerRef: v1.ObjectSelector{Name: "es"},
+					},
+				},
+			},
+			setAssocConfs: func(assocs []v1.Association) {
+				assocs[0].SetAssociationConf(&v1.AssociationConf{
+					// No CASecretName
+				})
+				assocs[1].SetAssociationConf(&v1.AssociationConf{
+					CASecretName: "fleet-kb-http-certs-public",
+				})
+			},
+			wantAssociationsLength: 1,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assocs := tt.params.Agent.GetAssociations()
+			tt.setAssocConfs(assocs)
+			associations := getVolumesFromAssociations(assocs)
+			require.Equal(t, tt.wantAssociationsLength, len(associations))
+		})
+	}
+}
+
 func Test_getRelatedEsAssoc(t *testing.T) {
 	for _, tt := range []struct {
 		name    string


### PR DESCRIPTION
14aa58f is the fix. In a6be319 I took the opportunity to do a little refactoring (remove the warnings due to the unnecessary `vols` slice allocation and the conflict between the package and the variable name for `association`).

Resolves https://github.com/elastic/cloud-on-k8s/issues/4832#issuecomment-919051998.