### PR TITLE
Use rbac.authorization.k8s.io/v1 rather than rbac.authorization.k8s.i…

### DIFF
--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -148,7 +148,7 @@ metadata:
   labels:
     k8s-app: metricbeat
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metricbeat


### PR DESCRIPTION
…o/v1beta1

The v1beta1 resources are no longer served by K8s 1.22: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122.
It turns out we were already using v1 everywhere except in this particular case.
Openshift 3.11 is also using v1.

Should fix the E2E test failure in https://github.com/elastic/cloud-on-k8s/pull/4857#issuecomment-923798966.