### PR TITLE
[2.0] Adding necessary ClusterRole permissions for elastic-agent (#5430)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -103,6 +103,7 @@ rules:
   resources:
   - pods
   - nodes
+  - namespaces
   verbs:
   - get
   - watch


### PR DESCRIPTION
Backports the following commits to 2.0:
 - Adding necessary ClusterRole permissions for elastic-agent (#5430)