### PR TITLE
Fix broken link affecting MS-64

### DIFF
--- a/docs/advanced-topics/service-meshes.asciidoc
+++ b/docs/advanced-topics/service-meshes.asciidoc
@@ -23,7 +23,7 @@ The instructions in this section describe how to connect the operator and manage
 
 These instructions have been tested with Istio {istio_version}. Older or newer versions of Istio might require additional configuration steps not documented here.
 
-CAUTION: Some Elastic Stack features such as link:https://www.elastic.co/guide/en/kibana/7.x/alerting-getting-started.html#alerting-getting-started[Kibana alerting and actions] rely on the Elasticsearch API keys feature which requires TLS to be enabled at the application level. If you want to use these features, you should not disable the self-signed certificate on the Elasticsearch resource and enable `PERMISSIVE` mode for the Elasticsearch service through a `DestinationRule` or `PeerAuthentication` resource. Strict mTLS mode is currently not compatible with Elastic Stack features requiring TLS to be enabled for the Elasticsearch HTTP layer.
+CAUTION: Some Elastic Stack features such as link:{kibana-ref}/alerting-getting-started.html#alerting-getting-started[Kibana alerting and actions] rely on the Elasticsearch API keys feature which requires TLS to be enabled at the application level. If you want to use these features, you should not disable the self-signed certificate on the Elasticsearch resource and enable `PERMISSIVE` mode for the Elasticsearch service through a `DestinationRule` or `PeerAuthentication` resource. Strict mTLS mode is currently not compatible with Elastic Stack features requiring TLS to be enabled for the Elasticsearch HTTP layer.
 
 IMPORTANT: If you use a Kubernetes distribution like Minikube, which does not have support for issuing third-party security tokens, you should explicitly set `automountServiceAccountToken` field to `true` in the Pod templates to allow Istio to fallback to default service account tokens. Refer to link:https://istio.io/docs/ops/best-practices/security/#configure-third-party-service-account-tokens[Istio security best practices] for more information.
 
@@ -72,7 +72,7 @@ spec:
 [...]
 ----
 
-As the default `failurePolicy` of the webhook is `Ignore`, the operator continues to function even if the above annotations are not present. The downside is that you are still able to submit an invalid manifest using `kubectl` without receiving any immediate feedback. 
+As the default `failurePolicy` of the webhook is `Ignore`, the operator continues to function even if the above annotations are not present. The downside is that you are still able to submit an invalid manifest using `kubectl` without receiving any immediate feedback.
 
 ECK has a fallback validation mechanism that reports validation failures as events associated with the relevant resource ({eck_resources_list}) that must be manually discovered by running `kubectl describe`. For example, to find the validation errors in an Elasticsearch resource named `quickstart`, you can run `kubectl describe elasticsearch quickstart`.
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

This PR fixes a broken hardcoded doc link to 7.x affecting the MS-64 release. It needs to be in a number of releases, from `master` all the way back to `1.2`: 

```
13:55:46 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud-on-k8s/1.2/k8s-service-mesh-istio.html contains broken links to:
13:55:46 INFO:build_docs:   - en/kibana/7.x/alerting-getting-started.html
13:55:46 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud-on-k8s/1.3/k8s-service-mesh-istio.html contains broken links to:
13:55:46 INFO:build_docs:   - en/kibana/7.x/alerting-getting-started.html
13:55:46 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud-on-k8s/1.4/k8s-service-mesh-istio.html contains broken links to:
13:55:46 INFO:build_docs:   - en/kibana/7.x/alerting-getting-started.html
13:55:46 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud-on-k8s/1.5/k8s-service-mesh-istio.html contains broken links to:
13:55:46 INFO:build_docs:   - en/kibana/7.x/alerting-getting-started.html
13:55:46 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud-on-k8s/1.6/k8s-service-mesh-istio.html contains broken links to:
13:55:46 INFO:build_docs:   - en/kibana/7.x/alerting-getting-started.html
13:55:46 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud-on-k8s/1.7/k8s-service-mesh-istio.html contains broken links to:
13:55:46 INFO:build_docs:   - en/kibana/7.x/alerting-getting-started.html
13:55:46 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud-on-k8s/1.8/k8s-service-mesh-istio.html contains broken links to:
13:55:46 INFO:build_docs:   - en/kibana/7.x/alerting-getting-started.html
13:55:46 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud-on-k8s/current/k8s-service-mesh-istio.html contains broken links to:
13:55:46 INFO:build_docs:   - en/kibana/7.x/alerting-getting-started.html
13:55:46 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud-on-k8s/master/k8s-service-mesh-istio.html contains broken links to:
13:55:46 INFO:build_docs:   - en/kibana/7.x/alerting-getting-started.html
```
