### PR TITLE
Restore operator binary installation in slash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,11 +42,11 @@ LABEL io.k8s.description="Elastic Cloud on Kubernetes automates the deployment, 
       org.opencontainers.image.version="$VERSION" \
       org.opencontainers.image.url="https://github.com/elastic/cloud-on-k8s/"
 
-COPY --from=builder /go/src/github.com/elastic/cloud-on-k8s/elastic-operator .
+COPY --from=builder /go/src/github.com/elastic/cloud-on-k8s/elastic-operator /elastic-operator
 COPY config/eck.yaml /conf/eck.yaml
 
 # Copy NOTICE.txt and LICENSE.txt into the image
 COPY *.txt /licenses/
 
-ENTRYPOINT ["./elastic-operator"]
+ENTRYPOINT ["/elastic-operator"]
 CMD ["manager"]


### PR DESCRIPTION
This commit reverts the location of the operator binary in the Docker image to how it was before #5580 (`/` instead of `/home/nonroot`). This change avoids having to modify internal tools that use `/`.