### PR TITLE
fix: Empty issuer DN not allowed in X509Certificates

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/security/custom-http-certificate.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/custom-http-certificate.asciidoc
@@ -29,26 +29,56 @@ This example illustrates how to issue a self-signed certificate for the <<{p}-de
 
 [source,yaml]
 ----
----
-apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
 metadata:
   name: selfsigned-issuer
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: quickstart-es-cert
+  name: my-selfsigned-ca
 spec:
   isCA: true
+  commonName: my-selfsigned-ca
+  secretName: root-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: ca-issuer
+spec:
+  ca:
+    secretName: root-secret
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: quickstart-es-cert  
+spec:
+  secretName: quickstart-es-cert
+  isCA: false
   dnsNames:
     - quickstart-es-http
     - quickstart-es-http.default.svc
     - quickstart-es-http.default.svc.cluster.local
+  subject:
+    organizations:
+      - quickstart
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
   issuerRef:
+    name: ca-issuer
     kind: Issuer
-    name: selfsigned-issuer
-  secretName: quickstart-es-cert
 ----


### PR DESCRIPTION
elasticsearch ElasticsearchSecurityException[failed to load SSL configuration [xpack.security.http.ssl]]; nested: ElasticsearchException[failed to initialize SSL TrustManager]; nested: CertificateParsingException[Empty issuer DN not allelasticsearch Likely root cause: java.security.cert.CertificateParsingException: Empty issuer DN not allowed in X509Certificates

See: https://github.com/jetstack/cert-manager/issues/3634

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/master/CONTRIBUTING.md)?
- If you submit code, is your pull request against master? We recommend pull requests against master. We will backport them as needed.
