### PR TITLE
Elastic Agent: use hostPath only as of 7.15.0

### DIFF
--- a/config/recipes/elastic-agent/kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/kubernetes-integration.yaml
@@ -15,9 +15,6 @@ spec:
         - name: agent
           securityContext:
             runAsUser: 0
-          volumeMounts:
-          - name: agent-data
-            mountPath: /usr/share/elastic-agent/data/elastic-agent-08e204/run
           env:
           - name: NODE_NAME
             valueFrom:
@@ -150,6 +147,13 @@ rules:
   - get
   - watch
   - list
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+    - leases
+  verbs:
+    - get
+    - create
+    - update
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/config/recipes/elastic-agent/system-integration.yaml
+++ b/config/recipes/elastic-agent/system-integration.yaml
@@ -13,9 +13,6 @@ spec:
         - name: agent
           securityContext:
             runAsUser: 0
-          volumeMounts:
-          - name: agent-data
-            mountPath: /usr/share/elastic-agent/data/elastic-agent-08e204/run
   config:
     id: 488e0b80-3634-11eb-8208-57893829af4e
     revision: 2

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -146,7 +146,7 @@ func buildPodTemplate(params Params, fleetCerts *certificates.CertificatesSecret
 
 	v, err := version.Parse(params.Agent.Spec.Version)
 	if err != nil {
-		return corev1.PodTemplateSpec{}, pkgerrors.Wrap(err, "unexpected error while parsing specified version")
+		return corev1.PodTemplateSpec{}, err // error unlikely and should have been caught during validation
 	}
 	// volume with agent data path if version > 7.15 (available since 7.13 but non-functional as agent tries to fork child
 	// processes in data path directory and hostPath volumes are always mounted non-exec)

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/tracing"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/volume"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/maps"
@@ -47,7 +48,7 @@ const (
 
 	DataVolumeName            = "agent-data"
 	DataMountHostPathTemplate = "/var/lib/elastic-agent/%s/%s/state"
-	DataMountPath             = "/usr/share/elastic-agent/state" // available since 7.14 without effect before that
+	DataMountPath             = "/usr/share/elastic-agent/state" // available since 7.13 functional since 7.15 without effect before that
 
 	// ConfigHashAnnotationName is an annotation used to store the Agent config hash.
 	ConfigHashAnnotationName = "agent.k8s.elastic.co/config-hash"
@@ -143,8 +144,16 @@ func buildPodTemplate(params Params, fleetCerts *certificates.CertificatesSecret
 			WithArgs("-e", "-c", path.Join(ConfigMountPath, ConfigFileName))
 	}
 
-	// volume with agent data path
-	vols = append(vols, createDataVolume(params))
+	v, err := version.Parse(params.Agent.Spec.Version)
+	if err != nil {
+		return corev1.PodTemplateSpec{}, pkgerrors.Wrap(err, "unexpected error while parsing specified version")
+	}
+	// volume with agent data path if version > 7.15 (available since 7.13 but non-functional as agent tries to fork child
+	// processes in data path directory and hostPath volumes are always mounted non-exec)
+	if v.GTE(version.MinFor(7, 15, 0)) {
+		vols = append(vols, createDataVolume(params))
+	}
+
 	// all volumes with CAs of direct associations
 	caAssocVols, err := getVolumesFromAssociations(params.Agent.GetAssociations())
 	if err != nil {


### PR DESCRIPTION
Adds a version gate to allow the hostPath volume only on 7.15 or later. 

Testing is purely through our e2e tests, which I can change if reviewers feel a unit test would be in order. I avoided it because the `buildPodTemplate` function seemed a bit hairy to unit test.

Excluded from release notes because it is a bug fix for yet unreleased functionality.