### PR TITLE
Add example code to the Quickstart

### DIFF
--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -48,6 +48,19 @@ IMPORTANT: Check the <<{p}-upgrading-eck,upgrade notes>> first if you are attemp
 ----
 kubectl create -f https://download.elastic.co/downloads/eck/{eck_version}/crds.yaml
 ----
++
+The following Elastic resources have been created:
++
+[source,sh]
+----
+customresourcedefinition.apiextensions.k8s.io/agents.agent.k8s.elastic.co created
+customresourcedefinition.apiextensions.k8s.io/apmservers.apm.k8s.elastic.co created
+customresourcedefinition.apiextensions.k8s.io/beats.beat.k8s.elastic.co created
+customresourcedefinition.apiextensions.k8s.io/elasticmapsservers.maps.k8s.elastic.co created
+customresourcedefinition.apiextensions.k8s.io/elasticsearches.elasticsearch.k8s.elastic.co created
+customresourcedefinition.apiextensions.k8s.io/enterprisesearches.enterprisesearch.k8s.elastic.co created
+customresourcedefinition.apiextensions.k8s.io/kibanas.kibana.k8s.elastic.co created
+----
 
 . Install the operator with its RBAC rules:
 +


### PR DESCRIPTION
This PR adds an example to show the output of the command `kubectl create -f https://download.elastic.co/downloads/eck/2.0.0/crds.yaml`

Fixes #5322