### PR TITLE
Remove unused reference to the observer

### DIFF
--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -91,7 +91,6 @@ func (d *defaultDriver) reconcileNodeSpecs(
 		parentCtx:            ctx,
 		k8sClient:            d.K8sClient(),
 		es:                   d.ES,
-		observedState:        observedState,
 		esState:              esState,
 		expectations:         d.Expectations,
 		validateStorageClass: d.OperatorParameters.ValidateStorageClass,

--- a/pkg/controller/elasticsearch/driver/upscale.go
+++ b/pkg/controller/elasticsearch/driver/upscale.go
@@ -14,7 +14,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/expectations"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/observer"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/version/zen1"
@@ -26,7 +25,6 @@ type upscaleCtx struct {
 	parentCtx            context.Context
 	k8sClient            k8s.Client
 	es                   esv1.Elasticsearch
-	observedState        observer.State
 	esState              ESState
 	expectations         *expectations.Expectations
 	validateStorageClass bool


### PR DESCRIPTION
While auditing the source code to understand where and how the observer is used I noticed that it is needlessly included in the upscale context.