### PR TITLE
E2E: make sure WithVersion is called in elasticsearch.Builder

### DIFF
--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -106,11 +106,9 @@ func newBuilder(name, randSuffix string) Builder {
 	return Builder{
 		Elasticsearch: esv1.Elasticsearch{
 			ObjectMeta: meta,
-			Spec: esv1.ElasticsearchSpec{
-				Version: def.Version,
-			},
 		},
 	}.
+		WithVersion(def.Version).
 		WithImage(def.Image).
 		WithSuffix(randSuffix).
 		WithLabel(run.TestNameLabel, name)


### PR DESCRIPTION
Otherwise snapshot tests will fail due to different snapshot versions of Elasticsearch being in use at the same time which are not compatible with each other: 

```
"address [10.112.80.116:9300], node [null], requesting [false] discovery result: Failed to deserialize response from handler [org.elasticsearch.transport.TransportService$ContextRestoreResponseHandler/org.elasticsearch.transport.TransportService$ContextRestoreResponseHandler/org.elasticsearch.action.ActionListenerResponseHandler@7a8d374/org.elasticsearch.action.ActionListener$DelegatingFailureActionListener/org.elasticsearch.action.ActionListener$MappedActionListener/org.elasticsearch.discovery.HandshakingTransportAddressConnector$1@5e5489a6/org.elasticsearch.transport.TransportService$$Lambda$5956/0x0000000801b8d658@3e551386/org.elasticsearch.transport.TransportService$$Lambda$5957/0x0000000801b8dac8@5f5d47e8]: remote node [{test-autoscaling-l5nw-es-master-0}{Nrymty08TcCczIDsMZiVsA}{xNbsCxaoSlC0YIVTnaclpg}{test-autoscaling-l5nw-es-master-0}{10.112.80.116}{10.112.80.116:9300}{m}{k8s_node_name=gke-eck-8x-snapshot-603--default-pool-ee6c7ee9-lmpg, xpack.installed=true}] is build [d81727ae3481ed320802a5520d02356aab9aed09] of version [8.3.0] but this node is build [ed782f880f50c2ca0c1c0f4e0..."
```
is a typically error message that we see as a result.