### PR TITLE
Update golangci-lint install script URL

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -13,7 +13,7 @@ ENV EKSCTL_VERSION=0.74.0
 ENV ECK_DIAG_VERSION=1.0.3
 
 # golangci-lint
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh \
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     | sh -s -- -b $(go env GOPATH)/bin v${GOLANGCILINT_VERSION}
 
 # kubebuilder to get required tools (etcd, apiserver, etc.)


### PR DESCRIPTION
`install.goreleaser.com` has been stopped: https://goreleaser.com/deprecations/#godownloader.

Use https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh instead (doc: https://golangci-lint.run/usage/install/).