### PR TITLE
Update the base Docker image of OpenShift installer

### DIFF
--- a/hack/deployer/clients/ocp/Dockerfile
+++ b/hack/deployer/clients/ocp/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:bullseye-curl as builder
 ARG CLIENT_VERSION
 
-
 # OpenShift installer and CLI to provision OCP clusters
 RUN curl -fsSLO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${CLIENT_VERSION}/openshift-install-linux-${CLIENT_VERSION}.tar.gz && \
     tar -zxf openshift-install-linux-${CLIENT_VERSION}.tar.gz openshift-install && \
@@ -12,7 +11,8 @@ RUN curl -fsSLO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${CLIE
     mv oc /usr/local/bin/oc && \
     rm openshift-client-linux-${CLIENT_VERSION}.tar.gz
 
-FROM scratch
+FROM gcr.io/distroless/base-debian11:nonroot
+
 # be able to make TLS requests to the GCloud API
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /usr/local/bin/openshift-install .


### PR DESCRIPTION
This commit changes the base Docker image used for the OpenShift installer from `scratch` to `gcr.io/distroless/base-debian11:nonroot` because since the latest version of the installer (4.11.x), the Terraform binary that is downloaded by the installer is not statically linked.