### PR TITLE
[2.0] Add known issue for Elastic Agent base image change in 7.17 (#5359)

### DIFF
--- a/docs/release-notes/2.0.0.asciidoc
+++ b/docs/release-notes/2.0.0.asciidoc
@@ -43,7 +43,6 @@ IMPORTANT: Operator Lifecycle Manager (OLM) and OpenShift OperatorHub users that
 
 * Fix Stack Monitoring with custom certificate without CA {pull}5310[#5310] (issue: {issue}5309[#5309])
 * Enterprise Search: avoid generating invalid config in the presence of user overrides {pull}5298[#5298] (issue: {issue}5290[#5290])
-* Support new Agent base image as of 7.17 {pull}5268[#5268]
 * Change upgrade path validation for 8.0 to only allow 7.17 {pull}5261[#5261] (issue: {issue}5258[#5258])
 * Adjust Agent startup command to Ubuntu base image {pull}5253[#5253] (issue: {issue}5250[#5250])
 * Do not delete last master-eligible node if other nodes are not up-to-date {pull}5242[#5242] (issue: {issue}5241[#5241])

--- a/docs/release-notes/highlights-1.9.0.asciidoc
+++ b/docs/release-notes/highlights-1.9.0.asciidoc
@@ -35,4 +35,4 @@ Following the Elastic Stack licensing changes in `7.11.0`, ECK `1.9.0` moves to 
 === Known issues
 
 - On Openshift versions 4.6 and below, when installing or upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and found in a `CrashLoopBackoff` within Kubernetes because of Webhook certificate location mismatches. More information and work-around can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[this issue].
-- When using the `elasticsearchRef` mechanism with Elastic Agent in version 7.17 and later its Pods will enter a `CrashLoopBackoff`. The issue will be fixed in ECK 2.0. A workaround is described in link:https://github.com/elastic/cloud-on-k8s/issues/5323#issuecomment-1028954034[this issue].
+- When using the `elasticsearchRef` mechanism with Elastic Agent in version 7.17 and later its Pods will enter a `CrashLoopBackoff`. The issue will be fixed in ECK 2.0 for Elasticsearch versions 8.0 and above. A workaround is described in link:https://github.com/elastic/cloud-on-k8s/issues/5323#issuecomment-1028954034[this issue].

--- a/docs/release-notes/highlights-1.9.1.asciidoc
+++ b/docs/release-notes/highlights-1.9.1.asciidoc
@@ -19,4 +19,4 @@ This release introduces a preemptive measure to mitigate link:https://github.com
 === Known issues
 
 - On Openshift versions 4.6 and below, when installing or upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and seen in a `CrashLoopBackoff` within Kubernetes because of Webhook certificate location mismatches. More information and workaround can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[this issue].
-- When using the `elasticsearchRef` mechanism with Elastic Agent in version 7.17 and later its Pods will enter a `CrashLoopBackoff`. The issue will be fixed in ECK 2.0. A workaround is described in link:https://github.com/elastic/cloud-on-k8s/issues/5323#issuecomment-1028954034[this issue].
+- When using the `elasticsearchRef` mechanism with Elastic Agent in version 7.17 and later its Pods will enter a `CrashLoopBackoff`. The issue will be fixed in ECK 2.0 for Elasticsearch versions 8.0 and above. A workaround is described in link:https://github.com/elastic/cloud-on-k8s/issues/5323#issuecomment-1028954034[this issue].

--- a/docs/release-notes/highlights-2.0.0.asciidoc
+++ b/docs/release-notes/highlights-2.0.0.asciidoc
@@ -23,3 +23,9 @@ Starting with ECK 2.0 the operator can make Kubernetes Node labels available as 
 ==== Smoother cluster operations using node lifecycle APIs
 
 When orchestrating Elasticsearch version 7.15.2 or later ECK will use the new link:https://www.elastic.co/guide/en/elasticsearch/reference/current/node-lifecycle-api.html[node lifecycle APIs] to orchestrate rolling upgrades and scale downs to make Elasticsearch aware of impending temporary or permanent shutdown of nodes.
+
+[float]
+[id="{p}-200-known-issues"]
+=== Known issues
+
+- When using the `elasticsearchRef` mechanism with Elastic Agent in version 7.17 its Pods will enter a `CrashLoopBackoff`. A workaround is described in link:https://github.com/elastic/cloud-on-k8s/issues/5323#issuecomment-1028954034[this issue].


### PR DESCRIPTION
Backports the following commits to 2.0:
 - Add known issue for Elastic Agent base image change in 7.17 (#5359)