### PR TITLE
adjusted recipes for default policy change

### DIFF
--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -38,7 +38,7 @@ spec:
       monitoring_enabled:
       - logs
       - metrics
-      unenroll_timeout: 900  
+      unenroll_timeout: 900
       is_default: true
       package_policies:
       - name: system-1

--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -39,6 +39,7 @@ spec:
       - logs
       - metrics
       unenroll_timeout: 900  
+      is_default: true
       package_policies:
       - name: system-1
         id: system-1

--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -11,48 +11,48 @@ spec:
     xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
     xpack.fleet.packages:
-      - name: system
-        version: latest
-      - name: elastic_agent
-        version: latest
-      - name: fleet_server
-        version: latest
-      - name: apm
-        version: latest
+    - name: system
+      version: latest
+    - name: elastic_agent
+      version: latest
+    - name: fleet_server
+      version: latest
+    - name: apm
+      version: latest
     xpack.fleet.agentPolicies:
-      - name: Fleet Server on ECK policy
-        id: eck-fleet-server
-        is_default_fleet_server: true
-        namespace: default
-        monitoring_enabled:
-          - logs
-          - metrics
-        package_policies:
-        - name: fleet_server-1
-          id: fleet_server-1
-          package:
-            name: fleet_server
-      - name: Elastic Agent on ECK policy
-        id: eck-agent
-        namespace: default
-        monitoring_enabled:
-          - logs
-          - metrics
-        unenroll_timeout: 900  
-        package_policies:
-          - name: system-1
-            id: system-1
-            package:
-              name: system
-          - package:
-            name: apm
-          name: apm-1
-          inputs:
-          - type: apm
-            enabled: true
-            vars:
-            - name: host
-              value: 0.0.0.0:8200    
+    - name: Fleet Server on ECK policy
+      id: eck-fleet-server
+      is_default_fleet_server: true
+      namespace: default
+      monitoring_enabled:
+      - logs
+      - metrics
+      package_policies:
+      - name: fleet_server-1
+        id: fleet_server-1
+        package:
+          name: fleet_server
+    - name: Elastic Agent on ECK policy
+      id: eck-agent
+      namespace: default
+      monitoring_enabled:
+      - logs
+      - metrics
+      unenroll_timeout: 900  
+      package_policies:
+      - name: system-1
+        id: system-1
+        package:
+          name: system
+      - package:
+          name: apm
+        name: apm-1
+        inputs:
+        - type: apm
+          enabled: true
+          vars:
+          - name: host
+            value: 0.0.0.0:8200    
 ---
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch

--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -11,20 +11,40 @@ spec:
     xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
     xpack.fleet.packages:
+    - name: system
+      version: latest
+    - name: elastic_agent
+      version: latest
+    - name: fleet_server
+      version: latest
     - name: apm
       version: latest
-    xpack.fleet.agentPolicies:
-    - name: Default Fleet Server on ECK policy
+  xpack.fleet.agentPolicies:
+    - name: Fleet Server on ECK policy
+      id: eck-fleet-server
       is_default_fleet_server: true
+      namespace: default
+      monitoring_enabled:
+        - logs
+        - metrics
       package_policies:
-      - package:
+      - name: fleet_server-1
+        id: fleet_server-1
+        package:
           name: fleet_server
-        name: fleet_server-1
-    - name: Default Elastic Agent on ECK policy
-      is_default: true
-      unenroll_timeout: 900
+    - name: Elastic Agent on ECK policy
+      id: eck-agent
+      namespace: default
+      monitoring_enabled:
+        - logs
+        - metrics
+      unenroll_timeout: 900  
       package_policies:
-      - package:
+        - name: system-1
+          id: system-1
+          package:
+            name: system
+        - package:
           name: apm
         name: apm-1
         inputs:
@@ -32,7 +52,7 @@ spec:
           enabled: true
           vars:
           - name: host
-            value: 0.0.0.0:8200
+            value: 0.0.0.0:8200    
 ---
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch

--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -11,48 +11,48 @@ spec:
     xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
     xpack.fleet.packages:
-    - name: system
-      version: latest
-    - name: elastic_agent
-      version: latest
-    - name: fleet_server
-      version: latest
-    - name: apm
-      version: latest
-  xpack.fleet.agentPolicies:
-    - name: Fleet Server on ECK policy
-      id: eck-fleet-server
-      is_default_fleet_server: true
-      namespace: default
-      monitoring_enabled:
-        - logs
-        - metrics
-      package_policies:
-      - name: fleet_server-1
-        id: fleet_server-1
-        package:
-          name: fleet_server
-    - name: Elastic Agent on ECK policy
-      id: eck-agent
-      namespace: default
-      monitoring_enabled:
-        - logs
-        - metrics
-      unenroll_timeout: 900  
-      package_policies:
-        - name: system-1
-          id: system-1
+      - name: system
+        version: latest
+      - name: elastic_agent
+        version: latest
+      - name: fleet_server
+        version: latest
+      - name: apm
+        version: latest
+    xpack.fleet.agentPolicies:
+      - name: Fleet Server on ECK policy
+        id: eck-fleet-server
+        is_default_fleet_server: true
+        namespace: default
+        monitoring_enabled:
+          - logs
+          - metrics
+        package_policies:
+        - name: fleet_server-1
+          id: fleet_server-1
           package:
-            name: system
-        - package:
-          name: apm
-        name: apm-1
-        inputs:
-        - type: apm
-          enabled: true
-          vars:
-          - name: host
-            value: 0.0.0.0:8200    
+            name: fleet_server
+      - name: Elastic Agent on ECK policy
+        id: eck-agent
+        namespace: default
+        monitoring_enabled:
+          - logs
+          - metrics
+        unenroll_timeout: 900  
+        package_policies:
+          - name: system-1
+            id: system-1
+            package:
+              name: system
+          - package:
+            name: apm
+          name: apm-1
+          inputs:
+          - type: apm
+            enabled: true
+            vars:
+            - name: host
+              value: 0.0.0.0:8200    
 ---
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -39,6 +39,7 @@ spec:
       - logs
       - metrics
       unenroll_timeout: 900  
+      is_default: true
       package_policies:
       - name: system-1
         id: system-1

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -11,19 +11,39 @@ spec:
     xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
     xpack.fleet.packages:
-    - name: log
-      version: latest
-    xpack.fleet.agentPolicies:
-    - name: Default Fleet Server on ECK policy
-      is_default_fleet_server: true
-      package_policies:
-      - package:
+  - name: system
+    version: latest
+  - name: elastic_agent
+    version: latest
+  - name: fleet_server
+    version: latest
+  - name: log
+    version: latest  
+xpack.fleet.agentPolicies:
+  - name: Fleet Server on ECK policy
+    id: eck-fleet-server
+    namespace: default
+    monitoring_enabled:
+      - logs
+      - metrics
+    is_default_fleet_server: true
+    package_policies:
+      - name: fleet_server-1
+        id: fleet_server-1
+        package:
           name: fleet_server
-        name: fleet_server-1
-    - name: Default Elastic Agent on ECK policy
-      is_default: true
-      unenroll_timeout: 900
-      package_policies:
+  - name: Elastic Agent on ECK policy
+    id: eck-agent
+    namespace: default
+    monitoring_enabled:
+      - logs
+      - metrics
+    unenroll_timeout: 900  
+    package_policies:
+      - name: system-1
+        id: system-1
+        package:
+          name: system
       - package:
           name: log
         name: log-1

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -11,57 +11,57 @@ spec:
     xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
     xpack.fleet.packages:
-      - name: system
-        version: latest
-      - name: elastic_agent
-        version: latest
-      - name: fleet_server
-        version: latest
-      - name: log
-        version: latest  
+    - name: system
+      version: latest
+    - name: elastic_agent
+      version: latest
+    - name: fleet_server
+      version: latest
+    - name: log
+      version: latest  
     xpack.fleet.agentPolicies:
-      - name: Fleet Server on ECK policy
-        id: eck-fleet-server
-        namespace: default
-        monitoring_enabled:
-          - logs
-          - metrics
-        is_default_fleet_server: true
-        package_policies:
-          - name: fleet_server-1
-            id: fleet_server-1
-            package:
-              name: fleet_server
-      - name: Elastic Agent on ECK policy
-        id: eck-agent
-        namespace: default
-        monitoring_enabled:
-          - logs
-          - metrics
-        unenroll_timeout: 900  
-        package_policies:
-          - name: system-1
-            id: system-1
-            package:
-              name: system
-          - package:
-              name: log
-            name: log-1
-            inputs:
-            - type: logfile
-              enabled: true
-              streams:
-              - data_stream:
-                  dataset: log.log
-                enabled: true
-                vars:
-                - name: paths
-                  value:
-                  - '/var/log/containers/*${kubernetes.container.id}.log'
-                - name: custom
-                  value: |
-                    symlinks: true
-                    condition: ${kubernetes.namespace} == 'default'
+    - name: Fleet Server on ECK policy
+      id: eck-fleet-server
+      namespace: default
+      monitoring_enabled:
+      - logs
+      - metrics
+      is_default_fleet_server: true
+      package_policies:
+      - name: fleet_server-1
+        id: fleet_server-1
+        package:
+          name: fleet_server
+    - name: Elastic Agent on ECK policy
+      id: eck-agent
+      namespace: default
+      monitoring_enabled:
+      - logs
+      - metrics
+      unenroll_timeout: 900  
+      package_policies:
+      - name: system-1
+        id: system-1
+        package:
+          name: system
+      - package:
+          name: log
+        name: log-1
+        inputs:
+        - type: logfile
+          enabled: true
+          streams:
+          - data_stream:
+              dataset: log.log
+            enabled: true
+            vars:
+            - name: paths
+              value:
+              - '/var/log/containers/*${kubernetes.container.id}.log'
+            - name: custom
+              value: |
+                symlinks: true
+                condition: ${kubernetes.namespace} == 'default'
 ---
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -11,57 +11,57 @@ spec:
     xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
     xpack.fleet.packages:
-  - name: system
-    version: latest
-  - name: elastic_agent
-    version: latest
-  - name: fleet_server
-    version: latest
-  - name: log
-    version: latest  
-xpack.fleet.agentPolicies:
-  - name: Fleet Server on ECK policy
-    id: eck-fleet-server
-    namespace: default
-    monitoring_enabled:
-      - logs
-      - metrics
-    is_default_fleet_server: true
-    package_policies:
-      - name: fleet_server-1
-        id: fleet_server-1
-        package:
-          name: fleet_server
-  - name: Elastic Agent on ECK policy
-    id: eck-agent
-    namespace: default
-    monitoring_enabled:
-      - logs
-      - metrics
-    unenroll_timeout: 900  
-    package_policies:
-      - name: system-1
-        id: system-1
-        package:
-          name: system
-      - package:
-          name: log
-        name: log-1
-        inputs:
-        - type: logfile
-          enabled: true
-          streams:
-          - data_stream:
-              dataset: log.log
-            enabled: true
-            vars:
-            - name: paths
-              value:
-              - '/var/log/containers/*${kubernetes.container.id}.log'
-            - name: custom
-              value: |
-                symlinks: true
-                condition: ${kubernetes.namespace} == 'default'
+      - name: system
+        version: latest
+      - name: elastic_agent
+        version: latest
+      - name: fleet_server
+        version: latest
+      - name: log
+        version: latest  
+    xpack.fleet.agentPolicies:
+      - name: Fleet Server on ECK policy
+        id: eck-fleet-server
+        namespace: default
+        monitoring_enabled:
+          - logs
+          - metrics
+        is_default_fleet_server: true
+        package_policies:
+          - name: fleet_server-1
+            id: fleet_server-1
+            package:
+              name: fleet_server
+      - name: Elastic Agent on ECK policy
+        id: eck-agent
+        namespace: default
+        monitoring_enabled:
+          - logs
+          - metrics
+        unenroll_timeout: 900  
+        package_policies:
+          - name: system-1
+            id: system-1
+            package:
+              name: system
+          - package:
+              name: log
+            name: log-1
+            inputs:
+            - type: logfile
+              enabled: true
+              streams:
+              - data_stream:
+                  dataset: log.log
+                enabled: true
+                vars:
+                - name: paths
+                  value:
+                  - '/var/log/containers/*${kubernetes.container.id}.log'
+                - name: custom
+                  value: |
+                    symlinks: true
+                    condition: ${kubernetes.namespace} == 'default'
 ---
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -11,21 +11,37 @@ spec:
     xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
     xpack.fleet.packages:
-    - name: kubernetes
-      # pinning this version as the next one introduced a kube-proxy host setting default that breaks this recipe,
-      # see https://github.com/elastic/integrations/pull/1565 for more details
-      version: 0.14.0
-    xpack.fleet.agentPolicies:
-    - name: Default Fleet Server on ECK policy
-      is_default_fleet_server: true
-      package_policies:
-      - package:
+  - name: system
+    version: latest
+  - name: elastic_agent
+    version: latest
+  - name: fleet_server
+    version: latest
+  - name: kubernetes
+    # pinning this version as the next one introduced a kube-proxy host setting default that breaks this recipe,
+    # see https://github.com/elastic/integrations/pull/1565 for more details
+    version: 0.14.0  
+xpack.fleet.agentPolicies:
+  - name: Fleet Server on ECK policy
+    id: eck-fleet-server
+    namespace: default
+    monitoring_enabled:
+      - logs
+      - metrics
+    is_default_fleet_server: true
+    package_policies:
+      - name: fleet_server-1
+        id: fleet_server-1
+        package:
           name: fleet_server
-        name: fleet_server-1
-    - name: Default Elastic Agent on ECK policy
-      is_default: true
-      unenroll_timeout: 900
-      package_policies:
+  - name: Elastic Agent on ECK policy
+    id: eck-agent
+    namespace: default
+    monitoring_enabled:
+      - logs
+      - metrics
+    unenroll_timeout: 900
+    package_policies:
       - package:
           name: system
         name: system-1

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -26,8 +26,8 @@ spec:
       id: eck-fleet-server
       namespace: default
       monitoring_enabled:
-        - logs
-        - metrics
+      - logs
+      - metrics
       is_default_fleet_server: true
       package_policies:
       - name: fleet_server-1

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -41,6 +41,7 @@ spec:
       - logs
       - metrics
       unenroll_timeout: 900
+      is_default: true
       package_policies:
       - package:
           name: system

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -20,7 +20,7 @@ spec:
     - name: kubernetes
       # pinning this version as the next one introduced a kube-proxy host setting default that breaks this recipe,
       # see https://github.com/elastic/integrations/pull/1565 for more details
-      version: 0.14.0  
+      version: 0.14.0
     xpack.fleet.agentPolicies:
     - name: Fleet Server on ECK policy
       id: eck-fleet-server

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -11,43 +11,43 @@ spec:
     xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
     xpack.fleet.packages:
-      - name: system
-        version: latest
-      - name: elastic_agent
-        version: latest
-      - name: fleet_server
-        version: latest
-      - name: kubernetes
-        # pinning this version as the next one introduced a kube-proxy host setting default that breaks this recipe,
-        # see https://github.com/elastic/integrations/pull/1565 for more details
-        version: 0.14.0  
+    - name: system
+      version: latest
+    - name: elastic_agent
+      version: latest
+    - name: fleet_server
+      version: latest
+    - name: kubernetes
+      # pinning this version as the next one introduced a kube-proxy host setting default that breaks this recipe,
+      # see https://github.com/elastic/integrations/pull/1565 for more details
+      version: 0.14.0  
     xpack.fleet.agentPolicies:
-      - name: Fleet Server on ECK policy
-        id: eck-fleet-server
-        namespace: default
-        monitoring_enabled:
-          - logs
-          - metrics
-        is_default_fleet_server: true
-        package_policies:
-          - name: fleet_server-1
-            id: fleet_server-1
-            package:
-              name: fleet_server
-      - name: Elastic Agent on ECK policy
-        id: eck-agent
-        namespace: default
-        monitoring_enabled:
-          - logs
-          - metrics
-        unenroll_timeout: 900
-        package_policies:
-          - package:
-              name: system
-            name: system-1
-          - package:
-              name: kubernetes
-            name: kubernetes-1
+    - name: Fleet Server on ECK policy
+      id: eck-fleet-server
+      namespace: default
+      monitoring_enabled:
+        - logs
+        - metrics
+      is_default_fleet_server: true
+      package_policies:
+      - name: fleet_server-1
+        id: fleet_server-1
+        package:
+          name: fleet_server
+    - name: Elastic Agent on ECK policy
+      id: eck-agent
+      namespace: default
+      monitoring_enabled:
+      - logs
+      - metrics
+      unenroll_timeout: 900
+      package_policies:
+      - package:
+          name: system
+        name: system-1
+      - package:
+          name: kubernetes
+        name: kubernetes-1
 ---
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -11,43 +11,43 @@ spec:
     xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
     xpack.fleet.packages:
-  - name: system
-    version: latest
-  - name: elastic_agent
-    version: latest
-  - name: fleet_server
-    version: latest
-  - name: kubernetes
-    # pinning this version as the next one introduced a kube-proxy host setting default that breaks this recipe,
-    # see https://github.com/elastic/integrations/pull/1565 for more details
-    version: 0.14.0  
-xpack.fleet.agentPolicies:
-  - name: Fleet Server on ECK policy
-    id: eck-fleet-server
-    namespace: default
-    monitoring_enabled:
-      - logs
-      - metrics
-    is_default_fleet_server: true
-    package_policies:
-      - name: fleet_server-1
-        id: fleet_server-1
-        package:
-          name: fleet_server
-  - name: Elastic Agent on ECK policy
-    id: eck-agent
-    namespace: default
-    monitoring_enabled:
-      - logs
-      - metrics
-    unenroll_timeout: 900
-    package_policies:
-      - package:
-          name: system
-        name: system-1
-      - package:
-          name: kubernetes
-        name: kubernetes-1
+      - name: system
+        version: latest
+      - name: elastic_agent
+        version: latest
+      - name: fleet_server
+        version: latest
+      - name: kubernetes
+        # pinning this version as the next one introduced a kube-proxy host setting default that breaks this recipe,
+        # see https://github.com/elastic/integrations/pull/1565 for more details
+        version: 0.14.0  
+    xpack.fleet.agentPolicies:
+      - name: Fleet Server on ECK policy
+        id: eck-fleet-server
+        namespace: default
+        monitoring_enabled:
+          - logs
+          - metrics
+        is_default_fleet_server: true
+        package_policies:
+          - name: fleet_server-1
+            id: fleet_server-1
+            package:
+              name: fleet_server
+      - name: Elastic Agent on ECK policy
+        id: eck-agent
+        namespace: default
+        monitoring_enabled:
+          - logs
+          - metrics
+        unenroll_timeout: 900
+        package_policies:
+          - package:
+              name: system
+            name: system-1
+          - package:
+              name: kubernetes
+            name: kubernetes-1
 ---
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch

--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -107,6 +107,7 @@ spec:
           - logs
           - metrics
         unenroll_timeout: 900  
+        is_default: true
         package_policies:
           - name: system-1
             id: system-1
@@ -291,6 +292,7 @@ spec:
           - logs
           - metrics
         unenroll_timeout: 900  
+        is_default: true
         package_policies:
           - name: system-1
             id: system-1

--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -304,7 +304,7 @@ spec:
 
 *  `xpack.fleet.packages` are required packages to enable Fleet Server and Elastic Agents to enroll. 
 
-*  `xpack.fleet.agentPolicies` policies are needed for Fleet Server and Elastic Agents to enroll to, see https://www.elastic.co/guide/en/fleet/current/agent-policy.html for more information.
+*  `xpack.fleet.agentPolicies` policies are needed for Fleet Server and Elastic Agents to enroll to, check https://www.elastic.co/guide/en/fleet/current/agent-policy.html for more information.
 
 [id="{p}-elastic-agent-fleet-configuration-setting-referenced-resources"]
 === Set referenced resources

--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -80,6 +80,38 @@ spec:
   config:
     xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-quickstart-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-quickstart-agent-http.default.svc:8220"]
+    xpack.fleet.packages:
+      - name: system
+        version: latest
+      - name: elastic_agent
+        version: latest
+      - name: fleet_server
+        version: latest
+    xpack.fleet.agentPolicies:
+      - name: Fleet Server on ECK policy
+        id: eck-fleet-server
+        is_default_fleet_server: true
+        namespace: default
+        monitoring_enabled:
+          - logs
+          - metrics
+        package_policies:
+        - name: fleet_server-1
+          id: fleet_server-1
+          package:
+            name: fleet_server
+      - name: Elastic Agent on ECK policy
+        id: eck-agent
+        namespace: default
+        monitoring_enabled:
+          - logs
+          - metrics
+        unenroll_timeout: 900  
+        package_policies:
+          - name: system-1
+            id: system-1
+            package:
+              name: system
 ---
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch
@@ -232,11 +264,47 @@ spec:
   config:
     xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-sample-es-http.default.svc:9200"]
     xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-sample-agent-http.default.svc:8220"]
+    xpack.fleet.packages:
+      - name: system
+        version: latest
+      - name: elastic_agent
+        version: latest
+      - name: fleet_server
+        version: latest
+    xpack.fleet.agentPolicies:
+      - name: Fleet Server on ECK policy
+        id: eck-fleet-server
+        is_default_fleet_server: true
+        namespace: default
+        monitoring_enabled:
+          - logs
+          - metrics
+        package_policies:
+        - name: fleet_server-1
+          id: fleet_server-1
+          package:
+            name: fleet_server
+      - name: Elastic Agent on ECK policy
+        id: eck-agent
+        namespace: default
+        monitoring_enabled:
+          - logs
+          - metrics
+        unenroll_timeout: 900  
+        package_policies:
+          - name: system-1
+            id: system-1
+            package:
+              name: system
 ----
 
 *  `xpack.fleet.agents.elasticsearch.hosts`  must point to the Elasticsearch cluster that Elastic Agents should send data to. For ECK-managed Elasticsearch clusters, ECK creates a Service accessible through `https://ES_RESOURCE_NAME-es-http.ES_RESOURCE_NAMESPACE.svc:9200` URL, where `ES_RESOURCE_NAME` is the name of Elasticsearch resource and `ES_RESOURCE_NAMESPACE` is the namespace it was deployed in.
 
 *  `xpack.fleet.agents.fleet_server.hosts` must point to Fleet Server that Elastic Agents should connect to. For ECK-managed Fleet Server instances, ECK creates a Service accessible through `https://FS_RESOURCE_NAME-agent-http.FS_RESOURCE_NAMESPACE.svc:8220` URL, where `FS_RESOURCE_NAME` is the name of Elastic Agent resource with Fleet Server enabled and `FS_RESOURCE_NAMESPACE` is the namespace it was deployed in.
+
+*  `xpack.fleet.packages` are required packages to enable Fleet Server and Elastic Agents to enroll. 
+
+*  `xpack.fleet.agentPolicies` policies are needed for Fleet Server and Elastic Agents to enroll to, see https://www.elastic.co/guide/en/fleet/current/agent-policy.html for more information.
 
 [id="{p}-elastic-agent-fleet-configuration-setting-referenced-resources"]
 === Set referenced resources


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/5262
To adjust recipes to the change in kibana (removing default policies), added system, elastic_agent, fleet_server packages to the preconfigured policies for ECK.
