### PR TITLE
[E2E] Update OCP version to 4.9.0

### DIFF
--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -110,7 +110,7 @@ pipeline {
                     build job: 'cloud-on-k8s-e2e-tests-ocp',
                         parameters: [
                             string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: operatorImage),
-                            string(name: 'OCP_VERSION', value: "4.8.10"),
+                            string(name: 'OCP_VERSION', value: "4.9.0"),
                             string(name: 'branch_specifier', value: GIT_COMMIT)
                         ],
                         wait: false

--- a/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp-all-but-latest.Jenkinsfile
@@ -30,23 +30,10 @@ pipeline {
                 }
             }
         }
-        // latest 4.8.x is taken care of by a separate job
+        // latest 4.9.x is taken care of by a separate job
         // individual build jobs will report error but we want to run all jobs in all cases so we catch the errors
         // and fail only the stage
-        stage("4.3.x") {
-            steps {
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                    build job: 'cloud-on-k8s-e2e-tests-ocp',
-                                    parameters: [
-                                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: JKS_PARAM_OPERATOR_IMAGE),
-                                        string(name: 'OCP_VERSION', value: "4.3.40"),
-                                        string(name: 'branch_specifier', value: GIT_COMMIT)
-                                    ],
-                                    wait: true
-                }
-            }
-        }
-        stage("4.4.x "){
+        stage("4.4.x") {
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     build job: 'cloud-on-k8s-e2e-tests-ocp',
@@ -78,7 +65,7 @@ pipeline {
                     build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
                                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: JKS_PARAM_OPERATOR_IMAGE),
-                                        string(name: 'OCP_VERSION', value: "4.6.43"),
+                                        string(name: 'OCP_VERSION', value: "4.6.48"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
                                     wait: true
@@ -91,7 +78,20 @@ pipeline {
                     build job: 'cloud-on-k8s-e2e-tests-ocp',
                                     parameters: [
                                         string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: JKS_PARAM_OPERATOR_IMAGE),
-                                        string(name: 'OCP_VERSION', value: "4.7.29"),
+                                        string(name: 'OCP_VERSION', value: "4.7.34"),
+                                        string(name: 'branch_specifier', value: GIT_COMMIT)
+                                    ],
+                                    wait: true
+                }
+            }
+        }
+        stage("4.8.x "){
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    build job: 'cloud-on-k8s-e2e-tests-ocp',
+                                    parameters: [
+                                        string(name: 'JKS_PARAM_OPERATOR_IMAGE', value: JKS_PARAM_OPERATOR_IMAGE),
+                                        string(name: 'OCP_VERSION', value: "4.8.15"),
                                         string(name: 'branch_specifier', value: GIT_COMMIT)
                                     ],
                                     wait: true


### PR DESCRIPTION
I ran a few smoke tests on OCP 4.9, deployed 1.8.0 with OLM and a few resources (ES,KB,APM) successfully.

This PR also removes the test for `4.3`, and updates the installer version for the other ones.