### PR TITLE
Fix resources limits conversion in ToInt64() used for logging

### DIFF
--- a/pkg/controller/autoscaling/elasticsearch/resources/resources.go
+++ b/pkg/controller/autoscaling/elasticsearch/resources/resources.go
@@ -316,20 +316,20 @@ func (nr NodeResources) ToInt64() NodeResourcesInt64 {
 		Requests: make(ResourceListInt64),
 		Limits:   make(ResourceListInt64),
 	}
-	for resource, value := range nr.Requests {
-		switch resource {
+	for res, value := range nr.Requests {
+		switch res {
 		case corev1.ResourceCPU:
-			rs64.Requests[resource] = value.MilliValue()
+			rs64.Requests[res] = value.MilliValue()
 		default:
-			rs64.Requests[resource] = value.Value()
+			rs64.Requests[res] = value.Value()
 		}
 	}
-	for resource, value := range nr.Limits {
-		switch resource {
+	for res, value := range nr.Limits {
+		switch res {
 		case corev1.ResourceCPU:
-			rs64.Requests[resource] = value.MilliValue()
+			rs64.Limits[res] = value.MilliValue()
 		default:
-			rs64.Requests[resource] = value.Value()
+			rs64.Limits[res] = value.Value()
 		}
 	}
 	return rs64


### PR DESCRIPTION
Fixed a small bug with no real impact because the method is only used for logging.

I also renamed the `resource` variable to `res` to avoid the collision with the imported package `k8s.io/apimachinery/pkg/api/resource`.