### PR TITLE
Fix e2e monitoring file/metricbeat configuration 

### DIFF
--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -84,12 +84,8 @@ spec:
       password: ${monitoring_pass}
       # Since E2E cluster's Elasticsearch instance may lag behind the newest version of Beat, we need to allow this scenario.
       allow_older_versions: true
-      # The maximum size to send in a single Elasticsearch bulk API index request. Needed if Elasticsearch is behind Cloud Ingress.
-      bulk_max_body_size: 10M
       # The maximum number of events to bulk in a single Elasticsearch bulk API index request. Needed if Elasticsearch is behind Cloud Ingress.
       bulk_max_size: 10
-      # The maximum byte size to send in a single Elasticsearch bulk API index request, regardless of compression. Needed if Elasticsearch is behind Cloud Ingress.
-      bulk_max_bytes: 10485760
   daemonSet:
     podTemplate:
       spec:
@@ -288,12 +284,8 @@ spec:
       password: ${monitoring_pass}
       # Since E2E cluster's Elasticsearch instance may lag behind the newest version of Beat, we need to allow this scenario.
       allow_older_versions: true
-      # The maximum size to send in a single Elasticsearch bulk API index request. Needed if Elasticsearch is behind Cloud Ingress.
-      bulk_max_body_size: 10M
       # The maximum number of events to bulk in a single Elasticsearch bulk API index request. Needed if Elasticsearch is behind Cloud Ingress.
       bulk_max_size: 10
-      # The maximum byte size to send in a single Elasticsearch bulk API index request, regardless of compression. Needed if Elasticsearch is behind Cloud Ingress.
-      bulk_max_bytes: 10485760
   secureSettings:
   - secretName: "eck-{{ .TestRun }}"
   daemonSet:

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -82,6 +82,14 @@ spec:
       hosts: ['${monitoring_url}']
       username: ${monitoring_user}
       password: ${monitoring_pass}
+      # Since E2E cluster's Elasticsearch instance may lag behind the newest version of Beat, we need to allow this scenario.
+      allow_older_versions: true
+      # The maximum size to send in a single Elasticsearch bulk API index request. Needed if Elasticsearch is behind Cloud Ingress.
+      bulk_max_body_size: 10M
+      # The maximum number of events to bulk in a single Elasticsearch bulk API index request. Needed if Elasticsearch is behind Cloud Ingress.
+      bulk_max_size: 10
+      # The maximum byte size to send in a single Elasticsearch bulk API index request, regardless of compression. Needed if Elasticsearch is behind Cloud Ingress.
+      bulk_max_bytes: 10485760
   daemonSet:
     podTemplate:
       spec:
@@ -278,6 +286,14 @@ spec:
       hosts: ['${monitoring_url}']
       username: ${monitoring_user}
       password: ${monitoring_pass}
+      # Since E2E cluster's Elasticsearch instance may lag behind the newest version of Beat, we need to allow this scenario.
+      allow_older_versions: true
+      # The maximum size to send in a single Elasticsearch bulk API index request. Needed if Elasticsearch is behind Cloud Ingress.
+      bulk_max_body_size: 10M
+      # The maximum number of events to bulk in a single Elasticsearch bulk API index request. Needed if Elasticsearch is behind Cloud Ingress.
+      bulk_max_size: 10
+      # The maximum byte size to send in a single Elasticsearch bulk API index request, regardless of compression. Needed if Elasticsearch is behind Cloud Ingress.
+      bulk_max_bytes: 10485760
   secureSettings:
   - secretName: "eck-{{ .TestRun }}"
   daemonSet:


### PR DESCRIPTION
Since e2e monitoring Elasticsearch cluster is behind a cloud ingress Load Balancer at this time, the filebeat/metricbeat configuration needs to be tweaked to work in that scenario.  See https://github.com/elastic/beats/issues/3688