### PR TITLE
Add license template for Helm Charts

### DIFF
--- a/deploy/eck-elasticsearch/templates/elasticsearch.yaml
+++ b/deploy/eck-elasticsearch/templates/elasticsearch.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "elasticsearch.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: enterprise
+    eck.k8s.elastic.co/license: {{ .Values.license | default "basic" | quote }}
     {{- if .Values.annotations }}
     {{- toYaml .Values.annotations | indent 4 }}
     {{- end }}

--- a/deploy/eck-elasticsearch/values.yaml
+++ b/deploy/eck-elasticsearch/values.yaml
@@ -20,7 +20,7 @@
 #
 version: 8.2.3
 
-# License of Elasticsearch. basic or enterprise
+# Elastic license. basic or enterprise
 #
 license: basic
 

--- a/deploy/eck-elasticsearch/values.yaml
+++ b/deploy/eck-elasticsearch/values.yaml
@@ -20,6 +20,10 @@
 #
 version: 8.2.3
 
+# License of Elasticsearch. basic or enterprise
+#
+license: basic
+
 # Labels that will be applied to Elasticsearch.
 #
 labels: {}

--- a/deploy/eck-kibana/templates/kibana.yaml
+++ b/deploy/eck-kibana/templates/kibana.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "kibana.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: enterprise
+    eck.k8s.elastic.co/license: {{ .Values.license | default "basic" | quote }}
     {{- if .Values.annotations }}
     {{- toYaml .Values.annotations | indent 4 }}
     {{- end }}

--- a/deploy/eck-kibana/values.yaml
+++ b/deploy/eck-kibana/values.yaml
@@ -20,7 +20,7 @@
 #
 version: 8.2.3
 
-# License of Elasticsearch. basic or enterprise
+# Elastic license. basic or enterprise
 #
 license: basic
 

--- a/deploy/eck-kibana/values.yaml
+++ b/deploy/eck-kibana/values.yaml
@@ -20,6 +20,10 @@
 #
 version: 8.2.3
 
+# License of Elasticsearch. basic or enterprise
+#
+license: basic
+
 # Labels that will be applied to Kibana.
 #
 labels: {}

--- a/deploy/eck-stack/examples/custom-elasticsearch-kibana.yaml
+++ b/deploy/eck-stack/examples/custom-elasticsearch-kibana.yaml
@@ -8,6 +8,10 @@ eck-elasticsearch:
   #
   version: 8.2.3
 
+  # Elastic license. basic or enterprise
+  #
+  license: basic
+
   nodeSets:
   - name: default
     count: 1
@@ -39,6 +43,10 @@ eck-kibana:
   # Version of Kibana.
   #
   version: 8.2.3
+
+  # Elastic license. basic or enterprise
+  #
+  license: basic
   
   spec:
     # Count of Kibana replicas to create.


### PR DESCRIPTION
At the moment, if you follow the official instructions, when you try to install the official [ElasticSearch](https://artifacthub.io/packages/helm/elastic/eck-elasticsearch) and [Kibana](https://artifacthub.io/packages/helm/elastic/eck-kibana) or [ECK Stack](https://artifacthub.io/packages/helm/elastic/eck-stack) Charts after installing the operator and CRDs, you will receive an error of mismatch between basic and enterprise licenses in Secret and Chart respectively.

Changes add:
- license templating

```yaml
# values.yaml
# Elastic license. basic or enterprise
#
license: basic
```

- default value for license - basic

```yaml
annotations:
  # eck.k8s.elastic.co/license: enterprise
  eck.k8s.elastic.co/license: {{ .Values.license | default "basic" | quote }}
 ```