### PR TITLE
Fix broken links affecting MS-64 release

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -4,7 +4,7 @@
 :idprefix: k8s-
 :s: k8s
 
-include::{asciidoc-dir}/../../shared/versions/stack/7.x.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 include::overview.asciidoc[]
 include::k8s-quickstart.asciidoc[]


### PR DESCRIPTION
This PR manually applies the changes from d2127b4904be4cf805fa446a4f58333a5904fe7f in `0.9` that don't seem to want to cherry pick cleanly into this branch. 