### PR TITLE
Elastic Maps Server: must not use standalone in combination with association mode as of 7.14

### DIFF
--- a/test/e2e/ems/ems_test.go
+++ b/test/e2e/ems/ems_test.go
@@ -2,6 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
+//go:build ems || e2e
 // +build ems e2e
 
 package ems
@@ -9,6 +10,7 @@ package ems
 import (
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/maps"
@@ -34,6 +36,20 @@ func TestElasticMapsServerCrossNSAssociation(t *testing.T) {
 	esWithLicense.BuildingThis = esBuilder
 
 	test.Sequence(nil, test.EmptySteps, esWithLicense, emsBuilder).RunSequential(t)
+}
+
+func TestElasticMapsServerStandalone(t *testing.T) {
+	if version.MustParse(test.Ctx().ElasticStackVersion).LT(version.MinFor(7, 14, 0)) {
+		// standalone mode is only supported as of 7.14
+		t.SkipNow()
+	}
+
+	name := "test-ems-standalone"
+	emsBuilder := maps.NewBuilder(name).
+		WithNodeCount(1).
+		WithRestrictedSecurityContext()
+
+	test.Sequence(nil, test.EmptySteps, emsBuilder).RunSequential(t)
 }
 
 func TestElasticMapsServerTLSDisabled(t *testing.T) {

--- a/test/e2e/ems/ems_test.go
+++ b/test/e2e/ems/ems_test.go
@@ -2,7 +2,6 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-//go:build ems || e2e
 // +build ems e2e
 
 package ems


### PR DESCRIPTION
#5172 missed an important test case: standalone EMS and specifying an association must not be combined or config validation will fail in EMS. This PR tries to remedy this bug and adds also an e2e test case for standalone mode as I should have done already in #5172 