### PR TITLE
Restore systematic ci-build-image call

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -44,7 +44,7 @@ ci:
 ci-interactive:
 	@ $(MAKE) DOCKER_OPTS=-i DOCKER_CMD=bash ci-internal
 
-ci-internal:
+ci-internal: ci-build-image
 	@ docker volume create --name $(ECK_CI_VOLUME) > /dev/null && \
 	  docker run --rm -t $(DOCKER_OPTS) \
 		-v /var/run/docker.sock:/var/run/docker.sock \


### PR DESCRIPTION
In #5535, I removed the systematic call to `ci-build-image` to call it once to reduce the total job execution time but this change impacts all other pipeline.

I prefer to temporarily revert this particular change and we can reintroduce it after we redesign the other pipelines like in #5535.

Relates to #5535.

