### PR TITLE
Increase default Beats guaranteed memory to 300Mi

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
@@ -278,7 +278,7 @@ If `resources` is not defined in the specification of an object, then the operat
 |APM Server |512Mi |512Mi
 |Elasticsearch |2Gi |2Gi
 |Kibana |1Gi |1Gi
-|Beat   |200Mi |200Mi
+|Beat   |300Mi |300Mi
 |Elastic Agent |350Mi |350Mi
 |Elastic Maps Sever |200Mi |200Mi
 |Enterprise Search |4Gi |4Gi

--- a/pkg/controller/beat/common/pod.go
+++ b/pkg/controller/beat/common/pod.go
@@ -40,11 +40,11 @@ const (
 var (
 	defaultResources = corev1.ResourceRequirements{
 		Limits: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceMemory: resource.MustParse("200Mi"),
+			corev1.ResourceMemory: resource.MustParse("300Mi"),
 			corev1.ResourceCPU:    resource.MustParse("100m"),
 		},
 		Requests: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceMemory: resource.MustParse("200Mi"),
+			corev1.ResourceMemory: resource.MustParse("300Mi"),
 			corev1.ResourceCPU:    resource.MustParse("100m"),
 		},
 	}


### PR DESCRIPTION
Fixes #5036 

We did test drive this in #5681, but that PR did not cover all e2e tests especially the recipe tests that use default settings and do not rely on the e2e config template. Consequently we still see OOMing on those tests. I have also reached out to the Beats team for guidance and would wait with merging until we get a response.