### PR TITLE
Update the license documentation

### DIFF
--- a/docs/operating-eck/licensing.asciidoc
+++ b/docs/operating-eck/licensing.asciidoc
@@ -80,7 +80,7 @@ kubectl create secret generic eck-license --from-file=my-license-file.json -n el
 kubectl label secret eck-license "license.k8s.elastic.co/scope"=operator -n elastic-system
 ----
 
-After you install a license into ECK, the Enterprise features of the operator, like Elasticsearch auto-scaling and support for the Elastic Maps Server are available. All the Elastic Stack applications you manage with ECK will have Platinum and Enterprise features enabled.  The link:https://www.elastic.co/guide/en/elasticsearch/reference/current/get-license.html[`_license`] API reports that individual Elasticsearch clusters are running under an Enterprise license, and the <<{p}-get-usage-data, elastic-licensing>> ConfigMap contains the current license level of the ECK operator. Applications created before you installed the license are upgraded to Platinum or Enterprise features without interruption of service after a short delay.
+After you install a license into ECK, the Enterprise features of the operator are available, like Elasticsearch autoscaling and support for Elastic Maps Server. All the Elastic Stack applications you manage with ECK will have Platinum and Enterprise features enabled.  The link:https://www.elastic.co/guide/en/elasticsearch/reference/current/get-license.html[`_license`] API reports that individual Elasticsearch clusters are running under an Enterprise license, and the <<{p}-get-usage-data, elastic-licensing>> ConfigMap contains the current license level of the ECK operator. The applications created before you installed the license are upgraded to Platinum or Enterprise features without interruption of service after a short delay.
 
 NOTE: The Elasticsearch `_license` API for versions before 8.0.0 reports a Platinum license level for backwards compatibility even if an Enterprise license is installed.
 
@@ -90,9 +90,9 @@ NOTE: The Elasticsearch `_license` API for versions before 8.0.0 reports a Plati
 == Update your license
 Before your current Enterprise license expires, you will receive a new Enterprise license from Elastic (provided that your subscription is valid).
 
-NOTE: You can check the expiry date of your license in the <<{p}-get-usage-data,elastic-licensing>> ConfigMap. Enterprise licenses are container licenses that include multiple licenses for individual Elasticsearch clusters with shorter expiry. Therefore, you will get a different expiry in Kibana or through the Elasticsearch link:https://www.elastic.co/guide/en/elasticsearch/reference/current/get-license.html[`_license`] API. ECK will automatically update the Elasticsearch cluster licenses until the expiry date of the ECK Enterprise license is reached.
+NOTE: You can check the expiry date of your license in the <<{p}-get-usage-data,elastic-licensing>> ConfigMap. Enterprise licenses are container licenses that include multiple licenses for individual Elasticsearch clusters with shorter expiry. Therefore, you get a different expiry in Kibana or through the Elasticsearch link:https://www.elastic.co/guide/en/elasticsearch/reference/current/get-license.html[`_license`] API. ECK automatically updates the Elasticsearch cluster licenses until the expiry date of the ECK Enterprise license is reached.
 
-To avoid any unintended downgrade of individual Elasticsearch clusters to a Basic license while installing the new license, we recommend installing the new Enterprise license as a new Kubernetes secret next to your existing Enterprise license. Just replace `eck-license` with a different name in the <<{p}-add-license,examples above>>. ECK will use the correct license automatically.
+To avoid any unintended downgrade of individual Elasticsearch clusters to a Basic license while installing the new license, we recommend installing the new Enterprise license as a new Kubernetes secret next to your existing Enterprise license. Just replace `eck-license` with a different name in the <<{p}-add-license,Kubernetes secret example>>. ECK will use the correct license automatically.
 
 Once you have created the new license secret you can safely delete the old license secret.
 

--- a/docs/operating-eck/licensing.asciidoc
+++ b/docs/operating-eck/licensing.asciidoc
@@ -92,7 +92,7 @@ Before your current Enterprise license expires, you will receive a new Enterpris
 
 NOTE: You can check the expiry date of your license in the <<{p}-get-usage-data,elastic-licensing>> ConfigMap. Enterprise licenses are container licenses that include multiple licenses for individual Elasticsearch clusters with shorter expiry. Therefore, you will get a different expiry in Kibana or through the Elasticsearch link:https://www.elastic.co/guide/en/elasticsearch/reference/current/get-license.html[`_license`] API. ECK will automatically update the Elasticsearch cluster licenses until the expiry date of the ECK Enterprise license is reached.
 
-To avoid any unintended downgrade of individual Elasticsearch clusters to a Basic license while installing the new license, we recommend to install the new Enterprise license as a new Kubernetes secret next to your existing Enterprise license. Just replace `eck-license` with a different name from the examples above. ECK will use the correct license automatically.
+To avoid any unintended downgrade of individual Elasticsearch clusters to a Basic license while installing the new license, we recommend installing the new Enterprise license as a new Kubernetes secret next to your existing Enterprise license. Just replace `eck-license` with a different name in the <<{p}-add-license,examples above>>. ECK will use the correct license automatically.
 
 Once you have created the new license secret you can safely delete the old license secret.
 

--- a/docs/operating-eck/licensing.asciidoc
+++ b/docs/operating-eck/licensing.asciidoc
@@ -48,9 +48,11 @@ At the end of the trial period, the Platinum and Enterprise features operate in 
 [float]
 [id="{p}-add-license"]
 == Add a license
-If you have a valid Enterprise subscription or a trial license extension, you will receive a license as a JSON file. The JSON file contains the cluster-level Enterprise licenses which enables ECK features, as well Platinum Stack licenses for recent and older Elasticsearch versions.
+If you have a valid Enterprise subscription or a trial license extension, you will receive a link to download a license as a JSON file.
 
-NOTE: After you install a license into ECK, all the Elastic Stack applications you manage with ECK have Platinum and Enterprise features enabled. Additionally, the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/get-license.html[`_license`] API reports that individual Elasticsearch clusters are running under a Platinum license, and the command `kubectl -n elastic-system get configmap elastic-licensing -o yaml` returns a JSON document that, among other things, contains the current license level of the ECK operator. Applications created before you installed the license are upgraded to Platinum or Enterprise features without interruption of service after a short delay.
+NOTE: When downloading the license choose the "Orchestration license" option.
+
+The downloaded JSON file contains the Enterprise orchestration license which enables ECK Enterprise features. Embedded in the orchestration license are also Enterprise stack licenses for recent Elasticsearch versions and Platinum licenses for older Elasticsearch versions that do not support Enterprise licenses.
 
 To add the license to your ECK installation, create a Kubernetes secret of the following form:
 
@@ -78,12 +80,17 @@ kubectl create secret generic eck-license --from-file=my-license-file.json -n el
 kubectl label secret eck-license "license.k8s.elastic.co/scope"=operator -n elastic-system
 ----
 
+After you install a license into ECK, the Enterprise features of the operator, like Elasticsearch auto-scaling and support for the Elastic Maps Server are available. All the Elastic Stack applications you manage with ECK will have Platinum and Enterprise features enabled.  The link:https://www.elastic.co/guide/en/elasticsearch/reference/current/get-license.html[`_license`] API reports that individual Elasticsearch clusters are running under an Enterprise license, and the <<{p}-get-usage-data, elastic-licensing>> ConfigMap contains the current license level of the ECK operator. Applications created before you installed the license are upgraded to Platinum or Enterprise features without interruption of service after a short delay.
+
+NOTE: The Elasticsearch `_license` API for versions before 8.0.0 reports a Platinum license level for backwards compatibility even if an Enterprise license is installed.
+
+
 [float]
 [id="{p}-update-license"]
 == Update your license
 Before your current Enterprise license expires, you will receive a new Enterprise license from Elastic (provided that your subscription is valid).
 
-NOTE: You can check the expiry date of your license in the license file that you received from Elastic. Enterprise licenses are container licenses that include multiple licenses for individual Elasticsearch clusters with shorter expiry. Therefore, you will get a different expiry in Kibana or through the Elasticsearch link:https://www.elastic.co/guide/en/elasticsearch/reference/current/get-license.html[`_license`] API. ECK will automatically update the Elasticsearch cluster licenses until the expiry date of the ECK Enterprise license is reached.
+NOTE: You can check the expiry date of your license in the <<{p}-get-usage-data,elastic-licensing>> ConfigMap. Enterprise licenses are container licenses that include multiple licenses for individual Elasticsearch clusters with shorter expiry. Therefore, you will get a different expiry in Kibana or through the Elasticsearch link:https://www.elastic.co/guide/en/elasticsearch/reference/current/get-license.html[`_license`] API. ECK will automatically update the Elasticsearch cluster licenses until the expiry date of the ECK Enterprise license is reached.
 
 To avoid any unintended downgrade of individual Elasticsearch clusters to a Basic license while installing the new license, we recommend to install the new Enterprise license as a new Kubernetes secret next to your existing Enterprise license. Just replace `eck-license` with a different name from the examples above. ECK will use the correct license automatically.
 


### PR DESCRIPTION
Fixes #5475 

Rendered preview: https://cloud-on-k8s_5509.docs-preview.app.elstc.co/diff

This PR adds a few clarifications, updates statements that are no longer accurate now that 8.x is the default Elastic stack version. Specifically it mentions to download the orchestration license and it explains that 7.x Elasticsearch clusters still report a Platinum license despite an Enterprise license being installed.