### PR TITLE
Fix non closed http responses (#5755)

### DIFF
--- a/hack/operatorhub/main.go
+++ b/hack/operatorhub/main.go
@@ -206,12 +206,7 @@ func makeRequest(url string) (io.Reader, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to GET %s: %w", url, err)
 	}
-
-	defer func() {
-		if resp.Body != nil {
-			resp.Body.Close()
-		}
-	}()
+	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, errNotFound

--- a/pkg/controller/association/secret.go
+++ b/pkg/controller/association/secret.go
@@ -130,11 +130,11 @@ func (r UnmanagedAssociationConnectionInfo) Request(path string, jsonPath string
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		return "", fmt.Errorf("error requesting %q, statusCode = %d", url, resp.StatusCode)
 	}
 
-	defer resp.Body.Close()
 	var obj interface{}
 	if err = json.NewDecoder(resp.Body).Decode(&obj); err != nil {
 		return "", err

--- a/pkg/controller/common/stackmon/config.go
+++ b/pkg/controller/common/stackmon/config.go
@@ -77,7 +77,11 @@ func newBeatConfig(client k8s.Client, beatName string, resource monitoring.HasMo
 	}
 
 	configHash := fnv.New32a()
-	configHash.Write(configBytes)
+
+	_, err = configHash.Write(configBytes)
+	if err != nil {
+		return beatConfig{}, err
+	}
 
 	configSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/test/enterprisesearch/http_client.go
+++ b/test/e2e/test/enterprisesearch/http_client.go
@@ -76,11 +76,11 @@ func (e EnterpriseSearchClient) doRequest(request *http.Request) ([]byte, error)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return nil, fmt.Errorf("http response status code is %d)", resp.StatusCode)
 	}
 
-	defer resp.Body.Close()
 	return ioutil.ReadAll(resp.Body)
 }
 

--- a/test/e2e/test/kibana/http_client.go
+++ b/test/e2e/test/kibana/http_client.go
@@ -77,7 +77,7 @@ func DoRequest(k *test.K8sClient, kb kbv1.Kibana, password string, method string
 	if err != nil {
 		return nil, errors.Wrap(err, "while doing request")
 	}
-
+	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return nil, &APIError{
 			StatusCode: resp.StatusCode,
@@ -85,6 +85,5 @@ func DoRequest(k *test.K8sClient, kb kbv1.Kibana, password string, method string
 		}
 	}
 
-	defer resp.Body.Close()
 	return ioutil.ReadAll(resp.Body)
 }

--- a/test/e2e/test/maps/http_client.go
+++ b/test/e2e/test/maps/http_client.go
@@ -59,13 +59,12 @@ func DoRequest(client *http.Client, ems v1alpha1.ElasticMapsServer, method, path
 	if err != nil {
 		return nil, fmt.Errorf("while making request: %w", err)
 	}
-
+	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return nil, &APIError{
 			StatusCode: resp.StatusCode,
 			msg:        fmt.Sprintf("fail to request %s, status is %d)", path, resp.StatusCode),
 		}
 	}
-	defer resp.Body.Close()
 	return ioutil.ReadAll(resp.Body)
 }


### PR DESCRIPTION
I would like to backport #5755 into `2.3` as it contains a fix for a fd leak.
Happy to close it if it raises some concerns.