### PR TITLE
Bump e2e tests stack versions

### DIFF
--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -112,14 +112,14 @@ pipeline {
                         }
                     }
                }
-               stage("7.17.3") {
+               stage("7.17.4") {
                     agent {
                         label 'linux'
                     }
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-717-${BUILD_NUMBER}-e2e", "7.17.3")
+                            runWith(lib, failedTests, "eck-717-${BUILD_NUMBER}-e2e", "7.17.4")
                         }
                     }
                }
@@ -145,14 +145,14 @@ pipeline {
                         }
                     }
                }
-               stage("8.2.0") {
+               stage("8.2.2") {
                     agent {
                         label 'linux'
                     }
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-820-${BUILD_NUMBER}-e2e", "8.2.0")
+                            runWith(lib, failedTests, "eck-820-${BUILD_NUMBER}-e2e", "8.2.2")
                         }
                     }
                }

--- a/test/e2e/stack_test.go
+++ b/test/e2e/stack_test.go
@@ -33,8 +33,8 @@ import (
 // TestVersionUpgradeOrdering deploys the entire stack, with resources associated together.
 // Then, it updates their version, and ensures a strict ordering is respected during the version upgrade.
 func TestVersionUpgradeOrdering(t *testing.T) {
-	initialVersion := "7.17.3"
-	updatedVersion := "8.2.0"
+	initialVersion := test.LatestReleasedVersion7x
+	updatedVersion := test.LatestReleasedVersion8x
 
 	// upgrading the entire stack can take some time, since we need to account for (in order):
 	// - Elasticsearch rolling upgrade

--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -16,9 +16,9 @@ const (
 	// LatestReleasedVersion6x is the latest released version for 6.x
 	LatestReleasedVersion6x = "6.8.23"
 	// LatestReleasedVersion7x is the latest released version for 7.x
-	LatestReleasedVersion7x = "7.17.3"
+	LatestReleasedVersion7x = "7.17.4"
 	// LatestReleasedVersion8x is the latest release version for 8.x
-	LatestReleasedVersion8x = "8.2.0"
+	LatestReleasedVersion8x = "8.2.2"
 )
 
 // SkipInvalidUpgrade skips a test that would do an invalid upgrade.


### PR DESCRIPTION
* 7.17.3 -> 7.17.4
* 8.2.0 -> 8.2.2