### PR TITLE
[2.4] Add 2.4 to list of versions requiring Pod restart #5958

### DIFF
--- a/docs/operating-eck/upgrading-eck.asciidoc
+++ b/docs/operating-eck/upgrading-eck.asciidoc
@@ -81,6 +81,7 @@ Upgrading the operator results in a one-time update to existing managed resource
 * 2.0
 * 2.1
 * 2.2
+* 2.4
 
 If you have a very large Elasticsearch cluster or multiple Elastic Stack deployments, this rolling restart might be disruptive or inconvenient. To have more control over when the pods belonging to a particular deployment should be restarted, you can <<{p}-exclude-resource,add an annotation>> to the corresponding resources to temporarily exclude them from being managed by the operator. When the time is convenient, you can remove the annotation and let the rolling restart go through.
 


### PR DESCRIPTION
# Backport

This will backport the following commit from `main` to `2.4`:
 - [Add 2.4 to list of versions requiring Pod restart (#5958)](https://github.com/elastic/cloud-on-k8s/pull/5958)

Note directly related to this PR (which is a backport) but I think only Agent deployments are restarted when upgrading from 2.3.0
I wonder if we could be more specific about what resources are affected by the upgrade.