### PR TITLE
Revert #3875 (updates github.com/prometheus/(common|client_golang))

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,6 @@
   "extends": [
     "config:base"
   ],
-  "ignoreDeps": ["github.com/prometheus/client_golang", "github.com/prometheus/common"],
   "labels": [">renovate"],
   "packageRules": [
     {


### PR DESCRIPTION
The current version of prometheus client_golang in ECK has a high impact vulnerability (CVE-2022-21698) that gets flagged by vulnerability scanners.  This package stopped being upgraded in https://github.com/elastic/cloud-on-k8s/pull/3875 due to https://github.com/prometheus/common/issues/255, but that has since been resolved.