### PR TITLE
Remove "all" namespace from managed namespaces

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -478,11 +478,6 @@ func startOperator(ctx context.Context) error {
 		// The managed cache should always include the operator namespace so that we can work with operator-internal resources.
 		managedNamespaces = append(managedNamespaces, operatorNamespace)
 
-		// Add the empty namespace to allow watching cluster-scoped resources if storage class validation is enabled.
-		if viper.GetBool(operator.ValidateStorageClassFlag) {
-			managedNamespaces = append(managedNamespaces, "")
-		}
-
 		opts.NewCache = cache.MultiNamespacedCacheBuilder(managedNamespaces)
 	}
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -565,7 +565,7 @@ func startOperator(ctx context.Context) error {
 	}
 
 	if viper.GetBool(operator.EnableWebhookFlag) {
-		setupWebhook(mgr, params.CertRotation, params.ValidateStorageClass, clientset, exposedNodeLabels)
+		setupWebhook(mgr, params.CertRotation, params.ValidateStorageClass, clientset, exposedNodeLabels, managedNamespaces)
 	}
 
 	enforceRbacOnRefs := viper.GetBool(operator.EnforceRBACOnRefsFlag)
@@ -782,7 +782,8 @@ func setupWebhook(
 	certRotation certificates.RotationParams,
 	validateStorageClass bool,
 	clientset kubernetes.Interface,
-	exposedNodeLabels esvalidation.NodeLabels) {
+	exposedNodeLabels esvalidation.NodeLabels,
+	managedNamespaces []string) {
 	manageWebhookCerts := viper.GetBool(operator.ManageWebhookCertsFlag)
 	if manageWebhookCerts {
 		log.Info("Automatic management of the webhook certificates enabled")
@@ -837,7 +838,7 @@ func setupWebhook(
 	}
 
 	// esv1 validating webhook is wired up differently, in order to access the k8s client
-	esvalidation.RegisterWebhook(mgr, validateStorageClass, exposedNodeLabels)
+	esvalidation.RegisterWebhook(mgr, validateStorageClass, exposedNodeLabels, managedNamespaces)
 
 	// wait for the secret to be populated in the local filesystem before returning
 	interval := time.Second * 1

--- a/pkg/apis/agent/v1alpha1/webhook.go
+++ b/pkg/apis/agent/v1alpha1/webhook.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	// webhookPath is the http path for the agent validating webhook.
+	// webhookPath is the HTTP path for the Elastic Agent validating webhook.
 	webhookPath = "/validate-agent-k8s-elastic-co-v1alpha1-agent"
 )
 
@@ -56,7 +56,7 @@ func (a *Agent) ValidateUpdate(old runtime.Object) error {
 	return a.validate(oldObj)
 }
 
-// WebhookPath returns the http path used by the validating webhook.
+// WebhookPath returns the HTTP path used by the validating webhook.
 func (a *Agent) WebhookPath() string {
 	return webhookPath
 }

--- a/pkg/apis/agent/v1alpha1/webhook.go
+++ b/pkg/apis/agent/v1alpha1/webhook.go
@@ -11,10 +11,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
+)
+
+const (
+	// webhookPath is the http path for the agent validating webhook.
+	webhookPath = "/validate-agent-k8s-elastic-co-v1alpha1-agent"
 )
 
 var (
@@ -26,22 +30,22 @@ var (
 
 var _ webhook.Validator = &Agent{}
 
-func (a *Agent) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(a).
-		Complete()
-}
-
+// ValidateCreate is called by the validating webhook to validate the create operation.
+// Satisfies the webhook.Validator interface.
 func (a *Agent) ValidateCreate() error {
 	validationLog.V(1).Info("Validate create", "name", a.Name)
 	return a.validate(nil)
 }
 
+// ValidateDelete is called by the validating webhook to validate the delete operation.
+// Satisfies the webhook.Validator interface.
 func (a *Agent) ValidateDelete() error {
 	validationLog.V(1).Info("Validate delete", "name", a.Name)
 	return nil
 }
 
+// ValidateUpdate is called by the validating webhook to validate the update operation.
+// Satisfies the webhook.Validator interface.
 func (a *Agent) ValidateUpdate(old runtime.Object) error {
 	validationLog.V(1).Info("Validate update", "name", a.Name)
 	oldObj, ok := old.(*Agent)
@@ -50,6 +54,11 @@ func (a *Agent) ValidateUpdate(old runtime.Object) error {
 	}
 
 	return a.validate(oldObj)
+}
+
+// WebhookPath returns the http path used by the validating webhook.
+func (a *Agent) WebhookPath() string {
+	return webhookPath
 }
 
 func (a *Agent) validate(old *Agent) error {

--- a/pkg/apis/apm/v1/webhook.go
+++ b/pkg/apis/apm/v1/webhook.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	// webhookPath is the http path for the apm validating webhook.
+	// webhookPath is the HTTP path for the APM Server validating webhook.
 	webhookPath = "/validate-apm-k8s-elastic-co-v1-apmserver"
 )
 
@@ -73,7 +73,7 @@ func (as *ApmServer) ValidateUpdate(old runtime.Object) error {
 	return as.validate(oldObj)
 }
 
-// WebhookPath returns the http path used by the validating webhook.
+// WebhookPath returns the HTTP path used by the validating webhook.
 func (as *ApmServer) WebhookPath() string {
 	return webhookPath
 }

--- a/pkg/apis/apm/v1/webhook.go
+++ b/pkg/apis/apm/v1/webhook.go
@@ -12,12 +12,16 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
+)
+
+const (
+	// webhookPath is the http path for the apm validating webhook.
+	webhookPath = "/validate-apm-k8s-elastic-co-v1-apmserver"
 )
 
 var (
@@ -43,22 +47,22 @@ var (
 
 var _ webhook.Validator = &ApmServer{}
 
-func (as *ApmServer) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(as).
-		Complete()
-}
-
+// ValidateCreate is called by the validating webhook to validate the create operation.
+// Satisfies the webhook.Validator interface.
 func (as *ApmServer) ValidateCreate() error {
 	validationLog.V(1).Info("Validate create", "name", as.Name)
 	return as.validate(nil)
 }
 
+// ValidateDelete is called by the validating webhook to validate the delete operation.
+// Satisfies the webhook.Validator interface.
 func (as *ApmServer) ValidateDelete() error {
 	validationLog.V(1).Info("Validate delete", "name", as.Name)
 	return nil
 }
 
+// ValidateUpdate is called by the validating webhook to validate the update operation.
+// Satisfies the webhook.Validator interface.
 func (as *ApmServer) ValidateUpdate(old runtime.Object) error {
 	validationLog.V(1).Info("Validate update", "name", as.Name)
 	oldObj, ok := old.(*ApmServer)
@@ -67,6 +71,11 @@ func (as *ApmServer) ValidateUpdate(old runtime.Object) error {
 	}
 
 	return as.validate(oldObj)
+}
+
+// WebhookPath returns the http path used by the validating webhook.
+func (as *ApmServer) WebhookPath() string {
+	return webhookPath
 }
 
 func (as *ApmServer) validate(old *ApmServer) error {

--- a/pkg/apis/apm/v1beta1/webhook.go
+++ b/pkg/apis/apm/v1beta1/webhook.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	// webhookPath is the http path for the apm validating webhook.
+	// webhookPath is the HTTP path for the APM Server validating webhook.
 	webhookPath = "/validate-apm-k8s-elastic-co-v1beta1-apmserver"
 )
 
@@ -68,7 +68,7 @@ func (as *ApmServer) ValidateUpdate(old runtime.Object) error {
 	return as.validate(oldObj)
 }
 
-// WebhookPath returns the http path used by the validating webhook.
+// WebhookPath returns the HTTP path used by the validating webhook.
 func (as *ApmServer) WebhookPath() string {
 	return webhookPath
 }

--- a/pkg/apis/apm/v1beta1/webhook.go
+++ b/pkg/apis/apm/v1beta1/webhook.go
@@ -11,12 +11,16 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
+)
+
+const (
+	// webhookPath is the http path for the apm validating webhook.
+	webhookPath = "/validate-apm-k8s-elastic-co-v1beta1-apmserver"
 )
 
 var (
@@ -38,22 +42,22 @@ var (
 
 var _ webhook.Validator = &ApmServer{}
 
-func (as *ApmServer) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(as).
-		Complete()
-}
-
+// ValidateCreate is called by the validating webhook to validate the create operation.
+// Satisfies the webhook.Validator interface.
 func (as *ApmServer) ValidateCreate() error {
 	validationLog.V(1).Info("Validate create", "name", as.Name)
 	return as.validate(nil)
 }
 
+// ValidateDelete is called by the validating webhook to validate the delete operation.
+// Satisfies the webhook.Validator interface.
 func (as *ApmServer) ValidateDelete() error {
 	validationLog.V(1).Info("Validate delete", "name", as.Name)
 	return nil
 }
 
+// ValidateUpdate is called by the validating webhook to validate the update operation.
+// Satisfies the webhook.Validator interface.
 func (as *ApmServer) ValidateUpdate(old runtime.Object) error {
 	validationLog.V(1).Info("Validate update", "name", as.Name)
 	oldObj, ok := old.(*ApmServer)
@@ -62,6 +66,11 @@ func (as *ApmServer) ValidateUpdate(old runtime.Object) error {
 	}
 
 	return as.validate(oldObj)
+}
+
+// WebhookPath returns the http path used by the validating webhook.
+func (as *ApmServer) WebhookPath() string {
+	return webhookPath
 }
 
 func (as *ApmServer) validate(old *ApmServer) error {

--- a/pkg/apis/beat/v1beta1/webhook.go
+++ b/pkg/apis/beat/v1beta1/webhook.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	// webhookPath is the http path for the beats validating webhook.
+	// webhookPath is the HTTP path for the Elastic Beats validating webhook.
 	webhookPath = "/validate-beat-k8s-elastic-co-v1beta1-beat"
 )
 
@@ -56,7 +56,7 @@ func (b *Beat) ValidateUpdate(old runtime.Object) error {
 	return b.validate(oldObj)
 }
 
-// WebhookPath returns the http path used by the validating webhook.
+// WebhookPath returns the HTTP path used by the validating webhook.
 func (b *Beat) WebhookPath() string {
 	return webhookPath
 }

--- a/pkg/apis/beat/v1beta1/webhook.go
+++ b/pkg/apis/beat/v1beta1/webhook.go
@@ -11,10 +11,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
+)
+
+const (
+	// webhookPath is the http path for the beats validating webhook.
+	webhookPath = "/validate-beat-k8s-elastic-co-v1beta1-beat"
 )
 
 var (
@@ -26,22 +30,22 @@ var (
 
 var _ webhook.Validator = &Beat{}
 
-func (b *Beat) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(b).
-		Complete()
-}
-
+// ValidateCreate is called by the validating webhook to validate the create operation.
+// Satisfies the webhook.Validator interface.
 func (b *Beat) ValidateCreate() error {
 	validationLog.V(1).Info("Validate create", "name", b.Name)
 	return b.validate(nil)
 }
 
+// ValidateDelete is called by the validating webhook to validate the delete operation.
+// Satisfies the webhook.Validator interface.
 func (b *Beat) ValidateDelete() error {
 	validationLog.V(1).Info("Validate delete", "name", b.Name)
 	return nil
 }
 
+// ValidateUpdate is called by the validating webhook to validate the update operation.
+// Satisfies the webhook.Validator interface.
 func (b *Beat) ValidateUpdate(old runtime.Object) error {
 	validationLog.V(1).Info("Validate update", "name", b.Name)
 	oldObj, ok := old.(*Beat)
@@ -50,6 +54,11 @@ func (b *Beat) ValidateUpdate(old runtime.Object) error {
 	}
 
 	return b.validate(oldObj)
+}
+
+// WebhookPath returns the http path used by the validating webhook.
+func (b *Beat) WebhookPath() string {
+	return webhookPath
 }
 
 func (b *Beat) validate(old *Beat) error {

--- a/pkg/apis/elasticsearch/v1beta1/webhook.go
+++ b/pkg/apis/elasticsearch/v1beta1/webhook.go
@@ -11,34 +11,36 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
 )
 
-// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1beta1,name=elastic-es-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
+const (
+	// webhookPath is the http path for the apm validating webhook.
+	webhookPath = "/validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch"
+)
 
-func (es *Elasticsearch) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(es).
-		Complete()
-}
+// +kubebuilder:webhook:path=/validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch,mutating=false,failurePolicy=ignore,groups=elasticsearch.k8s.elastic.co,resources=elasticsearches,verbs=create;update,versions=v1beta1,name=elastic-es-validation-v1beta1.k8s.elastic.co,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Exact
 
 var eslog = ulog.Log.WithName("es-validation")
 
 var _ webhook.Validator = &Elasticsearch{}
 
+// ValidateCreate is called by the validating webhook to validate the create operation.
+// Satisfies the webhook.Validator interface.
 func (es *Elasticsearch) ValidateCreate() error {
 	eslog.V(1).Info("validate create", "name", es.Name)
 	return es.validateElasticsearch()
 }
 
-// ValidateDelete is required to implement webhook.Validator, but we do not actually validate deletes
+// ValidateDelete is required to implement webhook.Validator, but we do not actually validate deletes.
 func (es *Elasticsearch) ValidateDelete() error {
 	return nil
 }
 
+// ValidateUpdate is called by the validating webhook to validate the update operation.
+// Satisfies the webhook.Validator interface.
 func (es *Elasticsearch) ValidateUpdate(old runtime.Object) error {
 	eslog.V(1).Info("validate update", "name", es.Name)
 	oldEs, ok := old.(*Elasticsearch)
@@ -58,6 +60,11 @@ func (es *Elasticsearch) ValidateUpdate(old runtime.Object) error {
 			es.Name, errs)
 	}
 	return es.validateElasticsearch()
+}
+
+// WebhookPath returns the http path used by the validating webhook.
+func (es *Elasticsearch) WebhookPath() string {
+	return webhookPath
 }
 
 func (es *Elasticsearch) validateElasticsearch() error {

--- a/pkg/apis/elasticsearch/v1beta1/webhook.go
+++ b/pkg/apis/elasticsearch/v1beta1/webhook.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	// webhookPath is the http path for the apm validating webhook.
+	// webhookPath is the HTTP path for the Elasticsearch validating webhook.
 	webhookPath = "/validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch"
 )
 
@@ -62,7 +62,7 @@ func (es *Elasticsearch) ValidateUpdate(old runtime.Object) error {
 	return es.validateElasticsearch()
 }
 
-// WebhookPath returns the http path used by the validating webhook.
+// WebhookPath returns the HTTP path used by the validating webhook.
 func (es *Elasticsearch) WebhookPath() string {
 	return webhookPath
 }

--- a/pkg/apis/enterprisesearch/v1/webhook.go
+++ b/pkg/apis/enterprisesearch/v1/webhook.go
@@ -11,12 +11,16 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
+)
+
+const (
+	// webhookPath is the http path for the enterprise search validating webhook.
+	webhookPath = "/validate-enterprisesearch-k8s-elastic-co-v1-enterprisesearch"
 )
 
 var (
@@ -38,22 +42,22 @@ var (
 
 var _ webhook.Validator = &EnterpriseSearch{}
 
-func (ent *EnterpriseSearch) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(ent).
-		Complete()
-}
-
+// ValidateCreate is called by the validating webhook to validate the create operation.
+// Satisfies the webhook.Validator interface.
 func (ent *EnterpriseSearch) ValidateCreate() error {
 	validationLog.V(1).Info("Validate create", "name", ent.Name)
 	return ent.validate(nil)
 }
 
+// ValidateDelete is called by the validating webhook to validate the delete operation.
+// Satisfies the webhook.Validator interface.
 func (ent *EnterpriseSearch) ValidateDelete() error {
 	validationLog.V(1).Info("Validate delete", "name", ent.Name)
 	return nil
 }
 
+// ValidateUpdate is called by the validating webhook to validate the update operation.
+// Satisfies the webhook.Validator interface.
 func (ent *EnterpriseSearch) ValidateUpdate(old runtime.Object) error {
 	validationLog.V(1).Info("Validate update", "name", ent.Name)
 	oldObj, ok := old.(*EnterpriseSearch)
@@ -62,6 +66,11 @@ func (ent *EnterpriseSearch) ValidateUpdate(old runtime.Object) error {
 	}
 
 	return ent.validate(oldObj)
+}
+
+// WebhookPath returns the http path used by the validating webhook.
+func (ent *EnterpriseSearch) WebhookPath() string {
+	return webhookPath
 }
 
 func (ent *EnterpriseSearch) validate(old *EnterpriseSearch) error {

--- a/pkg/apis/enterprisesearch/v1/webhook.go
+++ b/pkg/apis/enterprisesearch/v1/webhook.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	// webhookPath is the http path for the enterprise search validating webhook.
+	// webhookPath is the HTTP path for the Enterprise Search validating webhook.
 	webhookPath = "/validate-enterprisesearch-k8s-elastic-co-v1-enterprisesearch"
 )
 
@@ -68,7 +68,7 @@ func (ent *EnterpriseSearch) ValidateUpdate(old runtime.Object) error {
 	return ent.validate(oldObj)
 }
 
-// WebhookPath returns the http path used by the validating webhook.
+// WebhookPath returns the HTTP path used by the validating webhook.
 func (ent *EnterpriseSearch) WebhookPath() string {
 	return webhookPath
 }

--- a/pkg/apis/enterprisesearch/v1beta1/webhook.go
+++ b/pkg/apis/enterprisesearch/v1beta1/webhook.go
@@ -11,12 +11,16 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
+)
+
+const (
+	// webhookPath is the http path for the enterprise search validating webhook.
+	webhookPath = "/validate-enterprisesearch-k8s-elastic-co-v1beta1-enterprisesearch"
 )
 
 var (
@@ -38,22 +42,22 @@ var (
 
 var _ webhook.Validator = &EnterpriseSearch{}
 
-func (ent *EnterpriseSearch) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(ent).
-		Complete()
-}
-
+// ValidateCreate is called by the validating webhook to validate the create operation.
+// Satisfies the webhook.Validator interface.
 func (ent *EnterpriseSearch) ValidateCreate() error {
 	validationLog.V(1).Info("Validate create", "name", ent.Name)
 	return ent.validate(nil)
 }
 
+// ValidateDelete is called by the validating webhook to validate the delete operation.
+// Satisfies the webhook.Validator interface.
 func (ent *EnterpriseSearch) ValidateDelete() error {
 	validationLog.V(1).Info("Validate delete", "name", ent.Name)
 	return nil
 }
 
+// ValidateUpdate is called by the validating webhook to validate the update operation.
+// Satisfies the webhook.Validator interface.
 func (ent *EnterpriseSearch) ValidateUpdate(old runtime.Object) error {
 	validationLog.V(1).Info("Validate update", "name", ent.Name)
 	oldObj, ok := old.(*EnterpriseSearch)
@@ -62,6 +66,11 @@ func (ent *EnterpriseSearch) ValidateUpdate(old runtime.Object) error {
 	}
 
 	return ent.validate(oldObj)
+}
+
+// WebhookPath returns the http path used by the validating webhook.
+func (ent *EnterpriseSearch) WebhookPath() string {
+	return webhookPath
 }
 
 func (ent *EnterpriseSearch) validate(old *EnterpriseSearch) error {

--- a/pkg/apis/enterprisesearch/v1beta1/webhook.go
+++ b/pkg/apis/enterprisesearch/v1beta1/webhook.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	// webhookPath is the http path for the enterprise search validating webhook.
+	// webhookPath is the HTTP path for the Enterprise Search validating webhook.
 	webhookPath = "/validate-enterprisesearch-k8s-elastic-co-v1beta1-enterprisesearch"
 )
 
@@ -68,7 +68,7 @@ func (ent *EnterpriseSearch) ValidateUpdate(old runtime.Object) error {
 	return ent.validate(oldObj)
 }
 
-// WebhookPath returns the http path used by the validating webhook.
+// WebhookPath returns the HTTP path used by the validating webhook.
 func (ent *EnterpriseSearch) WebhookPath() string {
 	return webhookPath
 }

--- a/pkg/apis/kibana/v1/webhook.go
+++ b/pkg/apis/kibana/v1/webhook.go
@@ -11,7 +11,6 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
@@ -19,6 +18,11 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/stackmon/validations"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
+)
+
+const (
+	// webhookPath is the http path for the kibana validating webhook.
+	webhookPath = "/validate-kibana-k8s-elastic-co-v1-kibana"
 )
 
 var (
@@ -41,22 +45,22 @@ var (
 
 var _ webhook.Validator = &Kibana{}
 
-func (k *Kibana) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(k).
-		Complete()
-}
-
+// ValidateCreate is called by the validating webhook to validate the create operation.
+// Satisfies the webhook.Validator interface.
 func (k *Kibana) ValidateCreate() error {
 	validationLog.V(1).Info("Validate create", "name", k.Name)
 	return k.validate(nil)
 }
 
+// ValidateDelete is called by the validating webhook to validate the delete operation.
+// Satisfies the webhook.Validator interface.
 func (k *Kibana) ValidateDelete() error {
 	validationLog.V(1).Info("Validate delete", "name", k.Name)
 	return nil
 }
 
+// ValidateUpdate is called by the validating webhook to validate the update operation.
+// Satisfies the webhook.Validator interface.
 func (k *Kibana) ValidateUpdate(old runtime.Object) error {
 	validationLog.V(1).Info("Validate update", "name", k.Name)
 	oldObj, ok := old.(*Kibana)
@@ -65,6 +69,11 @@ func (k *Kibana) ValidateUpdate(old runtime.Object) error {
 	}
 
 	return k.validate(oldObj)
+}
+
+// WebhookPath returns the http path used by the validating webhook.
+func (k *Kibana) WebhookPath() string {
+	return webhookPath
 }
 
 func (k *Kibana) validate(old *Kibana) error {

--- a/pkg/apis/kibana/v1/webhook.go
+++ b/pkg/apis/kibana/v1/webhook.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	// webhookPath is the http path for the kibana validating webhook.
+	// webhookPath is the HTTP path for the Kibana validating webhook.
 	webhookPath = "/validate-kibana-k8s-elastic-co-v1-kibana"
 )
 
@@ -71,7 +71,7 @@ func (k *Kibana) ValidateUpdate(old runtime.Object) error {
 	return k.validate(oldObj)
 }
 
-// WebhookPath returns the http path used by the validating webhook.
+// WebhookPath returns the HTTP path used by the validating webhook.
 func (k *Kibana) WebhookPath() string {
 	return webhookPath
 }

--- a/pkg/apis/kibana/v1beta1/webhook.go
+++ b/pkg/apis/kibana/v1beta1/webhook.go
@@ -11,12 +11,16 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
+)
+
+const (
+	// webhookPath is the http path for the kibana validating webhook.
+	webhookPath = "/validate-kibana-k8s-elastic-co-v1beta1-kibana"
 )
 
 var (
@@ -38,22 +42,22 @@ var (
 
 var _ webhook.Validator = &Kibana{}
 
-func (k *Kibana) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(k).
-		Complete()
-}
-
+// ValidateCreate is called by the validating webhook to validate the create operation.
+// Satisfies the webhook.Validator interface.
 func (k *Kibana) ValidateCreate() error {
 	validationLog.V(1).Info("Validate create", "name", k.Name)
 	return k.validate(nil)
 }
 
+// ValidateDelete is called by the validating webhook to validate the delete operation.
+// Satisfies the webhook.Validator interface.
 func (k *Kibana) ValidateDelete() error {
 	validationLog.V(1).Info("Validate delete", "name", k.Name)
 	return nil
 }
 
+// ValidateUpdate is called by the validating webhook to validate the update operation.
+// Satisfies the webhook.Validator interface.
 func (k *Kibana) ValidateUpdate(old runtime.Object) error {
 	validationLog.V(1).Info("Validate update", "name", k.Name)
 	oldObj, ok := old.(*Kibana)
@@ -62,6 +66,11 @@ func (k *Kibana) ValidateUpdate(old runtime.Object) error {
 	}
 
 	return k.validate(oldObj)
+}
+
+// WebhookPath returns the http path used by the validating webhook.
+func (k *Kibana) WebhookPath() string {
+	return webhookPath
 }
 
 func (k *Kibana) validate(old *Kibana) error {

--- a/pkg/apis/kibana/v1beta1/webhook.go
+++ b/pkg/apis/kibana/v1beta1/webhook.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	// webhookPath is the http path for the kibana validating webhook.
+	// webhookPath is the HTTP path for the Kibana validating webhook.
 	webhookPath = "/validate-kibana-k8s-elastic-co-v1beta1-kibana"
 )
 
@@ -68,7 +68,7 @@ func (k *Kibana) ValidateUpdate(old runtime.Object) error {
 	return k.validate(oldObj)
 }
 
-// WebhookPath returns the http path used by the validating webhook.
+// WebhookPath returns the HTTP path used by the validating webhook.
 func (k *Kibana) WebhookPath() string {
 	return webhookPath
 }

--- a/pkg/apis/maps/v1alpha1/webhook.go
+++ b/pkg/apis/maps/v1alpha1/webhook.go
@@ -9,12 +9,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
+)
+
+const (
+	// webhookPath is the http path for the elastic maps server validating webhook.
+	webhookPath = "/validate-ems-k8s-elastic-co-v1alpha1-mapsservers"
 )
 
 var (
@@ -32,25 +36,30 @@ var (
 
 var _ webhook.Validator = &ElasticMapsServer{}
 
-func (m *ElasticMapsServer) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(m).
-		Complete()
-}
-
+// ValidateCreate is called by the validating webhook to validate the create operation.
+// Satisfies the webhook.Validator interface.
 func (m *ElasticMapsServer) ValidateCreate() error {
 	validationLog.V(1).Info("Validate create", "name", m.Name)
 	return m.validate()
 }
 
+// ValidateDelete is called by the validating webhook to validate the delete operation.
+// Satisfies the webhook.Validator interface.
 func (m *ElasticMapsServer) ValidateDelete() error {
 	validationLog.V(1).Info("Validate delete", "name", m.Name)
 	return nil
 }
 
+// ValidateUpdate is called by the validating webhook to validate the update operation.
+// Satisfies the webhook.Validator interface.
 func (m *ElasticMapsServer) ValidateUpdate(_ runtime.Object) error {
 	validationLog.V(1).Info("Validate update", "name", m.Name)
 	return m.validate()
+}
+
+// WebhookPath returns the http path used by the validating webhook.
+func (m *ElasticMapsServer) WebhookPath() string {
+	return webhookPath
 }
 
 func (m *ElasticMapsServer) validate() error {

--- a/pkg/apis/maps/v1alpha1/webhook.go
+++ b/pkg/apis/maps/v1alpha1/webhook.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	// webhookPath is the http path for the elastic maps server validating webhook.
+	// webhookPath is the HTTP path for the Elastic Maps Server validating webhook.
 	webhookPath = "/validate-ems-k8s-elastic-co-v1alpha1-mapsservers"
 )
 
@@ -57,7 +57,7 @@ func (m *ElasticMapsServer) ValidateUpdate(_ runtime.Object) error {
 	return m.validate()
 }
 
-// WebhookPath returns the http path used by the validating webhook.
+// WebhookPath returns the HTTP path used by the validating webhook.
 func (m *ElasticMapsServer) WebhookPath() string {
 	return webhookPath
 }

--- a/pkg/controller/common/webhook/webhook.go
+++ b/pkg/controller/common/webhook/webhook.go
@@ -77,7 +77,7 @@ func (v *validatingWebhook) Handle(_ context.Context, req admission.Request) adm
 
 	if req.Operation == admissionv1.Update {
 		oldObj := v.validator.DeepCopyObject()
-		err = v.decoder.DecodeRaw(req.Object, oldObj)
+		err = v.decoder.DecodeRaw(req.OldObject, oldObj)
 		if err != nil {
 			whlog.Error(err, "decoding old object from webhook request into type (%T)", oldObj)
 			return admission.Errored(http.StatusBadRequest, err)

--- a/pkg/controller/common/webhook/webhook.go
+++ b/pkg/controller/common/webhook/webhook.go
@@ -1,0 +1,87 @@
+package webhook
+
+import (
+	"context"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/elastic/cloud-on-k8s/pkg/utils/set"
+)
+
+// SetupValidatingWebhookWithConfig will register a set of validation functions
+// at a given path, with a given controller manager, ensuring that the objects
+// are within the namespaces that the operator manages.
+func SetupValidatingWebhookWithConfig(config *Config) error {
+	config.Manager.GetWebhookServer().Register(
+		config.WebhookPath,
+		&webhook.Admission{
+			Handler: &validatingWebhook{
+				validator:         config.Validator,
+				managedNamespaces: set.Make(config.ManagedNamespace...)}})
+	return nil
+}
+
+// Config is the configuration for setting up a webhook
+type Config struct {
+	Manager          ctrl.Manager
+	WebhookPath      string
+	ManagedNamespace []string
+	Validator        admission.Validator
+}
+
+type validatingWebhook struct {
+	decoder           *admission.Decoder
+	managedNamespaces set.StringSet
+	validator         admission.Validator
+}
+
+var _ admission.DecoderInjector = &validatingWebhook{}
+
+// InjectDecoder injects the decoder automatically.
+func (v *validatingWebhook) InjectDecoder(d *admission.Decoder) error {
+	v.decoder = d
+	return nil
+}
+
+// Handle satisfies the admission.Handler interface
+func (v *validatingWebhook) Handle(_ context.Context, req admission.Request) admission.Response {
+	obj := &unstructured.Unstructured{}
+	err := v.decoder.DecodeRaw(req.Object, obj)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// If this instance is not within the set of managed namespaces
+	// for this operator ignore this request.
+	if !v.managedNamespaces.Has(obj.GetNamespace()) {
+		return admission.Allowed("")
+	}
+
+	if req.Operation == admissionv1.Create {
+		err = v.validator.ValidateCreate()
+		if err != nil {
+			return admission.Denied(err.Error())
+		}
+	}
+
+	if req.Operation == admissionv1.Update {
+		err = v.validator.ValidateUpdate(req.Object.Object)
+		if err != nil {
+			return admission.Denied(err.Error())
+		}
+	}
+
+	if req.Operation == admissionv1.Delete {
+		err = v.validator.ValidateDelete()
+		if err != nil {
+			return admission.Denied(err.Error())
+		}
+	}
+
+	return admission.Allowed("")
+}

--- a/pkg/controller/common/webhook/webhook.go
+++ b/pkg/controller/common/webhook/webhook.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/davecgh/go-spew/spew"
 	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/set"
 )
@@ -68,8 +67,6 @@ func (v *validatingWebhook) Handle(_ context.Context, req admission.Request) adm
 		whlog.Error(err, "decoding object from webhook request into type (%T)", obj)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-
-	whlog.V(1).Info("webhook validation object after decode", "object", spew.Sdump(obj))
 
 	if req.Operation == admissionv1.Create {
 		err = obj.ValidateCreate()

--- a/pkg/controller/common/webhook/webhook.go
+++ b/pkg/controller/common/webhook/webhook.go
@@ -58,7 +58,11 @@ func (v *validatingWebhook) InjectDecoder(d *admission.Decoder) error {
 
 // Handle satisfies the admission.Handler interface
 func (v *validatingWebhook) Handle(_ context.Context, req admission.Request) admission.Response {
-	obj := v.validator.DeepCopyObject().(admission.Validator)
+	obj, ok := v.validator.DeepCopyObject().(admission.Validator)
+	if !ok {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("object (%T) to be validated couldn't be converted to admission.Validator", v.validator.DeepCopyObject()))
+	}
+
 	err := v.decoder.Decode(req, obj)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)

--- a/pkg/controller/common/webhook/webhook.go
+++ b/pkg/controller/common/webhook/webhook.go
@@ -75,7 +75,7 @@ func (v *validatingWebhook) Handle(_ context.Context, req admission.Request) adm
 
 	// If this instance is not within the set of managed namespaces
 	// for this operator ignore this request.
-	if !v.managedNamespaces.Has(metaObj.GetNamespace()) {
+	if v.managedNamespaces.Count() > 0 && !v.managedNamespaces.Has(metaObj.GetNamespace()) {
 		whlog.V(1).Info("Skipping resource validation", "name", metaObj.GetName(), "namespace", metaObj.GetNamespace())
 		return admission.Allowed(fmt.Sprintf("object namespace (%s) outside of managed namespaces: %s", metaObj.GetNamespace(), v.managedNamespaces.AsSlice()))
 	}

--- a/pkg/controller/common/webhook/webhook.go
+++ b/pkg/controller/common/webhook/webhook.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package webhook
 
 import (

--- a/pkg/controller/common/webhook/webhook_test.go
+++ b/pkg/controller/common/webhook/webhook_test.go
@@ -1,0 +1,227 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	agentv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/agent/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/set"
+)
+
+func asJSON(obj interface{}) []byte {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func Test_validatingWebhook_Handle(t *testing.T) {
+	type fields struct {
+		managedNamespaces set.StringSet
+		validator         admission.Validator
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		req    admission.Request
+		want   admission.Response
+	}{
+		{
+			"create properly validates valid agent, and returns allowed.",
+			fields{
+				set.Make("elastic"),
+				&agentv1alpha1.Agent{},
+			},
+			admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: asJSON(&agentv1alpha1.Agent{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "testAgent",
+								Namespace: "elastic",
+								Labels: map[string]string{
+									"test": "label1",
+								},
+							},
+							Spec: agentv1alpha1.AgentSpec{
+								Version:    "7.10.0",
+								Deployment: &agentv1alpha1.DeploymentSpec{},
+							},
+						}),
+					},
+				},
+			},
+			admission.Allowed(""),
+		},
+		{
+			"create agent is denied because of invalid version, and returns denied.",
+			fields{
+				set.Make("elastic"),
+				&agentv1alpha1.Agent{},
+			},
+			admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: asJSON(&agentv1alpha1.Agent{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "testAgent",
+								Namespace: "elastic",
+								Labels: map[string]string{
+									"test": "label1",
+								},
+							},
+							Spec: agentv1alpha1.AgentSpec{
+								Version:    "0.10.0",
+								Deployment: &agentv1alpha1.DeploymentSpec{},
+							},
+						}),
+					},
+				},
+			},
+			admission.Denied(`Agent.agent.k8s.elastic.co "testAgent" is invalid: spec.version: Invalid value: "0.10.0": Unsupported version: version 0.10.0 is lower than the lowest supported version of 7.10.0`),
+		},
+		{
+			"delete agent is always allowed",
+			fields{
+				set.Make("elastic"),
+				&agentv1alpha1.Agent{},
+			},
+			admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Delete,
+					Object: runtime.RawExtension{
+						Raw: asJSON(&agentv1alpha1.Agent{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "testAgent",
+								Namespace: "elastic",
+								Labels: map[string]string{
+									"test": "label1",
+								},
+							},
+							Spec: agentv1alpha1.AgentSpec{
+								Version:    "7.10.0",
+								Deployment: &agentv1alpha1.DeploymentSpec{},
+							},
+						}),
+					},
+				},
+			},
+			admission.Allowed(""),
+		},
+		{
+			"update agent is allowed when label is updated",
+			fields{
+				set.Make("elastic"),
+				&agentv1alpha1.Agent{},
+			},
+			admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{
+						Raw: asJSON(&agentv1alpha1.Agent{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "testAgent",
+								Namespace: "elastic",
+								Labels: map[string]string{
+									"test": "label1",
+								},
+							},
+							Spec: agentv1alpha1.AgentSpec{
+								Version:    "7.10.0",
+								Deployment: &agentv1alpha1.DeploymentSpec{},
+							},
+						}),
+					},
+					Object: runtime.RawExtension{
+						Raw: asJSON(&agentv1alpha1.Agent{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "testAgent",
+								Namespace: "elastic",
+								Labels: map[string]string{
+									"test": "label2",
+								},
+							},
+							Spec: agentv1alpha1.AgentSpec{
+								Version:    "7.10.0",
+								Deployment: &agentv1alpha1.DeploymentSpec{},
+							},
+						}),
+					},
+				},
+			},
+			admission.Allowed(""),
+		},
+		{
+			"update agent is denied when version downgrade is attempted",
+			fields{
+				set.Make("elastic"),
+				&agentv1alpha1.Agent{},
+			},
+			admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{
+						Raw: asJSON(&agentv1alpha1.Agent{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "testAgent",
+								Namespace: "elastic",
+								Labels: map[string]string{
+									"test": "label1",
+								},
+							},
+							Spec: agentv1alpha1.AgentSpec{
+								Version:    "7.10.1",
+								Deployment: &agentv1alpha1.DeploymentSpec{},
+							},
+						}),
+					},
+					Object: runtime.RawExtension{
+						Raw: asJSON(&agentv1alpha1.Agent{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "testAgent",
+								Namespace: "elastic",
+								Labels: map[string]string{
+									"test": "label1",
+								},
+							},
+							Spec: agentv1alpha1.AgentSpec{
+								Version:    "7.10.0",
+								Deployment: &agentv1alpha1.DeploymentSpec{},
+							},
+						}),
+					},
+				},
+			},
+			admission.Denied(`Agent.agent.k8s.elastic.co "testAgent" is invalid: spec.version: Forbidden: Version downgrades are not supported`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			decoder, _ := admission.NewDecoder(k8s.Scheme())
+			v := &validatingWebhook{
+				decoder:           decoder,
+				managedNamespaces: tt.fields.managedNamespaces,
+				validator:         tt.fields.validator,
+			}
+			if got := v.Handle(ctx, tt.req); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("validatingWebhook.Handle() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/common/webhook/webhook_test.go
+++ b/pkg/controller/common/webhook/webhook_test.go
@@ -40,12 +40,12 @@ func Test_validatingWebhook_Handle(t *testing.T) {
 		want   admission.Response
 	}{
 		{
-			"create properly validates valid agent, and returns allowed.",
-			fields{
+			name: "create properly validates valid agent, and returns allowed.",
+			fields: fields{
 				set.Make("elastic"),
 				&agentv1alpha1.Agent{},
 			},
-			admission.Request{
+			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
@@ -65,15 +65,15 @@ func Test_validatingWebhook_Handle(t *testing.T) {
 					},
 				},
 			},
-			admission.Allowed(""),
+			want: admission.Allowed(""),
 		},
 		{
-			"create agent is denied because of invalid version, and returns denied.",
-			fields{
+			name: "create agent is denied because of invalid version, and returns denied.",
+			fields: fields{
 				set.Make("elastic"),
 				&agentv1alpha1.Agent{},
 			},
-			admission.Request{
+			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
@@ -93,15 +93,15 @@ func Test_validatingWebhook_Handle(t *testing.T) {
 					},
 				},
 			},
-			admission.Denied(`Agent.agent.k8s.elastic.co "testAgent" is invalid: spec.version: Invalid value: "0.10.0": Unsupported version: version 0.10.0 is lower than the lowest supported version of 7.10.0`),
+			want: admission.Denied(`Agent.agent.k8s.elastic.co "testAgent" is invalid: spec.version: Invalid value: "0.10.0": Unsupported version: version 0.10.0 is lower than the lowest supported version of 7.10.0`),
 		},
 		{
-			"delete agent is always allowed",
-			fields{
+			name: "delete agent is always allowed",
+			fields: fields{
 				set.Make("elastic"),
 				&agentv1alpha1.Agent{},
 			},
-			admission.Request{
+			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Delete,
 					Object: runtime.RawExtension{
@@ -121,15 +121,15 @@ func Test_validatingWebhook_Handle(t *testing.T) {
 					},
 				},
 			},
-			admission.Allowed(""),
+			want: admission.Allowed(""),
 		},
 		{
-			"update agent is allowed when label is updated",
-			fields{
+			name: "update agent is allowed when label is updated",
+			fields: fields{
 				set.Make("elastic"),
 				&agentv1alpha1.Agent{},
 			},
-			admission.Request{
+			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Update,
 					OldObject: runtime.RawExtension{
@@ -164,15 +164,15 @@ func Test_validatingWebhook_Handle(t *testing.T) {
 					},
 				},
 			},
-			admission.Allowed(""),
+			want: admission.Allowed(""),
 		},
 		{
-			"update agent is denied when version downgrade is attempted",
-			fields{
+			name: "update agent is denied when version downgrade is attempted",
+			fields: fields{
 				set.Make("elastic"),
 				&agentv1alpha1.Agent{},
 			},
-			admission.Request{
+			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Update,
 					OldObject: runtime.RawExtension{
@@ -207,7 +207,7 @@ func Test_validatingWebhook_Handle(t *testing.T) {
 					},
 				},
 			},
-			admission.Denied(`Agent.agent.k8s.elastic.co "testAgent" is invalid: spec.version: Forbidden: Version downgrades are not supported`),
+			want: admission.Denied(`Agent.agent.k8s.elastic.co "testAgent" is invalid: spec.version: Forbidden: Version downgrades are not supported`),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/controller/elasticsearch/validation/webhook.go
+++ b/pkg/controller/elasticsearch/validation/webhook.go
@@ -63,7 +63,6 @@ func (wh *validatingWebhook) validateCreate(es esv1.Elasticsearch) error {
 	// for this operator ignore this request.
 	if !slices.Contains(wh.managedNamespaces, es.Namespace) {
 		return nil
-
 	}
 
 	eslog.V(1).Info("validate create", "name", es.Name)
@@ -75,10 +74,9 @@ func (wh *validatingWebhook) validateUpdate(prev esv1.Elasticsearch, curr esv1.E
 	// for this operator ignore this request.
 	if !slices.Contains(wh.managedNamespaces, curr.Namespace) {
 		return nil
-
 	}
-	eslog.V(1).Info("validate update", "name", curr.Name)
 
+	eslog.V(1).Info("validate update", "name", curr.Name)
 	var errs field.ErrorList
 	for _, val := range updateValidations(wh.client, wh.validateStorageClass) {
 		if err := val(prev, curr); err != nil {

--- a/pkg/controller/elasticsearch/validation/webhook.go
+++ b/pkg/controller/elasticsearch/validation/webhook.go
@@ -30,7 +30,7 @@ const (
 
 var eslog = ulog.Log.WithName("es-validation")
 
-// RegisterWebhook will register the elasticsearch validating webhook.
+// RegisterWebhook will register the Elasticsearch validating webhook.
 func RegisterWebhook(mgr ctrl.Manager, validateStorageClass bool, exposedNodeLabels NodeLabels, manaedNamespaces []string) {
 	wh := &validatingWebhook{
 		client:               mgr.GetClient(),

--- a/pkg/controller/elasticsearch/validation/webhook.go
+++ b/pkg/controller/elasticsearch/validation/webhook.go
@@ -89,7 +89,7 @@ func (wh *validatingWebhook) Handle(_ context.Context, req admission.Request) ad
 
 	// If this Elasticsearch instance is not within the set of managed namespaces
 	// for this operator ignore this request.
-	if !wh.managedNamespaces.Has(es.Namespace) {
+	if wh.managedNamespaces.Count() > 0 && !wh.managedNamespaces.Has(es.Namespace) {
 		eslog.V(1).Info("Skip Elasticsearch resource validation", "name", es.Name, "namespace", es.Namespace)
 		return admission.Allowed("")
 	}

--- a/pkg/controller/elasticsearch/validation/webhook.go
+++ b/pkg/controller/elasticsearch/validation/webhook.go
@@ -117,7 +117,7 @@ func (wh *validatingWebhook) Handle(_ context.Context, req admission.Request) ad
 	return admission.Allowed("")
 }
 
-// ValidateElasticsearch validates an elasticsearch instance against a set of validation funcs.
+// ValidateElasticsearch validates an Elasticsearch instance against a set of validation funcs.
 func ValidateElasticsearch(es esv1.Elasticsearch, exposedNodeLabels NodeLabels) error {
 	errs := check(es, validations(exposedNodeLabels))
 	if len(errs) > 0 {

--- a/pkg/controller/elasticsearch/validation/webhook_test.go
+++ b/pkg/controller/elasticsearch/validation/webhook_test.go
@@ -61,6 +61,24 @@ func Test_validatingWebhook_Handle(t *testing.T) {
 			want: admission.Allowed(""),
 		},
 		{
+			name: "request from un-managed namespace is ignored, and just accepted",
+			fields: fields{
+				client: k8s.NewFakeClient(),
+			},
+			args: args{
+				req: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: asJSON(&esv1.Elasticsearch{
+							ObjectMeta: metav1.ObjectMeta{Namespace: "unmanaged", Name: "name"},
+							Spec:       esv1.ElasticsearchSpec{Version: "7.9.0", NodeSets: []esv1.NodeSet{{Name: "set1", Count: 3}}},
+						}),
+					}},
+				},
+			},
+			want: admission.Allowed(""),
+		},
+		{
 			name: "reject invalid creation (no version provided)",
 			fields: fields{
 				client: k8s.NewFakeClient(),
@@ -133,6 +151,7 @@ func Test_validatingWebhook_Handle(t *testing.T) {
 				client:               tt.fields.client,
 				decoder:              decoder,
 				validateStorageClass: tt.fields.validateStorageClass,
+				managedNamespaces:    []string{"ns"},
 			}
 			got := wh.Handle(context.Background(), tt.args.req)
 			require.Equal(t, tt.want.Allowed, got.Allowed)

--- a/pkg/controller/elasticsearch/validation/webhook_test.go
+++ b/pkg/controller/elasticsearch/validation/webhook_test.go
@@ -17,6 +17,7 @@ import (
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/set"
 )
 
 func asJSON(obj interface{}) []byte {
@@ -151,7 +152,7 @@ func Test_validatingWebhook_Handle(t *testing.T) {
 				client:               tt.fields.client,
 				decoder:              decoder,
 				validateStorageClass: tt.fields.validateStorageClass,
-				managedNamespaces:    []string{"ns"},
+				managedNamespaces:    set.Make("ns"),
 			}
 			got := wh.Handle(context.Background(), tt.args.req)
 			require.Equal(t, tt.want.Allowed, got.Allowed)


### PR DESCRIPTION
Don't append the 'all' namespaces when storage class validation is enabled, as it causes 'unknown namespace' errors in controller-runtime, and cluster-scoped resources are handled properly now in ctrl-runtime.  This will supersede #5058, as it's a much simpler implementation to solve the same issue as the below PR better handles these types of situations in controller-runtime:  

https://github.com/kubernetes-sigs/controller-runtime/pull/1418

Tested with validation of storage class enabled, and successfully resized volumes from 100GB -> 200GB.

## Known Issues

Validating webhooks for things such as ES PV resizing are created "unscoped"

```
- admissionReviewVersions:
  - v1beta1
  clientConfig:
    service:
      name: elastic-operator-webhook
      namespace: elastic-system
      path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
      port: 443
  failurePolicy: Ignore
  matchPolicy: Exact
  name: elastic-es-validation-v1.k8s.elastic.co
  namespaceSelector: {}
  objectSelector: {}
  rules:
  - apiGroups:
    - elasticsearch.k8s.elastic.co
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    resources:
    - elasticsearches
    scope: '*'    <--- Here
```

https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/

`The scope field specifies if only cluster-scoped resources ("Cluster") or namespace-scoped resources ("Namespaced") will match this rule. "∗" means that there are no scope restrictions.`

This means that the webhook[s] get resources across the whole cluster, in namespaces that they do not manage, which generates the dreaded

```
"unable to get: elastic/testing-es-masters because of unknown namespace for the cache"
```

There seems to be 2 approaches to handles this situation:

1. Pass along `managedNamespaces` slice to webhook, and if the crud operation is outside of it's managed namespaces, allow it, ~~which brings up the question: "How are the same webhook, with different names, all cluster scoped, and with the same rules (when having the operator installed twice in a cluster, and validating ES objects) handled?  Do all have to validate, or just one?"~~ (validated all webhooks with appropriate rules receive the request, and any can allow/deny)
2. Work to get these webhooks `Namespaced` (which by looking at the operator framework docs, It wasn't clear how exactly to do this)