### PR TITLE
Update 2.2 known service account issue doc

### DIFF
--- a/docs/release-notes/highlights-2.2.0.asciidoc
+++ b/docs/release-notes/highlights-2.2.0.asciidoc
@@ -57,4 +57,4 @@ The <<{p}-stack-monitoring,Stack Monitoring>> feature is fully operational to be
 [float]
 [id="{p}-220-known-issues"]
 === Known issues
-- The migration to service account tokens can lead to unavailability of Kibana and Fleet Server which is especially noticeable on larger Elasticsearch clusters with many nodes. We are working on a fix to enable a migration without downtime in the next version of the ECK operator. If this is a concern we would recommend waiting with the upgrade until the fix is available. A workaround is explained in the link:https://github.com/elastic/cloud-on-k8s/issues/5684#issuecomment-1164614176[linked issue].
+- The migration to service account tokens can lead to unavailability of Kibana and Fleet Server which is especially noticeable on larger Elasticsearch clusters with many nodes. ECK 2.3 enables a migration without downtime. It is recommended to upgrade to ECK 2.3 to avoid this issue or to quickly restore availability on already affected installations.  More details can be found in the  link:https://github.com/elastic/cloud-on-k8s/issues/5684#issuecomment-1164614176[linked GitHub issue].


### PR DESCRIPTION
This adjusts guidance to the favour the upgrade to 2.3 as the best way out of the situation. I left the Github link intact in case to make the manual workaround still discoverable from our docs for users which cannot upgrade the operator right away. 