### PR TITLE
Add downward node labels api to telemetry

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1592,6 +1592,43 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 --------------------------------------------------------------------------------
+Module  : github.com/pmezard/go-difflib
+Version : v1.0.0
+Time    : 2016-01-10T10:55:54Z
+Licence : BSD-3-Clause
+
+Contents of probable licence file $GOMODCACHE/github.com/pmezard/go-difflib@v1.0.0/LICENSE:
+
+Copyright (c) 2013, Patrick Mezard
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+    The names of its contributors may not be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+--------------------------------------------------------------------------------
 Module  : github.com/prometheus/client_golang
 Version : v1.11.0
 Time    : 2021-06-07T12:32:16Z
@@ -15640,43 +15677,6 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
-
---------------------------------------------------------------------------------
-Module  : github.com/pmezard/go-difflib
-Version : v1.0.0
-Time    : 2016-01-10T10:55:54Z
-Licence : BSD-3-Clause
-
-Contents of probable licence file $GOMODCACHE/github.com/pmezard/go-difflib@v1.0.0/LICENSE:
-
-Copyright (c) 2013, Patrick Mezard
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-    Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-    The names of its contributors may not be used to endorse or promote
-products derived from this software without specific prior written
-permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 --------------------------------------------------------------------------------

--- a/docs/reference/dependencies.asciidoc
+++ b/docs/reference/dependencies.asciidoc
@@ -35,6 +35,7 @@ This page lists the third-party dependencies used to build {n}.
 | link:https://github.com/imdario/mergo[$$github.com/imdario/mergo$$] | v0.3.12 | BSD-3-Clause
 | link:https://github.com/magiconair/properties[$$github.com/magiconair/properties$$] | v1.8.5 | BSD-2-Clause
 | link:https://github.com/pkg/errors[$$github.com/pkg/errors$$] | v0.9.1 | BSD-2-Clause
+| link:https://github.com/pmezard/go-difflib[$$github.com/pmezard/go-difflib$$] | v1.0.0 | BSD-3-Clause
 | link:https://github.com/prometheus/client_golang[$$github.com/prometheus/client_golang$$] | v1.11.0 | Apache-2.0
 | link:https://github.com/prometheus/common[$$github.com/prometheus/common$$] | v0.26.0 | Apache-2.0
 | link:https://github.com/sethvargo/go-password[$$github.com/sethvargo/go-password$$] | v0.2.0 | MIT
@@ -143,7 +144,6 @@ This page lists the third-party dependencies used to build {n}.
 | link:https://github.com/pascaldekloe/goe[$$github.com/pascaldekloe/goe$$] | v0.1.0 | Public Domain
 | link:https://github.com/pelletier/go-toml[$$github.com/pelletier/go-toml$$] | v1.9.4 | Apache-2.0
 | link:https://github.com/pierrec/lz4[$$github.com/pierrec/lz4$$] | v2.5.2+incompatible | BSD-3-Clause
-| link:https://github.com/pmezard/go-difflib[$$github.com/pmezard/go-difflib$$] | v1.0.0 | BSD-3-Clause
 | link:https://github.com/prometheus/client_model[$$github.com/prometheus/client_model$$] | v0.2.0 | Apache-2.0
 | link:https://github.com/prometheus/procfs[$$github.com/prometheus/procfs$$] | v0.6.0 | Apache-2.0
 | link:https://github.com/ryanuber/go-glob[$$github.com/ryanuber/go-glob$$] | v1.0.0 | MIT

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/influxdata/tdigest v0.0.1 // indirect
 	github.com/magiconair/properties v1.8.5
 	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.26.0
 	github.com/sethvargo/go-password v0.2.0

--- a/pkg/telemetry/fixtures.go
+++ b/pkg/telemetry/fixtures.go
@@ -1,0 +1,93 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package telemetry
+
+import (
+	"bytes"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/require"
+)
+
+type TemplateData struct {
+	ElasticsearchTemplateData
+}
+
+type ElasticsearchTemplateData struct {
+	ResourceCount               int32
+	StackMonitoringLogsCount    int32
+	StackMonitoringMetricsCount int32
+	PodCount                    int32
+
+	*NodeLabelsTemplateData
+}
+
+type NodeLabelsTemplateData struct {
+	ResourceWithNodeLabelsCount int32
+	DistinctNodeLabelsCount     int32
+}
+
+func renderExpectedTemplate(t *testing.T, data TemplateData) []byte {
+	t.Helper()
+	tmpl, err := template.New("test").Parse(expectedTelemetryTemplate)
+	require.NoError(t, err)
+	tplBuffer := bytes.Buffer{}
+	require.NoError(t, tmpl.Execute(&tplBuffer, data))
+	return tplBuffer.Bytes()
+}
+
+const expectedTelemetryTemplate = `eck:
+  build:
+    date: "2019-09-20T07:00:00Z"
+    hash: b5316231
+    snapshot: "true"
+    version: 1.1.0
+  custom_operator_namespace: true
+  distribution: v1.16.13-gke.1
+  distributionChannel: test-channel
+  license:
+    eck_license_level: basic
+    enterprise_resource_units: "1"
+    total_managed_memory: 3.22GB
+  operator_uuid: 15039433-f873-41bd-b6e7-10ee3665cafa
+  stats:
+    agents:
+      multiple_refs: 0
+      pod_count: 0
+      resource_count: 0
+    apms:
+      pod_count: 0
+      resource_count: 0
+    beats:
+      auditbeat_count: 0
+      filebeat_count: 0
+      heartbeat_count: 0
+      journalbeat_count: 0
+      metricbeat_count: 0
+      packetbeat_count: 0
+      pod_count: 0
+      resource_count: 0
+    elasticsearches:
+      autoscaled_resource_count: 0
+ {{- if .ElasticsearchTemplateData.NodeLabelsTemplateData }}
+      downward_node_labels:
+        distinct_node_labels_count: {{ .ElasticsearchTemplateData.DistinctNodeLabelsCount }}
+        resource_count: {{ .ElasticsearchTemplateData.ResourceWithNodeLabelsCount }}
+{{- end }}
+      pod_count: {{ .ElasticsearchTemplateData.PodCount }}
+      resource_count: {{ .ElasticsearchTemplateData.ResourceCount }}
+      stack_monitoring_logs_count: {{ .ElasticsearchTemplateData.StackMonitoringLogsCount }}
+      stack_monitoring_metrics_count: {{ .ElasticsearchTemplateData.StackMonitoringMetricsCount }}
+    enterprisesearches:
+      pod_count: 0
+      resource_count: 0
+    kibanas:
+      pod_count: 0
+      resource_count: 1
+    maps:
+      pod_count: 0
+      resource_count: 0
+`


### PR DESCRIPTION
This PR adds downward node labels api to telemetry (follow-up to #5054)