### PR TITLE
Stop using deprecated xpack.fleet.agents.elasticsearch.host Kibana config

### DIFF
--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -8,7 +8,7 @@ spec:
   elasticsearchRef:
     name: elasticsearch
   config:
-    xpack.fleet.agents.elasticsearch.host: "https://elasticsearch-es-http.default.svc:9200"
+    xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
     xpack.fleet.packages:
     - name: apm

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -8,7 +8,7 @@ spec:
   elasticsearchRef:
     name: elasticsearch
   config:
-    xpack.fleet.agents.elasticsearch.host: "https://elasticsearch-es-http.default.svc:9200"
+    xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
     xpack.fleet.packages:
     - name: log

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -8,7 +8,7 @@ spec:
   elasticsearchRef:
     name: elasticsearch
   config:
-    xpack.fleet.agents.elasticsearch.host: "https://elasticsearch-es-http.default.svc:9200"
+    xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
     xpack.fleet.packages:
     - name: kubernetes

--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -78,7 +78,7 @@ spec:
   elasticsearchRef:
     name: elasticsearch-quickstart
   config:
-    xpack.fleet.agents.elasticsearch.host: "https://elasticsearch-quickstart-es-http.default.svc:9200"
+    xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-quickstart-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-quickstart-agent-http.default.svc:8220"]
 ---
 apiVersion: elasticsearch.k8s.elastic.co/v1
@@ -230,11 +230,11 @@ metadata:
   name: kibana-sample
 spec:
   config:
-    xpack.fleet.agents.elasticsearch.host: "https://elasticsearch-sample-es-http.default.svc:9200"
+    xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-quickstart-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-sample-agent-http.default.svc:8220"]
 ----
 
-*  `xpack.fleet.agents.elasticsearch.host`  must point to the Elasticsearch cluster that Elastic Agents should send data to. For ECK-managed Elasticsearch clusters, ECK creates a Service accessible through `https://ES_RESOURCE_NAME-es-http.ES_RESOURCE_NAMESPACE.svc:9200` URL, where `ES_RESOURCE_NAME` is the name of Elasticsearch resource and `ES_RESOURCE_NAMESPACE` is the namespace it was deployed in.
+*  `xpack.fleet.agents.elasticsearch.hosts`  must point to the Elasticsearch cluster that Elastic Agents should send data to. For ECK-managed Elasticsearch clusters, ECK creates a Service accessible through `https://ES_RESOURCE_NAME-es-http.ES_RESOURCE_NAMESPACE.svc:9200` URL, where `ES_RESOURCE_NAME` is the name of Elasticsearch resource and `ES_RESOURCE_NAMESPACE` is the namespace it was deployed in.
 
 *  `xpack.fleet.agents.fleet_server.hosts` must point to Fleet Server that Elastic Agents should connect to. For ECK-managed Fleet Server instances, ECK creates a Service accessible through `https://FS_RESOURCE_NAME-agent-http.FS_RESOURCE_NAMESPACE.svc:8220` URL, where `FS_RESOURCE_NAME` is the name of Elastic Agent resource with Fleet Server enabled and `FS_RESOURCE_NAMESPACE` is the namespace it was deployed in.
 
@@ -268,7 +268,7 @@ spec:
 ----
 
 
-Set `elasticsearchRefs` element in your Fleet Server to point to the Elasticsearch cluster that will manage Fleet. Leave `elasticsearchRefs` empty or unset for any Elastic Agent running in Fleet mode as the Elasticsearch cluster to target will come from Kibana `xpack.fleet.agents.elasticsearch.host` configuration element.
+Set `elasticsearchRefs` element in your Fleet Server to point to the Elasticsearch cluster that will manage Fleet. Leave `elasticsearchRefs` empty or unset for any Elastic Agent running in Fleet mode as the Elasticsearch cluster to target will come from Kibana `xpack.fleet.agents.elasticsearch.hosts` configuration element.
 
 NOTE: Currently, Elastic Agent in Fleet mode supports only a single output, so only a single Elasticsearch cluster can be referenced.
 

--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -230,7 +230,7 @@ metadata:
   name: kibana-sample
 spec:
   config:
-    xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-quickstart-es-http.default.svc:9200"]
+    xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-sample-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-sample-agent-http.default.svc:8220"]
 ----
 

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -169,11 +169,13 @@ func TestFleetMode(t *testing.T) {
 
 func fleetConfigForKibana(esRef v1.ObjectSelector, fsRef v1.ObjectSelector) map[string]interface{} {
 	return map[string]interface{}{
-		"xpack.fleet.agents.elasticsearch.host": fmt.Sprintf(
-			"https://%s-es-http.%s.svc:9200",
-			esRef.Name,
-			esRef.Namespace,
-		),
+		"xpack.fleet.agents.elasticsearch.hosts": []string{
+			fmt.Sprintf(
+				"https://%s-es-http.%s.svc:9200",
+				esRef.Name,
+				esRef.Namespace,
+			),
+		},
 		"xpack.fleet.agents.fleet_server.hosts": []string{
 			fmt.Sprintf(
 				"https://%s-agent-http.%s.svc:8220",

--- a/test/e2e/test/helper/yaml.go
+++ b/test/e2e/test/helper/yaml.go
@@ -391,15 +391,15 @@ func tweakConfigLiterals(config *commonv1.Config, suffix string, namespace strin
 
 	data := config.Data
 
-	elasticsearchHostKey := "xpack.fleet.agents.elasticsearch.host"
-	if val1, ok := data[elasticsearchHostKey]; ok {
+	elasticsearchHostsKey := "xpack.fleet.agents.elasticsearch.hosts"
+	if val1, ok := data[elasticsearchHostsKey]; ok {
 		if val2, ok := val1.(string); ok {
 			val2 = strings.ReplaceAll(
 				val2,
 				"elasticsearch-es-http.default",
 				fmt.Sprintf("elasticsearch-%s-es-http.%s", suffix, namespace),
 			)
-			data[elasticsearchHostKey] = val2
+			data[elasticsearchHostsKey] = val2
 		}
 	}
 

--- a/test/e2e/test/helper/yaml.go
+++ b/test/e2e/test/helper/yaml.go
@@ -392,29 +392,30 @@ func tweakConfigLiterals(config *commonv1.Config, suffix string, namespace strin
 	data := config.Data
 
 	elasticsearchHostsKey := "xpack.fleet.agents.elasticsearch.hosts"
-	if val1, ok := data[elasticsearchHostsKey]; ok {
-		if val2, ok := val1.(string); ok {
-			val2 = strings.ReplaceAll(
-				val2,
-				"elasticsearch-es-http.default",
-				fmt.Sprintf("elasticsearch-%s-es-http.%s", suffix, namespace),
-			)
-			data[elasticsearchHostsKey] = val2
+	if untypedHosts, ok := data[elasticsearchHostsKey]; ok {
+		if untypedHostsSlice, ok := untypedHosts.([]interface{}); ok {
+			for i, untypedHost := range untypedHostsSlice {
+				if host, ok := untypedHost.(string); ok {
+					untypedHostsSlice[i] = strings.ReplaceAll(
+						host,
+						"elasticsearch-es-http.default",
+						fmt.Sprintf("elasticsearch-%s-es-http.%s", suffix, namespace),
+					)
+				}
+			}
 		}
 	}
 
 	fleetServerHostsKey := "xpack.fleet.agents.fleet_server.hosts"
-	//nolint:nestif
-	if val1, ok := data[fleetServerHostsKey]; ok {
-		if val2, ok := val1.([]interface{}); ok {
-			if len(val2) > 0 {
-				if val3, ok := val2[0].(string); ok {
-					val3 = strings.ReplaceAll(
-						val3,
+	if untypedHosts, ok := data[fleetServerHostsKey]; ok {
+		if untypedHostsSlice, ok := untypedHosts.([]interface{}); ok {
+			for i, untypedHost := range untypedHostsSlice {
+				if host, ok := untypedHost.(string); ok {
+					untypedHostsSlice[i] = strings.ReplaceAll(
+						host,
 						"fleet-server-agent-http.default",
 						fmt.Sprintf("fleet-server-%s-agent-http.%s", suffix, namespace),
 					)
-					data[fleetServerHostsKey] = []interface{}{val3}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/5091.