### PR TITLE
Deployer: pick up cached vault auth token from env

### DIFF
--- a/hack/deployer/cmd/create.go
+++ b/hack/deployer/cmd/create.go
@@ -53,12 +53,7 @@ func CreateCommand() *cobra.Command {
 					return err
 				}
 
-				pullSecret, err := GetEnvVar("OCP_PULL_SECRET")
-				if err != nil {
-					return err
-				}
-
-				cfgData = fmt.Sprintf(runner.DefaultOCPRunConfigTemplate, user, gCloudProject, pullSecret)
+				cfgData = fmt.Sprintf(runner.DefaultOCPRunConfigTemplate, user, gCloudProject)
 			case runner.EKSDriverID:
 				// optional variable for local dev use
 				token, _ := os.LookupEnv("GITHUB_TOKEN")

--- a/hack/deployer/cmd/create.go
+++ b/hack/deployer/cmd/create.go
@@ -55,13 +55,9 @@ func CreateCommand() *cobra.Command {
 
 				cfgData = fmt.Sprintf(runner.DefaultOCPRunConfigTemplate, user, gCloudProject)
 			case runner.EKSDriverID:
-				// optional variable for local dev use
+				// optional variables for local dev use: preferably login to vault external to deployer and export VAULT_ADDR
 				token, _ := os.LookupEnv("GITHUB_TOKEN")
-
-				vaultAddr, err := GetEnvVar("VAULT_ADDR")
-				if err != nil {
-					return err
-				}
+				vaultAddr, _ := GetEnvVar("VAULT_ADDR")
 
 				cfgData = fmt.Sprintf(runner.DefaultEKSRunConfigTemplate, user, vaultAddr, token)
 			case runner.KindDriverID:

--- a/hack/deployer/runner/aks.go
+++ b/hack/deployer/runner/aks.go
@@ -39,9 +39,10 @@ type AKSDriver struct {
 
 func (gdf *AKSDriverFactory) Create(plan Plan) (Driver, error) {
 	var vaultClient *vault.Client
-	if plan.VaultInfo != nil {
+	// plan.ServiceAccount = true typically means a CI run vs a local run on a dev machine
+	if plan.ServiceAccount {
 		var err error
-		vaultClient, err = vault.NewClient(*plan.VaultInfo)
+		vaultClient, err = vault.NewClient(plan.VaultInfo)
 		if err != nil {
 			return nil, err
 		}

--- a/hack/deployer/runner/eks.go
+++ b/hack/deployer/runner/eks.go
@@ -193,7 +193,7 @@ func (e *EKSDriver) auth() error {
 
 // fetchSecrets gets secret configuration data from vault and populates driver's context map with it.
 func (e *EKSDriver) fetchSecrets() error {
-	client, err := vault.NewClient(*e.plan.VaultInfo)
+	client, err := vault.NewClient(e.plan.VaultInfo)
 	if err != nil {
 		return err
 	}

--- a/hack/deployer/runner/gcloud.go
+++ b/hack/deployer/runner/gcloud.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/elastic/cloud-on-k8s/hack/deployer/exec"
 	"github.com/elastic/cloud-on-k8s/hack/deployer/vault"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -23,18 +21,14 @@ const (
 
 // authToGCP authenticates the deployer to the Google Cloud Platform as a service account or as a user.
 func authToGCP(
-	vaultInfo *vault.Info, vaultPath string, serviceAccountVaultFieldName string,
+	vaultInfo vault.Info, vaultPath string, serviceAccountVaultFieldName string,
 	asServiceAccount bool, configureDocker bool, gCloudProject interface{},
 ) error {
 	//nolint:nestif
 	if asServiceAccount {
-		if vaultInfo == nil {
-			return errors.New("vault info not present in the plan to authenticate to GCP")
-		}
-
 		log.Println("Authenticating as service account...")
 
-		client, err := vault.NewClient(*vaultInfo)
+		client, err := vault.NewClient(vaultInfo)
 		if err != nil {
 			return err
 		}

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -235,7 +235,7 @@ func (d *OCPDriver) ensureClientImage() error {
 
 func (d *OCPDriver) ensurePullSecret() error {
 	if d.plan.Ocp.PullSecret == "" {
-		client, err := vault.NewClient(*d.plan.VaultInfo)
+		client, err := vault.NewClient(d.plan.VaultInfo)
 		if err != nil {
 			return err
 		}

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -32,7 +32,6 @@ overrides:
   clusterName: %s-dev-cluster
   ocp:
     gCloudProject: %s
-    pullSecret: '%s'
 `
 
 	OcpInstallerConfigTemplate = `apiVersion: v1

--- a/hack/deployer/runner/ocp3.go
+++ b/hack/deployer/runner/ocp3.go
@@ -70,7 +70,7 @@ func (d OCP3Driver) Execute() error {
 		return err
 	}
 
-	if err := writeGCloudSSHKey(*d.plan.VaultInfo); err != nil {
+	if err := writeGCloudSSHKey(d.plan.VaultInfo); err != nil {
 		return err
 	}
 

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -36,7 +36,7 @@ type Plan struct {
 	Eks            *EKSSettings   `yaml:"eks,omitempty"`
 	Kind           *KindSettings  `yaml:"kind,omitempty"`
 	Tanzu          *TanzuSettings `yaml:"tanzu,omitempty"`
-	VaultInfo      *vault.Info    `yaml:"vaultInfo,omitempty"`
+	VaultInfo      vault.Info     `yaml:"vaultInfo,omitempty"`
 	ServiceAccount bool           `yaml:"serviceAccount"`
 	Psp            bool           `yaml:"psp"`
 	DiskSetup      string         `yaml:"diskSetup"`

--- a/hack/deployer/runner/tanzu.go
+++ b/hack/deployer/runner/tanzu.go
@@ -58,10 +58,7 @@ func init() {
 type TanzuDriverFactory struct{}
 
 func (t TanzuDriverFactory) Create(plan Plan) (Driver, error) {
-	if plan.VaultInfo == nil {
-		return nil, fmt.Errorf("no vault credentials provided")
-	}
-	vaultClient, err := vault.NewClient(*plan.VaultInfo)
+	vaultClient, err := vault.NewClient(plan.VaultInfo)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Make deployer able to pick up cached vault auth Information from the environment. The intent here is to reduce friction for people setting up deployer for the first time. The second goal is to avoid having to store credentials, GitHub tokens or even pull secrets coming from vault in local unprotected configuration files on disk. Instead the only thing on disk will be the cached vault token (which already exists anyway once you logged in) 

I will update our documentation around this in a separate PR.