### PR TITLE
E2E: retry check cluster UUID check

### DIFF
--- a/test/e2e/test/elasticsearch/cluster_uuid.go
+++ b/test/e2e/test/elasticsearch/cluster_uuid.go
@@ -6,11 +6,8 @@ package elasticsearch
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"testing"
-
-	"github.com/stretchr/testify/require"
-
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 )
@@ -53,11 +50,18 @@ func CompareClusterUUIDStep(es esv1.Elasticsearch, k *test.K8sClient, previousCl
 	//nolint:thelper
 	return test.Step{
 		Name: "Cluster UUID should have been preserved",
-		Test: func(t *testing.T) {
+		Test: test.Eventually(func() error {
 			newClusterUUID, err := clusterUUID(es, k)
-			require.NoError(t, err)
-			require.NotEmpty(t, *previousClusterUUID)
-			require.Equal(t, *previousClusterUUID, newClusterUUID)
-		},
+			if err != nil {
+				return err
+			}
+			if previousClusterUUID == nil || *previousClusterUUID == "" {
+				return errors.New("test setup error previousClusterUUID is empty or nil")
+			}
+			if *previousClusterUUID != newClusterUUID {
+				return fmt.Errorf("cluster state lost, prev cluster UUID %s, current %s", *previousClusterUUID, newClusterUUID)
+			}
+			return nil
+		}),
 	}
 }

--- a/test/e2e/test/elasticsearch/cluster_uuid.go
+++ b/test/e2e/test/elasticsearch/cluster_uuid.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 )
@@ -47,7 +48,6 @@ func RetrieveClusterUUIDStep(es esv1.Elasticsearch, k *test.K8sClient, futureClu
 // CompareClusterUUIDStep compares the current clusterUUID with previousClusterUUID,
 // and fails if they don't match
 func CompareClusterUUIDStep(es esv1.Elasticsearch, k *test.K8sClient, previousClusterUUID *string) test.Step {
-	//nolint:thelper
 	return test.Step{
 		Name: "Cluster UUID should have been preserved",
 		Test: test.Eventually(func() error {


### PR DESCRIPTION
The "Cluster UUID should have been preserved" check sometimes fails if the connection to Elasticsearch times out. While this might point to an underlying issue with the Elasticsearch cluster, this step is not intended to test Elasticsearch availability. This PR thus wraps the step in `test.Eventually` to allow retries.