### PR TITLE
Fully qualified Docker image name for golang

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image used for continuous integration
-FROM golang:1.18.4
+FROM docker.io/library/golang:1.18.4
 
 ENV GOLANGCILINT_VERSION=1.45.2
 ENV SHELLCHECK_VERSION=0.8.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM --platform=$TARGETPLATFORM golang:1.18.4 as builder
+FROM --platform=$TARGETPLATFORM docker.io/library/golang:1.18.4 as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM --platform=$TARGETPLATFORM golang:1.18.4 as builder
+FROM --platform=$TARGETPLATFORM docker.io/library/golang:1.18.4 as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/hack/deployer/runner/client.go
+++ b/hack/deployer/runner/client.go
@@ -29,7 +29,7 @@ func ensureClientImage(driverID, clientVersion string, clientBuildDefDir string)
 
 	image, err := clientImageName(driverID, clientVersion, dockerfileName)
 	if err != nil {
-		return "", fmt.Errorf("while calculting docker image name %w", err)
+		return "", fmt.Errorf("while calculating docker image name %w", err)
 	}
 
 	if exists := checkImageExists(image); exists {

--- a/hack/manifest-gen/Dockerfile
+++ b/hack/manifest-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.4 as builder
+FROM docker.io/library/golang:1.18.4 as builder
 ADD . /manifest-gen
 WORKDIR /manifest-gen
 ENV GO111MODULE=on CGO_ENABLED=0 GOOS=linux 

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image for the E2E tests runner
-FROM --platform=$TARGETPLATFORM golang:1.18.4
+FROM --platform=$TARGETPLATFORM docker.io/library/golang:1.18.4
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
Uses a fully qualified Docker image name for golang to avoid a prompt when using a tool like buildah.


```
# Prompt example
STEP 1/17: FROM golang:1.18.4
? Please select an image: 
  ▸ docker.io/library/golang:1.18.4
    quay.io/golang:1.18.4
````

Relates to #5773.