### PR TITLE
Report incorrect license type in logs and events

### DIFF
--- a/pkg/controller/common/events/events.go
+++ b/pkg/controller/common/events/events.go
@@ -8,6 +8,8 @@ package events
 const (
 	// EventReasonDelayed describes events where a requested change was delayed e.g. to prevent data loss.
 	EventReasonDelayed = "Delayed"
+	// EventReasonInvalidLicense describes events where a user configured an invalid license for the operator.
+	EventReasonInvalidLicense = "InvalidLicense"
 	// EventReasonStalled describes events where a requested change is stalled and may not make progress without user
 	// intervention. There are transient states e.g. during a nodeSet rename where shards still do not have a place to
 	// move to until the new nodes come up and Elasticsearch will report a stalled shutdown. There are however also

--- a/pkg/controller/common/license/crud.go
+++ b/pkg/controller/common/license/crud.go
@@ -47,7 +47,7 @@ func EnterpriseLicensesOrErrors(c k8s.Client) ([]EnterpriseLicense, []error) {
 		ls := license
 		parsed, err := ParseEnterpriseLicense(ls.Data)
 		if err != nil {
-			errors = append(errors, NewError(&license, pkgerrors.Wrapf(err, "while parsing license in %v", k8s.ExtractNamespacedName(&ls))))
+			errors = append(errors, NewError(&ls, pkgerrors.Wrapf(err, "while parsing license in %v", k8s.ExtractNamespacedName(&ls))))
 		} else {
 			licenses = append(licenses, parsed)
 		}

--- a/pkg/controller/common/license/crud.go
+++ b/pkg/controller/common/license/crud.go
@@ -11,6 +11,7 @@ import (
 	pkgerrors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -18,6 +19,19 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/maps"
 )
+
+type Error struct {
+	Source runtime.Object
+	Err    error
+}
+
+func (e *Error) Error() string {
+	return e.Err.Error()
+}
+
+func NewError(src runtime.Object, err error) error {
+	return &Error{Source: src, Err: err}
+}
 
 // EnterpriseLicensesOrErrors lists all Enterprise licenses and all errors encountered during retrieval.
 func EnterpriseLicensesOrErrors(c k8s.Client) ([]EnterpriseLicense, []error) {
@@ -33,7 +47,7 @@ func EnterpriseLicensesOrErrors(c k8s.Client) ([]EnterpriseLicense, []error) {
 		ls := license
 		parsed, err := ParseEnterpriseLicense(ls.Data)
 		if err != nil {
-			errors = append(errors, pkgerrors.Wrapf(err, "unparseable license in %v", k8s.ExtractNamespacedName(&ls)))
+			errors = append(errors, NewError(&license, pkgerrors.Wrapf(err, "while parsing license in %v", k8s.ExtractNamespacedName(&ls))))
 		} else {
 			licenses = append(licenses, parsed)
 		}

--- a/pkg/controller/common/license/crud.go
+++ b/pkg/controller/common/license/crud.go
@@ -20,6 +20,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/maps"
 )
 
+// Error is a custom error type that captures the resource that contained an erroneous license file for use in Kubernetes events.
 type Error struct {
 	Source runtime.Object
 	Err    error

--- a/pkg/controller/common/license/model.go
+++ b/pkg/controller/common/license/model.go
@@ -75,7 +75,7 @@ func (l EnterpriseLicense) IsValid(instant time.Time) bool {
 
 // IsValidType returns true if the license type is set to one of the allowed values: enterprise or enterprise_trial.
 // Other values are possible to occur if a user mistakenly uploads a cluster license instead of an orchestration license
-// as the schema is otherwise compatible
+// as the schema is otherwise compatible.
 func (l EnterpriseLicense) IsValidType() bool {
 	return l.IsTrial() || l.License.Type == LicenseTypeEnterprise
 }

--- a/pkg/controller/common/license/model.go
+++ b/pkg/controller/common/license/model.go
@@ -73,6 +73,13 @@ func (l EnterpriseLicense) IsValid(instant time.Time) bool {
 		l.ExpiryTime().After(instant)
 }
 
+// IsValidType returns true if the license type is set to one of the allowed values: enterprise or enterprise_trial.
+// Other values are possible to occur if a user mistakenly uploads a cluster license instead of an orchestration license
+// as the schema is otherwise compatible
+func (l EnterpriseLicense) IsValidType() bool {
+	return l.IsTrial() || l.License.Type == LicenseTypeEnterprise
+}
+
 // IsTrial returns true if this is a self-generated trial license.
 func (l EnterpriseLicense) IsTrial() bool {
 	return l.License.Type == LicenseTypeEnterpriseTrial || l.License.Type == LicenseTypeLegacyTrial

--- a/pkg/controller/common/license/parser.go
+++ b/pkg/controller/common/license/parser.go
@@ -6,6 +6,7 @@ package license
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/pkg/errors"
 )
@@ -21,6 +22,9 @@ func ParseEnterpriseLicense(raw map[string][]byte) (EnterpriseLicense, error) {
 	err = json.Unmarshal(bytes, &license)
 	if err != nil {
 		return license, errors.Wrapf(err, "license cannot be unmarshalled")
+	}
+	if !license.IsValidType() {
+		return license, fmt.Errorf("[%s] license [%s] is not an enterprise license. Only orchestration licenses of type enterprise or enterprise_trial are supported", license.License.Type, license.License.UID)
 	}
 
 	return license, nil

--- a/pkg/controller/common/license/testdata/wrong-type.json
+++ b/pkg/controller/common/license/testdata/wrong-type.json
@@ -1,0 +1,13 @@
+{
+  "license": {
+    "uid": "57E312E2-6EA0-49D0-8E65-AA5017742ACF",
+    "type": "platinum",
+    "issue_date_in_millis": 1548115200000,
+    "expiry_date_in_millis": 1561247999999,
+    "max_nodes": 100,
+    "issued_to": "test org",
+    "issuer": "test issuer",
+    "signature": "test signature platinum",
+    "start_date_in_millis": 1548115200000
+  }
+}

--- a/pkg/controller/license/license_controller.go
+++ b/pkg/controller/license/license_controller.go
@@ -7,13 +7,15 @@ package license
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"time"
 
 	pkgerrors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -23,6 +25,7 @@ import (
 
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/events"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/license"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/operator"
@@ -78,6 +81,7 @@ func newReconciler(mgr manager.Manager, params operator.Parameters) *ReconcileLi
 		Client:     c,
 		Parameters: params,
 		checker:    license.NewLicenseChecker(c, params.OperatorNamespace),
+		recorder:   mgr.GetEventRecorderFor(name),
 	}
 }
 
@@ -149,18 +153,29 @@ type ReconcileLicenses struct {
 	// iteration is the number of times this controller has run its Reconcile method
 	iteration uint64
 	checker   license.Checker
+	recorder  record.EventRecorder
 }
 
 // findLicense tries to find the best Elastic stack license available.
-func findLicense(ctx context.Context, c k8s.Client, checker license.Checker, minVersion *version.Version) (esclient.License, string, bool) {
+func (r *ReconcileLicenses) findLicense(ctx context.Context, c k8s.Client, checker license.Checker, minVersion *version.Version) (esclient.License, string, bool) {
 	licenseList, errs := license.EnterpriseLicensesOrErrors(c)
 	if len(errs) > 0 {
 		ulog.FromContext(ctx).Info("Ignoring invalid license objects", "errors", errs)
+		recordInvalidLicenseEvents(errs, r.recorder)
 	}
 	valid := func(l license.EnterpriseLicense) (bool, error) {
 		return checker.Valid(ctx, l)
 	}
 	return license.BestMatch(ctx, minVersion, licenseList, valid)
+}
+
+func recordInvalidLicenseEvents(errs []error, recorder record.EventRecorder) {
+	for _, err := range errs {
+		var licenseErr *license.Error
+		if errors.As(err, &licenseErr) {
+			recorder.Event(licenseErr.Source, corev1.EventTypeWarning, events.EventReasonUnexpected, err.Error())
+		}
+	}
 }
 
 // reconcileSecret upserts a secret in the namespace of the Elasticsearch cluster containing the signature of its license.
@@ -208,7 +223,7 @@ func (r *ReconcileLicenses) reconcileClusterLicense(ctx context.Context, cluster
 	if err != nil {
 		return noResult, true, err
 	}
-	matchingSpec, parent, found := findLicense(ctx, r, r.checker, minVersion)
+	matchingSpec, parent, found := r.findLicense(ctx, r, r.checker, minVersion)
 	if !found {
 		// no matching license found, delete cluster level license if it exists to revert to basic
 		clusterLicenseNSN := types.NamespacedName{Namespace: cluster.Namespace, Name: esv1.LicenseSecretName(cluster.Name)}
@@ -250,7 +265,7 @@ func (r *ReconcileLicenses) reconcileInternal(ctx context.Context, request recon
 	cluster := esv1.Elasticsearch{}
 	err := r.Get(ctx, request.NamespacedName, &cluster)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// nothing to do no cluster
 			return res
 		}

--- a/pkg/controller/license/license_controller_test.go
+++ b/pkg/controller/license/license_controller_test.go
@@ -92,6 +92,7 @@ func enterpriseLicense(t *testing.T, licenseType client.ElasticsearchLicenseType
 		License: commonlicense.LicenseSpec{
 			ExpiryDateInMillis: expiry.Unix() * 1000,
 			StartDateInMillis:  time.Now().Add(-1*time.Minute).Unix() * 1000,
+			Type:               "enterprise",
 			ClusterLicenses: []commonlicense.ElasticsearchLicense{
 				{
 					License: client.License{


### PR DESCRIPTION
Fixes #5963 

by checking for the license type when parsing the user submitted license files and logging a more helpful error message. Also creates events in the license controller based on the errors during parsing. The license parsing also happens during license checks outside the license controller and the custom error allows us to limit the event creation to the license controller.