### PR TITLE
[1.9.1-wip] Configure JVM logging for ES < 7.12 to mitigate Log4Shell vulnerability CVE-2021-44228 (#5157)

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -7,7 +7,6 @@ package nodespec
 import (
 	"crypto/sha256"
 	"fmt"
-	"hash/fnv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -7,6 +7,8 @@ package nodespec
 import (
 	"crypto/sha256"
 	"fmt"
+	"hash/fnv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -27,6 +29,11 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/pointer"
 )
 
+const (
+	defaultFsGroup                    = 1000
+	log4j2FormatMsgNoLookupsParamName = "-Dlog4j2.formatMsgNoLookups"
+)
+
 // Starting 8.0.0, the Elasticsearch container does not run with the root user anymore. As a result,
 // we cannot chown the mounted volumes to the right user (id 1000) in an init container.
 // Instead, we can rely on Kubernetes `securityContext.fsGroup` feature: by setting it to 1000
@@ -35,8 +42,6 @@ import (
 // is forbidden: the user can either set `--set-default-security-context=false`, or override the
 // podTemplate securityContext to an empty value.
 var minDefaultSecurityContextVersion = version.MustParse("8.0.0")
-
-const defaultFsGroup = 1000
 
 // BuildPodTemplateSpec builds a new PodTemplateSpec for an Elasticsearch node.
 func BuildPodTemplateSpec(
@@ -100,6 +105,11 @@ func BuildPodTemplateSpec(
 		return corev1.PodTemplateSpec{}, err
 	}
 
+	if ver.LT(version.From(7, 2, 0)) {
+		// mitigate CVE-2021-44228
+		enableLog4JFormatMsgNoLookups(builder)
+	}
+
 	return builder.PodTemplate, nil
 }
 
@@ -153,4 +163,32 @@ func buildLabels(
 	}
 
 	return podLabels, nil
+}
+
+// enableLog4JFormatMsgNoLookups prepends the JVM parameter `-Dlog4j2.formatMsgNoLookups=true` to the environment variable `ES_JAVA_OPTS`
+// in order to mitigate the Log4Shell vulnerability CVE-2021-44228, if it is not yet defined by the user, for
+// versions of Elasticsearch before 7.2.0.
+func enableLog4JFormatMsgNoLookups(builder *defaults.PodTemplateBuilder) {
+	log4j2Param := fmt.Sprintf("%s=true", log4j2FormatMsgNoLookupsParamName)
+	for c, esContainer := range builder.PodTemplate.Spec.Containers {
+		if esContainer.Name != esv1.ElasticsearchContainerName {
+			continue
+		}
+		currentJvmOpts := ""
+		for e, envVar := range esContainer.Env {
+			if envVar.Name != settings.EnvEsJavaOpts {
+				continue
+			}
+			currentJvmOpts = envVar.Value
+			if !strings.Contains(currentJvmOpts, log4j2FormatMsgNoLookupsParamName) {
+				builder.PodTemplate.Spec.Containers[c].Env[e].Value = log4j2Param + " " + currentJvmOpts
+			}
+		}
+		if currentJvmOpts == "" {
+			builder.PodTemplate.Spec.Containers[c].Env = append(
+				builder.PodTemplate.Spec.Containers[c].Env,
+				corev1.EnvVar{Name: settings.EnvEsJavaOpts, Value: log4j2Param},
+			)
+		}
+	}
 }

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -11,7 +11,6 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/initcontainer"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
@@ -27,7 +26,6 @@ import (
 type esSampleBuilder struct {
 	userConfig              map[string]interface{}
 	esAdditionalAnnotations map[string]string
-	keystoreResources       *keystore.Resources
 }
 
 func newEsSampleBuilder() *esSampleBuilder {

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -321,3 +321,62 @@ func Test_getDefaultContainerPorts(t *testing.T) {
 		})
 	}
 }
+
+func Test_enableLog4JFormatMsgNoLookups(t *testing.T) {
+	tt := []struct {
+		name                       string
+		version                    string
+		userEnv                    []corev1.EnvVar
+		expectedEsJavaOptsEnvValue string
+	}{
+		{
+			name:                       "before 7.2.0, JVM log4j2.formatMsgNoLookups parameter is set by default",
+			version:                    "7.0.0",
+			userEnv:                    []corev1.EnvVar{{Name: "YO", Value: "LO"}},
+			expectedEsJavaOptsEnvValue: "-Dlog4j2.formatMsgNoLookups=true",
+		},
+		{
+			name:                       "before 7.2.0, JVM log4j2.formatMsgNoLookups parameter is merged with user-provided JVM parameters",
+			version:                    "7.1.0",
+			userEnv:                    []corev1.EnvVar{{Name: "ES_JAVA_OPTS", Value: "-Xms=42000 -Xmx=42000"}},
+			expectedEsJavaOptsEnvValue: "-Dlog4j2.formatMsgNoLookups=true -Xms=42000 -Xmx=42000",
+		},
+		{
+			name:                       "before 7.2.0, JVM log4j2.formatMsgNoLookups user-provided parameter is not overridden by us",
+			version:                    "7.1.0",
+			userEnv:                    []corev1.EnvVar{{Name: "ES_JAVA_OPTS", Value: "-Xms=42000 -Dlog4j2.formatMsgNoLookups=false -Xmx=42000"}},
+			expectedEsJavaOptsEnvValue: "-Xms=42000 -Dlog4j2.formatMsgNoLookups=false -Xmx=42000",
+		},
+		{
+			name:                       "since 7.2.0, JVM log4j2.formatMsgNoLookups parameter is not set by default",
+			version:                    "7.2.0",
+			userEnv:                    []corev1.EnvVar{{Name: "ES_JAVA_OPTS", Value: "-Xms=42000 -Xmx=42000"}},
+			expectedEsJavaOptsEnvValue: "-Xms=42000 -Xmx=42000",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			sampleES := newEsSampleBuilder().build()
+			// set version
+			sampleES.Spec.Version = tc.version
+			// set user env
+			sampleES.Spec.NodeSets[0].PodTemplate.Spec.Containers[1].Env = tc.userEnv
+
+			ver, err := version.Parse(sampleES.Spec.Version)
+			require.NoError(t, err)
+			cfg, err := settings.NewMergedESConfig(sampleES.Name, ver, corev1.IPv4Protocol, sampleES.Spec.HTTP, *sampleES.Spec.NodeSets[0].Config)
+			require.NoError(t, err)
+			actual, err := BuildPodTemplateSpec(k8s.NewFakeClient(), sampleES, sampleES.Spec.NodeSets[0], cfg, nil, false)
+			require.NoError(t, err)
+
+			env := actual.Spec.Containers[1].Env
+			envMap := make(map[string]string)
+			for _, e := range env {
+				envMap[e.Name] = e.Value
+			}
+			assert.Equal(t, len(env), len(envMap))
+			assert.Equal(t, tc.expectedEsJavaOptsEnvValue, envMap[settings.EnvEsJavaOpts])
+		})
+	}
+}

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -11,6 +11,7 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/initcontainer"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
@@ -22,6 +23,27 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+type esSampleBuilder struct {
+	userConfig              map[string]interface{}
+	esAdditionalAnnotations map[string]string
+	keystoreResources       *keystore.Resources
+}
+
+func newEsSampleBuilder() *esSampleBuilder {
+	return &esSampleBuilder{}
+}
+
+func (esb *esSampleBuilder) build() esv1.Elasticsearch {
+	es := sampleES.DeepCopy()
+	for k, v := range esb.esAdditionalAnnotations {
+		es.Annotations[k] = v
+	}
+	if esb.userConfig != nil {
+		es.Spec.NodeSets[0].Config = &commonv1.Config{Data: esb.userConfig}
+	}
+	return *es
+}
 
 var sampleES = esv1.Elasticsearch{
 	ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Backports the following commits to 1.9.1-wip:
 - Configure JVM logging for ES < 7.12 to mitigate Log4Shell vulnerability CVE-2021-44228 (#5157)