### PR TITLE
Avoid unnecessary DELETE calls to manage legacy transport secret

### DIFF
--- a/pkg/controller/elasticsearch/certificates/transport/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -74,11 +76,14 @@ func DeleteStatefulSetTransportCertificate(client k8s.Client, namespace string, 
 
 // DeleteLegacyTransportCertificate ensures that the former Secret which used to contain the transport certificates is deleted.
 func DeleteLegacyTransportCertificate(client k8s.Client, es esv1.Elasticsearch) error {
-	secret := corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: es.Namespace,
-			Name:      esv1.LegacyTransportCertsSecretSuffix(es.Name),
-		},
+	var secret corev1.Secret
+	// do a GET from the cache first before attempting a DElETE that hits the API server
+	err := client.Get(context.Background(), types.NamespacedName{Namespace: es.Namespace, Name: esv1.LegacyTransportCertsSecretSuffix(es.Name)}, &secret)
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
 	}
 	return client.Delete(context.Background(), &secret)
 }

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile.go
@@ -77,7 +77,7 @@ func DeleteStatefulSetTransportCertificate(client k8s.Client, namespace string, 
 // DeleteLegacyTransportCertificate ensures that the former Secret which used to contain the transport certificates is deleted.
 func DeleteLegacyTransportCertificate(client k8s.Client, es esv1.Elasticsearch) error {
 	var secret corev1.Secret
-	// do a GET from the cache first before attempting a DElETE that hits the API server
+	// do a GET from the cache first before attempting a DELETE that hits the API server
 	err := client.Get(context.Background(), types.NamespacedName{Namespace: es.Namespace, Name: esv1.LegacyTransportCertsSecretSuffix(es.Name)}, &secret)
 	if err != nil && apierrors.IsNotFound(err) {
 		return nil

--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -11,7 +11,6 @@ import (
 
 	"go.elastic.co/apm"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
@@ -114,7 +113,7 @@ func (d *defaultDriver) reconcileNodeSpecs(
 	actualStatefulSets = upscaleResults.ActualStatefulSets
 
 	// Once all the StatefulSets have been updated we can ensure that the former version of the transport certificates Secret is deleted.
-	if err := transport.DeleteLegacyTransportCertificate(d.Client, d.ES); err != nil && !apierrors.IsNotFound(err) {
+	if err := transport.DeleteLegacyTransportCertificate(d.Client, d.ES); err != nil {
 		results.WithError(err)
 	}
 


### PR DESCRIPTION
Related to #5450 

This PR proposes to do a GET (from cache) before DELETE to minimise impact on the API server. Alternative approach I could think of is to track the deletion in the orchestration hints annotation but that seemed costly/complicated compared to the almost free GET request.