### PR TITLE
E2E: Disable master change budget watcher on non-HA clusters

### DIFF
--- a/test/e2e/es/version_upgrade_test.go
+++ b/test/e2e/es/version_upgrade_test.go
@@ -55,10 +55,6 @@ func TestVersionUpgradeTwoNodes68xTo7x(t *testing.T) {
 	// due to minimum_master_nodes=2, the cluster is unavailable while the first master is upgraded
 	initial := elasticsearch.NewBuilder("test-version-up-2-68x-to-7x").
 		WithVersion(srcVersion).
-		// 8x non-HA upgrades cannot honour a change budget with maxUnavailable 1 because we are rolling both nodes at once
-		// setting the change budget accordingly allows this test to pass as otherwise the changeBudgetWatcher step would
-		// fail as it would detect a change budget violation.
-		WithChangeBudget(2, 2).
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
@@ -177,10 +173,6 @@ func TestVersionUpgradeTwoNodesToLatest7x(t *testing.T) {
 
 	initial := elasticsearch.NewBuilder("test-version-up-2-to-7x").
 		WithVersion(srcVersion).
-		// 8x non-HA upgrades cannot honour a change budget with maxUnavailable 1 because we are rolling both nodes at once
-		// setting the change budget accordingly allows this test to pass as otherwise the changeBudgetWatcher step would
-		// fail as it would detect a change budget violation.
-		WithChangeBudget(2, 2).
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().
@@ -215,10 +207,6 @@ func TestVersionUpgradeTwoNodesToLatest8x(t *testing.T) {
 
 	initial := elasticsearch.NewBuilder("test-version-up-2-to-8x").
 		WithVersion(srcVersion).
-		// 8x non-HA upgrades cannot honour a change budget with maxUnavailable 1 because we are rolling both nodes at once
-		// setting the change budget accordingly allows this test to pass as otherwise the changeBudgetWatcher step would
-		// fail as it would detect a change budget violation.
-		WithChangeBudget(2, 2).
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 
 	mutated := initial.WithNoESTopology().

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -75,7 +75,7 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 	var clusterGenerationBeforeMutation, clusterObservedGenerationBeforeMutation int64
 	var continuousHealthChecks *ContinuousHealthCheck
 	var dataIntegrityCheck *DataIntegrityCheck
-	mutatedFrom := b.MutatedFrom
+	mutatedFrom := b.MutatedFrom //nolint:ifshort
 	isMutated := true
 	if mutatedFrom == nil {
 		// cluster mutates to itself (same spec)
@@ -83,11 +83,17 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 		isMutated = false
 	}
 
-	masterChangeBudgetWatcher := NewMasterChangeBudgetWatcher(b.Elasticsearch)
-	changeBudgetWatcher := NewChangeBudgetWatcher(mutatedFrom.Elasticsearch.Spec, b.Elasticsearch)
+	watchers := []test.Watcher{
+		NewChangeBudgetWatcher(mutatedFrom.Elasticsearch.Spec, b.Elasticsearch),
+	}
+
+	isNonHAUpgrade := IsNonHAUpgrade(b)
+	if !isNonHAUpgrade {
+		watchers = append(watchers, NewMasterChangeBudgetWatcher(b.Elasticsearch))
+	}
 
 	//nolint:thelper
-	return test.StepList{
+	steps := test.StepList{
 		test.Step{
 			Name: "Add some data to the cluster before starting the mutation",
 			Test: func(t *testing.T) {
@@ -101,7 +107,7 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 				// Don't monitor cluster health if we're doing a rolling upgrade from a single data node or non-HA cluster.
 				// The cluster will become either unavailable (1 or 2 node cluster due to loss of quorum) or red
 				// (single data node when that node goes down).
-				return IsNonHAUpgrade(b)
+				return isNonHAUpgrade
 			},
 			Test: func(t *testing.T) {
 				var err error
@@ -110,20 +116,22 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 				continuousHealthChecks.Start()
 			},
 		},
-		masterChangeBudgetWatcher.StartStep(k),
-		changeBudgetWatcher.StartStep(k),
 		RetrieveClusterUUIDStep(b.Elasticsearch, k, &clusterIDBeforeMutation),
 		generation.RetrieveGenerationsStep(&b.Elasticsearch, k, &clusterGenerationBeforeMutation, &clusterObservedGenerationBeforeMutation),
-	}.
-		WithSteps(AnnotatePodsWithBuilderHash(*mutatedFrom, k)).
+	}
+
+	for _, watcher := range watchers {
+		steps = steps.WithStep(watcher.StartStep(k))
+	}
+
+	//nolint:thelper
+	steps = steps.WithSteps(AnnotatePodsWithBuilderHash(*mutatedFrom, k)).
 		WithSteps(b.UpgradeTestSteps(k)).
 		WithSteps(b.CheckK8sTestSteps(k)).
 		WithSteps(b.CheckStackTestSteps(k)).
 		WithSteps(test.StepList{
 			CompareClusterUUIDStep(b.Elasticsearch, k, &clusterIDBeforeMutation),
 			generation.CompareObjectGenerationsStep(&b.Elasticsearch, k, isMutated, clusterGenerationBeforeMutation, clusterObservedGenerationBeforeMutation),
-			masterChangeBudgetWatcher.StopStep(k),
-			changeBudgetWatcher.StopStep(k),
 			test.Step{
 				Name: "Elasticsearch cluster health should not have been red during mutation process",
 				Skip: func() bool {
@@ -147,6 +155,11 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 				}),
 			},
 		})
+
+	for _, watcher := range watchers {
+		steps = steps.WithStep(watcher.StopStep(k))
+	}
+	return steps
 }
 
 func IsNonHAUpgrade(b Builder) bool {

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -83,13 +83,13 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 		isMutated = false
 	}
 
-	watchers := []test.Watcher{
-		NewChangeBudgetWatcher(mutatedFrom.Elasticsearch.Spec, b.Elasticsearch),
-	}
-
+	var watchers []test.Watcher
 	isNonHAUpgrade := IsNonHAUpgrade(b)
 	if !isNonHAUpgrade {
-		watchers = append(watchers, NewMasterChangeBudgetWatcher(b.Elasticsearch))
+		watchers = []test.Watcher{
+			NewChangeBudgetWatcher(mutatedFrom.Elasticsearch.Spec, b.Elasticsearch),
+			NewMasterChangeBudgetWatcher(b.Elasticsearch),
+		}
 	}
 
 	//nolint:thelper


### PR DESCRIPTION
This fixes an oversight of the recently introduced revised rolling upgrade logic for non-HA clusters https://github.com/elastic/cloud-on-k8s/pull/5408

The master check budget watcher ensures that we add or remove on only one master at a time. For non-HA cluster we do however rotate all master nodes at once. This PR disables all the change budget checks if non-HA clusters are under test. 

It is worth noting however that this watcher did not reliably detect the one master at a time invariant violation. We had a number of successful test runs until the first failure exposed this oversight. 