### PR TITLE
E2E: adjust Enterprise search Kibana API path as of 7.16

### DIFF
--- a/test/e2e/test/kibana/checks_kb.go
+++ b/test/e2e/test/kibana/checks_kb.go
@@ -91,7 +91,7 @@ func (check *kbChecks) CheckEntSearchAccess(b Builder) test.Step {
 			path := "/api/enterprise_search/config_data"
 
 			// new API endpoint
-			if version.MustParse(b.Kibana.Spec.Version).GTE(version.MinFor(8, 0, 0)) {
+			if version.MustParse(b.Kibana.Spec.Version).GTE(version.MinFor(7, 16, 0)) {
 				path = "/internal/workplace_search/overview"
 			}
 			_, err = DoRequest(check.client, b.Kibana, password, "GET", path, nil)


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/111035 has been back ported to 7.16 so we need to adjust our expectations in the e2e test.