### PR TITLE
[1.9.1-wip] Add internal product header to requests (#5129)

### DIFF
--- a/pkg/controller/common/http.go
+++ b/pkg/controller/common/http.go
@@ -1,0 +1,11 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package common
+
+const (
+	InternalProductRequestHeaderKey    = "x-elastic-product-origin"
+	InternalProductRequestHeaderValue  = "cloud"
+	InternalProductRequestHeaderString = InternalProductRequestHeaderKey + ": " + InternalProductRequestHeaderValue
+)

--- a/pkg/controller/elasticsearch/client/base.go
+++ b/pkg/controller/elasticsearch/client/base.go
@@ -12,11 +12,13 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/hashicorp/go-multierror"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
-	"github.com/hashicorp/go-multierror"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 var log = ulog.Log.WithName("elasticsearch-client")
@@ -131,6 +133,12 @@ func (c *baseClient) request(
 	if err != nil {
 		return err
 	}
+
+	// Sets headers allowing ES to distinguish between deprecated APIs used internally and by the user
+	if request.Header == nil {
+		request.Header = make(http.Header)
+	}
+	request.Header.Set(common.InternalProductRequestHeaderKey, common.InternalProductRequestHeaderValue)
 
 	var skippedErr error
 	resp, err := c.doRequest(ctx, request)

--- a/pkg/controller/elasticsearch/client/client_test.go
+++ b/pkg/controller/elasticsearch/client/client_test.go
@@ -233,6 +233,7 @@ func TestClient_request(t *testing.T) {
 		HTTP: &http.Client{
 			Transport: requestAssertion(func(req *http.Request) {
 				assert.Equal(t, testPath, req.URL.Path)
+				assert.Equal(t, "cloud", req.Header.Get("x-elastic-product-origin"))
 			}),
 		},
 		Endpoint: "http://example.com",

--- a/pkg/controller/elasticsearch/nodespec/readiness_probe.go
+++ b/pkg/controller/elasticsearch/nodespec/readiness_probe.go
@@ -7,9 +7,11 @@ package nodespec
 import (
 	"path"
 
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
-	corev1 "k8s.io/api/core/v1"
 )
 
 func NewReadinessProbe() *corev1.Probe {
@@ -74,7 +76,8 @@ fi
 # request Elasticsearch on /
 # we are turning globbing off to allow for unescaped [] in case of IPv6
 ENDPOINT="${READINESS_PROBE_PROTOCOL:-https}://${LOOPBACK}:9200/"
-status=$(curl -o /dev/null -w "%{http_code}" --max-time ${READINESS_PROBE_TIMEOUT} -XGET -g -s -k ${BASIC_AUTH} $ENDPOINT)
+ORIGIN_HEADER="` + common.InternalProductRequestHeaderString + `"
+status=$(curl -o /dev/null -w "%{http_code}" --max-time ${READINESS_PROBE_TIMEOUT} -H "${ORIGIN_HEADER}" -XGET -g -s -k ${BASIC_AUTH} $ENDPOINT)
 curl_rc=$?
 
 if [[ ${curl_rc} -ne 0 ]]; then


### PR DESCRIPTION
Backports the following commits to 1.9.1-wip:
 - Add internal product header to requests (#5129)