### PR TITLE
Fix webhook generator to include matchPolicy of 'Exact'

### DIFF
--- a/hack/operatorhub/main.go
+++ b/hack/operatorhub/main.go
@@ -242,6 +242,7 @@ type WebhookDefinition struct {
 	ContainerPort           int                              `json:"containerPort"`
 	DeploymentName          string                           `json:"deploymentName"`
 	FailurePolicy           *admissionv1.FailurePolicyType   `json:"failurePolicy"`
+	MatchPolicy             admissionv1.MatchPolicyType      `json:"matchPolicy"`
 	GenerateName            string                           `json:"generateName"`
 	Rules                   []admissionv1.RuleWithOperations `json:"rules"`
 	SideEffects             *admissionv1.SideEffectClass     `json:"sideEffects"`
@@ -423,6 +424,7 @@ func validatingWebhookConfigurationToWebhookDefinition(webhookConfiguration admi
 			ContainerPort:           443,
 			DeploymentName:          "elastic-operator",
 			FailurePolicy:           webhook.FailurePolicy,
+			MatchPolicy:             admissionv1.Exact,
 			GenerateName:            webhook.Name,
 			Rules:                   webhook.Rules,
 			SideEffects:             webhook.SideEffects,


### PR DESCRIPTION
Fixes #5423 

This change includes `matchPolicy: Exact` in the OLM webhook generator such that v1beta1 webhooks will not try to validate v1 resources.

Test generated webhook

```
  webhookdefinitions:
    - admissionReviewVersions:
      - v1beta1
      containerPort: 443
      deploymentName: elastic-operator
      failurePolicy: Ignore
      generateName: elastic-agent-validation-v1alpha1.k8s.elastic.co
      matchPolicy: Exact
      rules:
      - apiGroups:
        - agent.k8s.elastic.co
        apiVersions:
        - v1alpha1
        operations:
        - CREATE
        - UPDATE
        resources:
        - agents
      sideEffects: None
      targetPort: 9443
      type: ValidatingAdmissionWebhook
      webhookPath: /validate-agent-k8s-elastic-co-v1alpha1-agent
```