### PR TITLE
E2E: adjust Kibana telemetry test to new format for 7.16+

### DIFF
--- a/test/e2e/test/kibana/checks_telemetry.go
+++ b/test/e2e/test/kibana/checks_telemetry.go
@@ -8,25 +8,32 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/elastic/cloud-on-k8s/pkg/telemetry"
+	"github.com/pkg/errors"
+
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 )
 
-func MakeTelemetryRequest(kbBuilder Builder, k *test.K8sClient) ([]byte, error) {
+func MakeTelemetryRequest(kbBuilder Builder, k *test.K8sClient) (StackStats, error) {
 	kbVersion := version.MustParse(kbBuilder.Kibana.Spec.Version)
 	apiVersion, payload := apiVersionAndTelemetryRequestBody(kbVersion)
 	uri := fmt.Sprintf("/api/telemetry/%s/clusters/_stats", apiVersion)
 	password, err := k.GetElasticPassword(kbBuilder.ElasticsearchRef().NamespacedName())
 	if err != nil {
-		return nil, err
+		return StackStats{}, err
 	}
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		return nil, err
+		return StackStats{}, err
 	}
 	// this call may fail (status 500) if the .security-7 index is not fully initialized yet,
 	// in which case we'll just retry that test step
-	return DoRequest(k, kbBuilder.Kibana, password, "POST", uri, payloadBytes)
+	bytes, err := DoRequest(k, kbBuilder.Kibana, password, "POST", uri, payloadBytes)
+	if err != nil {
+		return StackStats{}, err
+	}
+	return unmarshalTelemetryResponse(bytes, kbVersion)
 }
 
 func apiVersionAndTelemetryRequestBody(kbVersion version.Version) (string, telemetryRequest) {
@@ -53,4 +60,54 @@ type timeRange struct {
 type telemetryRequest struct {
 	TimeRange   *timeRange `json:"timeRange,omitempty"`
 	Unencrypted bool       `json:"unencrypted,omitempty"`
+}
+
+func unmarshalTelemetryResponse(bytes []byte, kbVersion version.Version) (StackStats, error) {
+	noStatsErr := errors.New("cluster stats is empty")
+
+	// telemetry response changed as of 7.16.0 to the following json key path
+	// .[0].stats.stack_stats.kibana.plugins.static_telemetry.eck
+	if kbVersion.GTE(version.MinFor(7, 16, 0)) {
+		var stats v3Stats
+		if err := json.Unmarshal(bytes, &stats); err != nil {
+			return StackStats{}, err
+		}
+		if len(stats) == 0 {
+
+			return StackStats{}, noStatsErr
+		}
+		return stats[0].Stats.StackStats, nil
+	}
+	// pre 7.16.0 json key path
+	// .[0].stack_stats.kibana.plugins.static_telemetry.eck
+	var stats v2Stats
+	if err := json.Unmarshal(bytes, &stats); err != nil {
+		return StackStats{}, err
+	}
+	if len(stats) == 0 {
+		return StackStats{}, noStatsErr
+	}
+	return stats[0].StackStats, nil
+}
+
+// v2Stats partially models the response from a request to /api/telemetry/v1/clusters/_stats >=7.16.0
+type v3Stats []struct {
+	Stats struct {
+		StackStats StackStats `json:"stack_stats"`
+	} `json:"stats"`
+}
+
+// v2Stats partially models the response from a request to /api/telemetry/v1/clusters/_stats <7.16.0
+type v2Stats []struct {
+	StackStats StackStats `json:"stack_stats"`
+}
+
+type StackStats struct {
+	Kibana struct {
+		Plugins struct {
+			StaticTelemetry struct {
+				telemetry.ECKTelemetry
+			} `json:"static_telemetry"`
+		} `json:"plugins"`
+	} `json:"kibana"`
 }


### PR DESCRIPTION
Structure of JSON document returned by the internal Kibana API we use to verify static telemetry data is picked up correctly has changed since 7.16 see https://github.com/elastic/kibana/pull/113525

This adjusts the test to expect the new structure for the relevant versions. 