### PR TITLE
[1.9] Stop using deprecated xpack.monitoring.* settings from 8.0 (#5118)

### DIFF
--- a/pkg/apis/elasticsearch/v1/fields.go
+++ b/pkg/apis/elasticsearch/v1/fields.go
@@ -46,8 +46,8 @@ const (
 
 	XPackLicenseUploadTypes = "xpack.license.upload.types" // supported >= 7.6.0 used as of 7.8.1
 
-	XPackMonitoringCollectionEnabled              = "xpack.monitoring.collection.enabled"
-	XPackMonitoringElasticsearchCollectionEnabled = "xpack.monitoring.elasticsearch.collection.enabled"
+	XPackMonitoringCollectionEnabled              = "xpack.monitoring.collection.enabled"               // < 8.0.0
+	XPackMonitoringElasticsearchCollectionEnabled = "xpack.monitoring.elasticsearch.collection.enabled" // < 8.0.0
 )
 
 var UnsupportedSettings = []string{

--- a/pkg/controller/elasticsearch/nodespec/resources.go
+++ b/pkg/controller/elasticsearch/nodespec/resources.go
@@ -57,7 +57,7 @@ func BuildExpectedResources(
 		if nodeSpec.Config != nil {
 			userCfg = *nodeSpec.Config
 		}
-		cfg, err := settings.NewMergedESConfig(es.Name, ver, ipFamily, es.Spec.HTTP, userCfg, stackmon.MonitoringConfig(es))
+		cfg, err := settings.NewMergedESConfig(es.Name, ver, ipFamily, es.Spec.HTTP, userCfg, stackmon.MonitoringConfig(ver, es))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/elasticsearch/stackmon/es_config.go
+++ b/pkg/controller/elasticsearch/stackmon/es_config.go
@@ -10,11 +10,12 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/stackmon/monitoring"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 )
 
 // MonitoringConfig returns the Elasticsearch settings to enable the collection of monitoring data
-func MonitoringConfig(es esv1.Elasticsearch) commonv1.Config {
-	if !monitoring.IsMetricsDefined(&es) {
+func MonitoringConfig(ver version.Version, es esv1.Elasticsearch) commonv1.Config {
+	if !monitoring.IsMetricsDefined(&es) || ver.GTE(version.MinFor(8, 0, 0)) {
 		return commonv1.Config{}
 	}
 	return commonv1.Config{Data: map[string]interface{}{


### PR DESCRIPTION
Backports the following commits to 1.9:
 - Stop using deprecated xpack.monitoring.* settings from 8.0 (#5118)