### PR TITLE
[1.6] Fix 1.5.0 release notes that mention ocp support ending with ECK 1.8 (#4906)

### DIFF
--- a/docs/release-notes/1.5.0.asciidoc
+++ b/docs/release-notes/1.5.0.asciidoc
@@ -39,4 +39,4 @@
 [float]
 === Deprecation
 
-* OpenShift 3.11 support will be deprecated in ECK 2.0. ECK 1.8 is the last version that will support OpenShift 3.11.
+* OpenShift 3.11 support will be deprecated in ECK 2.0.


### PR DESCRIPTION
Backports the following commits to 1.6:
 - Fix 1.5.0 release notes that mention ocp support ending with ECK 1.8 (#4906)