### PR TITLE
[1.9] Stop using deprecated setting earlier (#5085)

### DIFF
--- a/pkg/controller/enterprisesearch/config.go
+++ b/pkg/controller/enterprisesearch/config.go
@@ -274,7 +274,7 @@ func associationConfig(c k8s.Client, ent entv1.EnterpriseSearch) (*settings.Cano
 	}
 
 	cfg := settings.NewCanonicalConfig()
-	if ver.LT(version.MinFor(8, 0, 0)) {
+	if ver.LT(version.MinFor(7, 17, 0)) {
 		cfg = settings.MustCanonicalConfig(map[string]string{
 			"ent_search.auth.source": "elasticsearch-native",
 		})


### PR DESCRIPTION
Backports the following commits to 1.9:
 - Stop using deprecated setting earlier (#5085)