### PR TITLE
remove erroneous error check in finalizers RemoveAll

### DIFF
--- a/pkg/controller/common/finalizer/finalizers.go
+++ b/pkg/controller/common/finalizer/finalizers.go
@@ -26,9 +26,6 @@ func RemoveAll(c k8s.Client, obj client.Object) error {
 		return nil
 	}
 	filterFinalizers := filterFinalizers(accessor.GetFinalizers())
-	if err != nil {
-		return err
-	}
 	accessor.SetFinalizers(filterFinalizers)
 	return c.Update(context.Background(), obj)
 }


### PR DESCRIPTION
Upon looking at #3392 for APM, came upon this error check that seems to be unnecessary.  This simply removes it.