### PR TITLE
Add autodetect option to security context configuration

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -289,8 +289,8 @@ func Command() *cobra.Command {
 	)
 	cmd.Flags().String(
 		operator.SetDefaultSecurityContextFlag,
-		"",
-		"Enables setting the default security context with fsGroup=1000 for Elasticsearch 8.0+ Pods. Ignored pre-8.0. Possible values: true, false, \"\" (= auto-detect)",
+		"auto-detect",
+		"Enables setting the default security context with fsGroup=1000 for Elasticsearch 8.0+ Pods. Ignored pre-8.0. Possible values: true, false, auto-detect",
 	)
 
 	// hide development mode flags from the usage message
@@ -690,10 +690,10 @@ func chooseAndValidateIPFamily(ipFamilyStr string, ipFamilyDefault corev1.IPFami
 //    to determine whether or not we are running within an openshift cluster.  If we determine we are on an openshift cluster,
 //    then default to false, otherwise, return true.
 func determineSetDefaultSecurityContext(setDefaultSecurityContext string, clientset kubernetes.Interface) (bool, error) {
-	if len(setDefaultSecurityContext) > 0 {
-		return strconv.ParseBool(setDefaultSecurityContext)
+	if setDefaultSecurityContext == "auto-detect" {
+		return isOpenShift(clientset)
 	}
-	return isOpenShift(clientset)
+	return strconv.ParseBool(setDefaultSecurityContext)
 }
 
 func isOpenShift(clientset kubernetes.Interface) (bool, error) {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -693,6 +693,10 @@ func determineSetDefaultSecurityContext(setDefaultSecurityContext string, client
 	if len(setDefaultSecurityContext) > 0 {
 		return strconv.ParseBool(setDefaultSecurityContext)
 	}
+	return isOpenShift(clientset)
+}
+
+func isOpenShift(clientset kubernetes.Interface) (bool, error) {
 	openshiftSecurityGroupVersion := schema.GroupVersion{Group: "security.openshift.io", Version: "v1"}
 	apiResourceList, err := clientset.Discovery().ServerResourcesForGroupVersion(openshiftSecurityGroupVersion.String())
 	if err != nil {
@@ -720,7 +724,6 @@ func determineSetDefaultSecurityContext(setDefaultSecurityContext string, client
 
 	// we could not determine that we are running within an openshift cluster,
 	// so we will behave as if "setDefaultSecurityContext" was set to true.
-	log.V(1).Info("returning true as fallback")
 	return true, nil
 }
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -23,6 +23,7 @@ import (
 	"go.elastic.co/apm"
 	"go.uber.org/automaxprocs/maxprocs"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -708,6 +709,9 @@ func isOpenShift(clientset kubernetes.Interface) (bool, error) {
 				// behave as if "setDefaultSecurityContext" was set to false.
 				return false, nil
 			}
+		}
+		if apierrors.IsNotFound(err) {
+			return false, nil
 		}
 		return false, err
 	}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -686,10 +686,9 @@ func chooseAndValidateIPFamily(ipFamilyStr string, ipFamilyDefault corev1.IPFami
 
 // determineSetDefaultSecurityContext determines what settings we need to use for security context by using the following rules:
 // 1. If the setDefaultSecurityContext is explicitly set to either true, or false, use this value.
-// 2. use openshift detection pulled from kubevirt
-//    https://github.com/kubevirt/kubevirt/blob/f71e9c9615a6c36178169d66814586a93ba515b5/pkg/util/cluster/cluster.go#L21
-//    to determine whether or not we are running within an openshift cluster.  If we determine we are on an openshift cluster,
-//    then default to false, otherwise, return true.
+// 2. use OpenShift detection to determine whether or not we are running within an OpenShift cluster.
+//    If we determine we are on an OpenShift cluster, and since OpenShift automatically sets security context, return false,
+//    otherwise, return true as we'll need to set this security context on non-OpenShift clusters.
 func determineSetDefaultSecurityContext(setDefaultSecurityContext string, clientset kubernetes.Interface) (bool, error) {
 	if setDefaultSecurityContext == "auto-detect" {
 		openshift, err := isOpenShift(clientset)
@@ -698,6 +697,8 @@ func determineSetDefaultSecurityContext(setDefaultSecurityContext string, client
 	return strconv.ParseBool(setDefaultSecurityContext)
 }
 
+// OpenShift detection inspired by kubevirt
+//    https://github.com/kubevirt/kubevirt/blob/f71e9c9615a6c36178169d66814586a93ba515b5/pkg/util/cluster/cluster.go#L21
 func isOpenShift(clientset kubernetes.Interface) (bool, error) {
 	openshiftSecurityGroupVersion := schema.GroupVersion{Group: "security.openshift.io", Version: "v1"}
 	apiResourceList, err := clientset.Discovery().ServerResourcesForGroupVersion(openshiftSecurityGroupVersion.String())

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -697,37 +697,37 @@ func determineSetDefaultSecurityContext(setDefaultSecurityContext string, client
 	return strconv.ParseBool(setDefaultSecurityContext)
 }
 
-// OpenShift detection inspired by kubevirt
+// isOpenShift detects whether we are running on OpenShift.  Detection inspired by kubevirt
 //    https://github.com/kubevirt/kubevirt/blob/f71e9c9615a6c36178169d66814586a93ba515b5/pkg/util/cluster/cluster.go#L21
 func isOpenShift(clientset kubernetes.Interface) (bool, error) {
 	openshiftSecurityGroupVersion := schema.GroupVersion{Group: "security.openshift.io", Version: "v1"}
 	apiResourceList, err := clientset.Discovery().ServerResourcesForGroupVersion(openshiftSecurityGroupVersion.String())
 	if err != nil {
-		// in case of an error, check if security.openshift.io is the reason (unlikely).
+		// In case of an error, check if security.openshift.io is the reason (unlikely).
 		var e *discovery.ErrGroupDiscoveryFailed
 		if ok := errors.As(err, &e); ok {
 			if _, exists := e.Groups[openshiftSecurityGroupVersion]; exists {
-				// If security.openshift.io is the reason for the error, we are absolutely in openshift
+				// If security.openshift.io is the reason for the error, we are absolutely on OpenShift
 				return true, nil
 			}
 		}
-		// if the security.openshift.io group isn't found, we are not in openshift
+		// If the security.openshift.io group isn't found, we are not on OpenShift
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		}
 		return false, err
 	}
 
-	// search for "securitycontextconstraints" within the cluster's api resources,
-	// since this is an openshift specific api resource that does not exist outside of openshift.
+	// Search for "securitycontextconstraints" within the cluster's API resources,
+	// since this is an OpenShift specific API resource that does not exist outside of OpenShift.
 	for _, apiResource := range apiResourceList.APIResources {
 		if apiResource.Name == "securitycontextconstraints" {
-			// we have determined we are absolutely running within an openshift cluster
+			// we have determined we are absolutely running on OpenShift
 			return true, nil
 		}
 	}
 
-	// we could not determine that we are running within an openshift cluster,
+	// We could not determine that we are running on an OpenShift cluster,
 	// so we will behave as if "setDefaultSecurityContext" was set to true.
 	return false, nil
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -690,9 +690,8 @@ func chooseAndValidateIPFamily(ipFamilyStr string, ipFamilyDefault corev1.IPFami
 //    to determine whether or not we are running within an openshift cluster.  If we determine we are on an openshift cluster,
 //    then default to false, otherwise, return true.
 func determineSetDefaultSecurityContext(setDefaultSecurityContext string, clientset kubernetes.Interface) (bool, error) {
-	isSet, err := strconv.ParseBool(setDefaultSecurityContext)
-	if err == nil {
-		return isSet, nil
+	if len(setDefaultSecurityContext) > 0 {
+		return strconv.ParseBool(setDefaultSecurityContext)
 	}
 	_, apiResources, err := clientset.Discovery().ServerGroupsAndResources()
 	if err != nil && !discovery.IsGroupDiscoveryFailedError(err) {

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -198,44 +198,6 @@ func Test_garbageCollectSoftOwnedSecrets(t *testing.T) {
 	}
 }
 
-type fakeClientset struct {
-	kubernetes.Interface
-	discovery discovery.DiscoveryInterface
-}
-
-type fakeDiscovery struct {
-	discovery.DiscoveryInterface
-	resources                         []*metav1.APIResourceList
-	errServerResourcesForGroupVersion error
-}
-
-func (c *fakeClientset) Discovery() discovery.DiscoveryInterface {
-	return c.discovery
-}
-
-func (d *fakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
-	if d.errServerResourcesForGroupVersion != nil {
-		return nil, d.errServerResourcesForGroupVersion
-	}
-	for _, resourceList := range d.resources {
-		if resourceList.GroupVersion == groupVersion {
-			return resourceList, nil
-		}
-	}
-	return nil, fmt.Errorf("GroupVersion %q not found", groupVersion)
-}
-
-func newFakeK8sClientsetWithDiscovery(resources []*metav1.APIResourceList, discoveryError error) kubernetes.Interface {
-	discoveryClient := &fakeDiscovery{
-		resources:                         resources,
-		errServerResourcesForGroupVersion: discoveryError,
-	}
-	client := &fakeClientset{
-		discovery: discoveryClient,
-	}
-	return client
-}
-
 func Test_determineSetDefaultSecurityContext(t *testing.T) {
 	type args struct {
 		setDefaultSecurityContext string
@@ -337,4 +299,42 @@ func Test_determineSetDefaultSecurityContext(t *testing.T) {
 			}
 		})
 	}
+}
+
+type fakeClientset struct {
+	kubernetes.Interface
+	discovery discovery.DiscoveryInterface
+}
+
+type fakeDiscovery struct {
+	discovery.DiscoveryInterface
+	resources                         []*metav1.APIResourceList
+	errServerResourcesForGroupVersion error
+}
+
+func (c *fakeClientset) Discovery() discovery.DiscoveryInterface {
+	return c.discovery
+}
+
+func (d *fakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	if d.errServerResourcesForGroupVersion != nil {
+		return nil, d.errServerResourcesForGroupVersion
+	}
+	for _, resourceList := range d.resources {
+		if resourceList.GroupVersion == groupVersion {
+			return resourceList, nil
+		}
+	}
+	return nil, fmt.Errorf("GroupVersion %q not found", groupVersion)
+}
+
+func newFakeK8sClientsetWithDiscovery(resources []*metav1.APIResourceList, discoveryError error) kubernetes.Interface {
+	discoveryClient := &fakeDiscovery{
+		resources:                         resources,
+		errServerResourcesForGroupVersion: discoveryError,
+	}
+	client := &fakeClientset{
+		discovery: discoveryClient,
+	}
+	return client
 }

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -159,7 +159,12 @@ config:
   exposedNodeLabels: [ "topology.kubernetes.io/.*", "failure-domain.beta.kubernetes.io/.*" ]
 
   # setDefaultSecurityContext determines whether a default security context is set on application containers created by the operator.
-  setDefaultSecurityContext: true
+  # *note* that the default option now is "", which is using "auto-detect" to attempt to set this properly automatically when both running
+  # in an openshift cluster, and a standard kubernetes cluster.  Valid values are as follows:
+  #   ""    : auto detect
+  # "true"  : set pod security context when creating resources.
+  # "false" : do not set pod security context when creating resources.
+  setDefaultSecurityContext: ""
 
   # kubeClientTimeout sets the request timeout for Kubernetes API calls made by the operator.
   kubeClientTimeout: 60s

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -159,12 +159,12 @@ config:
   exposedNodeLabels: [ "topology.kubernetes.io/.*", "failure-domain.beta.kubernetes.io/.*" ]
 
   # setDefaultSecurityContext determines whether a default security context is set on application containers created by the operator.
-  # *note* that the default option now is "", which is using "auto-detect" to attempt to set this properly automatically when both running
+  # *note* that the default option now is "auto-detect" to attempt to set this properly automatically when both running
   # in an openshift cluster, and a standard kubernetes cluster.  Valid values are as follows:
-  #   ""    : auto detect
-  # "true"  : set pod security context when creating resources.
-  # "false" : do not set pod security context when creating resources.
-  setDefaultSecurityContext: ""
+  # "auto-detect" : auto detect
+  # "true"        : set pod security context when creating resources.
+  # "false"       : do not set pod security context when creating resources.
+  setDefaultSecurityContext: "auto-detect"
 
   # kubeClientTimeout sets the request timeout for Kubernetes API calls made by the operator.
   kubeClientTimeout: 60s


### PR DESCRIPTION
resolves #5061 

This change adds an option to the `set-default-security-context` flag to help the user with settings that pertain to [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).  It adds the `auto-detect` option ~~(which is triggered by simply not setting the `set-default-security-context` flag)~~ which does the following when set:

1. If the `set-default-security-context` flag is explicitly set to either true, or false, use this value.
2. if the `set-default-security-context` flag is set to `auto-detect` (the default value in helm charts) use openshift detection to determine whether or not we are running within an openshift cluster.  If we determine we are on an openshift cluster then default to setting this flag to `false` to allow openshift to set the security context properly, otherwise set this flag to `true` to allow the operator to set the security context appropriately.

Any other set value will throw a syntax error.

## testing
This was tested in both an openshift cluster, and vanilla cluster with the auto-detect option set and the results were as follows

### vanilla cluster

Elasticsearch stateful set had the following settings
```
spec.securityContext:
          fsGroup: 1000
```

### openshift cluster
```
container.securityContext:
      capabilities:
        drop:
        - KILL
        - MKNOD
        - SETGID
        - SETUID
      runAsUser: 1000630000

spec.securityContext:
    fsGroup: 1000630000
    seLinuxOptions:
      level: s0:c25,c15
```