### PR TITLE
Fix diagnostic archive wildcard for Tanzu pipeline

### DIFF
--- a/.ci/pipelines/e2e-tests-tanzu.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-tanzu.Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                         failedTests = lib.getListOfFailedTests()
                         googleStorageUpload bucket: "gs://devops-ci-artifacts/jobs/$JOB_NAME/$BUILD_NUMBER",
                             credentialsId: "devops-ci-gcs-plugin",
-                            pattern: "*.tgz",
+                            pattern: "*.zip",
                             sharedPublicly: true,
                             showInline: true
                     }


### PR DESCRIPTION
This was missed due to merging the diagnostic archive change from a branch that did not have the Tanzu job yet.