### PR TITLE
Main go routine does not exit if there's no error

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -619,7 +619,14 @@ func startOperator(ctx context.Context) error {
 		}
 	}()
 
-	return <-exitOnErr
+	for {
+		select {
+		case err = <-exitOnErr:
+			return err
+		case <-ctx.Done():
+			return nil
+		}
+	}
 }
 
 // asyncTasks schedules some tasks to be started when this instance of the operator is elected


### PR DESCRIPTION
To reproduce:

1. Send SGINT (`kill -SIGINT` or CTRL+C)
2. Operator does not stop 
3. Dump main goroutine:

```
goroutine 1 [chan receive]:
github.com/elastic/cloud-on-k8s/cmd/manager.startOperator({0x5a43210, 0xc00025c480})
        /Users/michael/go/src/github.com/elastic/cloud-on-k8s/cmd/manager/main.go:622 +0x20e5
github.com/elastic/cloud-on-k8s/cmd/manager.doRun(0xc000609680, {0x5776fa6, 0xb, 0xb})
        /Users/michael/go/src/github.com/elastic/cloud-on-k8s/cmd/manager/main.go:317 +0x91
github.com/spf13/cobra.(*Command).execute(0xc000609680, {0xc0006280b0, 0xb, 0xb})
        /Users/michael/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0xc000609400)
        /Users/michael/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/michael/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
main.main()
        /Users/michael/go/src/github.com/elastic/cloud-on-k8s/cmd/main.go:31 +0x245
```

`cloud-on-k8s/cmd/manager/main.go:622` is 

```golang
	return <-exitOnErr
```