### PR TITLE
Update Kubernetes/OCP compatibility statements for ECK 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Current features:
 
 Supported versions:
 
-*  Kubernetes 1.18-1.22
-*  OpenShift 4.5-4.9
+*  Kubernetes 1.19-1.23
+*  OpenShift 4.6-4.10
 *  Elasticsearch, Kibana, APM Server: 6.8+, 7.1+
 *  Enterprise Search: 7.7+
 *  Beats: 7.0+

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -1,5 +1,5 @@
-* Kubernetes 1.18-1.22
-* OpenShift 4.5-4.9
+* Kubernetes 1.19-1.23
+* OpenShift 4.6-4.10
 * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 * Helm: 3.2.0+
 * Elasticsearch, Kibana, APM Server: 6.8+, 7.1+

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -265,9 +265,9 @@ spec:
     Supported versions:
 
 
-    * Kubernetes 1.18-1.22
+    * Kubernetes 1.19-1.23
 
-    * OpenShift 4.5-4.9
+    * OpenShift 4.6-4.10
     
     * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
     


### PR DESCRIPTION
This updates the supported Kubernetes version ranges and OCP version ranges for the 2.0 release of the operator.
