### PR TITLE
[1.5] Add Elastic Agent recipe with multiple Elasticsearch clusters as outputs (#4870)

### DIFF
--- a/config/recipes/elastic-agent/README.asciidoc
+++ b/config/recipes/elastic-agent/README.asciidoc
@@ -13,3 +13,12 @@ Deploys Elastic Agent as a DaemonSet in standalone mode with system integration 
 ==== Kubernetes integration - `kubernetes-integration.yaml`
 
 Deploys Elastic Agent as a DaemonSet in standalone mode with Kubernetes integration enabled. Collects API server, Container, Event, Node, Pod, Volume and system metrics.
+
+==== Multiple Elasticsearch clusters output
+
+[source,sh,subs="attributes"]
+----
+kubectl apply -f {agent_recipes}/multi-output.yaml
+----
+
+Deploys two Elasticsearch clusters and two Kibana instances together with single Elastic Agent DaemonSet in standalone mode with System integration enabled. System metrics are sent to the `elasticsearch` cluster. Elastic Agent monitoring data is sent to `elasticsearch-mon` cluster.

--- a/config/recipes/elastic-agent/multi-output.yaml
+++ b/config/recipes/elastic-agent/multi-output.yaml
@@ -1,0 +1,238 @@
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: elastic-agent
+spec:
+  version: 7.14.0
+  elasticsearchRefs:
+  - outputName: default
+    name: elasticsearch
+  - outputName: monitoring
+    name: elasticsearch-mon
+  daemonSet:
+    podTemplate:
+      spec:
+        containers:
+        - name: agent
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /var/log
+            name: varlog
+        dnsPolicy: ClusterFirstWithHostNet
+        hostNetwork: true
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - hostPath:
+            path: /var/log
+          name: varlog
+  config:
+    id: 2d70a6f0-33a5-11eb-bb2f-418d0388a8cf
+    revision: 2
+    agent:
+      monitoring:
+        enabled: true
+        use_output: monitoring
+        logs: true
+        metrics: true
+    inputs:
+    - id: 2e187fb0-33a5-11eb-bb2f-418d0388a8cf
+      name: system-1
+      revision: 1
+      type: logfile
+      use_output: default
+      meta:
+        package:
+          name: system
+          version: 0.9.1
+      data_stream:
+        namespace: default
+      streams:
+      - id: logfile-system.auth
+        data_stream:
+          dataset: system.auth
+          type: logs
+        paths:
+        - /var/log/auth.log*
+        - /var/log/secure*
+        exclude_files:
+        - .gz$
+        multiline:
+          pattern: ^\s
+          match: after
+        processors:
+        - add_locale: { }
+        - add_fields:
+            target: ''
+            fields:
+              ecs.version: 1.5.0
+      - id: logfile-system.syslog
+        data_stream:
+          dataset: system.syslog
+          type: logs
+        paths:
+        - /var/log/messages*
+        - /var/log/syslog*
+        exclude_files:
+        - .gz$
+        multiline:
+          pattern: ^\s
+          match: after
+        processors:
+        - add_locale: { }
+        - add_fields:
+            target: ''
+            fields:
+              ecs.version: 1.5.0
+    - id: 2e187fb0-33a5-11eb-bb2f-418d0388a8cf
+      name: system-1
+      revision: 1
+      type: system/metrics
+      use_output: default
+      meta:
+        package:
+          name: system
+          version: 0.9.1
+      data_stream:
+        namespace: default
+      streams:
+      - id: system/metrics-system.cpu
+        data_stream:
+          dataset: system.cpu
+          type: metrics
+        metricsets:
+        - cpu
+        cpu.metrics:
+        - percentages
+        - normalized_percentages
+        period: 10s
+      - id: system/metrics-system.diskio
+        data_stream:
+          dataset: system.diskio
+          type: metrics
+        metricsets:
+        - diskio
+        diskio.include_devices: { }
+        period: 10s
+      - id: system/metrics-system.filesystem
+        data_stream:
+          dataset: system.filesystem
+          type: metrics
+        metricsets:
+        - filesystem
+        period: 1m
+        processors:
+        - drop_event.when.regexp:
+            system.filesystem.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
+      - id: system/metrics-system.fsstat
+        data_stream:
+          dataset: system.fsstat
+          type: metrics
+        metricsets:
+        - fsstat
+        period: 1m
+        processors:
+        - drop_event.when.regexp:
+            system.fsstat.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
+      - id: system/metrics-system.load
+        data_stream:
+          dataset: system.load
+          type: metrics
+        metricsets:
+        - load
+        period: 10s
+      - id: system/metrics-system.memory
+        data_stream:
+          dataset: system.memory
+          type: metrics
+        metricsets:
+        - memory
+        period: 10s
+      - id: system/metrics-system.network
+        data_stream:
+          dataset: system.network
+          type: metrics
+        metricsets:
+        - network
+        period: 10s
+        network.interfaces: { }
+      - id: system/metrics-system.process
+        data_stream:
+          dataset: system.process
+          type: metrics
+        metricsets:
+        - process
+        period: 10s
+        process.include_top_n.by_cpu: 5
+        process.include_top_n.by_memory: 5
+        process.cmdline.cache.enabled: true
+        process.cgroups.enabled: false
+        process.include_cpu_ticks: false
+        processes:
+        - .*
+      - id: system/metrics-system.process_summary
+        data_stream:
+          dataset: system.process_summary
+          type: metrics
+        metricsets:
+        - process_summary
+        period: 10s
+      - id: system/metrics-system.socket_summary
+        data_stream:
+          dataset: system.socket_summary
+          type: metrics
+        metricsets:
+        - socket_summary
+        period: 10s
+      - id: system/metrics-system.uptime
+        data_stream:
+          dataset: system.uptime
+          type: metrics
+        metricsets:
+        - uptime
+        period: 10s
+---
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch
+spec:
+  version: 7.14.0
+  nodeSets:
+  - name: default
+    count: 3
+    config:
+      node.store.allow_mmap: false
+---
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: kibana
+spec:
+  version: 7.14.0
+  count: 1
+  elasticsearchRef:
+    name: elasticsearch
+---
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch-mon
+spec:
+  version: 7.14.0
+  nodeSets:
+  - name: default
+    count: 3
+    config:
+      node.store.allow_mmap: false
+---
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: kibana-mon
+spec:
+  version: 7.14.0
+  count: 1
+  elasticsearchRef:
+    name: elasticsearch-mon
+...

--- a/docs/orchestrating-elastic-stack-applications/agent.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent.asciidoc
@@ -408,3 +408,12 @@ kubectl apply -f {agent_recipes}/kubernetes-integration.yaml
 ----
 
 Deploys Elastic Agent as a DaemonSet in standalone mode with Kubernetes integration enabled. Collects API server, Container, Event, Node, Pod, Volume and system metrics.
+
+=== Multiple Elasticsearch clusters output
+
+[source,sh,subs="attributes"]
+----
+kubectl apply -f {agent_recipes}/multi-output.yaml
+----
+
+Deploys two Elasticsearch clusters and two Kibana instances together with single Elastic Agent DaemonSet in standalone mode with System integration enabled. System metrics are sent to the `elasticsearch` cluster. Elastic Agent monitoring data is sent to `elasticsearch-mon` cluster.

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -63,6 +63,28 @@ func TestKubernetesIntegrationRecipe(t *testing.T) {
 	runBeatRecipe(t, "kubernetes-integration.yaml", customize)
 }
 
+func TestMultiOutputRecipe(t *testing.T) {
+	customize := func(builder agent.Builder) agent.Builder {
+		return builder.
+			WithRoles(agent.PSPClusterRoleName).
+			WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"), "monitoring").
+			WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"), "monitoring").
+			WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"), "monitoring").
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.cpu", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.diskio", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.fsstat", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.load", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.memory", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.network", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.process", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.process_summary", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.socket_summary", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"))
+	}
+
+	runBeatRecipe(t, "multi-output.yaml", customize)
+}
+
 func runBeatRecipe(
 	t *testing.T,
 	fileName string,


### PR DESCRIPTION
Backports the following commits to 1.5:
 - Add Elastic Agent recipe with multiple Elasticsearch clusters as outputs (#4870)