### PR TITLE
Do not set custom Fleet image/version on recipe tests

### DIFF
--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -154,6 +154,7 @@ func TestFleetMode(t *testing.T) {
 		WithDeployment().
 		WithFleetMode().
 		WithFleetServer().
+		WithFleetImage().
 		WithElasticsearchRefs(agent.ToOutput(esBuilder.Ref(), "default")).
 		WithKibanaRef(kbBuilder.Ref()).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.fleet_server", "default")).

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -154,7 +154,6 @@ func TestFleetMode(t *testing.T) {
 		WithDeployment().
 		WithFleetMode().
 		WithFleetServer().
-		WithFleetImage().
 		WithElasticsearchRefs(agent.ToOutput(esBuilder.Ref(), "default")).
 		WithKibanaRef(kbBuilder.Ref()).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.fleet_server", "default")).

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -98,7 +98,6 @@ func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
 		}
 
 		return builder.
-			WithFleetImage().
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.fleet_server", "default")).
@@ -147,7 +146,6 @@ func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
 		}
 
 		return builder.
-			WithFleetImage().
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.fleet_server", "default")).
@@ -172,7 +170,6 @@ func TestFleetAPMIntegrationRecipe(t *testing.T) {
 		}
 
 		return builder.
-			WithFleetImage().
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.fleet_server", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.apm_server", "default")).


### PR DESCRIPTION
Recent test failures for the `TestFleetKubernetesIntegrationRecipe` test can be explained by the setting of a custom Fleet image and version. This was intended for the custom build job that allows users to specify images and versions for each Elastic stack component. In the absence of such a definition the code falls back to the current version under test and the default image for the stack component. 

However in the case of our recipe test we use fixed versions. By setting the version to the version under test the builder created a version difference between Fleet (running on let's say `8.2.0-SNAPSHOT`) and its Agents (running `8.1.1` as defined in the recipe). The rollout of Fleet was never happening because of this difference as the operator waited for the upgrade of the linked Kibana and Elasticsearch instance to `8.2.0-SNAPSHOT` which of course never happened.