### PR TITLE
Check shard activity before removing a node

### DIFF
--- a/pkg/controller/elasticsearch/client/model.go
+++ b/pkg/controller/elasticsearch/client/model.go
@@ -45,6 +45,18 @@ type Health struct {
 	ActiveShardsPercentAsNumber float32                  `json:"active_shards_percent_as_number"`
 }
 
+// HasShardActivity indicates that there is some shard activity in the cluster.
+// It can be the case if some shards are being fetched, relocated or initialized.
+// It's only reliable if Health result was created with wait_for_events=languid
+// so that there are no pending initialisations in the task queue.
+// It returns true if the status request has timed out.
+func (h Health) HasShardActivity() bool {
+	return h.TimedOut || // make sure request did not time out (i.e. no pending events)
+		h.NumberOfInFlightFetch > 0 || // no shards being fetched
+		h.InitializingShards > 0 || // no shards initializing
+		h.RelocatingShards > 0 // no shards relocating
+}
+
 type ShardState string
 
 // These are possible shard states

--- a/pkg/controller/elasticsearch/client/shard.go
+++ b/pkg/controller/elasticsearch/client/shard.go
@@ -17,6 +17,7 @@ type AllocationSetter interface {
 
 // ShardLister captures Elasticsearch API calls around shards retrieval.
 type ShardLister interface {
+	HasShardActivity(ctx context.Context) (bool, error)
 	GetShards(ctx context.Context) (Shards, error)
 }
 
@@ -43,4 +44,12 @@ func (c *clientV6) GetShards(ctx context.Context) (Shards, error) {
 		return shards, err
 	}
 	return shards, nil
+}
+
+func (c *clientV6) HasShardActivity(ctx context.Context) (bool, error) {
+	health, err := c.GetClusterHealth(ctx)
+	if err != nil {
+		return false, err
+	}
+	return health.HasShardActivity(), nil
 }

--- a/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -756,6 +756,25 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 				finalReplicas:   2,
 			},
 		},
+		{
+			name: "downscale not possible: pending shard activity",
+			args: args{
+				ctx: downscaleContext{
+					reconcileState: reconcile.MustNewState(esv1.Elasticsearch{}),
+					nodeShutdown:   migration.NewShardMigration(es, &fakeESClient{}, migration.NewFakeShardLister(esclient.Shards{}).WithShardActivity()),
+				},
+				downscale: ssetDownscale{
+					initialReplicas: 3,
+					targetReplicas:  2,
+					finalReplicas:   2,
+				},
+			},
+			want: ssetDownscale{
+				initialReplicas: 3,
+				targetReplicas:  3,
+				finalReplicas:   2,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/elasticsearch/driver/downscale_test.go
+++ b/pkg/controller/elasticsearch/driver/downscale_test.go
@@ -761,7 +761,7 @@ func Test_calculatePerformableDownscale(t *testing.T) {
 			args: args{
 				ctx: downscaleContext{
 					reconcileState: reconcile.MustNewState(esv1.Elasticsearch{}),
-					nodeShutdown:   migration.NewShardMigration(es, &fakeESClient{}, migration.NewFakeShardLister(esclient.Shards{}).WithShardActivity()),
+					nodeShutdown:   migration.NewShardMigration(es, &fakeESClient{}, migration.NewFakeShardListerWithShardActivity(esclient.Shards{})),
 				},
 				downscale: ssetDownscale{
 					initialReplicas: 3,

--- a/pkg/controller/elasticsearch/driver/upgrade_predicates.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_predicates.go
@@ -646,9 +646,6 @@ func conflictingShards(shards1, shards2 []client.Shard) bool {
 // only reliable if Status result was created with wait_for_events=languid
 // so that there are no pending initialisations in the task queue
 func isSafeToRoll(health client.Health) bool {
-	return !health.TimedOut && // make sure request did not time out (i.e. no pending events)
-		health.Status != esv1.ElasticsearchRedHealth && // all primaries allocated
-		health.NumberOfInFlightFetch == 0 && // no shards being fetched
-		health.InitializingShards == 0 && // no shards initializing
-		health.RelocatingShards == 0 // no shards relocating
+	return !health.HasShardActivity() && // no shard activity
+		health.Status != esv1.ElasticsearchRedHealth // all primaries allocated
 }

--- a/pkg/controller/elasticsearch/migration/fixtures.go
+++ b/pkg/controller/elasticsearch/migration/fixtures.go
@@ -36,12 +36,14 @@ func (f *fakeShardLister) GetShards(_ context.Context) (esclient.Shards, error) 
 	return f.shards, f.err
 }
 
-func (f fakeShardLister) WithShardActivity() *fakeShardLister {
-	f.hasShardActivity = true
-	return &f
+func NewFakeShardListerWithShardActivity(shards esclient.Shards) esclient.ShardLister {
+	return &fakeShardLister{
+		shards:           shards,
+		hasShardActivity: true,
+	}
 }
 
-func NewFakeShardLister(shards esclient.Shards) *fakeShardLister {
+func NewFakeShardLister(shards esclient.Shards) esclient.ShardLister {
 	return &fakeShardLister{shards: shards}
 }
 

--- a/pkg/controller/elasticsearch/migration/fixtures.go
+++ b/pkg/controller/elasticsearch/migration/fixtures.go
@@ -23,15 +23,25 @@ func loadFileBytes(fileName string) []byte {
 }
 
 type fakeShardLister struct {
-	shards esclient.Shards
-	err    error
+	shards           esclient.Shards
+	hasShardActivity bool
+	err              error
+}
+
+func (f *fakeShardLister) HasShardActivity(_ context.Context) (bool, error) {
+	return f.hasShardActivity, nil
 }
 
 func (f *fakeShardLister) GetShards(_ context.Context) (esclient.Shards, error) {
 	return f.shards, f.err
 }
 
-func NewFakeShardLister(shards esclient.Shards) esclient.ShardLister {
+func (f fakeShardLister) WithShardActivity() *fakeShardLister {
+	f.hasShardActivity = true
+	return &f
+}
+
+func NewFakeShardLister(shards esclient.Shards) *fakeShardLister {
 	return &fakeShardLister{shards: shards}
 }
 


### PR DESCRIPTION
This PR is an attempt to solve https://github.com/elastic/cloud-on-k8s/issues/5713
During a node removal operation, it attempts to ensure that there is no pending shard activity before fetching the shards using `_cat/shards`.

Note that recent versions of Elasticsearch which are relying on the shutdown API should not be affected.

See also https://github.com/elastic/cloud-on-k8s/issues/3070 for more context. 