### PR TITLE
Add nodes permission to Fleet Server Service Account

### DIFF
--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -104,6 +104,7 @@ rules:
 - apiGroups: [""]
   resources:
   - pods
+  - nodes
   verbs:
   - get
   - watch

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -121,6 +121,7 @@ rules:
 - apiGroups: [""]
   resources:
   - pods
+  - nodes
   verbs:
   - get
   - watch

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -93,6 +93,7 @@ rules:
 - apiGroups: [""]
   resources:
   - pods
+  - nodes
   verbs:
   - get
   - watch


### PR DESCRIPTION
Nodes permission is required by default in `7.15.0` Fleet Server:

```
E0923 15:56:10.462455      13 reflector.go:127] pkg/mod/k8s.io/client-go@v0.19.4/tools/cache/reflector.go:156: Failed to watch *v1.Node: failed to list *v1.Node: nodes "gke-dkowalski-dev-cluste-default-pool-1ca149ae-hzcx" is forbidden: User "system:serviceaccount:e2e-mercury:fleet-server-tvq5" cannot list resource "nodes" in API group "" at the cluster scope
``` 

Hence adding it to our recipes.