### PR TITLE
E2E: adjust expectations for 8.0 license tests

### DIFF
--- a/test/e2e/es/license_test.go
+++ b/test/e2e/es/license_test.go
@@ -43,8 +43,9 @@ func TestEnterpriseLicenseSingle(t *testing.T) {
 		1*time.Second,
 		func(k *test.K8sClient, t *testing.T) {
 			require.NoError(t, licenseTestContext.CheckElasticsearchLicenseFn(
-				client.ElasticsearchLicenseTypeGold,
-				client.ElasticsearchLicenseTypePlatinum,
+				client.ElasticsearchLicenseTypeGold,       // pre 8.0 for backwards compatibility gold/platinum was reported
+				client.ElasticsearchLicenseTypePlatinum,   // even if an enterprise license was installed
+				client.ElasticsearchLicenseTypeEnterprise, // as of 8.0 enterprise is reported
 			))
 		},
 		test.NOOPCheck,
@@ -63,6 +64,7 @@ func TestEnterpriseLicenseSingle(t *testing.T) {
 			licenseTestContext.CheckElasticsearchLicense(
 				client.ElasticsearchLicenseTypeGold,
 				client.ElasticsearchLicenseTypePlatinum,
+				client.ElasticsearchLicenseTypeEnterprise, // as of 8.0 see comment above
 			),
 			// but we don't expect to go below that level until we delete the last license secret
 			licenseLevelWatch.StartStep(k),
@@ -114,6 +116,7 @@ func TestEnterpriseTrialLicense(t *testing.T) {
 			licenseTestContext.CheckElasticsearchLicense(
 				client.ElasticsearchLicenseTypeGold,
 				client.ElasticsearchLicenseTypePlatinum,
+				client.ElasticsearchLicenseTypeEnterprise, // as of 8.0 see comment above
 			),
 			// revert to basic again
 			licenseTestContext.DeleteEnterpriseLicenseSecret(trialSecretName),


### PR DESCRIPTION
As of 8.0 the backwards compatibility layer in the license API swaps its defaults. Prior Enterprise license were only reported if the `accept_enterprise` query param was used. Post 8.0 the actual license level is now reported an the flag is no longer supported. 