### PR TITLE
EKS deployer adjustments for eksctl 0.93.0

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -112,7 +112,6 @@ plans:
   eks:
     region: ap-northeast-3
     nodeCount: 3
-    nodeAMI: auto
 - id: eks-arm-ci
   operation: create
   clusterName: arm-ci
@@ -124,7 +123,6 @@ plans:
   eks:
     region: eu-west-1
     nodeCount: 3
-    nodeAMI: auto
 - id: eks-dev
   operation: create
   clusterName: dev
@@ -135,7 +133,6 @@ plans:
   eks:
     region: eu-west-2
     nodeCount: 3
-    nodeAMI: auto
 - id: e2e-monitor
   operation: create
   clusterName: e2e-monitor

--- a/hack/deployer/runner/eks.go
+++ b/hack/deployer/runner/eks.go
@@ -33,14 +33,10 @@ metadata:
   name: {{.ClusterName}}
   region: {{.Region}}
   version: "{{.KubernetesVersion}}"
-nodeGroups:
+managedNodeGroups:
   - name: ng-1
     instanceType: {{.MachineType}}
     desiredCapacity: {{.NodeCount}}
-    ami: {{.NodeAMI}}
-    iam:
-      instanceProfileARN: {{.InstanceProfileARN}}
-      instanceRoleARN: {{.InstanceRoleARN}}
 iam:
   withOIDC: false
   serviceRoleARN: {{.ServiceRoleARN}}
@@ -68,7 +64,6 @@ func (e EKSDriverFactory) Create(plan Plan) (Driver, error) {
 			"KubernetesVersion": plan.KubernetesVersion,
 			"NodeCount":         plan.Eks.NodeCount,
 			"MachineType":       plan.MachineType,
-			"NodeAMI":           plan.Eks.NodeAMI,
 			"WorkDir":           plan.Eks.WorkDir,
 		},
 	}, nil
@@ -194,11 +189,9 @@ func (e *EKSDriver) fetchSecrets() error {
 		return err
 	}
 	for vaultKey, ctxKey := range map[string]string{
-		"instance-profile": "InstanceProfileARN",
-		"instance-role":    "InstanceRoleARN",
-		"service-role":     "ServiceRoleARN",
-		"access-key":       awsAccessKeyID,
-		"secret-key":       awsSecretAccessKey,
+		"service-role": "ServiceRoleARN",
+		"access-key":   awsAccessKeyID,
+		"secret-key":   awsSecretAccessKey,
 	} {
 		val, err := client.Get(EKSVaultPath, vaultKey)
 		if err != nil {

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -84,7 +84,6 @@ type OCP3Settings struct {
 
 // EKSSettings are specific to Amazon EKS.
 type EKSSettings struct {
-	NodeAMI   string `yaml:"nodeAMI"`
 	NodeCount int    `yaml:"nodeCount"`
 	Region    string `yaml:"region"`
 	WorkDir   string `yaml:"workDir"`


### PR DESCRIPTION
https://github.com/elastic/cloud-on-k8s/pull/5579 upgraded `eksctl` but that version introduces a breaking change compared to the version we were using previously. 

https://eksctl.io/usage/nodegroup-override-announcement/

I have tried to address this by moving to managed node groups. I need to do some more testing on CI before this is OK to merge. A first test on my local machine was successful.