### PR TITLE
Support JSON marshalling of commonv1.Config on value receivers

### DIFF
--- a/pkg/apis/common/v1/config.go
+++ b/pkg/apis/common/v1/config.go
@@ -27,7 +27,7 @@ func NewConfig(cfg map[string]interface{}) Config {
 }
 
 // MarshalJSON implements the Marshaler interface.
-func (c *Config) MarshalJSON() ([]byte, error) {
+func (c Config) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.Data)
 }
 

--- a/pkg/apis/common/v1/config_test.go
+++ b/pkg/apis/common/v1/config_test.go
@@ -5,9 +5,11 @@
 package v1
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/stretchr/testify/require"
 )
 
 var testFixture = Config{
@@ -80,4 +82,30 @@ func TestConfig_DeepCopy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfig_JSONMarshal(t *testing.T) {
+	expectedJSON := "{\"foo\":\"bar\"}"
+	cfg := NewConfig(map[string]interface{}{
+		"foo": "bar",
+	})
+	cfgAsJSON, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	require.Equal(t, expectedJSON, string(cfgAsJSON))
+
+	cfgPtr := &cfg
+	cfgPtrAsJSON, err := json.Marshal(cfgPtr)
+	require.NoError(t, err)
+	require.Equal(t, expectedJSON, string(cfgPtrAsJSON))
+}
+
+func TestConfig_JSONUnmarshal(t *testing.T) {
+	bytesCfg := []byte("{\"foo\":\"bar\"}")
+	expectedCfg := NewConfig(map[string]interface{}{
+		"foo": "bar",
+	})
+	var cfg Config
+	err := json.Unmarshal(bytesCfg, &cfg)
+	require.NoError(t, err)
+	require.Equal(t, expectedCfg, cfg)
 }


### PR DESCRIPTION
Update `MarshalJSON()` method of `commonv1.Config` to use a variable receiver to make `json.Marshal` work with value and pointer receivers.

Resolves #5050.