### PR TITLE
Revert indentation in testdata/stream.json to fix Test_helper_streamTestJobOutput_withError

### DIFF
--- a/test/e2e/cmd/run/testdata/stream.json
+++ b/test/e2e/cmd/run/testdata/stream.json
@@ -1,10132 +1,1495 @@
-{
-    "Time": "2020-08-20T10:01:18.159868603Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e",
-    "Output": "testing: warning: no tests to run\n"
-}
-{
-    "Time": "2020-08-20T10:01:18.160083783Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e",
-    "Output": "PASS\n"
-}
-{
-    "Time": "2020-08-20T10:01:18.161043832Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e",
-    "Output": "ok  \tgithub.com/elastic/cloud-on-k8s/v2/test/e2e\t0.026s [no tests to run]\n"
-}
-{
-    "Time": "2020-08-20T10:01:18.161082655Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e",
-    "Elapsed": 0.026
-}
-{
-    "Time": "2020-08-20T10:01:21.452154224Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/apm",
-    "Output": "testing: warning: no tests to run\n"
-}
-{
-    "Time": "2020-08-20T10:01:21.45240745Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/apm",
-    "Output": "PASS\n"
-}
-{
-    "Time": "2020-08-20T10:01:21.453918772Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/apm",
-    "Output": "ok  \tgithub.com/elastic/cloud-on-k8s/v2/test/e2e/apm\t0.037s [no tests to run]\n"
-}
-{
-    "Time": "2020-08-20T10:01:21.453985823Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/apm",
-    "Elapsed": 0.037
-}
-{
-    "Time": "2020-08-20T10:01:24.924367369Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/beat",
-    "Output": "testing: warning: no tests to run\n"
-}
-{
-    "Time": "2020-08-20T10:01:24.924562614Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/beat",
-    "Output": "PASS\n"
-}
-{
-    "Time": "2020-08-20T10:01:24.926096221Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/beat",
-    "Output": "ok  \tgithub.com/elastic/cloud-on-k8s/v2/test/e2e/beat\t0.028s [no tests to run]\n"
-}
-{
-    "Time": "2020-08-20T10:01:24.926131275Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/beat",
-    "Elapsed": 0.028
-}
-{
-    "Time": "2020-08-20T10:01:25.878697373Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/cmd",
-    "Output": "?   \tgithub.com/elastic/cloud-on-k8s/v2/test/e2e/cmd\t[no test files]\n"
-}
-{
-    "Time": "2020-08-20T10:01:25.878846936Z",
-    "Action": "skip",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/cmd",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:01:29.244943846Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/cmd/run",
-    "Output": "testing: warning: no tests to run\n"
-}
-{
-    "Time": "2020-08-20T10:01:29.245155665Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/cmd/run",
-    "Output": "PASS\n"
-}
-{
-    "Time": "2020-08-20T10:01:29.246502997Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/cmd/run",
-    "Output": "ok  \tgithub.com/elastic/cloud-on-k8s/v2/test/e2e/cmd/run\t0.028s [no tests to run]\n"
-}
-{
-    "Time": "2020-08-20T10:01:29.246543557Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/cmd/run",
-    "Elapsed": 0.028
-}
-{
-    "Time": "2020-08-20T10:01:32.352678343Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/ent",
-    "Output": "testing: warning: no tests to run\n"
-}
-{
-    "Time": "2020-08-20T10:01:32.352881621Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/ent",
-    "Output": "PASS\n"
-}
-{
-    "Time": "2020-08-20T10:01:32.35460332Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/ent",
-    "Output": "ok  \tgithub.com/elastic/cloud-on-k8s/v2/test/e2e/ent\t0.028s [no tests to run]\n"
-}
-{
-    "Time": "2020-08-20T10:01:32.354653299Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/ent",
-    "Elapsed": 0.028
-}
-{
-    "Time": "2020-08-20T10:01:36.463695508Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS"
-}
-{
-    "Time": "2020-08-20T10:01:36.463945983Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS\n"
-}
-{
-    "Time": "2020-08-20T10:01:36.464120104Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS",
-    "Output": "{\"log.level\":\"info\",\"@timestamp\":\"2020-08-20T10:01:36.464Z\",\"log.logger\":\"e2e\",\"message\":\"Test context initialized\",\"service.version\":\"0.0.0-SNAPSHOT+00000000\",\"service.type\":\"eck\",\"ecs.version\":\"1.4.0\",\"context\":{\"operator\":{\"name\":\"fake-psp-1-operator\",\"namespace\":\"fake-psp-1-elastic-system\",\"managed_namespaces\":[\"fake-psp-1-e2e-mercury\",\"fake-psp-1-e2e-venus\"]},\"e2e_image\":\"docker.elastic.co/eck-ci/eck-e2e-tests:4422f017\",\"e2e_namespace\":\"fake-psp-1\",\"e2e_service_account\":\"fake-psp-1\",\"elastic_stack_version\":\"7.8.1\",\"log_verbosity\":0,\"operator_image\":\"docker.elastic.co/eck-snapshots/eck-operator:1.3.0-SNAPSHOT-2020-08-17-4422f01\",\"test_license\":\"\",\"test_license_pkey_path\":\"\",\"test_regex\":\"TestMutation*\",\"test_run\":\"fake-psp-1\",\"monitoring_secrets\":\"/Users/michael/go/src/github.com/elastic/cloud-on-k8s/note.out/my-monitoring-cluster.secret.yml\",\"test_timeout\":300000000000,\"auto_port_forwarding\":false,\"local\":false,\"ignore_webhook_failures\":false,\"ocp_cluster\":false,\"pipeline\":\"michael-pipeline-ocp\",\"build_n"
-}
-{
-    "Time": "2020-08-20T10:01:36.46415882Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS",
-    "Output": "umber\":\"602\",\"provider\":\"ocp\",\"clusterName\":\"eck-pr-3766\",\"kubernetes_version\":\"default\"}}\n"
-}
-{
-    "Time": "2020-08-20T10:01:37.418378609Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/K8S_should_be_accessible"
-}
-{
-    "Time": "2020-08-20T10:01:37.418418281Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/K8S_should_be_accessible",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/K8S_should_be_accessible\n"
-}
-{
-    "Time": "2020-08-20T10:01:37.442439286Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/K8S_should_be_accessible",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:01:37.442485017Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Label_test_pods"
-}
-{
-    "Time": "2020-08-20T10:01:37.442490163Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Label_test_pods",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Label_test_pods\n"
-}
-{
-    "Time": "2020-08-20T10:01:37.488151315Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Label_test_pods",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:01:37.488321805Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_CRDs_should_exist"
-}
-{
-    "Time": "2020-08-20T10:01:37.488443345Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_CRDs_should_exist",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Elasticsearch_CRDs_should_exist\n"
-}
-{
-    "Time": "2020-08-20T10:01:37.500481237Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_CRDs_should_exist",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:01:37.500534617Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Webhook_endpoint_should_not_be_empty"
-}
-{
-    "Time": "2020-08-20T10:01:37.500541458Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Webhook_endpoint_should_not_be_empty",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Webhook_endpoint_should_not_be_empty\n"
-}
-{
-    "Time": "2020-08-20T10:01:37.506470395Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Webhook_endpoint_should_not_be_empty",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:01:37.506552208Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Remove_Elasticsearch_if_it_already_exists"
-}
-{
-    "Time": "2020-08-20T10:01:37.506560149Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Remove_Elasticsearch_if_it_already_exists\n"
-}
-{
-    "Time": "2020-08-20T10:01:37.519353078Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:01:37.519392719Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Creating_an_Elasticsearch_cluster_should_succeed"
-}
-{
-    "Time": "2020-08-20T10:01:37.519403749Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Creating_an_Elasticsearch_cluster_should_succeed\n"
-}
-{
-    "Time": "2020-08-20T10:01:37.553908986Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_cluster_should_be_created"
-}
-{
-    "Time": "2020-08-20T10:01:37.553958854Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_cluster_should_be_created",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Elasticsearch_cluster_should_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:01:37.55794553Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed"
-}
-{
-    "Time": "2020-08-20T10:01:37.557995562Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed\n"
-}
-{
-    "Time": "2020-08-20T10:01:40.57063436Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "Retries (5m0s timeout): ..\n"
-}
-{
-    "Time": "2020-08-20T10:01:40.57068785Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready"
-}
-{
-    "Time": "2020-08-20T10:01:40.570695402Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.807049305Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready",
-    "Output": "Retries (30m0s timeout): ...........\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.80715182Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one"
-}
-{
-    "Time": "2020-08-20T10:02:10.807158608Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.823569233Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.823626489Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_be_created"
-}
-{
-    "Time": "2020-08-20T10:02:10.823634897Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_be_created",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_services_should_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.834629574Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_be_created",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.834677671Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_have_endpoints"
-}
-{
-    "Time": "2020-08-20T10:02:10.834684731Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_have_endpoints",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_services_should_have_endpoints\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.843110518Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_have_endpoints",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.843165296Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created"
-}
-{
-    "Time": "2020-08-20T10:02:10.843172948Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.884964878Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.885039543Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate"
-}
-{
-    "Time": "2020-08-20T10:02:10.885047891Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.904979676Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.905022386Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green"
-}
-{
-    "Time": "2020-08-20T10:02:10.905027632Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.90912104Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.909175378Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elastic_password_should_be_available"
-}
-{
-    "Time": "2020-08-20T10:02:10.909182766Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elastic_password_should_be_available",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Elastic_password_should_be_available\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.91367187Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elastic_password_should_be_available",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.913733988Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type"
-}
-{
-    "Time": "2020-08-20T10:02:10.913742477Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.920119221Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped"
-}
-{
-    "Time": "2020-08-20T10:02:10.920170664Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.924975251Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:02:10.925026242Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one"
-}
-{
-    "Time": "2020-08-20T10:02:10.925034755Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one\n"
-}
-{
-    "Time": "2020-08-20T10:02:11.067079725Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:02:11.067133184Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#01"
-}
-{
-    "Time": "2020-08-20T10:02:11.067139564Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#01",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#01\n"
-}
-{
-    "Time": "2020-08-20T10:02:11.177881447Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:02:11.177952956Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable"
-}
-{
-    "Time": "2020-08-20T10:02:11.177959954Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable\n"
-}
-{
-    "Time": "2020-08-20T10:02:11.20952144Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:02:11.209583888Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Add_some_data_to_the_cluster_before_starting_the_mutation"
-}
-{
-    "Time": "2020-08-20T10:02:11.209594012Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Add_some_data_to_the_cluster_before_starting_the_mutation\n"
-}
-{
-    "Time": "2020-08-20T10:02:13.350868072Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on"
-}
-{
-    "Time": "2020-08-20T10:02:13.350951629Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on\n"
-}
-{
-    "Time": "2020-08-20T10:02:13.35098242Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"
-}
-{
-    "Time": "2020-08-20T10:02:13.350988845Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"
-}
-{
-    "Time": "2020-08-20T10:02:13.350997579Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"
-}
-{
-    "Time": "2020-08-20T10:02:13.351003056Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"
-}
-{
-    "Time": "2020-08-20T10:02:13.351011051Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose"
-}
-{
-    "Time": "2020-08-20T10:02:13.351017085Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose\n"
-}
-{
-    "Time": "2020-08-20T10:02:13.372472803Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:02:13.372524609Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Annotate_Pods_with_a_hash_of_their_Builder_spec"
-}
-{
-    "Time": "2020-08-20T10:02:13.372532989Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Annotate_Pods_with_a_hash_of_their_Builder_spec\n"
-}
-{
-    "Time": "2020-08-20T10:02:13.426223412Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:02:13.426284821Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Applying_the_Elasticsearch_mutation_should_succeed"
-}
-{
-    "Time": "2020-08-20T10:02:13.426294442Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Applying_the_Elasticsearch_mutation_should_succeed\n"
-}
-{
-    "Time": "2020-08-20T10:02:13.462158492Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:02:13.462204208Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed#01"
-}
-{
-    "Time": "2020-08-20T10:02:13.46221182Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed#01\n"
-}
-{
-    "Time": "2020-08-20T10:02:13.471137934Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:02:13.471191423Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready#01"
-}
-{
-    "Time": "2020-08-20T10:02:13.471201474Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready#01\n"
-}
-{
-    "Time": "2020-08-20T10:05:17.58794311Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "Retries (30m0s timeout): ..............................................................\n"
-}
-{
-    "Time": "2020-08-20T10:05:17.588049948Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#02"
-}
-{
-    "Time": "2020-08-20T10:05:17.588062983Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#02",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#02\n"
-}
-{
-    "Time": "2020-08-20T10:05:17.600874688Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#02",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:05:17.600978836Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_be_created#01"
-}
-{
-    "Time": "2020-08-20T10:05:17.600987269Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_be_created#01",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_services_should_be_created#01\n"
-}
-{
-    "Time": "2020-08-20T10:05:17.608673585Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_be_created#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:05:17.608728778Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_have_endpoints#01"
-}
-{
-    "Time": "2020-08-20T10:05:17.608734605Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_have_endpoints#01",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_services_should_have_endpoints#01\n"
-}
-{
-    "Time": "2020-08-20T10:05:17.61744184Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_have_endpoints#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:05:17.61749592Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created#01"
-}
-{
-    "Time": "2020-08-20T10:05:17.61750434Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created#01",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created#01\n"
-}
-{
-    "Time": "2020-08-20T10:05:17.656063564Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:05:17.656121732Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate#01"
-}
-{
-    "Time": "2020-08-20T10:05:17.656134904Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate#01\n"
-}
-{
-    "Time": "2020-08-20T10:05:17.675754701Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:05:17.675808801Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green#01"
-}
-{
-    "Time": "2020-08-20T10:05:17.675817029Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green#01\n"
-}
-{
-    "Time": "2020-08-20T10:05:29.702958611Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "Retries (5m0s timeout): .....\n"
-}
-{
-    "Time": "2020-08-20T10:05:29.703028345Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elastic_password_should_be_available#01"
-}
-{
-    "Time": "2020-08-20T10:05:29.703037411Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elastic_password_should_be_available#01",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Elastic_password_should_be_available#01\n"
-}
-{
-    "Time": "2020-08-20T10:05:29.707755123Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elastic_password_should_be_available#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:05:29.707809459Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type#01"
-}
-{
-    "Time": "2020-08-20T10:05:29.70781869Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type#01\n"
-}
-{
-    "Time": "2020-08-20T10:05:29.714332375Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01"
-}
-{
-    "Time": "2020-08-20T10:05:29.71437226Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01\n"
-}
-{
-    "Time": "2020-08-20T10:05:29.718392712Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:05:29.718424306Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one#01"
-}
-{
-    "Time": "2020-08-20T10:05:29.718430538Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one#01\n"
-}
-{
-    "Time": "2020-08-20T10:05:29.76756575Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:05:29.767621696Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#03"
-}
-{
-    "Time": "2020-08-20T10:05:29.767629085Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#03",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#03\n"
-}
-{
-    "Time": "2020-08-20T10:05:29.802142209Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#03",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:05:29.802193617Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable#01"
-}
-{
-    "Time": "2020-08-20T10:05:29.802201471Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable#01\n"
-}
-{
-    "Time": "2020-08-20T10:05:29.838779646Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:05:29.838833292Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Cluster_UUID_should_have_been_preserved"
-}
-{
-    "Time": "2020-08-20T10:05:29.838840853Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Cluster_UUID_should_have_been_preserved",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Cluster_UUID_should_have_been_preserved\n"
-}
-{
-    "Time": "2020-08-20T10:05:29.871145827Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"
-}
-{
-    "Time": "2020-08-20T10:05:29.871194575Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"
-}
-{
-    "Time": "2020-08-20T10:05:29.871212387Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"
-}
-{
-    "Time": "2020-08-20T10:05:29.871218777Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"
-}
-{
-    "Time": "2020-08-20T10:05:29.871396412Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process"
-}
-{
-    "Time": "2020-08-20T10:05:29.871414366Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process\n"
-}
-{
-    "Time": "2020-08-20T10:05:29.87142831Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Data_added_initially_should_still_be_present"
-}
-{
-    "Time": "2020-08-20T10:05:29.871434058Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Data_added_initially_should_still_be_present",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Data_added_initially_should_still_be_present\n"
-}
-{
-    "Time": "2020-08-20T10:05:30.003831766Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Data_added_initially_should_still_be_present",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:05:30.003876559Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Deleting_Elasticsearch_should_return_no_error"
-}
-{
-    "Time": "2020-08-20T10:05:30.003882346Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Deleting_Elasticsearch_should_return_no_error",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Deleting_Elasticsearch_should_return_no_error\n"
-}
-{
-    "Time": "2020-08-20T10:05:30.02003686Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_should_not_be_there_anymore"
-}
-{
-    "Time": "2020-08-20T10:05:30.020076213Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_should_not_be_there_anymore",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Elasticsearch_should_not_be_there_anymore\n"
-}
-{
-    "Time": "2020-08-20T10:05:30.026138761Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_should_not_be_there_anymore",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:05:30.0262051Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_pods_should_eventually_be_removed"
-}
-{
-    "Time": "2020-08-20T10:05:30.026212899Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/Elasticsearch_pods_should_eventually_be_removed\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.219269279Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "Retries (5m0s timeout): ...........................\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.219354248Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/PVCs_should_eventually_be_removed"
-}
-{
-    "Time": "2020-08-20T10:06:48.219361422Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/PVCs_should_eventually_be_removed",
-    "Output": "=== RUN   TestMutationHTTPToHTTPS/PVCs_should_eventually_be_removed\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.225784143Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/PVCs_should_eventually_be_removed",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.225846034Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS",
-    "Output": "--- PASS: TestMutationHTTPToHTTPS (311.76s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.225860996Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/K8S_should_be_accessible",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/K8S_should_be_accessible (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.225870405Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/K8S_should_be_accessible",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:06:48.225884216Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Label_test_pods",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Label_test_pods (0.05s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.225902147Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Label_test_pods",
-    "Elapsed": 0.05
-}
-{
-    "Time": "2020-08-20T10:06:48.225910217Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_CRDs_should_exist",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Elasticsearch_CRDs_should_exist (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.225939611Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_CRDs_should_exist",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:06:48.225953024Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Webhook_endpoint_should_not_be_empty",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Webhook_endpoint_should_not_be_empty (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.225962051Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Webhook_endpoint_should_not_be_empty",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:06:48.225971658Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Remove_Elasticsearch_if_it_already_exists (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.225990251Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Remove_Elasticsearch_if_it_already_exists",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:06:48.22599896Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Creating_an_Elasticsearch_cluster_should_succeed (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226007542Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:06:48.226014737Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_cluster_should_be_created",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Elasticsearch_cluster_should_be_created (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.22602318Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_cluster_should_be_created",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:06:48.226032539Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed (3.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.22603992Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed",
-    "Elapsed": 3.01
-}
-{
-    "Time": "2020-08-20T10:06:48.226047351Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready (30.24s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226058968Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready",
-    "Elapsed": 30.24
-}
-{
-    "Time": "2020-08-20T10:06:48.226066348Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226073922Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:06:48.226080628Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_be_created",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_services_should_be_created (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226088993Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_be_created",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:06:48.226096795Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_have_endpoints",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_services_should_have_endpoints (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226105282Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_have_endpoints",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:06:48.226112905Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226123978Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:06:48.226131601Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226139465Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:06:48.226149291Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226158118Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:06:48.226167617Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elastic_password_should_be_available",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Elastic_password_should_be_available (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226175512Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elastic_password_should_be_available",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:06:48.226182363Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226190872Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:06:48.226203923Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226212341Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:06:48.226219108Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one (0.14s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226234104Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Elapsed": 0.14
-}
-{
-    "Time": "2020-08-20T10:06:48.226241697Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#01",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#01 (0.11s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226249901Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#01",
-    "Elapsed": 0.11
-}
-{
-    "Time": "2020-08-20T10:06:48.226256972Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226264987Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:06:48.226275246Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Add_some_data_to_the_cluster_before_starting_the_mutation (2.14s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.22628885Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Elapsed": 2.14
-}
-{
-    "Time": "2020-08-20T10:06:48.226296646Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226312571Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:06:48.226320804Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226331889Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:06:48.226367961Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226393314Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:06:48.226400301Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226410166Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:06:48.226419513Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Annotate_Pods_with_a_hash_of_their_Builder_spec (0.05s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226427232Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Elapsed": 0.05
-}
-{
-    "Time": "2020-08-20T10:06:48.226434167Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Applying_the_Elasticsearch_mutation_should_succeed (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226454836Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:06:48.226462796Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226470636Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:06:48.226480951Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready#01 (184.12s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.22649275Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready#01",
-    "Elapsed": 184.12
-}
-{
-    "Time": "2020-08-20T10:06:48.226499981Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#02",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#02 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226541962Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#02",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:06:48.226550673Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_be_created#01",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_services_should_be_created#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226560107Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_be_created#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:06:48.226569168Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_have_endpoints#01",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_services_should_have_endpoints#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226577038Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_services_should_have_endpoints#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:06:48.226603484Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created#01",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created#01 (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226717595Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created#01",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:06:48.226735182Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate#01 (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226741505Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate#01",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:06:48.226747257Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green#01 (12.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226779972Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green#01",
-    "Elapsed": 12.03
-}
-{
-    "Time": "2020-08-20T10:06:48.226788305Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elastic_password_should_be_available#01",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Elastic_password_should_be_available#01 (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.226796136Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elastic_password_should_be_available#01",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:06:48.226803448Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.22685238Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:06:48.226864903Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01 (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.22690158Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:06:48.226976431Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one#01 (0.05s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.22698697Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Elapsed": 0.05
-}
-{
-    "Time": "2020-08-20T10:06:48.227021844Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#03",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#03 (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.227031128Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#03",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:06:48.227038505Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable#01 (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.227046654Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable#01",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:06:48.227059642Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Cluster_UUID_should_have_been_preserved",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Cluster_UUID_should_have_been_preserved (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.227070298Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Cluster_UUID_should_have_been_preserved",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:06:48.227084576Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.227093431Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:06:48.227130707Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.227149445Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:06:48.227158301Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.22720967Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:06:48.227231855Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Data_added_initially_should_still_be_present",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Data_added_initially_should_still_be_present (0.13s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.227241713Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Data_added_initially_should_still_be_present",
-    "Elapsed": 0.13
-}
-{
-    "Time": "2020-08-20T10:06:48.227274805Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Deleting_Elasticsearch_should_return_no_error",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Deleting_Elasticsearch_should_return_no_error (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.227283976Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Deleting_Elasticsearch_should_return_no_error",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:06:48.227294331Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_should_not_be_there_anymore",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Elasticsearch_should_not_be_there_anymore (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.227307091Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_should_not_be_there_anymore",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:06:48.22731485Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/Elasticsearch_pods_should_eventually_be_removed (78.19s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.227328867Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/Elasticsearch_pods_should_eventually_be_removed",
-    "Elapsed": 78.19
-}
-{
-    "Time": "2020-08-20T10:06:48.227336994Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/PVCs_should_eventually_be_removed",
-    "Output": "    --- PASS: TestMutationHTTPToHTTPS/PVCs_should_eventually_be_removed (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:06:48.227401384Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS/PVCs_should_eventually_be_removed",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:06:48.227415501Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPToHTTPS",
-    "Elapsed": 311.76
-}
-{
-    "Time": "2020-08-20T10:06:48.227427825Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP"
-}
-{
-    "Time": "2020-08-20T10:06:48.227438023Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP\n"
-}
-{
-    "Time": "2020-08-20T10:06:49.180769581Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/K8S_should_be_accessible"
-}
-{
-    "Time": "2020-08-20T10:06:49.180810973Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/K8S_should_be_accessible",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/K8S_should_be_accessible\n"
-}
-{
-    "Time": "2020-08-20T10:06:49.201557518Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/K8S_should_be_accessible",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:06:49.201604461Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Label_test_pods"
-}
-{
-    "Time": "2020-08-20T10:06:49.201612765Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Label_test_pods",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Label_test_pods\n"
-}
-{
-    "Time": "2020-08-20T10:06:49.245880692Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Label_test_pods",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:06:49.245982216Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_CRDs_should_exist"
-}
-{
-    "Time": "2020-08-20T10:06:49.245991055Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_CRDs_should_exist",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Elasticsearch_CRDs_should_exist\n"
-}
-{
-    "Time": "2020-08-20T10:06:49.251164529Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_CRDs_should_exist",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:06:49.251206712Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Webhook_endpoint_should_not_be_empty"
-}
-{
-    "Time": "2020-08-20T10:06:49.25121438Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Webhook_endpoint_should_not_be_empty",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Webhook_endpoint_should_not_be_empty\n"
-}
-{
-    "Time": "2020-08-20T10:06:49.254817708Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Webhook_endpoint_should_not_be_empty",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:06:49.254858459Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Remove_Elasticsearch_if_it_already_exists"
-}
-{
-    "Time": "2020-08-20T10:06:49.25486549Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Remove_Elasticsearch_if_it_already_exists\n"
-}
-{
-    "Time": "2020-08-20T10:06:49.268445153Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:06:49.268485575Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Creating_an_Elasticsearch_cluster_should_succeed"
-}
-{
-    "Time": "2020-08-20T10:06:49.268493061Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Creating_an_Elasticsearch_cluster_should_succeed\n"
-}
-{
-    "Time": "2020-08-20T10:06:49.289528187Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_cluster_should_be_created"
-}
-{
-    "Time": "2020-08-20T10:06:49.289568445Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_cluster_should_be_created",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Elasticsearch_cluster_should_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:06:49.294658973Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed"
-}
-{
-    "Time": "2020-08-20T10:06:49.294710466Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed\n"
-}
-{
-    "Time": "2020-08-20T10:06:52.308767057Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "Retries (5m0s timeout): ..\n"
-}
-{
-    "Time": "2020-08-20T10:06:52.308836827Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready"
-}
-{
-    "Time": "2020-08-20T10:06:52.308845087Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready\n"
-}
-{
-    "Time": "2020-08-20T10:07:19.558308686Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready",
-    "Output": "Retries (30m0s timeout): ..........\n"
-}
-{
-    "Time": "2020-08-20T10:07:19.558406523Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one"
-}
-{
-    "Time": "2020-08-20T10:07:19.558418313Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one\n"
-}
-{
-    "Time": "2020-08-20T10:07:19.579587599Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:07:19.579628316Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_be_created"
-}
-{
-    "Time": "2020-08-20T10:07:19.579638621Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_be_created",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_services_should_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:07:19.599592343Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_be_created",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:07:19.59964511Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_have_endpoints"
-}
-{
-    "Time": "2020-08-20T10:07:19.599653264Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_have_endpoints",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_services_should_have_endpoints\n"
-}
-{
-    "Time": "2020-08-20T10:07:19.611109768Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_have_endpoints",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:07:19.611149002Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created"
-}
-{
-    "Time": "2020-08-20T10:07:19.611154022Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:07:19.671867255Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:07:19.671919276Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate"
-}
-{
-    "Time": "2020-08-20T10:07:19.671957213Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate\n"
-}
-{
-    "Time": "2020-08-20T10:07:19.694255824Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:07:19.694305406Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green"
-}
-{
-    "Time": "2020-08-20T10:07:19.694311893Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green\n"
-}
-{
-    "Time": "2020-08-20T10:07:22.704950828Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green",
-    "Output": "Retries (5m0s timeout): ..\n"
-}
-{
-    "Time": "2020-08-20T10:07:22.705063222Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elastic_password_should_be_available"
-}
-{
-    "Time": "2020-08-20T10:07:22.705086077Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elastic_password_should_be_available",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Elastic_password_should_be_available\n"
-}
-{
-    "Time": "2020-08-20T10:07:22.710041986Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elastic_password_should_be_available",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:07:22.710083098Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type"
-}
-{
-    "Time": "2020-08-20T10:07:22.710090495Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type\n"
-}
-{
-    "Time": "2020-08-20T10:07:22.719611098Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped"
-}
-{
-    "Time": "2020-08-20T10:07:22.719640499Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped\n"
-}
-{
-    "Time": "2020-08-20T10:07:22.724043921Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:07:22.724083609Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one"
-}
-{
-    "Time": "2020-08-20T10:07:22.724091367Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one\n"
-}
-{
-    "Time": "2020-08-20T10:07:22.86688393Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:07:22.867002446Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#01"
-}
-{
-    "Time": "2020-08-20T10:07:22.867016248Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#01",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#01\n"
-}
-{
-    "Time": "2020-08-20T10:07:22.995833339Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:07:22.995886108Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable"
-}
-{
-    "Time": "2020-08-20T10:07:22.995893607Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable\n"
-}
-{
-    "Time": "2020-08-20T10:07:23.029183142Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:07:23.029236693Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Add_some_data_to_the_cluster_before_starting_the_mutation"
-}
-{
-    "Time": "2020-08-20T10:07:23.029245074Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Add_some_data_to_the_cluster_before_starting_the_mutation\n"
-}
-{
-    "Time": "2020-08-20T10:07:25.04167077Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on"
-}
-{
-    "Time": "2020-08-20T10:07:25.041711754Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on\n"
-}
-{
-    "Time": "2020-08-20T10:07:25.041725953Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"
-}
-{
-    "Time": "2020-08-20T10:07:25.041732055Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"
-}
-{
-    "Time": "2020-08-20T10:07:25.041738445Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"
-}
-{
-    "Time": "2020-08-20T10:07:25.041743447Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"
-}
-{
-    "Time": "2020-08-20T10:07:25.041749818Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose"
-}
-{
-    "Time": "2020-08-20T10:07:25.041756911Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose\n"
-}
-{
-    "Time": "2020-08-20T10:07:25.180897351Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:07:25.180973447Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Annotate_Pods_with_a_hash_of_their_Builder_spec"
-}
-{
-    "Time": "2020-08-20T10:07:25.180982994Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Annotate_Pods_with_a_hash_of_their_Builder_spec\n"
-}
-{
-    "Time": "2020-08-20T10:07:25.230385839Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:07:25.230486835Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Applying_the_Elasticsearch_mutation_should_succeed"
-}
-{
-    "Time": "2020-08-20T10:07:25.230494915Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Applying_the_Elasticsearch_mutation_should_succeed\n"
-}
-{
-    "Time": "2020-08-20T10:07:25.264427064Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:07:25.26447194Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed#01"
-}
-{
-    "Time": "2020-08-20T10:07:25.264477334Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed#01\n"
-}
-{
-    "Time": "2020-08-20T10:07:25.272711928Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:07:25.272760463Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready#01"
-}
-{
-    "Time": "2020-08-20T10:07:25.272802295Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready#01\n"
-}
-{
-    "Time": "2020-08-20T10:10:29.418655635Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "Retries (30m0s timeout): ..............................................................\n"
-}
-{
-    "Time": "2020-08-20T10:10:29.418823314Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#02"
-}
-{
-    "Time": "2020-08-20T10:10:29.418833436Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#02",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#02\n"
-}
-{
-    "Time": "2020-08-20T10:10:29.427535021Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#02",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:10:29.427613543Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_be_created#01"
-}
-{
-    "Time": "2020-08-20T10:10:29.427622753Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_be_created#01",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_services_should_be_created#01\n"
-}
-{
-    "Time": "2020-08-20T10:10:29.43568902Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_be_created#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:10:29.435744783Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_have_endpoints#01"
-}
-{
-    "Time": "2020-08-20T10:10:29.435751313Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_have_endpoints#01",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_services_should_have_endpoints#01\n"
-}
-{
-    "Time": "2020-08-20T10:10:29.441703839Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_have_endpoints#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:10:29.44178511Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created#01"
-}
-{
-    "Time": "2020-08-20T10:10:29.4417941Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created#01",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created#01\n"
-}
-{
-    "Time": "2020-08-20T10:10:29.47498606Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:10:29.475039034Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate#01"
-}
-{
-    "Time": "2020-08-20T10:10:29.47505064Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate#01\n"
-}
-{
-    "Time": "2020-08-20T10:10:29.492744188Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:10:29.492798187Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green#01"
-}
-{
-    "Time": "2020-08-20T10:10:29.492806722Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green#01\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.501576647Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "Retries (5m0s timeout): ..\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.501634681Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elastic_password_should_be_available#01"
-}
-{
-    "Time": "2020-08-20T10:10:32.501643848Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elastic_password_should_be_available#01",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Elastic_password_should_be_available#01\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.506007001Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elastic_password_should_be_available#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.506054056Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type#01"
-}
-{
-    "Time": "2020-08-20T10:10:32.506063239Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type#01\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.512317872Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01"
-}
-{
-    "Time": "2020-08-20T10:10:32.512355874Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.516227441Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.516279826Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one#01"
-}
-{
-    "Time": "2020-08-20T10:10:32.516288792Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one#01\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.556203703Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.556265139Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#03"
-}
-{
-    "Time": "2020-08-20T10:10:32.556272721Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#03",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#03\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.576983471Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#03",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.577029662Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable#01"
-}
-{
-    "Time": "2020-08-20T10:10:32.577035075Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable#01\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.600270447Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.600318036Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Cluster_UUID_should_have_been_preserved"
-}
-{
-    "Time": "2020-08-20T10:10:32.600325805Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Cluster_UUID_should_have_been_preserved",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Cluster_UUID_should_have_been_preserved\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.617459667Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"
-}
-{
-    "Time": "2020-08-20T10:10:32.617514062Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.617538455Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"
-}
-{
-    "Time": "2020-08-20T10:10:32.617543001Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.617754866Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process"
-}
-{
-    "Time": "2020-08-20T10:10:32.61777105Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.617782149Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Data_added_initially_should_still_be_present"
-}
-{
-    "Time": "2020-08-20T10:10:32.617789326Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Data_added_initially_should_still_be_present",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Data_added_initially_should_still_be_present\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.731075823Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Data_added_initially_should_still_be_present",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.731135059Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Deleting_Elasticsearch_should_return_no_error"
-}
-{
-    "Time": "2020-08-20T10:10:32.731144965Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Deleting_Elasticsearch_should_return_no_error",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Deleting_Elasticsearch_should_return_no_error\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.741956084Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_should_not_be_there_anymore"
-}
-{
-    "Time": "2020-08-20T10:10:32.742008676Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_should_not_be_there_anymore",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Elasticsearch_should_not_be_there_anymore\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.746809404Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_should_not_be_there_anymore",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:10:32.746858055Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_pods_should_eventually_be_removed"
-}
-{
-    "Time": "2020-08-20T10:10:32.746865504Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/Elasticsearch_pods_should_eventually_be_removed\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.871150975Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "Retries (5m0s timeout): ................\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.87126411Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/PVCs_should_eventually_be_removed"
-}
-{
-    "Time": "2020-08-20T10:11:17.871278345Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/PVCs_should_eventually_be_removed",
-    "Output": "=== RUN   TestMutationHTTPSToHTTP/PVCs_should_eventually_be_removed\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.87603712Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/PVCs_should_eventually_be_removed",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876086539Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP",
-    "Output": "--- PASS: TestMutationHTTPSToHTTP (269.65s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876095708Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/K8S_should_be_accessible",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/K8S_should_be_accessible (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876103152Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/K8S_should_be_accessible",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:11:17.876114799Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Label_test_pods",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Label_test_pods (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876121492Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Label_test_pods",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:11:17.876127322Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_CRDs_should_exist",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Elasticsearch_CRDs_should_exist (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876134079Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_CRDs_should_exist",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:11:17.876140052Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Webhook_endpoint_should_not_be_empty",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Webhook_endpoint_should_not_be_empty (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876146268Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Webhook_endpoint_should_not_be_empty",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:11:17.876151809Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Remove_Elasticsearch_if_it_already_exists (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876159321Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Remove_Elasticsearch_if_it_already_exists",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:11:17.876165023Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Creating_an_Elasticsearch_cluster_should_succeed (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876171482Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:11:17.876177622Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_cluster_should_be_created",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Elasticsearch_cluster_should_be_created (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876184351Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_cluster_should_be_created",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:11:17.876189813Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed (3.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876196495Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed",
-    "Elapsed": 3.01
-}
-{
-    "Time": "2020-08-20T10:11:17.876202633Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready (27.25s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876208881Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready",
-    "Elapsed": 27.25
-}
-{
-    "Time": "2020-08-20T10:11:17.876214638Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876221068Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:11:17.876230997Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_be_created",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_services_should_be_created (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876241516Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_be_created",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:11:17.876247408Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_have_endpoints",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_services_should_have_endpoints (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876253712Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_have_endpoints",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:11:17.876259232Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created (0.06s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876265269Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created",
-    "Elapsed": 0.06
-}
-{
-    "Time": "2020-08-20T10:11:17.876271097Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876276875Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:11:17.876282402Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green (3.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876288535Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green",
-    "Elapsed": 3.01
-}
-{
-    "Time": "2020-08-20T10:11:17.876294175Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elastic_password_should_be_available",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Elastic_password_should_be_available (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876300966Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elastic_password_should_be_available",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:11:17.876306788Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876318866Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:11:17.876324701Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876330805Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:11:17.876336458Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one (0.14s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876343008Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Elapsed": 0.14
-}
-{
-    "Time": "2020-08-20T10:11:17.876348503Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#01",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#01 (0.13s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.87635479Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#01",
-    "Elapsed": 0.13
-}
-{
-    "Time": "2020-08-20T10:11:17.876360849Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876366744Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:11:17.876379581Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Add_some_data_to_the_cluster_before_starting_the_mutation (2.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876386442Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Elapsed": 2.01
-}
-{
-    "Time": "2020-08-20T10:11:17.876392405Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876402947Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:11:17.876413221Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876420925Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:11:17.876426991Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876433798Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:11:17.876439678Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose (0.14s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876446115Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Elapsed": 0.14
-}
-{
-    "Time": "2020-08-20T10:11:17.876452451Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Annotate_Pods_with_a_hash_of_their_Builder_spec (0.05s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876459599Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Elapsed": 0.05
-}
-{
-    "Time": "2020-08-20T10:11:17.876466123Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Applying_the_Elasticsearch_mutation_should_succeed (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.87647881Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:11:17.876496019Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876504073Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:11:17.876510033Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready#01 (184.15s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876516556Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready#01",
-    "Elapsed": 184.15
-}
-{
-    "Time": "2020-08-20T10:11:17.876522709Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#02",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#02 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876539207Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#02",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:11:17.876550588Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_be_created#01",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_services_should_be_created#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876557719Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_be_created#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:11:17.876563627Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_have_endpoints#01",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_services_should_have_endpoints#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876570523Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_services_should_have_endpoints#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:11:17.876576196Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created#01",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created#01 (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876582917Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created#01",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:11:17.876588738Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate#01 (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876597529Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate#01",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:11:17.876605671Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green#01 (3.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876613016Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green#01",
-    "Elapsed": 3.01
-}
-{
-    "Time": "2020-08-20T10:11:17.87662482Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elastic_password_should_be_available#01",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Elastic_password_should_be_available#01 (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876632296Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elastic_password_should_be_available#01",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:11:17.876644912Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876651601Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:11:17.876657701Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01 (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876664247Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:11:17.876675648Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one#01 (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876683261Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:11:17.876690393Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#03",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#03 (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876696887Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#03",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:11:17.876702929Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable#01 (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876709776Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable#01",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:11:17.876734046Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Cluster_UUID_should_have_been_preserved",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Cluster_UUID_should_have_been_preserved (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876741205Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Cluster_UUID_should_have_been_preserved",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:11:17.876747763Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876755124Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:11:17.876761266Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876768699Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:11:17.876776747Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876788091Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:11:17.87679431Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Data_added_initially_should_still_be_present",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Data_added_initially_should_still_be_present (0.11s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876800837Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Data_added_initially_should_still_be_present",
-    "Elapsed": 0.11
-}
-{
-    "Time": "2020-08-20T10:11:17.876805994Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Deleting_Elasticsearch_should_return_no_error",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Deleting_Elasticsearch_should_return_no_error (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876824909Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Deleting_Elasticsearch_should_return_no_error",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:11:17.876830643Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_should_not_be_there_anymore",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Elasticsearch_should_not_be_there_anymore (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876836933Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_should_not_be_there_anymore",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:11:17.876842898Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/Elasticsearch_pods_should_eventually_be_removed (45.12s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.87684979Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/Elasticsearch_pods_should_eventually_be_removed",
-    "Elapsed": 45.12
-}
-{
-    "Time": "2020-08-20T10:11:17.876856043Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/PVCs_should_eventually_be_removed",
-    "Output": "    --- PASS: TestMutationHTTPSToHTTP/PVCs_should_eventually_be_removed (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:11:17.876885891Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP/PVCs_should_eventually_be_removed",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:11:17.876898359Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationHTTPSToHTTP",
-    "Elapsed": 269.65
-}
-{
-    "Time": "2020-08-20T10:11:17.876910712Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated"
-}
-{
-    "Time": "2020-08-20T10:11:17.87691854Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated",
-    "Output": "=== RUN   TestMutationMdiToDedicated\n"
-}
-{
-    "Time": "2020-08-20T10:11:18.830106062Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/K8S_should_be_accessible"
-}
-{
-    "Time": "2020-08-20T10:11:18.83015156Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/K8S_should_be_accessible",
-    "Output": "=== RUN   TestMutationMdiToDedicated/K8S_should_be_accessible\n"
-}
-{
-    "Time": "2020-08-20T10:11:18.847969704Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/K8S_should_be_accessible",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:18.848012254Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Label_test_pods"
-}
-{
-    "Time": "2020-08-20T10:11:18.848017695Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Label_test_pods",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Label_test_pods\n"
-}
-{
-    "Time": "2020-08-20T10:11:18.881094868Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Label_test_pods",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:18.881146532Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_CRDs_should_exist"
-}
-{
-    "Time": "2020-08-20T10:11:18.881153944Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_CRDs_should_exist",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Elasticsearch_CRDs_should_exist\n"
-}
-{
-    "Time": "2020-08-20T10:11:18.887041245Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_CRDs_should_exist",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:18.887084658Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Webhook_endpoint_should_not_be_empty"
-}
-{
-    "Time": "2020-08-20T10:11:18.887092213Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Webhook_endpoint_should_not_be_empty",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Webhook_endpoint_should_not_be_empty\n"
-}
-{
-    "Time": "2020-08-20T10:11:18.891181261Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Webhook_endpoint_should_not_be_empty",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:18.891218961Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Remove_Elasticsearch_if_it_already_exists"
-}
-{
-    "Time": "2020-08-20T10:11:18.891224678Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Remove_Elasticsearch_if_it_already_exists\n"
-}
-{
-    "Time": "2020-08-20T10:11:18.90265472Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:18.902704136Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Creating_an_Elasticsearch_cluster_should_succeed"
-}
-{
-    "Time": "2020-08-20T10:11:18.902711642Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Creating_an_Elasticsearch_cluster_should_succeed\n"
-}
-{
-    "Time": "2020-08-20T10:11:18.921040148Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_cluster_should_be_created"
-}
-{
-    "Time": "2020-08-20T10:11:18.921095814Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_cluster_should_be_created",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Elasticsearch_cluster_should_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:11:18.926441927Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed"
-}
-{
-    "Time": "2020-08-20T10:11:18.926475113Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed\n"
-}
-{
-    "Time": "2020-08-20T10:11:21.941064201Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "Retries (5m0s timeout): ..\n"
-}
-{
-    "Time": "2020-08-20T10:11:21.941114608Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready"
-}
-{
-    "Time": "2020-08-20T10:11:21.941121621Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready",
-    "Output": "=== RUN   TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.070775526Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready",
-    "Output": "Retries (30m0s timeout): ........\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.070858298Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one"
-}
-{
-    "Time": "2020-08-20T10:11:43.070866762Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_version_should_be_the_expected_one\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.078835476Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.078877537Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_be_created"
-}
-{
-    "Time": "2020-08-20T10:11:43.078883013Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_be_created",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_services_should_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.087340301Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_be_created",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.087367851Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_have_endpoints"
-}
-{
-    "Time": "2020-08-20T10:11:43.087373323Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_have_endpoints",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_services_should_have_endpoints\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.094177594Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_have_endpoints",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.094212875Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Secrets_should_eventually_be_created"
-}
-{
-    "Time": "2020-08-20T10:11:43.094220135Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Secrets_should_eventually_be_created",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Secrets_should_eventually_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.138174656Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Secrets_should_eventually_be_created",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.138229316Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate"
-}
-{
-    "Time": "2020-08-20T10:11:43.138238033Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.150148191Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.150195198Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green"
-}
-{
-    "Time": "2020-08-20T10:11:43.150204003Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.157463398Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.157497671Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elastic_password_should_be_available"
-}
-{
-    "Time": "2020-08-20T10:11:43.157503265Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elastic_password_should_be_available",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Elastic_password_should_be_available\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.162881236Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elastic_password_should_be_available",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.162920004Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type"
-}
-{
-    "Time": "2020-08-20T10:11:43.162946552Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.169940721Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped"
-}
-{
-    "Time": "2020-08-20T10:11:43.169974516Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.176993831Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.177045144Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one"
-}
-{
-    "Time": "2020-08-20T10:11:43.177053497Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.317507322Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.317550979Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#01"
-}
-{
-    "Time": "2020-08-20T10:11:43.317556364Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#01",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#01\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.355095931Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.355156935Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable"
-}
-{
-    "Time": "2020-08-20T10:11:43.355163689Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.394024181Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:43.394070357Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Add_some_data_to_the_cluster_before_starting_the_mutation"
-}
-{
-    "Time": "2020-08-20T10:11:43.394076691Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Add_some_data_to_the_cluster_before_starting_the_mutation\n"
-}
-{
-    "Time": "2020-08-20T10:11:44.630517051Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on"
-}
-{
-    "Time": "2020-08-20T10:11:44.630568985Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on\n"
-}
-{
-    "Time": "2020-08-20T10:11:44.630582116Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"
-}
-{
-    "Time": "2020-08-20T10:11:44.630586665Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"
-}
-{
-    "Time": "2020-08-20T10:11:44.630598308Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"
-}
-{
-    "Time": "2020-08-20T10:11:44.630601913Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"
-}
-{
-    "Time": "2020-08-20T10:11:44.630606317Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose"
-}
-{
-    "Time": "2020-08-20T10:11:44.630611657Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose\n"
-}
-{
-    "Time": "2020-08-20T10:11:44.668744713Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:44.668796108Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Annotate_Pods_with_a_hash_of_their_Builder_spec"
-}
-{
-    "Time": "2020-08-20T10:11:44.668802276Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Annotate_Pods_with_a_hash_of_their_Builder_spec\n"
-}
-{
-    "Time": "2020-08-20T10:11:44.686542153Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:44.686599237Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Applying_the_Elasticsearch_mutation_should_succeed"
-}
-{
-    "Time": "2020-08-20T10:11:44.686607421Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Applying_the_Elasticsearch_mutation_should_succeed\n"
-}
-{
-    "Time": "2020-08-20T10:11:44.729992951Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:44.730049287Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed#01"
-}
-{
-    "Time": "2020-08-20T10:11:44.730056504Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed#01\n"
-}
-{
-    "Time": "2020-08-20T10:11:44.737819164Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:11:44.737862144Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready#01"
-}
-{
-    "Time": "2020-08-20T10:11:44.737870184Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "=== RUN   TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready#01\n"
-}
-{
-    "Time": "2020-08-20T10:12:56.943424747Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "Retries (30m0s timeout): .........................\n"
-}
-{
-    "Time": "2020-08-20T10:12:56.943731399Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#02"
-}
-{
-    "Time": "2020-08-20T10:12:56.943739733Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#02",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#02\n"
-}
-{
-    "Time": "2020-08-20T10:12:56.952350659Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#02",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:12:56.95240635Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_be_created#01"
-}
-{
-    "Time": "2020-08-20T10:12:56.952412921Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_be_created#01",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_services_should_be_created#01\n"
-}
-{
-    "Time": "2020-08-20T10:12:56.961293891Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_be_created#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:12:56.961354115Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_have_endpoints#01"
-}
-{
-    "Time": "2020-08-20T10:12:56.961362244Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_have_endpoints#01",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_services_should_have_endpoints#01\n"
-}
-{
-    "Time": "2020-08-20T10:12:56.968091303Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_have_endpoints#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:12:56.968164637Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Secrets_should_eventually_be_created#01"
-}
-{
-    "Time": "2020-08-20T10:12:56.968172372Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Secrets_should_eventually_be_created#01",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Secrets_should_eventually_be_created#01\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.009942436Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Secrets_should_eventually_be_created#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.00999315Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate#01"
-}
-{
-    "Time": "2020-08-20T10:12:57.009999642Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate#01\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.023171394Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.023218905Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green#01"
-}
-{
-    "Time": "2020-08-20T10:12:57.023224707Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green#01\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.027203313Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.027255848Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elastic_password_should_be_available#01"
-}
-{
-    "Time": "2020-08-20T10:12:57.027263583Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elastic_password_should_be_available#01",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Elastic_password_should_be_available#01\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.030788083Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elastic_password_should_be_available#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.030826528Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type#01"
-}
-{
-    "Time": "2020-08-20T10:12:57.030833379Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type#01\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.036164506Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01"
-}
-{
-    "Time": "2020-08-20T10:12:57.036200446Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.046720132Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.047008251Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one#01"
-}
-{
-    "Time": "2020-08-20T10:12:57.047127493Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one#01\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.094850467Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.09491779Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#03"
-}
-{
-    "Time": "2020-08-20T10:12:57.094939562Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#03",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#03\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.126357737Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#03",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.126412785Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable#01"
-}
-{
-    "Time": "2020-08-20T10:12:57.126421011Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "=== RUN   TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable#01\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.1644177Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.16447436Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Cluster_UUID_should_have_been_preserved"
-}
-{
-    "Time": "2020-08-20T10:12:57.164487647Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Cluster_UUID_should_have_been_preserved",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Cluster_UUID_should_have_been_preserved\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.201124015Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"
-}
-{
-    "Time": "2020-08-20T10:12:57.201171247Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.201186707Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"
-}
-{
-    "Time": "2020-08-20T10:12:57.20119302Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.201513847Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process"
-}
-{
-    "Time": "2020-08-20T10:12:57.20153699Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.201548216Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Data_added_initially_should_still_be_present"
-}
-{
-    "Time": "2020-08-20T10:12:57.201554468Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Data_added_initially_should_still_be_present",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Data_added_initially_should_still_be_present\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.316372744Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Data_added_initially_should_still_be_present",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.316434288Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Deleting_Elasticsearch_should_return_no_error"
-}
-{
-    "Time": "2020-08-20T10:12:57.316456097Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Deleting_Elasticsearch_should_return_no_error",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Deleting_Elasticsearch_should_return_no_error\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.328764802Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_should_not_be_there_anymore"
-}
-{
-    "Time": "2020-08-20T10:12:57.328985818Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_should_not_be_there_anymore",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Elasticsearch_should_not_be_there_anymore\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.332623819Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_should_not_be_there_anymore",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:12:57.332676723Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_pods_should_eventually_be_removed"
-}
-{
-    "Time": "2020-08-20T10:12:57.332685006Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "=== RUN   TestMutationMdiToDedicated/Elasticsearch_pods_should_eventually_be_removed\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.430509745Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "Retries (5m0s timeout): ..............\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.430648573Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/PVCs_should_eventually_be_removed"
-}
-{
-    "Time": "2020-08-20T10:13:36.430658861Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/PVCs_should_eventually_be_removed",
-    "Output": "=== RUN   TestMutationMdiToDedicated/PVCs_should_eventually_be_removed\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.434883755Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/PVCs_should_eventually_be_removed",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.43498877Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated",
-    "Output": "--- PASS: TestMutationMdiToDedicated (138.56s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435003125Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/K8S_should_be_accessible",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/K8S_should_be_accessible (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435010119Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/K8S_should_be_accessible",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:13:36.435071548Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Label_test_pods",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Label_test_pods (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435080626Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Label_test_pods",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:13:36.435086325Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_CRDs_should_exist",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Elasticsearch_CRDs_should_exist (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435092391Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_CRDs_should_exist",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.43509848Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Webhook_endpoint_should_not_be_empty",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Webhook_endpoint_should_not_be_empty (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435104252Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Webhook_endpoint_should_not_be_empty",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:13:36.435110171Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Remove_Elasticsearch_if_it_already_exists (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435117731Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Remove_Elasticsearch_if_it_already_exists",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.435129522Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Creating_an_Elasticsearch_cluster_should_succeed (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435136655Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:13:36.435143113Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_cluster_should_be_created",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Elasticsearch_cluster_should_be_created (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.43515004Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_cluster_should_be_created",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.435156363Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed (3.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435163559Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed",
-    "Elapsed": 3.01
-}
-{
-    "Time": "2020-08-20T10:13:36.4351764Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready (21.13s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435183769Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready",
-    "Elapsed": 21.13
-}
-{
-    "Time": "2020-08-20T10:13:36.435193846Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_version_should_be_the_expected_one (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435200836Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.435218497Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_be_created",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_services_should_be_created (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435224964Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_be_created",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.435235563Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_have_endpoints",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_services_should_have_endpoints (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435242174Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_have_endpoints",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.435251881Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Secrets_should_eventually_be_created",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Secrets_should_eventually_be_created (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435262579Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Secrets_should_eventually_be_created",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:13:36.435289232Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435296194Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.435306661Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435313935Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.435324456Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elastic_password_should_be_available",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Elastic_password_should_be_available (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.43533198Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elastic_password_should_be_available",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.435342349Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435349703Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.435355549Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435363146Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.435381142Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one (0.14s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435388587Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Elapsed": 0.14
-}
-{
-    "Time": "2020-08-20T10:13:36.435400915Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#01",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#01 (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435433141Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#01",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:13:36.435439284Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.43544639Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:13:36.435458644Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Add_some_data_to_the_cluster_before_starting_the_mutation (1.24s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435466834Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Elapsed": 1.24
-}
-{
-    "Time": "2020-08-20T10:13:36.435476378Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435581592Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:13:36.435589111Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435596778Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:13:36.435607725Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435614798Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:13:36.435620125Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.43562656Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:13:36.435633066Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Annotate_Pods_with_a_hash_of_their_Builder_spec (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435639953Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:13:36.435646541Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Applying_the_Elasticsearch_mutation_should_succeed (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435653505Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:13:36.435659498Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435666463Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.435672735Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready#01 (72.21s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435679555Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready#01",
-    "Elapsed": 72.21
-}
-{
-    "Time": "2020-08-20T10:13:36.435696363Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#02",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#02 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435706884Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#02",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.435712849Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_be_created#01",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_services_should_be_created#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435719042Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_be_created#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.435724558Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_have_endpoints#01",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_services_should_have_endpoints#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.43573066Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_services_should_have_endpoints#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.435736185Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Secrets_should_eventually_be_created#01",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Secrets_should_eventually_be_created#01 (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.43574236Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Secrets_should_eventually_be_created#01",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:13:36.435747772Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435758549Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.435782573Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green#01 (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435793301Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green#01",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:13:36.435803435Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elastic_password_should_be_available#01",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Elastic_password_should_be_available#01 (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435810036Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elastic_password_should_be_available#01",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:13:36.435818206Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435830972Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.435842511Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01 (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435850337Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:13:36.435860615Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one#01 (0.05s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435867874Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Elapsed": 0.05
-}
-{
-    "Time": "2020-08-20T10:13:36.4358787Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#03",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#03 (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435885124Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#03",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:13:36.435891143Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable#01 (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435902559Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable#01",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:13:36.435910718Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Cluster_UUID_should_have_been_preserved",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Cluster_UUID_should_have_been_preserved (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435936805Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Cluster_UUID_should_have_been_preserved",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:13:36.435943584Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435950029Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:13:36.435955736Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435961978Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:13:36.435967723Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435973974Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:13:36.435979225Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Data_added_initially_should_still_be_present",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Data_added_initially_should_still_be_present (0.11s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435984998Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Data_added_initially_should_still_be_present",
-    "Elapsed": 0.11
-}
-{
-    "Time": "2020-08-20T10:13:36.435990198Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Deleting_Elasticsearch_should_return_no_error",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Deleting_Elasticsearch_should_return_no_error (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.435996134Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Deleting_Elasticsearch_should_return_no_error",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:13:36.436004195Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_should_not_be_there_anymore",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Elasticsearch_should_not_be_there_anymore (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.436010785Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_should_not_be_there_anymore",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:13:36.436016685Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/Elasticsearch_pods_should_eventually_be_removed (39.10s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.436023673Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/Elasticsearch_pods_should_eventually_be_removed",
-    "Elapsed": 39.1
-}
-{
-    "Time": "2020-08-20T10:13:36.436029586Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/PVCs_should_eventually_be_removed",
-    "Output": "    --- PASS: TestMutationMdiToDedicated/PVCs_should_eventually_be_removed (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:13:36.436043268Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated/PVCs_should_eventually_be_removed",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:13:36.436048258Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMdiToDedicated",
-    "Elapsed": 138.56
-}
-{
-    "Time": "2020-08-20T10:13:36.436057374Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes"
-}
-{
-    "Time": "2020-08-20T10:13:36.436063468Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes",
-    "Output": "=== RUN   TestMutationMoreNodes\n"
-}
-{
-    "Time": "2020-08-20T10:13:37.388969408Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/K8S_should_be_accessible"
-}
-{
-    "Time": "2020-08-20T10:13:37.389008727Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/K8S_should_be_accessible",
-    "Output": "=== RUN   TestMutationMoreNodes/K8S_should_be_accessible\n"
-}
-{
-    "Time": "2020-08-20T10:13:37.405894719Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/K8S_should_be_accessible",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:13:37.405954812Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Label_test_pods"
-}
-{
-    "Time": "2020-08-20T10:13:37.405961945Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Label_test_pods",
-    "Output": "=== RUN   TestMutationMoreNodes/Label_test_pods\n"
-}
-{
-    "Time": "2020-08-20T10:13:37.436633704Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Label_test_pods",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:13:37.43669577Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_CRDs_should_exist"
-}
-{
-    "Time": "2020-08-20T10:13:37.436740033Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_CRDs_should_exist",
-    "Output": "=== RUN   TestMutationMoreNodes/Elasticsearch_CRDs_should_exist\n"
-}
-{
-    "Time": "2020-08-20T10:13:37.44112276Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_CRDs_should_exist",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:13:37.441166454Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Webhook_endpoint_should_not_be_empty"
-}
-{
-    "Time": "2020-08-20T10:13:37.441171719Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Webhook_endpoint_should_not_be_empty",
-    "Output": "=== RUN   TestMutationMoreNodes/Webhook_endpoint_should_not_be_empty\n"
-}
-{
-    "Time": "2020-08-20T10:13:37.445966696Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Webhook_endpoint_should_not_be_empty",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:13:37.446009863Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Remove_Elasticsearch_if_it_already_exists"
-}
-{
-    "Time": "2020-08-20T10:13:37.446017415Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "=== RUN   TestMutationMoreNodes/Remove_Elasticsearch_if_it_already_exists\n"
-}
-{
-    "Time": "2020-08-20T10:13:37.458632284Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:13:37.458676938Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Creating_an_Elasticsearch_cluster_should_succeed"
-}
-{
-    "Time": "2020-08-20T10:13:37.458682631Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Output": "=== RUN   TestMutationMoreNodes/Creating_an_Elasticsearch_cluster_should_succeed\n"
-}
-{
-    "Time": "2020-08-20T10:13:37.478898154Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_cluster_should_be_created"
-}
-{
-    "Time": "2020-08-20T10:13:37.478957603Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_cluster_should_be_created",
-    "Output": "=== RUN   TestMutationMoreNodes/Elasticsearch_cluster_should_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:13:37.483563615Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed"
-}
-{
-    "Time": "2020-08-20T10:13:37.483600144Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed\n"
-}
-{
-    "Time": "2020-08-20T10:13:40.498689375Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "Retries (5m0s timeout): ..\n"
-}
-{
-    "Time": "2020-08-20T10:13:40.498787586Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready"
-}
-{
-    "Time": "2020-08-20T10:13:40.498793792Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready",
-    "Output": "=== RUN   TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready\n"
-}
-{
-    "Time": "2020-08-20T10:13:58.61971321Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready",
-    "Output": "Retries (30m0s timeout): .......\n"
-}
-{
-    "Time": "2020-08-20T10:13:58.619836065Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one"
-}
-{
-    "Time": "2020-08-20T10:13:58.619842856Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_version_should_be_the_expected_one\n"
-}
-{
-    "Time": "2020-08-20T10:13:58.627892953Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:13:58.627968251Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_be_created"
-}
-{
-    "Time": "2020-08-20T10:13:58.627979516Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_be_created",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_services_should_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:13:58.63654803Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_be_created",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:13:58.636589116Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_have_endpoints"
-}
-{
-    "Time": "2020-08-20T10:13:58.636594985Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_have_endpoints",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_services_should_have_endpoints\n"
-}
-{
-    "Time": "2020-08-20T10:13:58.645386304Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_have_endpoints",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:13:58.645427605Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Secrets_should_eventually_be_created"
-}
-{
-    "Time": "2020-08-20T10:13:58.645432829Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Secrets_should_eventually_be_created",
-    "Output": "=== RUN   TestMutationMoreNodes/Secrets_should_eventually_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:13:58.68021572Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Secrets_should_eventually_be_created",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:13:58.680255024Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate"
-}
-{
-    "Time": "2020-08-20T10:13:58.680261594Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate\n"
-}
-{
-    "Time": "2020-08-20T10:13:58.688542869Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:13:58.688720318Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green"
-}
-{
-    "Time": "2020-08-20T10:13:58.688752652Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green\n"
-}
-{
-    "Time": "2020-08-20T10:14:01.698482353Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green",
-    "Output": "Retries (5m0s timeout): ..\n"
-}
-{
-    "Time": "2020-08-20T10:14:01.698538085Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elastic_password_should_be_available"
-}
-{
-    "Time": "2020-08-20T10:14:01.698543888Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elastic_password_should_be_available",
-    "Output": "=== RUN   TestMutationMoreNodes/Elastic_password_should_be_available\n"
-}
-{
-    "Time": "2020-08-20T10:14:01.703395807Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elastic_password_should_be_available",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:01.70344619Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type"
-}
-{
-    "Time": "2020-08-20T10:14:01.703455201Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Output": "=== RUN   TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type\n"
-}
-{
-    "Time": "2020-08-20T10:14:01.710376134Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped"
-}
-{
-    "Time": "2020-08-20T10:14:01.710425759Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "=== RUN   TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped\n"
-}
-{
-    "Time": "2020-08-20T10:14:01.714797541Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:01.714850978Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one"
-}
-{
-    "Time": "2020-08-20T10:14:01.714858903Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one\n"
-}
-{
-    "Time": "2020-08-20T10:14:01.852092497Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:01.852149487Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one#01"
-}
-{
-    "Time": "2020-08-20T10:14:01.852157345Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one#01",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_version_should_be_the_expected_one#01\n"
-}
-{
-    "Time": "2020-08-20T10:14:01.889250148Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:01.889294884Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable"
-}
-{
-    "Time": "2020-08-20T10:14:01.88930055Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable\n"
-}
-{
-    "Time": "2020-08-20T10:14:01.925439075Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:01.925480873Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Add_some_data_to_the_cluster_before_starting_the_mutation"
-}
-{
-    "Time": "2020-08-20T10:14:01.92548646Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Output": "=== RUN   TestMutationMoreNodes/Add_some_data_to_the_cluster_before_starting_the_mutation\n"
-}
-{
-    "Time": "2020-08-20T10:14:03.036980638Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Output": "{\"log.level\":\"info\",\"@timestamp\":\"2020-08-20T10:14:03.036Z\",\"log.logger\":\"e2e\",\"message\":\"Skipping test\",\"service.version\":\"0.0.0-SNAPSHOT+00000000\",\"service.type\":\"eck\",\"ecs.version\":\"1.4.0\",\"name\":\"Start querying Elasticsearch cluster health while mutation is going on\"}\n"
-}
-{
-    "Time": "2020-08-20T10:14:03.03705891Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"
-}
-{
-    "Time": "2020-08-20T10:14:03.037068304Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "=== RUN   TestMutationMoreNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"
-}
-{
-    "Time": "2020-08-20T10:14:03.03708119Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"
-}
-{
-    "Time": "2020-08-20T10:14:03.037087404Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "=== RUN   TestMutationMoreNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"
-}
-{
-    "Time": "2020-08-20T10:14:03.037096023Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose"
-}
-{
-    "Time": "2020-08-20T10:14:03.037101472Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "=== RUN   TestMutationMoreNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose\n"
-}
-{
-    "Time": "2020-08-20T10:14:03.069722955Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:03.069779393Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec"
-}
-{
-    "Time": "2020-08-20T10:14:03.069791376Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "=== RUN   TestMutationMoreNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec\n"
-}
-{
-    "Time": "2020-08-20T10:14:03.092266323Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:03.092323129Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Applying_the_Elasticsearch_mutation_should_succeed"
-}
-{
-    "Time": "2020-08-20T10:14:03.092331897Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "=== RUN   TestMutationMoreNodes/Applying_the_Elasticsearch_mutation_should_succeed\n"
-}
-{
-    "Time": "2020-08-20T10:14:03.115397158Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:03.115460681Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed#01"
-}
-{
-    "Time": "2020-08-20T10:14:03.115467622Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed#01\n"
-}
-{
-    "Time": "2020-08-20T10:14:03.123074432Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:03.123140068Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready#01"
-}
-{
-    "Time": "2020-08-20T10:14:03.123147107Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "=== RUN   TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready#01\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.293948052Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "Retries (30m0s timeout): ..........\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.29399644Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one#02"
-}
-{
-    "Time": "2020-08-20T10:14:30.294001725Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one#02",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_version_should_be_the_expected_one#02\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.304561826Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one#02",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.304614712Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_be_created#01"
-}
-{
-    "Time": "2020-08-20T10:14:30.304623941Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_be_created#01",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_services_should_be_created#01\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.313535823Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_be_created#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.313576846Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_have_endpoints#01"
-}
-{
-    "Time": "2020-08-20T10:14:30.313582107Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_have_endpoints#01",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_services_should_have_endpoints#01\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.323550075Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_have_endpoints#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.323594527Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Secrets_should_eventually_be_created#01"
-}
-{
-    "Time": "2020-08-20T10:14:30.323601839Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Secrets_should_eventually_be_created#01",
-    "Output": "=== RUN   TestMutationMoreNodes/Secrets_should_eventually_be_created#01\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.372250482Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Secrets_should_eventually_be_created#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.372294386Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate#01"
-}
-{
-    "Time": "2020-08-20T10:14:30.372306777Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate#01\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.385522624Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.385575117Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green#01"
-}
-{
-    "Time": "2020-08-20T10:14:30.385582545Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green#01\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.389266999Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.389309817Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elastic_password_should_be_available#01"
-}
-{
-    "Time": "2020-08-20T10:14:30.389318077Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elastic_password_should_be_available#01",
-    "Output": "=== RUN   TestMutationMoreNodes/Elastic_password_should_be_available#01\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.394830816Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elastic_password_should_be_available#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.394920207Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01"
-}
-{
-    "Time": "2020-08-20T10:14:30.394993937Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Output": "=== RUN   TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.399917287Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01"
-}
-{
-    "Time": "2020-08-20T10:14:30.399966079Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "=== RUN   TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.404077706Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.404118184Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01"
-}
-{
-    "Time": "2020-08-20T10:14:30.40412613Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.590404648Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.590466852Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one#03"
-}
-{
-    "Time": "2020-08-20T10:14:30.590472558Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one#03",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_version_should_be_the_expected_one#03\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.627450823Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one#03",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.627497024Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable#01"
-}
-{
-    "Time": "2020-08-20T10:14:30.627503Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "=== RUN   TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable#01\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.720325867Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.720373737Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Cluster_UUID_should_have_been_preserved"
-}
-{
-    "Time": "2020-08-20T10:14:30.720379383Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Cluster_UUID_should_have_been_preserved",
-    "Output": "=== RUN   TestMutationMoreNodes/Cluster_UUID_should_have_been_preserved\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.751327656Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"
-}
-{
-    "Time": "2020-08-20T10:14:30.751365716Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "=== RUN   TestMutationMoreNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.751373582Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"
-}
-{
-    "Time": "2020-08-20T10:14:30.751381563Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "=== RUN   TestMutationMoreNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.751631993Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "{\"log.level\":\"info\",\"@timestamp\":\"2020-08-20T10:14:30.751Z\",\"log.logger\":\"e2e\",\"message\":\"Skipping test\",\"service.version\":\"0.0.0-SNAPSHOT+00000000\",\"service.type\":\"eck\",\"ecs.version\":\"1.4.0\",\"name\":\"Elasticsearch cluster health should not have been red during mutation process\"}\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.751669961Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Data_added_initially_should_still_be_present"
-}
-{
-    "Time": "2020-08-20T10:14:30.751677414Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Data_added_initially_should_still_be_present",
-    "Output": "=== RUN   TestMutationMoreNodes/Data_added_initially_should_still_be_present\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.886111328Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Data_added_initially_should_still_be_present",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.886230095Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Deleting_Elasticsearch_should_return_no_error"
-}
-{
-    "Time": "2020-08-20T10:14:30.886259772Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Deleting_Elasticsearch_should_return_no_error",
-    "Output": "=== RUN   TestMutationMoreNodes/Deleting_Elasticsearch_should_return_no_error\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.896424013Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_should_not_be_there_anymore"
-}
-{
-    "Time": "2020-08-20T10:14:30.896468626Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_should_not_be_there_anymore",
-    "Output": "=== RUN   TestMutationMoreNodes/Elasticsearch_should_not_be_there_anymore\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.900874667Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_should_not_be_there_anymore",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:14:30.900903236Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_pods_should_eventually_be_removed"
-}
-{
-    "Time": "2020-08-20T10:14:30.900912204Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "=== RUN   TestMutationMoreNodes/Elasticsearch_pods_should_eventually_be_removed\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.010226776Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "Retries (5m0s timeout): ................\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.010277431Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/PVCs_should_eventually_be_removed"
-}
-{
-    "Time": "2020-08-20T10:15:16.010284174Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/PVCs_should_eventually_be_removed",
-    "Output": "=== RUN   TestMutationMoreNodes/PVCs_should_eventually_be_removed\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015206023Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/PVCs_should_eventually_be_removed",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015392346Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes",
-    "Output": "--- PASS: TestMutationMoreNodes (99.58s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015416477Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/K8S_should_be_accessible",
-    "Output": "    --- PASS: TestMutationMoreNodes/K8S_should_be_accessible (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015424381Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/K8S_should_be_accessible",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:15:16.015441323Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Label_test_pods",
-    "Output": "    --- PASS: TestMutationMoreNodes/Label_test_pods (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015448857Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Label_test_pods",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:15:16.015455276Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_CRDs_should_exist",
-    "Output": "    --- PASS: TestMutationMoreNodes/Elasticsearch_CRDs_should_exist (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015462752Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_CRDs_should_exist",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:15:16.015473984Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Webhook_endpoint_should_not_be_empty",
-    "Output": "    --- PASS: TestMutationMoreNodes/Webhook_endpoint_should_not_be_empty (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015495405Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Webhook_endpoint_should_not_be_empty",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:15:16.015504714Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "    --- PASS: TestMutationMoreNodes/Remove_Elasticsearch_if_it_already_exists (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015511769Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Remove_Elasticsearch_if_it_already_exists",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:15:16.015518198Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Output": "    --- PASS: TestMutationMoreNodes/Creating_an_Elasticsearch_cluster_should_succeed (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.01553188Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:15:16.015537547Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_cluster_should_be_created",
-    "Output": "    --- PASS: TestMutationMoreNodes/Elasticsearch_cluster_should_be_created (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015544483Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_cluster_should_be_created",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:15:16.015555265Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed (3.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015562844Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed",
-    "Elapsed": 3.02
-}
-{
-    "Time": "2020-08-20T10:15:16.015569047Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready",
-    "Output": "    --- PASS: TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready (18.12s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015584502Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready",
-    "Elapsed": 18.12
-}
-{
-    "Time": "2020-08-20T10:15:16.015590238Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_version_should_be_the_expected_one (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015596317Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:15:16.015606583Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_be_created",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_services_should_be_created (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015613211Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_be_created",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:15:16.01561939Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_have_endpoints",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_services_should_have_endpoints (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015632376Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_have_endpoints",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:15:16.015638335Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Secrets_should_eventually_be_created",
-    "Output": "    --- PASS: TestMutationMoreNodes/Secrets_should_eventually_be_created (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015643794Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Secrets_should_eventually_be_created",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:15:16.015649615Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015656356Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:15:16.015667706Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green (3.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.01567868Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green",
-    "Elapsed": 3.01
-}
-{
-    "Time": "2020-08-20T10:15:16.015691381Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elastic_password_should_be_available",
-    "Output": "    --- PASS: TestMutationMoreNodes/Elastic_password_should_be_available (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015698972Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elastic_password_should_be_available",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:15:16.015709176Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Output": "    --- PASS: TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.01571762Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:15:16.015724059Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "    --- PASS: TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015731105Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:15:16.015737478Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one (0.14s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015744653Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Elapsed": 0.14
-}
-{
-    "Time": "2020-08-20T10:15:16.015751078Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one#01",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_version_should_be_the_expected_one#01 (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015758031Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one#01",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:15:16.015764739Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015772031Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:15:16.015778212Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Output": "    --- PASS: TestMutationMoreNodes/Add_some_data_to_the_cluster_before_starting_the_mutation (1.11s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015788213Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Elapsed": 1.11
-}
-{
-    "Time": "2020-08-20T10:15:16.015799767Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "    --- PASS: TestMutationMoreNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015808449Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:15:16.015815121Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "    --- PASS: TestMutationMoreNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015822406Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:15:16.01582803Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "    --- PASS: TestMutationMoreNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015838137Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:15:16.015844762Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "    --- PASS: TestMutationMoreNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015852279Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:15:16.015858473Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "    --- PASS: TestMutationMoreNodes/Applying_the_Elasticsearch_mutation_should_succeed (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015865324Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:15:16.015876341Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015888996Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:15:16.015894942Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "    --- PASS: TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready#01 (27.17s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015901226Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready#01",
-    "Elapsed": 27.17
-}
-{
-    "Time": "2020-08-20T10:15:16.015941155Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one#02",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_version_should_be_the_expected_one#02 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015950778Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one#02",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:15:16.01596366Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_be_created#01",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_services_should_be_created#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.015971189Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_be_created#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:15:16.015978099Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_have_endpoints#01",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_services_should_have_endpoints#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.01598509Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_services_should_have_endpoints#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:15:16.015995513Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Secrets_should_eventually_be_created#01",
-    "Output": "    --- PASS: TestMutationMoreNodes/Secrets_should_eventually_be_created#01 (0.05s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.016002417Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Secrets_should_eventually_be_created#01",
-    "Elapsed": 0.05
-}
-{
-    "Time": "2020-08-20T10:15:16.016007667Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.016013649Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:15:16.016019816Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green#01 (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.016026598Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green#01",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:15:16.016033621Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elastic_password_should_be_available#01",
-    "Output": "    --- PASS: TestMutationMoreNodes/Elastic_password_should_be_available#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.016041808Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elastic_password_should_be_available#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:15:16.016048786Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Output": "    --- PASS: TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01 (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.016061074Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:15:16.016068129Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "    --- PASS: TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01 (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.016075368Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:15:16.016081549Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01 (0.19s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.016088412Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Elapsed": 0.19
-}
-{
-    "Time": "2020-08-20T10:15:16.01609478Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one#03",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_version_should_be_the_expected_one#03 (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.016101895Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_version_should_be_the_expected_one#03",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:15:16.016108066Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "    --- PASS: TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable#01 (0.09s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.016122783Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable#01",
-    "Elapsed": 0.09
-}
-{
-    "Time": "2020-08-20T10:15:16.016137778Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Cluster_UUID_should_have_been_preserved",
-    "Output": "    --- PASS: TestMutationMoreNodes/Cluster_UUID_should_have_been_preserved (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.016145626Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Cluster_UUID_should_have_been_preserved",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:15:16.016151947Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "    --- PASS: TestMutationMoreNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.016159564Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:15:16.01616626Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "    --- PASS: TestMutationMoreNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.01617388Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:15:16.016180126Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Data_added_initially_should_still_be_present",
-    "Output": "    --- PASS: TestMutationMoreNodes/Data_added_initially_should_still_be_present (0.13s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.016187412Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Data_added_initially_should_still_be_present",
-    "Elapsed": 0.13
-}
-{
-    "Time": "2020-08-20T10:15:16.016197493Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Deleting_Elasticsearch_should_return_no_error",
-    "Output": "    --- PASS: TestMutationMoreNodes/Deleting_Elasticsearch_should_return_no_error (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.016204359Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Deleting_Elasticsearch_should_return_no_error",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:15:16.016209751Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_should_not_be_there_anymore",
-    "Output": "    --- PASS: TestMutationMoreNodes/Elasticsearch_should_not_be_there_anymore (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.01621631Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_should_not_be_there_anymore",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:15:16.016224132Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "    --- PASS: TestMutationMoreNodes/Elasticsearch_pods_should_eventually_be_removed (45.11s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.016236783Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/Elasticsearch_pods_should_eventually_be_removed",
-    "Elapsed": 45.11
-}
-{
-    "Time": "2020-08-20T10:15:16.016248043Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/PVCs_should_eventually_be_removed",
-    "Output": "    --- PASS: TestMutationMoreNodes/PVCs_should_eventually_be_removed (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.016261591Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes/PVCs_should_eventually_be_removed",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:15:16.016271972Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationMoreNodes",
-    "Elapsed": 99.58
-}
-{
-    "Time": "2020-08-20T10:15:16.016313547Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes"
-}
-{
-    "Time": "2020-08-20T10:15:16.016334308Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes",
-    "Output": "=== RUN   TestMutationLessNodes\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.968913063Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/K8S_should_be_accessible"
-}
-{
-    "Time": "2020-08-20T10:15:16.968978026Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/K8S_should_be_accessible",
-    "Output": "=== RUN   TestMutationLessNodes/K8S_should_be_accessible\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.991020795Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/K8S_should_be_accessible",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:16.991061525Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Label_test_pods"
-}
-{
-    "Time": "2020-08-20T10:15:16.991066761Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Label_test_pods",
-    "Output": "=== RUN   TestMutationLessNodes/Label_test_pods\n"
-}
-{
-    "Time": "2020-08-20T10:15:17.039630327Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Label_test_pods",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:17.039698976Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_CRDs_should_exist"
-}
-{
-    "Time": "2020-08-20T10:15:17.039707404Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_CRDs_should_exist",
-    "Output": "=== RUN   TestMutationLessNodes/Elasticsearch_CRDs_should_exist\n"
-}
-{
-    "Time": "2020-08-20T10:15:17.044262804Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_CRDs_should_exist",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:17.044304104Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Webhook_endpoint_should_not_be_empty"
-}
-{
-    "Time": "2020-08-20T10:15:17.044311694Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Webhook_endpoint_should_not_be_empty",
-    "Output": "=== RUN   TestMutationLessNodes/Webhook_endpoint_should_not_be_empty\n"
-}
-{
-    "Time": "2020-08-20T10:15:17.050835415Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Webhook_endpoint_should_not_be_empty",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:17.050893237Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Remove_Elasticsearch_if_it_already_exists"
-}
-{
-    "Time": "2020-08-20T10:15:17.050906471Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "=== RUN   TestMutationLessNodes/Remove_Elasticsearch_if_it_already_exists\n"
-}
-{
-    "Time": "2020-08-20T10:15:17.070575422Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:17.07062391Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Creating_an_Elasticsearch_cluster_should_succeed"
-}
-{
-    "Time": "2020-08-20T10:15:17.070629972Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Output": "=== RUN   TestMutationLessNodes/Creating_an_Elasticsearch_cluster_should_succeed\n"
-}
-{
-    "Time": "2020-08-20T10:15:17.083115604Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_cluster_should_be_created"
-}
-{
-    "Time": "2020-08-20T10:15:17.083177278Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_cluster_should_be_created",
-    "Output": "=== RUN   TestMutationLessNodes/Elasticsearch_cluster_should_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:15:17.089109271Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed"
-}
-{
-    "Time": "2020-08-20T10:15:17.089154091Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "=== RUN   TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed\n"
-}
-{
-    "Time": "2020-08-20T10:15:20.104901612Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "Retries (5m0s timeout): ..\n"
-}
-{
-    "Time": "2020-08-20T10:15:20.104965608Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready"
-}
-{
-    "Time": "2020-08-20T10:15:20.104973409Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready",
-    "Output": "=== RUN   TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready\n"
-}
-{
-    "Time": "2020-08-20T10:15:44.261999786Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready",
-    "Output": "Retries (30m0s timeout): .........\n"
-}
-{
-    "Time": "2020-08-20T10:15:44.26209715Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one"
-}
-{
-    "Time": "2020-08-20T10:15:44.262106283Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one",
-    "Output": "=== RUN   TestMutationLessNodes/ES_version_should_be_the_expected_one\n"
-}
-{
-    "Time": "2020-08-20T10:15:44.271658103Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:44.271710648Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_be_created"
-}
-{
-    "Time": "2020-08-20T10:15:44.271719309Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_be_created",
-    "Output": "=== RUN   TestMutationLessNodes/ES_services_should_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:15:44.281968473Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_be_created",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:44.282023434Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_have_endpoints"
-}
-{
-    "Time": "2020-08-20T10:15:44.282032638Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_have_endpoints",
-    "Output": "=== RUN   TestMutationLessNodes/ES_services_should_have_endpoints\n"
-}
-{
-    "Time": "2020-08-20T10:15:44.292211958Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_have_endpoints",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:44.292265401Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Secrets_should_eventually_be_created"
-}
-{
-    "Time": "2020-08-20T10:15:44.292273795Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Secrets_should_eventually_be_created",
-    "Output": "=== RUN   TestMutationLessNodes/Secrets_should_eventually_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:15:44.326372134Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Secrets_should_eventually_be_created",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:44.326452162Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate"
-}
-{
-    "Time": "2020-08-20T10:15:44.326459792Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate",
-    "Output": "=== RUN   TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate\n"
-}
-{
-    "Time": "2020-08-20T10:15:44.344542334Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:44.344587797Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_cluster_health_should_eventually_be_green"
-}
-{
-    "Time": "2020-08-20T10:15:44.344595224Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_cluster_health_should_eventually_be_green",
-    "Output": "=== RUN   TestMutationLessNodes/ES_cluster_health_should_eventually_be_green\n"
-}
-{
-    "Time": "2020-08-20T10:15:50.358508464Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_cluster_health_should_eventually_be_green",
-    "Output": "Retries (5m0s timeout): ...\n"
-}
-{
-    "Time": "2020-08-20T10:15:50.358609322Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elastic_password_should_be_available"
-}
-{
-    "Time": "2020-08-20T10:15:50.358618228Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elastic_password_should_be_available",
-    "Output": "=== RUN   TestMutationLessNodes/Elastic_password_should_be_available\n"
-}
-{
-    "Time": "2020-08-20T10:15:50.363779328Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elastic_password_should_be_available",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:50.363823744Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type"
-}
-{
-    "Time": "2020-08-20T10:15:50.363830359Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Output": "=== RUN   TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type\n"
-}
-{
-    "Time": "2020-08-20T10:15:50.370251018Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped"
-}
-{
-    "Time": "2020-08-20T10:15:50.370285779Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "=== RUN   TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped\n"
-}
-{
-    "Time": "2020-08-20T10:15:50.374377365Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:50.374424218Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one"
-}
-{
-    "Time": "2020-08-20T10:15:50.37443241Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "=== RUN   TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one\n"
-}
-{
-    "Time": "2020-08-20T10:15:50.529414662Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:50.529458966Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one#01"
-}
-{
-    "Time": "2020-08-20T10:15:50.529464319Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one#01",
-    "Output": "=== RUN   TestMutationLessNodes/ES_version_should_be_the_expected_one#01\n"
-}
-{
-    "Time": "2020-08-20T10:15:50.566120578Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:50.566177414Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable"
-}
-{
-    "Time": "2020-08-20T10:15:50.566186049Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable",
-    "Output": "=== RUN   TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable\n"
-}
-{
-    "Time": "2020-08-20T10:15:50.612464937Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:50.612516325Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Add_some_data_to_the_cluster_before_starting_the_mutation"
-}
-{
-    "Time": "2020-08-20T10:15:50.612522463Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Output": "=== RUN   TestMutationLessNodes/Add_some_data_to_the_cluster_before_starting_the_mutation\n"
-}
-{
-    "Time": "2020-08-20T10:15:52.252681075Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on"
-}
-{
-    "Time": "2020-08-20T10:15:52.252720183Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on",
-    "Output": "=== RUN   TestMutationLessNodes/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on\n"
-}
-{
-    "Time": "2020-08-20T10:15:52.252733667Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"
-}
-{
-    "Time": "2020-08-20T10:15:52.252738314Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "=== RUN   TestMutationLessNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"
-}
-{
-    "Time": "2020-08-20T10:15:52.252748824Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"
-}
-{
-    "Time": "2020-08-20T10:15:52.252758424Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "=== RUN   TestMutationLessNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"
-}
-{
-    "Time": "2020-08-20T10:15:52.252766763Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose"
-}
-{
-    "Time": "2020-08-20T10:15:52.252772402Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "=== RUN   TestMutationLessNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose\n"
-}
-{
-    "Time": "2020-08-20T10:15:52.283816296Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:52.283861855Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec"
-}
-{
-    "Time": "2020-08-20T10:15:52.283868217Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "=== RUN   TestMutationLessNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec\n"
-}
-{
-    "Time": "2020-08-20T10:15:52.338348204Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:52.338409071Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Applying_the_Elasticsearch_mutation_should_succeed"
-}
-{
-    "Time": "2020-08-20T10:15:52.338416132Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "=== RUN   TestMutationLessNodes/Applying_the_Elasticsearch_mutation_should_succeed\n"
-}
-{
-    "Time": "2020-08-20T10:15:52.366109583Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:52.366159847Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed#01"
-}
-{
-    "Time": "2020-08-20T10:15:52.366168726Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "=== RUN   TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed#01\n"
-}
-{
-    "Time": "2020-08-20T10:15:52.374506838Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:15:52.374557718Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready#01"
-}
-{
-    "Time": "2020-08-20T10:15:52.374563146Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "=== RUN   TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready#01\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.706888144Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "Retries (30m0s timeout): ............................\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.70695606Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one#02"
-}
-{
-    "Time": "2020-08-20T10:17:13.706961997Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one#02",
-    "Output": "=== RUN   TestMutationLessNodes/ES_version_should_be_the_expected_one#02\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.717756087Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one#02",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.717807879Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_be_created#01"
-}
-{
-    "Time": "2020-08-20T10:17:13.717818316Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_be_created#01",
-    "Output": "=== RUN   TestMutationLessNodes/ES_services_should_be_created#01\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.725354172Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_be_created#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.725405271Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_have_endpoints#01"
-}
-{
-    "Time": "2020-08-20T10:17:13.725413272Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_have_endpoints#01",
-    "Output": "=== RUN   TestMutationLessNodes/ES_services_should_have_endpoints#01\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.738753057Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_have_endpoints#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.738797578Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Secrets_should_eventually_be_created#01"
-}
-{
-    "Time": "2020-08-20T10:17:13.738802791Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Secrets_should_eventually_be_created#01",
-    "Output": "=== RUN   TestMutationLessNodes/Secrets_should_eventually_be_created#01\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.774919507Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Secrets_should_eventually_be_created#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.774988023Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate#01"
-}
-{
-    "Time": "2020-08-20T10:17:13.774993977Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "=== RUN   TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate#01\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.783999608Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.784042569Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_cluster_health_should_eventually_be_green#01"
-}
-{
-    "Time": "2020-08-20T10:17:13.784047967Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "=== RUN   TestMutationLessNodes/ES_cluster_health_should_eventually_be_green#01\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.788833552Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.788876808Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elastic_password_should_be_available#01"
-}
-{
-    "Time": "2020-08-20T10:17:13.788881756Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elastic_password_should_be_available#01",
-    "Output": "=== RUN   TestMutationLessNodes/Elastic_password_should_be_available#01\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.793284413Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elastic_password_should_be_available#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.793344494Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01"
-}
-{
-    "Time": "2020-08-20T10:17:13.793353152Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Output": "=== RUN   TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.806559557Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01"
-}
-{
-    "Time": "2020-08-20T10:17:13.806598131Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "=== RUN   TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.813980568Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.814035671Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01"
-}
-{
-    "Time": "2020-08-20T10:17:13.814044444Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "=== RUN   TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.853908085Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.854038751Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one#03"
-}
-{
-    "Time": "2020-08-20T10:17:13.854046769Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one#03",
-    "Output": "=== RUN   TestMutationLessNodes/ES_version_should_be_the_expected_one#03\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.88199924Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one#03",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.882045652Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable#01"
-}
-{
-    "Time": "2020-08-20T10:17:13.882054149Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "=== RUN   TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable#01\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.91227191Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.912318714Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Cluster_UUID_should_have_been_preserved"
-}
-{
-    "Time": "2020-08-20T10:17:13.912324525Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Cluster_UUID_should_have_been_preserved",
-    "Output": "=== RUN   TestMutationLessNodes/Cluster_UUID_should_have_been_preserved\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.943326599Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"
-}
-{
-    "Time": "2020-08-20T10:17:13.943364806Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "=== RUN   TestMutationLessNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.943372287Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"
-}
-{
-    "Time": "2020-08-20T10:17:13.943377914Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "=== RUN   TestMutationLessNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.943583596Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process"
-}
-{
-    "Time": "2020-08-20T10:17:13.943600431Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process",
-    "Output": "=== RUN   TestMutationLessNodes/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process\n"
-}
-{
-    "Time": "2020-08-20T10:17:13.943611156Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Data_added_initially_should_still_be_present"
-}
-{
-    "Time": "2020-08-20T10:17:13.943616567Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Data_added_initially_should_still_be_present",
-    "Output": "=== RUN   TestMutationLessNodes/Data_added_initially_should_still_be_present\n"
-}
-{
-    "Time": "2020-08-20T10:17:14.028247668Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Data_added_initially_should_still_be_present",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:14.02829156Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Deleting_Elasticsearch_should_return_no_error"
-}
-{
-    "Time": "2020-08-20T10:17:14.028296667Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Deleting_Elasticsearch_should_return_no_error",
-    "Output": "=== RUN   TestMutationLessNodes/Deleting_Elasticsearch_should_return_no_error\n"
-}
-{
-    "Time": "2020-08-20T10:17:14.044658584Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_should_not_be_there_anymore"
-}
-{
-    "Time": "2020-08-20T10:17:14.044699271Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_should_not_be_there_anymore",
-    "Output": "=== RUN   TestMutationLessNodes/Elasticsearch_should_not_be_there_anymore\n"
-}
-{
-    "Time": "2020-08-20T10:17:14.049143033Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_should_not_be_there_anymore",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:14.049209001Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_pods_should_eventually_be_removed"
-}
-{
-    "Time": "2020-08-20T10:17:14.049214832Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "=== RUN   TestMutationLessNodes/Elasticsearch_pods_should_eventually_be_removed\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.135503906Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "Retries (5m0s timeout): ..............\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.135594023Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/PVCs_should_eventually_be_removed"
-}
-{
-    "Time": "2020-08-20T10:17:53.135602969Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/PVCs_should_eventually_be_removed",
-    "Output": "=== RUN   TestMutationLessNodes/PVCs_should_eventually_be_removed\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140082529Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/PVCs_should_eventually_be_removed",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140125573Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes",
-    "Output": "--- PASS: TestMutationLessNodes (157.12s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.14013754Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/K8S_should_be_accessible",
-    "Output": "    --- PASS: TestMutationLessNodes/K8S_should_be_accessible (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140144862Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/K8S_should_be_accessible",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:17:53.140155892Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Label_test_pods",
-    "Output": "    --- PASS: TestMutationLessNodes/Label_test_pods (0.05s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140163232Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Label_test_pods",
-    "Elapsed": 0.05
-}
-{
-    "Time": "2020-08-20T10:17:53.140170505Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_CRDs_should_exist",
-    "Output": "    --- PASS: TestMutationLessNodes/Elasticsearch_CRDs_should_exist (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140178254Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_CRDs_should_exist",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:17:53.140184368Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Webhook_endpoint_should_not_be_empty",
-    "Output": "    --- PASS: TestMutationLessNodes/Webhook_endpoint_should_not_be_empty (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140190207Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Webhook_endpoint_should_not_be_empty",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:17:53.140199955Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "    --- PASS: TestMutationLessNodes/Remove_Elasticsearch_if_it_already_exists (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140205537Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Remove_Elasticsearch_if_it_already_exists",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:17:53.140210274Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Output": "    --- PASS: TestMutationLessNodes/Creating_an_Elasticsearch_cluster_should_succeed (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140228046Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:17:53.140241423Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_cluster_should_be_created",
-    "Output": "    --- PASS: TestMutationLessNodes/Elasticsearch_cluster_should_be_created (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.14024959Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_cluster_should_be_created",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:17:53.140255043Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed (3.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140260416Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed",
-    "Elapsed": 3.02
-}
-{
-    "Time": "2020-08-20T10:17:53.140266505Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready",
-    "Output": "    --- PASS: TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready (24.16s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140272009Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready",
-    "Elapsed": 24.16
-}
-{
-    "Time": "2020-08-20T10:17:53.140277723Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_version_should_be_the_expected_one (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140283544Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:17:53.140295623Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_be_created",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_services_should_be_created (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140302645Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_be_created",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:17:53.140308621Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_have_endpoints",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_services_should_have_endpoints (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.14031526Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_have_endpoints",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:17:53.140335271Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Secrets_should_eventually_be_created",
-    "Output": "    --- PASS: TestMutationLessNodes/Secrets_should_eventually_be_created (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140348182Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Secrets_should_eventually_be_created",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:17:53.140353599Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140359483Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:17:53.140365048Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_cluster_health_should_eventually_be_green",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_cluster_health_should_eventually_be_green (6.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140370759Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_cluster_health_should_eventually_be_green",
-    "Elapsed": 6.01
-}
-{
-    "Time": "2020-08-20T10:17:53.140376823Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elastic_password_should_be_available",
-    "Output": "    --- PASS: TestMutationLessNodes/Elastic_password_should_be_available (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140394919Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elastic_password_should_be_available",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:17:53.140400906Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Output": "    --- PASS: TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140407551Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:17:53.140413304Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "    --- PASS: TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140425273Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:17:53.140430919Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one (0.15s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140437168Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Elapsed": 0.15
-}
-{
-    "Time": "2020-08-20T10:17:53.140442895Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one#01",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_version_should_be_the_expected_one#01 (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140448848Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one#01",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:17:53.140462667Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable (0.05s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140469219Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable",
-    "Elapsed": 0.05
-}
-{
-    "Time": "2020-08-20T10:17:53.140477653Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Output": "    --- PASS: TestMutationLessNodes/Add_some_data_to_the_cluster_before_starting_the_mutation (1.64s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140485869Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Elapsed": 1.64
-}
-{
-    "Time": "2020-08-20T10:17:53.140491375Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on",
-    "Output": "    --- PASS: TestMutationLessNodes/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140499271Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:17:53.140509618Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "    --- PASS: TestMutationLessNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.14051852Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:17:53.140524418Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "    --- PASS: TestMutationLessNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140536217Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:17:53.140541784Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "    --- PASS: TestMutationLessNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140548187Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:17:53.140558157Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "    --- PASS: TestMutationLessNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec (0.05s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140568501Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Elapsed": 0.05
-}
-{
-    "Time": "2020-08-20T10:17:53.140574067Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "    --- PASS: TestMutationLessNodes/Applying_the_Elasticsearch_mutation_should_succeed (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140579915Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:17:53.140585227Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140591065Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:17:53.140596756Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "    --- PASS: TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready#01 (81.33s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140602765Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready#01",
-    "Elapsed": 81.33
-}
-{
-    "Time": "2020-08-20T10:17:53.140629858Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one#02",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_version_should_be_the_expected_one#02 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140636643Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one#02",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:17:53.140642317Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_be_created#01",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_services_should_be_created#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.14064849Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_be_created#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:17:53.140653829Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_have_endpoints#01",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_services_should_have_endpoints#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.14066015Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_services_should_have_endpoints#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:17:53.140665555Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Secrets_should_eventually_be_created#01",
-    "Output": "    --- PASS: TestMutationLessNodes/Secrets_should_eventually_be_created#01 (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140671596Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Secrets_should_eventually_be_created#01",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:17:53.140676923Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140683441Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:17:53.140689317Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_cluster_health_should_eventually_be_green#01 (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140695814Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_cluster_health_should_eventually_be_green#01",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:17:53.140714393Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elastic_password_should_be_available#01",
-    "Output": "    --- PASS: TestMutationLessNodes/Elastic_password_should_be_available#01 (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140720523Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elastic_password_should_be_available#01",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:17:53.140725525Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Output": "    --- PASS: TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140731157Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:17:53.140737081Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "    --- PASS: TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140742773Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:17:53.140747833Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01 (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140753539Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:17:53.140758458Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one#03",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_version_should_be_the_expected_one#03 (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.14076706Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_version_should_be_the_expected_one#03",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:17:53.140772143Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "    --- PASS: TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable#01 (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140777587Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable#01",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:17:53.140782477Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Cluster_UUID_should_have_been_preserved",
-    "Output": "    --- PASS: TestMutationLessNodes/Cluster_UUID_should_have_been_preserved (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140838435Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Cluster_UUID_should_have_been_preserved",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:17:53.140858563Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "    --- PASS: TestMutationLessNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.14086619Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:17:53.140883105Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "    --- PASS: TestMutationLessNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140889871Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:17:53.140895859Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process",
-    "Output": "    --- PASS: TestMutationLessNodes/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140901577Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:17:53.140909832Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Data_added_initially_should_still_be_present",
-    "Output": "    --- PASS: TestMutationLessNodes/Data_added_initially_should_still_be_present (0.08s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140916013Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Data_added_initially_should_still_be_present",
-    "Elapsed": 0.08
-}
-{
-    "Time": "2020-08-20T10:17:53.140941919Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Deleting_Elasticsearch_should_return_no_error",
-    "Output": "    --- PASS: TestMutationLessNodes/Deleting_Elasticsearch_should_return_no_error (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140954928Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Deleting_Elasticsearch_should_return_no_error",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:17:53.140961387Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_should_not_be_there_anymore",
-    "Output": "    --- PASS: TestMutationLessNodes/Elasticsearch_should_not_be_there_anymore (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140968411Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_should_not_be_there_anymore",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:17:53.140980981Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "    --- PASS: TestMutationLessNodes/Elasticsearch_pods_should_eventually_be_removed (39.09s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.140987922Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/Elasticsearch_pods_should_eventually_be_removed",
-    "Elapsed": 39.09
-}
-{
-    "Time": "2020-08-20T10:17:53.140994557Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/PVCs_should_eventually_be_removed",
-    "Output": "    --- PASS: TestMutationLessNodes/PVCs_should_eventually_be_removed (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:17:53.141059008Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes/PVCs_should_eventually_be_removed",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:17:53.141071099Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationLessNodes",
-    "Elapsed": 157.12
-}
-{
-    "Time": "2020-08-20T10:17:53.141077299Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp"
-}
-{
-    "Time": "2020-08-20T10:17:53.141083935Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp",
-    "Output": "=== RUN   TestMutationResizeMemoryUp\n"
-}
-{
-    "Time": "2020-08-20T10:17:54.095852115Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/K8S_should_be_accessible"
-}
-{
-    "Time": "2020-08-20T10:17:54.095899912Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/K8S_should_be_accessible",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/K8S_should_be_accessible\n"
-}
-{
-    "Time": "2020-08-20T10:17:54.115283195Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/K8S_should_be_accessible",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:54.115337739Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Label_test_pods"
-}
-{
-    "Time": "2020-08-20T10:17:54.115345908Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Label_test_pods",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Label_test_pods\n"
-}
-{
-    "Time": "2020-08-20T10:17:54.155332125Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Label_test_pods",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:54.155386837Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_CRDs_should_exist"
-}
-{
-    "Time": "2020-08-20T10:17:54.155394549Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_CRDs_should_exist",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Elasticsearch_CRDs_should_exist\n"
-}
-{
-    "Time": "2020-08-20T10:17:54.161222281Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_CRDs_should_exist",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:54.161260363Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Webhook_endpoint_should_not_be_empty"
-}
-{
-    "Time": "2020-08-20T10:17:54.161265661Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Webhook_endpoint_should_not_be_empty",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Webhook_endpoint_should_not_be_empty\n"
-}
-{
-    "Time": "2020-08-20T10:17:54.166611924Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Webhook_endpoint_should_not_be_empty",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:54.166698709Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Remove_Elasticsearch_if_it_already_exists"
-}
-{
-    "Time": "2020-08-20T10:17:54.1667103Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Remove_Elasticsearch_if_it_already_exists\n"
-}
-{
-    "Time": "2020-08-20T10:17:54.191181142Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:17:54.191223135Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Creating_an_Elasticsearch_cluster_should_succeed"
-}
-{
-    "Time": "2020-08-20T10:17:54.191228573Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Creating_an_Elasticsearch_cluster_should_succeed\n"
-}
-{
-    "Time": "2020-08-20T10:17:54.211237739Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_cluster_should_be_created"
-}
-{
-    "Time": "2020-08-20T10:17:54.211297844Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_cluster_should_be_created",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Elasticsearch_cluster_should_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:17:54.218080635Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed"
-}
-{
-    "Time": "2020-08-20T10:17:54.218114308Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed\n"
-}
-{
-    "Time": "2020-08-20T10:17:57.233326503Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "Retries (5m0s timeout): ..\n"
-}
-{
-    "Time": "2020-08-20T10:17:57.233384642Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready"
-}
-{
-    "Time": "2020-08-20T10:17:57.23339288Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.423831639Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready",
-    "Output": "Retries (30m0s timeout): ...........\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.423941159Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one"
-}
-{
-    "Time": "2020-08-20T10:18:27.42395052Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.433882622Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.433947938Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_be_created"
-}
-{
-    "Time": "2020-08-20T10:18:27.43395662Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_be_created",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_services_should_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.44144043Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_be_created",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.441473607Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_have_endpoints"
-}
-{
-    "Time": "2020-08-20T10:18:27.441484981Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_have_endpoints",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_services_should_have_endpoints\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.447221383Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_have_endpoints",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.447256621Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Secrets_should_eventually_be_created"
-}
-{
-    "Time": "2020-08-20T10:18:27.447264161Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Secrets_should_eventually_be_created",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Secrets_should_eventually_be_created\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.486312389Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Secrets_should_eventually_be_created",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.486346162Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate"
-}
-{
-    "Time": "2020-08-20T10:18:27.486354665Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.515186859Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.515215535Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green"
-}
-{
-    "Time": "2020-08-20T10:18:27.515221175Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.521005034Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.521032891Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elastic_password_should_be_available"
-}
-{
-    "Time": "2020-08-20T10:18:27.521050723Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elastic_password_should_be_available",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Elastic_password_should_be_available\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.526680908Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elastic_password_should_be_available",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.52671489Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type"
-}
-{
-    "Time": "2020-08-20T10:18:27.526720352Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.533706741Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped"
-}
-{
-    "Time": "2020-08-20T10:18:27.533774092Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.53828118Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.53830867Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one"
-}
-{
-    "Time": "2020-08-20T10:18:27.538315864Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.673414181Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.673469643Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#01"
-}
-{
-    "Time": "2020-08-20T10:18:27.673476544Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#01",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#01\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.707551783Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.707595342Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable"
-}
-{
-    "Time": "2020-08-20T10:18:27.707604043Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.827205819Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:18:27.827257397Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Add_some_data_to_the_cluster_before_starting_the_mutation"
-}
-{
-    "Time": "2020-08-20T10:18:27.827270156Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Add_some_data_to_the_cluster_before_starting_the_mutation\n"
-}
-{
-    "Time": "2020-08-20T10:18:29.994002529Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on"
-}
-{
-    "Time": "2020-08-20T10:18:29.994054425Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on\n"
-}
-{
-    "Time": "2020-08-20T10:18:29.994642068Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"
-}
-{
-    "Time": "2020-08-20T10:18:29.99483486Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"
-}
-{
-    "Time": "2020-08-20T10:18:29.995105421Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"
-}
-{
-    "Time": "2020-08-20T10:18:29.995274425Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"
-}
-{
-    "Time": "2020-08-20T10:18:29.995303933Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose"
-}
-{
-    "Time": "2020-08-20T10:18:29.995311481Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose\n"
-}
-{
-    "Time": "2020-08-20T10:18:30.0313495Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:18:30.031391019Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Annotate_Pods_with_a_hash_of_their_Builder_spec"
-}
-{
-    "Time": "2020-08-20T10:18:30.031398932Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Annotate_Pods_with_a_hash_of_their_Builder_spec\n"
-}
-{
-    "Time": "2020-08-20T10:18:30.080664512Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:18:30.080707907Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Applying_the_Elasticsearch_mutation_should_succeed"
-}
-{
-    "Time": "2020-08-20T10:18:30.080713906Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Applying_the_Elasticsearch_mutation_should_succeed\n"
-}
-{
-    "Time": "2020-08-20T10:18:30.11082115Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:18:30.11087334Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed#01"
-}
-{
-    "Time": "2020-08-20T10:18:30.11087923Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed#01\n"
-}
-{
-    "Time": "2020-08-20T10:18:30.119819657Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:18:30.119867581Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready#01"
-}
-{
-    "Time": "2020-08-20T10:18:30.119875594Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready#01\n"
-}
-{
-    "Time": "2020-08-20T10:21:37.219836592Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "Retries (30m0s timeout): ...............................................................\n"
-}
-{
-    "Time": "2020-08-20T10:21:37.21997844Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#02"
-}
-{
-    "Time": "2020-08-20T10:21:37.219988296Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#02",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#02\n"
-}
-{
-    "Time": "2020-08-20T10:21:37.229189591Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#02",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:21:37.229251634Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_be_created#01"
-}
-{
-    "Time": "2020-08-20T10:21:37.229260162Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_be_created#01",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_services_should_be_created#01\n"
-}
-{
-    "Time": "2020-08-20T10:21:37.238680593Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_be_created#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:21:37.238739753Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_have_endpoints#01"
-}
-{
-    "Time": "2020-08-20T10:21:37.238747808Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_have_endpoints#01",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_services_should_have_endpoints#01\n"
-}
-{
-    "Time": "2020-08-20T10:21:37.248433476Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_have_endpoints#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:21:37.248544831Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Secrets_should_eventually_be_created#01"
-}
-{
-    "Time": "2020-08-20T10:21:37.248550433Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Secrets_should_eventually_be_created#01",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Secrets_should_eventually_be_created#01\n"
-}
-{
-    "Time": "2020-08-20T10:21:37.286382418Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Secrets_should_eventually_be_created#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:21:37.286428126Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate#01"
-}
-{
-    "Time": "2020-08-20T10:21:37.286437384Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate#01\n"
-}
-{
-    "Time": "2020-08-20T10:21:37.30505254Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:21:37.30510723Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green#01"
-}
-{
-    "Time": "2020-08-20T10:21:37.305115197Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green#01\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.340504179Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "Retries (5m0s timeout): .....\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.340579247Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elastic_password_should_be_available#01"
-}
-{
-    "Time": "2020-08-20T10:21:49.340586554Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elastic_password_should_be_available#01",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Elastic_password_should_be_available#01\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.345135178Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elastic_password_should_be_available#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.345176201Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type#01"
-}
-{
-    "Time": "2020-08-20T10:21:49.34518275Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type#01\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.351052533Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01"
-}
-{
-    "Time": "2020-08-20T10:21:49.351089222Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.354691395Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.354733955Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one#01"
-}
-{
-    "Time": "2020-08-20T10:21:49.354743559Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one#01\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.409267346Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.409318833Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#03"
-}
-{
-    "Time": "2020-08-20T10:21:49.409327184Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#03",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#03\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.44659469Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#03",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.446751085Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable#01"
-}
-{
-    "Time": "2020-08-20T10:21:49.446783263Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable#01\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.484353715Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.484407469Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Cluster_UUID_should_have_been_preserved"
-}
-{
-    "Time": "2020-08-20T10:21:49.484415254Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Cluster_UUID_should_have_been_preserved",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Cluster_UUID_should_have_been_preserved\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.529214059Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"
-}
-{
-    "Time": "2020-08-20T10:21:49.529251665Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.529267516Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"
-}
-{
-    "Time": "2020-08-20T10:21:49.529271512Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.529388176Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process"
-}
-{
-    "Time": "2020-08-20T10:21:49.529404753Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.529414464Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Data_added_initially_should_still_be_present"
-}
-{
-    "Time": "2020-08-20T10:21:49.529434087Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Data_added_initially_should_still_be_present",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Data_added_initially_should_still_be_present\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.667004784Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Data_added_initially_should_still_be_present",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.667056447Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Deleting_Elasticsearch_should_return_no_error"
-}
-{
-    "Time": "2020-08-20T10:21:49.667064798Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Deleting_Elasticsearch_should_return_no_error",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Deleting_Elasticsearch_should_return_no_error\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.67731282Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_should_not_be_there_anymore"
-}
-{
-    "Time": "2020-08-20T10:21:49.677362227Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_should_not_be_there_anymore",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Elasticsearch_should_not_be_there_anymore\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.683258973Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_should_not_be_there_anymore",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:21:49.683310148Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_pods_should_eventually_be_removed"
-}
-{
-    "Time": "2020-08-20T10:21:49.683317584Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/Elasticsearch_pods_should_eventually_be_removed\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.811792911Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "Retries (5m0s timeout): ................\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.811849225Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/PVCs_should_eventually_be_removed"
-}
-{
-    "Time": "2020-08-20T10:22:34.811857597Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/PVCs_should_eventually_be_removed",
-    "Output": "=== RUN   TestMutationResizeMemoryUp/PVCs_should_eventually_be_removed\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818182201Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/PVCs_should_eventually_be_removed",
-    "Output": "Retries (5m0s timeout): .\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818231819Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp",
-    "Output": "--- PASS: TestMutationResizeMemoryUp (281.68s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818241616Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/K8S_should_be_accessible",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/K8S_should_be_accessible (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818248293Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/K8S_should_be_accessible",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:22:34.818271108Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Label_test_pods",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Label_test_pods (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.81827843Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Label_test_pods",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:22:34.81828211Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_CRDs_should_exist",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Elasticsearch_CRDs_should_exist (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.81828587Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_CRDs_should_exist",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:22:34.818290654Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Webhook_endpoint_should_not_be_empty",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Webhook_endpoint_should_not_be_empty (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818294297Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Webhook_endpoint_should_not_be_empty",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:22:34.818297837Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Remove_Elasticsearch_if_it_already_exists",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Remove_Elasticsearch_if_it_already_exists (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818302593Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Remove_Elasticsearch_if_it_already_exists",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:22:34.818307512Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Creating_an_Elasticsearch_cluster_should_succeed (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818313429Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Creating_an_Elasticsearch_cluster_should_succeed",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:22:34.818318803Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_cluster_should_be_created",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Elasticsearch_cluster_should_be_created (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.81832426Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_cluster_should_be_created",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:22:34.818329303Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed (3.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818335384Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed",
-    "Elapsed": 3.02
-}
-{
-    "Time": "2020-08-20T10:22:34.818345586Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready (30.19s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818361106Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready",
-    "Elapsed": 30.19
-}
-{
-    "Time": "2020-08-20T10:22:34.818366688Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818372278Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:22:34.818377211Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_be_created",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_services_should_be_created (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818382992Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_be_created",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:22:34.818391494Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_have_endpoints",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_services_should_have_endpoints (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.81840188Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_have_endpoints",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:22:34.818407584Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Secrets_should_eventually_be_created",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Secrets_should_eventually_be_created (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818413335Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Secrets_should_eventually_be_created",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:22:34.818418306Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818424982Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:22:34.818430442Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.81843613Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:22:34.81845331Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elastic_password_should_be_available",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Elastic_password_should_be_available (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818459632Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elastic_password_should_be_available",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:22:34.8184645Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818471229Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:22:34.818476006Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.81848202Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:22:34.818494022Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one (0.14s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818500506Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one",
-    "Elapsed": 0.14
-}
-{
-    "Time": "2020-08-20T10:22:34.818505967Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#01",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#01 (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818511883Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#01",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:22:34.818516862Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable (0.12s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818522466Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable",
-    "Elapsed": 0.12
-}
-{
-    "Time": "2020-08-20T10:22:34.818527482Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Add_some_data_to_the_cluster_before_starting_the_mutation (2.17s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818533361Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Add_some_data_to_the_cluster_before_starting_the_mutation",
-    "Elapsed": 2.17
-}
-{
-    "Time": "2020-08-20T10:22:34.818538714Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818546163Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:22:34.818552075Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818558125Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:22:34.818563797Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818569934Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:22:34.818575424Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818599251Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:22:34.818612726Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Annotate_Pods_with_a_hash_of_their_Builder_spec (0.05s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818623134Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Annotate_Pods_with_a_hash_of_their_Builder_spec",
-    "Elapsed": 0.05
-}
-{
-    "Time": "2020-08-20T10:22:34.818629131Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Applying_the_Elasticsearch_mutation_should_succeed (0.03s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818635327Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Applying_the_Elasticsearch_mutation_should_succeed",
-    "Elapsed": 0.03
-}
-{
-    "Time": "2020-08-20T10:22:34.818641314Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.81864811Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:22:34.818653785Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready#01",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready#01 (187.10s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818660931Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready#01",
-    "Elapsed": 187.1
-}
-{
-    "Time": "2020-08-20T10:22:34.818674776Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#02",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#02 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.81868217Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#02",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:22:34.818687877Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_be_created#01",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_services_should_be_created#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818694064Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_be_created#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:22:34.818766138Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_have_endpoints#01",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_services_should_have_endpoints#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818776314Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_services_should_have_endpoints#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:22:34.818782369Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Secrets_should_eventually_be_created#01",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Secrets_should_eventually_be_created#01 (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818789377Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Secrets_should_eventually_be_created#01",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:22:34.818795046Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate#01",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate#01 (0.02s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.81880932Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate#01",
-    "Elapsed": 0.02
-}
-{
-    "Time": "2020-08-20T10:22:34.818815486Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green#01",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green#01 (12.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818821392Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green#01",
-    "Elapsed": 12.04
-}
-{
-    "Time": "2020-08-20T10:22:34.818827082Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elastic_password_should_be_available#01",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Elastic_password_should_be_available#01 (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818833276Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elastic_password_should_be_available#01",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:22:34.818838964Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type#01 (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818844796Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type#01",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:22:34.818850871Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01 (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818857028Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:22:34.818862608Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one#01 (0.05s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818868246Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one#01",
-    "Elapsed": 0.05
-}
-{
-    "Time": "2020-08-20T10:22:34.818873532Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#03",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#03 (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818879856Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#03",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:22:34.818885058Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable#01",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable#01 (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.81889074Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable#01",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:22:34.818896121Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Cluster_UUID_should_have_been_preserved",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Cluster_UUID_should_have_been_preserved (0.04s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818914394Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Cluster_UUID_should_have_been_preserved",
-    "Elapsed": 0.04
-}
-{
-    "Time": "2020-08-20T10:22:34.818935143Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818942928Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:22:34.818947962Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818954462Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:22:34.818959651Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process (0.00s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818965915Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process",
-    "Elapsed": 0
-}
-{
-    "Time": "2020-08-20T10:22:34.818977368Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Data_added_initially_should_still_be_present",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Data_added_initially_should_still_be_present (0.14s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.818984006Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Data_added_initially_should_still_be_present",
-    "Elapsed": 0.14
-}
-{
-    "Time": "2020-08-20T10:22:34.818991175Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Deleting_Elasticsearch_should_return_no_error",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Deleting_Elasticsearch_should_return_no_error (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.819001584Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Deleting_Elasticsearch_should_return_no_error",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:22:34.819007219Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_should_not_be_there_anymore",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Elasticsearch_should_not_be_there_anymore (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.819013301Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_should_not_be_there_anymore",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:22:34.819023868Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_pods_should_eventually_be_removed",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/Elasticsearch_pods_should_eventually_be_removed (45.13s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.819030339Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/Elasticsearch_pods_should_eventually_be_removed",
-    "Elapsed": 45.13
-}
-{
-    "Time": "2020-08-20T10:22:34.819036757Z",
-    "Action": "output",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/PVCs_should_eventually_be_removed",
-    "Output": "    --- PASS: TestMutationResizeMemoryUp/PVCs_should_eventually_be_removed (0.01s)\n"
-}
-{
-    "Time": "2020-08-20T10:22:34.81905663Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp/PVCs_should_eventually_be_removed",
-    "Elapsed": 0.01
-}
-{
-    "Time": "2020-08-20T10:22:34.819062086Z",
-    "Action": "pass",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryUp",
-    "Elapsed": 281.68
-}
-{
-    "Time": "2020-08-20T10:22:34.819068867Z",
-    "Action": "run",
-    "Package": "github.com/elastic/cloud-on-k8s/v2/test/e2e/es",
-    "Test": "TestMutationResizeMemoryDown"
-}
+{"Time":"2020-08-20T10:01:18.159868603Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e","Output":"testing: warning: no tests to run\n"}
+{"Time":"2020-08-20T10:01:18.160083783Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e","Output":"PASS\n"}
+{"Time":"2020-08-20T10:01:18.161043832Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e","Output":"ok  \tgithub.com/elastic/cloud-on-k8s/v2/test/e2e\t0.026s [no tests to run]\n"}
+{"Time":"2020-08-20T10:01:18.161082655Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e","Elapsed":0.026}
+{"Time":"2020-08-20T10:01:21.452154224Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/apm","Output":"testing: warning: no tests to run\n"}
+{"Time":"2020-08-20T10:01:21.45240745Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/apm","Output":"PASS\n"}
+{"Time":"2020-08-20T10:01:21.453918772Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/apm","Output":"ok  \tgithub.com/elastic/cloud-on-k8s/v2/test/e2e/apm\t0.037s [no tests to run]\n"}
+{"Time":"2020-08-20T10:01:21.453985823Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/apm","Elapsed":0.037}
+{"Time":"2020-08-20T10:01:24.924367369Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/beat","Output":"testing: warning: no tests to run\n"}
+{"Time":"2020-08-20T10:01:24.924562614Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/beat","Output":"PASS\n"}
+{"Time":"2020-08-20T10:01:24.926096221Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/beat","Output":"ok  \tgithub.com/elastic/cloud-on-k8s/v2/test/e2e/beat\t0.028s [no tests to run]\n"}
+{"Time":"2020-08-20T10:01:24.926131275Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/beat","Elapsed":0.028}
+{"Time":"2020-08-20T10:01:25.878697373Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/cmd","Output":"?   \tgithub.com/elastic/cloud-on-k8s/v2/test/e2e/cmd\t[no test files]\n"}
+{"Time":"2020-08-20T10:01:25.878846936Z","Action":"skip","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/cmd","Elapsed":0}
+{"Time":"2020-08-20T10:01:29.244943846Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/cmd/run","Output":"testing: warning: no tests to run\n"}
+{"Time":"2020-08-20T10:01:29.245155665Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/cmd/run","Output":"PASS\n"}
+{"Time":"2020-08-20T10:01:29.246502997Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/cmd/run","Output":"ok  \tgithub.com/elastic/cloud-on-k8s/v2/test/e2e/cmd/run\t0.028s [no tests to run]\n"}
+{"Time":"2020-08-20T10:01:29.246543557Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/cmd/run","Elapsed":0.028}
+{"Time":"2020-08-20T10:01:32.352678343Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/ent","Output":"testing: warning: no tests to run\n"}
+{"Time":"2020-08-20T10:01:32.352881621Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/ent","Output":"PASS\n"}
+{"Time":"2020-08-20T10:01:32.35460332Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/ent","Output":"ok  \tgithub.com/elastic/cloud-on-k8s/v2/test/e2e/ent\t0.028s [no tests to run]\n"}
+{"Time":"2020-08-20T10:01:32.354653299Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/ent","Elapsed":0.028}
+{"Time":"2020-08-20T10:01:36.463695508Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS"}
+{"Time":"2020-08-20T10:01:36.463945983Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS","Output":"=== RUN   TestMutationHTTPToHTTPS\n"}
+{"Time":"2020-08-20T10:01:36.464120104Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS","Output":"{\"log.level\":\"info\",\"@timestamp\":\"2020-08-20T10:01:36.464Z\",\"log.logger\":\"e2e\",\"message\":\"Test context initialized\",\"service.version\":\"0.0.0-SNAPSHOT+00000000\",\"service.type\":\"eck\",\"ecs.version\":\"1.4.0\",\"context\":{\"operator\":{\"name\":\"fake-psp-1-operator\",\"namespace\":\"fake-psp-1-elastic-system\",\"managed_namespaces\":[\"fake-psp-1-e2e-mercury\",\"fake-psp-1-e2e-venus\"]},\"e2e_image\":\"docker.elastic.co/eck-ci/eck-e2e-tests:4422f017\",\"e2e_namespace\":\"fake-psp-1\",\"e2e_service_account\":\"fake-psp-1\",\"elastic_stack_version\":\"7.8.1\",\"log_verbosity\":0,\"operator_image\":\"docker.elastic.co/eck-snapshots/eck-operator:1.3.0-SNAPSHOT-2020-08-17-4422f01\",\"test_license\":\"\",\"test_license_pkey_path\":\"\",\"test_regex\":\"TestMutation*\",\"test_run\":\"fake-psp-1\",\"monitoring_secrets\":\"/Users/michael/go/src/github.com/elastic/cloud-on-k8s/v2/note.out/my-monitoring-cluster.secret.yml\",\"test_timeout\":300000000000,\"auto_port_forwarding\":false,\"local\":false,\"ignore_webhook_failures\":false,\"ocp_cluster\":false,\"pipeline\":\"michael-pipeline-ocp\",\"build_n"}
+{"Time":"2020-08-20T10:01:36.46415882Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS","Output":"umber\":\"602\",\"provider\":\"ocp\",\"clusterName\":\"eck-pr-3766\",\"kubernetes_version\":\"default\"}}\n"}
+{"Time":"2020-08-20T10:01:37.418378609Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/K8S_should_be_accessible"}
+{"Time":"2020-08-20T10:01:37.418418281Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/K8S_should_be_accessible","Output":"=== RUN   TestMutationHTTPToHTTPS/K8S_should_be_accessible\n"}
+{"Time":"2020-08-20T10:01:37.442439286Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/K8S_should_be_accessible","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:01:37.442485017Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Label_test_pods"}
+{"Time":"2020-08-20T10:01:37.442490163Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Label_test_pods","Output":"=== RUN   TestMutationHTTPToHTTPS/Label_test_pods\n"}
+{"Time":"2020-08-20T10:01:37.488151315Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Label_test_pods","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:01:37.488321805Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_CRDs_should_exist"}
+{"Time":"2020-08-20T10:01:37.488443345Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_CRDs_should_exist","Output":"=== RUN   TestMutationHTTPToHTTPS/Elasticsearch_CRDs_should_exist\n"}
+{"Time":"2020-08-20T10:01:37.500481237Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_CRDs_should_exist","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:01:37.500534617Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Webhook_endpoint_should_not_be_empty"}
+{"Time":"2020-08-20T10:01:37.500541458Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Webhook_endpoint_should_not_be_empty","Output":"=== RUN   TestMutationHTTPToHTTPS/Webhook_endpoint_should_not_be_empty\n"}
+{"Time":"2020-08-20T10:01:37.506470395Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Webhook_endpoint_should_not_be_empty","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:01:37.506552208Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Remove_Elasticsearch_if_it_already_exists"}
+{"Time":"2020-08-20T10:01:37.506560149Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Remove_Elasticsearch_if_it_already_exists","Output":"=== RUN   TestMutationHTTPToHTTPS/Remove_Elasticsearch_if_it_already_exists\n"}
+{"Time":"2020-08-20T10:01:37.519353078Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Remove_Elasticsearch_if_it_already_exists","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:01:37.519392719Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Creating_an_Elasticsearch_cluster_should_succeed"}
+{"Time":"2020-08-20T10:01:37.519403749Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Creating_an_Elasticsearch_cluster_should_succeed","Output":"=== RUN   TestMutationHTTPToHTTPS/Creating_an_Elasticsearch_cluster_should_succeed\n"}
+{"Time":"2020-08-20T10:01:37.553908986Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_cluster_should_be_created"}
+{"Time":"2020-08-20T10:01:37.553958854Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_cluster_should_be_created","Output":"=== RUN   TestMutationHTTPToHTTPS/Elasticsearch_cluster_should_be_created\n"}
+{"Time":"2020-08-20T10:01:37.55794553Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed"}
+{"Time":"2020-08-20T10:01:37.557995562Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed\n"}
+{"Time":"2020-08-20T10:01:40.57063436Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed","Output":"Retries (5m0s timeout): ..\n"}
+{"Time":"2020-08-20T10:01:40.57068785Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready"}
+{"Time":"2020-08-20T10:01:40.570695402Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready","Output":"=== RUN   TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready\n"}
+{"Time":"2020-08-20T10:02:10.807049305Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready","Output":"Retries (30m0s timeout): ...........\n"}
+{"Time":"2020-08-20T10:02:10.80715182Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one"}
+{"Time":"2020-08-20T10:02:10.807158608Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one\n"}
+{"Time":"2020-08-20T10:02:10.823569233Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:02:10.823626489Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_be_created"}
+{"Time":"2020-08-20T10:02:10.823634897Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_be_created","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_services_should_be_created\n"}
+{"Time":"2020-08-20T10:02:10.834629574Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_be_created","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:02:10.834677671Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_have_endpoints"}
+{"Time":"2020-08-20T10:02:10.834684731Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_have_endpoints","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_services_should_have_endpoints\n"}
+{"Time":"2020-08-20T10:02:10.843110518Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_have_endpoints","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:02:10.843165296Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created"}
+{"Time":"2020-08-20T10:02:10.843172948Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created","Output":"=== RUN   TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created\n"}
+{"Time":"2020-08-20T10:02:10.884964878Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:02:10.885039543Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate"}
+{"Time":"2020-08-20T10:02:10.885047891Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate\n"}
+{"Time":"2020-08-20T10:02:10.904979676Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:02:10.905022386Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green"}
+{"Time":"2020-08-20T10:02:10.905027632Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green\n"}
+{"Time":"2020-08-20T10:02:10.90912104Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:02:10.909175378Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elastic_password_should_be_available"}
+{"Time":"2020-08-20T10:02:10.909182766Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elastic_password_should_be_available","Output":"=== RUN   TestMutationHTTPToHTTPS/Elastic_password_should_be_available\n"}
+{"Time":"2020-08-20T10:02:10.91367187Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elastic_password_should_be_available","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:02:10.913733988Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type"}
+{"Time":"2020-08-20T10:02:10.913742477Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type","Output":"=== RUN   TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type\n"}
+{"Time":"2020-08-20T10:02:10.920119221Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped"}
+{"Time":"2020-08-20T10:02:10.920170664Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"=== RUN   TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped\n"}
+{"Time":"2020-08-20T10:02:10.924975251Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:02:10.925026242Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one"}
+{"Time":"2020-08-20T10:02:10.925034755Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one\n"}
+{"Time":"2020-08-20T10:02:11.067079725Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:02:11.067133184Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#01"}
+{"Time":"2020-08-20T10:02:11.067139564Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#01","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#01\n"}
+{"Time":"2020-08-20T10:02:11.177881447Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:02:11.177952956Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable"}
+{"Time":"2020-08-20T10:02:11.177959954Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable\n"}
+{"Time":"2020-08-20T10:02:11.20952144Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:02:11.209583888Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Add_some_data_to_the_cluster_before_starting_the_mutation"}
+{"Time":"2020-08-20T10:02:11.209594012Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Add_some_data_to_the_cluster_before_starting_the_mutation","Output":"=== RUN   TestMutationHTTPToHTTPS/Add_some_data_to_the_cluster_before_starting_the_mutation\n"}
+{"Time":"2020-08-20T10:02:13.350868072Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on"}
+{"Time":"2020-08-20T10:02:13.350951629Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on","Output":"=== RUN   TestMutationHTTPToHTTPS/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on\n"}
+{"Time":"2020-08-20T10:02:13.35098242Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"}
+{"Time":"2020-08-20T10:02:13.350988845Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"=== RUN   TestMutationHTTPToHTTPS/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"}
+{"Time":"2020-08-20T10:02:13.350997579Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"}
+{"Time":"2020-08-20T10:02:13.351003056Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"=== RUN   TestMutationHTTPToHTTPS/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"}
+{"Time":"2020-08-20T10:02:13.351011051Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose"}
+{"Time":"2020-08-20T10:02:13.351017085Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"=== RUN   TestMutationHTTPToHTTPS/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose\n"}
+{"Time":"2020-08-20T10:02:13.372472803Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:02:13.372524609Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Annotate_Pods_with_a_hash_of_their_Builder_spec"}
+{"Time":"2020-08-20T10:02:13.372532989Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"=== RUN   TestMutationHTTPToHTTPS/Annotate_Pods_with_a_hash_of_their_Builder_spec\n"}
+{"Time":"2020-08-20T10:02:13.426223412Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:02:13.426284821Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Applying_the_Elasticsearch_mutation_should_succeed"}
+{"Time":"2020-08-20T10:02:13.426294442Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Applying_the_Elasticsearch_mutation_should_succeed","Output":"=== RUN   TestMutationHTTPToHTTPS/Applying_the_Elasticsearch_mutation_should_succeed\n"}
+{"Time":"2020-08-20T10:02:13.462158492Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Applying_the_Elasticsearch_mutation_should_succeed","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:02:13.462204208Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed#01"}
+{"Time":"2020-08-20T10:02:13.46221182Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed#01","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed#01\n"}
+{"Time":"2020-08-20T10:02:13.471137934Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:02:13.471191423Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready#01"}
+{"Time":"2020-08-20T10:02:13.471201474Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready#01","Output":"=== RUN   TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready#01\n"}
+{"Time":"2020-08-20T10:05:17.58794311Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready#01","Output":"Retries (30m0s timeout): ..............................................................\n"}
+{"Time":"2020-08-20T10:05:17.588049948Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#02"}
+{"Time":"2020-08-20T10:05:17.588062983Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#02","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#02\n"}
+{"Time":"2020-08-20T10:05:17.600874688Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#02","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:05:17.600978836Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_be_created#01"}
+{"Time":"2020-08-20T10:05:17.600987269Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_be_created#01","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_services_should_be_created#01\n"}
+{"Time":"2020-08-20T10:05:17.608673585Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_be_created#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:05:17.608728778Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_have_endpoints#01"}
+{"Time":"2020-08-20T10:05:17.608734605Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_have_endpoints#01","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_services_should_have_endpoints#01\n"}
+{"Time":"2020-08-20T10:05:17.61744184Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_have_endpoints#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:05:17.61749592Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created#01"}
+{"Time":"2020-08-20T10:05:17.61750434Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created#01","Output":"=== RUN   TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created#01\n"}
+{"Time":"2020-08-20T10:05:17.656063564Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:05:17.656121732Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate#01"}
+{"Time":"2020-08-20T10:05:17.656134904Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate#01","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate#01\n"}
+{"Time":"2020-08-20T10:05:17.675754701Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:05:17.675808801Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green#01"}
+{"Time":"2020-08-20T10:05:17.675817029Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green#01","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green#01\n"}
+{"Time":"2020-08-20T10:05:29.702958611Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green#01","Output":"Retries (5m0s timeout): .....\n"}
+{"Time":"2020-08-20T10:05:29.703028345Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elastic_password_should_be_available#01"}
+{"Time":"2020-08-20T10:05:29.703037411Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elastic_password_should_be_available#01","Output":"=== RUN   TestMutationHTTPToHTTPS/Elastic_password_should_be_available#01\n"}
+{"Time":"2020-08-20T10:05:29.707755123Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elastic_password_should_be_available#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:05:29.707809459Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type#01"}
+{"Time":"2020-08-20T10:05:29.70781869Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Output":"=== RUN   TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type#01\n"}
+{"Time":"2020-08-20T10:05:29.714332375Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01"}
+{"Time":"2020-08-20T10:05:29.71437226Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"=== RUN   TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01\n"}
+{"Time":"2020-08-20T10:05:29.718392712Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:05:29.718424306Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one#01"}
+{"Time":"2020-08-20T10:05:29.718430538Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one#01\n"}
+{"Time":"2020-08-20T10:05:29.76756575Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:05:29.767621696Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#03"}
+{"Time":"2020-08-20T10:05:29.767629085Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#03","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#03\n"}
+{"Time":"2020-08-20T10:05:29.802142209Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#03","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:05:29.802193617Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable#01"}
+{"Time":"2020-08-20T10:05:29.802201471Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable#01","Output":"=== RUN   TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable#01\n"}
+{"Time":"2020-08-20T10:05:29.838779646Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:05:29.838833292Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Cluster_UUID_should_have_been_preserved"}
+{"Time":"2020-08-20T10:05:29.838840853Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Cluster_UUID_should_have_been_preserved","Output":"=== RUN   TestMutationHTTPToHTTPS/Cluster_UUID_should_have_been_preserved\n"}
+{"Time":"2020-08-20T10:05:29.871145827Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"}
+{"Time":"2020-08-20T10:05:29.871194575Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"=== RUN   TestMutationHTTPToHTTPS/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"}
+{"Time":"2020-08-20T10:05:29.871212387Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"}
+{"Time":"2020-08-20T10:05:29.871218777Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"=== RUN   TestMutationHTTPToHTTPS/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"}
+{"Time":"2020-08-20T10:05:29.871396412Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process"}
+{"Time":"2020-08-20T10:05:29.871414366Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process","Output":"=== RUN   TestMutationHTTPToHTTPS/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process\n"}
+{"Time":"2020-08-20T10:05:29.87142831Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Data_added_initially_should_still_be_present"}
+{"Time":"2020-08-20T10:05:29.871434058Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Data_added_initially_should_still_be_present","Output":"=== RUN   TestMutationHTTPToHTTPS/Data_added_initially_should_still_be_present\n"}
+{"Time":"2020-08-20T10:05:30.003831766Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Data_added_initially_should_still_be_present","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:05:30.003876559Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Deleting_Elasticsearch_should_return_no_error"}
+{"Time":"2020-08-20T10:05:30.003882346Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Deleting_Elasticsearch_should_return_no_error","Output":"=== RUN   TestMutationHTTPToHTTPS/Deleting_Elasticsearch_should_return_no_error\n"}
+{"Time":"2020-08-20T10:05:30.02003686Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_should_not_be_there_anymore"}
+{"Time":"2020-08-20T10:05:30.020076213Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_should_not_be_there_anymore","Output":"=== RUN   TestMutationHTTPToHTTPS/Elasticsearch_should_not_be_there_anymore\n"}
+{"Time":"2020-08-20T10:05:30.026138761Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_should_not_be_there_anymore","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:05:30.0262051Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_pods_should_eventually_be_removed"}
+{"Time":"2020-08-20T10:05:30.026212899Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_pods_should_eventually_be_removed","Output":"=== RUN   TestMutationHTTPToHTTPS/Elasticsearch_pods_should_eventually_be_removed\n"}
+{"Time":"2020-08-20T10:06:48.219269279Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_pods_should_eventually_be_removed","Output":"Retries (5m0s timeout): ...........................\n"}
+{"Time":"2020-08-20T10:06:48.219354248Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/PVCs_should_eventually_be_removed"}
+{"Time":"2020-08-20T10:06:48.219361422Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/PVCs_should_eventually_be_removed","Output":"=== RUN   TestMutationHTTPToHTTPS/PVCs_should_eventually_be_removed\n"}
+{"Time":"2020-08-20T10:06:48.225784143Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/PVCs_should_eventually_be_removed","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:06:48.225846034Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS","Output":"--- PASS: TestMutationHTTPToHTTPS (311.76s)\n"}
+{"Time":"2020-08-20T10:06:48.225860996Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/K8S_should_be_accessible","Output":"    --- PASS: TestMutationHTTPToHTTPS/K8S_should_be_accessible (0.02s)\n"}
+{"Time":"2020-08-20T10:06:48.225870405Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/K8S_should_be_accessible","Elapsed":0.02}
+{"Time":"2020-08-20T10:06:48.225884216Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Label_test_pods","Output":"    --- PASS: TestMutationHTTPToHTTPS/Label_test_pods (0.05s)\n"}
+{"Time":"2020-08-20T10:06:48.225902147Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Label_test_pods","Elapsed":0.05}
+{"Time":"2020-08-20T10:06:48.225910217Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_CRDs_should_exist","Output":"    --- PASS: TestMutationHTTPToHTTPS/Elasticsearch_CRDs_should_exist (0.01s)\n"}
+{"Time":"2020-08-20T10:06:48.225939611Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_CRDs_should_exist","Elapsed":0.01}
+{"Time":"2020-08-20T10:06:48.225953024Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Webhook_endpoint_should_not_be_empty","Output":"    --- PASS: TestMutationHTTPToHTTPS/Webhook_endpoint_should_not_be_empty (0.01s)\n"}
+{"Time":"2020-08-20T10:06:48.225962051Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Webhook_endpoint_should_not_be_empty","Elapsed":0.01}
+{"Time":"2020-08-20T10:06:48.225971658Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Remove_Elasticsearch_if_it_already_exists","Output":"    --- PASS: TestMutationHTTPToHTTPS/Remove_Elasticsearch_if_it_already_exists (0.01s)\n"}
+{"Time":"2020-08-20T10:06:48.225990251Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Remove_Elasticsearch_if_it_already_exists","Elapsed":0.01}
+{"Time":"2020-08-20T10:06:48.22599896Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Creating_an_Elasticsearch_cluster_should_succeed","Output":"    --- PASS: TestMutationHTTPToHTTPS/Creating_an_Elasticsearch_cluster_should_succeed (0.03s)\n"}
+{"Time":"2020-08-20T10:06:48.226007542Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Creating_an_Elasticsearch_cluster_should_succeed","Elapsed":0.03}
+{"Time":"2020-08-20T10:06:48.226014737Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_cluster_should_be_created","Output":"    --- PASS: TestMutationHTTPToHTTPS/Elasticsearch_cluster_should_be_created (0.00s)\n"}
+{"Time":"2020-08-20T10:06:48.22602318Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_cluster_should_be_created","Elapsed":0}
+{"Time":"2020-08-20T10:06:48.226032539Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed (3.01s)\n"}
+{"Time":"2020-08-20T10:06:48.22603992Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed","Elapsed":3.01}
+{"Time":"2020-08-20T10:06:48.226047351Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready","Output":"    --- PASS: TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready (30.24s)\n"}
+{"Time":"2020-08-20T10:06:48.226058968Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready","Elapsed":30.24}
+{"Time":"2020-08-20T10:06:48.226066348Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one (0.02s)\n"}
+{"Time":"2020-08-20T10:06:48.226073922Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one","Elapsed":0.02}
+{"Time":"2020-08-20T10:06:48.226080628Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_be_created","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_services_should_be_created (0.01s)\n"}
+{"Time":"2020-08-20T10:06:48.226088993Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_be_created","Elapsed":0.01}
+{"Time":"2020-08-20T10:06:48.226096795Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_have_endpoints","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_services_should_have_endpoints (0.01s)\n"}
+{"Time":"2020-08-20T10:06:48.226105282Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_have_endpoints","Elapsed":0.01}
+{"Time":"2020-08-20T10:06:48.226112905Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created","Output":"    --- PASS: TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created (0.04s)\n"}
+{"Time":"2020-08-20T10:06:48.226123978Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created","Elapsed":0.04}
+{"Time":"2020-08-20T10:06:48.226131601Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate (0.02s)\n"}
+{"Time":"2020-08-20T10:06:48.226139465Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate","Elapsed":0.02}
+{"Time":"2020-08-20T10:06:48.226149291Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green (0.00s)\n"}
+{"Time":"2020-08-20T10:06:48.226158118Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green","Elapsed":0}
+{"Time":"2020-08-20T10:06:48.226167617Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elastic_password_should_be_available","Output":"    --- PASS: TestMutationHTTPToHTTPS/Elastic_password_should_be_available (0.00s)\n"}
+{"Time":"2020-08-20T10:06:48.226175512Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elastic_password_should_be_available","Elapsed":0}
+{"Time":"2020-08-20T10:06:48.226182363Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type","Output":"    --- PASS: TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type (0.01s)\n"}
+{"Time":"2020-08-20T10:06:48.226190872Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type","Elapsed":0.01}
+{"Time":"2020-08-20T10:06:48.226203923Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"    --- PASS: TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped (0.00s)\n"}
+{"Time":"2020-08-20T10:06:48.226212341Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Elapsed":0}
+{"Time":"2020-08-20T10:06:48.226219108Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one (0.14s)\n"}
+{"Time":"2020-08-20T10:06:48.226234104Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one","Elapsed":0.14}
+{"Time":"2020-08-20T10:06:48.226241697Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#01","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#01 (0.11s)\n"}
+{"Time":"2020-08-20T10:06:48.226249901Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#01","Elapsed":0.11}
+{"Time":"2020-08-20T10:06:48.226256972Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable (0.03s)\n"}
+{"Time":"2020-08-20T10:06:48.226264987Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable","Elapsed":0.03}
+{"Time":"2020-08-20T10:06:48.226275246Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Add_some_data_to_the_cluster_before_starting_the_mutation","Output":"    --- PASS: TestMutationHTTPToHTTPS/Add_some_data_to_the_cluster_before_starting_the_mutation (2.14s)\n"}
+{"Time":"2020-08-20T10:06:48.22628885Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Add_some_data_to_the_cluster_before_starting_the_mutation","Elapsed":2.14}
+{"Time":"2020-08-20T10:06:48.226296646Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on","Output":"    --- PASS: TestMutationHTTPToHTTPS/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on (0.00s)\n"}
+{"Time":"2020-08-20T10:06:48.226312571Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on","Elapsed":0}
+{"Time":"2020-08-20T10:06:48.226320804Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"    --- PASS: TestMutationHTTPToHTTPS/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"}
+{"Time":"2020-08-20T10:06:48.226331889Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Elapsed":0}
+{"Time":"2020-08-20T10:06:48.226367961Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"    --- PASS: TestMutationHTTPToHTTPS/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"}
+{"Time":"2020-08-20T10:06:48.226393314Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Elapsed":0}
+{"Time":"2020-08-20T10:06:48.226400301Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"    --- PASS: TestMutationHTTPToHTTPS/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose (0.02s)\n"}
+{"Time":"2020-08-20T10:06:48.226410166Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Elapsed":0.02}
+{"Time":"2020-08-20T10:06:48.226419513Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"    --- PASS: TestMutationHTTPToHTTPS/Annotate_Pods_with_a_hash_of_their_Builder_spec (0.05s)\n"}
+{"Time":"2020-08-20T10:06:48.226427232Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Annotate_Pods_with_a_hash_of_their_Builder_spec","Elapsed":0.05}
+{"Time":"2020-08-20T10:06:48.226434167Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Applying_the_Elasticsearch_mutation_should_succeed","Output":"    --- PASS: TestMutationHTTPToHTTPS/Applying_the_Elasticsearch_mutation_should_succeed (0.04s)\n"}
+{"Time":"2020-08-20T10:06:48.226454836Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Applying_the_Elasticsearch_mutation_should_succeed","Elapsed":0.04}
+{"Time":"2020-08-20T10:06:48.226462796Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed#01","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:06:48.226470636Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_certificate_authority_should_be_set_and_deployed#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:06:48.226480951Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready#01","Output":"    --- PASS: TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready#01 (184.12s)\n"}
+{"Time":"2020-08-20T10:06:48.22649275Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready#01","Elapsed":184.12}
+{"Time":"2020-08-20T10:06:48.226499981Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#02","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#02 (0.01s)\n"}
+{"Time":"2020-08-20T10:06:48.226541962Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#02","Elapsed":0.01}
+{"Time":"2020-08-20T10:06:48.226550673Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_be_created#01","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_services_should_be_created#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:06:48.226560107Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_be_created#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:06:48.226569168Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_have_endpoints#01","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_services_should_have_endpoints#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:06:48.226577038Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_services_should_have_endpoints#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:06:48.226603484Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created#01","Output":"    --- PASS: TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created#01 (0.04s)\n"}
+{"Time":"2020-08-20T10:06:48.226717595Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Secrets_should_eventually_be_created#01","Elapsed":0.04}
+{"Time":"2020-08-20T10:06:48.226735182Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate#01","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate#01 (0.02s)\n"}
+{"Time":"2020-08-20T10:06:48.226741505Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_pods_should_eventually_have_a_certificate#01","Elapsed":0.02}
+{"Time":"2020-08-20T10:06:48.226747257Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green#01","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green#01 (12.03s)\n"}
+{"Time":"2020-08-20T10:06:48.226779972Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_cluster_health_should_eventually_be_green#01","Elapsed":12.03}
+{"Time":"2020-08-20T10:06:48.226788305Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elastic_password_should_be_available#01","Output":"    --- PASS: TestMutationHTTPToHTTPS/Elastic_password_should_be_available#01 (0.00s)\n"}
+{"Time":"2020-08-20T10:06:48.226796136Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elastic_password_should_be_available#01","Elapsed":0}
+{"Time":"2020-08-20T10:06:48.226803448Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Output":"    --- PASS: TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:06:48.22685238Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:06:48.226864903Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"    --- PASS: TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01 (0.00s)\n"}
+{"Time":"2020-08-20T10:06:48.22690158Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Elapsed":0}
+{"Time":"2020-08-20T10:06:48.226976431Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one#01 (0.05s)\n"}
+{"Time":"2020-08-20T10:06:48.22698697Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_nodes_topology_should_eventually_be_the_expected_one#01","Elapsed":0.05}
+{"Time":"2020-08-20T10:06:48.227021844Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#03","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#03 (0.03s)\n"}
+{"Time":"2020-08-20T10:06:48.227031128Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_version_should_be_the_expected_one#03","Elapsed":0.03}
+{"Time":"2020-08-20T10:06:48.227038505Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable#01","Output":"    --- PASS: TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable#01 (0.04s)\n"}
+{"Time":"2020-08-20T10:06:48.227046654Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/ES_endpoint_should_eventually_be_reachable#01","Elapsed":0.04}
+{"Time":"2020-08-20T10:06:48.227059642Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Cluster_UUID_should_have_been_preserved","Output":"    --- PASS: TestMutationHTTPToHTTPS/Cluster_UUID_should_have_been_preserved (0.03s)\n"}
+{"Time":"2020-08-20T10:06:48.227070298Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Cluster_UUID_should_have_been_preserved","Elapsed":0.03}
+{"Time":"2020-08-20T10:06:48.227084576Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"    --- PASS: TestMutationHTTPToHTTPS/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"}
+{"Time":"2020-08-20T10:06:48.227093431Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Elapsed":0}
+{"Time":"2020-08-20T10:06:48.227130707Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"    --- PASS: TestMutationHTTPToHTTPS/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"}
+{"Time":"2020-08-20T10:06:48.227149445Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Elapsed":0}
+{"Time":"2020-08-20T10:06:48.227158301Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process","Output":"    --- PASS: TestMutationHTTPToHTTPS/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process (0.00s)\n"}
+{"Time":"2020-08-20T10:06:48.22720967Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process","Elapsed":0}
+{"Time":"2020-08-20T10:06:48.227231855Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Data_added_initially_should_still_be_present","Output":"    --- PASS: TestMutationHTTPToHTTPS/Data_added_initially_should_still_be_present (0.13s)\n"}
+{"Time":"2020-08-20T10:06:48.227241713Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Data_added_initially_should_still_be_present","Elapsed":0.13}
+{"Time":"2020-08-20T10:06:48.227274805Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Deleting_Elasticsearch_should_return_no_error","Output":"    --- PASS: TestMutationHTTPToHTTPS/Deleting_Elasticsearch_should_return_no_error (0.02s)\n"}
+{"Time":"2020-08-20T10:06:48.227283976Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Deleting_Elasticsearch_should_return_no_error","Elapsed":0.02}
+{"Time":"2020-08-20T10:06:48.227294331Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_should_not_be_there_anymore","Output":"    --- PASS: TestMutationHTTPToHTTPS/Elasticsearch_should_not_be_there_anymore (0.01s)\n"}
+{"Time":"2020-08-20T10:06:48.227307091Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_should_not_be_there_anymore","Elapsed":0.01}
+{"Time":"2020-08-20T10:06:48.22731485Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_pods_should_eventually_be_removed","Output":"    --- PASS: TestMutationHTTPToHTTPS/Elasticsearch_pods_should_eventually_be_removed (78.19s)\n"}
+{"Time":"2020-08-20T10:06:48.227328867Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/Elasticsearch_pods_should_eventually_be_removed","Elapsed":78.19}
+{"Time":"2020-08-20T10:06:48.227336994Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/PVCs_should_eventually_be_removed","Output":"    --- PASS: TestMutationHTTPToHTTPS/PVCs_should_eventually_be_removed (0.01s)\n"}
+{"Time":"2020-08-20T10:06:48.227401384Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS/PVCs_should_eventually_be_removed","Elapsed":0.01}
+{"Time":"2020-08-20T10:06:48.227415501Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPToHTTPS","Elapsed":311.76}
+{"Time":"2020-08-20T10:06:48.227427825Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP"}
+{"Time":"2020-08-20T10:06:48.227438023Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP","Output":"=== RUN   TestMutationHTTPSToHTTP\n"}
+{"Time":"2020-08-20T10:06:49.180769581Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/K8S_should_be_accessible"}
+{"Time":"2020-08-20T10:06:49.180810973Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/K8S_should_be_accessible","Output":"=== RUN   TestMutationHTTPSToHTTP/K8S_should_be_accessible\n"}
+{"Time":"2020-08-20T10:06:49.201557518Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/K8S_should_be_accessible","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:06:49.201604461Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Label_test_pods"}
+{"Time":"2020-08-20T10:06:49.201612765Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Label_test_pods","Output":"=== RUN   TestMutationHTTPSToHTTP/Label_test_pods\n"}
+{"Time":"2020-08-20T10:06:49.245880692Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Label_test_pods","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:06:49.245982216Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_CRDs_should_exist"}
+{"Time":"2020-08-20T10:06:49.245991055Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_CRDs_should_exist","Output":"=== RUN   TestMutationHTTPSToHTTP/Elasticsearch_CRDs_should_exist\n"}
+{"Time":"2020-08-20T10:06:49.251164529Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_CRDs_should_exist","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:06:49.251206712Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Webhook_endpoint_should_not_be_empty"}
+{"Time":"2020-08-20T10:06:49.25121438Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Webhook_endpoint_should_not_be_empty","Output":"=== RUN   TestMutationHTTPSToHTTP/Webhook_endpoint_should_not_be_empty\n"}
+{"Time":"2020-08-20T10:06:49.254817708Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Webhook_endpoint_should_not_be_empty","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:06:49.254858459Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Remove_Elasticsearch_if_it_already_exists"}
+{"Time":"2020-08-20T10:06:49.25486549Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Remove_Elasticsearch_if_it_already_exists","Output":"=== RUN   TestMutationHTTPSToHTTP/Remove_Elasticsearch_if_it_already_exists\n"}
+{"Time":"2020-08-20T10:06:49.268445153Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Remove_Elasticsearch_if_it_already_exists","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:06:49.268485575Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Creating_an_Elasticsearch_cluster_should_succeed"}
+{"Time":"2020-08-20T10:06:49.268493061Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Creating_an_Elasticsearch_cluster_should_succeed","Output":"=== RUN   TestMutationHTTPSToHTTP/Creating_an_Elasticsearch_cluster_should_succeed\n"}
+{"Time":"2020-08-20T10:06:49.289528187Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_cluster_should_be_created"}
+{"Time":"2020-08-20T10:06:49.289568445Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_cluster_should_be_created","Output":"=== RUN   TestMutationHTTPSToHTTP/Elasticsearch_cluster_should_be_created\n"}
+{"Time":"2020-08-20T10:06:49.294658973Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed"}
+{"Time":"2020-08-20T10:06:49.294710466Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed\n"}
+{"Time":"2020-08-20T10:06:52.308767057Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed","Output":"Retries (5m0s timeout): ..\n"}
+{"Time":"2020-08-20T10:06:52.308836827Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready"}
+{"Time":"2020-08-20T10:06:52.308845087Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready","Output":"=== RUN   TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready\n"}
+{"Time":"2020-08-20T10:07:19.558308686Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready","Output":"Retries (30m0s timeout): ..........\n"}
+{"Time":"2020-08-20T10:07:19.558406523Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one"}
+{"Time":"2020-08-20T10:07:19.558418313Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one\n"}
+{"Time":"2020-08-20T10:07:19.579587599Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:07:19.579628316Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_be_created"}
+{"Time":"2020-08-20T10:07:19.579638621Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_be_created","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_services_should_be_created\n"}
+{"Time":"2020-08-20T10:07:19.599592343Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_be_created","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:07:19.59964511Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_have_endpoints"}
+{"Time":"2020-08-20T10:07:19.599653264Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_have_endpoints","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_services_should_have_endpoints\n"}
+{"Time":"2020-08-20T10:07:19.611109768Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_have_endpoints","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:07:19.611149002Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created"}
+{"Time":"2020-08-20T10:07:19.611154022Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created","Output":"=== RUN   TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created\n"}
+{"Time":"2020-08-20T10:07:19.671867255Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:07:19.671919276Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate"}
+{"Time":"2020-08-20T10:07:19.671957213Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate\n"}
+{"Time":"2020-08-20T10:07:19.694255824Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:07:19.694305406Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green"}
+{"Time":"2020-08-20T10:07:19.694311893Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green\n"}
+{"Time":"2020-08-20T10:07:22.704950828Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green","Output":"Retries (5m0s timeout): ..\n"}
+{"Time":"2020-08-20T10:07:22.705063222Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elastic_password_should_be_available"}
+{"Time":"2020-08-20T10:07:22.705086077Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elastic_password_should_be_available","Output":"=== RUN   TestMutationHTTPSToHTTP/Elastic_password_should_be_available\n"}
+{"Time":"2020-08-20T10:07:22.710041986Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elastic_password_should_be_available","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:07:22.710083098Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type"}
+{"Time":"2020-08-20T10:07:22.710090495Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type","Output":"=== RUN   TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type\n"}
+{"Time":"2020-08-20T10:07:22.719611098Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped"}
+{"Time":"2020-08-20T10:07:22.719640499Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"=== RUN   TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped\n"}
+{"Time":"2020-08-20T10:07:22.724043921Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:07:22.724083609Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one"}
+{"Time":"2020-08-20T10:07:22.724091367Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one\n"}
+{"Time":"2020-08-20T10:07:22.86688393Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:07:22.867002446Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#01"}
+{"Time":"2020-08-20T10:07:22.867016248Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#01","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#01\n"}
+{"Time":"2020-08-20T10:07:22.995833339Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:07:22.995886108Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable"}
+{"Time":"2020-08-20T10:07:22.995893607Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable\n"}
+{"Time":"2020-08-20T10:07:23.029183142Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:07:23.029236693Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Add_some_data_to_the_cluster_before_starting_the_mutation"}
+{"Time":"2020-08-20T10:07:23.029245074Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Add_some_data_to_the_cluster_before_starting_the_mutation","Output":"=== RUN   TestMutationHTTPSToHTTP/Add_some_data_to_the_cluster_before_starting_the_mutation\n"}
+{"Time":"2020-08-20T10:07:25.04167077Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on"}
+{"Time":"2020-08-20T10:07:25.041711754Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on","Output":"=== RUN   TestMutationHTTPSToHTTP/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on\n"}
+{"Time":"2020-08-20T10:07:25.041725953Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"}
+{"Time":"2020-08-20T10:07:25.041732055Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"=== RUN   TestMutationHTTPSToHTTP/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"}
+{"Time":"2020-08-20T10:07:25.041738445Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"}
+{"Time":"2020-08-20T10:07:25.041743447Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"=== RUN   TestMutationHTTPSToHTTP/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"}
+{"Time":"2020-08-20T10:07:25.041749818Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose"}
+{"Time":"2020-08-20T10:07:25.041756911Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"=== RUN   TestMutationHTTPSToHTTP/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose\n"}
+{"Time":"2020-08-20T10:07:25.180897351Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:07:25.180973447Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Annotate_Pods_with_a_hash_of_their_Builder_spec"}
+{"Time":"2020-08-20T10:07:25.180982994Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"=== RUN   TestMutationHTTPSToHTTP/Annotate_Pods_with_a_hash_of_their_Builder_spec\n"}
+{"Time":"2020-08-20T10:07:25.230385839Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:07:25.230486835Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Applying_the_Elasticsearch_mutation_should_succeed"}
+{"Time":"2020-08-20T10:07:25.230494915Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Applying_the_Elasticsearch_mutation_should_succeed","Output":"=== RUN   TestMutationHTTPSToHTTP/Applying_the_Elasticsearch_mutation_should_succeed\n"}
+{"Time":"2020-08-20T10:07:25.264427064Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Applying_the_Elasticsearch_mutation_should_succeed","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:07:25.26447194Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed#01"}
+{"Time":"2020-08-20T10:07:25.264477334Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed#01","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed#01\n"}
+{"Time":"2020-08-20T10:07:25.272711928Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:07:25.272760463Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready#01"}
+{"Time":"2020-08-20T10:07:25.272802295Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready#01","Output":"=== RUN   TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready#01\n"}
+{"Time":"2020-08-20T10:10:29.418655635Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready#01","Output":"Retries (30m0s timeout): ..............................................................\n"}
+{"Time":"2020-08-20T10:10:29.418823314Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#02"}
+{"Time":"2020-08-20T10:10:29.418833436Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#02","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#02\n"}
+{"Time":"2020-08-20T10:10:29.427535021Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#02","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:10:29.427613543Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_be_created#01"}
+{"Time":"2020-08-20T10:10:29.427622753Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_be_created#01","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_services_should_be_created#01\n"}
+{"Time":"2020-08-20T10:10:29.43568902Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_be_created#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:10:29.435744783Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_have_endpoints#01"}
+{"Time":"2020-08-20T10:10:29.435751313Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_have_endpoints#01","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_services_should_have_endpoints#01\n"}
+{"Time":"2020-08-20T10:10:29.441703839Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_have_endpoints#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:10:29.44178511Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created#01"}
+{"Time":"2020-08-20T10:10:29.4417941Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created#01","Output":"=== RUN   TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created#01\n"}
+{"Time":"2020-08-20T10:10:29.47498606Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:10:29.475039034Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate#01"}
+{"Time":"2020-08-20T10:10:29.47505064Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate#01","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate#01\n"}
+{"Time":"2020-08-20T10:10:29.492744188Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:10:29.492798187Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green#01"}
+{"Time":"2020-08-20T10:10:29.492806722Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green#01","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green#01\n"}
+{"Time":"2020-08-20T10:10:32.501576647Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green#01","Output":"Retries (5m0s timeout): ..\n"}
+{"Time":"2020-08-20T10:10:32.501634681Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elastic_password_should_be_available#01"}
+{"Time":"2020-08-20T10:10:32.501643848Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elastic_password_should_be_available#01","Output":"=== RUN   TestMutationHTTPSToHTTP/Elastic_password_should_be_available#01\n"}
+{"Time":"2020-08-20T10:10:32.506007001Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elastic_password_should_be_available#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:10:32.506054056Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type#01"}
+{"Time":"2020-08-20T10:10:32.506063239Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Output":"=== RUN   TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type#01\n"}
+{"Time":"2020-08-20T10:10:32.512317872Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01"}
+{"Time":"2020-08-20T10:10:32.512355874Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"=== RUN   TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01\n"}
+{"Time":"2020-08-20T10:10:32.516227441Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:10:32.516279826Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one#01"}
+{"Time":"2020-08-20T10:10:32.516288792Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one#01\n"}
+{"Time":"2020-08-20T10:10:32.556203703Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:10:32.556265139Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#03"}
+{"Time":"2020-08-20T10:10:32.556272721Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#03","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#03\n"}
+{"Time":"2020-08-20T10:10:32.576983471Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#03","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:10:32.577029662Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable#01"}
+{"Time":"2020-08-20T10:10:32.577035075Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable#01","Output":"=== RUN   TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable#01\n"}
+{"Time":"2020-08-20T10:10:32.600270447Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:10:32.600318036Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Cluster_UUID_should_have_been_preserved"}
+{"Time":"2020-08-20T10:10:32.600325805Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Cluster_UUID_should_have_been_preserved","Output":"=== RUN   TestMutationHTTPSToHTTP/Cluster_UUID_should_have_been_preserved\n"}
+{"Time":"2020-08-20T10:10:32.617459667Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"}
+{"Time":"2020-08-20T10:10:32.617514062Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"=== RUN   TestMutationHTTPSToHTTP/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"}
+{"Time":"2020-08-20T10:10:32.617538455Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"}
+{"Time":"2020-08-20T10:10:32.617543001Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"=== RUN   TestMutationHTTPSToHTTP/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"}
+{"Time":"2020-08-20T10:10:32.617754866Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process"}
+{"Time":"2020-08-20T10:10:32.61777105Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process","Output":"=== RUN   TestMutationHTTPSToHTTP/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process\n"}
+{"Time":"2020-08-20T10:10:32.617782149Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Data_added_initially_should_still_be_present"}
+{"Time":"2020-08-20T10:10:32.617789326Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Data_added_initially_should_still_be_present","Output":"=== RUN   TestMutationHTTPSToHTTP/Data_added_initially_should_still_be_present\n"}
+{"Time":"2020-08-20T10:10:32.731075823Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Data_added_initially_should_still_be_present","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:10:32.731135059Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Deleting_Elasticsearch_should_return_no_error"}
+{"Time":"2020-08-20T10:10:32.731144965Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Deleting_Elasticsearch_should_return_no_error","Output":"=== RUN   TestMutationHTTPSToHTTP/Deleting_Elasticsearch_should_return_no_error\n"}
+{"Time":"2020-08-20T10:10:32.741956084Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_should_not_be_there_anymore"}
+{"Time":"2020-08-20T10:10:32.742008676Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_should_not_be_there_anymore","Output":"=== RUN   TestMutationHTTPSToHTTP/Elasticsearch_should_not_be_there_anymore\n"}
+{"Time":"2020-08-20T10:10:32.746809404Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_should_not_be_there_anymore","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:10:32.746858055Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_pods_should_eventually_be_removed"}
+{"Time":"2020-08-20T10:10:32.746865504Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_pods_should_eventually_be_removed","Output":"=== RUN   TestMutationHTTPSToHTTP/Elasticsearch_pods_should_eventually_be_removed\n"}
+{"Time":"2020-08-20T10:11:17.871150975Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_pods_should_eventually_be_removed","Output":"Retries (5m0s timeout): ................\n"}
+{"Time":"2020-08-20T10:11:17.87126411Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/PVCs_should_eventually_be_removed"}
+{"Time":"2020-08-20T10:11:17.871278345Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/PVCs_should_eventually_be_removed","Output":"=== RUN   TestMutationHTTPSToHTTP/PVCs_should_eventually_be_removed\n"}
+{"Time":"2020-08-20T10:11:17.87603712Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/PVCs_should_eventually_be_removed","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:17.876086539Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP","Output":"--- PASS: TestMutationHTTPSToHTTP (269.65s)\n"}
+{"Time":"2020-08-20T10:11:17.876095708Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/K8S_should_be_accessible","Output":"    --- PASS: TestMutationHTTPSToHTTP/K8S_should_be_accessible (0.02s)\n"}
+{"Time":"2020-08-20T10:11:17.876103152Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/K8S_should_be_accessible","Elapsed":0.02}
+{"Time":"2020-08-20T10:11:17.876114799Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Label_test_pods","Output":"    --- PASS: TestMutationHTTPSToHTTP/Label_test_pods (0.04s)\n"}
+{"Time":"2020-08-20T10:11:17.876121492Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Label_test_pods","Elapsed":0.04}
+{"Time":"2020-08-20T10:11:17.876127322Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_CRDs_should_exist","Output":"    --- PASS: TestMutationHTTPSToHTTP/Elasticsearch_CRDs_should_exist (0.01s)\n"}
+{"Time":"2020-08-20T10:11:17.876134079Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_CRDs_should_exist","Elapsed":0.01}
+{"Time":"2020-08-20T10:11:17.876140052Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Webhook_endpoint_should_not_be_empty","Output":"    --- PASS: TestMutationHTTPSToHTTP/Webhook_endpoint_should_not_be_empty (0.00s)\n"}
+{"Time":"2020-08-20T10:11:17.876146268Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Webhook_endpoint_should_not_be_empty","Elapsed":0}
+{"Time":"2020-08-20T10:11:17.876151809Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Remove_Elasticsearch_if_it_already_exists","Output":"    --- PASS: TestMutationHTTPSToHTTP/Remove_Elasticsearch_if_it_already_exists (0.01s)\n"}
+{"Time":"2020-08-20T10:11:17.876159321Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Remove_Elasticsearch_if_it_already_exists","Elapsed":0.01}
+{"Time":"2020-08-20T10:11:17.876165023Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Creating_an_Elasticsearch_cluster_should_succeed","Output":"    --- PASS: TestMutationHTTPSToHTTP/Creating_an_Elasticsearch_cluster_should_succeed (0.02s)\n"}
+{"Time":"2020-08-20T10:11:17.876171482Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Creating_an_Elasticsearch_cluster_should_succeed","Elapsed":0.02}
+{"Time":"2020-08-20T10:11:17.876177622Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_cluster_should_be_created","Output":"    --- PASS: TestMutationHTTPSToHTTP/Elasticsearch_cluster_should_be_created (0.01s)\n"}
+{"Time":"2020-08-20T10:11:17.876184351Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_cluster_should_be_created","Elapsed":0.01}
+{"Time":"2020-08-20T10:11:17.876189813Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed (3.01s)\n"}
+{"Time":"2020-08-20T10:11:17.876196495Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed","Elapsed":3.01}
+{"Time":"2020-08-20T10:11:17.876202633Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready","Output":"    --- PASS: TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready (27.25s)\n"}
+{"Time":"2020-08-20T10:11:17.876208881Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready","Elapsed":27.25}
+{"Time":"2020-08-20T10:11:17.876214638Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one (0.02s)\n"}
+{"Time":"2020-08-20T10:11:17.876221068Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one","Elapsed":0.02}
+{"Time":"2020-08-20T10:11:17.876230997Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_be_created","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_services_should_be_created (0.02s)\n"}
+{"Time":"2020-08-20T10:11:17.876241516Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_be_created","Elapsed":0.02}
+{"Time":"2020-08-20T10:11:17.876247408Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_have_endpoints","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_services_should_have_endpoints (0.01s)\n"}
+{"Time":"2020-08-20T10:11:17.876253712Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_have_endpoints","Elapsed":0.01}
+{"Time":"2020-08-20T10:11:17.876259232Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created","Output":"    --- PASS: TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created (0.06s)\n"}
+{"Time":"2020-08-20T10:11:17.876265269Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created","Elapsed":0.06}
+{"Time":"2020-08-20T10:11:17.876271097Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate (0.02s)\n"}
+{"Time":"2020-08-20T10:11:17.876276875Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate","Elapsed":0.02}
+{"Time":"2020-08-20T10:11:17.876282402Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green (3.01s)\n"}
+{"Time":"2020-08-20T10:11:17.876288535Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green","Elapsed":3.01}
+{"Time":"2020-08-20T10:11:17.876294175Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elastic_password_should_be_available","Output":"    --- PASS: TestMutationHTTPSToHTTP/Elastic_password_should_be_available (0.01s)\n"}
+{"Time":"2020-08-20T10:11:17.876300966Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elastic_password_should_be_available","Elapsed":0.01}
+{"Time":"2020-08-20T10:11:17.876306788Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type","Output":"    --- PASS: TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type (0.01s)\n"}
+{"Time":"2020-08-20T10:11:17.876318866Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type","Elapsed":0.01}
+{"Time":"2020-08-20T10:11:17.876324701Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"    --- PASS: TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped (0.00s)\n"}
+{"Time":"2020-08-20T10:11:17.876330805Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Elapsed":0}
+{"Time":"2020-08-20T10:11:17.876336458Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one (0.14s)\n"}
+{"Time":"2020-08-20T10:11:17.876343008Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one","Elapsed":0.14}
+{"Time":"2020-08-20T10:11:17.876348503Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#01","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#01 (0.13s)\n"}
+{"Time":"2020-08-20T10:11:17.87635479Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#01","Elapsed":0.13}
+{"Time":"2020-08-20T10:11:17.876360849Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable (0.03s)\n"}
+{"Time":"2020-08-20T10:11:17.876366744Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable","Elapsed":0.03}
+{"Time":"2020-08-20T10:11:17.876379581Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Add_some_data_to_the_cluster_before_starting_the_mutation","Output":"    --- PASS: TestMutationHTTPSToHTTP/Add_some_data_to_the_cluster_before_starting_the_mutation (2.01s)\n"}
+{"Time":"2020-08-20T10:11:17.876386442Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Add_some_data_to_the_cluster_before_starting_the_mutation","Elapsed":2.01}
+{"Time":"2020-08-20T10:11:17.876392405Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on","Output":"    --- PASS: TestMutationHTTPSToHTTP/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on (0.00s)\n"}
+{"Time":"2020-08-20T10:11:17.876402947Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on","Elapsed":0}
+{"Time":"2020-08-20T10:11:17.876413221Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"    --- PASS: TestMutationHTTPSToHTTP/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"}
+{"Time":"2020-08-20T10:11:17.876420925Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Elapsed":0}
+{"Time":"2020-08-20T10:11:17.876426991Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"    --- PASS: TestMutationHTTPSToHTTP/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"}
+{"Time":"2020-08-20T10:11:17.876433798Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Elapsed":0}
+{"Time":"2020-08-20T10:11:17.876439678Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"    --- PASS: TestMutationHTTPSToHTTP/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose (0.14s)\n"}
+{"Time":"2020-08-20T10:11:17.876446115Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Elapsed":0.14}
+{"Time":"2020-08-20T10:11:17.876452451Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"    --- PASS: TestMutationHTTPSToHTTP/Annotate_Pods_with_a_hash_of_their_Builder_spec (0.05s)\n"}
+{"Time":"2020-08-20T10:11:17.876459599Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Annotate_Pods_with_a_hash_of_their_Builder_spec","Elapsed":0.05}
+{"Time":"2020-08-20T10:11:17.876466123Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Applying_the_Elasticsearch_mutation_should_succeed","Output":"    --- PASS: TestMutationHTTPSToHTTP/Applying_the_Elasticsearch_mutation_should_succeed (0.03s)\n"}
+{"Time":"2020-08-20T10:11:17.87647881Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Applying_the_Elasticsearch_mutation_should_succeed","Elapsed":0.03}
+{"Time":"2020-08-20T10:11:17.876496019Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed#01","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:11:17.876504073Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_certificate_authority_should_be_set_and_deployed#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:11:17.876510033Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready#01","Output":"    --- PASS: TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready#01 (184.15s)\n"}
+{"Time":"2020-08-20T10:11:17.876516556Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready#01","Elapsed":184.15}
+{"Time":"2020-08-20T10:11:17.876522709Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#02","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#02 (0.01s)\n"}
+{"Time":"2020-08-20T10:11:17.876539207Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#02","Elapsed":0.01}
+{"Time":"2020-08-20T10:11:17.876550588Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_be_created#01","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_services_should_be_created#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:11:17.876557719Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_be_created#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:11:17.876563627Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_have_endpoints#01","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_services_should_have_endpoints#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:11:17.876570523Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_services_should_have_endpoints#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:11:17.876576196Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created#01","Output":"    --- PASS: TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created#01 (0.03s)\n"}
+{"Time":"2020-08-20T10:11:17.876582917Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Secrets_should_eventually_be_created#01","Elapsed":0.03}
+{"Time":"2020-08-20T10:11:17.876588738Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate#01","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate#01 (0.02s)\n"}
+{"Time":"2020-08-20T10:11:17.876597529Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_pods_should_eventually_have_a_certificate#01","Elapsed":0.02}
+{"Time":"2020-08-20T10:11:17.876605671Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green#01","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green#01 (3.01s)\n"}
+{"Time":"2020-08-20T10:11:17.876613016Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_cluster_health_should_eventually_be_green#01","Elapsed":3.01}
+{"Time":"2020-08-20T10:11:17.87662482Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elastic_password_should_be_available#01","Output":"    --- PASS: TestMutationHTTPSToHTTP/Elastic_password_should_be_available#01 (0.00s)\n"}
+{"Time":"2020-08-20T10:11:17.876632296Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elastic_password_should_be_available#01","Elapsed":0}
+{"Time":"2020-08-20T10:11:17.876644912Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Output":"    --- PASS: TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:11:17.876651601Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:11:17.876657701Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"    --- PASS: TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01 (0.00s)\n"}
+{"Time":"2020-08-20T10:11:17.876664247Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Elapsed":0}
+{"Time":"2020-08-20T10:11:17.876675648Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one#01 (0.04s)\n"}
+{"Time":"2020-08-20T10:11:17.876683261Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_nodes_topology_should_eventually_be_the_expected_one#01","Elapsed":0.04}
+{"Time":"2020-08-20T10:11:17.876690393Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#03","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#03 (0.02s)\n"}
+{"Time":"2020-08-20T10:11:17.876696887Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_version_should_be_the_expected_one#03","Elapsed":0.02}
+{"Time":"2020-08-20T10:11:17.876702929Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable#01","Output":"    --- PASS: TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable#01 (0.02s)\n"}
+{"Time":"2020-08-20T10:11:17.876709776Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/ES_endpoint_should_eventually_be_reachable#01","Elapsed":0.02}
+{"Time":"2020-08-20T10:11:17.876734046Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Cluster_UUID_should_have_been_preserved","Output":"    --- PASS: TestMutationHTTPSToHTTP/Cluster_UUID_should_have_been_preserved (0.02s)\n"}
+{"Time":"2020-08-20T10:11:17.876741205Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Cluster_UUID_should_have_been_preserved","Elapsed":0.02}
+{"Time":"2020-08-20T10:11:17.876747763Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"    --- PASS: TestMutationHTTPSToHTTP/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"}
+{"Time":"2020-08-20T10:11:17.876755124Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Elapsed":0}
+{"Time":"2020-08-20T10:11:17.876761266Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"    --- PASS: TestMutationHTTPSToHTTP/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"}
+{"Time":"2020-08-20T10:11:17.876768699Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Elapsed":0}
+{"Time":"2020-08-20T10:11:17.876776747Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process","Output":"    --- PASS: TestMutationHTTPSToHTTP/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process (0.00s)\n"}
+{"Time":"2020-08-20T10:11:17.876788091Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process","Elapsed":0}
+{"Time":"2020-08-20T10:11:17.87679431Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Data_added_initially_should_still_be_present","Output":"    --- PASS: TestMutationHTTPSToHTTP/Data_added_initially_should_still_be_present (0.11s)\n"}
+{"Time":"2020-08-20T10:11:17.876800837Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Data_added_initially_should_still_be_present","Elapsed":0.11}
+{"Time":"2020-08-20T10:11:17.876805994Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Deleting_Elasticsearch_should_return_no_error","Output":"    --- PASS: TestMutationHTTPSToHTTP/Deleting_Elasticsearch_should_return_no_error (0.01s)\n"}
+{"Time":"2020-08-20T10:11:17.876824909Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Deleting_Elasticsearch_should_return_no_error","Elapsed":0.01}
+{"Time":"2020-08-20T10:11:17.876830643Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_should_not_be_there_anymore","Output":"    --- PASS: TestMutationHTTPSToHTTP/Elasticsearch_should_not_be_there_anymore (0.00s)\n"}
+{"Time":"2020-08-20T10:11:17.876836933Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_should_not_be_there_anymore","Elapsed":0}
+{"Time":"2020-08-20T10:11:17.876842898Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_pods_should_eventually_be_removed","Output":"    --- PASS: TestMutationHTTPSToHTTP/Elasticsearch_pods_should_eventually_be_removed (45.12s)\n"}
+{"Time":"2020-08-20T10:11:17.87684979Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/Elasticsearch_pods_should_eventually_be_removed","Elapsed":45.12}
+{"Time":"2020-08-20T10:11:17.876856043Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/PVCs_should_eventually_be_removed","Output":"    --- PASS: TestMutationHTTPSToHTTP/PVCs_should_eventually_be_removed (0.00s)\n"}
+{"Time":"2020-08-20T10:11:17.876885891Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP/PVCs_should_eventually_be_removed","Elapsed":0}
+{"Time":"2020-08-20T10:11:17.876898359Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationHTTPSToHTTP","Elapsed":269.65}
+{"Time":"2020-08-20T10:11:17.876910712Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated"}
+{"Time":"2020-08-20T10:11:17.87691854Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated","Output":"=== RUN   TestMutationMdiToDedicated\n"}
+{"Time":"2020-08-20T10:11:18.830106062Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/K8S_should_be_accessible"}
+{"Time":"2020-08-20T10:11:18.83015156Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/K8S_should_be_accessible","Output":"=== RUN   TestMutationMdiToDedicated/K8S_should_be_accessible\n"}
+{"Time":"2020-08-20T10:11:18.847969704Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/K8S_should_be_accessible","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:18.848012254Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Label_test_pods"}
+{"Time":"2020-08-20T10:11:18.848017695Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Label_test_pods","Output":"=== RUN   TestMutationMdiToDedicated/Label_test_pods\n"}
+{"Time":"2020-08-20T10:11:18.881094868Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Label_test_pods","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:18.881146532Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_CRDs_should_exist"}
+{"Time":"2020-08-20T10:11:18.881153944Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_CRDs_should_exist","Output":"=== RUN   TestMutationMdiToDedicated/Elasticsearch_CRDs_should_exist\n"}
+{"Time":"2020-08-20T10:11:18.887041245Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_CRDs_should_exist","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:18.887084658Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Webhook_endpoint_should_not_be_empty"}
+{"Time":"2020-08-20T10:11:18.887092213Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Webhook_endpoint_should_not_be_empty","Output":"=== RUN   TestMutationMdiToDedicated/Webhook_endpoint_should_not_be_empty\n"}
+{"Time":"2020-08-20T10:11:18.891181261Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Webhook_endpoint_should_not_be_empty","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:18.891218961Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Remove_Elasticsearch_if_it_already_exists"}
+{"Time":"2020-08-20T10:11:18.891224678Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Remove_Elasticsearch_if_it_already_exists","Output":"=== RUN   TestMutationMdiToDedicated/Remove_Elasticsearch_if_it_already_exists\n"}
+{"Time":"2020-08-20T10:11:18.90265472Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Remove_Elasticsearch_if_it_already_exists","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:18.902704136Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Creating_an_Elasticsearch_cluster_should_succeed"}
+{"Time":"2020-08-20T10:11:18.902711642Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Creating_an_Elasticsearch_cluster_should_succeed","Output":"=== RUN   TestMutationMdiToDedicated/Creating_an_Elasticsearch_cluster_should_succeed\n"}
+{"Time":"2020-08-20T10:11:18.921040148Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_cluster_should_be_created"}
+{"Time":"2020-08-20T10:11:18.921095814Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_cluster_should_be_created","Output":"=== RUN   TestMutationMdiToDedicated/Elasticsearch_cluster_should_be_created\n"}
+{"Time":"2020-08-20T10:11:18.926441927Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed"}
+{"Time":"2020-08-20T10:11:18.926475113Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed","Output":"=== RUN   TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed\n"}
+{"Time":"2020-08-20T10:11:21.941064201Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed","Output":"Retries (5m0s timeout): ..\n"}
+{"Time":"2020-08-20T10:11:21.941114608Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready"}
+{"Time":"2020-08-20T10:11:21.941121621Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready","Output":"=== RUN   TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready\n"}
+{"Time":"2020-08-20T10:11:43.070775526Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready","Output":"Retries (30m0s timeout): ........\n"}
+{"Time":"2020-08-20T10:11:43.070858298Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one"}
+{"Time":"2020-08-20T10:11:43.070866762Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one","Output":"=== RUN   TestMutationMdiToDedicated/ES_version_should_be_the_expected_one\n"}
+{"Time":"2020-08-20T10:11:43.078835476Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:43.078877537Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_be_created"}
+{"Time":"2020-08-20T10:11:43.078883013Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_be_created","Output":"=== RUN   TestMutationMdiToDedicated/ES_services_should_be_created\n"}
+{"Time":"2020-08-20T10:11:43.087340301Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_be_created","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:43.087367851Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_have_endpoints"}
+{"Time":"2020-08-20T10:11:43.087373323Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_have_endpoints","Output":"=== RUN   TestMutationMdiToDedicated/ES_services_should_have_endpoints\n"}
+{"Time":"2020-08-20T10:11:43.094177594Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_have_endpoints","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:43.094212875Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Secrets_should_eventually_be_created"}
+{"Time":"2020-08-20T10:11:43.094220135Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Secrets_should_eventually_be_created","Output":"=== RUN   TestMutationMdiToDedicated/Secrets_should_eventually_be_created\n"}
+{"Time":"2020-08-20T10:11:43.138174656Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Secrets_should_eventually_be_created","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:43.138229316Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate"}
+{"Time":"2020-08-20T10:11:43.138238033Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate","Output":"=== RUN   TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate\n"}
+{"Time":"2020-08-20T10:11:43.150148191Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:43.150195198Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green"}
+{"Time":"2020-08-20T10:11:43.150204003Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green","Output":"=== RUN   TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green\n"}
+{"Time":"2020-08-20T10:11:43.157463398Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:43.157497671Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elastic_password_should_be_available"}
+{"Time":"2020-08-20T10:11:43.157503265Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elastic_password_should_be_available","Output":"=== RUN   TestMutationMdiToDedicated/Elastic_password_should_be_available\n"}
+{"Time":"2020-08-20T10:11:43.162881236Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elastic_password_should_be_available","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:43.162920004Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type"}
+{"Time":"2020-08-20T10:11:43.162946552Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type","Output":"=== RUN   TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type\n"}
+{"Time":"2020-08-20T10:11:43.169940721Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped"}
+{"Time":"2020-08-20T10:11:43.169974516Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"=== RUN   TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped\n"}
+{"Time":"2020-08-20T10:11:43.176993831Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:43.177045144Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one"}
+{"Time":"2020-08-20T10:11:43.177053497Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"=== RUN   TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one\n"}
+{"Time":"2020-08-20T10:11:43.317507322Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:43.317550979Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#01"}
+{"Time":"2020-08-20T10:11:43.317556364Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#01","Output":"=== RUN   TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#01\n"}
+{"Time":"2020-08-20T10:11:43.355095931Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:43.355156935Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable"}
+{"Time":"2020-08-20T10:11:43.355163689Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable","Output":"=== RUN   TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable\n"}
+{"Time":"2020-08-20T10:11:43.394024181Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:43.394070357Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Add_some_data_to_the_cluster_before_starting_the_mutation"}
+{"Time":"2020-08-20T10:11:43.394076691Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Add_some_data_to_the_cluster_before_starting_the_mutation","Output":"=== RUN   TestMutationMdiToDedicated/Add_some_data_to_the_cluster_before_starting_the_mutation\n"}
+{"Time":"2020-08-20T10:11:44.630517051Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on"}
+{"Time":"2020-08-20T10:11:44.630568985Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on","Output":"=== RUN   TestMutationMdiToDedicated/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on\n"}
+{"Time":"2020-08-20T10:11:44.630582116Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"}
+{"Time":"2020-08-20T10:11:44.630586665Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"=== RUN   TestMutationMdiToDedicated/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"}
+{"Time":"2020-08-20T10:11:44.630598308Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"}
+{"Time":"2020-08-20T10:11:44.630601913Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"=== RUN   TestMutationMdiToDedicated/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"}
+{"Time":"2020-08-20T10:11:44.630606317Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose"}
+{"Time":"2020-08-20T10:11:44.630611657Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"=== RUN   TestMutationMdiToDedicated/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose\n"}
+{"Time":"2020-08-20T10:11:44.668744713Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:44.668796108Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Annotate_Pods_with_a_hash_of_their_Builder_spec"}
+{"Time":"2020-08-20T10:11:44.668802276Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"=== RUN   TestMutationMdiToDedicated/Annotate_Pods_with_a_hash_of_their_Builder_spec\n"}
+{"Time":"2020-08-20T10:11:44.686542153Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:44.686599237Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Applying_the_Elasticsearch_mutation_should_succeed"}
+{"Time":"2020-08-20T10:11:44.686607421Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Applying_the_Elasticsearch_mutation_should_succeed","Output":"=== RUN   TestMutationMdiToDedicated/Applying_the_Elasticsearch_mutation_should_succeed\n"}
+{"Time":"2020-08-20T10:11:44.729992951Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Applying_the_Elasticsearch_mutation_should_succeed","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:44.730049287Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed#01"}
+{"Time":"2020-08-20T10:11:44.730056504Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed#01","Output":"=== RUN   TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed#01\n"}
+{"Time":"2020-08-20T10:11:44.737819164Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:11:44.737862144Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready#01"}
+{"Time":"2020-08-20T10:11:44.737870184Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready#01","Output":"=== RUN   TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready#01\n"}
+{"Time":"2020-08-20T10:12:56.943424747Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready#01","Output":"Retries (30m0s timeout): .........................\n"}
+{"Time":"2020-08-20T10:12:56.943731399Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#02"}
+{"Time":"2020-08-20T10:12:56.943739733Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#02","Output":"=== RUN   TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#02\n"}
+{"Time":"2020-08-20T10:12:56.952350659Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#02","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:12:56.95240635Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_be_created#01"}
+{"Time":"2020-08-20T10:12:56.952412921Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_be_created#01","Output":"=== RUN   TestMutationMdiToDedicated/ES_services_should_be_created#01\n"}
+{"Time":"2020-08-20T10:12:56.961293891Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_be_created#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:12:56.961354115Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_have_endpoints#01"}
+{"Time":"2020-08-20T10:12:56.961362244Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_have_endpoints#01","Output":"=== RUN   TestMutationMdiToDedicated/ES_services_should_have_endpoints#01\n"}
+{"Time":"2020-08-20T10:12:56.968091303Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_have_endpoints#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:12:56.968164637Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Secrets_should_eventually_be_created#01"}
+{"Time":"2020-08-20T10:12:56.968172372Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Secrets_should_eventually_be_created#01","Output":"=== RUN   TestMutationMdiToDedicated/Secrets_should_eventually_be_created#01\n"}
+{"Time":"2020-08-20T10:12:57.009942436Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Secrets_should_eventually_be_created#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:12:57.00999315Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate#01"}
+{"Time":"2020-08-20T10:12:57.009999642Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate#01","Output":"=== RUN   TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate#01\n"}
+{"Time":"2020-08-20T10:12:57.023171394Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:12:57.023218905Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green#01"}
+{"Time":"2020-08-20T10:12:57.023224707Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green#01","Output":"=== RUN   TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green#01\n"}
+{"Time":"2020-08-20T10:12:57.027203313Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:12:57.027255848Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elastic_password_should_be_available#01"}
+{"Time":"2020-08-20T10:12:57.027263583Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elastic_password_should_be_available#01","Output":"=== RUN   TestMutationMdiToDedicated/Elastic_password_should_be_available#01\n"}
+{"Time":"2020-08-20T10:12:57.030788083Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elastic_password_should_be_available#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:12:57.030826528Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type#01"}
+{"Time":"2020-08-20T10:12:57.030833379Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Output":"=== RUN   TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type#01\n"}
+{"Time":"2020-08-20T10:12:57.036164506Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01"}
+{"Time":"2020-08-20T10:12:57.036200446Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"=== RUN   TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01\n"}
+{"Time":"2020-08-20T10:12:57.046720132Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:12:57.047008251Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one#01"}
+{"Time":"2020-08-20T10:12:57.047127493Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"=== RUN   TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one#01\n"}
+{"Time":"2020-08-20T10:12:57.094850467Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:12:57.09491779Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#03"}
+{"Time":"2020-08-20T10:12:57.094939562Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#03","Output":"=== RUN   TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#03\n"}
+{"Time":"2020-08-20T10:12:57.126357737Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#03","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:12:57.126412785Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable#01"}
+{"Time":"2020-08-20T10:12:57.126421011Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable#01","Output":"=== RUN   TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable#01\n"}
+{"Time":"2020-08-20T10:12:57.1644177Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:12:57.16447436Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Cluster_UUID_should_have_been_preserved"}
+{"Time":"2020-08-20T10:12:57.164487647Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Cluster_UUID_should_have_been_preserved","Output":"=== RUN   TestMutationMdiToDedicated/Cluster_UUID_should_have_been_preserved\n"}
+{"Time":"2020-08-20T10:12:57.201124015Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"}
+{"Time":"2020-08-20T10:12:57.201171247Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"=== RUN   TestMutationMdiToDedicated/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"}
+{"Time":"2020-08-20T10:12:57.201186707Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"}
+{"Time":"2020-08-20T10:12:57.20119302Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"=== RUN   TestMutationMdiToDedicated/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"}
+{"Time":"2020-08-20T10:12:57.201513847Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process"}
+{"Time":"2020-08-20T10:12:57.20153699Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process","Output":"=== RUN   TestMutationMdiToDedicated/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process\n"}
+{"Time":"2020-08-20T10:12:57.201548216Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Data_added_initially_should_still_be_present"}
+{"Time":"2020-08-20T10:12:57.201554468Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Data_added_initially_should_still_be_present","Output":"=== RUN   TestMutationMdiToDedicated/Data_added_initially_should_still_be_present\n"}
+{"Time":"2020-08-20T10:12:57.316372744Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Data_added_initially_should_still_be_present","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:12:57.316434288Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Deleting_Elasticsearch_should_return_no_error"}
+{"Time":"2020-08-20T10:12:57.316456097Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Deleting_Elasticsearch_should_return_no_error","Output":"=== RUN   TestMutationMdiToDedicated/Deleting_Elasticsearch_should_return_no_error\n"}
+{"Time":"2020-08-20T10:12:57.328764802Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_should_not_be_there_anymore"}
+{"Time":"2020-08-20T10:12:57.328985818Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_should_not_be_there_anymore","Output":"=== RUN   TestMutationMdiToDedicated/Elasticsearch_should_not_be_there_anymore\n"}
+{"Time":"2020-08-20T10:12:57.332623819Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_should_not_be_there_anymore","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:12:57.332676723Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_pods_should_eventually_be_removed"}
+{"Time":"2020-08-20T10:12:57.332685006Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_pods_should_eventually_be_removed","Output":"=== RUN   TestMutationMdiToDedicated/Elasticsearch_pods_should_eventually_be_removed\n"}
+{"Time":"2020-08-20T10:13:36.430509745Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_pods_should_eventually_be_removed","Output":"Retries (5m0s timeout): ..............\n"}
+{"Time":"2020-08-20T10:13:36.430648573Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/PVCs_should_eventually_be_removed"}
+{"Time":"2020-08-20T10:13:36.430658861Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/PVCs_should_eventually_be_removed","Output":"=== RUN   TestMutationMdiToDedicated/PVCs_should_eventually_be_removed\n"}
+{"Time":"2020-08-20T10:13:36.434883755Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/PVCs_should_eventually_be_removed","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:13:36.43498877Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated","Output":"--- PASS: TestMutationMdiToDedicated (138.56s)\n"}
+{"Time":"2020-08-20T10:13:36.435003125Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/K8S_should_be_accessible","Output":"    --- PASS: TestMutationMdiToDedicated/K8S_should_be_accessible (0.02s)\n"}
+{"Time":"2020-08-20T10:13:36.435010119Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/K8S_should_be_accessible","Elapsed":0.02}
+{"Time":"2020-08-20T10:13:36.435071548Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Label_test_pods","Output":"    --- PASS: TestMutationMdiToDedicated/Label_test_pods (0.03s)\n"}
+{"Time":"2020-08-20T10:13:36.435080626Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Label_test_pods","Elapsed":0.03}
+{"Time":"2020-08-20T10:13:36.435086325Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_CRDs_should_exist","Output":"    --- PASS: TestMutationMdiToDedicated/Elasticsearch_CRDs_should_exist (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.435092391Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_CRDs_should_exist","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.43509848Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Webhook_endpoint_should_not_be_empty","Output":"    --- PASS: TestMutationMdiToDedicated/Webhook_endpoint_should_not_be_empty (0.00s)\n"}
+{"Time":"2020-08-20T10:13:36.435104252Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Webhook_endpoint_should_not_be_empty","Elapsed":0}
+{"Time":"2020-08-20T10:13:36.435110171Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Remove_Elasticsearch_if_it_already_exists","Output":"    --- PASS: TestMutationMdiToDedicated/Remove_Elasticsearch_if_it_already_exists (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.435117731Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Remove_Elasticsearch_if_it_already_exists","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.435129522Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Creating_an_Elasticsearch_cluster_should_succeed","Output":"    --- PASS: TestMutationMdiToDedicated/Creating_an_Elasticsearch_cluster_should_succeed (0.02s)\n"}
+{"Time":"2020-08-20T10:13:36.435136655Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Creating_an_Elasticsearch_cluster_should_succeed","Elapsed":0.02}
+{"Time":"2020-08-20T10:13:36.435143113Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_cluster_should_be_created","Output":"    --- PASS: TestMutationMdiToDedicated/Elasticsearch_cluster_should_be_created (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.43515004Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_cluster_should_be_created","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.435156363Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed","Output":"    --- PASS: TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed (3.01s)\n"}
+{"Time":"2020-08-20T10:13:36.435163559Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed","Elapsed":3.01}
+{"Time":"2020-08-20T10:13:36.4351764Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready","Output":"    --- PASS: TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready (21.13s)\n"}
+{"Time":"2020-08-20T10:13:36.435183769Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready","Elapsed":21.13}
+{"Time":"2020-08-20T10:13:36.435193846Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one","Output":"    --- PASS: TestMutationMdiToDedicated/ES_version_should_be_the_expected_one (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.435200836Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.435218497Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_be_created","Output":"    --- PASS: TestMutationMdiToDedicated/ES_services_should_be_created (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.435224964Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_be_created","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.435235563Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_have_endpoints","Output":"    --- PASS: TestMutationMdiToDedicated/ES_services_should_have_endpoints (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.435242174Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_have_endpoints","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.435251881Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Secrets_should_eventually_be_created","Output":"    --- PASS: TestMutationMdiToDedicated/Secrets_should_eventually_be_created (0.04s)\n"}
+{"Time":"2020-08-20T10:13:36.435262579Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Secrets_should_eventually_be_created","Elapsed":0.04}
+{"Time":"2020-08-20T10:13:36.435289232Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate","Output":"    --- PASS: TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.435296194Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.435306661Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green","Output":"    --- PASS: TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.435313935Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.435324456Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elastic_password_should_be_available","Output":"    --- PASS: TestMutationMdiToDedicated/Elastic_password_should_be_available (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.43533198Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elastic_password_should_be_available","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.435342349Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type","Output":"    --- PASS: TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.435349703Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.435355549Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"    --- PASS: TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.435363146Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.435381142Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"    --- PASS: TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one (0.14s)\n"}
+{"Time":"2020-08-20T10:13:36.435388587Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one","Elapsed":0.14}
+{"Time":"2020-08-20T10:13:36.435400915Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#01","Output":"    --- PASS: TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#01 (0.04s)\n"}
+{"Time":"2020-08-20T10:13:36.435433141Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#01","Elapsed":0.04}
+{"Time":"2020-08-20T10:13:36.435439284Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable","Output":"    --- PASS: TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable (0.04s)\n"}
+{"Time":"2020-08-20T10:13:36.43544639Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable","Elapsed":0.04}
+{"Time":"2020-08-20T10:13:36.435458644Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Add_some_data_to_the_cluster_before_starting_the_mutation","Output":"    --- PASS: TestMutationMdiToDedicated/Add_some_data_to_the_cluster_before_starting_the_mutation (1.24s)\n"}
+{"Time":"2020-08-20T10:13:36.435466834Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Add_some_data_to_the_cluster_before_starting_the_mutation","Elapsed":1.24}
+{"Time":"2020-08-20T10:13:36.435476378Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on","Output":"    --- PASS: TestMutationMdiToDedicated/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on (0.00s)\n"}
+{"Time":"2020-08-20T10:13:36.435581592Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on","Elapsed":0}
+{"Time":"2020-08-20T10:13:36.435589111Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"    --- PASS: TestMutationMdiToDedicated/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"}
+{"Time":"2020-08-20T10:13:36.435596778Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Elapsed":0}
+{"Time":"2020-08-20T10:13:36.435607725Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"    --- PASS: TestMutationMdiToDedicated/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"}
+{"Time":"2020-08-20T10:13:36.435614798Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Elapsed":0}
+{"Time":"2020-08-20T10:13:36.435620125Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"    --- PASS: TestMutationMdiToDedicated/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose (0.04s)\n"}
+{"Time":"2020-08-20T10:13:36.43562656Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Elapsed":0.04}
+{"Time":"2020-08-20T10:13:36.435633066Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"    --- PASS: TestMutationMdiToDedicated/Annotate_Pods_with_a_hash_of_their_Builder_spec (0.02s)\n"}
+{"Time":"2020-08-20T10:13:36.435639953Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Annotate_Pods_with_a_hash_of_their_Builder_spec","Elapsed":0.02}
+{"Time":"2020-08-20T10:13:36.435646541Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Applying_the_Elasticsearch_mutation_should_succeed","Output":"    --- PASS: TestMutationMdiToDedicated/Applying_the_Elasticsearch_mutation_should_succeed (0.04s)\n"}
+{"Time":"2020-08-20T10:13:36.435653505Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Applying_the_Elasticsearch_mutation_should_succeed","Elapsed":0.04}
+{"Time":"2020-08-20T10:13:36.435659498Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed#01","Output":"    --- PASS: TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.435666463Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_certificate_authority_should_be_set_and_deployed#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.435672735Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready#01","Output":"    --- PASS: TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready#01 (72.21s)\n"}
+{"Time":"2020-08-20T10:13:36.435679555Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/All_expected_Pods_should_eventually_be_ready#01","Elapsed":72.21}
+{"Time":"2020-08-20T10:13:36.435696363Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#02","Output":"    --- PASS: TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#02 (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.435706884Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#02","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.435712849Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_be_created#01","Output":"    --- PASS: TestMutationMdiToDedicated/ES_services_should_be_created#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.435719042Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_be_created#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.435724558Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_have_endpoints#01","Output":"    --- PASS: TestMutationMdiToDedicated/ES_services_should_have_endpoints#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.43573066Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_services_should_have_endpoints#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.435736185Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Secrets_should_eventually_be_created#01","Output":"    --- PASS: TestMutationMdiToDedicated/Secrets_should_eventually_be_created#01 (0.04s)\n"}
+{"Time":"2020-08-20T10:13:36.43574236Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Secrets_should_eventually_be_created#01","Elapsed":0.04}
+{"Time":"2020-08-20T10:13:36.435747772Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate#01","Output":"    --- PASS: TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.435758549Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_pods_should_eventually_have_a_certificate#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.435782573Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green#01","Output":"    --- PASS: TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green#01 (0.00s)\n"}
+{"Time":"2020-08-20T10:13:36.435793301Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_cluster_health_should_eventually_be_green#01","Elapsed":0}
+{"Time":"2020-08-20T10:13:36.435803435Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elastic_password_should_be_available#01","Output":"    --- PASS: TestMutationMdiToDedicated/Elastic_password_should_be_available#01 (0.00s)\n"}
+{"Time":"2020-08-20T10:13:36.435810036Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elastic_password_should_be_available#01","Elapsed":0}
+{"Time":"2020-08-20T10:13:36.435818206Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Output":"    --- PASS: TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.435830972Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.435842511Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"    --- PASS: TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01 (0.00s)\n"}
+{"Time":"2020-08-20T10:13:36.435850337Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Elapsed":0}
+{"Time":"2020-08-20T10:13:36.435860615Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"    --- PASS: TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one#01 (0.05s)\n"}
+{"Time":"2020-08-20T10:13:36.435867874Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_nodes_topology_should_eventually_be_the_expected_one#01","Elapsed":0.05}
+{"Time":"2020-08-20T10:13:36.4358787Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#03","Output":"    --- PASS: TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#03 (0.03s)\n"}
+{"Time":"2020-08-20T10:13:36.435885124Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_version_should_be_the_expected_one#03","Elapsed":0.03}
+{"Time":"2020-08-20T10:13:36.435891143Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable#01","Output":"    --- PASS: TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable#01 (0.04s)\n"}
+{"Time":"2020-08-20T10:13:36.435902559Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/ES_endpoint_should_eventually_be_reachable#01","Elapsed":0.04}
+{"Time":"2020-08-20T10:13:36.435910718Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Cluster_UUID_should_have_been_preserved","Output":"    --- PASS: TestMutationMdiToDedicated/Cluster_UUID_should_have_been_preserved (0.04s)\n"}
+{"Time":"2020-08-20T10:13:36.435936805Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Cluster_UUID_should_have_been_preserved","Elapsed":0.04}
+{"Time":"2020-08-20T10:13:36.435943584Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"    --- PASS: TestMutationMdiToDedicated/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"}
+{"Time":"2020-08-20T10:13:36.435950029Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Elapsed":0}
+{"Time":"2020-08-20T10:13:36.435955736Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"    --- PASS: TestMutationMdiToDedicated/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"}
+{"Time":"2020-08-20T10:13:36.435961978Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Elapsed":0}
+{"Time":"2020-08-20T10:13:36.435967723Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process","Output":"    --- PASS: TestMutationMdiToDedicated/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process (0.00s)\n"}
+{"Time":"2020-08-20T10:13:36.435973974Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process","Elapsed":0}
+{"Time":"2020-08-20T10:13:36.435979225Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Data_added_initially_should_still_be_present","Output":"    --- PASS: TestMutationMdiToDedicated/Data_added_initially_should_still_be_present (0.11s)\n"}
+{"Time":"2020-08-20T10:13:36.435984998Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Data_added_initially_should_still_be_present","Elapsed":0.11}
+{"Time":"2020-08-20T10:13:36.435990198Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Deleting_Elasticsearch_should_return_no_error","Output":"    --- PASS: TestMutationMdiToDedicated/Deleting_Elasticsearch_should_return_no_error (0.01s)\n"}
+{"Time":"2020-08-20T10:13:36.435996134Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Deleting_Elasticsearch_should_return_no_error","Elapsed":0.01}
+{"Time":"2020-08-20T10:13:36.436004195Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_should_not_be_there_anymore","Output":"    --- PASS: TestMutationMdiToDedicated/Elasticsearch_should_not_be_there_anymore (0.00s)\n"}
+{"Time":"2020-08-20T10:13:36.436010785Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_should_not_be_there_anymore","Elapsed":0}
+{"Time":"2020-08-20T10:13:36.436016685Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_pods_should_eventually_be_removed","Output":"    --- PASS: TestMutationMdiToDedicated/Elasticsearch_pods_should_eventually_be_removed (39.10s)\n"}
+{"Time":"2020-08-20T10:13:36.436023673Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/Elasticsearch_pods_should_eventually_be_removed","Elapsed":39.1}
+{"Time":"2020-08-20T10:13:36.436029586Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/PVCs_should_eventually_be_removed","Output":"    --- PASS: TestMutationMdiToDedicated/PVCs_should_eventually_be_removed (0.00s)\n"}
+{"Time":"2020-08-20T10:13:36.436043268Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated/PVCs_should_eventually_be_removed","Elapsed":0}
+{"Time":"2020-08-20T10:13:36.436048258Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMdiToDedicated","Elapsed":138.56}
+{"Time":"2020-08-20T10:13:36.436057374Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes"}
+{"Time":"2020-08-20T10:13:36.436063468Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes","Output":"=== RUN   TestMutationMoreNodes\n"}
+{"Time":"2020-08-20T10:13:37.388969408Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/K8S_should_be_accessible"}
+{"Time":"2020-08-20T10:13:37.389008727Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/K8S_should_be_accessible","Output":"=== RUN   TestMutationMoreNodes/K8S_should_be_accessible\n"}
+{"Time":"2020-08-20T10:13:37.405894719Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/K8S_should_be_accessible","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:13:37.405954812Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Label_test_pods"}
+{"Time":"2020-08-20T10:13:37.405961945Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Label_test_pods","Output":"=== RUN   TestMutationMoreNodes/Label_test_pods\n"}
+{"Time":"2020-08-20T10:13:37.436633704Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Label_test_pods","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:13:37.43669577Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_CRDs_should_exist"}
+{"Time":"2020-08-20T10:13:37.436740033Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_CRDs_should_exist","Output":"=== RUN   TestMutationMoreNodes/Elasticsearch_CRDs_should_exist\n"}
+{"Time":"2020-08-20T10:13:37.44112276Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_CRDs_should_exist","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:13:37.441166454Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Webhook_endpoint_should_not_be_empty"}
+{"Time":"2020-08-20T10:13:37.441171719Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Webhook_endpoint_should_not_be_empty","Output":"=== RUN   TestMutationMoreNodes/Webhook_endpoint_should_not_be_empty\n"}
+{"Time":"2020-08-20T10:13:37.445966696Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Webhook_endpoint_should_not_be_empty","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:13:37.446009863Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Remove_Elasticsearch_if_it_already_exists"}
+{"Time":"2020-08-20T10:13:37.446017415Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Remove_Elasticsearch_if_it_already_exists","Output":"=== RUN   TestMutationMoreNodes/Remove_Elasticsearch_if_it_already_exists\n"}
+{"Time":"2020-08-20T10:13:37.458632284Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Remove_Elasticsearch_if_it_already_exists","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:13:37.458676938Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Creating_an_Elasticsearch_cluster_should_succeed"}
+{"Time":"2020-08-20T10:13:37.458682631Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Creating_an_Elasticsearch_cluster_should_succeed","Output":"=== RUN   TestMutationMoreNodes/Creating_an_Elasticsearch_cluster_should_succeed\n"}
+{"Time":"2020-08-20T10:13:37.478898154Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_cluster_should_be_created"}
+{"Time":"2020-08-20T10:13:37.478957603Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_cluster_should_be_created","Output":"=== RUN   TestMutationMoreNodes/Elasticsearch_cluster_should_be_created\n"}
+{"Time":"2020-08-20T10:13:37.483563615Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed"}
+{"Time":"2020-08-20T10:13:37.483600144Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed","Output":"=== RUN   TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed\n"}
+{"Time":"2020-08-20T10:13:40.498689375Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed","Output":"Retries (5m0s timeout): ..\n"}
+{"Time":"2020-08-20T10:13:40.498787586Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready"}
+{"Time":"2020-08-20T10:13:40.498793792Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready","Output":"=== RUN   TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready\n"}
+{"Time":"2020-08-20T10:13:58.61971321Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready","Output":"Retries (30m0s timeout): .......\n"}
+{"Time":"2020-08-20T10:13:58.619836065Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one"}
+{"Time":"2020-08-20T10:13:58.619842856Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one","Output":"=== RUN   TestMutationMoreNodes/ES_version_should_be_the_expected_one\n"}
+{"Time":"2020-08-20T10:13:58.627892953Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:13:58.627968251Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_be_created"}
+{"Time":"2020-08-20T10:13:58.627979516Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_be_created","Output":"=== RUN   TestMutationMoreNodes/ES_services_should_be_created\n"}
+{"Time":"2020-08-20T10:13:58.63654803Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_be_created","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:13:58.636589116Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_have_endpoints"}
+{"Time":"2020-08-20T10:13:58.636594985Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_have_endpoints","Output":"=== RUN   TestMutationMoreNodes/ES_services_should_have_endpoints\n"}
+{"Time":"2020-08-20T10:13:58.645386304Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_have_endpoints","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:13:58.645427605Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Secrets_should_eventually_be_created"}
+{"Time":"2020-08-20T10:13:58.645432829Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Secrets_should_eventually_be_created","Output":"=== RUN   TestMutationMoreNodes/Secrets_should_eventually_be_created\n"}
+{"Time":"2020-08-20T10:13:58.68021572Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Secrets_should_eventually_be_created","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:13:58.680255024Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate"}
+{"Time":"2020-08-20T10:13:58.680261594Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate","Output":"=== RUN   TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate\n"}
+{"Time":"2020-08-20T10:13:58.688542869Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:13:58.688720318Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green"}
+{"Time":"2020-08-20T10:13:58.688752652Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green","Output":"=== RUN   TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green\n"}
+{"Time":"2020-08-20T10:14:01.698482353Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green","Output":"Retries (5m0s timeout): ..\n"}
+{"Time":"2020-08-20T10:14:01.698538085Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elastic_password_should_be_available"}
+{"Time":"2020-08-20T10:14:01.698543888Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elastic_password_should_be_available","Output":"=== RUN   TestMutationMoreNodes/Elastic_password_should_be_available\n"}
+{"Time":"2020-08-20T10:14:01.703395807Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elastic_password_should_be_available","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:01.70344619Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type"}
+{"Time":"2020-08-20T10:14:01.703455201Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type","Output":"=== RUN   TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type\n"}
+{"Time":"2020-08-20T10:14:01.710376134Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped"}
+{"Time":"2020-08-20T10:14:01.710425759Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"=== RUN   TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped\n"}
+{"Time":"2020-08-20T10:14:01.714797541Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:01.714850978Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one"}
+{"Time":"2020-08-20T10:14:01.714858903Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"=== RUN   TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one\n"}
+{"Time":"2020-08-20T10:14:01.852092497Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:01.852149487Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one#01"}
+{"Time":"2020-08-20T10:14:01.852157345Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one#01","Output":"=== RUN   TestMutationMoreNodes/ES_version_should_be_the_expected_one#01\n"}
+{"Time":"2020-08-20T10:14:01.889250148Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:01.889294884Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable"}
+{"Time":"2020-08-20T10:14:01.88930055Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable","Output":"=== RUN   TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable\n"}
+{"Time":"2020-08-20T10:14:01.925439075Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:01.925480873Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Add_some_data_to_the_cluster_before_starting_the_mutation"}
+{"Time":"2020-08-20T10:14:01.92548646Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Add_some_data_to_the_cluster_before_starting_the_mutation","Output":"=== RUN   TestMutationMoreNodes/Add_some_data_to_the_cluster_before_starting_the_mutation\n"}
+{"Time":"2020-08-20T10:14:03.036980638Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Add_some_data_to_the_cluster_before_starting_the_mutation","Output":"{\"log.level\":\"info\",\"@timestamp\":\"2020-08-20T10:14:03.036Z\",\"log.logger\":\"e2e\",\"message\":\"Skipping test\",\"service.version\":\"0.0.0-SNAPSHOT+00000000\",\"service.type\":\"eck\",\"ecs.version\":\"1.4.0\",\"name\":\"Start querying Elasticsearch cluster health while mutation is going on\"}\n"}
+{"Time":"2020-08-20T10:14:03.03705891Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"}
+{"Time":"2020-08-20T10:14:03.037068304Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"=== RUN   TestMutationMoreNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"}
+{"Time":"2020-08-20T10:14:03.03708119Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"}
+{"Time":"2020-08-20T10:14:03.037087404Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"=== RUN   TestMutationMoreNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"}
+{"Time":"2020-08-20T10:14:03.037096023Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose"}
+{"Time":"2020-08-20T10:14:03.037101472Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"=== RUN   TestMutationMoreNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose\n"}
+{"Time":"2020-08-20T10:14:03.069722955Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:03.069779393Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec"}
+{"Time":"2020-08-20T10:14:03.069791376Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"=== RUN   TestMutationMoreNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec\n"}
+{"Time":"2020-08-20T10:14:03.092266323Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:03.092323129Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Applying_the_Elasticsearch_mutation_should_succeed"}
+{"Time":"2020-08-20T10:14:03.092331897Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Applying_the_Elasticsearch_mutation_should_succeed","Output":"=== RUN   TestMutationMoreNodes/Applying_the_Elasticsearch_mutation_should_succeed\n"}
+{"Time":"2020-08-20T10:14:03.115397158Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Applying_the_Elasticsearch_mutation_should_succeed","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:03.115460681Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed#01"}
+{"Time":"2020-08-20T10:14:03.115467622Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed#01","Output":"=== RUN   TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed#01\n"}
+{"Time":"2020-08-20T10:14:03.123074432Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:03.123140068Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready#01"}
+{"Time":"2020-08-20T10:14:03.123147107Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready#01","Output":"=== RUN   TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready#01\n"}
+{"Time":"2020-08-20T10:14:30.293948052Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready#01","Output":"Retries (30m0s timeout): ..........\n"}
+{"Time":"2020-08-20T10:14:30.29399644Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one#02"}
+{"Time":"2020-08-20T10:14:30.294001725Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one#02","Output":"=== RUN   TestMutationMoreNodes/ES_version_should_be_the_expected_one#02\n"}
+{"Time":"2020-08-20T10:14:30.304561826Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one#02","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:30.304614712Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_be_created#01"}
+{"Time":"2020-08-20T10:14:30.304623941Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_be_created#01","Output":"=== RUN   TestMutationMoreNodes/ES_services_should_be_created#01\n"}
+{"Time":"2020-08-20T10:14:30.313535823Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_be_created#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:30.313576846Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_have_endpoints#01"}
+{"Time":"2020-08-20T10:14:30.313582107Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_have_endpoints#01","Output":"=== RUN   TestMutationMoreNodes/ES_services_should_have_endpoints#01\n"}
+{"Time":"2020-08-20T10:14:30.323550075Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_have_endpoints#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:30.323594527Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Secrets_should_eventually_be_created#01"}
+{"Time":"2020-08-20T10:14:30.323601839Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Secrets_should_eventually_be_created#01","Output":"=== RUN   TestMutationMoreNodes/Secrets_should_eventually_be_created#01\n"}
+{"Time":"2020-08-20T10:14:30.372250482Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Secrets_should_eventually_be_created#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:30.372294386Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate#01"}
+{"Time":"2020-08-20T10:14:30.372306777Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate#01","Output":"=== RUN   TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate#01\n"}
+{"Time":"2020-08-20T10:14:30.385522624Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:30.385575117Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green#01"}
+{"Time":"2020-08-20T10:14:30.385582545Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green#01","Output":"=== RUN   TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green#01\n"}
+{"Time":"2020-08-20T10:14:30.389266999Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:30.389309817Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elastic_password_should_be_available#01"}
+{"Time":"2020-08-20T10:14:30.389318077Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elastic_password_should_be_available#01","Output":"=== RUN   TestMutationMoreNodes/Elastic_password_should_be_available#01\n"}
+{"Time":"2020-08-20T10:14:30.394830816Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elastic_password_should_be_available#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:30.394920207Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01"}
+{"Time":"2020-08-20T10:14:30.394993937Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Output":"=== RUN   TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01\n"}
+{"Time":"2020-08-20T10:14:30.399917287Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01"}
+{"Time":"2020-08-20T10:14:30.399966079Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"=== RUN   TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01\n"}
+{"Time":"2020-08-20T10:14:30.404077706Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:30.404118184Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01"}
+{"Time":"2020-08-20T10:14:30.40412613Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"=== RUN   TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01\n"}
+{"Time":"2020-08-20T10:14:30.590404648Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:30.590466852Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one#03"}
+{"Time":"2020-08-20T10:14:30.590472558Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one#03","Output":"=== RUN   TestMutationMoreNodes/ES_version_should_be_the_expected_one#03\n"}
+{"Time":"2020-08-20T10:14:30.627450823Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one#03","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:30.627497024Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable#01"}
+{"Time":"2020-08-20T10:14:30.627503Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable#01","Output":"=== RUN   TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable#01\n"}
+{"Time":"2020-08-20T10:14:30.720325867Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:30.720373737Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Cluster_UUID_should_have_been_preserved"}
+{"Time":"2020-08-20T10:14:30.720379383Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Cluster_UUID_should_have_been_preserved","Output":"=== RUN   TestMutationMoreNodes/Cluster_UUID_should_have_been_preserved\n"}
+{"Time":"2020-08-20T10:14:30.751327656Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"}
+{"Time":"2020-08-20T10:14:30.751365716Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"=== RUN   TestMutationMoreNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"}
+{"Time":"2020-08-20T10:14:30.751373582Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"}
+{"Time":"2020-08-20T10:14:30.751381563Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"=== RUN   TestMutationMoreNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"}
+{"Time":"2020-08-20T10:14:30.751631993Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"{\"log.level\":\"info\",\"@timestamp\":\"2020-08-20T10:14:30.751Z\",\"log.logger\":\"e2e\",\"message\":\"Skipping test\",\"service.version\":\"0.0.0-SNAPSHOT+00000000\",\"service.type\":\"eck\",\"ecs.version\":\"1.4.0\",\"name\":\"Elasticsearch cluster health should not have been red during mutation process\"}\n"}
+{"Time":"2020-08-20T10:14:30.751669961Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Data_added_initially_should_still_be_present"}
+{"Time":"2020-08-20T10:14:30.751677414Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Data_added_initially_should_still_be_present","Output":"=== RUN   TestMutationMoreNodes/Data_added_initially_should_still_be_present\n"}
+{"Time":"2020-08-20T10:14:30.886111328Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Data_added_initially_should_still_be_present","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:30.886230095Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Deleting_Elasticsearch_should_return_no_error"}
+{"Time":"2020-08-20T10:14:30.886259772Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Deleting_Elasticsearch_should_return_no_error","Output":"=== RUN   TestMutationMoreNodes/Deleting_Elasticsearch_should_return_no_error\n"}
+{"Time":"2020-08-20T10:14:30.896424013Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_should_not_be_there_anymore"}
+{"Time":"2020-08-20T10:14:30.896468626Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_should_not_be_there_anymore","Output":"=== RUN   TestMutationMoreNodes/Elasticsearch_should_not_be_there_anymore\n"}
+{"Time":"2020-08-20T10:14:30.900874667Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_should_not_be_there_anymore","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:14:30.900903236Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_pods_should_eventually_be_removed"}
+{"Time":"2020-08-20T10:14:30.900912204Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_pods_should_eventually_be_removed","Output":"=== RUN   TestMutationMoreNodes/Elasticsearch_pods_should_eventually_be_removed\n"}
+{"Time":"2020-08-20T10:15:16.010226776Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_pods_should_eventually_be_removed","Output":"Retries (5m0s timeout): ................\n"}
+{"Time":"2020-08-20T10:15:16.010277431Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/PVCs_should_eventually_be_removed"}
+{"Time":"2020-08-20T10:15:16.010284174Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/PVCs_should_eventually_be_removed","Output":"=== RUN   TestMutationMoreNodes/PVCs_should_eventually_be_removed\n"}
+{"Time":"2020-08-20T10:15:16.015206023Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/PVCs_should_eventually_be_removed","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:16.015392346Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes","Output":"--- PASS: TestMutationMoreNodes (99.58s)\n"}
+{"Time":"2020-08-20T10:15:16.015416477Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/K8S_should_be_accessible","Output":"    --- PASS: TestMutationMoreNodes/K8S_should_be_accessible (0.02s)\n"}
+{"Time":"2020-08-20T10:15:16.015424381Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/K8S_should_be_accessible","Elapsed":0.02}
+{"Time":"2020-08-20T10:15:16.015441323Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Label_test_pods","Output":"    --- PASS: TestMutationMoreNodes/Label_test_pods (0.03s)\n"}
+{"Time":"2020-08-20T10:15:16.015448857Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Label_test_pods","Elapsed":0.03}
+{"Time":"2020-08-20T10:15:16.015455276Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_CRDs_should_exist","Output":"    --- PASS: TestMutationMoreNodes/Elasticsearch_CRDs_should_exist (0.00s)\n"}
+{"Time":"2020-08-20T10:15:16.015462752Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_CRDs_should_exist","Elapsed":0}
+{"Time":"2020-08-20T10:15:16.015473984Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Webhook_endpoint_should_not_be_empty","Output":"    --- PASS: TestMutationMoreNodes/Webhook_endpoint_should_not_be_empty (0.00s)\n"}
+{"Time":"2020-08-20T10:15:16.015495405Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Webhook_endpoint_should_not_be_empty","Elapsed":0}
+{"Time":"2020-08-20T10:15:16.015504714Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Remove_Elasticsearch_if_it_already_exists","Output":"    --- PASS: TestMutationMoreNodes/Remove_Elasticsearch_if_it_already_exists (0.01s)\n"}
+{"Time":"2020-08-20T10:15:16.015511769Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Remove_Elasticsearch_if_it_already_exists","Elapsed":0.01}
+{"Time":"2020-08-20T10:15:16.015518198Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Creating_an_Elasticsearch_cluster_should_succeed","Output":"    --- PASS: TestMutationMoreNodes/Creating_an_Elasticsearch_cluster_should_succeed (0.02s)\n"}
+{"Time":"2020-08-20T10:15:16.01553188Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Creating_an_Elasticsearch_cluster_should_succeed","Elapsed":0.02}
+{"Time":"2020-08-20T10:15:16.015537547Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_cluster_should_be_created","Output":"    --- PASS: TestMutationMoreNodes/Elasticsearch_cluster_should_be_created (0.00s)\n"}
+{"Time":"2020-08-20T10:15:16.015544483Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_cluster_should_be_created","Elapsed":0}
+{"Time":"2020-08-20T10:15:16.015555265Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed","Output":"    --- PASS: TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed (3.02s)\n"}
+{"Time":"2020-08-20T10:15:16.015562844Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed","Elapsed":3.02}
+{"Time":"2020-08-20T10:15:16.015569047Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready","Output":"    --- PASS: TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready (18.12s)\n"}
+{"Time":"2020-08-20T10:15:16.015584502Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready","Elapsed":18.12}
+{"Time":"2020-08-20T10:15:16.015590238Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one","Output":"    --- PASS: TestMutationMoreNodes/ES_version_should_be_the_expected_one (0.01s)\n"}
+{"Time":"2020-08-20T10:15:16.015596317Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one","Elapsed":0.01}
+{"Time":"2020-08-20T10:15:16.015606583Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_be_created","Output":"    --- PASS: TestMutationMoreNodes/ES_services_should_be_created (0.01s)\n"}
+{"Time":"2020-08-20T10:15:16.015613211Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_be_created","Elapsed":0.01}
+{"Time":"2020-08-20T10:15:16.01561939Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_have_endpoints","Output":"    --- PASS: TestMutationMoreNodes/ES_services_should_have_endpoints (0.01s)\n"}
+{"Time":"2020-08-20T10:15:16.015632376Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_have_endpoints","Elapsed":0.01}
+{"Time":"2020-08-20T10:15:16.015638335Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Secrets_should_eventually_be_created","Output":"    --- PASS: TestMutationMoreNodes/Secrets_should_eventually_be_created (0.03s)\n"}
+{"Time":"2020-08-20T10:15:16.015643794Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Secrets_should_eventually_be_created","Elapsed":0.03}
+{"Time":"2020-08-20T10:15:16.015649615Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate","Output":"    --- PASS: TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate (0.01s)\n"}
+{"Time":"2020-08-20T10:15:16.015656356Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate","Elapsed":0.01}
+{"Time":"2020-08-20T10:15:16.015667706Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green","Output":"    --- PASS: TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green (3.01s)\n"}
+{"Time":"2020-08-20T10:15:16.01567868Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green","Elapsed":3.01}
+{"Time":"2020-08-20T10:15:16.015691381Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elastic_password_should_be_available","Output":"    --- PASS: TestMutationMoreNodes/Elastic_password_should_be_available (0.00s)\n"}
+{"Time":"2020-08-20T10:15:16.015698972Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elastic_password_should_be_available","Elapsed":0}
+{"Time":"2020-08-20T10:15:16.015709176Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type","Output":"    --- PASS: TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type (0.01s)\n"}
+{"Time":"2020-08-20T10:15:16.01571762Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type","Elapsed":0.01}
+{"Time":"2020-08-20T10:15:16.015724059Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"    --- PASS: TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped (0.00s)\n"}
+{"Time":"2020-08-20T10:15:16.015731105Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Elapsed":0}
+{"Time":"2020-08-20T10:15:16.015737478Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"    --- PASS: TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one (0.14s)\n"}
+{"Time":"2020-08-20T10:15:16.015744653Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one","Elapsed":0.14}
+{"Time":"2020-08-20T10:15:16.015751078Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one#01","Output":"    --- PASS: TestMutationMoreNodes/ES_version_should_be_the_expected_one#01 (0.04s)\n"}
+{"Time":"2020-08-20T10:15:16.015758031Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one#01","Elapsed":0.04}
+{"Time":"2020-08-20T10:15:16.015764739Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable","Output":"    --- PASS: TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable (0.04s)\n"}
+{"Time":"2020-08-20T10:15:16.015772031Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable","Elapsed":0.04}
+{"Time":"2020-08-20T10:15:16.015778212Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Add_some_data_to_the_cluster_before_starting_the_mutation","Output":"    --- PASS: TestMutationMoreNodes/Add_some_data_to_the_cluster_before_starting_the_mutation (1.11s)\n"}
+{"Time":"2020-08-20T10:15:16.015788213Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Add_some_data_to_the_cluster_before_starting_the_mutation","Elapsed":1.11}
+{"Time":"2020-08-20T10:15:16.015799767Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"    --- PASS: TestMutationMoreNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"}
+{"Time":"2020-08-20T10:15:16.015808449Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Elapsed":0}
+{"Time":"2020-08-20T10:15:16.015815121Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"    --- PASS: TestMutationMoreNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"}
+{"Time":"2020-08-20T10:15:16.015822406Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Elapsed":0}
+{"Time":"2020-08-20T10:15:16.01582803Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"    --- PASS: TestMutationMoreNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose (0.03s)\n"}
+{"Time":"2020-08-20T10:15:16.015838137Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Elapsed":0.03}
+{"Time":"2020-08-20T10:15:16.015844762Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"    --- PASS: TestMutationMoreNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec (0.02s)\n"}
+{"Time":"2020-08-20T10:15:16.015852279Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec","Elapsed":0.02}
+{"Time":"2020-08-20T10:15:16.015858473Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Applying_the_Elasticsearch_mutation_should_succeed","Output":"    --- PASS: TestMutationMoreNodes/Applying_the_Elasticsearch_mutation_should_succeed (0.02s)\n"}
+{"Time":"2020-08-20T10:15:16.015865324Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Applying_the_Elasticsearch_mutation_should_succeed","Elapsed":0.02}
+{"Time":"2020-08-20T10:15:16.015876341Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed#01","Output":"    --- PASS: TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:15:16.015888996Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_certificate_authority_should_be_set_and_deployed#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:15:16.015894942Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready#01","Output":"    --- PASS: TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready#01 (27.17s)\n"}
+{"Time":"2020-08-20T10:15:16.015901226Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/All_expected_Pods_should_eventually_be_ready#01","Elapsed":27.17}
+{"Time":"2020-08-20T10:15:16.015941155Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one#02","Output":"    --- PASS: TestMutationMoreNodes/ES_version_should_be_the_expected_one#02 (0.01s)\n"}
+{"Time":"2020-08-20T10:15:16.015950778Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one#02","Elapsed":0.01}
+{"Time":"2020-08-20T10:15:16.01596366Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_be_created#01","Output":"    --- PASS: TestMutationMoreNodes/ES_services_should_be_created#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:15:16.015971189Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_be_created#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:15:16.015978099Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_have_endpoints#01","Output":"    --- PASS: TestMutationMoreNodes/ES_services_should_have_endpoints#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:15:16.01598509Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_services_should_have_endpoints#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:15:16.015995513Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Secrets_should_eventually_be_created#01","Output":"    --- PASS: TestMutationMoreNodes/Secrets_should_eventually_be_created#01 (0.05s)\n"}
+{"Time":"2020-08-20T10:15:16.016002417Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Secrets_should_eventually_be_created#01","Elapsed":0.05}
+{"Time":"2020-08-20T10:15:16.016007667Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate#01","Output":"    --- PASS: TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:15:16.016013649Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_pods_should_eventually_have_a_certificate#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:15:16.016019816Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green#01","Output":"    --- PASS: TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green#01 (0.00s)\n"}
+{"Time":"2020-08-20T10:15:16.016026598Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_cluster_health_should_eventually_be_green#01","Elapsed":0}
+{"Time":"2020-08-20T10:15:16.016033621Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elastic_password_should_be_available#01","Output":"    --- PASS: TestMutationMoreNodes/Elastic_password_should_be_available#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:15:16.016041808Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elastic_password_should_be_available#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:15:16.016048786Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Output":"    --- PASS: TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01 (0.00s)\n"}
+{"Time":"2020-08-20T10:15:16.016061074Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Elapsed":0}
+{"Time":"2020-08-20T10:15:16.016068129Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"    --- PASS: TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01 (0.00s)\n"}
+{"Time":"2020-08-20T10:15:16.016075368Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Elapsed":0}
+{"Time":"2020-08-20T10:15:16.016081549Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"    --- PASS: TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01 (0.19s)\n"}
+{"Time":"2020-08-20T10:15:16.016088412Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01","Elapsed":0.19}
+{"Time":"2020-08-20T10:15:16.01609478Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one#03","Output":"    --- PASS: TestMutationMoreNodes/ES_version_should_be_the_expected_one#03 (0.04s)\n"}
+{"Time":"2020-08-20T10:15:16.016101895Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_version_should_be_the_expected_one#03","Elapsed":0.04}
+{"Time":"2020-08-20T10:15:16.016108066Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable#01","Output":"    --- PASS: TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable#01 (0.09s)\n"}
+{"Time":"2020-08-20T10:15:16.016122783Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/ES_endpoint_should_eventually_be_reachable#01","Elapsed":0.09}
+{"Time":"2020-08-20T10:15:16.016137778Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Cluster_UUID_should_have_been_preserved","Output":"    --- PASS: TestMutationMoreNodes/Cluster_UUID_should_have_been_preserved (0.03s)\n"}
+{"Time":"2020-08-20T10:15:16.016145626Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Cluster_UUID_should_have_been_preserved","Elapsed":0.03}
+{"Time":"2020-08-20T10:15:16.016151947Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"    --- PASS: TestMutationMoreNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"}
+{"Time":"2020-08-20T10:15:16.016159564Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Elapsed":0}
+{"Time":"2020-08-20T10:15:16.01616626Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"    --- PASS: TestMutationMoreNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"}
+{"Time":"2020-08-20T10:15:16.01617388Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Elapsed":0}
+{"Time":"2020-08-20T10:15:16.016180126Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Data_added_initially_should_still_be_present","Output":"    --- PASS: TestMutationMoreNodes/Data_added_initially_should_still_be_present (0.13s)\n"}
+{"Time":"2020-08-20T10:15:16.016187412Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Data_added_initially_should_still_be_present","Elapsed":0.13}
+{"Time":"2020-08-20T10:15:16.016197493Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Deleting_Elasticsearch_should_return_no_error","Output":"    --- PASS: TestMutationMoreNodes/Deleting_Elasticsearch_should_return_no_error (0.01s)\n"}
+{"Time":"2020-08-20T10:15:16.016204359Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Deleting_Elasticsearch_should_return_no_error","Elapsed":0.01}
+{"Time":"2020-08-20T10:15:16.016209751Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_should_not_be_there_anymore","Output":"    --- PASS: TestMutationMoreNodes/Elasticsearch_should_not_be_there_anymore (0.00s)\n"}
+{"Time":"2020-08-20T10:15:16.01621631Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_should_not_be_there_anymore","Elapsed":0}
+{"Time":"2020-08-20T10:15:16.016224132Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_pods_should_eventually_be_removed","Output":"    --- PASS: TestMutationMoreNodes/Elasticsearch_pods_should_eventually_be_removed (45.11s)\n"}
+{"Time":"2020-08-20T10:15:16.016236783Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/Elasticsearch_pods_should_eventually_be_removed","Elapsed":45.11}
+{"Time":"2020-08-20T10:15:16.016248043Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/PVCs_should_eventually_be_removed","Output":"    --- PASS: TestMutationMoreNodes/PVCs_should_eventually_be_removed (0.00s)\n"}
+{"Time":"2020-08-20T10:15:16.016261591Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes/PVCs_should_eventually_be_removed","Elapsed":0}
+{"Time":"2020-08-20T10:15:16.016271972Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationMoreNodes","Elapsed":99.58}
+{"Time":"2020-08-20T10:15:16.016313547Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes"}
+{"Time":"2020-08-20T10:15:16.016334308Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes","Output":"=== RUN   TestMutationLessNodes\n"}
+{"Time":"2020-08-20T10:15:16.968913063Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/K8S_should_be_accessible"}
+{"Time":"2020-08-20T10:15:16.968978026Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/K8S_should_be_accessible","Output":"=== RUN   TestMutationLessNodes/K8S_should_be_accessible\n"}
+{"Time":"2020-08-20T10:15:16.991020795Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/K8S_should_be_accessible","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:16.991061525Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Label_test_pods"}
+{"Time":"2020-08-20T10:15:16.991066761Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Label_test_pods","Output":"=== RUN   TestMutationLessNodes/Label_test_pods\n"}
+{"Time":"2020-08-20T10:15:17.039630327Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Label_test_pods","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:17.039698976Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_CRDs_should_exist"}
+{"Time":"2020-08-20T10:15:17.039707404Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_CRDs_should_exist","Output":"=== RUN   TestMutationLessNodes/Elasticsearch_CRDs_should_exist\n"}
+{"Time":"2020-08-20T10:15:17.044262804Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_CRDs_should_exist","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:17.044304104Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Webhook_endpoint_should_not_be_empty"}
+{"Time":"2020-08-20T10:15:17.044311694Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Webhook_endpoint_should_not_be_empty","Output":"=== RUN   TestMutationLessNodes/Webhook_endpoint_should_not_be_empty\n"}
+{"Time":"2020-08-20T10:15:17.050835415Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Webhook_endpoint_should_not_be_empty","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:17.050893237Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Remove_Elasticsearch_if_it_already_exists"}
+{"Time":"2020-08-20T10:15:17.050906471Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Remove_Elasticsearch_if_it_already_exists","Output":"=== RUN   TestMutationLessNodes/Remove_Elasticsearch_if_it_already_exists\n"}
+{"Time":"2020-08-20T10:15:17.070575422Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Remove_Elasticsearch_if_it_already_exists","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:17.07062391Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Creating_an_Elasticsearch_cluster_should_succeed"}
+{"Time":"2020-08-20T10:15:17.070629972Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Creating_an_Elasticsearch_cluster_should_succeed","Output":"=== RUN   TestMutationLessNodes/Creating_an_Elasticsearch_cluster_should_succeed\n"}
+{"Time":"2020-08-20T10:15:17.083115604Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_cluster_should_be_created"}
+{"Time":"2020-08-20T10:15:17.083177278Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_cluster_should_be_created","Output":"=== RUN   TestMutationLessNodes/Elasticsearch_cluster_should_be_created\n"}
+{"Time":"2020-08-20T10:15:17.089109271Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed"}
+{"Time":"2020-08-20T10:15:17.089154091Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed","Output":"=== RUN   TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed\n"}
+{"Time":"2020-08-20T10:15:20.104901612Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed","Output":"Retries (5m0s timeout): ..\n"}
+{"Time":"2020-08-20T10:15:20.104965608Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready"}
+{"Time":"2020-08-20T10:15:20.104973409Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready","Output":"=== RUN   TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready\n"}
+{"Time":"2020-08-20T10:15:44.261999786Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready","Output":"Retries (30m0s timeout): .........\n"}
+{"Time":"2020-08-20T10:15:44.26209715Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one"}
+{"Time":"2020-08-20T10:15:44.262106283Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one","Output":"=== RUN   TestMutationLessNodes/ES_version_should_be_the_expected_one\n"}
+{"Time":"2020-08-20T10:15:44.271658103Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:44.271710648Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_be_created"}
+{"Time":"2020-08-20T10:15:44.271719309Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_be_created","Output":"=== RUN   TestMutationLessNodes/ES_services_should_be_created\n"}
+{"Time":"2020-08-20T10:15:44.281968473Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_be_created","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:44.282023434Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_have_endpoints"}
+{"Time":"2020-08-20T10:15:44.282032638Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_have_endpoints","Output":"=== RUN   TestMutationLessNodes/ES_services_should_have_endpoints\n"}
+{"Time":"2020-08-20T10:15:44.292211958Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_have_endpoints","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:44.292265401Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Secrets_should_eventually_be_created"}
+{"Time":"2020-08-20T10:15:44.292273795Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Secrets_should_eventually_be_created","Output":"=== RUN   TestMutationLessNodes/Secrets_should_eventually_be_created\n"}
+{"Time":"2020-08-20T10:15:44.326372134Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Secrets_should_eventually_be_created","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:44.326452162Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate"}
+{"Time":"2020-08-20T10:15:44.326459792Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate","Output":"=== RUN   TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate\n"}
+{"Time":"2020-08-20T10:15:44.344542334Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:44.344587797Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_cluster_health_should_eventually_be_green"}
+{"Time":"2020-08-20T10:15:44.344595224Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_cluster_health_should_eventually_be_green","Output":"=== RUN   TestMutationLessNodes/ES_cluster_health_should_eventually_be_green\n"}
+{"Time":"2020-08-20T10:15:50.358508464Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_cluster_health_should_eventually_be_green","Output":"Retries (5m0s timeout): ...\n"}
+{"Time":"2020-08-20T10:15:50.358609322Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elastic_password_should_be_available"}
+{"Time":"2020-08-20T10:15:50.358618228Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elastic_password_should_be_available","Output":"=== RUN   TestMutationLessNodes/Elastic_password_should_be_available\n"}
+{"Time":"2020-08-20T10:15:50.363779328Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elastic_password_should_be_available","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:50.363823744Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type"}
+{"Time":"2020-08-20T10:15:50.363830359Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type","Output":"=== RUN   TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type\n"}
+{"Time":"2020-08-20T10:15:50.370251018Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped"}
+{"Time":"2020-08-20T10:15:50.370285779Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"=== RUN   TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped\n"}
+{"Time":"2020-08-20T10:15:50.374377365Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:50.374424218Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one"}
+{"Time":"2020-08-20T10:15:50.37443241Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"=== RUN   TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one\n"}
+{"Time":"2020-08-20T10:15:50.529414662Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:50.529458966Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one#01"}
+{"Time":"2020-08-20T10:15:50.529464319Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one#01","Output":"=== RUN   TestMutationLessNodes/ES_version_should_be_the_expected_one#01\n"}
+{"Time":"2020-08-20T10:15:50.566120578Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:50.566177414Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable"}
+{"Time":"2020-08-20T10:15:50.566186049Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable","Output":"=== RUN   TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable\n"}
+{"Time":"2020-08-20T10:15:50.612464937Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:50.612516325Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Add_some_data_to_the_cluster_before_starting_the_mutation"}
+{"Time":"2020-08-20T10:15:50.612522463Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Add_some_data_to_the_cluster_before_starting_the_mutation","Output":"=== RUN   TestMutationLessNodes/Add_some_data_to_the_cluster_before_starting_the_mutation\n"}
+{"Time":"2020-08-20T10:15:52.252681075Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on"}
+{"Time":"2020-08-20T10:15:52.252720183Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on","Output":"=== RUN   TestMutationLessNodes/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on\n"}
+{"Time":"2020-08-20T10:15:52.252733667Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"}
+{"Time":"2020-08-20T10:15:52.252738314Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"=== RUN   TestMutationLessNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"}
+{"Time":"2020-08-20T10:15:52.252748824Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"}
+{"Time":"2020-08-20T10:15:52.252758424Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"=== RUN   TestMutationLessNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"}
+{"Time":"2020-08-20T10:15:52.252766763Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose"}
+{"Time":"2020-08-20T10:15:52.252772402Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"=== RUN   TestMutationLessNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose\n"}
+{"Time":"2020-08-20T10:15:52.283816296Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:52.283861855Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec"}
+{"Time":"2020-08-20T10:15:52.283868217Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"=== RUN   TestMutationLessNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec\n"}
+{"Time":"2020-08-20T10:15:52.338348204Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:52.338409071Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Applying_the_Elasticsearch_mutation_should_succeed"}
+{"Time":"2020-08-20T10:15:52.338416132Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Applying_the_Elasticsearch_mutation_should_succeed","Output":"=== RUN   TestMutationLessNodes/Applying_the_Elasticsearch_mutation_should_succeed\n"}
+{"Time":"2020-08-20T10:15:52.366109583Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Applying_the_Elasticsearch_mutation_should_succeed","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:52.366159847Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed#01"}
+{"Time":"2020-08-20T10:15:52.366168726Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed#01","Output":"=== RUN   TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed#01\n"}
+{"Time":"2020-08-20T10:15:52.374506838Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:15:52.374557718Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready#01"}
+{"Time":"2020-08-20T10:15:52.374563146Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready#01","Output":"=== RUN   TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready#01\n"}
+{"Time":"2020-08-20T10:17:13.706888144Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready#01","Output":"Retries (30m0s timeout): ............................\n"}
+{"Time":"2020-08-20T10:17:13.70695606Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one#02"}
+{"Time":"2020-08-20T10:17:13.706961997Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one#02","Output":"=== RUN   TestMutationLessNodes/ES_version_should_be_the_expected_one#02\n"}
+{"Time":"2020-08-20T10:17:13.717756087Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one#02","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:13.717807879Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_be_created#01"}
+{"Time":"2020-08-20T10:17:13.717818316Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_be_created#01","Output":"=== RUN   TestMutationLessNodes/ES_services_should_be_created#01\n"}
+{"Time":"2020-08-20T10:17:13.725354172Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_be_created#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:13.725405271Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_have_endpoints#01"}
+{"Time":"2020-08-20T10:17:13.725413272Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_have_endpoints#01","Output":"=== RUN   TestMutationLessNodes/ES_services_should_have_endpoints#01\n"}
+{"Time":"2020-08-20T10:17:13.738753057Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_have_endpoints#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:13.738797578Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Secrets_should_eventually_be_created#01"}
+{"Time":"2020-08-20T10:17:13.738802791Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Secrets_should_eventually_be_created#01","Output":"=== RUN   TestMutationLessNodes/Secrets_should_eventually_be_created#01\n"}
+{"Time":"2020-08-20T10:17:13.774919507Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Secrets_should_eventually_be_created#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:13.774988023Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate#01"}
+{"Time":"2020-08-20T10:17:13.774993977Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate#01","Output":"=== RUN   TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate#01\n"}
+{"Time":"2020-08-20T10:17:13.783999608Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:13.784042569Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_cluster_health_should_eventually_be_green#01"}
+{"Time":"2020-08-20T10:17:13.784047967Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_cluster_health_should_eventually_be_green#01","Output":"=== RUN   TestMutationLessNodes/ES_cluster_health_should_eventually_be_green#01\n"}
+{"Time":"2020-08-20T10:17:13.788833552Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_cluster_health_should_eventually_be_green#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:13.788876808Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elastic_password_should_be_available#01"}
+{"Time":"2020-08-20T10:17:13.788881756Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elastic_password_should_be_available#01","Output":"=== RUN   TestMutationLessNodes/Elastic_password_should_be_available#01\n"}
+{"Time":"2020-08-20T10:17:13.793284413Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elastic_password_should_be_available#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:13.793344494Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01"}
+{"Time":"2020-08-20T10:17:13.793353152Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Output":"=== RUN   TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01\n"}
+{"Time":"2020-08-20T10:17:13.806559557Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01"}
+{"Time":"2020-08-20T10:17:13.806598131Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"=== RUN   TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01\n"}
+{"Time":"2020-08-20T10:17:13.813980568Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:13.814035671Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01"}
+{"Time":"2020-08-20T10:17:13.814044444Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"=== RUN   TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01\n"}
+{"Time":"2020-08-20T10:17:13.853908085Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:13.854038751Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one#03"}
+{"Time":"2020-08-20T10:17:13.854046769Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one#03","Output":"=== RUN   TestMutationLessNodes/ES_version_should_be_the_expected_one#03\n"}
+{"Time":"2020-08-20T10:17:13.88199924Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one#03","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:13.882045652Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable#01"}
+{"Time":"2020-08-20T10:17:13.882054149Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable#01","Output":"=== RUN   TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable#01\n"}
+{"Time":"2020-08-20T10:17:13.91227191Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:13.912318714Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Cluster_UUID_should_have_been_preserved"}
+{"Time":"2020-08-20T10:17:13.912324525Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Cluster_UUID_should_have_been_preserved","Output":"=== RUN   TestMutationLessNodes/Cluster_UUID_should_have_been_preserved\n"}
+{"Time":"2020-08-20T10:17:13.943326599Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"}
+{"Time":"2020-08-20T10:17:13.943364806Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"=== RUN   TestMutationLessNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"}
+{"Time":"2020-08-20T10:17:13.943372287Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"}
+{"Time":"2020-08-20T10:17:13.943377914Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"=== RUN   TestMutationLessNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"}
+{"Time":"2020-08-20T10:17:13.943583596Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process"}
+{"Time":"2020-08-20T10:17:13.943600431Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process","Output":"=== RUN   TestMutationLessNodes/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process\n"}
+{"Time":"2020-08-20T10:17:13.943611156Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Data_added_initially_should_still_be_present"}
+{"Time":"2020-08-20T10:17:13.943616567Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Data_added_initially_should_still_be_present","Output":"=== RUN   TestMutationLessNodes/Data_added_initially_should_still_be_present\n"}
+{"Time":"2020-08-20T10:17:14.028247668Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Data_added_initially_should_still_be_present","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:14.02829156Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Deleting_Elasticsearch_should_return_no_error"}
+{"Time":"2020-08-20T10:17:14.028296667Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Deleting_Elasticsearch_should_return_no_error","Output":"=== RUN   TestMutationLessNodes/Deleting_Elasticsearch_should_return_no_error\n"}
+{"Time":"2020-08-20T10:17:14.044658584Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_should_not_be_there_anymore"}
+{"Time":"2020-08-20T10:17:14.044699271Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_should_not_be_there_anymore","Output":"=== RUN   TestMutationLessNodes/Elasticsearch_should_not_be_there_anymore\n"}
+{"Time":"2020-08-20T10:17:14.049143033Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_should_not_be_there_anymore","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:14.049209001Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_pods_should_eventually_be_removed"}
+{"Time":"2020-08-20T10:17:14.049214832Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_pods_should_eventually_be_removed","Output":"=== RUN   TestMutationLessNodes/Elasticsearch_pods_should_eventually_be_removed\n"}
+{"Time":"2020-08-20T10:17:53.135503906Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_pods_should_eventually_be_removed","Output":"Retries (5m0s timeout): ..............\n"}
+{"Time":"2020-08-20T10:17:53.135594023Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/PVCs_should_eventually_be_removed"}
+{"Time":"2020-08-20T10:17:53.135602969Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/PVCs_should_eventually_be_removed","Output":"=== RUN   TestMutationLessNodes/PVCs_should_eventually_be_removed\n"}
+{"Time":"2020-08-20T10:17:53.140082529Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/PVCs_should_eventually_be_removed","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:53.140125573Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes","Output":"--- PASS: TestMutationLessNodes (157.12s)\n"}
+{"Time":"2020-08-20T10:17:53.14013754Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/K8S_should_be_accessible","Output":"    --- PASS: TestMutationLessNodes/K8S_should_be_accessible (0.02s)\n"}
+{"Time":"2020-08-20T10:17:53.140144862Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/K8S_should_be_accessible","Elapsed":0.02}
+{"Time":"2020-08-20T10:17:53.140155892Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Label_test_pods","Output":"    --- PASS: TestMutationLessNodes/Label_test_pods (0.05s)\n"}
+{"Time":"2020-08-20T10:17:53.140163232Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Label_test_pods","Elapsed":0.05}
+{"Time":"2020-08-20T10:17:53.140170505Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_CRDs_should_exist","Output":"    --- PASS: TestMutationLessNodes/Elasticsearch_CRDs_should_exist (0.00s)\n"}
+{"Time":"2020-08-20T10:17:53.140178254Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_CRDs_should_exist","Elapsed":0}
+{"Time":"2020-08-20T10:17:53.140184368Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Webhook_endpoint_should_not_be_empty","Output":"    --- PASS: TestMutationLessNodes/Webhook_endpoint_should_not_be_empty (0.01s)\n"}
+{"Time":"2020-08-20T10:17:53.140190207Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Webhook_endpoint_should_not_be_empty","Elapsed":0.01}
+{"Time":"2020-08-20T10:17:53.140199955Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Remove_Elasticsearch_if_it_already_exists","Output":"    --- PASS: TestMutationLessNodes/Remove_Elasticsearch_if_it_already_exists (0.02s)\n"}
+{"Time":"2020-08-20T10:17:53.140205537Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Remove_Elasticsearch_if_it_already_exists","Elapsed":0.02}
+{"Time":"2020-08-20T10:17:53.140210274Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Creating_an_Elasticsearch_cluster_should_succeed","Output":"    --- PASS: TestMutationLessNodes/Creating_an_Elasticsearch_cluster_should_succeed (0.01s)\n"}
+{"Time":"2020-08-20T10:17:53.140228046Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Creating_an_Elasticsearch_cluster_should_succeed","Elapsed":0.01}
+{"Time":"2020-08-20T10:17:53.140241423Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_cluster_should_be_created","Output":"    --- PASS: TestMutationLessNodes/Elasticsearch_cluster_should_be_created (0.01s)\n"}
+{"Time":"2020-08-20T10:17:53.14024959Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_cluster_should_be_created","Elapsed":0.01}
+{"Time":"2020-08-20T10:17:53.140255043Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed","Output":"    --- PASS: TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed (3.02s)\n"}
+{"Time":"2020-08-20T10:17:53.140260416Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed","Elapsed":3.02}
+{"Time":"2020-08-20T10:17:53.140266505Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready","Output":"    --- PASS: TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready (24.16s)\n"}
+{"Time":"2020-08-20T10:17:53.140272009Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready","Elapsed":24.16}
+{"Time":"2020-08-20T10:17:53.140277723Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one","Output":"    --- PASS: TestMutationLessNodes/ES_version_should_be_the_expected_one (0.01s)\n"}
+{"Time":"2020-08-20T10:17:53.140283544Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one","Elapsed":0.01}
+{"Time":"2020-08-20T10:17:53.140295623Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_be_created","Output":"    --- PASS: TestMutationLessNodes/ES_services_should_be_created (0.01s)\n"}
+{"Time":"2020-08-20T10:17:53.140302645Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_be_created","Elapsed":0.01}
+{"Time":"2020-08-20T10:17:53.140308621Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_have_endpoints","Output":"    --- PASS: TestMutationLessNodes/ES_services_should_have_endpoints (0.01s)\n"}
+{"Time":"2020-08-20T10:17:53.14031526Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_have_endpoints","Elapsed":0.01}
+{"Time":"2020-08-20T10:17:53.140335271Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Secrets_should_eventually_be_created","Output":"    --- PASS: TestMutationLessNodes/Secrets_should_eventually_be_created (0.03s)\n"}
+{"Time":"2020-08-20T10:17:53.140348182Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Secrets_should_eventually_be_created","Elapsed":0.03}
+{"Time":"2020-08-20T10:17:53.140353599Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate","Output":"    --- PASS: TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate (0.02s)\n"}
+{"Time":"2020-08-20T10:17:53.140359483Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate","Elapsed":0.02}
+{"Time":"2020-08-20T10:17:53.140365048Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_cluster_health_should_eventually_be_green","Output":"    --- PASS: TestMutationLessNodes/ES_cluster_health_should_eventually_be_green (6.01s)\n"}
+{"Time":"2020-08-20T10:17:53.140370759Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_cluster_health_should_eventually_be_green","Elapsed":6.01}
+{"Time":"2020-08-20T10:17:53.140376823Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elastic_password_should_be_available","Output":"    --- PASS: TestMutationLessNodes/Elastic_password_should_be_available (0.01s)\n"}
+{"Time":"2020-08-20T10:17:53.140394919Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elastic_password_should_be_available","Elapsed":0.01}
+{"Time":"2020-08-20T10:17:53.140400906Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type","Output":"    --- PASS: TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type (0.01s)\n"}
+{"Time":"2020-08-20T10:17:53.140407551Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type","Elapsed":0.01}
+{"Time":"2020-08-20T10:17:53.140413304Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"    --- PASS: TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped (0.00s)\n"}
+{"Time":"2020-08-20T10:17:53.140425273Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Elapsed":0}
+{"Time":"2020-08-20T10:17:53.140430919Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"    --- PASS: TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one (0.15s)\n"}
+{"Time":"2020-08-20T10:17:53.140437168Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one","Elapsed":0.15}
+{"Time":"2020-08-20T10:17:53.140442895Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one#01","Output":"    --- PASS: TestMutationLessNodes/ES_version_should_be_the_expected_one#01 (0.04s)\n"}
+{"Time":"2020-08-20T10:17:53.140448848Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one#01","Elapsed":0.04}
+{"Time":"2020-08-20T10:17:53.140462667Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable","Output":"    --- PASS: TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable (0.05s)\n"}
+{"Time":"2020-08-20T10:17:53.140469219Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable","Elapsed":0.05}
+{"Time":"2020-08-20T10:17:53.140477653Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Add_some_data_to_the_cluster_before_starting_the_mutation","Output":"    --- PASS: TestMutationLessNodes/Add_some_data_to_the_cluster_before_starting_the_mutation (1.64s)\n"}
+{"Time":"2020-08-20T10:17:53.140485869Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Add_some_data_to_the_cluster_before_starting_the_mutation","Elapsed":1.64}
+{"Time":"2020-08-20T10:17:53.140491375Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on","Output":"    --- PASS: TestMutationLessNodes/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on (0.00s)\n"}
+{"Time":"2020-08-20T10:17:53.140499271Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on","Elapsed":0}
+{"Time":"2020-08-20T10:17:53.140509618Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"    --- PASS: TestMutationLessNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"}
+{"Time":"2020-08-20T10:17:53.14051852Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Elapsed":0}
+{"Time":"2020-08-20T10:17:53.140524418Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"    --- PASS: TestMutationLessNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"}
+{"Time":"2020-08-20T10:17:53.140536217Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Elapsed":0}
+{"Time":"2020-08-20T10:17:53.140541784Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"    --- PASS: TestMutationLessNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose (0.03s)\n"}
+{"Time":"2020-08-20T10:17:53.140548187Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Elapsed":0.03}
+{"Time":"2020-08-20T10:17:53.140558157Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"    --- PASS: TestMutationLessNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec (0.05s)\n"}
+{"Time":"2020-08-20T10:17:53.140568501Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Annotate_Pods_with_a_hash_of_their_Builder_spec","Elapsed":0.05}
+{"Time":"2020-08-20T10:17:53.140574067Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Applying_the_Elasticsearch_mutation_should_succeed","Output":"    --- PASS: TestMutationLessNodes/Applying_the_Elasticsearch_mutation_should_succeed (0.03s)\n"}
+{"Time":"2020-08-20T10:17:53.140579915Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Applying_the_Elasticsearch_mutation_should_succeed","Elapsed":0.03}
+{"Time":"2020-08-20T10:17:53.140585227Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed#01","Output":"    --- PASS: TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:17:53.140591065Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_certificate_authority_should_be_set_and_deployed#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:17:53.140596756Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready#01","Output":"    --- PASS: TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready#01 (81.33s)\n"}
+{"Time":"2020-08-20T10:17:53.140602765Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/All_expected_Pods_should_eventually_be_ready#01","Elapsed":81.33}
+{"Time":"2020-08-20T10:17:53.140629858Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one#02","Output":"    --- PASS: TestMutationLessNodes/ES_version_should_be_the_expected_one#02 (0.01s)\n"}
+{"Time":"2020-08-20T10:17:53.140636643Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one#02","Elapsed":0.01}
+{"Time":"2020-08-20T10:17:53.140642317Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_be_created#01","Output":"    --- PASS: TestMutationLessNodes/ES_services_should_be_created#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:17:53.14064849Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_be_created#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:17:53.140653829Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_have_endpoints#01","Output":"    --- PASS: TestMutationLessNodes/ES_services_should_have_endpoints#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:17:53.14066015Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_services_should_have_endpoints#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:17:53.140665555Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Secrets_should_eventually_be_created#01","Output":"    --- PASS: TestMutationLessNodes/Secrets_should_eventually_be_created#01 (0.04s)\n"}
+{"Time":"2020-08-20T10:17:53.140671596Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Secrets_should_eventually_be_created#01","Elapsed":0.04}
+{"Time":"2020-08-20T10:17:53.140676923Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate#01","Output":"    --- PASS: TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:17:53.140683441Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_pods_should_eventually_have_a_certificate#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:17:53.140689317Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_cluster_health_should_eventually_be_green#01","Output":"    --- PASS: TestMutationLessNodes/ES_cluster_health_should_eventually_be_green#01 (0.00s)\n"}
+{"Time":"2020-08-20T10:17:53.140695814Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_cluster_health_should_eventually_be_green#01","Elapsed":0}
+{"Time":"2020-08-20T10:17:53.140714393Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elastic_password_should_be_available#01","Output":"    --- PASS: TestMutationLessNodes/Elastic_password_should_be_available#01 (0.00s)\n"}
+{"Time":"2020-08-20T10:17:53.140720523Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elastic_password_should_be_available#01","Elapsed":0}
+{"Time":"2020-08-20T10:17:53.140725525Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Output":"    --- PASS: TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:17:53.140731157Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:17:53.140737081Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"    --- PASS: TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:17:53.140742773Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:17:53.140747833Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"    --- PASS: TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01 (0.04s)\n"}
+{"Time":"2020-08-20T10:17:53.140753539Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_nodes_topology_should_eventually_be_the_expected_one#01","Elapsed":0.04}
+{"Time":"2020-08-20T10:17:53.140758458Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one#03","Output":"    --- PASS: TestMutationLessNodes/ES_version_should_be_the_expected_one#03 (0.03s)\n"}
+{"Time":"2020-08-20T10:17:53.14076706Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_version_should_be_the_expected_one#03","Elapsed":0.03}
+{"Time":"2020-08-20T10:17:53.140772143Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable#01","Output":"    --- PASS: TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable#01 (0.03s)\n"}
+{"Time":"2020-08-20T10:17:53.140777587Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/ES_endpoint_should_eventually_be_reachable#01","Elapsed":0.03}
+{"Time":"2020-08-20T10:17:53.140782477Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Cluster_UUID_should_have_been_preserved","Output":"    --- PASS: TestMutationLessNodes/Cluster_UUID_should_have_been_preserved (0.03s)\n"}
+{"Time":"2020-08-20T10:17:53.140838435Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Cluster_UUID_should_have_been_preserved","Elapsed":0.03}
+{"Time":"2020-08-20T10:17:53.140858563Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"    --- PASS: TestMutationLessNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"}
+{"Time":"2020-08-20T10:17:53.14086619Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Elapsed":0}
+{"Time":"2020-08-20T10:17:53.140883105Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"    --- PASS: TestMutationLessNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"}
+{"Time":"2020-08-20T10:17:53.140889871Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Elapsed":0}
+{"Time":"2020-08-20T10:17:53.140895859Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process","Output":"    --- PASS: TestMutationLessNodes/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process (0.00s)\n"}
+{"Time":"2020-08-20T10:17:53.140901577Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process","Elapsed":0}
+{"Time":"2020-08-20T10:17:53.140909832Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Data_added_initially_should_still_be_present","Output":"    --- PASS: TestMutationLessNodes/Data_added_initially_should_still_be_present (0.08s)\n"}
+{"Time":"2020-08-20T10:17:53.140916013Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Data_added_initially_should_still_be_present","Elapsed":0.08}
+{"Time":"2020-08-20T10:17:53.140941919Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Deleting_Elasticsearch_should_return_no_error","Output":"    --- PASS: TestMutationLessNodes/Deleting_Elasticsearch_should_return_no_error (0.02s)\n"}
+{"Time":"2020-08-20T10:17:53.140954928Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Deleting_Elasticsearch_should_return_no_error","Elapsed":0.02}
+{"Time":"2020-08-20T10:17:53.140961387Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_should_not_be_there_anymore","Output":"    --- PASS: TestMutationLessNodes/Elasticsearch_should_not_be_there_anymore (0.00s)\n"}
+{"Time":"2020-08-20T10:17:53.140968411Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_should_not_be_there_anymore","Elapsed":0}
+{"Time":"2020-08-20T10:17:53.140980981Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_pods_should_eventually_be_removed","Output":"    --- PASS: TestMutationLessNodes/Elasticsearch_pods_should_eventually_be_removed (39.09s)\n"}
+{"Time":"2020-08-20T10:17:53.140987922Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/Elasticsearch_pods_should_eventually_be_removed","Elapsed":39.09}
+{"Time":"2020-08-20T10:17:53.140994557Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/PVCs_should_eventually_be_removed","Output":"    --- PASS: TestMutationLessNodes/PVCs_should_eventually_be_removed (0.00s)\n"}
+{"Time":"2020-08-20T10:17:53.141059008Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes/PVCs_should_eventually_be_removed","Elapsed":0}
+{"Time":"2020-08-20T10:17:53.141071099Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationLessNodes","Elapsed":157.12}
+{"Time":"2020-08-20T10:17:53.141077299Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp"}
+{"Time":"2020-08-20T10:17:53.141083935Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp","Output":"=== RUN   TestMutationResizeMemoryUp\n"}
+{"Time":"2020-08-20T10:17:54.095852115Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/K8S_should_be_accessible"}
+{"Time":"2020-08-20T10:17:54.095899912Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/K8S_should_be_accessible","Output":"=== RUN   TestMutationResizeMemoryUp/K8S_should_be_accessible\n"}
+{"Time":"2020-08-20T10:17:54.115283195Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/K8S_should_be_accessible","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:54.115337739Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Label_test_pods"}
+{"Time":"2020-08-20T10:17:54.115345908Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Label_test_pods","Output":"=== RUN   TestMutationResizeMemoryUp/Label_test_pods\n"}
+{"Time":"2020-08-20T10:17:54.155332125Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Label_test_pods","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:54.155386837Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_CRDs_should_exist"}
+{"Time":"2020-08-20T10:17:54.155394549Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_CRDs_should_exist","Output":"=== RUN   TestMutationResizeMemoryUp/Elasticsearch_CRDs_should_exist\n"}
+{"Time":"2020-08-20T10:17:54.161222281Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_CRDs_should_exist","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:54.161260363Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Webhook_endpoint_should_not_be_empty"}
+{"Time":"2020-08-20T10:17:54.161265661Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Webhook_endpoint_should_not_be_empty","Output":"=== RUN   TestMutationResizeMemoryUp/Webhook_endpoint_should_not_be_empty\n"}
+{"Time":"2020-08-20T10:17:54.166611924Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Webhook_endpoint_should_not_be_empty","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:54.166698709Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Remove_Elasticsearch_if_it_already_exists"}
+{"Time":"2020-08-20T10:17:54.1667103Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Remove_Elasticsearch_if_it_already_exists","Output":"=== RUN   TestMutationResizeMemoryUp/Remove_Elasticsearch_if_it_already_exists\n"}
+{"Time":"2020-08-20T10:17:54.191181142Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Remove_Elasticsearch_if_it_already_exists","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:17:54.191223135Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Creating_an_Elasticsearch_cluster_should_succeed"}
+{"Time":"2020-08-20T10:17:54.191228573Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Creating_an_Elasticsearch_cluster_should_succeed","Output":"=== RUN   TestMutationResizeMemoryUp/Creating_an_Elasticsearch_cluster_should_succeed\n"}
+{"Time":"2020-08-20T10:17:54.211237739Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_cluster_should_be_created"}
+{"Time":"2020-08-20T10:17:54.211297844Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_cluster_should_be_created","Output":"=== RUN   TestMutationResizeMemoryUp/Elasticsearch_cluster_should_be_created\n"}
+{"Time":"2020-08-20T10:17:54.218080635Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed"}
+{"Time":"2020-08-20T10:17:54.218114308Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed","Output":"=== RUN   TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed\n"}
+{"Time":"2020-08-20T10:17:57.233326503Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed","Output":"Retries (5m0s timeout): ..\n"}
+{"Time":"2020-08-20T10:17:57.233384642Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready"}
+{"Time":"2020-08-20T10:17:57.23339288Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready","Output":"=== RUN   TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready\n"}
+{"Time":"2020-08-20T10:18:27.423831639Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready","Output":"Retries (30m0s timeout): ...........\n"}
+{"Time":"2020-08-20T10:18:27.423941159Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one"}
+{"Time":"2020-08-20T10:18:27.42395052Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one","Output":"=== RUN   TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one\n"}
+{"Time":"2020-08-20T10:18:27.433882622Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:18:27.433947938Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_be_created"}
+{"Time":"2020-08-20T10:18:27.43395662Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_be_created","Output":"=== RUN   TestMutationResizeMemoryUp/ES_services_should_be_created\n"}
+{"Time":"2020-08-20T10:18:27.44144043Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_be_created","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:18:27.441473607Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_have_endpoints"}
+{"Time":"2020-08-20T10:18:27.441484981Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_have_endpoints","Output":"=== RUN   TestMutationResizeMemoryUp/ES_services_should_have_endpoints\n"}
+{"Time":"2020-08-20T10:18:27.447221383Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_have_endpoints","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:18:27.447256621Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Secrets_should_eventually_be_created"}
+{"Time":"2020-08-20T10:18:27.447264161Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Secrets_should_eventually_be_created","Output":"=== RUN   TestMutationResizeMemoryUp/Secrets_should_eventually_be_created\n"}
+{"Time":"2020-08-20T10:18:27.486312389Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Secrets_should_eventually_be_created","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:18:27.486346162Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate"}
+{"Time":"2020-08-20T10:18:27.486354665Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate","Output":"=== RUN   TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate\n"}
+{"Time":"2020-08-20T10:18:27.515186859Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:18:27.515215535Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green"}
+{"Time":"2020-08-20T10:18:27.515221175Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green","Output":"=== RUN   TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green\n"}
+{"Time":"2020-08-20T10:18:27.521005034Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:18:27.521032891Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elastic_password_should_be_available"}
+{"Time":"2020-08-20T10:18:27.521050723Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elastic_password_should_be_available","Output":"=== RUN   TestMutationResizeMemoryUp/Elastic_password_should_be_available\n"}
+{"Time":"2020-08-20T10:18:27.526680908Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elastic_password_should_be_available","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:18:27.52671489Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type"}
+{"Time":"2020-08-20T10:18:27.526720352Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type","Output":"=== RUN   TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type\n"}
+{"Time":"2020-08-20T10:18:27.533706741Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped"}
+{"Time":"2020-08-20T10:18:27.533774092Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"=== RUN   TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped\n"}
+{"Time":"2020-08-20T10:18:27.53828118Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:18:27.53830867Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one"}
+{"Time":"2020-08-20T10:18:27.538315864Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"=== RUN   TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one\n"}
+{"Time":"2020-08-20T10:18:27.673414181Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:18:27.673469643Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#01"}
+{"Time":"2020-08-20T10:18:27.673476544Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#01","Output":"=== RUN   TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#01\n"}
+{"Time":"2020-08-20T10:18:27.707551783Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:18:27.707595342Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable"}
+{"Time":"2020-08-20T10:18:27.707604043Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable","Output":"=== RUN   TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable\n"}
+{"Time":"2020-08-20T10:18:27.827205819Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:18:27.827257397Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Add_some_data_to_the_cluster_before_starting_the_mutation"}
+{"Time":"2020-08-20T10:18:27.827270156Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Add_some_data_to_the_cluster_before_starting_the_mutation","Output":"=== RUN   TestMutationResizeMemoryUp/Add_some_data_to_the_cluster_before_starting_the_mutation\n"}
+{"Time":"2020-08-20T10:18:29.994002529Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on"}
+{"Time":"2020-08-20T10:18:29.994054425Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on","Output":"=== RUN   TestMutationResizeMemoryUp/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on\n"}
+{"Time":"2020-08-20T10:18:29.994642068Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"}
+{"Time":"2020-08-20T10:18:29.99483486Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"=== RUN   TestMutationResizeMemoryUp/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"}
+{"Time":"2020-08-20T10:18:29.995105421Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"}
+{"Time":"2020-08-20T10:18:29.995274425Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"=== RUN   TestMutationResizeMemoryUp/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"}
+{"Time":"2020-08-20T10:18:29.995303933Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose"}
+{"Time":"2020-08-20T10:18:29.995311481Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"=== RUN   TestMutationResizeMemoryUp/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose\n"}
+{"Time":"2020-08-20T10:18:30.0313495Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:18:30.031391019Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Annotate_Pods_with_a_hash_of_their_Builder_spec"}
+{"Time":"2020-08-20T10:18:30.031398932Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"=== RUN   TestMutationResizeMemoryUp/Annotate_Pods_with_a_hash_of_their_Builder_spec\n"}
+{"Time":"2020-08-20T10:18:30.080664512Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:18:30.080707907Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Applying_the_Elasticsearch_mutation_should_succeed"}
+{"Time":"2020-08-20T10:18:30.080713906Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Applying_the_Elasticsearch_mutation_should_succeed","Output":"=== RUN   TestMutationResizeMemoryUp/Applying_the_Elasticsearch_mutation_should_succeed\n"}
+{"Time":"2020-08-20T10:18:30.11082115Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Applying_the_Elasticsearch_mutation_should_succeed","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:18:30.11087334Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed#01"}
+{"Time":"2020-08-20T10:18:30.11087923Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed#01","Output":"=== RUN   TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed#01\n"}
+{"Time":"2020-08-20T10:18:30.119819657Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:18:30.119867581Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready#01"}
+{"Time":"2020-08-20T10:18:30.119875594Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready#01","Output":"=== RUN   TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready#01\n"}
+{"Time":"2020-08-20T10:21:37.219836592Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready#01","Output":"Retries (30m0s timeout): ...............................................................\n"}
+{"Time":"2020-08-20T10:21:37.21997844Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#02"}
+{"Time":"2020-08-20T10:21:37.219988296Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#02","Output":"=== RUN   TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#02\n"}
+{"Time":"2020-08-20T10:21:37.229189591Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#02","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:21:37.229251634Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_be_created#01"}
+{"Time":"2020-08-20T10:21:37.229260162Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_be_created#01","Output":"=== RUN   TestMutationResizeMemoryUp/ES_services_should_be_created#01\n"}
+{"Time":"2020-08-20T10:21:37.238680593Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_be_created#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:21:37.238739753Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_have_endpoints#01"}
+{"Time":"2020-08-20T10:21:37.238747808Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_have_endpoints#01","Output":"=== RUN   TestMutationResizeMemoryUp/ES_services_should_have_endpoints#01\n"}
+{"Time":"2020-08-20T10:21:37.248433476Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_have_endpoints#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:21:37.248544831Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Secrets_should_eventually_be_created#01"}
+{"Time":"2020-08-20T10:21:37.248550433Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Secrets_should_eventually_be_created#01","Output":"=== RUN   TestMutationResizeMemoryUp/Secrets_should_eventually_be_created#01\n"}
+{"Time":"2020-08-20T10:21:37.286382418Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Secrets_should_eventually_be_created#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:21:37.286428126Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate#01"}
+{"Time":"2020-08-20T10:21:37.286437384Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate#01","Output":"=== RUN   TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate#01\n"}
+{"Time":"2020-08-20T10:21:37.30505254Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:21:37.30510723Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green#01"}
+{"Time":"2020-08-20T10:21:37.305115197Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green#01","Output":"=== RUN   TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green#01\n"}
+{"Time":"2020-08-20T10:21:49.340504179Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green#01","Output":"Retries (5m0s timeout): .....\n"}
+{"Time":"2020-08-20T10:21:49.340579247Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elastic_password_should_be_available#01"}
+{"Time":"2020-08-20T10:21:49.340586554Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elastic_password_should_be_available#01","Output":"=== RUN   TestMutationResizeMemoryUp/Elastic_password_should_be_available#01\n"}
+{"Time":"2020-08-20T10:21:49.345135178Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elastic_password_should_be_available#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:21:49.345176201Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type#01"}
+{"Time":"2020-08-20T10:21:49.34518275Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Output":"=== RUN   TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type#01\n"}
+{"Time":"2020-08-20T10:21:49.351052533Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01"}
+{"Time":"2020-08-20T10:21:49.351089222Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"=== RUN   TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01\n"}
+{"Time":"2020-08-20T10:21:49.354691395Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:21:49.354733955Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one#01"}
+{"Time":"2020-08-20T10:21:49.354743559Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"=== RUN   TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one#01\n"}
+{"Time":"2020-08-20T10:21:49.409267346Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:21:49.409318833Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#03"}
+{"Time":"2020-08-20T10:21:49.409327184Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#03","Output":"=== RUN   TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#03\n"}
+{"Time":"2020-08-20T10:21:49.44659469Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#03","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:21:49.446751085Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable#01"}
+{"Time":"2020-08-20T10:21:49.446783263Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable#01","Output":"=== RUN   TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable#01\n"}
+{"Time":"2020-08-20T10:21:49.484353715Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable#01","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:21:49.484407469Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Cluster_UUID_should_have_been_preserved"}
+{"Time":"2020-08-20T10:21:49.484415254Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Cluster_UUID_should_have_been_preserved","Output":"=== RUN   TestMutationResizeMemoryUp/Cluster_UUID_should_have_been_preserved\n"}
+{"Time":"2020-08-20T10:21:49.529214059Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time"}
+{"Time":"2020-08-20T10:21:49.529251665Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"=== RUN   TestMutationResizeMemoryUp/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time\n"}
+{"Time":"2020-08-20T10:21:49.529267516Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget"}
+{"Time":"2020-08-20T10:21:49.529271512Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"=== RUN   TestMutationResizeMemoryUp/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget\n"}
+{"Time":"2020-08-20T10:21:49.529388176Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process"}
+{"Time":"2020-08-20T10:21:49.529404753Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process","Output":"=== RUN   TestMutationResizeMemoryUp/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process\n"}
+{"Time":"2020-08-20T10:21:49.529414464Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Data_added_initially_should_still_be_present"}
+{"Time":"2020-08-20T10:21:49.529434087Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Data_added_initially_should_still_be_present","Output":"=== RUN   TestMutationResizeMemoryUp/Data_added_initially_should_still_be_present\n"}
+{"Time":"2020-08-20T10:21:49.667004784Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Data_added_initially_should_still_be_present","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:21:49.667056447Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Deleting_Elasticsearch_should_return_no_error"}
+{"Time":"2020-08-20T10:21:49.667064798Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Deleting_Elasticsearch_should_return_no_error","Output":"=== RUN   TestMutationResizeMemoryUp/Deleting_Elasticsearch_should_return_no_error\n"}
+{"Time":"2020-08-20T10:21:49.67731282Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_should_not_be_there_anymore"}
+{"Time":"2020-08-20T10:21:49.677362227Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_should_not_be_there_anymore","Output":"=== RUN   TestMutationResizeMemoryUp/Elasticsearch_should_not_be_there_anymore\n"}
+{"Time":"2020-08-20T10:21:49.683258973Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_should_not_be_there_anymore","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:21:49.683310148Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_pods_should_eventually_be_removed"}
+{"Time":"2020-08-20T10:21:49.683317584Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_pods_should_eventually_be_removed","Output":"=== RUN   TestMutationResizeMemoryUp/Elasticsearch_pods_should_eventually_be_removed\n"}
+{"Time":"2020-08-20T10:22:34.811792911Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_pods_should_eventually_be_removed","Output":"Retries (5m0s timeout): ................\n"}
+{"Time":"2020-08-20T10:22:34.811849225Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/PVCs_should_eventually_be_removed"}
+{"Time":"2020-08-20T10:22:34.811857597Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/PVCs_should_eventually_be_removed","Output":"=== RUN   TestMutationResizeMemoryUp/PVCs_should_eventually_be_removed\n"}
+{"Time":"2020-08-20T10:22:34.818182201Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/PVCs_should_eventually_be_removed","Output":"Retries (5m0s timeout): .\n"}
+{"Time":"2020-08-20T10:22:34.818231819Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp","Output":"--- PASS: TestMutationResizeMemoryUp (281.68s)\n"}
+{"Time":"2020-08-20T10:22:34.818241616Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/K8S_should_be_accessible","Output":"    --- PASS: TestMutationResizeMemoryUp/K8S_should_be_accessible (0.02s)\n"}
+{"Time":"2020-08-20T10:22:34.818248293Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/K8S_should_be_accessible","Elapsed":0.02}
+{"Time":"2020-08-20T10:22:34.818271108Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Label_test_pods","Output":"    --- PASS: TestMutationResizeMemoryUp/Label_test_pods (0.04s)\n"}
+{"Time":"2020-08-20T10:22:34.81827843Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Label_test_pods","Elapsed":0.04}
+{"Time":"2020-08-20T10:22:34.81828211Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_CRDs_should_exist","Output":"    --- PASS: TestMutationResizeMemoryUp/Elasticsearch_CRDs_should_exist (0.01s)\n"}
+{"Time":"2020-08-20T10:22:34.81828587Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_CRDs_should_exist","Elapsed":0.01}
+{"Time":"2020-08-20T10:22:34.818290654Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Webhook_endpoint_should_not_be_empty","Output":"    --- PASS: TestMutationResizeMemoryUp/Webhook_endpoint_should_not_be_empty (0.01s)\n"}
+{"Time":"2020-08-20T10:22:34.818294297Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Webhook_endpoint_should_not_be_empty","Elapsed":0.01}
+{"Time":"2020-08-20T10:22:34.818297837Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Remove_Elasticsearch_if_it_already_exists","Output":"    --- PASS: TestMutationResizeMemoryUp/Remove_Elasticsearch_if_it_already_exists (0.02s)\n"}
+{"Time":"2020-08-20T10:22:34.818302593Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Remove_Elasticsearch_if_it_already_exists","Elapsed":0.02}
+{"Time":"2020-08-20T10:22:34.818307512Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Creating_an_Elasticsearch_cluster_should_succeed","Output":"    --- PASS: TestMutationResizeMemoryUp/Creating_an_Elasticsearch_cluster_should_succeed (0.02s)\n"}
+{"Time":"2020-08-20T10:22:34.818313429Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Creating_an_Elasticsearch_cluster_should_succeed","Elapsed":0.02}
+{"Time":"2020-08-20T10:22:34.818318803Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_cluster_should_be_created","Output":"    --- PASS: TestMutationResizeMemoryUp/Elasticsearch_cluster_should_be_created (0.01s)\n"}
+{"Time":"2020-08-20T10:22:34.81832426Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_cluster_should_be_created","Elapsed":0.01}
+{"Time":"2020-08-20T10:22:34.818329303Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed (3.02s)\n"}
+{"Time":"2020-08-20T10:22:34.818335384Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed","Elapsed":3.02}
+{"Time":"2020-08-20T10:22:34.818345586Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready","Output":"    --- PASS: TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready (30.19s)\n"}
+{"Time":"2020-08-20T10:22:34.818361106Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready","Elapsed":30.19}
+{"Time":"2020-08-20T10:22:34.818366688Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one (0.01s)\n"}
+{"Time":"2020-08-20T10:22:34.818372278Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one","Elapsed":0.01}
+{"Time":"2020-08-20T10:22:34.818377211Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_be_created","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_services_should_be_created (0.01s)\n"}
+{"Time":"2020-08-20T10:22:34.818382992Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_be_created","Elapsed":0.01}
+{"Time":"2020-08-20T10:22:34.818391494Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_have_endpoints","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_services_should_have_endpoints (0.01s)\n"}
+{"Time":"2020-08-20T10:22:34.81840188Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_have_endpoints","Elapsed":0.01}
+{"Time":"2020-08-20T10:22:34.818407584Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Secrets_should_eventually_be_created","Output":"    --- PASS: TestMutationResizeMemoryUp/Secrets_should_eventually_be_created (0.04s)\n"}
+{"Time":"2020-08-20T10:22:34.818413335Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Secrets_should_eventually_be_created","Elapsed":0.04}
+{"Time":"2020-08-20T10:22:34.818418306Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate (0.03s)\n"}
+{"Time":"2020-08-20T10:22:34.818424982Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate","Elapsed":0.03}
+{"Time":"2020-08-20T10:22:34.818430442Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green (0.01s)\n"}
+{"Time":"2020-08-20T10:22:34.81843613Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green","Elapsed":0.01}
+{"Time":"2020-08-20T10:22:34.81845331Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elastic_password_should_be_available","Output":"    --- PASS: TestMutationResizeMemoryUp/Elastic_password_should_be_available (0.01s)\n"}
+{"Time":"2020-08-20T10:22:34.818459632Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elastic_password_should_be_available","Elapsed":0.01}
+{"Time":"2020-08-20T10:22:34.8184645Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type","Output":"    --- PASS: TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type (0.01s)\n"}
+{"Time":"2020-08-20T10:22:34.818471229Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type","Elapsed":0.01}
+{"Time":"2020-08-20T10:22:34.818476006Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Output":"    --- PASS: TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped (0.00s)\n"}
+{"Time":"2020-08-20T10:22:34.81848202Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped","Elapsed":0}
+{"Time":"2020-08-20T10:22:34.818494022Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one (0.14s)\n"}
+{"Time":"2020-08-20T10:22:34.818500506Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one","Elapsed":0.14}
+{"Time":"2020-08-20T10:22:34.818505967Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#01","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#01 (0.03s)\n"}
+{"Time":"2020-08-20T10:22:34.818511883Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#01","Elapsed":0.03}
+{"Time":"2020-08-20T10:22:34.818516862Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable (0.12s)\n"}
+{"Time":"2020-08-20T10:22:34.818522466Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable","Elapsed":0.12}
+{"Time":"2020-08-20T10:22:34.818527482Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Add_some_data_to_the_cluster_before_starting_the_mutation","Output":"    --- PASS: TestMutationResizeMemoryUp/Add_some_data_to_the_cluster_before_starting_the_mutation (2.17s)\n"}
+{"Time":"2020-08-20T10:22:34.818533361Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Add_some_data_to_the_cluster_before_starting_the_mutation","Elapsed":2.17}
+{"Time":"2020-08-20T10:22:34.818538714Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on","Output":"    --- PASS: TestMutationResizeMemoryUp/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on (0.00s)\n"}
+{"Time":"2020-08-20T10:22:34.818546163Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Start_querying_Elasticsearch_cluster_health_while_mutation_is_going_on","Elapsed":0}
+{"Time":"2020-08-20T10:22:34.818552075Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"    --- PASS: TestMutationResizeMemoryUp/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"}
+{"Time":"2020-08-20T10:22:34.818558125Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Starting_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Elapsed":0}
+{"Time":"2020-08-20T10:22:34.818563797Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"    --- PASS: TestMutationResizeMemoryUp/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"}
+{"Time":"2020-08-20T10:22:34.818569934Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Starting_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Elapsed":0}
+{"Time":"2020-08-20T10:22:34.818575424Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Output":"    --- PASS: TestMutationResizeMemoryUp/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose (0.04s)\n"}
+{"Time":"2020-08-20T10:22:34.818599251Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Retrieve_Elasticsearch_cluster_UUID_for_comparison_purpose","Elapsed":0.04}
+{"Time":"2020-08-20T10:22:34.818612726Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Annotate_Pods_with_a_hash_of_their_Builder_spec","Output":"    --- PASS: TestMutationResizeMemoryUp/Annotate_Pods_with_a_hash_of_their_Builder_spec (0.05s)\n"}
+{"Time":"2020-08-20T10:22:34.818623134Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Annotate_Pods_with_a_hash_of_their_Builder_spec","Elapsed":0.05}
+{"Time":"2020-08-20T10:22:34.818629131Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Applying_the_Elasticsearch_mutation_should_succeed","Output":"    --- PASS: TestMutationResizeMemoryUp/Applying_the_Elasticsearch_mutation_should_succeed (0.03s)\n"}
+{"Time":"2020-08-20T10:22:34.818635327Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Applying_the_Elasticsearch_mutation_should_succeed","Elapsed":0.03}
+{"Time":"2020-08-20T10:22:34.818641314Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed#01","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:22:34.81864811Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_certificate_authority_should_be_set_and_deployed#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:22:34.818653785Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready#01","Output":"    --- PASS: TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready#01 (187.10s)\n"}
+{"Time":"2020-08-20T10:22:34.818660931Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/All_expected_Pods_should_eventually_be_ready#01","Elapsed":187.1}
+{"Time":"2020-08-20T10:22:34.818674776Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#02","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#02 (0.01s)\n"}
+{"Time":"2020-08-20T10:22:34.81868217Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#02","Elapsed":0.01}
+{"Time":"2020-08-20T10:22:34.818687877Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_be_created#01","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_services_should_be_created#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:22:34.818694064Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_be_created#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:22:34.818766138Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_have_endpoints#01","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_services_should_have_endpoints#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:22:34.818776314Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_services_should_have_endpoints#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:22:34.818782369Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Secrets_should_eventually_be_created#01","Output":"    --- PASS: TestMutationResizeMemoryUp/Secrets_should_eventually_be_created#01 (0.04s)\n"}
+{"Time":"2020-08-20T10:22:34.818789377Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Secrets_should_eventually_be_created#01","Elapsed":0.04}
+{"Time":"2020-08-20T10:22:34.818795046Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate#01","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate#01 (0.02s)\n"}
+{"Time":"2020-08-20T10:22:34.81880932Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_pods_should_eventually_have_a_certificate#01","Elapsed":0.02}
+{"Time":"2020-08-20T10:22:34.818815486Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green#01","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green#01 (12.04s)\n"}
+{"Time":"2020-08-20T10:22:34.818821392Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_cluster_health_should_eventually_be_green#01","Elapsed":12.04}
+{"Time":"2020-08-20T10:22:34.818827082Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elastic_password_should_be_available#01","Output":"    --- PASS: TestMutationResizeMemoryUp/Elastic_password_should_be_available#01 (0.00s)\n"}
+{"Time":"2020-08-20T10:22:34.818833276Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elastic_password_should_be_available#01","Elapsed":0}
+{"Time":"2020-08-20T10:22:34.818838964Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Output":"    --- PASS: TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type#01 (0.01s)\n"}
+{"Time":"2020-08-20T10:22:34.818844796Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_data_volumes_should_be_of_the_specified_type#01","Elapsed":0.01}
+{"Time":"2020-08-20T10:22:34.818850871Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Output":"    --- PASS: TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01 (0.00s)\n"}
+{"Time":"2020-08-20T10:22:34.818857028Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Cluster_should_be_annotated_with_its_UUID_once_bootstrapped#01","Elapsed":0}
+{"Time":"2020-08-20T10:22:34.818862608Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one#01","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one#01 (0.05s)\n"}
+{"Time":"2020-08-20T10:22:34.818868246Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_nodes_topology_should_eventually_be_the_expected_one#01","Elapsed":0.05}
+{"Time":"2020-08-20T10:22:34.818873532Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#03","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#03 (0.04s)\n"}
+{"Time":"2020-08-20T10:22:34.818879856Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_version_should_be_the_expected_one#03","Elapsed":0.04}
+{"Time":"2020-08-20T10:22:34.818885058Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable#01","Output":"    --- PASS: TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable#01 (0.04s)\n"}
+{"Time":"2020-08-20T10:22:34.81889074Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/ES_endpoint_should_eventually_be_reachable#01","Elapsed":0.04}
+{"Time":"2020-08-20T10:22:34.818896121Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Cluster_UUID_should_have_been_preserved","Output":"    --- PASS: TestMutationResizeMemoryUp/Cluster_UUID_should_have_been_preserved (0.04s)\n"}
+{"Time":"2020-08-20T10:22:34.818914394Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Cluster_UUID_should_have_been_preserved","Elapsed":0.04}
+{"Time":"2020-08-20T10:22:34.818935143Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Output":"    --- PASS: TestMutationResizeMemoryUp/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time (0.00s)\n"}
+{"Time":"2020-08-20T10:22:34.818942928Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Stopping_to_master_additions_and_removals:_expect_single_master_added/removed_at_a_time","Elapsed":0}
+{"Time":"2020-08-20T10:22:34.818947962Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Output":"    --- PASS: TestMutationResizeMemoryUp/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget (0.00s)\n"}
+{"Time":"2020-08-20T10:22:34.818954462Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Stopping_to_pod_count_for_change_budget:_expect_to_stay_within_the_change_budget","Elapsed":0}
+{"Time":"2020-08-20T10:22:34.818959651Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process","Output":"    --- PASS: TestMutationResizeMemoryUp/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process (0.00s)\n"}
+{"Time":"2020-08-20T10:22:34.818965915Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_cluster_health_should_not_have_been_red_during_mutation_process","Elapsed":0}
+{"Time":"2020-08-20T10:22:34.818977368Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Data_added_initially_should_still_be_present","Output":"    --- PASS: TestMutationResizeMemoryUp/Data_added_initially_should_still_be_present (0.14s)\n"}
+{"Time":"2020-08-20T10:22:34.818984006Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Data_added_initially_should_still_be_present","Elapsed":0.14}
+{"Time":"2020-08-20T10:22:34.818991175Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Deleting_Elasticsearch_should_return_no_error","Output":"    --- PASS: TestMutationResizeMemoryUp/Deleting_Elasticsearch_should_return_no_error (0.01s)\n"}
+{"Time":"2020-08-20T10:22:34.819001584Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Deleting_Elasticsearch_should_return_no_error","Elapsed":0.01}
+{"Time":"2020-08-20T10:22:34.819007219Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_should_not_be_there_anymore","Output":"    --- PASS: TestMutationResizeMemoryUp/Elasticsearch_should_not_be_there_anymore (0.01s)\n"}
+{"Time":"2020-08-20T10:22:34.819013301Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_should_not_be_there_anymore","Elapsed":0.01}
+{"Time":"2020-08-20T10:22:34.819023868Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_pods_should_eventually_be_removed","Output":"    --- PASS: TestMutationResizeMemoryUp/Elasticsearch_pods_should_eventually_be_removed (45.13s)\n"}
+{"Time":"2020-08-20T10:22:34.819030339Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/Elasticsearch_pods_should_eventually_be_removed","Elapsed":45.13}
+{"Time":"2020-08-20T10:22:34.819036757Z","Action":"output","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/PVCs_should_eventually_be_removed","Output":"    --- PASS: TestMutationResizeMemoryUp/PVCs_should_eventually_be_removed (0.01s)\n"}
+{"Time":"2020-08-20T10:22:34.81905663Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp/PVCs_should_eventually_be_removed","Elapsed":0.01}
+{"Time":"2020-08-20T10:22:34.819062086Z","Action":"pass","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryUp","Elapsed":281.68}
+{"Time":"2020-08-20T10:22:34.819068867Z","Action":"run","Package":"github.com/elastic/cloud-on-k8s/v2/test/e2e/es","Test":"TestMutationResizeMemoryDown"}


### PR DESCRIPTION
In #5809, we indented the JSON objects in addition to the package renaming in the `testdata/stream.json` file, which breaks `Test_helper_streamTestJobOutput_withError` test.

This commits reverts the indentation to have one JSON object per line.