### PR TITLE
Reenable Enterprise Search upgrade test

### DIFF
--- a/test/e2e/ent/ent_test.go
+++ b/test/e2e/ent/ent_test.go
@@ -49,8 +49,6 @@ func TestEnterpriseSearchTLSDisabled(t *testing.T) {
 }
 
 func TestEnterpriseSearchVersionUpgradeToLatest7x(t *testing.T) {
-	t.Skip() // pending resolution of https://github.com/elastic/cloud-on-k8s/issues/4755
-
 	srcVersion := test.Ctx().ElasticStackVersion
 	dstVersion := test.LatestVersion7x
 


### PR DESCRIPTION
As this was fixed on Stack side in `7.15.0`, we can reenable the test. Tested locally with `7.7.0`->`7.15.0`.