### PR TITLE
Elasticsearch: always set discovery.seed_hosts to empty array

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/reserved-settings.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/reserved-settings.asciidoc
@@ -11,6 +11,8 @@ endif::[]
 The following Elasticsearch settings are managed by ECK:
 
 * `cluster.name`
+* `discovery.seed_hosts`
+* `discovery.seed_providers`
 * `discovery.zen.minimum_master_nodes` deprecated[7.0]
 * `cluster.initial_master_nodes` added[7.0]
 * `network.host`

--- a/pkg/apis/elasticsearch/v1/fields.go
+++ b/pkg/apis/elasticsearch/v1/fields.go
@@ -51,6 +51,8 @@ const (
 
 var UnsupportedSettings = []string{
 	ClusterName,
+	DiscoverySeedHosts,
+	DiscoverySeedProviders,
 	DiscoveryZenMinimumMasterNodes,
 	ClusterInitialMasterNodes,
 	NetworkHost,

--- a/pkg/apis/elasticsearch/v1/fields.go
+++ b/pkg/apis/elasticsearch/v1/fields.go
@@ -12,7 +12,7 @@ const (
 
 	DiscoveryZenHostsProvider = "discovery.zen.hosts_provider" // ES < 7.X
 	DiscoverySeedProviders    = "discovery.seed_providers"     // ES >= 7.X
-	DiscoverySeedHosts        = "discovery.seed_hosts"
+	DiscoverySeedHosts        = "discovery.seed_hosts"         // ES >= 7.X
 
 	NetworkHost        = "network.host"
 	NetworkPublishHost = "network.publish_host"

--- a/pkg/apis/elasticsearch/v1/fields.go
+++ b/pkg/apis/elasticsearch/v1/fields.go
@@ -12,6 +12,7 @@ const (
 
 	DiscoveryZenHostsProvider = "discovery.zen.hosts_provider" // ES < 7.X
 	DiscoverySeedProviders    = "discovery.seed_providers"     // ES >= 7.X
+	DiscoverySeedHosts        = "discovery.seed_hosts"
 
 	NetworkHost        = "network.host"
 	NetworkPublishHost = "network.publish_host"

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -277,7 +277,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 				"pod-template-label-name":                       "pod-template-label-value",
 			},
 			Annotations: map[string]string{
-				"elasticsearch.k8s.elastic.co/config-hash": "957591218",
+				"elasticsearch.k8s.elastic.co/config-hash": "3893049321",
 				"pod-template-annotation-name":             "pod-template-annotation-value",
 				"co.elastic.logs/module":                   "elasticsearch",
 			},
@@ -339,7 +339,7 @@ func Test_buildAnnotations(t *testing.T) {
 		{
 			name: "Sample Elasticsearch resource",
 			expectedAnnotations: map[string]string{
-				"elasticsearch.k8s.elastic.co/config-hash": "1382203021",
+				"elasticsearch.k8s.elastic.co/config-hash": "533641620",
 			},
 		},
 		{
@@ -352,7 +352,7 @@ func Test_buildAnnotations(t *testing.T) {
 				},
 			},
 			expectedAnnotations: map[string]string{
-				"elasticsearch.k8s.elastic.co/config-hash": "2958662249",
+				"elasticsearch.k8s.elastic.co/config-hash": "3131886472",
 			},
 		},
 		{
@@ -361,7 +361,7 @@ func Test_buildAnnotations(t *testing.T) {
 				esAnnotations: map[string]string{"eck.k8s.elastic.co/downward-node-labels": "topology.kubernetes.io/zone"},
 			},
 			expectedAnnotations: map[string]string{
-				"elasticsearch.k8s.elastic.co/config-hash": "481468635",
+				"elasticsearch.k8s.elastic.co/config-hash": "757126536",
 			},
 		},
 		{
@@ -370,7 +370,7 @@ func Test_buildAnnotations(t *testing.T) {
 				esAnnotations: map[string]string{"eck.k8s.elastic.co/downward-node-labels": "topology.kubernetes.io/zone,topology.kubernetes.io/region"},
 			},
 			expectedAnnotations: map[string]string{
-				"elasticsearch.k8s.elastic.co/config-hash": "3276316785",
+				"elasticsearch.k8s.elastic.co/config-hash": "3605766330",
 			},
 		},
 		{
@@ -382,7 +382,7 @@ func Test_buildAnnotations(t *testing.T) {
 				scriptsVersion: "84",
 			},
 			expectedAnnotations: map[string]string{
-				"elasticsearch.k8s.elastic.co/config-hash": "3641963559",
+				"elasticsearch.k8s.elastic.co/config-hash": "1607725946",
 			},
 		},
 		{
@@ -394,7 +394,7 @@ func Test_buildAnnotations(t *testing.T) {
 				scriptsVersion: "84",
 			},
 			expectedAnnotations: map[string]string{
-				"elasticsearch.k8s.elastic.co/config-hash": "3625185940",
+				"elasticsearch.k8s.elastic.co/config-hash": "1624503565",
 			},
 		},
 		{
@@ -406,7 +406,7 @@ func Test_buildAnnotations(t *testing.T) {
 				scriptsVersion: "85",
 			},
 			expectedAnnotations: map[string]string{
-				"elasticsearch.k8s.elastic.co/config-hash": "3917140820",
+				"elasticsearch.k8s.elastic.co/config-hash": "3194693445",
 			},
 		},
 	}

--- a/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/pkg/controller/elasticsearch/settings/merged_config.go
@@ -67,6 +67,10 @@ func baseConfig(clusterName string, ver version.Version, ipFamily corev1.IPFamil
 
 		esv1.PathData: volume.ElasticsearchDataMountPath,
 		esv1.PathLogs: volume.ElasticsearchLogsMountPath,
+
+		// to avoid misleading error messages about the inability to connect to localhost for discovery despite us using
+		// file based discovery
+		esv1.DiscoverySeedHosts: []string{},
 	}
 
 	// seed hosts setting name changed starting ES 7.X

--- a/pkg/controller/elasticsearch/settings/merged_config.go
+++ b/pkg/controller/elasticsearch/settings/merged_config.go
@@ -67,10 +67,6 @@ func baseConfig(clusterName string, ver version.Version, ipFamily corev1.IPFamil
 
 		esv1.PathData: volume.ElasticsearchDataMountPath,
 		esv1.PathLogs: volume.ElasticsearchLogsMountPath,
-
-		// to avoid misleading error messages about the inability to connect to localhost for discovery despite us using
-		// file based discovery
-		esv1.DiscoverySeedHosts: []string{},
 	}
 
 	// seed hosts setting name changed starting ES 7.X
@@ -79,6 +75,9 @@ func baseConfig(clusterName string, ver version.Version, ipFamily corev1.IPFamil
 		cfg[esv1.DiscoveryZenHostsProvider] = fileProvider
 	} else {
 		cfg[esv1.DiscoverySeedProviders] = fileProvider
+		// to avoid misleading error messages about the inability to connect to localhost for discovery despite us using
+		// file based discovery
+		cfg[esv1.DiscoverySeedHosts] = []string{}
 	}
 
 	return &CanonicalConfig{common.MustCanonicalConfig(cfg)}


### PR DESCRIPTION
Fixes #5834