### PR TITLE
[1.9.1-wip] Update golang Docker tag to v1.17.5 (#5149)

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image used for continuous integration
-FROM golang:1.17.2
+FROM golang:1.17.5
 
 ENV GOLANGCILINT_VERSION=1.38.0
 ENV SHELLCHECK_VERSION=0.7.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM --platform=$TARGETPLATFORM golang:1.17.2 as builder
+FROM --platform=$TARGETPLATFORM golang:1.17.5 as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/hack/manifest-gen/Dockerfile
+++ b/hack/manifest-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.2 as builder
+FROM golang:1.17.5 as builder
 ADD . /manifest-gen
 WORKDIR /manifest-gen
 ENV GO111MODULE=on CGO_ENABLED=0 GOOS=linux 

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image for the E2E tests runner
-FROM --platform=$TARGETPLATFORM golang:1.17.2
+FROM --platform=$TARGETPLATFORM golang:1.17.5
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
Backports the following commits to 1.9.1-wip:
 - Update golang Docker tag to v1.17.5 (#5149)