### PR TITLE
Fix helm chart rendering issues associated with indentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ hack/pipeline-validator/validator
 
 # ignore helm chart dependencies in eck-stack chart
 deploy/eck-stack/charts/*
+
+# Ignore eck-stack lockfile to allow upgrading of dependencies/child charts.
+deploy/eck-stack/Chart.lock

--- a/deploy/eck-elasticsearch/Chart.yaml
+++ b/deploy/eck-elasticsearch/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-elasticsearch
 description: A Helm chart to deploy Elasticsearch managed by the ECK Operator.
 kubeVersion: ">= 1.20.0-0"
 type: application
-version: 0.1.0
+version: 0.1.1
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/elasticsearch/

--- a/deploy/eck-elasticsearch/templates/_helpers.tpl
+++ b/deploy/eck-elasticsearch/templates/_helpers.tpl
@@ -38,7 +38,7 @@ helm.sh/chart: {{ include "elasticsearch.chart" . }}
 {{ include "elasticsearch.selectorLabels" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.labels }}
-{{ .Values.labels }}
+{{ toYaml .Values.labels }}
 {{- end }}
 {{- end }}
 

--- a/deploy/eck-elasticsearch/templates/elasticsearch.yaml
+++ b/deploy/eck-elasticsearch/templates/elasticsearch.yaml
@@ -8,32 +8,36 @@ metadata:
   annotations:
     eck.k8s.elastic.co/license: enterprise
     {{- if .Values.annotations }}
-    {{- toYaml .Values.annotations | indent 4 }}
+    {{- toYaml .Values.annotations | nindent 4 }}
     {{- end }}
 spec:
   {{- if .Values.updateStrategy }}
   updateStrategy:
-    {{- toYaml .Values.updateStrategy | indent 4 }}
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}
   {{- if .Values.secureSettings }}
   secureSettings:
-    {{- toYaml .Values.secureSettings | indent 2 }}
+    {{- toYaml .Values.secureSettings | nindent 2 }}
   {{- end }}
   {{- if .Values.transport }}
   transport:
-    {{- toYaml .Values.transport | indent 4 }}
+    {{- toYaml .Values.transport | nindent 4 }}
+  {{- end }}
+  {{- if .Values.http }}
+  http:
+    {{- toYaml .Values.http | nindent 4 }}
   {{- end }}
   version: {{ required "An Elasticsearch version is required" .Values.version }}
   {{- if .Values.monitoring }}
   monitoring:
-    {{- toYaml .Values.monitoring | indent 4 }}
+    {{- toYaml .Values.monitoring | nindent 4 }}
   {{- end }}
   {{- if .Values.remoteClusters }}
   remoteClusters:
-    {{- toYaml .Values.remoteClusters | indent 2 }}
+    {{- toYaml .Values.remoteClusters | nindent 2 }}
   {{- end }}
   {{- if eq (len .Values.nodeSets) 0 }}
   {{ fail "At least one nodeSet is required" }}
   {{- end }}
   nodeSets:
-{{ toYaml .Values.nodeSets | indent 4 }}
+{{ toYaml .Values.nodeSets | nindent 4 }}

--- a/deploy/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
+++ b/deploy/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
@@ -38,6 +38,110 @@ tests:
       - equal:
           path: metadata.name
           value: override
+  - it: should render labels, annotations, and additional custom values properly
+    set:
+      labels:
+        test: label
+      annotations:
+        test: annotation
+      monitoring:
+        metrics:
+          elasticsearchRefs:
+          - name: monitoring
+            namespace: observability
+        logs:
+          elasticsearchRefs:
+          - name: monitoring
+            namespace: observability
+      transport:
+        service:
+          metadata:
+            labels:
+              test: label
+          spec:
+            type: LoadBalancer
+      http:
+        service:
+          spec:
+            type: LoadBalancer
+      secureSettings:
+      - secretName: one-secure-settings-secret
+      - secretName: two-secure-settings-secret
+      updateStrategy:
+        changeBudget:
+          maxSurge: 3
+          maxUnavailable: 1
+      remoteClusters:
+      - name: cluster-one
+        elasticsearchRef:
+          name: cluster-one
+      - name: cluster-two
+        elasticsearchRef:
+          name: cluster-two
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Elasticsearch
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: quickstart
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: eck-elasticsearch
+            helm.sh/chart: eck-elasticsearch-0.1.1
+            test: label
+      - equal:
+          path: metadata.annotations
+          value:
+            eck.k8s.elastic.co/license: enterprise
+            test: annotation
+      - equal:
+          path: spec.monitoring
+          value:
+            metrics:
+              elasticsearchRefs:
+              - name: monitoring
+                namespace: observability
+            logs:
+              elasticsearchRefs:
+              - name: monitoring
+                namespace: observability
+      - equal:
+          path: spec.transport
+          value:
+            service:
+              metadata:
+                labels:
+                  test: label
+              spec:
+                type: LoadBalancer
+      - equal:
+          path: spec.http
+          value:
+            service:
+              spec:
+                type: LoadBalancer
+      - equal:
+          path: spec.secureSettings
+          value:
+          - secretName: one-secure-settings-secret
+          - secretName: two-secure-settings-secret
+      - equal:
+          path: spec.updateStrategy
+          value:
+            changeBudget:
+              maxSurge: 3
+              maxUnavailable: 1
+      - equal:
+          path: spec.remoteClusters
+          value:
+          - name: cluster-one
+            elasticsearchRef:
+              name: cluster-one
+          - name: cluster-two
+            elasticsearchRef:
+              name: cluster-two
   - it: should render node roles properly
     values:
       - ../../examples/hot-warm-cold.yaml

--- a/deploy/eck-kibana/Chart.yaml
+++ b/deploy/eck-kibana/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-kibana
 description: A Helm chart to deploy Kibana managed by the ECK Operator.
 kubeVersion: ">= 1.20.0-0"
 type: application
-version: 0.1.0
+version: 0.1.1
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/kibana

--- a/deploy/eck-kibana/templates/_helpers.tpl
+++ b/deploy/eck-kibana/templates/_helpers.tpl
@@ -38,7 +38,7 @@ helm.sh/chart: {{ include "kibana.chart" . }}
 {{ include "kibana.selectorLabels" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.labels }}
-{{ .Values.labels }}
+{{ toYaml .Values.labels }}
 {{- end }}
 {{- end }}
 

--- a/deploy/eck-kibana/templates/kibana.yaml
+++ b/deploy/eck-kibana/templates/kibana.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     eck.k8s.elastic.co/license: enterprise
     {{- if .Values.annotations }}
-    {{- toYaml .Values.annotations | indent 4 }}
+    {{- toYaml .Values.annotations | nindent 4 }}
     {{- end }}
 spec:
   version: {{ required "A Kibana version is required" .Values.version }}

--- a/deploy/eck-kibana/templates/tests/kibana_test.yaml
+++ b/deploy/eck-kibana/templates/tests/kibana_test.yaml
@@ -36,6 +36,30 @@ tests:
       - equal:
           path: metadata.name
           value: override
+  - it: should render custom labels, and annotations values properly
+    set:
+      labels:
+        test: label
+      annotations:
+        test: annotation
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Kibana
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: quickstart
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: eck-kibana
+            helm.sh/chart: eck-kibana-0.1.1
+            test: label
+      - equal:
+          path: metadata.annotations
+          value:
+            eck.k8s.elastic.co/license: enterprise
+            test: annotation
   - it: should render http service properly
     set:
       spec.elasticsearchRef.namespace: default

--- a/deploy/eck-stack/Chart.lock
+++ b/deploy/eck-stack/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: eck-elasticsearch
-  repository: file://../eck-elasticsearch
-  version: 0.1.0
-- name: eck-kibana
-  repository: file://../eck-kibana
-  version: 0.1.0
-digest: sha256:5d22239d6c40d5b35b4242db0af9c37ff6c59f3ed2afdd2ab2956ce0992e4320
-generated: "2022-07-19T08:58:27.453007-05:00"

--- a/deploy/eck-stack/Chart.yaml
+++ b/deploy/eck-stack/Chart.yaml
@@ -12,14 +12,14 @@ version: 0.1.0
 dependencies:
   - name: eck-elasticsearch
     condition: eck-elasticsearch.enabled
-    version: "0.1.0"
+    version: "0.1.1"
     # uncomment for local testing, and comment
     # the helm.elastic.co repository.
     # repository: "file://../eck-elasticsearch"
     repository: "https://helm.elastic.co"
   - name: eck-kibana
     condition: eck-kibana.enabled
-    version: "0.1.0"
+    version: "0.1.1"
     # uncomment for local testing, and comment
     # the helm.elastic.co repository.
     # repository: "file://../eck-kibana"


### PR DESCRIPTION
supercedes #5998 

Issues were found with the rendering of annotations/labels, and other specific Elasticsearch values.  This PR fixes all of the issues, and adds tests around the previously untested custom annotations, and labels values, and adds additional tests for custom Elasticsearch values.

# Notable change

This stops version control of the `eck-stack/Chart.lock` file, as it requires an unreleased version of the child charts, so it will not be able to be rendered accurately during child chart version upgrades. 