### PR TITLE
Set Pod Spec EnableServiceLinks to false by default

### DIFF
--- a/pkg/controller/agent/controller_test.go
+++ b/pkg/controller/agent/controller_test.go
@@ -149,7 +149,7 @@ func TestReconcileAgent_Reconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testAgent-agent",
 						Namespace: "test",
-						Labels:    addLabel(defaultLabels, hash.TemplateHashLabelName, "1678576940"),
+						Labels:    addLabel(defaultLabels, hash.TemplateHashLabelName, "3577950992"),
 					},
 					Status: appsv1.DeploymentStatus{
 						AvailableReplicas: 1,

--- a/pkg/controller/apmserver/deployment_test.go
+++ b/pkg/controller/apmserver/deployment_test.go
@@ -192,7 +192,7 @@ func expectedDeploymentParams() testParams {
 						Resources: DefaultResources,
 					}},
 					AutomountServiceAccountToken: ptrFalse(),
-					EnableServiceLinks: ptrFalse(),
+					EnableServiceLinks:           ptrFalse(),
 				},
 			},
 			Replicas: 0,

--- a/pkg/controller/apmserver/deployment_test.go
+++ b/pkg/controller/apmserver/deployment_test.go
@@ -192,6 +192,7 @@ func expectedDeploymentParams() testParams {
 						Resources: DefaultResources,
 					}},
 					AutomountServiceAccountToken: ptrFalse(),
+					EnableServiceLinks: ptrFalse(),
 				},
 			},
 			Replicas: 0,

--- a/pkg/controller/apmserver/pod_test.go
+++ b/pkg/controller/apmserver/pod_test.go
@@ -91,7 +91,7 @@ func TestNewPodSpec(t *testing.T) {
 						configSecretVol.Volume(), configVolume.Volume(), httpCertsSecretVol.Volume(),
 					},
 					AutomountServiceAccountToken: &varFalse,
-					EnableServiceLinks: &varFalse,
+					EnableServiceLinks:           &varFalse,
 					Containers: []corev1.Container{
 						{
 							Name:  apmv1.ApmServerContainerName,

--- a/pkg/controller/apmserver/pod_test.go
+++ b/pkg/controller/apmserver/pod_test.go
@@ -91,6 +91,7 @@ func TestNewPodSpec(t *testing.T) {
 						configSecretVol.Volume(), configVolume.Volume(), httpCertsSecretVol.Volume(),
 					},
 					AutomountServiceAccountToken: &varFalse,
+					EnableServiceLinks: &varFalse,
 					Containers: []corev1.Container{
 						{
 							Name:  apmv1.ApmServerContainerName,

--- a/pkg/controller/common/defaults/pod_template.go
+++ b/pkg/controller/common/defaults/pod_template.go
@@ -88,6 +88,10 @@ func (b *PodTemplateBuilder) setDefaults() *PodTemplateBuilder {
 	if b.PodTemplate.Spec.AutomountServiceAccountToken == nil {
 		b.PodTemplate.Spec.AutomountServiceAccountToken = &varFalse
 	}
+	// disable injecting services information into pod's environment variables, unless explicitly enabled by the user
+	if b.PodTemplate.Spec.EnableServiceLinks == nil {
+		b.PodTemplate.Spec.EnableServiceLinks = &varFalse
+	}
 
 	return b
 }

--- a/pkg/controller/common/defaults/pod_template_test.go
+++ b/pkg/controller/common/defaults/pod_template_test.go
@@ -32,6 +32,7 @@ func TestPodTemplateBuilder_setDefaults(t *testing.T) {
 			want: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varFalse,
+					EnableServiceLinks: &varFalse,
 					Containers: []corev1.Container{
 						{
 							Name: "mycontainer",
@@ -51,6 +52,27 @@ func TestPodTemplateBuilder_setDefaults(t *testing.T) {
 			want: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varTrue,
+					EnableServiceLinks: &varFalse,
+					Containers: []corev1.Container{
+						{
+							Name: "mycontainer",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "don't override user enable service links",
+			PodTemplate: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					EnableServiceLinks: &varTrue,
+				},
+			},
+			containerName: "mycontainer",
+			want: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					AutomountServiceAccountToken: &varFalse,
+					EnableServiceLinks: &varTrue,
 					Containers: []corev1.Container{
 						{
 							Name: "mycontainer",
@@ -77,6 +99,7 @@ func TestPodTemplateBuilder_setDefaults(t *testing.T) {
 			want: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varFalse,
+					EnableServiceLinks: &varFalse,
 					Containers: []corev1.Container{
 						{
 							Name: "usercontainer1",
@@ -1207,6 +1230,7 @@ func TestPodTemplateBuilder_WithContainers(t *testing.T) {
 			want: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varFalse,
+					EnableServiceLinks: &varFalse,
 					Containers: []corev1.Container{
 						{
 							Name: "maincontainer",
@@ -1224,6 +1248,7 @@ func TestPodTemplateBuilder_WithContainers(t *testing.T) {
 			PodTemplate: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varFalse,
+					EnableServiceLinks: &varFalse,
 					Containers: []corev1.Container{
 						{
 							Name: "maincontainer",
@@ -1245,6 +1270,7 @@ func TestPodTemplateBuilder_WithContainers(t *testing.T) {
 			want: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varFalse,
+					EnableServiceLinks: &varFalse,
 					Containers: []corev1.Container{
 						{
 							Name: "maincontainer",

--- a/pkg/controller/common/defaults/pod_template_test.go
+++ b/pkg/controller/common/defaults/pod_template_test.go
@@ -62,7 +62,7 @@ func TestPodTemplateBuilder_setDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "don't override user enable service links",
+			name: "don't override user enabled service links",
 			PodTemplate: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					EnableServiceLinks: &varTrue,

--- a/pkg/controller/common/defaults/pod_template_test.go
+++ b/pkg/controller/common/defaults/pod_template_test.go
@@ -32,7 +32,7 @@ func TestPodTemplateBuilder_setDefaults(t *testing.T) {
 			want: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varFalse,
-					EnableServiceLinks: &varFalse,
+					EnableServiceLinks:           &varFalse,
 					Containers: []corev1.Container{
 						{
 							Name: "mycontainer",
@@ -52,7 +52,7 @@ func TestPodTemplateBuilder_setDefaults(t *testing.T) {
 			want: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varTrue,
-					EnableServiceLinks: &varFalse,
+					EnableServiceLinks:           &varFalse,
 					Containers: []corev1.Container{
 						{
 							Name: "mycontainer",
@@ -72,7 +72,7 @@ func TestPodTemplateBuilder_setDefaults(t *testing.T) {
 			want: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varFalse,
-					EnableServiceLinks: &varTrue,
+					EnableServiceLinks:           &varTrue,
 					Containers: []corev1.Container{
 						{
 							Name: "mycontainer",
@@ -99,7 +99,7 @@ func TestPodTemplateBuilder_setDefaults(t *testing.T) {
 			want: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varFalse,
-					EnableServiceLinks: &varFalse,
+					EnableServiceLinks:           &varFalse,
 					Containers: []corev1.Container{
 						{
 							Name: "usercontainer1",
@@ -1230,7 +1230,7 @@ func TestPodTemplateBuilder_WithContainers(t *testing.T) {
 			want: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varFalse,
-					EnableServiceLinks: &varFalse,
+					EnableServiceLinks:           &varFalse,
 					Containers: []corev1.Container{
 						{
 							Name: "maincontainer",
@@ -1248,7 +1248,7 @@ func TestPodTemplateBuilder_WithContainers(t *testing.T) {
 			PodTemplate: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varFalse,
-					EnableServiceLinks: &varFalse,
+					EnableServiceLinks:           &varFalse,
 					Containers: []corev1.Container{
 						{
 							Name: "maincontainer",
@@ -1270,7 +1270,7 @@ func TestPodTemplateBuilder_WithContainers(t *testing.T) {
 			want: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varFalse,
-					EnableServiceLinks: &varFalse,
+					EnableServiceLinks:           &varFalse,
 					Containers: []corev1.Container{
 						{
 							Name: "maincontainer",

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -315,6 +315,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 			},
 			TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 			AutomountServiceAccountToken:  &varFalse,
+			EnableServiceLinks:  &varFalse,
 			Affinity:                      DefaultAffinity(sampleES.Name),
 		},
 	}

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -315,7 +315,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 			},
 			TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 			AutomountServiceAccountToken:  &varFalse,
-			EnableServiceLinks:  &varFalse,
+			EnableServiceLinks:            &varFalse,
 			Affinity:                      DefaultAffinity(sampleES.Name),
 		},
 	}

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -583,7 +583,7 @@ func expectedDeploymentParams() deployment.Params {
 					Resources: DefaultResources,
 				}},
 				AutomountServiceAccountToken: &falseVal,
-				EnableServiceLinks: &falseVal,
+				EnableServiceLinks:           &falseVal,
 			},
 		},
 	}

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -583,6 +583,7 @@ func expectedDeploymentParams() deployment.Params {
 					Resources: DefaultResources,
 				}},
 				AutomountServiceAccountToken: &falseVal,
+				EnableServiceLinks: &falseVal,
 			},
 		},
 	}


### PR DESCRIPTION
Set `EnableServiceLinks` to `false` in the Pod spec to prevent the injection of environment variables with service information into the Pods.

Resolves #2030.