### PR TITLE
Avoid DELETEs of non-existent secrets

### DIFF
--- a/pkg/controller/apmserver/deployment.go
+++ b/pkg/controller/apmserver/deployment.go
@@ -39,7 +39,7 @@ func (r *ReconcileApmServer) reconcileApmServerDeployment(
 		return state, err
 	}
 
-	keystoreResources, err := keystore.NewResources(
+	keystoreResources, err := keystore.ReconcileResources(
 		r,
 		as,
 		Namer,

--- a/pkg/controller/beat/common/pod.go
+++ b/pkg/controller/beat/common/pod.go
@@ -74,7 +74,7 @@ func buildPodTemplate(
 ) (corev1.PodTemplateSpec, error) {
 	podTemplate := params.GetPodTemplate()
 
-	keystoreResources, err := keystore.NewResources(
+	keystoreResources, err := keystore.ReconcileResources(
 		params,
 		&params.Beat,
 		namer,

--- a/pkg/controller/common/certificates/reconcile.go
+++ b/pkg/controller/common/certificates/reconcile.go
@@ -114,19 +114,19 @@ func (r Reconciler) ReconcileCAAndHTTPCerts(ctx context.Context) (*CertificatesS
 func (r *Reconciler) removeCAAndHTTPCertsSecrets() error {
 	owner := k8s.ExtractNamespacedName(r.Owner)
 	// remove public certs secret
-	if err := deleteIfExists(r.K8sClient,
+	if err := k8s.DeleteSecretIfExists(r.K8sClient,
 		types.NamespacedName{Namespace: owner.Namespace, Name: PublicCertsSecretName(r.Namer, owner.Name)},
 	); err != nil {
 		return err
 	}
 	// remove internal certs secret
-	if err := deleteIfExists(r.K8sClient,
+	if err := k8s.DeleteSecretIfExists(r.K8sClient,
 		types.NamespacedName{Namespace: owner.Namespace, Name: InternalCertsSecretName(r.Namer, owner.Name)},
 	); err != nil {
 		return err
 	}
 	// remove CA secret
-	if err := deleteIfExists(r.K8sClient,
+	if err := k8s.DeleteSecretIfExists(r.K8sClient,
 		types.NamespacedName{Namespace: owner.Namespace, Name: CAInternalSecretName(r.Namer, owner.Name, HTTPCAType)},
 	); err != nil {
 		return err
@@ -136,10 +136,4 @@ func (r *Reconciler) removeCAAndHTTPCertsSecrets() error {
 	r.DynamicWatches.Secrets.RemoveHandlerForKey(CertificateWatchKey(r.Namer, r.Owner.GetName()))
 
 	return nil
-}
-
-func deleteIfExists(c k8s.Client, secretRef types.NamespacedName) error {
-	return k8s.DeleteSecretIfExists(c, secretRef, func() {
-		log.Info("Deleting secret", "namespace", secretRef.Namespace, "secret_name", secretRef.Name)
-	})
 }

--- a/pkg/controller/common/certificates/reconcile.go
+++ b/pkg/controller/common/certificates/reconcile.go
@@ -10,7 +10,6 @@ import (
 
 	"go.elastic.co/apm"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -140,17 +139,7 @@ func (r *Reconciler) removeCAAndHTTPCertsSecrets() error {
 }
 
 func deleteIfExists(c k8s.Client, secretRef types.NamespacedName) error {
-	var secret corev1.Secret
-	err := c.Get(context.Background(), secretRef, &secret)
-	if err != nil && apierrors.IsNotFound(err) {
-		return nil
-	} else if err != nil {
-		return err
-	}
-	log.Info("Deleting secret", "namespace", secretRef.Namespace, "secret_name", secretRef.Name)
-	err = c.Delete(context.Background(), &secret)
-	if err != nil && apierrors.IsNotFound(err) {
-		return nil
-	}
-	return err
+	return k8s.DeleteSecretIfExists(c, secretRef, func() {
+		log.Info("Deleting secret", "namespace", secretRef.Namespace, "secret_name", secretRef.Name)
+	})
 }

--- a/pkg/controller/common/keystore/resources.go
+++ b/pkg/controller/common/keystore/resources.go
@@ -44,10 +44,11 @@ func WatchedSecretNames(hasKeystore HasKeystore) []string {
 	return names
 }
 
-// NewResources optionally returns a volume and init container to include in pods,
+// ReconcileResources optionally returns a volume and init container to include in Pods,
 // in order to create a Keystore from a Secret containing secure settings provided by
 // the user and referenced in the Elastic Stack application spec.
-func NewResources(
+// It reconciles the backing secret with the API server and sets up the necessary watches.
+func ReconcileResources(
 	r driver.Interface,
 	hasKeystore HasKeystore,
 	namer name.Namer,

--- a/pkg/controller/common/keystore/resources_test.go
+++ b/pkg/controller/common/keystore/resources_test.go
@@ -72,7 +72,7 @@ func fakeFlagInitContainersParameters(skipInitializedFlag bool) InitContainerPar
 	}
 }
 
-func TestResources(t *testing.T) {
+func TestReconcileResources(t *testing.T) {
 	varFalse := false
 	tests := []struct {
 		name                    string
@@ -226,7 +226,7 @@ echo "Keystore initialization successful."
 				Watches:      watches2.NewDynamicWatches(),
 				FakeRecorder: record.NewFakeRecorder(1000),
 			}
-			resources, err := NewResources(testDriver, &tt.kb, kbNamer, nil, tt.initContainerParameters)
+			resources, err := ReconcileResources(testDriver, &tt.kb, kbNamer, nil, tt.initContainerParameters)
 			require.NoError(t, err)
 			if tt.wantNil {
 				require.Nil(t, resources)

--- a/pkg/controller/common/keystore/user_secret.go
+++ b/pkg/controller/common/keystore/user_secret.go
@@ -103,7 +103,7 @@ func reconcileSecureSettings(
 	}
 	if len(aggregatedData) == 0 {
 		// no secure settings specified, delete any existing operator-managed settings secret
-		err := k8s.DeleteSecretIfExists(c, k8s.ExtractNamespacedName(&expected), nil)
+		err := k8s.DeleteSecretIfExists(c, k8s.ExtractNamespacedName(&expected))
 		return nil, err
 	}
 

--- a/pkg/controller/common/keystore/user_secret.go
+++ b/pkg/controller/common/keystore/user_secret.go
@@ -103,11 +103,7 @@ func reconcileSecureSettings(
 	}
 	if len(aggregatedData) == 0 {
 		// no secure settings specified, delete any existing operator-managed settings secret
-		err := c.Delete(context.Background(), &expected)
-		if apierrors.IsNotFound(err) {
-			// swallow not found errors
-			return nil, nil
-		}
+		err := k8s.DeleteSecretIfExists(c, k8s.ExtractNamespacedName(&expected), nil)
 		return nil, err
 	}
 

--- a/pkg/controller/elasticsearch/certificates/transport/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/transport/reconcile.go
@@ -76,7 +76,7 @@ func DeleteStatefulSetTransportCertificate(client k8s.Client, namespace string, 
 // DeleteLegacyTransportCertificate ensures that the former Secret which used to contain the transport certificates is deleted.
 func DeleteLegacyTransportCertificate(client k8s.Client, es esv1.Elasticsearch) error {
 	nsn := types.NamespacedName{Namespace: es.Namespace, Name: esv1.LegacyTransportCertsSecretSuffix(es.Name)}
-	return k8s.DeleteSecretIfExists(client, nsn, nil)
+	return k8s.DeleteSecretIfExists(client, nsn)
 }
 
 // reconcileNodeSetTransportCertificatesSecrets reconciles the secret which contains the transport certificates for

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -286,7 +286,7 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	}
 
 	// setup a keystore with secure settings in an init container, if specified by the user
-	keystoreResources, err := keystore.NewResources(
+	keystoreResources, err := keystore.ReconcileResources(
 		d,
 		&d.ES,
 		esv1.ESNamer,

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -205,7 +205,7 @@ func (d *driver) deploymentParams(kb *kbv1.Kibana) (deployment.Params, error) {
 		return deployment.Params{}, err
 	}
 	// setup a keystore with secure settings in an init container, if specified by the user
-	keystoreResources, err := keystore.NewResources(
+	keystoreResources, err := keystore.ReconcileResources(
 		d,
 		kb,
 		kbv1.KBNamer,

--- a/pkg/controller/license/license_controller.go
+++ b/pkg/controller/license/license_controller.go
@@ -200,9 +200,8 @@ func (r *ReconcileLicenses) reconcileClusterLicense(cluster esv1.Elasticsearch) 
 	if !found {
 		// no matching license found, delete cluster level license if it exists to revert to basic
 		clusterLicenseNSN := types.NamespacedName{Namespace: cluster.Namespace, Name: esv1.LicenseSecretName(cluster.Name)}
-		err := k8s.DeleteSecretIfExists(r.Client, clusterLicenseNSN, func() {
-			log.V(1).Info("No enterprise license found. Attempting to remove cluster license secret", "namespace", cluster.Namespace, "es_name", cluster.Name)
-		})
+		log.V(1).Info("No enterprise license found. Attempting to remove cluster license secret", "namespace", cluster.Namespace, "es_name", cluster.Name)
+		err := k8s.DeleteSecretIfExists(r.Client, clusterLicenseNSN)
 		return noResult, false, err
 	}
 	log.V(1).Info("Found license for cluster", "eck_license", parent, "es_license", matchingSpec.UID, "license_type", matchingSpec.Type, "namespace", cluster.Namespace, "es_name", cluster.Name)

--- a/pkg/controller/license/license_controller_test.go
+++ b/pkg/controller/license/license_controller_test.go
@@ -119,22 +119,34 @@ func enterpriseLicense(t *testing.T, licenseType client.ElasticsearchLicenseType
 
 func TestReconcileLicenses_reconcileInternal(t *testing.T) {
 	tests := []struct {
-		name             string
-		cluster          *esv1.Elasticsearch
-		k8sResources     []runtime.Object
-		wantErr          string
-		wantNewLicense   bool
-		wantRequeue      bool
-		wantRequeueAfter bool
+		name               string
+		cluster            *esv1.Elasticsearch
+		k8sResources       []runtime.Object
+		wantErr            string
+		wantClusterLicense bool
+		wantRequeue        bool
+		wantRequeueAfter   bool
 	}{
 		{
-			name:             "no existing license: nothing to do",
-			cluster:          cluster,
-			k8sResources:     []runtime.Object{cluster},
-			wantErr:          "",
-			wantNewLicense:   false,
-			wantRequeue:      false,
-			wantRequeueAfter: false,
+			name:               "no existing license: nothing to do",
+			cluster:            cluster,
+			k8sResources:       []runtime.Object{cluster},
+			wantErr:            "",
+			wantClusterLicense: false,
+			wantRequeue:        false,
+			wantRequeueAfter:   false,
+		},
+		{
+			name:    "no existing license but cluster license exists: delete cluster license",
+			cluster: cluster,
+			k8sResources: []runtime.Object{cluster, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name:      esv1.LicenseSecretName("cluster"),
+				Namespace: "namespace",
+			}}},
+			wantErr:            "",
+			wantClusterLicense: false,
+			wantRequeue:        false,
+			wantRequeueAfter:   false,
 		},
 		{
 			name:    "existing gold matching license",
@@ -143,10 +155,10 @@ func TestReconcileLicenses_reconcileInternal(t *testing.T) {
 				enterpriseLicense(t, client.ElasticsearchLicenseTypeGold, 1, false),
 				cluster,
 			},
-			wantErr:          "",
-			wantNewLicense:   true,
-			wantRequeue:      false,
-			wantRequeueAfter: true,
+			wantErr:            "",
+			wantClusterLicense: true,
+			wantRequeue:        false,
+			wantRequeueAfter:   true,
 		},
 		{
 			name:    "existing platinum matching license",
@@ -155,10 +167,10 @@ func TestReconcileLicenses_reconcileInternal(t *testing.T) {
 				enterpriseLicense(t, client.ElasticsearchLicenseTypePlatinum, 1, false),
 				cluster,
 			},
-			wantErr:          "",
-			wantNewLicense:   true,
-			wantRequeue:      false,
-			wantRequeueAfter: true,
+			wantErr:            "",
+			wantClusterLicense: true,
+			wantRequeue:        false,
+			wantRequeueAfter:   true,
 		},
 		{
 			name:    "existing license expired",
@@ -167,10 +179,10 @@ func TestReconcileLicenses_reconcileInternal(t *testing.T) {
 				enterpriseLicense(t, client.ElasticsearchLicenseTypePlatinum, 1, true),
 				cluster,
 			},
-			wantErr:          "",
-			wantNewLicense:   false,
-			wantRequeue:      false,
-			wantRequeueAfter: false,
+			wantErr:            "",
+			wantClusterLicense: false,
+			wantRequeue:        false,
+			wantRequeueAfter:   false,
 		},
 	}
 	for _, tt := range tests {
@@ -201,7 +213,7 @@ func TestReconcileLicenses_reconcileInternal(t *testing.T) {
 			licenseNsn.Name = esv1.LicenseSecretName(licenseNsn.Name)
 			var license corev1.Secret
 			err = client.Get(context.Background(), licenseNsn, &license)
-			if !tt.wantNewLicense {
+			if !tt.wantClusterLicense {
 				require.True(t, apierrors.IsNotFound(err))
 			} else {
 				require.NoError(t, err)

--- a/pkg/utils/k8s/k8sutils.go
+++ b/pkg/utils/k8s/k8sutils.go
@@ -168,18 +168,14 @@ func DeleteSecretMatching(c Client, opts ...client.ListOption) error {
 	return nil
 }
 
-// DeleteSecretIfExists deletes the secret identified by key if exists. Takes an optional hook function to be run when
-// a deletion is attempted.
-func DeleteSecretIfExists(c Client, key types.NamespacedName, onDelete func()) error {
+// DeleteSecretIfExists deletes the secret identified by key if exists.
+func DeleteSecretIfExists(c Client, key types.NamespacedName) error {
 	var secret corev1.Secret
 	err := c.Get(context.Background(), key, &secret)
 	if err != nil && apierrors.IsNotFound(err) {
 		return nil
 	} else if err != nil {
 		return err
-	}
-	if onDelete != nil {
-		onDelete()
 	}
 	err = c.Delete(context.Background(), &secret)
 	if err != nil && apierrors.IsNotFound(err) {

--- a/pkg/utils/k8s/k8sutils.go
+++ b/pkg/utils/k8s/k8sutils.go
@@ -181,7 +181,11 @@ func DeleteSecretIfExists(c Client, key types.NamespacedName, onDelete func()) e
 	if onDelete != nil {
 		onDelete()
 	}
-	return c.Delete(context.Background(), &secret)
+	err = c.Delete(context.Background(), &secret)
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
 }
 
 // PodsMatchingLabels returns Pods from the given namespace matching the given labels.

--- a/pkg/utils/k8s/k8sutils.go
+++ b/pkg/utils/k8s/k8sutils.go
@@ -168,6 +168,22 @@ func DeleteSecretMatching(c Client, opts ...client.ListOption) error {
 	return nil
 }
 
+// DeleteSecretIfExists deletes the secret identified by key if exists. Takes an optional hook function to be run when
+// a deletion is attempted.
+func DeleteSecretIfExists(c Client, key types.NamespacedName, onDelete func()) error {
+	var secret corev1.Secret
+	err := c.Get(context.Background(), key, &secret)
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	if onDelete != nil {
+		onDelete()
+	}
+	return c.Delete(context.Background(), &secret)
+}
+
 // PodsMatchingLabels returns Pods from the given namespace matching the given labels.
 func PodsMatchingLabels(c Client, namespace string, labels map[string]string) ([]corev1.Pod, error) {
 	var pods corev1.PodList


### PR DESCRIPTION
Related to https://github.com/elastic/cloud-on-k8s/issues/5450

This PR guards DELETE calls on secrets (cluster license, secure settings, legacy transport certs) with a GET call through a new shared utility function to remove unnecessary load on the API server. 

It also renames `keystore.NewResources`  to `keystore.ReconcileResources`, which I am happy to back out into a separate PR if that's people are uncomfortable. The reason for this rename was that while I was tracking down these DELETES, I was confused and surprised to find reconciliation activity happening in a function that appeared to be a simple constructor with `New*` in the name. 