### PR TITLE
Fix closing HTTP response bodies in E2E tests

### DIFF
--- a/test/e2e/es/disable_predicates_test.go
+++ b/test/e2e/es/disable_predicates_test.go
@@ -73,8 +73,8 @@ func TestRedClusterCanBeModifiedByDisablingPredicate(t *testing.T) {
 					r, err := http.NewRequest(http.MethodPut, "/test-index", bytes.NewBufferString(settings))
 					require.NoError(t, err)
 					response, err := esClient.Request(context.Background(), r)
-					defer response.Body.Close() // nolint
 					require.NoError(t, err)
+					defer response.Body.Close() // nolint
 				},
 			},
 			// wait for the cluster to become red
@@ -88,8 +88,8 @@ func TestRedClusterCanBeModifiedByDisablingPredicate(t *testing.T) {
 					r, err := http.NewRequest(http.MethodDelete, "/test-index", nil)
 					require.NoError(t, err)
 					response, err := esClient.Request(context.Background(), r)
-					defer response.Body.Close() // nolint
 					require.NoError(t, err)
+					defer response.Body.Close() // nolint
 				},
 			},
 		},

--- a/test/e2e/es/podtemplate_test.go
+++ b/test/e2e/es/podtemplate_test.go
@@ -217,8 +217,8 @@ func TestCustomConfiguration(t *testing.T) {
 					r, err := http.NewRequest(http.MethodPut, "/test-index", bytes.NewBufferString(settings))
 					require.NoError(t, err)
 					response, err := esClient.Request(context.Background(), r)
-					defer response.Body.Close() // nolint
 					require.NoError(t, err)
+					defer response.Body.Close() // nolint
 				},
 			},
 			{
@@ -233,8 +233,8 @@ func TestCustomConfiguration(t *testing.T) {
 					r, err := http.NewRequest(http.MethodGet, "/test-index/_analyze", bytes.NewBufferString(body))
 					require.NoError(t, err)
 					response, err := esClient.Request(context.Background(), r)
-					defer response.Body.Close() // nolint
 					require.NoError(t, err)
+					defer response.Body.Close() // nolint
 					actual, err := ioutil.ReadAll(response.Body)
 					require.NoError(t, err)
 					expected := `{"tokens":[{"token":"Elastic","start_offset":0,"end_offset":3,"type":"SYNONYM","position":0},{"token":"runs","start_offset":4,"end_offset":8,"type":"word","position":1},{"token":"Cloud","start_offset":4,"end_offset":8,"type":"SYNONYM","position":1},{"token":"Elasticsearch,","start_offset":9,"end_offset":23,"type":"word","position":2},{"token":"on","start_offset":9,"end_offset":23,"type":"SYNONYM","position":2},{"token":"Kibana","start_offset":24,"end_offset":30,"type":"word","position":3},{"token":"Kubernetes","start_offset":24,"end_offset":30,"type":"SYNONYM","position":3},{"token":"and","start_offset":31,"end_offset":34,"type":"word","position":4},{"token":"APM","start_offset":35,"end_offset":38,"type":"word","position":5},{"token":"Server","start_offset":39,"end_offset":45,"type":"word","position":6},{"token":"on","start_offset":46,"end_offset":48,"type":"word","position":7},{"token":"Kubernetes","start_offset":49,"end_offset":59,"type":"word","position":8}]}`


### PR DESCRIPTION
This commit moves `defer response.Body.Close()` after checking that there is no errors, otherwise code panics as there is no body in the response.

Resolves #5847.