### PR TITLE
Disable Fleet tests until predefined policy feature is fixed

### DIFF
--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -134,6 +134,9 @@ func TestMultipleOutputConfig(t *testing.T) {
 }
 
 func TestFleetMode(t *testing.T) {
+	// TODO remove once https://github.com/elastic/kibana/issues/126611 is fixed
+	t.SkipNow()
+
 	name := "test-agent-fleet"
 
 	esBuilder := elasticsearch.NewBuilder(name).

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -90,6 +90,9 @@ func TestMultiOutputRecipe(t *testing.T) {
 }
 
 func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
+	// TODO remove once https://github.com/elastic/kibana/issues/126611 is fixed
+	t.SkipNow()
+
 	customize := func(builder agent.Builder) agent.Builder {
 		builder = builder.WithRoles(agent.PSPClusterRoleName)
 
@@ -135,6 +138,9 @@ func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
+	// TODO remove once https://github.com/elastic/kibana/issues/126611 is fixed
+	t.SkipNow()
+
 	notLoggingPod := beat.NewPodBuilder("test")
 	loggingPod := beat.NewPodBuilder("test")
 	loggingPod.Pod.Namespace = "default"
@@ -164,6 +170,9 @@ func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetAPMIntegrationRecipe(t *testing.T) {
+	// TODO remove once https://github.com/elastic/kibana/issues/126611 is fixed
+	t.SkipNow()
+
 	customize := func(builder agent.Builder) agent.Builder {
 		builder = builder.WithRoles(agent.PSPClusterRoleName)
 


### PR DESCRIPTION
We rely on defining policies in Kibana configuration in these tests. However this feature is not working reliably at the moment. This PR therefore disables all Fleet tests for the time being.  Can be reverted one https://github.com/elastic/kibana/issues/126611 is fixed.
	