### PR TITLE
Add Elasticsearch observation interval as configurable value to Helm Chart

### DIFF
--- a/deploy/eck-operator/templates/configmap.yaml
+++ b/deploy/eck-operator/templates/configmap.yaml
@@ -46,3 +46,4 @@ data:
     namespaces: [{{ join "," .Values.managedNamespaces  }}]
     {{- end }}
     enable-leader-election: {{ .Values.config.enableLeaderElection }}
+    elasticsearch-observation-interval: {{ .Values.config.elasticsearchObservationInterval }}

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -182,6 +182,9 @@ config:
   # enableLeaderElection specifies whether leader election should be enabled
   enableLeaderElection: true
 
+  # Interval between observations of Elasticsearch health, non-positive values disable asynchronous observation.
+  elasticsearchObservationInterval: 10s
+
 # Prometheus PodMonitor configuration
 # Reference: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#podmonitor
 podMonitor:


### PR DESCRIPTION
resolves #5988 

Adds `config.elasticsearchObservationInterval` as a valid option to Helm Chart.

```
❯ helm install elastic-operator . -n elastic-system --set=installCRDs=true --version 2.4.0 --set=webhook.enabled=true --set config.elasticsearchObservationInterval=60s
❯ kc get configmap elastic-operator -n elastic-system -o yaml
apiVersion: v1
data:
  eck.yaml: |-
    log-verbosity: 0
    metrics-port: 0
    container-registry: docker.elastic.co
    max-concurrent-reconciles: 3
    ca-cert-validity: 8760h
    ca-cert-rotate-before: 24h
    cert-validity: 8760h
    cert-rotate-before: 24h
    exposed-node-labels: [topology.kubernetes.io/.*,failure-domain.beta.kubernetes.io/.*]
    set-default-security-context: auto-detect
    kube-client-timeout: 60s
    elasticsearch-client-timeout: 180s
    disable-telemetry: false
    distribution-channel: helm
    validate-storage-class: true
    enable-webhook: true
    webhook-name: elastic-operator.elastic-system.k8s.elastic.co
    enable-leader-election: true
    elasticsearch-observation-interval: 60s
kind: ConfigMap
```