### PR TITLE
Configurable Vault path for the deployer

### DIFF
--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -26,6 +26,8 @@ if [[ ${BUILD_ID:-} == "" ]]; then
   VAULT_SECRET_ID="dev"
 fi
 
+VAULT_ROOT_PATH="secret/devops-ci/cloud-on-k8s"
+
 # main
 
 # default empty stack version definition common to all environments to allow uniform invocation of the e2e test runner
@@ -65,6 +67,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
 CFG
 ;;
 
@@ -100,6 +103,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
   gke:
     gCloudProject: $GCLOUD_PROJECT
 CFG
@@ -173,6 +177,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
   gke:
     gCloudProject: $GCLOUD_PROJECT
 CFG
@@ -213,6 +218,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
   kind:
     nodeImage: ${kindNodeImage}
     ipFamily: ${ipFamily}
@@ -249,6 +255,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
   gke:
     gCloudProject: $GCLOUD_PROJECT
 CFG
@@ -287,6 +294,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
   gke:
     gCloudProject: $GCLOUD_PROJECT
 CFG
@@ -322,6 +330,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
   ocp:
     gCloudProject: $GCLOUD_PROJECT
 CFG
@@ -356,6 +365,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
   ocp3:
     gCloudProject: $GCLOUD_PROJECT
 CFG
@@ -390,6 +400,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
 CFG
 ;;
 
@@ -425,6 +436,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
 CFG
 ;;
 
@@ -457,6 +469,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
 CFG
 
 ;;
@@ -497,6 +510,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
   gke:
     gCloudProject: $GCLOUD_PROJECT
 CFG
@@ -534,6 +548,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
 CFG
 ;;
 
@@ -617,6 +632,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
   gke:
     gCloudProject: $GCLOUD_PROJECT
 CFG
@@ -635,6 +651,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
 CFG
 ;;
 
@@ -651,6 +668,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
 CFG
 ;;
 
@@ -667,6 +685,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
 CFG
 ;;
 
@@ -683,6 +702,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
 CFG
 ;;
 
@@ -700,6 +720,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
   ocp:
     gCloudProject: $GCLOUD_PROJECT
 CFG
@@ -718,6 +739,7 @@ overrides:
     address: $VAULT_ADDR
     roleId: $VAULT_ROLE_ID
     secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
   ocp3:
     gCloudProject: $GCLOUD_PROJECT
 CFG

--- a/hack/deployer/runner/azure/azure.go
+++ b/hack/deployer/runner/azure/azure.go
@@ -21,7 +21,7 @@ type Credentials struct {
 }
 
 const (
-	AKSVaultPath     = "secret/devops-ci/cloud-on-k8s/ci-azr-k8s-operator"
+	AKSVaultPath     = "ci-azr-k8s-operator"
 	azureClientImage = "mcr.microsoft.com/azure-cli"
 )
 

--- a/hack/deployer/runner/eks.go
+++ b/hack/deployer/runner/eks.go
@@ -26,7 +26,7 @@ overrides:
     address: %s
     token: %s
 `
-	EKSVaultPath            = "secret/devops-ci/cloud-on-k8s/ci-aws-k8s-operator"
+	EKSVaultPath            = "ci-aws-k8s-operator"
 	clusterCreationTemplate = `apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 metadata:

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	GKEDriverID                     = "gke"
-	GKEVaultPath                    = "secret/devops-ci/cloud-on-k8s/ci-gcp-k8s-operator"
+	GKEVaultPath                    = "ci-gcp-k8s-operator"
 	GKEServiceAccountVaultFieldName = "service-account"
 	DefaultGKERunConfigTemplate     = `id: gke-dev
 overrides:

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	OCPDriverID                     = "ocp"
-	OCPVaultPath                    = "secret/devops-ci/cloud-on-k8s/ci-ocp-k8s-operator"
+	OCPVaultPath                    = "ci-ocp-k8s-operator"
 	OCPServiceAccountVaultFieldName = "service-account"
 	OCPPullSecretFieldName          = "pull-secret"
 	OCPStateBucket                  = "eck-deployer-ocp-clusters-state"

--- a/hack/deployer/runner/tanzu.go
+++ b/hack/deployer/runner/tanzu.go
@@ -23,7 +23,7 @@ import (
 const (
 	TanzuDriverID                 = "tanzu"
 	TanzuInstallConfig            = "install-config.yaml"
-	TanzuVaultPath                = "secret/devops-ci/cloud-on-k8s/ci-tanzu-k8s-operator"
+	TanzuVaultPath                = "ci-tanzu-k8s-operator"
 	DefaultTanzuRunConfigTemplate = `id: tanzu-dev
 overrides:
   clusterName: %s-dev-cluster

--- a/hack/deployer/vault/vault.go
+++ b/hack/deployer/vault/vault.go
@@ -20,6 +20,7 @@ type Client struct {
 	secretID    string
 	token       string
 	clientToken string
+	rootPath    string
 }
 
 type Info struct {
@@ -28,6 +29,7 @@ type Info struct {
 	SecretId    string `yaml:"secretId"` //nolint:revive
 	Token       string `yaml:"token"`
 	ClientToken string `yaml:"clientToken"`
+	RootPath    string `yaml:"rootPath"`
 }
 
 func NewClient(info Info) (*Client, error) {
@@ -49,6 +51,7 @@ func NewClient(info Info) (*Client, error) {
 		secretID:    info.SecretId,
 		token:       info.Token,
 		clientToken: info.ClientToken,
+		rootPath:    info.RootPath,
 	}
 	if err := c.auth(); err != nil {
 		return nil, err
@@ -132,6 +135,7 @@ func readCachedToken() (string, error) {
 
 // ReadIntoFile is a helper function used to read from Vault into file
 func (v *Client) ReadIntoFile(fileName, secretPath, fieldName string) error {
+	secretPath = filepath.Join(v.rootPath, secretPath)
 	res, err := v.client.Logical().Read(secretPath)
 	if err != nil {
 		return err
@@ -152,6 +156,7 @@ func (v *Client) ReadIntoFile(fileName, secretPath, fieldName string) error {
 
 // Get fetches contents of a single field at a specified path in Vault
 func (v *Client) Get(secretPath string, fieldName string) (string, error) {
+	secretPath = filepath.Join(v.rootPath, secretPath)
 	result, err := v.GetMany(secretPath, fieldName)
 	if err != nil {
 		return "", err
@@ -163,6 +168,7 @@ func (v *Client) Get(secretPath string, fieldName string) (string, error) {
 // GetMany fetches contents of multiple fields at a specified path in Vault. If error is nil, result slice
 // will be of length len(fieldNames).
 func (v *Client) GetMany(secretPath string, fieldNames ...string) ([]string, error) {
+	secretPath = filepath.Join(v.rootPath, secretPath)
 	secret, err := v.client.Logical().Read(secretPath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit makes configurable the Vault path used by the deployer to retrieve the secrets for creating k8s clusters.

This will be useful for using the deployer in Jenkins and Buildkite at the same time, as both use different Vault paths for security reasons.

Relates to #5773.