### PR TITLE
[1.0] [DOCS] Fix links to ES upgrade docs (#5347)

### DIFF
--- a/docs/design/0009-pod-reuse-es-restart.md
+++ b/docs/design/0009-pod-reuse-es-restart.md
@@ -207,5 +207,5 @@ Chosen option: option 1, because that's the only one we have here? :)
 
 * [https://github.com/elastic/cloud-on-k8s/issues/454] Full cluster restart issue
 * [https://github.com/elastic/cloud-on-k8s/issues/453] Basic license support issue
-* [https://www.elastic.co/guide/en/elasticsearch/reference/current/restart-upgrade.html] Elasticsearch full cluster restart upgrade
-* [https://www.elastic.co/guide/en/elasticsearch/reference/current/rolling-upgrades.html] Elasticsearch rolling cluster restart upgrade
+* [https://www.elastic.co/guide/en/elasticsearch/reference/7.17/restart-upgrade.html] Elasticsearch full cluster restart upgrade
+* [https://www.elastic.co/guide/en/elasticsearch/reference/7.17/rolling-upgrades.html] Elasticsearch rolling cluster restart upgrade


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `1.0`:
 - [[DOCS] Fix links to ES upgrade docs (#5347)](https://github.com/elastic/cloud-on-k8s/pull/5347)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)