### PR TITLE
Revert permission changes for pod resources

### DIFF
--- a/deploy/eck-operator/templates/_helpers.tpl
+++ b/deploy/eck-operator/templates/_helpers.tpl
@@ -184,14 +184,6 @@ RBAC permissions
   - ""
   resources:
   - pods
-  verbs:
-  - get
-  - list
-  - watch
-  - delete
-- apiGroups:
-  - ""
-  resources:
   - events
   - persistentvolumeclaims
   - secrets


### PR DESCRIPTION
We use Pod creation to validate Pod template in a dry-run call. Without it, we fail with:

```
{"log.level":"info","@timestamp":"2021-09-16T04:01:21.930Z","log.logger":"statefulset","message":"Pod validation skipped","service.version":"1.9.0-SNAPSHOT+14609e2b","service.type":"eck","ecs.version":"1.4.0","namespace":"e2e-z8ir2-mercury","es_name":"test-autoscaling-cwdr","error":"pods is forbidden: User \"system:serviceaccount:e2e-z8ir2-elastic-system:e2e-z8ir2-operator\" cannot create resource \"pods\" in API group \"\" in the namespace \"e2e-z8ir2-mercury\""}
```