### PR TITLE
Bump Agent chart kubeVersion for consistency

### DIFF
--- a/deploy/eck-agent/Chart.yaml
+++ b/deploy/eck-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: eck-agent
 description: A Helm chart to deploy Elastic Agent managed by the ECK Operator.
-kubeVersion: ">= 1.20.0-0"
+kubeVersion: ">= 1.21.0-0"
 type: application
 version: 0.1.0
 sources:

--- a/deploy/eck-fleet-server/Chart.yaml
+++ b/deploy/eck-fleet-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: eck-fleet-server
 description: A Helm chart to deploy Elastic Fleet Server as an Agent managed by the ECK Operator.
-kubeVersion: ">= 1.20.0-0"
+kubeVersion: ">= 1.21.0-0"
 type: application
 version: 0.1.0
 sources:


### PR DESCRIPTION
We have moved to 1.21 in all the other charts.