### PR TITLE
Update supported versions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Current features:
 
 Supported versions:
 
-*  Kubernetes 1.17-1.21
-*  OpenShift 3.11, 4.3-4.7
+*  Kubernetes 1.18-1.22
+*  OpenShift 3.11, 4.4-4.8
 *  Elasticsearch, Kibana, APM Server: 6.8+, 7.1+
 *  Enterprise Search: 7.7+
 *  Beats: 7.0+


### PR DESCRIPTION
We now support:

*  Kubernetes 1.18-1.22
*  OpenShift 3.11, 4.4-4.8
