### PR TITLE
E2E: Azure disk exception

### DIFF
--- a/test/e2e/es/volume_test.go
+++ b/test/e2e/es/volume_test.go
@@ -233,7 +233,9 @@ func getResizeableStorageClass(k8sClient k8s.Client) (string, error) {
 		return "", err
 	}
 	for _, sc := range scs.Items {
-		if sc.AllowVolumeExpansion != nil && *sc.AllowVolumeExpansion {
+		// TODO https://github.com/Azure/AKS/issues/1477 azure-disk does not support resizing of "attached" disks, despite
+		// advertising it allows volume expansion. Remove the azure special case once this issue is resolved.
+		if sc.AllowVolumeExpansion != nil && *sc.AllowVolumeExpansion && sc.Provisioner != "kubernetes.io/azure-disk" {
 			return sc.Name, nil
 		}
 	}


### PR DESCRIPTION
Until https://github.com/Azure/AKS/issues/1477#issuecomment-901689783 is resolved exclude azure-disk explicitly. This is not needed for AKS where we have an `azurefile` based storageclass but the Tanzu e2e tests run on Azure directly and the default storage class there is provisioned by `azure-disk`.

Open to alternative solutions as well. I know this is not great.