### PR TITLE
E2E: update Tanzu to 1.5.4

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -178,7 +178,7 @@ plans:
   tanzu:
     location: eastus
     nodeCount: 3
-    installerImage: cloudonk8s.azurecr.io/tanzu-ci:47a15de6827f
+    installerImage: cloudonk8s.azurecr.io/tanzu-ci:1.5.4
 - id: tanzu-dev
   operation: create
   clusterName: tkg-dev
@@ -187,4 +187,4 @@ plans:
   tanzu:
     location: westeurope
     nodeCount: 3
-    installerImage: cloudonk8s.azurecr.io/tanzu-ci:47a15de6827f
+    installerImage: cloudonk8s.azurecr.io/tanzu-ci:1.5.4

--- a/hack/deployer/runner/azure/azure.go
+++ b/hack/deployer/runner/azure/azure.go
@@ -6,6 +6,7 @@ package azure
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/elastic/cloud-on-k8s/hack/deployer/exec"
 	"github.com/elastic/cloud-on-k8s/hack/deployer/runner/env"
@@ -44,7 +45,7 @@ func Login(creds Credentials) error {
 }
 
 func ExistsCmd(cmd *exec.Command) (bool, error) {
-	str, err := cmd.WithoutStreaming().Output()
+	str, err := cmd.WithoutStreaming().StdoutOnly().Output()
 	if err != nil {
 		return false, err
 	}
@@ -53,7 +54,7 @@ func ExistsCmd(cmd *exec.Command) (bool, error) {
 	}
 	var r response
 	if err := json.Unmarshal([]byte(str), &r); err != nil {
-		return false, err
+		return false, fmt.Errorf("failure to parse %s:  %w", str, err)
 	}
 	return r.Exists, nil
 }

--- a/hack/deployer/runner/tanzu.go
+++ b/hack/deployer/runner/tanzu.go
@@ -168,23 +168,8 @@ func (t *TanzuDriver) copyKubeconfig() error {
 // prepareCLI prepares the tanzu/az CLI by installing the necessary plugins and setting up configuration
 func (t *TanzuDriver) prepareCLI() error {
 	log.Println("Installing Tanzu CLI plugins")
-	/*	err := t.dockerizedTanzuCmd("plugin", "source", "add", "-t", "local", "-u", "/", "-n", "local").Run()
-		if err != nil {
-			return err
-		}
-
-	*/
-	err := t.dockerizedTanzuCmd("init").Run()
-	if err != nil {
-		return err
-	}
-	err = t.dockerizedTanzuCmd("plugin source list").Run()
-	if err != nil {
-		return err
-	}
-
-	return t.dockerizedTanzuCmd("plugin", "sync").Run()
-	// return t.dockerizedTanzuCmd("plugin", "install", "--local", "/", "all").Run()
+	// init also syncs the plugins
+	return t.dockerizedTanzuCmd("init").Run()
 }
 
 // teardownCLI uninstall the plugins again mainly to make the footprint of the installer state smaller and to avoid
@@ -243,7 +228,7 @@ func (t *TanzuDriver) create() error {
 	defer t.suspend()
 
 	cfgPathInContainer := t.tanzuContainerPath(TanzuInstallConfig)
-	if err := t.dockerizedTanzuCmd("management-cluster", "create", "--file", cfgPathInContainer, "-v", "9").Run(); err != nil {
+	if err := t.dockerizedTanzuCmd("management-cluster", "create", "--file", cfgPathInContainer).Run(); err != nil {
 		return err
 	}
 

--- a/hack/deployer/runner/tanzu.go
+++ b/hack/deployer/runner/tanzu.go
@@ -168,7 +168,23 @@ func (t *TanzuDriver) copyKubeconfig() error {
 // prepareCLI prepares the tanzu/az CLI by installing the necessary plugins and setting up configuration
 func (t *TanzuDriver) prepareCLI() error {
 	log.Println("Installing Tanzu CLI plugins")
-	return t.dockerizedTanzuCmd("plugin", "install", "--local", "/", "all").Run()
+	/*	err := t.dockerizedTanzuCmd("plugin", "source", "add", "-t", "local", "-u", "/", "-n", "local").Run()
+		if err != nil {
+			return err
+		}
+
+	*/
+	err := t.dockerizedTanzuCmd("init").Run()
+	if err != nil {
+		return err
+	}
+	err = t.dockerizedTanzuCmd("plugin source list").Run()
+	if err != nil {
+		return err
+	}
+
+	return t.dockerizedTanzuCmd("plugin", "sync").Run()
+	// return t.dockerizedTanzuCmd("plugin", "install", "--local", "/", "all").Run()
 }
 
 // teardownCLI uninstall the plugins again mainly to make the footprint of the installer state smaller and to avoid
@@ -227,7 +243,7 @@ func (t *TanzuDriver) create() error {
 	defer t.suspend()
 
 	cfgPathInContainer := t.tanzuContainerPath(TanzuInstallConfig)
-	if err := t.dockerizedTanzuCmd("management-cluster", "create", "--file", cfgPathInContainer).Run(); err != nil {
+	if err := t.dockerizedTanzuCmd("management-cluster", "create", "--file", cfgPathInContainer, "-v", "9").Run(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Update Tanzu Kubernetes Grid to 1.5.4. Small adjustment to changed plugin installation mechanism. Does currently not work on Apple M1 hardware due to an issue with the kind node image used by Tanzu. At least that's what I suspect after reading https://github.com/kubernetes-sigs/kind/pull/2478 I don't see a way of tweaking this but am still investigating. Tested this PR on Intel hardware successfully.