### PR TITLE
Set Agent container privileged on OpenShift if running as root

### DIFF
--- a/test/e2e/test/beat/builder.go
+++ b/test/e2e/test/beat/builder.go
@@ -205,14 +205,6 @@ func (b Builder) WithRestrictedSecurityContext() Builder {
 	return b
 }
 
-func (b Builder) WithContainerSecurityContext(securityContext corev1.SecurityContext) Builder {
-	for i := range b.PodTemplate.Spec.Containers {
-		b.PodTemplate.Spec.Containers[i].SecurityContext = &securityContext
-	}
-
-	return b
-}
-
 func (b Builder) WithLabel(key, value string) Builder {
 	if b.Beat.Labels == nil {
 		b.Beat.Labels = make(map[string]string)


### PR DESCRIPTION
This is an attempt to run Agent on OpenShift with an hostPath volume. An alternative would be to disable E2E Agent tests on OpenShift as it is the case for standalone Agents: https://github.com/elastic/cloud-on-k8s/blob/d5af986aad19d84ceee1d36fe2b94fef30c23775/test/e2e/agent/recipes_test.go#L212-L216

Related to https://github.com/elastic/cloud-on-k8s/pull/5890