### PR TITLE
Fix broken link affecting MS-64 release

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -4,7 +4,7 @@
 :idprefix: k8s-
 :s: k8s
 
-include::{asciidoc-dir}/../../shared/versions/stack/7.x.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 include::overview.asciidoc[]
 include::k8s-quickstart.asciidoc[]


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

This PR fixes a broken hardcoded doc link to 7.x affecting the MS-64 release. It needs to be in the `0.9` and `0.8` releases: 

```/tmp/docsbuild/target_repo/html/en/cloud-on-k8s/0.8/k8s-quickstart.html contains broken links to:
13:55:46 INFO:build_docs:   - en/elasticsearch/reference/7.x/getting-started.html
13:55:46 INFO:build_docs:   - en/kibana/7.x/introduction.html
13:55:46 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud-on-k8s/0.9/k8s-jvm-heap-size.html contains broken links to:
13:55:46 INFO:build_docs:   - en/elasticsearch/reference/7.x/important-settings.html
13:55:46 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud-on-k8s/0.9/k8s-quickstart.html contains broken links to:
13:55:46 INFO:build_docs:   - en/elasticsearch/reference/7.x/getting-started.html
13:55:46 INFO:build_docs:   - en/kibana/7.x/introduction.html
```
