### PR TITLE
Configure host path volume to point to correct path

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -535,3 +535,24 @@ To establish trust, the Pod needs to update the CA store through a call to `upda
 
 === Running Endpoint Security integration
 Running Endpoint Security link:https://www.elastic.co/guide/en/security/current/install-endpoint.html[integration] is not yet supported in containerized environments, like Kubernetes. This is not an ECK limitation, but the limitation of the integration itself. Note that you can use ECK to deploy Elasticsearch, Kibana and Fleet Server, and add Endpoint Security integration to your policies if Elastic Agents running those policies are deployed in non-containerized environments.
+
+=== Storing local state in host path volume
+Elastic Agent when managed by ECK stores local state in a host path volume. This ensures that integrations run by the agent can continue their work without duplicating work that has already been done after the Pod has been recreated for example because of a Pod configuration change.
+Multiple replicas of an agent, for example Fleet Servers, can not be deployed on the same underlying Kubernetes node as they would try to use the same host path. If local state storage in host path volumes is not desired this can be turned off by configuring an `emptyDir` volume instead:
+
+[source,yaml]
+----
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: fleet-server
+spec:
+  deployment:
+    replicas: 3
+    podTemplate:
+      spec:
+        volumes:
+        - name: agent-data
+          emptyDir: {}
+...
+----

--- a/docs/orchestrating-elastic-stack-applications/agent-standalone.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-standalone.asciidoc
@@ -415,3 +415,24 @@ kubectl apply -f {agent_recipes}/multi-output.yaml
 ----
 
 Deploys two Elasticsearch clusters and two Kibana instances together with single Elastic Agent DaemonSet in standalone mode with System integration enabled. System metrics are sent to the `elasticsearch` cluster. Elastic Agent monitoring data is sent to `elasticsearch-mon` cluster.
+
+
+=== Storing local state in host path volume
+Elastic Agent when managed by ECK stores local state in a host path volume. This ensures that integrations run by the agent can continue their work without duplicating work that has already been done after the Pod has been recreated for example because of a Pod configuration change.
+If local state storage in host path volumes is not desired this can be turned off by configuring an `emptyDir` volume instead:
+
+[source,yaml]
+----
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: elastic-agent
+spec:
+  deployment:
+    podTemplate:
+      spec:
+        volumes:
+        - name: agent-data
+          emptyDir: {}
+...
+----

--- a/pkg/controller/agent/controller_test.go
+++ b/pkg/controller/agent/controller_test.go
@@ -149,7 +149,7 @@ func TestReconcileAgent_Reconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testAgent-agent",
 						Namespace: "test",
-						Labels:    addLabel(defaultLabels, hash.TemplateHashLabelName, "3804494098"),
+						Labels:    addLabel(defaultLabels, hash.TemplateHashLabelName, "3369118503"),
 					},
 					Status: appsv1.DeploymentStatus{
 						AvailableReplicas: 1,

--- a/pkg/controller/agent/controller_test.go
+++ b/pkg/controller/agent/controller_test.go
@@ -149,7 +149,7 @@ func TestReconcileAgent_Reconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testAgent-agent",
 						Namespace: "test",
-						Labels:    addLabel(defaultLabels, hash.TemplateHashLabelName, "2370142397"),
+						Labels:    addLabel(defaultLabels, hash.TemplateHashLabelName, "3804494098"),
 					},
 					Status: appsv1.DeploymentStatus{
 						AvailableReplicas: 1,

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -47,7 +47,7 @@ const (
 
 	DataVolumeName            = "agent-data"
 	DataMountHostPathTemplate = "/var/lib/%s/%s/agent-data"
-	DataMountPath             = "/usr/share/data"
+	DataMountPath             = "/usr/share/elastic-agent/state" // available since 7.14 without effect before that
 
 	// ConfigHashAnnotationName is an annotation used to store the Agent config hash.
 	ConfigHashAnnotationName = "agent.k8s.elastic.co/config-hash"
@@ -141,11 +141,10 @@ func buildPodTemplate(params Params, fleetCerts *certificates.CertificatesSecret
 		builder = builder.
 			WithResources(defaultResources).
 			WithArgs("-e", "-c", path.Join(ConfigMountPath, ConfigFileName))
-
-		// volume with agent data path
-		vols = append(vols, createDataVolume(params))
 	}
 
+	// volume with agent data path
+	vols = append(vols, createDataVolume(params))
 	// all volumes with CAs of direct associations
 	caAssocVols, err := getVolumesFromAssociations(params.Agent.GetAssociations())
 	if err != nil {

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -46,7 +46,7 @@ const (
 	FleetCertsMountPath  = "/usr/share/fleet-server/config/http-certs"
 
 	DataVolumeName            = "agent-data"
-	DataMountHostPathTemplate = "/var/lib/%s/%s/agent-data"
+	DataMountHostPathTemplate = "/var/lib/elastic-agent/%s/%s/state"
 	DataMountPath             = "/usr/share/elastic-agent/state" // available since 7.14 without effect before that
 
 	// ConfigHashAnnotationName is an annotation used to store the Agent config hash.

--- a/test/e2e/agent/config.go
+++ b/test/e2e/agent/config.go
@@ -219,6 +219,8 @@ inputs:
     - mountPath: /var/log
       name: varlog
   dnsPolicy: ClusterFirstWithHostNet
+  securityContext:
+    runAsUser: 0
   terminationGracePeriodSeconds: 30
   volumes:
   - hostPath:


### PR DESCRIPTION
Fixes #4428 

Mount the host path volume to point to the path where Elastic Agent stores its local state. This should make sure that while running on the same version no duplicate ingestion is happening. After version upgrades the internal sub-paths within the state directory still change see https://github.com/elastic/elastic-agent/issues/750 and events will be re-ingested. 

This is a potentially breaking change as I am configuring the host path volume now independently of the mode the agents are running in: Fleet or stand-alone. It will be breaking for users who have configured a deployment with multiple replicas where more than one replicas is placed by the Kubernetes scheduler on the same K8s node. 

Can we mitigate the effects of this? We could optimistically assume that Deployments with multiple replicas will be mainly used for Fleet Server and not use the host path volumes in this case.

I tried to think of a test case but it is tricky without restarting Elastic Agent Pods to see if duplicates are ingested or not and no clear indication of ingest state (i.e. have we waited long enough for duplicates to appear etc)