### PR TITLE
[2.3] Fix ubi8 suffix in Makefile (#5772)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ IMG_VERSION        ?= $(VERSION)-$(TAG)
 
 BASE_IMG                     := $(REGISTRY)/$(REGISTRY_NAMESPACE)/$(IMG_NAME)
 OPERATOR_IMAGE               ?= $(BASE_IMG):$(IMG_VERSION)
-OPERATOR_IMAGE_UBI           ?= $(BASE_IMG)-ubi:$(IMG_VERSION)
+OPERATOR_IMAGE_UBI           ?= $(BASE_IMG)-ubi8:$(IMG_VERSION)
 OPERATOR_DOCKERHUB_IMAGE     ?= docker.io/elastic/$(IMG_NAME):$(IMG_VERSION)
 OPERATOR_DOCKERHUB_IMAGE_UBI ?= docker.io/elastic/$(IMG_NAME)-ubi8:$(IMG_VERSION)
 


### PR DESCRIPTION
Backport of the following PR in `2.3`:
* #5772 