### PR TITLE
Set current ECK version to 1.8.0 in the docs

### DIFF
--- a/docs/eck-attributes.asciidoc
+++ b/docs/eck-attributes.asciidoc
@@ -1,5 +1,5 @@
-:eck_version: 1.7.1
+:eck_version: 1.8.0
 :eck_crd_version: v1
-:eck_release_branch: 1.7
+:eck_release_branch: 1.8
 :eck_github: https://github.com/elastic/cloud-on-k8s
 :eck_resources_list: Elasticsearch, Kibana, APM Server, Enterprise Search, Beats, Elastic Agent, and Elastic Maps Server


### PR DESCRIPTION
This bumps the "current" ECK version to 1.8.0 in the ECK docs.
