### PR TITLE
[1.9.1-wip] Resource aggregator should handle missing memory settings (#5158)

### DIFF
--- a/pkg/license/aggregator.go
+++ b/pkg/license/aggregator.go
@@ -207,8 +207,13 @@ var maxHeapSizeRe = regexp.MustCompile(`-Xmx([0-9]+)([gGmMkK]?)(?:\s.*|$)`)
 // memFromJavaOpts extracts the maximum Java heap size from a Java options string, multiplies the value by 2
 // (giving twice the JVM memory to the container is a common thing people do)
 // and converts it to a resource.Quantity
+// If no value is found the function returns the 0 value.
 func memFromJavaOpts(javaOpts string) (resource.Quantity, error) {
 	match := maxHeapSizeRe.FindStringSubmatch(javaOpts)
+	if match == nil {
+		// Xmx is not set, return a 0 quantity
+		return resource.Quantity{}, nil
+	}
 	if len(match) != 3 {
 		return resource.Quantity{}, errors.Errorf("cannot extract max jvm heap size from %s", javaOpts)
 	}

--- a/pkg/license/aggregator_test.go
+++ b/pkg/license/aggregator_test.go
@@ -67,27 +67,6 @@ func TestMemFromJavaOpts(t *testing.T) {
 			expected: resource.MustParse("2Mi"),
 		},
 		{
-			name:   "without value",
-			actual: "-XmxM",
-			isErr:  true,
-		},
-		{
-			name:   "with an invalid Xmx",
-			actual: "-XMX1k",
-			isErr:  true,
-		},
-		{
-			name:   "with an invalid unit",
-			actual: "-Xmx64GB",
-			isErr:  true,
-		},
-		{
-			name:     "without xmx",
-			actual:   "-Xms1k",
-			expected: resource.MustParse("16777216k"),
-			isErr:    true,
-		},
-		{
 			name:     "with trailing spaces at the end",
 			actual:   "-Xms1k -Xmx8388608k   ",
 			expected: resource.MustParse("16777216Ki"),
@@ -96,6 +75,11 @@ func TestMemFromJavaOpts(t *testing.T) {
 			name:     "with trailing space at the beginning",
 			actual:   "  -Xms1k -Xmx8388608k",
 			expected: resource.MustParse("16777216Ki"),
+		},
+		{
+			name:     "no memory setting detected",
+			actual:   "-Dlog4j2.formatMsgNoLookups=true",
+			expected: resource.MustParse("0"),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Backports the following commits to 1.9.1-wip:
 - Resource aggregator should handle missing memory settings (#5158)