### PR TITLE
Clarify the purpose of the `elastic-system` namespace.

### DIFF
--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -55,7 +55,7 @@ kubectl create -f https://download.elastic.co/downloads/eck/{eck_version}/crds.y
 ----
 kubectl apply -f https://download.elastic.co/downloads/eck/{eck_version}/operator.yaml
 ----
-NOTE: The ECK operator runs by default in the `elastic-system` namespace. It is recommended that you choose a dedicated namespace for your workloads, rather then using the default namespace.
+NOTE: The ECK operator runs by default in the `elastic-system` namespace. It is recommended that you choose a dedicated namespace for your workloads, rather than using the default namespace.
 
 . Monitor the operator logs:
 +

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -55,7 +55,7 @@ kubectl create -f https://download.elastic.co/downloads/eck/{eck_version}/crds.y
 ----
 kubectl apply -f https://download.elastic.co/downloads/eck/{eck_version}/operator.yaml
 ----
-NOTE: The ECK operator runs by default in the `elastic-system` namespace. It is recommended that you choose a dedicated namespace for your workloads, rather than using the `elastic-system` namespace.
+NOTE: The ECK operator runs by default in the `elastic-system` namespace. It is recommended that you choose a dedicated namespace for your workloads, rather than using the `elastic-system` or the `default` namespace.
 
 . Monitor the operator logs:
 +

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -42,13 +42,20 @@ IMPORTANT: Read the <<{p}-upgrading-eck,upgrade notes>> first if you are attempt
 
 ====
 
-. Install link:https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/[custom resource definitions] and the operator with its RBAC rules:
+. Install link:https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/[custom resource definitions]:
 +
 [source,sh,subs="attributes"]
 ----
 kubectl create -f https://download.elastic.co/downloads/eck/{eck_version}/crds.yaml
+----
+
+. Install the operator with its RBAC rules:
++
+[source,sh,subs="attributes"]
+----
 kubectl apply -f https://download.elastic.co/downloads/eck/{eck_version}/operator.yaml
 ----
+NOTE: The ECK operator runs by default in the `elastic-system` namespace. It is recommended that you choose a dedicated namespace for your workloads, rather then using the default namespace.
 
 . Monitor the operator logs:
 +

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -55,7 +55,7 @@ kubectl create -f https://download.elastic.co/downloads/eck/{eck_version}/crds.y
 ----
 kubectl apply -f https://download.elastic.co/downloads/eck/{eck_version}/operator.yaml
 ----
-NOTE: The ECK operator runs by default in the `elastic-system` namespace. It is recommended that you choose a dedicated namespace for your workloads, rather than using the `default` namespace.
+NOTE: The ECK operator runs by default in the `elastic-system` namespace. It is recommended that you choose a dedicated namespace for your workloads, rather than using the `elastic-system` namespace.
 
 . Monitor the operator logs:
 +

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -55,7 +55,7 @@ kubectl create -f https://download.elastic.co/downloads/eck/{eck_version}/crds.y
 ----
 kubectl apply -f https://download.elastic.co/downloads/eck/{eck_version}/operator.yaml
 ----
-NOTE: The ECK operator runs by default in the `elastic-system` namespace. It is recommended that you choose a dedicated namespace for your workloads, rather than using the default namespace.
+NOTE: The ECK operator runs by default in the `elastic-system` namespace. It is recommended that you choose a dedicated namespace for your workloads, rather than using the `default` namespace.
 
 . Monitor the operator logs:
 +


### PR DESCRIPTION
This PR adds a note in the [Quickstart](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-eck.html) to clarify what the `elastic-system` namespace is used for.

Fixes #5170