### PR TITLE
Upgrade test harness: fix CRDs first install

### DIFF
--- a/hack/upgrade-test-harness/main.go
+++ b/hack/upgrade-test-harness/main.go
@@ -175,9 +175,10 @@ func setupUpcomingRelease(installYAML, targetYAML string) error {
 }
 
 func buildUpgradeFixtures(from *fixture.TestParam, to fixture.TestParam) ([]*fixture.Fixture, error) {
-	fixtures := []*fixture.Fixture{fixture.TestInstallOperator(to)}
+	isUpgrade := from != nil
+	fixtures := []*fixture.Fixture{fixture.TestInstallOperator(to, isUpgrade)}
 
-	if from != nil {
+	if isUpgrade {
 		testStatusOfResources, err := fixture.TestStatusOfResources(*from)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
If the `from` release contains a `crds.yaml` file then the upgrade test harness tool always attempts to replace CRDs, even if they have not be installed yet.

The problem can be reproduced using `go run main.go --from-release=v191 --to-release=upcoming` for example:

```
2022-06-23T10:31:07.039+0200    ERROR   eck-upgrade.fixture     [FAIL] InstallCRDs[v191]        {"step": "TestInstallOperator[v191]", "step": "InstallCRDs[v191]", "error": "[error when replacing \"testdata/v191/crds.yaml\": customresourcedefinitions.apiextensions.k8s.io \"agents.agent.k8s.elastic.co\" not found,
```