### PR TITLE
[2.2] Do not delete restart shutdowns before node rejoins cluster (#5618)

### DIFF
--- a/pkg/controller/elasticsearch/client/model.go
+++ b/pkg/controller/elasticsearch/client/model.go
@@ -420,6 +420,11 @@ var (
 // ShutdownStatus is the set of different status a shutdown requests can have.
 type ShutdownStatus string
 
+// Applies is a predicate that checks this status against a given shutdown struct and returns true if they are the same status.
+func (status ShutdownStatus) Applies(shutdown NodeShutdown) bool {
+	return shutdown.Status == status
+}
+
 var (
 	// ShutdownInProgress means a shutdown request has been accepted and is being processed in Elasticsearch.
 	ShutdownInProgress ShutdownStatus = "IN_PROGRESS"

--- a/pkg/controller/elasticsearch/driver/esstate_test.go
+++ b/pkg/controller/elasticsearch/driver/esstate_test.go
@@ -44,7 +44,8 @@ type fakeESClient struct { //nolint:maligned
 	clusterRoutingAllocation             esclient.ClusterRoutingAllocation
 	GetClusterRoutingAllocationCallCount int
 
-	Shutdowns map[string]esclient.NodeShutdown
+	Shutdowns            map[string]esclient.NodeShutdown
+	DeleteShutdownCalled bool
 
 	health                      esclient.Health
 	GetClusterHealthCalledCount int
@@ -124,7 +125,8 @@ func (f *fakeESClient) GetShutdown(_ context.Context, nodeID *string) (esclient.
 	return esclient.ShutdownResponse{Nodes: ns}, nil
 }
 
-func (f *fakeESClient) DeleteShutdown(ctx context.Context, nodeID string) error {
+func (f *fakeESClient) DeleteShutdown(_ context.Context, _ string) error {
+	f.DeleteShutdownCalled = true
 	return nil
 }
 

--- a/pkg/controller/elasticsearch/driver/upgrade.go
+++ b/pkg/controller/elasticsearch/driver/upgrade.go
@@ -117,10 +117,7 @@ func (d *defaultDriver) handleUpgrades(
 	}
 
 	// Maybe re-enable shards allocation and delete shutdowns if upgraded nodes are back into the cluster.
-	res := d.maybeCompleteNodeUpgrades(ctx, esClient, esState, nodeShutdown)
-	results.WithResults(res)
-
-	return results
+	return results.WithResults(d.maybeCompleteNodeUpgrades(ctx, esClient, esState, nodeShutdown))
 }
 
 type upgradeCtx struct {
@@ -307,16 +304,50 @@ func (d *defaultDriver) maybeCompleteNodeUpgrades(
 	esState ESState,
 	nodeShutdown *shutdown.NodeShutdown,
 ) *reconciler.Results {
+	results := &reconciler.Results{}
+	// Make sure all pods scheduled for upgrade have been upgraded.
+	done, reason, err := d.expectationsSatisfied()
+	if err != nil {
+		return results.WithError(err)
+	}
+	if !done {
+		reason := fmt.Sprintf("Completing node upgrade: %s", reason)
+		return results.WithReconciliationState(defaultRequeue.WithReason(reason))
+	}
+
+	// small optimisation: once expectations are satisfied we can already delete shutdowns that are complete and where the node
+	// is back in the cluster to avoid completed shutdowns from accumulating
+	if supportsNodeShutdown(esClient.Version()) {
+		// clear all shutdowns of type restart that have completed
+		results = results.WithError(nodeShutdown.Clear(ctx, esclient.ShutdownComplete.Applies, nodeShutdown.OnlyNodesInCluster))
+	}
+
+	statefulSets, err := sset.RetrieveActualStatefulSets(d.Client, k8s.ExtractNamespacedName(&d.ES))
+	if err != nil {
+		return results.WithError(err)
+	}
+
+	// Make sure all nodes scheduled for upgrade are back into the cluster.
+	nodesInCluster, err := esState.NodesInCluster(statefulSets.PodNames())
+	if err != nil {
+		return results.WithError(err)
+	}
+	if !nodesInCluster {
+		log.V(1).Info(
+			"Some upgraded nodes are not back in the cluster yet, cannot complete node upgrade",
+			"namespace", d.ES.Namespace,
+			"es_name", d.ES.Name,
+		)
+		return results.WithReconciliationState(defaultRequeue.WithReason("Nodes upgrade: some nodes are not back in the cluster yet"))
+	}
+
 	// we still have to enable shard allocation in cases where we just upgraded from
 	// a version that did not support node shutdown to a supported version.
-	results := d.maybeEnableShardsAllocation(ctx, esClient, esState)
-	if !results.HasError() && supportsNodeShutdown(esClient.Version()) {
-		// clear all shutdowns of type restart that have completed
-		// this relies on the fact the maybeEnableShardsAllocation checks expectations
-		err := nodeShutdown.Clear(ctx, &esclient.ShutdownComplete)
-		if err != nil {
-			results = results.WithError(err)
-		}
+	results = results.WithResults(d.maybeEnableShardsAllocation(ctx, esClient, esState))
+	if supportsNodeShutdown(esClient.Version()) {
+		// clear all shutdowns of type restart that have completed including those where the node is no longer in the cluster
+		// or node state was lost due to an external event
+		results = results.WithError(nodeShutdown.Clear(ctx, esclient.ShutdownComplete.Applies))
 	}
 	return results
 }
@@ -338,35 +369,6 @@ func (d *defaultDriver) maybeEnableShardsAllocation(
 	}
 	if alreadyEnabled {
 		return results
-	}
-
-	// Make sure all pods scheduled for upgrade have been upgraded.
-	done, reason, err := d.expectationsSatisfied()
-	if err != nil {
-		return results.WithError(err)
-	}
-	if !done {
-		reason := fmt.Sprintf("Enabling shards allocation: %s", reason)
-		return results.WithReconciliationState(defaultRequeue.WithReason(reason))
-	}
-
-	statefulSets, err := sset.RetrieveActualStatefulSets(d.Client, k8s.ExtractNamespacedName(&d.ES))
-	if err != nil {
-		return results.WithError(err)
-	}
-
-	// Make sure all nodes scheduled for upgrade are back into the cluster.
-	nodesInCluster, err := esState.NodesInCluster(statefulSets.PodNames())
-	if err != nil {
-		return results.WithError(err)
-	}
-	if !nodesInCluster {
-		log.V(1).Info(
-			"Some upgraded nodes are not back in the cluster yet, keeping shard allocations disabled",
-			"namespace", d.ES.Namespace,
-			"es_name", d.ES.Name,
-		)
-		return results.WithReconciliationState(defaultRequeue.WithReason("Nodes upgrade: some nodes are not back in the cluster yet"))
 	}
 
 	log.Info("Enabling shards allocation", "namespace", d.ES.Namespace, "es_name", d.ES.Name)

--- a/pkg/controller/elasticsearch/shutdown/node.go
+++ b/pkg/controller/elasticsearch/shutdown/node.go
@@ -68,6 +68,15 @@ func (ns *NodeShutdown) lookupNodeID(podName string) (string, error) {
 	return nodeID, nil
 }
 
+func (ns *NodeShutdown) nodeInCluster(nodeID string) bool {
+	for _, id := range ns.podToNodeID {
+		if id == nodeID {
+			return true
+		}
+	}
+	return false
+}
+
 // ReconcileShutdowns retrieves ongoing shutdowns and based on the given node names either cancels or creates new
 // shutdowns.
 func (ns *NodeShutdown) ReconcileShutdowns(ctx context.Context, leavingNodes []string) error {
@@ -76,7 +85,7 @@ func (ns *NodeShutdown) ReconcileShutdowns(ctx context.Context, leavingNodes []s
 	}
 	// cancel all ongoing shutdowns for the current shutdown type
 	if len(leavingNodes) == 0 {
-		return ns.Clear(ctx, nil)
+		return ns.Clear(ctx)
 	}
 
 	for _, node := range leavingNodes {
@@ -140,20 +149,38 @@ func logStatus(logger logr.Logger, podName string, shutdown esclient.NodeShutdow
 	}
 }
 
+// ClearCondition predicate that can be used to limit the Clear function.
+type ClearCondition func(esclient.NodeShutdown) bool
+
+// OnlyNodesInCluster is a predicate to limit the shutdowns to delete to nodes that are currently in the cluster.
+func (ns *NodeShutdown) OnlyNodesInCluster(s esclient.NodeShutdown) bool {
+	return ns.nodeInCluster(s.NodeID)
+}
+
 // Clear deletes shutdown requests matching the type of the NodeShutdown field typ and the given optional status.
 // Depending on the progress of the shutdown in question this means either a cancellation of the shutdown or a clean-up
 // after shutdown completion.
-func (ns *NodeShutdown) Clear(ctx context.Context, status *esclient.ShutdownStatus) error {
+func (ns *NodeShutdown) Clear(ctx context.Context, conditions ...ClearCondition) error {
 	if err := ns.initOnce(ctx); err != nil {
 		return err
 	}
-	for _, s := range ns.shutdowns {
-		if s.Is(ns.typ) && (status == nil || s.Status == *status) {
+	for k, s := range ns.shutdowns {
+		if s.Is(ns.typ) && allApply(conditions, s) {
 			ns.log.V(1).Info("Deleting shutdown", "type", ns.typ, "node_id", s.NodeID)
 			if err := ns.c.DeleteShutdown(ctx, s.NodeID); err != nil {
 				return fmt.Errorf("while deleting shutdown for %s: %w", s.NodeID, err)
 			}
+			delete(ns.shutdowns, k)
 		}
 	}
 	return nil
+}
+
+func allApply(conditions []ClearCondition, s esclient.NodeShutdown) bool {
+	for _, c := range conditions {
+		if !c(s) {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/controller/elasticsearch/shutdown/node_test.go
+++ b/pkg/controller/elasticsearch/shutdown/node_test.go
@@ -18,11 +18,11 @@ import (
 )
 
 var (
-	singleShutdownFixture = `{
+	singleRestartShutdownFixture = `{
   "nodes": [
     {
       "node_id": "txXw-Kd2Q6K0PbYMAPzH-Q",
-      "type": "REMOVE",
+      "type": "RESTART",
       "reason": "111800357",
       "shutdown_startedmillis": 1626780145861,
       "status": "COMPLETE",
@@ -107,23 +107,30 @@ var (
 )
 
 func TestNodeShutdown_Clear(t *testing.T) {
+	statusCondition := func(status esclient.ShutdownStatus) func(*NodeShutdown) []ClearCondition {
+		return func(*NodeShutdown) []ClearCondition {
+			return []ClearCondition{status.Applies}
+		}
+	}
+
 	type args struct {
-		typ    esclient.ShutdownType
-		status *esclient.ShutdownStatus
+		typ        esclient.ShutdownType
+		conditions func(shutdown *NodeShutdown) []ClearCondition
 	}
 	tests := []struct {
-		name       string
-		args       args
-		fixture    string
-		wantErr    bool
-		wantDelete bool
+		name        string
+		args        args
+		fixture     string
+		podToNodeID map[string]string
+		wantErr     bool
+		wantDelete  bool
 	}{
 		{
 			name:    "Respect type when deleting shutdowns",
 			fixture: shutdownFixture,
 			args: args{
-				typ:    esclient.Restart,
-				status: &esclient.ShutdownComplete,
+				typ:        esclient.Restart,
+				conditions: statusCondition(esclient.ShutdownComplete),
 			},
 			wantErr:    false,
 			wantDelete: false,
@@ -132,8 +139,8 @@ func TestNodeShutdown_Clear(t *testing.T) {
 			name:    "Respect status when deleting shutdowns",
 			fixture: shutdownFixture,
 			args: args{
-				typ:    esclient.Remove,
-				status: &esclient.ShutdownInProgress,
+				typ:        esclient.Remove,
+				conditions: statusCondition(esclient.ShutdownInProgress),
 			},
 			wantErr:    false,
 			wantDelete: false,
@@ -142,8 +149,10 @@ func TestNodeShutdown_Clear(t *testing.T) {
 			name:    "Allow all status values when deleting shutdowns",
 			fixture: shutdownFixture,
 			args: args{
-				typ:    esclient.Remove,
-				status: nil,
+				typ: esclient.Remove,
+				conditions: func(_ *NodeShutdown) []ClearCondition {
+					return nil
+				},
 			},
 			wantErr:    false,
 			wantDelete: true,
@@ -152,8 +161,35 @@ func TestNodeShutdown_Clear(t *testing.T) {
 			name:    "Should delete shutdowns",
 			fixture: shutdownFixture,
 			args: args{
-				typ:    esclient.Remove,
-				status: &esclient.ShutdownComplete,
+				typ:        esclient.Remove,
+				conditions: statusCondition(esclient.ShutdownComplete),
+			},
+			wantErr:    false,
+			wantDelete: true,
+		},
+		{
+			name: "Should not delete restart shutdowns if node not in cluster",
+			args: args{
+				typ: esclient.Restart,
+				conditions: func(shutdown *NodeShutdown) []ClearCondition {
+					return []ClearCondition{esclient.ShutdownComplete.Applies, shutdown.OnlyNodesInCluster}
+				},
+			},
+			fixture:    singleRestartShutdownFixture,
+			wantErr:    false,
+			wantDelete: false,
+		},
+		{
+			name: "Should delete restart shutdowns once node back in cluster",
+			args: args{
+				typ: esclient.Restart,
+				conditions: func(shutdown *NodeShutdown) []ClearCondition {
+					return []ClearCondition{esclient.ShutdownComplete.Applies, shutdown.OnlyNodesInCluster}
+				},
+			},
+			fixture: singleRestartShutdownFixture,
+			podToNodeID: map[string]string{
+				"pod-1": "txXw-Kd2Q6K0PbYMAPzH-Q",
 			},
 			wantErr:    false,
 			wantDelete: true,
@@ -161,8 +197,8 @@ func TestNodeShutdown_Clear(t *testing.T) {
 		{
 			name: "Should bubble up errors",
 			args: args{
-				typ:    esclient.Remove,
-				status: &esclient.ShutdownComplete,
+				typ:        esclient.Remove,
+				conditions: statusCondition(esclient.ShutdownComplete),
 			},
 			fixture:    `{not json`,
 			wantErr:    true,
@@ -184,12 +220,13 @@ func TestNodeShutdown_Clear(t *testing.T) {
 				}
 			})
 			ns := &NodeShutdown{
-				c:   client,
-				typ: tt.args.typ,
-				log: log.Log.WithName("test"),
+				c:           client,
+				typ:         tt.args.typ,
+				podToNodeID: tt.podToNodeID,
+				log:         log.Log.WithName("test"),
 			}
 
-			if err := ns.Clear(context.Background(), tt.args.status); (err != nil) != tt.wantErr {
+			if err := ns.Clear(context.Background(), tt.args.conditions(ns)...); (err != nil) != tt.wantErr {
 				t.Errorf("Clear() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.wantDelete != deleteCalled {
@@ -335,7 +372,7 @@ func TestNodeShutdown_ReconcileShutdowns(t *testing.T) {
 			fixtures: []string{
 				noShutdownFixture,
 				ackFixture,
-				singleShutdownFixture,
+				singleRestartShutdownFixture,
 			},
 			wantErr:     false,
 			wantMethods: []string{"GET", "PUT", "GET"},
@@ -353,11 +390,11 @@ func TestNodeShutdown_ReconcileShutdowns(t *testing.T) {
 			fixtures: []string{
 				noShutdownFixture,
 				ackFixture,
-				singleShutdownFixture,
+				singleRestartShutdownFixture,
 				ackFixture,
 				// technically incorrect as we are returning the same shutdown fixture as before. But we don't verify
 				// the responses, so good enough for this test.
-				singleShutdownFixture,
+				singleRestartShutdownFixture,
 			},
 			wantErr:     false,
 			wantMethods: []string{"GET", "PUT", "GET", "PUT", "GET"},


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.2`:
 - [Do not delete restart shutdowns before node rejoins cluster (#5618)](https://github.com/elastic/cloud-on-k8s/pull/5618)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)