### PR TITLE
[2.0] Change upgrade path validation for 8.0 to only allow 7.17 (#5261)

### DIFF
--- a/pkg/controller/elasticsearch/validation/validations.go
+++ b/pkg/controller/elasticsearch/validation/validations.go
@@ -272,11 +272,11 @@ func noDowngrades(current, proposed esv1.Elasticsearch) field.ErrorList {
 
 func validUpgradePath(current, proposed esv1.Elasticsearch) field.ErrorList {
 	var errs field.ErrorList
-	currentVer, err := version.Parse(current.Spec.Version)
-	if err != nil {
-		// this should not happen, since this is the already persisted version
-		errs = append(errs, field.Invalid(field.NewPath("spec").Child("version"), current.Spec.Version, parseStoredVersionErrMsg))
+	currentVer, ferr := currentVersion(current)
+	if ferr != nil {
+		errs = append(errs, ferr)
 	}
+
 	proposedVer, err := version.Parse(proposed.Spec.Version)
 	if err != nil {
 		errs = append(errs, field.Invalid(field.NewPath("spec").Child("version"), proposed.Spec.Version, parseVersionErrMsg))
@@ -296,6 +296,26 @@ func validUpgradePath(current, proposed esv1.Elasticsearch) field.ErrorList {
 		errs = append(errs, field.Invalid(field.NewPath("spec").Child("version"), proposed.Spec.Version, unsupportedUpgradeMsg))
 	}
 	return errs
+}
+
+func currentVersion(current esv1.Elasticsearch) (version.Version, *field.Error) {
+	// we do not have a version in the status let's use the version in the current spec instead which will not reflect
+	// actually running Pods but which is still better than no validation.
+	if current.Status.Version == "" {
+		currentVer, err := version.Parse(current.Spec.Version)
+		if err != nil {
+			// this should not happen, since this is the already persisted version
+			return version.Version{}, field.Invalid(field.NewPath("spec").Child("version"), current.Spec.Version, parseStoredVersionErrMsg)
+		}
+		return currentVer, nil
+	}
+	// if available use the status version which reflects the lowest version currently running in the cluster
+	currentVer, err := version.Parse(current.Status.Version)
+	if err != nil {
+		// this should not happen, since this is the version from the spec copied to the status by the operator
+		return version.Version{}, field.Invalid(field.NewPath("status").Child("version"), current.Status.Version, parseStoredVersionErrMsg)
+	}
+	return currentVer, nil
 }
 
 func validMonitoring(es esv1.Elasticsearch) field.ErrorList {

--- a/pkg/controller/elasticsearch/validation/validations_test.go
+++ b/pkg/controller/elasticsearch/validation/validations_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -381,6 +380,21 @@ func Test_validUpgradePath(t *testing.T) {
 			current:      es("6.8.0"),
 			proposed:     es("7.1.0"),
 			expectErrors: false,
+		},
+		{
+			name: "not yet fully upgraded rejected",
+			current: esv1.Elasticsearch{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "foo",
+				},
+				Spec: esv1.ElasticsearchSpec{Version: "7.17.0"},
+				Status: esv1.ElasticsearchStatus{
+					Version: "7.16.2",
+				},
+			},
+			proposed:     es("8.0.0"),
+			expectErrors: true, // still running at least one node with 7.16.2
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/controller/elasticsearch/version/supported_versions.go
+++ b/pkg/controller/elasticsearch/version/supported_versions.go
@@ -36,8 +36,8 @@ func technicallySupportedVersions(v version.Version) *version.MinMaxVersion {
 		}
 	case 8:
 		return &version.MinMaxVersion{
-			// 7.4.0 is the lowest version that offers a direct upgrade path to 8.0
-			Min: version.MustParse("7.4.0"),
+			// 7.17.0 is the lowest version that offers a direct upgrade path to 8.0
+			Min: version.MinFor(7, 17, 0), // allow snapshot builds here for testing
 			Max: version.MustParse("8.99.99"),
 		}
 	default:

--- a/pkg/controller/elasticsearch/version/supported_versions_test.go
+++ b/pkg/controller/elasticsearch/version/supported_versions_test.go
@@ -58,7 +58,7 @@ func TestSupportedVersions(t *testing.T) {
 				v: version.MustParse("8.0.0"),
 			},
 			supported: []version.Version{
-				version.MustParse("7.4.0"),
+				version.MustParse("7.17.0"),
 				version.MustParse("8.9.0"),
 			},
 			unsupported: []version.Version{


### PR DESCRIPTION
Backports the following commits to 2.0:
 - Change upgrade path validation for 8.0 to only allow 7.17 (#5261)