### PR TITLE
[DOC] vm.max_map_count: update init container example

### DIFF
--- a/config/samples/elasticsearch/elasticsearch.yaml
+++ b/config/samples/elasticsearch/elasticsearch.yaml
@@ -31,6 +31,7 @@ spec:
         # - name: sysctl
         #   securityContext:
         #     privileged: true
+        #     runAsUser: 0
         #   command: ['sh', '-c', 'sysctl -w vm.max_map_count=262144']
         ###
         # uncomment the line below if you are using a service mesh such as linkerd2 that uses service account tokens for pod identification.

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
@@ -30,6 +30,7 @@ spec:
         - name: sysctl
           securityContext:
             privileged: true
+            runAsUser: 0
           command: ['sh', '-c', 'sysctl -w vm.max_map_count=262144']
 EOF
 ----


### PR DESCRIPTION
Fixes #5410 by updating the examples that rely on the init container to increase `vm.max_map_count` 