### PR TITLE
Add Helm version to the Supported versions page

### DIFF
--- a/docs/operating-eck/installing-eck.asciidoc
+++ b/docs/operating-eck/installing-eck.asciidoc
@@ -31,14 +31,15 @@ This method is the quickest way to get started with ECK if you have full adminis
 [id="{p}-install-helm"]
 == Install ECK using the Helm chart
 
-
-Starting from version 1.3.0, an experimental Helm chart is available to install ECK. It is available from the Elastic Helm repository and can be added to your Helm repository list by running the following command:
+Starting from ECK 1.3.0, an experimental Helm chart is available to install ECK. It is available from the Elastic Helm repository and can be added to your Helm repository list by running the following command:
 
 [source, sh]
 ----
 helm repo add elastic https://helm.elastic.co
 helm repo update
 ----
+
+NOTE: The minimum supported version of Helm is 3.2.0.
 
 [float]
 [id="{p}-install-helm-global"]

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -1,12 +1,12 @@
 * Kubernetes 1.18-1.22
 * OpenShift 3.11, 4.4-4.8
 * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
+* Helm: 3.2.0+
 * Elasticsearch, Kibana, APM Server: 6.8+, 7.1+
 * Enterprise Search: 7.7+
 * Beats: 7.0+
 * Elastic Agent: 7.10+ (standalone), 7.14+ (Fleet)
 * Elastic Maps Server: 7.11+
-* Helm: 3.2.0+
 
 ECK should work with all conformant installers as listed in these link:https://github.com/cncf/k8s-conformance/blob/master/faq.md#what-is-a-distribution-hosted-platform-and-an-installer[FAQs]. Distributions include source patches and so may not work as-is with ECK.
 

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -6,6 +6,7 @@
 * Beats: 7.0+
 * Elastic Agent: 7.10+ (standalone), 7.14+ (Fleet)
 * Elastic Maps Server: 7.11+
+* Helm: 3.2.0+
 
 ECK should work with all conformant installers as listed in these link:https://github.com/cncf/k8s-conformance/blob/master/faq.md#what-is-a-distribution-hosted-platform-and-an-installer[FAQs]. Distributions include source patches and so may not work as-is with ECK.
 


### PR DESCRIPTION
This PR adds the Helm version to the [Supported versions](https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s_supported_versions.html) page in the public docs.

Fixes #4745