### PR TITLE
[2.1] Release notes and highlights for 2.1.0 (#5427)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-2.1.0>>
 * <<release-notes-2.0.0>>
 * <<release-notes-1.9.1>>
 * <<release-notes-1.9.0>>
@@ -31,6 +32,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/2.1.0.asciidoc[]
 include::release-notes/2.0.0.asciidoc[]
 include::release-notes/1.9.1.asciidoc[]
 include::release-notes/1.9.0.asciidoc[]

--- a/docs/release-notes/2.1.0.asciidoc
+++ b/docs/release-notes/2.1.0.asciidoc
@@ -1,0 +1,56 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-2.1.0]]
+== {n} version 2.1.0
+
+[[feature-2.1.0]]
+[float]
+=== New features
+
+* Allow predicates to be disabled on a case-by-case basis through annotation. {pull}5284[#5284] (issue: {issue}2092[#2092])
+
+[[enhancement-2.1.0]]
+[float]
+=== Enhancements
+
+* Elasticsearch: Set status.ObservedGeneration from metadata.Generation {pull}5331[#5331] (issue: {issue}3392[#3392])
+* Kibana: Set status.ObservedGeneration from metadata.Generation {pull}5409[#5409] (issue: {issue}3392[#3392])
+* Extend full upgrade to any version upgrade of non-HA Elasticsearch {pull}5408[#5408]
+* Handle resource conflict while updating status in association reconciler {pull}5337[#5337]
+* Improve Elasticsearch status sub-resource {pull}5328[#5328]
+* Use new node.roles notation in all example manifests {pull}5289[#5289] (issue: {issue}4130[#4130])
+* Handle data tiers during rolling upgrades {pull}5248[#5248] (issue: {issue}5228[#5228])
+* Isolate operator from HTTP service misconfiguration - Use internal service {pull}5211[#5211] (issue: {issue}4394[#4394])
+* Improve handling of managed namespaces - resolving 'unknown namespace for the cache' errors {pull}5187[#5187]
+
+[[bug-2.1.0]]
+[float]
+=== Bug fixes
+
+* Avoid reporting outdated Elasticsearch health on reconciliation error that prevents getting the real one {pull}5349[#5349] (issue: {issue}5330[#5330])
+* Only configure Stack Monitoring if association reconciled {pull}5339[#5339]
+* Do not attempt rolling upgrades for non-HA Elasticsearch clusters {pull}5327[#5327] (issue: {issue}5321[#5321])
+* Use precondition when deleting secrets {pull}5273[#5273] (issue: {issue}5249[#5249])
+* Support new Agent base image as of 7.17 {pull}5268[#5268]
+* Fix webhook match policy for OLM based installations {pull}5437[#5437] (issue: {issue}5423[#5423])
+* Fix Agent trust CA commands for all image variants {pull}5438[#5438] (issue: {issue}5434[#5434])
+
+[[docs-2.1.0]]
+[float]
+=== Documentation improvements
+
+* Add a sentence explaining the upgrade strategy restriction for non-HA Elasticsearch clusters {pull}5400[#5400]
+* Add example code to the Quickstart {pull}5378[#5378] (issue: {issue}5322[#5322])
+* Fix links to Elasticsearch upgrade docs {pull}5347[#5347]
+* Adjust Fleet recipes for default policy change {pull}5281[#5281] (issue: {issue}5262[#5262])
+
+[[nogroup-2.1.0]]
+[float]
+=== Misc
+
+* Update golang version to v1.17.8 {pull}5440[#5440]
+* Update module sigs.k8s.io/controller-runtime to v0.11.1 {pull}5384[#5384]
+* Update module sigs.k8s.io/kustomize/kyaml to v0.13.3 {pull}5380[#5380]
+* Update module github.com/google/go-cmp to v0.5.7 {pull}5264[#5264]
+

--- a/docs/release-notes/highlights-2.1.0.asciidoc
+++ b/docs/release-notes/highlights-2.1.0.asciidoc
@@ -1,0 +1,26 @@
+[[release-highlights-2.1.0]]
+== 2.1.0 release highlights
+
+[float]
+[id="{p}-210-new-and-notable"]
+=== New and notable
+
+New and notable changes in version 2.1.0 of {n}. Check <<release-notes-2.1.0>> for the full list of changes.
+
+[float]
+[id="{p}-210-improve-ES-status-sub-resource"]
+==== Improved Elasticsearch status sub-resource
+
+Additional information was added to the Elasticsearch status sub-resource, which provides rich details concerning the in-progress operations during upgrades, upscale, and downscale operations. New conditions fields include `ReconciliationComplete`, `RunningDesiredVersion`, and `ElasticsearchIsReachable` which gives information explaining why each condition is either True, or False. Also included is a new parent field `inProgressOperations`, which provides topology information for upgrades, upscale, and downscale operations.
+
+[float]
+[id="{p}-210-ES-Kibana-set-status-observed-generation"]
+==== Improved Elasticsearch and Kibana generation status
+
+An additional field `observedGeneration` is now maintained within Elasticsearch and Kibana's status sub-resource. This new field represents the current generation of the specification that the ECK operator is working to reconcile, and is intended to allow tools to deterministically monitor the rollout of custom resources.
+
+[float]
+[id="{p}-210-disabling-upgrade-predicates"]
+==== Allowing upgrade predicates to be selectively disabled
+
+Starting with ECK 2.1, the Elasticsearch clusters can have certain upgrade 'predicates' (rules) disabled on a case-by-case basis using annotations on the Elasticsearch custom resource, which allow full control over what rules are considered during the Elasticsearch upgrade process. Selectively disabling the predicates is extremely risky, and carries a high chance of either data loss, or causing a cluster to become completely unavailable. This feature is therefore intended exclusively as a troubleshooting mechanism of last resort. Check the link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-orchestration.html#k8s-advanced-upgrade-control[documentation] for more details.

--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the most important changes in each release. For the full list, check <<eck-release-notes>>.
 
+* <<release-highlights-2.1.0>>
 * <<release-highlights-2.0.0>>
 * <<release-highlights-1.9.1>>
 * <<release-highlights-1.9.0>>
@@ -30,6 +31,7 @@ This section summarizes the most important changes in each release. For the full
 
 --
 
+include::highlights-2.1.0.asciidoc[]
 include::highlights-2.0.0.asciidoc[]
 include::highlights-1.9.1.asciidoc[]
 include::highlights-1.9.0.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 2.1:
 - Release notes and highlights for 2.1.0 (#5427)