### PR TITLE
Update GKE versions after October 1 GKE release

### DIFF
--- a/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
@@ -35,17 +35,6 @@ pipeline {
         }
         stage('Run tests for different k8s versions in GKE') {
             parallel {
-                stage("1.18") {
-                    agent {
-                        label 'linux'
-                    }
-                    steps {
-                        unstash "source"
-                        script {
-                            runWith(lib, failedTests, '1.18', "eck-gke18-${BUILD_NUMBER}-e2e")
-                        }
-                    }
-                }
                 stage("1.19") {
                     agent {
                         label 'linux'
@@ -65,6 +54,17 @@ pipeline {
                         unstash "source"
                         script {
                             runWith(lib, failedTests, '1.20', "eck-gke20-${BUILD_NUMBER}-e2e")
+                        }
+                    }
+                }
+                stage("1.21") {
+                    agent {
+                        label 'linux'
+                    }
+                    steps {
+                        unstash "source"
+                        script {
+                            runWith(lib, failedTests, '1.21', "eck-gke21-${BUILD_NUMBER}-e2e")
                         }
                     }
                 }
@@ -92,7 +92,7 @@ pipeline {
         }
         cleanup {
             script {
-                clusters = ["eck-gke18-${BUILD_NUMBER}-e2e", "eck-gke19-${BUILD_NUMBER}-e2e", "eck-gke20-${BUILD_NUMBER}-e2e"]
+                clusters = ["eck-gke19-${BUILD_NUMBER}-e2e", "eck-gke20-${BUILD_NUMBER}-e2e", "eck-gke21-${BUILD_NUMBER}-e2e"]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
                         parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: clusters[i])],

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -3,7 +3,7 @@ plans:
   operation: create
   clusterName: ci
   provider: gke
-  kubernetesVersion: 1.18
+  kubernetesVersion: 1.20
   machineType: n1-standard-8
   serviceAccount: true
   psp: true
@@ -18,7 +18,7 @@ plans:
   operation: create
   clusterName: dev
   provider: gke
-  kubernetesVersion: 1.18
+  kubernetesVersion: 1.20
   machineType: n1-standard-8
   serviceAccount: false
   psp: false


### PR DESCRIPTION
This PR bumps GKE versions we use as right now we hit the below for most GKE jobs.

```
20:01:59  ERROR: (gcloud.beta.container.clusters.create) ResponseError: code=400, message=No valid versions with the prefix "1.18" found.
```

See https://cloud.google.com/kubernetes-engine/docs/release-notes#current_versions for details.