### PR TITLE
E2E: switch full-pr build to master GKE pipeline

### DIFF
--- a/.ci/jobs/e2e-tests-master-gke.yml
+++ b/.ci/jobs/e2e-tests-master-gke.yml
@@ -3,6 +3,11 @@
     description: Run ECK E2E tests on GKE, on every merge in master
     name: cloud-on-k8s-e2e-tests-master
     project-type: pipeline
+    parameters:
+      - bool:
+          name: SEND_NOTIFICATIONS
+          default: true
+          description: "Specified if job should send notifications to Slack. Enabled by default."
     triggers:
       - github
     concurrent: true

--- a/.ci/jobs/pr-gke-full.yml
+++ b/.ci/jobs/pr-gke-full.yml
@@ -12,7 +12,7 @@
             credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
             refspec: '+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*'
       # Jenkinsfile shared with the release build job
-      script-path: .ci/pipelines/build.Jenkinsfile
+      script-path: .ci/pipelines/e2e-tests-master-gke.Jenkinsfile
       lightweight-checkout: false
     triggers:
       - github-pull-request:

--- a/.ci/jobs/pr-gke-full.yml
+++ b/.ci/jobs/pr-gke-full.yml
@@ -3,6 +3,11 @@
     description: Build a PR version of ECK and run full suite of E2E tests
     name: cloud-on-k8s-pr-full
     project-type: pipeline
+    parameters:
+      - bool:
+          name: SEND_NOTIFICATIONS
+          default: false
+          description: "Specified if job should send notifications to Slack. Disabled by default."
     pipeline-scm:
       scm:
         - git:

--- a/.ci/pipelines/e2e-tests-master-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-master-gke.Jenkinsfile
@@ -78,15 +78,17 @@ pipeline {
     post {
         unsuccessful {
             script {
-                def msg = lib.generateSlackMessage("E2E tests failed!", env.BUILD_URL, failedTests)
+                if (params.SEND_NOTIFICATIONS) {
+                     def msg = lib.generateSlackMessage("E2E tests failed!", env.BUILD_URL, failedTests)
 
-                slackSend(
-                      channel: '#cloud-k8s',
-                      color: 'danger',
-                      message: msg,
-                    tokenCredentialId: 'cloud-ci-slack-integration-token',
-                    failOnError: true
-                )
+                     slackSend(
+                        channel: '#cloud-k8s',
+                        color: 'danger',
+                        message: msg,
+                        tokenCredentialId: 'cloud-ci-slack-integration-token',
+                        failOnError: true
+                    )
+                }
             }
         }
         cleanup {


### PR DESCRIPTION
As it rarely makes sense to test a PR change against all Kubernetes variants we support, this switches the build pipeline to the one we use to test the master branch. 

This also turns off Slack notifications in the case such a build fails. 

I am not sure how to test this other than trying it in the real environment. 