### PR TITLE
[2.2] Add 2.2 known issue about service token migration  (#5827)

### DIFF
--- a/docs/release-notes/highlights-2.2.0.asciidoc
+++ b/docs/release-notes/highlights-2.2.0.asciidoc
@@ -53,3 +53,8 @@ ECK supports link:https://www.elastic.co/guide/en/elasticsearch/reference/curren
 ==== Elasticsearch Self Stack Monitoring
 
 The <<{p}-stack-monitoring,Stack Monitoring>> feature is fully operational to be used for Elasticsearch self-monitoring.
+
+[float]
+[id="{p}-220-known-issues"]
+=== Known issues
+- The migration to service account tokens can lead to unavailability of Kibana and Fleet Server which is especially noticeable on larger Elasticsearch clusters with many nodes. We are working on a fix to enable a migration without downtime in the next version of the ECK operator. If this is a concern we would recommend waiting with the upgrade until the fix is available. A workaround is explained in the link:https://github.com/elastic/cloud-on-k8s/issues/5684#issuecomment-1164614176[linked issue].


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.2`:
 - [Add 2.2 known issue about service token migration  (#5827)](https://github.com/elastic/cloud-on-k8s/pull/5827)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)