### PR TITLE
Add support for Tanzu to deployer

### DIFF
--- a/.ci/jobs/e2e-tests-tanzu.yml
+++ b/.ci/jobs/e2e-tests-tanzu.yml
@@ -1,0 +1,27 @@
+---
+- job:
+    description: Run ECK E2E tests on Tanzu
+    name: cloud-on-k8s-e2e-tests-tanzu
+    project-type: pipeline
+    parameters:
+      - string:
+          name: branch_specifier
+          default: master
+          description: "the Git branch specifier to build (&lt;branchName&gt;,&lt;tagName&gt;, &lt;commitId&gt;, etc.)"
+      - string:
+          name: JKS_PARAM_OPERATOR_IMAGE
+          description: "ECK Docker image"
+      - bool:
+          name: SEND_NOTIFICATIONS
+          default: true
+          description: "Specified if job should send notifications to Slack. Enabled by default."
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/elastic/cloud-on-k8s
+            branches:
+              - ${branch_specifier}
+            credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
+            refspec: ${branch_specifier}
+      script-path: .ci/pipelines/e2e-tests-tanzu.Jenkinsfile
+      lightweight-checkout: false

--- a/.ci/pipelines/e2e-tests-tanzu.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-tanzu.Jenkinsfile
@@ -1,0 +1,82 @@
+// This library overrides the default checkout behavior to enable sleep+retries if there are errors
+// Added to help overcome some recurring github connection issues
+@Library('apm@current') _
+
+def failedTests = []
+def lib
+
+pipeline {
+
+    agent {
+        label 'linux'
+    }
+
+    options {
+        timeout(time: 600, unit: 'MINUTES')
+    }
+
+    environment {
+        VAULT_ADDR = credentials('vault-addr')
+        VAULT_ROLE_ID = credentials('vault-role-id')
+        VAULT_SECRET_ID = credentials('vault-secret-id')
+    }
+
+    stages {
+        stage('Load common scripts') {
+            steps {
+                script {
+                    lib = load ".ci/common/tests.groovy"
+                }
+            }
+        }
+        stage("Run E2E tests") {
+            steps {
+                sh '.ci/setenvconfig e2e/tanzu'
+                script {
+                    env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-test-artifacts TARGET=ci-e2e ci')
+
+                    sh 'make -C .ci TARGET=e2e-generate-xml ci'
+                    junit "e2e-tests.xml"
+
+                    if (env.SHELL_EXIT_CODE != 0) {
+                        failedTests = lib.getListOfFailedTests()
+                        googleStorageUpload bucket: "gs://devops-ci-artifacts/jobs/$JOB_NAME/$BUILD_NUMBER",
+                            credentialsId: "devops-ci-gcs-plugin",
+                            pattern: "*.tgz",
+                            sharedPublicly: true,
+                            showInline: true
+                    }
+
+                    sh 'exit $SHELL_EXIT_CODE'
+                }
+            }
+        }
+    }
+
+    post {
+        unsuccessful {
+            script {
+                if (params.SEND_NOTIFICATIONS) {
+                    Set<String> filter = new HashSet<>()
+                    filter.addAll(failedTests)
+                    def msg = lib.generateSlackMessage("E2E tests on Tanzu failed!", env.BUILD_URL, filter)
+
+                    slackSend(
+                        channel: '#cloud-k8s',
+                        color: 'danger',
+                        message: msg,
+                        tokenCredentialId: 'cloud-ci-slack-integration-token',
+                        failOnError: true
+                    )
+                }
+            }
+        }
+        cleanup {
+            script {
+                sh '.ci/setenvconfig cleanup/tanzu'
+                sh 'make -C .ci TARGET=run-deployer ci'
+            }
+            cleanWs()
+        }
+    }
+}

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -351,6 +351,38 @@ CFG
 ;;
 
 ######################################
+  e2e/tanzu)
+######################################
+
+write_env <<ENV
+IMG_SUFFIX=-ci
+E2E_REGISTRY_NAMESPACE=eck-ci
+
+GO_TAGS=release
+export LICENSE_PUBKEY=/go/src/github.com/elastic/cloud-on-k8s/.ci/license.key
+TEST_LICENSE=/go/src/github.com/elastic/cloud-on-k8s/.ci/test-license.json
+MONITORING_SECRETS=/go/src/github.com/elastic/cloud-on-k8s/.ci/monitoring-secrets.json
+
+OPERATOR_IMAGE=$JKS_PARAM_OPERATOR_IMAGE
+
+PIPELINE=e2e/tanzu
+BUILD_NUMBER=$BUILD_NUMBER
+E2E_PROVIDER=tanzu
+CLUSTER_NAME=$BUILD_TAG
+TEST_OPTS=-race
+ENV
+write_deployer_config <<CFG
+id: tanzu-ci
+overrides:
+  clusterName: $BUILD_TAG
+  vaultInfo:
+    address: $VAULT_ADDR
+    roleId: $VAULT_ROLE_ID
+    secretId: $VAULT_SECRET_ID
+CFG
+
+;;
+######################################
   e2e/stack-versions)
 ######################################
 
@@ -514,6 +546,22 @@ CFG
 
 write_deployer_config <<CFG
 id: aks-ci
+overrides:
+  operation: delete
+  clusterName: $BUILD_TAG
+  vaultInfo:
+    address: $VAULT_ADDR
+    roleId: $VAULT_ROLE_ID
+    secretId: $VAULT_SECRET_ID
+CFG
+;;
+
+######################################
+  cleanup/tanzu)
+######################################
+
+write_deployer_config <<CFG
+id: tanzu-ci
 overrides:
   operation: delete
   clusterName: $BUILD_TAG

--- a/Makefile
+++ b/Makefile
@@ -374,6 +374,11 @@ switch-eks:
 switch-kind:
 	@ echo "kind" > hack/deployer/config/provider
 
+switch-tanzu:
+	@ echo "tanzu" > hack/deployer/config/provider
+
+
+
 #################################
 ##  --    Docker images    --  ##
 #################################

--- a/hack/deployer/cmd/create.go
+++ b/hack/deployer/cmd/create.go
@@ -30,7 +30,7 @@ func CreateCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-
+			var cfgData string
 			switch provider {
 			case runner.GkeDriverID:
 				gCloudProject, err := GetEnvVar("GCLOUD_PROJECT")
@@ -38,22 +38,14 @@ func CreateCommand() *cobra.Command {
 					return err
 				}
 
-				data := fmt.Sprintf(runner.DefaultGkeRunConfigTemplate, user, gCloudProject)
-				fullPath := path.Join(filePath, runner.GkeConfigFileName)
-				if err := ioutil.WriteFile(fullPath, []byte(data), 0600); err != nil {
-					return err
-				}
+				cfgData = fmt.Sprintf(runner.DefaultGkeRunConfigTemplate, user, gCloudProject)
 			case runner.AksDriverID:
 				resourceGroup, err := GetEnvVar("RESOURCE_GROUP")
 				if err != nil {
 					return err
 				}
 
-				data := fmt.Sprintf(runner.DefaultAksRunConfigTemplate, user, resourceGroup)
-				fullPath := path.Join(filePath, runner.AksConfigFileName)
-				if err := ioutil.WriteFile(fullPath, []byte(data), 0600); err != nil {
-					return err
-				}
+				cfgData = fmt.Sprintf(runner.DefaultAksRunConfigTemplate, user, resourceGroup)
 			case runner.OcpDriverID:
 				gCloudProject, err := GetEnvVar("GCLOUD_PROJECT")
 				if err != nil {
@@ -65,11 +57,7 @@ func CreateCommand() *cobra.Command {
 					return err
 				}
 
-				data := fmt.Sprintf(runner.DefaultOcpRunConfigTemplate, user, gCloudProject, pullSecret)
-				fullPath := path.Join(filePath, runner.OcpConfigFileName)
-				if err := ioutil.WriteFile(fullPath, []byte(data), 0600); err != nil {
-					return err
-				}
+				cfgData = fmt.Sprintf(runner.DefaultOcpRunConfigTemplate, user, gCloudProject, pullSecret)
 			case runner.EKSDriverID:
 				// optional variable for local dev use
 				token, _ := os.LookupEnv("GITHUB_TOKEN")
@@ -79,20 +67,17 @@ func CreateCommand() *cobra.Command {
 					return err
 				}
 
-				data := fmt.Sprintf(runner.DefaultEKSRunConfigTemplate, user, vaultAddr, token)
-				fullPath := path.Join(filePath, runner.EKSConfigFileName)
-				if err := ioutil.WriteFile(fullPath, []byte(data), 0600); err != nil {
-					return err
-				}
+				cfgData = fmt.Sprintf(runner.DefaultEKSRunConfigTemplate, user, vaultAddr, token)
 			case runner.KindDriverID:
-				data := fmt.Sprintf(runner.DefaultKindRunConfigTemplate, user)
-				fullPath := path.Join(filePath, runner.KindConfigFileName)
-				return ioutil.WriteFile(fullPath, []byte(data), 0600)
+				cfgData = fmt.Sprintf(runner.DefaultKindRunConfigTemplate, user)
+			case runner.TanzuDriverID:
+				cfgData = fmt.Sprintf(runner.DefaultTanzuRunConfigTemplate, user)
 			default:
 				return fmt.Errorf("unknown provider %s", provider)
 			}
 
-			return nil
+			fullPath := path.Join(filePath, fmt.Sprintf("deployer-config-%s.yml", provider))
+			return ioutil.WriteFile(fullPath, []byte(cfgData), 0600)
 		},
 	}
 

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -167,3 +167,14 @@ plans:
     nodeCount: 3
     nodeImage: kindest/node:v1.21.1
     ipFamily: ipv4
+- id: tanzu-ci
+  operation: create
+  clusterName: tkg-ci
+  provider: tanzu
+  machineType: Standard_D8s_v3
+  diskSetup: kubectl apply -k hack/deployer/config/local-disks
+  tanzu:
+    location: eastus
+    nodeCount: 3
+    installerImage: cloudonk8s.azurecr.io/tanzu-ci:47a15de6827f
+

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -177,4 +177,12 @@ plans:
     location: eastus
     nodeCount: 3
     installerImage: cloudonk8s.azurecr.io/tanzu-ci:47a15de6827f
-
+- id: tanzu-dev
+  operation: create
+  clusterName: tkg-dev
+  provider: tanzu
+  machineType: Standard_D8s_v3
+  tanzu:
+    location: westeurope
+    nodeCount: 3
+    installerImage: cloudonk8s.azurecr.io/tanzu-ci:47a15de6827f

--- a/hack/deployer/runner/azure.go
+++ b/hack/deployer/runner/azure.go
@@ -1,0 +1,56 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package runner
+
+import "encoding/json"
+
+// TODO this should probably be a package
+
+type azureCredentials struct {
+	ClientID       string
+	ClientSecret   string
+	TenantID       string
+	SubscriptionID string
+}
+
+func newAzureCredentials(client *VaultClient) (azureCredentials, error) {
+	creds, err := client.GetMany(AksVaultPath, "appId", "password", "tenant", "subscription")
+	if err != nil {
+		return azureCredentials{}, err
+	}
+	return azureCredentials{
+		ClientID:       creds[0],
+		ClientSecret:   creds[1],
+		TenantID:       creds[2],
+		SubscriptionID: creds[3],
+	}, nil
+}
+
+func azureLogin(creds azureCredentials) error {
+	cmd := "az login --service-principal -u {{.AppId}} -p {{.TenantSecret}} --tenant {{.TenantId}}"
+	return NewCommand(cmd).
+		AsTemplate(map[string]interface{}{
+			"AppId":        creds.ClientID,
+			"TenantSecret": creds.ClientSecret,
+			"TenantId":     creds.TenantID,
+		}).
+		WithoutStreaming().
+		Run()
+}
+
+func azureExistsCmd(cmd *Command) (bool, error) {
+	str, err := cmd.WithoutStreaming().Output()
+	if err != nil {
+		return false, err
+	}
+	type response struct {
+		Exists bool `json:"exists"`
+	}
+	var r response
+	if err := json.Unmarshal([]byte(str), &r); err != nil {
+		return false, err
+	}
+	return r.Exists, nil
+}

--- a/hack/deployer/runner/eks.go
+++ b/hack/deployer/runner/eks.go
@@ -16,7 +16,6 @@ import (
 
 const (
 	EKSDriverID                 = "eks"
-	EKSConfigFileName           = "deployer-config-eks.yml"
 	DefaultEKSRunConfigTemplate = `id: eks-dev
 overrides:
   clusterName: %s-dev-cluster

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -14,7 +14,6 @@ const (
 	GkeDriverID                     = "gke"
 	GkeVaultPath                    = "secret/devops-ci/cloud-on-k8s/ci-gcp-k8s-operator"
 	GkeServiceAccountVaultFieldName = "service-account"
-	GkeConfigFileName               = "deployer-config-gke.yml"
 	DefaultGkeRunConfigTemplate     = `id: gke-dev
 overrides:
   clusterName: %s-dev-cluster

--- a/hack/deployer/runner/kind.go
+++ b/hack/deployer/runner/kind.go
@@ -25,7 +25,6 @@ const (
 overrides:
   clusterName: %s-dev-cluster
 `
-	KindConfigFileName = "deployer-config-kind.yml"
 	// manifest is a kind cluster template
 	// the explicit podSubnet definition can be removed as soon as https://github.com/kubernetes-sigs/kind/commit/60074a9e67ddc8d35d3468ab137358b62a4cf723
 	// will be available in a released version of kind and we don't rely on older versions anymore

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -23,7 +23,6 @@ const (
 	OcpServiceAccountVaultFieldName = "service-account"
 	OcpPullSecretFieldName          = "pull-secret"
 	OcpStateBucket                  = "eck-deployer-ocp-clusters-state"
-	OcpConfigFileName               = "deployer-config-ocp.yml"
 	DefaultOcpRunConfigTemplate     = `id: ocp-dev
 overrides:
   clusterName: %s-dev-cluster
@@ -409,21 +408,7 @@ func (d *OcpDriver) copyKubeconfig() error {
 }
 
 func (d *OcpDriver) removeKubeconfig() error {
-	if err := NewCommand("kubectl config get-contexts admin").Run(); err != nil {
-		// skip because the admin context does not exist in the kube config
-		return nil //nolint:nilerr
-	}
-
-	log.Printf("Removing context, user and cluster entry from kube config")
-	if err := NewCommand("kubectl config delete-context admin").Run(); err != nil {
-		return err
-	}
-	if err := NewCommand("kubectl config delete-user admin").Run(); err != nil {
-		return err
-	}
-	return NewCommand("kubectl config delete-cluster {{.ClusterName}}").
-		AsTemplate(map[string]interface{}{"ClusterName": d.plan.ClusterName}).
-		Run()
+	return removeKubeconfig("admin", "admin", "admin")
 }
 
 func (d *OcpDriver) bucketParams() map[string]interface{} {

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -29,24 +29,25 @@ type Plans struct {
 
 // Plan encapsulates information needed to provision a cluster
 type Plan struct {
-	Id                string        `yaml:"id"` //nolint:revive
-	Operation         string        `yaml:"operation"`
-	ClusterName       string        `yaml:"clusterName"`
-	ClientVersion     string        `yaml:"clientVersion"`
-	ClientBuildDefDir string        `yaml:"clientBuildDefDir"`
-	Provider          string        `yaml:"provider"`
-	KubernetesVersion string        `yaml:"kubernetesVersion"`
-	MachineType       string        `yaml:"machineType"`
-	Gke               *GkeSettings  `yaml:"gke,omitempty"`
-	Aks               *AksSettings  `yaml:"aks,omitempty"`
-	Ocp               *OcpSettings  `yaml:"ocp,omitempty"`
-	Ocp3              *Ocp3Settings `yaml:"ocp3,omitempty"`
-	EKS               *EKSSettings  `yaml:"eks,omitempty"`
-	Kind              *KindSettings `yaml:"kind,omitempty"`
-	VaultInfo         *VaultInfo    `yaml:"vaultInfo,omitempty"`
-	ServiceAccount    bool          `yaml:"serviceAccount"`
-	Psp               bool          `yaml:"psp"`
-	DiskSetup         string        `yaml:"diskSetup"`
+	Id                string         `yaml:"id"` //nolint:revive
+	Operation         string         `yaml:"operation"`
+	ClusterName       string         `yaml:"clusterName"`
+	ClientVersion     string         `yaml:"clientVersion"`
+	ClientBuildDefDir string         `yaml:"clientBuildDefDir"`
+	Provider          string         `yaml:"provider"`
+	KubernetesVersion string         `yaml:"kubernetesVersion"`
+	MachineType       string         `yaml:"machineType"`
+	Gke               *GkeSettings   `yaml:"gke,omitempty"`
+	Aks               *AksSettings   `yaml:"aks,omitempty"`
+	Ocp               *OcpSettings   `yaml:"ocp,omitempty"`
+	Ocp3              *Ocp3Settings  `yaml:"ocp3,omitempty"`
+	EKS               *EKSSettings   `yaml:"eks,omitempty"`
+	Kind              *KindSettings  `yaml:"kind,omitempty"`
+	Tanzu             *TanzuSettings `yaml:"tanzu,omitempty"`
+	VaultInfo         *VaultInfo     `yaml:"vaultInfo,omitempty"`
+	ServiceAccount    bool           `yaml:"serviceAccount"`
+	Psp               bool           `yaml:"psp"`
+	DiskSetup         string         `yaml:"diskSetup"`
 }
 
 type VaultInfo struct {
@@ -108,6 +109,13 @@ type KindSettings struct {
 	NodeCount int    `yaml:"nodeCount"`
 	NodeImage string `yaml:"nodeImage"`
 	IPFamily  string `yaml:"ipFamily"`
+}
+
+type TanzuSettings struct {
+	AksSettings    `yaml:",inline"`
+	InstallerImage string `yaml:"installerImage"`
+	WorkDir        string `yaml:"workDir"`
+	SSHPubKey      string `yaml:"sshPubKey"`
 }
 
 // RunConfig encapsulates Id used to choose a plan and a map of overrides to apply to the plan, expected to map to a file

--- a/hack/deployer/runner/tanzu.go
+++ b/hack/deployer/runner/tanzu.go
@@ -1,0 +1,407 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package runner
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"text/template"
+)
+
+const (
+	TanzuDriverID                 = "tanzu"
+	TanzuInstallConfig            = "install-config.yaml"
+	DefaultTanzuRunConfigTemplate = `id: tanzu-dev
+overrides:
+  clusterName: %s-dev-cluster
+`
+	TanzuInstallerConfigTemplate = `AZURE_CLIENT_ID: {{.AzureClientID}}  
+AZURE_CLIENT_SECRET: {{.AzureClientSecret}}
+AZURE_CONTROL_PLANE_MACHINE_TYPE: {{.AzureMachineType}} 
+AZURE_LOCATION: {{.AzureLocation}}
+AZURE_NODE_MACHINE_TYPE: {{.AzureMachineType}}
+AZURE_NODE_SUBNET_CIDR: 10.0.1.0/24
+AZURE_RESOURCE_GROUP: {{.ResourceGroup}}
+AZURE_SSH_PUBLIC_KEY_B64: {{.SSHPubKey}}
+AZURE_SUBSCRIPTION_ID: {{.AzureSubscriptionID}}
+AZURE_TENANT_ID: {{.AzureTenantID}}
+CLUSTER_PLAN: dev
+ENABLE_CEIP_PARTICIPATION: "false"
+IDENTITY_MANAGEMENT_TYPE: none
+INFRASTRUCTURE_PROVIDER: azure
+OS_ARCH: amd64
+OS_NAME: ubuntu
+OS_VERSION: "20.04"
+TKG_HTTP_PROXY_ENABLED: "false"
+CONTROL_PLANE_MACHINE_COUNT: 1
+WORKER_MACHINE_COUNT: {{.NodeCount}}
+`
+)
+
+func init() {
+	drivers[TanzuDriverID] = &TanzuDriverFactory{}
+}
+
+type TanzuDriverFactory struct{}
+
+func (t TanzuDriverFactory) Create(plan Plan) (Driver, error) {
+	if plan.VaultInfo == nil {
+		return nil, fmt.Errorf("no vault credentials provided")
+	}
+	vaultClient, err := NewClient(*plan.VaultInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	credentials, err := newAzureCredentials(vaultClient)
+	if err != nil {
+		return nil, err
+	}
+
+	// we have some legacy config in vault that probably should not be there: container registry name
+	// is not strictly sensitive information
+	acrName, err := vaultClient.Get(AksVaultPath, "acr-name")
+	if err != nil {
+		return nil, err
+	}
+
+	// users can optionally provide their SSH pubkey to log into hosts provisioned by this driver
+	// however we need a pubkey in any case to be able to run the installer, thus we have a default in vault.
+	if plan.Tanzu.SSHPubKey == "" {
+		key, err := vaultClient.Get("secret/devops-ci/cloud-on-k8s/ci-tanzu-k8s-operator", "ssh_public_key")
+		if err != nil {
+			return nil, err
+		}
+		plan.Tanzu.SSHPubKey = key
+	}
+
+	// we use the Azure resource group to simplify garbage collecting the created resources on delete, if users set this
+	// value they have to be aware that the referenced resource group will be deleted.
+	if plan.Tanzu.ResourceGroup == "" {
+		plan.Tanzu.ResourceGroup = plan.ClusterName
+	}
+
+	return &TanzuDriver{
+		plan:             plan,
+		azureCredentials: credentials,
+		acrName:          acrName,
+	}, nil
+}
+
+var _ DriverFactory = &TanzuDriverFactory{}
+
+type TanzuDriver struct {
+	plan             Plan
+	acrName          string
+	azureCredentials azureCredentials
+	// runtime state
+	installerStateDir string
+}
+
+func (t *TanzuDriver) Execute() error {
+	if err := run(t.setup()); err != nil {
+		return err
+	}
+
+	// we assume if the resource group exists that the management/workload clusters
+	// have been deployed. This is not a guarantee however that they are functional.
+	newDeployment, err := t.ensureResourceGroup()
+	if err != nil {
+		return err
+	}
+
+	switch t.plan.Operation {
+	case CreateAction:
+		if !newDeployment {
+			log.Println("Not creating cluster because it exists")
+			return nil
+		}
+		return t.create()
+	case DeleteAction:
+		// always attempt deletion
+		return t.delete()
+	}
+	return nil
+}
+
+func (t *TanzuDriver) GetCredentials() error {
+	if err := run(t.setup()); err != nil {
+		return err
+	}
+	return t.copyKubeconfig()
+}
+
+// copyKubeconfig extracts the kubeconfig for the workload cluster out of the installer state and
+// copies it to the main kube config (typically $HOME/.kube/config) where it is merged with existing configs.
+func (t *TanzuDriver) copyKubeconfig() error {
+	workloadConfigFile := "workload-kubeconfig"
+	tanzuContainerKubeconfigPath := filepath.Join("/root", workloadConfigFile)
+	if err := t.dockerizedTanzuCmd("cluster", "kubeconfig", "get", t.plan.ClusterName,
+		"--admin", "--export-file", tanzuContainerKubeconfigPath).Run(); err != nil {
+		return err
+	}
+	ciContainerKubeconfigPath := filepath.Join(t.installerStateDir, workloadConfigFile)
+	return mergeKubeconfig(ciContainerKubeconfigPath)
+}
+
+// perpareCLI prepares the tanzu CLI by installing the necessary plugins.
+func (t *TanzuDriver) perpareCLI() error {
+	log.Println("Installing Tanzu CLI plugins")
+	return t.dockerizedTanzuCmd("plugin", "install", "--local", "/", "all").Run()
+}
+
+// teardownCLI uninstall the plugins again mainly to make the footprint of the installer state smaller and to avoid
+// permissions issues when restoring that state as it also contains executables.
+func (t *TanzuDriver) teardownCLI() error {
+	return t.dockerizedTanzuCmd("plugin", "clean").Run()
+}
+
+// ensureWorkDir setups the workdir in a place that is accessible from the calling context (on CI deployer is called from
+// within another container). Users can also just set a fixed workdir via config which is useful for debugging.
+func (t *TanzuDriver) ensureWorkDir() error {
+	if t.installerStateDir != "" {
+		// already initialised
+		return nil
+	}
+	workDir := t.plan.Tanzu.WorkDir
+	if workDir == "" {
+		// base work dir in HOME dir otherwise mounting to container won't work without further settings adjustment
+		// in macOS in local mode. In CI mode we need the workdir to be in the volume shared between containers.
+		// having the work dir in HOME also underlines the importance of the work dir contents. The work dir is the only
+		// source to cleanly uninstall the cluster should the rsync fail.
+		var err error
+		workDir, err = ioutil.TempDir(os.Getenv("HOME"), t.plan.ClusterName)
+		if err != nil {
+			return err
+		}
+		log.Printf("Defaulting WorkDir: %s", workDir)
+	}
+
+	if err := os.MkdirAll(workDir, os.ModePerm); err != nil {
+		return err
+	}
+	t.installerStateDir = workDir
+	log.Printf("Using installer state dir: %s", workDir)
+	return nil
+}
+
+// create creates the Tanzu management and workload clusters and installs the storage class needed for e2e testing.
+func (t *TanzuDriver) create() error {
+	log.Println("Creating management cluster")
+	err := t.createInstallerConfig()
+	if err != nil {
+		return err
+	}
+	// run clean up and state upload to be able to continue to run operations later with a fresh Docker container
+	defer t.suspend()
+
+	cfgPathInContainer := filepath.Join("/root", TanzuInstallConfig)
+	if err := t.dockerizedTanzuCmd("management-cluster", "create", "--file", cfgPathInContainer).Run(); err != nil {
+		return err
+	}
+	log.Println("Creating workload cluster")
+	if err := t.dockerizedTanzuCmd("cluster", "create", t.plan.ClusterName, "--file", cfgPathInContainer).Run(); err != nil {
+		return err
+	}
+	return run([]func() error{
+		t.copyKubeconfig,
+		func() error {
+			return setupDisks(t.plan)
+		},
+		createStorageClass,
+	})
+}
+
+// createInstallerConfig renders the installer config into a file. This config can be used for both workload and management cluster
+// Tanzu ignores the worker machine count setting for management clusters.
+func (t *TanzuDriver) createInstallerConfig() error {
+	params := map[string]interface{}{
+		"AzureClientID":       t.azureCredentials.ClientID,
+		"AzureClientSecret":   t.azureCredentials.ClientSecret,
+		"AzureMachineType":    t.plan.MachineType,
+		"AzureLocation":       t.plan.Tanzu.Location,
+		"ResourceGroup":       t.plan.Tanzu.ResourceGroup,
+		"SSHPubKey":           t.plan.Tanzu.SSHPubKey,
+		"AzureSubscriptionID": t.azureCredentials.SubscriptionID,
+		"AzureTenantID":       t.azureCredentials.TenantID,
+		"NodeCount":           t.plan.Tanzu.NodeCount,
+	}
+	var cfg bytes.Buffer
+	if err := template.Must(template.New("tanzu-mgmt").Parse(TanzuInstallerConfigTemplate)).Execute(&cfg, params); err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(t.installerConfigFilePath(), cfg.Bytes(), 0600)
+}
+
+// installerConfigFilePath returns the path to the installer config valid in the context of deployer.
+func (t *TanzuDriver) installerConfigFilePath() string {
+	return filepath.Join(t.installerStateDir, TanzuInstallConfig)
+}
+
+// delete deletes the created resources simply by removing the Azure resource group
+func (t *TanzuDriver) delete() error {
+	return run([]func() error{
+		// shortcut deletion by not attempting deletion on application level but just delete the infrastructure
+		t.deleteResourceGroup,
+		t.deleteStorageContainer,
+		func() error {
+			user := fmt.Sprintf("%s-admin", t.plan.ClusterName)
+			context := fmt.Sprintf("%s@%s", user, t.plan.ClusterName)
+			return removeKubeconfig(context, t.plan.ClusterName, user)
+		},
+	})
+}
+
+// dockerizedTanzuCmd runs a tanzu CLI command inside a Docker container based off the Tanzu installer image.
+func (t *TanzuDriver) dockerizedTanzuCmd(args ...string) *Command {
+	params := map[string]interface{}{
+		"SharedVolume":        filepath.Join(SharedVolumeName(), filepath.Base(t.installerStateDir)),
+		"TanzuCLIDockerImage": t.plan.Tanzu.InstallerImage,
+		"Args":                args,
+	}
+	// We are mounting the shared volume into the installer container and configure it to be the HOME directory
+	// this is mainly so that we can save the installer state afterwards correctly as the Tanzu CLI is does not allow
+	// customizing where it saves its state. It always uses $HOME.
+	// We are mounting tmp as the installer needs a scratch space and writing into the container won't work
+	// We need host networking because the Tanzu installer will try to connect to a kind cluster it boots up
+	cmd := NewCommand(`docker run --rm \
+		-v {{.SharedVolume}}:/root \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v /tmp:/tmp \
+		-e HOME=/root \
+		-e PATH=/ \
+		--network host \
+		{{.TanzuCLIDockerImage}} \
+		/tanzu {{Join .Args " "}}`)
+	return cmd.AsTemplate(params)
+}
+
+// setup is a list of functions that need to run before any installer commands can run.
+func (t *TanzuDriver) setup() []func() error {
+	return []func() error{
+		t.loginToAzure,
+		t.loginToContainerRegistry,
+		t.ensureWorkDir,
+		t.ensureStorageContainer,
+		t.restoreInstallerState,
+		t.perpareCLI,
+	}
+}
+
+// suspend persists the installer state in a storage container so that further operations that need it can be run later.
+func (t *TanzuDriver) suspend() {
+	// clean up sensitive bits
+	if err := os.Remove(t.installerConfigFilePath()); err != nil {
+		log.Println(err.Error())
+	}
+
+	// uninstall plugins to reduce state size by ~ 400MB and avoid issues with missing execute permissions after restore
+	if err := t.teardownCLI(); err != nil {
+		log.Println(err.Error())
+	}
+
+	// persist state to storage bucket to be able to continue later to either get credentials or
+	// to delete resources
+	if err := t.persistInstallerState(); err != nil {
+		log.Println(err.Error())
+	}
+}
+
+// loginToAzure we use Azure as the infrastructure provider for Tanzu testing.
+func (t *TanzuDriver) loginToAzure() error {
+	log.Println("Logging in to Azure")
+	return azureLogin(t.azureCredentials)
+}
+
+// loginToContainerRegistry we use a private container registry to make the Tanzu CLI available in CI.
+func (t *TanzuDriver) loginToContainerRegistry() error {
+	log.Println("Logging in to container registry")
+	return NewCommand("az acr login --name {{.ContainerRegistry}}").
+		AsTemplate(map[string]interface{}{
+			"ContainerRegistry": t.acrName,
+		}).Run()
+}
+
+// ensureResourceGroup checks for the existence of an Azure resource group (which we name unless overridden after the
+// cluster we want to deploy)
+func (t *TanzuDriver) ensureResourceGroup() (bool, error) {
+	exists, err := NewCommand("az group exists --name {{.ResourceGroup}}").
+		AsTemplate(map[string]interface{}{
+			"ResourceGroup": t.plan.Tanzu.ResourceGroup,
+		}).WithoutStreaming().OutputContainsAny("true")
+	if err != nil || exists {
+		return false, err
+	}
+	log.Println("Creating Azure resource group")
+	err = NewCommand("az group create -l {{.Location}} --name {{.ResourceGroup}}").
+		AsTemplate(map[string]interface{}{
+			"Location":      t.plan.Tanzu.Location,
+			"ResourceGroup": t.plan.Tanzu.ResourceGroup,
+		}).WithoutStreaming().Run()
+	return true, err
+}
+
+func (t *TanzuDriver) deleteResourceGroup() error {
+	log.Println("Deleting Azure resource group")
+	return NewCommand("az group delete --name {{.ResourceGroup}} -y").AsTemplate(map[string]interface{}{
+		"ResourceGroup": t.plan.Tanzu.ResourceGroup,
+	}).Run()
+}
+
+func (t *TanzuDriver) storageContainerExists() (bool, error) {
+	return azureExistsCmd(NewCommand("az storage container exists --account-name cloudonk8s --name {{.StorageContainer}} --auth login").
+		AsTemplate(map[string]interface{}{
+			"StorageContainer": t.plan.ClusterName,
+		}))
+}
+
+func (t *TanzuDriver) ensureStorageContainer() error {
+	exists, err := t.storageContainerExists()
+	if err != nil {
+		return err
+	}
+	if exists {
+		log.Println("Reusing existing storage container to persist installer state")
+		return nil
+	}
+	log.Println("Creating new storage container to persist installer state")
+	return NewCommand("az storage container create --account-name cloudonk8s --name {{.StorageContainer}} --auth login").
+		AsTemplate(map[string]interface{}{
+			"StorageContainer": t.plan.ClusterName,
+		}).WithoutStreaming().Run()
+}
+
+func (t TanzuDriver) deleteStorageContainer() error {
+	log.Println("Deleting Azure storage container")
+	return NewCommand("az storage container delete --account-name cloudonk8s --name {{.StorageContainer}} --auth login").
+		AsTemplate(map[string]interface{}{
+			"StorageContainer": t.plan.ClusterName,
+		}).WithoutStreaming().Run()
+}
+
+func (t *TanzuDriver) persistInstallerState() error {
+	log.Println("Persisting installer state to Azure storage container")
+	return NewCommand(`az storage azcopy blob sync -c {{.StorageContainer}} --account-name cloudonk8s -s "{{.InstallerStateDir}}"`).
+		AsTemplate(map[string]interface{}{
+			"StorageContainer":  t.plan.ClusterName,
+			"InstallerStateDir": t.installerStateDir,
+		}).WithoutStreaming().Run()
+}
+
+func (t *TanzuDriver) restoreInstallerState() error {
+	log.Println("Restoring installer state from storage container if any")
+	return NewCommand(`az storage azcopy blob download -c {{.StorageContainer}} --account-name cloudonk8s -s '*' -d "{{.InstallerStateDir}}" --recursive`).
+		AsTemplate(map[string]interface{}{
+			"StorageContainer":  t.plan.ClusterName,
+			"InstallerStateDir": t.installerStateDir,
+		}).WithoutStreaming().Run()
+}
+
+var _ Driver = &TanzuDriver{}

--- a/hack/deployer/runner/tanzu.go
+++ b/hack/deployer/runner/tanzu.go
@@ -159,8 +159,8 @@ func (t *TanzuDriver) copyKubeconfig() error {
 	return mergeKubeconfig(ciContainerKubeconfigPath)
 }
 
-// perpareCLI prepares the tanzu/az CLI by installing the necessary plugins and setting up configuration
-func (t *TanzuDriver) perpareCLI() error {
+// prepareCLI prepares the tanzu/az CLI by installing the necessary plugins and setting up configuration
+func (t *TanzuDriver) prepareCLI() error {
 	log.Println("Installing Tanzu CLI plugins")
 	return t.dockerizedTanzuCmd("plugin", "install", "--local", "/", "all").Run()
 }
@@ -199,10 +199,13 @@ func (t *TanzuDriver) ensureWorkDir() error {
 	return nil
 }
 
+// tanzuContainerPath returns an absolute path valid inside the Tanzu installer container using the given relative path.
 func (t *TanzuDriver) tanzuContainerPath(path string) string {
 	return filepath.Join("/root", t.installerStateDirBasename, path)
 }
 
+// deployerContainerPath returns an absolute path valid inside the deployer environment (container or not) using the give
+// relative path.
 func (t TanzuDriver) deployerContainerPath(path string) string {
 	return filepath.Join(t.installerStateDirPath, path)
 }
@@ -309,7 +312,7 @@ func (t *TanzuDriver) setup() []func() error {
 		t.ensureWorkDir,
 		t.ensureStorageContainer,
 		t.restoreInstallerState,
-		t.perpareCLI,
+		t.prepareCLI,
 	}
 }
 

--- a/test/e2e/cmd/run/job.go
+++ b/test/e2e/cmd/run/job.go
@@ -82,8 +82,7 @@ func (j *Job) WithDependency(dependency *Job) *Job {
 // onPodEvent ensures that log streaming is started and also manages the internal state of the Job based on the events
 // received from the informer.
 func (j *Job) onPodEvent(client *kubernetes.Clientset, pod *corev1.Pod) {
-	//nolint:exhaustive
-	switch pod.Status.Phase {
+	switch pod.Status.Phase { //nolint:exhaustive
 	case corev1.PodRunning:
 		if !j.jobStarted {
 			j.jobStarted = true


### PR DESCRIPTION
This adds support for Tanzu to deployer. ~This has not been tested on CI yet but only from a local machine. This PR also does not add yet any CI job (pending successful testing on CI).~ There is some room for additional refactorings which I have left out to keep the PR easier to review.  The refactoring I had in mind centres mainly around splitting up the `runner` namespace and factoring out provider specific bits into separate packages. 

Regarding the mechanics of running Tanzu: I am using a private container repository for the installer image therefore deviating from the concept of building client images on the fly as need which we adopted for `kind` and `ocp`. This is mainly because we cannot share the Tanzu installer in a publicly accessible Docker image due to T&C restrictions around redistribution. Using this image we spin up a management cluster in Azure from which we can spin up the workload cluster which is then used to run our e2e test suite. While Tanzu also supports AWS I found the resource group abstraction in Azure helpful for a simpler cleanup of the created infrastructure and I ran into IAM issues on AWS with the profiles we are using, so I followed the path of least resistance here.