### PR TITLE
[1.9] Add nodes permission to Agent in Fleet mode quickstart (#4989)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -102,6 +102,7 @@ rules:
 - apiGroups: [""] # "" indicates the core API group
   resources:
   - pods
+  - nodes
   verbs:
   - get
   - watch


### PR DESCRIPTION
Backports the following commits to 1.9:
 - Add nodes permission to Agent in Fleet mode quickstart (#4989)