### PR TITLE
manifest-gen: only redirect stdout to /dev/null, not stderr

### DIFF
--- a/hack/manifest-gen/manifest-gen.sh
+++ b/hack/manifest-gen/manifest-gen.sh
@@ -73,7 +73,7 @@ while getopts "cug" OPT; do
             shift $((OPTIND-1))
             (
                 cd "$SCRIPT_DIR"
-                go build -o manifest-gen >/dev/null 2>&1
+                go build -o manifest-gen 1>/dev/null
                 ./manifest-gen --source="$EFFECTIVE_SRC_CHART_DIR" generate "$@"
                 rm manifest-gen
             )


### PR DESCRIPTION
If `make generate-crds-v1` fails during the `generate the operator manifests` phase, discarding the error output isn't helpful to debugging the situation.  This only redirects stdout to /dev/null.