### PR TITLE
[E2E] Fleet agent: use explicit policies

### DIFF
--- a/test/e2e/agent/config.go
+++ b/test/e2e/agent/config.go
@@ -5,6 +5,47 @@
 package agent
 
 const (
+	E2EFleetPolicies = `
+    xpack.fleet.packages:
+    - name: system
+      version: latest
+    - name: elastic_agent
+      version: latest
+    - name: fleet_server
+      version: latest
+    - name: kubernetes
+      # pinning this version as the next one introduced a kube-proxy host setting default that breaks this recipe,
+      # see https://github.com/elastic/integrations/pull/1565 for more details
+      version: 0.14.0
+    xpack.fleet.agentPolicies:
+    - name: Fleet Server on ECK policy
+      id: eck-fleet-server
+      namespace: default
+      monitoring_enabled:
+      - logs
+      - metrics
+      is_default_fleet_server: true
+      package_policies:
+      - name: fleet_server-1
+        id: fleet_server-1
+        package:
+          name: fleet_server
+    - name: Elastic Agent on ECK policy
+      id: eck-agent
+      namespace: default
+      monitoring_enabled:
+      - logs
+      - metrics
+      unenroll_timeout: 900
+      is_default: true
+      package_policies:
+      - package:
+          name: system
+        name: system-1
+      - package:
+          name: kubernetes
+        name: kubernetes-1`
+
 	E2EAgentSystemIntegrationConfig = `id: 2d70a6f0-33a5-11eb-bb2f-418d0388a8cf
 revision: 2
 agent:

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -2,6 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
+//go:build agent || e2e
 // +build agent e2e
 
 package agent
@@ -9,6 +10,8 @@ package agent
 import (
 	"fmt"
 	"testing"
+
+	"github.com/ghodss/yaml"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -153,7 +156,7 @@ func TestFleetMode(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
-	kbBuilder = kbBuilder.WithConfig(fleetConfigForKibana(esBuilder.Ref(), fleetServerBuilder.Ref()))
+	kbBuilder = kbBuilder.WithConfig(fleetConfigForKibana(t, esBuilder.Ref(), fleetServerBuilder.Ref()))
 
 	agentBuilder := agent.NewBuilder(name+"-ea").
 		WithRoles(agent.PSPClusterRoleName, agent.AgentFleetModeRoleName).
@@ -167,21 +170,27 @@ func TestFleetMode(t *testing.T) {
 	test.Sequence(nil, test.EmptySteps, esBuilder, kbBuilder, fleetServerBuilder, agentBuilder).RunSequential(t)
 }
 
-func fleetConfigForKibana(esRef v1.ObjectSelector, fsRef v1.ObjectSelector) map[string]interface{} {
-	return map[string]interface{}{
-		"xpack.fleet.agents.elasticsearch.hosts": []string{
-			fmt.Sprintf(
-				"https://%s-es-http.%s.svc:9200",
-				esRef.Name,
-				esRef.Namespace,
-			),
-		},
-		"xpack.fleet.agents.fleet_server.hosts": []string{
-			fmt.Sprintf(
-				"https://%s-agent-http.%s.svc:8220",
-				fsRef.Name,
-				fsRef.Namespace,
-			),
-		},
+func fleetConfigForKibana(t *testing.T, esRef v1.ObjectSelector, fsRef v1.ObjectSelector) map[string]interface{} {
+	t.Helper()
+	kibanaConfig := map[string]interface{}{}
+	err := yaml.Unmarshal([]byte(E2EFleetPolicies), &kibanaConfig)
+	if err != nil {
+		t.Fatalf("Unable to parse Fleet policies: %v", err)
 	}
+	kibanaConfig["xpack.fleet.agents.elasticsearch.hosts"] = []string{
+		fmt.Sprintf(
+			"https://%s-es-http.%s.svc:9200",
+			esRef.Name,
+			esRef.Namespace,
+		),
+	}
+
+	kibanaConfig["xpack.fleet.agents.fleet_server.hosts"] = []string{
+		fmt.Sprintf(
+			"https://%s-agent-http.%s.svc:8220",
+			fsRef.Name,
+			fsRef.Namespace,
+		),
+	}
+	return kibanaConfig
 }

--- a/test/e2e/agent/upgrade_test.go
+++ b/test/e2e/agent/upgrade_test.go
@@ -47,7 +47,7 @@ func TestAgentVersionUpgradeToLatest8x(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
-	kbBuilder = kbBuilder.WithConfig(fleetConfigForKibana(t, esBuilder.Ref(), fleetServerBuilder.Ref()))
+	kbBuilder = kbBuilder.WithConfig(fleetConfigForKibana(t, fleetServerBuilder.Agent.Spec.Version, esBuilder.Ref(), fleetServerBuilder.Ref()))
 
 	agentBuilder := agent.NewBuilder(name+"-ea").
 		WithVersion(srcVersion).

--- a/test/e2e/agent/upgrade_test.go
+++ b/test/e2e/agent/upgrade_test.go
@@ -47,7 +47,7 @@ func TestAgentVersionUpgradeToLatest8x(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
-	kbBuilder = kbBuilder.WithConfig(fleetConfigForKibana(esBuilder.Ref(), fleetServerBuilder.Ref()))
+	kbBuilder = kbBuilder.WithConfig(fleetConfigForKibana(t, esBuilder.Ref(), fleetServerBuilder.Ref()))
 
 	agentBuilder := agent.NewBuilder(name+"-ea").
 		WithVersion(srcVersion).


### PR DESCRIPTION
This is an attempt to fix https://github.com/elastic/cloud-on-k8s/issues/5047 (at least the error we are currently hitting: `unable to find policy named ""`)

Both `TestAgentVersionUpgradeToLatest8x` and `TestFleetMode` are ✅ locally with `8.0.0` and `8.1.0-SNAPSHOT`. Still testing with other versions...