### PR TITLE
Add delete verb operator permission for pod resources

### DIFF
--- a/deploy/eck-operator/templates/_helpers.tpl
+++ b/deploy/eck-operator/templates/_helpers.tpl
@@ -175,12 +175,20 @@ RBAC permissions
 - apiGroups:
   - ""
   resources:
-  - pods
   - endpoints
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
Turns out we do delete Pods:

```
{"log.level":"error","@timestamp":"2021-09-15T09:29:29.109Z","log.logger":"manager.eck-operator.controller.elasticsearch-controller","message":"Reconciler error","service.version":"1.9.0-SNAPSHOT+6123ca4a","service.type":"eck","ecs.version":"1.4.0","name":"es-w28k","namespace":"e2e-3gpao-mercury","error":"pods \"es-w28k-es-masterdata-2
\" is forbidden: User \"system:serviceaccount:e2e-3gpao-elastic-system:e2e-3gpao-operator\" cannot delete resource \"pods\" in API group \"\" in the namespace \"e2e-3gpao-mercury\"","errorCauses":[{"error":"pods \"es-w28k-es-masterdata-2\" is forbidden: User \"system:serviceaccount:e2e-3gpao-elastic-system:e2e-3gpao-operator\" cannot d
elete resource \"pods\" in API group \"\" in the namespace \"e2e-3gpao-mercury\""}],"error.stack_trace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.6/pkg/internal/controller/controller.go:253\nsigs.k8s.io/controller-runtime/pkg/internal/con
troller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.6/pkg/internal/controller/controller.go:214"}
```