### PR TITLE
Make tracing version specific, more logs

### DIFF
--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -24,7 +24,10 @@ import (
 )
 
 const (
-	continuousHealthCheckTimeout = 5 * time.Second
+	// as of 8.3. we see longer response times during master changes, some of them seemingly return with 400 Bad Request.
+	// Extending the request timeout to debug these requests. Once the problem is better understood we can
+	// instead increase the cluster unavailability threshold.
+	continuousHealthCheckTimeout = 30 * time.Second
 )
 
 // clusterUnavailabilityThreshold is the accepted duration for the cluster to temporarily not respond to requests
@@ -288,6 +291,7 @@ func (cu *clusterUnavailability) markUnavailable(err error) {
 		cu.start = time.Now()
 	}
 	if err != nil {
+		fmt.Printf("Unavailablity observed: %s\n", err)
 		cu.errors = append(cu.errors, err)
 	}
 }

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -291,7 +291,6 @@ func (cu *clusterUnavailability) markUnavailable(err error) {
 		cu.start = time.Now()
 	}
 	if err != nil {
-		fmt.Printf("Unavailablity observed: %s\n", err)
 		cu.errors = append(cu.errors, err)
 	}
 }

--- a/test/e2e/test/elasticsearch/steps_mutation_test.go
+++ b/test/e2e/test/elasticsearch/steps_mutation_test.go
@@ -40,6 +40,8 @@ func Test_clusterUnavailability(t *testing.T) {
 
 	// simulate a lower threshold we should have exceeded
 	cu.markUnavailable(errors.New("something else"))
+	cu.markUnavailable(errors.New("this is bad too"))
 	cu.threshold = time.Duration(0)
 	require.True(t, cu.hasExceededThreshold())
+	require.Equal(t, "[something else, this is bad too]", cu.Errors().Error())
 }


### PR DESCRIPTION
The HTTPTracer is only available as of 7.7.0. Also extending the request timeout on health checks. As explained in the comment this is equivalent to extending the unavailability threshold but I hope to capture some of the HTTP 400 responses I saw in the Elasticsearch logs (but it could also be that abandoned request are logged as HTTP 400). 

I expect this PR already to silence the test failures we have seen since moving to th 8.3. 