### PR TITLE
[2.0] Ent Search: avoid generating invalid config in the presence of user of user overrides (#5298)

### DIFF
--- a/pkg/controller/common/settings/canonical_config.go
+++ b/pkg/controller/common/settings/canonical_config.go
@@ -153,6 +153,19 @@ func (c *CanonicalConfig) HasKeys(keys []string) []string {
 	return has
 }
 
+// HasChildConfig returns true if c has a child config object below key.
+func (c *CanonicalConfig) HasChildConfig(key string) bool {
+	if c == nil {
+		return false
+	}
+	// We are expecting two kinds of error here:
+	// type mismatch: if key is pointing to a primitive value that means we don't have a child config
+	// missing path: if the key does not exist in the config we also do not have a child config
+	// There should be no other errors thrown by ucfg thus there is no error return type in this function.
+	_, err := c.asUCfg().Child(key, -1, Options...)
+	return err == nil
+}
+
 // Render returns the content of the configuration file,
 // with fields sorted alphabetically
 func (c *CanonicalConfig) Render() ([]byte, error) {

--- a/pkg/controller/common/settings/canonical_config_test.go
+++ b/pkg/controller/common/settings/canonical_config_test.go
@@ -451,3 +451,70 @@ func TestNewCanonicalConfigFrom(t *testing.T) {
 		})
 	}
 }
+
+func TestCanonicalConfig_HasChildConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		c    *CanonicalConfig
+		key  string
+		want bool
+	}{
+		{
+			name: "nil config",
+			c:    nil,
+			key:  "x",
+			want: false,
+		},
+		{
+			name: "empty config",
+			c:    MustCanonicalConfig(map[string]interface{}{}),
+			key:  "x",
+			want: false,
+		},
+		{
+			name: "valid top-level key but not a child config",
+			c: MustCanonicalConfig(map[string]interface{}{
+				"x": "y",
+			}),
+			key:  "x",
+			want: false,
+		},
+		{
+			name: "valid top level key",
+			c: MustCanonicalConfig(map[string]interface{}{
+				"x": map[string]interface{}{
+					"y": "1",
+					"z": "2",
+				},
+			}),
+			key:  "x",
+			want: true,
+		},
+		{
+			name: "valid nested  key",
+			c: MustCanonicalConfig(map[string]interface{}{
+				"x": map[string]interface{}{
+					"y": map[string]interface{}{},
+					"z": "2",
+				},
+			}),
+			key:  "x.y",
+			want: true,
+		},
+		{
+			name: "absent key",
+			c: MustCanonicalConfig(map[string]interface{}{
+				"x": "y",
+			}),
+			key:  "z",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.c.HasChildConfig(tt.key); got != tt.want {
+				t.Errorf("HasChildConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/enterprisesearch/config.go
+++ b/pkg/controller/enterprisesearch/config.go
@@ -151,10 +151,7 @@ func newConfig(driver driver.Interface, ent entv1.EnterpriseSearch, ipFamily cor
 		return nil, err
 	}
 	tlsCfg := tlsConfig(ent)
-	associationCfg, err := associationConfig(driver.K8sClient(), ent)
-	if err != nil {
-		return nil, err
-	}
+
 	specConfig := ent.Spec.Config
 	if specConfig == nil {
 		specConfig = &commonv1.Config{}
@@ -172,9 +169,21 @@ func newConfig(driver driver.Interface, ent entv1.EnterpriseSearch, ipFamily cor
 		return nil, err
 	}
 
+	userCfgHasAuth := userConfigHasAuth(userProvidedCfg, userProvidedSecretCfg)
+
+	associationCfg, err := associationConfig(driver.K8sClient(), ent, userCfgHasAuth)
+	if err != nil {
+		return nil, err
+	}
+
 	// merge with user settings last so they take precedence
 	err = cfg.MergeWith(reusedCfg, tlsCfg, associationCfg, userProvidedCfg, userProvidedSecretCfg)
 	return cfg, err
+}
+
+func userConfigHasAuth(userProvidedCfg, userProvidedSecretCfg *settings.CanonicalConfig) bool {
+	authSettings := "ent_search.auth"
+	return userProvidedCfg.HasChildConfig(authSettings) || userProvidedSecretCfg.HasChildConfig(authSettings)
 }
 
 // reusableSettings captures secrets settings in the Enterprise Search configuration that we want to reuse.
@@ -280,7 +289,7 @@ func defaultConfig(ent entv1.EnterpriseSearch, ipFamily corev1.IPFamily) (*setti
 	return settings.MustCanonicalConfig(settingsMap), nil
 }
 
-func associationConfig(c k8s.Client, ent entv1.EnterpriseSearch) (*settings.CanonicalConfig, error) {
+func associationConfig(c k8s.Client, ent entv1.EnterpriseSearch, userCfgHasAuth bool) (*settings.CanonicalConfig, error) {
 	if !ent.AssociationConf().IsConfigured() {
 		return settings.NewCanonicalConfig(), nil
 	}
@@ -291,7 +300,7 @@ func associationConfig(c k8s.Client, ent entv1.EnterpriseSearch) (*settings.Cano
 	}
 
 	cfg := settings.NewCanonicalConfig()
-	if ver.LT(version.MinFor(7, 17, 0)) {
+	if !userCfgHasAuth && ver.LT(version.MinFor(7, 14, 0)) {
 		cfg = settings.MustCanonicalConfig(map[string]string{
 			"ent_search.auth.source": "elasticsearch-native",
 		})


### PR DESCRIPTION
Backports the following commits to 2.0:
 - Ent Search: avoid generating invalid config in the presence of user of user overrides (#5298)