### PR TITLE
Upgrade PodDisruptionBudget API from v1beta1 to v1

### DIFF
--- a/config/crds/v1/all-crds.yaml
+++ b/config/crds/v1/all-crds.yaml
@@ -4063,10 +4063,9 @@ spec:
                         x-kubernetes-int-or-string: true
                       selector:
                         description: Label query over pods whose evictions are managed
-                          by the disruption budget. A null selector selects no pods.
-                          An empty selector ({}) also selects no pods, which differs
-                          from standard behavior of selecting all pods. In policy/v1,
-                          an empty selector will select all pods in the namespace.
+                          by the disruption budget. A null selector will match no
+                          pods, while an empty ({}) selector will select all pods
+                          within the namespace.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector

--- a/config/crds/v1/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
+++ b/config/crds/v1/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
@@ -8673,10 +8673,9 @@ spec:
                         x-kubernetes-int-or-string: true
                       selector:
                         description: Label query over pods whose evictions are managed
-                          by the disruption budget. A null selector selects no pods.
-                          An empty selector ({}) also selects no pods, which differs
-                          from standard behavior of selecting all pods. In policy/v1,
-                          an empty selector will select all pods in the namespace.
+                          by the disruption budget. A null selector will match no
+                          pods, while an empty ({}) selector will select all pods
+                          within the namespace.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -4093,10 +4093,9 @@ spec:
                         x-kubernetes-int-or-string: true
                       selector:
                         description: Label query over pods whose evictions are managed
-                          by the disruption budget. A null selector selects no pods.
-                          An empty selector ({}) also selects no pods, which differs
-                          from standard behavior of selecting all pods. In policy/v1,
-                          an empty selector will select all pods in the namespace.
+                          by the disruption budget. A null selector will match no
+                          pods, while an empty ({}) selector will select all pods
+                          within the namespace.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector

--- a/docs/reference/api-docs.asciidoc
+++ b/docs/reference/api-docs.asciidoc
@@ -513,7 +513,7 @@ PodDisruptionBudgetTemplate defines the template for creating a PodDisruptionBud
 | Field | Description
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`spec`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#poddisruptionbudgetspec-v1beta1-policy[$$PodDisruptionBudgetSpec$$]__ | Spec is the specification of the PDB.
+| *`spec`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#poddisruptionbudgetspec-v1-policy[$$PodDisruptionBudgetSpec$$]__ | Spec is the specification of the PDB.
 |===
 
 

--- a/pkg/apis/common/v1/common.go
+++ b/pkg/apis/common/v1/common.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -257,7 +257,7 @@ type PodDisruptionBudgetTemplate struct {
 
 	// Spec is the specification of the PDB.
 	// +kubebuilder:validation:Optional
-	Spec v1beta1.PodDisruptionBudgetSpec `json:"spec,omitempty"`
+	Spec policyv1.PodDisruptionBudgetSpec `json:"spec,omitempty"`
 }
 
 // IsDisabled returns true if the PodDisruptionBudget is explicitly disabled (not nil, but empty).

--- a/pkg/controller/elasticsearch/pdb/reconcile.go
+++ b/pkg/controller/elasticsearch/pdb/reconcile.go
@@ -17,6 +17,7 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -38,25 +39,22 @@ func Reconcile(ctx context.Context, k8sClient k8s.Client, es esv1.Elasticsearch,
 	// label the PDB with a hash of its content, for comparison purposes
 	expected.Labels = hash.SetTemplateHashLabel(expected.Labels, expected)
 
-	// reconcile actual vs. expected
-	var actual policyv1.PodDisruptionBudget
-	err = k8sClient.Get(ctx, k8s.ExtractNamespacedName(expected), &actual)
-	if err != nil && apierrors.IsNotFound(err) {
-		return k8sClient.Create(ctx, expected)
-	}
-
-	if hash.GetTemplateHashLabel(expected.Labels) != hash.GetTemplateHashLabel(actual.Labels) {
-		// Actual does not match expected, let's update the PDB.
-		// PDB Spec cannot be updated, we'll have to delete then recreate.
-		// Which means there is a time window in between where we don't have a PDB anymore.
-		// TODO: this is not true anymore starting k8s 1.15+ and this PR https://github.com/kubernetes/kubernetes/pull/69867
-		if err := deleteDefaultPDB(ctx, k8sClient, es); err != nil {
-			return err
-		}
-		return k8sClient.Create(ctx, expected)
-	}
-
-	return nil
+	reconciled := &policyv1.PodDisruptionBudget{}
+	return reconciler.ReconcileResource(
+		reconciler.Params{
+			Context:    ctx,
+			Client:     k8sClient,
+			Owner:      &es,
+			Expected:   expected,
+			Reconciled: reconciled,
+			NeedsUpdate: func() bool {
+				return hash.GetTemplateHashLabel(expected.Labels) != hash.GetTemplateHashLabel(reconciled.Labels)
+			},
+			UpdateReconciled: func() {
+				expected.DeepCopyInto(reconciled)
+			},
+		},
+	)
 }
 
 // deleteDefaultPDB deletes the default pdb if it exists.


### PR DESCRIPTION
This PR upgrades the API version used to manage `PodDisruptionBudget` from `v1beta1` to `v1` 

Fixes #4565 and #1773 