### PR TITLE
Update 1.9.x release highlights concerning Webhook issues in Openshift <= 4.6

### DIFF
--- a/docs/release-notes/highlights-1.9.0.asciidoc
+++ b/docs/release-notes/highlights-1.9.0.asciidoc
@@ -34,4 +34,4 @@ Following the Elastic Stack licensing changes in `7.11.0`, ECK `1.9.0` moves to 
 [id="{p}-190-known-issues"]
 === Known issues
 
-- Openshift versions 4.6 and below, upon installing/upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and seen in a `CrashLoopBackoff` within Kubernetes because of Webhook certificate location mismatches. More information and work-around can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[the issue].
+- On Openshift versions 4.6 and below, upon installing/upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and seen in a `CrashLoopBackoff` within Kubernetes because of Webhook certificate location mismatches. More information and work-around can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[the issue].

--- a/docs/release-notes/highlights-1.9.0.asciidoc
+++ b/docs/release-notes/highlights-1.9.0.asciidoc
@@ -29,3 +29,9 @@ To provide more functionalities and better user experience we are moving away fr
 [id="{p}-190-elastic-license-v2"]
 ==== Elastic Cloud on Kubernetes moves to Elastic License v2
 Following the Elastic Stack licensing changes in `7.11.0`, ECK `1.9.0` moves to Elastic License v2. For more details, check this link:https://www.elastic.co/blog/elastic-license-v2[blog post].
+
+[float]
+[id="{p}-120-known-issues"]
+=== Known issues
+
+- Openshift versions 4.6 and below, upon installing/upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and seen in a `CrashLoopBackoff` within Kubernetes because of Webhook certification location mismatches. More information can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[the issue].

--- a/docs/release-notes/highlights-1.9.0.asciidoc
+++ b/docs/release-notes/highlights-1.9.0.asciidoc
@@ -31,7 +31,7 @@ To provide more functionalities and better user experience we are moving away fr
 Following the Elastic Stack licensing changes in `7.11.0`, ECK `1.9.0` moves to Elastic License v2. For more details, check this link:https://www.elastic.co/blog/elastic-license-v2[blog post].
 
 [float]
-[id="{p}-120-known-issues"]
+[id="{p}-190-known-issues"]
 === Known issues
 
 - Openshift versions 4.6 and below, upon installing/upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and seen in a `CrashLoopBackoff` within Kubernetes because of Webhook certification location mismatches. More information can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[the issue].

--- a/docs/release-notes/highlights-1.9.0.asciidoc
+++ b/docs/release-notes/highlights-1.9.0.asciidoc
@@ -34,4 +34,4 @@ Following the Elastic Stack licensing changes in `7.11.0`, ECK `1.9.0` moves to 
 [id="{p}-190-known-issues"]
 === Known issues
 
-- Openshift versions 4.6 and below, upon installing/upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and seen in a `CrashLoopBackoff` within Kubernetes because of Webhook certification location mismatches. More information can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[the issue].
+- Openshift versions 4.6 and below, upon installing/upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and seen in a `CrashLoopBackoff` within Kubernetes because of Webhook certificate location mismatches. More information and work-around can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[the issue].

--- a/docs/release-notes/highlights-1.9.1.asciidoc
+++ b/docs/release-notes/highlights-1.9.1.asciidoc
@@ -15,7 +15,7 @@ New and notable changes in version 1.9.1 of {n}. See <<release-notes-1.9.1>> for
 This release introduces a preemptive measure to mitigate link:https://github.com/advisories/GHSA-jfh8-c2jp-5v3q[Log4Shell] vulnerability in Elasticsearch versions below `7.2`.
 
 [float]
-[id="{p}-120-known-issues"]
+[id="{p}-191-known-issues"]
 === Known issues
 
 - Openshift versions 4.6 and below, upon installing/upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and seen in a `CrashLoopBackoff` within Kubernetes because of Webhook certification location mismatches. More information can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[the issue].

--- a/docs/release-notes/highlights-1.9.1.asciidoc
+++ b/docs/release-notes/highlights-1.9.1.asciidoc
@@ -18,4 +18,4 @@ This release introduces a preemptive measure to mitigate link:https://github.com
 [id="{p}-191-known-issues"]
 === Known issues
 
-- Openshift versions 4.6 and below, upon installing/upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and seen in a `CrashLoopBackoff` within Kubernetes because of Webhook certification location mismatches. More information can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[the issue].
+- Openshift versions 4.6 and below, upon installing/upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and seen in a `CrashLoopBackoff` within Kubernetes because of Webhook certificate location mismatches. More information and work-around can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[the issue].

--- a/docs/release-notes/highlights-1.9.1.asciidoc
+++ b/docs/release-notes/highlights-1.9.1.asciidoc
@@ -13,3 +13,9 @@ New and notable changes in version 1.9.1 of {n}. See <<release-notes-1.9.1>> for
 ==== Mitigate CVE-2021-44228 in vulnerable Elasticsearch clusters
 
 This release introduces a preemptive measure to mitigate link:https://github.com/advisories/GHSA-jfh8-c2jp-5v3q[Log4Shell] vulnerability in Elasticsearch versions below `7.2`.
+
+[float]
+[id="{p}-120-known-issues"]
+=== Known issues
+
+- Openshift versions 4.6 and below, upon installing/upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and seen in a `CrashLoopBackoff` within Kubernetes because of Webhook certification location mismatches. More information can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[the issue].

--- a/docs/release-notes/highlights-1.9.1.asciidoc
+++ b/docs/release-notes/highlights-1.9.1.asciidoc
@@ -18,4 +18,4 @@ This release introduces a preemptive measure to mitigate link:https://github.com
 [id="{p}-191-known-issues"]
 === Known issues
 
-- Openshift versions 4.6 and below, upon installing/upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and seen in a `CrashLoopBackoff` within Kubernetes because of Webhook certificate location mismatches. More information and work-around can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[the issue].
+- On Openshift versions 4.6 and below, upon installing/upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and seen in a `CrashLoopBackoff` within Kubernetes because of Webhook certificate location mismatches. More information and work-around can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[the issue].


### PR DESCRIPTION
Update 1.9.x release highlights noting new webhooks issue found in openshift <= 4.6

(Will backport to 1.9 branch upon approval/merge)