### PR TITLE
Fix readiness probe script to let `xpack.security.http.ssl.client_authentication` be set to `required`

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/readiness_probe.go
+++ b/pkg/controller/elasticsearch/nodespec/readiness_probe.go
@@ -77,7 +77,9 @@ fi
 # we are turning globbing off to allow for unescaped [] in case of IPv6
 ENDPOINT="${READINESS_PROBE_PROTOCOL:-https}://${LOOPBACK}:9200/"
 ORIGIN_HEADER="` + common.InternalProductRequestHeaderString + `"
-status=$(curl -o /dev/null -w "%{http_code}" --max-time ${READINESS_PROBE_TIMEOUT} -H "${ORIGIN_HEADER}" -XGET -g -s -k ${BASIC_AUTH} $ENDPOINT)
+CERT_PATH="/usr/share/elasticsearch/config/http-certs"
+CERT_FLAGS="--cert ${CERT_PATH}/tls.crt --key ${CERT_PATH}/tls.key"
+status=$(curl -o /dev/null -w "%{http_code}" --max-time ${READINESS_PROBE_TIMEOUT} -H "${ORIGIN_HEADER}" -XGET -g -s ${CERT_FLAGS} -k ${BASIC_AUTH} $ENDPOINT)
 curl_rc=$?
 
 if [[ ${curl_rc} -ne 0 ]]; then


### PR DESCRIPTION
It looks like currently the `xpack.security.http.ssl.client_authentication` setting won't work if it is set to 'required.'  This is caused when the readiness_probe.sh tries to ping https://localhost:9200, but it doesn't present a cert or key file.  The fix is to simply set the --key and --cert flags of the curl request. This still works when ECK is configured to use custom certs because the operator always puts them in the `/usr/share/elasticsearch/config/http-certs/` directory, and it also continue to work even when SSL is disabled because the cert files will still be there.

It's worth pointing out that this setting isn't listed in the [Settings Managed by ECK](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-reserved-settings.html) doc page, which is why I decided to fix it. 