### PR TITLE
Adjust Agent startup command to Ubuntu base image

### DIFF
--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -6,7 +6,6 @@ package agent
 
 import (
 	"fmt"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"hash"
 	"path"
 	"sort"
@@ -29,6 +28,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
@@ -387,10 +387,10 @@ func getAssociatedFleetServer(params Params) (commonv1.Associated, error) {
 	return &fs, nil
 }
 
-func trustCAScript(version version.Version, caPath string) string {
+func trustCAScript(ver version.Version, caPath string) string {
 	sharedCAPath := "/etc/pki/ca-trust/source/anchors/"
 	updateCmd := "update-ca-trust"
-	if version.Major == 8 {
+	if ver.GTE(version.MinFor(8, 0, 0)) {
 		sharedCAPath = "/usr/local/share/ca-certificates"
 		updateCmd = "update-ca-certificates"
 	}

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -390,7 +390,7 @@ func getAssociatedFleetServer(params Params) (commonv1.Associated, error) {
 func trustCAScript(ver version.Version, caPath string) string {
 	sharedCAPath := "/etc/pki/ca-trust/source/anchors/"
 	updateCmd := "update-ca-trust"
-	if ver.GTE(version.MinFor(8, 0, 0)) {
+	if ver.Major >= 8 {
 		sharedCAPath = "/usr/local/share/ca-certificates"
 		updateCmd = "update-ca-certificates"
 	}

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -6,6 +6,7 @@ package agent
 
 import (
 	"fmt"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"hash"
 	"path"
 	"sort"
@@ -314,12 +315,17 @@ func applyRelatedEsAssoc(agent agentv1alpha1.Agent, esAssociation commonv1.Assoc
 		certificatesDir(esAssociation),
 	))
 
+	agentVersion, err := version.Parse(agent.Spec.Version)
+	if err != nil {
+		return nil, err
+	}
+
 	// Beats managed by the Elastic Agent don't trust the Elasticsearch CA that Elastic Agent itself is configured
 	// to trust. There is currently no way to configure those Beats to trust a particular CA. The intended way to handle
 	// it is to allow Fleet to provide Beat output settings, but due to https://github.com/elastic/kibana/issues/102794
 	// this is not supported outside of UI. To workaround this limitation the Agent is going to update Pod-wide CA store
 	// before starting Elastic Agent.
-	cmd := trustCAScript(path.Join(certificatesDir(esAssociation), CAFileName))
+	cmd := trustCAScript(agentVersion, path.Join(certificatesDir(esAssociation), CAFileName))
 	return builder.WithCommand([]string{"/usr/bin/env", "bash", "-c", cmd}), nil
 }
 
@@ -381,15 +387,22 @@ func getAssociatedFleetServer(params Params) (commonv1.Associated, error) {
 	return &fs, nil
 }
 
-func trustCAScript(caPath string) string {
+func trustCAScript(version version.Version, caPath string) string {
+	sharedCAPath := "/etc/pki/ca-trust/source/anchors/"
+	updateCmd := "update-ca-trust"
+	if version.Major == 8 {
+		sharedCAPath = "/usr/local/share/ca-certificates"
+		updateCmd = "update-ca-certificates"
+	}
+
 	return fmt.Sprintf(`#!/usr/bin/env bash
 set -e
 if [[ -f %[1]s ]]; then
-  cp %[1]s /etc/pki/ca-trust/source/anchors/
-  update-ca-trust
+  cp %[1]s %[2]s
+  %[3]s
 fi
 /usr/bin/tini -- /usr/local/bin/docker-entrypoint -e
-`, caPath)
+`, caPath, sharedCAPath, updateCmd)
 }
 
 func createDataVolume(params Params) volume.VolumeLike {

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -17,12 +17,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/go-test/deep"
+
 	agentv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/agent/v1alpha1"
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
-	"github.com/go-test/deep"
 )
 
 func Test_amendBuilderForFleetMode(t *testing.T) {

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"github.com/go-test/deep"
 	"path"
 	"testing"
 
@@ -23,6 +22,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/go-test/deep"
 )
 
 func Test_amendBuilderForFleetMode(t *testing.T) {


### PR DESCRIPTION
Fixes #5250 

As stated in the title this adjusts the CA trust script we are running on startup when Agent is associated with an Elasticsearch instance to the new Ubuntu base image Agent is using in 8.x