### PR TITLE
Support trial licenses inside enterprise_trial orchestration licenses

### DIFF
--- a/pkg/controller/common/license/match_test.go
+++ b/pkg/controller/common/license/match_test.go
@@ -225,14 +225,13 @@ func Test_bestMatchAt(t *testing.T) {
 							Type:               LicenseTypeEnterpriseTrial,
 							Issuer:             "API",
 							ClusterLicenses: []ElasticsearchLicense{
-								{License: license(twelveMonth, platinum)},
-								{License: license(twoMonth, gold)},
+								{License: license(twelveMonth, trial)},
 							},
 						},
 					},
 				},
 			},
-			want:      license(twelveMonth, platinum),
+			want:      license(twelveMonth, trial),
 			wantFound: true,
 		},
 		{

--- a/test/e2e/es/license_test.go
+++ b/test/e2e/es/license_test.go
@@ -165,8 +165,8 @@ func TestEnterpriseTrialExtension(t *testing.T) {
 			licenseTestContext.Init(),
 			licenseTestContext.CheckElasticsearchLicense(client.ElasticsearchLicenseTypeTrial),
 			licenseTestContext.CheckEnterpriseTrialLicenseValid(trialSecretName),
-			// simulate a trial extension
-			licenseTestContext.CreateTrialExtension(licenseSecretName, privateKey.(*rsa.PrivateKey)),
+			// simulate a trial extension: old style with Enterprise Elasticsearch license
+			licenseTestContext.CreateTrialExtension(licenseSecretName, privateKey.(*rsa.PrivateKey), client.ElasticsearchLicenseTypeEnterprise),
 			licenseTestContext.CheckElasticsearchLicense(
 				client.ElasticsearchLicenseTypePlatinum, // depends on ES version
 				client.ElasticsearchLicenseTypeEnterprise,
@@ -174,11 +174,10 @@ func TestEnterpriseTrialExtension(t *testing.T) {
 			// revert to basic again
 			licenseTestContext.DeleteAllEnterpriseLicenseSecrets(),
 			licenseTestContext.CheckElasticsearchLicense(client.ElasticsearchLicenseTypeBasic),
-			// repeatedly extending a trial is possible
-			licenseTestContext.CreateTrialExtension(licenseSecretName, privateKey.(*rsa.PrivateKey)),
+			// repeatedly extending a trial is possible: new style with Elasticsearch trial license
+			licenseTestContext.CreateTrialExtension(licenseSecretName, privateKey.(*rsa.PrivateKey), client.ElasticsearchLicenseTypeTrial),
 			licenseTestContext.CheckElasticsearchLicense(
-				client.ElasticsearchLicenseTypePlatinum, // depends on ES version
-				client.ElasticsearchLicenseTypeEnterprise,
+				client.ElasticsearchLicenseTypeTrial,
 			),
 			// cleanup license for the next tests
 			licenseTestContext.DeleteAllEnterpriseLicenseSecrets(),

--- a/test/e2e/test/elasticsearch/steps_license.go
+++ b/test/e2e/test/elasticsearch/steps_license.go
@@ -84,13 +84,13 @@ func (ltctx *LicenseTestContext) CreateEnterpriseLicenseSecret(secretName string
 	}
 }
 
-func (ltctx *LicenseTestContext) CreateTrialExtension(secretName string, privateKey *rsa.PrivateKey) test.Step {
+func (ltctx *LicenseTestContext) CreateTrialExtension(secretName string, privateKey *rsa.PrivateKey, esLicenseType client.ElasticsearchLicenseType) test.Step {
 	//nolint:thelper
 	return test.Step{
 		Name: "Creating a trial extension secret",
 		Test: func(t *testing.T) {
 			signer := license.NewSigner(privateKey)
-			clusterLicense, err := GenerateTestLicense(signer)
+			clusterLicense, err := GenerateTestLicense(signer, esLicenseType)
 			require.NoError(t, err)
 			trialExtension := license.EnterpriseLicense{
 				License: license.LicenseSpec{


### PR DESCRIPTION
Currently `enterprise_trial` orchestration licenses can only contain short-lived `enterprise` or `platinum` licenses (which one is applied depends on the version of Elasticsearch). This is confusing to users which expect a trial to be running if they apply a trial license. This PR prepares the ground to remedy this confusion by consistently using trial license across both the orchestrator and the Elastic stack. 

 I have adjusted the existing e2e test to cover both cases, which means we no longer test the "I can apply the same enterprise_trial multiple times (as long as it's valid)". But I would argue that this is only about being able to apply a regular `enterprise` license to Elasticsearch which we are already covering in another test. So instead we now testing once the old-style `enterprise_trial` with short-lived `enterprise` and `platinum` stack licenses and once the new-style `enterprise_trial` with a stack `trial` license inside.