### PR TITLE
Ignore ClusterIPs, and IPFamilyPolicy in services, and timestamp in license during reconciliation

### DIFF
--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -121,7 +121,17 @@ func (r LicensingResolver) Save(info LicensingInfo) error {
 		Expected:   &expected,
 		Reconciled: reconciled,
 		NeedsUpdate: func() bool {
-			return !reflect.DeepEqual(expected.Data, reconciled.Data)
+			// do not compare timestamp, as it will always change
+			expectedData, reconciledData := map[string]string{}, map[string]string{}
+			for k, v := range expected.Data {
+				expectedData[k] = v
+			}
+			for k, v := range reconciled.Data {
+				reconciledData[k] = v
+			}
+			delete(expectedData, "timestamp")
+			delete(reconciledData, "timestamp")
+			return !reflect.DeepEqual(expectedData, reconciledData)
 		},
 		UpdateReconciled: func() {
 			expected.DeepCopyInto(reconciled)


### PR DESCRIPTION
In testing, it was found that services are updated every reconciliation cycle, along with the license.  As for the license, the timestamp is always changing, which means it will always be updated.  As for the services, ClusterIP, and IPFamilies are currently ignored, as they're set server-side, but ClusterIPs, and IPFamilyPolicy were not being ignored, but are also set server side.  This updates the logic to also properly use or ignore these fields in services, and completely ignore timestamp when comparing license.  The tests were also updated to ensure consistency.
