### PR TITLE
Force-upgrade non-HA clusters

### DIFF
--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -128,8 +128,8 @@ func (d *defaultDriver) reconcileNodeSpecs(
 		return results.WithError(err)
 	}
 
-	// Phase 2: if there is any Pending or bootlooping Pod to upgrade, do it.
-	attempted, err := d.MaybeForceUpgrade(actualStatefulSets)
+	// Phase 2: if there is any Pending or bootlooping Pod or a non-HA setup to upgrade, do it.
+	attempted, err := d.MaybeForceUpgrade(actualStatefulSets, expectedResources.MasterNodesNames())
 	if err != nil || attempted {
 		// If attempted, we're in a transient state where it's safer to requeue.
 		// We don't want to re-upgrade in a regular way the pods we just force-upgraded.

--- a/pkg/controller/elasticsearch/driver/upgrade_forced_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_forced_test.go
@@ -6,9 +6,9 @@ package driver
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
Fixes #5321 

This is a somewhat naive solution to #5321 which simply force upgrades non-HA cluster. It has the benefit of being fairly straight-forward but it has the drawback that it does not follow upgrade guidance/does not call node shutdown but simply deletes the the Pods. Also it does not adjust quorum if the upgrade affects pre 7.x clusters and involves an implicit downscale of the master tier e.g. through a spec change.

I am looking into a more sophisticated solution as well. 
