### PR TITLE
Fix TestRemoteCluster E2E test for 8.0

### DIFF
--- a/test/e2e/es/remote_cluster_test.go
+++ b/test/e2e/es/remote_cluster_test.go
@@ -68,9 +68,15 @@ func TestRemoteCluster(t *testing.T) {
 			es1LicenseTestContext.Init(),
 			es2LicenseTestContext.Init(),
 			// Check that the first cluster is using a Platinum license
-			es1LicenseTestContext.CheckElasticsearchLicense(client.ElasticsearchLicenseTypePlatinum),
+			es1LicenseTestContext.CheckElasticsearchLicense(
+				client.ElasticsearchLicenseTypePlatinum,
+				client.ElasticsearchLicenseTypeEnterprise,
+			),
 			// Check that the second cluster is using a Platinum license
-			es1LicenseTestContext.CheckElasticsearchLicense(client.ElasticsearchLicenseTypePlatinum),
+			es1LicenseTestContext.CheckElasticsearchLicense(
+				client.ElasticsearchLicenseTypePlatinum,
+				client.ElasticsearchLicenseTypeEnterprise,
+			),
 			test.Step{
 				Name: "Add some data to the first cluster",
 				Test: func(t *testing.T) {


### PR DESCRIPTION
Fixes test [failure](https://devops-ci.elastic.co/view/cloud-on-k8s/job/cloud-on-k8s-e2e-tests-snapshot-versions-8x/281/testReport/junit/github/com_elastic_cloud-on-k8s_test_e2e_es/TestRemoteCluster_Elasticsearch_license_should_be__platinum_):

```
=== RUN   TestRemoteCluster/Elasticsearch_license_should_be_[platinum]
Retries (30m0s timeout): ........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
    step.go:43: 
        	Error Trace:	utils.go:87
        	Error:      	Received unexpected error:
        	            	expectedTypes license type [platinum] got enterprise
        	Test:       	TestRemoteCluster/Elasticsearch_license_should_be_[platinum]
{"log.level":"error","@timestamp":"2021-10-26T07:10:48.461Z","message":"stopping early","service.version":"0.0.0-SNAPSHOT+00000000","service.type":"eck","ecs.version":"1.4.0","error":"test failure","error.stack_trace":"github.com/elastic/cloud-on-k8s/test/e2e/test.StepList.RunSequential\n\t/go/src/github.com/elastic/cloud-on-k8s/test/e2e/test/step.go:44\ngithub.com/elastic/cloud-on-k8s/test/e2e/es.TestRemoteCluster\n\t/go/src/github.com/elastic/cloud-on-k8s/test/e2e/es/remote_cluster_test.go:108\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1259"}
    --- FAIL: TestRemoteCluster/Elasticsearch_license_should_be_[platinum] (1800.00s)
```