### PR TITLE
Add missing reference to release-highlights-1.8.0

### DIFF
--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the most important changes in each release. For the full list, see <<eck-release-notes>>.
 
+* <<release-highlights-1.8.0>>
 * <<release-highlights-1.7.1>>
 * <<release-highlights-1.7.0>>
 * <<release-highlights-1.6.0>>
@@ -26,6 +27,7 @@ This section summarizes the most important changes in each release. For the full
 
 --
 
+include::highlights-1.8.0.asciidoc[]
 include::highlights-1.7.1.asciidoc[]
 include::highlights-1.7.0.asciidoc[]
 include::highlights-1.6.0.asciidoc[]


### PR DESCRIPTION
This commit adds the missing reference to the 1.8.0 release highlight page.
