### PR TITLE
[2.4] Default Pod annotations should be a local variable (#5947)

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/defaults.go
+++ b/pkg/controller/elasticsearch/nodespec/defaults.go
@@ -12,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/settings"
@@ -39,11 +38,6 @@ var (
 		Limits: map[corev1.ResourceName]resource.Quantity{
 			corev1.ResourceMemory: DefaultMemoryLimits,
 		},
-	}
-
-	// DefaultAnnotations are the default annotations for the Elasticsearch pods
-	DefaultAnnotations = map[string]string{
-		annotation.FilebeatModuleAnnotation: "elasticsearch",
 	}
 )
 

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/container"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/hash"
@@ -174,7 +175,9 @@ func buildAnnotations(
 	scriptsVersion string,
 ) map[string]string {
 	// start from our defaults
-	annotations := DefaultAnnotations
+	annotations := map[string]string{
+		annotation.FilebeatModuleAnnotation: "elasticsearch",
+	}
 
 	configHash := fnv.New32a()
 	// hash of the ES config to rotate the pod on config changes


### PR DESCRIPTION
This will backport the following commits from `main` to `2.4`:

- Default Pod annotations should be a local variable (#5947)