### PR TITLE
Add known issue for Red Hat certified operator upgrades

### DIFF
--- a/docs/release-notes/highlights-1.9.0.asciidoc
+++ b/docs/release-notes/highlights-1.9.0.asciidoc
@@ -34,5 +34,6 @@ Following the Elastic Stack licensing changes in `7.11.0`, ECK `1.9.0` moves to 
 [id="{p}-190-known-issues"]
 === Known issues
 
+- When using the Red Hat certified version of the operator automatic upgrades from previous versions of ECK do not work. To upgrade remove the old ECK operator installation and install the new version manually. Because CRDs remain in place after removal this operation should not negatively affect existing Elastic Stack deployments managed by ECK.
 - On Openshift versions 4.6 and below, when installing or upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and found in a `CrashLoopBackoff` within Kubernetes because of Webhook certificate location mismatches. More information and work-around can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[this issue].
 - When using the `elasticsearchRef` mechanism with Elastic Agent in version 7.17 and later its Pods will enter a `CrashLoopBackoff`. The issue will be fixed in ECK 2.0 for Elasticsearch versions 8.0 and above. A workaround is described in link:https://github.com/elastic/cloud-on-k8s/issues/5323#issuecomment-1028954034[this issue].

--- a/docs/release-notes/highlights-1.9.0.asciidoc
+++ b/docs/release-notes/highlights-1.9.0.asciidoc
@@ -34,6 +34,5 @@ Following the Elastic Stack licensing changes in `7.11.0`, ECK `1.9.0` moves to 
 [id="{p}-190-known-issues"]
 === Known issues
 
-- When using the Red Hat certified version of the operator automatic upgrades from previous versions of ECK do not work. To upgrade remove the old ECK operator installation and install the new version manually. Because CRDs remain in place after removal this operation should not negatively affect existing Elastic Stack deployments managed by ECK.
 - On Openshift versions 4.6 and below, when installing or upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and found in a `CrashLoopBackoff` within Kubernetes because of Webhook certificate location mismatches. More information and work-around can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[this issue].
 - When using the `elasticsearchRef` mechanism with Elastic Agent in version 7.17 and later its Pods will enter a `CrashLoopBackoff`. The issue will be fixed in ECK 2.0 for Elasticsearch versions 8.0 and above. A workaround is described in link:https://github.com/elastic/cloud-on-k8s/issues/5323#issuecomment-1028954034[this issue].

--- a/docs/release-notes/highlights-1.9.1.asciidoc
+++ b/docs/release-notes/highlights-1.9.1.asciidoc
@@ -18,5 +18,6 @@ This release introduces a preemptive measure to mitigate link:https://github.com
 [id="{p}-191-known-issues"]
 === Known issues
 
+- When using the Red Hat certified version of the operator automatic upgrades from previous versions of ECK do not work. To upgrade remove the old ECK operator installation and install the new version manually. Because CRDs remain in place after removal this operation should not negatively affect existing Elastic Stack deployments managed by ECK.
 - On Openshift versions 4.6 and below, when installing or upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and seen in a `CrashLoopBackoff` within Kubernetes because of Webhook certificate location mismatches. More information and workaround can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[this issue].
 - When using the `elasticsearchRef` mechanism with Elastic Agent in version 7.17 and later its Pods will enter a `CrashLoopBackoff`. The issue will be fixed in ECK 2.0 for Elasticsearch versions 8.0 and above. A workaround is described in link:https://github.com/elastic/cloud-on-k8s/issues/5323#issuecomment-1028954034[this issue].

--- a/docs/release-notes/highlights-1.9.1.asciidoc
+++ b/docs/release-notes/highlights-1.9.1.asciidoc
@@ -18,6 +18,6 @@ This release introduces a preemptive measure to mitigate link:https://github.com
 [id="{p}-191-known-issues"]
 === Known issues
 
-- When using the Red Hat certified version of the operator automatic upgrades from previous versions of ECK do not work. To upgrade remove the old ECK operator installation and install the new version manually. Because CRDs remain in place after removal this operation should not negatively affect existing Elastic Stack deployments managed by ECK.
+- When using the Red Hat certified version of the operator, automatic upgrades from previous versions of ECK do not work. To upgrade uninstall the old ECK operator and install the new version manually. Because CRDs remain in place after uninstalling, this operation should not negatively affect existing Elastic Stack deployments managed by ECK.
 - On Openshift versions 4.6 and below, when installing or upgrading to 1.9.[0,1], the operator will be stuck in a state of `Installing` within the Openshift UI, and seen in a `CrashLoopBackoff` within Kubernetes because of Webhook certificate location mismatches. More information and workaround can be found in link:https://github.com/elastic/cloud-on-k8s/issues/5191[this issue].
 - When using the `elasticsearchRef` mechanism with Elastic Agent in version 7.17 and later its Pods will enter a `CrashLoopBackoff`. The issue will be fixed in ECK 2.0 for Elasticsearch versions 8.0 and above. A workaround is described in link:https://github.com/elastic/cloud-on-k8s/issues/5323#issuecomment-1028954034[this issue].

--- a/docs/release-notes/highlights-2.0.0.asciidoc
+++ b/docs/release-notes/highlights-2.0.0.asciidoc
@@ -28,4 +28,5 @@ When orchestrating Elasticsearch version 7.15.2 or later ECK will use the new li
 [id="{p}-200-known-issues"]
 === Known issues
 
+- When using the Red Hat certified version of the operator automatic upgrades from previous versions of ECK do not work. To upgrade remove the old ECK operator installation and install the new version manually. Because CRDs remain in place after removal this operation should not negatively affect existing Elastic Stack deployments managed by ECK.
 - When using the `elasticsearchRef` mechanism with Elastic Agent in version 7.17 its Pods will enter a `CrashLoopBackoff`. A workaround is described in link:https://github.com/elastic/cloud-on-k8s/issues/5323#issuecomment-1028954034[this issue].

--- a/docs/release-notes/highlights-2.0.0.asciidoc
+++ b/docs/release-notes/highlights-2.0.0.asciidoc
@@ -28,5 +28,5 @@ When orchestrating Elasticsearch version 7.15.2 or later ECK will use the new li
 [id="{p}-200-known-issues"]
 === Known issues
 
-- When using the Red Hat certified version of the operator automatic upgrades from previous versions of ECK do not work. To upgrade remove the old ECK operator installation and install the new version manually. Because CRDs remain in place after removal this operation should not negatively affect existing Elastic Stack deployments managed by ECK.
+- When using the Red Hat certified version of the operator, automatic upgrades from previous versions of ECK do not work. To upgrade uninstall the old ECK operator and install the new version manually. Because CRDs remain in place after uninstalling, this operation should not negatively affect existing Elastic Stack deployments managed by ECK.
 - When using the `elasticsearchRef` mechanism with Elastic Agent in version 7.17 its Pods will enter a `CrashLoopBackoff`. A workaround is described in link:https://github.com/elastic/cloud-on-k8s/issues/5323#issuecomment-1028954034[this issue].


### PR DESCRIPTION
This adds a known issue to the release highlights for 1.9.1 and 2.0.0 explaining the workaround for the broken upgrade graph on the Red Hat certified version of the operator
