### PR TITLE
Change loop into copy

### DIFF
--- a/pkg/controller/elasticsearch/driver/fixtures.go
+++ b/pkg/controller/elasticsearch/driver/fixtures.go
@@ -117,9 +117,7 @@ type upgradeTestPods []testPod
 
 func newUpgradeTestPods(pods ...testPod) upgradeTestPods {
 	result := make(upgradeTestPods, len(pods))
-	for i := range pods {
-		result[i] = pods[i]
-	}
+	copy(result, pods)
 	return result
 }
 


### PR DESCRIPTION
	// returns the number of elements copied, which will be the minimum of len(src) and len(dst).
	// won't handle "copy(dst, src []Type) int" nothing

copy method look better？
	// according to $GOPATH/src/builtin/builtin/copy() document
	// returns the number of elements copied, which will be the minimum of len(src) and len(dst).
	// so handle "copy(dst, src []Type) int" nothing，because len is the same!
