### PR TITLE
Use eck-diagnostics 1.1.0 to get Elastic Agent diagnostics

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -10,7 +10,7 @@ ENV DOCKER_VERSION=19.03.14
 ENV DOCKER_BUILDX_VERSION=0.8.2
 ENV GOTESTSUM_VERSION=1.8.0
 ENV EKSCTL_VERSION=0.74.0
-ENV ECK_DIAG_VERSION=1.0.3
+ENV ECK_DIAG_VERSION=1.1.0
 
 # golangci-lint
 RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -826,7 +826,7 @@ func (h *helper) dumpEventLog() {
 func (h *helper) runECKDiagnostics() {
 	operatorNS := h.testContext.Operator.Namespace
 	otherNS := append([]string{h.testContext.E2ENamespace}, h.testContext.Operator.ManagedNamespaces...)
-	cmd := exec.Command("eck-diagnostics", "-o", operatorNS, "-r", strings.Join(otherNS, ","))
+	cmd := exec.Command("eck-diagnostics", "-o", operatorNS, "-r", strings.Join(otherNS, ","), "--run-agent-diagnostics")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Title says it all hopefully it will help us diagnose Elastic Agent related test failures better.