### PR TITLE
Update dev documentation around Kind

### DIFF
--- a/dev-setup.md
+++ b/dev-setup.md
@@ -37,10 +37,10 @@ Run `make check-requisites` to check that all dependencies are installed.
 
 * [Kind](https://kind.sigs.k8s.io/)
 
-  The Make target assumes that your local kind binaries are suffixed with their version. For example `kind-0.9.0` and `kind-0.8.1`. The purpose of this convention is to allow running both versions of kind next to each other. For older Kubernetes versions up to 1.13 use `kind-0.8.1` and for the newer versions of Kubernetes starting with 1.14 use `kind-0.9.0`.
+  Use [deployer](/hack/deployer/README.md) (see the  [deployer README](/hack/deployer/README.md#typical-usage) on how to customize which version of Kind will be used):
 
   ```bash
-  make bootstrap-kind
+  make switch-kind bootstrap-cloud
   ```
 
 * Cloud providers

--- a/hack/deployer/README.md
+++ b/hack/deployer/README.md
@@ -28,6 +28,15 @@ Deployer is the provisioning tool that aims to be the interface to multiple Kube
     ```bash
     make switch-aks bootstrap-cloud
     ```
+* Kind
+  * No need to install the Kind CLI. Deployer will do that for you and run Kind inside a Docker container without changing the host system.
+  * Run from the [project root](/):
+
+    ```bash
+    make switch-kind bootstrap-cloud
+    ```
+
+  * This will give you a working Kind cluster based on default values. See [Advanced usage](#advanced-usage) on how to tweak these configuration defaults if the need arises. Relevant parameters for Kind are: `client_version` which is the version of Kind to use. Make sure to check the [Kind release notes](https://github.com/kubernetes-sigs/kind/releases) when changing the client version and make sure `kubernetesVersion` and `client_version` are compatible. `kind.nodeImage` allows you to use a specific Kind node image matching your chosen Kind version. Again, the [Kind release notes](https://github.com/kubernetes-sigs/kind/releases) list the compatibile pre-built node images for each version. `kind.ipFamily` allows you to switch between either an IPv4 or IPv6 network setup.
 
 ### Deprovision
 

--- a/hack/deployer/README.md
+++ b/hack/deployer/README.md
@@ -36,7 +36,7 @@ Deployer is the provisioning tool that aims to be the interface to multiple Kube
     make switch-kind bootstrap-cloud
     ```
 
-  * This will give you a working Kind cluster based on default values. See [Advanced usage](#advanced-usage) on how to tweak these configuration defaults if the need arises. Relevant parameters for Kind are: `client_version` which is the version of Kind to use. Make sure to check the [Kind release notes](https://github.com/kubernetes-sigs/kind/releases) when changing the client version and make sure `kubernetesVersion` and `client_version` are compatible. `kind.nodeImage` allows you to use a specific Kind node image matching your chosen Kind version. Again, the [Kind release notes](https://github.com/kubernetes-sigs/kind/releases) list the compatibile pre-built node images for each version. `kind.ipFamily` allows you to switch between either an IPv4 or IPv6 network setup.
+  * This will give you a working Kind cluster based on default values. See [Advanced usage](#advanced-usage) on how to tweak these configuration defaults if the need arises. Relevant parameters for Kind are: `client_version` which is the version of Kind to use. Make sure to check the [Kind release notes](https://github.com/kubernetes-sigs/kind/releases) when changing the client version and make sure `kubernetesVersion` and `client_version` are compatible. `kind.nodeImage` allows you to use a specific Kind node image matching your chosen Kind version. Again, the [Kind release notes](https://github.com/kubernetes-sigs/kind/releases) list the compatible pre-built node images for each version. `kind.ipFamily` allows you to switch between either an IPv4 or IPv6 network setup.
 
 ### Deprovision
 


### PR DESCRIPTION
Docs where outdate since we moved Kind into the `deployer` mechanism.
