### PR TITLE
Extend full upgrade to any version upgrade of non-HA ES

### DIFF
--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -306,7 +306,7 @@ func Test_isNonHACluster(t *testing.T) {
 	}
 }
 
-func Test_is8xVersionUpgrade(t *testing.T) {
+func Test_isVersionUpgrade(t *testing.T) {
 	tests := []struct {
 		name    string
 		es      esv1.Elasticsearch
@@ -314,16 +314,7 @@ func Test_is8xVersionUpgrade(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "not an 8x upgrade",
-			es: esv1.Elasticsearch{
-				Spec:   esv1.ElasticsearchSpec{Version: "7.17.0"},
-				Status: esv1.ElasticsearchStatus{Version: "6.8.0"},
-			},
-			want:    false,
-			wantErr: false,
-		},
-		{
-			name: "8x upgrade",
+			name: "upgrade",
 			es: esv1.Elasticsearch{
 				Spec:   esv1.ElasticsearchSpec{Version: "8.0.0"},
 				Status: esv1.ElasticsearchStatus{Version: "7.17.0"},
@@ -332,7 +323,7 @@ func Test_is8xVersionUpgrade(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "8x minor upgrade",
+			name: "minor upgrade",
 			es: esv1.Elasticsearch{
 				Spec:   esv1.ElasticsearchSpec{Version: "8.1.0"},
 				Status: esv1.ElasticsearchStatus{Version: "8.0.0"},
@@ -371,11 +362,11 @@ func Test_is8xVersionUpgrade(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := is8xVersionUpgrade(tt.es)
+			got, err := isVersionUpgrade(tt.es)
 			if tt.wantErr != (err != nil) {
 				t.Errorf("wantErr %v got %v", tt.wantErr, err)
 			}
-			assert.Equalf(t, tt.want, got, "is8xVersionUpgrade(%v)", tt.es)
+			assert.Equalf(t, tt.want, got, "isVersionUpgrade(%v)", tt.es)
 		})
 	}
 }

--- a/pkg/controller/elasticsearch/version/zen2/initial_master_nodes.go
+++ b/pkg/controller/elasticsearch/version/zen2/initial_master_nodes.go
@@ -125,7 +125,7 @@ func patchInitialMasterNodesConfig(nodeSpecResources nodespec.ResourcesList, ini
 }
 
 // nonHAZen1MasterUpgrade returns true if expected nodes in nodeSpecResources will lead to upgrading
-// the single or two node zen1-compatible master node currently running in the es cluster.
+// the one or two zen1-compatible master nodes currently running in the es cluster.
 // As we upgrade all nodes at once in one or two node clusters initial master nodes needs to be set as there is no
 // existing cluster to join once all v6 nodes have been terminated.
 func nonHAZen1MasterUpgrade(c k8s.Client, es esv1.Elasticsearch, nodeSpecResources nodespec.ResourcesList) (bool, error) {

--- a/pkg/controller/elasticsearch/version/zen2/initial_master_nodes.go
+++ b/pkg/controller/elasticsearch/version/zen2/initial_master_nodes.go
@@ -6,6 +6,7 @@ package zen2
 
 import (
 	"context"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/set"
 	"strings"
 
 	pkgerrors "github.com/pkg/errors"
@@ -75,7 +76,7 @@ func shouldSetInitialMasterNodes(es esv1.Elasticsearch, k8sClient k8s.Client, no
 		return true, nil
 	}
 	// - we're upgrading (effectively restarting) a single zen1 master to zen2
-	return singleZen1MasterUpgrade(k8sClient, es, nodeSpecResources)
+	return nonHAZen1MasterUpgrade(k8sClient, es, nodeSpecResources)
 }
 
 // RemoveZen2BootstrapAnnotation removes the initialMasterNodesAnnotation (if set) once zen2 is bootstrapped
@@ -123,47 +124,56 @@ func patchInitialMasterNodesConfig(nodeSpecResources nodespec.ResourcesList, ini
 	return nil
 }
 
-// singleZen1MasterUpgrade returns true if expected nodes in nodeSpecResources will lead to upgrading
-// the single zen1-compatible master node currently running in the es cluster.
-func singleZen1MasterUpgrade(c k8s.Client, es esv1.Elasticsearch, nodeSpecResources nodespec.ResourcesList) (bool, error) {
-	// looking for a single master node...
+// nonHAZen1MasterUpgrade returns true if expected nodes in nodeSpecResources will lead to upgrading
+// the single or two node zen1-compatible master node currently running in the es cluster.
+// As we upgrade all nodes at once in one or two node clusters initial master nodes needs to be set as there is no
+// existing cluster to join once all v6 nodes have been terminated.
+func nonHAZen1MasterUpgrade(c k8s.Client, es esv1.Elasticsearch, nodeSpecResources nodespec.ResourcesList) (bool, error) {
+	// looking for a non-HA master node setup...
 	masters, err := sset.GetActualMastersForCluster(c, es)
 	if err != nil {
 		return false, err
 	}
-	if len(masters) != 1 {
+	if len(masters) > 2 {
 		return false, nil
 	}
-	currentMaster := masters[0]
-	// ...not compatible with zen2...
-	v, err := label.ExtractVersion(currentMaster.Labels)
-	if err != nil {
-		return false, err
-	}
-	if versionCompatibleWithZen2(v) {
-		return false, nil
-	}
-	// ...that will be replaced
-	var targetMasters []string
-	for _, res := range nodeSpecResources {
-		if label.IsMasterNodeSet(res.StatefulSet) {
-			targetMasters = append(targetMasters, sset.PodNames(res.StatefulSet)...)
+
+	currentMasterNames := set.Make()
+	for _, currentMaster := range masters {
+		currentMasterNames.Add(currentMaster.Name)
+		// ...not compatible with zen2...
+		v, err := label.ExtractVersion(currentMaster.Labels)
+		if err != nil {
+			return false, err
+		}
+		// at least one master is already on Zen 2
+		if versionCompatibleWithZen2(v) {
+			return false, nil
 		}
 	}
-	if len(targetMasters) == 0 {
+
+	// ...that will be replaced
+	targetMasters := set.Make()
+	for _, res := range nodeSpecResources {
+		if label.IsMasterNodeSet(res.StatefulSet) {
+			targetMasters.MergeWith(set.Make(sset.PodNames(res.StatefulSet)...))
+		}
+	}
+	if targetMasters.Count() == 0 {
 		return false, nil
 	}
-	if len(targetMasters) > 1 {
+	if targetMasters.Count() > 2 {
 		// Covers the case where the user is upgrading to zen2 + adding more masters simultaneously.
 		// Additional masters will get created before the existing one gets upgraded/restarted.
 		return false, nil
 	}
-	if targetMasters[0] != currentMaster.Name {
-		// Covers the case where the existing master is replaced by another master in a different NodeSet.
+
+	if currentMasterNames.Diff(targetMasters).Count() > 0 {
+		// Covers the case where the existing masters are replaced by other masters in a different NodeSet.
 		// The new master will be created before the existing one gets removed.
 		return false, nil
 	}
-	// single zen1 master, will be replaced by a single zen2 master with the same name
+	// one or two zen1 masters, will be replaced by a one or two zen2 master with the same name
 	return true, nil
 }
 

--- a/pkg/controller/elasticsearch/version/zen2/initial_master_nodes.go
+++ b/pkg/controller/elasticsearch/version/zen2/initial_master_nodes.go
@@ -75,7 +75,7 @@ func shouldSetInitialMasterNodes(es esv1.Elasticsearch, k8sClient k8s.Client, no
 	if !bootstrap.AnnotatedForBootstrap(es) {
 		return true, nil
 	}
-	// - we're upgrading (effectively restarting) a single zen1 master to zen2
+	// - we're upgrading (effectively restarting) a non-HA zen1 cluster to zen2
 	return nonHAZen1MasterUpgrade(k8sClient, es, nodeSpecResources)
 }
 

--- a/pkg/controller/elasticsearch/version/zen2/initial_master_nodes.go
+++ b/pkg/controller/elasticsearch/version/zen2/initial_master_nodes.go
@@ -6,7 +6,6 @@ package zen2
 
 import (
 	"context"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/set"
 	"strings"
 
 	pkgerrors "github.com/pkg/errors"
@@ -19,6 +18,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/nodespec"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/set"
 )
 
 const (

--- a/pkg/utils/set/set.go
+++ b/pkg/utils/set/set.go
@@ -4,7 +4,9 @@
 
 package set
 
-import "sort"
+import (
+	"sort"
+)
 
 type StringSet map[string]struct{}
 
@@ -39,6 +41,17 @@ func (set StringSet) Has(s string) (exists bool) {
 		_, exists = set[s]
 	}
 	return
+}
+
+func (set StringSet) Diff(other StringSet) StringSet {
+	diff := Make()
+	for str := range set {
+		if other.Has(str) {
+			continue
+		}
+		diff.Add(str)
+	}
+	return diff
 }
 
 func (set StringSet) AsSlice() sort.StringSlice {

--- a/pkg/utils/set/set_test.go
+++ b/pkg/utils/set/set_test.go
@@ -288,3 +288,50 @@ func TestStringSet_MergeWith(t *testing.T) {
 		})
 	}
 }
+
+func TestStringSet_Diff(t *testing.T) {
+	tests := []struct {
+		name  string
+		set   StringSet
+		other StringSet
+		want  StringSet
+	}{
+		{
+			name:  "both nil",
+			set:   nil,
+			other: nil,
+			want:  StringSet{},
+		},
+		{
+			name:  "other nil",
+			set:   StringSet{"a": {}},
+			other: nil,
+			want:  StringSet{"a": {}},
+		},
+		{
+			name:  "same elements",
+			set:   StringSet{"a": {}},
+			other: StringSet{"a": {}},
+			want:  StringSet{},
+		},
+		{
+			name:  "b not in other",
+			set:   StringSet{"a": {}, "b": {}},
+			other: StringSet{"a": {}},
+			want:  StringSet{"b": {}},
+		},
+		{
+			name:  "b not in set",
+			set:   StringSet{"a": {}},
+			other: StringSet{"a": {}, "b": {}},
+			want:  StringSet{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.set.Diff(tt.other); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Diff() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/e2e/es/version_upgrade_test.go
+++ b/test/e2e/es/version_upgrade_test.go
@@ -55,6 +55,10 @@ func TestVersionUpgradeTwoNodes68xTo7x(t *testing.T) {
 	// due to minimum_master_nodes=2, the cluster is unavailable while the first master is upgraded
 	initial := elasticsearch.NewBuilder("test-version-up-2-68x-to-7x").
 		WithVersion(srcVersion).
+		// 8x non-HA upgrades cannot honour a change budget with maxUnavailable 1 because we are rolling both nodes at once
+		// setting the change budget accordingly allows this test to pass as otherwise the changeBudgetWatcher step would
+		// fail as it would detect a change budget violation.
+		WithChangeBudget(2, 2).
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
@@ -173,6 +177,10 @@ func TestVersionUpgradeTwoNodesToLatest7x(t *testing.T) {
 
 	initial := elasticsearch.NewBuilder("test-version-up-2-to-7x").
 		WithVersion(srcVersion).
+		// 8x non-HA upgrades cannot honour a change budget with maxUnavailable 1 because we are rolling both nodes at once
+		// setting the change budget accordingly allows this test to pass as otherwise the changeBudgetWatcher step would
+		// fail as it would detect a change budget violation.
+		WithChangeBudget(2, 2).
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().


### PR DESCRIPTION
Elasticsearch documentation [implies](https://www.elastic.co/guide/en/elastic-stack/8.0/upgrading-elasticsearch.html#rolling-upgrades) that two node clusters cannot be upgraded in a rolling fashion because we would be removing more than 50% of the nodes during the upgrade. A stricter validation of this invariant [introduced in 7.14](https://github.com/elastic/elasticsearch/pull/73358) was causing the test failures we have seen in our e2e test pipelines once [we had fixed the faulty non-HA upgrade test](https://github.com/elastic/cloud-on-k8s/pull/4961/files#diff-81988e08bfe062349de9bf20f8c0605cfffc3fd187250408ca118ee3e6a9956eL174) This affects any 7.x version but as of 7.14 there is an error and the nodes will not boot up. 

In the light of this information this PR extends the full rolling upgrade mode to any version upgrade. It also adjusts the setting of initial master nodes during the 6.x to 7.x transition to include two node clusters. This gives us a uniform way of handling those upgrades. 

There is still a case where an upgrade can get stuck that this PR does not cover: if a user combines a version upgrade with an upscale/downscale operation e.g. by bumping the Elasticsearch version and renaming the `nodeSet` at the same time. This will lead to something that looks like a rolling upgrade as we are removing the old nodes and adding new nodes one by one. There is still a chance that the upgrade gets stuck in that scenario and I don't see any easy way to fix that (other than through documentation)

One potential way of how the upgrade might get stuck is as follows:
* we create new node running in the new version but the image needs to be pulled or the startup is otherwise delayed
* we delete one of the existing nodes (in accordance with the change budget)
* the old node terminates before the new node joins the cluster and if the old node happened to be the master at the time the cluster now breaks down

I think this scenario can be avoided by setting a change budget with `maxUnavailable: 0` or by avoiding the combination of `nodeSet` addition/removal with a version upgrade. 