### PR TITLE
Fix ubi8 suffix in operatorhub template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ IMG_VERSION        ?= $(VERSION)-$(TAG)
 
 BASE_IMG                     := $(REGISTRY)/$(REGISTRY_NAMESPACE)/$(IMG_NAME)
 OPERATOR_IMAGE               ?= $(BASE_IMG):$(IMG_VERSION)
-OPERATOR_IMAGE_UBI           ?= $(BASE_IMG)-ubi:$(IMG_VERSION)
+OPERATOR_IMAGE_UBI           ?= $(BASE_IMG)-ubi8:$(IMG_VERSION)
 OPERATOR_DOCKERHUB_IMAGE     ?= docker.io/elastic/$(IMG_NAME):$(IMG_VERSION)
 OPERATOR_DOCKERHUB_IMAGE_UBI ?= docker.io/elastic/$(IMG_NAME)-ubi8:$(IMG_VERSION)
 

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -5,7 +5,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Database
     certified: 'false'
-    containerImage: {{ .OperatorRepo }}{{ if .UbiOnly }}-ubi{{ end }}:{{ .NewVersion }}
+    containerImage: {{ .OperatorRepo }}{{ if .UbiOnly }}-ubi8{{ end }}:{{ .NewVersion }}
     createdAt: {{ now | date "2006-01-02 15:04:05" }}
     description: Run Elasticsearch, Kibana, APM Server, Beats, Enterprise Search, Elastic Agent and Elastic Maps Server on Kubernetes and OpenShift
     repository: https://github.com/elastic/cloud-on-k8s
@@ -312,7 +312,7 @@ spec:
             spec:
               serviceAccountName: elastic-operator
               containers:
-              - image: {{ .OperatorRepo }}{{ if .UbiOnly }}-ubi{{ end }}:{{ .NewVersion }}
+              - image: {{ .OperatorRepo }}{{ if .UbiOnly }}-ubi8{{ end }}:{{ .NewVersion }}
                 name: manager
                 args:
                   - "manager"
@@ -332,7 +332,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.operatorNamespace']
                 - name: OPERATOR_IMAGE
-                  value: {{ .OperatorRepo }}{{ if .UbiOnly }}-ubi{{ end }}:{{ .NewVersion }}
+                  value: {{ .OperatorRepo }}{{ if .UbiOnly }}-ubi8{{ end }}:{{ .NewVersion }}
                 resources:
                   limits:
                     cpu: 1

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -5,7 +5,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Database
     certified: 'false'
-    containerImage: {{ .OperatorRepo }}{{ if .UbiOnly }}-ubi8{{ end }}:{{ .NewVersion }}
+    containerImage: {{ .OperatorRepo }}{{ if .UbiOnly }}-ubi{{ end }}:{{ .NewVersion }}
     createdAt: {{ now | date "2006-01-02 15:04:05" }}
     description: Run Elasticsearch, Kibana, APM Server, Beats, Enterprise Search, Elastic Agent and Elastic Maps Server on Kubernetes and OpenShift
     repository: https://github.com/elastic/cloud-on-k8s
@@ -312,7 +312,7 @@ spec:
             spec:
               serviceAccountName: elastic-operator
               containers:
-              - image: {{ .OperatorRepo }}{{ if .UbiOnly }}-ubi8{{ end }}:{{ .NewVersion }}
+              - image: {{ .OperatorRepo }}{{ if .UbiOnly }}-ubi{{ end }}:{{ .NewVersion }}
                 name: manager
                 args:
                   - "manager"
@@ -332,7 +332,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.operatorNamespace']
                 - name: OPERATOR_IMAGE
-                  value: {{ .OperatorRepo }}{{ if .UbiOnly }}-ubi8{{ end }}:{{ .NewVersion }}
+                  value: {{ .OperatorRepo }}{{ if .UbiOnly }}-ubi{{ end }}:{{ .NewVersion }}
                 resources:
                   limits:
                     cpu: 1


### PR DESCRIPTION
I think there is a discrepancy between the UBI image name in the [Makefile](https://github.com/elastic/cloud-on-k8s/blob/77c607ac4794f773e8a784f0bf40d78406f2b76f/Makefile#L50):

```Makefile
OPERATOR_IMAGE_UBI           ?= $(BASE_IMG)-ubi:$(IMG_VERSION)
```

And the one referenced in the operator hub template.