### PR TITLE
Update eksctl to 0.74.0 to support EKS > 1.18

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -12,7 +12,7 @@ ENV GOTESTSUM_VERSION=0.5.0
 ENV KIND_VERSION_0_8=0.8.1
 ENV KIND_VERSION_0_9=0.9.0
 ENV OPENSHIFT_TOOLS_VERSION=4.7.0
-ENV EKSCTL_VERSION=0.34.0
+ENV EKSCTL_VERSION=0.74.0
 ENV ECK_DIAG_VERSION=1.0.1
 
 # golangci-lint
@@ -83,7 +83,7 @@ RUN curl -fsSLO https://github.com/elastic/eck-diagnostics/releases/download/${E
     tar xzf eck-diagnostics_${ECK_DIAG_VERSION}_Linux_x86_64.tar.gz && \
     mv eck-diagnostics /usr/local/bin/eck-diagnostics
 
-RUN curl -fsSLO "https://github.com/weaveworks/eksctl/releases/download/${EKSCTL_VERSION}/eksctl_Linux_amd64.tar.gz" && \
+RUN curl -fsSLO "https://github.com/weaveworks/eksctl/releases/download/v${EKSCTL_VERSION}/eksctl_Linux_amd64.tar.gz" && \
     tar xzf eksctl_Linux_amd64.tar.gz && \
     mv eksctl /usr/local/bin/eksctl && \
     rm eksctl_Linux_amd64.tar.gz


### PR DESCRIPTION
Update eksctl to `0.74.0` which supports latest Kubernetes versions from N-1 to N-5: [`1.17, 1.18, 1.19, 1.20, 1.21`](https://github.com/weaveworks/eksctl/blob/738d9a8efd1f203a18486af090deac3685fbfc49/pkg/apis/eksctl.io/v1alpha5/types.go#L431-L440).

Following up the update to `1.20` #5069. 

---

Checked: the deployer succeeded in creating and deleting EKS with k8s `1.20` :heavy_check_mark: :
```go
> kubectl version
Client Version: version.Info{Major:"1", Minor:"14", GitVersion:"v1.14.7", GitCommit:"8fca2ec50a6133511b771a11559e24191b1aa2b4", GitTreeState:"clean", BuildDate:"2019-09-18T14:47:22Z", GoVersion:"go1.12.9", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"20+", GitVersion:"v1.20.7-eks-d88609", GitCommit:"d886092805d5cc3a47ed5cf0c43de38ce442dfcb", GitTreeState:"clean", BuildDate:"2021-07-31T00:29:12Z", GoVersion:"go1.15.12", Compiler:"gc", Platform:"linux/amd64"}
```