### PR TITLE
Fix Agent trust CA commands for all image variants

### DIFF
--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -76,6 +76,11 @@ const (
 	FleetServerElasticsearchUsername = "FLEET_SERVER_ELASTICSEARCH_USERNAME"
 	FleetServerElasticsearchPassword = "FLEET_SERVER_ELASTICSEARCH_PASSWORD" //nolint:gosec
 	FleetServerElasticsearchCA       = "FLEET_SERVER_ELASTICSEARCH_CA"
+
+	ubiSharedCAPath    = "/etc/pki/ca-trust/source/anchors/"
+	ubiUpdateCmd       = "/usr/bin/update-ca-trust"
+	debianSharedCAPath = "/usr/local/share/ca-certificates/"
+	debianUpdateCmd    = "/usr/sbin/update-ca-certificates"
 )
 
 var (
@@ -382,11 +387,6 @@ func getAssociatedFleetServer(params Params) (commonv1.Associated, error) {
 }
 
 func trustCAScript(caPath string) string {
-	redhatSharedCAPath := "/etc/pki/ca-trust/source/anchors/"
-	redhatUpdateCmd := "/usr/bin/update-ca-trust"
-	debianSharedCAPath := "/usr/local/share/ca-certificates/"
-	debianUpdateCmd := "/usr/sbin/update-ca-certificates"
-
 	return fmt.Sprintf(`#!/usr/bin/env bash
 set -e
 if [[ -f %[1]s ]]; then
@@ -399,7 +399,7 @@ if [[ -f %[1]s ]]; then
   fi
 fi
 /usr/bin/tini -- /usr/local/bin/docker-entrypoint -e
-`, caPath, redhatSharedCAPath, redhatUpdateCmd, debianSharedCAPath, debianUpdateCmd)
+`, caPath, ubiSharedCAPath, ubiUpdateCmd, debianSharedCAPath, debianUpdateCmd)
 }
 
 func createDataVolume(params Params) volume.VolumeLike {

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -28,7 +28,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
@@ -315,17 +314,12 @@ func applyRelatedEsAssoc(agent agentv1alpha1.Agent, esAssociation commonv1.Assoc
 		certificatesDir(esAssociation),
 	))
 
-	agentVersion, err := version.Parse(agent.Spec.Version)
-	if err != nil {
-		return nil, err
-	}
-
 	// Beats managed by the Elastic Agent don't trust the Elasticsearch CA that Elastic Agent itself is configured
 	// to trust. There is currently no way to configure those Beats to trust a particular CA. The intended way to handle
 	// it is to allow Fleet to provide Beat output settings, but due to https://github.com/elastic/kibana/issues/102794
 	// this is not supported outside of UI. To workaround this limitation the Agent is going to update Pod-wide CA store
 	// before starting Elastic Agent.
-	cmd := trustCAScript(agentVersion, path.Join(certificatesDir(esAssociation), CAFileName))
+	cmd := trustCAScript(path.Join(certificatesDir(esAssociation), CAFileName))
 	return builder.WithCommand([]string{"/usr/bin/env", "bash", "-c", cmd}), nil
 }
 
@@ -387,7 +381,7 @@ func getAssociatedFleetServer(params Params) (commonv1.Associated, error) {
 	return &fs, nil
 }
 
-func trustCAScript(ver version.Version, caPath string) string {
+func trustCAScript(caPath string) string {
 	redhatSharedCAPath := "/etc/pki/ca-trust/source/anchors/"
 	redhatUpdateCmd := "/usr/bin/update-ca-trust"
 	debianSharedCAPath := "/usr/local/share/ca-certificates/"

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -712,21 +712,6 @@ fi
 			assoc:   assocToOtherNs,
 			wantErr: true,
 		},
-		{
-			name: "garbage version",
-			agent: agentv1alpha1.Agent{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "agent",
-					Namespace: agentNs,
-				},
-				Spec: agentv1alpha1.AgentSpec{
-					FleetServerEnabled: false,
-					Version:            "NaN",
-				},
-			},
-			assoc:   assocToSameNs,
-			wantErr: true,
-		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			builder := generateBuilder()

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -677,48 +677,6 @@ fi
 			}),
 		},
 		{
-			name: "fleet server disabled, same namespace 7.17.0",
-			agent: agentv1alpha1.Agent{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "agent",
-					Namespace: agentNs,
-				},
-				Spec: agentv1alpha1.AgentSpec{
-					Version:            "7.17.0-SNAPSHOT",
-					FleetServerEnabled: false,
-				},
-			},
-			assoc:   assocToSameNs,
-			wantErr: false,
-			wantPodSpec: generatePodSpec(func(ps corev1.PodSpec) corev1.PodSpec {
-				ps.Volumes = expectedCAVolume
-				ps.Containers[0].VolumeMounts = expectedCAVolumeMount
-				ps.Containers[0].Command = expectedCmd
-				return ps
-			}),
-		},
-		{
-			name: "fleet server disabled, same namespace 8x",
-			agent: agentv1alpha1.Agent{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "agent",
-					Namespace: agentNs,
-				},
-				Spec: agentv1alpha1.AgentSpec{
-					Version:            "8.0.0",
-					FleetServerEnabled: false,
-				},
-			},
-			assoc:   assocToSameNs,
-			wantErr: false,
-			wantPodSpec: generatePodSpec(func(ps corev1.PodSpec) corev1.PodSpec {
-				ps.Volumes = expectedCAVolume
-				ps.Containers[0].VolumeMounts = expectedCAVolumeMount
-				ps.Containers[0].Command = expectedCmd
-				return ps
-			}),
-		},
-		{
 			name: "fleet server enabled 8x",
 			agent: agentv1alpha1.Agent{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Fixes #5434

On OCP when using the certified Red Hat operator version of ECK we are using UBI based images by default, which breaks Agent >= version 7.17.0 startup, since we assume we are running within Ubuntu image, not UBI based images.  This fixes that assumption by adjusting the init container's CA trust script to work in both redhat, and debian-based images.