### PR TITLE
Use static transaction names for APM

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -703,7 +703,7 @@ func asyncTasks(
 
 	// Garbage collect orphaned secrets leftover from deleted resources while the operator was not running
 	// - association user secrets
-	gcCtx := tracing.NewContextTransaction(ctx, tracer, "garbage-collection", "on_operator_start", nil)
+	gcCtx := tracing.NewContextTransaction(ctx, tracer, tracing.RunOnceTxType, "garbage-collection", nil)
 	err := garbageCollectUsers(gcCtx, cfg, managedNamespaces)
 	if err != nil {
 		log.Error(err, "exiting due to unrecoverable error")
@@ -956,7 +956,7 @@ func setupWebhook(
 }
 
 func reconcileWebhookCertsAndAddController(ctx context.Context, mgr manager.Manager, certRotation certificates.RotationParams, clientset kubernetes.Interface, tracer *apm.Tracer) error {
-	ctx = tracing.NewContextTransaction(ctx, tracer, "webhook", "reconcile", nil)
+	ctx = tracing.NewContextTransaction(ctx, tracer, tracing.ReconciliationTxType, "webhook", nil)
 	defer tracing.EndContextTransaction(ctx)
 	log.Info("Automatic management of the webhook certificates enabled")
 	// Ensure that all the certificates needed by the webhook server are already created

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -956,7 +956,7 @@ func setupWebhook(
 }
 
 func reconcileWebhookCertsAndAddController(ctx context.Context, mgr manager.Manager, certRotation certificates.RotationParams, clientset kubernetes.Interface, tracer *apm.Tracer) error {
-	ctx = tracing.NewContextTransaction(ctx, tracer, tracing.ReconciliationTxType, "webhook", nil)
+	ctx = tracing.NewContextTransaction(ctx, tracer, tracing.ReconciliationTxType, webhook.ControllerName, nil)
 	defer tracing.EndContextTransaction(ctx)
 	log.Info("Automatic management of the webhook certificates enabled")
 	// Ensure that all the certificates needed by the webhook server are already created

--- a/pkg/controller/agent/controller.go
+++ b/pkg/controller/agent/controller.go
@@ -123,7 +123,7 @@ type ReconcileAgent struct {
 // and what is in the Agent.Spec
 func (r *ReconcileAgent) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	ctx = common.NewReconciliationContext(ctx, &r.iteration, r.Tracer, controllerName, "agent_name", request)
-	defer common.LogReconciliationRunNoSideEffects(logconf.FromContext(ctx))()
+	defer common.LogReconciliationRun(logconf.FromContext(ctx))()
 	defer tracing.EndContextTransaction(ctx)
 
 	agent := &agentv1alpha1.Agent{}

--- a/pkg/controller/apmserver/controller.go
+++ b/pkg/controller/apmserver/controller.go
@@ -174,9 +174,9 @@ var _ driver.Interface = &ReconcileApmServer{}
 // Reconcile reads that state of the cluster for a ApmServer object and makes changes based on the state read
 // and what is in the ApmServer.Spec
 func (r *ReconcileApmServer) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	defer common.LogReconciliationRun(log, request, "as_name", &r.iteration)()
-	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, controllerName)
-	defer tracing.EndTransaction(tx)
+	ctx = common.NewReconciliationContext(ctx, &r.iteration, r.Tracer, controllerName, "as_name", request)
+	defer common.LogReconciliationRun(ulog.FromContext(ctx))()
+	defer tracing.EndContextTransaction(ctx)
 
 	var as apmv1.ApmServer
 	if err := r.Client.Get(ctx, request.NamespacedName, &as); err != nil {

--- a/pkg/controller/apmserver/controller.go
+++ b/pkg/controller/apmserver/controller.go
@@ -175,7 +175,7 @@ var _ driver.Interface = &ReconcileApmServer{}
 // and what is in the ApmServer.Spec
 func (r *ReconcileApmServer) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	defer common.LogReconciliationRun(log, request, "as_name", &r.iteration)()
-	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, request.NamespacedName, "apmserver")
+	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, controllerName)
 	defer tracing.EndTransaction(tx)
 
 	var as apmv1.ApmServer

--- a/pkg/controller/association/reconciler.go
+++ b/pkg/controller/association/reconciler.go
@@ -149,7 +149,7 @@ func (r *Reconciler) log(associatedNsName types.NamespacedName) logr.Logger {
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	defer common.LogReconciliationRun(r.logger, request, fmt.Sprintf("%s_name", r.AssociatedShortName), &r.iteration)()
-	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, request.NamespacedName, r.AssociationName)
+	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, r.AssociationName)
 	defer tracing.EndTransaction(tx)
 
 	associated := r.AssociatedObjTemplate()

--- a/pkg/controller/association/reconciler.go
+++ b/pkg/controller/association/reconciler.go
@@ -36,6 +36,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/hints"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
+	ulog "github.com/elastic/cloud-on-k8s/v2/pkg/utils/log"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/maps"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/rbac"
 )
@@ -148,9 +149,10 @@ func (r *Reconciler) log(associatedNsName types.NamespacedName) logr.Logger {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	defer common.LogReconciliationRun(r.logger, request, fmt.Sprintf("%s_name", r.AssociatedShortName), &r.iteration)()
-	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, r.AssociationName)
-	defer tracing.EndTransaction(tx)
+	nameField := fmt.Sprintf("%s_name", r.AssociatedShortName)
+	ctx = common.NewReconciliationContext(ctx, &r.iteration, r.Tracer, r.AssociationName, nameField, request)
+	defer common.LogReconciliationRun(ulog.FromContext(ctx))()
+	defer tracing.EndContextTransaction(ctx)
 
 	associated := r.AssociatedObjTemplate()
 	if err := r.Client.Get(ctx, request.NamespacedName, associated); err != nil {

--- a/pkg/controller/autoscaling/elasticsearch/controller.go
+++ b/pkg/controller/autoscaling/elasticsearch/controller.go
@@ -78,7 +78,7 @@ func NewReconciler(mgr manager.Manager, params operator.Parameters) *ReconcileEl
 // _autoscaling/capacity API and given the constraints provided by the user in the autoscaling specification.
 func (r *ReconcileElasticsearch) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	ctx = common.NewReconciliationContext(ctx, &r.iteration, r.Tracer, controllerName, "es_name", request)
-	defer common.LogReconciliationRunNoSideEffects(logconf.FromContext(ctx))()
+	defer common.LogReconciliationRun(logconf.FromContext(ctx))()
 	defer tracing.EndContextTransaction(ctx)
 
 	// Fetch the Elasticsearch instance

--- a/pkg/controller/beat/controller.go
+++ b/pkg/controller/beat/controller.go
@@ -128,7 +128,7 @@ type ReconcileBeat struct {
 // and what is in the Beat.Spec.
 func (r *ReconcileBeat) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	defer common.LogReconciliationRun(log, request, "beat_name", &r.iteration)()
-	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, request.NamespacedName, "beat")
+	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, controllerName)
 	defer tracing.EndTransaction(tx)
 
 	var beat beatv1beta1.Beat

--- a/pkg/controller/beat/controller.go
+++ b/pkg/controller/beat/controller.go
@@ -127,9 +127,9 @@ type ReconcileBeat struct {
 // Reconcile reads that state of the cluster for a Beat object and makes changes based on the state read
 // and what is in the Beat.Spec.
 func (r *ReconcileBeat) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	defer common.LogReconciliationRun(log, request, "beat_name", &r.iteration)()
-	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, controllerName)
-	defer tracing.EndTransaction(tx)
+	ctx = common.NewReconciliationContext(ctx, &r.iteration, r.Tracer, controllerName, "beat_name", request)
+	defer common.LogReconciliationRun(ulog.FromContext(ctx))()
+	defer tracing.EndContextTransaction(ctx)
 
 	var beat beatv1beta1.Beat
 	err := r.Client.Get(ctx, request.NamespacedName, &beat)

--- a/pkg/controller/common/controller.go
+++ b/pkg/controller/common/controller.go
@@ -40,7 +40,7 @@ func NewReconciliationContext(
 		tracer,
 		tracing.ReconciliationTxType,
 		controllerName,
-		map[string]string{"iteration": itString})
+		map[string]string{"iteration": itString, "name": request.Name, "namespace": request.Namespace})
 	return logconf.InitInContext(
 		newCtx,
 		controllerName,

--- a/pkg/controller/common/controller.go
+++ b/pkg/controller/common/controller.go
@@ -38,8 +38,8 @@ func NewReconciliationContext(
 	newCtx := tracing.NewContextTransaction(
 		ctx,
 		tracer,
+		tracing.ReconciliationTxType,
 		controllerName,
-		request.String(),
 		map[string]string{"iteration": itString})
 	return logconf.InitInContext(
 		newCtx,

--- a/pkg/controller/common/logging.go
+++ b/pkg/controller/common/logging.go
@@ -5,28 +5,14 @@
 package common
 
 import (
-	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// LogReconciliationRun is the common logging function used to record a reconciliation run.
-func LogReconciliationRun(log logr.Logger, request reconcile.Request, nameField string, iteration *uint64) func() {
-	currentIteration := atomic.AddUint64(iteration, 1)
-	startTime := time.Now()
-	log.Info("Starting reconciliation run", "iteration", currentIteration, "namespace", request.Namespace, nameField, request.Name)
-	return func() {
-		totalTime := time.Since(startTime)
-		log.Info("Ending reconciliation run", "iteration", currentIteration, "namespace", request.Namespace, nameField, request.Name, "took", totalTime)
-	}
-}
-
-// LogReconciliationRunNoSideEffects is the common logging function used to record a reconciliation run, it doesn't
-// increment the iteration. When all controllers move away from package level loggers and move to using one from the
-// context, the other logging function (LogReconciliationRun) can be removed in favor of this one.
-func LogReconciliationRunNoSideEffects(log logr.Logger) func() {
+// LogReconciliationRun is the common logging function used to record a reconciliation run, it doesn't
+// increment the iteration.
+func LogReconciliationRun(log logr.Logger) func() {
 	startTime := time.Now()
 	log.Info("Starting reconciliation run")
 	return func() {

--- a/pkg/controller/common/tracing/k8s.go
+++ b/pkg/controller/common/tracing/k8s.go
@@ -28,6 +28,6 @@ func ClientGoCacheTx(tracer *apm.Tracer) func() *apm.Transaction {
 			return nil
 		}
 		// if no transaction is running assume we are tracing cache refresh requests from client-go
-		return tracer.StartTransaction("client-go", PeriodicTxType)
+		return tracer.StartTransaction("client-go", string(PeriodicTxType))
 	}
 }

--- a/pkg/controller/common/tracing/k8s.go
+++ b/pkg/controller/common/tracing/k8s.go
@@ -28,6 +28,6 @@ func ClientGoCacheTx(tracer *apm.Tracer) func() *apm.Transaction {
 			return nil
 		}
 		// if no transaction is running assume we are tracing cache refresh requests from client-go
-		return tracer.StartTransaction("cache", "client-go")
+		return tracer.StartTransaction("client-go", PeriodicTxType)
 	}
 }

--- a/pkg/controller/common/tracing/transaction.go
+++ b/pkg/controller/common/tracing/transaction.go
@@ -10,35 +10,22 @@ import (
 	"go.elastic.co/apm/v2"
 )
 
-const ReconciliationTxType = "reconciliation"
-const PeriodicTxType = "periodic"
-const RunOnceTxType = "run-once"
+type TxType string
 
-// NewTransaction starts a new transaction and sets up a new context with that transaction that also contains the related
-// APM agent's tracer.
-func NewTransaction(ctx context.Context, t *apm.Tracer, txName string) (*apm.Transaction, context.Context) {
-	if t == nil {
-		return nil, ctx // apm turned off
-	}
-	tx := t.StartTransaction(txName, ReconciliationTxType)
-	return tx, apm.ContextWithTransaction(ctx, tx)
-}
-
-// EndTransaction nil safe version of APM agents tx.End()
-func EndTransaction(tx *apm.Transaction) {
-	if tx != nil {
-		tx.End()
-	}
-}
+const (
+	ReconciliationTxType TxType = "reconciliation"
+	PeriodicTxType       TxType = "periodic"
+	RunOnceTxType        TxType = "run-once"
+)
 
 // NewContextTransaction starts a new transaction and sets up a new context with that transaction that also contains the related
 // APM agent's tracer.
-func NewContextTransaction(ctx context.Context, t *apm.Tracer, txType, txName string, labels map[string]string) context.Context {
+func NewContextTransaction(ctx context.Context, t *apm.Tracer, txType TxType, txName string, labels map[string]string) context.Context {
 	if t == nil {
 		return ctx // apm turned off
 	}
 
-	tx := t.StartTransaction(txName, txType)
+	tx := t.StartTransaction(txName, string(txType))
 	for k, v := range labels {
 		tx.Context.SetLabel(k, v)
 	}

--- a/pkg/controller/common/tracing/transaction.go
+++ b/pkg/controller/common/tracing/transaction.go
@@ -8,16 +8,19 @@ import (
 	"context"
 
 	"go.elastic.co/apm/v2"
-	"k8s.io/apimachinery/pkg/types"
 )
+
+const ReconciliationTxType = "reconciliation"
+const PeriodicTxType = "periodic"
+const RunOnceTxType = "run-once"
 
 // NewTransaction starts a new transaction and sets up a new context with that transaction that also contains the related
 // APM agent's tracer.
-func NewTransaction(ctx context.Context, t *apm.Tracer, name types.NamespacedName, txType string) (*apm.Transaction, context.Context) {
+func NewTransaction(ctx context.Context, t *apm.Tracer, txName string) (*apm.Transaction, context.Context) {
 	if t == nil {
 		return nil, ctx // apm turned off
 	}
-	tx := t.StartTransaction(name.String(), txType)
+	tx := t.StartTransaction(txName, ReconciliationTxType)
 	return tx, apm.ContextWithTransaction(ctx, tx)
 }
 

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -155,9 +155,9 @@ type ReconcileElasticsearch struct {
 // Reconcile reads the state of the cluster for an Elasticsearch object and makes changes based on the state read and
 // what is in the Elasticsearch.Spec
 func (r *ReconcileElasticsearch) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	defer common.LogReconciliationRun(log, request, "es_name", &r.iteration)()
-	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, name)
-	defer tracing.EndTransaction(tx)
+	ctx = common.NewReconciliationContext(ctx, &r.iteration, r.Tracer, name, "es_name", request)
+	defer common.LogReconciliationRun(ulog.FromContext(ctx))()
+	defer tracing.EndContextTransaction(ctx)
 
 	// Fetch the Elasticsearch instance
 	var es esv1.Elasticsearch

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -156,7 +156,7 @@ type ReconcileElasticsearch struct {
 // what is in the Elasticsearch.Spec
 func (r *ReconcileElasticsearch) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	defer common.LogReconciliationRun(log, request, "es_name", &r.iteration)()
-	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, request.NamespacedName, "elasticsearch")
+	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, name)
 	defer tracing.EndTransaction(tx)
 
 	// Fetch the Elasticsearch instance

--- a/pkg/controller/elasticsearch/observer/observer.go
+++ b/pkg/controller/elasticsearch/observer/observer.go
@@ -114,7 +114,7 @@ func (o *Observer) observe() {
 	log.V(1).Info("Retrieving cluster state", "es_name", o.cluster.Name, "namespace", o.cluster.Namespace)
 
 	if o.settings.Tracer != nil {
-		tx := o.settings.Tracer.StartTransaction("elasticsearch-observer", tracing.PeriodicTxType)
+		tx := o.settings.Tracer.StartTransaction("elasticsearch-observer", string(tracing.PeriodicTxType))
 		defer tx.End()
 		ctx = apm.ContextWithTransaction(ctx, tx)
 	}

--- a/pkg/controller/elasticsearch/observer/observer.go
+++ b/pkg/controller/elasticsearch/observer/observer.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/tracing"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/client"
 	esclient "github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/client"
 	ulog "github.com/elastic/cloud-on-k8s/v2/pkg/utils/log"
@@ -113,7 +114,7 @@ func (o *Observer) observe() {
 	log.V(1).Info("Retrieving cluster state", "es_name", o.cluster.Name, "namespace", o.cluster.Namespace)
 
 	if o.settings.Tracer != nil {
-		tx := o.settings.Tracer.StartTransaction(o.cluster.String(), "elasticsearch_observer")
+		tx := o.settings.Tracer.StartTransaction("elasticsearch-observer", tracing.PeriodicTxType)
 		defer tx.End()
 		ctx = apm.ContextWithTransaction(ctx, tx)
 	}

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller.go
@@ -144,7 +144,7 @@ var _ driver.Interface = &ReconcileEnterpriseSearch{}
 // and what is in the EnterpriseSearch.Spec.
 func (r *ReconcileEnterpriseSearch) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	defer common.LogReconciliationRun(log, request, "ent_name", &r.iteration)()
-	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, request.NamespacedName, "enterprisesearch")
+	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, controllerName)
 	defer tracing.EndTransaction(tx)
 
 	var ent entv1.EnterpriseSearch

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller.go
@@ -143,9 +143,9 @@ var _ driver.Interface = &ReconcileEnterpriseSearch{}
 // Reconcile reads that state of the cluster for an EnterpriseSearch object and makes changes based on the state read
 // and what is in the EnterpriseSearch.Spec.
 func (r *ReconcileEnterpriseSearch) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	defer common.LogReconciliationRun(log, request, "ent_name", &r.iteration)()
-	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, controllerName)
-	defer tracing.EndTransaction(tx)
+	ctx = common.NewReconciliationContext(ctx, &r.iteration, r.Tracer, controllerName, "ent_name", request)
+	defer common.LogReconciliationRun(ulog.FromContext(ctx))()
+	defer tracing.EndContextTransaction(ctx)
 
 	var ent entv1.EnterpriseSearch
 	if err := r.Client.Get(ctx, request.NamespacedName, &ent); err != nil {

--- a/pkg/controller/kibana/controller.go
+++ b/pkg/controller/kibana/controller.go
@@ -126,7 +126,7 @@ type ReconcileKibana struct {
 // in the Kibana.Spec
 func (r *ReconcileKibana) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	defer common.LogReconciliationRun(log, request, "kibana_name", &r.iteration)()
-	tx, ctx := tracing.NewTransaction(ctx, r.params.Tracer, request.NamespacedName, "kibana")
+	tx, ctx := tracing.NewTransaction(ctx, r.params.Tracer, controllerName)
 	defer tracing.EndTransaction(tx)
 
 	// retrieve the kibana object

--- a/pkg/controller/kibana/controller.go
+++ b/pkg/controller/kibana/controller.go
@@ -125,9 +125,9 @@ type ReconcileKibana struct {
 // Reconcile reads that state of the cluster for a Kibana object and makes changes based on the state read and what is
 // in the Kibana.Spec
 func (r *ReconcileKibana) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	defer common.LogReconciliationRun(log, request, "kibana_name", &r.iteration)()
-	tx, ctx := tracing.NewTransaction(ctx, r.params.Tracer, controllerName)
-	defer tracing.EndTransaction(tx)
+	ctx = common.NewReconciliationContext(ctx, &r.iteration, r.params.Tracer, controllerName, "kibana_name", request)
+	defer common.LogReconciliationRun(ulog.FromContext(ctx))()
+	defer tracing.EndContextTransaction(ctx)
 
 	// retrieve the kibana object
 	var kb kbv1.Kibana

--- a/pkg/controller/license/license_controller.go
+++ b/pkg/controller/license/license_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/license"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/reconciler"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/tracing"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	esclient "github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/client"
 	eslabel "github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/label"
@@ -51,7 +52,10 @@ var log = ulog.Log.WithName(name)
 // In any case it schedules a new reconcile request to be processed when the license is about to expire.
 // This happens independently from any watch triggered reconcile request.
 func (r *ReconcileLicenses) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	defer common.LogReconciliationRun(log, request, "es_name", &r.iteration)()
+	ctx = common.NewReconciliationContext(ctx, &r.iteration, r.Tracer, name, "es_name", request)
+	defer common.LogReconciliationRun(ulog.FromContext(ctx))()
+	defer tracing.EndContextTransaction(ctx)
+
 	results := r.reconcileInternal(ctx, request)
 	current, err := results.Aggregate()
 	log.V(1).Info("Reconcile result", "requeue", current.Requeue, "requeueAfter", current.RequeueAfter)
@@ -73,8 +77,9 @@ func Add(mgr manager.Manager, p operator.Parameters) error {
 func newReconciler(mgr manager.Manager, params operator.Parameters) *ReconcileLicenses {
 	c := mgr.GetClient()
 	return &ReconcileLicenses{
-		Client:  c,
-		checker: license.NewLicenseChecker(c, params.OperatorNamespace),
+		Client:     c,
+		Parameters: params,
+		checker:    license.NewLicenseChecker(c, params.OperatorNamespace),
 	}
 }
 
@@ -141,6 +146,7 @@ var _ reconcile.Reconciler = &ReconcileLicenses{}
 // ReconcileLicenses reconciles EnterpriseLicenses with existing Elasticsearch clusters and creates ClusterLicenses for them.
 type ReconcileLicenses struct {
 	k8s.Client
+	operator.Parameters
 	// iteration is the number of times this controller has run its Reconcile method
 	iteration uint64
 	checker   license.Checker

--- a/pkg/controller/maps/controller.go
+++ b/pkg/controller/maps/controller.go
@@ -146,9 +146,9 @@ var _ driver.Interface = &ReconcileMapsServer{}
 // Reconcile reads that state of the cluster for a MapsServer object and makes changes based on the state read and what is
 // in the MapsServer.Spec
 func (r *ReconcileMapsServer) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	defer common.LogReconciliationRun(log, request, "name", &r.iteration)()
-	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, controllerName)
-	defer tracing.EndTransaction(tx)
+	ctx = common.NewReconciliationContext(ctx, &r.iteration, r.Tracer, controllerName, "name", request)
+	defer common.LogReconciliationRun(ulog.FromContext(ctx))()
+	defer tracing.EndContextTransaction(ctx)
 
 	// retrieve the EMS object
 	var ems emsv1alpha1.ElasticMapsServer

--- a/pkg/controller/maps/controller.go
+++ b/pkg/controller/maps/controller.go
@@ -147,7 +147,7 @@ var _ driver.Interface = &ReconcileMapsServer{}
 // in the MapsServer.Spec
 func (r *ReconcileMapsServer) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	defer common.LogReconciliationRun(log, request, "name", &r.iteration)()
-	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, request.NamespacedName, "maps")
+	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, controllerName)
 	defer tracing.EndTransaction(tx)
 
 	// retrieve the EMS object

--- a/pkg/controller/maps/controller.go
+++ b/pkg/controller/maps/controller.go
@@ -146,7 +146,7 @@ var _ driver.Interface = &ReconcileMapsServer{}
 // Reconcile reads that state of the cluster for a MapsServer object and makes changes based on the state read and what is
 // in the MapsServer.Spec
 func (r *ReconcileMapsServer) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	ctx = common.NewReconciliationContext(ctx, &r.iteration, r.Tracer, controllerName, "name", request)
+	ctx = common.NewReconciliationContext(ctx, &r.iteration, r.Tracer, controllerName, "maps_name", request)
 	defer common.LogReconciliationRun(ulog.FromContext(ctx))()
 	defer tracing.EndContextTransaction(ctx)
 
@@ -164,7 +164,7 @@ func (r *ReconcileMapsServer) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	if common.IsUnmanaged(&ems) {
-		log.Info("Object is currently not managed by this controller. Skipping reconciliation", "namespace", ems.Namespace, "name", ems.Name)
+		log.Info("Object is currently not managed by this controller. Skipping reconciliation", "namespace", ems.Namespace, "maps_name", ems.Name)
 		return reconcile.Result{}, nil
 	}
 
@@ -195,7 +195,7 @@ func (r *ReconcileMapsServer) doReconcile(ctx context.Context, ems emsv1alpha1.E
 
 	if !enabled {
 		msg := "Elastic Maps Server is an enterprise feature. Enterprise features are disabled"
-		log.Info(msg, "namespace", ems.Namespace, "name", ems.Name)
+		log.Info(msg, "namespace", ems.Namespace, "maps_name", ems.Name)
 		r.recorder.Eventf(&ems, corev1.EventTypeWarning, events.EventReconciliationError, msg)
 		// we don't have a good way of watching for the license level to change so just requeue with a reasonably long delay
 		return results.WithResult(reconcile.Result{Requeue: true, RequeueAfter: 5 * time.Minute}), status

--- a/pkg/controller/remoteca/controller.go
+++ b/pkg/controller/remoteca/controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/certificates/remoteca"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
+	ulog "github.com/elastic/cloud-on-k8s/v2/pkg/utils/log"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/rbac"
 )
 
@@ -84,9 +85,9 @@ type ReconcileRemoteCa struct {
 // Reconcile reads that state of the cluster for the expected remote clusters in this Kubernetes cluster.
 // It copies the remote CA Secrets so they can be trusted by every peer Elasticsearch clusters.
 func (r *ReconcileRemoteCa) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	defer common.LogReconciliationRun(log, request, "es_name", &r.iteration)()
-	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, name)
-	defer tracing.EndTransaction(tx)
+	ctx = common.NewReconciliationContext(ctx, &r.iteration, r.Tracer, name, "es_name", request)
+	defer common.LogReconciliationRun(ulog.FromContext(ctx))()
+	defer tracing.EndContextTransaction(ctx)
 
 	// Fetch the local Elasticsearch spec
 	es := esv1.Elasticsearch{}

--- a/pkg/controller/remoteca/controller.go
+++ b/pkg/controller/remoteca/controller.go
@@ -85,7 +85,7 @@ type ReconcileRemoteCa struct {
 // It copies the remote CA Secrets so they can be trusted by every peer Elasticsearch clusters.
 func (r *ReconcileRemoteCa) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	defer common.LogReconciliationRun(log, request, "es_name", &r.iteration)()
-	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, request.NamespacedName, "remoteca")
+	tx, ctx := tracing.NewTransaction(ctx, r.Tracer, name)
 	defer tracing.EndTransaction(tx)
 
 	// Fetch the local Elasticsearch spec

--- a/pkg/controller/webhook/webhook_certificates_controller.go
+++ b/pkg/controller/webhook/webhook_certificates_controller.go
@@ -6,7 +6,6 @@ package webhook
 
 import (
 	"context"
-	"strconv"
 	"time"
 
 	pkgerrors "github.com/pkg/errors"
@@ -54,8 +53,8 @@ type ReconcileWebhookResources struct {
 }
 
 func (r *ReconcileWebhookResources) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	defer common.LogReconciliationRun(log, request, "validating_webhook_configuration", &r.iteration)()
-	ctx = tracing.NewContextTransaction(ctx, r.tracer, tracing.ReconciliationTxType, "webhook", map[string]string{"iteration": strconv.FormatUint(r.iteration, 10)})
+	ctx = common.NewReconciliationContext(ctx, &r.iteration, r.tracer, ControllerName, "validating_webhook_configuration", request)
+	defer common.LogReconciliationRun(ulog.FromContext(ctx))()
 	defer tracing.EndContextTransaction(ctx)
 
 	res := r.reconcileInternal(ctx)

--- a/pkg/controller/webhook/webhook_certificates_controller.go
+++ b/pkg/controller/webhook/webhook_certificates_controller.go
@@ -55,7 +55,7 @@ type ReconcileWebhookResources struct {
 
 func (r *ReconcileWebhookResources) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	defer common.LogReconciliationRun(log, request, "validating_webhook_configuration", &r.iteration)()
-	ctx = tracing.NewContextTransaction(ctx, r.tracer, "webhook", "reconcile", map[string]string{"iteration": strconv.FormatUint(r.iteration, 10)})
+	ctx = tracing.NewContextTransaction(ctx, r.tracer, tracing.ReconciliationTxType, "webhook", map[string]string{"iteration": strconv.FormatUint(r.iteration, 10)})
 	defer tracing.EndContextTransaction(ctx)
 
 	res := r.reconcileInternal(ctx)

--- a/pkg/license/reporter.go
+++ b/pkg/license/reporter.go
@@ -61,7 +61,7 @@ func (r ResourceReporter) Start(ctx context.Context, refreshPeriod time.Duration
 
 // Report licensing information by publishing metrics and updating the config map.
 func (r ResourceReporter) Report(ctx context.Context) error {
-	ctx = tracing.NewContextTransaction(ctx, r.tracer, "resource-reporter", "license_info", nil)
+	ctx = tracing.NewContextTransaction(ctx, r.tracer, tracing.PeriodicTxType, "resource-reporter", nil)
 	defer tracing.EndContextTransaction(ctx)
 
 	licensingInfo, err := r.Get(ctx)

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -131,7 +131,7 @@ func (r *Reporter) getResourceStats(ctx context.Context) (map[string]interface{}
 }
 
 func (r *Reporter) report(ctx context.Context) {
-	ctx = tracing.NewContextTransaction(ctx, r.tracer, "telemetry-reporter", "report", nil)
+	ctx = tracing.NewContextTransaction(ctx, r.tracer, tracing.PeriodicTxType, "telemetry-reporter", nil)
 	defer tracing.EndContextTransaction(ctx)
 
 	stats, err := r.getResourceStats(ctx)


### PR DESCRIPTION
Fixes #5840 

Instead of using names derived from the name of the resource being reconciled, use static names that represent the individual controllers. The idea is to facilitate comparability between similar transactions rather than creating an ever increasing number of transaction names to aggregate over. 

Also standardised the transaction types to three options: `periodic`, `run-once` and `reconciliation` to represent the three main types of work being done in the operator. `reconciliation` is the same term @david-kow has been using in his recent work.  Hope that make sense. 