### PR TITLE
Fix chart "annotations" field identation

### DIFF
--- a/deploy/eck-elasticsearch/templates/elasticsearch.yaml
+++ b/deploy/eck-elasticsearch/templates/elasticsearch.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     eck.k8s.elastic.co/license: enterprise
     {{- if .Values.annotations }}
-    {{- toYaml .Values.annotations | indent 4 }}
+    {{- toYaml .Values.annotations | nindent 4 }}
     {{- end }}
 spec:
   {{- if .Values.updateStrategy }}

--- a/deploy/eck-kibana/templates/kibana.yaml
+++ b/deploy/eck-kibana/templates/kibana.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     eck.k8s.elastic.co/license: enterprise
     {{- if .Values.annotations }}
-    {{- toYaml .Values.annotations | indent 4 }}
+    {{- toYaml .Values.annotations | nindent 4 }}
     {{- end }}
 spec:
   version: {{ required "A Kibana version is required" .Values.version }}


### PR DESCRIPTION
Adding the `nindent` prepends a newline to the beginning of the string to prevent the new annotation from being on the same line.

**Example using `indent` (before):**
![indent-example](https://user-images.githubusercontent.com/74715150/188479802-fbe17495-9e9e-4ec9-9919-034652e47c91.png)

**Example using `nindent` (after):**
![nindent-example](https://user-images.githubusercontent.com/74715150/188479776-52d86750-380d-4392-8097-0ccb9f172465.png)
