### PR TITLE
Prevent deadlock in TestDynamicEnqueueRequest

### DIFF
--- a/pkg/controller/common/watches/handler_integration_test.go
+++ b/pkg/controller/common/watches/handler_integration_test.go
@@ -58,7 +58,7 @@ func TestDynamicEnqueueRequest(t *testing.T) {
 	// Fixtures
 	watched := types.NamespacedName{
 		Namespace: "default",
-		Name:      "watched1-" + rand.String(10),
+		Name:      "watched-" + rand.String(10),
 	}
 	testObj := &corev1.Secret{
 		ObjectMeta: k8s.ToObjectMeta(watched),


### PR DESCRIPTION
This PR introduces a preventive measure to stop `TestDynamicEnqueueRequest` from a deadlock. It happens because, contrary to our expectations, we can receive more than one event even though we only do a single update after registering our handler. In my tests I saw we can receive two or even three updates. Since the channel we use is unbuffered and we do a single read, our handler is blocked. As staying in the handler prevents from shutting down gracefully, we timeout after 30 seconds with an error and fail the test.

The change makes the handler respect the provided context, allowing `controller-runtime` to shut down gracefully. 

I've also randomized the name to facilitate running the test multiple times, as it seems the teardown is not thorough and resources with same name clash.

Before the change (although with random resource name) I was getting around 1% failure rate every time on the below:

`go test -v -race -count 1000 -tags=integration pkg/controller/common/watches/handler_integration_test.go`

After the change running (note 3k count):

`go test -v -race -count 3000 -tags=integration pkg/controller/common/watches/handler_integration_test.go`

Passes without any failures.

Fixes https://github.com/elastic/cloud-on-k8s/issues/4692.