### PR TITLE
E2E: EKS wait for deletion

### DIFF
--- a/hack/deployer/runner/eks.go
+++ b/hack/deployer/runner/eks.go
@@ -100,7 +100,8 @@ func (e *EKSDriver) Execute() error {
 	case DeleteAction:
 		if exists {
 			log.Printf("Deleting cluster ...")
-			return e.newCmd("eksctl delete cluster -v 0 --name {{.ClusterName}} --region {{.Region}}").Run()
+			// --wait to surface failures to delete all resources in the Cloud formation
+			return e.newCmd("eksctl delete cluster -v 0 --name {{.ClusterName}} --region {{.Region}} --wait").Run()
 		}
 		log.Printf("Not deleting cluster as it does not exist")
 	case CreateAction:


### PR DESCRIPTION
I did a manual test and checked that after the deployer command returned there was no Cloud formation stack left. 