### PR TITLE
Ent Search: avoid generating invalid config in the presence of user of user overrides

### DIFF
--- a/pkg/controller/common/settings/canonical_config.go
+++ b/pkg/controller/common/settings/canonical_config.go
@@ -159,10 +159,7 @@ func (c *CanonicalConfig) HasChildConfig(key string) bool {
 		return false
 	}
 	_, err := c.asUCfg().Child(key, -1, Options...)
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 // Render returns the content of the configuration file,

--- a/pkg/controller/common/settings/canonical_config.go
+++ b/pkg/controller/common/settings/canonical_config.go
@@ -158,6 +158,10 @@ func (c *CanonicalConfig) HasChildConfig(key string) bool {
 	if c == nil {
 		return false
 	}
+	// We are expecting two kinds of error here:
+	// type mismatch: if key is pointing to a primitive value that means we don't have a child config
+	// missing path: if the key does not exist in the config we also do not have a child config
+	// There should be no other errors thrown by ucfg thus there is no error return type in this function.
 	_, err := c.asUCfg().Child(key, -1, Options...)
 	return err == nil
 }

--- a/pkg/controller/common/settings/canonical_config.go
+++ b/pkg/controller/common/settings/canonical_config.go
@@ -153,6 +153,18 @@ func (c *CanonicalConfig) HasKeys(keys []string) []string {
 	return has
 }
 
+// HasChildConfig returns true if c has a child config object below key.
+func (c *CanonicalConfig) HasChildConfig(key string) bool {
+	if c == nil {
+		return false
+	}
+	_, err := c.asUCfg().Child(key, -1, Options...)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
 // Render returns the content of the configuration file,
 // with fields sorted alphabetically
 func (c *CanonicalConfig) Render() ([]byte, error) {

--- a/pkg/controller/common/settings/canonical_config_test.go
+++ b/pkg/controller/common/settings/canonical_config_test.go
@@ -451,3 +451,70 @@ func TestNewCanonicalConfigFrom(t *testing.T) {
 		})
 	}
 }
+
+func TestCanonicalConfig_HasChildConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		c    *CanonicalConfig
+		key  string
+		want bool
+	}{
+		{
+			name: "nil config",
+			c:    nil,
+			key:  "x",
+			want: false,
+		},
+		{
+			name: "empty config",
+			c:    MustCanonicalConfig(map[string]interface{}{}),
+			key:  "x",
+			want: false,
+		},
+		{
+			name: "valid top-level key but not a child config",
+			c: MustCanonicalConfig(map[string]interface{}{
+				"x": "y",
+			}),
+			key:  "x",
+			want: false,
+		},
+		{
+			name: "valid top level key",
+			c: MustCanonicalConfig(map[string]interface{}{
+				"x": map[string]interface{}{
+					"y": "1",
+					"z": "2",
+				},
+			}),
+			key:  "x",
+			want: true,
+		},
+		{
+			name: "valid nested  key",
+			c: MustCanonicalConfig(map[string]interface{}{
+				"x": map[string]interface{}{
+					"y": map[string]interface{}{},
+					"z": "2",
+				},
+			}),
+			key:  "x.y",
+			want: true,
+		},
+		{
+			name: "absent key",
+			c: MustCanonicalConfig(map[string]interface{}{
+				"x": "y",
+			}),
+			key:  "z",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.c.HasChildConfig(tt.key); got != tt.want {
+				t.Errorf("HasChildConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/enterprisesearch/config.go
+++ b/pkg/controller/enterprisesearch/config.go
@@ -151,10 +151,7 @@ func newConfig(driver driver.Interface, ent entv1.EnterpriseSearch, ipFamily cor
 		return nil, err
 	}
 	tlsCfg := tlsConfig(ent)
-	associationCfg, err := associationConfig(driver.K8sClient(), ent)
-	if err != nil {
-		return nil, err
-	}
+
 	specConfig := ent.Spec.Config
 	if specConfig == nil {
 		specConfig = &commonv1.Config{}
@@ -172,9 +169,21 @@ func newConfig(driver driver.Interface, ent entv1.EnterpriseSearch, ipFamily cor
 		return nil, err
 	}
 
+	userCfgHasAuth := userConfigHasAuth(userProvidedCfg, userProvidedSecretCfg)
+
+	associationCfg, err := associationConfig(driver.K8sClient(), ent, userCfgHasAuth)
+	if err != nil {
+		return nil, err
+	}
+
 	// merge with user settings last so they take precedence
 	err = cfg.MergeWith(reusedCfg, tlsCfg, associationCfg, userProvidedCfg, userProvidedSecretCfg)
 	return cfg, err
+}
+
+func userConfigHasAuth(userProvidedCfg, userProvidedSecretCfg *settings.CanonicalConfig) bool {
+	authSettings := "ent_search.auth"
+	return userProvidedCfg.HasChildConfig(authSettings) || userProvidedSecretCfg.HasChildConfig(authSettings)
 }
 
 // reusableSettings captures secrets settings in the Enterprise Search configuration that we want to reuse.
@@ -280,7 +289,7 @@ func defaultConfig(ent entv1.EnterpriseSearch, ipFamily corev1.IPFamily) (*setti
 	return settings.MustCanonicalConfig(settingsMap), nil
 }
 
-func associationConfig(c k8s.Client, ent entv1.EnterpriseSearch) (*settings.CanonicalConfig, error) {
+func associationConfig(c k8s.Client, ent entv1.EnterpriseSearch, userCfgHasAuth bool) (*settings.CanonicalConfig, error) {
 	if !ent.AssociationConf().IsConfigured() {
 		return settings.NewCanonicalConfig(), nil
 	}
@@ -291,7 +300,7 @@ func associationConfig(c k8s.Client, ent entv1.EnterpriseSearch) (*settings.Cano
 	}
 
 	cfg := settings.NewCanonicalConfig()
-	if ver.LT(version.MinFor(7, 17, 0)) {
+	if !userCfgHasAuth && ver.LT(version.MinFor(7, 14, 0)) {
 		cfg = settings.MustCanonicalConfig(map[string]string{
 			"ent_search.auth.source": "elasticsearch-native",
 		})


### PR DESCRIPTION
Fixes #5290 

The issue as all the details. But in short the changes are: 
* do not generate the `ent_search.auth.source` setting as of ES 7.14
* do not generate the above setting in the presence of user the defined auth settings to avoid generating invalid config (this applies to 7.10-7.13)

I hope I have covered all cases, the risk here is that I missed a combination that would lead to one of the following issues:
1. the auto-migration between 7.13 and 7.14 not working due to the missing setting
2. a variant of a user setting that implicitly requires the generated setting to be present

I think I can exclude both cases based on my research but I still wanted to highlight them here because I find the various possible permutations of settings and Elastic stack versions quite complicated.

Here is my reasoning: 
1. we already defaulted to the `elasticsearch-native` setting before 7.14 so there is nothing to migrate. If a user forcibly went back to `standard` auth this settings override will be preserved regardless
2. pre 7.10 there was only one key `ent_search.auth.source` and `ent_search.auth.name` the latter only valid when SAML was in use, a user had to override `source` anyway to use that. Post 7.10 the new namespaced auth config format was incompatible with the setting we were generating anyway so the fact that we did not have any user reports about this tells me that nobody was using that because if so we would have had this bug report earlier. 
