### PR TITLE
[1.9.1-wip] Add 1.9.1 release notes (#5174)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-1.9.1>>
 * <<release-notes-1.9.0>>
 * <<release-notes-1.8.0>>
 * <<release-notes-1.7.1>>
@@ -29,6 +30,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/1.9.1.asciidoc[]
 include::release-notes/1.9.0.asciidoc[]
 include::release-notes/1.8.0.asciidoc[]
 include::release-notes/1.7.1.asciidoc[]

--- a/docs/release-notes/1.9.0.asciidoc
+++ b/docs/release-notes/1.9.0.asciidoc
@@ -48,6 +48,8 @@ spec:
 [float]
 === Enhancements
 
+* Stop using deprecated xpack.monitoring.* settings {pull}5136[#5136] (issue: {issue}5083[#5083])
+* Stop using Enterprise Search deprecated setting in 7.17+ {pull}5085[#5085] (issue: {issue}5082[#5082])
 * Add logging for call to ES {pull}4958[#4958] (issue: {issue}4935[#4935])
 * Shorten the reconciliation loop duration if Elasticsearch is down {pull}4938[#4938] (issues: {issue}2939[#2939], {issue}3496[#3496])
 * Ignore ClusterIPs, and IPFamilyPolicy in services, and timestamp in license during reconciliation {pull}4929[#4929]
@@ -61,6 +63,7 @@ spec:
 [float]
 === Bug fixes
 
+* Add kibana.host setting only to Enterprise Search 7.15+ {pull}5122[#5122]
 * Avoid updating the association status when no association {pull}4986[#4986] (issue: {issue}4985[#4985])
 * Forcibly recreate Beat keystore {pull}4942[#4942] (issues: {issue}4527[#4527], {issue}4926[#4926])
 * Init. fs container: make cp more resilient {pull}4888[#4888] (issue: {issue}4877[#4877])
@@ -73,4 +76,3 @@ spec:
 * Update module github.com/go-test/deep to v1.0.8 {pull}4948[#4948]
 * Update golang Docker tag to v1.17.2 {pull}4934[#4934]
 * Update module github.com/spf13/viper to v1.9.0 {pull}4847[#4847]
-

--- a/docs/release-notes/1.9.1.asciidoc
+++ b/docs/release-notes/1.9.1.asciidoc
@@ -1,0 +1,29 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-1.9.1]]
+== {n} version 1.9.1
+
+
+[[enhancement-1.9.1]]
+[float]
+=== Enhancements
+
+* Add log4j2.formatMsgNoLookups logging property to ES < 7.2 {pull}5157[#5157]
+
+This change will mitigate the link:https://github.com/advisories/GHSA-jfh8-c2jp-5v3q[Log4Shell] vulnerability (CVE-2021-44228) in susceptible Elasticsearch clusters (below version `7.2`). ECK will prepend the `-Dlog4j2.formatMsgNoLookups=true` JVM parameter to the environment variable `ES_JAVA_OPTS`` if it is not yet defined by the user. This triggers a rolling restart of all Pods of the affected Elasticsearch clusters to apply these changes.
+
+* Add internal product header to requests {pull}5129[#5129]
+
+[[bug-1.9.1]]
+[float]
+=== Bug fixes
+
+* Resource aggregator should handle missing memory settings {pull}5158[#5158]
+
+[[nogroup-1.9.1]]
+[float]
+=== Misc
+
+* Update golang Docker tag to v1.17.5 {pull}5149[#5149]
+

--- a/docs/release-notes/highlights-1.9.1.asciidoc
+++ b/docs/release-notes/highlights-1.9.1.asciidoc
@@ -1,0 +1,15 @@
+[[release-highlights-1.9.1]]
+== 1.9.1 release highlights
+
+[float]
+[id="{p}-191-new-and-notable"]
+=== New and notable
+
+New and notable changes in version 1.9.1 of {n}. See <<release-notes-1.9.1>> for the full list of changes.
+
+
+[float]
+[id="{p}-191-mitigate"]
+==== Mitigate CVE-2021-44228 in vulnerable Elasticsearch clusters
+
+This release introduces a preemptive measure to mitigate link:https://github.com/advisories/GHSA-jfh8-c2jp-5v3q[Log4Shell] vulnerability in Elasticsearch versions below `7.2`.

--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the most important changes in each release. For the full list, see <<eck-release-notes>>.
 
+* <<release-highlights-1.9.1>>
 * <<release-highlights-1.9.0>>
 * <<release-highlights-1.8.0>>
 * <<release-highlights-1.7.1>>
@@ -28,6 +29,7 @@ This section summarizes the most important changes in each release. For the full
 
 --
 
+include::highlights-1.9.1.asciidoc[]
 include::highlights-1.9.0.asciidoc[]
 include::highlights-1.8.0.asciidoc[]
 include::highlights-1.7.1.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 1.9.1-wip:
 - Add 1.9.1 release notes (#5174)