### PR TITLE
Only configure Stack Monitoring if association reconciled

### DIFF
--- a/pkg/controller/common/stackmon/monitoring/monitoring.go
+++ b/pkg/controller/common/stackmon/monitoring/monitoring.go
@@ -18,11 +18,19 @@ type HasMonitoring interface {
 	MonitoringAssociation(ref commonv1.ObjectSelector) commonv1.Association
 }
 
-func AreAssocConfigured(resource HasMonitoring) bool {
-	return IsMetricsAssocConfigured(resource) && IsLogsAssocConfigured(resource)
+// IsReconcilable return true if a resource has at least one association defined in its specification
+// and all defined associations are configured.
+func IsReconcilable(resource HasMonitoring) bool {
+	return IsDefined(resource) && isMetricsAssocConfigured(resource) && isLogsAssocConfigured(resource)
 }
 
-func IsMetricsAssocConfigured(resource HasMonitoring) bool {
+// IsDefined return true if a resource has at least one association for Stack Monitoring defined in its specification
+// (can be one for logs or one for metrics).
+func IsDefined(resource HasMonitoring) bool {
+	return IsMetricsDefined(resource) || IsLogsDefined(resource)
+}
+
+func isMetricsAssocConfigured(resource HasMonitoring) bool {
 	refs := resource.GetMonitoringMetricsRefs()
 	for _, ref := range refs {
 		if !resource.MonitoringAssociation(ref).AssociationConf().IsConfigured() {
@@ -32,7 +40,7 @@ func IsMetricsAssocConfigured(resource HasMonitoring) bool {
 	return true
 }
 
-func IsLogsAssocConfigured(resource HasMonitoring) bool {
+func isLogsAssocConfigured(resource HasMonitoring) bool {
 	refs := resource.GetMonitoringLogsRefs()
 	for _, ref := range refs {
 		if !resource.MonitoringAssociation(ref).AssociationConf().IsConfigured() {
@@ -40,10 +48,6 @@ func IsLogsAssocConfigured(resource HasMonitoring) bool {
 		}
 	}
 	return true
-}
-
-func IsDefined(resource HasMonitoring) bool {
-	return IsMetricsDefined(resource) || IsLogsDefined(resource)
 }
 
 func IsMetricsDefined(resource HasMonitoring) bool {

--- a/pkg/controller/common/stackmon/monitoring/monitoring.go
+++ b/pkg/controller/common/stackmon/monitoring/monitoring.go
@@ -21,33 +21,22 @@ type HasMonitoring interface {
 // IsReconcilable return true if a resource has at least one association defined in its specification
 // and all defined associations are configured.
 func IsReconcilable(resource HasMonitoring) bool {
-	return IsDefined(resource) && isMetricsAssocConfigured(resource) && isLogsAssocConfigured(resource)
+	if !IsDefined(resource) {
+		return false
+	}
+	allRefs := append(resource.GetMonitoringMetricsRefs(), resource.GetMonitoringLogsRefs()...)
+	for _, ref := range allRefs {
+		if !resource.MonitoringAssociation(ref).AssociationConf().IsConfigured() {
+			return false
+		}
+	}
+	return true
 }
 
 // IsDefined return true if a resource has at least one association for Stack Monitoring defined in its specification
 // (can be one for logs or one for metrics).
 func IsDefined(resource HasMonitoring) bool {
 	return IsMetricsDefined(resource) || IsLogsDefined(resource)
-}
-
-func isMetricsAssocConfigured(resource HasMonitoring) bool {
-	refs := resource.GetMonitoringMetricsRefs()
-	for _, ref := range refs {
-		if !resource.MonitoringAssociation(ref).AssociationConf().IsConfigured() {
-			return false
-		}
-	}
-	return true
-}
-
-func isLogsAssocConfigured(resource HasMonitoring) bool {
-	refs := resource.GetMonitoringLogsRefs()
-	for _, ref := range refs {
-		if !resource.MonitoringAssociation(ref).AssociationConf().IsConfigured() {
-			return false
-		}
-	}
-	return true
 }
 
 func IsMetricsDefined(resource HasMonitoring) bool {

--- a/pkg/controller/common/stackmon/monitoring/monitoring.go
+++ b/pkg/controller/common/stackmon/monitoring/monitoring.go
@@ -18,6 +18,36 @@ type HasMonitoring interface {
 	MonitoringAssociation(ref commonv1.ObjectSelector) commonv1.Association
 }
 
+func AreAssocConfigured(resource HasMonitoring) bool {
+	return IsMetricsAssocConfigured(resource) && IsLogsAssocConfigured(resource)
+}
+
+func IsMetricsAssocConfigured(resource HasMonitoring) bool {
+	if !IsMetricsDefined(resource) {
+		return false
+	}
+	refs := resource.GetMonitoringMetricsRefs()
+	for _, ref := range refs {
+		if !resource.MonitoringAssociation(ref).AssociationConf().IsConfigured() {
+			return false
+		}
+	}
+	return true
+}
+
+func IsLogsAssocConfigured(resource HasMonitoring) bool {
+	if !IsLogsDefined(resource) {
+		return false
+	}
+	refs := resource.GetMonitoringLogsRefs()
+	for _, ref := range refs {
+		if !resource.MonitoringAssociation(ref).AssociationConf().IsConfigured() {
+			return false
+		}
+	}
+	return true
+}
+
 func IsDefined(resource HasMonitoring) bool {
 	return IsMetricsDefined(resource) || IsLogsDefined(resource)
 }

--- a/pkg/controller/common/stackmon/monitoring/monitoring.go
+++ b/pkg/controller/common/stackmon/monitoring/monitoring.go
@@ -23,9 +23,6 @@ func AreAssocConfigured(resource HasMonitoring) bool {
 }
 
 func IsMetricsAssocConfigured(resource HasMonitoring) bool {
-	if !IsMetricsDefined(resource) {
-		return false
-	}
 	refs := resource.GetMonitoringMetricsRefs()
 	for _, ref := range refs {
 		if !resource.MonitoringAssociation(ref).AssociationConf().IsConfigured() {
@@ -36,9 +33,6 @@ func IsMetricsAssocConfigured(resource HasMonitoring) bool {
 }
 
 func IsLogsAssocConfigured(resource HasMonitoring) bool {
-	if !IsLogsDefined(resource) {
-		return false
-	}
 	refs := resource.GetMonitoringLogsRefs()
 	for _, ref := range refs {
 		if !resource.MonitoringAssociation(ref).AssociationConf().IsConfigured() {

--- a/pkg/controller/common/stackmon/monitoring/monitoring_test.go
+++ b/pkg/controller/common/stackmon/monitoring/monitoring_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
@@ -26,6 +27,156 @@ var (
 		},
 	}
 )
+
+func TestIsReconcilable(t *testing.T) {
+	tests := []struct {
+		name string
+		es   esv1.Elasticsearch
+		want bool
+	}{
+		{
+			name: "without monitoring",
+			es: esv1.Elasticsearch{
+				Spec: esv1.ElasticsearchSpec{
+					Version: "7.13.1",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "with metrics monitoring defined but not configured",
+			es: esv1.Elasticsearch{
+				Spec: esv1.ElasticsearchSpec{
+					Monitoring: esv1.Monitoring{
+						Metrics: esv1.MetricsMonitoring{
+							ElasticsearchRefs: []commonv1.ObjectSelector{{Name: "m1", Namespace: "b"}},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "with metrics monitoring defined and configured",
+			es: esv1.Elasticsearch{
+				Spec: esv1.ElasticsearchSpec{
+					Monitoring: esv1.Monitoring{
+						Metrics: esv1.MetricsMonitoring{
+							ElasticsearchRefs: []commonv1.ObjectSelector{{Name: "m1", Namespace: "b"}},
+						},
+					},
+				},
+				AssocConfs: map[types.NamespacedName]commonv1.AssociationConf{
+					types.NamespacedName{Name: "m1", Namespace: "b"}: {URL: "https://es.xyz", AuthSecretName: "-"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "with logs monitoring defined and configured",
+			es: esv1.Elasticsearch{
+				Spec: esv1.ElasticsearchSpec{
+					Monitoring: esv1.Monitoring{
+						Logs: esv1.LogsMonitoring{
+							ElasticsearchRefs: []commonv1.ObjectSelector{{Name: "m1", Namespace: "b"}},
+						},
+					},
+				},
+				AssocConfs: map[types.NamespacedName]commonv1.AssociationConf{
+					types.NamespacedName{Name: "m1", Namespace: "b"}: {URL: "https://es.xyz", AuthSecretName: "-"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "with metrics and logs monitoring defined and partially configured",
+			es: esv1.Elasticsearch{
+				Spec: esv1.ElasticsearchSpec{
+					Monitoring: esv1.Monitoring{
+						Metrics: esv1.MetricsMonitoring{
+							ElasticsearchRefs: []commonv1.ObjectSelector{{Name: "m1", Namespace: "b"}},
+						},
+						Logs: esv1.LogsMonitoring{
+							ElasticsearchRefs: []commonv1.ObjectSelector{{Name: "m2", Namespace: "b"}},
+						},
+					},
+				},
+				AssocConfs: map[types.NamespacedName]commonv1.AssociationConf{
+					types.NamespacedName{Name: "m1", Namespace: "b"}: {URL: "https://es.xyz", AuthSecretName: "-"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "with metrics and logs monitoring defined and partially configured",
+			es: esv1.Elasticsearch{
+				Spec: esv1.ElasticsearchSpec{
+					Monitoring: esv1.Monitoring{
+						Metrics: esv1.MetricsMonitoring{
+							ElasticsearchRefs: []commonv1.ObjectSelector{{Name: "m1", Namespace: "b"}},
+						},
+						Logs: esv1.LogsMonitoring{
+							ElasticsearchRefs: []commonv1.ObjectSelector{{Name: "m2", Namespace: "b"}},
+						},
+					},
+				},
+				AssocConfs: map[types.NamespacedName]commonv1.AssociationConf{
+					types.NamespacedName{Name: "m1", Namespace: "b"}: {URL: "https://es.xyz", AuthSecretName: "-"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "with logs and metrics monitoring defined and configured",
+			es: esv1.Elasticsearch{
+				Spec: esv1.ElasticsearchSpec{
+					Monitoring: esv1.Monitoring{
+						Metrics: esv1.MetricsMonitoring{
+							ElasticsearchRefs: []commonv1.ObjectSelector{{Name: "m1", Namespace: "b"}},
+						},
+						Logs: esv1.LogsMonitoring{
+							ElasticsearchRefs: []commonv1.ObjectSelector{{Name: "m1", Namespace: "b"}},
+						},
+					},
+				},
+				AssocConfs: map[types.NamespacedName]commonv1.AssociationConf{
+					types.NamespacedName{Name: "m1", Namespace: "b"}: {URL: "https://m1.xyz", AuthSecretName: "-"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "with distinct logs and metrics monitoring defined and configured",
+			es: esv1.Elasticsearch{
+				Spec: esv1.ElasticsearchSpec{
+					Monitoring: esv1.Monitoring{
+						Metrics: esv1.MetricsMonitoring{
+							ElasticsearchRefs: []commonv1.ObjectSelector{{Name: "m1", Namespace: "b"}},
+						},
+						Logs: esv1.LogsMonitoring{
+							ElasticsearchRefs: []commonv1.ObjectSelector{{Name: "m2", Namespace: "b"}},
+						},
+					},
+				},
+				AssocConfs: map[types.NamespacedName]commonv1.AssociationConf{
+					types.NamespacedName{Name: "m1", Namespace: "b"}: {URL: "https://m1.xyz", AuthSecretName: "-"},
+					types.NamespacedName{Name: "m2", Namespace: "b"}: {URL: "https://m2.xyz", AuthSecretName: "-"},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsReconcilable(&tc.es)
+			if got != tc.want {
+				t.Errorf("IsReconcilable() got = %v, want %v", got, tc.want)
+				return
+			}
+		})
+	}
+}
 
 func TestIsDefined(t *testing.T) {
 	assert.False(t, IsDefined(&sampleEs))

--- a/pkg/controller/elasticsearch/stackmon/beat_config.go
+++ b/pkg/controller/elasticsearch/stackmon/beat_config.go
@@ -25,8 +25,7 @@ var (
 
 // ReconcileConfigSecrets reconciles the secrets holding beats configuration
 func ReconcileConfigSecrets(client k8s.Client, es esv1.Elasticsearch) error {
-	// no monitoring defined or yet configured, skip
-	if !monitoring.IsDefined(&es) || !monitoring.AreAssocConfigured(&es) {
+	if !monitoring.IsReconcilable(&es) {
 		return nil
 	}
 
@@ -41,7 +40,7 @@ func ReconcileConfigSecrets(client k8s.Client, es esv1.Elasticsearch) error {
 		}
 	}
 
-	if monitoring.IsMetricsDefined(&es) {
+	if monitoring.IsLogsDefined(&es) {
 		b, err := Filebeat(client, es)
 		if err != nil {
 			return err

--- a/pkg/controller/elasticsearch/stackmon/beat_config.go
+++ b/pkg/controller/elasticsearch/stackmon/beat_config.go
@@ -25,7 +25,12 @@ var (
 
 // ReconcileConfigSecrets reconciles the secrets holding beats configuration
 func ReconcileConfigSecrets(client k8s.Client, es esv1.Elasticsearch) error {
-	if monitoring.IsMetricsAssocConfigured(&es) {
+	// no monitoring defined or yet configured, skip
+	if !monitoring.IsDefined(&es) || !monitoring.AreAssocConfigured(&es) {
+		return nil
+	}
+
+	if monitoring.IsMetricsDefined(&es) {
 		b, err := Metricbeat(client, es)
 		if err != nil {
 			return err
@@ -36,7 +41,7 @@ func ReconcileConfigSecrets(client k8s.Client, es esv1.Elasticsearch) error {
 		}
 	}
 
-	if monitoring.IsLogsAssocConfigured(&es) {
+	if monitoring.IsMetricsDefined(&es) {
 		b, err := Filebeat(client, es)
 		if err != nil {
 			return err

--- a/pkg/controller/elasticsearch/stackmon/beat_config.go
+++ b/pkg/controller/elasticsearch/stackmon/beat_config.go
@@ -25,7 +25,7 @@ var (
 
 // ReconcileConfigSecrets reconciles the secrets holding beats configuration
 func ReconcileConfigSecrets(client k8s.Client, es esv1.Elasticsearch) error {
-	if monitoring.IsMetricsDefined(&es) {
+	if monitoring.IsMetricsAssocConfigured(&es) {
 		b, err := Metricbeat(client, es)
 		if err != nil {
 			return err
@@ -36,7 +36,7 @@ func ReconcileConfigSecrets(client k8s.Client, es esv1.Elasticsearch) error {
 		}
 	}
 
-	if monitoring.IsLogsDefined(&es) {
+	if monitoring.IsLogsAssocConfigured(&es) {
 		b, err := Filebeat(client, es)
 		if err != nil {
 			return err

--- a/pkg/controller/elasticsearch/stackmon/sidecar.go
+++ b/pkg/controller/elasticsearch/stackmon/sidecar.go
@@ -55,8 +55,8 @@ func Filebeat(client k8s.Client, es esv1.Elasticsearch) (stackmon.BeatSidecar, e
 // WithMonitoring updates the Elasticsearch Pod template builder to deploy Metricbeat and Filebeat in sidecar containers
 // in the Elasticsearch pod and injects the volumes for the beat configurations and the ES CA certificates.
 func WithMonitoring(client k8s.Client, builder *defaults.PodTemplateBuilder, es esv1.Elasticsearch) (*defaults.PodTemplateBuilder, error) {
-	// no monitoring defined, skip
-	if !monitoring.IsDefined(&es) {
+	// no monitoring defined or yet configured, skip
+	if !monitoring.IsDefined(&es) || !monitoring.AreAssocConfigured(&es) {
 		return builder, nil
 	}
 

--- a/pkg/controller/elasticsearch/stackmon/sidecar.go
+++ b/pkg/controller/elasticsearch/stackmon/sidecar.go
@@ -55,8 +55,7 @@ func Filebeat(client k8s.Client, es esv1.Elasticsearch) (stackmon.BeatSidecar, e
 // WithMonitoring updates the Elasticsearch Pod template builder to deploy Metricbeat and Filebeat in sidecar containers
 // in the Elasticsearch pod and injects the volumes for the beat configurations and the ES CA certificates.
 func WithMonitoring(client k8s.Client, builder *defaults.PodTemplateBuilder, es esv1.Elasticsearch) (*defaults.PodTemplateBuilder, error) {
-	// no monitoring defined or yet configured, skip
-	if !monitoring.IsDefined(&es) || !monitoring.AreAssocConfigured(&es) {
+	if !monitoring.IsReconcilable(&es) {
 		return builder, nil
 	}
 

--- a/pkg/controller/kibana/stackmon/beat_config.go
+++ b/pkg/controller/kibana/stackmon/beat_config.go
@@ -25,7 +25,12 @@ var (
 
 // ReconcileConfigSecrets reconciles the secrets holding beats configuration
 func ReconcileConfigSecrets(client k8s.Client, kb kbv1.Kibana) error {
-	if monitoring.IsMetricsAssocConfigured(&kb) {
+	// no monitoring defined or yet configured, skip
+	if !monitoring.IsDefined(&kb) || !monitoring.AreAssocConfigured(&kb) {
+		return nil
+	}
+
+	if monitoring.IsMetricsDefined(&kb) {
 		b, err := Metricbeat(client, kb)
 		if err != nil {
 			return err
@@ -36,7 +41,7 @@ func ReconcileConfigSecrets(client k8s.Client, kb kbv1.Kibana) error {
 		}
 	}
 
-	if monitoring.IsLogsAssocConfigured(&kb) {
+	if monitoring.IsLogsDefined(&kb) {
 		b, err := Filebeat(client, kb)
 		if err != nil {
 			return err

--- a/pkg/controller/kibana/stackmon/beat_config.go
+++ b/pkg/controller/kibana/stackmon/beat_config.go
@@ -25,8 +25,7 @@ var (
 
 // ReconcileConfigSecrets reconciles the secrets holding beats configuration
 func ReconcileConfigSecrets(client k8s.Client, kb kbv1.Kibana) error {
-	// no monitoring defined or yet configured, skip
-	if !monitoring.IsDefined(&kb) || !monitoring.AreAssocConfigured(&kb) {
+	if !monitoring.IsReconcilable(&kb) {
 		return nil
 	}
 

--- a/pkg/controller/kibana/stackmon/beat_config.go
+++ b/pkg/controller/kibana/stackmon/beat_config.go
@@ -25,7 +25,7 @@ var (
 
 // ReconcileConfigSecrets reconciles the secrets holding beats configuration
 func ReconcileConfigSecrets(client k8s.Client, kb kbv1.Kibana) error {
-	if monitoring.IsMetricsDefined(&kb) {
+	if monitoring.IsMetricsAssocConfigured(&kb) {
 		b, err := Metricbeat(client, kb)
 		if err != nil {
 			return err
@@ -36,7 +36,7 @@ func ReconcileConfigSecrets(client k8s.Client, kb kbv1.Kibana) error {
 		}
 	}
 
-	if monitoring.IsLogsDefined(&kb) {
+	if monitoring.IsLogsAssocConfigured(&kb) {
 		b, err := Filebeat(client, kb)
 		if err != nil {
 			return err

--- a/pkg/controller/kibana/stackmon/sidecar.go
+++ b/pkg/controller/kibana/stackmon/sidecar.go
@@ -69,8 +69,8 @@ func Filebeat(client k8s.Client, kb kbv1.Kibana) (stackmon.BeatSidecar, error) {
 // WithMonitoring updates the Kibana Pod template builder to deploy Metricbeat and Filebeat in sidecar containers
 // in the Kibana pod and injects the volumes for the beat configurations and the ES CA certificates.
 func WithMonitoring(client k8s.Client, builder *defaults.PodTemplateBuilder, kb kbv1.Kibana) (*defaults.PodTemplateBuilder, error) {
-	// no monitoring defined, skip
-	if !monitoring.IsDefined(&kb) {
+	// no monitoring defined or yet configured, skip
+	if !monitoring.IsDefined(&kb) || !monitoring.AreAssocConfigured(&kb) {
 		return builder, nil
 	}
 

--- a/pkg/controller/kibana/stackmon/sidecar.go
+++ b/pkg/controller/kibana/stackmon/sidecar.go
@@ -69,8 +69,7 @@ func Filebeat(client k8s.Client, kb kbv1.Kibana) (stackmon.BeatSidecar, error) {
 // WithMonitoring updates the Kibana Pod template builder to deploy Metricbeat and Filebeat in sidecar containers
 // in the Kibana pod and injects the volumes for the beat configurations and the ES CA certificates.
 func WithMonitoring(client k8s.Client, builder *defaults.PodTemplateBuilder, kb kbv1.Kibana) (*defaults.PodTemplateBuilder, error) {
-	// no monitoring defined or yet configured, skip
-	if !monitoring.IsDefined(&kb) || !monitoring.AreAssocConfigured(&kb) {
+	if !monitoring.IsReconcilable(&kb) {
 		return builder, nil
 	}
 


### PR DESCRIPTION
Currently, if a referenced monitoring Elasticsearch does not exist, Stack Monitoring is still configured with empty values in beat configs causing the beats to `CrashLoopBackOff`.

This happens only for ES-ES. For KB-ES, the call to `AllowVersion()` checks that `assoc.AssociationConf() != nil`, so the reconciliation is aborted if the association is not yet configured. I fixed both for consistency.
