### PR TITLE
Allow Fleet Server to be run without TLS.

### DIFF
--- a/pkg/controller/agent/driver.go
+++ b/pkg/controller/agent/driver.go
@@ -108,7 +108,7 @@ func internalReconcile(params Params) (*reconciler.Results, agentv1alpha1.AgentS
 
 	configHash := fnv.New32a()
 	var fleetCerts *certificates.CertificatesSecret
-	if params.Agent.Spec.FleetServerEnabled {
+	if params.Agent.Spec.FleetServerEnabled && params.Agent.Spec.HTTP.TLS.Enabled() {
 		var caResults *reconciler.Results
 		fleetCerts, caResults = certificates.Reconciler{
 			K8sClient:             params.Client,

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -282,12 +282,12 @@ func applyEnvVars(params Params, fleetToken EnrollmentAPIKey, builder *defaults.
 		return nil, err
 	}
 
-	if params.Agent.Spec.FleetServerEnabled && !params.Agent.Spec.HTTP.TLS.Enabled() {
-		// Force FLEET_SERVER_HOST environment variable to Pod IP, as without this, Fleet Server only binds to localhost.
-		builder = builder.WithEnv(corev1.EnvVar{Name: FleetServerHost, Value: "", ValueFrom: &corev1.EnvVarSource{
-			FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIP"},
-		}})
-	}
+	// if params.Agent.Spec.FleetServerEnabled && !params.Agent.Spec.HTTP.TLS.Enabled() {
+	// 	// Force FLEET_SERVER_HOST environment variable to Pod IP, as without this, Fleet Server only binds to localhost.
+	// 	builder = builder.WithEnv(corev1.EnvVar{Name: FleetServerHost, Value: "", ValueFrom: &corev1.EnvVarSource{
+	// 		FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIP"},
+	// 	}})
+	// }
 
 	return builder, nil
 }

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -75,7 +75,6 @@ const (
 	FleetServerElasticsearchUsername = "FLEET_SERVER_ELASTICSEARCH_USERNAME"
 	FleetServerElasticsearchPassword = "FLEET_SERVER_ELASTICSEARCH_PASSWORD" //nolint:gosec
 	FleetServerElasticsearchCA       = "FLEET_SERVER_ELASTICSEARCH_CA"
-	FleetServerHost                  = "FLEET_SERVER_HOST"
 	FleetServerPolicyID              = "FLEET_SERVER_POLICY_ID"
 	FleetServerServiceToken          = "FLEET_SERVER_SERVICE_TOKEN" //nolint:gosec
 
@@ -282,13 +281,6 @@ func applyEnvVars(params Params, fleetToken EnrollmentAPIKey, builder *defaults.
 	} else if _, err := reconciler.ReconcileSecret(params.Context, params.Client, envVarsSecret, &params.Agent); err != nil {
 		return nil, err
 	}
-
-	// if params.Agent.Spec.FleetServerEnabled && !params.Agent.Spec.HTTP.TLS.Enabled() {
-	// 	// Force FLEET_SERVER_HOST environment variable to Pod IP, as without this, Fleet Server only binds to localhost.
-	// 	builder = builder.WithEnv(corev1.EnvVar{Name: FleetServerHost, Value: "", ValueFrom: &corev1.EnvVarSource{
-	// 		FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIP"},
-	// 	}})
-	// }
 
 	return builder, nil
 }

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -517,7 +517,7 @@ func getFleetSetupFleetEnvVars(_ context.Context, agent agentv1alpha1.Agent, cli
 		fleetURL := assocConf.GetURL()
 		fleetCfg[FleetURL] = fleetURL
 
-		if !strings.Contains(fleetURL, "https://") {
+		if !strings.HasPrefix(fleetURL, "https://") {
 			fleetCfg[FleetInsecure] = "true"
 		}
 

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -11,6 +11,7 @@ import (
 	"hash"
 	"path"
 	"sort"
+	"strings"
 
 	pkgerrors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -521,9 +522,10 @@ func getFleetSetupFleetEnvVars(_ context.Context, agent agentv1alpha1.Agent, cli
 		if err != nil {
 			return nil, err
 		}
-		fleetCfg[FleetURL] = assocConf.GetURL()
+		fleetURL := assocConf.GetURL()
+		fleetCfg[FleetURL] = fleetURL
 
-		if agent.Spec.HTTP.Protocol() == "http" {
+		if !strings.Contains(fleetURL, "https://") {
 			fleetCfg[FleetInsecure] = "true"
 		}
 

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -349,6 +349,16 @@ func (b Builder) WithObjects(objs ...k8sclient.Object) Builder {
 	return b
 }
 
+func (b Builder) WithTLSDisabled(disabled bool) Builder {
+	if b.Agent.Spec.HTTP.TLS.SelfSignedCertificate == nil {
+		b.Agent.Spec.HTTP.TLS.SelfSignedCertificate = &commonv1.SelfSignedCertificate{}
+	} else {
+		b.Agent.Spec.HTTP.TLS.SelfSignedCertificate = b.Agent.Spec.HTTP.TLS.SelfSignedCertificate.DeepCopy()
+	}
+	b.Agent.Spec.HTTP.TLS.SelfSignedCertificate.Disabled = disabled
+	return b
+}
+
 func (b Builder) Ref() commonv1.ObjectSelector {
 	return commonv1.ObjectSelector{
 		Name:      b.Agent.Name,


### PR DESCRIPTION
closes #6000 

This potential change allows Fleet Server, running as Elastic Agent, to be run without TLS for such scenarios as running within a service mesh which could provide mTLS between applications/services, similar to how we allow Elasticsearch, and Kibana to run without TLS.

This additionally solves a panic when currently attempting to disable TLS on Fleet server:

```
[elastic-operator-0] {"log.level":"info","@timestamp":"2022-09-14T20:10:55.031Z","log.logger":"manager.eck-operator","message":"Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference","service.version":"2.4.0+96282ca9","service.type":"eck","ecs.version":"1.4.0","controller":"agent-controller","object":{"name":"eck-fleet-eck-fleet-server","namespace":"istio-enabled"},"namespace":"istio-enabled","name":"eck-fleet-eck-fleet-server","reconcileID":"c0330ea8-bda6-48d5-8552-d25327c3959e"}
[elastic-operator-0] panic: runtime error: invalid memory address or nil pointer dereference [recovered]
[elastic-operator-0] 	panic: runtime error: invalid memory address or nil pointer dereference
[elastic-operator-0] [signal SIGSEGV: segmentation violation code=0x1 addr=0x120 pc=0x1769409]
[elastic-operator-0]
[elastic-operator-0] goroutine 2739 [running]:
[elastic-operator-0] sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
[elastic-operator-0] 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:118 +0x1f4
[elastic-operator-0] panic({0x1a81660, 0x2de94a0})
[elastic-operator-0] 	/usr/local/go/src/runtime/panic.go:838 +0x207
[elastic-operator-0] github.com/elastic/cloud-on-k8s/v2/pkg/controller/agent.internalReconcile({{0x2017448, 0xc00180b110}, {0x201e198, 0xc00020c820}, {0x2016768, 0xc0007c2b80}, {0xc0007bff20, 0xc0007bff80, 0xc0007da000, 0xc0007da060}, ...})
[elastic-operator-0] 	/go/src/github.com/elastic/cloud-on-k8s/pkg/controller/agent/driver.go:130 +0xe89
[elastic-operator-0] github.com/elastic/cloud-on-k8s/v2/pkg/controller/agent.(*ReconcileAgent).doReconcile(_, {_, _}, {{{0x18b3b85, 0x5}, {0xc0017f21a0, 0x1d}}, {{0xc0006eb800, 0x1a}, {0x0, ...}, ...}, ...})
[elastic-operator-0] 	/go/src/github.com/elastic/cloud-on-k8s/pkg/controller/agent/controller.go:181 +0x585
[elastic-operator-0] github.com/elastic/cloud-on-k8s/v2/pkg/controller/agent.(*ReconcileAgent).Reconcile(0xc000772f20, {0x2017448?, 0xc00180b020?}, {{{0xc00076ebb0?, 0x10?}, {0xc000213500?, 0x40d927?}}})
[elastic-operator-0] 	/go/src/github.com/elastic/cloud-on-k8s/pkg/controller/agent/controller.go:147 +0x478
[elastic-operator-0] sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x20173a0?, {0x2017448?, 0xc00180b020?}, {{{0xc00076ebb0?, 0x1c017c0?}, {0xc000213500?, 0x4041f4?}}})
[elastic-operator-0] 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:121 +0xc8
[elastic-operator-0] sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0004a2d20, {0x20173a0, 0xc000634a80}, {0x1b01ee0?, 0xc0004d1be0?})
[elastic-operator-0] 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:320 +0x33c
[elastic-operator-0] sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0004a2d20, {0x20173a0, 0xc000634a80})
[elastic-operator-0] 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:273 +0x1d9
[elastic-operator-0] sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
[elastic-operator-0] 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:234 +0x85
[elastic-operator-0] created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
[elastic-operator-0] 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:230 +0x325
^C[1]    43051 terminated  kubetail -n elastic-system -l app.kubernetes.io/instance=elastic-operator  1m
```

Also, an e2e test was added to ensure the full functionality all the way back to data within Elasticsearch.