### PR TITLE
Update doc pages that use the repository-gcs plugin

### DIFF
--- a/docs/advanced-topics/custom-images.asciidoc
+++ b/docs/advanced-topics/custom-images.asciidoc
@@ -7,7 +7,7 @@ endif::[]
 [id="{p}-{page_id}"]
 = Create custom images
 
-You can create your own custom application images ({eck_resources_list}) instead of using the base images provided by Elastic. You might want to do this to have a canonical image with all the necessary plugins pre-loaded rather than <<{p}-init-containers-plugin-downloads,installing them through an init container>> each time a Pod starts.  You must use the official image as the base for custom images. For example, if you want to create an Elasticsearch {version} image with the link:https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/repository-gcs.html[Google Cloud Storage Repository Plugin], you can do the following:
+You can create your own custom application images ({eck_resources_list}) instead of using the base images provided by Elastic. You might want to do this to have a canonical image with all the necessary plugins pre-loaded rather than <<{p}-init-containers-plugin-downloads,installing them through an init container>> each time a Pod starts.  You must use the official image as the base for custom images. For example, if you want to create an Elasticsearch {version} image with the link:https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-icu.html[ICU Analysis Plugin], you can do the following:
 
 
 
@@ -16,22 +16,22 @@ You can create your own custom application images ({eck_resources_list}) instead
 [subs="attributes"]
 ----
 FROM docker.elastic.co/elasticsearch/elasticsearch:{version}
-RUN bin/elasticsearch-plugin install --batch repository-gcs
+RUN bin/elasticsearch-plugin install --batch analysis-icu
 ----
 
 . Build the image with:
 +
 [subs="attributes"]
 ----
-docker build --tag elasticsearch-gcs:{version}
+docker build --tag elasticsearch-icu:{version}
 ----
 
 There are various hosting options for your images. If you use Google Kubernetes Engine, it is automatically configured to use the Google Container Registry. Check https://cloud.google.com/container-registry/docs/using-with-google-cloud-platform#google-kubernetes-engine[Using Container Registry with Google Cloud] for more information. To use the image, you can then https://cloud.google.com/container-registry/docs/pushing-and-pulling#pushing_an_image_to_a_registry[push to the registry] with:
 
 [subs="attributes"]
 ----
-docker tag elasticsearch-gcs:{version} gcr.io/$PROJECT-ID/elasticsearch-gcs:{version}
-docker push gcr.io/$PROJECT-ID/elasticsearch-gcs:{version}
+docker tag elasticsearch-icu:{version} gcr.io/$PROJECT-ID/elasticsearch-icu:{version}
+docker push gcr.io/$PROJECT-ID/elasticsearch-icu:{version}
 ----
 
 
@@ -41,7 +41,7 @@ Configure your Elasticsearch specification to use the newly pushed image, for ex
 ----
 spec:
   version: {version}
-  image: gcr.io/$PROJECT-ID/elasticsearch-gcs:{version}
+  image: gcr.io/$PROJECT-ID/elasticsearch-icu:{version}
 ----
 
 NOTE: Providing the correct version is always required as ECK reasons about APIs and capabilities available to it based on the version field.

--- a/docs/advanced-topics/service-meshes.asciidoc
+++ b/docs/advanced-topics/service-meshes.asciidoc
@@ -178,7 +178,7 @@ spec:
               - sh
               - -c
               - |
-                bin/elasticsearch-plugin install --batch repository-gcs
+                bin/elasticsearch-plugin install --batch analysis-icu
 ----
 
 <1> Plugins are downloaded over the HTTPS port (443) and needs to be allowed when Istio CNI is installed.

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/init-containers-plugin-downloads.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/init-containers-plugin-downloads.asciidoc
@@ -24,7 +24,7 @@ spec:
           - sh
           - -c
           - |
-            bin/elasticsearch-plugin install --batch repository-gcs
+            bin/elasticsearch-plugin install --batch analysis-icu
 ----
 
 You can also override the Elasticsearch container image to use your own image with the plugins already installed, as described in <<{p}-custom-images,custom images>>. For more information on both these options, you can check the <<{p}-snapshots,Create automated snapshots>> section and the Kubernetes documentation on https://kubernetes.io/docs/concepts/workloads/pods/init-containers/[init containers].
@@ -32,5 +32,5 @@ You can also override the Elasticsearch container image to use your own image wi
 The init container inherits:
 
 * The image of the main container image, if one is not explicitly set.
-* The volume mounts from the main container unless a volume mount with the same name and mount path is present in the init container definition 
+* The volume mounts from the main container unless a volume mount with the same name and mount path is present in the init container definition
 * The Pod name and IP address environment variables.

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/snapshots.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/snapshots.asciidoc
@@ -17,6 +17,8 @@ To set up automated snapshots for Elasticsearch on Kubernetes you have to:
 
 The examples below use the https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/repository-gcs.html[Google Cloud Storage Repository Plugin].
 
+NOTE: Support for S3, GCS and Azure repositories is bundled in Elasticsearch by default from version 8.0.
+
 For more information on Elasticsearch snapshots, check https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html[Snapshot and Restore].
 
 [id="{p}-install-plugin"]
@@ -75,7 +77,7 @@ kubectl apply -f elasticsearch.yaml
 [id="{p}-secure-settings"]
 == Configure GCS credentials through the Elasticsearch keystore
 
-The Elasticsearch GCS repository plugin requires a JSON file that contains service account credentials. These need to be added as secure settings to the Elasticsearch keystore. For more details, check https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/repository-gcs-usage.html[Google Cloud Storage Repository Plugin].
+The Elasticsearch GCS repository plugin requires a JSON file that contains service account credentials. These need to be added as secure settings to the Elasticsearch keystore. For more details, check https://www.elastic.co/guide/en/elasticsearch/reference/current/repository-gcs.html[Google Cloud Storage Repository].
 
 Using ECK, you can automatically inject secure settings into a cluster node by providing them through a secret in the Elasticsearch Spec.
 


### PR DESCRIPTION
- Update 'Create custom images' doc: replace `Google Cloud Storage Repository Plugin` by `ICU Analysis Plugin` in the examples
- Same in the 'Init containers for plugin downloads' and 'Services Meshes' doc
-  Add a note in 'Create automated snapshots' doc about  bundled plugins in ES from version 8.0

Resolves #5457.