### PR TITLE
E2E: add additional node to TestMutationRollingDownscaleCombination

### DIFF
--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -174,12 +174,12 @@ func TestMutationSecondMasterSetDown(t *testing.T) {
 func TestMutationRollingDownscaleCombination(t *testing.T) {
 	b := elasticsearch.NewBuilder("test-combined-upgrade-downscale").
 		WithESMasterNodes(1, elasticsearch.DefaultResources).
-		WithNamedESDataNodes(1, "data-1", elasticsearch.DefaultResources).
+		WithNamedESDataNodes(2, "data-1", elasticsearch.DefaultResources).
 		WithNamedESDataNodes(2, "data-2", elasticsearch.DefaultResources)
 
 	mutated := b.WithNoESTopology().
 		WithESMasterNodes(1, elasticsearch.DefaultResources).
-		WithNamedESDataNodes(1, "data-1", elasticsearch.DefaultResources).
+		WithNamedESDataNodes(2, "data-1", elasticsearch.DefaultResources).
 		WithNamedESDataNodes(1, "data-2", elasticsearch.DefaultResources). // scaling down data-2
 		WithAdditionalConfig(map[string]map[string]interface{}{
 			"data-1": {


### PR DESCRIPTION
Fix #3764

Add an additional data node to the cluster to avoid a situation where shards have no place to go due to shard allocation awareness.