### PR TITLE
Fix missing .gitignore that breaks builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ hack/deployer/config/provider
 deployer-config.yml
 .env
 .registry.env
+stack-versions-def.json
 
 # ignore test output
 integration-tests.json


### PR DESCRIPTION
I forgot to tell git to ignore the new `stack-versions-def.json` file that we use for the custom build jobs to describe the desired combination of the Elastic Stack images that should be used in a test run.