### PR TITLE
Move kibana xpack kubernetes package back to latest in recipe

### DIFF
--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -18,9 +18,7 @@ spec:
     - name: fleet_server
       version: latest
     - name: kubernetes
-      # pinning this version as the next one introduced a kube-proxy host setting default that breaks this recipe,
-      # see https://github.com/elastic/integrations/pull/1565 for more details
-      version: 0.14.0
+      version: latest
     xpack.fleet.agentPolicies:
     - name: Fleet Server on ECK policy
       id: eck-fleet-server


### PR DESCRIPTION
Move kibana xpack kubernetes package back to latest in recipe, as referenced issue has been merged/resolved.

closes #5872 