### PR TITLE
[DOCS] Fix cross-doc links

### DIFF
--- a/docs/release-notes/highlights-1.4.0.asciidoc
+++ b/docs/release-notes/highlights-1.4.0.asciidoc
@@ -11,7 +11,7 @@ New and notable changes in version 1.4.0 of {n}. See <<release-notes-1.4.0>> for
 [id="{p}-140-agent-support"]
 ==== Support for Elastic Agent
 
-link:https://www.elastic.co/guide/en/fleet/7.16/elastic-agent-installation-configuration.html[Elastic Agent] provides a unified way to monitor logs, metrics, and other types of data from your Kubernetes infrastructure quickly and easily. You can use a single Elastic Agent deployment to replace multiple Beats deployments that were previously required to collect the different types of data you want to monitor. ECK 1.4.0 introduces experimental support for Elastic Agent in link:https://www.elastic.co/guide/en/fleet/7.16/install-standalone-elastic-agent.html[standalone mode] as a technology preview.
+link:https://www.elastic.co/guide/en/fleet/7.16/elastic-agent-installation.html[Elastic Agent] provides a unified way to monitor logs, metrics, and other types of data from your Kubernetes infrastructure quickly and easily. You can use a single Elastic Agent deployment to replace multiple Beats deployments that were previously required to collect the different types of data you want to monitor. ECK 1.4.0 introduces experimental support for Elastic Agent in link:https://www.elastic.co/guide/en/fleet/7.16/install-standalone-elastic-agent.html[standalone mode] as a technology preview.
 
 
 [float]

--- a/docs/release-notes/highlights-1.4.0.asciidoc
+++ b/docs/release-notes/highlights-1.4.0.asciidoc
@@ -11,7 +11,7 @@ New and notable changes in version 1.4.0 of {n}. See <<release-notes-1.4.0>> for
 [id="{p}-140-agent-support"]
 ==== Support for Elastic Agent
 
-link:https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation-configuration.html[Elastic Agent] provides a unified way to monitor logs, metrics, and other types of data from your Kubernetes infrastructure quickly and easily. You can use a single Elastic Agent deployment to replace multiple Beats deployments that were previously required to collect the different types of data you want to monitor. ECK 1.4.0 introduces experimental support for Elastic Agent in link:https://www.elastic.co/guide/en/fleet/7.16/install-standalone-elastic-agent.html[standalone mode] as a technology preview.
+link:https://www.elastic.co/guide/en/fleet/7.16/elastic-agent-installation-configuration.html[Elastic Agent] provides a unified way to monitor logs, metrics, and other types of data from your Kubernetes infrastructure quickly and easily. You can use a single Elastic Agent deployment to replace multiple Beats deployments that were previously required to collect the different types of data you want to monitor. ECK 1.4.0 introduces experimental support for Elastic Agent in link:https://www.elastic.co/guide/en/fleet/7.16/install-standalone-elastic-agent.html[standalone mode] as a technology preview.
 
 
 [float]


### PR DESCRIPTION
The repository plugins are becoming Elasticsearch modules, so the docs are moving into the ES reference. These hardcoded links to current break the build when those changes are made. Will switch each version to link to 7.17, and then switch master back to current once the changes on the ES side are merged.

