### PR TITLE
[a11y] Fix latinisms occurrences

### DIFF
--- a/config/crds/v1/all-crds.yaml
+++ b/config/crds/v1/all-crds.yaml
@@ -1365,7 +1365,7 @@ spec:
                 type: array
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. Elasticsearch) in a different namespace.
+                  resource to a resource (for ex. Elasticsearch) in a different namespace.
                   Can only be used if ECK is enforcing RBAC on references.
                 type: string
               version:
@@ -2294,7 +2294,7 @@ spec:
                 type: string
               type:
                 description: Type is the type of the Beat to deploy (filebeat, metricbeat,
-                  heartbeat, auditbeat, journalbeat, packetbeat, etc.). Any string
+                  heartbeat, auditbeat, journalbeat, packetbeat, and so on). Any string
                   can be used, but well-known types will have the image field defaulted
                   and have the appropriate Elasticsearch roles created automatically.
                   It also allows for dashboard setup when combined with a `KibanaRef`.
@@ -2860,7 +2860,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. Elasticsearch) in a different namespace.
+                  resource to a resource (for ex. Elasticsearch) in a different namespace.
                   Can only be used if ECK is enforcing RBAC on references.
                 type: string
               version:
@@ -4015,9 +4015,9 @@ spec:
                 type: array
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. a remote Elasticsearch cluster) in a
-                  different namespace. Can only be used if ECK is enforcing RBAC on
-                  references.
+                  resource to a resource (for ex. a remote Elasticsearch cluster)
+                  in a different namespace. Can only be used if ECK is enforcing RBAC
+                  on references.
                 type: string
               transport:
                 description: Transport holds transport layer settings for Elasticsearch.
@@ -6194,7 +6194,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. Elasticsearch) in a different namespace.
+                  resource to a resource (for ex. Elasticsearch) in a different namespace.
                   Can only be used if ECK is enforcing RBAC on references.
                 type: string
               version:
@@ -6739,7 +6739,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. Elasticsearch) in a different namespace.
+                  resource to a resource (for ex. Elasticsearch) in a different namespace.
                   Can only be used if ECK is enforcing RBAC on references.
                 type: string
               version:
@@ -7425,7 +7425,7 @@ spec:
                 type: array
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. Elasticsearch) in a different namespace.
+                  resource to a resource (for ex. Elasticsearch) in a different namespace.
                   Can only be used if ECK is enforcing RBAC on references.
                 type: string
               version:

--- a/config/crds/v1/bases/apm.k8s.elastic.co_apmservers.yaml
+++ b/config/crds/v1/bases/apm.k8s.elastic.co_apmservers.yaml
@@ -7631,7 +7631,7 @@ spec:
                 type: array
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. Elasticsearch) in a different namespace.
+                  resource to a resource (for ex. Elasticsearch) in a different namespace.
                   Can only be used if ECK is enforcing RBAC on references.
                 type: string
               version:

--- a/config/crds/v1/bases/beat.k8s.elastic.co_beats.yaml
+++ b/config/crds/v1/bases/beat.k8s.elastic.co_beats.yaml
@@ -15155,7 +15155,7 @@ spec:
                 type: string
               type:
                 description: Type is the type of the Beat to deploy (filebeat, metricbeat,
-                  heartbeat, auditbeat, journalbeat, packetbeat, etc.). Any string
+                  heartbeat, auditbeat, journalbeat, packetbeat, and so on). Any string
                   can be used, but well-known types will have the image field defaulted
                   and have the appropriate Elasticsearch roles created automatically.
                   It also allows for dashboard setup when combined with a `KibanaRef`.

--- a/config/crds/v1/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
+++ b/config/crds/v1/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
@@ -8714,9 +8714,9 @@ spec:
                 type: array
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. a remote Elasticsearch cluster) in a
-                  different namespace. Can only be used if ECK is enforcing RBAC on
-                  references.
+                  resource to a resource (for ex. a remote Elasticsearch cluster)
+                  in a different namespace. Can only be used if ECK is enforcing RBAC
+                  on references.
                 type: string
               transport:
                 description: Transport holds transport layer settings for Elasticsearch.

--- a/config/crds/v1/bases/enterprisesearch.k8s.elastic.co_enterprisesearches.yaml
+++ b/config/crds/v1/bases/enterprisesearch.k8s.elastic.co_enterprisesearches.yaml
@@ -7585,7 +7585,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. Elasticsearch) in a different namespace.
+                  resource to a resource (for ex. Elasticsearch) in a different namespace.
                   Can only be used if ECK is enforcing RBAC on references.
                 type: string
               version:
@@ -15200,7 +15200,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. Elasticsearch) in a different namespace.
+                  resource to a resource (for ex. Elasticsearch) in a different namespace.
                   Can only be used if ECK is enforcing RBAC on references.
                 type: string
               version:

--- a/config/crds/v1/bases/kibana.k8s.elastic.co_kibanas.yaml
+++ b/config/crds/v1/bases/kibana.k8s.elastic.co_kibanas.yaml
@@ -7703,7 +7703,7 @@ spec:
                 type: array
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. Elasticsearch) in a different namespace.
+                  resource to a resource (for ex. Elasticsearch) in a different namespace.
                   Can only be used if ECK is enforcing RBAC on references.
                 type: string
               version:

--- a/config/crds/v1/bases/maps.k8s.elastic.co_elasticmapsservers.yaml
+++ b/config/crds/v1/bases/maps.k8s.elastic.co_elasticmapsservers.yaml
@@ -7586,7 +7586,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. Elasticsearch) in a different namespace.
+                  resource to a resource (for ex. Elasticsearch) in a different namespace.
                   Can only be used if ECK is enforcing RBAC on references.
                 type: string
               version:

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -1377,7 +1377,7 @@ spec:
                 type: array
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. Elasticsearch) in a different namespace.
+                  resource to a resource (for ex. Elasticsearch) in a different namespace.
                   Can only be used if ECK is enforcing RBAC on references.
                 type: string
               version:
@@ -2312,7 +2312,7 @@ spec:
                 type: string
               type:
                 description: Type is the type of the Beat to deploy (filebeat, metricbeat,
-                  heartbeat, auditbeat, journalbeat, packetbeat, etc.). Any string
+                  heartbeat, auditbeat, journalbeat, packetbeat, and so on). Any string
                   can be used, but well-known types will have the image field defaulted
                   and have the appropriate Elasticsearch roles created automatically.
                   It also allows for dashboard setup when combined with a `KibanaRef`.
@@ -2884,7 +2884,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. Elasticsearch) in a different namespace.
+                  resource to a resource (for ex. Elasticsearch) in a different namespace.
                   Can only be used if ECK is enforcing RBAC on references.
                 type: string
               version:
@@ -4045,9 +4045,9 @@ spec:
                 type: array
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. a remote Elasticsearch cluster) in a
-                  different namespace. Can only be used if ECK is enforcing RBAC on
-                  references.
+                  resource to a resource (for ex. a remote Elasticsearch cluster)
+                  in a different namespace. Can only be used if ECK is enforcing RBAC
+                  on references.
                 type: string
               transport:
                 description: Transport holds transport layer settings for Elasticsearch.
@@ -6230,7 +6230,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. Elasticsearch) in a different namespace.
+                  resource to a resource (for ex. Elasticsearch) in a different namespace.
                   Can only be used if ECK is enforcing RBAC on references.
                 type: string
               version:
@@ -6775,7 +6775,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. Elasticsearch) in a different namespace.
+                  resource to a resource (for ex. Elasticsearch) in a different namespace.
                   Can only be used if ECK is enforcing RBAC on references.
                 type: string
               version:
@@ -7467,7 +7467,7 @@ spec:
                 type: array
               serviceAccountName:
                 description: ServiceAccountName is used to check access from the current
-                  resource to a resource (eg. Elasticsearch) in a different namespace.
+                  resource to a resource (for ex. Elasticsearch) in a different namespace.
                   Can only be used if ECK is enforcing RBAC on references.
                 type: string
               version:

--- a/docs/advanced-topics/custom-images.asciidoc
+++ b/docs/advanced-topics/custom-images.asciidoc
@@ -7,7 +7,7 @@ endif::[]
 [id="{p}-{page_id}"]
 = Create custom images
 
-You can create your own custom application images ({eck_resources_list}) instead of using the base images provided by Elastic. You might want to do this to have a canonical image with all the necessary plugins pre-loaded rather than <<{p}-init-containers-plugin-downloads,installing them via an init container>> each time a Pod starts.  You must use the official image as the base for custom images. For example, if you want to create an Elasticsearch {version} image with the link:https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/repository-gcs.html[Google Cloud Storage Repository Plugin], you can do the following:
+You can create your own custom application images ({eck_resources_list}) instead of using the base images provided by Elastic. You might want to do this to have a canonical image with all the necessary plugins pre-loaded rather than <<{p}-init-containers-plugin-downloads,installing them through an init container>> each time a Pod starts.  You must use the official image as the base for custom images. For example, if you want to create an Elasticsearch {version} image with the link:https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/repository-gcs.html[Google Cloud Storage Repository Plugin], you can do the following:
 
 
 

--- a/docs/advanced-topics/service-meshes.asciidoc
+++ b/docs/advanced-topics/service-meshes.asciidoc
@@ -81,7 +81,7 @@ ECK has a fallback validation mechanism that reports validation failures as even
 
 This section assumes that you are deploying ECK custom resources to a namespace that has link:https://istio.io/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection[automatic sidecar injection] enabled.
 
-If you have configured Istio in link:https://istio.io/docs/concepts/security/#permissive-mode[permissive mode], examples defined elsewhere in the ECK documentation will continue to work without requiring any modifications. However, if you have enabled strict mutual TLS authentication between services either via global (`MeshPolicy`) or namespace-level (`Policy`) configuration, the following modifications to the resource manifests are necessary for correct operation.
+If you have configured Istio in link:https://istio.io/docs/concepts/security/#permissive-mode[permissive mode], examples defined elsewhere in the ECK documentation will continue to work without requiring any modifications. However, if you have enabled strict mutual TLS authentication between services either through global (`MeshPolicy`) or namespace-level (`Policy`) configuration, the following modifications to the resource manifests are necessary for correct operation.
 
 [id="{p}-service-mesh-istio-elasticsearch"]
 ==== Elasticsearch

--- a/docs/design/0001-no-stateful-sets.md
+++ b/docs/design/0001-no-stateful-sets.md
@@ -17,7 +17,7 @@ We manage stateful workloads. StatefulSets were designed in order to manage stat
 
 > Manages the deployment and scaling of a set of Pods , and provides guarantees about the ordering and uniqueness of these Pods.
 
-Each pod ends up with a sticky network identifier and an ordinal index, reused on rescheduling, along with its persistent storage. There is a global order in pods of a StatefulSet (pod-1, pod-2, pod-3, etc.) which determines scaling and ordering in rolling operations.
+Each pod ends up with a sticky network identifier and an ordinal index, reused on rescheduling, along with its persistent storage. There is a global order in pods of a StatefulSet (pod-1, pod-2, pod-3, and so on) which determines scaling and ordering in rolling operations.
 
 
 ### Elasticsearch topologies
@@ -27,8 +27,8 @@ In a given StatefulSet, all pods have the exact same spec.
 From our perspective, instances can be configured with several options:
 
 - Elasticsearch version
-- node types: master-only, master-data, data-only, master-data-ingest, coordinating-only, ML, APM, etc.
-- availability zones: as-1, az-2, etc.
+- node types: master-only, master-data, data-only, master-data-ingest, coordinating-only, ML, APM, and so on
+- availability zones: as-1, az-2, and so on
 - instance configuration type: hot/warm architectures
 
 In complex production-ready scenarios, we might want to configure a cluster with:
@@ -72,7 +72,7 @@ Overall, we would lose a lot of flexibility in the way we'd like to run rolling 
 We decided to implement our own controller that manages pods directly.
 
 ### Positive Consequences
-* The immediate benefit in working with Pods directly is more control over the the cluster lifecycle. We can handle rolling upgrades, version migrations, cluster growth, volume reuse (or not), multi-AZ orchestration, etc. with much more flexibility.
+* The immediate benefit in working with Pods directly is more control over the the cluster lifecycle. We can handle rolling upgrades, version migrations, cluster growth, volume reuse (or not), and multi-AZ orchestration with much more flexibility.
 * Relying on StatefulSets forces us to depend on the StatefulSet controller releases, updates and bug fixes, since it has direct control over the pods themselves. 
 * Pods are a core concept of K8s, with well-known behaviours thoroughly tested in the field. Their spec and behaviour is less likely to evolve in a direction that does not suit us.
 * We could rely on StatefulSets: it would simplify a part of the code, and complexify another part of the code. Because of complex cluster topologies, we would still need to handle several StatefulSets for a single cluster, which is not much more simpler than handling several pods directly. 

--- a/docs/design/0002-global-operator/0002-global-operator.md
+++ b/docs/design/0002-global-operator/0002-global-operator.md
@@ -48,7 +48,7 @@ Examples of the "placeholder" controllers (additional controllers) that would be
 - Licensing controller: applies an installation-wide enterprise license to each cluster.
 - Placeholder controllers (not fully specified, but present in order to show that there would be more than one non-namespaced controller):
     - Telemetry controller: provides telemetry that can be reported upstream.
-    - Update controller: pings upstream to periodically check for new versions / security patches etc.
+    - Update controller: pings upstream to periodically check for new versions, security patches, and so on.
     - Centralized user management controller: ensures relevant clusters have a centrally defined set of realms configured.
 
 

--- a/docs/design/0004-licensing.md
+++ b/docs/design/0004-licensing.md
@@ -55,8 +55,8 @@ spec:
 ### Option  2: License pool and license controller 
 
 We support a pool of licenses and create a license controller that applies the most suitable license to the individual cluster deployments.  Pool of licenses is to be understood as one or more enterprise licenses in the namespace of the license controller. The controller selects a license from the pool of licenses using one of two heuristics:
-1. find a suitable license. Suitable is defined similar to our current practice in ESS: in descending precedence order of platinum, gold, standard and with the best match with regards to license validity (at least n days after license start, at least n days before license expiry). 
-2. the cluster can also express the desire to be issued with a specific kind of license via a special label for example `k8s.elastic.co\desired-license=platinum` in which case the controller tries to find a match with regards to license validity (at least n days after license start, at least n days before license expiry) of the right type. 
+1. Find a suitable license. Suitable is defined similar to our current practice in ESS: in descending precedence order of platinum, gold, standard and with the best match with regards to license validity (at least n days after license start, at least n days before license expiry). 
+2. The cluster can also express the desire to be issued with a specific kind of license through a special label for example `k8s.elastic.co\desired-license=platinum` in which case the controller tries to find a match with regards to license validity (at least n days after license start, at least n days before license expiry) of the right type. 
 
 
 #### Workflow

--- a/docs/design/0005-configurable-operator.md
+++ b/docs/design/0005-configurable-operator.md
@@ -65,7 +65,7 @@ Because of the increased complexity in mapping the exact RBAC permissions and de
 ```bash
 # cli sample usage (exact specification TBD)
 > ./elastic-operator generate --config=operators.yaml
-# generates one or multiple yaml files ready-to-deploy, including Deployment, ServiceAccount, (Cluster)Roles, (Cluster)RoleBindings, etc.
+# generates one or multiple yaml files ready-to-deploy, including Deployment, ServiceAccount, (Cluster)Roles, (Cluster)RoleBindings.
 ```
 
 ```yaml
@@ -113,7 +113,7 @@ Chosen option: option 2 (configurable operator), because it gives us more flexib
   * a single cluster-wide operator
   * one operator per namespace
   * one operator for all production namespaces, another one for all staging namespaces
-  * etc.
+  * and so on
 * We don't have to require cluster-level permissions to handle enterprise licensing
 * A single operator concept, no namespace/global/ecosystem vocabulary madness
 
@@ -134,8 +134,8 @@ Pros:
 
 Cons:
 
-* Need for a "hybrid" version to deploy everything in a single restricted namespace (eg. "default"), which is a bit confusing
-* The global-operator needs elevated permissions on the cluster (eg. read access to all secrets)
+* Need for a "hybrid" version to deploy everything in a single restricted namespace (for ex. default), which is a bit confusing
+* The global-operator needs elevated permissions on the cluster (for ex. read access to all secrets)
 * One might want to use several global-operators on a single cluster
 * One operator per namespace might lead to deploy too many operators
 
@@ -149,7 +149,7 @@ Pros:
   * a single cluster-wide operator
   * one operator per namespace
   * one operator for all production namespaces, another one for all staging namespaces
-  * etc.
+  * and so on
 * Restricted RBAC permissions according to one's exact needs
 * A "single" operator simplifies communication around the project
 * Actually a superset of option 1, the concept of global + namespaces operators can be easily implemented

--- a/docs/design/0006-certificate-management.md
+++ b/docs/design/0006-certificate-management.md
@@ -32,13 +32,13 @@ How do we manage nodes certificates with our operator?
 
 #### CA
 
-The operator on the cluster *is* the certificate authority (CA) for all the clusters it manages. It is able to issue certificates based on certificate signing requests (CSR) that pods provide. It manages one CA certificate (and associated private key) per cluster (eg. if the operator manages 3 clusters in 3 different namespaces, it uses 3 different CAs).
+The operator on the cluster *is* the certificate authority (CA) for all the clusters it manages. It is able to issue certificates based on certificate signing requests (CSR) that pods provide. It manages one CA certificate (and associated private key) per cluster (for ex. if the operator manages 3 clusters in 3 different namespaces, it uses 3 different CAs).
 
 #### Issuing certificates
 
 At each reconciliation loop, the operator can decide to issue a signed certificate for a given pod. It makes sense to issue a new certificate when:
 
-* there is no certificate (eg. pod was just created)
+* there is no certificate (for ex. the pod was just created)
 * existing certificate is expired
 * existing certificate is invalid or corrupted
 * existing certificate does not match the current CA
@@ -55,7 +55,7 @@ Some options:
 * *Option A*: the private key is generated when the operator starts on first cluster reconciliation, and kept in-memory for the lifecycle of the operator. If the operator restarts, it needs to generate a new private key, and issues new certificates for all clusters. While existing TCP connections between nodes will not be impacted, this might provoke a downtime on the cluster while new certificates are propagated.
 * *Option B*: the private key is stored as a secret in the apiserver. Created by the operator itself if it does not exist yet. Persisted and reuse through operator restarts.
 * *Option C*: similar to B, but with the private key [wrapped in another layer of encryption](https://tools.ietf.org/html/rfc3394) in the apiserver. Access to the KEK (key encryption-key) must be handled separately.
-* *Option D*: the private key is stored in an external service (eg. Vault) and requested or provided to the operator at startup.
+* *Option D*: the private key is stored in an external service (for ex. Vault) and requested or provided to the operator at startup.
 
 Options C and D are preferable, but need to setup an additional system. Option A is secure, but can lead to downtime and a herd effect: when the operator restarts, it needs to regenerate all certificates. Option B is not secure if we consider the apiserver storage as not secure enough.
 
@@ -101,11 +101,11 @@ Options to consider:
   * The sidecar could be notified by the operator either through an HTTP request, or a special file in a mounted secret volume.
   * If done on a regular basis, the sidecar itself could be responsible for the decision of rotating its private key on its own, and does not even need a notification from the operator. The operator still needs to know there is a new CSR to request.
 * *Option B*: don't rotate private keys in pods.
-  * If a pod private key is compromised, replace the pod by a new one, for which a new private key, csr and certificate will be created.
+  * If a pod private key is compromised, replace the pod by a new one, for which a new private key, CSR and certificate will be created.
   * It requires some extra mechanism in the operator to safely evacuate or replace a pod by a new one.
   * It could take some time (compared to option A) to safely migrate data.
 
-Chosen option: option B. Simpler to implement, and we do need a way to safely replace/evacuate pods for other reasons (eg. node going down, hdd failures, etc.).
+Chosen option: option B. Simpler to implement, and we do need a way to safely replace/evacuate pods for other reasons (For example, node going down, hdd failures, and so on).
 
 #### CA cert rotation
 
@@ -145,7 +145,7 @@ Biggest advantage of Option B compared to Option A is that it is safe for a new 
 
 ### Option 2 - rely on a service mesh TLS implementation
 
-Some service meshes handle TLS authentication automatically through sidecar containers mounted in pods (eg. Istio and Envoy, Linkerd). Currently, it's mandatory in Elasticsearch to enable TLS encryption. Hence we cannot easily delegate TLS entirely to additional services. Moreover, it sounds wrong to force users to use a particular service mesh, that includes its own security problems.
+Some service meshes handle TLS authentication automatically through sidecar containers mounted in pods (for ex. Istio and Envoy, Linkerd). Currently, it's mandatory in Elasticsearch to enable TLS encryption. Hence we cannot easily delegate TLS entirely to additional services. Moreover, it sounds wrong to force users to use a particular service mesh, that includes its own security problems.
 
 ### Option 3 - let users provide their own private keys and certificates
 

--- a/docs/design/0006-sidecar-health.md
+++ b/docs/design/0006-sidecar-health.md
@@ -42,7 +42,7 @@ The ES readiness probe will fail if ES never becomes ready.
 ## Decision Drivers
 
 * Error distinction: a sidecar failure should be easily identified from an Elasticsearch failure
-* Error side effect: a sidecar failure should not increase the unvailability of Elasticsearch compared to the current situation
+* Error side effect: a sidecar failure should not increase the unavailability of Elasticsearch compared to the current situation
 * Promote reliability and simplicity because health-checking is a critical part of the system
 
 ## Considered Options
@@ -78,7 +78,7 @@ the call to the ES API. ES is considered ready when `/` is reachable.
 This solution implies that the probe through the sidecar will poll Elasticsearch.
 
 * Good, because it's well integrated with Kubernetes. Kubernetes will restart the sidecar container if the probe fails. It could
- probably resolve some issues related to the state of the system (e.g. out of memory, too many connections).
+ probably resolve some issues related to the state of the system (for example, out of memory, too many connections).
 * Good, because exposing the health over HTTP allows easily the collect by other systems
 * Good, because it's easy to expose the cluster state in another HTTP endpoint
 * Bad, because Kubernetes will restart the sidecar container if the liveness probe fails. And if that happens indefinitely, the
@@ -113,10 +113,9 @@ Then, the operator polls this endpoint and reports any change in the health stat
 
 Sending the status as an event has the added benefit of giving us richer behaviour on top of the polling.
 It makes the state of the sidecar process observable. We could for example return a revision of the secrets the sidecar process has
-seen in the response to the health/status check and implement coordinated behaviour on top of that: e.g. do x only if all sidecars have
-seen secret revison y.
+seen in the response to the health/status check and implement coordinated behaviour on top of that: for example, do x only if all sidecars have seen secret revision y.
 
-* Good, because it does not use readiness/liveness probes that can provoke a container restart or a service inavailability
+* Good, because it does not use readiness/liveness probes that can provoke a container restart or a service unavailability
 * Good, because it can give us an aggregated view of all the sidecar healths
 * Good, because it makes the state of the sidecar process observable
 * Good, because it gives more options to react to failures

--- a/docs/design/0007-local-volume-total-capacity.md
+++ b/docs/design/0007-local-volume-total-capacity.md
@@ -30,9 +30,9 @@ We need a way to make sure pod scheduling takes available disk space into consid
 
 One way to circumvent these problems is to consider that each kubernetes node is composed of:
 
-* X amount of RAM capacity (eg. 10GB)
-* Y amount of disk space (eg. 1TB)
-* A ration Y/X can be expressed as the ram-to-disk storage multiplier (eg. 100 in this scenario)
+* X amount of RAM capacity (for ex. 10GB)
+* Y amount of disk space (for ex. 1TB)
+* A ration Y/X can be expressed as the ram-to-disk storage multiplier (for ex. 100 in this scenario)
 
 If all nodes in the kubernetes cluster respect this approach and use the same ram-to-disk multiplier, we can consider the node will run out of RAM (hence be unschedulable for new pods) before it runs out of disk.
 
@@ -47,7 +47,7 @@ It requires:
 
 Instead of having a single cluster-wide provisioner, we have one provisioner per node, responsible for provisioning PersistentVolume corresponding to the node. Let's call it the "node volume provisioner" (name TBD). The global provisioner does not exist anymore.
 
-On startup, the node volume provisioner inspects the available disk space (eg. 10TB total). It creates a single PersistentVolume resource on the apiserver, with node affinity set to the node it's running on. This PersistentVolume covers the entire available disk space (10TB). This PersistentVolume is not bound to any PersistentVolumeClaim yet. So far, this is quite similar to what's done by the [static local volume provisioner](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner), except we probably want to consider a single PV with the entire LVM disk space (spanning over multiple disks) instead of creating one PV per disk.
+On startup, the node volume provisioner inspects the available disk space (for ex. 10TB total). It creates a single PersistentVolume resource on the apiserver, with node affinity set to the node it's running on. This PersistentVolume covers the entire available disk space (10TB). This PersistentVolume is not bound to any PersistentVolumeClaim yet. So far, this is quite similar to what's done by the [static local volume provisioner](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner), except we probably want to consider a single PV with the entire LVM disk space (spanning over multiple disks) instead of creating one PV per disk.
 
 #### PVC/PV binding
 

--- a/docs/design/0008-volume-management.md
+++ b/docs/design/0008-volume-management.md
@@ -10,7 +10,7 @@ We decided to rely on StatefulSets to manage PersistentVolumes. While this ADR r
 ## Context and Problem Statement
 
 The aim of this document is to capture some scenarios where a pvc gets orphaned and define how the “reuse pvc” mechanism must behave.
-This document does not deal with the reuse of a PVC after the spec of the cluster has been updated _(i.e. "inline" VS "grow-and-shrink" updates)_.
+This document does not deal with the reuse of a PVC after the spec of the cluster has been updated _(that is, "inline" VS "grow-and-shrink" updates)_.
 It is a complex scenario which deserves its own ADR.
 
 
@@ -25,7 +25,7 @@ The reasons can be classified into 2 main categories:
   * Hardware failure
   * VM instance is deleted
   * Kernel panic
-  * Any runtime panic (e.g. `containerd` crash)
+  * Any runtime panic (for example `containerd` crash)
   * Eviction, but it is not supposed to happen as long as we use a [QoS class of Guaranteed](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed)
 * There is an **external voluntary** disruption
   * The node hosting the Pod is drained because, some _(non exhaustive)_ examples are:
@@ -88,7 +88,7 @@ The solution must be able to handle the following use cases:
 
 ### UC1: The K8S cluster is suffering a external involuntary disruption and the volumes cannot be recovered
 
-In this scenario we must consider the data as permanently lost _(e.g. vm with local storage has been destroyed)_.
+In this scenario we must consider the data as permanently lost _(for example vm with local storage has been destroyed)_.
 
 We need to give a way to the user to instruct the Elastic operator that:
 * It should immediately move the volume into a `Recovering` strategy.
@@ -102,7 +102,7 @@ If it takes to much time to schedule the pod then the volume is moved into one o
 ### UC3: As an admin I want to plan a voluntary disruption and the volumes cannot be recovered
 
 In this scenario the administrator want to definitively evacuate a node and the data will not be available
-anymore (e.g.: a server with a local storage is definitively removed from the cluster)
+anymore (for example, a server with a local storage is definitively removed from the cluster)
 
 It is usually done in two steps:
 
@@ -132,7 +132,7 @@ The annotation `elasticsearch.k8s.elastic.co/delete` can be set on a PVC with th
 
 `kubectl` can be extended with new sub-commands: https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/
 
-e.g.:
+for example:
 ```bash
 $ kubectl elastic migrate elasticsearch-sample-es-qlvprlqnnk -n default # will migrate the data then delete the pod and the pvc
 $ kubectl elastic delete elasticsearch-sample-es-qlvprlqnnk -n default # will delete the pod **and** the pvc
@@ -151,7 +151,7 @@ Pros:
 
 Cons:
 * If the volume can't be recovered the user will have to remove the `Finalizer`
-* Administrator has to `uncordon` the node and delete manually _(a.k.a. error prone)_ the `PVC` if he wants to drain it.
+* Administrator has to `uncordon` the node and delete manually _(also known as error prone)_ the `PVC` if he wants to drain it.
 
 ### Option 2
 Pros:

--- a/docs/design/0009-pod-reuse-es-restart.md
+++ b/docs/design/0009-pod-reuse-es-restart.md
@@ -19,7 +19,7 @@ Reusing pods may also be useful in other situations, where simply restarting Ela
 
 * It must be possible to perform a "full cluster restart" and reuse existing pods.
 * Configuration changes should be propagated through a volume mount, not through the pod spec.
-* Operator client cache inconsistencies must be taken into consideration (eg. don't restart a pod 3 times because of a stale cache).
+* Operator client cache inconsistencies must be taken into consideration (for ex. don't restart a pod 3 times because of a stale cache).
 * Volume propagation time must be taken into consideration (it can take more than 1 minute, the ES restart must not happen before the new configuration is there).
 * It should be resilient to operator restart.
 
@@ -45,7 +45,7 @@ Other options that are considered not good enough:
 ### Configuration through a secret volume
 
 We need to move away from storing Elasticsearch settings (from `elasticsearch.yml`) in the pod environment variables, because it prevents us from reusing pods. Instead, we can store the `elasticsearch.yml` file in a secret volume, mounted into the Elasticsearch pod.
-Why a secret volume and not a configmap volume? Because it may contain some secrets (eg. Slack or email credentials).
+Why a secret volume and not a configmap volume? Because it may contain some secrets (for ex. Slack or email credentials).
 
 #### Order of creations
 
@@ -119,18 +119,18 @@ Note: this does not represent the _entire_ reconciliation loop, it focuses on th
     * Create the pod
 * Maybe delete deprecated pods
     * Exclude pod from shard allocations
-    * Check if the pod does not hold any primary shard, or requeue
+    * Check if the pod does not hold any primary shard, or re-queue
     * Delete the pod
     * Delete the configuration secret (would be garbage collected, but still)
 * Handle pods reuse and pods restarts (always executed)
     * Annotate each pod to reuse, unless already annotated
         * `restart-phase: schedule` for restarting the ES process. The operator has no reason to apply this (a human could).
         * `restart-phase: schedule-rolling` for restarting ES processes one by one. The operator would apply this to perform a safe restart (default case).
-        * `restart-phase: schedule-coordinated` for all ES processes at once (full cluster restart). The operator would apply this to switch TLS setting following a license change (eg. basic with no TLS to Gold with TLS).
+        * `restart-phase: schedule-coordinated` for all ES processes at once (full cluster restart). The operator would apply this to switch TLS setting following a license change (for ex. basic with no TLS to Gold with TLS).
      * Handle pods in a _schedule_ phase
         * If annotated with `schedule`: annotate them with `restart-phase: stop`.
         * If annotated with `schedule-rolling`
-            * If there are some pods in another phase (eg. `stop`), requeue.
+            * If there are some pods in another phase (for ex. `stop`), re-queue.
             * Else, deterministically pick the best pod to get started with, and annotate it with `restart-phase: stop`.
         * If annotated with `schedule-coordinated`: annotate them with `restart-phase: stop-coordinated`.
      * Handle pods in a _stop_ phase
@@ -138,7 +138,7 @@ Note: this does not represent the _entire_ reconciliation loop, it focuses on th
             * Disable shards allocations in the cluster (avoids shards of the temporarily stopped node to be moved around)
             * Perform a sync flush, for fast recovery during restarts
             * Request a stop to the process manager: `POST /es/stop` (idempotent)
-            * Check if ES is stopped (`GET /es/status`), or requeue
+            * Check if ES is stopped (`GET /es/status`), or re-queue
             * Annotate pod with `restart-phase: start`
         * If annotated with `stop-coordinated`
             * Apply the same steps as above, but:
@@ -147,8 +147,8 @@ Note: this does not represent the _entire_ reconciliation loop, it focuses on th
      * Handle pods in a `start` phase
         * If annotated with `start`:
             * If the pod is marked for reuse, update the configuration secret with the new expected configuration (else, we'll use the current one)
-            * Check if the config (expected one if reuse, else current one) is propagated to the pod by requesting the process manager (`GET /es/status` should return the configuration file checksum), or requeue.
-            * Update the pods labels if required (eg. new node types)
+            * Check if the config (expected one if reuse, else current one) is propagated to the pod by requesting the process manager (`GET /es/status` should return the configuration file checksum), or re-queue.
+            * Update the pods labels if required (for ex. new node types)
             * Start the ES process: `POST /es/start` (idempotent)
             * Wait until the ES process is started (`GET /es/status`)
             * Enable shards allocations
@@ -156,7 +156,7 @@ Note: this does not represent the _entire_ reconciliation loop, it focuses on th
         * If annotated with `start-coordinated`:
             * Perform the same steps as above, but wait until *all* ES processes are started before enabling shards allocations
 * Garbage-collect useless resources
-    * Configuration secrets that do not match any pod and existed for more than eg. 15min are safe to delete
+    * Configuration secrets that do not match any pod and existed for more than for ex. 15min are safe to delete
 
 #### State machine specifics
 
@@ -166,7 +166,7 @@ It is important in the algorithm outlined above that:
 * transition to the next step is resilient to stale cache. If a pod is annotated with the `start` phase, it should be ok to perform all steps of the `stop` phase again (no-op). However the cache cannot go back in time: once we reach the `start` phase we must not perform the `stop` phase at the next iteration. Our apiserver and cache implementation consistency model guarantee this behaviour.
 * the operator can restart at any point: on restart it should get back to the current phase.
 * a pod that should be reused will be reflected in the results of the comparison algorithm. However, once its configuration has been updated (but before it is actually restarted), it might not be reflected anymore. The comparison would then be based on the "new" configuration (not yet applied to the ES process), and the pod would require no change. That's OK: the ES process will still eventually be restarted with this correct new configuration, since annotated in the `start` phase.
-* if a pod is no longer requested for reuse (eg. user changed their mind and reverted ES spec to the previous version) but is in the middle of a restart process, it will still go through that restart process. Depending on when the user reverted back the ES spec, compared to the pod current phase in the state machine:
+* if a pod is no longer requested for reuse (for ex. user changed their mind and reverted ES spec to the previous version) but is in the middle of a restart process, it will still go through that restart process. Depending on when the user reverted back the ES spec, compared to the pod current phase in the state machine:
     * if the new config was not yet applied, the ES process will still be restarted with its current config
     * if the new config was already applied and the ES process is starting, we'll have to wait for the restart process to be over before the pod can be reused with the old configuration (and restarted again). Depending on the pods reuse choices, we might end up reverting the original configuration to different pods. But eventually things will get back to the expected state.
 

--- a/docs/design/0010-license-checks.md
+++ b/docs/design/0010-license-checks.md
@@ -13,15 +13,15 @@ behaviour are any commercial features available to licensed operators only.
 
 ## Decision Drivers 
 
-* we currently suppport multiple deployment options for the operator: single namespace and multi-namespace.
-* for the activation of commerical features we need a minimal amount of protection against tampering.
+* we currently support multiple deployment options for the operator: single namespace and multi-namespace.
+* for the activation of commercial features we need a minimal amount of protection against tampering.
 * we consider admission controllers as optional means of verification and don't want to rely on them for functionality that does not exist in other places as well.
 * we regard licenses as somewhat sensitive data that should not be shared freely across all namespaces and controllers.
   
 
 ## Considered Options
 
-1. Configure license statically at operator startup (e.g. via shared secret bound in all instances) or via simple flag for trial mode
+1. Configure license statically at operator startup (for example through shared secret bound in all instances) or with a simple flag for trial mode
 2. Configure license dynamically and use admission control to label resources (licensed-until timestamp) 
 3. Create a shared secret (`ControllerLicense`) in every relevant namespace with tamper proof evidence of the current Enterprise license 
 
@@ -32,7 +32,7 @@ Option 3.
 
 ### Additional design details
 
-Create a new CRD e.g. called `ControllerLicense` that will be created
+Create a new CRD called `ControllerLicense` that will be created
 by the (global) license controller. It CAN use the same signer we use
 for the Enterprise licenses but a different installation specific
 private/public key pair.
@@ -112,7 +112,7 @@ operator (the latter is the underlying assumption for the graph above).
 * Good, because it simplifies the decision for the trial vs. basic decision on cluster creation (but: we might not need that at all if we start with basic by default).
 * Good, because it is independent of the deployment scenario chosen for the operator.
 * Bad, because it does not solve the burden of proof for commercial feature enablement.
-  We would still need a copy of the actual license in all namespaces that have controllers with commericial features (currently only the global one).
+  We would still need a copy of the actual license in all namespaces that have controllers with commercial features (currently only the global one).
 * Bad, because it would require an operator restart to update license information.   
 
 ### Dynamically configured license and admission controller

--- a/docs/design/0011-process-manager.md
+++ b/docs/design/0011-process-manager.md
@@ -3,7 +3,7 @@
 * Status: rejected (implementation removed) in July 2019. The keystore updater is moved into an init container to adopt the same 
 pattern used for Kibana and APM server. With the move towards the StatefulSet way of doing rolling restarts, we no longer need a
 process manager to perform Elasticsearch cluster restart. The zombie reaping problem only exists when another process is started
-in the container (e.g. kubectl exec) and should probably be handled in the official images.
+in the container (for example kubectl exec) and should probably be handled in the official images.
 Main benefits are code and architecture simplicity as well as respecting k8s standards.
 * Deciders: cloud-on-k8s team
 * Date: 2019-05-28
@@ -20,8 +20,7 @@ The existence of the process manager is driven by three needs:
 
 We chose to provide a Kubernetes native way to users to update the Elasticsearch keystore through a Kubernetes Secret.
 
-The keystore updater is a custom go binary that watches a Volume mounted from a Kubernetes Secret and synchronizes its content
-in the Elasticsearch keystore. Users just have to update the Secret to update the Elasticsearch keystore.
+The keystore updater is a custom go binary that watches a Volume mounted from a Kubernetes Secret and synchronizes its content in the Elasticsearch keystore. Users just have to update the Secret to update the Elasticsearch keystore.
 
 The keystore updater must be able to access the elasticsearch-keystore binary, request the Elasticsearch API endpoint 
 and be run in a long-running process.
@@ -86,7 +85,7 @@ How to perform cluster restart?
     that no other pod will be scheduled on that node, taking up all resources available on the node, preventing the replacing pod to be scheduled.
 * Inject a process manager into the standard Elasticsearch container/image
     * ++ would allow us to restart without recreating the pod, unless we need to change pod resources or environment variables, in which case the above applies
-    * ~ has the disadvantage of being fairly intrusive and complex (copying binaries via initcontainers, overriding command etc)
+    * ~ has the disadvantage of being fairly intrusive and complex (copying binaries through initcontainers, overriding command etc)
 * Use a liveness probe to make Kubernetes restart the container
     * -- hard to coordinate across an ES cluster
     * -- scheduling of restart is somewhat delayed (maybe not a big issue)
@@ -101,7 +100,7 @@ How to perform cluster restart?
 PID 1 zombie reaping problem?
 * Inject a process manager to properly handle signals and reap orphaned zombie processes
 * Use [pid namespace sharing](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/#understanding-process-namespace-sharing)
-    * -- it is off by default in the versions of Kubernetes we support (controlled via `--docker-disable-shared-pid=false`) and there is an experimental new way of doing it in 1.14+ which again we don't know if people are using it
+    * -- it is off by default in the versions of Kubernetes we support (controlled through `--docker-disable-shared-pid=false`) and there is an experimental new way of doing it in 1.14+ which again we don't know if people are using it
 
 ## Decision Outcome
 
@@ -129,7 +128,7 @@ to run the keystore updater and manage the Elasticsearch process in one containe
 ### Negative Consequences
 
 * Share CPU and memory resources with the Elasticsearch container
-* A bit intrusive (copying binaries via init containers, overriding command etc)
+* A bit intrusive (copying binaries through init containers, overriding command, and so on)
 * A bit complex (os signal handling)
 
 ## Links

--- a/docs/design/adr-template.md
+++ b/docs/design/adr-template.md
@@ -8,12 +8,12 @@ Technical Story: [description | ticket/issue URL] <!-- optional -->
 
 ## Context and Problem Statement
 
-[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+[Describe the context and problem statement, for example, in free form using two to three sentences. You may want to articulate the problem in form of a question.]
 
 ## Decision Drivers <!-- optional -->
 
-* [driver 1, e.g., a force, facing concern, …]
-* [driver 2, e.g., a force, facing concern, …]
+* [driver 1, for example, a force, facing concern, …]
+* [driver 2, for example, a force, facing concern, …]
 * … <!-- numbers of drivers can vary -->
 
 ## Considered Options
@@ -25,16 +25,16 @@ Technical Story: [description | ticket/issue URL] <!-- optional -->
 
 ## Decision Outcome
 
-Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (check below)].
+Chosen option: "[option 1]", because [justification. For example, only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (check below)].
 
 ### Positive Consequences <!-- optional -->
 
-* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* [For example, improvement of quality attribute satisfaction, follow-up decisions required, …]
 * …
 
 ### Negative Consequences <!-- optional -->
 
-* [e.g., compromising quality attribute, follow-up decisions required, …]
+* [For example, compromising quality attribute, follow-up decisions required, …]
 * …
 
 ## Pros and Cons of the Options <!-- optional -->

--- a/docs/operating-eck/eck-permissions.asciidoc
+++ b/docs/operating-eck/eck-permissions.asciidoc
@@ -58,7 +58,7 @@ These permissions are needed by the Service Account that ECK operator runs as.
 |Endpoint||no|Checking availability of service endpoints.
 |Event||no|Emitting events concerning reconciliation progress and issues.
 |PersistentVolumeClaim||no|Expanding existing volumes. Check link:https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html#k8s_updating_the_volume_claim_settings[docs] to learn more.
-|Secret||no|Reading/writing configuration, passwords, certificates, etc.
+|Secret||no|Reading/writing configuration, passwords, certificates, and so on.
 |Service||no|Creating Services fronting Elastic Stack applications.
 |ConfigMap||no|Reading/writing configuration.
 |StatefulSet|apps|no|Deploying Elasticsearch

--- a/docs/operating-eck/licensing.asciidoc
+++ b/docs/operating-eck/licensing.asciidoc
@@ -83,7 +83,7 @@ kubectl label secret eck-license "license.k8s.elastic.co/scope"=operator -n elas
 == Update your license
 Before your current Enterprise license expires, you will receive a new Enterprise license from Elastic (provided that your subscription is valid).
 
-NOTE: You can check the expiry date of your license in the license file that you received from Elastic. Enterprise licenses are container licenses that include multiple licenses for individual Elasticsearch clusters with shorter expiry. Therefore, you will get a different expiry in Kibana or via the Elasticsearch link:https://www.elastic.co/guide/en/elasticsearch/reference/current/get-license.html[`_license`] API. ECK will automatically update the Elasticsearch cluster licenses until the expiry date of the ECK Enterprise license is reached.
+NOTE: You can check the expiry date of your license in the license file that you received from Elastic. Enterprise licenses are container licenses that include multiple licenses for individual Elasticsearch clusters with shorter expiry. Therefore, you will get a different expiry in Kibana or through the Elasticsearch link:https://www.elastic.co/guide/en/elasticsearch/reference/current/get-license.html[`_license`] API. ECK will automatically update the Elasticsearch cluster licenses until the expiry date of the ECK Enterprise license is reached.
 
 To avoid any unintended downgrade of individual Elasticsearch clusters to a Basic license while installing the new license, we recommend to install the new Enterprise license as a new Kubernetes secret next to your existing Enterprise license. Just replace `eck-license` with a different name from the examples above. ECK will use the correct license automatically.
 
@@ -107,7 +107,7 @@ The operator periodically writes the total amount of Elastic resources under man
 }
 ----
 
-If the operator metrics endpoint is enabled via the `--metrics-port` flag (check <<{p}-operator-config>>), license usage data will be included in the reported metrics. 
+If the operator metrics endpoint is enabled with the `--metrics-port` flag (check <<{p}-operator-config>>), license usage data will be included in the reported metrics. 
 
 [source,shell]
 ----

--- a/docs/operating-eck/troubleshooting/common-problems.asciidoc
+++ b/docs/operating-eck/troubleshooting/common-problems.asciidoc
@@ -200,7 +200,7 @@ For more information, check <<{p}-troubleshooting-methods>>.
 == ECK operator upgrade stays pending when using OLM
 
 When using link:https://github.com/operator-framework/operator-lifecycle-manager[Operator Lifecycle Manager] (OLM) to install and upgrade the ECK operator an upgrade of ECK will not complete on older versions of OLM.
-This is due to an link:https://github.com/operator-framework/operator-lifecycle-manager/pull/1659[issue] in OLM itself that is fixed in version 0.16.0 or later. OLM is also used behind the scenes when you install ECK as a link:https://catalog.redhat.com/software/operators/detail/5f32f067651c4c0bcecf1bfe[Red Hat Certified Operator] on OpenShift or as a community operator via link:https://operatorhub.io/operator/elastic-cloud-eck[operatorhub.io].
+This is due to an link:https://github.com/operator-framework/operator-lifecycle-manager/pull/1659[issue] in OLM itself that is fixed in version 0.16.0 or later. OLM is also used behind the scenes when you install ECK as a link:https://catalog.redhat.com/software/operators/detail/5f32f067651c4c0bcecf1bfe[Red Hat Certified Operator] on OpenShift or as a community operator through link:https://operatorhub.io/operator/elastic-cloud-eck[operatorhub.io].
 
 [source,sh]
 ----

--- a/docs/operating-eck/webhook.asciidoc
+++ b/docs/operating-eck/webhook.asciidoc
@@ -71,7 +71,7 @@ This section describes how you can use your own certificates for the webhook ins
 [id="{p}-{page_id}-own-ca"]
 ==== Use a certificate signed by your own CA
 
-- The certificate must have a Subject Alternative Name (SAN) of the form `<service_name>.<namespace>.svc` (e.g. `elastic-webhook-server.elastic-system.svc`). A typical OpenSSL command to generate such a certificate would be as follows:
+- The certificate must have a Subject Alternative Name (SAN) of the form `<service_name>.<namespace>.svc` (for example `elastic-webhook-server.elastic-system.svc`). A typical OpenSSL command to generate such a certificate would be as follows:
 +
 [source,sh]
 ----

--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -537,7 +537,7 @@ Deploys single instance Elastic Agent Deployment in Fleet mode with APM integrat
 Elastic Agent in Fleet mode has to run as root, and in the same namespace as the Elasticsearch cluster it connects to.
 
 Due to current configuration limitations on Fleet/Elastic Agent side, ECK needs to establish trust between Elastic Agents and Elasticsearch. ECK can fetch the required Elasticsearch CA correctly if both resources are in the same namespace.
-To establish trust, the Pod needs to update the CA store via a call to `update-ca-trust` before Elastic Agent runs. To call it successfully, the Pod needs to run with elevated privileges.
+To establish trust, the Pod needs to update the CA store through a call to `update-ca-trust` before Elastic Agent runs. To call it successfully, the Pod needs to run with elevated privileges.
 
 === Running Endpoint Security integration
 Running Endpoint Security link:https://www.elastic.co/guide/en/security/current/install-endpoint.html[integration] is not yet supported in containerized environments, like Kubernetes. This is not an ECK limitation, but the limitation of the integration itself. Note that you can use ECK to deploy Elasticsearch, Kibana and Fleet Server, and add Endpoint Security integration to your policies if Elastic Agents running those policies are deployed in non-containerized environments.

--- a/docs/orchestrating-elastic-stack-applications/agent-standalone.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-standalone.asciidoc
@@ -164,7 +164,7 @@ spec:
             period: 10s
 ----
 
-Alternatively, it can be provided via a Secret specified in the `configRef` element. The Secret must have an `agent.yml` entry with this configuration:
+Alternatively, it can be provided through a Secret specified in the `configRef` element. The Secret must have an `agent.yml` entry with this configuration:
 [source,yaml,subs="attributes,+macros"]
 ----
 apiVersion: agent.k8s.elastic.co/v1alpha1
@@ -259,7 +259,7 @@ The `elasticsearchRefs` element allows ECK to automatically configure Elastic Ag
 
 If the `elasticsearchRefs` element is specified, ECK populates the outputs section of the Elastic Agent configuration. ECK creates a user with appropriate roles and permissions and uses its credentials. If required, it also mounts the CA certificate in all Agent Pods, and recreates Pods when this certificate changes.
 
-The outputs can also be set manually. To do that, remove the `elasticsearchRefs` element from the specification and include an appropriate output configuration in the `config`, or indirectly via the `configRef` mechanism.
+The outputs can also be set manually. To do that, remove the `elasticsearchRefs` element from the specification and include an appropriate output configuration in the `config`, or indirectly through the `configRef` mechanism.
 
 [source,yaml,subs="attributes,+macros"]
 ----

--- a/docs/orchestrating-elastic-stack-applications/beat.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/beat.asciidoc
@@ -155,7 +155,7 @@ spec:
           runAsUser: 0
 ----
 
-Alternatively, it can be provided via a Secret specified in the `configRef` element:
+Alternatively, it can be provided through a Secret specified in the `configRef` element:
 [source,yaml,subs="attributes,+macros"]
 ----
 apiVersion: beat.k8s.elastic.co/v1beta1

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/jvm-heap-dumps.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/jvm-heap-dumps.asciidoc
@@ -11,7 +11,7 @@ endif::[]
 == Ensure sufficient storage
 Elasticsearch is link:https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#heap-dump-path[configured by default] to take heap dumps on out-of-memory exceptions to the default data directory. The default data directory is `/usr/share/elasticsearch/data` in the official Docker images that ECK uses. If you are running Elasticsearch with a large heap that is as large as the remaining space on the data volume, this can lead to a situation where Elasticsearch is no longer able to start. To avoid this scenario you have two options:
 
-.  Choose a different path by setting `-XX:HeapDumpPath=` via the  `ES_JAVA_OPTS` variable to a path where a volume with sufficient storage space is mounted
+.  Choose a different path by setting `-XX:HeapDumpPath=` with the  `ES_JAVA_OPTS` variable to a path where a volume with sufficient storage space is mounted
 .  <<{p}-volume-claim-templates,Resize the data volume>> to a sufficiently large size if your volume provisioner supports volume expansion
 
 == Taking add-hoc heap dumps

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/remote-clusters.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/remote-clusters.asciidoc
@@ -51,7 +51,7 @@ NOTE: While it is technically possible to configure remote cluster connections u
 You can configure a remote cluster connection to an ECK-managed Elasticsearch cluster from another cluster running outside the Kubernetes cluster as follows:
 
 . Make sure that both clusters trust each other's certificate authority.
-. Configure the remote cluster connection via the Elasticsearch REST API.
+. Configure the remote cluster connection through the Elasticsearch REST API.
 
 Consider the following example:
 
@@ -117,7 +117,7 @@ spec:
 
 . Repeat the above steps to add the CA of `cluster-two` to `cluster-one` as well.
 
-=== Configure the remote cluster connection via the Elasticsearch REST API
+=== Configure the remote cluster connection through the Elasticsearch REST API
 
 Expose the transport layer of `cluster-one`.
 
@@ -133,7 +133,7 @@ spec:
       spec:
         type: LoadBalancer <1>
 ----
-<1> On cloud providers which support external load balancers, setting the type field to LoadBalancer provisions a load balancer for your Service. Alternatively, expose the service via one of the Kubernetes Ingress controllers that support TCP services.
+<1> On cloud providers which support external load balancers, setting the type field to LoadBalancer provisions a load balancer for your Service. Alternatively, expose the service through one of the Kubernetes Ingress controllers that support TCP services.
 
 Finally, configure `cluster-one` as a remote cluster in `cluster-two` using the Elasticsearch REST API:
 

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/security-context.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/security-context.asciidoc
@@ -12,7 +12,7 @@ In Kubernetes, a https://kubernetes.io/docs/tasks/configure-pod-container/securi
 
 == Run as non-root Elasticsearch
 
-By default, the Elastisearch container is run as root and its entrypoint is responsible to run the Elasticsearch process with the `elasticsearch` user (defined with ID 1000). In the background, ECK makes sure via an `initContainer` that the data volume is writable for the `elasticsearch` user.
+By default, the Elastisearch container is run as root and its entrypoint is responsible to run the Elasticsearch process with the `elasticsearch` user (defined with ID 1000). In the background, ECK uses an `initContainer` to make sure that the data volume is writable for the `elasticsearch` user.
 
 To run the Elastisearch container as a non-root user, you need to configure the Elasticsearch manifest with an appropriate security context to make the data volume writable to the `elasticsearch` user by specifying the right group ID through the `fsGroup`.
 

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/snapshots.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/snapshots.asciidoc
@@ -73,7 +73,7 @@ kubectl apply -f elasticsearch.yaml
 ----
 
 [id="{p}-secure-settings"]
-== Configure GCS credentials via the Elasticsearch keystore
+== Configure GCS credentials through the Elasticsearch keystore
 
 The Elasticsearch GCS repository plugin requires a JSON file that contains service account credentials. These need to be added as secure settings to the Elasticsearch keystore. For more details, check https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/repository-gcs-usage.html[Google Cloud Storage Repository Plugin].
 

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
@@ -9,7 +9,7 @@ endif::[]
 = Virtual memory
 
 By default, Elasticsearch uses memory mapping (`mmap`) to efficiently access indices.
-Usually, default values for virtual address space on Linux distributions are too low for Elasticsearch to work properly, which may result in out-of-memory exceptions. This is why link:k8s-quickstart.html[the quickstart example] disables `mmap` via the `node.store.allow_mmap: false` setting. For production workloads, it is strongly recommended to increase the kernel setting `vm.max_map_count` to `262144` and leave `node.store.allow_mmap` unset.
+Usually, default values for virtual address space on Linux distributions are too low for Elasticsearch to work properly, which may result in out-of-memory exceptions. This is why link:k8s-quickstart.html[the quickstart example] disables `mmap` through the `node.store.allow_mmap: false` setting. For production workloads, it is strongly recommended to increase the kernel setting `vm.max_map_count` to `262144` and leave `node.store.allow_mmap` unset.
 
 The kernel setting `vm.max_map_count=262144` can be set on the host either directly or by a dedicated init container, which must be privileged. To add an init container that changes the host kernel setting before your Elasticsearch pod starts, you can use the following example Elasticsearch spec:
 [source,yaml,subs="attributes,+macros"]

--- a/docs/orchestrating-elastic-stack-applications/maps.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/maps.asciidoc
@@ -45,7 +45,7 @@ spec:
   count: 1
 ----
 
-Versions of {ems} prior to 7.14 need a connection to Elasticseach to verify the installed license. You define the connection via the `elasticsearchRef` attribute:
+Versions of {ems} prior to 7.14 need a connection to Elasticseach to verify the installed license. You define the connection with the `elasticsearchRef` attribute:
 
 [source,yaml,subs="attributes"]
 ----
@@ -199,7 +199,7 @@ spec:
      logging.level: debug
 ----
 
-Alternatively, settings can be provided via a Secret specified in the `configRef` element:
+Alternatively, settings can be provided through a Secret specified in the `configRef` element:
 [source,yaml,subs="attributes,+macros"]
 ----
 apiVersion: maps.k8s.elastic.co/v1alpha1

--- a/docs/orchestrating-elastic-stack-applications/security/custom-http-certificate.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/custom-http-certificate.asciidoc
@@ -8,7 +8,7 @@ endif::[]
 [id="{p}-{page_id}"]
 = Custom HTTP certificate
 
-You can provide your own CA and certificates instead of the self-signed certificate to connect to Elastic stack applications via HTTPS using a Kubernetes secret.
+You can provide your own CA and certificates instead of the self-signed certificate to connect to Elastic stack applications through HTTPS using a Kubernetes secret.
 
 Check <<{p}-setting-up-your-own-certificate>> to learn how to do that.
 

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -271,7 +271,7 @@ kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | ba
 [id="{p}-upgrade-deployment"]
 == Upgrade your deployment
 
-You can add and modify most elements of the original cluster specification provided that they translate to valid transformations of the underlying Kubernetes resources (e.g., <<{p}-volume-claim-templates, existing volume claims cannot be downsized>>). The operator will attempt to apply your changes with minimal disruption to the existing cluster. You should ensure that the Kubernetes cluster has sufficient resources to accommodate the changes (extra storage space, sufficient memory and CPU resources to temporarily spin up new pods etc.).
+You can add and modify most elements of the original cluster specification provided that they translate to valid transformations of the underlying Kubernetes resources (for example <<{p}-volume-claim-templates, existing volume claims cannot be downsized>>). The operator will attempt to apply your changes with minimal disruption to the existing cluster. You should ensure that the Kubernetes cluster has sufficient resources to accommodate the changes (extra storage space, sufficient memory and CPU resources to temporarily spin up new pods, and so on).
 
 For example, you can grow the cluster to three Elasticsearch nodes:
 

--- a/docs/reference/api-docs.asciidoc
+++ b/docs/reference/api-docs.asciidoc
@@ -203,7 +203,7 @@ ApmServerSpec holds the specification of an APM Server.
 | *`kibanaRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster. It allows APM agent central configuration management in Kibana.
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the APM Server pods.
 | *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-secretsource[$$SecretSource$$]__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for APM Server.
-| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (eg. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
 |===
 
 
@@ -302,7 +302,7 @@ BeatSpec defines the desired state of a Beat.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`type`* __string__ | Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, auditbeat, journalbeat, packetbeat, etc.). Any string can be used, but well-known types will have the image field defaulted and have the appropriate Elasticsearch roles created automatically. It also allows for dashboard setup when combined with a `KibanaRef`.
+| *`type`* __string__ | Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, auditbeat, journalbeat, packetbeat, and so on). Any string can be used, but well-known types will have the image field defaulted and have the appropriate Elasticsearch roles created automatically. It also allows for dashboard setup when combined with a `KibanaRef`.
 | *`version`* __string__ | Version of the Beat.
 | *`elasticsearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster.
 | *`kibanaRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster. It allows automatic setup of dashboards and visualizations.
@@ -1020,7 +1020,7 @@ ElasticsearchSpec holds the specification of an Elasticsearch cluster.
 | *`podDisruptionBudget`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-poddisruptionbudgettemplate[$$PodDisruptionBudgetTemplate$$]__ | PodDisruptionBudget provides access to the default pod disruption budget for the Elasticsearch cluster. The default budget selects all cluster pods and sets `maxUnavailable` to 1. To disable, set `PodDisruptionBudget` to the empty value (`{}` in YAML).
 | *`auth`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-elasticsearch-v1-auth[$$Auth$$]__ | Auth contains user authentication and authorization security settings for Elasticsearch.
 | *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-secretsource[$$SecretSource$$]__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Elasticsearch.
-| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (eg. a remote Elasticsearch cluster) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
 | *`remoteClusters`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-elasticsearch-v1-remotecluster[$$RemoteCluster$$] array__ | RemoteClusters enables you to establish uni-directional connections to a remote Elasticsearch cluster.
 | *`volumeClaimDeletePolicy`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-elasticsearch-v1-volumeclaimdeletepolicy[$$VolumeClaimDeletePolicy$$]__ | VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets. Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion. Defaults to DeleteOnScaledownAndClusterDeletion.
 | *`monitoring`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-elasticsearch-v1-monitoring[$$Monitoring$$]__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster. See https://www.elastic.co/guide/en/elasticsearch/reference/current/monitor-elasticsearch-cluster.html. Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different Elasticsearch monitoring clusters running in the same Kubernetes cluster.
@@ -1537,7 +1537,7 @@ EnterpriseSearchSpec holds the specification of an Enterprise Search resource.
 | *`http`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-httpconfig[$$HTTPConfig$$]__ | HTTP holds the HTTP layer configuration for Enterprise Search resource.
 | *`elasticsearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | ElasticsearchRef is a reference to the Elasticsearch cluster running in the same Kubernetes cluster.
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Enterprise Search pods.
-| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (eg. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
 |===
 
 
@@ -1591,7 +1591,7 @@ EnterpriseSearchSpec holds the specification of an Enterprise Search resource.
 | *`http`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-httpconfig[$$HTTPConfig$$]__ | HTTP holds the HTTP layer configuration for Enterprise Search resource.
 | *`elasticsearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | ElasticsearchRef is a reference to the Elasticsearch cluster running in the same Kubernetes cluster.
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Enterprise Search pods.
-| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (eg. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
 |===
 
 
@@ -1646,7 +1646,7 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`http`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-httpconfig[$$HTTPConfig$$]__ | HTTP holds the HTTP layer configuration for Kibana.
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods
 | *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-secretsource[$$SecretSource$$]__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana.
-| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (eg. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
 | *`monitoring`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-kibana-v1-monitoring[$$Monitoring$$]__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana. See https://www.elastic.co/guide/en/kibana/current/xpack-monitoring.html. Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different Elasticsearch monitoring clusters running in the same Kubernetes cluster.
 |===
 
@@ -1828,7 +1828,7 @@ MapsSpec holds the specification of an Elastic Maps Server instance.
 | *`configRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-configsource[$$ConfigSource$$]__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Elastic Maps Server configuration. Configuration settings are merged and have precedence over settings specified in `config`.
 | *`http`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-pkg-apis-common-v1-httpconfig[$$HTTPConfig$$]__ | HTTP holds the HTTP layer configuration for Elastic Maps Server.
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Elastic Maps Server pods
-| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (eg. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
 |===
 
 

--- a/docs/release-notes/1.2.1.asciidoc
+++ b/docs/release-notes/1.2.1.asciidoc
@@ -17,7 +17,7 @@
 [float]
 === Bug fixes
 
-* Avoid pollution of map constants via defensive copy {pull}3599[#3599]
+* Avoid pollution of map constants through defensive copy {pull}3599[#3599]
 * Fix filebeat securityContext in recipes {pull}3596[#3596]
 * Check if CA Secret is expected before validating its name {pull}3527[#3527] (issue: {issue}3523[#3523])
 * Fix memory corruption from pod template validation {pull}3524[#3524] (issue: {issue}3421[#3421])

--- a/docs/release-notes/highlights-1.1.0.asciidoc
+++ b/docs/release-notes/highlights-1.1.0.asciidoc
@@ -63,7 +63,7 @@ The concept of `global` and `namespace` operator roles no longer exists, and as 
 [id="{p}-110-breaking-port-names"]
 ==== Container port name change
 
-Container ports of managed resources are now named according to the protocol (`https` for TLS enabled ports and `http` for TLS disabled ports). Previously they were named `http` regardless of the protocol being used. If you have any configurations that refer to the container ports by name (Ingress configurations, for example), review those to ensure that they use the correct name. One option may be to temporarily change to targeting the port number (e.g. `9200` for Elasticsearch), rather than the name, before updating ECK. Once the container port is updated to the new name, you can change to targeting the port name again.
+Container ports of managed resources are now named according to the protocol (`https` for TLS enabled ports and `http` for TLS disabled ports). Previously they were named `http` regardless of the protocol being used. If you have any configurations that refer to the container ports by name (Ingress configurations, for example), review those to ensure that they use the correct name. One option may be to temporarily change to targeting the port number (for example `9200` for Elasticsearch), rather than the name, before updating ECK. Once the container port is updated to the new name, you can change to targeting the port name again.
 
 [float]
 [id="{p}-110-breaking-readiness-probe"]

--- a/pkg/apis/apm/v1/apmserver_types.go
+++ b/pkg/apis/apm/v1/apmserver_types.go
@@ -54,7 +54,7 @@ type ApmServerSpec struct {
 	// SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for APM Server.
 	SecureSettings []commonv1.SecretSource `json:"secureSettings,omitempty"`
 
-	// ServiceAccountName is used to check access from the current resource to a resource (eg. Elasticsearch) in a different namespace.
+	// ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
 	// Can only be used if ECK is enforcing RBAC on references.
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`

--- a/pkg/apis/beat/v1beta1/beat_types.go
+++ b/pkg/apis/beat/v1beta1/beat_types.go
@@ -26,7 +26,7 @@ var (
 
 // BeatSpec defines the desired state of a Beat.
 type BeatSpec struct {
-	// Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, auditbeat, journalbeat, packetbeat, etc.).
+	// Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, auditbeat, journalbeat, packetbeat, and so on).
 	// Any string can be used, but well-known types will have the image field defaulted and have the appropriate
 	// Elasticsearch roles created automatically. It also allows for dashboard setup when combined with a `KibanaRef`.
 	// +kubebuilder:validation:MaxLength=20

--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -95,7 +95,7 @@ type ElasticsearchSpec struct {
 	// +kubebuilder:validation:Optional
 	SecureSettings []commonv1.SecretSource `json:"secureSettings,omitempty"`
 
-	// ServiceAccountName is used to check access from the current resource to a resource (eg. a remote Elasticsearch cluster) in a different namespace.
+	// ServiceAccountName is used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.
 	// Can only be used if ECK is enforcing RBAC on references.
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`

--- a/pkg/apis/enterprisesearch/v1/enterprisesearch_types.go
+++ b/pkg/apis/enterprisesearch/v1/enterprisesearch_types.go
@@ -56,7 +56,7 @@ type EnterpriseSearchSpec struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	PodTemplate corev1.PodTemplateSpec `json:"podTemplate,omitempty"`
 
-	// ServiceAccountName is used to check access from the current resource to a resource (eg. Elasticsearch) in a different namespace.
+	// ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
 	// Can only be used if ECK is enforcing RBAC on references.
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`

--- a/pkg/apis/enterprisesearch/v1beta1/enterprisesearch_types.go
+++ b/pkg/apis/enterprisesearch/v1beta1/enterprisesearch_types.go
@@ -52,7 +52,7 @@ type EnterpriseSearchSpec struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	PodTemplate corev1.PodTemplateSpec `json:"podTemplate,omitempty"`
 
-	// ServiceAccountName is used to check access from the current resource to a resource (eg. Elasticsearch) in a different namespace.
+	// ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
 	// Can only be used if ECK is enforcing RBAC on references.
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`

--- a/pkg/apis/kibana/v1/kibana_types.go
+++ b/pkg/apis/kibana/v1/kibana_types.go
@@ -92,7 +92,7 @@ type KibanaSpec struct {
 	// SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana.
 	SecureSettings []commonv1.SecretSource `json:"secureSettings,omitempty"`
 
-	// ServiceAccountName is used to check access from the current resource to a resource (eg. Elasticsearch) in a different namespace.
+	// ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
 	// Can only be used if ECK is enforcing RBAC on references.
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`

--- a/pkg/apis/maps/v1alpha1/maps_types.go
+++ b/pkg/apis/maps/v1alpha1/maps_types.go
@@ -51,7 +51,7 @@ type MapsSpec struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	PodTemplate corev1.PodTemplateSpec `json:"podTemplate,omitempty"`
 
-	// ServiceAccountName is used to check access from the current resource to a resource (eg. Elasticsearch) in a different namespace.
+	// ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
 	// Can only be used if ECK is enforcing RBAC on references.
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`

--- a/pkg/controller/common/certificates/reconcile.go
+++ b/pkg/controller/common/certificates/reconcile.go
@@ -31,7 +31,7 @@ type Reconciler struct {
 	K8sClient      k8s.Client
 	DynamicWatches watches.DynamicWatches
 
-	Owner client.Object // owner for the TLS certificates (eg. Elasticsearch, Kibana)
+	Owner client.Object // owner for the TLS certificates (for ex. Elasticsearch, Kibana)
 
 	TLSOptions    commonv1.TLSOptions               // TLS options of the object
 	ExtraHTTPSANs []commonv1.SubjectAlternativeName // SANs dynamically set by a controller, only used in the self signed cert


### PR DESCRIPTION
This PR replaces latinisms with more accessible content:

- eg., e.g.  =>  for ex., for example
- i.e.  =>  that is
- etc.  =>  and so on
- via  =>  through, with

Rel: #5306
The generated content in `../reference/api-docs.asciidoc` is not in scope.


For reference: [How to create accessible web content](https://docs.google.com/document/d/1IGuMf16-cwxx8BX1Z9PWsFWsTPxicwTkX_r7UOhjd4E/edit#heading=h.iykpo698d18b)