### PR TITLE
Stricter notion of esReacheable: require health response

### DIFF
--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -224,6 +224,8 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	defer esClient.Close()
 
 	esReachable, err := services.IsServiceReady(d.Client, *internalService)
+	// use unknown health as a proxy for a cluster not responding to requests
+	esReachable = esReachable && observedState() != esv1.ElasticsearchUnknownHealth
 	if err != nil {
 		return results.WithError(err)
 	}

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -378,10 +378,9 @@ func esReachableConditionMessage(internalService *corev1.Service, isServiceReady
 	switch {
 	case !isServiceReady:
 		return fmt.Sprintf("Service %s/%s has no endpoint", internalService.Namespace, internalService.Name)
-	case isServiceReady && !isRespondingToRequests:
+	case !isRespondingToRequests:
 		return fmt.Sprintf("Service %s/%s has endpoints but Elasticsearch is unavailable", internalService.Namespace, internalService.Name)
-	case isServiceReady && isRespondingToRequests:
+	default:
 		return fmt.Sprintf("Service %s/%s has endpoints", internalService.Namespace, internalService.Name)
 	}
-	return ""
 }

--- a/pkg/controller/elasticsearch/driver/driver_test.go
+++ b/pkg/controller/elasticsearch/driver/driver_test.go
@@ -1,0 +1,57 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package driver
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_esReachableConditionMessage(t *testing.T) {
+	type args struct {
+		internalService        *corev1.Service
+		isServiceReady         bool
+		isRespondingToRequests bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			args: args{
+				internalService:        &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: "namespace"}},
+				isServiceReady:         false,
+				isRespondingToRequests: false,
+			},
+			want: "Service namespace/name has no endpoint",
+		},
+		{
+			args: args{
+				internalService:        &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: "namespace"}},
+				isServiceReady:         true,
+				isRespondingToRequests: false,
+			},
+			want: "Service namespace/name has endpoints but Elasticsearch is unavailable",
+		},
+		{
+			args: args{
+				internalService:        &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: "namespace"}},
+				isServiceReady:         true,
+				isRespondingToRequests: true,
+			},
+			want: "Service namespace/name has endpoints",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := esReachableConditionMessage(tt.args.internalService, tt.args.isServiceReady, tt.args.isRespondingToRequests); got != tt.want {
+				t.Errorf("esReachableConditionMessage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #5776 

Simplest (?) possible fix without doing extra requests. The goal is avoid confusing error messages like "could not verify license" but instead have a meaningful status like "Elasticsearch is not reachable". The implication here is that `esReachable` is now tied to the first successful observation of cluster health. Those happen asynchronously in the observer mechanism and are not done inside the reconciliation loop. I think that is OK as the cluster is not available immediately but with a certain delay anyway, depending on hardware and the time it takes for the ES container in the Pods to become ready. If the timing is unfortunate we might lose an additional 10 seconds (which is the current observation interval) which seems acceptable to me.