### PR TITLE
Makefile: add support for TARGETPLATFORM variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,7 @@ else
 endif
 	
 
-TARGETPLATFORM ?= "linux/amd64"
+TARGETPLATFORM ?= linux/amd64
 
 docker-build: go-generate generate-config-file 
 	DOCKER_BUILDKIT=1 docker build . \

--- a/Makefile
+++ b/Makefile
@@ -396,12 +396,15 @@ else
 endif
 	
 
+TARGETPLATFORM ?= "linux/amd64"
+
 docker-build: go-generate generate-config-file 
 	DOCKER_BUILDKIT=1 docker build . \
 		--progress=plain \
 		--build-arg GO_LDFLAGS='$(GO_LDFLAGS)' \
 		--build-arg GO_TAGS='$(GO_TAGS)' \
 		--build-arg VERSION='$(VERSION)' \
+		--build-arg TARGETPLATFORM='$(TARGETPLATFORM)' \
 		-t $(OPERATOR_IMAGE)
 
 docker-push:


### PR DESCRIPTION
Unless I'm missing something it is not possible to create `linux/amd64` Docker images on my `arm64` laptop because `TARGETPLATFORM` is never set: https://github.com/elastic/cloud-on-k8s/blob/3901aca32b4e47124ed3dc7546fedda737efb10b/Dockerfile#L2