### PR TITLE
Improve ES status health reporting

### DIFF
--- a/pkg/controller/common/certificates/reconcile.go
+++ b/pkg/controller/common/certificates/reconcile.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"time"
 
-	"go.elastic.co/apm"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -18,7 +17,6 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	commonname "github.com/elastic/cloud-on-k8s/pkg/controller/common/name"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
@@ -53,9 +51,6 @@ type Reconciler struct {
 // - a Secret containing the public-facing HTTP certificates (same as the internal one, but without the key)
 // If TLS is disabled, self-signed certificates are still reconciled, for simplicity/consistency, but not used.
 func (r Reconciler) ReconcileCAAndHTTPCerts(ctx context.Context) (*CertificatesSecret, *reconciler.Results) {
-	span, _ := apm.StartSpan(ctx, "reconcile_certs", tracing.SpanTypeApp)
-	defer span.End()
-
 	results := reconciler.NewResult(ctx)
 
 	if !r.TLSOptions.Enabled() && r.GarbageCollectSecrets {

--- a/pkg/controller/common/certificates/reconcile.go
+++ b/pkg/controller/common/certificates/reconcile.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"time"
 
+	"go.elastic.co/apm"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -17,6 +18,7 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	commonname "github.com/elastic/cloud-on-k8s/pkg/controller/common/name"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
@@ -51,6 +53,9 @@ type Reconciler struct {
 // - a Secret containing the public-facing HTTP certificates (same as the internal one, but without the key)
 // If TLS is disabled, self-signed certificates are still reconciled, for simplicity/consistency, but not used.
 func (r Reconciler) ReconcileCAAndHTTPCerts(ctx context.Context) (*CertificatesSecret, *reconciler.Results) {
+	span, _ := apm.StartSpan(ctx, "reconcile_certs", tracing.SpanTypeApp)
+	defer span.End()
+
 	results := reconciler.NewResult(ctx)
 
 	if !r.TLSOptions.Enabled() && r.GarbageCollectSecrets {

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -115,10 +115,6 @@ var _ commondriver.Interface = &defaultDriver{}
 func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	results := reconciler.NewResult(ctx)
 
-	// reset the Elasticsearch health to 'unknown' so that if reconciliation fails before the observer has had a chance to get it,
-	// we stop reporting a state that may be out of date
-	d.ReconcileState.UpdateElasticsearchPendingUnknownHealth()
-
 	// garbage collect secrets attached to this cluster that we don't need anymore
 	if err := cleanup.DeleteOrphanedSecrets(ctx, d.Client, d.ES); err != nil {
 		return results.WithError(err)

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -186,7 +186,7 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	// always update the Elasticsearch state bits with the latest observed state
 	d.ReconcileState.UpdateElasticsearchState(*resourcesState, observedState())
 
-	_, res = certificates.ReconcileTransport(
+	res = certificates.ReconcileTransport(
 		ctx,
 		d,
 		d.ES,

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -115,6 +115,10 @@ var _ commondriver.Interface = &defaultDriver{}
 func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	results := reconciler.NewResult(ctx)
 
+	// reset the Elasticsearch health to 'unknown' so that if reconciliation fails before the observer has had a chance to get it,
+	// we stop reporting a state that may be out of date
+	d.ReconcileState.UpdateElasticsearchPendingUnknownHealth()
+
 	// garbage collect secrets attached to this cluster that we don't need anymore
 	if err := cleanup.DeleteOrphanedSecrets(ctx, d.Client, d.ES); err != nil {
 		return results.WithError(err)
@@ -146,10 +150,6 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	}
 
 	warnUnsupportedDistro(resourcesState.AllPods, d.ReconcileState.Recorder)
-
-	// reset the health status to avoid reporting an old health status that can occur if there is a reconciliation error
-	// before the health status observer is started
-	d.ReconcileState.UpdateElasticsearchState(*resourcesState, observer.State{ClusterHealth: &esclient.Health{Status: "unknown"}})
 
 	controllerUser, err := user.ReconcileUsersAndRoles(ctx, d.Client, d.ES, d.DynamicWatches(), d.Recorder())
 	if err != nil {
@@ -187,7 +187,7 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 		),
 	)
 
-	// always update the elasticsearch state bits
+	// always update the Elasticsearch state bits with the latest observed state
 	d.ReconcileState.UpdateElasticsearchState(*resourcesState, observedState())
 
 	_, res = certificates.ReconcileTransport(

--- a/pkg/controller/elasticsearch/reconcile/state.go
+++ b/pkg/controller/elasticsearch/reconcile/state.go
@@ -13,7 +13,6 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
-	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/hints"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/observer"
@@ -127,12 +126,6 @@ func (s *State) UpdateElasticsearchReady(
 	observedState observer.State,
 ) *State {
 	return s.updateWithPhase(esv1.ElasticsearchReadyPhase, resourcesState, observedState)
-}
-
-// UpdateElasticsearchUnknown marks Elasticsearch as being the applying changes phase with an unknown health in the resource status.
-func (s *State) UpdateElasticsearchPendingUnknownHealth() *State {
-	unknownState := observer.State{ClusterHealth: &esclient.Health{Status: esv1.ElasticsearchUnknownHealth}}
-	return s.updateWithPhase(esv1.ElasticsearchApplyingChangesPhase, ResourcesState{}, unknownState)
 }
 
 // IsElasticsearchReady reports if Elasticsearch is ready.

--- a/pkg/controller/elasticsearch/reconcile/state.go
+++ b/pkg/controller/elasticsearch/reconcile/state.go
@@ -38,7 +38,11 @@ func NewState(c esv1.Elasticsearch) (*State, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &State{Recorder: events.NewRecorder(), cluster: c, status: *c.Status.DeepCopy(), hints: hints}, nil
+	status := *c.Status.DeepCopy()
+	// reset the health to 'unknown' so that if reconciliation fails before the observer has had a chance to get it,
+	// we stop reporting a health that may be out of date
+	status.Health = esv1.ElasticsearchUnknownHealth
+	return &State{Recorder: events.NewRecorder(), cluster: c, status: status, hints: hints}, nil
 }
 
 // MustNewState like NewState but panics on error. Use recommended only in test code.

--- a/pkg/controller/elasticsearch/reconcile/state.go
+++ b/pkg/controller/elasticsearch/reconcile/state.go
@@ -13,6 +13,7 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/hints"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/observer"
@@ -122,6 +123,12 @@ func (s *State) UpdateElasticsearchReady(
 	observedState observer.State,
 ) *State {
 	return s.updateWithPhase(esv1.ElasticsearchReadyPhase, resourcesState, observedState)
+}
+
+// UpdateElasticsearchUnknown marks Elasticsearch as being the applying changes phase with an unknown health in the resource status.
+func (s *State) UpdateElasticsearchPendingUnknownHealth() *State {
+	unknownState := observer.State{ClusterHealth: &esclient.Health{Status: esv1.ElasticsearchUnknownHealth}}
+	return s.updateWithPhase(esv1.ElasticsearchApplyingChangesPhase, ResourcesState{}, unknownState)
 }
 
 // IsElasticsearchReady reports if Elasticsearch is ready.

--- a/pkg/controller/elasticsearch/reconcile/state_test.go
+++ b/pkg/controller/elasticsearch/reconcile/state_test.go
@@ -146,7 +146,11 @@ func TestState_Apply(t *testing.T) {
 			name:       "defaults",
 			cluster:    esv1.Elasticsearch{},
 			wantEvents: []events.Event{},
-			wantStatus: nil,
+			wantStatus: &esv1.ElasticsearchStatus{
+				AvailableNodes: 0,
+				Health:         esv1.ElasticsearchUnknownHealth,
+				Phase:          "",
+			},
 		},
 		{
 			name:    "no degraded health event on cluster formation",


### PR DESCRIPTION
2 first commits are more an optimization:
- Split HTTP and transport certs reconciliation in order to be able to retrieve the cluster health despite an issue with the transport certs.
- Start the observer and start it as soon as possible.

Those after could be enough:
- Initialize health state to unknown in the NewState constructor

Relates to #5330.

### Testing

- Create an ES cluster
```yaml
apiVersion: elasticsearch.k8s.elastic.co/v1
kind: Elasticsearch
metadata:
  name: eight
spec:
  version: 8.0.0
  # http:
  # transport:
  #   tls:
  #     certificate:
  #       secretName: ca-that-does-not-exist
  nodeSets:
  - name: master
    count: 1
    config:
      node.store.allow_mmap: false
```
- Make cluster health yellow
```
# create an index with 1 replica
-XPUT /my-index-1 -d '{"settings":{"number_of_shards":1,"number_of_replicas":1}}'
```
- Break the transport service by configuring a CA Secret that doesn't exist in the cluster

Uncomment `transport.tls.certificate.secretName` and reapply.

- Make cluster health green Again
```
# delete the index
-XDELETE /my-index-1
```

- Cluster should be reported as `green` and not stuck in the `yellow` state, with phase `ApplyingChanges`.

- Do the same by breaking the `http` service. This time the operator will report an `unknown` state as the observer depends on this service, still in phase `ApplyingChanges`.

