### PR TITLE
E2E: update monitoring agent version to 8.2.3 (#5780)

### DIFF
--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -5,7 +5,7 @@ metadata:
   name: e2e-agent
   namespace: {{ .E2ENamespace }}
 spec:
-  version: 7.15.1 # needs to less or equal to e2e-monitor version
+  version: 8.2.3 # needs to less or equal to e2e-monitor version
   elasticsearchRefs:
     - secretName: eck-{{ .TestRun }}
   daemonSet:


### PR DESCRIPTION
Backport the following PR into `2.3`:
* #5780 