### PR TITLE
Fix elasticsearch status subresource is updated infinitely

### DIFF
--- a/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -810,7 +810,7 @@ func Test_attemptDownscale(t *testing.T) {
 			expectedStatefulSets: []appsv1.StatefulSet{
 				sset.TestSset{Name: "default", Version: "7.1.0", Replicas: 3, Master: true, Data: true}.Build(),
 			},
-			expectedDownscaledNodes: []esv1.DownscaledNode{}, // expectedDownscaledNodes is not updated
+			expectedDownscaledNodes: nil, // expectedDownscaledNodes is not updated
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/controller/elasticsearch/reconcile/status.go
+++ b/pkg/controller/elasticsearch/reconcile/status.go
@@ -105,22 +105,25 @@ func (u *UpscaleReporter) HasPendingNewNodes() bool {
 // Merge creates a new upscale status using the reported upscale status and an existing upscale status.
 func (u *UpscaleReporter) Merge(other esv1.UpscaleOperation) esv1.UpscaleOperation {
 	upscaleOperation := other.DeepCopy()
-	if u == nil || (len(u.nodes)+len(other.Nodes) == 0) {
+	if u == nil {
 		return *upscaleOperation
 	}
-	nodes := make([]esv1.NewNode, 0, len(u.nodes))
-	for name, node := range u.nodes {
-		nodes = append(nodes, esv1.NewNode{
-			Name:    name,
-			Status:  node.Status,
-			Message: node.Message,
+	var nodes []esv1.NewNode
+	if len(u.nodes) != 0 {
+		nodes = make([]esv1.NewNode, 0, len(u.nodes))
+		for name, node := range u.nodes {
+			nodes = append(nodes, esv1.NewNode{
+				Name:    name,
+				Status:  node.Status,
+				Message: node.Message,
+			})
+		}
+		// Sort for stable comparison
+		sort.Slice(nodes, func(i, j int) bool {
+			return nodes[i].Name < nodes[j].Name
 		})
 	}
-	// Sort for stable comparison
-	sort.Slice(nodes, func(i, j int) bool {
-		return nodes[i].Name < nodes[j].Name
-	})
-	if (u.nodes != nil && !reflect.DeepEqual(nodes, other.Nodes)) || upscaleOperation.Nodes == nil {
+	if !reflect.DeepEqual(nodes, other.Nodes) || upscaleOperation.LastUpdatedTime.IsZero() {
 		upscaleOperation.Nodes = nodes
 		upscaleOperation.LastUpdatedTime = metav1.Now()
 	}
@@ -188,23 +191,26 @@ func (u *UpgradeReporter) RecordPredicatesResult(predicatesResult map[string]str
 // Merge creates a new upgrade status using the reported upgrade status and an existing upgrade status.
 func (u *UpgradeReporter) Merge(other esv1.UpgradeOperation) esv1.UpgradeOperation {
 	upgradeOperation := other.DeepCopy()
-	if u == nil || (len(u.nodes)+len(other.Nodes) == 0) {
+	if u == nil {
 		return *upgradeOperation
 	}
-	nodes := make([]esv1.UpgradedNode, 0, len(u.nodes))
-	for _, node := range u.nodes {
-		nodes = append(nodes, esv1.UpgradedNode{
-			Name:      node.Name,
-			Predicate: node.Predicate,
-			Message:   node.Message,
-			Status:    node.Status,
+	var nodes []esv1.UpgradedNode
+	if len(u.nodes) != 0 {
+		nodes = make([]esv1.UpgradedNode, 0, len(u.nodes))
+		for _, node := range u.nodes {
+			nodes = append(nodes, esv1.UpgradedNode{
+				Name:      node.Name,
+				Predicate: node.Predicate,
+				Message:   node.Message,
+				Status:    node.Status,
+			})
+		}
+		// Sort for stable comparison
+		sort.Slice(nodes, func(i, j int) bool {
+			return nodes[i].Name < nodes[j].Name
 		})
 	}
-	// Sort for stable comparison
-	sort.Slice(nodes, func(i, j int) bool {
-		return nodes[i].Name < nodes[j].Name
-	})
-	if (u.nodes != nil && !reflect.DeepEqual(nodes, other.Nodes)) || upgradeOperation.Nodes == nil {
+	if !reflect.DeepEqual(nodes, other.Nodes) || upgradeOperation.LastUpdatedTime.IsZero() {
 		upgradeOperation.Nodes = nodes
 		upgradeOperation.LastUpdatedTime = metav1.Now()
 	}
@@ -240,22 +246,25 @@ func (d *DownscaleReporter) RecordNodesToBeRemoved(nodes []string) {
 // Merge creates a new downscale status using the reported downscale status and an existing downscale status.
 func (d *DownscaleReporter) Merge(other esv1.DownscaleOperation) esv1.DownscaleOperation {
 	downscaleOperation := other.DeepCopy()
-	if d == nil || (len(d.nodes)+len(other.Nodes) == 0) {
+	if d == nil {
 		return other
 	}
-	nodes := make([]esv1.DownscaledNode, 0, len(d.nodes))
-	for _, node := range d.nodes {
-		nodes = append(nodes, esv1.DownscaledNode{
-			Name:           node.Name,
-			ShutdownStatus: node.ShutdownStatus,
-			Explanation:    node.Explanation,
+	var nodes []esv1.DownscaledNode
+	if len(d.nodes) != 0 {
+		nodes = make([]esv1.DownscaledNode, 0, len(d.nodes))
+		for _, node := range d.nodes {
+			nodes = append(nodes, esv1.DownscaledNode{
+				Name:           node.Name,
+				ShutdownStatus: node.ShutdownStatus,
+				Explanation:    node.Explanation,
+			})
+		}
+		// Sort for stable comparison
+		sort.Slice(nodes, func(i, j int) bool {
+			return nodes[i].Name < nodes[j].Name
 		})
 	}
-	// Sort for stable comparison
-	sort.Slice(nodes, func(i, j int) bool {
-		return nodes[i].Name < nodes[j].Name
-	})
-	if (d.nodes != nil && !reflect.DeepEqual(nodes, other.Nodes)) || downscaleOperation.Nodes == nil {
+	if !reflect.DeepEqual(nodes, other.Nodes) || downscaleOperation.LastUpdatedTime.IsZero() {
 		downscaleOperation.Nodes = nodes
 		downscaleOperation.LastUpdatedTime = metav1.Now()
 	}

--- a/pkg/controller/elasticsearch/reconcile/status.go
+++ b/pkg/controller/elasticsearch/reconcile/status.go
@@ -123,7 +123,7 @@ func (u *UpscaleReporter) Merge(other esv1.UpscaleOperation) esv1.UpscaleOperati
 			return nodes[i].Name < nodes[j].Name
 		})
 	}
-	if !reflect.DeepEqual(nodes, other.Nodes) || upscaleOperation.LastUpdatedTime.IsZero() {
+	if (u.nodes != nil && !reflect.DeepEqual(nodes, other.Nodes)) || upscaleOperation.LastUpdatedTime.IsZero() {
 		upscaleOperation.Nodes = nodes
 		upscaleOperation.LastUpdatedTime = metav1.Now()
 	}
@@ -210,7 +210,7 @@ func (u *UpgradeReporter) Merge(other esv1.UpgradeOperation) esv1.UpgradeOperati
 			return nodes[i].Name < nodes[j].Name
 		})
 	}
-	if !reflect.DeepEqual(nodes, other.Nodes) || upgradeOperation.LastUpdatedTime.IsZero() {
+	if (u.nodes != nil && !reflect.DeepEqual(nodes, other.Nodes)) || upgradeOperation.LastUpdatedTime.IsZero() {
 		upgradeOperation.Nodes = nodes
 		upgradeOperation.LastUpdatedTime = metav1.Now()
 	}
@@ -264,7 +264,7 @@ func (d *DownscaleReporter) Merge(other esv1.DownscaleOperation) esv1.DownscaleO
 			return nodes[i].Name < nodes[j].Name
 		})
 	}
-	if !reflect.DeepEqual(nodes, other.Nodes) || downscaleOperation.LastUpdatedTime.IsZero() {
+	if (d.nodes != nil && !reflect.DeepEqual(nodes, other.Nodes)) || downscaleOperation.LastUpdatedTime.IsZero() {
 		downscaleOperation.Nodes = nodes
 		downscaleOperation.LastUpdatedTime = metav1.Now()
 	}

--- a/pkg/controller/elasticsearch/reconcile/status.go
+++ b/pkg/controller/elasticsearch/reconcile/status.go
@@ -105,7 +105,7 @@ func (u *UpscaleReporter) HasPendingNewNodes() bool {
 // Merge creates a new upscale status using the reported upscale status and an existing upscale status.
 func (u *UpscaleReporter) Merge(other esv1.UpscaleOperation) esv1.UpscaleOperation {
 	upscaleOperation := other.DeepCopy()
-	if u == nil {
+	if u == nil || (len(u.nodes)+len(other.Nodes) == 0) {
 		return *upscaleOperation
 	}
 	nodes := make([]esv1.NewNode, 0, len(u.nodes))
@@ -188,7 +188,7 @@ func (u *UpgradeReporter) RecordPredicatesResult(predicatesResult map[string]str
 // Merge creates a new upgrade status using the reported upgrade status and an existing upgrade status.
 func (u *UpgradeReporter) Merge(other esv1.UpgradeOperation) esv1.UpgradeOperation {
 	upgradeOperation := other.DeepCopy()
-	if u == nil {
+	if u == nil || (len(u.nodes)+len(other.Nodes) == 0) {
 		return *upgradeOperation
 	}
 	nodes := make([]esv1.UpgradedNode, 0, len(u.nodes))
@@ -240,7 +240,7 @@ func (d *DownscaleReporter) RecordNodesToBeRemoved(nodes []string) {
 // Merge creates a new downscale status using the reported downscale status and an existing downscale status.
 func (d *DownscaleReporter) Merge(other esv1.DownscaleOperation) esv1.DownscaleOperation {
 	downscaleOperation := other.DeepCopy()
-	if d == nil {
+	if d == nil || (len(d.nodes)+len(other.Nodes) == 0) {
 		return other
 	}
 	nodes := make([]esv1.DownscaledNode, 0, len(d.nodes))

--- a/pkg/controller/elasticsearch/reconcile/status_test.go
+++ b/pkg/controller/elasticsearch/reconcile/status_test.go
@@ -361,13 +361,13 @@ func TestStatusReporter_MergeStatusReportingWith(t *testing.T) {
 				},
 				InProgressOperations: esv1.InProgressOperations{
 					DownscaleOperation: esv1.DownscaleOperation{
-						Nodes: []esv1.DownscaledNode{},
+						Nodes: nil,
 					},
 					UpgradeOperation: esv1.UpgradeOperation{
-						Nodes: []esv1.UpgradedNode{},
+						Nodes: nil,
 					},
 					UpscaleOperation: esv1.UpscaleOperation{
-						Nodes: []esv1.NewNode{},
+						Nodes: nil,
 					},
 				},
 			},

--- a/pkg/controller/elasticsearch/reconcile/status_test.go
+++ b/pkg/controller/elasticsearch/reconcile/status_test.go
@@ -257,6 +257,122 @@ func TestStatusReporter_MergeStatusReportingWith(t *testing.T) {
 			},
 			wantPendingNewNodes: true,
 		},
+		{
+			name: "Merge empty status",
+			state: func() *State {
+				s := MustNewState(esv1.Elasticsearch{})
+				return s
+			},
+			args: args{
+				otherStatus: esv1.ElasticsearchStatus{},
+			},
+			wantElasticsearchStatus: esv1.ElasticsearchStatus{},
+			wantPendingNewNodes:     false,
+		},
+		{
+			name: "Merge empty status with nil slices of nodes",
+			state: func() *State {
+				s := MustNewState(esv1.Elasticsearch{})
+				return s
+			},
+			args: args{
+				otherStatus: esv1.ElasticsearchStatus{
+					Phase: esv1.ElasticsearchResourceInvalid,
+					Conditions: esv1.Conditions{
+						{
+							Type:    "ReconciliationComplete",
+							Status:  "True",
+							Message: "initially reconciled",
+						},
+					},
+					InProgressOperations: esv1.InProgressOperations{
+						DownscaleOperation: esv1.DownscaleOperation{
+							Nodes: nil,
+						},
+						UpgradeOperation: esv1.UpgradeOperation{
+							Nodes: nil,
+						},
+						UpscaleOperation: esv1.UpscaleOperation{
+							Nodes: nil,
+						},
+					},
+				},
+			},
+			wantElasticsearchStatus: esv1.ElasticsearchStatus{
+				Phase: esv1.ElasticsearchResourceInvalid,
+				Conditions: esv1.Conditions{
+					{
+						Type:    "ReconciliationComplete",
+						Status:  "True",
+						Message: "initially reconciled",
+					},
+				},
+				InProgressOperations: esv1.InProgressOperations{
+					DownscaleOperation: esv1.DownscaleOperation{
+						Nodes: nil,
+					},
+					UpgradeOperation: esv1.UpgradeOperation{
+						Nodes: nil,
+					},
+					UpscaleOperation: esv1.UpscaleOperation{
+						Nodes: nil,
+					},
+				},
+			},
+			wantPendingNewNodes: false,
+		},
+		{
+			name: "Merge empty status with empty slices of nodes",
+			state: func() *State {
+				s := MustNewState(esv1.Elasticsearch{})
+				return s
+			},
+			args: args{
+				otherStatus: esv1.ElasticsearchStatus{
+					Phase: esv1.ElasticsearchResourceInvalid,
+					Conditions: esv1.Conditions{
+						{
+							Type:    "ReconciliationComplete",
+							Status:  "True",
+							Message: "initially reconciled",
+						},
+					},
+					InProgressOperations: esv1.InProgressOperations{
+						DownscaleOperation: esv1.DownscaleOperation{
+							Nodes: []esv1.DownscaledNode{},
+						},
+						UpgradeOperation: esv1.UpgradeOperation{
+							Nodes: []esv1.UpgradedNode{},
+						},
+						UpscaleOperation: esv1.UpscaleOperation{
+							Nodes: []esv1.NewNode{},
+						},
+					},
+				},
+			},
+			wantElasticsearchStatus: esv1.ElasticsearchStatus{
+				Phase: esv1.ElasticsearchResourceInvalid,
+				Conditions: esv1.Conditions{
+					{
+						Type:    "ReconciliationComplete",
+						Status:  "True",
+						Message: "initially reconciled",
+					},
+				},
+				InProgressOperations: esv1.InProgressOperations{
+					DownscaleOperation: esv1.DownscaleOperation{
+						Nodes: []esv1.DownscaledNode{},
+					},
+					UpgradeOperation: esv1.UpgradeOperation{
+						Nodes: []esv1.UpgradedNode{},
+					},
+					UpscaleOperation: esv1.UpscaleOperation{
+						Nodes: []esv1.NewNode{},
+					},
+				},
+			},
+			wantPendingNewNodes: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This commit makes sure that we don't convert a nil slice of nodes into an empty slice in the previous status during the merge with the current status. 

Resolves #5532.