### PR TITLE
Don't log non-standard ES JSON error responses as errors

### DIFF
--- a/pkg/controller/elasticsearch/client/client_test.go
+++ b/pkg/controller/elasticsearch/client/client_test.go
@@ -278,6 +278,16 @@ func TestAPIError_Error(t *testing.T) {
 				`StackTrace: RootCause:[{Reason:[stack-sample-es-575vhzs8ln][10.60.1.22:9300][cluster:admin/settings/update] Type:remote_transport_exception}]}}`,
 		},
 		{
+			name: "JSON non-error response",
+			fields: fields{newAPIError(context.Background(), &http.Response{
+				StatusCode: 408,
+				Status:     "408 Request Timeout",
+				Body:       io.NopCloser(bytes.NewBufferString(fixtures.TimeoutSample)),
+			})},
+			want: "408 Request Timeout: {Status:0 Error:{CausedBy:{Reason: Type:} Reason: Type: StackTrace: RootCause:[]}}",
+		},
+
+		{
 			name: "non-JSON error response",
 			fields: fields{newAPIError(context.Background(), &http.Response{
 				StatusCode: 500,

--- a/pkg/controller/elasticsearch/client/error.go
+++ b/pkg/controller/elasticsearch/client/error.go
@@ -47,7 +47,7 @@ func newAPIError(ctx context.Context, response *http.Response) error {
 	if err := json.Unmarshal(body, &errorResponse); err != nil {
 		// Only log at the debug level since it is expected to not be able to parse all types of errors.
 		// Some errors, like 408 on /_cluster/health may return a different body structure.
-		log.V(1).Error(err, "Cannot parse Elasticsearch error response body")
+		log.V(1).Info("Unexpected Elasticsearch error response", "http.response.body.content", string(body))
 		return apiError
 	}
 	apiError.ErrorResponse = errorResponse

--- a/pkg/controller/elasticsearch/client/test_fixtures/errors.go
+++ b/pkg/controller/elasticsearch/client/test_fixtures/errors.go
@@ -24,4 +24,23 @@ const (
     }
 }
 `
+	TimeoutSample = `
+{
+  "cluster_name" : "testcluster",
+  "status" : "yellow",
+  "timed_out" : true,
+  "number_of_nodes" : 1,
+  "number_of_data_nodes" : 1,
+  "active_primary_shards" : 1,
+  "active_shards" : 1,
+  "relocating_shards" : 0,
+  "initializing_shards" : 0,
+  "unassigned_shards" : 1,
+  "delayed_unassigned_shards": 0,
+  "number_of_pending_tasks" : 1,
+  "number_of_in_flight_fetch": 0,
+  "task_max_waiting_in_queue_millis": 0,
+  "active_shards_percent_as_number": 50.0
+}
+`
 )


### PR DESCRIPTION
Fixes #5473

Only controversial bit is maybe the logging of the whole response body but I thought it might be acceptable as the client is always Elasticsearch we roughly know the responses that are being returned. However a proxy in-between like Envoy might change that. Curious about your thoughts.