### PR TITLE
Doc: An upgrade to ECK 1.7 does not cause a restart

### DIFF
--- a/docs/operating-eck/upgrading-eck.asciidoc
+++ b/docs/operating-eck/upgrading-eck.asciidoc
@@ -77,7 +77,6 @@ This will update the ECK installation to the latest binary and update the CRDs a
 Upgrading the operator results in a one-time update to existing managed resources in the cluster. This potentially triggers a rolling restart of pods by Kubernetes to apply those changes. The following table shows the target version that would cause a rolling restart.
 
 * 1.6
-* 1.7
 * 1.9
 * 2.0
 


### PR DESCRIPTION
An upgrade to ECK 1.7 does not cause a rolling restart of all Pods. I had a cluster with 6.8 and 7.17 deployments and both kept running unchanged after the upgrade. I also did not find any indication in the release notes that would indicate that we introduced change that could cause such an upgrade.