### PR TITLE
Note to user when overwriting environment variables using .registry.env

### DIFF
--- a/hack/docker.sh
+++ b/hack/docker.sh
@@ -20,6 +20,7 @@ retry() { "$SCRIPT_DIR/retry.sh" 5 "$@"; }
 # source variables if present
 if [[ -f ${REGISTRY_ENV} ]]; then
     # shellcheck disable=SC2046
+    echo "potentially overwriting environment variables using contents of .registry.env file"
     export $(sed "s|[[:space:]]*=[[:space:]]*|=|g" "${REGISTRY_ENV}")
 fi
 

--- a/hack/docker.sh
+++ b/hack/docker.sh
@@ -19,8 +19,8 @@ retry() { "$SCRIPT_DIR/retry.sh" 5 "$@"; }
 
 # source variables if present
 if [[ -f ${REGISTRY_ENV} ]]; then
-    # shellcheck disable=SC2046
     echo "potentially overwriting environment variables using contents of .registry.env file"
+    # shellcheck disable=SC2046
     export $(sed "s|[[:space:]]*=[[:space:]]*|=|g" "${REGISTRY_ENV}")
 fi
 

--- a/hack/docker.sh
+++ b/hack/docker.sh
@@ -38,7 +38,7 @@ docker-login() {
 
     # Since this check doesn't work very well in Jenkins, and Jenkins sets
     # environment variable 'CI' only perform this check when not in Jenkins.
-    if [[ -z "${CI}" && -f ~/.docker/config.json && $(grep -q "${registry}" ~/.docker/config.json) ]]; then
+    if [[ -z "${CI}" && -f ~/.docker/config.json ]] && grep -q "${registry}" ~/.docker/config.json; then
         echo "not authenticating to ${registry} as configuration block already exists in ~/.docker/config.json"
         return
     fi

--- a/hack/docker.sh
+++ b/hack/docker.sh
@@ -28,6 +28,13 @@ docker-login() {
     local image=$1
     local registry=${image%%"/"*}
 
+    # Since this check doesn't work very well in Jenkins, and Jenkins sets
+    # environment variable 'CI' only perform this check when not in Jenkins.
+    if [[ -z "${CI}" && -f ~/.docker/config.json && `grep $registry ~/.docker/config.json` ]]; then
+        echo "not authenticating to ${registry} as configuration block already exists in ~/.docker/config.json"
+        return
+    fi
+
     case "$image" in
 
         docker.elastic.co/*)

--- a/hack/docker.sh
+++ b/hack/docker.sh
@@ -33,7 +33,7 @@ docker-login() {
 
     # Since this check doesn't work very well in Jenkins, and Jenkins sets
     # environment variable 'CI' only perform this check when not in Jenkins.
-    if [[ -z "${CI}" && -f ~/.docker/config.json && $(grep $registry ~/.docker/config.json) ]]; then
+    if [[ -z "${CI}" && -f ~/.docker/config.json && $(grep -q "${registry}" ~/.docker/config.json) ]]; then
         echo "not authenticating to ${registry} as configuration block already exists in ~/.docker/config.json"
         return
     fi

--- a/hack/docker.sh
+++ b/hack/docker.sh
@@ -33,7 +33,7 @@ docker-login() {
 
     # Since this check doesn't work very well in Jenkins, and Jenkins sets
     # environment variable 'CI' only perform this check when not in Jenkins.
-    if [[ -z "${CI}" && -f ~/.docker/config.json && `grep $registry ~/.docker/config.json` ]]; then
+    if [[ -z "${CI}" && -f ~/.docker/config.json && $(grep $registry ~/.docker/config.json) ]]; then
         echo "not authenticating to ${registry} as configuration block already exists in ~/.docker/config.json"
         return
     fi

--- a/hack/docker.sh
+++ b/hack/docker.sh
@@ -20,9 +20,14 @@ REGISTRY_ENV="$SCRIPT_DIR/../.registry.env"
 
 retry() { "$SCRIPT_DIR/retry.sh" 5 "$@"; }
 
+if [[ -f "${REGISTRY_ENV}" && "${DOCKER_LOGIN:-}" != "" ]]; then
+    echo "error: setting DOCKER_LOGIN/DOCKER_PASSWORD is incompatible the '.registry.env' file"
+    echo "either unset the environment variables, or remove the '.registry.env' file"
+    exit
+fi
+
 # source variables if present
 if [[ -f ${REGISTRY_ENV} ]]; then
-    echo "potentially overwriting environment variables using contents of .registry.env file"
     # shellcheck disable=SC2046
     export $(sed "s|[[:space:]]*=[[:space:]]*|=|g" "${REGISTRY_ENV}")
 fi

--- a/hack/docker.sh
+++ b/hack/docker.sh
@@ -12,6 +12,9 @@
 
 set -euo pipefail
 
+# ensure environment variable is set before testing if it's a zero value.
+CI=${CI:-}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REGISTRY_ENV="$SCRIPT_DIR/../.registry.env"
 


### PR DESCRIPTION
Attempting to push to docker registry using `make docker-push`, and having your environment variables for `DOCKER_LOGIN`, and `DOCKER_PASSWORD` overwritten with the contents of `.registry.env` file without warning is frustrating.

```
❯ make docker-push DOCKER_LOGIN=my-user DOCKER_PASSWORD=mypassword
>> Image == docker.elastic.co/eck-dev/eck-operator-mmontgomery:2.3.0-SNAPSHOT-bfed29a2
Authentication to docker.elastic.co...
Login Succeeded
Push docker.elastic.co/eck-dev/eck-operator-mmontgomery:2.3.0-SNAPSHOT-bfed29a2...
The push refers to repository [docker.elastic.co/eck-dev/eck-operator-mmontgomery]
denied: requested access to the resource is denied
```

Would a note to the console such as `potentially overwriting environment variables using contents of .registry.env file` be preferred?