### PR TITLE
Delete old shutdowns before creating new ones

### DIFF
--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -458,7 +458,8 @@ func Test_defaultDriver_maybeCompleteNodeUpgrades(t *testing.T) {
 			shutdowns:      shutdownFixture,
 			runtimeObjects: append(testSset.Pods(), testSset.BuildPtr()),
 			assertions: func(results *reconciler.Results, esClient *fakeESClient) {
-				require.False(t, esClient.DeleteShutdownCalled) // will be called outside now TODO fix test
+				// shutdown will be cleaned up already outside of completeNodeUpgrades
+				require.False(t, esClient.DeleteShutdownCalled)
 				require.False(t, esClient.EnableShardAllocationCalled)
 				reconciled, _ := results.IsReconciled()
 				require.False(t, reconciled)

--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -458,7 +458,7 @@ func Test_defaultDriver_maybeCompleteNodeUpgrades(t *testing.T) {
 			shutdowns:      shutdownFixture,
 			runtimeObjects: append(testSset.Pods(), testSset.BuildPtr()),
 			assertions: func(results *reconciler.Results, esClient *fakeESClient) {
-				require.True(t, esClient.DeleteShutdownCalled)
+				require.False(t, esClient.DeleteShutdownCalled) // will be called outside now TODO fix test
 				require.False(t, esClient.EnableShardAllocationCalled)
 				reconciled, _ := results.IsReconciled()
 				require.False(t, reconciled)


### PR DESCRIPTION
Fixes #5628

Moves the cleanup at the beginning of the upgrade function to make sure we don't end up with left over shutdowns and then don't get to clean them up in time because we exit early after node deletions. 