### PR TITLE
Skip node shutdown check for non-HA clusters

### DIFF
--- a/test/e2e/test/elasticsearch/checks_restart.go
+++ b/test/e2e/test/elasticsearch/checks_restart.go
@@ -58,7 +58,7 @@ func newNodeShutdownWatcher(es esv1.Elasticsearch) test.Watcher {
 			require.Empty(t, observedErrors)
 		},
 		func() bool {
-			return version.MustParse(es.Spec.Version).LT(shutdown.MinVersion)
+			return version.MustParse(es.Spec.Version).LT(shutdown.MinVersion) && es.Spec.NodeCount() > 2
 		},
 	)
 }

--- a/test/e2e/test/elasticsearch/checks_restart.go
+++ b/test/e2e/test/elasticsearch/checks_restart.go
@@ -58,6 +58,7 @@ func newNodeShutdownWatcher(es esv1.Elasticsearch) test.Watcher {
 			require.Empty(t, observedErrors)
 		},
 		func() bool {
+			// do not run this check on versions that do not support node shutdown or non-HA clusters were we restart all nodes at once
 			return version.MustParse(es.Spec.Version).LT(shutdown.MinVersion) && es.Spec.NodeCount() > 2
 		},
 	)


### PR DESCRIPTION
When I added the node shutdown check to the e2e tests in https://github.com/elastic/cloud-on-k8s/pull/5642 I ran all tests via our PR e2e job but this runs them on the current stack version i.e. 8.2.0 so all version upgrade tests were not run. This hid an incorrect assumption I had made about the legitimate number of restarts that can exist at given time. When we upgrade non-HA clusters we restart all nodes at once so it is OK to have more restarts in flight at the same time than the change budget allows. 

I opted to disable the check as a whole on small clusters instead of adjusting the formula to keep the calculation simple.