### PR TITLE
Do not upgrade all Elasticsearch nodes of a given tier at once

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/orchestration.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/orchestration.asciidoc
@@ -210,6 +210,9 @@ Force an upgrade of all the master-ineligible nodes before upgrading the last ma
 ** do_not_delete_pods_with_same_shards
 +
 Do not allow two pods containing the same shard to be deleted at the same time.
+** do_not_delete_all_members_of_a_tier
++
+Do not delete all nodes that share the same node roles at once. This ensures that there is always availability for each configured tier of nodes during a rolling upgrade.
 
 Any of these predicates can be disabled by adding an annotation with the key of `eck.k8s.elastic.co/disable-upgrade-predicates` to the Elasticsearch metadata, specifically naming the predicate that is needing to be disabled.  Also, all predicates can be disabled by replacing the name of any predicatae with "*".
 

--- a/pkg/controller/elasticsearch/driver/fixtures.go
+++ b/pkg/controller/elasticsearch/driver/fixtures.go
@@ -181,20 +181,9 @@ func (u upgradeTestPods) toRuntimeObjects(version string, maxUnavailable int, f 
 }
 
 func (u upgradeTestPods) toCurrentPods() []corev1.Pod {
-	var result []corev1.Pod
+	result := make([]corev1.Pod, 0, len(u))
 	for _, testPod := range u {
 		result = append(result, testPod.toPod())
-	}
-	return result
-}
-
-func (u upgradeTestPods) toMasterPods() []corev1.Pod {
-	var result []corev1.Pod
-	for _, testPod := range u {
-		pod := testPod.toPod()
-		if label.IsMasterNode(pod) {
-			result = append(result, pod)
-		}
 	}
 	return result
 }

--- a/pkg/controller/elasticsearch/driver/fixtures.go
+++ b/pkg/controller/elasticsearch/driver/fixtures.go
@@ -180,6 +180,14 @@ func (u upgradeTestPods) toRuntimeObjects(version string, maxUnavailable int, f 
 	return result
 }
 
+func (u upgradeTestPods) toCurrentPods() []corev1.Pod {
+	var result []corev1.Pod
+	for _, testPod := range u {
+		result = append(result, testPod.toPod())
+	}
+	return result
+}
+
 func (u upgradeTestPods) toMasterPods() []corev1.Pod {
 	var result []corev1.Pod
 	for _, testPod := range u {

--- a/pkg/controller/elasticsearch/driver/upgrade_pods_deletion.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_pods_deletion.go
@@ -48,8 +48,7 @@ func (ctx *upgradeCtx) Delete() ([]corev1.Pod, error) {
 		ctx.healthyPods,
 		ctx.podsToUpgrade,
 		ctx.expectedMasters,
-		ctx.actualMasters,
-		ctx.numberOfPods,
+		ctx.currentPods,
 	)
 	log.V(1).Info("Applying predicates",
 		"maxUnavailableReached", maxUnavailableReached,

--- a/pkg/controller/elasticsearch/driver/upgrade_predicates.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_predicates.go
@@ -276,7 +276,7 @@ var predicates = [...]Predicate{
 			context PredicateContext,
 			candidate corev1.Pod,
 			deletedPods []corev1.Pod,
-			maxUnavailableReached bool,
+			_ bool,
 		) (b bool, e error) {
 			if candidate.DeletionTimestamp != nil {
 				// Pod is already terminating, skip it
@@ -563,8 +563,8 @@ var predicates = [...]Predicate{
 		fn: func(
 			context PredicateContext,
 			candidate corev1.Pod,
-			deletedPods []corev1.Pod,
-			maxUnavailableReached bool,
+			_ []corev1.Pod,
+			_ bool,
 		) (bool, error) {
 			healthyPodRoleHisto := map[common.TrueFalseLabel]int{}
 			currentPodRoleHisto := map[common.TrueFalseLabel]int{}

--- a/pkg/controller/elasticsearch/driver/upgrade_predicates.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_predicates.go
@@ -604,8 +604,9 @@ var predicates = [...]Predicate{
 						log.V(1).Info(
 							"Delaying upgrade for Pod to ensure tier availability",
 							"node_role", role,
+							"namespace", candidate.Namespace,
 							"candidate", candidate.Name,
-							"healty", healthy,
+							"healthy_pods_with_role", healthy,
 						)
 						return false, nil
 					}

--- a/pkg/controller/elasticsearch/driver/upgrade_predicates_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_predicates_test.go
@@ -1029,6 +1029,27 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 			wantShardsAllocationDisabled: false,
 		},
 		{
+			name: "Do allow the deletion of unhealthy Pods in a tier",
+			fields: fields{
+				esVersion: "8.0.0",
+				upgradeTestPods: newUpgradeTestPods(
+					newTestPod("ingest-0").withRoles(esv1.IngestRole).isHealthy(false).needsUpgrade(true).isInCluster(true),
+					newTestPod("ingest-1").withRoles(esv1.IngestRole).isHealthy(true).needsUpgrade(true).isInCluster(true),
+				),
+				shutdowns: map[string]client.NodeShutdown{
+					"ingest-0": {Status: client.ShutdownComplete},
+					"ingest-1": {Status: client.ShutdownComplete},
+				},
+				maxUnavailable: 2,
+				shardLister:    migration.NewFakeShardLister(client.Shards{}),
+				health:         client.Health{Status: esv1.ElasticsearchGreenHealth},
+				podFilter:      nothing,
+			},
+			deleted:                      []string{"ingest-0"},
+			wantErr:                      false,
+			wantShardsAllocationDisabled: false,
+		},
+		{
 			name: "Pod deleted while upgrading",
 			fields: fields{
 				esVersion: "7.5.0",

--- a/pkg/controller/elasticsearch/driver/upgrade_predicates_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_predicates_test.go
@@ -1010,6 +1010,25 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 			wantShardsAllocationDisabled: false,
 		},
 		{
+			name: "But allow deletion of single node tiers",
+			fields: fields{
+				esVersion: "8.0.0",
+				upgradeTestPods: newUpgradeTestPods(
+					newTestPod("ingest-0").withRoles(esv1.IngestRole).isHealthy(true).needsUpgrade(true).isInCluster(true),
+				),
+				shutdowns: map[string]client.NodeShutdown{
+					"ingest-0": {Status: client.ShutdownComplete},
+				},
+				maxUnavailable: 1,
+				shardLister:    migration.NewFakeShardLister(client.Shards{}),
+				health:         client.Health{Status: esv1.ElasticsearchGreenHealth},
+				podFilter:      nothing,
+			},
+			deleted:                      []string{"ingest-0"},
+			wantErr:                      false,
+			wantShardsAllocationDisabled: false,
+		},
+		{
 			name: "Pod deleted while upgrading",
 			fields: fields{
 				esVersion: "7.5.0",

--- a/pkg/controller/elasticsearch/driver/upgrade_predicates_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_predicates_test.go
@@ -256,9 +256,9 @@ func TestUpgradePodsDeletion_WithNodeTypeMutations(t *testing.T) {
 			expectations:    expectations.NewExpectations(k8sClient),
 			reconcileState:  reconcile.MustNewState(esv1.Elasticsearch{}),
 			expectedMasters: tt.fields.upgradeTestPods.toMasters(tt.fields.mutation),
-			actualMasters:   tt.fields.upgradeTestPods.toMasterPods(),
 			podsToUpgrade:   tt.fields.upgradeTestPods.toUpgrade(),
 			healthyPods:     tt.fields.upgradeTestPods.toHealthyPods(),
+			currentPods:     tt.fields.upgradeTestPods.toCurrentPods(),
 		}
 
 		deleted, err := ctx.Delete()
@@ -987,6 +987,29 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 			wantShardsAllocationDisabled: true,
 		},
 		{
+			name: "Do not delete all nodes of a tier",
+			fields: fields{
+				esVersion: "8.0.0",
+				upgradeTestPods: newUpgradeTestPods(
+					newTestPod("ingest-0").withRoles(esv1.IngestRole).isHealthy(true).needsUpgrade(true).isInCluster(true),
+					newTestPod("ingest-ml-0").withRoles(esv1.IngestRole, esv1.MLRole).isHealthy(true).needsUpgrade(true).isInCluster(true),
+					newTestPod("ingest-ml-1").withRoles(esv1.IngestRole, esv1.MLRole).isHealthy(true).needsUpgrade(true).isInCluster(true),
+				),
+				shutdowns: map[string]client.NodeShutdown{
+					"ingest-0":    {Status: client.ShutdownComplete},
+					"ingest-ml-0": {Status: client.ShutdownComplete},
+					"ingest-ml-1": {Status: client.ShutdownComplete},
+				},
+				maxUnavailable: 3,
+				shardLister:    migration.NewFakeShardLister(client.Shards{}),
+				health:         client.Health{Status: esv1.ElasticsearchGreenHealth},
+				podFilter:      nothing,
+			},
+			deleted:                      []string{"ingest-0", "ingest-ml-1"},
+			wantErr:                      false,
+			wantShardsAllocationDisabled: false,
+		},
+		{
 			name: "Pod deleted while upgrading",
 			fields: fields{
 				esVersion: "7.5.0",
@@ -1114,7 +1137,7 @@ func TestUpgradePodsDeletion_Delete(t *testing.T) {
 				expectedMasters: tt.fields.upgradeTestPods.toMasters(noMutation),
 				podsToUpgrade:   tt.fields.upgradeTestPods.toUpgrade(),
 				healthyPods:     tt.fields.upgradeTestPods.toHealthyPods(),
-				numberOfPods:    len(tt.fields.upgradeTestPods),
+				currentPods:     tt.fields.upgradeTestPods.toCurrentPods(),
 				nodeShutdown:    nodeShutdown,
 			}
 

--- a/pkg/controller/elasticsearch/label/label.go
+++ b/pkg/controller/elasticsearch/label/label.go
@@ -58,6 +58,20 @@ const (
 	Type = "elasticsearch"
 )
 
+// NonMasterRoles are all Elasticsearch node roles except master or voting-only.
+var NonMasterRoles = []common.TrueFalseLabel{
+	NodeTypesDataLabelName,
+	NodeTypesDataHotLabelName,
+	NodeTypesDataColdLabelName,
+	NodeTypesDataFrozenLabelName,
+	NodeTypesDataContentLabelName,
+	NodeTypesDataWarmLabelName,
+	NodeTypesIngestLabelName,
+	NodeTypesMLLabelName,
+	NodeTypesRemoteClusterClientLabelName,
+	NodeTypesTransformLabelName,
+}
+
 // IsMasterNode returns true if the pod has the master node label
 func IsMasterNode(pod corev1.Pod) bool {
 	return NodeTypesMasterLabelName.HasValue(true, pod.Labels)


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/1753

Introduces a new upgrade predicate to prevent deletion of all the nodes of a given tier. Tier to be understood here as a generalisation of the existing "data tier" notion to all non-master roles. 

Master nodes (and voting only nodes) are excluded as we are handling those already in existing predicates and generally apply much stricter rules to them (just one master node at a time can be upgraded no matter how permissive the change budget)

The focus here is on the existing nodes in the cluster and not on the expected nodes. My rationale is that the purpose of this predicate is to prevent degradation of the existing service for which the future state of the service is irrelevant. 

I have tested a few scenarios manually: 

* single node tiers which are treated as special case
* node role changes (addition/removal of node roles to existing nodeSets)
* misconfiguration scenarios (configuration change leads to pending or crash looping Pods

I think the PR could potentially benefit from capturing these scenarios in additional automated tests but I thought I raise it already to get some initial feedback.
