### PR TITLE
Setup the same exposed-node-labels parameter in dev mode as in helm charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ go-run:
 				--operator-namespace=default \
 				--namespaces=$(MANAGED_NAMESPACES) \
 				--manage-webhook-certs=false \
+				--exposed-node-labels=topology.kubernetes.io/.*,failure-domain.beta.kubernetes.io/.* \
 				2>&1 | grep -v "dev-portforward" # remove dev-portforward logs from the output
 
 go-debug:


### PR DESCRIPTION
The feature to auto-expose node labels does not seem to work by default in dev mode,
whereas it does with the Helm chart. This commit adds the same argument to the make go-run target.
