### PR TITLE
Reset phase on each reconciliation in Elasticsearch status

### DIFF
--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -200,13 +200,9 @@ func (r *ReconcileElasticsearch) Reconcile(ctx context.Context, request reconcil
 	}
 
 	if isReconciled, message := results.IsReconciled(); !isReconciled {
-		// Do not overwrite other "non-ready" phases like MigratingData
-		if state.IsElasticsearchPhase(esv1.ElasticsearchReadyPhase) {
-			state.UpdateWithPhase(esv1.ElasticsearchApplyingChangesPhase)
-		}
+		state.UpdateWithPhase(esv1.ElasticsearchApplyingChangesPhase)
 		state.ReportCondition(esv1.ReconciliationComplete, corev1.ConditionFalse, message)
-	} else if !state.IsElasticsearchPhase(esv1.ElasticsearchResourceInvalid) {
-		// Do not overwrite invalid phase
+	} else {
 		state.UpdateWithPhase(esv1.ElasticsearchReadyPhase)
 	}
 

--- a/pkg/controller/elasticsearch/reconcile/state.go
+++ b/pkg/controller/elasticsearch/reconcile/state.go
@@ -41,6 +41,9 @@ func NewState(c esv1.Elasticsearch) (*State, error) {
 	// reset the health to 'unknown' so that if reconciliation fails before the observer has had a chance to get it,
 	// we stop reporting a health that may be out of date
 	status.Health = esv1.ElasticsearchUnknownHealth
+	// reset the phase to an empty string so that we do not report an outdated phase given that certain phases are
+	// stickier than others (eg. invalid)
+	status.Phase = ""
 	return &State{
 		Recorder: events.NewRecorder(),
 		StatusReporter: &StatusReporter{
@@ -101,6 +104,14 @@ func (s *State) UpdateClusterHealth(clusterHealth esv1.ElasticsearchHealth) *Sta
 func (s *State) UpdateWithPhase(
 	phase esv1.ElasticsearchOrchestrationPhase,
 ) *State {
+	switch {
+	// do not overwrite the Invalid marker
+	case s.status.Phase == esv1.ElasticsearchResourceInvalid:
+		return s
+	// do not overwrite non-ready phases like MigratingData
+	case s.status.Phase != "" && phase == esv1.ElasticsearchApplyingChangesPhase:
+		return s
+	}
 	s.status.Phase = phase
 	return s
 }
@@ -150,11 +161,6 @@ func (s *State) UpdateMinRunningVersion(
 	s.ReportCondition(esv1.RunningDesiredVersion, corev1.ConditionTrue, fmt.Sprintf("All nodes are running version %s", runningVersion))
 
 	return s
-}
-
-// IsElasticsearchPhase reports if Elasticsearch is in the provided phase.
-func (s *State) IsElasticsearchPhase(phase esv1.ElasticsearchOrchestrationPhase) bool {
-	return s.status.Phase == phase
 }
 
 // UpdateElasticsearchInvalidWithEvent is a convenient method to set the phase to esv1.ElasticsearchResourceInvalid


### PR DESCRIPTION
Fixes #5506 

Instead of carrying the previous phase over from persisted state this PR proposes to reset the phase on each reconciliation to a neutral value (""). Because we set a phase value even in the presence of errors this should ensure that phase values like `Invalid` that we give priority over other values do not stick around forever.  Also moved the priority logic into the state struct method. 

