### PR TITLE
[E2E] Kibana monitoring: fix index pattern

### DIFF
--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -236,6 +236,9 @@ func (b Builder) WithMonitoring(metricsESRef commonv1.ObjectSelector, logsESRef 
 
 func (b Builder) GetMetricsIndexPattern() string {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
+	if v.GTE(version.MinFor(8, 3, 0)) {
+		return ".monitoring-kibana-8-mb"
+	}
 	if v.GTE(version.MinFor(8, 0, 0)) {
 		return fmt.Sprintf("metricbeat-%d.%d.%d*", v.Major, v.Minor, v.Patch)
 	}


### PR DESCRIPTION
Starting with `8.3.0` Kibana metrics are stored in a datastream named `.monitoring-kibana-8-mb`:

```json
{
	"data_streams": [{
		"name": ".monitoring-kibana-8-mb",
		"timestamp_field": {
			"name": "@timestamp"
		},
		"indices": [{
			"index_name": ".ds-.monitoring-kibana-8-mb-2022.06.07-000001",
			"index_uuid": "Vdhet3M4TuSGnl7VbiB2Ng"
		}],
		"generation": 1,
		"status": "GREEN",
		"template": ".monitoring-kibana-mb",
		"ilm_policy": ".monitoring-8-ilm-policy",
		"hidden": false,
		"system": false,
		"allow_custom_routing": false,
		"replicated": false
	}, {
		"name": "metricbeat-8.3.0",
		"timestamp_field": {
			"name": "@timestamp"
		},
		"indices": [{
			"index_name": ".ds-metricbeat-8.3.0-2022.06.07-000001",
			"index_uuid": "oLS2m11LQoGshCicd7YwHw"
		}],
		"generation": 1,
		"status": "GREEN",
		"template": "metricbeat-8.3.0",
		"ilm_policy": "metricbeat",
		"hidden": false,
		"system": false,
		"allow_custom_routing": false,
		"replicated": false
	}]
}
```

This PR fixes a flaky test on the last 8.3 snapshot release:
```
List of failed tests:
TestKBStackMonitoring
TestKBStackMonitoring/Check_that_documents_are_indexed_in_index_metricbeat-8.3.0*
```

Note that `TestESStackMonitoring` does not seem to be affected for now.