### PR TITLE
E2E: adjust continuous health check for non-HA clusters

### DIFF
--- a/pkg/utils/retry/retry.go
+++ b/pkg/utils/retry/retry.go
@@ -47,7 +47,6 @@ func UntilSuccess(f func() error, timeout time.Duration, retryInterval time.Dura
 			if err == nil {
 				return nil
 			}
-			println(err.Error())
 			lastErr = err
 			retryTimer := time.NewTimer(retryInterval)
 			select {

--- a/pkg/utils/retry/retry.go
+++ b/pkg/utils/retry/retry.go
@@ -47,6 +47,7 @@ func UntilSuccess(f func() error, timeout time.Duration, retryInterval time.Dura
 			if err == nil {
 				return nil
 			}
+			println(err.Error())
 			lastErr = err
 			retryTimer := time.NewTimer(retryInterval)
 			select {

--- a/test/e2e/test/elasticsearch/settings.go
+++ b/test/e2e/test/elasticsearch/settings.go
@@ -11,18 +11,26 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
 )
 
+func MustNumMasterNodes(es esv1.Elasticsearch) int {
+	return mustNumNodes(esv1.MasterRole, es)
+}
+
 func MustNumDataNodes(es esv1.Elasticsearch) int {
+	return mustNumNodes(esv1.DataRole, es)
+}
+
+func mustNumNodes(role esv1.NodeRole, es esv1.Elasticsearch) int {
 	var numNodes int
 	ver := version.MustParse(es.Spec.Version)
 	for _, n := range es.Spec.NodeSets {
-		if isDataNode(n, ver) {
+		if hasRoles(role, n, ver) {
 			numNodes += int(n.Count)
 		}
 	}
 	return numNodes
 }
 
-func isDataNode(node esv1.NodeSet, ver version.Version) bool {
+func hasRoles(role esv1.NodeRole, node esv1.NodeSet, ver version.Version) bool {
 	if node.Config == nil {
 		return esv1.DefaultCfg(ver).Node.HasRole(esv1.DataRole)
 	}
@@ -36,5 +44,5 @@ func isDataNode(node esv1.NodeSet, ver version.Version) bool {
 	if err != nil {
 		panic(err)
 	}
-	return nodeCfg.Node.HasRole(esv1.DataRole)
+	return nodeCfg.Node.HasRole(role)
 }

--- a/test/e2e/test/elasticsearch/settings.go
+++ b/test/e2e/test/elasticsearch/settings.go
@@ -23,14 +23,14 @@ func mustNumNodes(role esv1.NodeRole, es esv1.Elasticsearch) int {
 	var numNodes int
 	ver := version.MustParse(es.Spec.Version)
 	for _, n := range es.Spec.NodeSets {
-		if hasRoles(role, n, ver) {
+		if hasRole(role, n, ver) {
 			numNodes += int(n.Count)
 		}
 	}
 	return numNodes
 }
 
-func hasRoles(role esv1.NodeRole, node esv1.NodeSet, ver version.Version) bool {
+func hasRole(role esv1.NodeRole, node esv1.NodeSet, ver version.Version) bool {
 	if node.Config == nil {
 		return esv1.DefaultCfg(ver).Node.HasRole(esv1.DataRole)
 	}


### PR DESCRIPTION
This adjusts the skip condition on the continuous health check we run during mutation tests to account for non-HA clusters. A single node or two master node configuration will loose availability due to loss of quorum during a rolling upgrade and we did not account for that in our previous checks. 

The fact that this only now shows up in our CI after such a long time is due to the fact that this behaviour was covered up by two other conditions (at least that is my theory):
* for 6.8.x we always allowed for a generous 120 seconds of downtime which must have been enough to upgrade the current master node and re-establish quorum (not verified)
*  for 7.x we had a bug in the test where we tested an upgrade from `dstVersion` to `dstVersion` which means no update at all. This was fixed in https://github.com/elastic/cloud-on-k8s/pull/4961/files#diff-81988e08bfe062349de9bf20f8c0605cfffc3fd187250408ca118ee3e6a9956eR175