### PR TITLE
[2.2] Delete old shutdowns before creating new ones (#5629)

### DIFF
--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -458,7 +458,8 @@ func Test_defaultDriver_maybeCompleteNodeUpgrades(t *testing.T) {
 			shutdowns:      shutdownFixture,
 			runtimeObjects: append(testSset.Pods(), testSset.BuildPtr()),
 			assertions: func(results *reconciler.Results, esClient *fakeESClient) {
-				require.True(t, esClient.DeleteShutdownCalled)
+				// shutdown will be cleaned up already outside of completeNodeUpgrades
+				require.False(t, esClient.DeleteShutdownCalled)
 				require.False(t, esClient.EnableShardAllocationCalled)
 				reconciled, _ := results.IsReconciled()
 				require.False(t, reconciled)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.2`:
 - [Delete old shutdowns before creating new ones (#5629)](https://github.com/elastic/cloud-on-k8s/pull/5629)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)