### PR TITLE
Isolate operator from http service misconfiguration

### DIFF
--- a/pkg/controller/autoscaling/elasticsearch/controller.go
+++ b/pkg/controller/autoscaling/elasticsearch/controller.go
@@ -192,7 +192,7 @@ func newElasticsearchClient(
 	if err != nil {
 		return nil, err
 	}
-	url, err := services.ElasticsearchURLFromRandomPod(es, resourcesState.CurrentPodsByPhase[corev1.PodRunning])
+	url, err := services.ElasticsearchURLFromRandomPod(resourcesState.CurrentPodsByPhase[corev1.PodRunning])
 	if err != nil {
 		log := logconf.FromContext(ctx)
 		log.V(1).Info("could not get a URL to communicate with elasticsearch from a random pod, failing back to using external service", "error", err)

--- a/pkg/controller/autoscaling/elasticsearch/controller.go
+++ b/pkg/controller/autoscaling/elasticsearch/controller.go
@@ -192,7 +192,12 @@ func newElasticsearchClient(
 	if err != nil {
 		return nil, err
 	}
-	url := services.AttemptRandomElasticsearchPodURL(es, resourcesState.CurrentPodsByPhase[corev1.PodPhase(corev1.PodReady)])
+	url, err := services.ElasticsearchURLFromRandomPod(es, resourcesState.CurrentPodsByPhase[corev1.PodRunning])
+	if err != nil {
+		log := logconf.FromContext(ctx)
+		log.V(1).Info("could not get a URL to communicate with elasticsearch from a random pod, failing back to using external service", "error", err)
+		url = services.ElasticsearchURL(es, resourcesState.CurrentPodsByPhase[corev1.PodRunning])
+	}
 	v, err := version.Parse(es.Spec.Version)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/autoscaling/elasticsearch/controller.go
+++ b/pkg/controller/autoscaling/elasticsearch/controller.go
@@ -192,7 +192,7 @@ func newElasticsearchClient(
 	if err != nil {
 		return nil, err
 	}
-	url := services.RandomElasticsearchPodURL(es, resourcesState.CurrentPodsByPhase[corev1.PodRunning])
+	url := services.AttemptRandomElasticsearchPodURL(es, resourcesState.CurrentPodsByPhase[corev1.PodPhase(corev1.PodReady)])
 	v, err := version.Parse(es.Spec.Version)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/autoscaling/elasticsearch/driver.go
+++ b/pkg/controller/autoscaling/elasticsearch/driver.go
@@ -92,7 +92,7 @@ func newStatusBuilder(log logr.Logger, autoscalingSpec esv1.AutoscalingSpec) *st
 	return statusBuilder
 }
 
-// Check if the Elasticsearch has any pods ready to handle requests.
+// Check if Elasticsearch has any pods ready to handle requests.
 func (r *ReconcileElasticsearch) isElasticsearchReachable(ctx context.Context, es esv1.Elasticsearch) (bool, error) {
 	defer tracing.Span(&ctx)()
 	resourcesState, err := esReconcile.NewResourcesStateFromAPI(r.Client, es)

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -309,7 +309,11 @@ func (d *defaultDriver) newElasticsearchClient(
 	v version.Version,
 	caCerts []*x509.Certificate,
 ) esclient.Client {
-	url := services.AttemptRandomElasticsearchPodURL(d.ES, state.CurrentPodsByPhase[corev1.PodPhase(corev1.PodReady)])
+	url, err := services.ElasticsearchURLFromRandomPod(d.ES, state.CurrentPodsByPhase[corev1.PodRunning])
+	if err != nil {
+		log.V(1).Info("could not get a URL to communicate with elasticsearch from a random pod, failing back to using external service", "error", err)
+		url = services.ElasticsearchURL(d.ES, state.CurrentPodsByPhase[corev1.PodRunning])
+	}
 	return esclient.NewElasticsearchClient(
 		d.OperatorParameters.Dialer,
 		k8s.ExtractNamespacedName(&d.ES),

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -327,7 +327,12 @@ func (d *defaultDriver) isReachable() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return len(resourcesState.CurrentPodsByPhase[corev1.PodPhase(corev1.PodReady)]) > 0, nil
+	for _, pod := range resourcesState.CurrentPods {
+		if pod.Status.Phase == corev1.PodRunning && k8s.IsPodReady(pod) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // warnUnsupportedDistro sends an event of type warning if the Elasticsearch Docker image is not a supported

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -195,12 +195,11 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	defer cancel()
 
 	var health esclient.Health
+	esReachable := false
 	health, err = esClient.GetClusterHealth(healthCtx)
-	if err != nil {
-		return results.WithError(err)
+	if err == nil && !health.TimedOut {
+		esReachable = true
 	}
-
-	esReachable := !health.TimedOut
 
 	var currentLicense esclient.License
 	if esReachable {

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -309,7 +309,7 @@ func (d *defaultDriver) newElasticsearchClient(
 	v version.Version,
 	caCerts []*x509.Certificate,
 ) esclient.Client {
-	url := services.ElasticsearchURL(d.ES, state.CurrentPodsByPhase[corev1.PodRunning])
+	url := services.RandomElasticsearchPodURL(d.ES, state.CurrentPodsByPhase[corev1.PodRunning])
 	return esclient.NewElasticsearchClient(
 		d.OperatorParameters.Dialer,
 		k8s.ExtractNamespacedName(&d.ES),

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -309,10 +309,10 @@ func (d *defaultDriver) newElasticsearchClient(
 	v version.Version,
 	caCerts []*x509.Certificate,
 ) esclient.Client {
-	url, err := services.ElasticsearchURLFromRandomPod(d.ES, state.CurrentPodsByPhase[corev1.PodRunning])
+	url, err := services.ElasticsearchURLFromRandomPod(state.CurrentPodsByPhase[corev1.PodRunning])
 	if err != nil {
 		log.V(1).Info("could not get a URL to communicate with elasticsearch from a random pod, failing back to using external service", "error", err)
-		url = services.ElasticsearchURL(d.ES, state.CurrentPodsByPhase[corev1.PodRunning])
+		url = services.ExternalServiceURL(d.ES)
 	}
 	return esclient.NewElasticsearchClient(
 		d.OperatorParameters.Dialer,

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -195,11 +195,8 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	defer cancel()
 
 	var health esclient.Health
-	esReachable := false
 	health, err = esClient.GetClusterHealth(healthCtx)
-	if err == nil && !health.TimedOut {
-		esReachable = true
-	}
+	esReachable := (err == nil && !health.TimedOut)
 
 	var currentLicense esclient.License
 	if esReachable {

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -191,7 +191,7 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	)
 	defer esClient.Close()
 
-	healthCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	healthCtx, cancel := context.WithTimeout(context.Background(), esclient.Timeout(d.ES))
 	defer cancel()
 
 	var health esclient.Health

--- a/pkg/controller/elasticsearch/driver/driver_test.go
+++ b/pkg/controller/elasticsearch/driver/driver_test.go
@@ -1,0 +1,171 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package driver
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	v1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/services"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+)
+
+func defaultElasticsearchObject() *v1.Elasticsearch {
+	return &v1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testcluster",
+			Namespace: "testing",
+			Labels: map[string]string{
+				label.ClusterNameLabelName: "testcluster",
+			},
+		},
+	}
+}
+
+func defaultElasticsearchK8sRuntimeObjects(podStatus corev1.PodStatus) []runtime.Object {
+	return []runtime.Object{
+		defaultElasticsearchObject(),
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testclusterpod0",
+				Namespace: "testing",
+				Labels: map[string]string{
+					label.ClusterNameLabelName: "testcluster",
+				},
+			},
+			Status: podStatus,
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      services.ExternalServiceName("testcluster"),
+				Namespace: "testing",
+			},
+		}}
+}
+
+func Test_defaultDriver_isReachable(t *testing.T) {
+	type fields struct {
+		DefaultDriverParameters DefaultDriverParameters
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    bool
+		wantErr bool
+	}{
+		{
+			"elasticsearch pods with phase running, containers, and pod ready is true",
+			fields{
+				DefaultDriverParameters: DefaultDriverParameters{
+					Client: k8s.NewFakeClient(defaultElasticsearchK8sRuntimeObjects(corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.PodReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					})...),
+					ES: *defaultElasticsearchObject(),
+				},
+			},
+			true,
+			false,
+		},
+		{
+			"elasticsearch pods with phase failed, containers, and pod ready is false",
+			fields{
+				DefaultDriverParameters: DefaultDriverParameters{
+					Client: k8s.NewFakeClient(defaultElasticsearchK8sRuntimeObjects(corev1.PodStatus{
+						Phase: corev1.PodFailed,
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.PodReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					})...),
+					ES: *defaultElasticsearchObject(),
+				},
+			},
+			false,
+			false,
+		},
+		{
+			"elasticsearch pods with phase running, containers and pod not ready is false",
+			fields{
+				DefaultDriverParameters: DefaultDriverParameters{
+					Client: k8s.NewFakeClient(defaultElasticsearchK8sRuntimeObjects(corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionFalse,
+							},
+							{
+								Type:   corev1.PodReady,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					})...),
+					ES: *defaultElasticsearchObject(),
+				},
+			},
+			false,
+			false,
+		},
+		{
+			"elasticsearch pods with phase running, containers ready but pod not ready is false",
+			fields{
+				DefaultDriverParameters: DefaultDriverParameters{
+					Client: k8s.NewFakeClient(defaultElasticsearchK8sRuntimeObjects(corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.PodReady,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					})...),
+					ES: *defaultElasticsearchObject(),
+				},
+			},
+			false,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &defaultDriver{
+				DefaultDriverParameters: tt.fields.DefaultDriverParameters,
+			}
+			got, err := d.isReachable()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("defaultDriver.isReachable() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("defaultDriver.isReachable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/elasticsearch/services/services.go
+++ b/pkg/controller/elasticsearch/services/services.go
@@ -140,7 +140,7 @@ func ElasticsearchURL(es esv1.Elasticsearch, pods []corev1.Pod) string {
 	return ExternalServiceURL(es)
 }
 
-// AttemptRandomElasticsearchPodURL will return a URL to communicate with a random Elasticsearch pod from the
+// ElasticsearchURLFromRandomPod will return a URL to communicate with a random Elasticsearch pod from the
 // given set of pods.  If for some reason a pod URL cannot be generated, an error is returned.
 func ElasticsearchURLFromRandomPod(es esv1.Elasticsearch, pods []corev1.Pod) (string, error) {
 	if len(pods) == 0 {

--- a/pkg/controller/elasticsearch/services/services.go
+++ b/pkg/controller/elasticsearch/services/services.go
@@ -157,6 +157,9 @@ func ElasticsearchURL(es esv1.Elasticsearch, pods []corev1.Pod) string {
 // given set of pods.  If for some reason a pod URL cannot be generated, the external Elasticsearch
 // service URL will be returned.
 func RandomElasticsearchPodURL(es esv1.Elasticsearch, pods []corev1.Pod) string {
+	if len(pods) == 0 {
+		return ExternalServiceURL(es)
+	}
 	randomPod := pods[rand.Intn(len(pods))] //nolint:gosec
 	if podURL := ElasticsearchPodURL(randomPod); podURL != "" {
 		return podURL

--- a/pkg/controller/elasticsearch/services/services.go
+++ b/pkg/controller/elasticsearch/services/services.go
@@ -159,5 +159,5 @@ func ElasticsearchPodURL(pod corev1.Pod) (string, error) {
 		return fmt.Sprintf("%s://%s.%s.%s:%d", scheme, pod.Name, sset, pod.Namespace, network.HTTPPort), nil
 	}
 	return "", fmt.Errorf(
-		"could not generate URL from given pod as the pod does not have both %s, and %s labels; existing labels: %v", label.HTTPSchemeLabelName, label.StatefulSetNameLabelName, pod.Labels)
+		"could not generate URL from pod %s as the pod does not have both %s, and %s labels; existing labels: %v", pod.Name, label.HTTPSchemeLabelName, label.StatefulSetNameLabelName, pod.Labels)
 }

--- a/pkg/controller/elasticsearch/services/services.go
+++ b/pkg/controller/elasticsearch/services/services.go
@@ -151,6 +151,7 @@ func ElasticsearchURLFromRandomPod(es esv1.Elasticsearch, pods []corev1.Pod) (st
 }
 
 // ElasticsearchPodURL calculates the URL for the given Pod based on the Pods metadata.
+// If the pod is missing any of the required labels, an error is returned.
 func ElasticsearchPodURL(pod corev1.Pod) (string, error) {
 	scheme, hasSchemeLabel := pod.Labels[label.HTTPSchemeLabelName]
 	sset, hasSsetLabel := pod.Labels[label.StatefulSetNameLabelName]

--- a/pkg/controller/elasticsearch/services/services.go
+++ b/pkg/controller/elasticsearch/services/services.go
@@ -157,7 +157,6 @@ func ElasticsearchURL(es esv1.Elasticsearch, pods []corev1.Pod) string {
 // given set of pods.  If for some reason a pod URL cannot be generated, the external Elasticsearch
 // service URL will be returned.
 func RandomElasticsearchPodURL(es esv1.Elasticsearch, pods []corev1.Pod) string {
-	// switch to sending requests directly to a random pod instead of going through the service
 	randomPod := pods[rand.Intn(len(pods))] //nolint:gosec
 	if podURL := ElasticsearchPodURL(randomPod); podURL != "" {
 		return podURL

--- a/pkg/controller/elasticsearch/services/services.go
+++ b/pkg/controller/elasticsearch/services/services.go
@@ -148,10 +148,19 @@ func ElasticsearchURL(es esv1.Elasticsearch, pods []corev1.Pod) string {
 	}
 	if schemeChange {
 		// switch to sending requests directly to a random pod instead of going through the service
-		randomPod := pods[rand.Intn(len(pods))] //nolint:gosec
-		if podURL := ElasticsearchPodURL(randomPod); podURL != "" {
-			return podURL
-		}
+		return RandomElasticsearchPodURL(es, pods)
+	}
+	return ExternalServiceURL(es)
+}
+
+// RandomElasticsearchPodURL will return a URL to communicate with a random Elasticsearch pod from the
+// given set of pods.  If for some reason a pod URL cannot be generated, the external Elasticsearch
+// service URL will be returned.
+func RandomElasticsearchPodURL(es esv1.Elasticsearch, pods []corev1.Pod) string {
+	// switch to sending requests directly to a random pod instead of going through the service
+	randomPod := pods[rand.Intn(len(pods))] //nolint:gosec
+	if podURL := ElasticsearchPodURL(randomPod); podURL != "" {
+		return podURL
 	}
 	return ExternalServiceURL(es)
 }

--- a/pkg/controller/elasticsearch/services/services.go
+++ b/pkg/controller/elasticsearch/services/services.go
@@ -103,6 +103,7 @@ func NewExternalService(es esv1.Elasticsearch) *corev1.Service {
 }
 
 // IsServiceReady checks if a service has one or more ready endpoints.
+// *Note* this is unused now.  Should we simply remove? --mmontgomery
 func IsServiceReady(c k8s.Client, service corev1.Service) (bool, error) {
 	endpoints := corev1.Endpoints{}
 	namespacedName := types.NamespacedName{Namespace: service.Namespace, Name: service.Name}

--- a/pkg/controller/elasticsearch/services/services_test.go
+++ b/pkg/controller/elasticsearch/services/services_test.go
@@ -403,7 +403,7 @@ func TestElasticsearchURLFromRandomPod(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ElasticsearchURLFromRandomPod(tt.args.es, tt.args.pods)
+			got, err := ElasticsearchURLFromRandomPod(tt.args.pods)
 			assert.Equal(t, tt.expectedError, err, "AttemptRandomElasticsearchPodURL() expected error '%v', got '%v'", tt.expectedError, err)
 			assert.Equal(t, tt.want, got, "AttemptRandomElasticsearchPodURL() = %v, want %v", got, tt.want)
 		})

--- a/pkg/controller/elasticsearch/services/services_test.go
+++ b/pkg/controller/elasticsearch/services/services_test.go
@@ -342,7 +342,7 @@ func TestNewTransportService(t *testing.T) {
 	}
 }
 
-func TestRandomElasticsearchPodURL(t *testing.T) {
+func TestAttemptRandomElasticsearchPodURL(t *testing.T) {
 	type args struct {
 		es   esv1.Elasticsearch
 		pods []corev1.Pod
@@ -397,8 +397,8 @@ func TestRandomElasticsearchPodURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := RandomElasticsearchPodURL(tt.args.es, tt.args.pods); got != tt.want {
-				t.Errorf("RandomElasticsearchPodURL() = %v, want %v", got, tt.want)
+			if got := AttemptRandomElasticsearchPodURL(tt.args.es, tt.args.pods); got != tt.want {
+				t.Errorf("AttemptRandomElasticsearchPodURL() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/controller/elasticsearch/services/services_test.go
+++ b/pkg/controller/elasticsearch/services/services_test.go
@@ -398,7 +398,7 @@ func TestElasticsearchURLFromRandomPod(t *testing.T) {
 			},
 			"",
 			fmt.Errorf(
-				"could not generate URL from given pod as the pod does not have both %s, and %s labels; existing labels: %v", label.HTTPSchemeLabelName, label.StatefulSetNameLabelName, map[string]string{}),
+				"could not generate URL from pod pod0 as the pod does not have both %s, and %s labels; existing labels: %v", label.HTTPSchemeLabelName, label.StatefulSetNameLabelName, map[string]string{}),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/controller/elasticsearch/services/services_test.go
+++ b/pkg/controller/elasticsearch/services/services_test.go
@@ -343,7 +343,7 @@ func TestNewTransportService(t *testing.T) {
 	}
 }
 
-func TestAttemptRandomElasticsearchPodURL(t *testing.T) {
+func TestElasticsearchURLFromRandomPod(t *testing.T) {
 	type args struct {
 		es   esv1.Elasticsearch
 		pods []corev1.Pod

--- a/test/e2e/test/elasticsearch/checks_http.go
+++ b/test/e2e/test/elasticsearch/checks_http.go
@@ -42,7 +42,10 @@ func CheckHTTPConnectivityWithCA(es esv1.Elasticsearch, k *test.K8sClient, caCer
 	}
 
 	for _, p := range reconcile.AvailableElasticsearchNodes(pods) {
-		url := services.ElasticsearchPodURL(p)
+		url, err := services.ElasticsearchPodURL(p)
+		if err != nil {
+			return err
+		}
 		esClient := client.NewElasticsearchClient(
 			dialer,
 			k8s.ExtractNamespacedName(&es),
@@ -52,7 +55,7 @@ func CheckHTTPConnectivityWithCA(es esv1.Elasticsearch, k *test.K8sClient, caCer
 			caCert,
 			client.Timeout(es),
 		)
-		_, err := esClient.GetClusterInfo(context.Background())
+		_, err = esClient.GetClusterInfo(context.Background())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When constructing ES client during ES reconcile, choose random healthy pod instead of service.
When constructing ES client during autoscaling, choose random healthy pod instead of service.

resolves #4394
