### PR TITLE
Use service accounts for Kibana and Fleet Server

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/security/users-and-roles.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/users-and-roles.asciidoc
@@ -24,6 +24,8 @@ kubectl get secret quickstart-es-elastic-user -o go-template='{{.data.elastic | 
 
 == Creating custom users
 
+WARNING: Do not run the `elasticsearch-service-tokens` command inside an Elasticsearch Pod managed by the operator. This would overwrite the service account tokens used internally to authenticate the Elastic stack applications.
+
 === Native realm
 
 You can create custom users in the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/native-realm.html[Elasticsearch native realm] using link:https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api.html#security-user-apis[Elasticsearch user management APIs].

--- a/pkg/apis/agent/v1alpha1/agent_types.go
+++ b/pkg/apis/agent/v1alpha1/agent_types.go
@@ -204,6 +204,10 @@ type Agent struct {
 
 var _ commonv1.Associated = &Agent{}
 
+func (a *Agent) GetVersion() string {
+	return a.Spec.Version
+}
+
 func (a *Agent) GetAssociations() []commonv1.Association {
 	associations := make([]commonv1.Association, 0)
 	for _, ref := range a.Spec.ElasticsearchRefs {

--- a/pkg/apis/agent/v1alpha1/agent_types.go
+++ b/pkg/apis/agent/v1alpha1/agent_types.go
@@ -7,18 +7,22 @@ package v1alpha1
 import (
 	"fmt"
 
+	"github.com/blang/semver/v4"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 )
 
 const (
 	// Kind is inferred from the struct name using reflection in SchemeBuilder.Register()
 	// we duplicate it as a constant here for practical purposes.
 	Kind = "Agent"
+	// FleetServerServiceAccount is the Elasticsearch service account to be used to authenticate.
+	FleetServerServiceAccount commonv1.ServiceAccountName = "fleet-server"
 )
 
 // AgentSpec defines the desired state of the Agent
@@ -204,9 +208,7 @@ type Agent struct {
 
 var _ commonv1.Associated = &Agent{}
 
-func (a *Agent) GetVersion() string {
-	return a.Spec.Version
-}
+var FleetServerServiceAccountMinVersion = semver.MustParse("8.0.0")
 
 func (a *Agent) GetAssociations() []commonv1.Association {
 	associations := make([]commonv1.Association, 0)
@@ -294,6 +296,20 @@ type AgentESAssociation struct {
 
 var _ commonv1.Association = &AgentESAssociation{}
 
+func (aea *AgentESAssociation) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
+	if !aea.Spec.FleetServerEnabled {
+		return "", nil
+	}
+	v, err := version.Parse(aea.Spec.Version)
+	if err != nil {
+		return "", err
+	}
+	if v.GTE(FleetServerServiceAccountMinVersion) {
+		return FleetServerServiceAccount, nil
+	}
+	return "", nil
+}
+
 func (aea *AgentESAssociation) AssociationID() string {
 	return fmt.Sprintf("%s-%s", aea.ref.Namespace, aea.ref.Name)
 }
@@ -350,6 +366,10 @@ type AgentKibanaAssociation struct {
 
 var _ commonv1.Association = &AgentKibanaAssociation{}
 
+func (a *AgentKibanaAssociation) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
+	return "", nil
+}
+
 func (a *AgentKibanaAssociation) AssociationConf() *commonv1.AssociationConf {
 	return a.kbAssocConf
 }
@@ -389,6 +409,10 @@ type AgentFleetServerAssociation struct {
 }
 
 var _ commonv1.Association = &AgentFleetServerAssociation{}
+
+func (a *AgentFleetServerAssociation) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
+	return "", nil
+}
 
 func (a *AgentFleetServerAssociation) AssociationConf() *commonv1.AssociationConf {
 	return a.fsAssocConf

--- a/pkg/apis/agent/v1alpha1/agent_types.go
+++ b/pkg/apis/agent/v1alpha1/agent_types.go
@@ -208,7 +208,7 @@ type Agent struct {
 
 var _ commonv1.Associated = &Agent{}
 
-var FleetServerServiceAccountMinVersion = semver.MustParse("8.0.0")
+var FleetServerServiceAccountMinVersion = semver.MustParse("7.17.0")
 
 func (a *Agent) GetAssociations() []commonv1.Association {
 	associations := make([]commonv1.Association, 0)

--- a/pkg/apis/apm/v1/apmserver_types.go
+++ b/pkg/apis/apm/v1/apmserver_types.go
@@ -132,6 +132,10 @@ func (as *ApmServer) EffectiveVersion() string {
 	return ver
 }
 
+func (as *ApmServer) GetVersion() string {
+	return as.Spec.Version
+}
+
 func (as *ApmServer) GetAssociations() []commonv1.Association {
 	associations := make([]commonv1.Association, 0)
 

--- a/pkg/apis/apm/v1/apmserver_types.go
+++ b/pkg/apis/apm/v1/apmserver_types.go
@@ -132,8 +132,8 @@ func (as *ApmServer) EffectiveVersion() string {
 	return ver
 }
 
-func (as *ApmServer) GetVersion() string {
-	return as.Spec.Version
+func (as *ApmServer) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
+	return "", nil
 }
 
 func (as *ApmServer) GetAssociations() []commonv1.Association {

--- a/pkg/apis/beat/v1beta1/beat_types.go
+++ b/pkg/apis/beat/v1beta1/beat_types.go
@@ -191,6 +191,10 @@ func (b *Beat) SetAssociationStatusMap(typ commonv1.AssociationType, status comm
 
 var _ commonv1.Associated = &Beat{}
 
+func (b *Beat) GetVersion() string {
+	return b.Spec.Version
+}
+
 func (b *Beat) GetAssociations() []commonv1.Association {
 	associations := make([]commonv1.Association, 0)
 

--- a/pkg/apis/beat/v1beta1/beat_types.go
+++ b/pkg/apis/beat/v1beta1/beat_types.go
@@ -191,8 +191,8 @@ func (b *Beat) SetAssociationStatusMap(typ commonv1.AssociationType, status comm
 
 var _ commonv1.Associated = &Beat{}
 
-func (b *Beat) GetVersion() string {
-	return b.Spec.Version
+func (b *Beat) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
+	return "", nil
 }
 
 func (b *Beat) GetAssociations() []commonv1.Association {

--- a/pkg/apis/common/v1/association.go
+++ b/pkg/apis/common/v1/association.go
@@ -146,6 +146,7 @@ type Associated interface {
 type Association interface {
 	Associated
 
+	// ElasticServiceAccount returns the Elasticsearch service account name to be used for authentication.
 	ElasticServiceAccount() (ServiceAccountName, error)
 
 	// Associated can be used to retrieve the associated object

--- a/pkg/apis/common/v1/association.go
+++ b/pkg/apis/common/v1/association.go
@@ -133,6 +133,7 @@ const (
 type Associated interface {
 	metav1.Object
 	runtime.Object
+	GetVersion() string
 	ServiceAccountName() string
 	GetAssociations() []Association
 	AssociationStatusMap(typ AssociationType) AssociationStatusMap
@@ -188,11 +189,12 @@ func FormatNameWithID(template string, id string) string {
 
 // AssociationConf holds the association configuration of a referenced resource in an association.
 type AssociationConf struct {
-	AuthSecretName string `json:"authSecretName"`
-	AuthSecretKey  string `json:"authSecretKey"`
-	CACertProvided bool   `json:"caCertProvided"`
-	CASecretName   string `json:"caSecretName"`
-	URL            string `json:"url"`
+	AuthSecretName   string `json:"authSecretName"`
+	AuthSecretKey    string `json:"authSecretKey"`
+	IsServiceAccount bool   `json:"isServiceAccount"`
+	CACertProvided   bool   `json:"caCertProvided"`
+	CASecretName     string `json:"caSecretName"`
+	URL              string `json:"url"`
 	// Version of the referenced resource. If a version upgrade is in progress,
 	// matches the lowest running version. May be empty if unknown.
 	Version string `json:"version"`

--- a/pkg/apis/common/v1/association.go
+++ b/pkg/apis/common/v1/association.go
@@ -122,6 +122,8 @@ const (
 	NoAuthRequiredValue = "-"
 )
 
+type ServiceAccountName string
+
 // Associated represents an Elastic stack resource that is associated with other stack resources.
 // Examples:
 // - Kibana can be associated with Elasticsearch
@@ -133,7 +135,6 @@ const (
 type Associated interface {
 	metav1.Object
 	runtime.Object
-	GetVersion() string
 	ServiceAccountName() string
 	GetAssociations() []Association
 	AssociationStatusMap(typ AssociationType) AssociationStatusMap
@@ -144,6 +145,8 @@ type Associated interface {
 // +kubebuilder:object:generate=false
 type Association interface {
 	Associated
+
+	ElasticServiceAccount() (ServiceAccountName, error)
 
 	// Associated can be used to retrieve the associated object
 	Associated() Associated

--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -442,8 +442,8 @@ func (es *Elasticsearch) ServiceAccountName() string {
 	return es.Spec.ServiceAccountName
 }
 
-func (es *Elasticsearch) GetVersion() string {
-	return es.Spec.Version
+func (es *Elasticsearch) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
+	return "", nil
 }
 
 // IsAutoscalingDefined returns true if there is an autoscaling configuration in the annotations.

--- a/pkg/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_types.go
@@ -442,6 +442,10 @@ func (es *Elasticsearch) ServiceAccountName() string {
 	return es.Spec.ServiceAccountName
 }
 
+func (es *Elasticsearch) GetVersion() string {
+	return es.Spec.Version
+}
+
 // IsAutoscalingDefined returns true if there is an autoscaling configuration in the annotations.
 func (es Elasticsearch) IsAutoscalingDefined() bool {
 	_, ok := es.Annotations[ElasticsearchAutoscalingSpecAnnotationName]

--- a/pkg/apis/enterprisesearch/v1/enterprisesearch_types.go
+++ b/pkg/apis/enterprisesearch/v1/enterprisesearch_types.go
@@ -111,8 +111,8 @@ func (ent *EnterpriseSearch) RequiresAssociation() bool {
 	return ent.Spec.ElasticsearchRef.Name != ""
 }
 
-func (ent *EnterpriseSearch) GetVersion() string {
-	return ent.Spec.Version
+func (ent *EnterpriseSearch) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
+	return "", nil
 }
 
 func (ent *EnterpriseSearch) GetAssociations() []commonv1.Association {

--- a/pkg/apis/enterprisesearch/v1/enterprisesearch_types.go
+++ b/pkg/apis/enterprisesearch/v1/enterprisesearch_types.go
@@ -111,6 +111,10 @@ func (ent *EnterpriseSearch) RequiresAssociation() bool {
 	return ent.Spec.ElasticsearchRef.Name != ""
 }
 
+func (ent *EnterpriseSearch) GetVersion() string {
+	return ent.Spec.Version
+}
+
 func (ent *EnterpriseSearch) GetAssociations() []commonv1.Association {
 	associations := make([]commonv1.Association, 0)
 	if ent.Spec.ElasticsearchRef.IsDefined() {

--- a/pkg/apis/enterprisesearch/v1beta1/enterprisesearch_types.go
+++ b/pkg/apis/enterprisesearch/v1beta1/enterprisesearch_types.go
@@ -107,6 +107,10 @@ func (ent *EnterpriseSearch) RequiresAssociation() bool {
 	return ent.Spec.ElasticsearchRef.Name != ""
 }
 
+func (ent *EnterpriseSearch) GetVersion() string {
+	return ent.Spec.Version
+}
+
 func (ent *EnterpriseSearch) GetAssociations() []commonv1.Association {
 	associations := make([]commonv1.Association, 0)
 	if ent.Spec.ElasticsearchRef.IsDefined() {

--- a/pkg/apis/enterprisesearch/v1beta1/enterprisesearch_types.go
+++ b/pkg/apis/enterprisesearch/v1beta1/enterprisesearch_types.go
@@ -107,8 +107,8 @@ func (ent *EnterpriseSearch) RequiresAssociation() bool {
 	return ent.Spec.ElasticsearchRef.Name != ""
 }
 
-func (ent *EnterpriseSearch) GetVersion() string {
-	return ent.Spec.Version
+func (ent *EnterpriseSearch) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
+	return "", nil
 }
 
 func (ent *EnterpriseSearch) GetAssociations() []commonv1.Association {

--- a/pkg/apis/kibana/v1/kibana_types.go
+++ b/pkg/apis/kibana/v1/kibana_types.go
@@ -165,6 +165,10 @@ func (k *Kibana) ServiceAccountName() string {
 	return k.Spec.ServiceAccountName
 }
 
+func (k *Kibana) GetVersion() string {
+	return k.Spec.Version
+}
+
 // -- associations
 
 var _ commonv1.Associated = &Kibana{}

--- a/pkg/apis/kibana/v1/kibana_types.go
+++ b/pkg/apis/kibana/v1/kibana_types.go
@@ -169,7 +169,7 @@ func (k *Kibana) ServiceAccountName() string {
 	return k.Spec.ServiceAccountName
 }
 
-var KibanaServiceAccountMinVersion = semver.MustParse("8.0.0")
+var KibanaServiceAccountMinVersion = semver.MustParse("7.17.0")
 
 // -- associations
 

--- a/pkg/apis/maps/v1alpha1/maps_types.go
+++ b/pkg/apis/maps/v1alpha1/maps_types.go
@@ -123,6 +123,10 @@ func (m *ElasticMapsServer) SetAssociationStatusMap(typ commonv1.AssociationType
 	return nil
 }
 
+func (m *ElasticMapsServer) GetVersion() string {
+	return m.Spec.Version
+}
+
 func (m *ElasticMapsServer) GetAssociations() []commonv1.Association {
 	associations := make([]commonv1.Association, 0)
 	if m.Spec.ElasticsearchRef.IsDefined() {

--- a/pkg/apis/maps/v1alpha1/maps_types.go
+++ b/pkg/apis/maps/v1alpha1/maps_types.go
@@ -123,8 +123,8 @@ func (m *ElasticMapsServer) SetAssociationStatusMap(typ commonv1.AssociationType
 	return nil
 }
 
-func (m *ElasticMapsServer) GetVersion() string {
-	return m.Spec.Version
+func (m *ElasticMapsServer) ElasticServiceAccount() (commonv1.ServiceAccountName, error) {
+	return "", nil
 }
 
 func (m *ElasticMapsServer) GetAssociations() []commonv1.Association {

--- a/pkg/controller/agent/config_test.go
+++ b/pkg/controller/agent/config_test.go
@@ -12,6 +12,7 @@ import (
 
 	agentv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/agent/v1alpha1"
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
@@ -87,9 +88,11 @@ func TestExtractConnectionSettings(t *testing.T) {
 			}),
 			assocType: commonv1.KibanaAssociationType,
 			wantConnectionSettings: connectionSettings{
-				host:     "url",
-				username: "user",
-				password: "password",
+				host: "url",
+				credentials: association.Credentials{
+					Username: "user",
+					Password: "password",
+				},
 			},
 			wantErr: false,
 		},
@@ -107,10 +110,12 @@ func TestExtractConnectionSettings(t *testing.T) {
 			}),
 			assocType: commonv1.KibanaAssociationType,
 			wantConnectionSettings: connectionSettings{
-				host:     "url",
-				ca:       "/mnt/elastic-internal/kibana-association/ns/kibana/certs/ca.crt",
-				username: "user",
-				password: "password",
+				host: "url",
+				ca:   "/mnt/elastic-internal/kibana-association/ns/kibana/certs/ca.crt",
+				credentials: association.Credentials{
+					Username: "user",
+					Password: "password",
+				},
 			},
 			wantErr: false,
 		},

--- a/pkg/controller/apmserver/config.go
+++ b/pkg/controller/apmserver/config.go
@@ -110,15 +110,15 @@ func newElasticsearchConfigFromSpec(c k8s.Client, esAssociation apmv1.ApmEsAssoc
 	}
 
 	// Get username and password
-	username, password, err := association.ElasticsearchAuthSettings(c, &esAssociation)
+	credentials, err := association.ElasticsearchAuthSettings(c, &esAssociation)
 	if err != nil {
 		return nil, err
 	}
 
 	tmpOutputCfg := map[string]interface{}{
 		"output.elasticsearch.hosts":    []string{esAssociation.AssociationConf().GetURL()},
-		"output.elasticsearch.username": username,
-		"output.elasticsearch.password": password,
+		"output.elasticsearch.username": credentials.Username,
+		"output.elasticsearch.password": credentials.Password,
 	}
 	if esAssociation.AssociationConf().GetCACertProvided() {
 		tmpOutputCfg["output.elasticsearch.ssl.certificate_authorities"] = []string{filepath.Join(certificatesDir(esAssociation.AssociationType()), certificates.CAFileName)}
@@ -133,7 +133,7 @@ func newKibanaConfigFromSpec(c k8s.Client, kibanaAssociation apmv1.ApmKibanaAsso
 	}
 
 	// Get username and password
-	username, password, err := association.ElasticsearchAuthSettings(c, &kibanaAssociation)
+	credentials, err := association.ElasticsearchAuthSettings(c, &kibanaAssociation)
 	if err != nil {
 		return nil, err
 	}
@@ -141,8 +141,8 @@ func newKibanaConfigFromSpec(c k8s.Client, kibanaAssociation apmv1.ApmKibanaAsso
 	tmpOutputCfg := map[string]interface{}{
 		"apm-server.kibana.enabled":  true,
 		"apm-server.kibana.host":     kibanaAssociation.AssociationConf().GetURL(),
-		"apm-server.kibana.username": username,
-		"apm-server.kibana.password": password,
+		"apm-server.kibana.username": credentials.Username,
+		"apm-server.kibana.password": credentials.Password,
 	}
 	if kibanaAssociation.AssociationConf().GetCACertProvided() {
 		tmpOutputCfg["apm-server.kibana.ssl.certificate_authorities"] = []string{filepath.Join(certificatesDir(kibanaAssociation.AssociationType()), certificates.CAFileName)}

--- a/pkg/controller/association/conf.go
+++ b/pkg/controller/association/conf.go
@@ -84,27 +84,39 @@ func IsConfiguredIfSet(association commonv1.Association, r record.EventRecorder)
 	return true
 }
 
+type Credentials struct {
+	Username, Password, ServiceAccountToken string
+}
+
+func (c Credentials) HasServiceAccountToken() bool {
+	return len(c.ServiceAccountToken) > 0
+}
+
 // ElasticsearchAuthSettings returns the user and the password to be used by an associated object to authenticate
 // against an Elasticsearch cluster.
 // This is also used for transitive authentication that relies on Elasticsearch native realm (eg. APMServer -> Kibana)
-func ElasticsearchAuthSettings(c k8s.Client, association commonv1.Association) (username, password string, err error) {
+func ElasticsearchAuthSettings(c k8s.Client, association commonv1.Association) (Credentials, error) {
 	assocConf := association.AssociationConf()
 	if !assocConf.AuthIsConfigured() {
-		return "", "", nil
+		return Credentials{}, nil
 	}
 
 	secretObjKey := types.NamespacedName{Namespace: association.GetNamespace(), Name: assocConf.AuthSecretName}
 	var secret corev1.Secret
 	if err := c.Get(context.Background(), secretObjKey, &secret); err != nil {
-		return "", "", err
+		return Credentials{}, err
 	}
 
 	data, ok := secret.Data[assocConf.AuthSecretKey]
 	if !ok {
-		return "", "", errors.Errorf("auth secret key %s doesn't exist", assocConf.AuthSecretKey)
+		return Credentials{}, errors.Errorf("auth secret key %s doesn't exist", assocConf.AuthSecretKey)
 	}
 
-	return assocConf.AuthSecretKey, string(data), nil
+	if assocConf.IsServiceAccount {
+		return Credentials{ServiceAccountToken: string(data)}, nil
+	}
+
+	return Credentials{Username: assocConf.AuthSecretKey, Password: string(data)}, nil
 }
 
 // AllowVersion returns true if the given resourceVersion is lower or equal to the associations' versions.

--- a/pkg/controller/association/conf.go
+++ b/pkg/controller/association/conf.go
@@ -92,7 +92,7 @@ func (c Credentials) HasServiceAccountToken() bool {
 	return len(c.ServiceAccountToken) > 0
 }
 
-// ElasticsearchAuthSettings returns the user and the password to be used by an associated object to authenticate
+// ElasticsearchAuthSettings returns the credentials to be used by an associated object to authenticate
 // against an Elasticsearch cluster.
 // This is also used for transitive authentication that relies on Elasticsearch native realm (eg. APMServer -> Kibana)
 func ElasticsearchAuthSettings(c k8s.Client, association commonv1.Association) (Credentials, error) {

--- a/pkg/controller/association/conf_test.go
+++ b/pkg/controller/association/conf_test.go
@@ -326,16 +326,16 @@ func TestElasticsearchAuthSettings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			apmEsAssociation.SetAssociationConf(&tt.assocConf)
-			gotUsername, gotPassword, err := ElasticsearchAuthSettings(tt.client, &apmEsAssociation)
+			gotCredentials, err := ElasticsearchAuthSettings(tt.client, &apmEsAssociation)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getCredentials() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if gotUsername != tt.wantUsername {
-				t.Errorf("getCredentials() gotUsername = %v, want %v", gotUsername, tt.wantUsername)
+			if gotCredentials.Username != tt.wantUsername {
+				t.Errorf("getCredentials() gotUsername = %v, want %v", gotCredentials.Username, tt.wantUsername)
 			}
-			if gotPassword != tt.wantPassword {
-				t.Errorf("getCredentials() gotPassword = %v, want %v", gotPassword, tt.wantPassword)
+			if gotCredentials.Password != tt.wantPassword {
+				t.Errorf("getCredentials() gotPassword = %v, want %v", gotCredentials.Password, tt.wantPassword)
 			}
 		})
 	}

--- a/pkg/controller/association/controller/agent_es.go
+++ b/pkg/controller/association/controller/agent_es.go
@@ -14,7 +14,6 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	eslabel "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/rbac"
@@ -30,10 +29,6 @@ const (
 	// AgentAssociationLabelType marks resources created for an association originating from Agent
 	// with the target resource type (e.g. "elasticsearch").
 	AgentAssociationLabelType = "agentassociation.k8s.elastic.co/type"
-)
-
-var (
-	FleetServerServiceAccountMinVersion = version.MustParse("8.0.0")
 )
 
 func AddAgentES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params operator.Parameters) error {
@@ -58,9 +53,6 @@ func AddAgentES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params 
 		AssociationResourceNamespaceLabelName: eslabel.ClusterNamespaceLabelName,
 
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{
-			ServiceAccount: func() (association.ServiceAccountName, version.Version) {
-				return association.FleetServer, FleetServerServiceAccountMinVersion
-			},
 			ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.ObjectSelector, error) {
 				return true, association.AssociationRef(), nil
 			},

--- a/pkg/controller/association/controller/agent_es.go
+++ b/pkg/controller/association/controller/agent_es.go
@@ -14,6 +14,7 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	eslabel "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/rbac"
@@ -29,6 +30,10 @@ const (
 	// AgentAssociationLabelType marks resources created for an association originating from Agent
 	// with the target resource type (e.g. "elasticsearch").
 	AgentAssociationLabelType = "agentassociation.k8s.elastic.co/type"
+)
+
+var (
+	FleetServerServiceAccountMinVersion = version.MustParse("8.0.0")
 )
 
 func AddAgentES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params operator.Parameters) error {
@@ -53,6 +58,9 @@ func AddAgentES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params 
 		AssociationResourceNamespaceLabelName: eslabel.ClusterNamespaceLabelName,
 
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{
+			ServiceAccount: func() (association.ServiceAccountName, version.Version) {
+				return association.FleetServer, FleetServerServiceAccountMinVersion
+			},
 			ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.ObjectSelector, error) {
 				return true, association.AssociationRef(), nil
 			},

--- a/pkg/controller/association/controller/kibana_es.go
+++ b/pkg/controller/association/controller/kibana_es.go
@@ -16,7 +16,6 @@ import (
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	eslabel "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/rbac"
@@ -35,10 +34,6 @@ const (
 
 	// KibanaSystemUserBuiltinRole is the name of the built-in role for the Kibana system user.
 	KibanaSystemUserBuiltinRole = "kibana_system"
-)
-
-var (
-	KibanaServiceAccountMinVersion = version.MustParse("8.0.0")
 )
 
 func AddKibanaES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params operator.Parameters) error {

--- a/pkg/controller/association/controller/kibana_es.go
+++ b/pkg/controller/association/controller/kibana_es.go
@@ -63,9 +63,6 @@ func AddKibanaES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params
 		AssociationResourceNamespaceLabelName: eslabel.ClusterNamespaceLabelName,
 
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{
-			ServiceAccount: func() (association.ServiceAccountName, version.Version) {
-				return association.Kibana, KibanaServiceAccountMinVersion
-			},
 			ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.ObjectSelector, error) {
 				return true, association.AssociationRef(), nil
 			},

--- a/pkg/controller/association/controller/kibana_es.go
+++ b/pkg/controller/association/controller/kibana_es.go
@@ -16,6 +16,7 @@ import (
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	eslabel "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/rbac"
@@ -34,6 +35,10 @@ const (
 
 	// KibanaSystemUserBuiltinRole is the name of the built-in role for the Kibana system user.
 	KibanaSystemUserBuiltinRole = "kibana_system"
+)
+
+var (
+	KibanaServiceAccountMinVersion = version.MustParse("8.0.0")
 )
 
 func AddKibanaES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params operator.Parameters) error {
@@ -58,6 +63,9 @@ func AddKibanaES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params
 		AssociationResourceNamespaceLabelName: eslabel.ClusterNamespaceLabelName,
 
 		ElasticsearchUserCreation: &association.ElasticsearchUserCreation{
+			ServiceAccount: func() (association.ServiceAccountName, version.Version) {
+				return association.Kibana, KibanaServiceAccountMinVersion
+			},
 			ElasticsearchRef: func(c k8s.Client, association commonv1.Association) (bool, commonv1.ObjectSelector, error) {
 				return true, association.AssociationRef(), nil
 			},

--- a/pkg/controller/association/gc_test.go
+++ b/pkg/controller/association/gc_test.go
@@ -47,12 +47,107 @@ func newUserSecret(
 	}
 }
 
+func newServiceAccountSecret(
+	namespace, name,
+	associationNamespaceLabel, associationNameLabel,
+	associationNamespaceValue, associationNameValue string,
+) runtime.Object {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				associationNameLabel:      associationNameValue,
+				associationNamespaceLabel: associationNamespaceValue,
+				common.TypeLabelName:      esuser.ServiceAccountTokenType,
+			},
+		},
+	}
+}
+
 func TestUsersGarbageCollector_GC(t *testing.T) {
 	client := k8s.NewFakeClient(
 		// Create 5 secrets, 3 actually used and 2 orphaned
 		newUserSecret("es", "ns1-kb-orphaned-xxxx-kibana-user", KibanaAssociationLabelNamespace, KibanaAssociationLabelName, "ns1", "orphaned-kibana"),
 		newUserSecret("es", "ns1-kb-kibana1-w2fz-kibana-user", KibanaAssociationLabelNamespace, KibanaAssociationLabelName, "ns1", "kibana1"),
 		newUserSecret("es", "ns1-kb-kibana2-fy8i-kibana-user", KibanaAssociationLabelNamespace, KibanaAssociationLabelName, "ns2", "kibana2"),
+		newUserSecret("es", "ns1-kb-orphaned-xxxx-apm-user", ApmAssociationLabelNamespace, ApmAssociationLabelName, "ns1", "orphaned-apm"),
+		newUserSecret("es", "ns1-kb-apm1-yrfa-apm-user", ApmAssociationLabelNamespace, ApmAssociationLabelName, "ns1", "apm1"),
+		&kbv1.Kibana{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kibana1",
+				Namespace: "ns1",
+			},
+		},
+		&kbv1.Kibana{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kibana2",
+				Namespace: "ns2",
+			},
+		},
+		&apmv1.ApmServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "apm1",
+				Namespace: "ns1",
+			},
+		},
+	)
+
+	ugc := &UsersGarbageCollector{
+		client:            client,
+		managedNamespaces: []string{AllNamespaces},
+	}
+
+	// register some resources
+	ugc.For(&apmv1.ApmServerList{}, ApmAssociationLabelNamespace, ApmAssociationLabelName)
+	ugc.For(&kbv1.KibanaList{}, KibanaAssociationLabelNamespace, KibanaAssociationLabelName)
+
+	err := ugc.DoGarbageCollection()
+	if err != nil {
+		t.Errorf("UsersGarbageCollector.DoGarbageCollection() error = %v", err)
+		return
+	}
+
+	// kibana1, kibana2 and apm1 user Secret must still be present
+	s := &corev1.Secret{}
+	err = client.Get(context.Background(), types.NamespacedName{
+		Namespace: "es",
+		Name:      "ns1-kb-kibana1-w2fz-kibana-user",
+	}, s)
+	assert.NoError(t, err)
+	err = client.Get(context.Background(), types.NamespacedName{
+		Namespace: "es",
+		Name:      "ns1-kb-kibana2-fy8i-kibana-user",
+	}, s)
+	assert.NoError(t, err)
+	err = client.Get(context.Background(), types.NamespacedName{
+		Namespace: "es",
+		Name:      "ns1-kb-apm1-yrfa-apm-user",
+	}, s)
+	assert.NoError(t, err)
+
+	// Orphaned secret must have been deleted
+	err = client.Get(context.Background(), types.NamespacedName{
+		Namespace: "es",
+		Name:      "ns1-kb-orphaned-xxxx-kibana-user",
+	}, s)
+	assert.NotNil(t, err)
+	assert.True(t, errors.IsNotFound(err))
+
+	err = client.Get(context.Background(), types.NamespacedName{
+		Namespace: "es",
+		Name:      "ns1-kb-orphaned-xxxx-apm-user",
+	}, s)
+	assert.NotNil(t, err)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestServiceAccountsGarbageCollector_GC(t *testing.T) {
+	client := k8s.NewFakeClient(
+		// Create 5 secrets, 3 actually used and 2 orphaned
+		newServiceAccountSecret("es", "ns1-kb-orphaned-xxxx-kibana-user", KibanaAssociationLabelNamespace, KibanaAssociationLabelName, "ns1", "orphaned-kibana"),
+		newServiceAccountSecret("es", "ns1-kb-kibana1-w2fz-kibana-user", KibanaAssociationLabelNamespace, KibanaAssociationLabelName, "ns1", "kibana1"),
+		newServiceAccountSecret("es", "ns1-kb-kibana2-fy8i-kibana-user", KibanaAssociationLabelNamespace, KibanaAssociationLabelName, "ns2", "kibana2"),
 		newUserSecret("es", "ns1-kb-orphaned-xxxx-apm-user", ApmAssociationLabelNamespace, ApmAssociationLabelName, "ns1", "orphaned-apm"),
 		newUserSecret("es", "ns1-kb-apm1-yrfa-apm-user", ApmAssociationLabelNamespace, ApmAssociationLabelName, "ns1", "apm1"),
 		&kbv1.Kibana{

--- a/pkg/controller/association/reconciler.go
+++ b/pkg/controller/association/reconciler.go
@@ -30,6 +30,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -89,6 +90,9 @@ type ElasticsearchUserCreation struct {
 	// ElasticsearchRef is a function which returns the maybe transitive Elasticsearch reference (eg. APMServer -> Kibana -> Elasticsearch).
 	// In the case of a transitive reference this is used to create the Elasticsearch user.
 	ElasticsearchRef func(c k8s.Client, association commonv1.Association) (bool, commonv1.ObjectSelector, error)
+	// ServiceAccount is the service account to be used, it should return an empty string if not supported.
+	// Version is the minimum version supported for using service tokens.
+	ServiceAccount func() (ServiceAccountName, version.Version)
 	// UserSecretSuffix is used as a suffix in the name of the secret holding user data in the associated namespace.
 	UserSecretSuffix string
 	// ESUserRole is the role to use for the Elasticsearch user created by the association.
@@ -291,6 +295,36 @@ func (r *Reconciler) reconcileAssociation(ctx context.Context, association commo
 		return commonv1.AssociationPending, err
 	}
 
+	associatedVersion, err := version.Parse(association.GetVersion())
+	if err != nil {
+		return commonv1.AssociationPending, err
+	}
+	// Detect if we should use a service account. If it is the case create the related Secrets and update the association
+	// configuration on the associated resource.
+	if sa := getServiceAccount(r.ElasticsearchUserCreation, associatedVersion); len(sa) > 0 {
+		applicationSecretName := secretKey(association, r.ElasticsearchUserCreation.UserSecretSuffix)
+		r.log(k8s.ExtractNamespacedName(association)).V(1).Info("Ensure service account exists", "sa", sa)
+		err := ReconcileServiceAccounts(
+			ctx,
+			r.Client,
+			es,
+			assocLabels,
+			secretKey(association, r.ElasticsearchUserCreation.UserSecretSuffix),
+			UserKey(association, es.Namespace, r.ElasticsearchUserCreation.UserSecretSuffix),
+			sa,
+			association.GetName(),
+			association.GetUID(),
+		)
+		if err != nil {
+			return commonv1.AssociationFailed, err
+		}
+		expectedAssocConf.AuthSecretName = applicationSecretName.Name
+		expectedAssocConf.AuthSecretKey = "token"
+		expectedAssocConf.IsServiceAccount = true
+		// update the association configuration if necessary
+		return r.updateAssocConf(ctx, expectedAssocConf, association)
+	}
+
 	userRole, err := r.ElasticsearchUserCreation.ESUserRole(association.Associated())
 	if err != nil {
 		return commonv1.AssociationFailed, err
@@ -314,6 +348,17 @@ func (r *Reconciler) reconcileAssociation(ctx context.Context, association commo
 
 	// update the association configuration if necessary
 	return r.updateAssocConf(ctx, expectedAssocConf, association)
+}
+
+func getServiceAccount(esUserCreation *ElasticsearchUserCreation, esVersion version.Version) ServiceAccountName {
+	if esUserCreation == nil || esUserCreation.ServiceAccount == nil {
+		return ""
+	}
+	sa, minVer := esUserCreation.ServiceAccount()
+	if esVersion.GTE(minVer) {
+		return sa
+	}
+	return ""
 }
 
 // getElasticsearch attempts to retrieve the referenced Elasticsearch resource. If not found, it removes

--- a/pkg/controller/association/reconciler.go
+++ b/pkg/controller/association/reconciler.go
@@ -305,7 +305,7 @@ func (r *Reconciler) reconcileAssociation(ctx context.Context, association commo
 			r.Client,
 			es,
 			assocLabels,
-			secretKey(association, r.ElasticsearchUserCreation.UserSecretSuffix),
+			applicationSecretName,
 			UserKey(association, es.Namespace, r.ElasticsearchUserCreation.UserSecretSuffix),
 			serviceAccount,
 			association.GetName(),

--- a/pkg/controller/association/service_account.go
+++ b/pkg/controller/association/service_account.go
@@ -1,0 +1,309 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package association
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"go.elastic.co/apm"
+	"golang.org/x/crypto/pbkdf2"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
+	esuser "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/user"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+)
+
+type ServiceAccountName string
+
+const (
+	Namespace string = "elastic"
+
+	Kibana      ServiceAccountName = "kibana"
+	FleetServer ServiceAccountName = "fleet-server"
+
+	ServiceAccountNameField       = "serviceAccount"
+	ServiceAccountTokenValueField = "token"
+)
+
+func applicationSecretLabels(es esv1.Elasticsearch) map[string]string {
+	return common.AddCredentialsLabel(map[string]string{
+		label.ClusterNamespaceLabelName: es.Namespace,
+		label.ClusterNameLabelName:      es.Name,
+	})
+}
+
+func esSecretsLabels(es esv1.Elasticsearch) map[string]string {
+	return map[string]string{
+		label.ClusterNamespaceLabelName: es.Namespace,
+		label.ClusterNameLabelName:      es.Name,
+		common.TypeLabelName:            "service-account-token",
+	}
+}
+
+// reconcileApplicationSecret reconciles the Secret which contains the application token.
+func reconcileApplicationSecret(
+	ctx context.Context,
+	client k8s.Client,
+	es esv1.Elasticsearch,
+	applicationSecretName types.NamespacedName,
+	commonLabels map[string]string,
+	tokenName string,
+	serviceAccount ServiceAccountName,
+) (*Token, error) {
+	span, _ := apm.StartSpan(ctx, "reconcile_sa_token_application", tracing.SpanTypeApp)
+	defer span.End()
+
+	applicationStore := corev1.Secret{}
+	err := client.Get(context.Background(), applicationSecretName, &applicationStore)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	var token *Token
+	if k8serrors.IsNotFound(err) || len(applicationStore.Data) == 0 {
+		// Secret does not exist or is empty, create a new token
+		token, err = newApplicationToken(serviceAccount, tokenName)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Attempt to read current token, create a new one in case of an error.
+		token, err = getOrCreateToken(&es, applicationSecretName.Name, applicationStore.Data, serviceAccount, tokenName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	labels := applicationSecretLabels(es)
+	for labelName, labelValue := range commonLabels {
+		labels[labelName] = labelValue
+	}
+	applicationStore = corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      applicationSecretName.Name,
+			Namespace: applicationSecretName.Namespace,
+			Labels:    labels,
+		},
+		Data: map[string][]byte{
+			esuser.ServiceAccountTokenNameField: []byte(token.TokenName),
+			ServiceAccountTokenValueField:       []byte(token.Token),
+			esuser.ServiceAccountHashField:      []byte(token.Hash),
+			ServiceAccountNameField:             []byte(token.ServiceAccountName),
+		},
+	}
+
+	if _, err := reconciler.ReconcileSecret(client, applicationStore, nil); err != nil {
+		return nil, err
+	}
+
+	return token, err
+}
+
+func getOrCreateToken(
+	es *esv1.Elasticsearch,
+	secretName string,
+	secretData map[string][]byte,
+	serviceAccountName ServiceAccountName,
+	tokenName string,
+) (*Token, error) {
+	token := getCurrentApplicationToken(es, secretName, secretData)
+	if token == nil {
+		// We need to create a new token
+		return newApplicationToken(serviceAccountName, tokenName)
+	}
+	return token, nil
+}
+
+// reconcileElasticsearchSecret ensures the Secret for Elasticsearch exists and hold the expected token.
+func reconcileElasticsearchSecret(
+	ctx context.Context,
+	client k8s.Client,
+	es esv1.Elasticsearch,
+	elasticsearchSecretName types.NamespacedName,
+	commonLabels map[string]string,
+	token Token,
+) error {
+	span, _ := apm.StartSpan(ctx, "reconcile_sa_token_elasticsearch", tracing.SpanTypeApp)
+	defer span.End()
+	fullyQualifiedName := token.ServiceAccountName + "/" + token.TokenName
+	labels := esSecretsLabels(es)
+	for labelName, labelValue := range commonLabels {
+		labels[labelName] = labelValue
+	}
+	esSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      elasticsearchSecretName.Name,
+			Namespace: elasticsearchSecretName.Namespace,
+			Labels:    labels,
+		},
+		Data: map[string][]byte{
+			esuser.ServiceAccountTokenNameField: []byte(fullyQualifiedName),
+			esuser.ServiceAccountHashField:      []byte(token.Hash),
+		},
+	}
+	_, err := reconciler.ReconcileSecret(client, esSecret, &es)
+	return err
+}
+
+func ReconcileServiceAccounts(
+	ctx context.Context,
+	client k8s.Client,
+	es esv1.Elasticsearch,
+	commonLabels map[string]string,
+	applicationSecretName types.NamespacedName,
+	elasticsearchSecretName types.NamespacedName,
+	serviceAccount ServiceAccountName,
+	applicationName string,
+	applicationUID types.UID,
+) error {
+	tokenName := tokenName(applicationSecretName.Namespace, applicationName, applicationUID)
+	token, err := reconcileApplicationSecret(ctx, client, es, applicationSecretName, commonLabels, tokenName, serviceAccount)
+	if err != nil {
+		return err
+	}
+	return reconcileElasticsearchSecret(ctx, client, es, elasticsearchSecretName, commonLabels, *token)
+}
+
+// getCurrentApplicationToken returns the current token from the application Secret, or nil if the content of the Secret is not valid.
+func getCurrentApplicationToken(es *esv1.Elasticsearch, secretName string, secretData map[string][]byte) *Token {
+	if len(secretData) == 0 {
+		log.V(1).Info("secret is empty", "es_name", es.Name, "namespace", es.Namespace, "secret", secretName)
+		return nil
+	}
+	result := &Token{}
+	if value := getFieldOrNil(es, secretName, secretData, esuser.ServiceAccountTokenNameField); value != nil && len(*value) > 0 {
+		result.TokenName = *value
+	} else {
+		return nil
+	}
+
+	if value := getFieldOrNil(es, secretName, secretData, ServiceAccountTokenValueField); value != nil && len(*value) > 0 {
+		result.Token = *value
+	} else {
+		return nil
+	}
+
+	if value := getFieldOrNil(es, secretName, secretData, esuser.ServiceAccountHashField); value != nil && len(*value) > 0 {
+		result.Hash = *value
+	} else {
+		return nil
+	}
+
+	if value := getFieldOrNil(es, secretName, secretData, ServiceAccountNameField); value != nil && len(*value) > 0 {
+		result.ServiceAccountName = *value
+	} else {
+		return nil
+	}
+
+	return result
+}
+
+func getFieldOrNil(es *esv1.Elasticsearch, secretName string, secretData map[string][]byte, fieldName string) *string {
+	data, exists := secretData[fieldName]
+	if !exists {
+		log.V(1).Info(fmt.Sprintf("%s field is missing in service account token Secret", fieldName), "es_name", es.Name, "namespace", es.Namespace, "secret", secretName)
+		return nil
+	}
+	fieldValue := string(data)
+	return &fieldValue
+}
+
+var prefix = [...]byte{0x0, 0x1, 0x0, 0x1}
+
+// newApplicationToken generates a new token for a given service account.
+func newApplicationToken(serviceAccountName ServiceAccountName, tokenName string) (*Token, error) {
+	secret := common.RandomBytes(64)
+	hash, err := pbkdf2Key(secret)
+	if err != nil {
+		return nil, err
+	}
+
+	fullyQualifiedName := fmt.Sprintf("%s/%s", Namespace, serviceAccountName)
+	suffix := []byte(fmt.Sprintf("%s/%s:%s", fullyQualifiedName, tokenName, secret))
+	token := base64.StdEncoding.EncodeToString(append(prefix[:], suffix...))
+
+	return &Token{
+		ServiceAccountName: fullyQualifiedName,
+		TokenName:          tokenName,
+		Token:              token,
+		Hash:               hash,
+	}, nil
+}
+
+func tokenName(
+	applicationNamespace, applicationName string,
+	applicationUID types.UID,
+) string {
+	return fmt.Sprintf("%s_%s_%s", applicationNamespace, applicationName, applicationUID)
+}
+
+// Token stores all the required data for a given service account token.
+type Token struct {
+	ServiceAccountName string
+	TokenName          string
+	Token              string
+	Hash               string
+}
+
+func (u Token) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		ServiceAccountName string `json:"serviceAccountName"`
+		TokenName          string `json:"tokenName"`
+		Token              string `json:"token"`
+		Hash               string `json:"hash"`
+	}{
+		ServiceAccountName: u.ServiceAccountName,
+		TokenName:          u.TokenName,
+		Token:              "REDACTED",
+		Hash:               "REDACTED",
+	})
+}
+
+// -- crypto
+
+const (
+	pbkdf2StretchPrefix     = "{PBKDF2_STRETCH}"
+	pbkdf2DefaultCost       = 10000
+	pbkdf2KeyLength         = 32
+	pbkdf2DefaultSaltLength = 32
+)
+
+// pbkdf2Key derives a key from the provided secret, as expected by the service tokens file store in Elasticsearch.
+func pbkdf2Key(secret []byte) (string, error) {
+	var result strings.Builder
+	result.WriteString(pbkdf2StretchPrefix)
+	result.WriteString(strconv.Itoa(pbkdf2DefaultCost))
+	result.WriteString("$")
+
+	salt := make([]byte, pbkdf2DefaultSaltLength)
+	if _, err := rand.Read(salt); err != nil {
+		return "", err
+	}
+	result.WriteString(base64.StdEncoding.EncodeToString(salt))
+	result.WriteString("$")
+
+	hashedSecret := sha512.Sum512(secret)
+	hashedSecretAsString := hex.EncodeToString(hashedSecret[:])
+
+	dk := pbkdf2.Key([]byte(hashedSecretAsString), salt, pbkdf2DefaultCost, pbkdf2KeyLength, sha512.New)
+	result.WriteString(base64.StdEncoding.EncodeToString(dk))
+	return result.String(), nil
+}

--- a/pkg/controller/association/service_account.go
+++ b/pkg/controller/association/service_account.go
@@ -50,7 +50,7 @@ func esSecretsLabels(es esv1.Elasticsearch) map[string]string {
 	return map[string]string{
 		label.ClusterNamespaceLabelName: es.Namespace,
 		label.ClusterNameLabelName:      es.Name,
-		common.TypeLabelName:            "service-account-token",
+		common.TypeLabelName:            esuser.ServiceAccountTokenType,
 	}
 }
 

--- a/pkg/controller/association/service_account.go
+++ b/pkg/controller/association/service_account.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
@@ -31,13 +32,8 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
 
-type ServiceAccountName string
-
 const (
 	Namespace string = "elastic"
-
-	Kibana      ServiceAccountName = "kibana"
-	FleetServer ServiceAccountName = "fleet-server"
 
 	ServiceAccountNameField       = "serviceAccount"
 	ServiceAccountTokenValueField = "token"
@@ -66,7 +62,7 @@ func reconcileApplicationSecret(
 	applicationSecretName types.NamespacedName,
 	commonLabels map[string]string,
 	tokenName string,
-	serviceAccount ServiceAccountName,
+	serviceAccount commonv1.ServiceAccountName,
 ) (*Token, error) {
 	span, _ := apm.StartSpan(ctx, "reconcile_sa_token_application", tracing.SpanTypeApp)
 	defer span.End()
@@ -121,7 +117,7 @@ func getOrCreateToken(
 	es *esv1.Elasticsearch,
 	secretName string,
 	secretData map[string][]byte,
-	serviceAccountName ServiceAccountName,
+	serviceAccountName commonv1.ServiceAccountName,
 	tokenName string,
 ) (*Token, error) {
 	token := getCurrentApplicationToken(es, secretName, secretData)
@@ -170,7 +166,7 @@ func ReconcileServiceAccounts(
 	commonLabels map[string]string,
 	applicationSecretName types.NamespacedName,
 	elasticsearchSecretName types.NamespacedName,
-	serviceAccount ServiceAccountName,
+	serviceAccount commonv1.ServiceAccountName,
 	applicationName string,
 	applicationUID types.UID,
 ) error {
@@ -229,7 +225,7 @@ func getFieldOrNil(es *esv1.Elasticsearch, secretName string, secretData map[str
 var prefix = [...]byte{0x0, 0x1, 0x0, 0x1}
 
 // newApplicationToken generates a new token for a given service account.
-func newApplicationToken(serviceAccountName ServiceAccountName, tokenName string) (*Token, error) {
+func newApplicationToken(serviceAccountName commonv1.ServiceAccountName, tokenName string) (*Token, error) {
 	secret := common.RandomBytes(64)
 	hash, err := pbkdf2Key(secret)
 	if err != nil {

--- a/pkg/controller/association/service_account_test.go
+++ b/pkg/controller/association/service_account_test.go
@@ -1,0 +1,373 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package association
+
+import (
+	"context"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/pbkdf2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+)
+
+var (
+	existingElasticsearch = esv1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "elasticsearch-sample",
+			Namespace:       "e2e-mercury",
+			UID:             types.UID("eda4b94f-687d-4797-af3b-e46b248b82af"),
+			ResourceVersion: "4242",
+			Generation:      3,
+		},
+	}
+
+	existingKibana = kbv1.Kibana{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "kibana-sample",
+			Namespace:       "e2e-venus",
+			UID:             types.UID("892ff7d8-9cf2-48f0-89bc-5a530e77a930"),
+			ResourceVersion: "8819",
+			Generation:      2,
+		},
+		Spec: kbv1.KibanaSpec{
+			Count: 1,
+			ElasticsearchRef: commonv1.ObjectSelector{
+				Name:      "elasticsearch-sample",
+				Namespace: "e2e-mercury",
+			},
+		},
+	}
+
+	expectedKibanaUserSecret = corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "e2e-venus",
+			Name:      "kibana-sample-kibana-user",
+			UID:       types.UID("6f5cb31d-69c4-409d-8b8d-8eafafc6bbd7"),
+			Labels: map[string]string{
+				"eck.k8s.elastic.co/credentials":                 "true",
+				"elasticsearch.k8s.elastic.co/cluster-name":      "elasticsearch-sample",
+				"elasticsearch.k8s.elastic.co/cluster-namespace": "e2e-mercury",
+				"kibanaassociation.k8s.elastic.co/name":          "kibana-sample",
+				"kibanaassociation.k8s.elastic.co/namespace":     "e2e-venus",
+				"kibanaassociation.k8s.elastic.co/type":          "elasticsearch",
+			},
+			ResourceVersion: "3442951",
+		},
+		Data: map[string][]byte{
+			"serviceAccount": []byte("elastic/kibana"),
+			"name":           []byte("e2e-venus_kibana-sample_892ff7d8-9cf2-48f0-89bc-5a530e77a930"),
+			"token":          []byte("AAEAAWVsYXN0aWMva2liYW5hL2RlZmF1bHRfa2liYW5hXzUzYWExOWJiLWM5ZTAtNDhiYS05MTU1LWEyODQ1YmNlZDdmNDpRTzNEVFhuSlZhQ0lnR1FZNjJ0QWRsMEZWSU1FQWhYV1hKcjYxdUdDRGFQMUh4YTNPa3BNSXdOSHkzUTFJbVN2"),
+			"hash":           []byte("{PBKDF2_STRETCH}10000$p2YH/lyhXWlOgCbaiPGrArfChZYADB06Aoh9wAbuoPY=$AHRvi+YQK0TZ4kzvWhLiL5+Z1L+UQTVmz7PXndtSou0="),
+		},
+	}
+
+	expectedElasticsearchUserSecret = corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "e2e-mercury",
+			Name:            "e2e-venus-kibana-sample-kibana-user",
+			UID:             types.UID("0c60f0f4-5847-48b7-b539-c76746a7394f"),
+			ResourceVersion: "3443557",
+			Labels: map[string]string{
+				"common.k8s.elastic.co/type":                     "service-account-token",
+				"elasticsearch.k8s.elastic.co/cluster-name":      "elasticsearch-sample",
+				"elasticsearch.k8s.elastic.co/cluster-namespace": "e2e-mercury",
+				"kibanaassociation.k8s.elastic.co/name":          "kibana-sample",
+				"kibanaassociation.k8s.elastic.co/namespace":     "e2e-venus",
+				"kibanaassociation.k8s.elastic.co/type":          "elasticsearch",
+			},
+		},
+		Data: map[string][]byte{
+			"name": []byte("elastic/kibana/e2e-venus_kibana-sample_892ff7d8-9cf2-48f0-89bc-5a530e77a930"),
+			"hash": []byte("{PBKDF2_STRETCH}10000$p2YH/lyhXWlOgCbaiPGrArfChZYADB06Aoh9wAbuoPY=$AHRvi+YQK0TZ4kzvWhLiL5+Z1L+UQTVmz7PXndtSou0="),
+		},
+	}
+)
+
+func Test_ReconcileServiceAccounts(t *testing.T) {
+	type args struct {
+		client         k8s.Client
+		applicationUID types.UID
+		serviceAccount ServiceAccountName
+	}
+	tests := []struct {
+		name                                 string
+		args                                 args
+		wantNewToken                         bool
+		wantKibanaUserResourceVersion        string
+		wantElasticsearchUserResourceVersion string
+		wantErr                              bool
+	}{
+		{
+			name: "both secrets do not exist",
+			args: args{
+				client:         k8s.NewFakeClient(existingElasticsearch.DeepCopy(), existingKibana.DeepCopy()),
+				applicationUID: existingKibana.UID,
+				serviceAccount: "kibana",
+			},
+			wantNewToken:                         true,
+			wantKibanaUserResourceVersion:        "1", // new Secret
+			wantElasticsearchUserResourceVersion: "1", // new Secret
+		},
+		{
+			name: "both secrets already exist, do not update",
+			args: args{
+				client: k8s.NewFakeClient(
+					existingElasticsearch.DeepCopy(),
+					existingKibana.DeepCopy(),
+					expectedKibanaUserSecret.DeepCopy(),
+					expectedElasticsearchUserSecret.DeepCopy(),
+				),
+				// Kibana resource UID
+				applicationUID: existingKibana.UID,
+				serviceAccount: "kibana",
+			},
+			wantKibanaUserResourceVersion:        "3442951", // not updated
+			wantElasticsearchUserResourceVersion: "3443557", // not updated
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			commonLabels := map[string]string{
+				"elasticsearch.k8s.elastic.co/cluster-name":      "elasticsearch-sample",
+				"elasticsearch.k8s.elastic.co/cluster-namespace": "e2e-mercury",
+				"kibanaassociation.k8s.elastic.co/type":          "elasticsearch",
+				"kibanaassociation.k8s.elastic.co/name":          "kibana-sample",
+				"kibanaassociation.k8s.elastic.co/namespace":     "e2e-venus",
+			}
+			applicationSecretName := types.NamespacedName{Namespace: "e2e-venus", Name: "kibana-sample-kibana-user"}
+			elasticsearchSecretName := types.NamespacedName{Namespace: "e2e-mercury", Name: "e2e-venus-kibana-sample-kibana-user"}
+			err := ReconcileServiceAccounts(
+				context.Background(),
+				tt.args.client,
+				existingElasticsearch,
+				commonLabels,
+				applicationSecretName,
+				elasticsearchSecretName,
+				tt.args.serviceAccount,
+				existingKibana.Name,
+				existingKibana.UID,
+			)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("store.EnsureTokenExists() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// Check Secrets once ReconcileServiceAccounts has been called
+			reconciledKibanaSecret := corev1.Secret{}
+			assert.NoError(t, tt.args.client.Get(context.Background(), applicationSecretName, &reconciledKibanaSecret))
+			assert.Equal(t, expectedKibanaUserSecret.Labels, reconciledKibanaSecret.Labels, "Labels on application SA secret are not equal")
+			assert.Equal(t, tt.wantKibanaUserResourceVersion, reconciledKibanaSecret.ResourceVersion, "Unexpected Kibana Secret resource version")
+
+			reconciledElasticsearchSecret := corev1.Secret{}
+			assert.NoError(t, tt.args.client.Get(context.Background(), elasticsearchSecretName, &reconciledElasticsearchSecret))
+			assert.Equal(t, expectedElasticsearchUserSecret.Labels, reconciledElasticsearchSecret.Labels, "Labels on Elasticsearch SA secret are not equal")
+			assert.Equal(t, tt.wantElasticsearchUserResourceVersion, reconciledElasticsearchSecret.ResourceVersion, "Unexpected Elasticsearch Secret resource version")
+
+			assert.Equal(t, 4, len(reconciledKibanaSecret.Data))
+
+			serviceAccountName, exist := reconciledKibanaSecret.Data["serviceAccount"]
+			assert.True(t, exist)
+			assert.Equal(t, "elastic/kibana", string(serviceAccountName))
+
+			name, exist := reconciledKibanaSecret.Data["name"]
+			assert.True(t, exist)
+			assert.Equal(t, "e2e-venus_kibana-sample_892ff7d8-9cf2-48f0-89bc-5a530e77a930", string(name))
+
+			hash, exist := reconciledKibanaSecret.Data["hash"]
+			assert.True(t, exist)
+			token, exist := reconciledKibanaSecret.Data["token"]
+			assert.True(t, exist)
+
+			assert.Equal(t, 2, len(reconciledElasticsearchSecret.Data))
+			esName, exist := reconciledElasticsearchSecret.Data["name"]
+			assert.True(t, exist)
+			assert.Equal(t, "elastic/kibana/e2e-venus_kibana-sample_892ff7d8-9cf2-48f0-89bc-5a530e77a930", string(esName))
+
+			esHash, exist := reconciledElasticsearchSecret.Data["hash"]
+			assert.True(t, exist)
+			assert.Equal(t, hash, esHash)
+
+			if tt.wantNewToken {
+				// Only check that the expected fields are there and that the generated token is valid
+				verifyToken(t, string(token), string(hash), "kibana", string(name))
+			} else {
+				// Reuse existing hash and token
+				hash, exist := reconciledKibanaSecret.Data["hash"]
+				assert.True(t, exist)
+				assert.Equal(t, "{PBKDF2_STRETCH}10000$p2YH/lyhXWlOgCbaiPGrArfChZYADB06Aoh9wAbuoPY=$AHRvi+YQK0TZ4kzvWhLiL5+Z1L+UQTVmz7PXndtSou0=", string(hash))
+				token, exist := reconciledKibanaSecret.Data["token"]
+				assert.True(t, exist)
+				assert.Equal(t, "AAEAAWVsYXN0aWMva2liYW5hL2RlZmF1bHRfa2liYW5hXzUzYWExOWJiLWM5ZTAtNDhiYS05MTU1LWEyODQ1YmNlZDdmNDpRTzNEVFhuSlZhQ0lnR1FZNjJ0QWRsMEZWSU1FQWhYV1hKcjYxdUdDRGFQMUh4YTNPa3BNSXdOSHkzUTFJbVN2", string(token))
+			}
+		})
+	}
+}
+
+func Test_newApplicationToken(t *testing.T) {
+	type args struct {
+		serviceAccountName ServiceAccountName
+		tokenName          string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Simple test with Key validation",
+			args: args{
+				serviceAccountName: Kibana,
+				tokenName:          "e2e-venus-kibana-kibana-sample",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newApplicationToken(tt.args.serviceAccountName, tt.args.tokenName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newApplicationToken() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			verifyToken(t, got.Token, got.Hash, string(tt.args.serviceAccountName), tt.args.tokenName)
+		})
+	}
+}
+
+var (
+	secretRegEx     = regexp.MustCompile(`^([-\w]+)\/([-\w]+)\/([-\w]+)\:(\w+)$`)
+	pbkdf2HashRegEx = regexp.MustCompile(`^\{PBKDF2_STRETCH\}10000\$(.*)\$(.*)$`)
+)
+
+func verifyToken(t *testing.T, b64token, hash, serviceAccount, tokenName string) {
+	t.Helper()
+
+	// Validate the hash
+	sub := pbkdf2HashRegEx.FindStringSubmatch(hash)
+	assert.Equal(t, 3, len(sub), "PBKDF2 hash does not match regexp %s", pbkdf2HashRegEx)
+	salt, err := base64.StdEncoding.DecodeString(sub[1])
+	assert.NoError(t, err, "Unexpected error while decoding salt")
+	assert.Equal(t, len(salt), pbkdf2DefaultSaltLength)
+	hashString, err := base64.StdEncoding.DecodeString(sub[2])
+	assert.NoError(t, err, "Unexpected error while decoding hash string")
+	assert.True(t, len(hashString) > 0, "Hash string should not be empty")
+
+	// Validate the token
+	token, err := base64.StdEncoding.DecodeString(b64token)
+	assert.NoError(t, err, "Unexpected error while decoding token")
+	// Check token prefix
+	assert.Equal(t, byte(0x00), token[0])
+	assert.Equal(t, byte(0x01), token[1])
+	assert.Equal(t, byte(0x00), token[2])
+	assert.Equal(t, byte(0x01), token[3])
+	// Decode and check token suffix
+	secretSuffix := string(token[4:])
+	assert.True(t, len(secretSuffix) > 0, "Secret body should not be empty")
+	tokenSuffix := secretRegEx.FindStringSubmatch(secretSuffix)
+	assert.Equal(t, 5, len(tokenSuffix), "Secret suffix does not match regexp")
+	assert.Equal(t, Namespace, tokenSuffix[1])
+	assert.Equal(t, serviceAccount, tokenSuffix[2])
+	assert.Equal(t, tokenName, tokenSuffix[3])
+	clearTextTokenSecret := tokenSuffix[4]
+
+	verify(t, []byte(clearTextTokenSecret), hash)
+}
+
+func Test_hash(t *testing.T) {
+	type args struct {
+		secret []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Simple hash test",
+			args: args{
+				secret: []byte("asecret"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := pbkdf2Key(tt.args.secret)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("hash() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				assert.Nil(t, got)
+			} else {
+				assert.NotNil(t, got)
+				verify(t, tt.args.secret, got)
+			}
+		})
+	}
+}
+
+func verify(t *testing.T, password []byte, hash string) {
+	t.Helper()
+
+	// password is hashed using sha512 and converted to a hex string
+	hashedSecret := sha512.Sum512(password)
+	hashedSecretAsString := hex.EncodeToString(hashedSecret[:])
+
+	// Base64 string length : (4*(n/3)) rounded up to the next multiple of 4 because of padding.
+	// n is 32 (PBKDF2_KEY_LENGTH in bytes), so tokenLength is 44
+	tokenLength := 44
+	hashChars := hash[len(hash)-tokenLength:]
+	saltChars := hash[len(hash)-(2*tokenLength+1) : len(hash)-(tokenLength+1)]
+	salt, err := base64.StdEncoding.DecodeString(saltChars)
+	assert.NoError(t, err)
+
+	costChars := hash[len(pbkdf2StretchPrefix) : len(hash)-(2*tokenLength+2)]
+	cost, err := strconv.Atoi(costChars)
+	assert.NoError(t, err)
+
+	dk := pbkdf2.Key([]byte(hashedSecretAsString), salt, cost, pbkdf2KeyLength, sha512.New)
+	computedPwdHash := base64.StdEncoding.EncodeToString(dk)
+
+	assert.Equal(t, hashChars, computedPwdHash)
+}
+
+func Test_TokenMarshalJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		token Token
+		want  string
+	}{
+		{
+			name: "Secret data should not be serialized",
+			token: Token{
+				ServiceAccountName: "service_account",
+				TokenName:          "token_name",
+				Token:              "secret",
+				Hash:               "secret",
+			},
+			want: `{"serviceAccountName":"service_account","tokenName":"token_name","token":"REDACTED","hash":"REDACTED"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ser, err := json.Marshal(tt.token)
+			assert.Nil(t, err)
+			assert.Equal(t, string(ser), tt.want)
+		})
+	}
+}

--- a/pkg/controller/association/service_account_test.go
+++ b/pkg/controller/association/service_account_test.go
@@ -103,7 +103,7 @@ func Test_ReconcileServiceAccounts(t *testing.T) {
 	type args struct {
 		client         k8s.Client
 		applicationUID types.UID
-		serviceAccount ServiceAccountName
+		serviceAccount commonv1.ServiceAccountName
 	}
 	tests := []struct {
 		name                                 string
@@ -221,7 +221,7 @@ func Test_ReconcileServiceAccounts(t *testing.T) {
 
 func Test_newApplicationToken(t *testing.T) {
 	type args struct {
-		serviceAccountName ServiceAccountName
+		serviceAccountName commonv1.ServiceAccountName
 		tokenName          string
 	}
 	tests := []struct {
@@ -232,7 +232,7 @@ func Test_newApplicationToken(t *testing.T) {
 		{
 			name: "Simple test with Key validation",
 			args: args{
-				serviceAccountName: Kibana,
+				serviceAccountName: kbv1.KibanaServiceAccount,
 				tokenName:          "e2e-venus-kibana-kibana-sample",
 			},
 		},

--- a/pkg/controller/beat/common/config.go
+++ b/pkg/controller/beat/common/config.go
@@ -25,7 +25,7 @@ func buildOutputConfig(client k8s.Client, associated beatv1beta1.BeatESAssociati
 		return settings.NewCanonicalConfig(), nil
 	}
 
-	username, password, err := association.ElasticsearchAuthSettings(client, &associated)
+	credentials, err := association.ElasticsearchAuthSettings(client, &associated)
 	if err != nil {
 		return settings.NewCanonicalConfig(), err
 	}
@@ -33,8 +33,8 @@ func buildOutputConfig(client k8s.Client, associated beatv1beta1.BeatESAssociati
 	esOutput := map[string]interface{}{
 		"output.elasticsearch": map[string]interface{}{
 			"hosts":    []string{associated.AssociationConf().GetURL()},
-			"username": username,
-			"password": password,
+			"username": credentials.Username,
+			"password": credentials.Password,
 		},
 	}
 
@@ -51,7 +51,7 @@ func BuildKibanaConfig(client k8s.Client, associated beatv1beta1.BeatKibanaAssoc
 		return settings.NewCanonicalConfig(), nil
 	}
 
-	username, password, err := association.ElasticsearchAuthSettings(client, &associated)
+	credentials, err := association.ElasticsearchAuthSettings(client, &associated)
 	if err != nil {
 		return settings.NewCanonicalConfig(), err
 	}
@@ -60,8 +60,8 @@ func BuildKibanaConfig(client k8s.Client, associated beatv1beta1.BeatKibanaAssoc
 		"setup.dashboards.enabled": true,
 		"setup.kibana": map[string]interface{}{
 			"host":     associated.AssociationConf().GetURL(),
-			"username": username,
-			"password": password,
+			"username": credentials.Username,
+			"password": credentials.Password,
 		},
 	}
 

--- a/pkg/controller/common/stackmon/config.go
+++ b/pkg/controller/common/stackmon/config.go
@@ -100,14 +100,14 @@ func newBeatConfig(client k8s.Client, beatName string, resource monitoring.HasMo
 }
 
 func buildOutputConfig(client k8s.Client, assoc commonv1.Association) (map[string]interface{}, volume.VolumeLike, error) {
-	username, password, err := association.ElasticsearchAuthSettings(client, assoc)
+	credentials, err := association.ElasticsearchAuthSettings(client, assoc)
 	if err != nil {
 		return nil, volume.SecretVolume{}, err
 	}
 
 	outputConfig := map[string]interface{}{
-		"username": username,
-		"password": password,
+		"username": credentials.Username,
+		"password": credentials.Password,
 		"hosts":    []string{assoc.AssociationConf().GetURL()},
 	}
 

--- a/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
+++ b/pkg/controller/elasticsearch/initcontainer/prepare_fs.go
@@ -78,6 +78,10 @@ var (
 				Source: stringsutil.Concat(esvolume.UnicastHostsVolumeMountPath, "/", esvolume.UnicastHostsFile),
 				Target: stringsutil.Concat(EsConfigSharedVolume.ContainerMountPath, "/", esvolume.UnicastHostsFile),
 			},
+			{
+				Source: stringsutil.Concat(esvolume.XPackFileRealmVolumeMountPath, "/", esvolume.ServiceAccountsFile),
+				Target: stringsutil.Concat(EsConfigSharedVolume.ContainerMountPath, "/", esvolume.ServiceAccountsFile),
+			},
 		},
 	}
 	// defaultResources are the default request and limits for the init container.

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -207,7 +207,8 @@ func TestBuildPodTemplateSpecWithDefaultSecurityContext(t *testing.T) {
 			cfg, err := settings.NewMergedESConfig(es.Name, tt.version, corev1.IPv4Protocol, es.Spec.HTTP, *es.Spec.NodeSets[0].Config)
 			require.NoError(t, err)
 
-			actual, err := BuildPodTemplateSpec(k8s.NewFakeClient(), es, es.Spec.NodeSets[0], cfg, nil, tt.setDefaultFSGroup)
+			client := k8s.NewFakeClient(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: es.Namespace, Name: esv1.ScriptsConfigMap(es.Name)}})
+			actual, err := BuildPodTemplateSpec(client, es, es.Spec.NodeSets[0], cfg, nil, tt.setDefaultFSGroup)
 			require.NoError(t, err)
 			require.Equal(t, tt.wantSecurityContext, actual.Spec.SecurityContext)
 		})
@@ -222,7 +223,8 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 	cfg, err := settings.NewMergedESConfig(sampleES.Name, ver, corev1.IPv4Protocol, sampleES.Spec.HTTP, *nodeSet.Config)
 	require.NoError(t, err)
 
-	actual, err := BuildPodTemplateSpec(k8s.NewFakeClient(), sampleES, sampleES.Spec.NodeSets[0], cfg, nil, false)
+	client := k8s.NewFakeClient(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: sampleES.Namespace, Name: esv1.ScriptsConfigMap(sampleES.Name)}})
+	actual, err := BuildPodTemplateSpec(client, sampleES, sampleES.Spec.NodeSets[0], cfg, nil, false)
 	require.NoError(t, err)
 
 	// build expected PodTemplateSpec
@@ -275,7 +277,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 				"pod-template-label-name":                       "pod-template-label-value",
 			},
 			Annotations: map[string]string{
-				"elasticsearch.k8s.elastic.co/config-hash": "1382203021",
+				"elasticsearch.k8s.elastic.co/config-hash": "957591218",
 				"pod-template-annotation-name":             "pod-template-annotation-value",
 				"co.elastic.logs/module":                   "elasticsearch",
 			},
@@ -326,6 +328,7 @@ func Test_buildAnnotations(t *testing.T) {
 		cfg               map[string]interface{}
 		esAnnotations     map[string]string
 		keystoreResources *keystore.Resources
+		scriptsVersion    string
 	}
 	tests := []struct {
 		name                string
@@ -371,14 +374,15 @@ func Test_buildAnnotations(t *testing.T) {
 			},
 		},
 		{
-			name: "With keystore",
+			name: "With keystore and scripts version",
 			args: args{
 				keystoreResources: &keystore.Resources{
 					Version: "42",
 				},
+				scriptsVersion: "84",
 			},
 			expectedAnnotations: map[string]string{
-				"elasticsearch.k8s.elastic.co/config-hash": "2597721387",
+				"elasticsearch.k8s.elastic.co/config-hash": "3641963559",
 			},
 		},
 		{
@@ -387,9 +391,22 @@ func Test_buildAnnotations(t *testing.T) {
 				keystoreResources: &keystore.Resources{
 					Version: "43",
 				},
+				scriptsVersion: "84",
 			},
 			expectedAnnotations: map[string]string{
-				"elasticsearch.k8s.elastic.co/config-hash": "2580943768",
+				"elasticsearch.k8s.elastic.co/config-hash": "3625185940",
+			},
+		},
+		{
+			name: "With another script version",
+			args: args{
+				keystoreResources: &keystore.Resources{
+					Version: "42",
+				},
+				scriptsVersion: "85",
+			},
+			expectedAnnotations: map[string]string{
+				"elasticsearch.k8s.elastic.co/config-hash": "3917140820",
 			},
 		},
 	}
@@ -400,7 +417,7 @@ func Test_buildAnnotations(t *testing.T) {
 			require.NoError(t, err)
 			cfg, err := settings.NewMergedESConfig(es.Name, ver, corev1.IPv4Protocol, es.Spec.HTTP, *es.Spec.NodeSets[0].Config)
 			require.NoError(t, err)
-			got := buildAnnotations(es, cfg, tt.args.keystoreResources)
+			got := buildAnnotations(es, cfg, tt.args.keystoreResources, tt.args.scriptsVersion)
 
 			for expectedAnnotation, expectedValue := range tt.expectedAnnotations {
 				actualValue, exists := got[expectedAnnotation]
@@ -497,7 +514,8 @@ func Test_enableLog4JFormatMsgNoLookups(t *testing.T) {
 			require.NoError(t, err)
 			cfg, err := settings.NewMergedESConfig(sampleES.Name, ver, corev1.IPv4Protocol, sampleES.Spec.HTTP, *sampleES.Spec.NodeSets[0].Config)
 			require.NoError(t, err)
-			actual, err := BuildPodTemplateSpec(k8s.NewFakeClient(), sampleES, sampleES.Spec.NodeSets[0], cfg, nil, false)
+			client := k8s.NewFakeClient(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: sampleES.Namespace, Name: esv1.ScriptsConfigMap(sampleES.Name)}})
+			actual, err := BuildPodTemplateSpec(client, sampleES, sampleES.Spec.NodeSets[0], cfg, nil, false)
 			require.NoError(t, err)
 
 			env := actual.Spec.Containers[1].Env

--- a/pkg/controller/elasticsearch/user/associated.go
+++ b/pkg/controller/elasticsearch/user/associated.go
@@ -21,6 +21,8 @@ import (
 const (
 	// AssociatedUserType is used to annotate an associated user secret, most likely created by an association controller.
 	AssociatedUserType = "user"
+	// ServiceAccountTokenType is used to annotate a secret that contains a service account token, most likely created by an association controller.
+	ServiceAccountTokenType = "service-account-token"
 
 	// UserNameField is the field in the secret that contains the username.
 	UserNameField = "name"

--- a/pkg/controller/elasticsearch/user/reconcile.go
+++ b/pkg/controller/elasticsearch/user/reconcile.go
@@ -14,8 +14,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
@@ -59,13 +61,46 @@ func ReconcileUsersAndRoles(
 		return esclient.BasicAuth{}, err
 	}
 
+	// reconcile the service accounts
+	saTokens, err := aggregateServiceAccountTokens(c, es)
+	if err != nil {
+		return esclient.BasicAuth{}, err
+	}
+
 	// reconcile the aggregate secret
-	if err := reconcileRolesFileRealmSecret(c, es, roles, fileRealm); err != nil {
+	if err := reconcileRolesFileRealmSecret(c, es, roles, fileRealm, saTokens); err != nil {
 		return esclient.BasicAuth{}, err
 	}
 
 	// return the controller user for next reconciliation steps to interact with Elasticsearch
 	return controllerUser, nil
+}
+
+func aggregateServiceAccountTokens(c k8s.Client, es esv1.Elasticsearch) (ServiceAccountTokens, error) {
+	// list all associated user secrets
+	var serviceAccountSecrets corev1.SecretList
+	if err := c.List(context.Background(),
+		&serviceAccountSecrets,
+		client.InNamespace(es.Namespace),
+		client.MatchingLabels(
+			map[string]string{
+				label.ClusterNameLabelName: es.Name,
+				common.TypeLabelName:       "service-account-token",
+			},
+		),
+	); err != nil {
+		return nil, err
+	}
+
+	var tokens ServiceAccountTokens
+	for _, secret := range serviceAccountSecrets.Items {
+		token, err := getServiceAccountToken(secret)
+		if err != nil {
+			return nil, err
+		}
+		tokens = tokens.Add(token)
+	}
+	return tokens, nil
 }
 
 func getExistingFileRealm(c k8s.Client, es esv1.Elasticsearch) (filerealm.Realm, error) {
@@ -150,13 +185,20 @@ func RolesFileRealmSecretKey(es esv1.Elasticsearch) types.NamespacedName {
 }
 
 // reconcileRolesFileRealmSecret creates or updates the single secret holding the file realm and the file-based roles.
-func reconcileRolesFileRealmSecret(c k8s.Client, es esv1.Elasticsearch, roles RolesFileContent, fileRealm filerealm.Realm) error {
+func reconcileRolesFileRealmSecret(
+	c k8s.Client,
+	es esv1.Elasticsearch,
+	roles RolesFileContent,
+	fileRealm filerealm.Realm,
+	saTokens ServiceAccountTokens,
+) error {
 	secretData := fileRealm.FileBytes()
 	rolesBytes, err := roles.FileBytes()
 	if err != nil {
 		return err
 	}
 	secretData[RolesFile] = rolesBytes
+	secretData[ServiceTokensFileName] = saTokens.ToBytes()
 
 	expected := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/elasticsearch/user/reconcile.go
+++ b/pkg/controller/elasticsearch/user/reconcile.go
@@ -85,7 +85,7 @@ func aggregateServiceAccountTokens(c k8s.Client, es esv1.Elasticsearch) (Service
 		client.MatchingLabels(
 			map[string]string{
 				label.ClusterNameLabelName: es.Name,
-				common.TypeLabelName:       "service-account-token",
+				common.TypeLabelName:       ServiceAccountTokenType,
 			},
 		),
 	); err != nil {

--- a/pkg/controller/elasticsearch/user/service_account.go
+++ b/pkg/controller/elasticsearch/user/service_account.go
@@ -1,0 +1,71 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package user
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type ServiceAccountToken struct {
+	FullyQualifiedServiceAccountName string
+	HashedSecret                     string
+}
+
+type ServiceAccountTokens []ServiceAccountToken
+
+const (
+	ServiceTokensFileName = "service_tokens"
+
+	ServiceAccountTokenNameField = "name"
+	ServiceAccountHashField      = "hash"
+)
+
+// getServiceAccountToken reads a service account token from a secret.
+func getServiceAccountToken(secret corev1.Secret) (ServiceAccountToken, error) {
+	token := ServiceAccountToken{}
+	if len(secret.Data) == 0 {
+		return token, fmt.Errorf("service account token secret %s/%s is empty", secret.Namespace, secret.Name)
+	}
+
+	if serviceAccountName, ok := secret.Data[ServiceAccountTokenNameField]; ok && len(serviceAccountName) > 0 {
+		token.FullyQualifiedServiceAccountName = string(serviceAccountName)
+	} else {
+		return token, fmt.Errorf(fieldNotFound, ServiceAccountTokenNameField, secret.Namespace, secret.Name)
+	}
+
+	if hash, ok := secret.Data[ServiceAccountHashField]; ok && len(hash) > 0 {
+		token.HashedSecret = string(hash)
+	} else {
+		return token, fmt.Errorf(fieldNotFound, ServiceAccountHashField, secret.Namespace, secret.Name)
+	}
+
+	return token, nil
+}
+
+func (s ServiceAccountTokens) Add(serviceAccountToken ServiceAccountToken) ServiceAccountTokens {
+	return append(s, serviceAccountToken)
+}
+
+func (s *ServiceAccountTokens) ToBytes() []byte {
+	if s == nil {
+		return []byte{}
+	}
+	// Ensure that the file is sorted for stable comparison.
+	sort.SliceStable(*s, func(i, j int) bool {
+		return (*s)[i].FullyQualifiedServiceAccountName < (*s)[j].FullyQualifiedServiceAccountName
+	})
+	var result strings.Builder
+	for _, serviceToken := range *s {
+		result.WriteString(serviceToken.FullyQualifiedServiceAccountName)
+		result.WriteString(":")
+		result.WriteString(serviceToken.HashedSecret)
+		result.WriteString("\n")
+	}
+	return []byte(result.String())
+}

--- a/pkg/controller/elasticsearch/user/user_provided.go
+++ b/pkg/controller/elasticsearch/user/user_provided.go
@@ -151,6 +151,6 @@ func handleSecretNotFound(recorder record.EventRecorder, es esv1.Elasticsearch, 
 
 func handleInvalidSecretData(recorder record.EventRecorder, es esv1.Elasticsearch, secretName string, err error) {
 	msg := "invalid data in secret"
-	log.Error(errors.Wrap(err, "msg"), "namespace", es.Namespace, "es_name", es.Name, "secret_name", secretName)
+	log.Error(errors.Wrap(err, "msg"), msg, "namespace", es.Namespace, "es_name", es.Name, "secret_name", secretName)
 	recorder.Event(&es, corev1.EventTypeWarning, events.EventReasonUnexpected, msg+": "+secretName)
 }

--- a/pkg/controller/elasticsearch/user/user_provided.go
+++ b/pkg/controller/elasticsearch/user/user_provided.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -151,6 +150,6 @@ func handleSecretNotFound(recorder record.EventRecorder, es esv1.Elasticsearch, 
 
 func handleInvalidSecretData(recorder record.EventRecorder, es esv1.Elasticsearch, secretName string, err error) {
 	msg := "invalid data in secret"
-	log.Error(errors.Wrap(err, "msg"), msg, "namespace", es.Namespace, "es_name", es.Name, "secret_name", secretName)
+	log.Error(err, msg, "namespace", es.Namespace, "es_name", es.Name, "secret_name", secretName)
 	recorder.Event(&es, corev1.EventTypeWarning, events.EventReasonUnexpected, msg+": "+secretName)
 }

--- a/pkg/controller/elasticsearch/volume/names.go
+++ b/pkg/controller/elasticsearch/volume/names.go
@@ -43,4 +43,6 @@ const (
 	DownwardAPIMountPath  = "/mnt/elastic-internal/downward-api"
 	LabelsFile            = "labels"
 	AnnotationsFile       = "annotations"
+
+	ServiceAccountsFile = "service_tokens"
 )

--- a/pkg/controller/enterprisesearch/config.go
+++ b/pkg/controller/enterprisesearch/config.go
@@ -306,14 +306,14 @@ func associationConfig(c k8s.Client, ent entv1.EnterpriseSearch, userCfgHasAuth 
 		})
 	}
 
-	username, password, err := association.ElasticsearchAuthSettings(c, &ent)
+	credentials, err := association.ElasticsearchAuthSettings(c, &ent)
 	if err != nil {
 		return nil, err
 	}
 	if err := cfg.MergeWith(settings.MustCanonicalConfig(map[string]string{
 		"elasticsearch.host":     ent.AssociationConf().URL,
-		"elasticsearch.username": username,
-		"elasticsearch.password": password,
+		"elasticsearch.username": credentials.Username,
+		"elasticsearch.password": credentials.Password,
 	})); err != nil {
 		return nil, err
 	}

--- a/pkg/controller/enterprisesearch/version_upgrade.go
+++ b/pkg/controller/enterprisesearch/version_upgrade.go
@@ -201,7 +201,7 @@ func (r *VersionUpgrade) serviceURL() string {
 
 // readOnlyModeRequest builds the HTTP request to toggle the read-only mode on Enterprise Search.
 func (r *VersionUpgrade) readOnlyModeRequest(enabled bool) (*http.Request, error) {
-	username, password, err := association.ElasticsearchAuthSettings(r.k8sClient, &r.ent)
+	credentials, err := association.ElasticsearchAuthSettings(r.k8sClient, &r.ent)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func (r *VersionUpgrade) readOnlyModeRequest(enabled bool) (*http.Request, error
 	}
 
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	req.SetBasicAuth(username, password)
+	req.SetBasicAuth(credentials.Username, credentials.Password)
 
 	return req, nil
 }

--- a/pkg/controller/kibana/config_settings.go
+++ b/pkg/controller/kibana/config_settings.go
@@ -136,27 +136,23 @@ func NewConfigSettings(ctx context.Context, client k8s.Client, kb kbv1.Kibana, v
 	if err != nil {
 		return CanonicalConfig{}, err
 	}
+	var credentialsCfg *settings.CanonicalConfig
 	if credentials.HasServiceAccountToken() {
-		err := cfg.MergeWith(
+		credentialsCfg =
 			settings.MustCanonicalConfig(
 				map[string]interface{}{
 					ElasticsearchServiceAccountToken: credentials.ServiceAccountToken,
 				},
-			))
-		if err != nil {
-			return CanonicalConfig{}, err
-		}
+			)
+
 	} else {
-		err := cfg.MergeWith(
+		credentialsCfg =
 			settings.MustCanonicalConfig(
 				map[string]interface{}{
 					ElasticsearchUsername: credentials.Username,
 					ElasticsearchPassword: credentials.Password,
 				},
-			))
-		if err != nil {
-			return CanonicalConfig{}, err
-		}
+			)
 	}
 
 	// merge the configuration with userSettings last so they take precedence
@@ -167,6 +163,7 @@ func NewConfigSettings(ctx context.Context, client k8s.Client, kb kbv1.Kibana, v
 		entSearchCfg,
 		monitoringCfg,
 		settings.MustCanonicalConfig(elasticsearchTLSSettings(kb)),
+		credentialsCfg,
 		userSettings,
 	)
 	if err != nil {

--- a/pkg/controller/kibana/config_settings.go
+++ b/pkg/controller/kibana/config_settings.go
@@ -144,7 +144,6 @@ func NewConfigSettings(ctx context.Context, client k8s.Client, kb kbv1.Kibana, v
 					ElasticsearchServiceAccountToken: credentials.ServiceAccountToken,
 				},
 			)
-
 	} else {
 		credentialsCfg =
 			settings.MustCanonicalConfig(

--- a/pkg/controller/maps/config.go
+++ b/pkg/controller/maps/config.go
@@ -112,14 +112,14 @@ func associationConfig(c k8s.Client, ems emsv1alpha1.ElasticMapsServer) (*settin
 	if !ems.AssociationConf().IsConfigured() {
 		return cfg, nil
 	}
-	username, password, err := association.ElasticsearchAuthSettings(c, &ems)
+	credentials, err := association.ElasticsearchAuthSettings(c, &ems)
 	if err != nil {
 		return nil, err
 	}
 	if err := cfg.MergeWith(settings.MustCanonicalConfig(map[string]string{
 		"elasticsearch.host":     ems.AssociationConf().URL,
-		"elasticsearch.username": username,
-		"elasticsearch.password": password,
+		"elasticsearch.username": credentials.Username,
+		"elasticsearch.password": credentials.Password,
 	})); err != nil {
 		return nil, err
 	}

--- a/test/e2e/test/elasticsearch/checks_k8s.go
+++ b/test/e2e/test/elasticsearch/checks_k8s.go
@@ -154,7 +154,7 @@ func CheckSecrets(b Builder, k *test.K8sClient) test.Step {
 			},
 			{
 				Name: esName + "-es-xpack-file-realm",
-				Keys: []string{"users", "users_roles", "roles.yml"},
+				Keys: []string{"users", "users_roles", "roles.yml", "service_tokens"},
 				Labels: map[string]string{
 					"common.k8s.elastic.co/type":                "elasticsearch",
 					"elasticsearch.k8s.elastic.co/cluster-name": esName,

--- a/test/e2e/test/kibana/checks_k8s.go
+++ b/test/e2e/test/kibana/checks_k8s.go
@@ -10,6 +10,8 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/association/controller"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/checks"
@@ -53,17 +55,35 @@ func CheckSecrets(b Builder, k *test.K8sClient) test.Step {
 						"kibanaassociation.k8s.elastic.co/namespace": b.Kibana.Namespace,
 					},
 				},
-				test.ExpectedSecret{
-					Name: kbName + "-kibana-user",
-					Keys: []string{b.Kibana.Namespace + "-" + kbName + "-kibana-user"},
-					Labels: map[string]string{
-						"eck.k8s.elastic.co/credentials":             "true",
-						"elasticsearch.k8s.elastic.co/cluster-name":  b.Kibana.Spec.ElasticsearchRef.Name,
-						"kibanaassociation.k8s.elastic.co/name":      kbName,
-						"kibanaassociation.k8s.elastic.co/namespace": b.Kibana.Namespace,
-					},
-				},
 			)
+			kbVersion := version.MustParse(b.Kibana.GetVersion())
+			if kbVersion.GTE(controller.KibanaServiceAccountMinVersion) {
+				expected = append(expected,
+					test.ExpectedSecret{
+						Name: kbName + "-kibana-user",
+						Keys: []string{"hash", "name", "serviceAccount", "token"},
+						Labels: map[string]string{
+							"eck.k8s.elastic.co/credentials":             "true",
+							"elasticsearch.k8s.elastic.co/cluster-name":  b.Kibana.Spec.ElasticsearchRef.Name,
+							"kibanaassociation.k8s.elastic.co/name":      kbName,
+							"kibanaassociation.k8s.elastic.co/namespace": b.Kibana.Namespace,
+						},
+					},
+				)
+			} else {
+				expected = append(expected,
+					test.ExpectedSecret{
+						Name: kbName + "-kibana-user",
+						Keys: []string{b.Kibana.Namespace + "-" + kbName + "-kibana-user"},
+						Labels: map[string]string{
+							"eck.k8s.elastic.co/credentials":             "true",
+							"elasticsearch.k8s.elastic.co/cluster-name":  b.Kibana.Spec.ElasticsearchRef.Name,
+							"kibanaassociation.k8s.elastic.co/name":      kbName,
+							"kibanaassociation.k8s.elastic.co/namespace": b.Kibana.Namespace,
+						},
+					},
+				)
+			}
 		}
 		if b.Kibana.Spec.HTTP.TLS.Enabled() {
 			expected = append(expected,

--- a/test/e2e/test/kibana/checks_k8s.go
+++ b/test/e2e/test/kibana/checks_k8s.go
@@ -10,7 +10,6 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/association/controller"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
@@ -56,8 +55,11 @@ func CheckSecrets(b Builder, k *test.K8sClient) test.Step {
 					},
 				},
 			)
-			kbVersion := version.MustParse(b.Kibana.GetVersion())
-			if kbVersion.GTE(controller.KibanaServiceAccountMinVersion) {
+			v, err := version.Parse(b.Kibana.Spec.Version)
+			if err != nil {
+				panic(err) // should not happen in an e2e test
+			}
+			if v.GTE(kbv1.KibanaServiceAccountMinVersion) {
 				expected = append(expected,
 					test.ExpectedSecret{
 						Name: kbName + "-kibana-user",


### PR DESCRIPTION
Fixes #5244

Note that this PR does not involve creating new `Secrets` to manage the service accounts. The main motivation is that I think we are already managing a lot of `Secrets`/`Watches`, my first thought was to reuse the existing ones:
* For each association the 2 association `Secrets`, as they already exist, are "reused"
* `config/service_tokens` is stored in `<esname>-es-xpack-file-realm` (`Secret` name is a bit misleading, however it already contains the `roles.yml` file which, IIUC, is not tied to the file realm)

Opened as draft for the following reasons, but still good for a first review:
* I need to test for versions before 8.0
* I have to run e2e tests