### PR TITLE
Also set unenroll_timeout for Fleet Server

### DIFF
--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -27,6 +27,7 @@ spec:
       monitoring_enabled:
       - logs
       - metrics
+      unenroll_timeout: 900
       package_policies:
       - name: fleet_server-1
         id: fleet_server-1

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -26,6 +26,7 @@ spec:
       monitoring_enabled:
       - logs
       - metrics
+      unenroll_timeout: 900
       is_default_fleet_server: true
       package_policies:
       - name: fleet_server-1

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -26,6 +26,7 @@ spec:
       monitoring_enabled:
       - logs
       - metrics
+      unenroll_timeout: 900
       is_default_fleet_server: true
       package_policies:
       - name: fleet_server-1

--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -95,6 +95,7 @@ spec:
         monitoring_enabled:
           - logs
           - metrics
+        unenroll_timeout: 900
         package_policies:
         - name: fleet_server-1
           id: fleet_server-1
@@ -106,7 +107,7 @@ spec:
         monitoring_enabled:
           - logs
           - metrics
-        unenroll_timeout: 900  
+        unenroll_timeout: 900
         is_default: true
         package_policies:
           - name: system-1
@@ -281,6 +282,7 @@ spec:
         monitoring_enabled:
           - logs
           - metrics
+        unenroll_timeout: 900
         package_policies:
         - name: fleet_server-1
           id: fleet_server-1
@@ -292,7 +294,7 @@ spec:
         monitoring_enabled:
           - logs
           - metrics
-        unenroll_timeout: 900  
+        unenroll_timeout: 900
         is_default: true
         package_policies:
           - name: system-1

--- a/test/e2e/agent/config.go
+++ b/test/e2e/agent/config.go
@@ -24,6 +24,7 @@ const (
       monitoring_enabled:
       - logs
       - metrics
+      unenroll_timeout: 900
       is_default_fleet_server: true
       package_policies:
       - name: fleet_server-1


### PR DESCRIPTION
Not sure why `unenroll_timeout` is not set for the Fleet server in our examples. It has the same effect as on "regular" agents: It eventually removes former Fleet servers that have been replaced by rolling out new Pods.

<img width="1196" alt="image" src="https://user-images.githubusercontent.com/976373/181506658-326c302c-91fc-4ff1-b166-c37ba5a5de56.png">
