### PR TITLE
Update fleet custom logs integration recipe in 7.15.1

### DIFF
--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -12,7 +12,7 @@ spec:
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
     xpack.fleet.packages:
     - name: log
-      version: latest
+      version: 0.4.6 # pinning this version as the next one breaks this recipe, until https://github.com/elastic/cloud-on-k8s/issues/5105 is solved
     xpack.fleet.agentPolicies:
     - name: Default Fleet Server on ECK policy
       is_default_fleet_server: true

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -12,7 +12,7 @@ spec:
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
     xpack.fleet.packages:
     - name: log
-      version: 0.4.6 # pinning this version as the next one breaks this recipe, until https://github.com/elastic/cloud-on-k8s/issues/5105 is solved
+      version: latest
     xpack.fleet.agentPolicies:
     - name: Default Fleet Server on ECK policy
       is_default_fleet_server: true

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -1,9 +1,10 @@
+# pinning the stack version to 7.15.1 because 7.15.2 breaks this recipe, see https://github.com/elastic/cloud-on-k8s/issues/5105 for more details.
 apiVersion: kibana.k8s.elastic.co/v1
 kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.15.2
+  version: 7.15.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -48,7 +49,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.15.2
+  version: 7.15.1
   nodeSets:
   - name: default
     count: 3
@@ -60,7 +61,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 7.15.2
+  version: 7.15.1
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -81,7 +82,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 7.15.2
+  version: 7.15.1
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -36,7 +36,8 @@ spec:
             enabled: true
             vars:
             - name: paths
-              value: '/var/log/containers/*${kubernetes.container.id}.log'
+              value:
+              - '/var/log/containers/*${kubernetes.container.id}.log'
             - name: custom
               value: |
                 symlinks: true


### PR DESCRIPTION
Specify `paths` as an array value but temporarily pin the stack version to `7.15.1` because it breaks in `7.15.2`.

Relates to #5105.