### PR TITLE
Allow small network errors during load+mutation testing.

### DIFF
--- a/test/e2e/es/mutation_test.go
+++ b/test/e2e/es/mutation_test.go
@@ -13,14 +13,15 @@ import (
 	"testing"
 	"time"
 
-	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/dev/portforward"
-	"github.com/elastic/cloud-on-k8s/test/e2e/test"
-	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
 	"github.com/stretchr/testify/assert"
 	vegeta "github.com/tsenart/vegeta/lib"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/dev/portforward"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
 )
 
 // TestMutationHTTPToHTTPS creates a 3 node cluster running without TLS on the HTTP layer,
@@ -288,9 +289,24 @@ func TestMutationWhileLoadTesting(t *testing.T) {
 			metrics.Close()
 			bytes, _ := json.Marshal(metrics)
 			msgAndArgs := []interface{}{"metrics: ", string(bytes)}
-			assert.Equal(t, 1, len(metrics.StatusCodes), msgAndArgs)
-			if _, ok := metrics.StatusCodes["401"]; !ok {
-				assert.Fail(t, "all status codes should be 401", msgAndArgs)
+			switch len(metrics.StatusCodes) {
+			case 1:
+				if _, ok := metrics.StatusCodes["401"]; !ok {
+					assert.Fail(t, "all status codes should be 401", msgAndArgs)
+				}
+			case 2:
+				// allow 5 or less network errors during load testing, as we randomly see these during testing.
+				if metrics.StatusCodes["0"] > 5 {
+					assert.Fail(t, "large number of network errors while mutating and load testing", msgAndArgs)
+				}
+				for k := range metrics.StatusCodes {
+					if k == "0" || k == "401" {
+						continue
+					}
+					assert.Fail(t, "only '401', and '0' error codes are allowed while mutating during load testing", msgAndArgs)
+				}
+			default:
+				assert.Fail(t, "large number of errors while mutating and load testing", msgAndArgs)
 			}
 		})
 


### PR DESCRIPTION
Since we've recently seen a small uptick in network errors during Elasticsearch mutation + load testing, and we're writing these off as acceptable due to k8s networking stack, these changes modify the Elasticsearch mutation+load testing end-to-end test(s) to allow for 5 or less network errors (status code "0" in Vegeta terminology).  If a percentage of total is preferred, then let me know and I can make that change.