### PR TITLE
Remove references to ioutil

### DIFF
--- a/cmd/license-initializer/main.go
+++ b/cmd/license-initializer/main.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -86,7 +85,7 @@ var publicKeyBytes = []byte{
 }
 `
 
-	bytes, err := ioutil.ReadFile(pubkeyFile)
+	bytes, err := os.ReadFile(pubkeyFile)
 	if err != nil {
 		handleErr(errors.Wrapf(err, "Failed to read %v", pubkeyFile))
 	}

--- a/cmd/license-initializer/main_test.go
+++ b/cmd/license-initializer/main_test.go
@@ -8,7 +8,7 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -17,7 +17,7 @@ import (
 
 func Test_generateSrc(t *testing.T) {
 	path := filepath.Join("testdata", "expected.src")
-	expectedBytes, err := ioutil.ReadFile(path)
+	expectedBytes, err := os.ReadFile(path)
 	require.NoError(t, err)
 	input := filepath.Join("testdata", "test.key")
 	var out bytes.Buffer

--- a/hack/deployer/cmd/create.go
+++ b/hack/deployer/cmd/create.go
@@ -6,7 +6,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -69,7 +68,7 @@ func CreateCommand() *cobra.Command {
 			}
 
 			fullPath := path.Join(filePath, fmt.Sprintf("deployer-config-%s.yml", provider))
-			return ioutil.WriteFile(fullPath, []byte(cfgData), 0600)
+			return os.WriteFile(fullPath, []byte(cfgData), 0600)
 		},
 	}
 

--- a/hack/deployer/runner/eks.go
+++ b/hack/deployer/runner/eks.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -117,7 +116,7 @@ func (e *EKSDriver) Execute() error {
 			}
 			createCfgFile := filepath.Join(e.ctx["WorkDir"].(string), "cluster.yaml") //nolint:forcetypeassert
 			e.ctx["CreateCfgFile"] = createCfgFile
-			if err := ioutil.WriteFile(createCfgFile, createCfg.Bytes(), 0600); err != nil {
+			if err := os.WriteFile(createCfgFile, createCfg.Bytes(), 0600); err != nil {
 				return fmt.Errorf("while writing create cfg %w", err)
 			}
 			if err := e.newCmd(`eksctl create cluster -v 0 -f {{.CreateCfgFile}}`).Run(); err != nil {
@@ -150,7 +149,7 @@ func (e *EKSDriver) ensureWorkDir() error {
 	if e.ctx["WorkDir"] != "" {
 		return nil
 	}
-	dir, err := ioutil.TempDir("", e.ctx["ClusterName"].(string))
+	dir, err := os.MkdirTemp("", e.ctx["ClusterName"].(string))
 	if err != nil {
 		return err
 	}
@@ -232,7 +231,7 @@ func (e *EKSDriver) writeAWSCredentials() error {
 	}
 	log.Printf("Writing aws credentials")
 	fileContents := fmt.Sprintf(awsAuthTemplate, awsAccessKeyID, e.ctx[awsAccessKeyID], awsSecretAccessKey, e.ctx[awsSecretAccessKey])
-	return ioutil.WriteFile(file, []byte(fileContents), 0600)
+	return os.WriteFile(file, []byte(fileContents), 0600)
 }
 
 var _ Driver = &EKSDriver{}

--- a/hack/deployer/runner/kind.go
+++ b/hack/deployer/runner/kind.go
@@ -96,7 +96,7 @@ func (k *KindDriver) create() error {
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tmpManifest.Name())
+	defer os.Remove(tmpManifest.Name())
 
 	// Delete any previous e2e kind cluster with the same name
 	err = k.delete()

--- a/hack/deployer/runner/kind.go
+++ b/hack/deployer/runner/kind.go
@@ -7,7 +7,6 @@ package runner
 import (
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -97,7 +96,7 @@ func (k *KindDriver) create() error {
 	if err != nil {
 		return err
 	}
-	defer os.Remove(tmpManifest.Name())
+	defer os.RemoveAll(tmpManifest.Name())
 
 	// Delete any previous e2e kind cluster with the same name
 	err = k.delete()
@@ -149,7 +148,7 @@ func (k *KindDriver) delete() error {
 
 func (k *KindDriver) createTmpManifest() (*os.File, error) {
 	// HOME is shared between CI container and Kind container
-	f, err := ioutil.TempFile(os.Getenv("HOME"), "kind-cluster")
+	f, err := os.CreateTemp(os.Getenv("HOME"), "kind-cluster")
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +220,7 @@ func (k *KindDriver) getKubeConfig() (*os.File, error) {
 	}
 
 	// Persist kubeconfig for reliability in following kubectl commands
-	kubeCfg, err := ioutil.TempFile("", "kubeconfig")
+	kubeCfg, err := os.CreateTemp("", "kubeconfig")
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +247,7 @@ func (k *KindDriver) GetCredentials() error {
 
 func (k *KindDriver) createTmpStorageClass() (string, error) {
 	tmpFile := filepath.Join(os.Getenv("HOME"), storageClassFileName)
-	err := ioutil.WriteFile(tmpFile, []byte(storageClass), fs.ModePerm)
+	err := os.WriteFile(tmpFile, []byte(storageClass), fs.ModePerm)
 	return tmpFile, err
 }
 

--- a/hack/deployer/runner/kubeconfig.go
+++ b/hack/deployer/runner/kubeconfig.go
@@ -7,7 +7,6 @@ package runner
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -35,7 +34,7 @@ func mergeKubeconfig(kubeConfig string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(hostKubeconfig, []byte(merged), 0600)
+	return os.WriteFile(hostKubeconfig, []byte(merged), 0600)
 }
 
 func removeKubeconfig(context, clusterName, userName string) error {

--- a/hack/deployer/runner/ocp.go
+++ b/hack/deployer/runner/ocp.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -171,7 +170,7 @@ func (d *OCPDriver) create() error {
 	}
 
 	installConfig := filepath.Join(d.runtimeState.ClusterStateDir, "install-config.yaml")
-	err := ioutil.WriteFile(installConfig, tpl.Bytes(), 0600)
+	err := os.WriteFile(installConfig, tpl.Bytes(), 0600)
 	if err != nil {
 		return err
 	}
@@ -260,7 +259,7 @@ func (d *OCPDriver) ensureWorkDir() error {
 		// having the work dir in HOME also underlines the importance of the work dir contents. The work dir is the only
 		// source to cleanly uninstall the cluster should the rsync fail.
 		var err error
-		workDir, err = ioutil.TempDir(os.Getenv("HOME"), d.plan.ClusterName)
+		workDir, err = os.MkdirTemp(os.Getenv("HOME"), d.plan.ClusterName)
 		if err != nil {
 			return err
 		}

--- a/hack/deployer/runner/ocp3.go
+++ b/hack/deployer/runner/ocp3.go
@@ -6,7 +6,6 @@ package runner
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -149,7 +148,7 @@ func (d OCP3Driver) writeAnsibleVarsFile() error {
 	}
 	varsFile := filepath.Join(os.Getenv("HOME"), AnsibleVarsFilename)
 	/* #nosec */
-	if err := ioutil.WriteFile(varsFile, varsBytes, 0644); err != nil {
+	if err := os.WriteFile(varsFile, varsBytes, 0644); err != nil {
 		return fmt.Errorf("while writing Ansible variables file %w", err)
 	}
 	return nil

--- a/hack/deployer/runner/settings.go
+++ b/hack/deployer/runner/settings.go
@@ -5,7 +5,7 @@
 package runner
 
 import (
-	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v3"
 
@@ -110,7 +110,7 @@ type RunConfig struct {
 }
 
 func ParseFiles(plansFile, runConfigFile string) (Plans, RunConfig, error) {
-	yml, err := ioutil.ReadFile(plansFile)
+	yml, err := os.ReadFile(plansFile)
 	if err != nil {
 		return Plans{}, RunConfig{}, err
 	}
@@ -121,7 +121,7 @@ func ParseFiles(plansFile, runConfigFile string) (Plans, RunConfig, error) {
 		return Plans{}, RunConfig{}, err
 	}
 
-	yml, err = ioutil.ReadFile(runConfigFile)
+	yml, err = os.ReadFile(runConfigFile)
 	if err != nil {
 		return Plans{}, RunConfig{}, err
 	}

--- a/hack/deployer/runner/tanzu.go
+++ b/hack/deployer/runner/tanzu.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -187,7 +186,7 @@ func (t *TanzuDriver) ensureWorkDir() error {
 		// base work dir in HOME dir otherwise mounting to container won't work without further settings adjustment
 		// in macOS in local mode. In CI mode we need the workdir to be in the volume shared between containers.
 		var err error
-		workDir, err = ioutil.TempDir(os.Getenv("HOME"), t.plan.ClusterName)
+		workDir, err = os.MkdirTemp(os.Getenv("HOME"), t.plan.ClusterName)
 		if err != nil {
 			return err
 		}
@@ -261,7 +260,7 @@ func (t *TanzuDriver) createInstallerConfig() error {
 		return err
 	}
 
-	return ioutil.WriteFile(t.installerConfigFilePath(), cfg.Bytes(), 0600)
+	return os.WriteFile(t.installerConfigFilePath(), cfg.Bytes(), 0600)
 }
 
 // installerConfigFilePath returns the path to the installer config valid in the context of deployer.

--- a/hack/deployer/vault/vault.go
+++ b/hack/deployer/vault/vault.go
@@ -6,7 +6,6 @@ package vault
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -126,7 +125,7 @@ func readCachedToken() (string, error) {
 		return "", err
 	}
 
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
@@ -150,7 +149,7 @@ func (v *Client) ReadIntoFile(fileName, secretPath, fieldName string) error {
 		return fmt.Errorf("field %s at %s is not a string, that's unexpected", fieldName, secretPath)
 	}
 
-	return ioutil.WriteFile(fileName, []byte(stringServiceAccount), 0600)
+	return os.WriteFile(fileName, []byte(stringServiceAccount), 0600)
 }
 
 // Get fetches contents of a single field at a specified path in Vault

--- a/hack/operatorhub/main.go
+++ b/hack/operatorhub/main.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -176,7 +175,7 @@ func (c *config) HasDigestPinning() bool {
 }
 
 func loadConfig(path string) (*config, error) {
-	confBytes, err := ioutil.ReadFile(path)
+	confBytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %s: %w", path, err)
 	}

--- a/hack/pipeline-validator/main.go
+++ b/hack/pipeline-validator/main.go
@@ -12,7 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"mime/multipart"
 	"net/http"
@@ -96,7 +96,7 @@ func getToken() (*CSRFToken, error) {
 		return nil, fmt.Errorf("received status code %d", resp.StatusCode)
 	}
 
-	bytes, err := ioutil.ReadAll(resp.Body)
+	bytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func getToken() (*CSRFToken, error) {
 }
 
 func validate(token *CSRFToken, pipeline string) (string, error) {
-	bytez, err := ioutil.ReadFile(pipeline)
+	bytez, err := os.ReadFile(pipeline)
 	if err != nil {
 		return "", err
 	}
@@ -147,7 +147,7 @@ func validate(token *CSRFToken, pipeline string) (string, error) {
 		return "", fmt.Errorf("received status code %d", resp.StatusCode)
 	}
 
-	bytez, err = ioutil.ReadAll(resp.Body)
+	bytez, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/hack/release-notes/github/pr_loader.go
+++ b/hack/release-notes/github/pr_loader.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -126,7 +125,7 @@ func (loader *prLoader) mkRequest(client *http.Client, cursor *string) (*apiResp
 
 	defer func() {
 		if resp.Body != nil {
-			_, _ = io.Copy(ioutil.Discard, resp.Body)
+			_, _ = io.Copy(io.Discard, resp.Body)
 			resp.Body.Close()
 		}
 	}()
@@ -135,7 +134,7 @@ func (loader *prLoader) mkRequest(client *http.Client, cursor *string) (*apiResp
 		return nil, fmt.Errorf("received status %s from the API", resp.Status)
 	}
 
-	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, maxPayloadSize))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxPayloadSize))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/hack/release-notes/github/pr_loader_test.go
+++ b/hack/release-notes/github/pr_loader_test.go
@@ -8,9 +8,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -36,10 +36,10 @@ var (
 )
 
 func TestDoLoadPullRequests(t *testing.T) {
-	firstPayload, err := ioutil.ReadFile("testdata/payload1.json")
+	firstPayload, err := os.ReadFile("testdata/payload1.json")
 	require.NoError(t, err)
 
-	secondPayload, err := ioutil.ReadFile("testdata/payload2.json")
+	secondPayload, err := os.ReadFile("testdata/payload2.json")
 	require.NoError(t, err)
 
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -48,7 +48,7 @@ func TestDoLoadPullRequests(t *testing.T) {
 			Variables map[string]interface{} `json:"variables"`
 		}
 
-		reqBytes, err := ioutil.ReadAll(r.Body)
+		reqBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/hack/release-notes/github/pr_processor_test.go
+++ b/hack/release-notes/github/pr_processor_test.go
@@ -5,14 +5,14 @@
 package github
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestExtractIssues(t *testing.T) {
-	issueBody, err := ioutil.ReadFile("testdata/issue_body.txt")
+	issueBody, err := os.ReadFile("testdata/issue_body.txt")
 	require.NoError(t, err)
 
 	want := []int{3040, 3042, 3133, 3134}

--- a/hack/upgrade-test-harness/config/config.go
+++ b/hack/upgrade-test-harness/config/config.go
@@ -6,7 +6,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -35,7 +34,7 @@ func (f *File) ReleasePos(name string) (int, error) {
 
 // Load the configuration from a YAML file.
 func Load(path string) (*File, error) {
-	confBytes, err := ioutil.ReadFile(path)
+	confBytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/agent/config_test.go
+++ b/pkg/controller/agent/config_test.go
@@ -5,7 +5,7 @@ package agent
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -157,7 +157,7 @@ func Test_extractClientConnectionSettings(t *testing.T) {
 	}
 
 	// setup cert fixtures
-	bytes, err := ioutil.ReadFile(filepath.Join("testdata", "ca.crt"))
+	bytes, err := os.ReadFile(filepath.Join("testdata", "ca.crt"))
 	require.NoError(t, err)
 	certs, err := certificates.ParsePEMCerts(bytes)
 	require.NoError(t, err)

--- a/pkg/controller/agent/fleet_test.go
+++ b/pkg/controller/agent/fleet_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -284,7 +284,7 @@ func mockFleetResponses(rs map[request]response) *mockFleetAPI {
 			callLog[r]++
 			return &http.Response{
 				StatusCode: response.code,
-				Body:       ioutil.NopCloser(strings.NewReader(response.body)),
+				Body:       io.NopCloser(strings.NewReader(response.body)),
 				Request:    req,
 			}
 		}

--- a/pkg/controller/autoscaling/elasticsearch/controller_test.go
+++ b/pkg/controller/autoscaling/elasticsearch/controller_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -215,7 +215,7 @@ func TestReconcile(t *testing.T) {
 			if tt.args.esManifest != "" {
 				// Load the current Elasticsearch resource from the sample files.
 				es := esv1.Elasticsearch{}
-				bytes, err := ioutil.ReadFile(filepath.Join("testdata", tt.args.esManifest, "elasticsearch.yml"))
+				bytes, err := os.ReadFile(filepath.Join("testdata", tt.args.esManifest, "elasticsearch.yml"))
 				require.NoError(t, err)
 				if err := yaml.Unmarshal(bytes, &es); err != nil {
 					t.Fatalf("yaml.Unmarshal error = %v, wantErr %v", err, tt.wantErr)
@@ -259,7 +259,7 @@ func TestReconcile(t *testing.T) {
 				require.NoError(t, k8sClient.Get(context.Background(), client.ObjectKey{Namespace: "testns", Name: "testes"}, &updatedElasticsearch))
 				// Read expected the expected Elasticsearch resource.
 				expectedElasticsearch := esv1.Elasticsearch{}
-				bytes, err := ioutil.ReadFile(filepath.Join("testdata", tt.args.esManifest, "elasticsearch-expected.yml"))
+				bytes, err := os.ReadFile(filepath.Join("testdata", tt.args.esManifest, "elasticsearch-expected.yml"))
 				require.NoError(t, err)
 				require.NoError(t, yaml.Unmarshal(bytes, &expectedElasticsearch))
 				assert.Equal(t, updatedElasticsearch.Spec, expectedElasticsearch.Spec, "Updated Elasticsearch spec. is not the expected one")
@@ -339,7 +339,7 @@ func newFakeEsClient(t *testing.T) *fakeEsClient {
 
 func (f *fakeEsClient) withCapacity(testdata string) *fakeEsClient {
 	policies := esclient.AutoscalingCapacityResult{}
-	bytes, err := ioutil.ReadFile("testdata/" + testdata + "/capacity.json")
+	bytes, err := os.ReadFile("testdata/" + testdata + "/capacity.json")
 	if err != nil {
 		f.t.Fatalf("Error while reading autoscaling capacity content: %v", err)
 	}

--- a/pkg/controller/common/certificates/ca_reconcile.go
+++ b/pkg/controller/common/certificates/ca_reconcile.go
@@ -11,7 +11,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -283,7 +283,7 @@ func BuildCAFromFile(path string) (*CA, error) {
 		return nil, err
 	}
 
-	bytes, err := ioutil.ReadFile(certFile)
+	bytes, err := os.ReadFile(certFile)
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +301,7 @@ func BuildCAFromFile(path string) (*CA, error) {
 	}
 	cert := certs[0]
 
-	privateKeyBytes, err := ioutil.ReadFile(privateKeyFile)
+	privateKeyBytes, err := os.ReadFile(privateKeyFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/common/certificates/ca_reconcile_integration_test.go
+++ b/pkg/controller/common/certificates/ca_reconcile_integration_test.go
@@ -8,7 +8,6 @@ package certificates
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -91,7 +90,7 @@ func TestBuildCAFromFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// creating a temp dir inside testdata so that we can simply link to the test files
-			tempDir, err := ioutil.TempDir("testdata", "ca-from-file")
+			tempDir, err := os.MkdirTemp("testdata", "ca-from-file")
 			require.NoError(t, err)
 			defer os.RemoveAll(tempDir)
 
@@ -162,7 +161,7 @@ func Test_detectCAFileNames(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 			for _, f := range tt.files {
-				require.NoError(t, ioutil.WriteFile(filepath.Join(dir, f), []byte("contents"), 0644))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, f), []byte("contents"), 0644))
 			}
 
 			cert, key, err := detectCAFileNames(dir)

--- a/pkg/controller/common/certificates/secret_test.go
+++ b/pkg/controller/common/certificates/secret_test.go
@@ -5,7 +5,7 @@
 package certificates
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -252,7 +252,7 @@ func TestCertificatesSecret_Validate(t *testing.T) {
 }
 
 func loadFileBytes(fileName string) []byte {
-	contents, err := ioutil.ReadFile(filepath.Join("testdata", fileName))
+	contents, err := os.ReadFile(filepath.Join("testdata", fileName))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/controller/common/license/fixtures_test.go
+++ b/pkg/controller/common/license/fixtures_test.go
@@ -9,7 +9,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -58,7 +58,7 @@ var emptyTrialLicenseFixture = EnterpriseLicense{
 }
 
 func externallySignedLicenseFixture() (EnterpriseLicense, error) {
-	exptectedBytes, err := ioutil.ReadFile("testdata/externally-generated-lic.json")
+	exptectedBytes, err := os.ReadFile("testdata/externally-generated-lic.json")
 	if err != nil {
 		return EnterpriseLicense{}, err
 	}

--- a/pkg/controller/common/license/model_test.go
+++ b/pkg/controller/common/license/model_test.go
@@ -6,7 +6,7 @@ package license
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -225,7 +225,7 @@ func Test_unmarshalModel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var license EnterpriseLicense
-			bytes, err := ioutil.ReadFile(tt.args.licenseFile)
+			bytes, err := os.ReadFile(tt.args.licenseFile)
 			require.NoError(t, err)
 
 			if err := json.Unmarshal(bytes, &license); (err != nil) != tt.wantErr {

--- a/pkg/controller/common/license/parser_test.go
+++ b/pkg/controller/common/license/parser_test.go
@@ -5,7 +5,7 @@
 package license
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -13,9 +13,9 @@ import (
 )
 
 func TestParseEnterpriseLicenses(t *testing.T) {
-	good, err := ioutil.ReadFile("testdata/test-license.json")
+	good, err := os.ReadFile("testdata/test-license.json")
 	require.NoError(t, err)
-	bad, err := ioutil.ReadFile("testdata/test-error.json")
+	bad, err := os.ReadFile("testdata/test-error.json")
 	require.NoError(t, err)
 
 	type args struct {

--- a/pkg/controller/elasticsearch/client/autoscaling_test.go
+++ b/pkg/controller/elasticsearch/client/autoscaling_test.go
@@ -7,8 +7,9 @@ package client_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -35,7 +36,7 @@ func TestClient_CreateAutoscalingPolicy(t *testing.T) {
 			require.Equal(t, tt.expectedPath, req.URL.Path)
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader(`{"acknowledged": true}`)),
+				Body:       io.NopCloser(strings.NewReader(`{"acknowledged": true}`)),
 				Header:     make(http.Header),
 				Request:    req,
 			}
@@ -61,7 +62,7 @@ func TestClient_DeleteAutoscalingPolicies(t *testing.T) {
 			require.Equal(t, tt.expectedPath, req.URL.Path)
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader(`{"acknowledged": true}`)),
+				Body:       io.NopCloser(strings.NewReader(`{"acknowledged": true}`)),
 				Header:     make(http.Header),
 				Request:    req,
 			}
@@ -73,11 +74,11 @@ func TestClient_DeleteAutoscalingPolicies(t *testing.T) {
 func TestClient_GetAutoscalingCapacity(t *testing.T) {
 	testClient := NewMockClient(version.MustParse("7.11.0"), func(req *http.Request) *http.Response {
 		require.Equal(t, "/_autoscaling/capacity", req.URL.Path)
-		fixture, err := ioutil.ReadFile(filepath.Join("testdata", "autoscaling.json"))
+		fixture, err := os.ReadFile(filepath.Join("testdata", "autoscaling.json"))
 		assert.NoError(t, err)
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader(fixture)),
+			Body:       io.NopCloser(bytes.NewReader(fixture)),
 			Header:     make(http.Header),
 			Request:    req,
 		}

--- a/pkg/controller/elasticsearch/client/client_test.go
+++ b/pkg/controller/elasticsearch/client/client_test.go
@@ -11,7 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"sort"
@@ -143,7 +143,7 @@ func requestAssertion(test func(req *http.Request)) RoundTripFunc {
 		test(req)
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewBufferString(`{}`)),
+			Body:       io.NopCloser(bytes.NewBufferString(`{}`)),
 			Header:     make(http.Header),
 			Request:    req,
 		}
@@ -271,7 +271,7 @@ func TestAPIError_Error(t *testing.T) {
 			fields: fields{newAPIError(&http.Response{
 				StatusCode: 400,
 				Status:     "400 Bad Request",
-				Body:       ioutil.NopCloser(bytes.NewBufferString(fixtures.ErrorSample)),
+				Body:       io.NopCloser(bytes.NewBufferString(fixtures.ErrorSample)),
 			})},
 			want: `400 Bad Request: {Status:400 Error:{CausedBy:{Reason:cannot set discovery.zen.minimum_master_nodes to more than the current master nodes count [1] ` +
 				`Type:illegal_argument_exception} Reason:illegal value can't update [discovery.zen.minimum_master_nodes] from [1] to [6] Type:illegal_argument_exception ` +
@@ -282,7 +282,7 @@ func TestAPIError_Error(t *testing.T) {
 			fields: fields{newAPIError(&http.Response{
 				StatusCode: 500,
 				Status:     "500 Internal Server Error",
-				Body:       ioutil.NopCloser(bytes.NewBufferString("")),
+				Body:       io.NopCloser(bytes.NewBufferString("")),
 			})},
 			want: "500 Internal Server Error: {Status:0 Error:{CausedBy:{Reason: Type:} Reason: Type: StackTrace: RootCause:[]}}",
 		},
@@ -302,7 +302,7 @@ func TestClientGetNodes(t *testing.T) {
 		require.Equal(t, expectedPath, req.URL.Path)
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(strings.NewReader(fixtures.NodesSample)),
+			Body:       io.NopCloser(strings.NewReader(fixtures.NodesSample)),
 			Header:     make(http.Header),
 			Request:    req,
 		}
@@ -320,7 +320,7 @@ func TestClientGetNodesStats(t *testing.T) {
 		require.Equal(t, expectedPath, req.URL.Path)
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(strings.NewReader(fixtures.NodesStatsSample)),
+			Body:       io.NopCloser(strings.NewReader(fixtures.NodesStatsSample)),
 			Header:     make(http.Header),
 			Request:    req,
 		}
@@ -338,7 +338,7 @@ func TestGetInfo(t *testing.T) {
 		require.Equal(t, expectedPath, req.URL.Path)
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(strings.NewReader(fixtures.InfoSample)),
+			Body:       io.NopCloser(strings.NewReader(fixtures.InfoSample)),
 			Header:     make(http.Header),
 			Request:    req,
 		}
@@ -477,7 +477,7 @@ func TestClient_AddVotingConfigExclusions(t *testing.T) {
 			require.Equal(t, tt.expectedQuery, req.URL.RawQuery, tt.version)
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader("")),
+				Body:       io.NopCloser(strings.NewReader("")),
 			}
 		})
 		err := client.AddVotingConfigExclusions(context.Background(), []string{"a", "b"})
@@ -510,7 +510,7 @@ func TestClient_DeleteVotingConfigExclusions(t *testing.T) {
 			require.Equal(t, tt.expectedPath, req.URL.Path)
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader("")),
+				Body:       io.NopCloser(strings.NewReader("")),
 			}
 		})
 		err := client.DeleteVotingConfigExclusions(context.Background(), false)
@@ -546,7 +546,7 @@ func TestClient_SetMinimumMasterNodes(t *testing.T) {
 			require.Equal(t, tt.expectedPath, req.URL.Path)
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader("")),
+				Body:       io.NopCloser(strings.NewReader("")),
 			}
 		})
 		err := client.SetMinimumMasterNodes(context.Background(), 1)
@@ -655,7 +655,7 @@ func TestClient_ClusterBootstrappedForZen2(t *testing.T) {
 				require.Equal(t, tt.expectedPath, req.URL.Path)
 				return &http.Response{
 					StatusCode: 200,
-					Body:       ioutil.NopCloser(strings.NewReader(tt.apiResponse)),
+					Body:       io.NopCloser(strings.NewReader(tt.apiResponse)),
 				}
 			})
 			bootstrappedForZen2, err := client.ClusterBootstrappedForZen2(context.Background())
@@ -711,7 +711,7 @@ func TestGetClusterHealthWaitForAllEvents(t *testing.T) {
 					require.Equal(t, expectedRawQuery, req.URL.RawQuery)
 					return &http.Response{
 						StatusCode: 408,
-						Body: ioutil.NopCloser(strings.NewReader(
+						Body: io.NopCloser(strings.NewReader(
 							`
 {
 	"cluster_name": "elasticsearch-sample",
@@ -762,7 +762,7 @@ func TestGetClusterHealthWaitForAllEvents(t *testing.T) {
 					require.Equal(t, expectedRawQuery, req.URL.RawQuery)
 					return &http.Response{
 						StatusCode: 200,
-						Body: ioutil.NopCloser(strings.NewReader(
+						Body: io.NopCloser(strings.NewReader(
 							`
 {
 	"cluster_name": "elasticsearch-sample",

--- a/pkg/controller/elasticsearch/client/error.go
+++ b/pkg/controller/elasticsearch/client/error.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -28,7 +28,7 @@ func newAPIError(response *http.Response) error {
 		StatusCode: response.StatusCode,
 	}
 	// We may need to read the body multiple times, read the full body and store it as an array of bytes.
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		// We were not able to read the body, log this I/O error and return the API error with the status.
 		log.Error(err, "Cannot read Elasticsearch error response body")
@@ -36,7 +36,7 @@ func newAPIError(response *http.Response) error {
 	}
 	// Reset the response body to the original unread state. It allows a caller to read again the body if necessary,
 	// for example in the case of a 408.
-	response.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+	response.Body = io.NopCloser(bytes.NewBuffer(body))
 
 	// Parse the body to get the details about the API error, as they are stored by Elasticsearch.
 	var errorResponse ErrorResponse

--- a/pkg/controller/elasticsearch/client/license_test.go
+++ b/pkg/controller/elasticsearch/client/license_test.go
@@ -6,7 +6,7 @@ package client
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -39,7 +39,7 @@ func TestClient_GetLicense(t *testing.T) {
 			require.Equal(t, tt.expectedPath, req.URL.Path)
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader(fixtures.LicenseGetSample)),
+				Body:       io.NopCloser(strings.NewReader(fixtures.LicenseGetSample)),
 				Header:     make(http.Header),
 				Request:    req,
 			}
@@ -77,7 +77,7 @@ func TestClient_UpdateLicense(t *testing.T) {
 			require.Equal(t, tt.expectedPath, req.URL.Path)
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader(fixtures.LicenseUpdateResponseSample)),
+				Body:       io.NopCloser(strings.NewReader(fixtures.LicenseUpdateResponseSample)),
 				Header:     make(http.Header),
 				Request:    req,
 			}
@@ -123,7 +123,7 @@ func TestClient_StartBasic(t *testing.T) {
 			require.Equal(t, tt.expectedPath, req.URL.Path)
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader(`{"acknowledged":true,"basic_was_started":true}`)),
+				Body:       io.NopCloser(strings.NewReader(`{"acknowledged":true,"basic_was_started":true}`)),
 				Header:     make(http.Header),
 				Request:    req,
 			}

--- a/pkg/controller/elasticsearch/client/mock.go
+++ b/pkg/controller/elasticsearch/client/mock.go
@@ -5,7 +5,7 @@
 package client
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -36,7 +36,7 @@ func NewMockClientWithUser(v version.Version, u BasicAuth, fn RoundTripFunc) Cli
 func NewMockResponse(statusCode int, r *http.Request, body string) *http.Response {
 	return &http.Response{
 		StatusCode: statusCode,
-		Body:       ioutil.NopCloser(strings.NewReader(body)),
+		Body:       io.NopCloser(strings.NewReader(body)),
 		Header:     make(http.Header),
 		Request:    r,
 	}

--- a/pkg/controller/elasticsearch/client/security_test.go
+++ b/pkg/controller/elasticsearch/client/security_test.go
@@ -6,7 +6,7 @@ package client
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -39,7 +39,7 @@ func Test_GetServiceAccountCredentials(t *testing.T) {
 				require.Equal(t, "/_security/service/elastic/kibana/credential", req.URL.Path)
 				return &http.Response{
 					StatusCode: 200,
-					Body: ioutil.NopCloser(strings.NewReader(
+					Body: io.NopCloser(strings.NewReader(
 						`{
 	"service_account": "elastic/kibana",
 	"count": 1,

--- a/pkg/controller/elasticsearch/driver/desired_nodes_test.go
+++ b/pkg/controller/elasticsearch/driver/desired_nodes_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -492,7 +493,7 @@ func Test_defaultDriver_updateDesiredNodes(t *testing.T) {
 
 			wantClient := wantClient{}
 			if tt.want.testdata != "" {
-				parsedRequest, err := ioutil.ReadFile("testdata/desired_nodes/" + tt.want.testdata)
+				parsedRequest, err := os.ReadFile("testdata/desired_nodes/" + tt.want.testdata)
 				assert.NoError(t, err)
 				wantClient.request = string(parsedRequest)
 				// Elasticsearch UID must have been used as the history ID
@@ -795,14 +796,14 @@ func fakeEsClient(t *testing.T, esVersion string, err bool, want wantClient) *de
 			assert.Equal(t, want.version, gotVersion)
 
 			// Compare the request
-			gotRequest, err := ioutil.ReadAll(req.Body)
+			gotRequest, err := io.ReadAll(req.Body)
 			assert.NoError(t, err)
 			require.JSONEq(t, want.request, string(gotRequest))
 		}
 
 		return &http.Response{
 			StatusCode: statusCode,
-			Body:       ioutil.NopCloser(bytes.NewBufferString(`{"acknowledged":true}`)),
+			Body:       io.NopCloser(bytes.NewBufferString(`{"acknowledged":true}`)),
 		}
 	})
 	return &desiredNodesFakeClient{Client: c}

--- a/pkg/controller/elasticsearch/migration/fixtures.go
+++ b/pkg/controller/elasticsearch/migration/fixtures.go
@@ -7,14 +7,14 @@ package migration
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	esclient "github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/client"
 )
 
 func loadFileBytes(fileName string) []byte {
-	contents, err := ioutil.ReadFile(filepath.Join("testdata", fileName))
+	contents, err := os.ReadFile(filepath.Join("testdata", fileName))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/controller/elasticsearch/observer/manager_test.go
+++ b/pkg/controller/elasticsearch/observer/manager_test.go
@@ -6,7 +6,7 @@ package observer
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -142,7 +142,7 @@ func flappingEsClient() client.Client {
 			retErr = true
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(fixtures.HealthSample)),
+				Body:       io.NopCloser(bytes.NewBufferString(fixtures.HealthSample)),
 				Header:     make(http.Header),
 				Request:    req,
 			}

--- a/pkg/controller/elasticsearch/observer/observer_test.go
+++ b/pkg/controller/elasticsearch/observer/observer_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -32,7 +31,7 @@ func fakeEsClient200(user client.BasicAuth) client.Client {
 		func(req *http.Request) *http.Response {
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(fixtures.SampleShards)),
+				Body:       io.NopCloser(bytes.NewBufferString(fixtures.SampleShards)),
 				Header:     make(http.Header),
 				Request:    req,
 			}
@@ -121,7 +120,7 @@ func fakeEsClient(healthRespErr bool) client.Client {
 		var respBody io.ReadCloser
 
 		if strings.Contains(req.URL.RequestURI(), "health") {
-			respBody = ioutil.NopCloser(bytes.NewBufferString(fixtures.HealthSample))
+			respBody = io.NopCloser(bytes.NewBufferString(fixtures.HealthSample))
 			if healthRespErr {
 				statusCode = 500
 			}

--- a/pkg/controller/elasticsearch/shutdown/node_test.go
+++ b/pkg/controller/elasticsearch/shutdown/node_test.go
@@ -7,7 +7,7 @@ package shutdown
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -214,7 +214,7 @@ func TestNodeShutdown_Clear(t *testing.T) {
 				}
 				return &http.Response{
 					StatusCode: 200,
-					Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(tt.fixture))),
+					Body:       io.NopCloser(bytes.NewBuffer([]byte(tt.fixture))),
 					Header:     make(http.Header),
 					Request:    req,
 				}
@@ -312,7 +312,7 @@ func TestNodeShutdown_ShutdownStatus(t *testing.T) {
 			client := esclient.NewMockClient(version.MustParse("7.15.2"), func(req *http.Request) *http.Response {
 				return &http.Response{
 					StatusCode: 200,
-					Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(tt.fixture))),
+					Body:       io.NopCloser(bytes.NewBuffer([]byte(tt.fixture))),
 					Header:     make(http.Header),
 					Request:    req,
 				}
@@ -438,7 +438,7 @@ func TestNodeShutdown_ReconcileShutdowns(t *testing.T) {
 				methodsCalled = append(methodsCalled, req.Method)
 				return &http.Response{
 					StatusCode: 200,
-					Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(tt.fixtures[i]))),
+					Body:       io.NopCloser(bytes.NewBuffer([]byte(tt.fixtures[i]))),
 					Header:     make(http.Header),
 					Request:    req,
 				}

--- a/pkg/controller/enterprisesearch/version_upgrade.go
+++ b/pkg/controller/enterprisesearch/version_upgrade.go
@@ -10,7 +10,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -194,7 +194,7 @@ func (r *VersionUpgrade) setReadOnlyMode(ctx context.Context, enabled bool) erro
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		respBody, err := ioutil.ReadAll(resp.Body)
+		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/enterprisesearch/version_upgrade_test.go
+++ b/pkg/controller/enterprisesearch/version_upgrade_test.go
@@ -7,7 +7,7 @@ package enterprisesearch
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -88,14 +88,14 @@ type roundTripChecks struct {
 func (f fakeRoundTrip) RoundTrip(req *http.Request) (*http.Response, error) {
 	f.checks.called = true
 	f.checks.withURL = req.URL.String()
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, err
 	}
 	f.checks.withBody = string(body)
 	return &http.Response{
 		StatusCode: f.checks.returnStatusCode,
-		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+		Body:       io.NopCloser(bytes.NewReader(nil)),
 	}, nil
 }
 
@@ -329,7 +329,7 @@ func TestVersionUpgrade_readOnlyModeRequest(t *testing.T) {
 			require.Equal(t, tt.wantURL, req.URL.String())
 
 			// check body
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			require.NoError(t, err)
 			require.Equal(t, tt.wantBody, string(body))
 

--- a/pkg/utils/fs/watcher_integration_test.go
+++ b/pkg/utils/fs/watcher_integration_test.go
@@ -9,7 +9,6 @@ package fs
 import (
 	"context"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,7 +42,7 @@ func TestNewFileWatcher(t *testing.T) {
 		}
 	}
 
-	dir, err := ioutil.TempDir("", "file-watcher-test")
+	dir, err := os.MkdirTemp("", "file-watcher-test")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(dir)
@@ -62,14 +61,14 @@ func TestNewFileWatcher(t *testing.T) {
 	}
 
 	// file 2 exists before watcher is set up
-	require.NoError(t, ioutil.WriteFile(file2, []byte("contents"), 0644))
+	require.NoError(t, os.WriteFile(file2, []byte("contents"), 0644))
 
 	// setup watcher
 	watcher := NewFileWatcher(ctx, []string{file1, file2, file3, file4}, onChange, 1*time.Millisecond)
 
 	// file 1 and 3 is only created afterwards
-	require.NoError(t, ioutil.WriteFile(file1, []byte("contents"), 0644))
-	require.NoError(t, ioutil.WriteFile(file3, []byte("contents"), 0644))
+	require.NoError(t, os.WriteFile(file1, []byte("contents"), 0644))
+	require.NoError(t, os.WriteFile(file3, []byte("contents"), 0644))
 
 	// we start watcher only now to be able to simulate multiple events happening in one observation interval
 	// which would otherwise lead to a flaky test
@@ -78,13 +77,13 @@ func TestNewFileWatcher(t *testing.T) {
 	requireEventEquals(events, []string{file1, file3}, 1*time.Second)
 
 	// create a new file 4 once the watcher has been started
-	require.NoError(t, ioutil.WriteFile(file4, []byte("contents"), 0644))
+	require.NoError(t, os.WriteFile(file4, []byte("contents"), 0644))
 	requireEventEquals(events, []string{file4}, 1*time.Second)
 	// sometimes mtime is changed more than once on write apparently
 	allowOptionalEvent(events, []string{file4}, 100*time.Millisecond)
 
 	// update file 2
-	require.NoError(t, ioutil.WriteFile(file2, []byte("new contents"), 0644))
+	require.NoError(t, os.WriteFile(file2, []byte("new contents"), 0644))
 	requireEventEquals(events, []string{file2}, 1*time.Second)
 	// sometimes mtime is changed more than once on write apparently
 	allowOptionalEvent(events, []string{file2}, 100*time.Millisecond)
@@ -95,7 +94,7 @@ func TestNewFileWatcher(t *testing.T) {
 
 	// files that are not watched should not trigger events
 	notWatched := filepath.Join(dir, "not-watched")
-	require.NoError(t, ioutil.WriteFile(notWatched, []byte("contents"), 0644))
+	require.NoError(t, os.WriteFile(notWatched, []byte("contents"), 0644))
 	requireNoEvent(events, 100*time.Millisecond)
 
 }

--- a/pkg/utils/test/webhook.go
+++ b/pkg/utils/test/webhook.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -77,6 +76,7 @@ func ValidationWebhookFailed(causeRegexes ...string) func(*testing.T, *admission
 }
 
 // RunValidationWebhookTests runs a series of ValidationWebhookTestCases
+//
 //nolint:thelper
 func RunValidationWebhookTests(t *testing.T, gvk metav1.GroupVersionKind, validator admission.Validator, tests ...ValidationWebhookTestCase) {
 	controllerscheme.SetupScheme()
@@ -124,7 +124,7 @@ func RunValidationWebhookTests(t *testing.T, gvk metav1.GroupVersionKind, valida
 			require.NoError(t, err)
 			defer func() {
 				if resp.Body != nil {
-					_, _ = io.Copy(ioutil.Discard, resp.Body)
+					_, _ = io.Copy(io.Discard, resp.Body)
 					resp.Body.Close()
 				}
 			}()
@@ -138,7 +138,7 @@ func RunValidationWebhookTests(t *testing.T, gvk metav1.GroupVersionKind, valida
 func decodeResponse(t *testing.T, decoder runtime.Decoder, body io.Reader) *admissionv1beta1.AdmissionResponse {
 	t.Helper()
 
-	responseBytes, err := ioutil.ReadAll(body)
+	responseBytes, err := io.ReadAll(body)
 	require.NoError(t, err, "Failed to read response body")
 
 	response := &admissionv1beta1.AdmissionReview{}

--- a/support/reattach-pv/main.go
+++ b/support/reattach-pv/main.go
@@ -7,7 +7,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -93,7 +92,7 @@ func main() {
 
 // esFromFile parses an Elasticsearch resource from the given yaml manifest path.
 func esFromFile(path string) (esv1.Elasticsearch, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return esv1.Elasticsearch{}, err
 	}

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -144,7 +143,7 @@ func (h *helper) initTestContext() error {
 
 	var stackImages test.ElasticStackImages
 	if h.elasticStackImagesPath != "" {
-		bytes, err := ioutil.ReadFile(h.elasticStackImagesPath)
+		bytes, err := os.ReadFile(h.elasticStackImagesPath)
 		if err != nil {
 			return fmt.Errorf("unable to read Elastic Stack images config file: %w", err)
 		}
@@ -254,7 +253,7 @@ func isOcp3Cluster(h *helper) bool {
 func (h *helper) initTestSecrets() error {
 	h.testSecrets = map[string]string{}
 	if h.testLicense != "" {
-		bytes, err := ioutil.ReadFile(h.testLicense)
+		bytes, err := os.ReadFile(h.testLicense)
 		if err != nil {
 			return fmt.Errorf("reading %v: %w", h.testLicense, err)
 		}
@@ -263,7 +262,7 @@ func (h *helper) initTestSecrets() error {
 	}
 
 	if h.testLicensePKeyPath != "" {
-		bytes, err := ioutil.ReadFile(h.testLicensePKeyPath)
+		bytes, err := os.ReadFile(h.testLicensePKeyPath)
 		if err != nil {
 			return fmt.Errorf("reading %v: %w", h.testLicensePKeyPath, err)
 		}
@@ -272,7 +271,7 @@ func (h *helper) initTestSecrets() error {
 	}
 
 	if h.monitoringSecrets != "" {
-		bytes, err := ioutil.ReadFile(h.monitoringSecrets)
+		bytes, err := os.ReadFile(h.monitoringSecrets)
 		if err != nil {
 			return fmt.Errorf("reading %v: %w", h.monitoringSecrets, err)
 		}
@@ -377,7 +376,7 @@ func (h *helper) renderManifestFromHelm(valuesFile, namespace string, installCRD
 		return fmt.Errorf("failed to generate manifest %s: %w", manifestFile, err)
 	}
 
-	if err := ioutil.WriteFile(manifestFile, manifestBytes, 0600); err != nil {
+	if err := os.WriteFile(manifestFile, manifestBytes, 0600); err != nil {
 		return fmt.Errorf("failed to write manifest %s: %w", manifestFile, err)
 	}
 
@@ -770,7 +769,7 @@ func (h *helper) renderTemplate(templatePath string, param interface{}) (string,
 		return "", errors.Wrapf(err, "failed to parse template at %s", templatePath)
 	}
 
-	outFile, err := ioutil.TempFile(h.scratchDir, filepath.Base(templatePath))
+	outFile, err := os.CreateTemp(h.scratchDir, filepath.Base(templatePath))
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to create tmp file: %s", templatePath)
 	}

--- a/test/e2e/cmd/run/run_test.go
+++ b/test/e2e/cmd/run/run_test.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -80,7 +80,7 @@ func Test_helper_streamTestJobOutput_withError(t *testing.T) {
 	log = logf.Log.WithName("streamTestJobOutput_withError")
 
 	stopLogStream := make(chan struct{})
-	sampleLogs, err := ioutil.ReadFile("testdata/stream.json")
+	sampleLogs, err := os.ReadFile("testdata/stream.json")
 	require.NoError(t, err)
 	streamProvider := NewFakeLogStreamProvider(sampleLogs, stopLogStream, true)
 
@@ -88,7 +88,7 @@ func Test_helper_streamTestJobOutput_withError(t *testing.T) {
 	writer := bytes.NewBuffer([]byte{})
 	streamTestJobOutput(streamProvider, goLangTestTimestampParser, writer, streamErrors, stopLogStream)
 
-	got, err := ioutil.ReadAll(writer)
+	got, err := io.ReadAll(writer)
 	require.NoError(t, err)
 
 	// Check that we had one error
@@ -103,7 +103,7 @@ func Test_helper_streamTestJobOutput(t *testing.T) {
 	log = logf.Log.WithName("streamTestJobOutput")
 
 	stopLogStream := make(chan struct{})
-	sampleLogs, err := ioutil.ReadFile("testdata/stream.json")
+	sampleLogs, err := os.ReadFile("testdata/stream.json")
 	require.NoError(t, err)
 	streamProvider := NewFakeLogStreamProvider(sampleLogs, stopLogStream, false)
 
@@ -112,7 +112,7 @@ func Test_helper_streamTestJobOutput(t *testing.T) {
 	streamTestJobOutput(streamProvider, goLangTestTimestampParser, writer, streamErrors, stopLogStream)
 
 	// Check that the data are the expected ones
-	got, err := ioutil.ReadAll(writer)
+	got, err := io.ReadAll(writer)
 	require.NoError(t, err)
 
 	errorCount := len(streamErrors)

--- a/test/e2e/es/license_test.go
+++ b/test/e2e/es/license_test.go
@@ -9,7 +9,7 @@ package es
 import (
 	"crypto/rsa"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -26,7 +26,7 @@ func TestEnterpriseLicenseSingle(t *testing.T) {
 		t.SkipNow()
 	}
 
-	licenseBytes, err := ioutil.ReadFile(test.Ctx().TestLicense)
+	licenseBytes, err := os.ReadFile(test.Ctx().TestLicense)
 	require.NoError(t, err)
 
 	k := test.NewK8sClientOrFatal()
@@ -90,7 +90,7 @@ func TestEnterpriseTrialLicense(t *testing.T) {
 		t.SkipNow()
 	}
 
-	licenseBytes, err := ioutil.ReadFile(test.Ctx().TestLicense)
+	licenseBytes, err := os.ReadFile(test.Ctx().TestLicense)
 	require.NoError(t, err)
 
 	esBuilder := elasticsearch.NewBuilder("test-es-trial-license").
@@ -142,7 +142,7 @@ func TestEnterpriseTrialExtension(t *testing.T) {
 		// skip this test if the dev private key is not configured e.g. because we are testing a production build
 		t.SkipNow()
 	}
-	privateKeyBytes, err := ioutil.ReadFile(test.Ctx().TestLicensePKeyPath)
+	privateKeyBytes, err := os.ReadFile(test.Ctx().TestLicensePKeyPath)
 	require.NoError(t, err)
 	privateKey, err := x509.ParsePKCS8PrivateKey(privateKeyBytes)
 	require.NoError(t, err)

--- a/test/e2e/es/podtemplate_test.go
+++ b/test/e2e/es/podtemplate_test.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -235,7 +235,7 @@ func TestCustomConfiguration(t *testing.T) {
 					response, err := esClient.Request(context.Background(), r)
 					require.NoError(t, err)
 					defer response.Body.Close() // nolint
-					actual, err := ioutil.ReadAll(response.Body)
+					actual, err := io.ReadAll(response.Body)
 					require.NoError(t, err)
 					expected := `{"tokens":[{"token":"Elastic","start_offset":0,"end_offset":3,"type":"SYNONYM","position":0},{"token":"runs","start_offset":4,"end_offset":8,"type":"word","position":1},{"token":"Cloud","start_offset":4,"end_offset":8,"type":"SYNONYM","position":1},{"token":"Elasticsearch,","start_offset":9,"end_offset":23,"type":"word","position":2},{"token":"on","start_offset":9,"end_offset":23,"type":"SYNONYM","position":2},{"token":"Kibana","start_offset":24,"end_offset":30,"type":"word","position":3},{"token":"Kubernetes","start_offset":24,"end_offset":30,"type":"SYNONYM","position":3},{"token":"and","start_offset":31,"end_offset":34,"type":"word","position":4},{"token":"APM","start_offset":35,"end_offset":38,"type":"word","position":5},{"token":"Server","start_offset":39,"end_offset":45,"type":"word","position":6},{"token":"on","start_offset":46,"end_offset":48,"type":"word","position":7},{"token":"Kubernetes","start_offset":49,"end_offset":59,"type":"word","position":8}]}`
 					assert.Equal(t, string(actual), expected)

--- a/test/e2e/es/remote_cluster_test.go
+++ b/test/e2e/es/remote_cluster_test.go
@@ -10,8 +10,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -50,7 +50,7 @@ func TestRemoteCluster(t *testing.T) {
 		WithRestrictedSecurityContext().
 		WithRemoteCluster(es1Builder)
 	es2LicenseTestContext := elasticsearch.NewLicenseTestContext(test.NewK8sClientOrFatal(), es2Builder.Elasticsearch)
-	licenseBytes, err := ioutil.ReadFile(test.Ctx().TestLicense)
+	licenseBytes, err := os.ReadFile(test.Ctx().TestLicense)
 	require.NoError(t, err)
 	trialSecretName := "eck-license"
 

--- a/test/e2e/test/agent/checks.go
+++ b/test/e2e/test/agent/checks.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/client"
@@ -146,7 +146,7 @@ func request(esClient client.Client, url string) ([]byte, error) {
 		return nil, err
 	}
 	defer res.Body.Close()
-	resultBytes, err := ioutil.ReadAll(res.Body)
+	resultBytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/test/apmserver/checks_apm.go
+++ b/test/e2e/test/apmserver/checks_apm.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -303,7 +303,7 @@ func countIndex(esClient client.Client, indexName string) (int, error) {
 		return 0, err
 	}
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return 0, err
 	}

--- a/test/e2e/test/beat/checks.go
+++ b/test/e2e/test/beat/checks.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	beatcommon "github.com/elastic/cloud-on-k8s/v2/pkg/controller/beat/common"
@@ -75,7 +75,7 @@ func checkEvent(url string, check func(int) error) ValidationFunc {
 			return err
 		}
 		defer res.Body.Close()
-		resultBytes, err := ioutil.ReadAll(res.Body)
+		resultBytes, err := io.ReadAll(res.Body)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/test/checks/monitoring.go
+++ b/test/e2e/test/checks/monitoring.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -145,7 +145,7 @@ func containsDocuments(esClient esClient.Client, indexPattern string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	resultBytes, err := ioutil.ReadAll(resp.Body)
+	resultBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/test/common_steps.go
+++ b/test/e2e/test/common_steps.go
@@ -6,7 +6,7 @@ package test
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -92,7 +92,7 @@ func LicenseTestBuilder() WrappedBuilder {
 				Step{
 					Name: "Create an Enterprise license secret",
 					Test: func(t *testing.T) {
-						licenseBytes, err := ioutil.ReadFile(Ctx().TestLicense)
+						licenseBytes, err := os.ReadFile(Ctx().TestLicense)
 						require.NoError(t, err)
 						DeleteAllEnterpriseLicenseSecrets(t, k)
 						CreateEnterpriseLicenseSecret(t, k, "eck-license", licenseBytes)

--- a/test/e2e/test/elasticsearch/checks_data.go
+++ b/test/e2e/test/elasticsearch/checks_data.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -147,7 +147,7 @@ func (dc *DataIntegrityCheck) Verify() error {
 	}
 	defer response.Body.Close()
 	var results client.SearchResults
-	resultBytes, err := ioutil.ReadAll(response.Body)
+	resultBytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/test/elasticsearch/debug.go
+++ b/test/e2e/test/elasticsearch/debug.go
@@ -7,7 +7,7 @@ package elasticsearch
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/client"
@@ -42,7 +42,7 @@ func printResponse(esClient client.Client, url string) {
 		return
 	}
 	defer response.Body.Close()
-	bytes, err := ioutil.ReadAll(response.Body)
+	bytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		fmt.Printf("error while reading response body: %v \n", err)
 		return

--- a/test/e2e/test/enterprisesearch/http_client.go
+++ b/test/e2e/test/enterprisesearch/http_client.go
@@ -10,7 +10,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -81,7 +81,7 @@ func (e EnterpriseSearchClient) doRequest(request *http.Request) ([]byte, error)
 		return nil, fmt.Errorf("http response status code is %d)", resp.StatusCode)
 	}
 
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func (e EnterpriseSearchClient) HealthCheck() error {

--- a/test/e2e/test/kibana/http_client.go
+++ b/test/e2e/test/kibana/http_client.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -74,5 +74,5 @@ func DoRequest(k *test.K8sClient, kb kbv1.Kibana, password string, method string
 		return nil, err
 	}
 
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }

--- a/test/e2e/test/maps/http_client.go
+++ b/test/e2e/test/maps/http_client.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -66,5 +66,5 @@ func DoRequest(client *http.Client, ems v1alpha1.ElasticMapsServer, method, path
 			msg:        fmt.Sprintf("fail to request %s, status is %d)", path, resp.StatusCode),
 		}
 	}
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }


### PR DESCRIPTION
`io/ioutil` is deprecated since Go 1.16 and reported as such when `golangci-lint` is upgraded to its latest version.