### PR TITLE
Adjust validations in TestMetricbeatStackMonitoringRecipe for version 8.0.0

### DIFF
--- a/test/e2e/beat/recipes_test.go
+++ b/test/e2e/beat/recipes_test.go
@@ -134,7 +134,6 @@ func TestMetricbeatStackMonitoringRecipe(t *testing.T) {
 			beat.HasMonitoringEvent("kibana_stats.kibana.status:green"),
 		}
 
-		fmt.Println("DEBUG", builder.Beat.Spec.Version)
 		if version.MustParse(builder.Beat.Spec.Version).LT(version.MinFor(8, 0, 0)) {
 			// before 8.0.0, `metricset.name` was not indexed
 			metricbeatValidations = []beat.ValidationFunc{

--- a/test/e2e/beat/recipes_test.go
+++ b/test/e2e/beat/recipes_test.go
@@ -123,24 +123,39 @@ func TestMetricbeatStackMonitoringRecipe(t *testing.T) {
 			}
 		}
 
-		return builder.
-			WithRoles(beat.PSPClusterRoleName).
-			WithESValidations(
-				// metricbeat validations
-				// TODO: see if we can add validation for ccr, ml_job, and shard metricsets
+		metricbeatValidations := []beat.ValidationFunc{
+			beat.HasMonitoringEvent("metricset.name:cluster_stats"),
+			beat.HasMonitoringEvent("metricset.name:enrich"),
+			beat.HasMonitoringEvent("metricset.name:index"),
+			beat.HasMonitoringEvent("metricset.name:index_summary"),
+			beat.HasMonitoringEvent("metricset.name:node_stats"),
+			beat.HasMonitoringEvent("metricset.name:stats"),
+			beat.HasMonitoringEvent("metricset.name:shard"),
+			beat.HasMonitoringEvent("kibana_stats.kibana.status:green"),
+		}
+
+		fmt.Println("DEBUG", builder.Beat.Spec.Version)
+		if version.MustParse(builder.Beat.Spec.Version).LT(version.MinFor(8, 0, 0)) {
+			// before 8.0.0, `metricset.name` was not indexed
+			metricbeatValidations = []beat.ValidationFunc{
 				beat.HasMonitoringEvent("type:cluster_stats"),
 				beat.HasMonitoringEvent("type:enrich_coordinator_stats"),
-				// from the elasticsearch.index metricset
 				beat.HasMonitoringEvent("type:index_stats"),
 				beat.HasMonitoringEvent("type:index_recovery"),
-				// elasticsearch.index.summary metricset
 				beat.HasMonitoringEvent("type:indices_stats"),
 				beat.HasMonitoringEvent("node_stats.node_master:true"),
 				beat.HasMonitoringEvent("kibana_stats.kibana.status:green"),
+			}
+		}
+
+		return builder.
+			WithRoles(beat.PSPClusterRoleName).
+			WithESValidations(append(
+				metricbeatValidations,
 				// filebeat validations
 				beat.HasEventFromPod(pod.Name),
 				beat.HasMessageContaining(loggedString),
-			)
+			)...)
 	}
 
 	runBeatRecipe(t, "stack_monitoring.yaml", customize, pod)


### PR DESCRIPTION
Resolves #5387.

We could run queries that will work in 7x and 8x using bool filter but I prefer to have the exact queries for each version.

The Stack version in the recipes is currently fixed but it will change after #4903. This shouldn't be a problem because we have the version of the resource from the constructor that has already been transformed.