### PR TITLE
Bump the operator memory limit to 1Gi for larger deployments

### DIFF
--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -32,7 +32,7 @@ imagePullSecrets: []
 resources:
   limits:
     cpu: 1
-    memory: 512Mi
+    memory: 1Gi
   requests:
     cpu: 100m
     memory: 150Mi

--- a/docs/operating-eck/troubleshooting/common-problems.asciidoc
+++ b/docs/operating-eck/troubleshooting/common-problems.asciidoc
@@ -12,11 +12,11 @@ endif::[]
 
 On very large Kubernetes clusters with many hundreds of resources (pods, secrets, config maps, and so on), the operator may fail to start with its pod getting killed with a `OOMKilled` message. This is an issue with the `controller-runtime` framework on top of which the operator is built. Even though the operator is only interested in the resources created by itself, the framework code needs to gather information about all relevant resources in the Kubernetes cluster in order to provide the filtered view of cluster state required by the operator. On very large clusters, this information gathering can use up a lot of memory and exceed the default resource limit defined for the operator pod.
 
-The default link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory[memory limit] for the operator pod is set to 512 MiB. You can increase (or decrease) this limit to a value suited to your cluster as follows:
+The default link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory[memory limit] for the operator pod is set to 1 Gi. You can increase (or decrease) this limit to a value suited to your cluster as follows:
 
 [source,sh]
 ----
-kubectl patch sts elastic-operator -n elastic-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager", "resources":{"limits":{"memory":"768Mi"}}}]}}}}'
+kubectl patch sts elastic-operator -n elastic-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager", "resources":{"limits":{"memory":"2Gi"}}}]}}}}'
 ----
 
 

--- a/hack/manifest-gen/testdata/kube116.yaml
+++ b/hack/manifest-gen/testdata/kube116.yaml
@@ -32,7 +32,7 @@ imagePullSecrets: []
 resources:
   limits:
     cpu: 1
-    memory: 512Mi
+    memory: 1Gi
   requests:
     cpu: 100m
     memory: 150Mi

--- a/hack/manifest-gen/testdata/no_defaults.yaml
+++ b/hack/manifest-gen/testdata/no_defaults.yaml
@@ -23,7 +23,7 @@ imagePullSecrets:
 resources:
   limits:
     cpu: 1
-    memory: 512Mi
+    memory: 1Gi
   requests:
     cpu: 100m
     memory: 150Mi

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -336,7 +336,7 @@ spec:
                 resources:
                   limits:
                     cpu: 1
-                    memory: 512Mi
+                    memory: 1Gi
                   requests:
                     cpu: 100m
                     memory: 150Mi


### PR DESCRIPTION
Fixes #5177

Bumps the memory limit to 1Gi to accommodate larger deployments with a large client cache. The memory limit can be changed already today by the user either directly or in case of OLM through the subscription config. But given that memory limits do not affect the scheduling decision and we know that larger k8s clusters with lots of objects will require more memory in the operator given our current use of cached clients increasing the limit to 1Gi should not hurt and save users the additional task of increasing the limit in many (most?) cases. 
