### PR TITLE
Extend full upgrade to any 8x version upgrade of non-HA ES

### DIFF
--- a/pkg/controller/elasticsearch/driver/upgrade.go
+++ b/pkg/controller/elasticsearch/driver/upgrade.go
@@ -97,11 +97,11 @@ func (d *defaultDriver) handleUpgrades(
 
 	var deletedPods []corev1.Pod
 
-	isVersionUpgrade, err := isVersionUpgrade(d.ES)
+	is8xVersionUpgrade, err := is8xVersionUpgrade(d.ES)
 	if err != nil {
 		return results.WithError(err)
 	}
-	shouldDoFullRestartUpgrade := isNonHACluster(currentPods, expectedMasters) && isVersionUpgrade
+	shouldDoFullRestartUpgrade := isNonHACluster(currentPods, expectedMasters) && is8xVersionUpgrade
 	if shouldDoFullRestartUpgrade {
 		// unconditional full cluster upgrade
 		deletedPods, err = run(upgrade.DeleteAll)
@@ -206,7 +206,9 @@ func isNonHACluster(actualPods []corev1.Pod, expectedMasters []string) bool {
 	return len(actualMasters) <= 2
 }
 
-func isVersionUpgrade(es esv1.Elasticsearch) (bool, error) {
+// is8xVersionUpgrade returns true if a version upgrade involves 8.x which displays different behaviour during version upgrades
+// than previous Elastic Stack versions.
+func is8xVersionUpgrade(es esv1.Elasticsearch) (bool, error) {
 	specVersion, err := version.Parse(es.Spec.Version)
 	if err != nil {
 		return false, err
@@ -215,7 +217,7 @@ func isVersionUpgrade(es esv1.Elasticsearch) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return specVersion.GT(statusVersion), nil
+	return specVersion.Major == 8 && specVersion.GT(statusVersion), nil
 }
 
 func healthyPods(

--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -306,7 +306,7 @@ func Test_isNonHACluster(t *testing.T) {
 	}
 }
 
-func Test_isVersionUpgrade(t *testing.T) {
+func Test_is8xVersionUpgrade(t *testing.T) {
 	tests := []struct {
 		name    string
 		es      esv1.Elasticsearch
@@ -314,7 +314,7 @@ func Test_isVersionUpgrade(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "upgrade",
+			name: "not an 8x upgrade",
 			es: esv1.Elasticsearch{
 				Spec:   esv1.ElasticsearchSpec{Version: "7.17.0"},
 				Status: esv1.ElasticsearchStatus{Version: "6.8.0"},
@@ -322,7 +322,24 @@ func Test_isVersionUpgrade(t *testing.T) {
 			want:    true,
 			wantErr: false,
 		},
-
+		{
+			name: "8x upgrade",
+			es: esv1.Elasticsearch{
+				Spec:   esv1.ElasticsearchSpec{Version: "8.0.0"},
+				Status: esv1.ElasticsearchStatus{Version: "7.17.0"},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "8x minor upgrade",
+			es: esv1.Elasticsearch{
+				Spec:   esv1.ElasticsearchSpec{Version: "8.1.0"},
+				Status: esv1.ElasticsearchStatus{Version: "8.0.0"},
+			},
+			want:    true,
+			wantErr: false,
+		},
 		{
 			name: "not an upgrade",
 			es: esv1.Elasticsearch{
@@ -354,11 +371,11 @@ func Test_isVersionUpgrade(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := isVersionUpgrade(tt.es)
+			got, err := is8xVersionUpgrade(tt.es)
 			if tt.wantErr != (err != nil) {
 				t.Errorf("wantErr %v got %v", tt.wantErr, err)
 			}
-			assert.Equalf(t, tt.want, got, "isVersionUpgrade(%v)", tt.es)
+			assert.Equalf(t, tt.want, got, "is8xVersionUpgrade(%v)", tt.es)
 		})
 	}
 }

--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -306,7 +306,7 @@ func Test_isNonHACluster(t *testing.T) {
 	}
 }
 
-func Test_isMajorVersionUpgrade(t *testing.T) {
+func Test_isVersionUpgrade(t *testing.T) {
 	tests := []struct {
 		name    string
 		es      esv1.Elasticsearch
@@ -314,7 +314,7 @@ func Test_isMajorVersionUpgrade(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "major upgrade",
+			name: "upgrade",
 			es: esv1.Elasticsearch{
 				Spec:   esv1.ElasticsearchSpec{Version: "7.17.0"},
 				Status: esv1.ElasticsearchStatus{Version: "6.8.0"},
@@ -324,10 +324,10 @@ func Test_isMajorVersionUpgrade(t *testing.T) {
 		},
 
 		{
-			name: "not a major upgrade",
+			name: "not an upgrade",
 			es: esv1.Elasticsearch{
 				Spec:   esv1.ElasticsearchSpec{Version: "7.17.0"},
-				Status: esv1.ElasticsearchStatus{Version: "7.16.0"},
+				Status: esv1.ElasticsearchStatus{Version: "7.17.0"},
 			},
 			want:    false,
 			wantErr: false,
@@ -354,11 +354,11 @@ func Test_isMajorVersionUpgrade(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := isMajorVersionUpgrade(tt.es)
+			got, err := isVersionUpgrade(tt.es)
 			if tt.wantErr != (err != nil) {
 				t.Errorf("wantErr %v got %v", tt.wantErr, err)
 			}
-			assert.Equalf(t, tt.want, got, "isMajorVersionUpgrade(%v)", tt.es)
+			assert.Equalf(t, tt.want, got, "isVersionUpgrade(%v)", tt.es)
 		})
 	}
 }

--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -319,7 +319,7 @@ func Test_is8xVersionUpgrade(t *testing.T) {
 				Spec:   esv1.ElasticsearchSpec{Version: "7.17.0"},
 				Status: esv1.ElasticsearchStatus{Version: "6.8.0"},
 			},
-			want:    true,
+			want:    false,
 			wantErr: false,
 		},
 		{

--- a/test/e2e/es/version_upgrade_test.go
+++ b/test/e2e/es/version_upgrade_test.go
@@ -207,7 +207,10 @@ func TestVersionUpgradeTwoNodesToLatest8x(t *testing.T) {
 
 	initial := elasticsearch.NewBuilder("test-version-up-2-to-8x").
 		WithVersion(srcVersion).
-		WithChangeBudget(2, 2). // 8x non-HA upgrades cannot honour a change budget with maxUnavailable 1
+		// 8x non-HA upgrades cannot honour a change budget with maxUnavailable 1 because we are rolling both nodes at once
+		// setting the change budget accordingly allows this test to pass as otherwise the changeBudgetWatcher step would
+		// fail as it would detect a change budget violation.
+		WithChangeBudget(2, 2).
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().

--- a/test/e2e/es/version_upgrade_test.go
+++ b/test/e2e/es/version_upgrade_test.go
@@ -207,6 +207,7 @@ func TestVersionUpgradeTwoNodesToLatest8x(t *testing.T) {
 
 	initial := elasticsearch.NewBuilder("test-version-up-2-to-8x").
 		WithVersion(srcVersion).
+		WithChangeBudget(2, 2). // 8x non-HA upgrades cannot honour a change budget with maxUnavailable 1
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().


### PR DESCRIPTION
Follow up to https://github.com/elastic/cloud-on-k8s/pull/5327 

I originally tested #5327 with 7.x and 8.0 upgrades. I did not however re-test before merging that the upgrades also work successfully with the by then released 8.0 on the 8.0->8.1 upgrade path. As evidenced by recent CI failures this is not the case. The behaviour we observed with major version upgrades from 7.last to 8.0 is also observable during minor upgrades from 8.0 to 8.1: i.e. depending on which node is currently the master node the cluster can disintegrate in such a way that a rolling upgrade with its invariant of green or yellow cluster health between node restarts cannot proceed. 

This PR extends therefore the condition that enables upgrades through simultaneous restarts of all nodes to any version 8.x upgrade in a non-HA cluster.

For 6.8 to 7.x we want to keep the previous behaviour because we need to bootstrap the new Zen2 mechanisms correctly. 

An alternative implementation to fix this issue could be as follows (I am open to that as well):

* do full simultaneous restarts on any 1/2 node cluster upgrade
* change the mechanisms that bootstraps Zen2 to also set `initial_master_ nodes` on 2 node cluster upgrades to cover the 6.x  to 7.x case

This would give us a more uniform approach across Elastic stack versions with less version specific exceptions. 