### PR TITLE
Remove unnecessary trailing space in CI Dockerfile

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -84,7 +84,7 @@ RUN curl -fsSLO "https://github.com/weaveworks/eksctl/releases/download/v${EKSCT
     rm eksctl_Linux_amd64.tar.gz
 
 RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
-    chmod 700 get_helm.sh && \ 
+    chmod 700 get_helm.sh && \
     ./get_helm.sh -v v${HELM_VERSION} --no-sudo && \
     rm get_helm.sh
 


### PR DESCRIPTION
Removes an unnecessary trailing space.