### PR TITLE
Add APM Server Deprecation Message

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
@@ -7,7 +7,7 @@ endif::[]
 [id="{p}-{page_id}"]
 = Run APM Server on ECK
 
-WARNING: As of version 8.0, the standalone APM Server binary is deprecated, and will be removed in a future release. Consider using <<{p}-elastic-agent-fleet,Elastic Agent in Fleet-managed mode with ECK>>. Refer to the link:https://www.elastic.co/guide/en/apm/guide/current/apm-quick-start.html[Elastic APM integration] for additional details.
+WARNING: As of version 8.0.0, the standalone APM Server binary is deprecated and will be removed in a future release. Consider using <<{p}-elastic-agent-fleet,Elastic Agent in Fleet-managed mode with ECK>>. Refer to the link:https://www.elastic.co/guide/en/apm/guide/current/apm-quick-start.html[Elastic APM integration] for additional details.
 
 This section describes how to deploy, configure and access an APM Server with ECK.
 

--- a/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
@@ -7,6 +7,8 @@ endif::[]
 [id="{p}-{page_id}"]
 = Run APM Server on ECK
 
+WARNING: As of version 8.0, the standalone APM Server binary is deprecated, and will be removed in a future release. Consider using <<{p}-elastic-agent-fleet,Elastic Agent in Fleet-managed mode with ECK>>. Refer to the link:https://www.elastic.co/guide/en/apm/guide/current/apm-quick-start.html[Elastic APM integration] for additional details.
+
 This section describes how to deploy, configure and access an APM Server with ECK.
 
 * <<{p}-apm-eck-managed-es,Use an Elasticsearch cluster managed by ECK>>

--- a/pkg/controller/apmserver/controller.go
+++ b/pkg/controller/apmserver/controller.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"sync/atomic"
 
+	"github.com/blang/semver/v4"
 	"go.elastic.co/apm"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -253,6 +254,8 @@ func (r *ReconcileApmServer) doReconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, nil // will eventually retry
 	}
 
+	r.warnIfDeprecated(asVersion, as)
+
 	state, err = r.reconcileApmServerDeployment(ctx, state, as)
 	if err != nil {
 		if apierrors.IsConflict(err) {
@@ -274,6 +277,18 @@ func (r *ReconcileApmServer) doReconcile(ctx context.Context, request reconcile.
 	res, err := results.WithError(err).Aggregate()
 	k8s.EmitErrorEvent(r.recorder, err, as, events.EventReconciliationError, "Reconciliation error: %v", err)
 	return res, err
+}
+
+func (r *ReconcileApmServer) warnIfDeprecated(version semver.Version, as *apmv1.ApmServer) {
+	if version.GTE(semver.MustParse("8.0.0")) {
+		message := "The standalone APM Server binary is deprecated as of version 8.0.0 and will be removed in a future release.  Consider using Elastic Agent in Fleet-managed mode."
+		log.Info(
+			message,
+			"namespace", as.Namespace,
+			"es_name", as.Name,
+		)
+		r.Recorder().Eventf(as, corev1.EventTypeWarning, events.EventReasonValidation, message)
+	}
 }
 
 func (r *ReconcileApmServer) validate(ctx context.Context, as *apmv1.ApmServer) error {

--- a/pkg/controller/apmserver/controller.go
+++ b/pkg/controller/apmserver/controller.go
@@ -281,11 +281,11 @@ func (r *ReconcileApmServer) doReconcile(ctx context.Context, request reconcile.
 
 func (r *ReconcileApmServer) warnIfDeprecated(version semver.Version, as *apmv1.ApmServer) {
 	if version.GTE(semver.MustParse("8.0.0")) {
-		message := "The standalone APM Server binary is deprecated as of version 8.0.0 and will be removed in a future release.  Consider using Elastic Agent in Fleet-managed mode."
+		message := "The standalone APM Server binary is deprecated as of version 8.0.0 and will be removed in a future release. Consider using Elastic Agent in Fleet-managed mode."
 		log.Info(
 			message,
 			"namespace", as.Namespace,
-			"es_name", as.Name,
+			"as_name", as.Name,
 		)
 		r.Recorder().Eventf(as, corev1.EventTypeWarning, events.EventReasonValidation, message)
 	}


### PR DESCRIPTION
resolves #5419 

This adds an APM Server deprecation warning to the documentation, as well as adding a log message during reconciliation, and an event to the associated namespace.