### PR TITLE
Avoid unnecessary DELETE when managing ES license secret

### DIFF
--- a/pkg/controller/license/license_controller_test.go
+++ b/pkg/controller/license/license_controller_test.go
@@ -119,22 +119,34 @@ func enterpriseLicense(t *testing.T, licenseType client.ElasticsearchLicenseType
 
 func TestReconcileLicenses_reconcileInternal(t *testing.T) {
 	tests := []struct {
-		name             string
-		cluster          *esv1.Elasticsearch
-		k8sResources     []runtime.Object
-		wantErr          string
-		wantNewLicense   bool
-		wantRequeue      bool
-		wantRequeueAfter bool
+		name               string
+		cluster            *esv1.Elasticsearch
+		k8sResources       []runtime.Object
+		wantErr            string
+		wantClusterLicense bool
+		wantRequeue        bool
+		wantRequeueAfter   bool
 	}{
 		{
-			name:             "no existing license: nothing to do",
-			cluster:          cluster,
-			k8sResources:     []runtime.Object{cluster},
-			wantErr:          "",
-			wantNewLicense:   false,
-			wantRequeue:      false,
-			wantRequeueAfter: false,
+			name:               "no existing license: nothing to do",
+			cluster:            cluster,
+			k8sResources:       []runtime.Object{cluster},
+			wantErr:            "",
+			wantClusterLicense: false,
+			wantRequeue:        false,
+			wantRequeueAfter:   false,
+		},
+		{
+			name:    "no existing license but cluster license exists: delete cluster license",
+			cluster: cluster,
+			k8sResources: []runtime.Object{cluster, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name:      esv1.LicenseSecretName("cluster"),
+				Namespace: "namespace",
+			}}},
+			wantErr:            "",
+			wantClusterLicense: false,
+			wantRequeue:        false,
+			wantRequeueAfter:   false,
 		},
 		{
 			name:    "existing gold matching license",
@@ -143,10 +155,10 @@ func TestReconcileLicenses_reconcileInternal(t *testing.T) {
 				enterpriseLicense(t, client.ElasticsearchLicenseTypeGold, 1, false),
 				cluster,
 			},
-			wantErr:          "",
-			wantNewLicense:   true,
-			wantRequeue:      false,
-			wantRequeueAfter: true,
+			wantErr:            "",
+			wantClusterLicense: true,
+			wantRequeue:        false,
+			wantRequeueAfter:   true,
 		},
 		{
 			name:    "existing platinum matching license",
@@ -155,10 +167,10 @@ func TestReconcileLicenses_reconcileInternal(t *testing.T) {
 				enterpriseLicense(t, client.ElasticsearchLicenseTypePlatinum, 1, false),
 				cluster,
 			},
-			wantErr:          "",
-			wantNewLicense:   true,
-			wantRequeue:      false,
-			wantRequeueAfter: true,
+			wantErr:            "",
+			wantClusterLicense: true,
+			wantRequeue:        false,
+			wantRequeueAfter:   true,
 		},
 		{
 			name:    "existing license expired",
@@ -167,10 +179,10 @@ func TestReconcileLicenses_reconcileInternal(t *testing.T) {
 				enterpriseLicense(t, client.ElasticsearchLicenseTypePlatinum, 1, true),
 				cluster,
 			},
-			wantErr:          "",
-			wantNewLicense:   false,
-			wantRequeue:      false,
-			wantRequeueAfter: false,
+			wantErr:            "",
+			wantClusterLicense: false,
+			wantRequeue:        false,
+			wantRequeueAfter:   false,
 		},
 	}
 	for _, tt := range tests {
@@ -201,7 +213,7 @@ func TestReconcileLicenses_reconcileInternal(t *testing.T) {
 			licenseNsn.Name = esv1.LicenseSecretName(licenseNsn.Name)
 			var license corev1.Secret
 			err = client.Get(context.Background(), licenseNsn, &license)
-			if !tt.wantNewLicense {
+			if !tt.wantClusterLicense {
 				require.True(t, apierrors.IsNotFound(err))
 			} else {
 				require.NoError(t, err)


### PR DESCRIPTION
Related to https://github.com/elastic/cloud-on-k8s/issues/5450

Removes an unconditional DELETE call when reconciling the Elasticsearch cluster license secret. This only affects installations running with a Basic license or those downgrading from an Enterprise license to basic e.g because the license expired. I added an initial GET to check if there is something to delete in the first place before we delete.