### PR TITLE
Adding necessary ClusterRole permissions for elastic-agent in fleet server quick start 

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -136,6 +136,7 @@ rules:
   resources:
   - pods
   - nodes
+  - namespaces
   verbs:
   - get
   - watch


### PR DESCRIPTION
In the quick start guide of fleet-managed elastic agent on ECK, there is a YAML that deploys the environment.
The RBAC of elastic-agent inside that YAML doesn't include the namespaces resource in the core API group.
This causes the fleet agent to log failures and not spin up correctly since it cannot list the namespaces.
I've added the required permissions for the fleet agent to continue it's work
This PR resolves this issue: https://github.com/elastic/cloud-on-k8s/issues/5429