### PR TITLE
Refactor upgrade completion logic

### DIFF
--- a/pkg/controller/elasticsearch/driver/node_shutdown.go
+++ b/pkg/controller/elasticsearch/driver/node_shutdown.go
@@ -36,7 +36,7 @@ func newShutdownInterface(
 }
 
 func supportsNodeShutdown(v version.Version) bool {
-	return v.GTE(version.MustParse("7.15.2"))
+	return v.GTE(shutdown.MinVersion)
 }
 
 // maybeRemoveTransientSettings removes left-over transient settings if we are using node shutdown and have not removed

--- a/pkg/controller/elasticsearch/driver/upgrade.go
+++ b/pkg/controller/elasticsearch/driver/upgrade.go
@@ -306,7 +306,8 @@ func (d *defaultDriver) maybeCompleteNodeUpgrades(
 	nodeShutdown *shutdown.NodeShutdown,
 ) *reconciler.Results {
 	results := &reconciler.Results{}
-	// Make sure all pods scheduled for upgrade have been upgraded. TODO this is redundant in the current call hierarchy
+	// Make sure all pods scheduled for upgrade have been upgraded.
+	// This is a redundant check in the current call hierarchy but makes the invariant explicit and testing easier.
 	done, reason, err := d.expectationsSatisfied()
 	if err != nil {
 		return results.WithError(err)

--- a/pkg/controller/elasticsearch/driver/upgrade.go
+++ b/pkg/controller/elasticsearch/driver/upgrade.go
@@ -67,13 +67,8 @@ func (d *defaultDriver) handleUpgrades(
 	logger := log.WithValues("namespace", d.ES.Namespace, "es_name", d.ES.Name)
 	nodeShutdown := shutdown.NewNodeShutdown(esClient, nodeNameToID, esclient.Restart, d.ES.ResourceVersion, logger)
 
-	// once expectations are satisfied we can already delete shutdowns that are complete and where the node
-	// is back in the cluster to avoid completed shutdowns from accumulating and affecting node availability calculations
-	// in Elasticsearch for example for indices with `auto_expand_replicas` setting.
-	if supportsNodeShutdown(esClient.Version()) {
-		// clear all shutdowns of type restart that have completed
-		results = results.WithError(nodeShutdown.Clear(ctx, esclient.ShutdownComplete.Applies, nodeShutdown.OnlyNodesInCluster))
-	}
+	// Maybe re-enable shards allocation and delete shutdowns if upgraded nodes are back into the cluster.
+	results.WithResults(d.maybeCompleteNodeUpgrades(ctx, esClient, esState, nodeShutdown))
 
 	// Get the list of pods currently existing in the StatefulSetList
 	currentPods, err := statefulSets.GetActualPods(d.Client)
@@ -123,9 +118,7 @@ func (d *defaultDriver) handleUpgrades(
 		// Some Pods have not been updated, ensure that we retry later
 		results.WithReconciliationState(defaultRequeue.WithReason("Nodes upgrade in progress"))
 	}
-
-	// Maybe re-enable shards allocation and delete shutdowns if upgraded nodes are back into the cluster.
-	return results.WithResults(d.maybeCompleteNodeUpgrades(ctx, esClient, esState, nodeShutdown))
+	return results
 }
 
 type upgradeCtx struct {
@@ -313,7 +306,7 @@ func (d *defaultDriver) maybeCompleteNodeUpgrades(
 	nodeShutdown *shutdown.NodeShutdown,
 ) *reconciler.Results {
 	results := &reconciler.Results{}
-	// Make sure all pods scheduled for upgrade have been upgraded.
+	// Make sure all pods scheduled for upgrade have been upgraded. TODO this is redundant in the current call hierarchy
 	done, reason, err := d.expectationsSatisfied()
 	if err != nil {
 		return results.WithError(err)
@@ -321,6 +314,13 @@ func (d *defaultDriver) maybeCompleteNodeUpgrades(
 	if !done {
 		reason := fmt.Sprintf("Completing node upgrade: %s", reason)
 		return results.WithReconciliationState(defaultRequeue.WithReason(reason))
+	}
+	// once expectations are satisfied we can already delete shutdowns that are complete and where the node
+	// is back in the cluster to avoid completed shutdowns from accumulating and affecting node availability calculations
+	// in Elasticsearch for example for indices with `auto_expand_replicas` setting.
+	if supportsNodeShutdown(esClient.Version()) {
+		// clear all shutdowns of type restart that have completed
+		results = results.WithError(nodeShutdown.Clear(ctx, esclient.ShutdownComplete.Applies, nodeShutdown.OnlyNodesInCluster))
 	}
 
 	statefulSets, err := sset.RetrieveActualStatefulSets(d.Client, k8s.ExtractNamespacedName(&d.ES))

--- a/pkg/controller/elasticsearch/driver/upgrade_test.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_test.go
@@ -458,8 +458,7 @@ func Test_defaultDriver_maybeCompleteNodeUpgrades(t *testing.T) {
 			shutdowns:      shutdownFixture,
 			runtimeObjects: append(testSset.Pods(), testSset.BuildPtr()),
 			assertions: func(results *reconciler.Results, esClient *fakeESClient) {
-				// shutdown will be cleaned up already outside of completeNodeUpgrades
-				require.False(t, esClient.DeleteShutdownCalled)
+				require.True(t, esClient.DeleteShutdownCalled)
 				require.False(t, esClient.EnableShardAllocationCalled)
 				reconciled, _ := results.IsReconciled()
 				require.False(t, reconciled)

--- a/pkg/controller/elasticsearch/shutdown/interface.go
+++ b/pkg/controller/elasticsearch/shutdown/interface.go
@@ -7,8 +7,12 @@ package shutdown
 import (
 	"context"
 
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 )
+
+var MinVersion = version.MinFor(7, 15, 2)
 
 // NodeShutdownStatus describes the current shutdown status of an Elasticsearch node/Pod.
 // Partially duplicates the Elasticsearch API to allow a version agnostic implementation in the controller.

--- a/pkg/controller/elasticsearch/shutdown/interface.go
+++ b/pkg/controller/elasticsearch/shutdown/interface.go
@@ -8,7 +8,6 @@ import (
 	"context"
 
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
-
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 )
 

--- a/test/e2e/test/elasticsearch/checks_restart.go
+++ b/test/e2e/test/elasticsearch/checks_restart.go
@@ -15,8 +15,8 @@ import (
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/shutdown"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/shutdown"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 )
 

--- a/test/e2e/test/elasticsearch/checks_restart.go
+++ b/test/e2e/test/elasticsearch/checks_restart.go
@@ -10,13 +10,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/shutdown"
-
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/shutdown"
 	esclient "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 )
@@ -52,7 +51,7 @@ func newNodeShutdownWatcher(es esv1.Elasticsearch) test.Watcher {
 				}
 			}
 			if len(restarts) > maxConcurrentRestarts {
-				observedErrors = append(observedErrors, fmt.Errorf("expected %d, got %d, restarts: %v", maxConcurrentRestarts, len(restarts), restarts))
+				observedErrors = append(observedErrors, fmt.Errorf("expected less than %d, got %d, restarts: %v", maxConcurrentRestarts, len(restarts), restarts))
 			}
 		},
 		func(k *test.K8sClient, t *testing.T) { //nolint:thelper

--- a/test/e2e/test/elasticsearch/checks_restart.go
+++ b/test/e2e/test/elasticsearch/checks_restart.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/shutdown"
+
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
@@ -57,7 +59,7 @@ func newNodeShutdownWatcher(es esv1.Elasticsearch) test.Watcher {
 			require.Empty(t, observedErrors)
 		},
 		func() bool {
-			return version.MustParse(es.Spec.Version).LT(version.MinFor(7, 15, 2))
+			return version.MustParse(es.Spec.Version).LT(shutdown.MinVersion)
 		},
 	)
 }

--- a/test/e2e/test/elasticsearch/checks_restart.go
+++ b/test/e2e/test/elasticsearch/checks_restart.go
@@ -40,7 +40,8 @@ func newNodeShutdownWatcher(es esv1.Elasticsearch) test.Watcher {
 			defer cancel()
 			shutdowns, err := client.GetShutdown(ctx, nil)
 			if err != nil {
-				// allow a certain amount of errors here?
+				// we allow errors here, we are not testing for ES availability
+				fmt.Printf("error while getting node shutdowns: %s", err)
 				return
 			}
 			var restarts []esclient.NodeShutdown

--- a/test/e2e/test/elasticsearch/checks_restart.go
+++ b/test/e2e/test/elasticsearch/checks_restart.go
@@ -1,7 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License
-// 2.0; you may not use this file except in compliance with the Elastic License
-// 2.0.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package elasticsearch
 
@@ -25,9 +24,8 @@ func newNodeShutdownWatcher(es esv1.Elasticsearch) test.Watcher {
 	maxConcurrentRestarts := int(*es.Spec.UpdateStrategy.ChangeBudget.GetMaxUnavailableOrDefault())
 	return test.NewConditionalWatcher("watch for correct node shutdown API usage",
 		1*time.Second,
-		func(k *test.K8sClient, t *testing.T) {
+		func(k *test.K8sClient, t *testing.T) { //nolint:thelper
 			client, err := NewElasticsearchClient(es, k)
-			defer client.Close()
 			if err != nil {
 				fmt.Printf("error while creating the Elasticsearch client: %s", err)
 				if !errors.As(err, &PotentialNetworkError) {
@@ -36,6 +34,7 @@ func newNodeShutdownWatcher(es esv1.Elasticsearch) test.Watcher {
 				}
 				return
 			}
+			defer client.Close()
 			ctx, cancel := context.WithTimeout(context.Background(), continuousHealthCheckTimeout)
 			defer cancel()
 			shutdowns, err := client.GetShutdown(ctx, nil)
@@ -54,7 +53,7 @@ func newNodeShutdownWatcher(es esv1.Elasticsearch) test.Watcher {
 				observedErrors = append(observedErrors, fmt.Errorf("expected %d, got %d, restarts: %v", maxConcurrentRestarts, len(restarts), restarts))
 			}
 		},
-		func(k *test.K8sClient, t *testing.T) {
+		func(k *test.K8sClient, t *testing.T) { //nolint:thelper
 			require.Empty(t, observedErrors)
 		},
 		func() bool {

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -125,7 +125,7 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 
 	for _, watcher := range watchers {
 		// avoid closure over loop iteration variable which will become the receiver of StartStep
-		// leading only watchFn being executed
+		// leading to only one watchFn being executed
 		w := watcher
 		steps = steps.WithStep(w.StartStep(k))
 	}

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -74,7 +74,6 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 	var clusterGenerationBeforeMutation, clusterObservedGenerationBeforeMutation int64
 	var continuousHealthChecks *ContinuousHealthCheck
 	var dataIntegrityCheck *DataIntegrityCheck
-	// var shutdownCheck *continuousNodeRestartCheck
 	mutatedFrom := b.MutatedFrom
 	isMutated := true
 	if mutatedFrom == nil {

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
@@ -75,6 +74,7 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 	var clusterGenerationBeforeMutation, clusterObservedGenerationBeforeMutation int64
 	var continuousHealthChecks *ContinuousHealthCheck
 	var dataIntegrityCheck *DataIntegrityCheck
+	// var shutdownCheck *continuousNodeRestartCheck
 	mutatedFrom := b.MutatedFrom
 	isMutated := true
 	if mutatedFrom == nil {
@@ -83,13 +83,16 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 		isMutated = false
 	}
 
-	var watchers []test.Watcher
+	watchers := []test.Watcher{
+		newNodeShutdownWatcher(b.Elasticsearch),
+	}
+
 	isNonHAUpgrade := IsNonHAUpgrade(b)
 	if !isNonHAUpgrade {
-		watchers = []test.Watcher{
+		watchers = append(watchers,
 			NewChangeBudgetWatcher(mutatedFrom.Elasticsearch.Spec, b.Elasticsearch),
 			NewMasterChangeBudgetWatcher(b.Elasticsearch),
-		}
+		)
 	}
 
 	//nolint:thelper
@@ -121,7 +124,10 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 	}
 
 	for _, watcher := range watchers {
-		steps = steps.WithStep(watcher.StartStep(k))
+		// avoid closure over loop iteration variable which will become the receiver of StartStep
+		// leading only watchFn being executed
+		w := watcher
+		steps = steps.WithStep(w.StartStep(k))
 	}
 
 	//nolint:thelper
@@ -157,7 +163,8 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 		})
 
 	for _, watcher := range watchers {
-		steps = steps.WithStep(watcher.StopStep(k))
+		w := watcher
+		steps = steps.WithStep(w.StopStep(k))
 	}
 	return steps
 }
@@ -225,18 +232,10 @@ func (hc *ContinuousHealthCheck) Start() {
 				// recreate the Elasticsearch client at each iteration, since we may have switched protocol from http to https during the mutation
 				client, err := hc.esClientFactory()
 				if err != nil {
-					// according to https://github.com/kubernetes/client-go/blob/fb61a7c88cb9f599363919a34b7c54a605455ffc/rest/request.go#L959-L960,
-					// client-go requests may return *errors.StatusError or *errors.UnexpectedObjectError, or http client errors.
-					// It turns out catching network errors (timeout, connection refused, dns problem) is not trivial
-					// (see https://stackoverflow.com/questions/22761562/portable-way-to-detect-different-kinds-of-network-error-in-golang),
-					// so here we do the opposite: catch expected apiserver errors, and consider the rest are network errors.
-					switch err.(type) { //nolint:errorlint
-					case *k8serrors.StatusError, *k8serrors.UnexpectedObjectError:
+					fmt.Printf("error while creating the Elasticsearch client: %s", err)
+					if !errors.As(err, &PotentialNetworkError) {
 						// explicit apiserver error, consider as healthcheck failure
 						hc.AppendErr(err)
-					default:
-						// likely a network error, log and ignore
-						fmt.Printf("error while creating the Elasticsearch client: %s", err)
 					}
 					continue
 				}


### PR DESCRIPTION
Fixes #5632 

Modest refactoring to keep all the upgrade completion logic in one function and just move it to the top.

Adds a watcher for node shutdowns to the e2e tests that do rolling upgrades to ensure we only have as many concurred node shutdowns as the change budget allows nodes to be unavailable. 

Fixes a subtle bug with the watchers caused by closing over the loop iteration variable which meant that we were executing only the last watch function in the list of watchers despite logging the correct watchers names! Deserves a separate explanation somewhere once I find the time, took me a while to figure out. 