### PR TITLE
[1.9] Stop using deprecated xpack.monitoring.* settings (#5136)

### DIFF
--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -222,9 +222,6 @@ spec:
     count: 3
     config:
       node.store.allow_mmap: false
-      # https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-metricbeat.html
-      xpack.monitoring.collection.enabled: true
-      xpack.monitoring.elasticsearch.collection.enabled: false
     podTemplate:
       metadata:
         labels:

--- a/pkg/apis/elasticsearch/v1/fields.go
+++ b/pkg/apis/elasticsearch/v1/fields.go
@@ -45,9 +45,6 @@ const (
 	XPackSecurityTransportSslVerificationMode       = "xpack.security.transport.ssl.verification_mode"
 
 	XPackLicenseUploadTypes = "xpack.license.upload.types" // supported >= 7.6.0 used as of 7.8.1
-
-	XPackMonitoringCollectionEnabled              = "xpack.monitoring.collection.enabled"               // < 8.0.0
-	XPackMonitoringElasticsearchCollectionEnabled = "xpack.monitoring.elasticsearch.collection.enabled" // < 8.0.0
 )
 
 var UnsupportedSettings = []string{

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -165,7 +165,7 @@ func TestBuildPodTemplateSpecWithDefaultSecurityContext(t *testing.T) {
 			es.Spec.Version = tt.version.String()
 			es.Spec.NodeSets[0].PodTemplate.Spec.SecurityContext = tt.userSecurityContext
 
-			cfg, err := settings.NewMergedESConfig(es.Name, tt.version, corev1.IPv4Protocol, es.Spec.HTTP, *es.Spec.NodeSets[0].Config, commonv1.Config{})
+			cfg, err := settings.NewMergedESConfig(es.Name, tt.version, corev1.IPv4Protocol, es.Spec.HTTP, *es.Spec.NodeSets[0].Config)
 			require.NoError(t, err)
 
 			actual, err := BuildPodTemplateSpec(k8s.NewFakeClient(), es, es.Spec.NodeSets[0], cfg, nil, tt.setDefaultFSGroup)
@@ -179,7 +179,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 	nodeSet := sampleES.Spec.NodeSets[0]
 	ver, err := version.Parse(sampleES.Spec.Version)
 	require.NoError(t, err)
-	cfg, err := settings.NewMergedESConfig(sampleES.Name, ver, corev1.IPv4Protocol, sampleES.Spec.HTTP, *nodeSet.Config, commonv1.Config{})
+	cfg, err := settings.NewMergedESConfig(sampleES.Name, ver, corev1.IPv4Protocol, sampleES.Spec.HTTP, *nodeSet.Config)
 	require.NoError(t, err)
 
 	actual, err := BuildPodTemplateSpec(k8s.NewFakeClient(), sampleES, sampleES.Spec.NodeSets[0], cfg, nil, false)

--- a/pkg/controller/elasticsearch/nodespec/resources.go
+++ b/pkg/controller/elasticsearch/nodespec/resources.go
@@ -16,7 +16,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/stackmon"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
 // Resources contain per-NodeSet resources to be created.
@@ -57,7 +57,7 @@ func BuildExpectedResources(
 		if nodeSpec.Config != nil {
 			userCfg = *nodeSpec.Config
 		}
-		cfg, err := settings.NewMergedESConfig(es.Name, ver, ipFamily, es.Spec.HTTP, userCfg, stackmon.MonitoringConfig(ver, es))
+		cfg, err := settings.NewMergedESConfig(es.Name, ver, ipFamily, es.Spec.HTTP, userCfg)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/elasticsearch/nodespec/resources.go
+++ b/pkg/controller/elasticsearch/nodespec/resources.go
@@ -5,7 +5,6 @@
 package nodespec
 
 import (
-	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 

--- a/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/pkg/controller/elasticsearch/settings/merged_config.go
@@ -32,21 +32,15 @@ func NewMergedESConfig(
 	ipFamily corev1.IPFamily,
 	httpConfig commonv1.HTTPConfig,
 	userConfig commonv1.Config,
-	monitoringConfig commonv1.Config,
 ) (CanonicalConfig, error) {
 	userCfg, err := common.NewCanonicalConfigFrom(userConfig.Data)
 	if err != nil {
 		return CanonicalConfig{}, err
 	}
 	config := baseConfig(clusterName, ver, ipFamily).CanonicalConfig
-	monitoringCfg, err := common.NewCanonicalConfigFrom(monitoringConfig.Data)
-	if err != nil {
-		return CanonicalConfig{}, err
-	}
 	err = config.MergeWith(
 		xpackConfig(ver, httpConfig).CanonicalConfig,
 		userCfg,
-		monitoringCfg,
 	)
 	if err != nil {
 		return CanonicalConfig{}, err

--- a/pkg/controller/elasticsearch/settings/merged_config_test.go
+++ b/pkg/controller/elasticsearch/settings/merged_config_test.go
@@ -219,7 +219,6 @@ func TestNewMergedESConfig(t *testing.T) {
 				tt.ipFamily,
 				commonv1.HTTPConfig{},
 				commonv1.Config{Data: tt.cfgData},
-				commonv1.Config{},
 			)
 			require.NoError(t, err)
 			tt.assert(cfg)

--- a/pkg/controller/elasticsearch/stackmon/es_config.go
+++ b/pkg/controller/elasticsearch/stackmon/es_config.go
@@ -6,23 +6,7 @@ package stackmon
 
 import (
 	corev1 "k8s.io/api/core/v1"
-
-	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
-	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/stackmon/monitoring"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 )
-
-// MonitoringConfig returns the Elasticsearch settings to enable the collection of monitoring data
-func MonitoringConfig(ver version.Version, es esv1.Elasticsearch) commonv1.Config {
-	if !monitoring.IsMetricsDefined(&es) || ver.GTE(version.MinFor(8, 0, 0)) {
-		return commonv1.Config{}
-	}
-	return commonv1.Config{Data: map[string]interface{}{
-		esv1.XPackMonitoringCollectionEnabled:              true,
-		esv1.XPackMonitoringElasticsearchCollectionEnabled: false,
-	}}
-}
 
 // fileLogStyleEnvVar returns the environment variable to configure the Elasticsearch container to write logs to disk
 func fileLogStyleEnvVar() corev1.EnvVar {


### PR DESCRIPTION
Backports the following commits to 1.9:
- #5136 