### PR TITLE
Update test jobs to use 8.2.0

### DIFF
--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -58,14 +58,14 @@ pipeline {
                 )}"""
             }
             parallel {
-                stage("8.2.0-SNAPSHOT") {
+                stage("8.3.0-SNAPSHOT") {
                      agent {
                         label 'linux'
                     }
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-8x-snapshot-${BUILD_NUMBER}-e2e", "8.2.0-SNAPSHOT")
+                            runWith(lib, failedTests, "eck-8x-snapshot-${BUILD_NUMBER}-e2e", "8.3.0-SNAPSHOT")
                         }
                     }
                 }

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -46,17 +46,6 @@ pipeline {
                         }
                     }
                 }
-                stage("7.10.2") {
-                    agent {
-                        label 'linux'
-                    }
-                    steps {
-                        unstash "source"
-                        script {
-                            runWith(lib, failedTests, "eck-710-${BUILD_NUMBER}-e2e", "7.10.2")
-                        }
-                    }
-                }
                 stage("7.11.2") {
                     agent {
                         label 'linux'
@@ -156,6 +145,17 @@ pipeline {
                         }
                     }
                }
+               stage("8.2.0") {
+                    agent {
+                        label 'linux'
+                    }
+                    steps {
+                        unstash "source"
+                        script {
+                            runWith(lib, failedTests, "eck-820-${BUILD_NUMBER}-e2e", "8.2.0")
+                        }
+                    }
+               }
             }
         }
     }
@@ -186,7 +186,6 @@ pipeline {
             script {
                 clusters = [
                     "eck-68-${BUILD_NUMBER}-e2e",
-                    "eck-710-${BUILD_NUMBER}-e2e",
                     "eck-711-${BUILD_NUMBER}-e2e",
                     "eck-712-${BUILD_NUMBER}-e2e",
                     "eck-713-${BUILD_NUMBER}-e2e",
@@ -195,7 +194,8 @@ pipeline {
                     "eck-716-${BUILD_NUMBER}-e2e",
                     "eck-717-${BUILD_NUMBER}-e2e",
                     "eck-800-${BUILD_NUMBER}-e2e",
-                    "eck-810-${BUILD_NUMBER}-e2e"
+                    "eck-810-${BUILD_NUMBER}-e2e",
+                    "eck-820-${BUILD_NUMBER}-e2e"
                 ]
                 for (int i = 0; i < clusters.size(); i++) {
                     build job: 'cloud-on-k8s-e2e-cleanup',

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -112,14 +112,14 @@ pipeline {
                         }
                     }
                }
-               stage("7.17.1") {
+               stage("7.17.3") {
                     agent {
                         label 'linux'
                     }
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-717-${BUILD_NUMBER}-e2e", "7.17.1")
+                            runWith(lib, failedTests, "eck-717-${BUILD_NUMBER}-e2e", "7.17.3")
                         }
                     }
                }
@@ -134,14 +134,14 @@ pipeline {
                         }
                     }
                }
-               stage("8.1.0") {
+               stage("8.1.3") {
                     agent {
                         label 'linux'
                     }
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-810-${BUILD_NUMBER}-e2e", "8.1.0")
+                            runWith(lib, failedTests, "eck-810-${BUILD_NUMBER}-e2e", "8.1.3")
                         }
                     }
                }


### PR DESCRIPTION
Updates the stack versions test job to test the 8.2.0 release. Drops 7.10 from the list of tested versions and starts testing 8.3.0-SNAPSHOT.

Dropping 7.10 to keep the overall number of versions under test bounded. 