### PR TITLE
Allow K8S node labels to be propagated as pod annotations

### DIFF
--- a/deploy/eck-operator/templates/_helpers.tpl
+++ b/deploy/eck-operator/templates/_helpers.tpl
@@ -343,3 +343,17 @@ RBAC permissions on non-namespaced resources
   - patch
   - delete
 {{- end -}}
+
+{{/*
+RBAC permissions to read node labels
+*/}}
+{{- define "eck-operator.readNodeLabelsRbacRule" -}}
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+{{- end -}}

--- a/deploy/eck-operator/templates/cluster-roles.yaml
+++ b/deploy/eck-operator/templates/cluster-roles.yaml
@@ -9,6 +9,9 @@ metadata:
 rules:
 {{ template "eck-operator.rbacRules" . | toYaml | indent 2 }}
 {{ template "eck-operator.clusterWideRbacRules" . | toYaml | indent 2 }}
+{{ if .Values.config.exposedNodeLabels }}
+{{ template "eck-operator.readNodeLabelsRbacRule" . | toYaml | indent 2 }}
+{{ end -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/eck-operator/templates/configmap.yaml
+++ b/deploy/eck-operator/templates/configmap.yaml
@@ -16,6 +16,9 @@ data:
     ca-cert-rotate-before: {{ .Values.config.caRotateBefore }}
     cert-validity: {{ .Values.config.certificatesValidity }}
     cert-rotate-before: {{ .Values.config.certificatesRotateBefore }}
+    {{- if .Values.config.exposedNodeLabels }}
+    exposed-node-labels: [{{ join "," .Values.config.exposedNodeLabels  }}]
+    {{- end }}
     set-default-security-context: {{ .Values.config.setDefaultSecurityContext }}
     kube-client-timeout: {{ .Values.config.kubeClientTimeout }}
     elasticsearch-client-timeout: {{ .Values.config.elasticsearchClientTimeout }}

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -155,6 +155,9 @@ config:
   # certificatesRotateBefore defines when to rotate a certificate that is due to expire.
   certificatesRotateBefore: 24h
 
+  # exposedNodeLabels is an array of node labels which are allowed to be copied as annotations on Elasticsearch Pods.
+  exposedNodeLabels: [ "topology.kubernetes.io/.*", "failure-domain.beta.kubernetes.io/.*" ]
+
   # setDefaultSecurityContext determines whether a default security context is set on application containers created by the operator.
   setDefaultSecurityContext: true
 

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -155,7 +155,7 @@ config:
   # certificatesRotateBefore defines when to rotate a certificate that is due to expire.
   certificatesRotateBefore: 24h
 
-  # exposedNodeLabels is an array of node labels which are allowed to be copied as annotations on Elasticsearch Pods.
+  # exposedNodeLabels is an array of regular expressions of node labels which are allowed to be copied as annotations on Elasticsearch Pods.
   exposedNodeLabels: [ "topology.kubernetes.io/.*", "failure-domain.beta.kubernetes.io/.*" ]
 
   # setDefaultSecurityContext determines whether a default security context is set on application containers created by the operator.

--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -20,8 +20,8 @@ import (
 
 const (
 	ElasticsearchContainerName = "elasticsearch"
-	// NodeLabelsToPodsAnnotationsAnnotation holds an optional list of expected node labels to be set as annotations on the Elasticsearch Pods.
-	NodeLabelsToPodsAnnotationsAnnotation = "eck.k8s.elastic.co/downward-node-labels"
+	// DownwardNodeLabelsAnnotation holds an optional list of expected node labels to be set as annotations on the Elasticsearch Pods.
+	DownwardNodeLabelsAnnotation = "eck.k8s.elastic.co/downward-node-labels"
 	// SuspendAnnotation allows users to annotate the Elasticsearch resource with the names of Pods they want to suspend
 	// for debugging purposes.
 	SuspendAnnotation = "eck.k8s.elastic.co/suspend"
@@ -456,9 +456,9 @@ type Elasticsearch struct {
 	AssocConfs map[types.NamespacedName]commonv1.AssociationConf `json:"-"`
 }
 
-// NodeLabelsToPodsAnnotations returns the set of expected node labels to be copied as annotations on the Elasticsearch Pods.
-func (es Elasticsearch) NodeLabelsToPodsAnnotations() []string {
-	expectedAnnotations, exist := es.Annotations[NodeLabelsToPodsAnnotationsAnnotation]
+// DownwardNodeLabels returns the set of expected node labels to be copied as annotations on the Elasticsearch Pods.
+func (es Elasticsearch) DownwardNodeLabels() []string {
+	expectedAnnotations, exist := es.Annotations[DownwardNodeLabelsAnnotation]
 	expectedAnnotations = strings.TrimSpace(expectedAnnotations)
 	if !exist || expectedAnnotations == "" {
 		return nil
@@ -466,9 +466,9 @@ func (es Elasticsearch) NodeLabelsToPodsAnnotations() []string {
 	return strings.Split(expectedAnnotations, ",")
 }
 
-// HasNodeLabelsToPodsAnnotations returns true if some node labels are expected on the Elasticsearch Pods.
-func (es Elasticsearch) HasNodeLabelsToPodsAnnotations() bool {
-	return len(es.NodeLabelsToPodsAnnotations()) > 0
+// HasDownwardNodeLabels returns true if some node labels are expected on the Elasticsearch Pods.
+func (es Elasticsearch) HasDownwardNodeLabels() bool {
+	return len(es.DownwardNodeLabels()) > 0
 }
 
 // IsMarkedForDeletion returns true if the Elasticsearch is going to be deleted

--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -20,6 +20,8 @@ import (
 
 const (
 	ElasticsearchContainerName = "elasticsearch"
+	// NodeLabelsToPodsAnnotationsAnnotation holds an optional list of expected node labels to be set as annotations on the Elasticsearch Pods.
+	NodeLabelsToPodsAnnotationsAnnotation = "eck.k8s.elastic.co/downward-node-labels"
 	// SuspendAnnotation allows users to annotate the Elasticsearch resource with the names of Pods they want to suspend
 	// for debugging purposes.
 	SuspendAnnotation = "eck.k8s.elastic.co/suspend"
@@ -452,6 +454,21 @@ type Elasticsearch struct {
 	Spec       ElasticsearchSpec                                 `json:"spec,omitempty"`
 	Status     ElasticsearchStatus                               `json:"status,omitempty"`
 	AssocConfs map[types.NamespacedName]commonv1.AssociationConf `json:"-"`
+}
+
+// NodeLabelsToPodsAnnotations returns the set of expected node labels to be copied as annotations on the Elasticsearch Pods.
+func (es Elasticsearch) NodeLabelsToPodsAnnotations() []string {
+	expectedAnnotations, exist := es.Annotations[NodeLabelsToPodsAnnotationsAnnotation]
+	expectedAnnotations = strings.TrimSpace(expectedAnnotations)
+	if !exist || expectedAnnotations == "" {
+		return nil
+	}
+	return strings.Split(expectedAnnotations, ",")
+}
+
+// HasNodeLabelsToPodsAnnotations returns true if some node labels are expected on the Elasticsearch Pods.
+func (es Elasticsearch) HasNodeLabelsToPodsAnnotations() bool {
+	return len(es.NodeLabelsToPodsAnnotations()) > 0
 }
 
 // IsMarkedForDeletion returns true if the Elasticsearch is going to be deleted

--- a/pkg/controller/autoscaling/elasticsearch/controller.go
+++ b/pkg/controller/autoscaling/elasticsearch/controller.go
@@ -117,7 +117,7 @@ func (r *ReconcileElasticsearch) Reconcile(ctx context.Context, request reconcil
 	}
 
 	// Validate Elasticsearch and Autoscaling spec
-	if err := validation.ValidateElasticsearch(es); err != nil {
+	if err := validation.ValidateElasticsearch(es, r.ExposedNodeLabels); err != nil {
 		log.Error(
 			err,
 			"Elasticsearch manifest validation failed",

--- a/pkg/controller/common/operator/flags.go
+++ b/pkg/controller/common/operator/flags.go
@@ -21,6 +21,7 @@ const (
 	EnableTracingFlag             = "enable-tracing"
 	EnableWebhookFlag             = "enable-webhook"
 	EnforceRBACOnRefsFlag         = "enforce-rbac-on-refs"
+	ExposedNodeLabels             = "exposed-node-labels"
 	IPFamilyFlag                  = "ip-family"
 	KubeClientTimeout             = "kube-client-timeout"
 	ManageWebhookCertsFlag        = "manage-webhook-certs"

--- a/pkg/controller/common/operator/parameters.go
+++ b/pkg/controller/common/operator/parameters.go
@@ -10,11 +10,14 @@ import (
 
 	"github.com/elastic/cloud-on-k8s/pkg/about"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	esvalidation "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/validation"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/net"
 )
 
 // Parameters contain parameters to create new operators.
 type Parameters struct {
+	// ExposedNodeLabels are the labels which are allowed to be automatically set as annotations on Elasticsearch Pods.
+	ExposedNodeLabels esvalidation.NodeLabels
 	// OperatorNamespace is the control plane namespace of the operator.
 	OperatorNamespace string
 	// OperatorInfo is information about the operator

--- a/pkg/controller/common/operator/parameters.go
+++ b/pkg/controller/common/operator/parameters.go
@@ -16,7 +16,7 @@ import (
 
 // Parameters contain parameters to create new operators.
 type Parameters struct {
-	// ExposedNodeLabels are the labels which are allowed to be automatically set as annotations on Elasticsearch Pods.
+	// ExposedNodeLabels holds regular expressions of node labels which are allowed to be automatically set as annotations on Elasticsearch Pods.
 	ExposedNodeLabels esvalidation.NodeLabels
 	// OperatorNamespace is the control plane namespace of the operator.
 	OperatorNamespace string

--- a/pkg/controller/elasticsearch/configmap/configmap.go
+++ b/pkg/controller/elasticsearch/configmap/configmap.go
@@ -38,7 +38,7 @@ func ReconcileScriptsConfigMap(ctx context.Context, c k8s.Client, es esv1.Elasti
 	span, _ := apm.StartSpan(ctx, "reconcile_scripts", tracing.SpanTypeApp)
 	defer span.End()
 
-	fsScript, err := initcontainer.RenderPrepareFsScript()
+	fsScript, err := initcontainer.RenderPrepareFsScript(es.NodeLabelsToPodsAnnotations())
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/elasticsearch/configmap/configmap.go
+++ b/pkg/controller/elasticsearch/configmap/configmap.go
@@ -38,7 +38,7 @@ func ReconcileScriptsConfigMap(ctx context.Context, c k8s.Client, es esv1.Elasti
 	span, _ := apm.StartSpan(ctx, "reconcile_scripts", tracing.SpanTypeApp)
 	defer span.End()
 
-	fsScript, err := initcontainer.RenderPrepareFsScript(es.NodeLabelsToPodsAnnotations())
+	fsScript, err := initcontainer.RenderPrepareFsScript(es.DownwardNodeLabels())
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -151,6 +151,9 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 		return results.WithError(err)
 	}
 
+	// Patch the Pods to add the expected node labels as annotations
+	results.WithResults(annotatePodsWithNodeLabels(ctx, d.Client, d.ES))
+
 	resourcesState, err := reconcile.NewResourcesStateFromAPI(d.Client, d.ES)
 	if err != nil {
 		return results.WithError(err)

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -151,7 +151,8 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 		return results.WithError(err)
 	}
 
-	// Patch the Pods to add the expected node labels as annotations
+	// Patch the Pods to add the expected node labels as annotations. Record the error, if any, but do not stop the
+	// reconciliation loop as we don't want to prevent other updates from being applied to the cluster.
 	results.WithResults(annotatePodsWithNodeLabels(ctx, d.Client, d.ES))
 
 	resourcesState, err := reconcile.NewResourcesStateFromAPI(d.Client, d.ES)

--- a/pkg/controller/elasticsearch/driver/node_labels.go
+++ b/pkg/controller/elasticsearch/driver/node_labels.go
@@ -1,0 +1,115 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package driver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"go.elastic.co/apm"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+)
+
+// isPodScheduled returns if the Pod is scheduled. If true it also returns the node name.
+func isPodScheduled(pod *corev1.Pod) (bool, string) {
+	status := pod.Status
+	for i := range status.Conditions {
+		if !(status.Conditions[i].Type == corev1.PodScheduled) {
+			continue
+		}
+		return status.Conditions[i].Status == corev1.ConditionTrue && pod.Spec.NodeName != "", pod.Spec.NodeName
+	}
+	return false, ""
+}
+
+// annotatePodsWithNodeLabels annotates all the Pods with the expected node labels.
+func annotatePodsWithNodeLabels(ctx context.Context, c k8s.Client, es esv1.Elasticsearch) *reconciler.Results {
+	span, ctx := apm.StartSpan(ctx, "annotate_pods_with_node_labels", tracing.SpanTypeApp)
+	defer span.End()
+	results := reconciler.NewResult(ctx)
+	if !es.HasNodeLabelsToPodsAnnotations() {
+		return results
+	}
+	actualPods, err := sset.GetActualPodsForCluster(c, es)
+	if err != nil {
+		return results.WithError(err)
+	}
+	for _, pod := range actualPods {
+		results.WithError(annotatePodWithNodeLabels(c, pod, es))
+	}
+	return results
+}
+
+func annotatePodWithNodeLabels(c k8s.Client, pod corev1.Pod, es esv1.Elasticsearch) error {
+	scheduled, nodeName := isPodScheduled(&pod)
+	if !scheduled {
+		return nil
+	}
+	node := &corev1.Node{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: nodeName}, node); err != nil {
+		return err
+	}
+	// Get the missing annotations.
+	podAnnotations, err := getPodAnnotations(&pod, es.NodeLabelsToPodsAnnotations(), node.Labels)
+	if err != nil {
+		return err
+	}
+	// Stop early if there is no annotation to set.
+	if len(podAnnotations) == 0 {
+		return nil
+	}
+	log.Info("Setting Pod annotations from node labels", "err", err, "namespace", es.Namespace, "es_name", es.Name, "pod", pod.Name, "annotations", podAnnotations)
+	mergePatch, err := json.Marshal(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": podAnnotations,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if err := c.Patch(context.Background(), &pod, client.RawPatch(types.StrategicMergePatchType, mergePatch)); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+// getPodAnnotations returns missing annotations, and their values, expected on a given Pod.
+// It also ensures that labels exist on the K8S node, if not the case an error is returned.
+func getPodAnnotations(pod *corev1.Pod, expectedAnnotations []string, nodeLabels map[string]string) (map[string]string, error) {
+	podAnnotations := make(map[string]string)
+	var missingLabels []string
+	for _, expectedAnnotation := range expectedAnnotations {
+		value, ok := nodeLabels[expectedAnnotation]
+		if !ok {
+			missingLabels = append(missingLabels, expectedAnnotation)
+			continue
+		}
+		// Check if the annotations is already set
+		if _, alreadyExists := pod.Annotations[expectedAnnotation]; alreadyExists {
+			continue
+		}
+		podAnnotations[expectedAnnotation] = value
+	}
+	if len(missingLabels) > 0 {
+		return nil,
+			fmt.Errorf(
+				"following annotations are expected to be set on Pod %s/%s but do not exist as node labels: %s",
+				pod.Namespace,
+				pod.Name,
+				strings.Join(missingLabels, ","))
+	}
+	return podAnnotations, nil
+}

--- a/pkg/controller/elasticsearch/driver/node_labels.go
+++ b/pkg/controller/elasticsearch/driver/node_labels.go
@@ -40,7 +40,7 @@ func annotatePodsWithNodeLabels(ctx context.Context, c k8s.Client, es esv1.Elast
 	span, ctx := apm.StartSpan(ctx, "annotate_pods_with_node_labels", tracing.SpanTypeApp)
 	defer span.End()
 	results := reconciler.NewResult(ctx)
-	if !es.HasNodeLabelsToPodsAnnotations() {
+	if !es.HasDownwardNodeLabels() {
 		return results
 	}
 	actualPods, err := sset.GetActualPodsForCluster(c, es)
@@ -63,7 +63,7 @@ func annotatePodWithNodeLabels(c k8s.Client, pod corev1.Pod, es esv1.Elasticsear
 		return err
 	}
 	// Get the missing annotations.
-	podAnnotations, err := getPodAnnotations(&pod, es.NodeLabelsToPodsAnnotations(), node.Labels)
+	podAnnotations, err := getPodAnnotations(&pod, es.DownwardNodeLabels(), node.Labels)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/elasticsearch/driver/node_labels_test.go
+++ b/pkg/controller/elasticsearch/driver/node_labels_test.go
@@ -1,0 +1,208 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package driver
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/stretchr/testify/assert"
+)
+
+// expectedPodsAnnotations holds pod -> expectedAnnotation -> expectedValue
+type expectedPodsAnnotations map[string]map[string]string
+
+func (e expectedPodsAnnotations) isEmpty() bool {
+	return len(e) == 0
+}
+
+func (e expectedPodsAnnotations) assertPodsMatch(t *testing.T, pods []corev1.Pod) {
+	t.Helper()
+	assert.Equal(t, len(e), len(pods), "expected %d Pods with annotations, got %d Pods", len(e), len(pods))
+	for _, pod := range pods {
+		expectedAnnotations, exists := e[pod.Name]
+		assert.True(t, exists)
+		for expectedAnnotation, expectedValue := range expectedAnnotations {
+			actualValue, exists := pod.Annotations[expectedAnnotation]
+			assert.True(t, exists, "Pod %s: expected annotation %s", pod.Name, expectedAnnotation)
+			assert.Equal(
+				t,
+				expectedValue,
+				actualValue,
+				"Pod %s: expected value \"%s\" for annotation \"%s\", got value \"%s\"",
+				pod.Name, expectedValue, expectedAnnotation, actualValue,
+			)
+		}
+	}
+}
+
+const esName = "elasticsearch-sample"
+
+func Test_annotatePodsWithNodeLabels(t *testing.T) {
+	type args struct {
+		ctx     context.Context
+		es      *esv1.Elasticsearch
+		objects []runtime.Object
+	}
+	tests := []struct {
+		name                string
+		args                args
+		wantErrMsg          string
+		expectedAnnotations expectedPodsAnnotations
+	}{
+		{
+			name: "No annotations on K8S nodes",
+			args: args{
+				es: &esv1.Elasticsearch{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        esName,
+						Namespace:   "ns",
+						Annotations: map[string]string{"eck.k8s.elastic.co/downward-node-labels": "topology.kubernetes.io/region,topology.kubernetes.io/zone"},
+					},
+				},
+				objects: []runtime.Object{
+					newPodBuilder("elasticsearch-sample-es-default-0").scheduledOn("k8s-node-0").build(),
+					newPodBuilder("elasticsearch-sample-es-default-1").scheduledOn("k8s-node-1").build(),
+					&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "k8s-node-0"}},
+					&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "k8s-node-1"}},
+				},
+				ctx: context.Background(),
+			},
+			wantErrMsg: "following annotations are expected to be set on Pod ns/elasticsearch-sample-es-default-0 but do not exist as node labels: topology.kubernetes.io/region,topology.kubernetes.io/zone",
+		},
+		{
+			name: "No initial annotations on the Pods",
+			args: args{
+				es: &esv1.Elasticsearch{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        esName,
+						Namespace:   "ns",
+						Annotations: map[string]string{"eck.k8s.elastic.co/downward-node-labels": "topology.kubernetes.io/region,topology.kubernetes.io/zone"},
+					},
+				},
+				objects: []runtime.Object{
+					newPodBuilder("elasticsearch-sample-es-default-0").scheduledOn("k8s-node-0").build(),
+					newPodBuilder("elasticsearch-sample-es-default-1").scheduledOn("k8s-node-1").build(),
+					&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "k8s-node-0", Labels: map[string]string{"topology.kubernetes.io/region": "europe-west1", "topology.kubernetes.io/zone": "europe-west1-a"}}},
+					&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "k8s-node-1", Labels: map[string]string{"topology.kubernetes.io/region": "europe-west1", "topology.kubernetes.io/zone": "europe-west1-b"}}},
+				},
+				ctx: context.Background(),
+			},
+			expectedAnnotations: expectedPodsAnnotations{
+				"elasticsearch-sample-es-default-0": {
+					"topology.kubernetes.io/region": "europe-west1",
+					"topology.kubernetes.io/zone":   "europe-west1-a",
+				},
+				"elasticsearch-sample-es-default-1": {
+					"topology.kubernetes.io/region": "europe-west1",
+					"topology.kubernetes.io/zone":   "europe-west1-b",
+				},
+			},
+		},
+		{
+			name: "With initial annotations on the Pods",
+			args: args{
+				es: &esv1.Elasticsearch{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        esName,
+						Namespace:   "ns",
+						Annotations: map[string]string{"eck.k8s.elastic.co/downward-node-labels": "topology.kubernetes.io/region,topology.kubernetes.io/zone"},
+					},
+				},
+				objects: []runtime.Object{
+					newPodBuilder("elasticsearch-sample-es-default-0").scheduledOn("k8s-node-0").withAnnotation(map[string]string{"foo": "bar"}).build(),
+					newPodBuilder("elasticsearch-sample-es-default-1").scheduledOn("k8s-node-1").withAnnotation(map[string]string{"foo": "bar"}).build(),
+					&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "k8s-node-0", Labels: map[string]string{"topology.kubernetes.io/region": "europe-west1", "topology.kubernetes.io/zone": "europe-west1-a"}}},
+					&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "k8s-node-1", Labels: map[string]string{"topology.kubernetes.io/region": "europe-west1", "topology.kubernetes.io/zone": "europe-west1-b"}}},
+				},
+				ctx: context.Background(),
+			},
+			expectedAnnotations: expectedPodsAnnotations{
+				"elasticsearch-sample-es-default-0": {
+					"topology.kubernetes.io/region": "europe-west1",
+					"topology.kubernetes.io/zone":   "europe-west1-a",
+					"foo":                           "bar",
+				},
+				"elasticsearch-sample-es-default-1": {
+					"topology.kubernetes.io/region": "europe-west1",
+					"topology.kubernetes.io/zone":   "europe-west1-b",
+					"foo":                           "bar",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allObjects := append(tt.args.objects, tt.args.es)
+			k8sClient := k8s.NewFakeClient(allObjects...)
+			got := annotatePodsWithNodeLabels(tt.args.ctx, k8sClient, *tt.args.es)
+			_, err := got.Aggregate()
+			if tt.wantErrMsg != "" {
+				assert.Containsf(t, err.Error(), tt.wantErrMsg, "expected error containing %q, got %s", tt.wantErrMsg, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			if !tt.expectedAnnotations.isEmpty() {
+				podList := &corev1.PodList{}
+				assert.NoError(t, k8sClient.List(context.Background(), podList))
+				tt.expectedAnnotations.assertPodsMatch(t, podList.Items)
+			}
+		})
+	}
+}
+
+type podBuilder struct {
+	podName, nodeName string
+	scheduled         bool
+	annotations       map[string]string
+}
+
+func newPodBuilder(podName string) *podBuilder {
+	return &podBuilder{
+		podName: podName,
+	}
+}
+
+func (pb *podBuilder) scheduledOn(nodeName string) *podBuilder {
+	pb.scheduled = true
+	pb.nodeName = nodeName
+	return pb
+}
+
+func (pb *podBuilder) withAnnotation(annotations map[string]string) *podBuilder {
+	pb.annotations = annotations
+	return pb
+}
+
+func (pb *podBuilder) build() *corev1.Pod {
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pb.podName, Namespace: "ns",
+			Labels:      map[string]string{"elasticsearch.k8s.elastic.co/cluster-name": esName},
+			Annotations: pb.annotations,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: pb.nodeName,
+		},
+	}
+	if pb.scheduled {
+		pod.Status = corev1.PodStatus{
+			Phase: "",
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodScheduled,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		}
+	}
+	return &pod
+}

--- a/pkg/controller/elasticsearch/driver/node_labels_test.go
+++ b/pkg/controller/elasticsearch/driver/node_labels_test.go
@@ -8,13 +8,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
-	"github.com/stretchr/testify/assert"
 )
 
 // expectedPodsAnnotations holds pod -> expectedAnnotation -> expectedValue

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -222,7 +222,7 @@ func (r *ReconcileElasticsearch) internalReconcile(
 
 	span, ctx := apm.StartSpan(ctx, "validate", tracing.SpanTypeApp)
 	// this is the same validation as the webhook, but we run it again here in case the webhook has not been configured
-	err := validation.ValidateElasticsearch(es)
+	err := validation.ValidateElasticsearch(es, r.ExposedNodeLabels)
 	span.End()
 
 	if err != nil {

--- a/pkg/controller/elasticsearch/initcontainer/initcontainer.go
+++ b/pkg/controller/elasticsearch/initcontainer/initcontainer.go
@@ -22,9 +22,10 @@ const (
 func NewInitContainers(
 	transportCertificatesVolume volume.SecretVolume,
 	keystoreResources *keystore.Resources,
+	nodeLabelsAsAnnotations []string,
 ) ([]corev1.Container, error) {
 	var containers []corev1.Container
-	prepareFsContainer, err := NewPrepareFSInitContainer(transportCertificatesVolume)
+	prepareFsContainer, err := NewPrepareFSInitContainer(transportCertificatesVolume, nodeLabelsAsAnnotations)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/elasticsearch/initcontainer/initcontainer_test.go
+++ b/pkg/controller/elasticsearch/initcontainer/initcontainer_test.go
@@ -39,7 +39,7 @@ func TestNewInitContainers(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			containers, err := NewInitContainers(volume.SecretVolume{}, tt.args.keystoreResources)
+			containers, err := NewInitContainers(volume.SecretVolume{}, tt.args.keystoreResources, []string{})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedNumberOfContainers, len(containers))
 		})

--- a/pkg/controller/elasticsearch/initcontainer/prepare_fs_script_test.go
+++ b/pkg/controller/elasticsearch/initcontainer/prepare_fs_script_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestRenderScriptTemplate(t *testing.T) {
+	expectedAnnotations := "topology.kubernetes.io/zone topology.kubernetes.io/region"
 	tests := []struct {
 		name           string
 		params         TemplateParams
@@ -33,6 +34,14 @@ func TestRenderScriptTemplate(t *testing.T) {
 				"yes | cp -avf /usr/share/elasticsearch/plugins/* /mnt/elastic-internal/elasticsearch-plugins-local/",
 				"ln -sf /secrets/users /usr/share/elasticsearch/users",
 			},
+		},
+		{
+			name: "With expected annotations",
+			params: TemplateParams{
+				PluginVolumes:       PluginVolumes,
+				ExpectedAnnotations: &expectedAnnotations,
+			},
+			wantSubstr: []string{},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/controller/elasticsearch/initcontainer/prepare_fs_script_test.go
+++ b/pkg/controller/elasticsearch/initcontainer/prepare_fs_script_test.go
@@ -34,6 +34,9 @@ func TestRenderScriptTemplate(t *testing.T) {
 				"yes | cp -avf /usr/share/elasticsearch/plugins/* /mnt/elastic-internal/elasticsearch-plugins-local/",
 				"ln -sf /secrets/users /usr/share/elasticsearch/users",
 			},
+			dontWantSubstr: []string{
+				"expected_annotations",
+			},
 		},
 		{
 			name: "With expected annotations",
@@ -41,7 +44,11 @@ func TestRenderScriptTemplate(t *testing.T) {
 				PluginVolumes:       PluginVolumes,
 				ExpectedAnnotations: &expectedAnnotations,
 			},
-			wantSubstr: []string{},
+			wantSubstr: []string{
+				"echo \"Waiting for the following annotations to be set on Pod: topology.kubernetes.io/zone topology.kubernetes.io/region\"",
+				"expected_annotations=(topology.kubernetes.io/zone topology.kubernetes.io/region)",
+				"while ! annotations_exist \"${expected_annotations[@]}\"; do sleep 2; done",
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -47,7 +47,7 @@ func BuildPodTemplateSpec(
 	keystoreResources *keystore.Resources,
 	setDefaultSecurityContext bool,
 ) (corev1.PodTemplateSpec, error) {
-	downwardAPIVolume := volume.DownwardAPI{}.WithAnnotations(es.HasNodeLabelsToPodsAnnotations())
+	downwardAPIVolume := volume.DownwardAPI{}.WithAnnotations(es.HasDownwardNodeLabels())
 	volumes, volumeMounts := buildVolumes(es.Name, nodeSet, keystoreResources, downwardAPIVolume)
 
 	labels, err := buildLabels(es, cfg, nodeSet, keystoreResources)
@@ -61,7 +61,7 @@ func BuildPodTemplateSpec(
 	initContainers, err := initcontainer.NewInitContainers(
 		transportCertificatesVolume(esv1.StatefulSet(es.Name, nodeSet.Name)),
 		keystoreResources,
-		es.NodeLabelsToPodsAnnotations(),
+		es.DownwardNodeLabels(),
 	)
 	if err != nil {
 		return corev1.PodTemplateSpec{}, err
@@ -104,8 +104,8 @@ func BuildPodTemplateSpec(
 	}
 
 	// inherit the node labels list to trigger a restart when changed
-	if es.HasNodeLabelsToPodsAnnotations() {
-		builder = builder.WithAnnotations(map[string]string{esv1.NodeLabelsToPodsAnnotationsAnnotation: es.Annotations[esv1.NodeLabelsToPodsAnnotationsAnnotation]})
+	if es.HasDownwardNodeLabels() {
+		builder = builder.WithAnnotations(map[string]string{esv1.DownwardNodeLabelsAnnotation: es.Annotations[esv1.DownwardNodeLabelsAnnotation]})
 	}
 
 	return builder.PodTemplate, nil

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
+
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -191,12 +193,12 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 	terminationGracePeriodSeconds := DefaultTerminationGracePeriodSeconds
 	varFalse := false
 
-	volumes, volumeMounts := buildVolumes(sampleES.Name, nodeSet, nil)
+	volumes, volumeMounts := buildVolumes(sampleES.Name, nodeSet, nil, volume.DownwardAPI{})
 	// should be sorted
 	sort.Slice(volumes, func(i, j int) bool { return volumes[i].Name < volumes[j].Name })
 	sort.Slice(volumeMounts, func(i, j int) bool { return volumeMounts[i].Name < volumeMounts[j].Name })
 
-	initContainers, err := initcontainer.NewInitContainers(transportCertificatesVolume(sampleES.Name), nil)
+	initContainers, err := initcontainer.NewInitContainers(transportCertificatesVolume(sampleES.Name), nil, nil)
 	require.NoError(t, err)
 	// init containers should be patched with volume and inherited env vars and image
 	headlessSvcEnvVar := corev1.EnvVar{Name: "HEADLESS_SERVICE_NAME", Value: "name-es-nodeset-1"}

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -8,8 +8,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
-
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,12 +17,51 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/initcontainer"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
 )
+
+type esSampleBuilder struct {
+	userConfig              map[string]interface{}
+	esAdditionalAnnotations map[string]string
+	keystoreResources       *keystore.Resources
+}
+
+func newEsSampleBuilder() *esSampleBuilder {
+	return &esSampleBuilder{}
+}
+
+func (esb *esSampleBuilder) build() esv1.Elasticsearch {
+	es := sampleES.DeepCopy()
+	for k, v := range esb.esAdditionalAnnotations {
+		es.Annotations[k] = v
+	}
+	if esb.userConfig != nil {
+		es.Spec.NodeSets[0].Config = &commonv1.Config{Data: esb.userConfig}
+	}
+	return *es
+}
+
+func (esb *esSampleBuilder) withUserConfig(userConfig map[string]interface{}) *esSampleBuilder {
+	esb.userConfig = userConfig
+	return esb
+}
+
+func (esb *esSampleBuilder) addEsAnnotations(esAnnotations map[string]string) *esSampleBuilder {
+	esb.esAdditionalAnnotations = esAnnotations
+	return esb
+}
+
+func (esb *esSampleBuilder) withKeystoreResources(keystoreResources *keystore.Resources) *esSampleBuilder {
+	esb.keystoreResources = keystoreResources
+	return esb
+}
 
 var sampleES = esv1.Elasticsearch{
 	ObjectMeta: metav1.ObjectMeta{
@@ -164,7 +201,7 @@ func TestBuildPodTemplateSpecWithDefaultSecurityContext(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			es := *sampleES.DeepCopy()
+			es := newEsSampleBuilder().build()
 			es.Spec.Version = tt.version.String()
 			es.Spec.NodeSets[0].PodTemplate.Spec.SecurityContext = tt.userSecurityContext
 
@@ -179,6 +216,7 @@ func TestBuildPodTemplateSpecWithDefaultSecurityContext(t *testing.T) {
 }
 
 func TestBuildPodTemplateSpec(t *testing.T) {
+	sampleES := newEsSampleBuilder().build()
 	nodeSet := sampleES.Spec.NodeSets[0]
 	ver, err := version.Parse(sampleES.Spec.Version)
 	require.NoError(t, err)
@@ -282,6 +320,113 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 
 	deep.MaxDepth = 25
 	require.Nil(t, deep.Equal(expected, actual))
+}
+
+func Test_buildLabels(t *testing.T) {
+	type args struct {
+		cfg               map[string]interface{}
+		esAnnotations     map[string]string
+		keystoreResources *keystore.Resources
+	}
+	tests := []struct {
+		name             string
+		args             args
+		expectedLabels   map[string]string
+		unexpectedLabels []string
+		wantErr          bool
+	}{
+		{
+			name: "Sample Elasticsearch resource",
+			expectedLabels: map[string]string{
+				"elasticsearch.k8s.elastic.co/config-hash": "3415561705",
+			},
+			unexpectedLabels: []string{label.SecureSettingsHashLabelName},
+		},
+		{
+			name: "Updated configuration",
+			args: args{
+				cfg: map[string]interface{}{
+					"node.attr.foo": "bar",
+					"node.master":   "false",
+					"node.data":     "true",
+				},
+			},
+			expectedLabels: map[string]string{
+				"elasticsearch.k8s.elastic.co/config-hash": "651857461",
+			},
+			unexpectedLabels: []string{label.SecureSettingsHashLabelName},
+		},
+		{
+			name: "Simple Elasticsearch resource, with downward node labels",
+			args: args{
+				esAnnotations: map[string]string{"eck.k8s.elastic.co/downward-node-labels": "topology.kubernetes.io/zone"},
+			},
+			expectedLabels: map[string]string{
+				"elasticsearch.k8s.elastic.co/config-hash": "1775712178",
+			},
+			unexpectedLabels: []string{label.SecureSettingsHashLabelName},
+		},
+		{
+			name: "Simple Elasticsearch resource, with other downward node labels",
+			args: args{
+				esAnnotations: map[string]string{"eck.k8s.elastic.co/downward-node-labels": "topology.kubernetes.io/zone,topology.kubernetes.io/region"},
+			},
+			expectedLabels: map[string]string{
+				"elasticsearch.k8s.elastic.co/config-hash": "826289284",
+			},
+			unexpectedLabels: []string{label.SecureSettingsHashLabelName},
+		},
+		{
+			name: "With keystore",
+			args: args{
+				keystoreResources: &keystore.Resources{
+					Version: "42",
+				},
+			},
+			expectedLabels: map[string]string{
+				"elasticsearch.k8s.elastic.co/config-hash":          "3415561705",
+				"elasticsearch.k8s.elastic.co/secure-settings-hash": "3d24353c0d9d445310597750ba9d4d4f3dcf7940eeb57ccd7fa70b3e",
+			},
+		},
+		{
+			name: "With another keystore version",
+			args: args{
+				keystoreResources: &keystore.Resources{
+					Version: "43",
+				},
+			},
+			expectedLabels: map[string]string{
+				"elasticsearch.k8s.elastic.co/config-hash":          "3415561705",
+				"elasticsearch.k8s.elastic.co/secure-settings-hash": "66d178281474e50ee7040e2270f5c889cbfdfaf11a930aae6d6f5028",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			es := newEsSampleBuilder().withKeystoreResources(tt.args.keystoreResources).withUserConfig(tt.args.cfg).addEsAnnotations(tt.args.esAnnotations).build()
+			ver, err := version.Parse(sampleES.Spec.Version)
+			require.NoError(t, err)
+			cfg, err := settings.NewMergedESConfig(es.Name, ver, corev1.IPv4Protocol, es.Spec.HTTP, *es.Spec.NodeSets[0].Config, commonv1.Config{})
+			require.NoError(t, err)
+			got, err := buildLabels(es, cfg, es.Spec.NodeSets[0], tt.args.keystoreResources)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildLabels() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			for expectedLabel, expectedValue := range tt.expectedLabels {
+				actualValue, exists := got[expectedLabel]
+				assert.True(t, exists, "expected label: %s", expectedLabel)
+				assert.Equal(t, expectedValue, actualValue, "expected value for label %s: %s, got %s", expectedLabel, expectedValue, actualValue)
+			}
+
+			for _, unexpectedLabel := range tt.unexpectedLabels {
+				_, exists := got[unexpectedLabel]
+				assert.False(t, exists, "unexpected label: %s", unexpectedLabel)
+			}
+
+		})
+	}
 }
 
 func Test_getDefaultContainerPorts(t *testing.T) {

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -424,7 +424,6 @@ func Test_buildLabels(t *testing.T) {
 				_, exists := got[unexpectedLabel]
 				assert.False(t, exists, "unexpected label: %s", unexpectedLabel)
 			}
-
 		})
 	}
 }

--- a/pkg/controller/elasticsearch/nodespec/volumes.go
+++ b/pkg/controller/elasticsearch/nodespec/volumes.go
@@ -17,9 +17,12 @@ import (
 	esvolume "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
 )
 
-var downwardAPIVolume = volume.DownwardAPI{}
-
-func buildVolumes(esName string, nodeSpec esv1.NodeSet, keystoreResources *keystore.Resources) ([]corev1.Volume, []corev1.VolumeMount) {
+func buildVolumes(
+	esName string,
+	nodeSpec esv1.NodeSet,
+	keystoreResources *keystore.Resources,
+	downwardAPIVolume volume.DownwardAPI,
+) ([]corev1.Volume, []corev1.VolumeMount) {
 	configVolume := settings.ConfigSecretVolume(esv1.StatefulSet(esName, nodeSpec.Name))
 	probeSecret := volume.NewSelectiveSecretVolumeWithMountPath(
 		esv1.InternalUsersSecret(esName), esvolume.ProbeUserVolumeName,

--- a/pkg/controller/elasticsearch/validation/node_labels.go
+++ b/pkg/controller/elasticsearch/validation/node_labels.go
@@ -1,0 +1,36 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package validation
+
+import (
+	"fmt"
+	"regexp"
+)
+
+type NodeLabels []*regexp.Regexp
+
+func NewExposedNodeLabels(exposedNodeLabels []string) (NodeLabels, error) {
+	if len(exposedNodeLabels) == 0 {
+		return nil, nil
+	}
+	compiledNodeLabels := make([]*regexp.Regexp, len(exposedNodeLabels))
+	for i, exposedNodeLabel := range exposedNodeLabels {
+		r, err := regexp.Compile(exposedNodeLabel)
+		if err != nil {
+			return nil, fmt.Errorf("exposed node label \"%s\" cannot be compiled as a regular expression: %w", exposedNodeLabel, err)
+		}
+		compiledNodeLabels[i] = r
+	}
+	return compiledNodeLabels, nil
+}
+
+func (n NodeLabels) IsAllowed(nodeLabel string) bool {
+	for _, r := range n {
+		if r.MatchString(nodeLabel) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/elasticsearch/validation/node_labels_test.go
+++ b/pkg/controller/elasticsearch/validation/node_labels_test.go
@@ -1,0 +1,72 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package validation_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/validation"
+)
+
+func TestNodeLabels_IsAllowed(t *testing.T) {
+	type args struct {
+		nodeLabel string
+	}
+	tests := []struct {
+		name              string
+		exposedNodeLabels []string
+		args              args
+		want              bool
+		wantErr           bool
+	}{
+		{
+			name:              "Cannot parse label",
+			exposedNodeLabels: []string{"*"},
+			args: args{
+				nodeLabel: "kubernetes.io/zone",
+			},
+			wantErr: true,
+		},
+		{
+			name:              "Matching topology label",
+			exposedNodeLabels: []string{"topology.kubernetes.io/*", "failure-domain.beta.kubernetes.io/*"},
+			args: args{
+				nodeLabel: "topology.kubernetes.io/zone",
+			},
+			want: true,
+		},
+		{
+			name:              "Matching topology label 2",
+			exposedNodeLabels: []string{"topology.kubernetes.io/*", "failure-domain.beta.kubernetes.io/*"},
+			args: args{
+				nodeLabel: "failure-domain.beta.kubernetes.io/region",
+			},
+			want: true,
+		},
+		{
+			name:              "Not matching topology label",
+			exposedNodeLabels: []string{"topology.kubernetes.io/*", "failure-domain.beta.kubernetes.io/*"},
+			args: args{
+				nodeLabel: "kubernetes.io/zone",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodeLabels, err := validation.NewExposedNodeLabels(tt.exposedNodeLabels)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err, "no error expected when building validation.NodeLabels")
+				if got := nodeLabels.IsAllowed(tt.args.nodeLabel); got != tt.want {
+					t.Errorf("NodeLabels.IsAllowed() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/elasticsearch/validation/node_labels_test.go
+++ b/pkg/controller/elasticsearch/validation/node_labels_test.go
@@ -32,6 +32,30 @@ func TestNodeLabels_IsAllowed(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:              "Any label",
+			exposedNodeLabels: []string{".*"},
+			args: args{
+				nodeLabel: "kubernetes.io/zone",
+			},
+			want: true,
+		},
+		{
+			name:              "Fixed string",
+			exposedNodeLabels: []string{"kubernetes.io/zone"},
+			args: args{
+				nodeLabel: "kubernetes.io/zone",
+			},
+			want: true,
+		},
+		{
+			name:              "Fixed string",
+			exposedNodeLabels: []string{"kubernetes.io/zone"},
+			args: args{
+				nodeLabel: "kubernetes.io/region",
+			},
+			want: false,
+		},
+		{
 			name:              "Matching topology label",
 			exposedNodeLabels: []string{"topology.kubernetes.io/*", "failure-domain.beta.kubernetes.io/*"},
 			args: args{

--- a/pkg/controller/elasticsearch/validation/validations.go
+++ b/pkg/controller/elasticsearch/validation/validations.go
@@ -77,14 +77,14 @@ func validations(exposedNodeLabels NodeLabels) []validation {
 
 func validNodeLabels(proposed esv1.Elasticsearch, exposedNodeLabels NodeLabels) field.ErrorList {
 	var errs field.ErrorList
-	for _, nodeLabel := range proposed.NodeLabelsToPodsAnnotations() {
+	for _, nodeLabel := range proposed.DownwardNodeLabels() {
 		if exposedNodeLabels.IsAllowed(nodeLabel) {
 			continue
 		}
 		errs = append(
 			errs,
 			field.Invalid(
-				field.NewPath("metadata").Child("annotations", esv1.NodeLabelsToPodsAnnotationsAnnotation),
+				field.NewPath("metadata").Child("annotations", esv1.DownwardNodeLabelsAnnotation),
 				nodeLabel,
 				notAllowedNodesLabelMsg,
 			),

--- a/pkg/controller/elasticsearch/validation/validations.go
+++ b/pkg/controller/elasticsearch/validation/validations.go
@@ -40,21 +40,10 @@ const (
 	unsupportedConfigErrMsg  = "Configuration setting is reserved for internal use. User-configured use is unsupported"
 	unsupportedUpgradeMsg    = "Unsupported version upgrade path. Check the Elasticsearch documentation for supported upgrade paths."
 	unsupportedVersionMsg    = "Unsupported version"
+	notAllowedNodesLabelMsg  = "Node label not in the exposed node labels list"
 )
 
 type validation func(esv1.Elasticsearch) field.ErrorList
-
-// validations are the validation funcs that apply to creates or updates
-var validations = []validation{
-	noUnknownFields,
-	validName,
-	hasCorrectNodeRoles,
-	supportedVersion,
-	validSanIP,
-	validAutoscalingConfiguration,
-	validPVCNaming,
-	validMonitoring,
-}
 
 type updateValidation func(esv1.Elasticsearch, esv1.Elasticsearch) field.ErrorList
 
@@ -67,6 +56,41 @@ func updateValidations(k8sClient k8s.Client, validateStorageClass bool) []update
 			return validPVCModification(current, proposed, k8sClient, validateStorageClass)
 		},
 	}
+}
+
+// validations are the validation funcs that apply to creates or updates
+func validations(exposedNodeLabels NodeLabels) []validation {
+	return []validation{
+		func(proposed esv1.Elasticsearch) field.ErrorList {
+			return validNodeLabels(proposed, exposedNodeLabels)
+		},
+		noUnknownFields,
+		validName,
+		hasCorrectNodeRoles,
+		supportedVersion,
+		validSanIP,
+		validAutoscalingConfiguration,
+		validPVCNaming,
+		validMonitoring,
+	}
+}
+
+func validNodeLabels(proposed esv1.Elasticsearch, exposedNodeLabels NodeLabels) field.ErrorList {
+	var errs field.ErrorList
+	for _, nodeLabel := range proposed.NodeLabelsToPodsAnnotations() {
+		if exposedNodeLabels.IsAllowed(nodeLabel) {
+			continue
+		}
+		errs = append(
+			errs,
+			field.Invalid(
+				field.NewPath("metadata").Child("annotations", esv1.NodeLabelsToPodsAnnotationsAnnotation),
+				nodeLabel,
+				notAllowedNodesLabelMsg,
+			),
+		)
+	}
+	return errs
 }
 
 func check(es esv1.Elasticsearch, validations []validation) field.ErrorList {

--- a/pkg/controller/elasticsearch/validation/validations_test.go
+++ b/pkg/controller/elasticsearch/validation/validations_test.go
@@ -7,6 +7,8 @@ package validation
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -482,6 +484,53 @@ func Test_autoscalingValidation(t *testing.T) {
 			actualErrors := len(actual) > 0
 			if tt.expectErrors != actualErrors {
 				t.Errorf("failed validAutoscalingConfiguration(). Name: %v, actual %v, wanted: %v, value: %v", tt.name, actual, tt.expectErrors, tt.es.Spec.NodeSets)
+			}
+		})
+	}
+}
+
+func Test_validNodeLabels(t *testing.T) {
+	type args struct {
+		proposed          esv1.Elasticsearch
+		exposedNodeLabels []string
+	}
+	tests := []struct {
+		name         string
+		args         args
+		expectErrors bool
+	}{
+		{
+			name: "Invalid node label",
+			args: args{
+				proposed: esv1.Elasticsearch{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{esv1.NodeLabelsToPodsAnnotationsAnnotation: "failure-domain.beta.kubernetes.io/zone"},
+					},
+				},
+				exposedNodeLabels: []string{"topology.kubernetes.io/*"},
+			},
+			expectErrors: true, // "failure-domain.beta.kubernetes.io/zone" does not match "topology.kubernetes.io/*"
+		},
+		{
+			name: "Valid node label",
+			args: args{
+				proposed: esv1.Elasticsearch{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{esv1.NodeLabelsToPodsAnnotationsAnnotation: "failure-domain.beta.kubernetes.io/zone"},
+					},
+				},
+				exposedNodeLabels: []string{"topology.kubernetes.io/*", "failure-domain.beta.kubernetes.io/*"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exposedNodeLabels, err := NewExposedNodeLabels(tt.args.exposedNodeLabels)
+			assert.NoError(t, err)
+			actual := validNodeLabels(tt.args.proposed, exposedNodeLabels)
+			actualErrors := len(actual) > 0
+			if tt.expectErrors != actualErrors {
+				t.Errorf("failed validNodeLabels(), actual %v, wanted: %v", actualErrors, tt.expectErrors)
 			}
 		})
 	}

--- a/pkg/controller/elasticsearch/validation/validations_test.go
+++ b/pkg/controller/elasticsearch/validation/validations_test.go
@@ -504,7 +504,7 @@ func Test_validNodeLabels(t *testing.T) {
 			args: args{
 				proposed: esv1.Elasticsearch{
 					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{esv1.NodeLabelsToPodsAnnotationsAnnotation: "failure-domain.beta.kubernetes.io/zone"},
+						Annotations: map[string]string{esv1.DownwardNodeLabelsAnnotation: "failure-domain.beta.kubernetes.io/zone"},
 					},
 				},
 				exposedNodeLabels: []string{"topology.kubernetes.io/*"},
@@ -516,7 +516,7 @@ func Test_validNodeLabels(t *testing.T) {
 			args: args{
 				proposed: esv1.Elasticsearch{
 					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{esv1.NodeLabelsToPodsAnnotationsAnnotation: "failure-domain.beta.kubernetes.io/zone"},
+						Annotations: map[string]string{esv1.DownwardNodeLabelsAnnotation: "failure-domain.beta.kubernetes.io/zone"},
 					},
 				},
 				exposedNodeLabels: []string{"topology.kubernetes.io/*", "failure-domain.beta.kubernetes.io/*"},

--- a/pkg/controller/elasticsearch/volume/names.go
+++ b/pkg/controller/elasticsearch/volume/names.go
@@ -42,4 +42,5 @@ const (
 	DownwardAPIVolumeName = "downward-api"
 	DownwardAPIMountPath  = "/mnt/elastic-internal/downward-api"
 	LabelsFile            = "labels"
+	AnnotationsFile       = "annotations"
 )


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/3933

## How to test (tested on GKE)

* Start the operator with the following flag: `--exposed-node-labels="topology.kubernetes.io/.*,failure-domain.beta.kubernetes.io/.*"`
* Annotate an Elasticsearch deployment: `k annotate --overwrite es/elasticsearch-sample   eck.k8s.elastic.co/downward-node-labels="topology.kubernetes.io/zone,topology.kubernetes.io/region"`
* Wait for the Pods to be restarted
* Check the annotations: `k get pod -l common.k8s.elastic.co/type=elasticsearch -o go-template='{{range .items}}{{.metadata.annotations}}{{printf "\n"}}{{end}}'`

To get the logs of the init script you can run `k logs  elasticsearch-sample-es-default-0 -c elastic-internal-init-filesystem  -f`

## Misc

* I eventually decided to reuse the `elastic-internal-init-filesystem` init container to wait for the annotations to be set.
* This PR should not restart the current `RUNNING` Pods. The `elastic-internal-init-filesystem` init-container should be left untouched as long as the feature is not used on an Elasticsearch resource.
* Pods are patched early in the reconciliation loop. I'm not sure if there's an ideal place (or a place we should avoid)
* A Pod is considered as scheduled when both its `Spec.NodeName` has a non-empty value and the relevant condition `PodScheduled` is set to `True` (see K8S binding code [here](https://github.com/kubernetes/kubernetes/blob/6c357f9996070fd015e08eec24f07c82b4b8b4a6/pkg/registry/core/pod/storage/storage.go#L217-L230))
* The primary intent for this PR is to propagate _topology_ node labels, hence node labels are considered as immutable and K8S `Nodes` are not watched.
* When an Elasticsearch resource is submitted the admission controller only check that the node label is allowed. Node labels are not checked until the Pod is scheduled. This is mostly because node labels may be inconsistent.
* I'll try to think about some e2e tests in a subsequent PR.

## To be addressed in follow up PRs

- [ ] Update documentation, including `docs/operating-eck/operating-eck.asciidoc`
- [ ] Add E2E Tests
- [ ] Enable telemetry  