### PR TITLE
Include documentation improvements in the release notes

### DIFF
--- a/hack/release-notes/main.go
+++ b/hack/release-notes/main.go
@@ -45,6 +45,7 @@ var (
 		">feature":     "New features",
 		">enhancement": "Enhancements",
 		">bug":         "Bug fixes",
+		">docs":        "Documentation improvements",
 		noGroup:        "Misc",
 	}
 
@@ -54,13 +55,13 @@ var (
 		">feature",
 		">enhancement",
 		">bug",
+		">docs",
 		noGroup,
 	}
 
 	ignoredLabels = map[string]struct{}{
 		">non-issue":                 {},
 		">refactoring":               {},
-		">docs":                      {},
 		">test":                      {},
 		":ci":                        {},
 		"backport":                   {},


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/5006. PRs with doc changes we want to expose in the release notes should have version label.