### PR TITLE
Add log4j2.formatMsgNoLookups logging property to ES < 7.12

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -106,7 +106,7 @@ func BuildPodTemplateSpec(
 	}
 
 	if ver.LT(version.From(7, 2, 0)) {
-	        // mitigate CVE-2021-44228
+		// mitigate CVE-2021-44228
 		enableLog4JFormatMsgNoLookups(builder)
 	}
 

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -105,7 +105,10 @@ func BuildPodTemplateSpec(
 		return corev1.PodTemplateSpec{}, err
 	}
 
-	maybeAlterJvmOpts(builder, ver)
+	if ver.LT(version.From(7, 2, 0)) {
+	        // mitigate CVE-2021-44228
+		enableLog4JFormatMsgNoLookups(builder)
+	}
 
 	return builder.PodTemplate, nil
 }

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -176,9 +176,9 @@ const (
 	log4j2FormatMsgNoLookupsParamName = "-Dlog4j2.formatMsgNoLookups"
 )
 
-// enableLog4JFormatMsgNoLookups adds the JVM parameter `-Dlog4j2.formatMsgNoLookups=true` to the environment variable `ES_JAVA_OPTS`
-// in order to mitigate the possible Log4Shell vulnerability CVE-2021-44228, if it is not yet defined by the user, for
-// versions of Elasticsearch lower than 7.2.0.
+// enableLog4JFormatMsgNoLookups prepends the JVM parameter `-Dlog4j2.formatMsgNoLookups=true` to the environment variable `ES_JAVA_OPTS`
+// in order to mitigate the Log4Shell vulnerability CVE-2021-44228, if it is not yet defined by the user, for
+// versions of Elasticsearch before 7.2.0.
 func enableLog4JFormatMsgNoLookups(builder *defaults.PodTemplateBuilder) {
 	log4j2Param := fmt.Sprintf("%s=true", log4j2FormatMsgNoLookupsParamName)
 	for c, esContainer := range builder.PodTemplate.Spec.Containers {

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -29,6 +29,11 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
 )
 
+const (
+	defaultFsGroup                    = 1000
+	log4j2FormatMsgNoLookupsParamName = "-Dlog4j2.formatMsgNoLookups"
+)
+
 // Starting 8.0.0, the Elasticsearch container does not run with the root user anymore. As a result,
 // we cannot chown the mounted volumes to the right user (id 1000) in an init container.
 // Instead, we can rely on Kubernetes `securityContext.fsGroup` feature: by setting it to 1000
@@ -37,8 +42,6 @@ import (
 // is forbidden: the user can either set `--set-default-security-context=false`, or override the
 // podTemplate securityContext to an empty value.
 var minDefaultSecurityContextVersion = version.MustParse("8.0.0")
-
-const defaultFsGroup = 1000
 
 // BuildPodTemplateSpec builds a new PodTemplateSpec for an Elasticsearch node.
 func BuildPodTemplateSpec(
@@ -171,10 +174,6 @@ func buildLabels(
 
 	return podLabels, nil
 }
-
-const (
-	log4j2FormatMsgNoLookupsParamName = "-Dlog4j2.formatMsgNoLookups"
-)
 
 // enableLog4JFormatMsgNoLookups prepends the JVM parameter `-Dlog4j2.formatMsgNoLookups=true` to the environment variable `ES_JAVA_OPTS`
 // in order to mitigate the Log4Shell vulnerability CVE-2021-44228, if it is not yet defined by the user, for

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -170,7 +170,8 @@ func buildLabels(
 }
 
 // maybeAlterJvmOpts adds the JVM parameter `-Dlog4j2.formatMsgNoLookups=true` to the environment variable `ES_JAVA_OPTS`
-// in order to mitigate the possible Log4Shell vulnerability CVE-2021-44228, if it is not yet defined by the user.
+// in order to mitigate the possible Log4Shell vulnerability CVE-2021-44228, if it is not yet defined by the user, for
+// versions of Elasticsearch lower than 7.2.0.
 func maybeAlterJvmOpts(builder *defaults.PodTemplateBuilder, ver version.Version) {
 	if ver.LT(version.From(7, 2, 0)) { //nolint:nestif
 		log4j2ParamName := "-Dlog4j2.formatMsgNoLookups"

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -469,7 +469,7 @@ func Test_getDefaultContainerPorts(t *testing.T) {
 	}
 }
 
-func Test_maybeAlterJvmOpts(t *testing.T) {
+func Test_enableLog4JFormatMsgNoLookups(t *testing.T) {
 	tt := []struct {
 		name                       string
 		version                    string

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -468,3 +468,62 @@ func Test_getDefaultContainerPorts(t *testing.T) {
 		})
 	}
 }
+
+func Test_maybeAlterJvmOpts(t *testing.T) {
+	tt := []struct {
+		name                       string
+		version                    string
+		userEnv                    []corev1.EnvVar
+		expectedEsJavaOptsEnvValue string
+	}{
+		{
+			name:                       "before 7.2.0, JVM log4j2.formatMsgNoLookups parameter is set by default",
+			version:                    "7.0.0",
+			userEnv:                    []corev1.EnvVar{{Name: "YO", Value: "LO"}},
+			expectedEsJavaOptsEnvValue: "-Dlog4j2.formatMsgNoLookups=true",
+		},
+		{
+			name:                       "before 7.2.0, JVM log4j2.formatMsgNoLookups parameter is merged with user-provided JVM parameters",
+			version:                    "7.1.0",
+			userEnv:                    []corev1.EnvVar{{Name: "ES_JAVA_OPTS", Value: "-Xms=42000 -Xmx=42000"}},
+			expectedEsJavaOptsEnvValue: "-Dlog4j2.formatMsgNoLookups=true -Xms=42000 -Xmx=42000",
+		},
+		{
+			name:                       "before 7.2.0, JVM log4j2.formatMsgNoLookups user-provided parameter is not overridden by us",
+			version:                    "7.1.0",
+			userEnv:                    []corev1.EnvVar{{Name: "ES_JAVA_OPTS", Value: "-Xms=42000 -Dlog4j2.formatMsgNoLookups=false -Xmx=42000"}},
+			expectedEsJavaOptsEnvValue: "-Xms=42000 -Dlog4j2.formatMsgNoLookups=false -Xmx=42000",
+		},
+		{
+			name:                       "since 7.2.0, JVM log4j2.formatMsgNoLookups parameter is not set by default",
+			version:                    "7.2.0",
+			userEnv:                    []corev1.EnvVar{{Name: "ES_JAVA_OPTS", Value: "-Xms=42000 -Xmx=42000"}},
+			expectedEsJavaOptsEnvValue: "-Xms=42000 -Xmx=42000",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			sampleES := newEsSampleBuilder().build()
+			// set version
+			sampleES.Spec.Version = tc.version
+			// set user env
+			sampleES.Spec.NodeSets[0].PodTemplate.Spec.Containers[1].Env = tc.userEnv
+
+			ver, err := version.Parse(sampleES.Spec.Version)
+			require.NoError(t, err)
+			cfg, err := settings.NewMergedESConfig(sampleES.Name, ver, corev1.IPv4Protocol, sampleES.Spec.HTTP, *sampleES.Spec.NodeSets[0].Config)
+			require.NoError(t, err)
+			actual, err := BuildPodTemplateSpec(k8s.NewFakeClient(), sampleES, sampleES.Spec.NodeSets[0], cfg, nil, false)
+			require.NoError(t, err)
+
+			env := actual.Spec.Containers[1].Env
+			envMap := make(map[string]string)
+			for _, e := range env {
+				envMap[e.Name] = e.Value
+			}
+			assert.Equal(t, len(env), len(envMap))
+			assert.Equal(t, tc.expectedEsJavaOptsEnvValue, envMap[settings.EnvEsJavaOpts])
+		})
+	}
+}


### PR DESCRIPTION
Prepends the JVM parameter `-Dlog4j2.formatMsgNoLookups=true` to the environment variable `ES_JAVA_OPTS`
in order to mitigate the Log4Shell vulnerability CVE-2021-44228, if it is not yet defined by the user,
for versions of Elasticsearch before `7.2.0`.