### PR TITLE
[DOCS] Fix cross-doc links

### DIFF
--- a/docs/advanced-topics/custom-images.asciidoc
+++ b/docs/advanced-topics/custom-images.asciidoc
@@ -7,7 +7,7 @@ endif::[]
 [id="{p}-{page_id}"]
 = Create custom images
 
-You can create your own custom application images ({eck_resources_list}) instead of using the base images provided by Elastic. You might want to do this to have a canonical image with all the necessary plugins pre-loaded rather than <<{p}-init-containers-plugin-downloads,installing them via an init container>> each time a Pod starts.  You must use the official image as the base for custom images. For example, if you want to create an Elasticsearch {version} image with the link:https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-gcs.html[Google Cloud Storage Repository Plugin], you can do the following:
+You can create your own custom application images ({eck_resources_list}) instead of using the base images provided by Elastic. You might want to do this to have a canonical image with all the necessary plugins pre-loaded rather than <<{p}-init-containers-plugin-downloads,installing them via an init container>> each time a Pod starts.  You must use the official image as the base for custom images. For example, if you want to create an Elasticsearch {version} image with the link:https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/repository-gcs.html[Google Cloud Storage Repository Plugin], you can do the following:
 
 
 

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/snapshots.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/snapshots.asciidoc
@@ -15,7 +15,7 @@ To set up automated snapshots for Elasticsearch on Kubernetes you have to:
 . Register the snapshot repository with the Elasticsearch API.
 . Set up a https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/[CronJob] to take snapshots on a schedule.
 
-The examples below use the https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-gcs.html[Google Cloud Storage Repository Plugin].
+The examples below use the https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/repository-gcs.html[Google Cloud Storage Repository Plugin].
 
 For more information on Elasticsearch snapshots, see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html[Snapshot and Restore].
 
@@ -75,7 +75,7 @@ kubectl apply -f elasticsearch.yaml
 [id="{p}-secure-settings"]
 == Configure GCS credentials via the Elasticsearch keystore
 
-The Elasticsearch GCS repository plugin requires a JSON file that contains service account credentials. These need to be added as secure settings to the Elasticsearch keystore. For more details, see https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-gcs-usage.html[Google Cloud Storage Repository Plugin].
+The Elasticsearch GCS repository plugin requires a JSON file that contains service account credentials. These need to be added as secure settings to the Elasticsearch keystore. For more details, see https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/repository-gcs-usage.html[Google Cloud Storage Repository Plugin].
 
 Using ECK, you can automatically inject secure settings into a cluster node by providing them through a secret in the Elasticsearch Spec.
 


### PR DESCRIPTION
The repository plugins are becoming Elasticsearch modules, so the docs are moving into the ES reference. These hardcoded links to current break the build when those changes are made. Will switch each version to link to 7.17, and then switch master back to current once the changes on the ES side are merged.

