### PR TITLE
Support new Agent base image as of 7.17

### DIFF
--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -390,7 +390,7 @@ func getAssociatedFleetServer(params Params) (commonv1.Associated, error) {
 func trustCAScript(ver version.Version, caPath string) string {
 	sharedCAPath := "/etc/pki/ca-trust/source/anchors/"
 	updateCmd := "update-ca-trust"
-	if ver.Major >= 8 {
+	if ver.GTE(version.MinFor(7, 17, 0)) {
 		sharedCAPath = "/usr/local/share/ca-certificates"
 		updateCmd = "update-ca-certificates"
 	}

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -629,7 +629,8 @@ func Test_applyRelatedEsAssoc(t *testing.T) {
 			MountPath: "/mnt/elastic-internal/elasticsearch-association/agent-ns/elasticsearch/certs",
 		},
 	}
-	expected8xCmd := []string{"/usr/bin/env", "bash", "-c", `#!/usr/bin/env bash
+	// as of version 7.17 Agent uses an Ubuntu base image
+	expectedUbuntuCmd := []string{"/usr/bin/env", "bash", "-c", `#!/usr/bin/env bash
 set -e
 if [[ -f /mnt/elastic-internal/elasticsearch-association/agent-ns/elasticsearch/certs/ca.crt ]]; then
   cp /mnt/elastic-internal/elasticsearch-association/agent-ns/elasticsearch/certs/ca.crt /usr/local/share/ca-certificates
@@ -681,6 +682,27 @@ fi
 			}),
 		},
 		{
+			name: "fleet server disabled, same namespace 7.17.0",
+			agent: agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "agent",
+					Namespace: agentNs,
+				},
+				Spec: agentv1alpha1.AgentSpec{
+					Version:            "7.17.0-SNAPSHOT",
+					FleetServerEnabled: false,
+				},
+			},
+			assoc:   assocToSameNs,
+			wantErr: false,
+			wantPodSpec: generatePodSpec(func(ps corev1.PodSpec) corev1.PodSpec {
+				ps.Volumes = expectedCAVolume
+				ps.Containers[0].VolumeMounts = expectedCAVolumeMount
+				ps.Containers[0].Command = expectedUbuntuCmd
+				return ps
+			}),
+		},
+		{
 			name: "fleet server disabled, same namespace 8x",
 			agent: agentv1alpha1.Agent{
 				ObjectMeta: metav1.ObjectMeta{
@@ -697,7 +719,7 @@ fi
 			wantPodSpec: generatePodSpec(func(ps corev1.PodSpec) corev1.PodSpec {
 				ps.Volumes = expectedCAVolume
 				ps.Containers[0].VolumeMounts = expectedCAVolumeMount
-				ps.Containers[0].Command = expected8xCmd
+				ps.Containers[0].Command = expectedUbuntuCmd
 				return ps
 			}),
 		},
@@ -718,7 +740,7 @@ fi
 			wantPodSpec: generatePodSpec(func(ps corev1.PodSpec) corev1.PodSpec {
 				ps.Volumes = expectedCAVolume
 				ps.Containers[0].VolumeMounts = expectedCAVolumeMount
-				ps.Containers[0].Command = expected8xCmd
+				ps.Containers[0].Command = expectedUbuntuCmd
 				return ps
 			}),
 		},


### PR DESCRIPTION
Addresses the fallout of https://github.com/elastic/beats/pull/29817

The original fix in #5253 incorrectly assumed that the base image change would only affect 8.x versions. As evidenced by recent test failures that is not the case: https://devops-ci.elastic.co/job/cloud-on-k8s-e2e-tests-snapshot-versions/497//testReport

This applies the logic for the Ubuntu base image as of version 7.17. 