### PR TITLE
E2E: metricbeat index names do not include pre-release indicator

### DIFF
--- a/test/e2e/test/checks/monitoring.go
+++ b/test/e2e/test/checks/monitoring.go
@@ -157,7 +157,7 @@ func containsDocuments(esClient esClient.Client, indexPattern string) error {
 
 	// 1 index must exist
 	if len(indices) != 1 {
-		return fmt.Errorf("expected [%d] index [%s], found [%d]", len(indices), indexPattern, 1)
+		return fmt.Errorf("expected [%d] index [%s], found [%d]", 1, indexPattern, len(indices))
 	}
 	docsCount, err := strconv.Atoi(indices[0].DocsCount)
 	if err != nil {

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -457,10 +457,10 @@ func (b Builder) WithMonitoring(metricsESRef commonv1.ObjectSelector, logsESRef 
 }
 
 func (b Builder) GetMetricsIndexPattern() string {
-	if version.MustParse(test.Ctx().ElasticStackVersion).GTE(version.MinFor(8, 0, 0)) {
-		return fmt.Sprintf("metricbeat-%s*", test.Ctx().ElasticStackVersion)
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
+	if v.GTE(version.MinFor(8, 0, 0)) {
+		return fmt.Sprintf("metricbeat-%d.%d.%d*", v.Major, v.Minor, v.Patch)
 	}
-
 	return ".monitoring-es-*"
 }
 

--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -191,8 +191,9 @@ func (b Builder) WithMonitoring(metricsESRef commonv1.ObjectSelector, logsESRef 
 }
 
 func (b Builder) GetMetricsIndexPattern() string {
-	if version.MustParse(test.Ctx().ElasticStackVersion).GTE(version.MinFor(8, 0, 0)) {
-		return fmt.Sprintf("metricbeat-%s*", test.Ctx().ElasticStackVersion)
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
+	if v.GTE(version.MinFor(8, 0, 0)) {
+		return fmt.Sprintf("metricbeat-%d.%d.%d*", v.Major, v.Minor, v.Patch)
 	}
 
 	return ".monitoring-kibana-*"


### PR DESCRIPTION
To address https://devops-ci.elastic.co/job/cloud-on-k8s-e2e-tests-snapshot-versions-8x/294//testReport