### PR TITLE
Update doc to customize pods

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/customize-pods.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/customize-pods.asciidoc
@@ -58,8 +58,8 @@ spec:
       containers:
         - name: kibana
           env:
-            - name: LOGGING_VERBOSE
-              value: "true"
+            - name: NODE_OPTIONS
+              value:  "--max-old-space-size=2048"
 ----
 
 NOTE: Configuration for other Elastic stack applications, like APM Server, Enterprise Search or Beats, is identical to the Kibana configuration except for the `apiVersion` and `kind` fields.


### PR DESCRIPTION
Updates the documentation for customizing a Kibana pod as the environement `LOGGING_VERBOSE`variable has been deprecated for some time. 
I chose an env var that updates the allocated memory setting like in the Elasticsearch example above.