### PR TITLE
Operatorhub: Ensure local yaml files have a proper "end of directives" marker

### DIFF
--- a/hack/operatorhub/main.go
+++ b/hack/operatorhub/main.go
@@ -164,6 +164,9 @@ func getInstallManifestStream(conf *config, manifestPaths []string) (io.Reader, 
 			return nil, closer, fmt.Errorf("failed to open %s: %w", manifestPaths, err)
 		}
 		rs = append(rs, r)
+		// if we're using local yaml files, ensure that they have a proper
+		// end of directives marker between them.
+		rs = append(rs, strings.NewReader("---\n"))
 	}
 	return io.MultiReader(rs...), closer, nil
 }

--- a/hack/operatorhub/main.go
+++ b/hack/operatorhub/main.go
@@ -166,7 +166,7 @@ func getInstallManifestStream(conf *config, manifestPaths []string) (io.Reader, 
 		rs = append(rs, r)
 		// if we're using local yaml files, ensure that they have a proper
 		// end of directives marker between them.
-		rs = append(rs, strings.NewReader("---\n"))
+		rs = append(rs, strings.NewReader(yamlSeparator))
 	}
 	return io.MultiReader(rs...), closer, nil
 }


### PR DESCRIPTION
When running the `hack/operatorhub` tool with local yaml manifests:

example
```
go run main.go --conf=config.yaml --yaml-manifest=../../config/crds.yaml --yaml-manifest=../../config/operator.yaml
```

You will find that the Kibana CRD is missing from the processed files:

```
❯ find community-operators/2.1.0
community-operators/2.1.0
community-operators/2.1.0/agents.agent.k8s.elastic.co.crd.yaml
community-operators/2.1.0/apmservers.apm.k8s.elastic.co.crd.yaml
community-operators/2.1.0/elasticmapsservers.maps.k8s.elastic.co.crd.yaml
community-operators/2.1.0/elastic-cloud-eck.v2.1.0.clusterserviceversion.yaml
community-operators/2.1.0/beats.beat.k8s.elastic.co.crd.yaml
community-operators/2.1.0/elasticsearches.elasticsearch.k8s.elastic.co.crd.yaml
community-operators/2.1.0/enterprisesearches.enterprisesearch.k8s.elastic.co.crd.yaml
```

Upon debugging, you find that the kibana CRD yaml, which happens to be the last directive/document in the `crds.yaml` file, and the first directive/document in the `operator.yaml`, which is this:

```
# Source: eck-operator/templates/operator-namespace.yaml
apiVersion: v1
kind: Namespace
metadata:
  name: elastic-system
  labels:
    name: elastic-system
```

are appended together, and attempted to be processed without a "end of directives" marker `---` between them, which fails silently.  Adding some debugging to print the yaml bytes [here](https://github.com/elastic/cloud-on-k8s/blob/main/hack/operatorhub/main.go#L291), and a `default` block to the switch statement [here](https://github.com/elastic/cloud-on-k8s/blob/main/hack/operatorhub/main.go#L319) shows you that they are appended together:

```
2022/03/08 08:19:33 bytes: # Source: eck-operator-crds/templates/all-crds.yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  annotations:
    controller-gen.kubebuilder.io/version: v0.8.0
  creationTimestamp: null
  labels:
    app.kubernetes.io/instance: 'elastic-operator'
    app.kubernetes.io/name: 'eck-operator-crds'
    app.kubernetes.io/version: '2.2.0-SNAPSHOT'
  name: kibanas.kibana.k8s.elastic.co
---cut---
  - name: v1alpha1
    schema:
      openAPIV3Schema:
        description: to not break compatibility when upgrading from previous versions of the CRD
        type: object
    served: false
    storage: false
status:
  acceptedNames:
    kind: ""
    plural: ""
  conditions: []
  storedVersions: []

# Source: eck-operator/templates/operator-namespace.yaml
apiVersion: v1
kind: Namespace
metadata:
  name: elastic-system
  labels:
    name: elastic-system
2022/03/08 08:19:33 unknown type: *v1.Namespace
2022/03/08 08:19:33 bytes: # Source: eck-operator/templates/service-account.yaml
```

Unsure if adding this `---` block between files is the best approach, but wanted to get some eyes on this issue to work towards some sort of resolution.