### PR TITLE
Refactor Elasticsearch HTTP error handling

### DIFF
--- a/pkg/controller/elasticsearch/client/client.go
+++ b/pkg/controller/elasticsearch/client/client.go
@@ -7,8 +7,6 @@ package client
 import (
 	"context"
 	"crypto/x509"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -136,51 +134,4 @@ func NewElasticsearchClient(
 		HTTP:     common.HTTPClient(dialer, caCerts, timeout),
 	}
 	return versioned(base, v)
-}
-
-// APIError is a non 2xx response from the Elasticsearch API
-type APIError struct {
-	response *http.Response
-}
-
-// Error() implements the error interface.
-func (e *APIError) Error() string {
-	defer e.response.Body.Close()
-	reason := "unknown"
-	// Elasticsearch has a detailed error message in the response body
-	var errMsg ErrorResponse
-	err := json.NewDecoder(e.response.Body).Decode(&errMsg)
-	if err == nil {
-		reason = errMsg.Error.Reason
-	}
-	return fmt.Sprintf("%s: %s", e.response.Status, reason)
-}
-
-// IsForbidden checks whether the error was an HTTP 403 error.
-func IsForbidden(err error) bool {
-	return isHTTPError(err, http.StatusForbidden)
-}
-
-// IsNotFound checks whether the error was an HTTP 404 error.
-func IsNotFound(err error) bool {
-	return isHTTPError(err, http.StatusNotFound)
-}
-
-// IsTimeout checks whether the error was an HTTP 408 error
-func IsTimeout(err error) bool {
-	return isHTTPError(err, http.StatusRequestTimeout)
-}
-
-// IsConflict checks whether the error was an HTTP 409 error.
-func IsConflict(err error) bool {
-	return isHTTPError(err, http.StatusConflict)
-}
-
-func isHTTPError(err error, statusCode int) bool {
-	apiErr := new(APIError)
-	if errors.As(err, &apiErr) {
-		return apiErr.response.StatusCode == statusCode
-	}
-
-	return false
 }

--- a/pkg/controller/elasticsearch/client/error.go
+++ b/pkg/controller/elasticsearch/client/error.go
@@ -1,0 +1,92 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+// APIError is a non 2xx response from the Elasticsearch API
+type APIError struct {
+	Status        string
+	StatusCode    int
+	ErrorResponse ErrorResponse
+}
+
+// newAPIError converts an HTTP response into an API error, attempting to parse the body to include the details about the error.
+func newAPIError(response *http.Response) error {
+	defer response.Body.Close()
+	apiError := &APIError{
+		Status:     response.Status,
+		StatusCode: response.StatusCode,
+	}
+	// We may need to read the body multiple times, read the full body and store it as an array of bytes.
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		// We were not able to read the body, log this I/O error and return the API error with the status.
+		log.Error(err, "Cannot read error body")
+		return apiError
+	}
+	// Reset the response body to the original unread state. It allows a caller to read again the body if necessary,
+	// for example in the case of a 408.
+	response.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+
+	// Parse the body to get the details about the API error, as they are stored by Elasticsearch.
+	var errorResponse ErrorResponse
+	if err := json.Unmarshal(body, &errorResponse); err != nil {
+		// Only log at the debug level since it is expected to not be able to parse all types of errors.
+		// Some errors, like 408 on /_cluster/health may return a different body structure.
+		log.V(1).Error(err, "Cannot parse error body")
+		return apiError
+	}
+	apiError.ErrorResponse = errorResponse
+	return apiError
+}
+
+// Error() implements the error interface.
+func (a *APIError) Error() string {
+	return fmt.Sprintf("%s: %+v", a.Status, a.ErrorResponse)
+}
+
+func newDecoratedHTTPError(request *http.Request, err error) error {
+	if request == nil {
+		return err
+	}
+	return fmt.Errorf(`elasticsearch client failed for %s: %w`, request.URL.Redacted(), err)
+}
+
+// IsForbidden checks whether the error was an HTTP 403 error.
+func IsForbidden(err error) bool {
+	return isHTTPError(err, http.StatusForbidden)
+}
+
+// IsNotFound checks whether the error was an HTTP 404 error.
+func IsNotFound(err error) bool {
+	return isHTTPError(err, http.StatusNotFound)
+}
+
+// IsTimeout checks whether the error was an HTTP 408 error
+func IsTimeout(err error) bool {
+	return isHTTPError(err, http.StatusRequestTimeout)
+}
+
+// IsConflict checks whether the error was an HTTP 409 error.
+func IsConflict(err error) bool {
+	return isHTTPError(err, http.StatusConflict)
+}
+
+func isHTTPError(err error, statusCode int) bool {
+	apiErr := new(APIError)
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == statusCode
+	}
+
+	return false
+}


### PR DESCRIPTION
This PR fixes #4918.

It also removes `response *http.Response` from the `APIError` object, which is currently preventing `Error()` from being called multiple times:

```golang
// Error() implements the error interface.
func (e *APIError) Error() string {
	defer e.response.Body.Close() # body is closed the first
	reason := "unknown"
	// Elasticsearch has a detailed error message in the response body
	var errMsg ErrorResponse
	err := json.NewDecoder(e.response.Body).Decode(&errMsg) // subsequent calls fail
	if err == nil {
		reason = errMsg.Error.Reason
	}
	return fmt.Sprintf("%s: %s", e.response.Status, reason)
}
```

This is for example the case when an `APIError` is aggregated in [`zapcode.encodeError`](https://github.com/uber-go/zap/blob/42e70dd4e9258b142fca9fc01c639fb3c8e8f664/zapcore/error.go#L63) :

```golang
func encodeError(key string, err error, enc ObjectEncoder) (retErr error) {

        basic := err.Error() // Error() is called a first time

        switch e := err.(type) {
        case errorGroup:
                return enc.AddArray(key+"Causes", errArray(e.Errors())) // Error() is called a second time
```

This is the reason why the error message may contain `unknown` in the error cause:

```json
{
    "log.level": "error",
    "@timestamp": "2021-09-23T14:25:54.121Z",
    "log.logger": "manager.eck-operator.controller.elasticsearch-controller",
    "message": "Reconciler error",
    "service.version": "1.7.1+26876766",
    "service.type": "eck",
    "ecs.version": "1.4.0",
    "name": "my-cluster",
    "namespace": "elastic-system",
    "error": "400 Bad Request: closed",
    "errorCauses": [
        {
            "error": "400 Bad Request: unknown"
        }
    ],
    "error.stack_trace": "sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.2/pkg/internal/controller/controller.go:253\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.2/pkg/internal/controller/controller.go:214"
}
```