### PR TITLE
[DOCS] Remove unneeded backtick from code snippet

### DIFF
--- a/docs/operating-eck/upgrading-eck.asciidoc
+++ b/docs/operating-eck/upgrading-eck.asciidoc
@@ -47,7 +47,7 @@ If you skipped a release in which new CRDs where introduced, you will see an err
 
 [source,shell,subs="attributes"]
 ----
-kubectl create -f https://download.elastic.co/downloads/eck/{eck_version}/crds.yaml`
+kubectl create -f https://download.elastic.co/downloads/eck/{eck_version}/crds.yaml
 ----
 
 ================================


### PR DESCRIPTION
Removes a backtick from a code snippet in the documentation for upgrading ECK.
Fixes a minor annoyance when someone (i.e. me) copy pastes the command into their terminal and bash thinks we we're starting command substitution.