### PR TITLE
E2E: Run ECK diagnostics for any failed step

### DIFF
--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -88,6 +88,8 @@ func doRun(flags runFlags) error {
 
 	for _, step := range steps {
 		if err := step(); err != nil {
+			helper.dumpEventLog()
+			helper.runECKDiagnostics()
 			return err
 		}
 	}
@@ -526,8 +528,6 @@ func (h *helper) runTestsRemote() error {
 	close(stopChan)
 
 	if err != nil {
-		h.dumpEventLog()
-		h.runECKDiagnostics()
 		return errors.Wrap(err, "test run failed")
 	}
 


### PR DESCRIPTION
Currently we dump k8s events and run eck-diagnostics only if the `runTestsRemote` step fails. When for example `waitForOperatorToBeReady` fails, we remain blind. This commit moves the eck-diagnostics run so we have it for any failed step.

It helped me in #5773.
This may also help to diagnose https://github.com/elastic/cloud-on-k8s/issues/5825 and future errors when the operator pod is never ready.
