### PR TITLE
Configure APM integration in 8.x E2E tests

### DIFF
--- a/config/samples/apm/apm_es_kibana.yaml
+++ b/config/samples/apm/apm_es_kibana.yaml
@@ -23,6 +23,10 @@ spec:
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"
+  config:
+    xpack.fleet.packages:
+    - name: apm
+      version: latest
 ---
 apiVersion: apm.k8s.elastic.co/v1
 kind: ApmServer

--- a/pkg/controller/association/controller/apm_es.go
+++ b/pkg/controller/association/controller/apm_es.go
@@ -100,6 +100,14 @@ func getAPMElasticsearchRoles(associated commonv1.Associated) (string, error) {
 		return "", err
 	}
 
+	// 8.0.x and above
+	if v.GTE(version.MinFor(8, 0, 0)) {
+		return strings.Join([]string{
+			user.ApmUserRoleV80, // Retrieve cluster details (e.g. version) and manage apm-* indices
+			"apm_system",        // To collect metrics about APM Server
+		}, ","), nil
+	}
+
 	// 7.5.x and above
 	if v.GTE(version.From(7, 5, 0)) {
 		return strings.Join([]string{

--- a/pkg/controller/elasticsearch/user/reconcile_test.go
+++ b/pkg/controller/elasticsearch/user/reconcile_test.go
@@ -75,6 +75,6 @@ func Test_aggregateRoles(t *testing.T) {
 	c := k8s.NewFakeClient(sampleUserProvidedRolesSecret...)
 	roles, err := aggregateRoles(c, sampleEsWithAuth, initDynamicWatches(), record.NewFakeRecorder(10))
 	require.NoError(t, err)
-	require.Len(t, roles, 50)
+	require.Len(t, roles, 51)
 	require.Contains(t, roles, ProbeUserRole, "role1", "role2")
 }

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -85,10 +85,10 @@ var (
 			},
 		},
 		ApmUserRoleV80: esclient.Role{
-			Cluster: []string{"monitor/main"},
+			Cluster: []string{"cluster:monitor/main", "manage_index_templates"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{"traces-apm*", "metrics-apm*", "logs-apm*", "apm-*", "traces-apm.rum-*", "traces-apm.sampled-*"},
+					Names:      []string{"traces-apm*", "metrics-apm*", "logs-apm*"},
 					Privileges: []string{"auto_configure", "create_doc"},
 				},
 				{

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -30,6 +30,8 @@ const (
 	ApmUserRoleV7 = "eck_apm_user_role_v7"
 	// ApmUserRoleV75 is the name of the role used by APMServer instances to connect to Elasticsearch from version 7.5
 	ApmUserRoleV75 = "eck_apm_user_role_v75"
+	// ApmUserRoleV80 is the name of the role used by APMServer instances to connect to Elasticsearch from version 8.0
+	ApmUserRoleV80 = "eck_apm_user_role_v80"
 
 	// ApmAgentUserRole is the name of the role used by APMServer instances to connect to Kibana
 	ApmAgentUserRole = "eck_apm_agent_user_role"
@@ -79,6 +81,19 @@ var (
 				{
 					Names:      []string{"apm-*"},
 					Privileges: []string{"manage", "create_doc", "create_index"},
+				},
+			},
+		},
+		ApmUserRoleV80: esclient.Role{
+			Cluster: []string{"monitor/main"},
+			Indices: []esclient.IndexRole{
+				{
+					Names:      []string{"traces-apm*", "metrics-apm*", "logs-apm*", "apm-*", "traces-apm.rum-*", "traces-apm.sampled-*"},
+					Privileges: []string{"auto_configure", "create_doc"},
+				},
+				{
+					Names:      []string{"traces-apm.sampled-*"},
+					Privileges: []string{"maintenance", "monitor", "read"},
 				},
 			},
 		},

--- a/test/e2e/apm/association_test.go
+++ b/test/e2e/apm/association_test.go
@@ -42,7 +42,8 @@ func TestCrossNSAssociation(t *testing.T) {
 		WithConfig(map[string]interface{}{
 			"apm-server.ilm.enabled":                           false,
 			"setup.template.settings.index.number_of_replicas": 0, // avoid ES yellow state on a 1 node ES cluster
-		})
+		}).
+		WithoutIntegrationCheck()
 
 	test.Sequence(nil, test.EmptySteps, esBuilder, apmBuilder).RunSequential(t)
 }
@@ -89,7 +90,8 @@ func TestAPMAssociationWithNonExistentES(t *testing.T) {
 		WithElasticsearchRef(commonv1.ObjectSelector{
 			Name: "non-existent-es",
 		}).
-		WithNodeCount(1)
+		WithNodeCount(1).
+		WithoutIntegrationCheck()
 
 	k := test.NewK8sClientOrFatal()
 	steps := test.StepList{}
@@ -123,7 +125,8 @@ func TestAPMAssociationWhenReferencedESDisappears(t *testing.T) {
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
 	apmBuilder := apmserver.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
-		WithNodeCount(1)
+		WithNodeCount(1).
+		WithoutIntegrationCheck()
 
 	failureSteps := func(k *test.K8sClient) test.StepList {
 		return test.StepList{

--- a/test/e2e/apm/association_test.go
+++ b/test/e2e/apm/association_test.go
@@ -66,7 +66,8 @@ func TestAPMKibanaAssociation(t *testing.T) {
 		WithNamespace(ns).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1).
-		WithRestrictedSecurityContext()
+		WithRestrictedSecurityContext().
+		WithAPMIntegration()
 
 	apmBuilder := apmserver.NewBuilder(name).
 		WithNamespace(ns).

--- a/test/e2e/apm/configuration_test.go
+++ b/test/e2e/apm/configuration_test.go
@@ -64,7 +64,8 @@ func TestUpdateConfiguration(t *testing.T) {
 		WithNamespace(namespace).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithVersion(test.Ctx().ElasticStackVersion).
-		WithRestrictedSecurityContext()
+		WithRestrictedSecurityContext().
+		WithoutIntegrationCheck()
 
 	apmName := apmBuilder.ApmServer.Name
 	apmNamespacedName := types.NamespacedName{
@@ -101,7 +102,7 @@ func TestUpdateConfiguration(t *testing.T) {
 					if config.Output.Elasticsearch.Hosts[0] != esHost {
 						return fmt.Errorf("expected es host %s but got %s", esHost, config.Output.Elasticsearch.Hosts[0])
 					}
-					if config.Output.Elasticsearch.CompressionLevel != 0{ // CompressionLevel is not set by default
+					if config.Output.Elasticsearch.CompressionLevel != 0 { // CompressionLevel is not set by default
 						return fmt.Errorf("expected compression level 0 but got %d", config.Output.Elasticsearch.CompressionLevel)
 					}
 					return nil

--- a/test/e2e/apm/standalone_test.go
+++ b/test/e2e/apm/standalone_test.go
@@ -15,32 +15,34 @@ import (
 )
 
 // TestApmStandalone runs a test suite on an APM server that is not outputting to Elasticsearch
-func TestApmStandalone(t *testing.T) {
+func TestAPMStandalone(t *testing.T) {
 	apmBuilder := apmserver.NewBuilder("standalone").
 		WithConfig(map[string]interface{}{
 			"output.console": map[string]interface{}{
 				"pretty": true,
 			},
-		})
+		}).
+		WithoutIntegrationCheck()
 
 	test.Sequence(nil, test.EmptySteps, apmBuilder).
 		RunSequential(t)
 }
 
-func TestApmStandaloneWithRUM(t *testing.T) {
+func TestAPMStandaloneWithRUM(t *testing.T) {
 	apmBuilder := apmserver.NewBuilder("standalone-with-rum").
 		WithConfig(map[string]interface{}{
 			"output.console": map[string]interface{}{
 				"pretty": true,
 			},
 		}).
-		WithRUM(true)
+		WithRUM(true).
+		WithoutIntegrationCheck()
 
 	test.Sequence(nil, test.EmptySteps, apmBuilder).
 		RunSequential(t)
 }
 
-func TestApmStandaloneNoTLS(t *testing.T) {
+func TestAPMStandaloneNoTLS(t *testing.T) {
 	apmBuilder := apmserver.NewBuilder("standalone-no-tls").
 		WithConfig(map[string]interface{}{
 			"output.console": map[string]interface{}{
@@ -53,7 +55,8 @@ func TestApmStandaloneNoTLS(t *testing.T) {
 					Disabled: true,
 				},
 			},
-		})
+		}).
+		WithoutIntegrationCheck()
 
 	test.Sequence(nil, test.EmptySteps, apmBuilder).
 		RunSequential(t)

--- a/test/e2e/naming_test.go
+++ b/test/e2e/naming_test.go
@@ -66,7 +66,8 @@ func testLongestPossibleName(t *testing.T) {
 		WithNodeCount(1).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithVersion(test.Ctx().ElasticStackVersion).
-		WithRestrictedSecurityContext()
+		WithRestrictedSecurityContext().
+		WithAPMIntegration()
 
 	apmNamePrefix := strings.Join([]string{esNamePrefix, "apm"}, "-")
 	apmName := strings.Join([]string{apmNamePrefix, strings.Repeat("x", name.MaxResourceNameLength-len(apmNamePrefix)-1)}, "-")

--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -53,7 +53,8 @@ func TestVersionUpgradeOrdering(t *testing.T) {
 		WithNodeCount(1).
 		WithVersion(initialVersion).
 		WithElasticsearchRef(esRef).
-		WithRestrictedSecurityContext()
+		WithRestrictedSecurityContext().
+		WithAPMIntegration()
 	kbUpdated := kb.WithVersion(updatedVersion)
 	kbRef := commonv1.ObjectSelector{Namespace: kb.Kibana.Namespace, Name: kb.Kibana.Name}
 	apm := apmserver.NewBuilder("apm").

--- a/test/e2e/test/apmserver/builder.go
+++ b/test/e2e/test/apmserver/builder.go
@@ -150,6 +150,10 @@ func (b Builder) WithPodLabel(key, value string) Builder {
 	return b
 }
 
+// WithoutIntegrationCheck adds APM Server configuration that prevents APM Server from checking for APM index templates.
+// Starting with 8.0.0, these templates are installed by APM integration. As all integrations are installed through
+// Kibana, when there is no Kibana in the deployment, the index templates are not present and our E2E tests checks
+// would fail.
 func (b Builder) WithoutIntegrationCheck() Builder {
 	if version.MustParse(b.ApmServer.Spec.Version).LT(version.MinFor(8, 0, 0)) {
 		// disabling integration check is not necessary below 8.0.0, no-op

--- a/test/e2e/test/apmserver/builder.go
+++ b/test/e2e/test/apmserver/builder.go
@@ -13,6 +13,7 @@ import (
 
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/cmd/run"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
@@ -147,6 +148,17 @@ func (b Builder) WithPodLabel(key, value string) Builder {
 	labels[key] = value
 	b.ApmServer.Spec.PodTemplate.Labels = labels
 	return b
+}
+
+func (b Builder) WithoutIntegrationCheck() Builder {
+	if version.MustParse(b.ApmServer.Spec.Version).LT(version.MinFor(8, 0, 0)) {
+		// disabling integration check is not necessary below 8.0.0, no-op
+		return b
+	}
+
+	return b.WithConfig(map[string]interface{}{
+		"apm-server.data_streams.wait_for_integration": false,
+	})
 }
 
 func (b Builder) NSN() types.NamespacedName {

--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -176,6 +176,22 @@ func (b Builder) WithTLSDisabled(disabled bool) Builder {
 	return b
 }
 
+func (b Builder) WithAPMIntegration() Builder {
+	if version.MustParse(b.Kibana.Spec.Version).LT(version.MinFor(8, 0, 0)) {
+		// configuring APM integration is not necessary below 8.0.0, no-op
+		return b
+	}
+
+	return b.WithConfig(map[string]interface{}{
+		"xpack.fleet.packages": []map[string]interface{}{
+			{
+				"name":    "apm",
+				"version": "latest",
+			},
+		},
+	})
+}
+
 func (b Builder) WithConfig(config map[string]interface{}) Builder {
 	b.Kibana.Spec.Config = &commonv1.Config{
 		Data: config,

--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -176,6 +176,8 @@ func (b Builder) WithTLSDisabled(disabled bool) Builder {
 	return b
 }
 
+// WithAPMIntegration adds configuration that makes Kibana install APM integration on start up. Starting with 8.0.0,
+// index templates for APM Server are not installed by APM Server, but during APM integration installation in Kibana.
 func (b Builder) WithAPMIntegration() Builder {
 	if version.MustParse(b.Kibana.Spec.Version).LT(version.MinFor(8, 0, 0)) {
 		// configuring APM integration is not necessary below 8.0.0, no-op


### PR DESCRIPTION
This PR:

- adds APM package integration to Kibana config in APM sample manifest
- adds a new role to use by APM Server in `8.x`
- adds `.WithAPMIntegration()` helper to Kibana builder and uses it where appropriate
- fixes E2E tests checks for APM in `8.x`