### PR TITLE
Update minimum supported Elasticsearch version to upgrade to 8.0

### DIFF
--- a/pkg/controller/elasticsearch/version/supported_versions.go
+++ b/pkg/controller/elasticsearch/version/supported_versions.go
@@ -36,8 +36,8 @@ func technicallySupportedVersions(v version.Version) *version.MinMaxVersion {
 		}
 	case 8:
 		return &version.MinMaxVersion{
-			// 7.16.0 is the lowest version that offers a direct upgrade path to 8.0
-			Min: version.MustParse("7.16.0"),
+			// 7.17.0 is the lowest version that offers a direct upgrade path to 8.0
+			Min: version.MustParse("7.17.0"),
 			Max: version.MustParse("8.99.99"),
 		}
 	default:

--- a/pkg/controller/elasticsearch/version/supported_versions.go
+++ b/pkg/controller/elasticsearch/version/supported_versions.go
@@ -36,8 +36,8 @@ func technicallySupportedVersions(v version.Version) *version.MinMaxVersion {
 		}
 	case 8:
 		return &version.MinMaxVersion{
-			// 7.4.0 is the lowest version that offers a direct upgrade path to 8.0
-			Min: version.MustParse("7.4.0"),
+			// 7.16.0 is the lowest version that offers a direct upgrade path to 8.0
+			Min: version.MustParse("7.16.0"),
 			Max: version.MustParse("8.99.99"),
 		}
 	default:

--- a/pkg/controller/elasticsearch/version/supported_versions_test.go
+++ b/pkg/controller/elasticsearch/version/supported_versions_test.go
@@ -58,11 +58,12 @@ func TestSupportedVersions(t *testing.T) {
 				v: version.MustParse("8.0.0"),
 			},
 			supported: []version.Version{
-				version.MustParse("7.4.0"),
+				version.MustParse("7.16.0"),
+				version.MustParse("7.17.0"),
 				version.MustParse("8.9.0"),
 			},
 			unsupported: []version.Version{
-				version.MustParse("7.1.0"), // supported by ECK but no direct upgrade path to 8.x
+				version.MustParse("7.15.0"), // supported by ECK but no direct upgrade path to 8.x
 			},
 		},
 	}

--- a/pkg/controller/elasticsearch/version/supported_versions_test.go
+++ b/pkg/controller/elasticsearch/version/supported_versions_test.go
@@ -58,7 +58,6 @@ func TestSupportedVersions(t *testing.T) {
 				v: version.MustParse("8.0.0"),
 			},
 			supported: []version.Version{
-				version.MustParse("7.16.0"),
 				version.MustParse("7.17.0"),
 				version.MustParse("8.9.0"),
 			},

--- a/pkg/controller/elasticsearch/version/supported_versions_test.go
+++ b/pkg/controller/elasticsearch/version/supported_versions_test.go
@@ -62,7 +62,7 @@ func TestSupportedVersions(t *testing.T) {
 				version.MustParse("8.9.0"),
 			},
 			unsupported: []version.Version{
-				version.MustParse("7.15.0"), // supported by ECK but no direct upgrade path to 8.x
+				version.MustParse("7.16.99"), // supported by ECK but no direct upgrade path to 8.x
 			},
 		},
 	}


### PR DESCRIPTION
Update to `7.17.0` the minimum supported Elasticsearch version to upgrade to `8.0`.

Relates to #4951.