### PR TITLE
[DOCS] Fix cross-doc links

### DIFF
--- a/docs/custom-images.asciidoc
+++ b/docs/custom-images.asciidoc
@@ -6,7 +6,7 @@ endif::[]
 [id="{p}-custom-images"]
 == Creating custom images
 
-You can create your own custom Elasticsearch or Kibana image instead of using the base image provided by Elastic. You might want to do this to preload plugins in the image rather than having to link:k8s-init-containers-plugin-downloads.html[install them via init container] each time a pod starts. To do this, you must use the official image as the base for it to function properly. For example, if you want to create an Elasticsearch {version} image with the https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-gcs.html[Google Cloud Storage Repository Plugin], you can do the following:
+You can create your own custom Elasticsearch or Kibana image instead of using the base image provided by Elastic. You might want to do this to preload plugins in the image rather than having to link:k8s-init-containers-plugin-downloads.html[install them via init container] each time a pod starts. To do this, you must use the official image as the base for it to function properly. For example, if you want to create an Elasticsearch {version} image with the https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/repository-gcs.html[Google Cloud Storage Repository Plugin], you can do the following:
 
 . Create a `Dockerfile` containing:
 +

--- a/docs/snapshots.asciidoc
+++ b/docs/snapshots.asciidoc
@@ -13,7 +13,7 @@ To set up automated snapshots for Elasticsearch on Kubernetes you have to:
 . Register the snapshot repository with the Elasticsearch API.
 . Set up a https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/[CronJob] to take snapshots on a schedule.
 
-The examples below use the https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-gcs.html[Google Cloud Storage Repository Plugin].
+The examples below use the https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/repository-gcs.html[Google Cloud Storage Repository Plugin].
 
 For more information on Elasticsearch snapshots, see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html[Snapshot and Restore].
 
@@ -75,7 +75,7 @@ kubectl apply -f elasticsearch.yaml
 [id="{p}-secure-settings"]
 ==== Configure GCS credentials via the Elasticsearch keystore
 
-The Elasticsearch GCS repository plugin requires a JSON file that contains service account credentials. These need to be added as secure settings to the Elasticsearch keystore. For more details, see https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-gcs-usage.html[Google Cloud Storage Repository Plugin].
+The Elasticsearch GCS repository plugin requires a JSON file that contains service account credentials. These need to be added as secure settings to the Elasticsearch keystore. For more details, see https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/repository-gcs-usage.html[Google Cloud Storage Repository Plugin].
 
 Using ECK, you can automatically inject secure settings into a cluster node by providing them through a secret in the Elasticsearch Spec.
 


### PR DESCRIPTION
The repository plugins are becoming Elasticsearch modules, so the docs are moving into the ES reference. These hardcoded links to current break the build when those changes are made. Will switch each version to link to 7.17, and then switch master back to current once the changes on the ES side are merged.

