### PR TITLE
Add initcontainers to documentation for zone awareness.

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
@@ -245,6 +245,13 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.annotations['topology.kubernetes.io/zone']
+        initContainers:
+        - name: elastic-internal-init-keystore
+          env:
+          - name: ZONE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['topology.kubernetes.io/zone']
         topologySpreadConstraints:
           - maxSkew: 1
             topologyKey: topology.kubernetes.io/zone

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
@@ -245,13 +245,14 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        initContainers:
-        - name: elastic-internal-init-keystore
-          env:
-          - name: ZONE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.annotations['topology.kubernetes.io/zone']
+        // The initContainers section is only required if using secureSettings in conjunction with zone awareness.
+        // initContainers:
+        // - name: elastic-internal-init-keystore
+        //   env:
+        //   - name: ZONE
+        //     valueFrom:
+        //       fieldRef:
+        //         fieldPath: metadata.annotations['topology.kubernetes.io/zone']
         topologySpreadConstraints:
           - maxSkew: 1
             topologyKey: topology.kubernetes.io/zone

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
@@ -238,6 +238,14 @@ spec:
       cluster.routing.allocation.awareness.attributes: k8s_node_name,zone
     podTemplate:
       spec:
+        # The initContainers section is only required if using secureSettings in conjunction with zone awareness.
+        # initContainers:
+        # - name: elastic-internal-init-keystore
+        #   env:
+        #   - name: ZONE
+        #     valueFrom:
+        #       fieldRef:
+        #         fieldPath: metadata.annotations['topology.kubernetes.io/zone']
         containers:
         - name: elasticsearch
           env:
@@ -245,14 +253,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        // The initContainers section is only required if using secureSettings in conjunction with zone awareness.
-        // initContainers:
-        // - name: elastic-internal-init-keystore
-        //   env:
-        //   - name: ZONE
-        //     valueFrom:
-        //       fieldRef:
-        //         fieldPath: metadata.annotations['topology.kubernetes.io/zone']
         topologySpreadConstraints:
           - maxSkew: 1
             topologyKey: topology.kubernetes.io/zone

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/es-secure-settings.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/es-secure-settings.asciidoc
@@ -72,4 +72,4 @@ data:
 
 Check <<{p}-snapshots,How to create automated snapshots>> for an example use case.
 
-WARNING: If using <<{p}-advanced-node-scheduling>> in conjunction with secure settings, ensure you add an `initContainers` section to the `podTemplate` to ensure all the required environment variables exist for the initialization of the keystore.  Refer to <<{p}-availability-zone-awareness-example,Zone Awareness>> for a complete example.
+WARNING: If using <<{p}-advanced-node-scheduling>> in conjunction with secure settings, you have to add an `initContainers` section to the `podTemplate` to ensure all the required environment variables exist for the initialization of the keystore.  Refer to <<{p}-availability-zone-awareness-example,Zone Awareness>> for a complete example.

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/es-secure-settings.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/es-secure-settings.asciidoc
@@ -72,4 +72,4 @@ data:
 
 Check <<{p}-snapshots,How to create automated snapshots>> for an example use case.
 
-WARNING: If using <<advanced-node-scheduling>> in conjunction with secure settings, ensure you add an `initContainers` section to the `podTemplate` to ensure all the required environment variables exist for the initialization of the keystore.  A working example exists on the xref:advanced-node-scheduling#{p}-availability-zone-awareness-example[Advanced Node Scheduling/Zone Awareness] documentation.
+WARNING: If using <<{p}-advanced-node-scheduling>> in conjunction with secure settings, ensure you add an `initContainers` section to the `podTemplate` to ensure all the required environment variables exist for the initialization of the keystore.  A working example exists in the <<{p}-availability-zone-awareness-example,Zone Awareness>> documentation.

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/es-secure-settings.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/es-secure-settings.asciidoc
@@ -72,4 +72,4 @@ data:
 
 Check <<{p}-snapshots,How to create automated snapshots>> for an example use case.
 
-WARNING: If using <<{p}-advanced-node-scheduling>> in conjunction with secure settings, ensure you add an `initContainers` section to the `podTemplate` to ensure all the required environment variables exist for the initialization of the keystore.  A working example exists in the <<{p}-availability-zone-awareness-example,Zone Awareness>> documentation.
+WARNING: If using <<{p}-advanced-node-scheduling>> in conjunction with secure settings, ensure you add an `initContainers` section to the `podTemplate` to ensure all the required environment variables exist for the initialization of the keystore.  Refer to <<{p}-availability-zone-awareness-example,Zone Awareness>> for a complete example.

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/es-secure-settings.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/es-secure-settings.asciidoc
@@ -71,3 +71,5 @@ data:
 ----
 
 Check <<{p}-snapshots,How to create automated snapshots>> for an example use case.
+
+WARNING: If using <<advanced-node-scheduling>> in conjunction with secure settings, ensure you add an `initContainers` section to the `podTemplate` to ensure all the required environment variables exist for the initialization of the keystore.  A working example exists on the xref:advanced-node-scheduling#{p}-availability-zone-awareness-example[Advanced Node Scheduling/Zone Awareness] documentation.


### PR DESCRIPTION
resolves #5558 

This updates the documentation for zone awareness to include adding the environment variable section for the init containers as well as the Elasticsearch containers, as when `secureSettings` are used in conjunction with this [configuration](https://www.elastic.co/guide/en/cloud-on-k8s/2.1/k8s-advanced-node-scheduling.html#k8s-availability-zone-awareness-example), the init container for initializing the keystore fails with `Exception in thread "main" java.lang.IllegalArgumentException: Could not resolve placeholder 'ZONE'`