### PR TITLE
Point Elastic doc links to current instead of master

### DIFF
--- a/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
+++ b/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
@@ -1,7 +1,7 @@
 # This file contains an example of Roles, RoleBindings and ServiceAccount which allow the associations to be established
 # between resources living in different namespaces if the access control between resources across namespaces is enabled.
 # This example is only valid if ECK is started with the related option.
-# See https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-operator-config.html.
+# See https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-operator-config.html.
 ---
 apiVersion: v1
 kind: Namespace

--- a/config/samples/apm/apm_es_kibana.yaml
+++ b/config/samples/apm/apm_es_kibana.yaml
@@ -11,7 +11,7 @@ spec:
     count: 3
     config:
       # This setting could have performance implications for production clusters.
-      # See: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+      # See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
       node.store.allow_mmap: false
 ---
 apiVersion: kibana.k8s.elastic.co/v1

--- a/config/samples/enterprisesearch/ent_es.yaml
+++ b/config/samples/enterprisesearch/ent_es.yaml
@@ -10,7 +10,7 @@ spec:
       count: 1
       config:
         # This setting could have performance implications for production clusters.
-        # See: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+        # See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
         node.store.allow_mmap: false
 ---
 apiVersion: enterprisesearch.k8s.elastic.co/v1

--- a/config/samples/kibana/kibana_es.yaml
+++ b/config/samples/kibana/kibana_es.yaml
@@ -10,7 +10,7 @@ spec:
     count: 1
     config:
       # This setting could have performance implications for production clusters.
-      # See: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+      # See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
       node.store.allow_mmap: false
 ---
 apiVersion: kibana.k8s.elastic.co/v1

--- a/docs/advanced-topics/custom-images.asciidoc
+++ b/docs/advanced-topics/custom-images.asciidoc
@@ -7,7 +7,7 @@ endif::[]
 [id="{p}-{page_id}"]
 = Create custom images
 
-You can create your own custom application images ({eck_resources_list}) instead of using the base images provided by Elastic. You might want to do this to have a canonical image with all the necessary plugins pre-loaded rather than <<{p}-init-containers-plugin-downloads,installing them via an init container>> each time a Pod starts.  You must use the official image as the base for custom images. For example, if you want to create an Elasticsearch {version} image with the link:https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-gcs.html[Google Cloud Storage Repository Plugin], you can do the following:
+You can create your own custom application images ({eck_resources_list}) instead of using the base images provided by Elastic. You might want to do this to have a canonical image with all the necessary plugins pre-loaded rather than <<{p}-init-containers-plugin-downloads,installing them via an init container>> each time a Pod starts.  You must use the official image as the base for custom images. For example, if you want to create an Elasticsearch {version} image with the link:https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-gcs.html[Google Cloud Storage Repository Plugin], you can do the following:
 
 
 

--- a/docs/design/0006-sidecar-health.md
+++ b/docs/design/0006-sidecar-health.md
@@ -127,4 +127,4 @@ seen secret revison y.
 
 * [Discussion issue](https://github.com/elastic/cloud-on-k8s/issues/432)
 * https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
-* https://www.elastic.co/guide/en/beats/filebeat/master/running-on-kubernetes.html
+* https://www.elastic.co/guide/en/beats/filebeat/current/running-on-kubernetes.html

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/autoscaling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/autoscaling.asciidoc
@@ -12,7 +12,7 @@ NOTE: Elasticsearch autoscaling requires a valid Enterprise license or Enterpris
 
 experimental[]
 
-ECK can leverage the link:https://www.elastic.co/guide/en/elasticsearch/reference/master/autoscaling-apis.html[autoscaling API] introduced in Elasticsearch 7.11 to adjust automatically the number of Pods and the allocated resources in a tier. Currently, autoscaling is supported for Elasticsearch link:https://www.elastic.co/guide/en/elasticsearch/reference/current/data-tiers.html[data tiers] and machine learning nodes.
+ECK can leverage the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-apis.html[autoscaling API] introduced in Elasticsearch 7.11 to adjust automatically the number of Pods and the allocated resources in a tier. Currently, autoscaling is supported for Elasticsearch link:https://www.elastic.co/guide/en/elasticsearch/reference/current/data-tiers.html[data tiers] and machine learning nodes.
 
 [float]
 [id="{p}-enable"]

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/snapshots.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/snapshots.asciidoc
@@ -15,7 +15,7 @@ To set up automated snapshots for Elasticsearch on Kubernetes you have to:
 . Register the snapshot repository with the Elasticsearch API.
 . Set up a https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/[CronJob] to take snapshots on a schedule.
 
-The examples below use the https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-gcs.html[Google Cloud Storage Repository Plugin].
+The examples below use the https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-gcs.html[Google Cloud Storage Repository Plugin].
 
 For more information on Elasticsearch snapshots, see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html[Snapshot and Restore].
 
@@ -75,7 +75,7 @@ kubectl apply -f elasticsearch.yaml
 [id="{p}-secure-settings"]
 == Configure GCS credentials via the Elasticsearch keystore
 
-The Elasticsearch GCS repository plugin requires a JSON file that contains service account credentials. These need to be added as secure settings to the Elasticsearch keystore. For more details, see https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-gcs-usage.html[Google Cloud Storage Repository Plugin].
+The Elasticsearch GCS repository plugin requires a JSON file that contains service account credentials. These need to be added as secure settings to the Elasticsearch keystore. For more details, see https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-gcs-usage.html[Google Cloud Storage Repository Plugin].
 
 Using ECK, you can automatically inject secure settings into a cluster node by providing them through a secret in the Elasticsearch Spec.
 

--- a/pkg/controller/common/annotation/pod.go
+++ b/pkg/controller/common/annotation/pod.go
@@ -22,7 +22,7 @@ const (
 
 	// FilebeatModuleAnnotation is the name of the annotation applied to pods to give a hint to filebeat so that it
 	// uses the appropriate module to analyze the logs of the container.
-	// https://www.elastic.co/guide/en/beats/filebeat/master/configuration-autodiscover-hints.html#_co_elastic_logsmodule
+	// https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html#_co_elastic_logsmodule
 	FilebeatModuleAnnotation = "co.elastic.logs/module"
 )
 


### PR DESCRIPTION
Point Elastic doc links that uses `master` to `current`. 

Relates to #5017.