### PR TITLE
E2E: update snapshot version under test and fix version check

### DIFF
--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
                 )}"""
             }
             parallel {
-                stage("7.16.0-SNAPSHOT") {
+                stage("7.17.0-SNAPSHOT") {
                      agent {
                         label 'linux'
                     }

--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-7x-snapshot-${BUILD_NUMBER}-e2e", "7.16.0-SNAPSHOT")
+                            runWith(lib, failedTests, "eck-7x-snapshot-${BUILD_NUMBER}-e2e", "7.17.0-SNAPSHOT")
                         }
                     }
                 }

--- a/pkg/controller/common/version/version.go
+++ b/pkg/controller/common/version/version.go
@@ -74,7 +74,7 @@ func Parse(v string) (Version, error) {
 	return semver.Parse(v)
 }
 
-// Parse attempts to parse a version string and panics if it fails.
+// MustParse attempts to parse a version string and panics if it fails.
 func MustParse(v string) Version {
 	return semver.MustParse(v)
 }

--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -13,9 +13,9 @@ import (
 
 // Elastic Stack versions used in the E2E tests
 const (
-	// Minimum version for 6.8.x tested with the operator
+	// MinVersion68x minimum version for 6.8.x tested with the operator
 	MinVersion68x = "6.8.20"
-	// Current latest version for 7.x
+	// LatestVersion7x current latest version for 7.x
 	LatestVersion7x = "7.16.2" // version to synchronize with the latest release of the Elastic Stack
 )
 
@@ -38,6 +38,11 @@ func isValidUpgrade(from string, to string) (bool, error) {
 		return false, fmt.Errorf("failed to parse version '%s': %w", from, err)
 	}
 	dstVer, err := version.Parse(to)
+	if srcVer.Pre != nil && dstVer.Pre == nil {
+		// an upgrade from a pre-release version to a released version must not be tested (mainly due to incompatible licensing)
+		// but an upgrade from a released version to a pre-release version is to be tested (to catch any new issues before the release)
+		return false, nil
+	}
 	if err != nil {
 		return false, fmt.Errorf("failed to parse version '%s': %w", to, err)
 	}

--- a/test/e2e/test/version_test.go
+++ b/test/e2e/test/version_test.go
@@ -28,6 +28,7 @@ func TestIsValidUpgrade(t *testing.T) {
 		{from: "7.6.1", to: "7.6.0", isValid: false},
 		{from: "7.6.0", to: "6.8.5", isValid: false},
 		{from: "7.6.0", to: "9.0.0", isValid: false},
+		{from: "7.6.0-SNAPSHOT", to: "7.7.0", isValid: false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
To fix https://devops-ci.elastic.co/job/cloud-on-k8s-e2e-tests-snapshot-versions/493/testReport/
