### PR TITLE
[2.1] Adding necessary ClusterRole permissions for elastic-agent (#5430)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -136,6 +136,7 @@ rules:
   resources:
   - pods
   - nodes
+  - namespaces
   verbs:
   - get
   - watch


### PR DESCRIPTION
Backports the following commits to 2.1:
 - Adding necessary ClusterRole permissions for elastic-agent (#5430)