### PR TITLE
Revert "Upgrade PodDisruptionBudget API from v1beta1 to v1"

### DIFF
--- a/config/crds/v1/all-crds.yaml
+++ b/config/crds/v1/all-crds.yaml
@@ -4039,9 +4039,10 @@ spec:
                         x-kubernetes-int-or-string: true
                       selector:
                         description: Label query over pods whose evictions are managed
-                          by the disruption budget. A null selector will match no
-                          pods, while an empty ({}) selector will select all pods
-                          within the namespace.
+                          by the disruption budget. A null selector selects no pods.
+                          An empty selector ({}) also selects no pods, which differs
+                          from standard behavior of selecting all pods. In policy/v1,
+                          an empty selector will select all pods in the namespace.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector

--- a/config/crds/v1/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
+++ b/config/crds/v1/bases/elasticsearch.k8s.elastic.co_elasticsearches.yaml
@@ -8673,9 +8673,10 @@ spec:
                         x-kubernetes-int-or-string: true
                       selector:
                         description: Label query over pods whose evictions are managed
-                          by the disruption budget. A null selector will match no
-                          pods, while an empty ({}) selector will select all pods
-                          within the namespace.
+                          by the disruption budget. A null selector selects no pods.
+                          An empty selector ({}) also selects no pods, which differs
+                          from standard behavior of selecting all pods. In policy/v1,
+                          an empty selector will select all pods in the namespace.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -4069,9 +4069,10 @@ spec:
                         x-kubernetes-int-or-string: true
                       selector:
                         description: Label query over pods whose evictions are managed
-                          by the disruption budget. A null selector will match no
-                          pods, while an empty ({}) selector will select all pods
-                          within the namespace.
+                          by the disruption budget. A null selector selects no pods.
+                          An empty selector ({}) also selects no pods, which differs
+                          from standard behavior of selecting all pods. In policy/v1,
+                          an empty selector will select all pods in the namespace.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector

--- a/docs/reference/api-docs.asciidoc
+++ b/docs/reference/api-docs.asciidoc
@@ -513,7 +513,7 @@ PodDisruptionBudgetTemplate defines the template for creating a PodDisruptionBud
 | Field | Description
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`spec`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#poddisruptionbudgetspec-v1-policy[$$PodDisruptionBudgetSpec$$]__ | Spec is the specification of the PDB.
+| *`spec`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#poddisruptionbudgetspec-v1beta1-policy[$$PodDisruptionBudgetSpec$$]__ | Spec is the specification of the PDB.
 |===
 
 

--- a/pkg/apis/common/v1/common.go
+++ b/pkg/apis/common/v1/common.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 
 	v1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -257,7 +257,7 @@ type PodDisruptionBudgetTemplate struct {
 
 	// Spec is the specification of the PDB.
 	// +kubebuilder:validation:Optional
-	Spec policyv1.PodDisruptionBudgetSpec `json:"spec,omitempty"`
+	Spec v1beta1.PodDisruptionBudgetSpec `json:"spec,omitempty"`
 }
 
 // IsDisabled returns true if the PodDisruptionBudget is explicitly disabled (not nil, but empty).

--- a/pkg/controller/elasticsearch/pdb/reconcile_test.go
+++ b/pkg/controller/elasticsearch/pdb/reconcile_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -29,14 +29,14 @@ import (
 )
 
 func TestReconcile(t *testing.T) {
-	defaultPDB := func() *policyv1.PodDisruptionBudget {
-		return &policyv1.PodDisruptionBudget{
+	defaultPDB := func() *v1beta1.PodDisruptionBudget {
+		return &v1beta1.PodDisruptionBudget{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      esv1.DefaultPodDisruptionBudget("cluster"),
 				Namespace: "ns",
 				Labels:    map[string]string{label.ClusterNameLabelName: "cluster", common.TypeLabelName: label.Type},
 			},
-			Spec: policyv1.PodDisruptionBudgetSpec{
+			Spec: v1beta1.PodDisruptionBudgetSpec{
 				MinAvailable: intStrPtr(intstr.FromInt(3)),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -56,7 +56,7 @@ func TestReconcile(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		wantPDB *policyv1.PodDisruptionBudget
+		wantPDB *v1beta1.PodDisruptionBudget
 	}{
 		{
 			name: "no existing pdb: should create one",
@@ -83,13 +83,13 @@ func TestReconcile(t *testing.T) {
 				es:           defaultEs,
 				statefulSets: sset.StatefulSetList{sset.TestSset{Replicas: 5, Master: true, Data: true}.Build()},
 			},
-			wantPDB: &policyv1.PodDisruptionBudget{
+			wantPDB: &v1beta1.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      esv1.DefaultPodDisruptionBudget("cluster"),
 					Namespace: "ns",
 					Labels:    map[string]string{label.ClusterNameLabelName: "cluster", common.TypeLabelName: label.Type},
 				},
-				Spec: policyv1.PodDisruptionBudgetSpec{
+				Spec: v1beta1.PodDisruptionBudgetSpec{
 					MinAvailable: intStrPtr(intstr.FromInt(5)),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -118,7 +118,7 @@ func TestReconcile(t *testing.T) {
 			err := Reconcile(context.Background(), tt.args.k8sClient, tt.args.es, tt.args.statefulSets)
 			require.NoError(t, err)
 			pdbNsn := types.NamespacedName{Namespace: tt.args.es.Namespace, Name: esv1.DefaultPodDisruptionBudget(tt.args.es.Name)}
-			var retrieved policyv1.PodDisruptionBudget
+			var retrieved v1beta1.PodDisruptionBudget
 			err = tt.args.k8sClient.Get(context.Background(), pdbNsn, &retrieved)
 			if tt.wantPDB == nil {
 				require.True(t, errors.IsNotFound(err))
@@ -132,12 +132,12 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
-func withHashLabel(pdb *policyv1.PodDisruptionBudget) *policyv1.PodDisruptionBudget {
+func withHashLabel(pdb *v1beta1.PodDisruptionBudget) *v1beta1.PodDisruptionBudget {
 	pdb.Labels = hash.SetTemplateHashLabel(pdb.Labels, pdb)
 	return pdb
 }
 
-func withOwnerRef(pdb *policyv1.PodDisruptionBudget, es esv1.Elasticsearch) *policyv1.PodDisruptionBudget {
+func withOwnerRef(pdb *v1beta1.PodDisruptionBudget, es esv1.Elasticsearch) *v1beta1.PodDisruptionBudget {
 	if err := controllerutil.SetControllerReference(&es, pdb, scheme.Scheme); err != nil {
 		panic(err)
 	}
@@ -156,7 +156,7 @@ func Test_expectedPDB(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want *policyv1.PodDisruptionBudget
+		want *v1beta1.PodDisruptionBudget
 	}{
 		{
 			name: "PDB disabled in the spec",
@@ -172,13 +172,13 @@ func Test_expectedPDB(t *testing.T) {
 				es:           esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "ns"}},
 				statefulSets: sset.StatefulSetList{sset.TestSset{Replicas: 3, Master: true, Data: true}.Build()},
 			},
-			want: &policyv1.PodDisruptionBudget{
+			want: &v1beta1.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      esv1.DefaultPodDisruptionBudget("cluster"),
 					Namespace: "ns",
 					Labels:    map[string]string{label.ClusterNameLabelName: "cluster", common.TypeLabelName: label.Type},
 				},
-				Spec: policyv1.PodDisruptionBudgetSpec{
+				Spec: v1beta1.PodDisruptionBudgetSpec{
 					MinAvailable: intStrPtr(intstr.FromInt(3)),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -203,13 +203,13 @@ func Test_expectedPDB(t *testing.T) {
 				},
 				statefulSets: sset.StatefulSetList{sset.TestSset{Replicas: 3, Master: true, Data: true}.Build()},
 			},
-			want: &policyv1.PodDisruptionBudget{
+			want: &v1beta1.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      esv1.DefaultPodDisruptionBudget("cluster"),
 					Namespace: "ns",
 					Labels:    map[string]string{"a": "b", "c": "d", label.ClusterNameLabelName: "cluster", common.TypeLabelName: label.Type},
 				},
-				Spec: policyv1.PodDisruptionBudgetSpec{
+				Spec: v1beta1.PodDisruptionBudgetSpec{
 					MinAvailable: intStrPtr(intstr.FromInt(3)),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -227,18 +227,18 @@ func Test_expectedPDB(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "ns"},
 					Spec: esv1.ElasticsearchSpec{
 						PodDisruptionBudget: &commonv1.PodDisruptionBudgetTemplate{
-							Spec: policyv1.PodDisruptionBudgetSpec{MinAvailable: intStrPtr(intstr.FromInt(42))}},
+							Spec: v1beta1.PodDisruptionBudgetSpec{MinAvailable: intStrPtr(intstr.FromInt(42))}},
 					},
 				},
 				statefulSets: sset.StatefulSetList{sset.TestSset{Replicas: 3, Master: true, Data: true}.Build()},
 			},
-			want: &policyv1.PodDisruptionBudget{
+			want: &v1beta1.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      esv1.DefaultPodDisruptionBudget("cluster"),
 					Namespace: "ns",
 					Labels:    map[string]string{label.ClusterNameLabelName: "cluster", common.TypeLabelName: label.Type},
 				},
-				Spec: policyv1.PodDisruptionBudgetSpec{
+				Spec: v1beta1.PodDisruptionBudgetSpec{
 					MinAvailable: intStrPtr(intstr.FromInt(42)),
 				},
 			},


### PR DESCRIPTION
Reverts elastic/cloud-on-k8s#5689

It fails with `no matches for kind \"PodDisruptionBudget\" in version \"policy/v1\""` on `v1.20.15-gke.8000`