### PR TITLE
[E2E][GKE] Retry to patch StorageClasses on error

### DIFF
--- a/hack/deployer/runner/gke.go
+++ b/hack/deployer/runner/gke.go
@@ -8,9 +8,12 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/ghodss/yaml"
 	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/elastic/cloud-on-k8s/v2/hack/deployer/exec"
 )
@@ -179,18 +182,20 @@ func (d *GKEDriver) setupLabelsForGCEProvider() error {
 			storageClass.Parameters = make(map[string]string)
 		}
 		storageClass.Parameters["labels"] = labels
-		// Delete the storage class as it is not allowed to patch parameters.
-		if err := exec.NewCommand(fmt.Sprintf("kubectl delete sc %s", storageClass.Name)).Run(); err != nil {
-			return err
-		}
-		// Apply the new one
 		storageClassYaml, err := yaml.Marshal(storageClass)
 		if err != nil {
 			return err
 		}
-		if err := exec.NewCommand(fmt.Sprintf(`cat <<EOF | kubectl apply -f -
+
+		if err := retry.OnError(
+			wait.Backoff{Duration: 10 * time.Millisecond, Steps: 5},
+			func(err error) bool { return true },
+			func() error {
+				return exec.NewCommand(fmt.Sprintf(`cat <<EOF | kubectl replace --force -f -
 %s
-EOF`, string(storageClassYaml))).Run(); err != nil {
+EOF`, string(storageClassYaml))).Run()
+			},
+		); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Attempt to fix #5949 

I believe the root cause is a race condition between the addons manager, which periodically attempts to recreate the storage classes,  and the deployer.
Since storage classes cannot be patched (see https://github.com/kubernetes/kubernetes/issues/106996), and the addons manager cannot be configured, I'm not sure I have a better idea than to retry recreating the storage classes.