### PR TITLE
Add note for air-gapped environments for pulling the Support diag image

### DIFF
--- a/docs/operating-eck/troubleshooting/take-eck-dump.asciidoc
+++ b/docs/operating-eck/troubleshooting/take-eck-dump.asciidoc
@@ -28,6 +28,8 @@ eck-diagnostics -o <operator-namespaces> -r <resources-namespaces>
 
 By default, the tool automatically runs link:https://github.com/elastic/support-diagnostics[support diagnostics] for every Elasticsearch cluster and Kibana instance. This requires the temporary deployment of additional Pods into the Kubernetes cluster. If this is not what you want, you can turn off the feature by specifying the `--run-stack-diagnostics=false` flag.
 
+Note that the ECK diagnostics will spawn a pod `docker.elastic.co/eck-dev/support-diagnostics:x.y.z` to gather Elasticsearch cluster diagnostics, but in air-gapped environments with no access to the `docker.elastic.co` registry, you should copy the (latest) image to your internal image registry and then run the ECK-diagnostics with the additional flag `--diagnostic-image internal-image-for-support-diagnostic>` to get Elasticsearch cluster information.
+
 
 [float]
 == Example

--- a/docs/operating-eck/troubleshooting/take-eck-dump.asciidoc
+++ b/docs/operating-eck/troubleshooting/take-eck-dump.asciidoc
@@ -28,7 +28,7 @@ eck-diagnostics -o <operator-namespaces> -r <resources-namespaces>
 
 By default, the tool automatically runs link:https://github.com/elastic/support-diagnostics[support diagnostics] for every Elasticsearch cluster and Kibana instance. This requires the temporary deployment of additional Pods into the Kubernetes cluster. If this is not what you want, you can turn off the feature by specifying the `--run-stack-diagnostics=false` flag.
 
-Note that the ECK diagnostics will spawn a pod `docker.elastic.co/eck-dev/support-diagnostics:x.y.z` to gather Elasticsearch cluster diagnostics, but in air-gapped environments with no access to the `docker.elastic.co` registry, you should copy the (latest) image to your internal image registry and then run the ECK-diagnostics with the additional flag `--diagnostic-image internal-image-for-support-diagnostic>` to get Elasticsearch cluster information.
+In air-gapped environments with no access to the `docker.elastic.co` registry, you should copy the latest support-diagnostics Docker image to your internal image registry and then run the tool with the additional flag `--diagnostic-image <custom-support-diagnostics-image-name>`.
 
 
 [float]


### PR DESCRIPTION
A lot of ECK clusters are air-gapped, meaning they have no access to our docker.elastic.co registry, so we should add a note as it's not immediately clear a manual actions is required for people that would need to get the Elasticsearch & Kibana diagnostics. I made a quick draft, feel free to edit the wording/phrasing.
