### PR TITLE
Base Kind client image on official Docker-in-Docker image

### DIFF
--- a/hack/deployer/clients/kind/Dockerfile
+++ b/hack/deployer/clients/kind/Dockerfile
@@ -1,17 +1,7 @@
-FROM buildpack-deps:bullseye-curl as builder
+FROM docker:20.10-dind
 
 ARG CLIENT_VERSION
-ENV DOCKER_VERSION=19.03.13
 
-# Docker client to build and push images
-RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz && \
-    tar xzf docker-${DOCKER_VERSION}.tgz --strip 1 -C /usr/local/bin docker/docker && \
-    rm docker-${DOCKER_VERSION}.tgz
-# Kind to run k8s cluster locally in Docker
-RUN curl -fsSLO https://github.com/kubernetes-sigs/kind/releases/download/v${CLIENT_VERSION}/kind-linux-amd64 && \
-    mv kind-linux-amd64 /usr/local/bin/kind && chmod +x /usr/local/bin/kind
-
-FROM scratch
-
-COPY --from=builder /usr/local/bin/kind .
-COPY --from=builder /usr/local/bin/docker .
+RUN apk add --no-cache curl && \
+    curl -fsSLO https://github.com/kubernetes-sigs/kind/releases/download/v${CLIENT_VERSION}/kind-linux-amd64 && \
+    mv kind-linux-amd64 /usr/local/bin/kind && chmod +x /usr/local/bin/kind \

--- a/hack/deployer/runner/kind.go
+++ b/hack/deployer/runner/kind.go
@@ -197,9 +197,8 @@ func (k *KindDriver) cmd(args ...string) *exec.Command {
 		-v {{.SharedVolume}}:/home \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-e HOME=/home \
-		-e PATH=/ \
 		{{.KindClientImage}} \
-		/kind {{Join .Args " "}} --name {{.ClusterName}}`)
+		kind {{Join .Args " "}} --name {{.ClusterName}}`)
 	return cmd.AsTemplate(params)
 }
 


### PR DESCRIPTION
We are doing Docker in Docker to create Kind k8s clusters but 
we just copy the Docker binary for it and it can be problematic
in certain environment.

This commit changes the Kind client image to base it on the official
 Docker in Docker image that does more than just copy the 
binary (see [dockerd-entrypoint.sh](https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh) and [docker/hack/dind](https://github.com/moby/moby/blob/master/hack/dind)).


Relates to #5773.