### PR TITLE
[1.8] Fix Agent volumes when an association has no CA (#4833)

### DIFF
--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -252,16 +252,17 @@ func writeEsAssocToConfigHash(params Params, esAssociation commonv1.Association,
 }
 
 func getVolumesFromAssociations(associations []commonv1.Association) []volume.VolumeLike {
-	vols := []volume.VolumeLike{}
-	for i, association := range associations {
-		if !association.AssociationConf().CAIsConfigured() {
-			return nil
+	var vols []volume.VolumeLike //nolint:prealloc
+	for i, assoc := range associations {
+		if !assoc.AssociationConf().CAIsConfigured() {
+			// skip as there is no volume to mount if association has no CA configured
+			continue
 		}
-		caSecretName := association.AssociationConf().GetCASecretName()
+		caSecretName := assoc.AssociationConf().GetCASecretName()
 		vols = append(vols, volume.NewSecretVolumeWithMountPath(
 			caSecretName,
-			fmt.Sprintf("%s-certs-%d", association.AssociationType(), i),
-			certificatesDir(association),
+			fmt.Sprintf("%s-certs-%d", assoc.AssociationType(), i),
+			certificatesDir(assoc),
 		))
 	}
 	return vols

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -185,6 +185,66 @@ func Test_amendBuilderForFleetMode(t *testing.T) {
 	}
 }
 
+func Test_getVolumesFromAssociations(t *testing.T) {
+	// Note: we use setAssocConfs to set the AssociationConfs which are normally set in the reconciliation loop.
+	for _, tt := range []struct {
+		name                   string
+		params                 Params
+		setAssocConfs          func(assocs []v1.Association)
+		wantAssociationsLength int
+	}{
+		{
+			name: "fleet mode enabled, kb ref, fleet ref",
+			params: Params{
+				Agent: agentv1alpha1.Agent{
+					Spec: agentv1alpha1.AgentSpec{
+						Mode:           agentv1alpha1.AgentFleetMode,
+						KibanaRef:      v1.ObjectSelector{Name: "kibana"},
+						FleetServerRef: v1.ObjectSelector{Name: "fleet"},
+					},
+				},
+			},
+			setAssocConfs: func(assocs []v1.Association) {
+				assocs[0].SetAssociationConf(&v1.AssociationConf{
+					CASecretName: "kibana-kb-http-certs-public",
+				})
+				assocs[1].SetAssociationConf(&v1.AssociationConf{
+					CASecretName: "fleet-agent-http-certs-public",
+				})
+			},
+			wantAssociationsLength: 2,
+		},
+		{
+			name: "fleet mode enabled, kb no tls ref, fleet ref",
+			params: Params{
+				Agent: agentv1alpha1.Agent{
+					Spec: agentv1alpha1.AgentSpec{
+						Mode:           agentv1alpha1.AgentFleetMode,
+						KibanaRef:      v1.ObjectSelector{Name: "kibana"},
+						FleetServerRef: v1.ObjectSelector{Name: "fleet"},
+					},
+				},
+			},
+			setAssocConfs: func(assocs []v1.Association) {
+				assocs[0].SetAssociationConf(&v1.AssociationConf{
+					// No CASecretName
+				})
+				assocs[1].SetAssociationConf(&v1.AssociationConf{
+					CASecretName: "fleet-agent-http-certs-public",
+				})
+			},
+			wantAssociationsLength: 1,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assocs := tt.params.Agent.GetAssociations()
+			tt.setAssocConfs(assocs)
+			associations := getVolumesFromAssociations(assocs)
+			require.Equal(t, tt.wantAssociationsLength, len(associations))
+		})
+	}
+}
+
 func Test_getRelatedEsAssoc(t *testing.T) {
 	for _, tt := range []struct {
 		name    string


### PR DESCRIPTION
Backports the following commits to 1.8:

- #4833