### PR TITLE
Fix Beats Stack Monitoring e2e tests

### DIFF
--- a/test/e2e/test/beat/builder.go
+++ b/test/e2e/test/beat/builder.go
@@ -334,7 +334,7 @@ func (b Builder) GetMetricsIndexPattern() string {
 	if v.GTE(version.MinFor(8, 0, 0)) {
 		return fmt.Sprintf("metricbeat-%d.%d.%d*", v.Major, v.Minor, v.Patch)
 	}
-	return ".monitoring-beat-*"
+	return ".monitoring-beats-*"
 }
 
 func (b Builder) Name() string {


### PR DESCRIPTION
#5878 Broke Beats e2e tests in 2 ways

1. When stack monitoring is enabled, only versions 7.14+ are supported, and this wasn't being checked in e2e tests.
2. The index name that v7 Metricbeat uses in e2e tests had a typo.

Split beats e2e tests for with/without stack monitoring:
* No validation of supported versions without stack monitoring
* validate version when stack monitoring is enabled.

Fix typo of index name in v7 metricbeat e2e tests when stack monitoring is enabled.
