### PR TITLE
[E2E] Do not expect generation to be incremented if spec has not changed

### DIFF
--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -75,9 +75,11 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 	var continuousHealthChecks *ContinuousHealthCheck
 	var dataIntegrityCheck *DataIntegrityCheck
 	mutatedFrom := b.MutatedFrom
+	isMutated := true
 	if mutatedFrom == nil {
 		// cluster mutates to itself (same spec)
 		mutatedFrom = &b
+		isMutated = false
 	}
 
 	masterChangeBudgetWatcher := NewMasterChangeBudgetWatcher(b.Elasticsearch)
@@ -118,7 +120,7 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 		WithSteps(b.CheckStackTestSteps(k)).
 		WithSteps(test.StepList{
 			CompareClusterUUIDStep(b.Elasticsearch, k, &clusterIDBeforeMutation),
-			CompareClusterGenerationsStep(b.Elasticsearch, k, &clusterGenerationBeforeMutation, &clusterObservedGenerationBeforeMutation),
+			CompareClusterGenerationsStep(b.Elasticsearch, k, isMutated, clusterGenerationBeforeMutation, clusterObservedGenerationBeforeMutation),
 			masterChangeBudgetWatcher.StopStep(k),
 			changeBudgetWatcher.StopStep(k),
 			test.Step{


### PR DESCRIPTION
Fix e2e test [failure](https://devops-ci.elastic.co/job/cloud-on-k8s-e2e-tests-gke-k8s-versions/661/) `beat.TestVersionUpgradeToLatest8x/Cluster_metadata.generation,_and_status.observedGeneration_should_have_been_incremented_from_previous_state,_and_should_be_equal`

