### PR TITLE
E2E monitor: move from IP to URL

### DIFF
--- a/config/e2e/helm-monitoring-operator.yaml
+++ b/config/e2e/helm-monitoring-operator.yaml
@@ -6,7 +6,7 @@ managedNamespaces: [{{ .E2ENamespace }}]
 
 image:
   repository: docker.elastic.co/eck/eck-operator
-  tag: 1.4.0
+  tag: 1.8.0
 
 podAnnotations:
   co.elastic.metrics/metricsets: collector

--- a/config/e2e/helm-operator-under-test.yaml
+++ b/config/e2e/helm-operator-under-test.yaml
@@ -21,7 +21,6 @@ tracing:
   enabled: true
   config:
     ELASTIC_APM_SERVER_URL: null
-    ELASTIC_APM_SERVER_CERT: "/mnt/elastic/apm.crt"
     ELASTIC_APM_ENVIRONMENT: "{{ .Pipeline }}-{{ .BuildNumber }}-{{ .Provider }}-{{ .ClusterName }}-{{ .KubernetesMajorMinor }}-{{ .ElasticStackVersion }}"
 
 env:
@@ -36,16 +35,6 @@ env:
         name: "eck-{{ .TestRun }}"
         key: apm_secret_token
 
-volumeMounts:
-  - name: apm-cert
-    mountPath: /mnt/elastic/apm.crt
-    subPath: "apm_server_cert"
-    readOnly: true
-
-volumes:
-  - name: apm-cert
-    secret:
-      secretName: "eck-{{ .TestRun }}"
 {{ end }}
   
 

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -79,11 +79,9 @@ spec:
     - name: clusterName
       type: keyword
     output.elasticsearch:
-      hosts: ['https://${monitoring_ip}:9200']
+      hosts: ['${monitoring_url}']
       username: ${monitoring_user}
       password: ${monitoring_pass}
-      ssl.certificate_authorities:
-      - /mnt/elastic/monitoring-ca.crt
   daemonSet:
     podTemplate:
       spec:
@@ -110,10 +108,6 @@ spec:
             name: dockersock
           - mountPath: /hostfs/proc
             name: proc
-          - name: monitoring-ca
-            mountPath: /mnt/elastic/monitoring-ca.crt
-            readOnly: true
-            subPath: monitoring_ca
           env:
           - name: NODE_NAME
             valueFrom:
@@ -134,9 +128,6 @@ spec:
         - hostPath:
             path: /proc
           name: proc
-        - name: monitoring-ca
-          secret:
-            secretName: "eck-{{ .TestRun }}"
   secureSettings:
   - secretName: "eck-{{ .TestRun }}"
 ---
@@ -284,11 +275,9 @@ spec:
     - name: build_number
       type: keyword
     output.elasticsearch:
-      hosts: ['https://${monitoring_ip}:9200']
+      hosts: ['${monitoring_url}']
       username: ${monitoring_user}
       password: ${monitoring_pass}
-      ssl.certificate_authorities:
-      - /mnt/elastic/monitoring-ca.crt
   secureSettings:
   - secretName: "eck-{{ .TestRun }}"
   daemonSet:
@@ -317,10 +306,6 @@ spec:
             mountPath: /var/log/pods
           - name: varlibdockercontainers
             mountPath: /var/lib/docker/containers
-          - name: monitoring-ca
-            mountPath: /mnt/elastic/monitoring-ca.crt
-            readOnly: true
-            subPath: monitoring_ca
           env:
           - name: NODE_NAME
             valueFrom:
@@ -336,9 +321,6 @@ spec:
         - name: varlibdockercontainers
           hostPath:
             path: /var/lib/docker/containers
-        - name: monitoring-ca
-          secret:
-            secretName: "eck-{{ .TestRun }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -294,6 +294,13 @@ spec:
             runAsUser: 0
         containers:
         - name: filebeat
+          resources:
+            requests:
+              memory: 300Mi
+              cpu: 0.5
+            limits:
+              memory: 500Mi
+              cpu: 0.5
           securityContext:
             runAsUser: 0
             {{ if .OcpCluster }}

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -261,11 +261,9 @@ func (h *helper) initTestSecrets() error {
 		}
 
 		monitoringSecrets := struct {
-			MonitoringIP   string `json:"monitoring_ip"`
+			MonitoringURL  string `json:"monitoring_url"`
 			MonitoringUser string `json:"monitoring_user"`
 			MonitoringPass string `json:"monitoring_pass"`
-			MonitoringCA   string `json:"monitoring_ca"`
-			APMServerCert  string `json:"apm_server_cert"`
 			APMSecretToken string `json:"apm_secret_token"`
 			APMServerURL   string `json:"apm_server_url"`
 		}{}
@@ -274,13 +272,11 @@ func (h *helper) initTestSecrets() error {
 			return fmt.Errorf("unmarshal %v, %w", h.monitoringSecrets, err)
 		}
 
-		h.testSecrets["monitoring_ip"] = monitoringSecrets.MonitoringIP
+		h.testSecrets["monitoring_url"] = monitoringSecrets.MonitoringURL
 		h.testSecrets["monitoring_user"] = monitoringSecrets.MonitoringUser
 		h.testSecrets["monitoring_pass"] = monitoringSecrets.MonitoringPass
-		h.testSecrets["monitoring_ca"] = monitoringSecrets.MonitoringCA
 
 		h.operatorSecrets = map[string]string{}
-		h.operatorSecrets["apm_server_cert"] = monitoringSecrets.APMServerCert
 		h.operatorSecrets["apm_secret_token"] = monitoringSecrets.APMSecretToken
 		h.operatorSecrets["apm_server_url"] = monitoringSecrets.APMServerURL
 	}


### PR DESCRIPTION
This allows us to move the ES and APM endpoints behind Let's encrypt certificates managed by an Ingress controller. The new URL will therefore be at 443 so we need to remove the hard-coded port here. 

This also does a few other things to get better visibility into the recent test failures:

* upgrades the monitoring operator to 1.8
* bumps Filebeat resources to 300Mi (I will follow up with an issue to bump the default in the operator code)