### PR TITLE
[1.7] Add missing descriptions to Elastic Agent recipes README (#4861)

### DIFF
--- a/config/recipes/elastic-agent/README.asciidoc
+++ b/config/recipes/elastic-agent/README.asciidoc
@@ -6,10 +6,26 @@ IMPORTANT: These examples are for illustration purposes only and should not be c
 
 CAUTION: Some of these examples use the `node.store.allow_mmap: false` configuration value to avoid configuring memory mapping settings on the underlying host. This could have a significant performance impact on your Elasticsearch clusters and should not be used in production without careful consideration. See https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html for more information.
 
-==== System integration - `system-integration.yaml`
+==== Standalone mode
+
+===== System integration - `system-integration.yaml`
 
 Deploys Elastic Agent as a DaemonSet in standalone mode with system integration enabled. Collects syslog logs, auth logs and system metrics (for CPU, I/O, filesystem, memory, network, process and others).
 
-==== Kubernetes integration - `kubernetes-integration.yaml`
+===== Kubernetes integration - `kubernetes-integration.yaml`
 
 Deploys Elastic Agent as a DaemonSet in standalone mode with Kubernetes integration enabled. Collects API server, Container, Event, Node, Pod, Volume and system metrics.
+
+==== Fleet mode
+
+===== System and Kubernetes integrations - `fleet-kubernetes-integration.yaml`
+
+Deploys Elastic Agent as a DaemonSet in Fleet mode with System and Kubernetes integrations enabled. System integration collects syslog logs, auth logs and system metrics (for CPU, I/O, filesystem, memory, network, process and others). Kubernetes integrations collects API server, Container, Event, Node, Pod, Volume and system metrics.
+
+===== Custom logs integration with autodiscover - `fleet-custom-logs-integration.yaml`
+
+Deploys Elastic Agent as a DaemonSet in Fleet mode with Custom Logs integration enabled. Collects logs from all Pods in the `default` namespace using autodiscover feature.
+
+===== APM integration - `fleet-apm-integration.yaml`
+
+Deploys single instance Elastic Agent Deployment in Fleet mode with APM integration enabled.

--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -433,7 +433,7 @@ Deploys Elastic Agent as a DaemonSet in Fleet mode with Custom Logs integration 
 kubectl apply -f {agent_recipes}/fleet-apm-integration.yaml
 ----
 
-Deploys single instance Elastic Agent Deployment with APM integration enabled.
+Deploys single instance Elastic Agent Deployment in Fleet mode with APM integration enabled.
 
 [id="{p}-elastic-agent-fleet-known-limitation"]
 == Known limitation


### PR DESCRIPTION
Backports the following commits to 1.7:
 - Add missing descriptions to Elastic Agent recipes README (#4861)