### PR TITLE
[DOC] Update Network Policies

### DIFF
--- a/docs/advanced-topics/network-policies.asciidoc
+++ b/docs/advanced-topics/network-policies.asciidoc
@@ -37,9 +37,9 @@ kubectl label namespace team-b eck.k8s.elastic.co/tenant=team-b
 
 To set up the network policies correctly you must know the operator Pod selector and the Kubernetes API server IP. They may vary depending on your environment and how the operator has been installed.
 
-=== Operator Ood selector
+=== Operator Pod selector
 
-The operator Pod labels depends on how the operator has been installed, refer to the following table to know what label name should be used in the network policies.
+The operator Pod label depends on how the operator has been installed, refer to the following table to know what label name should be used in the network policies.
 
 [cols="1,1"]
 |===

--- a/docs/advanced-topics/network-policies.asciidoc
+++ b/docs/advanced-topics/network-policies.asciidoc
@@ -39,7 +39,7 @@ To set up the network policies correctly you must know the operator Pod selector
 
 === Operator Pod selector
 
-The operator Pod label depends on how the operator has been installed, refer to the following table to know what label name should be used in the network policies.
+The operator Pod label depends on how the operator has been installed. Check the following table to know which label name is used in the network policies.
 
 [cols="1,1"]
 |===
@@ -458,7 +458,7 @@ spec:
 == Isolating {agent} and {fleet}
 
 
-NOTE: Some {agent} policies may require additional access rules than what is listed here.
+NOTE: Some {agent} policies may require additional access rules other than those listed here.
 
 
 [cols="h,1"]

--- a/docs/advanced-topics/network-policies.asciidoc
+++ b/docs/advanced-topics/network-policies.asciidoc
@@ -12,6 +12,7 @@ endif::[]
 :es_http_port: 9200
 :es_transport_port: 9300
 :kb_port: 5601
+:fleet_server_port: 8220
 :webhook_port: 9443
 
 
@@ -57,7 +58,7 @@ The minimal set of permissions required are as follows:
 
 Assuming that the Kubernetes API server IP address is `10.0.0.1`, the following network policy implements this minimal set of permissions.
 
-NOTE: Run `kubectl cluster-info | grep master` to obtain the API server IP address for your cluster.
+NOTE: Run `kubectl get endpoints kubernetes -n default` to obtain the API server IP address for your cluster.
 
 [source,yaml,subs="attributes"]
 ----
@@ -100,7 +101,7 @@ spec:
       protocol: TCP
   podSelector:
     matchLabels:
-      control-plane: elastic-operator
+      app.kubernetes.io/name: elastic-operator
 ----
 
 
@@ -152,7 +153,7 @@ spec:
           eck.k8s.elastic.co/operator-name: elastic-operator
       podSelector:
         matchLabels:
-          control-plane: elastic-operator
+          app.kubernetes.io/name: elastic-operator
     - namespaceSelector:
         matchLabels:
           eck.k8s.elastic.co/tenant: team-a
@@ -223,6 +224,9 @@ spec:
   - ports:
     - port: {dns_port}
       protocol: UDP
+    # [Optional] If Agent is deployed, this is to allow Kibana to access the Elastic Package Registry (https://epr.elastic.co).
+    # - port: 443
+    #   protocol: TCP
   ingress:
   - from:
     - namespaceSelector:
@@ -424,4 +428,85 @@ spec:
   podSelector:
     matchLabels:
       common.k8s.elastic.co/type: beat
+----
+
+[float]
+[id="{p}-{page_id}-agent-isolation"]
+== Isolating {agent} and {fleet}
+
+
+NOTE: Some {agent} policies may require additional access rules than what is listed here.
+
+
+[cols="h,1"]
+|===
+| Egress (outgoing)  a|
+
+* TCP port {es_http_port} to {es} nodes in the namespace.
+* TCP port {kb_port} to {kib} instances in the namespace.
+* TCP port {fleet_server_port} to {fleet} instances in the namespace.
+* UDP port {dns_port} for DNS lookup.
+
+|===
+
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eck-agent
+  namespace: team-a
+spec:
+  egress:
+    - ports:
+        - port: {fleet_server_port}
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              eck.k8s.elastic.co/tenant: team-a
+          podSelector:
+            matchLabels:
+              common.k8s.elastic.co/type: agent
+    - ports:
+        - port: {kb_port}
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              eck.k8s.elastic.co/tenant: team-a
+          podSelector:
+            matchLabels:
+              common.k8s.elastic.co/type: kibana
+    - ports:
+        - port: {es_http_port}
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              eck.k8s.elastic.co/tenant: team-a
+          podSelector:
+            matchLabels:
+              common.k8s.elastic.co/type: elasticsearch
+    - ports:
+        - port: {dns_port}
+          protocol: UDP
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.0.0.1/32
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              eck.k8s.elastic.co/tenant: team-a
+      ports:
+        - port: {fleet_server_port}
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      common.k8s.elastic.co/type: agent
 ----

--- a/docs/advanced-topics/network-policies.asciidoc
+++ b/docs/advanced-topics/network-policies.asciidoc
@@ -33,7 +33,35 @@ kubectl label namespace team-a eck.k8s.elastic.co/tenant=team-a
 kubectl label namespace team-b eck.k8s.elastic.co/tenant=team-b
 ----
 
+== Prerequisites
 
+To set up the network policies correctly you must know the operator Pod selector and the Kubernetes API server IP. They may vary depending on your environment and how the operator has been installed.
+
+=== Operator Ood selector
+
+The operator Pod labels depends on how the operator has been installed, refer to the following table to know what label name should be used in the network policies.
+
+[cols="1,1"]
+|===
+|Installation method |Pod selector
+
+| YAML manifests  a|
+
+`control-plane: elastic-operator`
+
+| Helm Charts a|
+
+`app.kubernetes.io/name: elastic-operator`
+
+|===
+
+NOTE: The examples in this section assume that the ECK operator has been installed using the Helm chart.
+
+=== Kubernetes API server IP
+
+Run `kubectl get endpoints kubernetes -n default` to obtain the API server IP address for your cluster.
+
+NOTE: The following examples assume that the Kubernetes API server IP address is `10.0.0.1`.
 
 [float]
 [id="{p}-{page_id}-operator-isolation"]
@@ -54,11 +82,6 @@ The minimal set of permissions required are as follows:
 * TCP port {webhook_port} for webhook requests from the Kubernetes API server.
 
 |===
-
-
-Assuming that the Kubernetes API server IP address is `10.0.0.1`, the following network policy implements this minimal set of permissions.
-
-NOTE: Run `kubectl get endpoints kubernetes -n default` to obtain the API server IP address for your cluster.
 
 [source,yaml,subs="attributes"]
 ----


### PR DESCRIPTION
Fixes #5765

This PR also:
* Fixes the operator label name which is now `app.kubernetes.io/name`
* Adds a sample for Agent and Fleet Server