### PR TITLE
moved monitoring section to right place

### DIFF
--- a/docs/advanced-topics/stack-monitoring.asciidoc
+++ b/docs/advanced-topics/stack-monitoring.asciidoc
@@ -137,17 +137,17 @@ You can customize the Filebeat and Metricbeat containers through the Pod templat
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch
 spec:
+  monitoring:
+    metrics:
+      elasticsearchRef:
+        name: monitoring
+        namespace: observability
+    logs:
+      elasticsearchRef:
+        name: monitoring
+        namespace: observability
   nodeSets:
   - name: default
-    monitoring:
-      metrics:
-        elasticsearchRef:
-          name: monitoring
-          namespace: observability
-      logs:
-        elasticsearchRef:
-          name: monitoring
-          namespace: observability
     podTemplate:
       spec:
         containers:


### PR DESCRIPTION
on Override beats pod template the monitoring was at the wrong place. I think monitoring has to be at spec level and not at nodeSets level.