### PR TITLE
E2E avoid implicitly resetting configured stack version for Fleet

### DIFF
--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -305,9 +305,12 @@ func (b Builder) WithFleetServer() Builder {
 }
 
 func (b Builder) WithFleetImage() Builder {
-	def := test.Ctx().ImageDefinitionFor(FleetServerPseudoKind)
-	b.Agent.Spec.Image = def.Image
-	b.Agent.Spec.Version = def.Version
+	// do not override image or version unless an explicit override exists as builder might already have been configured
+	// with a specific version which we do want to preserve.
+	if def := test.Ctx().ImageDefinitionOrNil(FleetServerPseudoKind); def != nil {
+		b.Agent.Spec.Image = def.Image
+		b.Agent.Spec.Version = def.Version
+	}
 	return b
 }
 

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -152,13 +152,12 @@ func (c Context) ImageDefinitionFor(kind string) ElasticStackImageDefinition {
 
 // ImageDefinitionOrNil returns a specific override for the given kind of resource. Returns nil if no override exists.
 func (c Context) ImageDefinitionOrNil(kind string) *ElasticStackImageDefinition {
-	var result *ElasticStackImageDefinition
 	for _, def := range c.ElasticStackImages {
 		if kind == def.Kind {
-			result = &def
+			return &def
 		}
 	}
-	return result
+	return nil
 }
 
 // ClusterResource is a generic cluster resource.

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -150,6 +150,17 @@ func (c Context) ImageDefinitionFor(kind string) ElasticStackImageDefinition {
 	return ElasticStackImageDefinition{Version: c.ElasticStackVersion}
 }
 
+// ImageDefinitionOrNil returns a specific override for the given kind of resource. Returns nil if no override exists.
+func (c Context) ImageDefinitionOrNil(kind string) *ElasticStackImageDefinition {
+	var result *ElasticStackImageDefinition
+	for _, def := range c.ElasticStackImages {
+		if kind == def.Kind {
+			result = &def
+		}
+	}
+	return result
+}
+
 // ClusterResource is a generic cluster resource.
 type ClusterResource struct {
 	Name      string `json:"name"`


### PR DESCRIPTION
This aims to fix recent test failures of `TestAgentVersionUpgradeToLatest8x`. The cause of the failure is unfortunate interaction between two recently made tweaks to the e2e runner:
* https://github.com/elastic/cloud-on-k8s/pull/5439
* https://github.com/elastic/cloud-on-k8s/pull/5555

#5555 flips the version under test if the latest released version is lower than the version under test. e.g. if we test `8.2.0-SNAPSHOT` and the latest version release was (until yesterday) `8.1.1` then `8.1.1` would be used as the start version in the test and `8.2.0-SNAPSHOT` as the target version we try to upgrade to. 

#5439 however added some implicit version switching logic that tries to take the version under test from a config file. Now if that file does not exist as it is the case most of the time it should fall back to the version and image configured globally in the test context. Unfortunately when applying this fallback it reset the flipped version from #5555 

The fix attempts to respect any version set in the builder unless said configuration file exists with specific version overrides.