### PR TITLE
custom-http-certificate: delete a duplicate spec

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/security/custom-http-certificate.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/custom-http-certificate.asciidoc
@@ -112,7 +112,4 @@ spec:
     kind: Issuer
     name: ca-issuer
   secretName: quickstart-es-cert
-  subject:
-    organizations:
-      - quickstart
 ----


### PR DESCRIPTION
## Description

Hello, 

Here's just a tiny contribution, `subject` spec is present two times in this example 👍 

Regards,
