### PR TITLE
Elastic Maps: Set status.ObservedGeneration from metadata.Generation

### DIFF
--- a/pkg/apis/maps/v1alpha1/maps_types.go
+++ b/pkg/apis/maps/v1alpha1/maps_types.go
@@ -60,7 +60,14 @@ type MapsSpec struct {
 // MapsStatus defines the observed state of Elastic Maps Server
 type MapsStatus struct {
 	commonv1.DeploymentStatus `json:",inline"`
-	AssociationStatus         commonv1.AssociationStatus `json:"associationStatus,omitempty"`
+
+	AssociationStatus commonv1.AssociationStatus `json:"associationStatus,omitempty"`
+
+	// ObservedGeneration is the most recent generation observed for this Elastic Maps Server.
+	// It corresponds to the metadata generation, which is updated on mutation by the API Server.
+	// If the generation observed in status diverges from the generation in metadata, the Elastic
+	// Maps controller has not yet processed the changes contained in the Elastic Maps specification.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // IsMarkedForDeletion returns true if the Elastic Maps Server instance is going to be deleted
@@ -141,6 +148,11 @@ func (m *ElasticMapsServer) AssociationID() string {
 
 var _ commonv1.Associated = &ElasticMapsServer{}
 var _ commonv1.Association = &ElasticMapsServer{}
+
+// GetObservedGeneration will return the observed generation from the Elastic Maps status.
+func (m *ElasticMapsServer) GetObservedGeneration() int64 {
+	return m.Status.ObservedGeneration
+}
 
 // +kubebuilder:object:root=true
 

--- a/pkg/controller/maps/controller.go
+++ b/pkg/controller/maps/controller.go
@@ -167,9 +167,34 @@ func (r *ReconcileMapsServer) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, nil
 	}
 
+	// MapsServer will be deleted nothing to do other than remove the watches
+	if ems.IsMarkedForDeletion() {
+		return reconcile.Result{}, r.onDelete(k8s.ExtractNamespacedName(&ems))
+	}
+
+	// main reconciliation logic
+	results, status := r.doReconcile(ctx, ems)
+	updateStatusErr := r.updateStatus(ems, status)
+	if updateStatusErr != nil {
+		if apierrors.IsConflict(updateStatusErr) {
+			log.V(1).Info(
+				"Conflict while updating status",
+				"namespace", ems.Namespace,
+				"beat_name", ems.Name)
+			return results.WithResult(reconcile.Result{Requeue: true}).Aggregate()
+		}
+		results.WithError(updateStatusErr)
+	}
+	return results.Aggregate()
+}
+
+func (r *ReconcileMapsServer) doReconcile(ctx context.Context, ems emsv1alpha1.ElasticMapsServer) (*reconciler.Results, emsv1alpha1.MapsStatus) {
+	results := reconciler.NewResult(ctx)
+	status := newStatus(ems)
+
 	enabled, err := r.licenseChecker.EnterpriseFeaturesEnabled()
 	if err != nil {
-		return reconcile.Result{}, err
+		return results.WithError(err), status
 	}
 
 	if !enabled {
@@ -177,38 +202,28 @@ func (r *ReconcileMapsServer) Reconcile(ctx context.Context, request reconcile.R
 		log.Info(msg, "namespace", ems.Namespace, "name", ems.Name)
 		r.recorder.Eventf(&ems, corev1.EventTypeWarning, events.EventReconciliationError, msg)
 		// we don't have a good way of watching for the license level to change so just requeue with a reasonably long delay
-		return reconcile.Result{Requeue: true, RequeueAfter: 5 * time.Minute}, nil
-	}
-
-	// MapsServer will be deleted nothing to do other than remove the watches
-	if ems.IsMarkedForDeletion() {
-		return reconcile.Result{}, r.onDelete(k8s.ExtractNamespacedName(&ems))
+		return results.WithResult(reconcile.Result{Requeue: true, RequeueAfter: 5 * time.Minute}), status
 	}
 
 	isEsAssocConfigured, err := association.IsConfiguredIfSet(&ems, r.recorder)
 	if err != nil {
-		return reconcile.Result{}, err
+		return results.WithError(err), status
 	}
 	if !isEsAssocConfigured {
-		return reconcile.Result{}, nil
+		return results, status
 	}
 
-	// main reconciliation logic
-	return r.doReconcile(ctx, ems)
-}
-
-func (r *ReconcileMapsServer) doReconcile(ctx context.Context, ems emsv1alpha1.ElasticMapsServer) (reconcile.Result, error) {
 	// Run validation in case the webhook is disabled
 	if err := r.validate(ctx, ems); err != nil {
-		return reconcile.Result{}, err
+		return results.WithError(err), status
 	}
 
 	svc, err := common.ReconcileService(ctx, r.Client, NewService(ems), &ems)
 	if err != nil {
-		return reconcile.Result{}, err
+		return results.WithError(err), status
 	}
 
-	_, results := certificates.Reconciler{
+	_, results = certificates.Reconciler{
 		K8sClient:             r.K8sClient(),
 		DynamicWatches:        r.DynamicWatches(),
 		Owner:                 &ems,
@@ -221,46 +236,54 @@ func (r *ReconcileMapsServer) doReconcile(ctx context.Context, ems emsv1alpha1.E
 		GarbageCollectSecrets: true,
 	}.ReconcileCAAndHTTPCerts(ctx)
 	if results.HasError() {
-		res, err := results.Aggregate()
+		_, err := results.Aggregate()
 		k8s.EmitErrorEvent(r.recorder, err, &ems, events.EventReconciliationError, "Certificate reconciliation error: %v", err)
-		return res, err
+		return results, status
 	}
 
 	emsVersion, err := version.Parse(ems.Spec.Version)
 	if err != nil {
-		return reconcile.Result{}, err
+		return results.WithError(err), status
 	}
 	logger := log.WithValues("namespace", ems.Namespace, "maps_name", ems.Name) // TODO  mapping explosion
 	assocAllowed, err := association.AllowVersion(emsVersion, ems.Associated(), logger, r.recorder)
 	if err != nil {
-		return reconcile.Result{}, err
+		return results.WithError(err), status
 	}
 	if !assocAllowed {
-		return reconcile.Result{}, nil // will eventually retry once updated
+		// will eventually retry once updated, along with the results
+		// from the certificate reconciliation having a retry after a time period
+		return results, status
 	}
 
 	configSecret, err := reconcileConfig(r, ems, r.IPFamily)
 	if err != nil {
-		return reconcile.Result{}, err
+		return results.WithError(err), status
 	}
 
 	// build a hash of various inputs to rotate Pods on any change
 	configHash, err := buildConfigHash(r.K8sClient(), ems, configSecret)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("build config hash: %w", err)
+		return results.WithError(fmt.Errorf("build config hash: %w", err)), status
 	}
 
 	deploy, err := r.reconcileDeployment(ctx, ems, configHash)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("reconcile deployment: %w", err)
+		return results.WithError(fmt.Errorf("reconcile deployment: %w", err)), status
 	}
 
-	err = r.updateStatus(ems, deploy)
+	status, err = r.getStatus(ems, deploy)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("updating status: %w", err)
+		return results.WithError(fmt.Errorf("calculating status: %w", err)), status
 	}
 
-	return results.Aggregate()
+	return results, status
+}
+
+func newStatus(ems emsv1alpha1.ElasticMapsServer) emsv1alpha1.MapsStatus {
+	status := ems.Status
+	status.ObservedGeneration = ems.Generation
+	return status
 }
 
 func (r *ReconcileMapsServer) validate(ctx context.Context, ems emsv1alpha1.ElasticMapsServer) error {
@@ -363,33 +386,36 @@ func (r *ReconcileMapsServer) deploymentParams(ems emsv1alpha1.ElasticMapsServer
 	}, nil
 }
 
-func (r *ReconcileMapsServer) updateStatus(ems emsv1alpha1.ElasticMapsServer, deploy appsv1.Deployment) error {
+func (r *ReconcileMapsServer) getStatus(ems emsv1alpha1.ElasticMapsServer, deploy appsv1.Deployment) (emsv1alpha1.MapsStatus, error) {
+	status := newStatus(ems)
 	pods, err := k8s.PodsMatchingLabels(r.K8sClient(), ems.Namespace, map[string]string{NameLabelName: ems.Name})
 	if err != nil {
-		return err
+		return status, err
 	}
 	deploymentStatus, err := common.DeploymentStatus(ems.Status.DeploymentStatus, deploy, pods, versionLabelName)
 	if err != nil {
-		return err
+		return status, err
 	}
-	newStatus := emsv1alpha1.MapsStatus{
-		DeploymentStatus:  deploymentStatus,
-		AssociationStatus: ems.Status.AssociationStatus,
-	}
+	status.DeploymentStatus = deploymentStatus
+	status.AssociationStatus = ems.Status.AssociationStatus
 
-	if reflect.DeepEqual(newStatus, ems.Status) {
+	return status, nil
+}
+
+func (r *ReconcileMapsServer) updateStatus(ems emsv1alpha1.ElasticMapsServer, status emsv1alpha1.MapsStatus) error {
+	if reflect.DeepEqual(status, ems.Status) {
 		return nil // nothing to do
 	}
-	if newStatus.IsDegraded(ems.Status.DeploymentStatus) {
+	if status.IsDegraded(ems.Status.DeploymentStatus) {
 		r.recorder.Event(&ems, corev1.EventTypeWarning, events.EventReasonUnhealthy, "Elastic Maps Server health degraded")
 	}
 	log.V(1).Info("Updating status",
 		"iteration", atomic.LoadUint64(&r.iteration),
 		"namespace", ems.Namespace,
 		"maps_name", ems.Name,
-		"status", newStatus,
+		"status", status,
 	)
-	ems.Status = newStatus
+	ems.Status = status
 	return common.UpdateStatus(r.Client, &ems)
 }
 

--- a/pkg/controller/maps/controller_test.go
+++ b/pkg/controller/maps/controller_test.go
@@ -33,12 +33,16 @@ var nsnFixture = types.NamespacedName{
 }
 var emsFixture = v1alpha1.ElasticMapsServer{
 	ObjectMeta: metav1.ObjectMeta{
-		Namespace: nsnFixture.Namespace,
-		Name:      nsnFixture.Name,
+		Namespace:  nsnFixture.Namespace,
+		Name:       nsnFixture.Name,
+		Generation: 2,
 	},
 	Spec: v1alpha1.MapsSpec{
 		Version: "7.12.0",
 		Count:   1,
+	},
+	Status: v1alpha1.MapsStatus{
+		ObservedGeneration: 1,
 	},
 }
 
@@ -76,7 +80,10 @@ func TestReconcileMapsServer_Reconcile(t *testing.T) {
 			name: "Resource marked for deletion",
 			reconciler: ReconcileMapsServer{
 				Client: k8s.NewFakeClient(&v1alpha1.ElasticMapsServer{
-					ObjectMeta: metav1.ObjectMeta{Name: nsnFixture.Name, Namespace: nsnFixture.Namespace, DeletionTimestamp: &timeFixture},
+					ObjectMeta: metav1.ObjectMeta{Name: nsnFixture.Name, Namespace: nsnFixture.Namespace, DeletionTimestamp: &timeFixture, Generation: 2},
+					Status: v1alpha1.MapsStatus{
+						ObservedGeneration: 1,
+					},
 				}),
 				licenseChecker: license.MockLicenseChecker{EnterpriseEnabled: true},
 				dynamicWatches: watches.NewDynamicWatches(),
@@ -91,6 +98,11 @@ func TestReconcileMapsServer_Reconcile(t *testing.T) {
 			post: func(r ReconcileMapsServer) {
 				// watches should have been cleared
 				require.Empty(t, r.DynamicWatches().Secrets.Registrations())
+
+				// observedGeneration should not have been updated
+				var ems v1alpha1.ElasticMapsServer
+				require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: nsnFixture.Name, Namespace: nsnFixture.Namespace}, &ems))
+				require.Equal(t, int64(1), ems.Status.ObservedGeneration)
 			},
 			wantErr: false,
 		},
@@ -121,6 +133,11 @@ func TestReconcileMapsServer_Reconcile(t *testing.T) {
 			post: func(r ReconcileMapsServer) {
 				e := <-r.recorder.(*record.FakeRecorder).Events
 				require.Equal(t, "Warning ReconciliationError Elastic Maps Server is an enterprise feature. Enterprise features are disabled", e)
+
+				// observedGeneration should have been updated
+				var ems v1alpha1.ElasticMapsServer
+				require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: nsnFixture.Name, Namespace: nsnFixture.Namespace}, &ems))
+				require.Equal(t, int64(2), ems.Status.ObservedGeneration)
 			},
 			wantRequeue:      true,
 			wantRequeueAfter: true, // license recheck
@@ -131,15 +148,25 @@ func TestReconcileMapsServer_Reconcile(t *testing.T) {
 			reconciler: ReconcileMapsServer{
 				Client: k8s.NewFakeClient(&v1alpha1.ElasticMapsServer{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      nsnFixture.Name,
-						Namespace: nsnFixture.Namespace,
+						Name:       nsnFixture.Name,
+						Namespace:  nsnFixture.Namespace,
+						Generation: 2,
 					},
 					Spec: v1alpha1.MapsSpec{
 						Version: "7.10.0", // unsupported version
 					},
+					Status: v1alpha1.MapsStatus{
+						ObservedGeneration: 1,
+					},
 				}),
 				licenseChecker: license.MockLicenseChecker{EnterpriseEnabled: true},
 				recorder:       record.NewFakeRecorder(10),
+			},
+			post: func(r ReconcileMapsServer) {
+				// observedGeneration should have been updated
+				var ems v1alpha1.ElasticMapsServer
+				require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: nsnFixture.Name, Namespace: nsnFixture.Namespace}, &ems))
+				require.Equal(t, int64(2), ems.Status.ObservedGeneration)
 			},
 			wantErr: true,
 		},
@@ -148,12 +175,16 @@ func TestReconcileMapsServer_Reconcile(t *testing.T) {
 			reconciler: ReconcileMapsServer{
 				Client: k8s.NewFakeClient(&v1alpha1.ElasticMapsServer{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      nsnFixture.Name,
-						Namespace: nsnFixture.Namespace,
+						Name:       nsnFixture.Name,
+						Namespace:  nsnFixture.Namespace,
+						Generation: 2,
 					},
 					Spec: v1alpha1.MapsSpec{
 						Version:          "7.12.0",
 						ElasticsearchRef: commonv1.ObjectSelector{Name: "es", Namespace: "ns"},
+					},
+					Status: v1alpha1.MapsStatus{
+						ObservedGeneration: 1,
 					},
 				}),
 				dynamicWatches: watches.NewDynamicWatches(),
@@ -163,6 +194,11 @@ func TestReconcileMapsServer_Reconcile(t *testing.T) {
 			post: func(r ReconcileMapsServer) {
 				e := <-r.recorder.(*record.FakeRecorder).Events
 				require.Equal(t, "Warning AssociationError Association backend for elasticsearch is not configured", e)
+
+				// observedGeneration should have been updated
+				var ems v1alpha1.ElasticMapsServer
+				require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: nsnFixture.Name, Namespace: nsnFixture.Namespace}, &ems))
+				require.Equal(t, int64(2), ems.Status.ObservedGeneration)
 			},
 			wantErr: false,
 		},
@@ -176,10 +212,14 @@ func TestReconcileMapsServer_Reconcile(t *testing.T) {
 						Annotations: map[string]string{
 							"association.k8s.elastic.co/es-conf": `{"authSecretName":"test-resource-maps-user","authSecretKey":"ns-test-resource-maps-user","caCertProvided":true,"caSecretName": "test-resource-es-ca","url":"https://es-es-http.ns.svc:9200","version":"7.10.0"}`,
 						},
+						Generation: 2,
 					},
 					Spec: v1alpha1.MapsSpec{
 						Version:          "7.12.0",
 						ElasticsearchRef: commonv1.ObjectSelector{Name: "es", Namespace: "ns"},
+					},
+					Status: v1alpha1.MapsStatus{
+						ObservedGeneration: 1,
 					},
 				}),
 				dynamicWatches: watches.NewDynamicWatches(),
@@ -189,8 +229,15 @@ func TestReconcileMapsServer_Reconcile(t *testing.T) {
 			post: func(r ReconcileMapsServer) {
 				e := <-r.recorder.(*record.FakeRecorder).Events
 				require.Equal(t, "Warning Delayed Delaying deployment of version 7.12.0 since the referenced elasticsearch is not upgraded yet", e)
+
+				// observedGeneration should have been updated
+				var ems v1alpha1.ElasticMapsServer
+				require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: nsnFixture.Name, Namespace: nsnFixture.Namespace}, &ems))
+				require.Equal(t, int64(2), ems.Status.ObservedGeneration)
 			},
 			wantErr: false,
+			// retry from certificate reconciliation.
+			wantRequeueAfter: true,
 		},
 		{
 			name: "Happy path: first reconciliation",
@@ -237,6 +284,11 @@ func TestReconcileMapsServer_Reconcile(t *testing.T) {
 				require.Equal(t, int32(1), *dep.Spec.Replicas)
 				// with the config hash annotation set
 				require.NotEmpty(t, dep.Spec.Template.Annotations[configHashAnnotationName])
+
+				// observedGeneration should have been updated
+				var ems v1alpha1.ElasticMapsServer
+				require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: nsnFixture.Name, Namespace: nsnFixture.Namespace}, &ems))
+				require.Equal(t, int64(2), ems.Status.ObservedGeneration)
 			},
 			wantRequeue:      false,
 			wantRequeueAfter: true, // certificate refresh


### PR DESCRIPTION
related to #3392

This change allows status.ObservedGeneration to be kept in sync with metadata.Generation according to the rules described in the above issue. This change adds a set of unit tests which show more details into when observedGeneration will, and will not be updated according to any errors/situations that may occur during reconciliation. End to end tests are in progress.

Remaining Items (Reason for Draft)

- [ ] E2E test