### PR TITLE
Resource aggregator should handle missing memory settings

### DIFF
--- a/pkg/license/aggregator.go
+++ b/pkg/license/aggregator.go
@@ -208,8 +208,13 @@ var maxHeapSizeRe = regexp.MustCompile(`-Xmx([0-9]+)([gGmMkK]?)(?:\s.*|$)`)
 // memFromJavaOpts extracts the maximum Java heap size from a Java options string, multiplies the value by 2
 // (giving twice the JVM memory to the container is a common thing people do)
 // and converts it to a resource.Quantity
+// If no value is found the function returns the 0 value.
 func memFromJavaOpts(javaOpts string) (resource.Quantity, error) {
 	match := maxHeapSizeRe.FindStringSubmatch(javaOpts)
+	if match == nil {
+		// Xmx is not set, return a 0 quantity
+		return resource.Quantity{}, nil
+	}
 	if len(match) != 3 {
 		return resource.Quantity{}, errors.Errorf("cannot extract max jvm heap size from %s", javaOpts)
 	}

--- a/pkg/license/aggregator_test.go
+++ b/pkg/license/aggregator_test.go
@@ -68,27 +68,6 @@ func TestMemFromJavaOpts(t *testing.T) {
 			expected: resource.MustParse("2Mi"),
 		},
 		{
-			name:   "without value",
-			actual: "-XmxM",
-			isErr:  true,
-		},
-		{
-			name:   "with an invalid Xmx",
-			actual: "-XMX1k",
-			isErr:  true,
-		},
-		{
-			name:   "with an invalid unit",
-			actual: "-Xmx64GB",
-			isErr:  true,
-		},
-		{
-			name:     "without xmx",
-			actual:   "-Xms1k",
-			expected: resource.MustParse("16777216k"),
-			isErr:    true,
-		},
-		{
 			name:     "with trailing spaces at the end",
 			actual:   "-Xms1k -Xmx8388608k   ",
 			expected: resource.MustParse("16777216Ki"),
@@ -97,6 +76,11 @@ func TestMemFromJavaOpts(t *testing.T) {
 			name:     "with trailing space at the beginning",
 			actual:   "  -Xms1k -Xmx8388608k",
 			expected: resource.MustParse("16777216Ki"),
+		},
+		{
+			name:     "no memory setting detected",
+			actual:   "-Dlog4j2.formatMsgNoLookups=true",
+			expected: resource.MustParse("0"),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This PR fixes a bug where a user might want to set some JVM parameters without JVM memory settings (`Xmx`). To reproduce create the following Elasticsearch resource:

```yaml
apiVersion: elasticsearch.k8s.elastic.co/v1
kind: Elasticsearch
metadata:
  name: es
spec:
  version: 6.8.21
  nodeSets:
    - name: master
      config:
        node.master: true
        node.data: true
        node.ingest: true
        node.store.allow_mmap: false
      podTemplate:
        spec:
          containers:
            - name: elasticsearch
              env:
                - name: ES_JAVA_OPTS
                  value: "-Dlog4j2.formatMsgNoLookups=true"
      count: 1
```

Operator logs:

```
2021-12-14T10:23:36.616+0100    ERROR   resource        Failed to report licensing information
{
  "service.version": "XXXXXXX",
     "error": "failed to aggregate Elasticsearch memory: cannot extract max jvm heap size from -Dlog4j2.formatMsgNoLookups=true", "errorVerbose": "cannot extract max jvm heap size from -Dlog4j2.formatMsgNoLookups=true\n..."
}
```

This PR also removes unit tests cases where the JVM would not be able to start (`Unrecognized option`, `Invalid maximum heap size` ...)