### PR TITLE
Update apm-es association to use ca.crt

### DIFF
--- a/pkg/controller/apmserver/deployment.go
+++ b/pkg/controller/apmserver/deployment.go
@@ -109,7 +109,7 @@ func (r *ReconcileApmServer) deploymentParams(
 			if err := r.Get(context.Background(), key, &publicCASecret); err != nil {
 				return deployment.Params{}, err
 			}
-			if certPem, ok := publicCASecret.Data[certificates.CertFileName]; ok {
+			if certPem, ok := publicCASecret.Data[certificates.CAFileName]; ok {
 				_, _ = configChecksum.Write(certPem)
 			}
 

--- a/pkg/controller/apmserver/deployment_test.go
+++ b/pkg/controller/apmserver/deployment_test.go
@@ -276,7 +276,7 @@ func TestReconcileApmServer_deploymentParams(t *testing.T) {
 							Name: "es-ca",
 						},
 						Data: map[string][]byte{
-							certificates.CertFileName: []byte("es-ca-cert"),
+							certificates.CAFileName: []byte("es-ca-cert"),
 						},
 					},
 				},
@@ -321,7 +321,7 @@ func TestReconcileApmServer_deploymentParams(t *testing.T) {
 							Name: "es-ca",
 						},
 						Data: map[string][]byte{
-							certificates.CertFileName: []byte("es-ca-cert"),
+							certificates.CAFileName: []byte("es-ca-cert"),
 						},
 					},
 					&corev1.Secret{
@@ -329,7 +329,7 @@ func TestReconcileApmServer_deploymentParams(t *testing.T) {
 							Name: "kb-ca",
 						},
 						Data: map[string][]byte{
-							certificates.CertFileName: []byte("kb-ca-cert"),
+							certificates.CAFileName: []byte("kb-ca-cert"),
 						},
 					},
 				},


### PR DESCRIPTION
This uses the content of `ca.crt` instead of `tls.crt` to hash the CA of the referenced resource in an APMServer-Elasticsearch association.

I missed it in #5277.