### PR TITLE
Skip remote clusters reconciliation if remote clusters are not defined

### DIFF
--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -175,6 +175,11 @@ func (r RemoteCluster) ConfigHash() string {
 	return hash.HashObject(r)
 }
 
+func (es Elasticsearch) IsRemoteClustersDefined() bool {
+	return len(es.Spec.RemoteClusters) > 0 &&
+		es.Spec.RemoteClusters[0].Name != "" && es.Spec.RemoteClusters[0].ElasticsearchRef.IsDefined()
+}
+
 // NodeCount returns the total number of nodes of the Elasticsearch cluster
 func (es ElasticsearchSpec) NodeCount() int32 {
 	count := int32(0)

--- a/pkg/controller/elasticsearch/remotecluster/elasticsearch.go
+++ b/pkg/controller/elasticsearch/remotecluster/elasticsearch.go
@@ -37,6 +37,10 @@ func UpdateSettings(
 	licenseChecker license.Checker,
 	es esv1.Elasticsearch,
 ) (bool, error) {
+	if !es.IsRemoteClustersDefined() {
+		return false, nil
+	}
+
 	span, _ := apm.StartSpan(ctx, "update_remote_clusters", tracing.SpanTypeApp)
 	defer span.End()
 

--- a/pkg/controller/remoteca/controller.go
+++ b/pkg/controller/remoteca/controller.go
@@ -128,8 +128,11 @@ func doReconcile(
 	r *ReconcileRemoteCa,
 	localEs *esv1.Elasticsearch,
 ) (reconcile.Result, error) {
-	localClusterKey := k8s.ExtractNamespacedName(localEs)
+	if !localEs.IsRemoteClustersDefined() {
+		return reconcile.Result{}, nil
+	}
 
+	localClusterKey := k8s.ExtractNamespacedName(localEs)
 	expectedRemoteClusters, err := getExpectedRemoteClusters(ctx, r.Client, localEs)
 	if err != nil {
 		return reconcile.Result{}, err


### PR DESCRIPTION
This is a small improvement to not start to reconcile remote clusters or update remote clusters settings in ES when remote clusters are not defined in the ES specification.