### PR TITLE
Comment and tests for autoscaling memory, CPU, and storage ranges

### DIFF
--- a/pkg/controller/autoscaling/elasticsearch/autoscaler/linear_scaler.go
+++ b/pkg/controller/autoscaling/elasticsearch/autoscaler/linear_scaler.go
@@ -16,6 +16,7 @@ import (
 
 // cpuFromMemory computes a CPU quantity within the specified allowed range by the user proportionally
 // to the amount of memory requested by the autoscaling API.
+// Invalid memory and CPU ranges with max less than min are rejected during pre-creation/update validation.
 func cpuFromMemory(requiredMemoryCapacity resource.Quantity, memoryRange, cpuRange esv1.QuantityRange) resource.Quantity {
 	allowedMemoryRange := memoryRange.Max.Value() - memoryRange.Min.Value()
 	if allowedMemoryRange == 0 {
@@ -48,6 +49,7 @@ func cpuFromMemory(requiredMemoryCapacity resource.Quantity, memoryRange, cpuRan
 
 // memoryFromStorage computes a memory quantity within the specified allowed range by the user proportionally
 // to the amount of storage requested by the autoscaling API.
+// Invalid storage and memory ranges with max less than min are rejected during pre-creation/update validation.
 func memoryFromStorage(requiredStorageCapacity resource.Quantity, storageRange, memoryRange esv1.QuantityRange) resource.Quantity {
 	allowedStorageRange := storageRange.Max.Value() - storageRange.Min.Value()
 	if allowedStorageRange == 0 {

--- a/pkg/controller/autoscaling/elasticsearch/autoscaler/linear_scaler_test.go
+++ b/pkg/controller/autoscaling/elasticsearch/autoscaler/linear_scaler_test.go
@@ -80,6 +80,31 @@ func Test_memoryFromStorage(t *testing.T) {
 			},
 			wantMemory: qPtr("2Gi"),
 		},
+		// Test that there is no out of bounds error with invalid ranges even though it shouldn't happen thanks to the validation layer.°
+		{
+			name: "Invalid memory range: max less than min",
+			args: args{
+				requiredStorageCapacity: q("2Gi"),
+				autoscalingSpec:         NewAutoscalingSpecBuilder("my-autoscaling-policy").WithMemory("4Gi", "1Gi").WithStorage("2Gi", "2Gi").Build(),
+			},
+			wantMemory: qPtr("4Gi"),
+		},
+		{
+			name: "Invalid storage range: max less than min",
+			args: args{
+				requiredStorageCapacity: q("2Gi"),
+				autoscalingSpec:         NewAutoscalingSpecBuilder("my-autoscaling-policy").WithMemory("2Gi", "2Gi").WithStorage("3Gi", "1Gi").Build(),
+			},
+			wantMemory: qPtr("2Gi"),
+		},
+		{
+			name: "Invalid memory and storage ranges: max less than min",
+			args: args{
+				requiredStorageCapacity: q("2Gi"),
+				autoscalingSpec:         NewAutoscalingSpecBuilder("my-autoscaling-policy").WithMemory("4Gi", "1Gi").WithStorage("3Gi", "2Gi").Build(),
+			},
+			wantMemory: qPtr("1Gi"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -131,6 +156,31 @@ func Test_cpuFromMemory(t *testing.T) {
 				autoscalingSpec:        NewAutoscalingSpecBuilder("my-autoscaling-policy").WithCPU("4", "4").WithMemory("1Gi", "3Gi").Build(),
 			},
 			wantCPU: qPtr("4000m"),
+		},
+		// Test that there is no out of bounds error with invalid ranges even though it shouldn't happen thanks to the validation layer.
+		{
+			name: "Invalid memory range: max less than min",
+			args: args{
+				requiredMemoryCapacity: q("2Gi"),
+				autoscalingSpec:        NewAutoscalingSpecBuilder("my-autoscaling-policy").WithCPU("4", "1").WithMemory("2Gi", "2Gi").Build(),
+			},
+			wantCPU: qPtr("4000m"),
+		},
+		{
+			name: "Invalid CPU range: max less than min",
+			args: args{
+				requiredMemoryCapacity: q("2Gi"),
+				autoscalingSpec:        NewAutoscalingSpecBuilder("my-autoscaling-policy").WithCPU("4", "4").WithMemory("3Gi", "2Gi").Build(),
+			},
+			wantCPU: qPtr("4000m"),
+		},
+		{
+			name: "Invalid CPU and memory ranges: max less than min",
+			args: args{
+				requiredMemoryCapacity: q("2Gi"),
+				autoscalingSpec:        NewAutoscalingSpecBuilder("my-autoscaling-policy").WithCPU("4", "1").WithMemory("3Gi", "2Gi").Build(),
+			},
+			wantCPU: qPtr("1000m"),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Clearly explain that there is no need to validate again autoscaling memory, CPU, and storage ranges.