### PR TITLE
[2.0] Remove "experimental" from Helm chart description (#5588)

### DIFF
--- a/docs/operating-eck/installing-eck.asciidoc
+++ b/docs/operating-eck/installing-eck.asciidoc
@@ -31,7 +31,7 @@ This method is the quickest way to get started with ECK if you have full adminis
 [id="{p}-install-helm"]
 == Install ECK using the Helm chart
 
-Starting from ECK 1.3.0, an experimental Helm chart is available to install ECK. It is available from the Elastic Helm repository and can be added to your Helm repository list by running the following command:
+Starting from ECK 1.3.0, a Helm chart is available to install ECK. It is available from the Elastic Helm repository and can be added to your Helm repository list by running the following command:
 
 [source, sh]
 ----


### PR DESCRIPTION
Backports the following commits to 2.0:
 - Remove "experimental" from Helm chart description (#5588)