### PR TITLE
Upgrade stack version to 8.1.0 in samples and tests

### DIFF
--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -58,14 +58,14 @@ pipeline {
                 )}"""
             }
             parallel {
-                stage("8.1.0-SNAPSHOT") {
+                stage("8.2.0-SNAPSHOT") {
                      agent {
                         label 'linux'
                     }
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-8x-snapshot-${BUILD_NUMBER}-e2e", "8.1.0-SNAPSHOT")
+                            runWith(lib, failedTests, "eck-8x-snapshot-${BUILD_NUMBER}-e2e", "8.2.0-SNAPSHOT")
                         }
                     }
                 }

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-68-${BUILD_NUMBER}-e2e", "6.8.17")
+                            runWith(lib, failedTests, "eck-68-${BUILD_NUMBER}-e2e", "6.8.23")
                         }
                     }
                 }

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -145,25 +145,25 @@ pipeline {
                         }
                     }
                }
-               stage("7.17.0") {
+               stage("7.17.1") {
                     agent {
                         label 'linux'
                     }
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-717-${BUILD_NUMBER}-e2e", "7.17.0")
+                            runWith(lib, failedTests, "eck-717-${BUILD_NUMBER}-e2e", "7.17.1")
                         }
                     }
                }
-               stage("8.0.0") {
+               stage("8.0.1") {
                     agent {
                         label 'linux'
                     }
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-800-${BUILD_NUMBER}-e2e", "8.0.0")
+                            runWith(lib, failedTests, "eck-800-${BUILD_NUMBER}-e2e", "8.0.1")
                         }
                     }
                }

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -46,28 +46,6 @@ pipeline {
                         }
                     }
                 }
-                stage("7.6.2") {
-                    agent {
-                        label 'linux'
-                    }
-                    steps {
-                        unstash "source"
-                        script {
-                            runWith(lib, failedTests, "eck-76-${BUILD_NUMBER}-e2e", "7.6.2")
-                        }
-                    }
-                }
-                stage("7.7.1") {
-                    agent {
-                        label 'linux'
-                    }
-                    steps {
-                        unstash "source"
-                        script {
-                            runWith(lib, failedTests, "eck-77-${BUILD_NUMBER}-e2e", "7.7.1")
-                        }
-                    }
-                }
                 stage("7.8.1") {
                     agent {
                         label 'linux'
@@ -178,6 +156,28 @@ pipeline {
                         }
                     }
                }
+               stage("8.0.0") {
+                    agent {
+                        label 'linux'
+                    }
+                    steps {
+                        unstash "source"
+                        script {
+                            runWith(lib, failedTests, "eck-800-${BUILD_NUMBER}-e2e", "8.0.0")
+                        }
+                    }
+               }
+               stage("8.1.0") {
+                    agent {
+                        label 'linux'
+                    }
+                    steps {
+                        unstash "source"
+                        script {
+                            runWith(lib, failedTests, "eck-810-${BUILD_NUMBER}-e2e", "8.1.0")
+                        }
+                    }
+               }
             }
         }
     }
@@ -208,8 +208,6 @@ pipeline {
             script {
                 clusters = [
                     "eck-68-${BUILD_NUMBER}-e2e",
-                    "eck-76-${BUILD_NUMBER}-e2e",
-                    "eck-77-${BUILD_NUMBER}-e2e",
                     "eck-78-${BUILD_NUMBER}-e2e",
                     "eck-79-${BUILD_NUMBER}-e2e",
                     "eck-710-${BUILD_NUMBER}-e2e",
@@ -219,7 +217,9 @@ pipeline {
                     "eck-714-${BUILD_NUMBER}-e2e",
                     "eck-715-${BUILD_NUMBER}-e2e",
                     "eck-716-${BUILD_NUMBER}-e2e",
-                    "eck-717-${BUILD_NUMBER}-e2e"
+                    "eck-717-${BUILD_NUMBER}-e2e",
+                    "eck-800-${BUILD_NUMBER}-e2e",
+                    "eck-810-${BUILD_NUMBER}-e2e"
                 ]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',

--- a/Makefile
+++ b/Makefile
@@ -430,7 +430,7 @@ ifneq ($(strip $(E2E_IMG_TAG_SUFFIX)),) # If the suffix is not empty, append it 
 endif
 
 E2E_IMG                    ?= $(REGISTRY)/$(E2E_REGISTRY_NAMESPACE)/eck-e2e-tests:$(E2E_IMG_TAG)
-E2E_STACK_VERSION          ?= 8.0.0
+E2E_STACK_VERSION          ?= 8.1.0
 export TESTS_MATCH         ?= "^Test" # can be overriden to eg. TESTS_MATCH=TestMutationMoreNodes to match a single test
 export E2E_JSON            ?= false
 TEST_TIMEOUT               ?= 30m

--- a/Makefile
+++ b/Makefile
@@ -430,7 +430,7 @@ ifneq ($(strip $(E2E_IMG_TAG_SUFFIX)),) # If the suffix is not empty, append it 
 endif
 
 E2E_IMG                    ?= $(REGISTRY)/$(E2E_REGISTRY_NAMESPACE)/eck-e2e-tests:$(E2E_IMG_TAG)
-E2E_STACK_VERSION          ?= 8.1.0
+E2E_STACK_VERSION          ?= 8.1.1
 export TESTS_MATCH         ?= "^Test" # can be overriden to eg. TESTS_MATCH=TestMutationMoreNodes to match a single test
 export E2E_JSON            ?= false
 TEST_TIMEOUT               ?= 30m

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -8,7 +8,7 @@ metadata:
     k8s-app: metricbeat
 spec:
   type: metricbeat
-  version: 8.0.0
+  version: 8.1.0
   config:
     metricbeat.modules:
     - module: kubernetes
@@ -224,7 +224,7 @@ metadata:
     k8s-app: filebeat
 spec:
   type: filebeat
-  version: 8.0.0
+  version: 8.1.0
   config:
     max_backoff: 1s # reduces worst case delay between log being written and picked up by Filebeat to 1s
     close_inactive: 1h # keep harvester open for 1h on inactive files as our test timeout is longer than default 5m

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -8,7 +8,7 @@ metadata:
     k8s-app: metricbeat
 spec:
   type: metricbeat
-  version: 8.1.0
+  version: 8.1.1
   config:
     metricbeat.modules:
     - module: kubernetes
@@ -224,7 +224,7 @@ metadata:
     k8s-app: filebeat
 spec:
   type: filebeat
-  version: 8.1.0
+  version: 8.1.1
   config:
     max_backoff: 1s # reduces worst case delay between log being written and picked up by Filebeat to 1s
     close_inactive: 1h # keep harvester open for 1h on inactive files as our test timeout is longer than default 5m

--- a/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
+++ b/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
@@ -4,7 +4,7 @@ metadata:
   name: apm-server-quickstart
   namespace: default
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   config:
     name: elastic-apm

--- a/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
+++ b/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
@@ -4,7 +4,7 @@ metadata:
   name: apm-server-quickstart
   namespace: default
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   config:
     name: elastic-apm

--- a/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
+++ b/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
@@ -84,7 +84,7 @@ metadata:
   name: elasticsearch-sample
   namespace: elasticsearch-ns
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
     - name: default
       count: 1
@@ -97,7 +97,7 @@ metadata:
   name: kibana-sample
   namespace: kibana-ns
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"
@@ -111,7 +111,7 @@ metadata:
   name: apm-apm-sample
   namespace: apmserver-ns
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
+++ b/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
@@ -84,7 +84,7 @@ metadata:
   name: elasticsearch-sample
   namespace: elasticsearch-ns
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
     - name: default
       count: 1
@@ -97,7 +97,7 @@ metadata:
   name: kibana-sample
   namespace: kibana-ns
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"
@@ -111,7 +111,7 @@ metadata:
   name: apm-apm-sample
   namespace: apmserver-ns
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/config/recipes/autoscaling/elasticsearch.yaml
+++ b/config/recipes/autoscaling/elasticsearch.yaml
@@ -37,7 +37,7 @@ metadata:
           }]
       }
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
     - name: master
       count: 1

--- a/config/recipes/autoscaling/elasticsearch.yaml
+++ b/config/recipes/autoscaling/elasticsearch.yaml
@@ -37,7 +37,7 @@ metadata:
           }]
       }
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
     - name: master
       count: 1

--- a/config/recipes/beats/auditbeat_hosts.yaml
+++ b/config/recipes/beats/auditbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: auditbeat
 spec:
   type: auditbeat
-  version: 8.1.0
+  version: 8.1.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -76,7 +76,7 @@ spec:
         #    path: /run
         #initContainers:
         #- name: cos-init
-        #  image: docker.elastic.co/beats/auditbeat:8.1.0
+        #  image: docker.elastic.co/beats/auditbeat:8.1.1
         #  volumeMounts:
         #  - name: run
         #    mountPath: /run
@@ -118,7 +118,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -130,7 +130,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/auditbeat_hosts.yaml
+++ b/config/recipes/beats/auditbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: auditbeat
 spec:
   type: auditbeat
-  version: 8.0.0
+  version: 8.1.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -76,7 +76,7 @@ spec:
         #    path: /run
         #initContainers:
         #- name: cos-init
-        #  image: docker.elastic.co/beats/auditbeat:8.0.0
+        #  image: docker.elastic.co/beats/auditbeat:8.1.0
         #  volumeMounts:
         #  - name: run
         #    mountPath: /run
@@ -118,7 +118,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -130,7 +130,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.1.0
+  version: 8.1.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -100,7 +100,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -112,7 +112,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.0.0
+  version: 8.1.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -100,7 +100,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -112,7 +112,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
+++ b/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.0.0
+  version: 8.1.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -102,7 +102,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -114,7 +114,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
+++ b/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.1.0
+  version: 8.1.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -102,7 +102,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -114,7 +114,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_no_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_no_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.0.0
+  version: 8.1.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -53,7 +53,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -65,7 +65,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_no_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_no_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.1.0
+  version: 8.1.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -53,7 +53,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -65,7 +65,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/heartbeat_es_kb_health.yaml
+++ b/config/recipes/beats/heartbeat_es_kb_health.yaml
@@ -4,7 +4,7 @@ metadata:
   name: heartbeat
 spec:
   type: heartbeat
-  version: 8.1.0
+  version: 8.1.1
   elasticsearchRef:
     name: elasticsearch
   config:
@@ -27,7 +27,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -39,7 +39,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/heartbeat_es_kb_health.yaml
+++ b/config/recipes/beats/heartbeat_es_kb_health.yaml
@@ -4,7 +4,7 @@ metadata:
   name: heartbeat
 spec:
   type: heartbeat
-  version: 8.0.0
+  version: 8.1.0
   elasticsearchRef:
     name: elasticsearch
   config:
@@ -27,7 +27,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -39,7 +39,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/metricbeat_hosts.yaml
+++ b/config/recipes/beats/metricbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 8.1.0
+  version: 8.1.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -174,7 +174,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -186,7 +186,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/metricbeat_hosts.yaml
+++ b/config/recipes/beats/metricbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 8.0.0
+  version: 8.1.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -174,7 +174,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -186,7 +186,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/openshift_monitoring.yaml
+++ b/config/recipes/beats/openshift_monitoring.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 8.1.0
+  version: 8.1.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -221,7 +221,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.1.0
+  version: 8.1.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -316,7 +316,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -328,7 +328,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/openshift_monitoring.yaml
+++ b/config/recipes/beats/openshift_monitoring.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 8.0.0
+  version: 8.1.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -221,7 +221,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.0.0
+  version: 8.1.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -316,7 +316,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -328,7 +328,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/packetbeat_dns_http.yaml
+++ b/config/recipes/beats/packetbeat_dns_http.yaml
@@ -4,7 +4,7 @@ metadata:
   name: packetbeat
 spec:
   type: packetbeat
-  version: 8.0.0
+  version: 8.1.0
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -44,7 +44,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -56,7 +56,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/packetbeat_dns_http.yaml
+++ b/config/recipes/beats/packetbeat_dns_http.yaml
@@ -4,7 +4,7 @@ metadata:
   name: packetbeat
 spec:
   type: packetbeat
-  version: 8.1.0
+  version: 8.1.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -44,7 +44,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -56,7 +56,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -6,7 +6,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 8.1.0
+  version: 8.1.1
   elasticsearchRef:
     name: elasticsearch-monitoring
   config:
@@ -118,7 +118,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.1.0
+  version: 8.1.1
   elasticsearchRef:
     name: elasticsearch-monitoring
   kibanaRef:
@@ -216,7 +216,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -232,7 +232,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -249,7 +249,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-monitoring
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -261,7 +261,7 @@ kind: Kibana
 metadata:
   name: kibana-monitoring
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch-monitoring

--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -6,7 +6,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 8.0.0
+  version: 8.1.0
   elasticsearchRef:
     name: elasticsearch-monitoring
   config:
@@ -118,7 +118,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.0.0
+  version: 8.1.0
   elasticsearchRef:
     name: elasticsearch-monitoring
   kibanaRef:
@@ -216,7 +216,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -232,7 +232,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -249,7 +249,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-monitoring
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -261,7 +261,7 @@ kind: Kibana
 metadata:
   name: kibana-monitoring
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch-monitoring

--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -60,7 +60,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -72,7 +72,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 8.1.0
+  version: 8.1.1
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -93,7 +93,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 8.1.0
+  version: 8.1.1
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -60,7 +60,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -72,7 +72,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 8.0.0
+  version: 8.1.0
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -93,7 +93,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 8.0.0
+  version: 8.1.0
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -69,7 +69,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -81,7 +81,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 8.1.0
+  version: 8.1.1
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -102,7 +102,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 8.1.0
+  version: 8.1.1
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -69,7 +69,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -81,7 +81,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 8.0.0
+  version: 8.1.0
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -102,7 +102,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 8.0.0
+  version: 8.1.0
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -55,7 +55,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -67,7 +67,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 8.0.0
+  version: 8.1.0
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -88,7 +88,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 8.0.0
+  version: 8.1.0
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -55,7 +55,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -67,7 +67,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 8.1.0
+  version: 8.1.1
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -88,7 +88,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 8.1.0
+  version: 8.1.1
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/kubernetes-integration.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 8.0.0
+  version: 8.1.0
   elasticsearchRefs:
   - name: elasticsearch
   daemonSet:
@@ -175,7 +175,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -187,7 +187,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/elastic-agent/kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/kubernetes-integration.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 8.1.0
+  version: 8.1.1
   elasticsearchRefs:
   - name: elasticsearch
   daemonSet:
@@ -175,7 +175,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -187,7 +187,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/elastic-agent/multi-output.yaml
+++ b/config/recipes/elastic-agent/multi-output.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 8.0.0
+  version: 8.1.0
   elasticsearchRefs:
   - outputName: default
     name: elasticsearch
@@ -197,7 +197,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -209,7 +209,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -219,7 +219,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-mon
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -231,7 +231,7 @@ kind: Kibana
 metadata:
   name: kibana-mon
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch-mon

--- a/config/recipes/elastic-agent/multi-output.yaml
+++ b/config/recipes/elastic-agent/multi-output.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 8.1.0
+  version: 8.1.1
   elasticsearchRefs:
   - outputName: default
     name: elasticsearch
@@ -197,7 +197,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -209,7 +209,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -219,7 +219,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-mon
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -231,7 +231,7 @@ kind: Kibana
 metadata:
   name: kibana-mon
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch-mon

--- a/config/recipes/elastic-agent/system-integration.yaml
+++ b/config/recipes/elastic-agent/system-integration.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 8.0.0
+  version: 8.1.0
   elasticsearchRefs:
   - name: elasticsearch
   daemonSet:
@@ -34,7 +34,7 @@ spec:
       meta:
         package:
           name: system
-          version: 8.0.0
+          version: 8.1.0
       data_stream:
         namespace: default
       streams:
@@ -139,7 +139,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -151,7 +151,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/elastic-agent/system-integration.yaml
+++ b/config/recipes/elastic-agent/system-integration.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 8.1.0
+  version: 8.1.1
   elasticsearchRefs:
   - name: elasticsearch
   daemonSet:
@@ -34,7 +34,7 @@ spec:
       meta:
         package:
           name: system
-          version: 8.1.0
+          version: 8.1.1
       data_stream:
         namespace: default
       streams:
@@ -139,7 +139,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -151,7 +151,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/gclb/01-elastic-stack.yaml
+++ b/config/recipes/gclb/01-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.1.0
+  version: 8.1.1
   http:
     service:
       metadata:
@@ -45,7 +45,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   http:
     service:

--- a/config/recipes/gclb/01-elastic-stack.yaml
+++ b/config/recipes/gclb/01-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.0.0
+  version: 8.1.0
   http:
     service:
       metadata:
@@ -45,7 +45,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   http:
     service:

--- a/config/recipes/gclb/99-kibana-path.yaml
+++ b/config/recipes/gclb/99-kibana-path.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: thor
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   config:
     # Make Kibana aware of the fact that it is behind a proxy

--- a/config/recipes/gclb/99-kibana-path.yaml
+++ b/config/recipes/gclb/99-kibana-path.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: thor
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   config:
     # Make Kibana aware of the fact that it is behind a proxy

--- a/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
+++ b/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 8.1.0
+  version: 8.1.1
   http:
     tls:
       selfSignedCertificate:
@@ -82,7 +82,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   http:
     tls:

--- a/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
+++ b/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 8.0.0
+  version: 8.1.0
   http:
     tls:
       selfSignedCertificate:
@@ -82,7 +82,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   http:
     tls:

--- a/config/recipes/logstash/logstash.yaml
+++ b/config/recipes/logstash/logstash.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: eck-logstash
     app.kubernetes.io/component: elasticsearch
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
     - name: default
       count: 3
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/name: eck-logstash
     app.kubernetes.io/component: kibana
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -92,7 +92,7 @@ spec:
     spec:
       containers:
         - name: logstash
-          image: docker.elastic.co/logstash/logstash:8.1.0
+          image: docker.elastic.co/logstash/logstash:8.1.1
           ports:
             - name: "tcp-beats"
               containerPort: 5044
@@ -150,7 +150,7 @@ metadata:
     app.kubernetes.io/component: filebeat
 spec:
   type: filebeat
-  version: 8.1.0
+  version: 8.1.1
   config:
     filebeat.inputs:
       - type: log

--- a/config/recipes/logstash/logstash.yaml
+++ b/config/recipes/logstash/logstash.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: eck-logstash
     app.kubernetes.io/component: elasticsearch
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
     - name: default
       count: 3
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/name: eck-logstash
     app.kubernetes.io/component: kibana
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -92,7 +92,7 @@ spec:
     spec:
       containers:
         - name: logstash
-          image: docker.elastic.co/logstash/logstash:8.0.0
+          image: docker.elastic.co/logstash/logstash:8.1.0
           ports:
             - name: "tcp-beats"
               containerPort: 5044
@@ -150,7 +150,7 @@ metadata:
     app.kubernetes.io/component: filebeat
 spec:
   type: filebeat
-  version: 8.0.0
+  version: 8.1.0
   config:
     filebeat.inputs:
       - type: log

--- a/config/recipes/maps/01-ems.yaml
+++ b/config/recipes/maps/01-ems.yaml
@@ -3,5 +3,5 @@ kind: ElasticMapsServer
 metadata:
   name: ems-sample
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1

--- a/config/recipes/maps/01-ems.yaml
+++ b/config/recipes/maps/01-ems.yaml
@@ -3,5 +3,5 @@ kind: ElasticMapsServer
 metadata:
   name: ems-sample
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1

--- a/config/recipes/maps/02-es-kb.yaml
+++ b/config/recipes/maps/02-es-kb.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
     - name: default
       count: 3
@@ -27,7 +27,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   config:
     # Configure this to a domain you control

--- a/config/recipes/maps/02-es-kb.yaml
+++ b/config/recipes/maps/02-es-kb.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
     - name: default
       count: 3
@@ -27,7 +27,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   config:
     # Configure this to a domain you control

--- a/config/recipes/traefik/02-elastic-stack.yaml
+++ b/config/recipes/traefik/02-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: master
     count: 1
@@ -41,7 +41,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: hulk
@@ -53,7 +53,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: hulk

--- a/config/recipes/traefik/02-elastic-stack.yaml
+++ b/config/recipes/traefik/02-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: master
     count: 1
@@ -41,7 +41,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: hulk
@@ -53,7 +53,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: hulk

--- a/config/samples/apm/apm_es_kibana.yaml
+++ b/config/samples/apm/apm_es_kibana.yaml
@@ -5,7 +5,7 @@ kind: Elasticsearch
 metadata:
   name: es-apm-sample
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 3
@@ -19,7 +19,7 @@ kind: Kibana
 metadata:
   name: kb-apm-sample
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"
@@ -33,7 +33,7 @@ kind: ApmServer
 metadata:
   name: apm-apm-sample
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"

--- a/config/samples/apm/apm_es_kibana.yaml
+++ b/config/samples/apm/apm_es_kibana.yaml
@@ -5,7 +5,7 @@ kind: Elasticsearch
 metadata:
   name: es-apm-sample
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 3
@@ -19,7 +19,7 @@ kind: Kibana
 metadata:
   name: kb-apm-sample
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"
@@ -33,7 +33,7 @@ kind: ApmServer
 metadata:
   name: apm-apm-sample
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"

--- a/config/samples/elasticsearch/elasticsearch.yaml
+++ b/config/samples/elasticsearch/elasticsearch.yaml
@@ -7,7 +7,7 @@ metadata:
   #  eck.k8s.elastic.co/downward-node-labels: "topology.kubernetes.io/zone"
   name: elasticsearch-sample
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     config:

--- a/config/samples/elasticsearch/elasticsearch.yaml
+++ b/config/samples/elasticsearch/elasticsearch.yaml
@@ -7,7 +7,7 @@ metadata:
   #  eck.k8s.elastic.co/downward-node-labels: "topology.kubernetes.io/zone"
   name: elasticsearch-sample
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     config:

--- a/config/samples/enterprisesearch/ent_es.yaml
+++ b/config/samples/enterprisesearch/ent_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
     - name: default
       count: 1
@@ -18,7 +18,7 @@ kind: EnterpriseSearch
 metadata:
   name: ent-sample
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: elasticsearch-sample

--- a/config/samples/enterprisesearch/ent_es.yaml
+++ b/config/samples/enterprisesearch/ent_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
     - name: default
       count: 1
@@ -18,7 +18,7 @@ kind: EnterpriseSearch
 metadata:
   name: ent-sample
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: elasticsearch-sample

--- a/config/samples/kibana/kibana_es.yaml
+++ b/config/samples/kibana/kibana_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 8.1.0
+  version: 8.1.1
   nodeSets:
   - name: default
     count: 1
@@ -18,7 +18,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: 8.1.0
+  version: 8.1.1
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/config/samples/kibana/kibana_es.yaml
+++ b/config/samples/kibana/kibana_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 8.0.0
+  version: 8.1.0
   nodeSets:
   - name: default
     count: 1
@@ -18,7 +18,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: 8.0.0
+  version: 8.1.0
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -134,6 +134,10 @@ func TestMultipleOutputConfig(t *testing.T) {
 }
 
 func TestFleetMode(t *testing.T) {
+	if version.MustParse(test.Ctx().ElasticStackVersion).LT(version.MinFor(8, 1, 0)) {
+		t.SkipNow()
+	}
+
 	name := "test-agent-fleet"
 
 	esBuilder := elasticsearch.NewBuilder(name).

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -134,9 +134,6 @@ func TestMultipleOutputConfig(t *testing.T) {
 }
 
 func TestFleetMode(t *testing.T) {
-	// TODO remove once https://github.com/elastic/kibana/issues/126611 is fixed
-	t.SkipNow()
-
 	name := "test-agent-fleet"
 
 	esBuilder := elasticsearch.NewBuilder(name).

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -134,7 +134,9 @@ func TestMultipleOutputConfig(t *testing.T) {
 }
 
 func TestFleetMode(t *testing.T) {
-	if version.MustParse(test.Ctx().ElasticStackVersion).LT(version.MinFor(8, 1, 0)) {
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
+	// installation of policies and integrations through Kibana file based configuration was broken between those versions:
+	if v.LT(version.MinFor(8, 1, 0)) && v.GTE(version.MinFor(8, 0, 0)) {
 		t.SkipNow()
 	}
 

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -90,9 +90,6 @@ func TestMultiOutputRecipe(t *testing.T) {
 }
 
 func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
-	// TODO remove once https://github.com/elastic/kibana/issues/126611 is fixed
-	t.SkipNow()
-
 	customize := func(builder agent.Builder) agent.Builder {
 		builder = builder.WithRoles(agent.PSPClusterRoleName)
 
@@ -107,8 +104,7 @@ func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.elastic_agent", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default")).
-			// TODO reenable when https://github.com/elastic/beats/issues/27127 is fixed
-			// WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.fleet_server", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.fleet_server", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default")).
 			// TODO API server should generate event in time but on kind we see repeatedly no metrics being reported in time
 			// see https://github.com/elastic/cloud-on-k8s/issues/4092
@@ -138,9 +134,6 @@ func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
-	// TODO remove once https://github.com/elastic/kibana/issues/126611 is fixed
-	t.SkipNow()
-
 	notLoggingPod := beat.NewPodBuilder("test")
 	loggingPod := beat.NewPodBuilder("test")
 	loggingPod.Pod.Namespace = "default"
@@ -159,9 +152,8 @@ func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "generic", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.elastic_agent", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default")).
-			// TODO reenable next two when https://github.com/elastic/beats/issues/27127 is fixed
-			// WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.fleet_server", "default")).
-			// WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.fleet_server", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default")).
 			WithDefaultESValidation(agent.HasEvent("/_search?q=message:" + loggingPod.Logged)).
 			WithDefaultESValidation(agent.NoEvent("/_search?q=message:" + notLoggingPod.Logged))
 	}
@@ -170,9 +162,6 @@ func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetAPMIntegrationRecipe(t *testing.T) {
-	// TODO remove once https://github.com/elastic/kibana/issues/126611 is fixed
-	t.SkipNow()
-
 	customize := func(builder agent.Builder) agent.Builder {
 		builder = builder.WithRoles(agent.PSPClusterRoleName)
 
@@ -185,11 +174,10 @@ func TestFleetAPMIntegrationRecipe(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.fleet_server", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.apm_server", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.elastic_agent", "default")).
-			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.apm_server", "default"))
-		// TODO reenable next three when https://github.com/elastic/beats/issues/27127 is fixed
-		// WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.fleet_server", "default")).
-		// WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default")).
-		// WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.apm_server", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.fleet_server", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default")).
 	}
 
 	runAgentRecipe(t, "fleet-apm-integration.yaml", customize)

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -177,7 +177,7 @@ func TestFleetAPMIntegrationRecipe(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.apm_server", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.fleet_server", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default")).
-			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
 	}
 
 	runAgentRecipe(t, "fleet-apm-integration.yaml", customize)

--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -34,7 +34,7 @@ import (
 // Then, it updates their version, and ensures a strict ordering is respected during the version upgrade.
 func TestVersionUpgradeOrdering(t *testing.T) {
 	initialVersion := "7.17.0"
-	updatedVersion := "8.0.0"
+	updatedVersion := "8.1.0"
 
 	// upgrading the entire stack can take some time, since we need to account for (in order):
 	// - Elasticsearch rolling upgrade

--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -34,7 +34,7 @@ import (
 // Then, it updates their version, and ensures a strict ordering is respected during the version upgrade.
 func TestVersionUpgradeOrdering(t *testing.T) {
 	initialVersion := "7.17.0"
-	updatedVersion := "8.1.0"
+	updatedVersion := "8.1.1"
 
 	// upgrading the entire stack can take some time, since we need to account for (in order):
 	// - Elasticsearch rolling upgrade

--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -14,11 +14,11 @@ import (
 // Elastic Stack versions used in the E2E tests. These should be updated as new versions for each major are released.
 const (
 	// LatestReleasedVersion6x is the latest released version for 6.x
-	LatestReleasedVersion6x = "6.8.20"
+	LatestReleasedVersion6x = "6.8.23"
 	// LatestReleasedVersion7x is the latest released version for 7.x
 	LatestReleasedVersion7x = "7.17.1"
 	// LatestReleasedVersion8x is the latest release version for 8.x
-	LatestReleasedVersion8x = "8.1.0"
+	LatestReleasedVersion8x = "8.1.1"
 	// LatestSnapshotVersion8x is the latest snapshot version for 8.x
 	LatestSnapshotVersion8x = "8.2.0-SNAPSHOT"
 )

--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -16,11 +16,11 @@ const (
 	// LatestReleasedVersion6x is the latest released version for 6.x
 	LatestReleasedVersion6x = "6.8.20"
 	// LatestReleasedVersion7x is the latest released version for 7.x
-	LatestReleasedVersion7x = "7.17.0"
+	LatestReleasedVersion7x = "7.17.1"
 	// LatestReleasedVersion8x is the latest release version for 8.x
 	LatestReleasedVersion8x = "8.1.0"
 	// LatestSnapshotVersion8x is the latest snapshot version for 8.x
-	LatestSnapshotVersion8x = "8.1.0-SNAPSHOT"
+	LatestSnapshotVersion8x = "8.2.0-SNAPSHOT"
 )
 
 // SkipInvalidUpgrade skips a test that would do an invalid upgrade.

--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -18,7 +18,7 @@ const (
 	// LatestReleasedVersion7x is the latest released version for 7.x
 	LatestReleasedVersion7x = "7.17.0"
 	// LatestReleasedVersion8x is the latest release version for 8.x
-	LatestReleasedVersion8x = "8.0.0"
+	LatestReleasedVersion8x = "8.1.0"
 	// LatestSnapshotVersion8x is the latest snapshot version for 8.x
 	LatestSnapshotVersion8x = "8.1.0-SNAPSHOT"
 )


### PR DESCRIPTION
* Bump Elastic Stack version in tests, recipes, samples to 8.1.0
* Start testing 8.2.0-SNAPSHOT
* Stop testing 7.6 and 7.7 (maybe a bit controversial but my intent here is to keep the overall number of test pipelines we run bounded) 
* Reenable tests and assertions that should work after issues have been fixed in 8.1