### PR TITLE
[E2E] Test K8S 1.24 with Kind 0.14

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -19,3 +19,4 @@ docker pull kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725d
 docker pull kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
 docker pull kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
 docker pull kindest/node:v1.23.3@sha256:0df8215895129c0d3221cda19847d1296c4f29ec93487339149333bd9d899e5a
+docker pull kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -13,8 +13,6 @@ docker pull "$(make -C .ci --no-print-directory print-ci-image)"
 
 # Kind images (https://hub.docker.com/r/kindest/node/tags)
 # Pull exact images due to image incompatibility between kind 0.8 and 0.9 see https://github.com/kubernetes-sigs/kind/releases
-docker pull kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c
-docker pull kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
 docker pull kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
 docker pull kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
 docker pull kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047

--- a/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
@@ -36,17 +36,6 @@ pipeline {
         stage('Run tests on different versions of vanilla K8s') {
             // Do not forget to keep in sync the kind node image versions in `.ci/packer_cache.sh`.
             parallel {
-                stage("1.19.11") {
-                    agent {
-                        label 'eck'
-                    }
-                    steps {
-                        unstash "source"
-                        script {
-                            runTests(lib, failedTests, "kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729", "0.11.1", "ipv4")
-                        }
-                    }
-                }
                 stage("1.20.7") {
                     agent {
                         label 'eck'
@@ -110,6 +99,28 @@ pipeline {
                         unstash "source"
                         script {
                             runTests(lib, failedTests, "kindest/node:v1.23.3@sha256:0df8215895129c0d3221cda19847d1296c4f29ec93487339149333bd9d899e5a", "0.11.1", "ipv6")
+                        }
+                    }
+                }
+                stage("1.24.0 IPv4") {
+                    agent {
+                        label 'eck'
+                    }
+                    steps {
+                        unstash "source"
+                        script {
+                            runTests(lib, failedTests, "kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e", "0.14.0", "ipv4")
+                        }
+                    }
+                }
+                stage("1.24.0 IPv6") {
+                    agent {
+                        label 'eck'
+                    }
+                    steps {
+                        unstash "source"
+                        script {
+                            runTests(lib, failedTests, "kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e", "0.14.0", "ipv6")
                         }
                     }
                 }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Current features:
 
 Supported versions:
 
-*  Kubernetes 1.19-1.23
+*  Kubernetes 1.20-1.24
 *  OpenShift 4.6-4.10
 *  Elasticsearch, Kibana, APM Server: 6.8+, 7.1+, 8+
 *  Enterprise Search: 7.7+, 8+

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -1,4 +1,4 @@
-* Kubernetes 1.19-1.23
+* Kubernetes 1.20-1.24
 * OpenShift 4.6-4.10
 * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 * Helm: 3.2.0+

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -265,7 +265,7 @@ spec:
     Supported versions:
 
 
-    * Kubernetes 1.19-1.23
+    * Kubernetes 1.20-1.24
 
     * OpenShift 4.6-4.10
 


### PR DESCRIPTION
* Add 2 stages (IPv4 + IPv6) to test the operator on K8S 1.24 using Kind 0.14
* Remove Kind stage for K8S 1.19
* Update `README.md` and `docs/supported-versions.asciidoc`