### PR TITLE
Add link to 1.8.0 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-1.8.0>>
 * <<release-notes-1.7.1>>
 * <<release-notes-1.7.0>>
 * <<release-notes-1.6.0>>
@@ -27,6 +28,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/1.8.0.asciidoc[]
 include::release-notes/1.7.1.asciidoc[]
 include::release-notes/1.7.0.asciidoc[]
 include::release-notes/1.6.0.asciidoc[]


### PR DESCRIPTION
Add the missing link to the 1.8.0 release notes in the main release-notes page.