### PR TITLE
License check annotation 

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -601,7 +601,7 @@ func startOperator(ctx context.Context) error {
 	}
 
 	if viper.GetBool(operator.EnableWebhookFlag) {
-		setupWebhook(ctx, mgr, params.CertRotation, params.ValidateStorageClass, clientset, exposedNodeLabels, managedNamespaces, tracer)
+		setupWebhook(ctx, mgr, params, clientset, exposedNodeLabels, managedNamespaces, tracer)
 	}
 
 	enforceRbacOnRefs := viper.GetBool(operator.EnforceRBACOnRefsFlag)
@@ -884,15 +884,14 @@ func garbageCollectSoftOwnedSecrets(ctx context.Context, k8sClient k8s.Client) {
 func setupWebhook(
 	ctx context.Context,
 	mgr manager.Manager,
-	certRotation certificates.RotationParams,
-	validateStorageClass bool,
+	params operator.Parameters,
 	clientset kubernetes.Interface,
 	exposedNodeLabels esvalidation.NodeLabels,
 	managedNamespaces []string,
 	tracer *apm.Tracer) {
 	manageWebhookCerts := viper.GetBool(operator.ManageWebhookCertsFlag)
 	if manageWebhookCerts {
-		if err := reconcileWebhookCertsAndAddController(ctx, mgr, certRotation, clientset, tracer); err != nil {
+		if err := reconcileWebhookCertsAndAddController(ctx, mgr, params.CertRotation, clientset, tracer); err != nil {
 			log.Error(err, "unable to setup the webhook certificates")
 			os.Exit(1)
 		}
@@ -927,8 +926,9 @@ func setupWebhook(
 		}
 	}
 
+	checker := commonlicense.NewLicenseChecker(mgr.GetClient(), params.OperatorNamespace)
 	// esv1 validating webhook is wired up differently, in order to access the k8s client
-	esvalidation.RegisterWebhook(mgr, validateStorageClass, exposedNodeLabels, managedNamespaces)
+	esvalidation.RegisterWebhook(mgr, params.ValidateStorageClass, exposedNodeLabels, checker, managedNamespaces)
 
 	// wait for the secret to be populated in the local filesystem before returning
 	interval := time.Second * 1

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -897,6 +897,7 @@ func setupWebhook(
 		}
 	}
 
+	checker := commonlicense.NewLicenseChecker(mgr.GetClient(), params.OperatorNamespace)
 	// setup webhooks for supported types
 	webhookObjects := []interface {
 		runtime.Object
@@ -920,13 +921,13 @@ func setupWebhook(
 			WebhookPath:      obj.WebhookPath(),
 			ManagedNamespace: managedNamespaces,
 			Validator:        obj,
+			LicenseChecker:   checker,
 		}); err != nil {
 			gvk := obj.GetObjectKind().GroupVersionKind()
 			log.Error(err, "Failed to setup webhook", "group", gvk.Group, "version", gvk.Version, "kind", gvk.Kind)
 		}
 	}
 
-	checker := commonlicense.NewLicenseChecker(mgr.GetClient(), params.OperatorNamespace)
 	// esv1 validating webhook is wired up differently, in order to access the k8s client
 	esvalidation.RegisterWebhook(mgr, params.ValidateStorageClass, exposedNodeLabels, checker, managedNamespaces)
 

--- a/pkg/controller/agent/config.go
+++ b/pkg/controller/agent/config.go
@@ -17,6 +17,7 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
@@ -41,7 +42,7 @@ func reconcileConfig(params Params, configHash hash.Hash) *reconciler.Results {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: params.Agent.Namespace,
 			Name:      ConfigSecretName(params.Agent.Name),
-			Labels:    common.AddCredentialsLabel(NewLabels(params.Agent)),
+			Labels:    labels.AddCredentialsLabel(NewLabels(params.Agent)),
 		},
 		Data: map[string][]byte{
 			ConfigFileName: cfgBytes,

--- a/pkg/controller/agent/labels.go
+++ b/pkg/controller/agent/labels.go
@@ -6,7 +6,7 @@ package agent
 
 import (
 	agentv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/agent/v1alpha1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 )
 
 const (
@@ -23,7 +23,7 @@ const (
 // NewLabels returns the set of common labels for an Elastic Agent.
 func NewLabels(agent agentv1alpha1.Agent) map[string]string {
 	return map[string]string{
-		common.TypeLabelName: TypeLabelValue,
+		labels.TypeLabelName: TypeLabelValue,
 		NameLabelName:        agent.Name,
 	}
 }

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -21,11 +21,11 @@ import (
 	agentv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/agent/v1alpha1"
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	commonassociation "github.com/elastic/cloud-on-k8s/pkg/controller/common/association"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/container"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/defaults"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
@@ -244,7 +244,7 @@ func applyEnvVars(params Params, builder *defaults.PodTemplateBuilder) (*default
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      EnvVarsSecretName(params.Agent.Name),
 			Namespace: params.Agent.Namespace,
-			Labels:    common.AddCredentialsLabel(NewLabels(params.Agent)),
+			Labels:    labels.AddCredentialsLabel(NewLabels(params.Agent)),
 		},
 		Data: map[string][]byte{},
 	}

--- a/pkg/controller/apmserver/controller.go
+++ b/pkg/controller/apmserver/controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/finalizer"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/keystore"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
@@ -321,7 +322,7 @@ func reconcileApmServerToken(ctx context.Context, c k8s.Client, as *apmv1.ApmSer
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: as.Namespace,
 			Name:      SecretToken(as.Name),
-			Labels:    common.AddCredentialsLabel(NewLabels(as.Name)),
+			Labels:    labels.AddCredentialsLabel(NewLabels(as.Name)),
 		},
 		Data: make(map[string][]byte),
 	}

--- a/pkg/controller/apmserver/controller_test.go
+++ b/pkg/controller/apmserver/controller_test.go
@@ -25,6 +25,7 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/compare"
@@ -222,7 +223,7 @@ func mkService() corev1.Service {
 			Namespace: "test",
 			Labels: map[string]string{
 				ApmServerNameLabelName: "apm-test",
-				common.TypeLabelName:   Type,
+				labels.TypeLabelName:   Type,
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -235,7 +236,7 @@ func mkService() corev1.Service {
 			},
 			Selector: map[string]string{
 				ApmServerNameLabelName: "apm-test",
-				common.TypeLabelName:   Type,
+				labels.TypeLabelName:   Type,
 			},
 		},
 	}

--- a/pkg/controller/apmserver/labels.go
+++ b/pkg/controller/apmserver/labels.go
@@ -4,7 +4,7 @@
 
 package apmserver
 
-import "github.com/elastic/cloud-on-k8s/pkg/controller/common"
+import "github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 
 const (
 	// ApmServerNameLabelName used to represent an ApmServer in k8s resources
@@ -19,6 +19,6 @@ const (
 func NewLabels(apmServerName string) map[string]string {
 	return map[string]string{
 		ApmServerNameLabelName: apmServerName,
-		common.TypeLabelName:   Type,
+		labels.TypeLabelName:   Type,
 	}
 }

--- a/pkg/controller/association/gc.go
+++ b/pkg/controller/association/gc.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	esuser "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
@@ -88,13 +88,13 @@ func (ugc *UsersGarbageCollector) getUserSecrets() ([]v1.Secret, error) {
 
 func getUserSecretsInNamespace(c k8s.Client, namespace string) ([]v1.Secret, error) {
 	userSecrets := v1.SecretList{}
-	userLabels := client.MatchingLabels(map[string]string{common.TypeLabelName: esuser.AssociatedUserType})
+	userLabels := client.MatchingLabels(map[string]string{labels.TypeLabelName: esuser.AssociatedUserType})
 	if err := c.List(context.Background(), &userSecrets, client.InNamespace(namespace), userLabels); err != nil {
 		return nil, err
 	}
 
 	serviceAccountSecrets := v1.SecretList{}
-	serviceAccountLabels := client.MatchingLabels(map[string]string{common.TypeLabelName: esuser.ServiceAccountTokenType})
+	serviceAccountLabels := client.MatchingLabels(map[string]string{labels.TypeLabelName: esuser.ServiceAccountTokenType})
 	if err := c.List(context.Background(), &serviceAccountSecrets, client.InNamespace(namespace), serviceAccountLabels); err != nil {
 		return nil, err
 	}

--- a/pkg/controller/association/gc_test.go
+++ b/pkg/controller/association/gc_test.go
@@ -17,7 +17,7 @@ import (
 
 	apmv1 "github.com/elastic/cloud-on-k8s/pkg/apis/apm/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	esuser "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
@@ -41,7 +41,7 @@ func newUserSecret(
 			Labels: map[string]string{
 				associationNameLabel:      associationNameValue,
 				associationNamespaceLabel: associationNamespaceValue,
-				common.TypeLabelName:      esuser.AssociatedUserType,
+				labels.TypeLabelName:      esuser.AssociatedUserType,
 			},
 		},
 	}
@@ -59,7 +59,7 @@ func newServiceAccountSecret(
 			Labels: map[string]string{
 				associationNameLabel:      associationNameValue,
 				associationNamespaceLabel: associationNamespaceValue,
-				common.TypeLabelName:      esuser.ServiceAccountTokenType,
+				labels.TypeLabelName:      esuser.ServiceAccountTokenType,
 			},
 		},
 	}

--- a/pkg/controller/association/reconciler.go
+++ b/pkg/controller/association/reconciler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/name"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
@@ -117,7 +118,7 @@ func (a AssociationInfo) userLabelSelector(
 	association types.NamespacedName,
 ) client.MatchingLabels {
 	return maps.Merge(
-		map[string]string{common.TypeLabelName: user.AssociatedUserType},
+		map[string]string{labels.TypeLabelName: user.AssociatedUserType},
 		a.AssociationResourceLabels(associated, association),
 	)
 }

--- a/pkg/controller/association/resources_test.go
+++ b/pkg/controller/association/resources_test.go
@@ -17,7 +17,7 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	esuser "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
@@ -54,7 +54,7 @@ func Test_deleteOrphanedResources(t *testing.T) {
 		"kibana.k8s.elastic.co/namespace":            esFixture.Namespace,
 	}
 
-	userSecretLabels := maps.Merge(map[string]string{common.TypeLabelName: esuser.AssociatedUserType}, associationLabels)
+	userSecretLabels := maps.Merge(map[string]string{labels.TypeLabelName: esuser.AssociatedUserType}, associationLabels)
 
 	assertExpectObjectsExist := func(t *testing.T, c k8s.Client) {
 		t.Helper()
@@ -96,7 +96,7 @@ func Test_deleteOrphanedResources(t *testing.T) {
 				Spec: kbv1.KibanaSpec{
 					ElasticsearchRef: commonv1.ObjectSelector{ // ElasticsearchRef without a namespace
 						Name: esFixture.Name,
-						//Namespace: esFixture.Namespace, No namespace on purpose
+						// Namespace: esFixture.Namespace, No namespace on purpose
 					},
 				},
 			},

--- a/pkg/controller/association/service_account.go
+++ b/pkg/controller/association/service_account.go
@@ -25,6 +25,7 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
@@ -40,7 +41,7 @@ const (
 )
 
 func applicationSecretLabels(es esv1.Elasticsearch) map[string]string {
-	return common.AddCredentialsLabel(map[string]string{
+	return labels.AddCredentialsLabel(map[string]string{
 		label.ClusterNamespaceLabelName: es.Namespace,
 		label.ClusterNameLabelName:      es.Name,
 	})
@@ -50,7 +51,7 @@ func esSecretsLabels(es esv1.Elasticsearch) map[string]string {
 	return map[string]string{
 		label.ClusterNamespaceLabelName: es.Namespace,
 		label.ClusterNameLabelName:      es.Name,
-		common.TypeLabelName:            esuser.ServiceAccountTokenType,
+		labels.TypeLabelName:            esuser.ServiceAccountTokenType,
 	}
 }
 

--- a/pkg/controller/association/user.go
+++ b/pkg/controller/association/user.go
@@ -17,6 +17,7 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	commonlabels "github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
 	eslabel "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
@@ -96,7 +97,7 @@ func reconcileEsUserSecret(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secKey.Name,
 			Namespace: secKey.Namespace,
-			Labels:    common.AddCredentialsLabel(labels),
+			Labels:    commonlabels.AddCredentialsLabel(labels),
 		},
 		Data: map[string][]byte{},
 	}

--- a/pkg/controller/association/user_test.go
+++ b/pkg/controller/association/user_test.go
@@ -19,7 +19,7 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	esuser "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -91,7 +91,7 @@ func Test_reconcileEsUser(t *testing.T) {
 				assert.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: userName, Namespace: "default"}, &esUser))
 				expectedLabels := map[string]string{
 					associationLabelName:       kibanaFixture.Name,
-					common.TypeLabelName:       esuser.AssociatedUserType,
+					labels.TypeLabelName:       esuser.AssociatedUserType,
 					label.ClusterNameLabelName: "es-foo",
 				}
 				for k, v := range expectedLabels {
@@ -192,7 +192,7 @@ func Test_reconcileEsUser(t *testing.T) {
 							Labels: map[string]string{
 								associationLabelName:       kibanaFixture.Name,
 								associationLabelNamespace:  kibanaFixture.Namespace,
-								common.TypeLabelName:       esuser.AssociatedUserType,
+								labels.TypeLabelName:       esuser.AssociatedUserType,
 								label.ClusterNameLabelName: esFixture.Name,
 							},
 						},

--- a/pkg/controller/autoscaling/elasticsearch/controller.go
+++ b/pkg/controller/autoscaling/elasticsearch/controller.go
@@ -117,7 +117,7 @@ func (r *ReconcileElasticsearch) Reconcile(ctx context.Context, request reconcil
 	}
 
 	// Validate Elasticsearch and Autoscaling spec
-	if err := validation.ValidateElasticsearch(es, r.ExposedNodeLabels); err != nil {
+	if err := validation.ValidateElasticsearch(es, r.licenseChecker, r.ExposedNodeLabels); err != nil {
 		log.Error(
 			err,
 			"Elasticsearch manifest validation failed",

--- a/pkg/controller/beat/common/config.go
+++ b/pkg/controller/beat/common/config.go
@@ -14,6 +14,7 @@ import (
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -134,7 +135,7 @@ func reconcileConfig(
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: params.Beat.Namespace,
 			Name:      ConfigSecretName(params.Beat.Spec.Type, params.Beat.Name),
-			Labels:    common.AddCredentialsLabel(NewLabels(params.Beat)),
+			Labels:    labels.AddCredentialsLabel(NewLabels(params.Beat)),
 		},
 		Data: map[string][]byte{
 			ConfigFileName: cfgBytes,

--- a/pkg/controller/beat/common/labels.go
+++ b/pkg/controller/beat/common/labels.go
@@ -6,7 +6,7 @@ package common
 
 import (
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/pkg/apis/beat/v1beta1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 )
 
 const (
@@ -19,7 +19,7 @@ const (
 
 func NewLabels(beat beatv1beta1.Beat) map[string]string {
 	return map[string]string{
-		common.TypeLabelName: TypeLabelValue,
+		labels.TypeLabelName: TypeLabelValue,
 		NameLabelName:        beat.Name,
 	}
 }

--- a/pkg/controller/common/http/http.go
+++ b/pkg/controller/common/http/http.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-package common
+package http
 
 const (
 	InternalProductRequestHeaderKey    = "x-elastic-product-origin"

--- a/pkg/controller/common/http/http_client.go
+++ b/pkg/controller/common/http/http_client.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-package common
+package http
 
 import (
 	"crypto/tls"
@@ -17,14 +17,14 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/utils/net"
 )
 
-// HTTPClient returns an http.Client configured for targeting a service managed by ECK.
+// Client returns an http.Client configured for targeting a service managed by ECK.
 // Features:
 // - use the custom dialer if provided (can be nil) for eg. custom port-forwarding
 // - use the provided ca certs for TLS verification (can be nil)
 // - verify TLS certs, but ignore the server name: users may provide their own TLS certificate that may not
 // match Kubernetes internal service name, but only the user-facing public endpoint
 // - set APM spans with each request
-func HTTPClient(dialer net.Dialer, caCerts []*x509.Certificate, timeout time.Duration) *http.Client {
+func Client(dialer net.Dialer, caCerts []*x509.Certificate, timeout time.Duration) *http.Client {
 	certPool := x509.NewCertPool()
 	for _, c := range caCerts {
 		certPool.AddCert(c)

--- a/pkg/controller/common/labels/labels.go
+++ b/pkg/controller/common/labels/labels.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-package common
+package labels
 
 import (
 	"strconv"

--- a/pkg/controller/common/labels/labels_test.go
+++ b/pkg/controller/common/labels/labels_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-package common
+package labels
 
 import (
 	"testing"

--- a/pkg/controller/common/license/annotation.go
+++ b/pkg/controller/common/license/annotation.go
@@ -1,0 +1,22 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package license
+
+import (
+	"strings"
+)
+
+const Annotation = "eck.k8s.elastic.co/license"
+
+func HasRequestedLicenseLevel(annotations map[string]string, checker Checker) (bool, error) {
+	requestedLevel, exists := annotations[Annotation]
+	if !exists {
+		return true, nil // no annotation no restrictions
+	}
+	if OperatorLicenseType(strings.ToLower(requestedLevel)) == LicenseTypeBasic {
+		return true, nil // basic is always allowed
+	}
+	return checker.EnterpriseFeaturesEnabled() // if enterprise features are on, everything is allowed.
+}

--- a/pkg/controller/common/license/annotation.go
+++ b/pkg/controller/common/license/annotation.go
@@ -10,12 +10,17 @@ import (
 
 const Annotation = "eck.k8s.elastic.co/license"
 
+// HasRequestedLicenseLevel returns true if the operator license level matches the level expressed in the map of annotations.
 func HasRequestedLicenseLevel(annotations map[string]string, checker Checker) (bool, error) {
 	requestedLevel, exists := annotations[Annotation]
 	if !exists {
 		return true, nil // no annotation no restrictions
 	}
-	if OperatorLicenseType(strings.ToLower(requestedLevel)) == LicenseTypeBasic {
+	requestedLicenseType := OperatorLicenseType(strings.ToLower(requestedLevel))
+	if _, exists := OperatorLicenseTypeOrder[requestedLicenseType]; !exists {
+		return true, nil // be lenient in case of misspelled or incorrect license names
+	}
+	if requestedLicenseType == LicenseTypeBasic {
 		return true, nil // basic is always allowed
 	}
 	return checker.EnterpriseFeaturesEnabled() // if enterprise features are on, everything is allowed.

--- a/pkg/controller/common/license/annotation_test.go
+++ b/pkg/controller/common/license/annotation_test.go
@@ -1,0 +1,109 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package license
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasRequestedLicenseLevel(t *testing.T) {
+	type args struct {
+		annotations map[string]string
+		checker     Checker
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "no request OK",
+			args: args{
+				annotations: nil,
+				checker:     MockLicenseChecker{},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "requesting basic on basic OK",
+			args: args{
+				annotations: map[string]string{
+					Annotation: "basic",
+				},
+				checker: MockLicenseChecker{},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "requesting enterprise on basic NOK",
+			args: args{
+				annotations: map[string]string{
+					Annotation: "enterprise",
+				},
+				checker: MockLicenseChecker{},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "requesting non-existing license on basic OK",
+			args: args{
+				annotations: map[string]string{
+					Annotation: "foo",
+				},
+				checker: MockLicenseChecker{},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "requesting basic on enterprise OK",
+			args: args{
+				annotations: map[string]string{
+					Annotation: "basic",
+				},
+				checker: MockLicenseChecker{EnterpriseEnabled: true},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "requesting enterprise on enterprise OK",
+			args: args{
+				annotations: map[string]string{
+					Annotation: "enterprise",
+				},
+				checker: MockLicenseChecker{EnterpriseEnabled: true},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "requesting non-existing license on enterprise OK",
+			args: args{
+				annotations: map[string]string{
+					Annotation: "bar",
+				},
+				checker: MockLicenseChecker{EnterpriseEnabled: true},
+			},
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := HasRequestedLicenseLevel(tt.args.annotations, tt.args.checker)
+			if tt.wantErr != (err != nil) {
+				t.Errorf("HasRequestedLicenseLevel expected err %v but was %v", tt.wantErr, err)
+			}
+			assert.Equalf(t, tt.want, got, "HasRequestedLicenseLevel(%v, %v)", tt.args.annotations, tt.args.checker)
+		})
+	}
+}

--- a/pkg/controller/common/license/crud.go
+++ b/pkg/controller/common/license/crud.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/maps"
 )
@@ -80,7 +80,7 @@ func CreateTrialLicense(ctx context.Context, c k8s.Client, nsn types.NamespacedN
 			Name:      nsn.Name,
 			Namespace: nsn.Namespace,
 			Labels: map[string]string{
-				common.TypeLabelName: Type,
+				labels.TypeLabelName: Type,
 				LicenseLabelType:     string(LicenseTypeEnterpriseTrial),
 			},
 			Annotations: map[string]string{

--- a/pkg/controller/common/license/detection.go
+++ b/pkg/controller/common/license/detection.go
@@ -7,12 +7,12 @@ package license
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 )
 
 func isLicenseType(secret corev1.Secret, licenseType OperatorLicenseType) bool {
 	// is it a license at all (but be lenient if user omitted label)?
-	baseType, hasLabel := secret.Labels[common.TypeLabelName]
+	baseType, hasLabel := secret.Labels[labels.TypeLabelName]
 	if hasLabel && baseType != Type {
 		return false
 	}

--- a/pkg/controller/common/license/detection_test.go
+++ b/pkg/controller/common/license/detection_test.go
@@ -10,7 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 )
 
 func Test_isLicenseType(t *testing.T) {
@@ -37,7 +37,7 @@ func Test_isLicenseType(t *testing.T) {
 				secret: corev1.Secret{
 					ObjectMeta: v1.ObjectMeta{
 						Labels: map[string]string{
-							common.TypeLabelName: "foo",
+							labels.TypeLabelName: "foo",
 							LicenseLabelType:     string(LicenseTypeEnterpriseTrial),
 						},
 					},
@@ -52,7 +52,7 @@ func Test_isLicenseType(t *testing.T) {
 				secret: corev1.Secret{
 					ObjectMeta: v1.ObjectMeta{
 						Labels: map[string]string{
-							common.TypeLabelName: Type,
+							labels.TypeLabelName: Type,
 							LicenseLabelType:     string(LicenseTypeEnterpriseTrial),
 						},
 					},
@@ -67,7 +67,7 @@ func Test_isLicenseType(t *testing.T) {
 				secret: corev1.Secret{
 					ObjectMeta: v1.ObjectMeta{
 						Labels: map[string]string{
-							common.TypeLabelName: Type,
+							labels.TypeLabelName: Type,
 							LicenseLabelType:     string(LicenseTypeEnterprise),
 						},
 					},

--- a/pkg/controller/common/license/fixtures_test.go
+++ b/pkg/controller/common/license/fixtures_test.go
@@ -17,7 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 )
 
 var (
@@ -87,7 +87,7 @@ func asRuntimeObject(l EnterpriseLicense) runtime.Object {
 			Namespace: "test-system",
 			Name:      fmt.Sprintf("test-%s-license", string(l.License.Type)),
 			Labels: map[string]string{
-				common.TypeLabelName: Type,
+				labels.TypeLabelName: Type,
 				LicenseLabelScope:    string(LicenseScopeOperator),
 				LicenseLabelType:     string(l.License.Type),
 			},

--- a/pkg/controller/common/license/labels.go
+++ b/pkg/controller/common/license/labels.go
@@ -7,7 +7,7 @@ package license
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 )
 
 const (
@@ -31,7 +31,7 @@ const (
 // LabelsForOperatorScope creates a map of labels for operator scope with licence type set to the given value.
 func LabelsForOperatorScope(t OperatorLicenseType) map[string]string {
 	return map[string]string{
-		common.TypeLabelName: Type,
+		labels.TypeLabelName: Type,
 		LicenseLabelScope:    string(LicenseScopeOperator),
 		LicenseLabelType:     string(t),
 	}

--- a/pkg/controller/common/webhook/validation.go
+++ b/pkg/controller/common/webhook/validation.go
@@ -31,7 +31,7 @@ func hasRequestedLicenseLevel(obj runtime.Object, checker license.Checker) field
 	annotations, err := accessor.Annotations(obj)
 	if err != nil {
 		whlog.Error(err, "while accessing runtime object metadata")
-		return nil
+		return nil // we do not want to block admission because of it
 	}
 	var errs field.ErrorList
 	ok, err := license.HasRequestedLicenseLevel(annotations, checker)

--- a/pkg/controller/common/webhook/validation.go
+++ b/pkg/controller/common/webhook/validation.go
@@ -1,0 +1,46 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package webhook
+
+import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/license"
+)
+
+func (v *validatingWebhook) commonValidations(req admission.Request, obj runtime.Object) error {
+	errorList := hasRequestedLicenseLevel(obj, v.licenseChecker)
+	if len(errorList) > 0 {
+		return apierrors.NewInvalid(schema.GroupKind{
+			Group: req.Kind.Group,
+			Kind:  req.Kind.Kind,
+		}, req.Name, errorList)
+	}
+	return nil
+}
+
+func hasRequestedLicenseLevel(obj runtime.Object, checker license.Checker) field.ErrorList {
+	accessor := meta.NewAccessor()
+	annotations, err := accessor.Annotations(obj)
+	if err != nil {
+		whlog.Error(err, "while accessing runtime object metadata")
+		return nil
+	}
+	var errs field.ErrorList
+	ok, err := license.HasRequestedLicenseLevel(annotations, checker)
+	if err != nil {
+		whlog.Error(err, "while checking license level during validation")
+		return nil
+	}
+	if !ok {
+		errs = append(errs, field.Invalid(field.NewPath("metadata").Child("annotations").Child(license.Annotation), "enterprise", "Enterprise license required but ECK operator is running on a Basic license"))
+	}
+	return errs
+}

--- a/pkg/controller/common/webhook/webhook.go
+++ b/pkg/controller/common/webhook/webhook.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/license"
 	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/set"
 )
@@ -29,6 +30,7 @@ func SetupValidatingWebhookWithConfig(config *Config) error {
 		&webhook.Admission{
 			Handler: &validatingWebhook{
 				validator:         config.Validator,
+				licenseChecker:    config.LicenseChecker,
 				managedNamespaces: set.Make(config.ManagedNamespace...)}})
 	return nil
 }
@@ -38,12 +40,14 @@ type Config struct {
 	Manager          ctrl.Manager
 	WebhookPath      string
 	ManagedNamespace []string
+	LicenseChecker   license.Checker
 	Validator        admission.Validator
 }
 
 type validatingWebhook struct {
 	decoder           *admission.Decoder
 	managedNamespaces set.StringSet
+	licenseChecker    license.Checker
 	validator         admission.Validator
 }
 
@@ -66,6 +70,10 @@ func (v *validatingWebhook) Handle(_ context.Context, req admission.Request) adm
 	if err != nil {
 		whlog.Error(err, "decoding object from webhook request into type (%T)", obj)
 		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if err := v.commonValidations(req, obj); err != nil {
+		return admission.Denied(err.Error())
 	}
 
 	if req.Operation == admissionv1.Create {

--- a/pkg/controller/elasticsearch/certificates/remoteca/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/remoteca/reconcile.go
@@ -14,8 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -29,7 +29,7 @@ const (
 func Labels(esName string) client.MatchingLabels {
 	return map[string]string{
 		label.ClusterNameLabelName: esName,
-		common.TypeLabelName:       TypeLabelValue,
+		labels.TypeLabelName:       TypeLabelValue,
 	}
 }
 

--- a/pkg/controller/elasticsearch/certificates/remoteca/reconcile_test.go
+++ b/pkg/controller/elasticsearch/certificates/remoteca/reconcile_test.go
@@ -15,8 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
@@ -45,7 +45,7 @@ func TestReconcile(t *testing.T) {
 							Namespace: "ns1",
 							Labels: map[string]string{
 								label.ClusterNameLabelName: "es1",
-								common.TypeLabelName:       TypeLabelValue,
+								labels.TypeLabelName:       TypeLabelValue,
 							},
 						},
 						Data: map[string][]byte{certificates.CAFileName: []byte("cert1\n")},
@@ -56,7 +56,7 @@ func TestReconcile(t *testing.T) {
 							Namespace: "ns1",
 							Labels: map[string]string{
 								label.ClusterNameLabelName: "es1",
-								common.TypeLabelName:       TypeLabelValue,
+								labels.TypeLabelName:       TypeLabelValue,
 							},
 						},
 						Data: map[string][]byte{certificates.CAFileName: []byte("cert2\n")},
@@ -77,7 +77,7 @@ func TestReconcile(t *testing.T) {
 							Namespace: "ns1",
 							Labels: map[string]string{
 								label.ClusterNameLabelName: "es1",
-								common.TypeLabelName:       TypeLabelValue,
+								labels.TypeLabelName:       TypeLabelValue,
 							},
 						},
 						Data: map[string][]byte{certificates.CAFileName: []byte("cert1\n")},
@@ -88,7 +88,7 @@ func TestReconcile(t *testing.T) {
 							Namespace: "ns1",
 							Labels: map[string]string{
 								label.ClusterNameLabelName: "es1",
-								common.TypeLabelName:       "foo",
+								labels.TypeLabelName:       "foo",
 							},
 						},
 						Data: map[string][]byte{certificates.CAFileName: []byte("cert3\n")},
@@ -99,7 +99,7 @@ func TestReconcile(t *testing.T) {
 							Namespace: "ns1",
 							Labels: map[string]string{
 								label.ClusterNameLabelName: "es1",
-								common.TypeLabelName:       TypeLabelValue,
+								labels.TypeLabelName:       TypeLabelValue,
 							},
 						},
 						Data: map[string][]byte{certificates.CAFileName: []byte("cert2\n")},

--- a/pkg/controller/elasticsearch/client/base.go
+++ b/pkg/controller/elasticsearch/client/base.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	commonhttp "github.com/elastic/cloud-on-k8s/pkg/controller/common/http"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	ulog "github.com/elastic/cloud-on-k8s/pkg/utils/log"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
@@ -138,7 +138,7 @@ func (c *baseClient) request(
 	if request.Header == nil {
 		request.Header = make(http.Header)
 	}
-	request.Header.Set(common.InternalProductRequestHeaderKey, common.InternalProductRequestHeaderValue)
+	request.Header.Set(commonhttp.InternalProductRequestHeaderKey, commonhttp.InternalProductRequestHeaderValue)
 
 	var skippedErr error
 	resp, err := c.doRequest(ctx, request)

--- a/pkg/controller/elasticsearch/client/client.go
+++ b/pkg/controller/elasticsearch/client/client.go
@@ -15,8 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/annotation"
+	commonhttp "github.com/elastic/cloud-on-k8s/pkg/controller/common/http"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/net"
 )
@@ -151,7 +151,7 @@ func NewElasticsearchClient(
 		Endpoint: esURL,
 		User:     esUser,
 		caCerts:  caCerts,
-		HTTP:     common.HTTPClient(dialer, caCerts, timeout),
+		HTTP:     commonhttp.Client(dialer, caCerts, timeout),
 		es:       es,
 	}
 	return versioned(base, v)

--- a/pkg/controller/elasticsearch/driver/upgrade_predicates.go
+++ b/pkg/controller/elasticsearch/driver/upgrade_predicates.go
@@ -11,7 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
@@ -570,13 +570,13 @@ var predicates = [...]Predicate{
 				return true, nil
 			}
 
-			healthyPodRoleHisto := map[common.TrueFalseLabel]int{}
-			currentPodRoleHisto := map[common.TrueFalseLabel]int{}
+			healthyPodRoleHisto := map[labels.TrueFalseLabel]int{}
+			currentPodRoleHisto := map[labels.TrueFalseLabel]int{}
 			// look at the current pods because we want to prevent taking away from current capacity for a tier
 			// not future capacity as per the expected Pod definitions expressed in the resourcesList
 			for _, pod := range context.currentPods {
 				// ignore voting_only and master we are handling those in dedicated predicates
-				forEachNonMasterRole(pod, func(role common.TrueFalseLabel) {
+				forEachNonMasterRole(pod, func(role labels.TrueFalseLabel) {
 					currentPodRoleHisto[role]++
 				})
 			}
@@ -587,7 +587,7 @@ var predicates = [...]Predicate{
 				if pod.Name == candidate.Name {
 					continue
 				}
-				forEachNonMasterRole(pod, func(role common.TrueFalseLabel) {
+				forEachNonMasterRole(pod, func(role labels.TrueFalseLabel) {
 					healthyPodRoleHisto[role]++
 				})
 			}
@@ -617,7 +617,7 @@ var predicates = [...]Predicate{
 	},
 }
 
-func forEachNonMasterRole(pod corev1.Pod, f func(falseLabel common.TrueFalseLabel)) {
+func forEachNonMasterRole(pod corev1.Pod, f func(falseLabel labels.TrueFalseLabel)) {
 	for _, role := range label.NonMasterRoles {
 		if role.HasValue(true, pod.Labels) {
 			f(role)

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -251,7 +251,7 @@ func (r *ReconcileElasticsearch) internalReconcile(
 
 	span, ctx := apm.StartSpan(ctx, "validate", tracing.SpanTypeApp)
 	// this is the same validation as the webhook, but we run it again here in case the webhook has not been configured
-	err := validation.ValidateElasticsearch(es, r.ExposedNodeLabels)
+	err := validation.ValidateElasticsearch(es, r.licenseChecker, r.ExposedNodeLabels)
 	span.End()
 
 	if err != nil {

--- a/pkg/controller/elasticsearch/label/label.go
+++ b/pkg/controller/elasticsearch/label/label.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 )
 
@@ -28,29 +28,29 @@ const (
 	// StatefulSetNameLabelName used to store the name of the statefulset.
 	StatefulSetNameLabelName = "elasticsearch.k8s.elastic.co/statefulset-name"
 	// NodeTypesMasterLabelName is a label set to true on nodes with the master role
-	NodeTypesMasterLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-master"
+	NodeTypesMasterLabelName labels.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-master"
 	// NodeTypesDataLabelName is a label set to true on nodes with the data role
-	NodeTypesDataLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-data"
+	NodeTypesDataLabelName labels.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-data"
 	// NodeTypesIngestLabelName is a label set to true on nodes with the ingest role
-	NodeTypesIngestLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-ingest"
+	NodeTypesIngestLabelName labels.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-ingest"
 	// NodeTypesMLLabelName is a label set to true on nodes with the ml role
-	NodeTypesMLLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-ml"
+	NodeTypesMLLabelName labels.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-ml"
 	// NodeTypesTransformLabelName is a label set to true on nodes with the transform role
-	NodeTypesTransformLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-transform"
+	NodeTypesTransformLabelName labels.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-transform"
 	// NodeTypesRemoteClusterClientLabelName is a label set to true on nodes with the remote_cluster_client role
-	NodeTypesRemoteClusterClientLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-remote_cluster_client"
+	NodeTypesRemoteClusterClientLabelName labels.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-remote_cluster_client"
 	// NodeTypesVotingOnlyLabelName is a label set to true on voting-only master-eligible nodes
-	NodeTypesVotingOnlyLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-voting_only"
+	NodeTypesVotingOnlyLabelName labels.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-voting_only"
 	// NodeTypesDataColdLabelName is a label set to true on nodes with the data_cold role.
-	NodeTypesDataColdLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-data_cold"
+	NodeTypesDataColdLabelName labels.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-data_cold"
 	// NodeTypesDataContentLabelName is a label set to true on nodes with the data_content role.
-	NodeTypesDataContentLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-data_content"
+	NodeTypesDataContentLabelName labels.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-data_content"
 	// NodeTypesDataHotLabelName is a label set to true on nodes with the data_hot role.
-	NodeTypesDataHotLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-data_hot"
+	NodeTypesDataHotLabelName labels.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-data_hot"
 	// NodeTypesDataWarmLabelName is a label set to true on nodes with the data_warm role.
-	NodeTypesDataWarmLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-data_warm"
+	NodeTypesDataWarmLabelName labels.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-data_warm"
 	// NodeTypesDataFrozenLabelName is a label set to true on nodes with the data_frozen role.
-	NodeTypesDataFrozenLabelName common.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-data_frozen"
+	NodeTypesDataFrozenLabelName labels.TrueFalseLabel = "elasticsearch.k8s.elastic.co/node-data_frozen"
 
 	HTTPSchemeLabelName = "elasticsearch.k8s.elastic.co/http-scheme"
 
@@ -59,7 +59,7 @@ const (
 )
 
 // NonMasterRoles are all Elasticsearch node roles except master or voting-only.
-var NonMasterRoles = []common.TrueFalseLabel{
+var NonMasterRoles = []labels.TrueFalseLabel{
 	NodeTypesDataLabelName,
 	NodeTypesDataHotLabelName,
 	NodeTypesDataColdLabelName,
@@ -116,7 +116,7 @@ func ExtractVersion(labels map[string]string) (version.Version, error) {
 func NewLabels(es types.NamespacedName) map[string]string {
 	return map[string]string{
 		ClusterNameLabelName: es.Name,
-		common.TypeLabelName: Type,
+		labels.TypeLabelName: Type,
 	}
 }
 

--- a/pkg/controller/elasticsearch/label/label_test.go
+++ b/pkg/controller/elasticsearch/label/label_test.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	v1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 )
 
@@ -121,7 +121,7 @@ func TestNewPodLabels(t *testing.T) {
 			},
 			want: map[string]string{
 				ClusterNameLabelName:             "name",
-				common.TypeLabelName:             "elasticsearch",
+				labels.TypeLabelName:             "elasticsearch",
 				VersionLabelName:                 "7.1.0",
 				string(NodeTypesMasterLabelName): "false",
 				string(NodeTypesDataLabelName):   "false",
@@ -150,7 +150,7 @@ func TestNewPodLabels(t *testing.T) {
 			},
 			want: map[string]string{
 				ClusterNameLabelName:                 "name",
-				common.TypeLabelName:                 "elasticsearch",
+				labels.TypeLabelName:                 "elasticsearch",
 				VersionLabelName:                     "7.3.0",
 				string(NodeTypesMasterLabelName):     "false",
 				string(NodeTypesDataLabelName):       "true",
@@ -179,7 +179,7 @@ func TestNewPodLabels(t *testing.T) {
 			},
 			want: map[string]string{
 				ClusterNameLabelName:                          "name",
-				common.TypeLabelName:                          "elasticsearch",
+				labels.TypeLabelName:                          "elasticsearch",
 				VersionLabelName:                              "7.7.0",
 				string(NodeTypesMasterLabelName):              "false",
 				string(NodeTypesDataLabelName):                "true",
@@ -206,7 +206,7 @@ func TestNewPodLabels(t *testing.T) {
 			},
 			want: map[string]string{
 				ClusterNameLabelName:                          "name",
-				common.TypeLabelName:                          "elasticsearch",
+				labels.TypeLabelName:                          "elasticsearch",
 				VersionLabelName:                              "7.10.0",
 				string(NodeTypesMasterLabelName):              "true",
 				string(NodeTypesDataLabelName):                "true",
@@ -237,7 +237,7 @@ func TestNewPodLabels(t *testing.T) {
 			},
 			want: map[string]string{
 				ClusterNameLabelName:                          "name",
-				common.TypeLabelName:                          "elasticsearch",
+				labels.TypeLabelName:                          "elasticsearch",
 				VersionLabelName:                              "7.12.0",
 				string(NodeTypesMasterLabelName):              "true",
 				string(NodeTypesDataLabelName):                "true",

--- a/pkg/controller/elasticsearch/nodespec/readiness_probe.go
+++ b/pkg/controller/elasticsearch/nodespec/readiness_probe.go
@@ -9,7 +9,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/http"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
 )
@@ -76,7 +76,7 @@ fi
 # request Elasticsearch on /
 # we are turning globbing off to allow for unescaped [] in case of IPv6
 ENDPOINT="${READINESS_PROBE_PROTOCOL:-https}://${LOOPBACK}:9200/"
-ORIGIN_HEADER="` + common.InternalProductRequestHeaderString + `"
+ORIGIN_HEADER="` + http.InternalProductRequestHeaderString + `"
 status=$(curl -o /dev/null -w "%{http_code}" --max-time ${READINESS_PROBE_TIMEOUT} -H "${ORIGIN_HEADER}" -XGET -g -s -k ${BASIC_AUTH} $ENDPOINT)
 curl_rc=$?
 

--- a/pkg/controller/elasticsearch/pdb/reconcile_test.go
+++ b/pkg/controller/elasticsearch/pdb/reconcile_test.go
@@ -25,9 +25,9 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/comparison"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
 )
@@ -38,7 +38,7 @@ func TestReconcile(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      esv1.DefaultPodDisruptionBudget("cluster"),
 				Namespace: "ns",
-				Labels:    map[string]string{label.ClusterNameLabelName: "cluster", common.TypeLabelName: label.Type},
+				Labels:    map[string]string{label.ClusterNameLabelName: "cluster", labels.TypeLabelName: label.Type},
 			},
 			Spec: policyv1.PodDisruptionBudgetSpec{
 				MinAvailable: intStrPtr(intstr.FromInt(3)),
@@ -90,7 +90,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      esv1.DefaultPodDisruptionBudget("cluster"),
 					Namespace: "ns",
-					Labels:    map[string]string{label.ClusterNameLabelName: "cluster", common.TypeLabelName: label.Type},
+					Labels:    map[string]string{label.ClusterNameLabelName: "cluster", labels.TypeLabelName: label.Type},
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: intStrPtr(intstr.FromInt(5)),
@@ -191,7 +191,7 @@ func Test_expectedPDB(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      esv1.DefaultPodDisruptionBudget("cluster"),
 					Namespace: "ns",
-					Labels:    map[string]string{label.ClusterNameLabelName: "cluster", common.TypeLabelName: label.Type},
+					Labels:    map[string]string{label.ClusterNameLabelName: "cluster", labels.TypeLabelName: label.Type},
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: intStrPtr(intstr.FromInt(3)),
@@ -222,7 +222,7 @@ func Test_expectedPDB(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      esv1.DefaultPodDisruptionBudget("cluster"),
 					Namespace: "ns",
-					Labels:    map[string]string{"a": "b", "c": "d", label.ClusterNameLabelName: "cluster", common.TypeLabelName: label.Type},
+					Labels:    map[string]string{"a": "b", "c": "d", label.ClusterNameLabelName: "cluster", labels.TypeLabelName: label.Type},
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: intStrPtr(intstr.FromInt(3)),
@@ -251,7 +251,7 @@ func Test_expectedPDB(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      esv1.DefaultPodDisruptionBudget("cluster"),
 					Namespace: "ns",
-					Labels:    map[string]string{label.ClusterNameLabelName: "cluster", common.TypeLabelName: label.Type},
+					Labels:    map[string]string{label.ClusterNameLabelName: "cluster", labels.TypeLabelName: label.Type},
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: intStrPtr(intstr.FromInt(42)),

--- a/pkg/controller/elasticsearch/services/services_test.go
+++ b/pkg/controller/elasticsearch/services/services_test.go
@@ -15,7 +15,7 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/network"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/compare"
@@ -265,7 +265,7 @@ func mkHTTPService() corev1.Service {
 			Namespace: "test",
 			Labels: map[string]string{
 				label.ClusterNameLabelName: "elasticsearch-test",
-				common.TypeLabelName:       label.Type,
+				labels.TypeLabelName:       label.Type,
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -278,7 +278,7 @@ func mkHTTPService() corev1.Service {
 			},
 			Selector: map[string]string{
 				label.ClusterNameLabelName: "elasticsearch-test",
-				common.TypeLabelName:       label.Type,
+				labels.TypeLabelName:       label.Type,
 			},
 		},
 	}
@@ -291,7 +291,7 @@ func mkTransportService() corev1.Service {
 			Namespace: "test",
 			Labels: map[string]string{
 				label.ClusterNameLabelName: "elasticsearch-test",
-				common.TypeLabelName:       label.Type,
+				labels.TypeLabelName:       label.Type,
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -307,7 +307,7 @@ func mkTransportService() corev1.Service {
 			},
 			Selector: map[string]string{
 				label.ClusterNameLabelName: "elasticsearch-test",
-				common.TypeLabelName:       label.Type,
+				labels.TypeLabelName:       label.Type,
 			},
 		},
 	}

--- a/pkg/controller/elasticsearch/user/associated.go
+++ b/pkg/controller/elasticsearch/user/associated.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
@@ -45,7 +45,7 @@ type AssociatedUser struct {
 func AssociatedUserLabels(es esv1.Elasticsearch) map[string]string {
 	return map[string]string{
 		label.ClusterNameLabelName: es.Name,
-		common.TypeLabelName:       AssociatedUserType,
+		labels.TypeLabelName:       AssociatedUserType,
 	}
 }
 

--- a/pkg/controller/elasticsearch/user/predefined.go
+++ b/pkg/controller/elasticsearch/user/predefined.go
@@ -16,6 +16,7 @@ import (
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/user/filerealm"
@@ -111,7 +112,7 @@ func reconcilePredefinedUsers(
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: secretNsn.Namespace,
 			Name:      secretNsn.Name,
-			Labels:    common.AddCredentialsLabel(label.NewLabels(k8s.ExtractNamespacedName(&es))),
+			Labels:    labels.AddCredentialsLabel(label.NewLabels(k8s.ExtractNamespacedName(&es))),
 		},
 		Data: secretData,
 	}

--- a/pkg/controller/elasticsearch/user/reconcile.go
+++ b/pkg/controller/elasticsearch/user/reconcile.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
@@ -85,7 +85,7 @@ func aggregateServiceAccountTokens(c k8s.Client, es esv1.Elasticsearch) (Service
 		client.MatchingLabels(
 			map[string]string{
 				label.ClusterNameLabelName: es.Name,
-				common.TypeLabelName:       ServiceAccountTokenType,
+				labels.TypeLabelName:       ServiceAccountTokenType,
 			},
 		),
 	); err != nil {

--- a/pkg/controller/elasticsearch/validation/validations.go
+++ b/pkg/controller/elasticsearch/validation/validations.go
@@ -342,7 +342,7 @@ func validAssociations(es esv1.Elasticsearch) field.ErrorList {
 
 func validLicenseLevel(es esv1.Elasticsearch, checker license.Checker) field.ErrorList {
 	var errs field.ErrorList
-	ok, err := license.HasRequestedLicenseLevel(&es, checker)
+	ok, err := license.HasRequestedLicenseLevel(es.Annotations, checker)
 	if err != nil {
 		log.Error(err, "while checking license level during validation")
 		return nil // ignore the error here

--- a/pkg/controller/elasticsearch/validation/validations.go
+++ b/pkg/controller/elasticsearch/validation/validations.go
@@ -13,6 +13,7 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/license"
 	stackmon "github.com/elastic/cloud-on-k8s/pkg/controller/common/stackmon/validations"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	esversion "github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/version"
@@ -59,7 +60,7 @@ func updateValidations(k8sClient k8s.Client, validateStorageClass bool) []update
 }
 
 // validations are the validation funcs that apply to creates or updates
-func validations(exposedNodeLabels NodeLabels) []validation {
+func validations(checker license.Checker, exposedNodeLabels NodeLabels) []validation {
 	return []validation{
 		func(proposed esv1.Elasticsearch) field.ErrorList {
 			return validNodeLabels(proposed, exposedNodeLabels)
@@ -73,6 +74,9 @@ func validations(exposedNodeLabels NodeLabels) []validation {
 		validPVCNaming,
 		validMonitoring,
 		validAssociations,
+		func(proposed esv1.Elasticsearch) field.ErrorList {
+			return validLicenseLevel(proposed, checker)
+		},
 	}
 }
 
@@ -334,4 +338,17 @@ func validAssociations(es esv1.Elasticsearch) field.ErrorList {
 	err1 := commonv1.CheckAssociationRefs(monitoringPath.Child("metrics"), es.GetMonitoringMetricsRefs()...)
 	err2 := commonv1.CheckAssociationRefs(monitoringPath.Child("logs"), es.GetMonitoringLogsRefs()...)
 	return append(err1, err2...)
+}
+
+func validLicenseLevel(es esv1.Elasticsearch, checker license.Checker) field.ErrorList {
+	var errs field.ErrorList
+	ok, err := license.HasRequestedLicenseLevel(&es, checker)
+	if err != nil {
+		log.Error(err, "while checking license level during validation")
+		return nil // ignore the error here
+	}
+	if !ok {
+		errs = append(errs, field.Invalid(field.NewPath("metadata").Child("annotations").Child(license.Annotation), "enterprise", "Enterprise license required but ECK operator is running on a Basic license"))
+	}
+	return errs
 }

--- a/pkg/controller/enterprisesearch/config.go
+++ b/pkg/controller/enterprisesearch/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/driver"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
@@ -77,7 +78,7 @@ func ReconcileConfig(ctx context.Context, driver driver.Interface, ent entv1.Ent
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ent.Namespace,
 			Name:      ConfigName(ent.Name),
-			Labels:    common.AddCredentialsLabel(Labels(ent.Name)),
+			Labels:    labels.AddCredentialsLabel(Labels(ent.Name)),
 		},
 		Data: map[string][]byte{
 			ConfigFilename:         cfgBytes,

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller_test.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller_test.go
@@ -23,6 +23,7 @@ import (
 	entv1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
@@ -249,7 +250,7 @@ func TestReconcileEnterpriseSearch_doReconcile_AssociationDelaysVersionUpgrade(t
 			Name:      "ent-pod1",
 			Labels: map[string]string{
 				EnterpriseSearchNameLabelName: ent.Name,
-				common.TypeLabelName:          Type,
+				labels.TypeLabelName:          Type,
 				VersionLabelName:              "7.7.0",
 			},
 		},

--- a/pkg/controller/enterprisesearch/labels.go
+++ b/pkg/controller/enterprisesearch/labels.go
@@ -6,7 +6,7 @@ package enterprisesearch
 
 import (
 	entv1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 )
 
 const (
@@ -24,7 +24,7 @@ const (
 func Labels(entName string) map[string]string {
 	return map[string]string{
 		EnterpriseSearchNameLabelName: entName,
-		common.TypeLabelName:          Type,
+		labels.TypeLabelName:          Type,
 	}
 }
 

--- a/pkg/controller/enterprisesearch/version_upgrade.go
+++ b/pkg/controller/enterprisesearch/version_upgrade.go
@@ -23,9 +23,9 @@ import (
 
 	entv1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/events"
+	commonhttp "github.com/elastic/cloud-on-k8s/pkg/controller/common/http"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/net"
@@ -168,7 +168,7 @@ func (r *VersionUpgrade) setReadOnlyMode(ctx context.Context, enabled bool) erro
 		if err != nil {
 			return err
 		}
-		httpClient = common.HTTPClient(r.dialer, tlsCerts, 0)
+		httpClient = commonhttp.Client(r.dialer, tlsCerts, 0)
 		defer httpClient.CloseIdleConnections()
 	}
 

--- a/pkg/controller/enterprisesearch/version_upgrade_test.go
+++ b/pkg/controller/enterprisesearch/version_upgrade_test.go
@@ -20,7 +20,7 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	entv1 "github.com/elastic/cloud-on-k8s/pkg/apis/enterprisesearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
 )
@@ -56,7 +56,7 @@ func podWithVersion(name string, version string) *corev1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "ns", Name: name, Labels: map[string]string{
 				EnterpriseSearchNameLabelName: "ent",
-				common.TypeLabelName:          Type,
+				labels.TypeLabelName:          Type,
 				VersionLabelName:              version,
 			},
 		},

--- a/pkg/controller/kibana/config_reconcile.go
+++ b/pkg/controller/kibana/config_reconcile.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
@@ -95,7 +95,7 @@ func ReconcileConfigSecret(
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: kb.Namespace,
 			Name:      SecretName(kb),
-			Labels: common.AddCredentialsLabel(map[string]string{
+			Labels: labels.AddCredentialsLabel(map[string]string{
 				KibanaNameLabelName: kb.Name,
 			}),
 		},

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -23,9 +23,9 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/deployment"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/kibana/network"
@@ -771,7 +771,7 @@ func mkService() corev1.Service {
 			Namespace: "test",
 			Labels: map[string]string{
 				KibanaNameLabelName:  "kibana-test",
-				common.TypeLabelName: Type,
+				labels.TypeLabelName: Type,
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -784,7 +784,7 @@ func mkService() corev1.Service {
 			},
 			Selector: map[string]string{
 				KibanaNameLabelName:  "kibana-test",
-				common.TypeLabelName: Type,
+				labels.TypeLabelName: Type,
 			},
 		},
 	}

--- a/pkg/controller/kibana/labels.go
+++ b/pkg/controller/kibana/labels.go
@@ -4,7 +4,9 @@
 
 package kibana
 
-import "github.com/elastic/cloud-on-k8s/pkg/controller/common"
+import (
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
+)
 
 const (
 	// KibanaNameLabelName used to represent a Kibana in k8s resources
@@ -24,6 +26,6 @@ const (
 func NewLabels(kibanaName string) map[string]string {
 	return map[string]string{
 		KibanaNameLabelName:  kibanaName,
-		common.TypeLabelName: Type,
+		labels.TypeLabelName: Type,
 	}
 }

--- a/pkg/controller/license/license_controller.go
+++ b/pkg/controller/license/license_controller.go
@@ -23,6 +23,7 @@ import (
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/license"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
@@ -174,7 +175,7 @@ func reconcileSecret(
 			Name:      secretName,
 			Namespace: cluster.Namespace,
 			Labels: map[string]string{
-				common.TypeLabelName:      license.Type,
+				labels.TypeLabelName:      license.Type,
 				license.LicenseLabelName:  parent,
 				license.LicenseLabelScope: string(license.LicenseScopeElasticsearch),
 				license.LicenseLabelType:  esLicense.Type,

--- a/pkg/controller/maps/config.go
+++ b/pkg/controller/maps/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/driver"
+	commonlabels "github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/volume"
@@ -51,7 +52,7 @@ func reconcileConfig(ctx context.Context, driver driver.Interface, ems emsv1alph
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ems.Namespace,
 			Name:      Config(ems.Name),
-			Labels:    common.AddCredentialsLabel(labels(ems.Name)),
+			Labels:    commonlabels.AddCredentialsLabel(labels(ems.Name)),
 		},
 		Data: map[string][]byte{
 			ConfigFilename: cfgBytes,

--- a/pkg/controller/maps/labels.go
+++ b/pkg/controller/maps/labels.go
@@ -6,7 +6,7 @@ package maps
 
 import (
 	emsv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/maps/v1alpha1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	commonlabels "github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 )
 
 const (
@@ -23,8 +23,8 @@ const (
 // labels constructs a new set of labels for a MapsServer pod
 func labels(emsName string) map[string]string {
 	return map[string]string{
-		NameLabelName:        emsName,
-		common.TypeLabelName: Type,
+		NameLabelName:              emsName,
+		commonlabels.TypeLabelName: Type,
 	}
 }
 

--- a/pkg/controller/remoteca/controller.go
+++ b/pkg/controller/remoteca/controller.go
@@ -21,6 +21,7 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/license"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
@@ -280,7 +281,7 @@ func remoteClustersInvolvedWith(
 	if err := c.List(ctx,
 		&remoteCAList,
 		client.MatchingLabels(map[string]string{
-			common.TypeLabelName:            remoteca.TypeLabelValue,
+			labels.TypeLabelName:            remoteca.TypeLabelValue,
 			RemoteClusterNamespaceLabelName: es.Namespace,
 			RemoteClusterNameLabelName:      es.Name,
 		}),

--- a/pkg/controller/remoteca/watches.go
+++ b/pkg/controller/remoteca/watches.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	commonlabels "github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates/remoteca"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/certificates/transport"
@@ -55,10 +55,10 @@ func AddWatches(c controller.Controller, r *ReconcileRemoteCa) error {
 func newRequestsFromMatchedLabels() handler.MapFunc {
 	return func(obj client.Object) []reconcile.Request {
 		labels := obj.GetLabels()
-		if !maps.ContainsKeys(labels, RemoteClusterNameLabelName, RemoteClusterNamespaceLabelName, common.TypeLabelName) {
+		if !maps.ContainsKeys(labels, RemoteClusterNameLabelName, RemoteClusterNamespaceLabelName, commonlabels.TypeLabelName) {
 			return nil
 		}
-		if labels[common.TypeLabelName] != remoteca.TypeLabelValue {
+		if labels[commonlabels.TypeLabelName] != remoteca.TypeLabelValue {
 			return nil
 		}
 		return []reconcile.Request{

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -19,7 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/license"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/tracing"
@@ -126,7 +126,7 @@ func (r LicensingResolver) Save(ctx context.Context, info LicensingInfo) error {
 			Namespace: nsn.Namespace,
 			Name:      nsn.Name,
 			Labels: map[string]string{
-				common.TypeLabelName: Type,
+				labels.TypeLabelName: Type,
 			},
 		},
 		Data: info.toMap(),

--- a/test/e2e/beat/upgrade_test.go
+++ b/test/e2e/beat/upgrade_test.go
@@ -14,7 +14,7 @@ import (
 
 	beatcommon "github.com/elastic/cloud-on-k8s/pkg/controller/beat/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/beat/filebeat"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/beat"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch"
@@ -46,7 +46,7 @@ func TestBeatVersionUpgradeToLatest7x(t *testing.T) {
 	opts := []client.ListOption{
 		client.InNamespace(fbBuilder.Beat.Namespace),
 		client.MatchingLabels(map[string]string{
-			common.TypeLabelName:     beatcommon.TypeLabelValue,
+			labels.TypeLabelName:     beatcommon.TypeLabelValue,
 			beatcommon.NameLabelName: fbBuilder.Beat.Name,
 		}),
 	}
@@ -84,7 +84,7 @@ func TestVersionUpgradeToLatest8x(t *testing.T) {
 	opts := []client.ListOption{
 		client.InNamespace(fbBuilder.Beat.Namespace),
 		client.MatchingLabels(map[string]string{
-			common.TypeLabelName:     beatcommon.TypeLabelValue,
+			labels.TypeLabelName:     beatcommon.TypeLabelValue,
 			beatcommon.NameLabelName: fbBuilder.Beat.Name,
 		}),
 	}

--- a/test/e2e/kb/version_upgrade_test.go
+++ b/test/e2e/kb/version_upgrade_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/reconcile"
 	kibana2 "github.com/elastic/cloud-on-k8s/pkg/controller/kibana"
 	"github.com/elastic/cloud-on-k8s/test/e2e/test"
@@ -47,7 +47,7 @@ func TestVersionUpgradeToLatest7x(t *testing.T) {
 	opts := []client.ListOption{
 		client.InNamespace(kbBuilder.Kibana.Namespace),
 		client.MatchingLabels(map[string]string{
-			common.TypeLabelName:        kibana2.Type,
+			labels.TypeLabelName:        kibana2.Type,
 			kibana2.KibanaNameLabelName: kbBuilder.Kibana.Name,
 		}),
 	}
@@ -96,7 +96,7 @@ func TestVersionUpgradeAndRespecToLatest7x(t *testing.T) {
 	opts := []client.ListOption{
 		client.InNamespace(kbBuilder1.Kibana.Namespace),
 		client.MatchingLabels(map[string]string{
-			common.TypeLabelName:        kibana2.Type,
+			labels.TypeLabelName:        kibana2.Type,
 			kibana2.KibanaNameLabelName: kbBuilder1.Kibana.Name,
 		}),
 	}
@@ -153,7 +153,7 @@ func TestVersionUpgradeToLatest8x(t *testing.T) {
 	opts := []client.ListOption{
 		client.InNamespace(kbBuilder.Kibana.Namespace),
 		client.MatchingLabels(map[string]string{
-			common.TypeLabelName:        kibana2.Type,
+			labels.TypeLabelName:        kibana2.Type,
 			kibana2.KibanaNameLabelName: kbBuilder.Kibana.Name,
 		}),
 	}
@@ -199,7 +199,7 @@ func TestVersionUpgradeAndRespecToLatest8x(t *testing.T) {
 	opts := []client.ListOption{
 		client.InNamespace(kbBuilder1.Kibana.Namespace),
 		client.MatchingLabels(map[string]string{
-			common.TypeLabelName:        kibana2.Type,
+			labels.TypeLabelName:        kibana2.Type,
 			kibana2.KibanaNameLabelName: kbBuilder1.Kibana.Name,
 		}),
 	}

--- a/test/e2e/test/common_steps.go
+++ b/test/e2e/test/common_steps.go
@@ -15,8 +15,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/hash"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/license"
 )
 
@@ -50,7 +50,7 @@ func CreateEnterpriseLicenseSecret(t *testing.T, k *K8sClient, secretName string
 				Namespace: Ctx().ManagedNamespace(0),
 				Name:      secretName,
 				Labels: map[string]string{
-					common.TypeLabelName:      license.Type,
+					labels.TypeLabelName:      license.Type,
 					license.LicenseLabelScope: string(license.LicenseScopeOperator),
 				},
 			},
@@ -67,7 +67,7 @@ func DeleteAllEnterpriseLicenseSecrets(t *testing.T, k *K8sClient) {
 	Eventually(func() error {
 		// Delete operator license secret
 		var licenseSecrets corev1.SecretList
-		err := k.Client.List(context.Background(), &licenseSecrets, k8sclient.MatchingLabels(map[string]string{common.TypeLabelName: license.Type}))
+		err := k.Client.List(context.Background(), &licenseSecrets, k8sclient.MatchingLabels(map[string]string{labels.TypeLabelName: license.Type}))
 		if err != nil {
 			return err
 		}

--- a/test/e2e/test/elasticsearch/steps_license.go
+++ b/test/e2e/test/elasticsearch/steps_license.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/license"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/client"
 	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
@@ -130,7 +130,7 @@ func (ltctx *LicenseTestContext) CreateEnterpriseTrialLicenseSecret(secretName s
 					Name:      secretName,
 					Labels: map[string]string{
 						license.LicenseLabelType: string(license.LicenseTypeEnterpriseTrial),
-						common.TypeLabelName:     license.Type,
+						labels.TypeLabelName:     license.Type,
 					},
 					Annotations: map[string]string{
 						license.EULAAnnotation: license.EULAAcceptedValue,

--- a/test/e2e/test/k8s_client.go
+++ b/test/e2e/test/k8s_client.go
@@ -36,8 +36,8 @@ import (
 	"github.com/elastic/cloud-on-k8s/pkg/controller/agent"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/apmserver"
 	beatcommon "github.com/elastic/cloud-on-k8s/pkg/controller/beat/common"
-	"github.com/elastic/cloud-on-k8s/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/common/name"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/volume"
@@ -373,7 +373,7 @@ func (k K8sClient) CreateOrUpdate(objs ...client.Object) error {
 func ESPodListOptions(esNamespace, esName string) []k8sclient.ListOption {
 	ns := k8sclient.InNamespace(esNamespace)
 	matchLabels := k8sclient.MatchingLabels(map[string]string{
-		common.TypeLabelName:       label.Type,
+		labels.TypeLabelName:       label.Type,
 		label.ClusterNameLabelName: esName,
 	})
 	return []k8sclient.ListOption{ns, matchLabels}
@@ -400,7 +400,7 @@ func KibanaPodListOptions(kbNamespace, kbName string) []k8sclient.ListOption {
 func ApmServerPodListOptions(apmNamespace, apmName string) []k8sclient.ListOption {
 	ns := k8sclient.InNamespace(apmNamespace)
 	matchLabels := k8sclient.MatchingLabels(map[string]string{
-		common.TypeLabelName:             apmserver.Type,
+		labels.TypeLabelName:             apmserver.Type,
 		apmserver.ApmServerNameLabelName: apmName,
 	})
 	return []k8sclient.ListOption{ns, matchLabels}
@@ -409,7 +409,7 @@ func ApmServerPodListOptions(apmNamespace, apmName string) []k8sclient.ListOptio
 func EnterpriseSearchPodListOptions(entNamespace, entName string) []k8sclient.ListOption {
 	ns := k8sclient.InNamespace(entNamespace)
 	matchLabels := k8sclient.MatchingLabels(map[string]string{
-		common.TypeLabelName:                           enterprisesearch.Type,
+		labels.TypeLabelName:                           enterprisesearch.Type,
 		enterprisesearch.EnterpriseSearchNameLabelName: entName,
 	})
 	return []k8sclient.ListOption{ns, matchLabels}
@@ -418,7 +418,7 @@ func EnterpriseSearchPodListOptions(entNamespace, entName string) []k8sclient.Li
 func AgentPodListOptions(agentNamespace, agentName string) []k8sclient.ListOption {
 	ns := k8sclient.InNamespace(agentNamespace)
 	matchLabels := k8sclient.MatchingLabels(map[string]string{
-		common.TypeLabelName: agent.TypeLabelValue,
+		labels.TypeLabelName: agent.TypeLabelValue,
 		agent.NameLabelName:  agent.Name(agentName),
 	})
 	return []k8sclient.ListOption{ns, matchLabels}
@@ -427,7 +427,7 @@ func AgentPodListOptions(agentNamespace, agentName string) []k8sclient.ListOptio
 func BeatPodListOptions(beatNamespace, beatName, beatType string) []k8sclient.ListOption {
 	ns := k8sclient.InNamespace(beatNamespace)
 	matchLabels := k8sclient.MatchingLabels(map[string]string{
-		common.TypeLabelName:     beatcommon.TypeLabelValue,
+		labels.TypeLabelName:     beatcommon.TypeLabelValue,
 		beatcommon.NameLabelName: beatcommon.Name(beatName, beatType),
 	})
 	return []k8sclient.ListOption{ns, matchLabels}
@@ -436,7 +436,7 @@ func BeatPodListOptions(beatNamespace, beatName, beatType string) []k8sclient.Li
 func MapsPodListOptions(emsNS, emsName string) []k8sclient.ListOption {
 	ns := k8sclient.InNamespace(emsNS)
 	matchLabels := k8sclient.MatchingLabels(map[string]string{
-		common.TypeLabelName: maps.Type,
+		labels.TypeLabelName: maps.Type,
 		maps.NameLabelName:   emsName,
 	})
 	return []k8sclient.ListOption{ns, matchLabels}


### PR DESCRIPTION
Support an annotation on all Elastic resources to request a certain license level in the operator.  Pre-req of https://github.com/elastic/cloud-on-k8s/pull/5781

I had to move a few things around for this to break a few import cycles, I hope that the changes and new packages names are self-explanatory and generally an improvement over the status quo.

I feel like there is room for a larger refactoring of the web hook logic in which we use just one method for both Elasticsearch and all the other applications. Also I found https://github.com/elastic/cloud-on-k8s/issues/5814