### PR TITLE
Decrease default Elasticsearch client timeout

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -179,7 +179,7 @@ func Command() *cobra.Command {
 	)
 	cmd.Flags().Duration(
 		operator.ElasticsearchClientTimeout,
-		3*time.Minute,
+		30*time.Second,
 		"Default timeout for requests made by the Elasticsearch client.",
 	)
 	cmd.Flags().Bool(

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -162,7 +162,7 @@ config:
   kubeClientTimeout: 60s
 
   # elasticsearchClientTimeout sets the request timeout for Elasticsearch API calls made by the operator.
-  elasticsearchClientTimeout: 180s
+  elasticsearchClientTimeout: 30s
 
   # validateStorageClass specifies whether storage classes volume expansion support should be verified.
   # Can be disabled if cluster-wide storage class RBAC access is not available.

--- a/docs/operating-eck/operator-config.asciidoc
+++ b/docs/operating-eck/operator-config.asciidoc
@@ -21,7 +21,7 @@ ECK can be configured using either command line flags or environment variables.
 |container-registry |docker.elastic.co | Container registry to use for pulling Elastic Stack container images.
 |disable-config-watch| false| Watch the configuration file for changes and restart to apply them. Only effective when the `--config` flag is used to set the configuration file.
 |disable-telemetry| false| Disable periodically updating ECK telemetry data for Kibana to consume.
-|elasticsearch-client-timeout| 180s| Default timeout for requests made by the Elasticsearch client.
+|elasticsearch-client-timeout| 30s| Default timeout for requests made by the Elasticsearch client.
 |enable-leader-election | true | Enable leader election. Must be set to true if using multiple replicas of the operator
 |enable-tracing | false | Enable APM tracing in the operator process. Use environment variables to configure APM server URL, credentials, and so on. See link:https://www.elastic.co/guide/en/apm/agent/go/1.x/configuration.html[Apm Go Agent reference] for details.
 |enable-webhook | false | Enables a validating webhook server in the operator process.

--- a/docs/operating-eck/troubleshooting/troubleshooting-methods.asciidoc
+++ b/docs/operating-eck/troubleshooting/troubleshooting-methods.asciidoc
@@ -175,7 +175,7 @@ you can get errors reporting a conflict while updating a resource. You can ignor
 
 The operator needs to communicate with each Elasticsearch cluster in order to perform orchestration tasks. The default timeout for such requests can be configured by setting the `elasticsearch-client-timeout` value as described in <<{p}-operator-config>>. If you have a particularly overloaded Elasticsearch cluster that is taking longer to process API requests, you can temporarily change the timeout and frequency of API calls made by the operator to that single cluster by annotating the relevant `Elasticsearch` resource. The supported list of annotations are:
 
-- `eck.k8s.elastic.co/es-client-timeout`: Request timeout for the API requests made by the Elasticsearch client. Defaults to 3 minutes.
+- `eck.k8s.elastic.co/es-client-timeout`: Request timeout for the API requests made by the Elasticsearch client. Defaults to 30 seconds.
 - `eck.k8s.elastic.co/es-observer-interval`: How often Elasticsearch should be checked by the operator to obtain health information. Defaults to 10 seconds.
 
 To set the Elasticsearch client timeout to 60 seconds for a cluster named `quickstart`, you can run the following command:

--- a/pkg/controller/elasticsearch/client/client.go
+++ b/pkg/controller/elasticsearch/client/client.go
@@ -27,7 +27,7 @@ const (
 )
 
 // DefaultESClientTimeout is the default timeout value for Elasticsearch requests.
-var DefaultESClientTimeout = 3 * time.Minute
+var DefaultESClientTimeout = 30 * time.Second
 
 // BasicAuth contains credentials for an Elasticsearch user.
 type BasicAuth struct {


### PR DESCRIPTION
To short-circuit the reconciliation loop if Elasticsearch is down and give back to reconcile other clusters.

Resolves #3496.