### PR TITLE
CronJob batch/v1beta1 no longer served in 1.25

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/snapshots.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/snapshots.asciidoc
@@ -170,7 +170,7 @@ If you are running older versions of Elasticsearch without the snapshot lifecycl
 [source,yaml]
 ----
 # snapshotter.yml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: elasticsearch-sample-snapshotter


### PR DESCRIPTION
Update the `CronJob` API version used in our documentation. The `batch/v1beta1` API version of CronJob will no longer be served in K8S v1.25.