### PR TITLE
[1.9] Correctly set eck_release_branch doc attribute

### DIFF
--- a/docs/eck-attributes.asciidoc
+++ b/docs/eck-attributes.asciidoc
@@ -1,5 +1,5 @@
 :eck_version: 1.9.0
 :eck_crd_version: v1
-:eck_release_branch: 1.8
+:eck_release_branch: 1.9
 :eck_github: https://github.com/elastic/cloud-on-k8s
 :eck_resources_list: Elasticsearch, Kibana, APM Server, Enterprise Search, Beats, Elastic Agent, and Elastic Maps Server


### PR DESCRIPTION
Correctly sets the `eck_release_branch` doc attribute for the `1.9` branch, used to generate links to the GitHub repository in the documentation.