### PR TITLE
[E2E][GKE] Use labels to garbage collect unused Persistent Disks

### DIFF
--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -313,6 +313,7 @@ func (d *GKEDriver) delete() error {
 	if err := d.deleteDisks(disks); err != nil {
 		return err
 	}
+	deletedDisks := len(disks)
 
 	// This is the "legacy" way to detect orphaned disks. Keep using it while all disks do not have labels.
 	cmd = `gcloud compute disks list --filter="name~^gke-{{.PVCPrefix}}.*-pvc-.+" --format="value[separator=','](name,zone)" --project {{.GCloudProject}}`
@@ -322,6 +323,12 @@ func (d *GKEDriver) delete() error {
 	}
 	if err := d.deleteDisks(disks); err != nil {
 		return err
+	}
+	deletedDisks += len(disks)
+	if deletedDisks == 0 {
+		log.Println("No GCE persistent disks deleted")
+	} else {
+		log.Println(fmt.Sprintf("%d GCE persistent disks deleted", deletedDisks))
 	}
 
 	return nil

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -183,7 +183,7 @@ func (d *GKEDriver) patchGCEProvider() error {
 		if storageClass.Parameters == nil {
 			storageClass.Parameters = make(map[string]string)
 		}
-		storageClass.Parameters["resourcesLabels"] = labels
+		storageClass.Parameters["labels"] = labels
 		// Delete the storage class as it is not allowed to patch parameters.
 		if err := exec.NewCommand(fmt.Sprintf("kubectl delete sc %s", storageClass.Name)).Run(); err != nil {
 			return err

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -63,7 +63,7 @@ func (gdf *GKEDriverFactory) Create(plan Plan) (Driver, error) {
 		servicesIPv4CIDR = plan.Gke.ServicesIPv4CIDR
 	}
 
-	user, err := exec.NewCommand(`gcloud auth list --filter=status:ACTIVE --format="value(account)"`).Output()
+	user, err := exec.NewCommand(`gcloud auth list --filter=status:ACTIVE --format="value(account)"`).WithoutStreaming().Output()
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +248,7 @@ func (d *GKEDriver) create() error {
 		return err
 	}
 	return exec.NewCommand(`gcloud beta container --quiet --project {{.GCloudProject}} clusters create {{.ClusterName}} ` +
-		`--resourcesLabels "` + labels + `" --region {{.Region}} --no-enable-basic-auth --cluster-version {{.KubernetesVersion}} ` +
+		`--labels "` + labels + `" --region {{.Region}} --no-enable-basic-auth --cluster-version {{.KubernetesVersion}} ` +
 		`--machine-type {{.MachineType}} --disk-type pd-ssd --disk-size 30 ` +
 		`--local-ssd-count {{.LocalSsdCount}} --scopes {{.GcpScopes}} --num-nodes {{.NodeCountPerZone}} ` +
 		`--addons HorizontalPodAutoscaling,HttpLoadBalancing ` +

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -163,7 +163,7 @@ const (
 )
 
 func (d *GKEDriver) patchGCEProvider() error {
-	storageClassesYaml, err := exec.NewCommand(fmt.Sprintf("kubectl get sc -o yaml")).WithoutStreaming().Output()
+	storageClassesYaml, err := exec.NewCommand("kubectl get sc -o yaml").WithoutStreaming().Output()
 	if err != nil {
 		return err
 	}
@@ -328,7 +328,7 @@ func (d *GKEDriver) delete() error {
 	if deletedDisks == 0 {
 		log.Println("No GCE persistent disks deleted")
 	} else {
-		log.Println(fmt.Sprintf("%d GCE persistent disks deleted", deletedDisks))
+		log.Printf("%d GCE persistent disks deleted", deletedDisks)
 	}
 
 	return nil

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -121,7 +121,7 @@ func (d *GKEDriver) Execute() error {
 			}
 		}
 
-		if err := d.patchGCEProvider(); err != nil {
+		if err := d.setupLabelsForGCEProvider(); err != nil {
 			return err
 		}
 
@@ -162,7 +162,9 @@ const (
 	GoogleComputeEngineStorageProvider = "pd.csi.storage.gke.io"
 )
 
-func (d *GKEDriver) patchGCEProvider() error {
+// setupLabelsForGCEProvider adds the "labels" parameter in the GCE storage classes.
+// These labels are automatically applied to GCE Persistent Disks provisioned using these storage classes.
+func (d *GKEDriver) setupLabelsForGCEProvider() error {
 	storageClassesYaml, err := exec.NewCommand("kubectl get sc -o yaml").WithoutStreaming().Output()
 	if err != nil {
 		return err

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -259,9 +259,9 @@ func (d *GKEDriver) create() error {
 		Run()
 }
 
-// unqualifiedUsername attempts to extract the username part of current account name.
-// This is mostly to be able to set the user name as a label value, in which lowercase letters ([a-z]),
-// numeric characters ([0-9]), underscores (_) and dashes (-) are allowed.
+// username attempts to extract the username from the current account.
+// When used in labels the "unqualified" parameter should be set to true, it's because only lowercase letters ([a-z]),
+// numeric characters ([0-9]), underscores (_) and dashes (-) are allowed as label values.
 func (d *GKEDriver) username(unqualified bool) (string, error) {
 	userInContext, hasUser := d.ctx["User"]
 	if !hasUser {

--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -121,10 +121,6 @@ func (d *GKEDriver) Execute() error {
 			}
 		}
 
-		if err := d.setupLabelsForGCEProvider(); err != nil {
-			return err
-		}
-
 		if d.plan.Gke.Private {
 			log.Printf("a private cluster has been created, please retrieve credentials manually and create storage class and provider if needed")
 			log.Printf("to authorize a VM to access this cluster run the following command:\n"+
@@ -142,6 +138,10 @@ func (d *GKEDriver) Execute() error {
 		}
 
 		if err := d.GetCredentials(); err != nil {
+			return err
+		}
+
+		if err := d.setupLabelsForGCEProvider(); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
This PR does 2 things:

1. It adds labels on resources created by a GKE cluster, including the GCE `Persistent Disks` provisioned as part of the K8S `PersistentVolumes` infrastructure.

* You can for example use these filters to list `Persistent Disks` by user:

```
gcloud compute disks list --filter='labels.username=michael_morello'
NAME                                         LOCATION        LOCATION_SCOPE  SIZE_GB  TYPE         STATUS
gke-barkbay-dev2-default-pool-83770c6e-qn81  europe-west2-a  zone            30       pd-ssd       READY
pvc-ba1162c2-aab9-496b-9838-06fb4a57945f     europe-west2-a  zone            2        pd-ssd       READY
gke-barkbay-dev2-default-pool-4d611566-qs39  europe-west2-b  zone            30       pd-ssd       READY
pvc-695d6dd8-a90b-4e85-960b-6db02de4277c     europe-west2-b  zone            2        pd-ssd       READY
gke-barkbay-dev2-default-pool-920a7074-5z24  europe-west2-c  zone            30       pd-ssd       READY
pvc-f2fd2f38-4712-406b-b0f3-bec8d0e88aa0     europe-west2-c  zone            2        pd-ssd       READY
gke-barkbay-dev1-default-pool-c28a62de-fk63  europe-west9-b  zone            30       pd-ssd       READY
pvc-8d3cb9ba-3639-4108-bfb4-744156b3be86     europe-west9-b  zone            1        pd-balanced  READY
gke-barkbay-dev1-default-pool-e7b51f8d-8wcw  europe-west9-a  zone            30       pd-ssd       READY
pvc-5e88cb38-05ea-4f3a-8a70-aba58bb695eb     europe-west9-a  zone            1        pd-balanced  READY
gke-barkbay-dev1-default-pool-66696f3e-ncvt  europe-west9-c  zone            30       pd-ssd       READY
pvc-b03174c7-7f4b-4c4d-a6f5-8534f6e9f737     europe-west9-c  zone            1        pd-balanced  READY
```

* Or filter by user and region:

```
gcloud compute disks list --filter='labels.username=michael_morello AND labels.region=europe-west2'
NAME                                         LOCATION        LOCATION_SCOPE  SIZE_GB  TYPE    STATUS
gke-barkbay-dev2-default-pool-83770c6e-qn81  europe-west2-a  zone            30       pd-ssd  READY
pvc-ba1162c2-aab9-496b-9838-06fb4a57945f     europe-west2-a  zone            2        pd-ssd  READY
gke-barkbay-dev2-default-pool-4d611566-qs39  europe-west2-b  zone            30       pd-ssd  READY
pvc-695d6dd8-a90b-4e85-960b-6db02de4277c     europe-west2-b  zone            2        pd-ssd  READY
gke-barkbay-dev2-default-pool-920a7074-5z24  europe-west2-c  zone            30       pd-ssd  READY
pvc-f2fd2f38-4712-406b-b0f3-bec8d0e88aa0     europe-west2-c  zone            2        pd-ssd  READY
```

* Or list unused disks:

```
gcloud compute disks list --filter='labels.username=michael_morello AND labels.region=europe-west9 AND -users:*'
NAME                                      LOCATION        LOCATION_SCOPE  SIZE_GB  TYPE         STATUS
pvc-8d3cb9ba-3639-4108-bfb4-744156b3be86  europe-west9-b  zone            1        pd-balanced  READY
pvc-5e88cb38-05ea-4f3a-8a70-aba58bb695eb  europe-west9-a  zone            1        pd-balanced  READY
pvc-b03174c7-7f4b-4c4d-a6f5-8534f6e9f737  europe-west9-c  zone            1        pd-balanced  READY
```

2. It attempts to detect and delete unsused disk using those labels.

Fix #5935