### PR TITLE
Support/Enable Operator Lifecycle Manager Webhooks

### DIFF
--- a/hack/operatorhub/main.go
+++ b/hack/operatorhub/main.go
@@ -360,7 +360,7 @@ func buildRenderParams(conf *config, packageIndex int, extracts *yamlExtracts) (
 		return crdList[i].Name <= crdList[j].Name
 	})
 
-	webhookDefinitionList := make([]WebhookDefinition, 0)
+	var webhookDefinitionList []WebhookDefinition
 
 	for _, webhook := range extracts.operatorWebhooks {
 		webhookDefinitionList = append(webhookDefinitionList, validatingWebhookConfigurationToWebhookDefinition(webhook)...)

--- a/hack/operatorhub/main.go
+++ b/hack/operatorhub/main.go
@@ -233,7 +233,7 @@ type CRD struct {
 	Def         []byte
 }
 
-// WebhookDefinition cooresponds to a WebhookDefinition within an OLM
+// WebhookDefinition corresponds to a WebhookDefinition within an OLM
 // ClusterServiceVersion.
 // See https://olm.operatorframework.io/docs/advanced-tasks/adding-admission-and-conversion-webhooks/
 type WebhookDefinition struct {

--- a/hack/operatorhub/main.go
+++ b/hack/operatorhub/main.go
@@ -233,6 +233,9 @@ type CRD struct {
 	Def         []byte
 }
 
+// WebhookDefinition cooresponds to a WebhookDefinition within an OLM
+// ClusterServiceVersion.
+// See https://olm.operatorframework.io/docs/advanced-tasks/adding-admission-and-conversion-webhooks/
 type WebhookDefinition struct {
 	AdmissionReviewVersions []string                         `json:"admissionReviewVersions"`
 	ContainerPort           int                              `json:"containerPort"`
@@ -400,6 +403,8 @@ func buildRenderParams(conf *config, packageIndex int, extracts *yamlExtracts) (
 	}, nil
 }
 
+// validatingWebhookConfigurationToWebhookDefinition converts a standard validating webhook configuration resource
+// to an OLM webhook definition resource.
 func validatingWebhookConfigurationToWebhookDefinition(webhookConfiguration admissionv1.ValidatingWebhookConfiguration) []WebhookDefinition {
 	webhookDefinitions := make([]WebhookDefinition, 0)
 	for _, webhook := range webhookConfiguration.Webhooks {

--- a/hack/operatorhub/main.go
+++ b/hack/operatorhub/main.go
@@ -272,8 +272,7 @@ func extractYAMLParts(stream io.Reader) (*yamlExtracts, error) {
 	yamlReader := yaml.NewYAMLReader(bufio.NewReader(stream))
 
 	parts := &yamlExtracts{
-		crds:             make(map[string]*CRD),
-		operatorWebhooks: make([]admissionv1.ValidatingWebhookConfiguration, 0),
+		crds: make(map[string]*CRD),
 	}
 
 	for {
@@ -406,7 +405,7 @@ func buildRenderParams(conf *config, packageIndex int, extracts *yamlExtracts) (
 // validatingWebhookConfigurationToWebhookDefinition converts a standard validating webhook configuration resource
 // to an OLM webhook definition resource.
 func validatingWebhookConfigurationToWebhookDefinition(webhookConfiguration admissionv1.ValidatingWebhookConfiguration) []WebhookDefinition {
-	webhookDefinitions := make([]WebhookDefinition, 0)
+	var webhookDefinitions []WebhookDefinition
 	for _, webhook := range webhookConfiguration.Webhooks {
 		webhookDefinitions = append(webhookDefinitions, WebhookDefinition{
 			Type:                    "ValidatingAdmissionWebhook",

--- a/hack/operatorhub/main.go
+++ b/hack/operatorhub/main.go
@@ -360,7 +360,7 @@ func buildRenderParams(conf *config, packageIndex int, extracts *yamlExtracts) (
 	webhookDefinitionList := make([]WebhookDefinition, 0)
 
 	for _, webhook := range extracts.operatorWebhooks {
-		webhookDefinitionList = append(webhookDefinitionList, validatingWebhooksToWebhookDefinition(webhook)...)
+		webhookDefinitionList = append(webhookDefinitionList, validatingWebhookConfigurationToWebhookDefinition(webhook)...)
 	}
 
 	webhooks, err := gyaml.Marshal(webhookDefinitionList)
@@ -400,7 +400,7 @@ func buildRenderParams(conf *config, packageIndex int, extracts *yamlExtracts) (
 	}, nil
 }
 
-func validatingWebhooksToWebhookDefinition(webhookConfiguration admissionv1.ValidatingWebhookConfiguration) []WebhookDefinition {
+func validatingWebhookConfigurationToWebhookDefinition(webhookConfiguration admissionv1.ValidatingWebhookConfiguration) []WebhookDefinition {
 	webhookDefinitions := make([]WebhookDefinition, 0)
 	for _, webhook := range webhookConfiguration.Webhooks {
 		webhookDefinitions = append(webhookDefinitions, WebhookDefinition{

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -317,6 +317,8 @@ spec:
                 args:
                   - "manager"
                   - "--config=/conf/eck.yaml"
+                  - "--manage-webhook-certs=false"
+                  - "--enable-webhook"
                   {{- range  .AdditionalArgs }}
                   - "{{.}}"
                   {{- end }}
@@ -338,6 +340,10 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 150Mi
+                ports:
+                - containerPort: 9443
+                  name: https-webhook
+                  protocol: TCP
               terminationGracePeriodSeconds: 10
       permissions:
       - rules:
@@ -372,3 +378,5 @@ spec:
     name: Elastic
   replaces: {{ .PackageName }}.v{{ .PrevVersion }}
   version: {{ .NewVersion }}
+  webhookdefinitions:
+{{- .OperatorWebhooks | nindent 4 }}


### PR DESCRIPTION
These changes will enable the eck webhook in OCP clusters with operators managed by the Operator Lifecycle Manager, or any kubernetes cluster with operators managed by the OLM.

closes #4993 

Tested with 

```
❯ oc version
Client Version: 4.9.5
Server Version: 4.7.0
Kubernetes Version: v1.20.0+bd9e442
```

After installing eck-operator using catalog
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: elastic-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: docker.io/mmontg1/operators:1.8.0-rc2
  displayName: Elastic ECK Operator
  publisher: elastic.co
```

and subscription
```
---
apiVersion: v1
kind: Namespace
metadata:
  name: elastic
---
apiVersion: operators.coreos.com/v1
kind: OperatorGroup
metadata:
  annotations:
    olm.providedAPIs: ApmServer.v1.apm.k8s.elastic.co,Elasticsearch.v1.elasticsearch.k8s.elastic.co,Kibana.v1.kibana.k8s.elastic.co
  name: elastic-cloud-eck-group
  namespace: elastic
spec:
  targetNamespaces: []
---
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: elastic-cloud-eck
  namespace: elastic
spec:
  channel: stable
  name: elastic-cloud-eck
  source: elastic-operators
  sourceNamespace: openshift-marketplace
```

We have the following elastic webhooks installed
```
❯ kc get MutatingWebhookConfiguration,ValidatingWebhookConfiguration -A | grep elastic
validatingwebhookconfiguration.admissionregistration.k8s.io/elastic-agent-validation-v1alpha1.k8s.elastic.co-2rw4r   1          18h
validatingwebhookconfiguration.admissionregistration.k8s.io/elastic-apm-validation-v1.k8s.elastic.co-5vlls           1          18h
validatingwebhookconfiguration.admissionregistration.k8s.io/elastic-apm-validation-v1beta1.k8s.elastic.co-wmq2k      1          18h
validatingwebhookconfiguration.admissionregistration.k8s.io/elastic-beat-validation-v1beta1.k8s.elastic.co-8wrln     1          18h
validatingwebhookconfiguration.admissionregistration.k8s.io/elastic-ent-validation-v1.k8s.elastic.co-sdkch           1          18h
validatingwebhookconfiguration.admissionregistration.k8s.io/elastic-ent-validation-v1beta1.k8s.elastic.co-xnbsb      1          18h
validatingwebhookconfiguration.admissionregistration.k8s.io/elastic-es-validation-v1.k8s.elastic.co-8q6wh            1          18h
validatingwebhookconfiguration.admissionregistration.k8s.io/elastic-es-validation-v1beta1.k8s.elastic.co-swz48       1          18h
validatingwebhookconfiguration.admissionregistration.k8s.io/elastic-kb-validation-v1.k8s.elastic.co-mld76            1          18h
validatingwebhookconfiguration.admissionregistration.k8s.io/elastic-kb-validation-v1beta1.k8s.elastic.co-m5zhl       1          18h
```

And the deployment has the necessary arguments
```
❯ kc get deployment -n elastic elastic-operator -o json | jq '.spec.template.spec.containers[0].args'
[
  "manager",
  "--config=/conf/eck.yaml",
  "--manage-webhook-certs=false",
  "--enable-webhook",
  "--distribution-channel=community-operators"
]
```

And an invalid ES instance is rejected by the validating webhook, as expected
```
❯ kc apply -f config/samples/elasticsearch/elasticsearch-invalid-cluster-nomaster.yaml
Error from server (Elasticsearch.elasticsearch.k8s.elastic.co "invalid-cluster-nomaster" is invalid: spec.nodeSets: Required value: Elasticsearch needs to have at least one master node): error when creating "config/samples/elasticsearch/elasticsearch-invalid-cluster-nomaster.yaml": admission webhook "elastic-es-validation-v1.k8s.elastic.co" denied the request: Elasticsearch.elasticsearch.k8s.elastic.co "invalid-cluster-nomaster" is invalid: spec.nodeSets: Required value: Elasticsearch needs to have at least one master node
```