### PR TITLE
Update cert manager.io examples in the doc and recipes

### DIFF
--- a/config/recipes/istio-gateway/02-prereq-selfsigning-issuer.yaml
+++ b/config/recipes/istio-gateway/02-prereq-selfsigning-issuer.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: selfsigning-issuer

--- a/config/recipes/istio-gateway/04-certificates.yaml
+++ b/config/recipes/istio-gateway/04-certificates.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ekmnt-elasticsearch-cert
@@ -15,7 +15,7 @@ spec:
     name: selfsigning-issuer
     kind: ClusterIssuer
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ekmnt-kibana-cert

--- a/config/recipes/istio-gateway/04-certificates.yaml
+++ b/config/recipes/istio-gateway/04-certificates.yaml
@@ -14,6 +14,9 @@ spec:
   issuerRef:
     name: selfsigning-issuer
     kind: ClusterIssuer
+  subject:
+    organizations:
+      - ekmnt
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -30,3 +33,6 @@ spec:
   issuerRef:
     name: selfsigning-issuer
     kind: ClusterIssuer
+  subject:
+    organizations:
+      - ekmnt

--- a/config/recipes/traefik/00-prereq-cluster-issuer.yaml
+++ b/config/recipes/traefik/00-prereq-cluster-issuer.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: selfsigning-issuer

--- a/config/recipes/traefik/01-certificate.yaml
+++ b/config/recipes/traefik/01-certificate.yaml
@@ -15,3 +15,6 @@ spec:
   issuerRef:
     name: selfsigning-issuer
     kind: ClusterIssuer
+  subject:
+    organizations:
+      - hulk

--- a/config/recipes/traefik/01-certificate.yaml
+++ b/config/recipes/traefik/01-certificate.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: hulk-certs

--- a/docs/operating-eck/webhook.asciidoc
+++ b/docs/operating-eck/webhook.asciidoc
@@ -130,6 +130,9 @@ spec:
     kind: ClusterIssuer
     name: self-signing-issuer
   secretName: elastic-webhook-server-cert
+  subject:
+    organizations:
+      - example
 ----
 
 - Annotate the `ValidatingWebhookConfiguration` to inject the CA bundle:

--- a/docs/operating-eck/webhook.asciidoc
+++ b/docs/operating-eck/webhook.asciidoc
@@ -118,7 +118,7 @@ This section describes how to use link:https://cert-manager.io/[cert-manager] to
 +
 [source,yaml]
 ----
-apiVersion: cert-manager.io/v1beta1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: elastic-webhook-server-cert

--- a/docs/orchestrating-elastic-stack-applications/security/custom-http-certificate.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/custom-http-certificate.asciidoc
@@ -30,7 +30,7 @@ This example illustrates how to issue a self-signed certificate for the <<{p}-de
 [source,yaml]
 ----
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer

--- a/docs/orchestrating-elastic-stack-applications/security/custom-http-certificate.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/custom-http-certificate.asciidoc
@@ -51,4 +51,7 @@ spec:
     kind: Issuer
     name: selfsigned-issuer
   secretName: quickstart-es-cert
+  subject:
+    organizations:
+      - quickstart
 ----

--- a/docs/orchestrating-elastic-stack-applications/security/custom-http-certificate.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/custom-http-certificate.asciidoc
@@ -55,3 +55,64 @@ spec:
     organizations:
       - quickstart
 ----
+
+
+Here is another example to issue multiple certificates from the same self-signed CA:
+
+[source,yaml]
+----
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: selfsigned-ca
+spec:
+  isCA: true
+  commonName: selfsigned-ca
+  secretName: root-ca-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    kind: ClusterIssuer
+    name: selfsigned-issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: ca-issuer
+spec:
+  ca:
+    secretName: root-ca-secret
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: quickstart-es-cert
+spec:
+  isCA: false
+  dnsNames:
+    - quickstart-es-http
+    - quickstart-es-http.default.svc
+    - quickstart-es-http.default.svc.cluster.local
+  subject:
+    organizations:
+      - quickstart
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  issuerRef:
+    kind: Issuer
+    name: ca-issuer
+  secretName: quickstart-es-cert
+  subject:
+    organizations:
+      - quickstart
+----


### PR DESCRIPTION
- Bump to `cert-manager.io/v1` 
- Set `subject.organizations` to not generate a certificate that is rejected as malformed by Java, due to lack of an issuer DN
- Add an example to issue multiple certificates from the same self-signed CA

Resolves #4845.