### PR TITLE
Fix 1.8.0 release notes for Openshift 3.11 compatibility

### DIFF
--- a/docs/release-notes/1.8.0.asciidoc
+++ b/docs/release-notes/1.8.0.asciidoc
@@ -12,7 +12,7 @@
 
 The operator does not rely on the `$PRE_STOP_MAX_WAIT_SECONDS` environment variable to control <<{p}-prestop,Elasticsearch Pods PreStop hook>> anymore. Use `$PRE_STOP_ADDITIONAL_WAIT_SECONDS` instead (defaults to 50 seconds).
 
-* Note the next minor ECK version (1.9.0) will drop support for Openshift 3.11.
+* Note ECK will drop support for Openshift 3.11 starting ECK version 2.0.
 
 [[enhancement-1.8.0]]
 [float]

--- a/docs/release-notes/1.8.0.asciidoc
+++ b/docs/release-notes/1.8.0.asciidoc
@@ -12,7 +12,7 @@
 
 The operator does not rely on the `$PRE_STOP_MAX_WAIT_SECONDS` environment variable to control <<{p}-prestop,Elasticsearch Pods PreStop hook>> anymore. Use `$PRE_STOP_ADDITIONAL_WAIT_SECONDS` instead (defaults to 50 seconds).
 
-* Note ECK will drop support for Openshift 3.11 starting ECK version 2.0.
+* Note ECK will drop support for OpenShift 3.11 starting ECK version 2.0.
 
 [[enhancement-1.8.0]]
 [float]

--- a/docs/release-notes/highlights-1.8.0.asciidoc
+++ b/docs/release-notes/highlights-1.8.0.asciidoc
@@ -17,7 +17,7 @@ The ECK operator Helm chart is now generally available. It provides an easy way 
 [id="{p}-180-openshift-311"]
 ==== OpenShift 3.11 support
 
-The ECK 1.x major release series is the last to support Openshift 3.11. Starting ECK 2.0, Openshift 3.11 link:https://www.elastic.co/support/matrix#matrix_kubernetes[won't be supported anymore].
+The ECK 1.x major release series is the last to support OpenShift 3.11. Starting ECK 2.0, OpenShift 3.11 link:https://www.elastic.co/support/matrix#matrix_kubernetes[won't be supported anymore].
 
 [float]
 [id="{p}-180-bugfixes"]

--- a/docs/release-notes/highlights-1.8.0.asciidoc
+++ b/docs/release-notes/highlights-1.8.0.asciidoc
@@ -15,7 +15,7 @@ The ECK operator Helm chart is now generally available. It provides an easy way 
 
 [float]
 [id="{p}-180-openshift-311"]
-==== Openshift 3.11 support
+==== OpenShift 3.11 support
 
 The ECK 1.x major release series is the last to support Openshift 3.11. Starting ECK 2.0, Openshift 3.11 link:https://www.elastic.co/support/matrix#matrix_kubernetes[won't be supported anymore].
 

--- a/docs/release-notes/highlights-1.8.0.asciidoc
+++ b/docs/release-notes/highlights-1.8.0.asciidoc
@@ -15,9 +15,9 @@ The ECK operator Helm chart is now generally available. It provides an easy way 
 
 [float]
 [id="{p}-180-openshift-311"]
-==== Last minor version to support Openshift 3.11
+==== Openshift 3.11 support
 
-The ECK 1.8.x minor release series is the last to support Openshift 3.11. Starting ECK 1.9.0, Openshift 3.11 link:https://www.elastic.co/support/matrix#matrix_kubernetes[won't be supported anymore].
+The ECK 1.x major release series is the last to support Openshift 3.11. Starting ECK 2.0, Openshift 3.11 link:https://www.elastic.co/support/matrix#matrix_kubernetes[won't be supported anymore].
 
 [float]
 [id="{p}-180-bugfixes"]


### PR DESCRIPTION
We decided to support Openshift up to ECK 2.0, not ECK 1.9.0 as mentioned in those notes.
Should be backported to 1.8.