### PR TITLE
Update operatorhub config file with new ECK and stack versions

### DIFF
--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -1,6 +1,6 @@
-newVersion: 1.7.1
-prevVersion: 1.7.0
-stackVersion: 7.14.0
+newVersion: 1.8.0
+prevVersion: 1.7.1
+stackVersion: 7.15.0
 crds:
   - name: elasticsearches.elasticsearch.k8s.elastic.co
     displayName: Elasticsearch Cluster


### PR DESCRIPTION
Update the operator/config.yml file for ECK 1.8.0 and stack 7.15.0.
