### PR TITLE
Allow predicates to disabled on a case-by-case basis via annotation.

### DIFF
--- a/pkg/controller/elasticsearch/driver/fixtures.go
+++ b/pkg/controller/elasticsearch/driver/fixtures.go
@@ -116,11 +116,12 @@ func newUpgradeTestPods(pods ...testPod) upgradeTestPods {
 	return result
 }
 
-func (u upgradeTestPods) toES(version string, maxUnavailable int) esv1.Elasticsearch {
+func (u upgradeTestPods) toES(version string, maxUnavailable int, annotations map[string]string) esv1.Elasticsearch {
 	return esv1.Elasticsearch{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      TestEsName,
-			Namespace: TestEsNamespace,
+			Name:        TestEsName,
+			Namespace:   TestEsNamespace,
+			Annotations: annotations,
 		},
 		Spec: esv1.ElasticsearchSpec{
 			Version: version,
@@ -159,7 +160,7 @@ func (u upgradeTestPods) toStatefulSetList() sset.StatefulSetList {
 	return statefulSetList
 }
 
-func (u upgradeTestPods) toRuntimeObjects(version string, maxUnavailable int, f filter) []runtime.Object {
+func (u upgradeTestPods) toRuntimeObjects(version string, maxUnavailable int, f filter, annotations map[string]string) []runtime.Object {
 	var result []runtime.Object
 	for _, testPod := range u {
 		pod := testPod.toPod()
@@ -167,7 +168,7 @@ func (u upgradeTestPods) toRuntimeObjects(version string, maxUnavailable int, f 
 			result = append(result, &pod)
 		}
 	}
-	es := u.toES(version, maxUnavailable)
+	es := u.toES(version, maxUnavailable, annotations)
 	result = append(result, &es)
 	return result
 }

--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -188,7 +188,7 @@ func Test_healthyPods(t *testing.T) {
 			esState := &testESState{
 				inCluster: tt.args.pods.podsInCluster(),
 			}
-			client := k8s.NewFakeClient(tt.args.pods.toRuntimeObjects("7.5.0", 0, nothing)...)
+			client := k8s.NewFakeClient(tt.args.pods.toRuntimeObjects("7.5.0", 0, nothing, nil)...)
 			got, err := healthyPods(client, tt.args.statefulSets, esState)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("healthyPods() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Closes #2092 

This change will allow ECK user to disable certain upgrade predicates, by name, via an annotation on the Elasticsearch CRD, thus allowing clusters to be "forced" to be upgraded in scenarios where the default predicates (that disallow upgrade because of a set of rules) are too restrictive.

Use Case 1:

Cluster is a "red" state because of an un-assignable shard.  This cluster would never be allowed to be upgraded with the standard set of upgrade predicates in place.

If the following annotation was added to the cluster

```yaml
apiVersion: elasticsearch.k8s.elastic.co/v1
kind: Elasticsearch
metadata:
  name: testing
  annotations:
    eck.k8s.elastic.co/disable-upgrade-predicates: "only_restart_healthy_node_if_green_or_yellow"
spec:
  version: 7.15.1
```

And the version was bumped to `7.15.2`, then this cluster's nodes would be allowed to be upgraded in this scenario, even with the cluster in a "red" state.

Use Case 2:

A test Elasticsearch cluster has been setup, and regardless of any state of the cluster, a user wants to force an upgrade.

With the following annotation, and a version bump to `7.15.2`, all predicates will be disabled, allowing an upgrade to proceed regardless of the state of the cluster:

```yaml
apiVersion: elasticsearch.k8s.elastic.co/v1
kind: Elasticsearch
metadata:
  name: testing
  annotations:
    eck.k8s.elastic.co/disable-upgrade-predicates: "*"
spec:
  version: 7.15.1
```

Discussion Points

* Do we want to allow anything other than disabling one predicate, or disabling all predicates?  Such as disabling 2 or more predicates specifically?  The way this is designed at the moment, this wouldn't be allowed.

Todo
- [ ] Write documentation