### PR TITLE
Allow license type parametrization

### DIFF
--- a/deploy/eck-elasticsearch/Chart.yaml
+++ b/deploy/eck-elasticsearch/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-elasticsearch
 description: A Helm chart to deploy Elasticsearch managed by the ECK Operator.
 kubeVersion: ">= 1.20.0-0"
 type: application
-version: 0.1.1
+version: 0.1.2
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/elasticsearch/

--- a/deploy/eck-elasticsearch/templates/elasticsearch.yaml
+++ b/deploy/eck-elasticsearch/templates/elasticsearch.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "elasticsearch.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: enterprise
+    eck.k8s.elastic.co/license: {{ .Values.licenseType }}
     {{- if .Values.annotations }}
     {{- toYaml .Values.annotations | nindent 4 }}
     {{- end }}

--- a/deploy/eck-elasticsearch/values.yaml
+++ b/deploy/eck-elasticsearch/values.yaml
@@ -20,6 +20,11 @@
 #
 version: 8.2.3
 
+# License type to use, allowed values are `basic` and `enterprise`.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-licensing.html
+#
+licenseType: enterprise
+
 # Labels that will be applied to Elasticsearch.
 #
 labels: {}

--- a/deploy/eck-kibana/Chart.yaml
+++ b/deploy/eck-kibana/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-kibana
 description: A Helm chart to deploy Kibana managed by the ECK Operator.
 kubeVersion: ">= 1.20.0-0"
 type: application
-version: 0.1.1
+version: 0.1.2
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/kibana

--- a/deploy/eck-kibana/templates/kibana.yaml
+++ b/deploy/eck-kibana/templates/kibana.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "kibana.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: enterprise
+    eck.k8s.elastic.co/license: {{ .Values.licenseType }}
     {{- if .Values.annotations }}
     {{- toYaml .Values.annotations | nindent 4 }}
     {{- end }}

--- a/deploy/eck-kibana/values.yaml
+++ b/deploy/eck-kibana/values.yaml
@@ -20,6 +20,11 @@
 #
 version: 8.2.3
 
+# License type to use, allowed values are `basic` and `enterprise`.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-licensing.html
+#
+licenseType: enterprise
+
 # Labels that will be applied to Kibana.
 #
 labels: {}

--- a/deploy/eck-stack/Chart.yaml
+++ b/deploy/eck-stack/Chart.yaml
@@ -7,19 +7,19 @@ description: |
   * Kibana
 kubeVersion: ">= 1.20.0-0"
 type: application
-version: 0.1.0
+version: 0.1.1
 
 dependencies:
   - name: eck-elasticsearch
     condition: eck-elasticsearch.enabled
-    version: "0.1.1"
+    version: "0.1.2"
     # uncomment for local testing, and comment
     # the helm.elastic.co repository.
     # repository: "file://../eck-elasticsearch"
     repository: "https://helm.elastic.co"
   - name: eck-kibana
     condition: eck-kibana.enabled
-    version: "0.1.1"
+    version: "0.1.2"
     # uncomment for local testing, and comment
     # the helm.elastic.co repository.
     # repository: "file://../eck-kibana"


### PR DESCRIPTION
Signed-off-by: Basilio Vera <basilio.vera@softonic.com>

The helm charts that are provided by eck-stack for generating Elasticsearch clusters and its Kibana have "enterprise" license value hardcoded in the template.

With this you can use a parameter in your chart to use "basic" license instead. The default values remain the same maintaining backwards compatibility.
