### PR TITLE
Move ci tasks to europe-west6

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -10,7 +10,7 @@ plans:
   # use kustomize in GKE to remove the NVMe provisioning already taken care of by the platform
   diskSetup: kubectl apply -k hack/deployer/config/local-disks
   gke:
-    region: europe-west2
+    region: europe-west6
     localSsdCount: 1
     nodeCountPerZone: 1
     gcpScopes: https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append
@@ -73,7 +73,7 @@ plans:
   machineType: n1-standard-8
   serviceAccount: true
   ocp:
-    region: europe-west2
+    region: europe-west6
     nodeCount: 3
 - id: ocp-dev
   operation: create


### PR DESCRIPTION
To resolve capacity issues in CI tasks `[gke-ci,ocp-ci]`
```
Error waiting for instance to create: The zone 'projects/****/zones/europe-west2-b' does not have enough resources available to fulfill the request.  '(resource type:compute)'.
```
Moving them to europe-west6, which is geographically "near" west2 (London), and has a decent CO2 footprint (can't hurt).

See [GCP regions](https://cloud.google.com/compute/docs/regions-zones), which shows that europe-west6 supports the N1 type we use in GCP.