### PR TITLE
Revert "only redirect stdout to /dev/null, not stderr, as seeing failures is helpful. (#5462)"

### DIFF
--- a/hack/manifest-gen/manifest-gen.sh
+++ b/hack/manifest-gen/manifest-gen.sh
@@ -73,7 +73,7 @@ while getopts "cug" OPT; do
             shift $((OPTIND-1))
             (
                 cd "$SCRIPT_DIR"
-                go build -o manifest-gen 1>/dev/null
+                go build -o manifest-gen >/dev/null 2>&1
                 ./manifest-gen --source="$EFFECTIVE_SRC_CHART_DIR" generate "$@"
                 rm manifest-gen
             )


### PR DESCRIPTION
This reverts commit 0e0dd19e2b2bc3db1717aa097276e12c1c6dff5d.

We capture output from the manifest-gen.sh script as manifests to apply to Kubernetes. It appears that downloading go modules during the build of the command itself is otherwise captured as well and produces invalid manifests. 

This is just to get our builds working again. We can revisit the issues that triggered the reverted commit ie. the error handling and the conflation of tool build and tool run etc. in a separate PR. 

