### PR TITLE
Backport release notes to 1.8

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-1.8.0>>
 * <<release-notes-1.7.1>>
 * <<release-notes-1.7.0>>
 * <<release-notes-1.6.0>>
@@ -27,6 +28,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/1.8.0.asciidoc[]
 include::release-notes/1.7.1.asciidoc[]
 include::release-notes/1.7.0.asciidoc[]
 include::release-notes/1.6.0.asciidoc[]

--- a/docs/release-notes/1.8.0.asciidoc
+++ b/docs/release-notes/1.8.0.asciidoc
@@ -25,6 +25,7 @@ The operator does not rely on the `$PRE_STOP_MAX_WAIT_SECONDS` environment varia
 [float]
 === Bug fixes
 
+* Fix Agent volumes when an association has no CA {pull}4833[#4833] (issue: {issue}4832[#4832]
 * Fix handling CAs in Agent controller {pull}4807[#4807] (issue: {issue}4790[#4790])
 * Improve Elasticsearch cluster health API timeout handling {pull}4803[#4803] (issue: {issue}4507[#4507])
 * Agent: fix Elasticsearch association error message {pull}4792[#4792]

--- a/docs/release-notes/1.8.0.asciidoc
+++ b/docs/release-notes/1.8.0.asciidoc
@@ -1,0 +1,42 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-1.8.0]]
+== {n} version 1.8.0
+
+[[breaking-1.8.0]]
+[float]
+=== Breaking changes
+
+* Remove non-functional pre-stop hook parts {pull}4801[#4801] (issue: {issue}4698[#4698])
+
+The operator does not rely on the `$PRE_STOP_MAX_WAIT_SECONDS` environment variable to control <<{p}-prestop,Elasticsearch Pods PreStop hook>> anymore. Use `$PRE_STOP_ADDITIONAL_WAIT_SECONDS` instead (defaults to 50 seconds).
+
+* Note the next minor ECK version (1.9.0) will drop support for Openshift 3.11.
+
+[[enhancement-1.8.0]]
+[float]
+=== Enhancements
+
+* Drop "properties: {}" from empty-v1alpha1-patch {pull}4813[#4813]
+* Remove beta label from Helm documentation {pull}4802[#4802] (issue: {issue}4796[#4796])
+
+[[bug-1.8.0]]
+[float]
+=== Bug fixes
+
+* Fix handling CAs in Agent controller {pull}4807[#4807] (issue: {issue}4790[#4790])
+* Improve Elasticsearch cluster health API timeout handling {pull}4803[#4803] (issue: {issue}4507[#4507])
+* Agent: fix Elasticsearch association error message {pull}4792[#4792]
+
+[[nogroup-1.8.0]]
+[float]
+=== Misc
+
+* Update module gopkg.in/yaml.v1 to v2 {pull}4788[#4788]
+* Update module github.com/fsnotify/fsnotify to v1.5.0 {pull}4778[#4778]
+* Update golang Docker tag to v1.17.0 {pull}4766[#4766]
+* Update module sigs.k8s.io/controller-runtime to v0.9.6 {pull}4747[#4747]
+* Update module go.uber.org/zap to v1.19.0 {pull}4742[#4742]
+* Update module sigs.k8s.io/controller-tools to v0.6.2 {pull}4697[#4697]
+

--- a/docs/release-notes/highlights-1.8.0.asciidoc
+++ b/docs/release-notes/highlights-1.8.0.asciidoc
@@ -1,0 +1,26 @@
+[[release-highlights-1.8.0]]
+== 1.8.0 release highlights
+
+[float]
+[id="{p}-180-new-and-notable"]
+=== New and notable
+
+New and notable changes in version 1.8.0 of {n}. See <<release-notes-1.8.0>> for the full list of changes.
+
+[float]
+[id="{p}-180-helm-chart-ga"]
+==== ECK Helm Chart graduating from beta to GA
+
+The ECK operator Helm chart is now generally available. It provides an easy way to install and configure the operator along with its Custom Resource Definitions.
+
+[float]
+[id="{p}-180-openshift-311"]
+==== Last minor version to support Openshift 3.11
+
+The ECK 1.8.x minor release series is the last to support Openshift 3.11. Starting ECK 1.9.0, Openshift 3.11 link:https://www.elastic.co/support/matrix#matrix_kubernetes[won't be supported anymore].
+
+[float]
+[id="{p}-180-bugfixes"]
+==== Bug fixes
+
+Several bugs have been fixed in this release, including Elastic Agent certificates handling and inconsistent Elasticsearch Pod PreStop hook.


### PR DESCRIPTION
Backport 1.8.0 release notes PRs into 1.8 branch (#4838, #4839, #4828).