### PR TITLE
Add default securityContext to the manager container

### DIFF
--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -51,7 +51,15 @@ podSecurityContext:
   runAsNonRoot: true
 
 # securityContext defines the security context of the operator container.
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
 
 # nodeSelector defines the node selector for the operator pod.
 nodeSelector: {}


### PR DESCRIPTION
This PR sets a default security context to improve the security of the operator container.

It also avoids the following warning to be reported if [Pod Security Standard](https://kubernetes.io/docs/tutorials/security/cluster-level-pss/) are in place as it is the case in OpenShift 4.11:

```
W0915 14:52:29.426212   70832 warnings.go:70] would violate PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "manager" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "manager" must set securityContext.capabilities.drop=["ALL"]), seccompProfile (pod or container "manager" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```