### PR TITLE
E2E: Resize azure/aks vms from v3 -> v5

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -46,7 +46,7 @@ plans:
   clusterName: ci
   provider: aks
   kubernetesVersion: 1.22.6
-  machineType: Standard_D8s_v3
+  machineType: Standard_D8d_v5
   serviceAccount: true
   psp: false
   diskSetup: kubectl apply -k hack/deployer/config/local-disks
@@ -59,7 +59,7 @@ plans:
   clusterName: dev
   provider: aks
   kubernetesVersion: 1.22.6
-  machineType: Standard_D8s_v3
+  machineType: Standard_D8d_v5
   serviceAccount: false
   psp: false
   aks:


### PR DESCRIPTION
Fixes #5825 

Since AKS E2E tests appear to be failing because of disk pressure, let's take the opportunity to upgrade the version type of our VMs, and leverage more local storage.

Comparison of proposed instance type change: 

| Size  | vCPU | Memory: GiB | TempStorage (ssd) GiB | Cost/hr | Architecture |
| ------------- | ------------- | ---- | ---- | --- | -- |
| Standard_D8s_v3  | 8  |  32 | 64 | 0.3840 | 3rd Generation Intel® Xeon® Platinum 8370C (Ice Lake), (Cascade Lake), (Broadwell) or (Haswell) |
| Standard_D8ds_v5  | 8 |  32 | 300 | 0.4520 | 3rd Generation Intel® Xeon® Platinum 8370C (Ice Lake) |