### PR TITLE
Small changes 

### DIFF
--- a/pkg/controller/elasticsearch/certificates/transport/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile.go
@@ -7,7 +7,6 @@ package transport
 import (
 	"bytes"
 	"context"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/set"
 	"reflect"
 	"strings"
 	"time"
@@ -49,10 +48,7 @@ func ReconcileTransportCertificatesSecrets(
 	if err != nil {
 		return results.WithError(err)
 	}
-	ssets := set.Make()
-	for _, actualStatefulSet := range actualStatefulSets {
-		ssets.Add(actualStatefulSet.Name)
-	}
+	ssets := actualStatefulSets.Names()
 	for _, nodeSet := range es.Spec.NodeSets {
 		ssets.Add(esv1.StatefulSet(es.Name, nodeSet.Name))
 	}

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile.go
@@ -7,6 +7,7 @@ package transport
 import (
 	"bytes"
 	"context"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/set"
 	"reflect"
 	"strings"
 	"time"
@@ -26,7 +27,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/set"
 )
 
 var log = ulog.Log.WithName("transport")

--- a/pkg/controller/elasticsearch/sset/list.go
+++ b/pkg/controller/elasticsearch/sset/list.go
@@ -11,7 +11,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -56,15 +55,6 @@ func (l StatefulSetList) Names() set.StringSet {
 		names.Add(statefulSet.Name)
 	}
 	return names
-}
-
-// ObjectMetas returns a list of MetaObject from the StatefulSetList.
-func (l StatefulSetList) ObjectMetas() []metav1.ObjectMeta {
-	objs := make([]metav1.ObjectMeta, len(l))
-	for i, sset := range l {
-		objs[i] = sset.ObjectMeta
-	}
-	return objs
 }
 
 // ToUpdate filters the StatefulSetList to the ones having an update revision scheduled.


### PR DESCRIPTION
This PR removes the unused function ObjectMetas and changes the _for_ loop that adds the names in the [ReconcileTransportCertificatesSecrets](https://github.com/elastic/cloud-on-k8s/blob/9d375cc128b52cef1e6d784b95b39e8b951e0344/pkg/controller/elasticsearch/certificates/transport/reconcile.go#L37) function.