### PR TITLE
Cleanup in declaration of enabled/disabled linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,7 +85,6 @@ linters:
     - prealloc
     - predeclared
     - revive
-    - exportloopref
     - staticcheck
     - structcheck
     - thelper

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,5 +108,4 @@ issues:
   exclude-rules:
     - path: (^test/.*\.go|.*_test\.go)
       linters:
-        - goconst
         - unparam

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,7 @@ linters:
     - nlreturn
     - paralleltest
     - rowserrcheck
+    - scopelint
     - sqlclosecheck
     - stylecheck
     - testpackage
@@ -108,5 +109,4 @@ issues:
     - path: (^test/.*\.go|.*_test\.go)
       linters:
         - goconst
-        - scopelint
         - unparam


### PR DESCRIPTION
Small cleanup in declaration of enabled/disabled linters:
- Refactoring disabling of `scopelint` linter: use `disable` list instead of `issues.exclude-rules`
- Remove `goconst` linter from `issues.exclude-rules`  because already in the `disable` list
- Remove duplicate `exportloopref` linter in the `enable` list