### PR TITLE
Retry E2E job a single time.

### DIFF
--- a/config/e2e/e2e_job.yaml
+++ b/config/e2e/e2e_job.yaml
@@ -21,6 +21,7 @@ spec:
 {{ if not .Context.Ocp3Cluster }}
   ttlSecondsAfterFinished: 360
 {{ end }}
+  backoffLimit: 1
   template:
     metadata:
       annotations:
@@ -61,5 +62,5 @@ spec:
         - name: test-secrets
           secret:
             secretName: "eck-{{ .Context.TestRun }}"
-      restartPolicy: Never
+      restartPolicy: OnFailure
   backoffLimit: 0 # don't retry a failed test

--- a/test/e2e/cmd/run/job.go
+++ b/test/e2e/cmd/run/job.go
@@ -25,6 +25,7 @@ type Job struct {
 	jobStarted    bool // keep track of the first Pod running event
 	podSucceeded  bool // keep track of when we're done
 	stopRequested bool // keep track when a stop request has already been requested
+	numFailures   int  // keep track of number of times the job has failed
 
 	// Job logs management
 	timestampExtractor timestampExtractor

--- a/test/e2e/cmd/run/job_manager.go
+++ b/test/e2e/cmd/run/job_manager.go
@@ -143,7 +143,7 @@ func (jm *JobsManager) Start() {
 				job.numFailures++
 				// One of the managed Job/Pod has failed, wait for logs and return.
 				jm.err = errors.Errorf("Pod %s has failed.  Total failures: %d", newPod.Name, job.numFailures)
-				// We are seeing random ci job failures in Azure, so let's at least let the statefulset retry the job
+				// We are seeing random ci job failures in Azure, so let's at least let the job retry
 				// one time before we completely fail.
 				if job.numFailures > 1 {
 					log.Error(jm.err, "Pod is in failed state, retry limit exceeded", "name", newPod.Name)


### PR DESCRIPTION
Since we continue to see odd failures in Azure/AKS for our CI jobs, let's allow the k8s job controlling the test run to retry the job a single time.

According to [k8s job documentation](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy), setting the following on the job should allow this:

```
job.spec.backoffLimit: 1
job.spec.template.spec.restartPolicy: OnFailure
```