### PR TITLE
Fix 'unbound variable' error when running `make install-crds`

### DIFF
--- a/hack/manifest-gen/manifest-gen.sh
+++ b/hack/manifest-gen/manifest-gen.sh
@@ -80,7 +80,7 @@ while getopts "cug" OPT; do
             (
                 cd "$SCRIPT_DIR"
                 go build -o manifest-gen >/dev/null 2>&1
-                ./manifest-gen --source="$EFFECTIVE_SRC_CHART_DIR" generate "$@[@]"
+                ./manifest-gen --source="$EFFECTIVE_SRC_CHART_DIR" generate "$@"
                 rm manifest-gen
             )
             exit 0


### PR DESCRIPTION
On mac with bash version 3.x, I consistently get `unbound variable` error when running `make install-crds`.  I don't think this is an issue on bash v4.

Is there a reason we were declaring a new variable?

```
❯ bash --version
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin20)
Copyright (C) 2007 Free Software Foundation, Inc.

❯ make install-crds
# we use this in pkg/controller/common/license
go generate -tags='' ./pkg/... ./cmd/...
# Generate webhook manifest
# Webhook definitions exist in both pkg/apis and pkg/controller/elasticsearch/validation
/Users/mmontgomery/.goenv/shims/controller-gen webhook object:headerFile=./hack/boilerplate.go.txt paths=./pkg/apis/... paths=./pkg/controller/elasticsearch/validation/...
# Generate manifests e.g. CRD, RBAC etc.
/Users/mmontgomery/.goenv/shims/controller-gen crd:crdVersions=v1,generateEmbeddedObjectMeta=true paths="./pkg/apis/..." output:crd:artifacts:config=config/crds/v1/bases
# apply patches to work around some CRD generation issues, and merge them into a single file
kubectl kustomize config/crds/v1/patches > config/crds/v1/all-crds.yaml
# generate a CRD only version without the operator manifests
./hack/manifest-gen/manifest-gen.sh: line 84: ARGS[@]: unbound variable
make: *** [generate-crds-v1] Error 1
```