### PR TITLE
Helm Charts for ECK Resources

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,8 +1,8 @@
-# ECK Operator Helm Chart
+# ECK Operator and ECK resources Helm Chart
 
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/elastic)](https://artifacthub.io/packages/search?repo=elastic)
 
-This directory contains the Helm chart for deploying the ECK operator.
+This directory contains the Helm chart for deploying the ECK operator and the resources managed by the ECK Operator
 
 ## Usage
 
@@ -32,4 +32,6 @@ View the available settings for customizing the installation.
 helm show values eck-operator
 ```
 
+# ECK Resources Helm Charts Usage
 
+Go to `eck-resources/` to know how to do that.

--- a/deploy/eck-resources/README.md
+++ b/deploy/eck-resources/README.md
@@ -1,0 +1,13 @@
+# ECK Resources Helm Charts Usage
+
+This Helm chart is a lightweight way to configure ECK resources managed by ECK Operator.
+
+## Requirements
+
+- Install ECK Operator
+
+## Usage
+
+Each folder corresponds to the respective resource, each folder has an `examples/` folder that contains specific/custom use cases that you can use to deploy.
+
+By default, the main charts will deploy the quickstart examples, for more information about ECK check our [docs](https://www.elastic.co/guide/en/cloud-on-k8s/current/index.html). 

--- a/deploy/eck-resources/apm-server/.helmignore
+++ b/deploy/eck-resources/apm-server/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/eck-resources/apm-server/Chart.yaml
+++ b/deploy/eck-resources/apm-server/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: apm-server
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/deploy/eck-resources/apm-server/examples/custom-apm.yaml
+++ b/deploy/eck-resources/apm-server/examples/custom-apm.yaml
@@ -1,0 +1,6 @@
+custom:
+  config:
+    output:
+      elasticsearch:
+        headers:
+          X-My-Header: Just an example of a custom settings

--- a/deploy/eck-resources/apm-server/examples/reference-an-existing-es.yaml
+++ b/deploy/eck-resources/apm-server/examples/reference-an-existing-es.yaml
@@ -1,0 +1,23 @@
+config:
+  config:
+    output:
+      elasticsearch:
+        hosts: ["my-own-elasticsearch-cluster:9200"]
+        username: elastic
+        password: "${ES_PASSWORD}"
+        protocol: "https"
+        ssl.certificate_authorities: ["/usr/share/apm-server/config/elasticsearch-ca/tls.crt"]
+  podTemplate:
+    spec:
+      containers:
+      - name: apm-server
+        volumeMounts:
+        - mountPath: /usr/share/apm-server/config/elasticsearch-ca
+          name: elasticsearch-ca
+          readOnly: true
+      volumes:
+      - name: elasticsearch-ca
+        secret:
+          defaultMode: 420
+          optional: false
+          secretName: es-ca # This is the secret that holds the Elasticsearch CA cert

--- a/deploy/eck-resources/apm-server/examples/secure-setting.yaml
+++ b/deploy/eck-resources/apm-server/examples/secure-setting.yaml
@@ -1,0 +1,2 @@
+secureSettings:
+  - secretName: apm-secret-settings

--- a/deploy/eck-resources/apm-server/templates/NOTES.txt
+++ b/deploy/eck-resources/apm-server/templates/NOTES.txt
@@ -1,0 +1,9 @@
+
+
+
+
+- Check APM resource status
+  $ kubectl get apmservers --namespace={{ .Release.Namespace }}
+
+- To retrieve the list of all the APM Services, use the following command:
+  $ kubectl get service --selector='common.k8s.elastic.co/type=apm-server'

--- a/deploy/eck-resources/apm-server/templates/_helpers.tpl
+++ b/deploy/eck-resources/apm-server/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "apm-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "apm-server.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/eck-resources/apm-server/templates/apm.yaml
+++ b/deploy/eck-resources/apm-server/templates/apm.yaml
@@ -1,0 +1,17 @@
+apiVersion: apm.k8s.elastic.co/v1
+kind: ApmServer
+metadata:
+  name: {{ .Values.APMServerName }}
+spec:
+  version: {{ .Values.version }}
+  count: {{ .Values.count }}
+  {{- if .Values.secureSettings }}
+  secureSettings:
+{{ toYaml .Values.secureSettings | indent 2  }}
+  {{- end }}
+  elasticsearchRef:
+    name: {{ .Values.elasticsearchRef }}
+{{- if .Values.config }}
+  config:
+{{ toYaml .Values.config | indent 2 }}
+{{- end }}

--- a/deploy/eck-resources/apm-server/values.yaml
+++ b/deploy/eck-resources/apm-server/values.yaml
@@ -1,0 +1,12 @@
+---
+version: 8.2.0
+
+count: 1
+
+APMServerName: "quickstart"
+
+elasticsearchRef: "quickstart"
+
+config: {}
+
+secureSettings: {}

--- a/deploy/eck-resources/beats/.helmignore
+++ b/deploy/eck-resources/beats/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/eck-resources/beats/Chart.yaml
+++ b/deploy/eck-resources/beats/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: beats
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/deploy/eck-resources/beats/templates/NOTES.txt
+++ b/deploy/eck-resources/beats/templates/NOTES.txt
@@ -1,0 +1,4 @@
+HAPPY BEATS!
+
+- Check the beats status
+  $ kubectl get beats --namespace={{ .Release.Namespace }}

--- a/deploy/eck-resources/beats/templates/_helpers.tpl
+++ b/deploy/eck-resources/beats/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "beats.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "beats.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/eck-resources/beats/templates/beats.yaml
+++ b/deploy/eck-resources/beats/templates/beats.yaml
@@ -1,0 +1,13 @@
+apiVersion: beat.k8s.elastic.co/v1beta1
+kind: Beat
+metadata:
+  name: {{ .Values.beatName }}
+spec:
+  type: {{ .Values.type }}
+  version: {{ .Values.version }}
+  elasticsearchRef:
+    name: {{ .Values.elasticsearchRef }}
+  config:
+{{ toYaml .Values.config | indent 4 }}
+  daemonSet:
+{{ toYaml .Values.daemonSet | indent 4 }}

--- a/deploy/eck-resources/beats/values.yaml
+++ b/deploy/eck-resources/beats/values.yaml
@@ -1,0 +1,41 @@
+---
+version: 8.2.0
+
+type: filebeat
+
+beatName: "quickstart"
+
+elasticsearchRef: "quickstart"
+
+config:
+  filebeat.inputs:
+  - type: container
+    paths:
+    - /var/log/containers/*.log
+
+daemonSet:
+  podTemplate:
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      securityContext:
+        runAsUser: 0
+      containers:
+      - name: filebeat
+        volumeMounts:
+        - name: varlogcontainers
+          mountPath: /var/log/containers
+        - name: varlogpods
+          mountPath: /var/log/pods
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+      volumes:
+      - name: varlogcontainers
+        hostPath:
+          path: /var/log/containers
+      - name: varlogpods
+        hostPath:
+          path: /var/log/pods
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers

--- a/deploy/eck-resources/elasticsearch/.helmignore
+++ b/deploy/eck-resources/elasticsearch/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/eck-resources/elasticsearch/Chart.yaml
+++ b/deploy/eck-resources/elasticsearch/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: elasticsearch
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/deploy/eck-resources/elasticsearch/README.md
+++ b/deploy/eck-resources/elasticsearch/README.md
@@ -1,0 +1,33 @@
+# ECK Elasticsearch resource Helm Charts Usage
+
+This Helm chart is a lightweight way to configure Elasticsearch resources managed by ECK Operator.
+
+## Usage
+
+- This repo includes a number of examples configurations which can be used as a reference. They are also used in the automated testing of this chart.
+- This chart deploy an Elasticsearch resource using the [quickstart example](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-elasticsearch.html)
+
+## Installing
+
+- Make sure you have the ECK Operator up and running
+- Clone this repo
+  `git clone git@github.com:elastic/cloud-on-k8s.git`
+- Install the Elasticsearch chart by running:
+    `helm install elasticsearch deploy/eck-resources/elasticsearch/`
+
+This will deploy 1 Elasticsearch instance containing all the roles. 
+
+## Configuration
+
+| Parameter                          | Description                                                                                                                                                                                                                                                                                                       | Default                                          |
+|------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|
+| `version`          | The version will define the Elasticsearch version that will be deployed | 8.2.0
+| `esName`                     | This will be used as the Elasticsearch resource name | quickstart
+| `labels` | Configurable labels applied to all Elasticsearch pods | {}
+| `annotations` | Configurable annotations applied to all Elasticsearch pods | {}
+| `monitoring` | Configure the stack monitoring, for more info check this [doc page](https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-stack-monitoring.html) | {}
+| `transport` | This setting deal with how you want to expose Elasticsearch services, check the [docs](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-transport-settings.html) | {}
+| `http` |  This settings deals with the http session, check this [doc page](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-kibana-http-configuration.html) | {}
+| `secureSettings` | Configure secure settings with Kubernetes Secrets, see the [docs](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-es-secure-settings.html) | {}
+| `updateStrategy` | This setting will limit the number of simultaneous changes, more info [here](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-update-strategy.html) | {}
+| `esSpec` | This setting define the main `nodeSet` block |

--- a/deploy/eck-resources/elasticsearch/examples/README.md
+++ b/deploy/eck-resources/elasticsearch/examples/README.md
@@ -4,121 +4,136 @@ This directory contains helm charts with custom example configurations.
 
 # Usage
 
-##### Advanced Elasticsearch node scheduling
+### Advanced Elasticsearch node scheduling
 For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html
 
 **affinity-and-selector.yaml** 
+
 This chart will restrict the scheduling to a particular set of Kubernetes nodes based on labels, use a `NodeSelector`. The example schedules Elasticsearch Pods on Kubernetes nodes tagged with `environment: production`. To install it:
 
 `helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/affinity-and-selector.yaml`
 
-##### Autoscaling
+### Autoscaling
 For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-autoscaling.html
 
 **autoscaling.yaml** 
+
 This chart define autoscaling policy that applies to one or more NodeSets. To install
 
 `helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/autoscaling.yaml`
 
-##### Volume Claim Template
+### Volume Claim Template
 For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
 
 **custom-persistent-volume-claim.yaml**
+
 Define your own volume claim template with the desired storage capacity and (optionally) the Kubernetes storage class to associate with the persistent volume. To install it:
 
 `helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/custom-persistent-volume-claim.yaml`
 
-##### Hot-Warm-Cold topologies
+### Hot-Warm-Cold topologies
 For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html#k8s-hot-warm-topologies
 
 **hot-warm-cold.yaml**
+
 By combining Elasticsearch shard allocation awareness with Kubernetes node affinity, you can set up an Elasticsearch cluster with hot-warm topology:
 
 `helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/hot-warm-cold.yaml`
 
-##### Mounting Volumes
+### Mounting Volumes
 
 **mounting-volumes.yaml**
+
 If you wish mount Volumes into Elasticsearch resource, you can have a look at this chart, in this example, we are mounting a volume which store a `metadata.xml` file. To install:
 
 `helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/mounting-volumes.yaml`
 
-##### Pod Disruption Budget
+### Pod Disruption Budget
 For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-pod-disruption-budget.html
 
 **pod-disruption-budget.yaml**
+
 This chart will limit the disruption to your application when its pods need to be rescheduled for some reason such as upgrades or routine maintenance work on the Kubernetes nodes. To install
 
 `helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/pod-disruption-budget.yaml`
 
-##### Pod PreStop hook
+### Pod PreStop hook
 For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-prestop.html 
 
 **pod-prestop-hook.yaml**
+
 This chart will minimize unavailability when pods are terminated. To install it:
 
 `helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/pod-prestop-hook.yaml`
 
-##### Readiness probe
+### Readiness probe
 For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-readiness.html
 
 **readiness-probe.yaml**
+
 By default, the readiness probe checks that the Pod responds to HTTP requests within a timeout of three seconds. This is acceptable in most cases. But if for your use case you need to adjust it, you can install this chart by running:
 
 `helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/readiness-probe.yaml`
 
-##### Remote Cluster
+### Remote Cluster
 For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-remote-clusters.html
 
 **remote-cluster.yaml**
+
 This chart will enables you to establish uni-directional connections to a remote cluster. To install it:
 
 `helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/remote-cluster.yaml`
 
-##### SAML
+### SAML
 For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/2.2/k8s-saml-authentication.html
 
 **saml-settings.yaml**
+
 This chart is an example on how to setup SAML with ECK. To install it:
 
 `helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/saml-settings.yaml`
 
-##### Secure Setting
+### Secure Setting
 For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-es-secure-settings.html
 
 **secure-settings.yaml**
+
 To add reference of existing Secrets into the Elasticsearch resource, you can run:
 
 `helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/secure-settings.yaml`
 
-##### Security Context
+### Security Context
 For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-security-context.html
 
 **security-context.yaml**
+
 Defines privilege and access control settings for a Pod. To install it:
 
 `helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/security-context.yaml`
 
-##### Topology spread constrains and availability zone awareness
+### Topology spread constrains and availability zone awareness
 For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html#k8s-availability-zone-awareness
 
 **spread-constrains-allocation-awareness.yaml**
+
 This chart will deal with logical failure domains, available in a running Pod. Combined with Elasticsearch shard allocation awareness and Kubernetes topology spread constraints, you can create an availability zone-aware Elasticsearch cluster. To install it:
 
 `helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/spread-constrains-allocation-awareness.yaml`
 
-##### Stack Monitoring
+### Stack Monitoring
 For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/2.2/k8s-stack-monitoring.html 
 
 **stack-monitoring.yaml**
+
 To enable stack monitoring, simply reference the monitoring Elasticsearch cluster in the spec.monitoring section of their specification.
 
 `helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/stack-monitoring.yaml`
 
-##### Transport Settings
+### Transport Settings
 For more info check, https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-transport-settings.html
 
 **transport-settings.yaml**
+
 In the spec.transport.service. section, you can change the Kubernetes service used to expose the Elasticsearch transport module:
 
 `helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/transport-settings.yaml`

--- a/deploy/eck-resources/elasticsearch/examples/README.md
+++ b/deploy/eck-resources/elasticsearch/examples/README.md
@@ -1,0 +1,125 @@
+# Examples
+
+This directory contains helm charts with custom example configurations. 
+
+# Usage
+
+##### Advanced Elasticsearch node scheduling
+For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html
+
+**affinity-and-selector.yaml** 
+This chart will restrict the scheduling to a particular set of Kubernetes nodes based on labels, use a `NodeSelector`. The example schedules Elasticsearch Pods on Kubernetes nodes tagged with `environment: production`. To install it:
+
+`helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/affinity-and-selector.yaml`
+
+##### Autoscaling
+For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-autoscaling.html
+
+**autoscaling.yaml** 
+This chart define autoscaling policy that applies to one or more NodeSets. To install
+
+`helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/autoscaling.yaml`
+
+##### Volume Claim Template
+For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
+
+**custom-persistent-volume-claim.yaml**
+Define your own volume claim template with the desired storage capacity and (optionally) the Kubernetes storage class to associate with the persistent volume. To install it:
+
+`helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/custom-persistent-volume-claim.yaml`
+
+##### Hot-Warm-Cold topologies
+For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html#k8s-hot-warm-topologies
+
+**hot-warm-cold.yaml**
+By combining Elasticsearch shard allocation awareness with Kubernetes node affinity, you can set up an Elasticsearch cluster with hot-warm topology:
+
+`helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/hot-warm-cold.yaml`
+
+##### Mounting Volumes
+
+**mounting-volumes.yaml**
+If you wish mount Volumes into Elasticsearch resource, you can have a look at this chart, in this example, we are mounting a volume which store a `metadata.xml` file. To install:
+
+`helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/mounting-volumes.yaml`
+
+##### Pod Disruption Budget
+For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-pod-disruption-budget.html
+
+**pod-disruption-budget.yaml**
+This chart will limit the disruption to your application when its pods need to be rescheduled for some reason such as upgrades or routine maintenance work on the Kubernetes nodes. To install
+
+`helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/pod-disruption-budget.yaml`
+
+##### Pod PreStop hook
+For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-prestop.html 
+
+**pod-prestop-hook.yaml**
+This chart will minimize unavailability when pods are terminated. To install it:
+
+`helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/pod-prestop-hook.yaml`
+
+##### Readiness probe
+For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-readiness.html
+
+**readiness-probe.yaml**
+By default, the readiness probe checks that the Pod responds to HTTP requests within a timeout of three seconds. This is acceptable in most cases. But if for your use case you need to adjust it, you can install this chart by running:
+
+`helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/readiness-probe.yaml`
+
+##### Remote Cluster
+For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-remote-clusters.html
+
+**remote-cluster.yaml**
+This chart will enables you to establish uni-directional connections to a remote cluster. To install it:
+
+`helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/remote-cluster.yaml`
+
+##### SAML
+For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/2.2/k8s-saml-authentication.html
+
+**saml-settings.yaml**
+This chart is an example on how to setup SAML with ECK. To install it:
+
+`helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/saml-settings.yaml`
+
+##### Secure Setting
+For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-es-secure-settings.html
+
+**secure-settings.yaml**
+To add reference of existing Secrets into the Elasticsearch resource, you can run:
+
+`helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/secure-settings.yaml`
+
+##### Security Context
+For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-security-context.html
+
+**security-context.yaml**
+Defines privilege and access control settings for a Pod. To install it:
+
+`helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/security-context.yaml`
+
+##### Topology spread constrains and availability zone awareness
+For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html#k8s-availability-zone-awareness
+
+**spread-constrains-allocation-awareness.yaml**
+This chart will deal with logical failure domains, available in a running Pod. Combined with Elasticsearch shard allocation awareness and Kubernetes topology spread constraints, you can create an availability zone-aware Elasticsearch cluster. To install it:
+
+`helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/spread-constrains-allocation-awareness.yaml`
+
+##### Stack Monitoring
+For more info, check https://www.elastic.co/guide/en/cloud-on-k8s/2.2/k8s-stack-monitoring.html 
+
+**stack-monitoring.yaml**
+To enable stack monitoring, simply reference the monitoring Elasticsearch cluster in the spec.monitoring section of their specification.
+
+`helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/stack-monitoring.yaml`
+
+##### Transport Settings
+For more info check, https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-transport-settings.html
+
+**transport-settings.yaml**
+In the spec.transport.service. section, you can change the Kubernetes service used to expose the Elasticsearch transport module:
+
+`helm install elasticsearch deploy/eck-resources/elasticsearch/ --values deploy/eck-resources/elasticsearch/examples/transport-settings.yaml`
+

--- a/deploy/eck-resources/elasticsearch/examples/affinity-and-selector.yaml
+++ b/deploy/eck-resources/elasticsearch/examples/affinity-and-selector.yaml
@@ -1,0 +1,21 @@
+---
+esSpec:
+  nodeSets:
+  - name: default
+    count: 1
+    config:
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        nodeSelector:
+          environment: production # Adjust to the corresponding node selector
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: environment
+                  operator: In
+                  values:
+                  - production
+

--- a/deploy/eck-resources/elasticsearch/examples/autoscaling.yaml
+++ b/deploy/eck-resources/elasticsearch/examples/autoscaling.yaml
@@ -1,0 +1,53 @@
+---
+annotations: 
+  elasticsearch.alpha.elastic.co/autoscaling-spec: |
+    {
+        "policies": [{
+            "name": "di",
+            "roles": ["data", "ingest" , "transform"],
+            "deciders": {
+              "proactive_storage": {
+                  "forecast_window": "5m"
+              }
+            },
+            "resources": {
+                "nodeCount": { "min": 3, "max": 8 },
+                "cpu": { "min": 2, "max": 8 },
+                "memory": { "min": "2Gi", "max": "16Gi" },
+                "storage": { "min": "64Gi", "max": "512Gi" }
+            }
+        },
+        {
+            "name": "ml",
+            "roles": ["ml"],
+            "deciders": {
+                "ml": {
+                    "down_scale_delay": "10m"
+                }
+            },
+            "resources": {
+                "nodeCount": { "min": 1, "max": 9 },
+                "cpu": { "min": 1, "max": 4 },
+                "memory": { "min": "2Gi", "max": "8Gi" }
+            }
+        }]
+    }
+
+esSpec:
+  nodeSets:
+    - name: master
+      count: 1
+      config:
+        node:
+          roles: [ "master" ]
+          store.allow_mmap: false
+    - name: di
+      config:
+        node:
+          roles: [ "data", "ingest", "transform" ]
+          store.allow_mmap: false
+    - name: ml
+      config:
+        node:
+          roles: [ "ml" ]
+          store.allow_mmap: false

--- a/deploy/eck-resources/elasticsearch/examples/custom-persistent-volume-claim.yaml
+++ b/deploy/eck-resources/elasticsearch/examples/custom-persistent-volume-claim.yaml
@@ -1,0 +1,17 @@
+---
+esSpec:
+  nodeSets:
+  - name: default
+    count: 1
+    config:
+      node.store.allow_mmap: false
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Gi
+        storageClassName: sc-warm-cold         # Adjust to the corresponding storage class name

--- a/deploy/eck-resources/elasticsearch/examples/hot-warm-cold.yaml
+++ b/deploy/eck-resources/elasticsearch/examples/hot-warm-cold.yaml
@@ -1,0 +1,99 @@
+---
+esSpec:
+  nodeSets:
+  - name: hot
+    count: 1
+    config:
+      node.roles: ["data_hot", "data_content", "ingest", "master"]
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 16Gi
+              cpu: 4
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: beta.kubernetes.io/instance-type
+                  operator: In
+                  values:
+                  - highio # Adjust the isntance-type accordingly with your setup
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Ti
+        storageClassName: local-storage # Change to your storage class name
+  - name: warm
+    count: 1
+    config:
+      node.roles: ["data_warm"]
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 16Gi
+              cpu: 2
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: beta.kubernetes.io/instance-type
+                  operator: In
+                  values:
+                  - highstorage # Adjust the isntance-type accordingly with your setup
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Ti
+        storageClassName: local-storage # Change to your sotrage class name
+  - name: cold
+    count: 1
+    config:
+      node.roles: ["data_cold"]
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 8Gi
+              cpu: 2
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: beta.kubernetes.io/instance-type
+                  operator: In
+                  values:
+                  - highstorage # Adjust the isntance-type accordingly with your setup
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Ti
+        storageClassName: local-storage # Change to your sotrage class name

--- a/deploy/eck-resources/elasticsearch/examples/mounting-volumes.yaml
+++ b/deploy/eck-resources/elasticsearch/examples/mounting-volumes.yaml
@@ -1,0 +1,21 @@
+---
+esSpec:
+  nodeSets:
+  - name: default
+    count: 1
+    config:
+      node.roles: ["master", "data", "ingest"]
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          volumeMounts:
+          - name: my-volume
+            mountPath:  /usr/share/elasticsearch/config/metadata.xml
+            subPath: metadata.xml
+            readOnly: false
+        volumes:
+        - name: my-volume
+          configMap:
+            name: my-cm

--- a/deploy/eck-resources/elasticsearch/examples/pod-disruption-budget.yaml
+++ b/deploy/eck-resources/elasticsearch/examples/pod-disruption-budget.yaml
@@ -1,0 +1,14 @@
+---
+esSpec:
+  nodeSets:
+  - name: default
+    count: 3
+    config:
+      node.roles: ["master", "data", "ingest"]
+      node.store.allow_mmap: false
+  podDisruptionBudget:
+    spec:
+      minAvailable: 2
+      selector:
+        matchLabels:
+          elasticsearch.k8s.elastic.co/cluster-name: quickstart

--- a/deploy/eck-resources/elasticsearch/examples/pod-prestop-hook.yaml
+++ b/deploy/eck-resources/elasticsearch/examples/pod-prestop-hook.yaml
@@ -1,0 +1,12 @@
+---
+esSpec:
+  nodeSets:
+    - name: default
+      count: 1
+      podTemplate:
+        spec:
+          containers:
+          - name: elasticsearch
+            env:
+            - name: PRE_STOP_ADDITIONAL_WAIT_SECONDS
+              value: "5"

--- a/deploy/eck-resources/elasticsearch/examples/readiness-probe.yaml
+++ b/deploy/eck-resources/elasticsearch/examples/readiness-probe.yaml
@@ -1,0 +1,23 @@
+---
+esSpec:
+  nodeSets:
+  - name: default
+    count: 1
+    podTemplate:
+       spec:
+         containers:
+         - name: elasticsearch
+           readinessProbe:
+             exec:
+               command:
+               - bash
+               - -c
+               - /mnt/elastic-internal/scripts/readiness-probe-script.sh
+             failureThreshold: 3
+             initialDelaySeconds: 10
+             periodSeconds: 12
+             successThreshold: 1
+             timeoutSeconds: 12
+           env:
+           - name: READINESS_PROBE_TIMEOUT
+             value: "10"

--- a/deploy/eck-resources/elasticsearch/examples/remote-cluster.yaml
+++ b/deploy/eck-resources/elasticsearch/examples/remote-cluster.yaml
@@ -1,0 +1,5 @@
+---
+remoteClusters:
+  - name: cluster-two
+    elasticsearchRef:
+      name: cluster-two

--- a/deploy/eck-resources/elasticsearch/examples/saml-settings.yaml
+++ b/deploy/eck-resources/elasticsearch/examples/saml-settings.yaml
@@ -1,0 +1,18 @@
+---
+esSpec:
+  nodeSets:
+  - name: default
+    count: 1
+    config:
+      node.roles: ["master", "data", "ingest"]
+      node.store.allow_mmap: false
+      xpack.security.authc.realms: # Make sure to adjust the idp endpoints accordingly
+        saml:
+          saml1:
+            attributes.principal: nameid
+            idp.entity_id: urn:quickstart.eu.auth0.com
+            idp.metadata.path: https://quickstart.eu.auth0.com/samlp/metadata/nbNudmA4FTPI3kO6im0o5KPV3gugxxQI
+            order: 2
+            sp.acs: https://kibana.quickstart.co/api/security/v1/saml
+            sp.entity_id: https://quickstart.co
+            sp.logout: https://kibana.quickstart.co/logout

--- a/deploy/eck-resources/elasticsearch/examples/secure-settings.yaml
+++ b/deploy/eck-resources/elasticsearch/examples/secure-settings.yaml
@@ -1,0 +1,4 @@
+---
+secureSettings: 
+  - secretName: one-secure-settings-secret
+  - secretName: two-secure-settings-secret

--- a/deploy/eck-resources/elasticsearch/examples/security-context.yaml
+++ b/deploy/eck-resources/elasticsearch/examples/security-context.yaml
@@ -1,0 +1,10 @@
+---
+esSpec:
+  nodeSets:
+  - name: default
+    count: 3
+    podTemplate:
+      spec:
+        securityContext:
+          runAsUser: 1234 
+          fsGroup: 1234 

--- a/deploy/eck-resources/elasticsearch/examples/spread-constrains-allocation-awareness.yaml
+++ b/deploy/eck-resources/elasticsearch/examples/spread-constrains-allocation-awareness.yaml
@@ -1,0 +1,31 @@
+---
+annotations:
+  eck.k8s.elastic.co/downward-node-labels: "topology.kubernetes.io/zone"
+
+esSpec:
+  nodeSets:
+  - name: default
+    count: 1
+    config:
+      node.roles: ["master", "data", "ingest"]
+      node.store.allow_mmap: false
+      node.attr.zone: ${ZONE}
+      cluster.routing.allocation.awareness.attributes: k8s_node_name,zone
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          env:
+          - name: ZONE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['topology.kubernetes.io/zone']
+        topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels: # Adjust to the corresponding es/statefulset name
+                elasticsearch.k8s.elastic.co/cluster-name: quickstart
+                elasticsearch.k8s.elastic.co/statefulset-name: quickstart-es-default
+

--- a/deploy/eck-resources/elasticsearch/examples/stack-monitoring.yaml
+++ b/deploy/eck-resources/elasticsearch/examples/stack-monitoring.yaml
@@ -1,0 +1,7 @@
+monitoring:
+  metrics:
+    elasticsearchRefs:
+      - name: monitoring
+  logs:
+    elasticsearchRefs:
+      - name: monitoring

--- a/deploy/eck-resources/elasticsearch/examples/transport-settings.yaml
+++ b/deploy/eck-resources/elasticsearch/examples/transport-settings.yaml
@@ -1,0 +1,8 @@
+---
+transport:
+  service:
+    metadata:
+      labels:
+        my-custom: label
+    spec:
+      type: LoadBalancer

--- a/deploy/eck-resources/elasticsearch/templates/NOTES.txt
+++ b/deploy/eck-resources/elasticsearch/templates/NOTES.txt
@@ -1,0 +1,2 @@
+1. Check Elasticsearch cluster status
+  $ kubectl get es --namespace={{ .Release.Namespace }} -l common.k8s.elastic.co/type=elasticsearch

--- a/deploy/eck-resources/elasticsearch/templates/_helpers.tpl
+++ b/deploy/eck-resources/elasticsearch/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "elasticsearch.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+i{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "elasticsearch.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "elasticsearch.uname" -}}
+{{- if empty .Values.fullnameOverride -}}
+{{- if empty .Values.nameOverride -}}
+{{ .Values.clusterName }}
+{{- else -}}
+{{ .Values.nameOverride }}
+{{- end -}}
+{{- else -}}
+{{ .Values.fullnameOverride }}
+{{- end -}}
+{{- end -}}

--- a/deploy/eck-resources/elasticsearch/templates/elasticsearch.yaml
+++ b/deploy/eck-resources/elasticsearch/templates/elasticsearch.yaml
@@ -1,0 +1,35 @@
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: {{ .Values.esName }}
+  {{- if .Values.labels }}
+  labels:
+    {{ toYaml .Values.labels | indent 4 }}
+  {{- end }}
+  {{- if .Values.annotations }}
+  annotations:
+{{ toYaml .Values.annotations | indent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.updateStrategy }}
+  updateStrategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
+  {{- end }}
+  {{- if .Values.secureSettings }}
+  secureSettings:
+{{ toYaml .Values.secureSettings | indent 2 }}
+  {{- end }}
+  {{- if .Values.transport }}
+  transport:
+{{ toYaml .Values.transport | indent 4 }}
+  {{- end }}
+  version: {{ .Values.version }}
+  {{- if .Values.monitoring }}
+  monitoring:
+{{ toYaml .Values.monitoring | indent 4 }}
+  {{- end }}
+{{ toYaml .Values.esSpec | indent 2 }}
+{{- if .Values.remoteClusters }}
+  remoteClusters:
+{{ toYaml .Values.remoteClusters | indent 2 }}
+{{- end }}

--- a/deploy/eck-resources/elasticsearch/values.yaml
+++ b/deploy/eck-resources/elasticsearch/values.yaml
@@ -1,0 +1,42 @@
+---
+version: 8.2.0
+
+esName: "quickstart"
+
+labels: {}
+
+annotations: {}
+ 
+monitoring: {}
+
+transport: {}
+
+http: {}
+
+secureSettings: {}
+
+updateStrategy: {}
+
+esSpec: 
+  nodeSets:
+  - name: default
+    count: 1
+    config:
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            requests:
+              cpu: 1
+            limits:
+              memory: 1Gi
+#        initContainers: # Uncomment these lines in case you want to increase vm.max_map_count and/or use initContainers, see https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+#        - name: sysctl
+#          securityContext:
+#            privileged: true
+#            runAsUser: 0
+#          command: ['sh', '-c', 'sysctl -w vm.max_map_count=262144']
+
+remoteClusters: {}

--- a/deploy/eck-resources/fleet-managed-elastic-agent/.helmignore
+++ b/deploy/eck-resources/fleet-managed-elastic-agent/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/eck-resources/fleet-managed-elastic-agent/Chart.yaml
+++ b/deploy/eck-resources/fleet-managed-elastic-agent/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: fleet-managed-elastic-agent
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/deploy/eck-resources/fleet-managed-elastic-agent/templates/NOTES.txt
+++ b/deploy/eck-resources/fleet-managed-elastic-agent/templates/NOTES.txt
@@ -1,0 +1,5 @@
+- Monitor the status of Fleet Server and Elastic Agent.
+  $ kubectl get agent
+
+- List all the Pods belonging to a given Elastic Agent specification.
+  $ kubectl get pods --selector='agent.k8s.elastic.co/name=elastic-agent'

--- a/deploy/eck-resources/fleet-managed-elastic-agent/templates/_helpers.tpl
+++ b/deploy/eck-resources/fleet-managed-elastic-agent/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fleet-managed-elastic-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fleet-managed-elastic-agent.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/eck-resources/fleet-managed-elastic-agent/templates/fleet-server.yaml
+++ b/deploy/eck-resources/fleet-managed-elastic-agent/templates/fleet-server.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: {{ .Values.FleetServerName }}
+spec:
+  version: {{ .Values.version }}
+  kibanaRef:
+    name: {{ .Values.KibanaRef }}
+  elasticsearchRefs:
+  - name: {{ .Values.elasticsearchRef }}
+  mode: {{ .Values.mode }}
+  fleetServerEnabled: {{ .Values.fleetServerEnabled }}
+  deployment:
+    replicas: {{ .Values.replicas }}
+    podTemplate:
+      spec:
+        serviceAccountName: elastic-agent
+        automountServiceAccountToken: true
+        securityContext:
+          runAsUser: 0
+---
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: {{ .Values.elasticAgentName }}
+spec:
+  version: {{ .Values.version }}
+  kibanaRef:
+    name: {{ .Values.KibanaRef }}
+  fleetServerRef:
+    name: {{ .Values.fleetServerRef }}
+  mode: {{ .Values.mode }}
+  daemonSet:
+    podTemplate:
+      spec:
+        serviceAccountName: elastic-agent
+        automountServiceAccountToken: true
+        securityContext:
+          runAsUser: 0

--- a/deploy/eck-resources/fleet-managed-elastic-agent/values.yaml
+++ b/deploy/eck-resources/fleet-managed-elastic-agent/values.yaml
@@ -1,0 +1,18 @@
+---
+version: 8.2.0
+
+FleetServerName: "fleet-server"
+
+KibanaRef: "quickstart"
+
+elasticsearchRef: "quickstart"
+
+mode: "fleet"
+
+fleetServerEnabled: "true"
+
+replicas: 1
+
+elasticAgentName: "elastic-agent"
+
+fleetServerRef: "fleet-server"

--- a/deploy/eck-resources/kibana/.helmignore
+++ b/deploy/eck-resources/kibana/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/eck-resources/kibana/Chart.yaml
+++ b/deploy/eck-resources/kibana/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: kibana
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/deploy/eck-resources/kibana/examples/custom-kibana.yaml
+++ b/deploy/eck-resources/kibana/examples/custom-kibana.yaml
@@ -1,0 +1,23 @@
+KibanaSpec:
+  config: 
+     elasticsearch.requestHeadersWhitelist:
+     - authorization
+  elasticsearchRef:
+    name: quickstart # Make sure to use your own elasticsearch name resource, see https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-kibana.html
+    namespace: default
+  podTemplate:
+    spec:
+      containers:
+      - name: kibana
+        env:
+          - name: NODE_OPTIONS
+            value: "--max-old-space-size=2048"
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 0.5
+          limits:
+            memory: 2.5Gi
+            cpu: 2
+      nodeSelector:
+        type: frontend

--- a/deploy/eck-resources/kibana/examples/es-not-managed-by-eck.yaml
+++ b/deploy/eck-resources/kibana/examples/es-not-managed-by-eck.yaml
@@ -1,0 +1,5 @@
+esOutofECK: # Enable it if you are want to connect Kibana to an Elasticsearch that's NOT managed by ECK
+  enabled: true
+  elasticsearch_hosts: "https://es.example.com:9200"
+  elasticsearch_username: elastic
+  secret_name: kibana-elasticsearch-credentials # Create a secret to store the elasticsearch credentias, see https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-kibana-es.html#k8s-kibana-external-es

--- a/deploy/eck-resources/kibana/examples/fleet-kubernetes-integration.yaml
+++ b/deploy/eck-resources/kibana/examples/fleet-kubernetes-integration.yaml
@@ -1,0 +1,46 @@
+KibanaSpec:
+  count: 1
+  elasticsearchRef:
+    name: quickstart
+    namespace: default
+  config:
+# Change the es/fkeet server hosts accordingly
+    xpack.fleet.agents.elasticsearch.hosts: ["https://quickstart-es-http.default.svc:9200"]
+    xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
+    xpack.fleet.packages:
+    - name: system
+      version: latest
+    - name: elastic_agent
+      version: latest
+    - name: fleet_server
+      version: latest
+    - name: kubernetes
+      version: 1.17.2
+    xpack.fleet.agentPolicies:
+    - name: Fleet Server on ECK policy
+      id: eck-fleet-server
+      namespace: default
+      monitoring_enabled:
+      - logs
+      - metrics
+      is_default_fleet_server: true
+      package_policies:
+      - name: fleet_server-1
+        id: fleet_server-1
+        package:
+          name: fleet_server
+    - name: Elastic Agent on ECK policy
+      id: eck-agent
+      namespace: default
+      monitoring_enabled:
+      - logs
+      - metrics
+      unenroll_timeout: 900
+      is_default: true
+      package_policies:
+      - package:
+          name: system
+        name: system-1
+      - package:
+          name: kubernetes
+        name: kubernetes-1

--- a/deploy/eck-resources/kibana/examples/http-configuration.yaml
+++ b/deploy/eck-resources/kibana/examples/http-configuration.yaml
@@ -1,0 +1,18 @@
+version: 8.2.0
+
+KibanaName: "quickstart"
+
+KibanaSpec:
+  count: 1
+  elasticsearchRef:
+    name: quickstart # Make sure to use your own elasticsearch name resource, see https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-kibana.html
+    namespace: default
+  http:
+    service:
+      spec:
+        type: LoadBalancer # default is ClusterIP
+    tls:
+      selfSignedCertificate:
+        subjectAltNames:
+        - ip: 1.2.3.4
+        - dns: kibana.example.com

--- a/deploy/eck-resources/kibana/examples/secure-settings.yaml
+++ b/deploy/eck-resources/kibana/examples/secure-settings.yaml
@@ -1,0 +1,13 @@
+version: 8.2.0
+
+KibanaName: "quickstart"
+
+KibanaSpec:
+  count: 1
+  elasticsearchRef:
+    name: quickstart # Make sure to use your own elasticsearch name resource, see https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-kibana.html
+    namespace: default
+
+secureSettings:
+  - secretName: kibana-secret-settings
+

--- a/deploy/eck-resources/kibana/templates/NOTES.txt
+++ b/deploy/eck-resources/kibana/templates/NOTES.txt
@@ -1,0 +1,2 @@
+2. Check Kibana resource status
+  $ kubectl get kibana --namespace={{ .Release.Namespace }}

--- a/deploy/eck-resources/kibana/templates/_helpers.tpl
+++ b/deploy/eck-resources/kibana/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kibana.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "kibana.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/eck-resources/kibana/templates/kibana.yaml
+++ b/deploy/eck-resources/kibana/templates/kibana.yaml
@@ -1,0 +1,20 @@
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: {{ .Values.KibanaName }}
+spec:
+  version: {{ .Values.version }}
+  count: {{ .Values.count }}
+  {{- if .Values.esOutofECK.enabled }}
+  config:
+    elasticsearch.hosts:
+      {{ .Values.esOutofECK.elasticsearch_hosts }}
+  secureSettings:
+    - secretName: {{ .Values.esOutofECK.secret_name }}
+  {{- else }}
+{{ toYaml .Values.KibanaSpec | indent 2 }}
+  {{- end }}
+{{- if .Values.secureSettings }}
+  secureSettings:
+{{ toYaml .Values.secureSettings | indent 2 }}
+{{- end }}

--- a/deploy/eck-resources/kibana/values.yaml
+++ b/deploy/eck-resources/kibana/values.yaml
@@ -1,0 +1,16 @@
+---
+version: 8.2.0
+
+count: 1
+
+KibanaName: "quickstart"
+
+esOutofECK: {}
+
+KibanaSpec:
+  count: 1
+  elasticsearchRef:
+    name: quickstart # Make sure to use your own elasticsearch name resource, see https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-kibana.html
+    namespace: default
+
+secureSettings: {}

--- a/deploy/eck-resources/recipes/README.md
+++ b/deploy/eck-resources/recipes/README.md
@@ -1,0 +1,15 @@
+# ECK Resources Helm Charts Recipes
+
+This folder contains ECK commom use cases.
+
+##### Observability
+`observability/`
+
+If you wish to deploy ECK for observability purpose, you can run only one command, and we you will have:
+- Elasticsearch 
+- Kibana
+- Fleet
+- Kubernetes Integration
+
+To install:
+`helm install observability deploy/eck-resources/recipes/observability/`

--- a/deploy/eck-resources/recipes/observability/.helmignore
+++ b/deploy/eck-resources/recipes/observability/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/eck-resources/recipes/observability/Chart.yaml
+++ b/deploy/eck-resources/recipes/observability/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: observability
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0
+
+dependencies:
+  - name: elasticsearch
+  - name: kibana
+  - name: fleet-managed-elastic-agent

--- a/deploy/eck-resources/recipes/observability/charts/elasticsearch/.helmignore
+++ b/deploy/eck-resources/recipes/observability/charts/elasticsearch/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/eck-resources/recipes/observability/charts/elasticsearch/Chart.yaml
+++ b/deploy/eck-resources/recipes/observability/charts/elasticsearch/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: elasticsearch
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/deploy/eck-resources/recipes/observability/charts/elasticsearch/recipes/stack-monitoring.yaml
+++ b/deploy/eck-resources/recipes/observability/charts/elasticsearch/recipes/stack-monitoring.yaml
@@ -1,0 +1,7 @@
+monitoring:
+  metrics:
+    elasticsearchRefs:
+      - name: monitoring
+  logs:
+    elasticsearchRefs:
+      - name: monitoring

--- a/deploy/eck-resources/recipes/observability/charts/elasticsearch/templates/NOTES.txt
+++ b/deploy/eck-resources/recipes/observability/charts/elasticsearch/templates/NOTES.txt
@@ -1,0 +1,2 @@
+1. Check Elasticsearch cluster status
+  $ kubectl get es --namespace={{ .Release.Namespace }} -l common.k8s.elastic.co/type=elasticsearch

--- a/deploy/eck-resources/recipes/observability/charts/elasticsearch/templates/_helpers.tpl
+++ b/deploy/eck-resources/recipes/observability/charts/elasticsearch/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "elasticsearch.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+i{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "elasticsearch.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "elasticsearch.uname" -}}
+{{- if empty .Values.fullnameOverride -}}
+{{- if empty .Values.nameOverride -}}
+{{ .Values.clusterName }}
+{{- else -}}
+{{ .Values.nameOverride }}
+{{- end -}}
+{{- else -}}
+{{ .Values.fullnameOverride }}
+{{- end -}}
+{{- end -}}

--- a/deploy/eck-resources/recipes/observability/charts/elasticsearch/templates/elasticsearch.yaml
+++ b/deploy/eck-resources/recipes/observability/charts/elasticsearch/templates/elasticsearch.yaml
@@ -1,0 +1,35 @@
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: {{ .Values.esName }}
+  {{- if .Values.labels }}
+  labels:
+    {{ toYaml .Values.labels | indent 4 }}
+  {{- end }}
+  {{- if .Values.annotations }}
+  annotations:
+{{ toYaml .Values.annotations | indent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.updateStrategy }}
+  updateStrategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
+  {{- end }}
+  {{- if .Values.secureSettings }}
+  secureSettings:
+{{ toYaml .Values.secureSettings | indent 2 }}
+  {{- end }}
+  {{- if .Values.transport }}
+  transport:
+{{ toYaml .Values.transport | indent 4 }}
+  {{- end }}
+  version: {{ .Values.version }}
+  {{- if .Values.monitoring }}
+  monitoring:
+{{ toYaml .Values.monitoring | indent 4 }}
+  {{- end }}
+{{ toYaml .Values.esSpec | indent 2 }}
+{{- if .Values.remoteClusters }}
+  remoteClusters:
+{{ toYaml .Values.remoteClusters | indent 2 }}
+{{- end }}

--- a/deploy/eck-resources/recipes/observability/charts/elasticsearch/values.yaml
+++ b/deploy/eck-resources/recipes/observability/charts/elasticsearch/values.yaml
@@ -1,0 +1,44 @@
+---
+version: 8.2.0
+
+esName: "quickstart"
+
+labels: {}
+
+annotations: {}
+ 
+monitoring: {}
+
+transport: {}
+
+http: {}
+
+secureSettings: {}
+
+updateStrategy: {}
+
+esSpec: 
+  nodeSets:
+  - name: default
+    count: 1
+    config:
+      node.roles: ["master", "data", "ingest", "remote_cluster_client"]
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            requests:
+              cpu: 1
+            limits:
+              memory: 1Gi
+# Uncomment these lines in case you want to increase vm.max_map_count and/or use initContainers, see https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+#        initContainers:
+#        - name: sysctl
+#          securityContext:
+#            privileged: true
+#            runAsUser: 0
+#          command: ['sh', '-c', 'sysctl -w vm.max_map_count=262144']
+
+remoteClusters: {}

--- a/deploy/eck-resources/recipes/observability/charts/fleet-managed-elastic-agent/.helmignore
+++ b/deploy/eck-resources/recipes/observability/charts/fleet-managed-elastic-agent/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/eck-resources/recipes/observability/charts/fleet-managed-elastic-agent/Chart.yaml
+++ b/deploy/eck-resources/recipes/observability/charts/fleet-managed-elastic-agent/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: fleet-managed-elastic-agent
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/deploy/eck-resources/recipes/observability/charts/fleet-managed-elastic-agent/templates/NOTES.txt
+++ b/deploy/eck-resources/recipes/observability/charts/fleet-managed-elastic-agent/templates/NOTES.txt
@@ -1,0 +1,5 @@
+- Monitor the status of Fleet Server and Elastic Agent.
+  $ kubectl get agent
+
+- List all the Pods belonging to a given Elastic Agent specification.
+  $ kubectl get pods --selector='agent.k8s.elastic.co/name=elastic-agent'

--- a/deploy/eck-resources/recipes/observability/charts/fleet-managed-elastic-agent/templates/_helpers.tpl
+++ b/deploy/eck-resources/recipes/observability/charts/fleet-managed-elastic-agent/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fleet-managed-elastic-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fleet-managed-elastic-agent.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/eck-resources/recipes/observability/charts/fleet-managed-elastic-agent/templates/fleet-server.yaml
+++ b/deploy/eck-resources/recipes/observability/charts/fleet-managed-elastic-agent/templates/fleet-server.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: {{ .Values.FleetServerName }}
+spec:
+  version: {{ .Values.version }}
+  kibanaRef:
+    name: {{ .Values.KibanaRef }}
+  elasticsearchRefs:
+  - name: {{ .Values.elasticsearchRef }}
+  mode: {{ .Values.mode }}
+  fleetServerEnabled: {{ .Values.fleetServerEnabled }}
+  deployment:
+    replicas: {{ .Values.replicas }}
+    podTemplate:
+      spec:
+        serviceAccountName: elastic-agent
+        automountServiceAccountToken: true
+        securityContext:
+          runAsUser: 0
+---
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: {{ .Values.elasticAgentName }}
+spec:
+  version: {{ .Values.version }}
+  kibanaRef:
+    name: {{ .Values.KibanaRef }}
+  fleetServerRef:
+    name: {{ .Values.fleetServerRef }}
+  mode: {{ .Values.mode }}
+  daemonSet:
+    podTemplate:
+      spec:
+        serviceAccountName: elastic-agent
+        automountServiceAccountToken: true
+        securityContext:
+          runAsUser: 0

--- a/deploy/eck-resources/recipes/observability/charts/fleet-managed-elastic-agent/values.yaml
+++ b/deploy/eck-resources/recipes/observability/charts/fleet-managed-elastic-agent/values.yaml
@@ -1,0 +1,18 @@
+---
+version: 8.2.0
+
+FleetServerName: "fleet-server"
+
+KibanaRef: "quickstart"
+
+elasticsearchRef: "quickstart"
+
+mode: "fleet"
+
+fleetServerEnabled: "true"
+
+replicas: 1
+
+elasticAgentName: "elastic-agent"
+
+fleetServerRef: "fleet-server"

--- a/deploy/eck-resources/recipes/observability/charts/kibana/.helmignore
+++ b/deploy/eck-resources/recipes/observability/charts/kibana/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/eck-resources/recipes/observability/charts/kibana/Chart.yaml
+++ b/deploy/eck-resources/recipes/observability/charts/kibana/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: kibana
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/deploy/eck-resources/recipes/observability/charts/kibana/templates/NOTES.txt
+++ b/deploy/eck-resources/recipes/observability/charts/kibana/templates/NOTES.txt
@@ -1,0 +1,2 @@
+2. Check Kibana resource status
+  $ kubectl get kibana --namespace={{ .Release.Namespace }}

--- a/deploy/eck-resources/recipes/observability/charts/kibana/templates/_helpers.tpl
+++ b/deploy/eck-resources/recipes/observability/charts/kibana/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kibana.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "kibana.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/eck-resources/recipes/observability/charts/kibana/templates/kibana.yaml
+++ b/deploy/eck-resources/recipes/observability/charts/kibana/templates/kibana.yaml
@@ -1,0 +1,20 @@
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: {{ .Values.KibanaName }}
+spec:
+  version: {{ .Values.version }}
+  count: {{ .Values.count }}
+  {{- if .Values.esOutofECK }}
+  config:
+    elasticsearch.hosts:
+      {{ .Values.esOutofECK.elasticsearch_hosts }}
+  secureSettings:
+    - secretName: {{ .Values.esOutofECK.secret_name }}
+  {{- else }}
+{{ toYaml .Values.KibanaSpec | indent 2 }}
+  {{- end }}
+{{- if .Values.secureSettings }}
+  secureSettings:
+{{ toYaml .Values.secureSettings | indent 2 }}
+{{- end }}

--- a/deploy/eck-resources/recipes/observability/charts/kibana/values.yaml
+++ b/deploy/eck-resources/recipes/observability/charts/kibana/values.yaml
@@ -1,0 +1,57 @@
+---
+version: 8.2.0
+
+count: 1
+
+KibanaName: "quickstart"
+
+esOutofECK: {}
+
+KibanaSpec:
+  count: 1
+  elasticsearchRef:
+    name: quickstart
+    namespace: default
+  config:
+# Change the es/fkeet server hosts accordingly
+    xpack.fleet.agents.elasticsearch.hosts: ["https://quickstart-es-http.default.svc:9200"]
+    xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
+    xpack.fleet.packages:
+    - name: system
+      version: latest
+    - name: elastic_agent
+      version: latest
+    - name: fleet_server
+      version: latest
+    - name: kubernetes
+      version: 1.17.2
+    xpack.fleet.agentPolicies:
+    - name: Fleet Server on ECK policy
+      id: eck-fleet-server
+      namespace: default
+      monitoring_enabled:
+      - logs
+      - metrics
+      is_default_fleet_server: true
+      package_policies:
+      - name: fleet_server-1
+        id: fleet_server-1
+        package:
+          name: fleet_server
+    - name: Elastic Agent on ECK policy
+      id: eck-agent
+      namespace: default
+      monitoring_enabled:
+      - logs
+      - metrics
+      unenroll_timeout: 900
+      is_default: true
+      package_policies:
+      - package:
+          name: system
+        name: system-1
+      - package:
+          name: kubernetes
+        name: kubernetes-1
+
+secureSettings: {}

--- a/deploy/eck-resources/recipes/observability/templates/NOTES.txt
+++ b/deploy/eck-resources/recipes/observability/templates/NOTES.txt
@@ -1,0 +1,16 @@
+HAPPY OBSERVABILITY!
+
+You've just installed ECK with Fleet and Kubernetes integration by default, to check the status of your resources, please run:
+
+- Elasticsearch status
+  $ kubectl get elasticsearch --namespace={{ .Release.Namespace }}
+
+- Kibana status
+  $ kubectl get kibana --namespace={{ .Release.Namespace }}
+
+- Agents status
+ $ kubectl get agents --namespace={{ .Release.Namespace } 
+   
+- Watch all cluster members come up.
+  $ kubectl get pods --namespace={{ .Release.Namespace }} -l common.k8s.elastic.co/type=elasticsearch
+  $ kubectl get pods --namespace={{ .Release.Namespace }} -l common.k8s.elastic.co/type=kibana

--- a/deploy/eck-resources/recipes/observability/templates/_helpers.tpl
+++ b/deploy/eck-resources/recipes/observability/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "observability.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "observability.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/eck-resources/recipes/observability/values.yaml
+++ b/deploy/eck-resources/recipes/observability/values.yaml
@@ -1,0 +1,67 @@
+---
+version: 8.2.0
+
+FleetServerName: "fleet-server-quickstart"
+
+KibanaRef: "quickstart"
+
+elasticsearchRef: "quickstart"
+
+mode: "fleet"
+
+fleetServerEnabled: "true"
+
+replicas: 1
+
+elasticAgentName: "elastic-agent-quickstart"
+
+fleetServerRef: "fleet-server-quickstart"
+---
+count: 1
+
+KibanaName: "quickstart"
+
+esOutofECK: {}
+
+KibanaSpec:
+  count: 1
+  elasticsearchRef:
+    name: quickstart # Make sure to use your own elasticsearch name resource, see https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-kibana.html
+    namespace: default
+
+secureSettings: {}
+---
+esName: "quickstart"
+
+labels: {}
+
+annotations: {}
+ 
+monitoring: {}
+
+transport: {}
+
+http: {}
+
+secureSettings: {}
+
+updateStrategy: {}
+
+esSpec: 
+  nodeSets:
+  - name: default
+    count: 1
+    config:
+      node.roles: ["master", "data", "ingest", "remote_cluster_client"]
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            requests:
+              cpu: 1
+            limits:
+              memory: 1Gi
+
+remoteClusters: {}


### PR DESCRIPTION
Fix #5505 

This PR contains the first version of the ECK resources using helm-charts

The main idea is to keep the configuration as simple as possible, and as organized as possible. With this in mind, the default configuration will deploy the quickstart examples.

The main `values.yaml` in each folder/resource has a minimal version/definition. The `examples/` has a set of examples on how to custom the charts, I tried to cover all the options we have on this [page](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elasticsearch-specification.html).

The `recipes/` folder contains examples on how to set up observability (for instance), the idea here is to have recipes ready to handle some specific use cases.

TO BE DONE:

- [ ] Deploy Elastic Maps Server
- [ ] Deploy Enterprise Search
- [ ] Beats/Kibana/APM/Fleet Docs
- [ ] Add more `recipes/`

cc @jmlrt @Kushmaro 