### PR TITLE
Update NOTICE for new year 2022

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,4 +1,4 @@
-Copyright 2018-2021 Elasticsearch BV
+Copyright 2018-2022 Elasticsearch BV
 
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).


### PR DESCRIPTION
Builds are failing because the NOTICE file is not updated yet to reflect the new year. This changes the year range to include 2022.
