### PR TITLE
Elastic APM Server: Set status.ObservedGeneration from metadata.Generation

### DIFF
--- a/config/crds/v1/all-crds.yaml
+++ b/config/crds/v1/all-crds.yaml
@@ -1398,6 +1398,15 @@ spec:
                 description: KibanaAssociationStatus is the status of any auto-linking
                   to Kibana.
                 type: string
+              observedGeneration:
+                description: ObservedGeneration represents the .metadata.generation
+                  that the status is based upon. It corresponds to the metadata generation,
+                  which is updated on mutation by the API Server. If the generation
+                  observed in status diverges from the generation in metadata, the
+                  APM Server controller has not yet processed the changes contained
+                  in the APM Server specification.
+                format: int64
+                type: integer
               secretTokenSecret:
                 description: SecretTokenSecretName is the name of the Secret that
                   contains the secret token

--- a/config/crds/v1/bases/apm.k8s.elastic.co_apmservers.yaml
+++ b/config/crds/v1/bases/apm.k8s.elastic.co_apmservers.yaml
@@ -7664,6 +7664,15 @@ spec:
                 description: KibanaAssociationStatus is the status of any auto-linking
                   to Kibana.
                 type: string
+              observedGeneration:
+                description: ObservedGeneration represents the .metadata.generation
+                  that the status is based upon. It corresponds to the metadata generation,
+                  which is updated on mutation by the API Server. If the generation
+                  observed in status diverges from the generation in metadata, the
+                  APM Server controller has not yet processed the changes contained
+                  in the APM Server specification.
+                format: int64
+                type: integer
               secretTokenSecret:
                 description: SecretTokenSecretName is the name of the Secret that
                   contains the secret token

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -1410,6 +1410,15 @@ spec:
                 description: KibanaAssociationStatus is the status of any auto-linking
                   to Kibana.
                 type: string
+              observedGeneration:
+                description: ObservedGeneration represents the .metadata.generation
+                  that the status is based upon. It corresponds to the metadata generation,
+                  which is updated on mutation by the API Server. If the generation
+                  observed in status diverges from the generation in metadata, the
+                  APM Server controller has not yet processed the changes contained
+                  in the APM Server specification.
+                format: int64
+                type: integer
               secretTokenSecret:
                 description: SecretTokenSecretName is the name of the Secret that
                   contains the secret token

--- a/pkg/apis/apm/v1/apmserver_types.go
+++ b/pkg/apis/apm/v1/apmserver_types.go
@@ -63,14 +63,25 @@ type ApmServerSpec struct {
 // ApmServerStatus defines the observed state of ApmServer
 type ApmServerStatus struct {
 	commonv1.DeploymentStatus `json:",inline"`
+
 	// ExternalService is the name of the service the agents should connect to.
 	ExternalService string `json:"service,omitempty"`
+
 	// SecretTokenSecretName is the name of the Secret that contains the secret token
 	SecretTokenSecretName string `json:"secretTokenSecret,omitempty"`
+
 	// ElasticsearchAssociationStatus is the status of any auto-linking to Elasticsearch clusters.
 	ElasticsearchAssociationStatus commonv1.AssociationStatus `json:"elasticsearchAssociationStatus,omitempty"`
+
 	// KibanaAssociationStatus is the status of any auto-linking to Kibana.
 	KibanaAssociationStatus commonv1.AssociationStatus `json:"kibanaAssociationStatus,omitempty"`
+
+	// ObservedGeneration represents the .metadata.generation that the status is based upon.
+	// It corresponds to the metadata generation, which is updated on mutation by the API Server.
+	// If the generation observed in status diverges from the generation in metadata, the APM Server
+	// controller has not yet processed the changes contained in the APM Server specification.
+	// +kubebuilder:validation:Optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/controller/apmserver/controller_test.go
+++ b/pkg/controller/apmserver/controller_test.go
@@ -350,8 +350,7 @@ func TestReconcileApmServer_Reconcile(t *testing.T) {
 			},
 		},
 		{
-			// This could be a potential existing issue.  Do we want observedGeneration to be updated here?
-			name: "With Elasticsearch association not ready, observedGeneration is not updated",
+			name: "With Elasticsearch association not ready, observedGeneration is updated",
 			fields: fields{
 				Client: k8s.NewFakeClient(
 					withESReference(sampleAPMObject, commonv1.ObjectSelector{Name: "testes"}),
@@ -370,7 +369,7 @@ func TestReconcileApmServer_Reconcile(t *testing.T) {
 				var apm apmv1.ApmServer
 				err := f.Client.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "test"}, &apm)
 				require.NoError(t, err)
-				require.Equal(t, int64(1), apm.Status.ObservedGeneration)
+				require.Equal(t, int64(2), apm.Status.ObservedGeneration)
 			},
 		},
 		{

--- a/pkg/controller/apmserver/controller_test.go
+++ b/pkg/controller/apmserver/controller_test.go
@@ -8,15 +8,22 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
+	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
@@ -254,4 +261,313 @@ func mkAPMServer(httpConf commonv1.HTTPConfig) apmv1.ApmServer {
 			HTTP: httpConf,
 		},
 	}
+}
+
+func TestReconcileApmServer_Reconcile(t *testing.T) {
+	sampleAPMObject := apmv1.ApmServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "test",
+			Name:       "test",
+			Generation: 2,
+		},
+		Spec: apmv1.ApmServerSpec{
+			Version: "7.0.1",
+			Count:   1,
+		},
+		Status: apmv1.ApmServerStatus{
+			ObservedGeneration: 1,
+		},
+	}
+	defaultRequest := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+	type fields struct {
+		Client         k8s.Client
+		recorder       record.EventRecorder
+		dynamicWatches watches.DynamicWatches
+		Parameters     operator.Parameters
+	}
+	type args struct {
+		ctx     context.Context
+		request reconcile.Request
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		want     reconcile.Result
+		wantErr  bool
+		validate func(*testing.T, fields)
+	}{
+		{
+			name: "unmanaged apm server does not increment observedGeneration",
+			fields: fields{
+				Client: k8s.NewFakeClient(
+					withAnnotations(sampleAPMObject, map[string]string{common.ManagedAnnotation: "false"}),
+				),
+				recorder:       record.NewFakeRecorder(100),
+				dynamicWatches: watches.NewDynamicWatches(),
+				Parameters:     operator.Parameters{},
+			},
+			args: args{
+				ctx:     context.Background(),
+				request: defaultRequest,
+			},
+			want:    reconcile.Result{},
+			wantErr: false,
+			validate: func(t *testing.T, f fields) {
+				var apm apmv1.ApmServer
+				err := f.Client.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "test"}, &apm)
+				require.NoError(t, err)
+				require.Equal(t, int64(1), apm.Status.ObservedGeneration)
+			},
+		},
+		{
+			name: "Legacy finalizer on apm server gets removed, and updates observedGeneration",
+			fields: fields{
+				Client: k8s.NewFakeClient(
+					withFinalizers(sampleAPMObject, []string{"finalizer.elasticsearch.k8s.elastic.co/secure-settings-secret"}),
+				),
+				recorder:       record.NewFakeRecorder(100),
+				dynamicWatches: watches.NewDynamicWatches(),
+				Parameters:     operator.Parameters{},
+			},
+			args: args{
+				ctx:     context.Background(),
+				request: defaultRequest,
+			},
+			want:    reconcile.Result{},
+			wantErr: false,
+			validate: func(t *testing.T, f fields) {
+				var apm apmv1.ApmServer
+				err := f.Client.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "test"}, &apm)
+				require.NoError(t, err)
+				require.Len(t, apm.ObjectMeta.Finalizers, 0)
+				require.Equal(t, int64(2), apm.Status.ObservedGeneration)
+			},
+		},
+		{
+			// This could be a potential existing issue.  Do we want observedGeneration to be updated here?
+			name: "With Elasticsearch association not ready, observedGeneration is not updated",
+			fields: fields{
+				Client: k8s.NewFakeClient(
+					withESReference(sampleAPMObject, commonv1.ObjectSelector{Name: "testes"}),
+				),
+				recorder:       record.NewFakeRecorder(100),
+				dynamicWatches: watches.NewDynamicWatches(),
+				Parameters:     operator.Parameters{},
+			},
+			args: args{
+				ctx:     context.Background(),
+				request: defaultRequest,
+			},
+			want:    reconcile.Result{},
+			wantErr: false,
+			validate: func(t *testing.T, f fields) {
+				var apm apmv1.ApmServer
+				err := f.Client.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "test"}, &apm)
+				require.NoError(t, err)
+				require.Equal(t, int64(1), apm.Status.ObservedGeneration)
+			},
+		},
+		{
+			name: "With Elasticsearch association ready, but apm version not allowed with es version, observedGeneration is updated",
+			fields: fields{
+				Client: k8s.NewFakeClient(
+					&esv1.Elasticsearch{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "testes",
+							Namespace: "test",
+						},
+						Spec: esv1.ElasticsearchSpec{
+							Version: "7.16.2",
+						},
+					},
+					withAssociationConf(*(withESReference(sampleAPMObject, commonv1.ObjectSelector{Name: "testes", Namespace: "test"})), commonv1.AssociationConf{
+						AuthSecretName: "testes-es-elastic-user",
+						AuthSecretKey:  "elastic",
+						CASecretName:   "ca-secret",
+						CACertProvided: false,
+						URL:            "https://es:9200",
+						// This will be considered an invalid version, as it's considered 'not reported yet'.
+						Version: "",
+					}),
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "testes-es-elastic-user",
+							Namespace: "test",
+						},
+						Data: map[string][]byte{
+							"elastic": []byte("password"),
+						},
+					},
+				),
+				recorder:       record.NewFakeRecorder(100),
+				dynamicWatches: watches.NewDynamicWatches(),
+				Parameters:     operator.Parameters{},
+			},
+			args: args{
+				ctx:     context.Background(),
+				request: defaultRequest,
+			},
+			want:    reconcile.Result{},
+			wantErr: false,
+			validate: func(t *testing.T, f fields) {
+				var apm apmv1.ApmServer
+				err := f.Client.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "test"}, &apm)
+				require.NoError(t, err)
+				require.Equal(t, int64(2), apm.Status.ObservedGeneration)
+			},
+		},
+		{
+			name: "With validation issues, observedGeneration is updated",
+			fields: fields{
+				Client: k8s.NewFakeClient(
+					withName(sampleAPMObject, "superlongapmservernamecausesvalidationissues"),
+				),
+				recorder:       record.NewFakeRecorder(100),
+				dynamicWatches: watches.NewDynamicWatches(),
+				Parameters:     operator.Parameters{},
+			},
+			args: args{
+				ctx: context.Background(),
+				request: reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      "superlongapmservernamecausesvalidationissues",
+						Namespace: "test",
+					},
+				},
+			},
+			want:    reconcile.Result{},
+			wantErr: true,
+			validate: func(t *testing.T, f fields) {
+				var apm apmv1.ApmServer
+				err := f.Client.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "superlongapmservernamecausesvalidationissues"}, &apm)
+				require.NoError(t, err)
+				require.Equal(t, int64(2), apm.Status.ObservedGeneration)
+			},
+		},
+		{
+			name: "Reconcile of standard apm object updates observedGeneration, and creates deployment",
+			fields: fields{
+				Client: k8s.NewFakeClient(
+					&sampleAPMObject,
+				),
+				recorder:       record.NewFakeRecorder(100),
+				dynamicWatches: watches.NewDynamicWatches(),
+				Parameters:     operator.Parameters{},
+			},
+			args: args{
+				ctx:     context.Background(),
+				request: defaultRequest,
+			},
+			want:    reconcile.Result{},
+			wantErr: false,
+			validate: func(t *testing.T, f fields) {
+				var apm apmv1.ApmServer
+				err := f.Client.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "test"}, &apm)
+				require.NoError(t, err)
+				require.Len(t, apm.ObjectMeta.Finalizers, 0)
+				require.Equal(t, int64(2), apm.Status.ObservedGeneration)
+				var deploymentList appsv1.DeploymentList
+				err = f.Client.List(context.Background(), &deploymentList)
+				require.NoError(t, err)
+				require.Len(t, deploymentList.Items, 1)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ReconcileApmServer{
+				Client:         tt.fields.Client,
+				recorder:       tt.fields.recorder,
+				dynamicWatches: tt.fields.dynamicWatches,
+				Parameters:     tt.fields.Parameters,
+			}
+			var apm apmv1.ApmServer
+			getErr := association.FetchWithAssociations(context.Background(), r.Client, tt.args.request, &apm)
+			require.NoError(t, getErr)
+			got, err := r.Reconcile(tt.args.ctx, tt.args.request)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileApmServer.Reconcile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			// RequeueAfter is ignored here, as certificate reconciler sets this to expiration of the generated certificates.
+			if !cmp.Equal(got, tt.want, cmpopts.IgnoreFields(reconcile.Result{}, "RequeueAfter")) {
+				t.Errorf("ReconcileApmServer.Reconcile() = %v, want %v", got, tt.want)
+			}
+			tt.validate(t, tt.fields)
+		})
+	}
+}
+
+func withAnnotations(apm apmv1.ApmServer, annotations map[string]string) *apmv1.ApmServer {
+	obj := apm.DeepCopy()
+	obj.ObjectMeta.Annotations = annotations
+	return obj
+}
+
+func withFinalizers(apm apmv1.ApmServer, finalizers []string) *apmv1.ApmServer {
+	obj := apm.DeepCopy()
+	obj.ObjectMeta.Finalizers = finalizers
+	return obj
+}
+
+func withESReference(apm apmv1.ApmServer, selector commonv1.ObjectSelector) *apmv1.ApmServer {
+	obj := apm.DeepCopy()
+	obj.Spec.ElasticsearchRef = selector
+	return obj
+}
+
+func withAssociationConf(apm apmv1.ApmServer, conf commonv1.AssociationConf) *apmv1.ApmServer {
+	obj := apm.DeepCopy()
+	association := apmv1.NewApmEsAssociation(obj)
+	association.SetAssociationConf(
+		&commonv1.AssociationConf{
+			AuthSecretName: "auth-secret",
+			AuthSecretKey:  "elastic",
+			CASecretName:   "ca-secret",
+			CACertProvided: true,
+			URL:            "https://es.svc:9200",
+		},
+	)
+	association.SetAnnotations(map[string]string{
+		association.AssociationConfAnnotationName(): `{"authSecretName":"auth-secret", "authSecretKey":"elastic", "caSecretName": "ca-secret", "url":"https://es.svc:9200"}`,
+	})
+	associated := association.Associated()
+	return associated.(*apmv1.ApmServer)
+}
+
+func withName(apm apmv1.ApmServer, name string) *apmv1.ApmServer {
+	obj := apm.DeepCopy()
+	obj.ObjectMeta.Name = name
+	return obj
+}
+
+var _ client.Client = &fakeK8sClient{}
+
+type fakeK8sClient struct {
+	client.Client
+
+	internalClient client.Client
+
+	errors []error
+}
+
+func newFakeK8sClient(errors []error, objs ...runtime.Object) client.Client {
+	return &fakeK8sClient{
+		internalClient: k8s.NewFakeClient(objs...),
+		errors:         errors,
+	}
+}
+
+func (f *fakeK8sClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	if len(f.errors) > 0 {
+		defer func() { f.errors = f.errors[1:] }()
+		return f.errors[0]
+	}
+	return f.internalClient.Get(ctx, key, obj)
 }

--- a/pkg/controller/apmserver/state.go
+++ b/pkg/controller/apmserver/state.go
@@ -26,7 +26,9 @@ type State struct {
 // NewState creates a new reconcile state based on the given request and ApmServer resource with the resource
 // state reset to empty.
 func NewState(request reconcile.Request, as *apmv1.ApmServer) State {
-	return State{Request: request, ApmServer: as, originalApmServer: as.DeepCopy()}
+	current := as.DeepCopy()
+	current.Status.ObservedGeneration = as.Generation
+	return State{Request: request, ApmServer: current, originalApmServer: as}
 }
 
 // UpdateApmServerState updates the ApmServer status based on the given deployment.

--- a/test/e2e/apm/upgrade_test.go
+++ b/test/e2e/apm/upgrade_test.go
@@ -1,0 +1,40 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build agent || e2e
+// +build agent e2e
+
+package apm
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/apmserver"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
+)
+
+// TODO: This is not working; the upgrade doesn't appear to be happening for es, or apmserver.
+func TestAPMServerVersionUpgradeToLatest8x(t *testing.T) {
+	srcVersion := test.Ctx().ElasticStackVersion
+	dstVersion := test.LatestSnapshotVersion8x
+
+	test.SkipInvalidUpgrade(t, srcVersion, dstVersion)
+
+	name := "apmserver-upgrade"
+	esBuilder := elasticsearch.NewBuilder(name).
+		WithVersion(srcVersion).
+		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
+
+	apmServerBuilder := apmserver.NewBuilder(name).WithElasticsearchRef(esBuilder.Ref())
+
+	test.RunMutations(
+		t,
+		[]test.Builder{esBuilder, apmServerBuilder},
+		[]test.Builder{
+			esBuilder.WithVersion(dstVersion).WithMutatedFrom(&esBuilder),
+			apmServerBuilder.WithVersion(dstVersion),
+		},
+	)
+}

--- a/test/e2e/test/apmserver/steps_mutation.go
+++ b/test/e2e/test/apmserver/steps_mutation.go
@@ -10,10 +10,17 @@ import (
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test/generation"
 )
 
 func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
-	panic("not implemented")
+	var apmServerGenerationBeforeMutation, apmServerObservedGenerationBeforeMutation int64
+	return test.StepList{
+		generation.RetrieveAgentGenerationsStep(&b.ApmServer, k, &apmServerGenerationBeforeMutation, &apmServerObservedGenerationBeforeMutation),
+	}.WithSteps(b.UpgradeTestSteps(k)).
+		WithSteps(b.CheckK8sTestSteps(k)).
+		WithSteps(b.CheckStackTestSteps(k)).
+		WithStep(generation.CompareObjectGenerationsStep(&b.ApmServer, k, &apmServerGenerationBeforeMutation, &apmServerObservedGenerationBeforeMutation))
 }
 
 func (b Builder) UpgradeTestSteps(k *test.K8sClient) test.StepList {

--- a/test/e2e/test/generation/generation.go
+++ b/test/e2e/test/generation/generation.go
@@ -1,0 +1,92 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package generation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
+	"github.com/elastic/cloud-on-k8s/test/e2e/test"
+)
+
+func getGeneration(obj client.Object, k *test.K8sClient) (int64, error) {
+	if err := k.Client.Get(context.Background(), types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}, obj); err != nil {
+		return 0, err
+	}
+
+	return obj.GetGeneration(), nil
+}
+
+func getObservedGeneration(obj client.Object, k *test.K8sClient) (int64, error) {
+	if err := k.Client.Get(context.Background(), types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}, obj); err != nil {
+		return 0, err
+	}
+
+	switch v := obj.(type) {
+	case *apmv1.ApmServer:
+		return v.Status.ObservedGeneration, nil
+	default:
+		return 0, fmt.Errorf("unsupported type while retrieving status.observedGeneration: %T", v)
+	}
+}
+
+// RetrieveAgentGenerationsStep stores the current metadata.Generation, and status.ObservedGeneration into the given fields.
+func RetrieveAgentGenerationsStep(obj client.Object, k *test.K8sClient, generation, observedGeneration *int64) test.Step {
+	return test.Step{
+		Name: "Retrieve Objects metadata.Generation, and status.ObservedGeneration for comparison purpose",
+		Test: test.Eventually(func() error {
+			objGeneration, err := getGeneration(obj, k)
+			if err != nil {
+				return err
+			}
+			*generation = objGeneration
+			objObservedGeneration, err := getObservedGeneration(obj, k)
+			if err != nil {
+				return err
+			}
+			*observedGeneration = objObservedGeneration
+			return nil
+		}),
+	}
+}
+
+// CompareObjectGenerationsStep compares the current object's metadata.generation, and status.observedGeneration
+// and fails if they don't match expectations.
+func CompareObjectGenerationsStep(obj client.Object, k *test.K8sClient, previousObjectGeneration, previousObjectObservedGeneration *int64) test.Step {
+	return test.Step{
+		Name: "Cluster metadata.generation, and status.observedGeneration should have been incremented from previous state, and should be equal",
+		Test: test.Eventually(func() error {
+			newObjectGeneration, err := getGeneration(obj, k)
+			if err != nil {
+				return err
+			}
+			if newObjectGeneration == 0 {
+				return errors.New("expected object's metadata.generation to not be empty")
+			}
+			newObjectObservedGeneration, err := getObservedGeneration(obj, k)
+			if err != nil {
+				return err
+			}
+			if newObjectObservedGeneration == 0 {
+				return errors.New("expected object's status.observedGeneration to not be empty")
+			}
+			if newObjectGeneration <= *previousObjectGeneration {
+				return errors.New("expected object's metadata.generation to be incremented")
+			}
+			if newObjectObservedGeneration <= *previousObjectObservedGeneration {
+				return errors.New("expected object's status.observedGeneration to be incremented")
+			}
+			if newObjectGeneration != newObjectObservedGeneration {
+				return fmt.Errorf("expected object's metadata.generation and status.observedGeneration to be equal; generation: %d, observedGeneration: %d", newObjectGeneration, newObjectObservedGeneration)
+			}
+			return nil
+		}),
+	}
+}


### PR DESCRIPTION
related to https://github.com/elastic/cloud-on-k8s/issues/3392
related to https://github.com/elastic/cloud-on-k8s/pull/5331

This change allows status.ObservedGeneration to be kept in sync with metadata.Generation according to the rules described in the above issue. This change adds a set of unit tests which show more details into when observedGeneration will, and will not be updated according to any errors that may occur during reconciliation. An end-to-end test is also added to show how the change is intended to function in a true cluster.