### PR TITLE
Update dependency golang to v1.17.9

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image used for continuous integration
-FROM golang:1.17.8
+FROM golang:1.17.9
 
 ENV GOLANGCILINT_VERSION=1.38.0
 ENV SHELLCHECK_VERSION=0.7.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM --platform=$TARGETPLATFORM golang:1.17.8 as builder
+FROM --platform=$TARGETPLATFORM golang:1.17.9 as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/hack/manifest-gen/Dockerfile
+++ b/hack/manifest-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.8 as builder
+FROM golang:1.17.9 as builder
 ADD . /manifest-gen
 WORKDIR /manifest-gen
 ENV GO111MODULE=on CGO_ENABLED=0 GOOS=linux 

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image for the E2E tests runner
-FROM --platform=$TARGETPLATFORM golang:1.17.8
+FROM --platform=$TARGETPLATFORM golang:1.17.9
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
Updates minor version of golang in the `2.2` branch to address security issues.

--------------

  These minor release includes three security fixes following the security
  policy:

  * encoding/pem: fix stack overflow in Decode

    A large (more than 5 MB) PEM input can cause a stack overflow in Decode,
    leading the program to crash.
    Thanks to Juho Nurminen of Mattermost who reported the error.
    This is CVE-2022-24675 and https://go.dev/issue/51853.

  * crypto/elliptic: tolerate all oversized scalars in generic P-256

    A crafted scalar input longer than 32 bytes can cause
    P256().ScalarMult or P256().ScalarBaseMult to panic. Indirect uses
    through crypto/ecdsa and crypto/tls are unaffected. amd64, arm64,
    ppc64le, and s390x are unaffected.
    This was discovered thanks to a Project Wycheproof test vector.
    This is CVE-2022-28327 and https://go.dev/issue/52075.

  * crypto/x509: non-compliant certificates can cause a panic in Verify on   macOS in Go 1.18

    Verifying certificate chains containing certificates which are not
    compliant with RFC 5280 causes Certificate.Verify to panic on macOS.
    These chains can be delivered through TLS and can cause a crypto/tls
    or net/http client to crash.
    Thanks to Tailscale for doing weird things and finding this.
    This is CVE-2022-27536 and https://go.dev/issue/51759.

  Full release note: https://go.dev/doc/devel/release#go1.18.minor