### PR TITLE
E2E: TestGlobalCA with restricted security context

### DIFF
--- a/test/e2e/global_ca_test.go
+++ b/test/e2e/global_ca_test.go
@@ -45,6 +45,7 @@ func TestGlobalCA(t *testing.T) {
 	ent := enterprisesearch.NewBuilder(name).
 		WithNodeCount(1).
 		WithElasticsearchRef(es.Ref()).
+		WithRestrictedSecurityContext().
 		WithGlobalCA(true)
 	testPod := beat.NewPodBuilder(name)
 	agent := elasticagent.NewBuilder(name).


### PR DESCRIPTION
I ran my local tests on a cluster without a PodSecurityPolicy so the error we are currently seeing in CI was not caught by me. This adds a restricted security context to the EnterpriseSearch builder, which fixes the test.