### PR TITLE
[2.4] Elastic Agent: use hostPath only as of 7.15.0 (#5934)

### DIFF
--- a/config/recipes/elastic-agent/kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/kubernetes-integration.yaml
@@ -15,9 +15,6 @@ spec:
         - name: agent
           securityContext:
             runAsUser: 0
-          volumeMounts:
-          - name: agent-data
-            mountPath: /usr/share/elastic-agent/data/elastic-agent-08e204/run
           env:
           - name: NODE_NAME
             valueFrom:
@@ -150,6 +147,13 @@ rules:
   - get
   - watch
   - list
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+    - leases
+  verbs:
+    - get
+    - create
+    - update
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/config/recipes/elastic-agent/system-integration.yaml
+++ b/config/recipes/elastic-agent/system-integration.yaml
@@ -13,9 +13,6 @@ spec:
         - name: agent
           securityContext:
             runAsUser: 0
-          volumeMounts:
-          - name: agent-data
-            mountPath: /usr/share/elastic-agent/data/elastic-agent-08e204/run
   config:
     id: 488e0b80-3634-11eb-8208-57893829af4e
     revision: 2


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.4`:
 - [Elastic Agent: use hostPath only as of 7.15.0 (#5934)](https://github.com/elastic/cloud-on-k8s/pull/5934)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)