### PR TITLE
Remove compat flag from go mod tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ ALL_V1_CRDS=config/crds/v1/all-crds.yaml
 generate: tidy generate-crds-v1 generate-config-file generate-api-docs generate-notice-file
 
 tidy:
-	go mod tidy -compat=1.17
+	go mod tidy
 
 go-generate:
 	# we use this in pkg/controller/common/license


### PR DESCRIPTION
No need to keep forcing --compat to 1.17 since we updated go to 1.19 (#5939).