### PR TITLE
E2E: move 8.0 workaround to mutation steps

### DIFF
--- a/test/e2e/test/elasticsearch/steps_creation.go
+++ b/test/e2e/test/elasticsearch/steps_creation.go
@@ -7,10 +7,6 @@ package elasticsearch
 import (
 	"context"
 	"fmt"
-	"testing"
-	"time"
-
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // auth on gke
 
@@ -41,16 +37,6 @@ func (b Builder) CreationTestSteps(k *test.K8sClient) test.StepList {
 					// TODO this is incomplete
 					return nil
 				}),
-			},
-			test.Step{
-				Name: "Give Elasticsearch some time to allocate internal indices",
-				Test: func(_ *testing.T) {
-					// TODO remove this step once https://github.com/elastic/cloud-on-k8s/issues/5040 does not apply anymore
-					time.Sleep(30 * time.Second)
-				},
-				Skip: func() bool {
-					return version.MustParse(b.Elasticsearch.Spec.Version).LT(version.MinFor(7, 16, 0))
-				},
 			},
 		})
 }

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -85,6 +85,16 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 	//nolint:thelper
 	return test.StepList{
 		test.Step{
+			Name: "Give Elasticsearch some time to allocate internal indices",
+			Test: func(_ *testing.T) {
+				// TODO remove this step once https://github.com/elastic/cloud-on-k8s/issues/5040 does not apply anymore
+				time.Sleep(30 * time.Second)
+			},
+			Skip: func() bool {
+				return version.MustParse(b.Elasticsearch.Spec.Version).LT(version.MinFor(7, 16, 0))
+			},
+		},
+		test.Step{
 			Name: "Add some data to the cluster before starting the mutation",
 			Test: func(t *testing.T) {
 				dataIntegrityCheck = NewDataIntegrityCheck(k, b)


### PR DESCRIPTION
https://github.com/elastic/cloud-on-k8s/pull/5041 was ineffective because I naively put the step right after the check for an Elasticsearch clusters existence. That check only checks for the existence in the Kubernetes API. At that point in time no Elasticsearch node is booted yet and the 30 second wait time is doing nothing to improve the success rate of the test.  This PR moves the step to the mutation steps which run any kind of update to the cluster which would be affected by the issue. 