### PR TITLE
E2E: add missing license for EMS test

### DIFF
--- a/test/e2e/ems/ems_test.go
+++ b/test/e2e/ems/ems_test.go
@@ -48,7 +48,10 @@ func TestElasticMapsServerStandalone(t *testing.T) {
 		WithNodeCount(1).
 		WithRestrictedSecurityContext()
 
-	test.Sequence(nil, test.EmptySteps, emsBuilder).RunSequential(t)
+	emsWithLicense := test.LicenseTestBuilder()
+	emsWithLicense.BuildingThis = emsBuilder
+
+	test.Sequence(nil, test.EmptySteps, emsWithLicense).RunSequential(t)
 }
 
 func TestElasticMapsServerTLSDisabled(t *testing.T) {


### PR DESCRIPTION
Elastic Maps Server needs a valid license. #5225 introduced a new e2e test without a license which I did not spot because I already had a license installed in my test cluster 😞 
