### PR TITLE
Isolate operator from http service misconfiguration - Use internal service

### DIFF
--- a/pkg/apis/elasticsearch/v1/name.go
+++ b/pkg/apis/elasticsearch/v1/name.go
@@ -19,6 +19,7 @@ const (
 	configSecretSuffix                           = "config"
 	secureSettingsSecretSuffix                   = "secure-settings"
 	httpServiceSuffix                            = "http"
+	internalHTTPServiceSuffix                    = "internal-http"
 	transportServiceSuffix                       = "transport"
 	elasticUserSecretSuffix                      = "elastic-user"
 	internalUsersSecretSuffix                    = "internal-users"
@@ -126,6 +127,10 @@ func LegacyTransportCertsSecretSuffix(esName string) string {
 
 func TransportService(esName string) string {
 	return ESNamer.Suffix(esName, transportServiceSuffix)
+}
+
+func InternalHTTPService(esName string) string {
+	return ESNamer.Suffix(esName, internalHTTPServiceSuffix)
 }
 
 func HTTPService(esName string) string {

--- a/pkg/controller/autoscaling/elasticsearch/controller_test.go
+++ b/pkg/controller/autoscaling/elasticsearch/controller_test.go
@@ -51,13 +51,13 @@ var (
 	fakeService = &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "testns",
-			Name:      services.ExternalServiceName("testes"),
+			Name:      services.InternalServiceName("testes"),
 		},
 	}
 	fakeEndpoints = &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "testns",
-			Name:      services.ExternalServiceName("testes"),
+			Name:      services.InternalServiceName("testes"),
 		},
 		Subsets: []corev1.EndpointSubset{{
 			Addresses: []corev1.EndpointAddress{{

--- a/pkg/controller/autoscaling/elasticsearch/driver.go
+++ b/pkg/controller/autoscaling/elasticsearch/driver.go
@@ -93,14 +93,14 @@ func newStatusBuilder(log logr.Logger, autoscalingSpec esv1.AutoscalingSpec) *st
 // Check if the Service is available.
 func (r *ReconcileElasticsearch) isElasticsearchReachable(ctx context.Context, es esv1.Elasticsearch) (bool, error) {
 	defer tracing.Span(&ctx)()
-	externalService, err := services.GetInternalService(r.Client, es)
+	internalService, err := services.GetInternalService(r.Client, es)
 	if apierrors.IsNotFound(err) {
 		return false, nil
 	}
 	if err != nil {
 		return false, tracing.CaptureError(ctx, err)
 	}
-	esReachable, err := services.IsServiceReady(r.Client, externalService)
+	esReachable, err := services.IsServiceReady(r.Client, internalService)
 	if err != nil {
 		return false, tracing.CaptureError(ctx, err)
 	}

--- a/pkg/controller/autoscaling/elasticsearch/driver.go
+++ b/pkg/controller/autoscaling/elasticsearch/driver.go
@@ -93,7 +93,7 @@ func newStatusBuilder(log logr.Logger, autoscalingSpec esv1.AutoscalingSpec) *st
 // Check if the Service is available.
 func (r *ReconcileElasticsearch) isElasticsearchReachable(ctx context.Context, es esv1.Elasticsearch) (bool, error) {
 	defer tracing.Span(&ctx)()
-	externalService, err := services.GetExternalService(r.Client, es)
+	externalService, err := services.GetInternalService(r.Client, es)
 	if apierrors.IsNotFound(err) {
 		return false, nil
 	}

--- a/pkg/controller/elasticsearch/services/services.go
+++ b/pkg/controller/elasticsearch/services/services.go
@@ -117,9 +117,6 @@ func NewInternalService(es esv1.Elasticsearch) *corev1.Service {
 			},
 			Selector:                 label.NewLabels(k8s.ExtractNamespacedName(&es)),
 			PublishNotReadyAddresses: false,
-			IPFamilies: []corev1.IPFamily{
-				corev1.IPv4Protocol,
-			},
 		},
 	}
 }

--- a/pkg/controller/elasticsearch/services/services_test.go
+++ b/pkg/controller/elasticsearch/services/services_test.go
@@ -241,7 +241,9 @@ func TestNewInternalService(t *testing.T) {
 			},
 			wantSvc: func() corev1.Service {
 				svc := mkHTTPService()
+				svc.Spec.Type = corev1.ServiceTypeClusterIP
 				svc.Spec.Ports[0].Name = "https"
+				svc.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol}
 				svc.Name = "elasticsearch-test-es-internal-http"
 				return svc
 			},

--- a/pkg/controller/elasticsearch/services/services_test.go
+++ b/pkg/controller/elasticsearch/services/services_test.go
@@ -243,7 +243,6 @@ func TestNewInternalService(t *testing.T) {
 				svc := mkHTTPService()
 				svc.Spec.Type = corev1.ServiceTypeClusterIP
 				svc.Spec.Ports[0].Name = "https"
-				svc.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol}
 				svc.Name = "elasticsearch-test-es-internal-http"
 				return svc
 			},

--- a/pkg/controller/elasticsearch/services/services_test.go
+++ b/pkg/controller/elasticsearch/services/services_test.go
@@ -88,7 +88,7 @@ func TestElasticsearchURL(t *testing.T) {
 					},
 				},
 			},
-			want: "https://my-cluster-es-http.my-ns.svc:9200",
+			want: "https://my-cluster-es-internal-http.my-ns.svc:9200",
 		},
 		{
 			name: "scheme change in progress: random pod address",
@@ -127,7 +127,7 @@ func TestElasticsearchURL(t *testing.T) {
 					{},
 				},
 			},
-			want: "https://my-cluster-es-http.my-ns.svc:9200",
+			want: "https://my-cluster-es-internal-http.my-ns.svc:9200",
 		},
 		{
 			name: "unexpected: partially missing pod labels: fallback to service",
@@ -148,7 +148,7 @@ func TestElasticsearchURL(t *testing.T) {
 					},
 				},
 			},
-			want: "https://my-cluster-es-http.my-ns.svc:9200",
+			want: "https://my-cluster-es-internal-http.my-ns.svc:9200",
 		},
 	}
 	for _, tt := range tests {
@@ -217,6 +217,41 @@ func TestNewExternalService(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			es := mkElasticsearch(tc.httpConf)
 			haveSvc := NewExternalService(es)
+			compare.JSONEqual(t, tc.wantSvc(), haveSvc)
+		})
+	}
+}
+
+func TestNewInternalService(t *testing.T) {
+	testCases := []struct {
+		name     string
+		httpConf commonv1.HTTPConfig
+		wantSvc  func() corev1.Service
+	}{
+		{
+			name: "user supplied selector is not applied to internal service",
+			httpConf: commonv1.HTTPConfig{
+				Service: commonv1.ServiceTemplate{
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"app": "coordinating-node",
+						},
+					},
+				},
+			},
+			wantSvc: func() corev1.Service {
+				svc := mkHTTPService()
+				svc.Spec.Ports[0].Name = "https"
+				svc.Name = "elasticsearch-test-es-internal-http"
+				return svc
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			es := mkElasticsearch(tc.httpConf)
+			haveSvc := NewInternalService(es)
 			compare.JSONEqual(t, tc.wantSvc(), haveSvc)
 		})
 	}


### PR DESCRIPTION
Since #5005 has been open, with active discussion for quite some time, I thought it would be useful to go back to the beginning and look at what we were trying to accomplish in the original issue #4394, which was ensuring that the user can't misconfigure the operator so it can't manage an Elasticsearch cluster.  In the original PR, we chose to go the route of choosing a random pod for communication between the operator, and the ES cluster, which caused its own set of concerns once we both saw the implementation, and tested the consequences of the implementation.  

This PR shows the changes that would be applied to the operator if we chose the other route, which was managing an internal service that does not inherit the selector defined within the custom resources's spec.  This will, at least, give us more information to make a better decision about which route we believe is best to move either solution forward to resolving the initial issue.

To be clear, only one of #5005, or this issue (or none if we so choose) will be merged.  The other will be closed as is.

resolves #4394 