### PR TITLE
Increase Filebeat memory for e2e tests

### DIFF
--- a/test/e2e/beat/config.go
+++ b/test/e2e/beat/config.go
@@ -27,6 +27,14 @@ processors:
   automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
   containers:
   - name: filebeat
+    # increase memory by +50% compared to the default value
+    resources:
+      requests:
+        cpu: 100m
+        memory: 300Mi
+      limits:
+        cpu: 100m
+        memory: 300Mi
     volumeMounts:
     - mountPath: /var/lib/docker/containers
       name: varlibdockercontainers


### PR DESCRIPTION
We regularly have flaky e2e tests with Filebeat OOMKilled. This is not always the root cause of test failure but sometimes it is.

Before maybe updating the default (200Mi), I would like to test with 300Mi.

Relates to #5036.