### PR TITLE
[E2E] Disable TestJournalbeatHostsRecipe on Kind

### DIFF
--- a/test/e2e/beat/recipes_test.go
+++ b/test/e2e/beat/recipes_test.go
@@ -223,6 +223,12 @@ func TestPacketbeatDnsHttpRecipe(t *testing.T) {
 }
 
 func TestJournalbeatHostsRecipe(t *testing.T) {
+	if test.Ctx().Provider == "kind" {
+		// Journalbeat does not generate events on latest Kind node images.
+		// Since Journalbeat is no longer maintained and developed we skip this test on Kind.
+		t.SkipNow()
+	}
+
 	customize := func(builder beat.Builder) beat.Builder {
 		return builder
 	}


### PR DESCRIPTION
`TestJournalbeatHostsRecipe` is failing on Kind. It can be reproduced with the latest Kind node images, I guess it is failing since https://github.com/elastic/cloud-on-k8s/pull/6028/.

For example, the test works fine with `kindest/node:v1.24.1@sha256:11276ce4763d5600379c0104c4cb51bf7420c8c02937708e958ad68d08e0910c`, but fails with `kindest/node:v1.25.2@sha256:9be91e9e9cdf116809841fc77ebdb8845443c4c72fe5218f3ae9eb57fdb4bace`

I have run Journalbeat in `debug` mode (see logs below), and spent a fair amount of time trying to understand what changes in the new node images prevent `Journalbeat` to read the systemd journal without success.

Given that:

* Journalbeat has always been an experimental product.
* Journalbeat is no more developed (last version is `7.15.2`).
* The problem is likely related to the product itself, and not the operator.

I would be tempted to stop my effort here and disable this test on Kind.

FWIW here are the logs in debug mode:

<details>
<summary>kindest/node:v1.24.1</summary>

```
2022-09-30T08:31:06.545Z        INFO    instance/beat.go:665    Home path: [/usr/share/journalbeat] Config path: [/usr/share/journalbeat] Data path: [/usr/share/journalbeat/data] Logs path: [/usr/share/journalbeat/logs]
2022-09-30T08:31:06.545Z        DEBUG   [beat]  instance/beat.go:723    Beat metadata path: /usr/share/journalbeat/data/meta.json
2022-09-30T08:31:06.639Z        INFO    instance/beat.go:673    Beat ID: 082c1903-a7d0-4bce-b41e-4917c8e61e33
2022-09-30T08:31:06.640Z        DEBUG   [add_cloud_metadata]    add_cloud_metadata/providers.go:128     add_cloud_metadata: starting to fetch metadata, timeout=3s
2022-09-30T08:31:09.642Z        DEBUG   [add_cloud_metadata]    add_cloud_metadata/providers.go:172     add_cloud_metadata: timed-out waiting for all responses
2022-09-30T08:31:09.642Z        DEBUG   [add_cloud_metadata]    add_cloud_metadata/providers.go:131     add_cloud_metadata: fetchMetadata ran for 3.001790919s
2022-09-30T08:31:09.642Z        INFO    [add_cloud_metadata]    add_cloud_metadata/add_cloud_metadata.go:101    add_cloud_metadata: hosting provider type not detected.
2022-09-30T08:31:09.642Z        DEBUG   [processors]    processors/processor.go:120     Generated new processors: add_cloud_metadata={}, add_host_metadata=[netinfo.enabled=[true], cache.ttl=[5m0s]]
2022-09-30T08:31:09.642Z        DEBUG   [seccomp]       seccomp/seccomp.go:107  No seccomp policy is defined
2022-09-30T08:31:09.642Z        INFO    [beat]  instance/beat.go:1014   Beat info       {"system_info": {"beat": {"path": {"config": "/usr/share/journalbeat", "data": "/usr/share/journalbeat/data", "home": "/usr/share/journalbeat", "logs": "/usr/share/journalbeat/logs"}, "type": "journalbeat", "uuid": "082c1903-a7d0-4bce-b41e-4917c8e61e33"}}}
2022-09-30T08:31:09.642Z        INFO    [beat]  instance/beat.go:1023   Build info      {"system_info": {"build": {"commit": "fd322dad6ceafec40c84df4d2a0694ea357d16cc", "libbeat": "7.15.2", "time": "2021-11-04T15:37:27.000Z", "version": "7.15.2"}}}
2022-09-30T08:31:09.642Z        INFO    [beat]  instance/beat.go:1026   Go runtime info {"system_info": {"go": {"os":"linux","arch":"arm64","max_procs":6,"version":"go1.16.6"}}}
2022-09-30T08:31:09.643Z        INFO    [beat]  instance/beat.go:1030   Host info       {"system_info": {"host": {"architecture":"aarch64","boot_time":"2022-09-30T06:31:10Z","containerized":false,"name":"20-15-worker","ip":["127.0.0.1/8","::1/128","10.244.1.1/32","10.244.1.1/32","10.244.1.1/32","10.244.1.1/32","172.18.0.2/16","fc00:f853:ccd:e793::2/64","fe80::42:acff:fe12:2/64"],"kernel_version":"5.10.104-linuxkit","mac":["26:4b:29:80:90:2c","02:f6:29:2e:e6:e3","42:17:e2:26:83:3a","36:b9:97:54:ec:a0","02:42:ac:12:00:02"],"os":{"type":"linux","family":"redhat","platform":"centos","name":"CentOS Linux","version":"7 (AltArch)","major":7,"minor":9,"patch":2009,"codename":"AltArch"},"timezone":"UTC","timezone_offset_sec":0,"id":"264b17f8278d4c5ba30d6dd3debb961c"}}}
2022-09-30T08:31:09.643Z        INFO    [beat]  instance/beat.go:1059   Process info    {"system_info": {"process": {"capabilities": {"inheritable":null,"permitted":["chown","dac_override","fowner","fsetid","kill","setgid","setuid","setpcap","net_bind_service","net_raw","sys_chroot","mknod","audit_write","setfcap"],"effective":["chown","dac_override","fowner","fsetid","kill","setgid","setuid","setpcap","net_bind_service","net_raw","sys_chroot","mknod","audit_write","setfcap"],"bounding":["chown","dac_override","fowner","fsetid","kill","setgid","setuid","setpcap","net_bind_service","net_raw","sys_chroot","mknod","audit_write","setfcap"],"ambient":null}, "cwd": "/usr/share/journalbeat", "exe": "/usr/share/journalbeat/journalbeat", "name": "journalbeat", "pid": 10, "ppid": 1, "seccomp": {"mode":"disabled","no_new_privs":false}, "start_time": "2022-09-30T08:31:05.410Z"}}}
2022-09-30T08:31:09.644Z        INFO    instance/beat.go:309    Setup Beat: journalbeat; Version: 7.15.2
2022-09-30T08:31:09.644Z        DEBUG   [beat]  instance/beat.go:335    Initializing output plugins
2022-09-30T08:31:09.644Z        INFO    [index-management]      idxmgmt/std.go:184      Set output.elasticsearch.index to 'journalbeat-7.15.2' as ILM is enabled.
2022-09-30T08:31:09.644Z        WARN    [cfgwarn]       tlscommon/config.go:100 DEPRECATED: Treating the CommonName field on X.509 certificates as a host name when no Subject Alternative Names are present is going to be removed. Please update your certificates if needed. Will be removed in version: 8.0.0
2022-09-30T08:31:09.644Z        DEBUG   [tls]   tlscommon/tls.go:172    Successfully loaded CA certificate: /mnt/elastic-internal/elasticsearch-certs/ca.crt
2022-09-30T08:31:09.644Z        INFO    [esclientleg]   eslegclient/connection.go:100   elasticsearch url: https://elasticsearch-sbcx-es-http.e2e-mercury.svc:9200
2022-09-30T08:31:09.644Z        DEBUG   [tls]   tlscommon/tls.go:172    Successfully loaded CA certificate: /mnt/elastic-internal/elasticsearch-certs/ca.crt
2022-09-30T08:31:09.647Z        DEBUG   [publisher]     pipeline/consumer.go:148        start pipeline event consumer
2022-09-30T08:31:09.648Z        INFO    [publisher]     pipeline/module.go:113  Beat name: 20-15-worker
2022-09-30T08:31:09.648Z        WARN    [cfgwarn]       beater/journalbeat.go:55        EXPERIMENTAL: Journalbeat is experimental.
2022-09-30T08:31:09.652Z        DEBUG   [input] reader/journal.go:75    New journal is opened for reading       {"path": "LOCAL_SYSTEM_JOURNAL"}
2022-09-30T08:31:09.652Z        DEBUG   [input] input/input.go:118      New input is created for paths []
2022-09-30T08:31:09.652Z        INFO    [monitoring]    log/log.go:142  Starting metrics logging every 30s
2022-09-30T08:31:09.652Z        INFO    instance/beat.go:473    journalbeat start running.
2022-09-30T08:31:09.652Z        INFO    [journalbeat]   beater/journalbeat.go:93        journalbeat is running! Hit CTRL-C to stop it.
2022-09-30T08:31:10.754Z        DEBUG   [processors]    processing/processors.go:203    Publish event: {
[...]
2022-09-30T08:31:39.660Z        ERROR   metrics/metrics.go:380  error getting cgroup stats: error fetching stats for controller io: error fetching IO stats: error fetching io.pressure for path /sys/fs/cgroup:: open /sys/fs/cgroup/io.pressure: no such file or directory
2022-09-30T08:31:39.661Z        INFO    [monitoring]    log/log.go:184  Non-zero metrics in the last 30s        {"monitoring": {"metrics": {"beat":{"cpu":{"system":{"ticks":150,"time":{"ms":157}},"total":{"ticks":340,"time":{"ms":356},"value":340},"user":{"ticks":190,"time":{"ms":199}}},"handles":{"limit":{"hard":1048576,"soft":1048576},"open":11},"info":{"ephemeral_id":"7e870aeb-d421-4e54-9116-5f6cf5d8ed66","uptime":{"ms":33511},"version":"7.15.2"},"memstats":{"gc_next":15825040,"memory_alloc":11178832,"memory_sys":76235784,"memory_total":38424352,"rss":87044096},"runtime":{"goroutines":16}},"journalbeat":{"journals":{"journal_0":{"path":"LOCAL_SYSTEM_JOURNAL","size_in_bytes":8388608}},"libbeat":{"output":{"events":{"acked":44,"batches":3,"total":44},"read":{"bytes":16394},"type":"elasticsearch","write":{"bytes":162167}},"pipeline":{"clients":1,"events":{"active":8,"published":52,"retry":20,"total":52},"queue":{"acked":44,"max_events":4096}}}},"system":{"cpu":{"cores":6},"load":{"1":1.22,"15":4.41,"5":3.3,"norm":{"1":0.2033,"15":0.735,"5":0.55}}}}}}
2022-09-30T08:31:40.057Z        DEBUG   [elasticsearch] elasticsearch/client.go:230     PublishEvents: 8 events have been published to elasticsearch in 12.819833ms.
2022-09-30T08:31:40.057Z        DEBUG   [publisher]     memqueue/ackloop.go:160 ackloop: receive ack [3: 0, 8]
2022-09-30T08:31:40.057Z        DEBUG   [publisher]     memqueue/eventloop.go:535       broker ACK events: count=8, start-seq=45, end-seq=52
2022-09-30T08:31:40.057Z        DEBUG   [input] input/input.go:143      journalbeat successfully published events       {"event.count": 8}
2022-09-30T08:31:40.057Z        DEBUG   [publisher]     memqueue/ackloop.go:128 ackloop: return ack to broker loop:8
2022-09-30T08:31:40.057Z        DEBUG   [publisher]     memqueue/ackloop.go:131 ackloop:  done send ack
2022-09-30T08:31:40.146Z        DEBUG   [processors]    processing/processors.go:203    Publish event: {
[  ... at this point JournalBeat is publishing events as expected ...]
```

</details>

<details>
<summary>kindest/node:v1.25.2</summary>

```
2022-09-30T08:45:00.217Z        INFO    instance/beat.go:665    Home path: [/usr/share/journalbeat] Config path: [/usr/share/journalbeat] Data path: [/usr/share/journalbeat/data] Logs path: [/usr/share/journalbeat/logs]
2022-09-30T08:45:00.217Z        DEBUG   [beat]  instance/beat.go:723    Beat metadata path: /usr/share/journalbeat/data/meta.json
2022-09-30T08:45:00.221Z        INFO    instance/beat.go:673    Beat ID: ff597711-8400-4b84-b98a-1798692e9375
2022-09-30T08:45:00.222Z        DEBUG   [add_cloud_metadata]    add_cloud_metadata/providers.go:128     add_cloud_metadata: starting to fetch metadata, timeout=3s
2022-09-30T08:45:00.224Z        DEBUG   [add_cloud_metadata]    add_cloud_metadata/providers.go:165     add_cloud_metadata: received disposition for openstack after 1.844834ms. result=[provider:openstack, error=failed requesting openstack metadata: Get "https://169.254.169.254/2009-04-04/meta-data/instance-id": dial tcp 169.254.169.254:443: connect: connection refused, metadata={}]
2022-09-30T08:45:00.310Z        DEBUG   [add_cloud_metadata]    add_cloud_metadata/providers.go:165     add_cloud_metadata: received disposition for aws after 3.286209ms. result=[provider:aws, error=failed requesting aws metadata: Get "http://169.254.169.254/2014-02-25/dynamic/instance-identity/document": dial tcp 169.254.169.254:80: connect: connection refused, metadata={}]
2022-09-30T08:45:00.311Z        DEBUG   [add_cloud_metadata]    add_cloud_metadata/providers.go:165     add_cloud_metadata: received disposition for gcp after 89.092792ms. result=[provider:gcp, error=failed requesting gcp metadata: Get "http://169.254.169.254/computeMetadata/v1/?recursive=true&alt=json": dial tcp 169.254.169.254:80: connect: connection refused, metadata={}]
2022-09-30T08:45:00.312Z        DEBUG   [add_cloud_metadata]    add_cloud_metadata/providers.go:165     add_cloud_metadata: received disposition for openstack after 89.961584ms. result=[provider:openstack, error=failed requesting openstack metadata: Get "http://169.254.169.254/2009-04-04/meta-data/instance-id": dial tcp 169.254.169.254:80: connect: connection refused, metadata={}]
2022-09-30T08:45:00.312Z        DEBUG   [add_cloud_metadata]    add_cloud_metadata/providers.go:165     add_cloud_metadata: received disposition for digitalocean after 90.17775ms. result=[provider:digitalocean, error=failed requesting digitalocean metadata: Get "http://169.254.169.254/metadata/v1.json": dial tcp 169.254.169.254:80: connect: connection refused, metadata={}]
2022-09-30T08:45:00.412Z        DEBUG   [add_cloud_metadata]    add_cloud_metadata/providers.go:165     add_cloud_metadata: received disposition for azure after 189.489125ms. result=[provider:azure, error=failed requesting azure metadata: Get "http://169.254.169.254/metadata/instance/compute?api-version=2017-04-02": dial tcp 169.254.169.254:80: connect: connection refused, metadata={}]
2022-09-30T08:45:00.412Z        DEBUG   [add_cloud_metadata]    add_cloud_metadata/providers.go:131     add_cloud_metadata: fetchMetadata ran for 189.560959ms
2022-09-30T08:45:00.412Z        INFO    [add_cloud_metadata]    add_cloud_metadata/add_cloud_metadata.go:101    add_cloud_metadata: hosting provider type not detected.
2022-09-30T08:45:00.412Z        DEBUG   [processors]    processors/processor.go:120     Generated new processors: add_cloud_metadata={}, add_host_metadata=[netinfo.enabled=[true], cache.ttl=[5m0s]]
2022-09-30T08:45:00.412Z        DEBUG   [seccomp]       seccomp/seccomp.go:107  No seccomp policy is defined
2022-09-30T08:45:00.412Z        INFO    [beat]  instance/beat.go:1014   Beat info       {"system_info": {"beat": {"path": {"config": "/usr/share/journalbeat", "data": "/usr/share/journalbeat/data", "home": "/usr/share/journalbeat", "logs": "/usr/share/journalbeat/logs"}, "type": "journalbeat", "uuid": "ff597711-8400-4b84-b98a-1798692e9375"}}}
2022-09-30T08:45:00.412Z        INFO    [beat]  instance/beat.go:1023   Build info      {"system_info": {"build": {"commit": "fd322dad6ceafec40c84df4d2a0694ea357d16cc", "libbeat": "7.15.2", "time": "2021-11-04T15:37:27.000Z", "version": "7.15.2"}}}
2022-09-30T08:45:00.412Z        INFO    [beat]  instance/beat.go:1026   Go runtime info {"system_info": {"go": {"os":"linux","arch":"arm64","max_procs":6,"version":"go1.16.6"}}}
2022-09-30T08:45:00.414Z        INFO    [beat]  instance/beat.go:1030   Host info       {"system_info": {"host": {"architecture":"aarch64","boot_time":"2022-09-30T06:31:10Z","containerized":false,"name":"kind-worker","ip":["127.0.0.1/8","::1/128","10.244.1.1/32","10.244.1.1/32","172.18.0.4/16","fc00:f853:ccd:e793::4/64","fe80::42:acff:fe12:4/64"],"kernel_version":"5.10.104-linuxkit","mac":["16:93:ee:aa:78:ae","a2:ee:a9:f4:4b:95","02:42:ac:12:00:04"],"os":{"type":"linux","family":"redhat","platform":"centos","name":"CentOS Linux","version":"7 (AltArch)","major":7,"minor":9,"patch":2009,"codename":"AltArch"},"timezone":"UTC","timezone_offset_sec":0,"id":"1338ddaf1ab9476ab96b5b873b971328"}}}
2022-09-30T08:45:00.415Z        INFO    [beat]  instance/beat.go:1059   Process info    {"system_info": {"process": {"capabilities": {"inheritable":null,"permitted":["chown","dac_override","fowner","fsetid","kill","setgid","setuid","setpcap","net_bind_service","net_raw","sys_chroot","mknod","audit_write","setfcap"],"effective":["chown","dac_override","fowner","fsetid","kill","setgid","setuid","setpcap","net_bind_service","net_raw","sys_chroot","mknod","audit_write","setfcap"],"bounding":["chown","dac_override","fowner","fsetid","kill","setgid","setuid","setpcap","net_bind_service","net_raw","sys_chroot","mknod","audit_write","setfcap"],"ambient":null}, "cwd": "/usr/share/journalbeat", "exe": "/usr/share/journalbeat/journalbeat", "name": "journalbeat", "pid": 10, "ppid": 1, "seccomp": {"mode":"disabled","no_new_privs":false}, "start_time": "2022-09-30T08:44:58.700Z"}}}
2022-09-30T08:45:00.415Z        INFO    instance/beat.go:309    Setup Beat: journalbeat; Version: 7.15.2
2022-09-30T08:45:00.415Z        DEBUG   [beat]  instance/beat.go:335    Initializing output plugins
2022-09-30T08:45:00.415Z        INFO    [index-management]      idxmgmt/std.go:184      Set output.elasticsearch.index to 'journalbeat-7.15.2' as ILM is enabled.
2022-09-30T08:45:00.415Z        WARN    [cfgwarn]       tlscommon/config.go:100 DEPRECATED: Treating the CommonName field on X.509 certificates as a host name when no Subject Alternative Names are present is going to be removed. Please update your certificates if needed. Will be removed in version: 8.0.0
2022-09-30T08:45:00.415Z        DEBUG   [tls]   tlscommon/tls.go:172    Successfully loaded CA certificate: /mnt/elastic-internal/elasticsearch-certs/ca.crt
2022-09-30T08:45:00.416Z        INFO    [esclientleg]   eslegclient/connection.go:100   elasticsearch url: https://elasticsearch-b288-es-http.e2e-mercury.svc:9200
2022-09-30T08:45:00.417Z        DEBUG   [tls]   tlscommon/tls.go:172    Successfully loaded CA certificate: /mnt/elastic-internal/elasticsearch-certs/ca.crt
2022-09-30T08:45:00.418Z        DEBUG   [publisher]     pipeline/consumer.go:148        start pipeline event consumer
2022-09-30T08:45:00.418Z        INFO    [publisher]     pipeline/module.go:113  Beat name: kind-worker
2022-09-30T08:45:00.418Z        WARN    [cfgwarn]       beater/journalbeat.go:55        EXPERIMENTAL: Journalbeat is experimental.
2022-09-30T08:45:00.522Z        DEBUG   [input] reader/journal.go:75    New journal is opened for reading       {"path": "LOCAL_SYSTEM_JOURNAL"}
2022-09-30T08:45:00.522Z        DEBUG   [input] input/input.go:118      New input is created for paths []
2022-09-30T08:45:00.524Z        INFO    [monitoring]    log/log.go:142  Starting metrics logging every 30s
2022-09-30T08:45:00.524Z        INFO    instance/beat.go:473    journalbeat start running.
2022-09-30T08:45:00.526Z        INFO    [journalbeat]   beater/journalbeat.go:93        journalbeat is running! Hit CTRL-C to stop it.
2022-09-30T08:45:30.537Z        ERROR   metrics/metrics.go:380  error getting cgroup stats: error fetching stats for controller io: error fetching IO stats: error fetching io.pressure for path /sys/fs/cgroup:: open /sys/fs/cgroup/io.pressure: no such file or directory
2022-09-30T08:45:30.537Z        INFO    [monitoring]    log/log.go:184  Non-zero metrics in the last 30s        {"monitoring": {"metrics": {"beat":{"cpu":{"system":{"ticks":110,"time":{"ms":113}},"total":{"ticks":170,"time":{"ms":178},"value":170},"user":{"ticks":60,"time":{"ms":65}}},"handles":{"limit":{"hard":1048576,"soft":1048576},"open":9},"info":{"ephemeral_id":"b67de36a-ce01-4ec3-bbec-31c90915f4a3","uptime":{"ms":30916},"version":"7.15.2"},"memstats":{"gc_next":10737440,"memory_alloc":5881536,"memory_sys":75580424,"memory_total":14122160,"rss":76820480},"runtime":{"goroutines":14}},"journalbeat":{"journals":{"journal_0":{"path":"LOCAL_SYSTEM_JOURNAL"}},"libbeat":{"output":{"type":"elasticsearch"},"pipeline":{"clients":1,"queue":{"max_events":4096}}},"system":{"cpu":{"cores":6},"load":{"1":14.49,"15":6.37,"5":9.44,"norm":{"1":2.415,"15":1.0617,"5":1.5733}}}}}}}
2022-09-30T08:46:00.724Z        ERROR   metrics/metrics.go:380  error getting cgroup stats: error fetching stats for controller io: error fetching IO stats: error fetching io.pressure for path /sys/fs/cgroup:: open /sys/fs/cgroup/io.pressure: no such file or directory
2022-09-30T08:46:00.815Z        INFO    [monitoring]    log/log.go:184  Non-zero metrics in the last 30s        {"monitoring": {"metrics": {"beat":{"cpu":{"system":{"ticks":120,"time":{"ms":20}},"total":{"ticks":190,"time":{"ms":28},"value":190},"user":{"ticks":70,"time":{"ms":8}}},"handles":{"limit":{"hard":1048576,"soft":1048576},"open":9},"info":{"ephemeral_id":"b67de36a-ce01-4ec3-bbec-31c90915f4a3","uptime":{"ms":60910},"version":"7.15.2"},"memstats":{"gc_next":10737440,"memory_alloc":6442704,"memory_total":14683328,"rss":77078528},"runtime":{"goroutines":14}},"libbeat":{"config":{"module":{"running":0}},"output":{"events":{"active":0},"type":"elasticsearch"},"pipeline":{"clients":1,"events":{"active":0},"queue":{"max_events":4096}}},"system":{"cpu":{"cores":6},"load":{"1":14.99,"15":6.68,"5":10.07,"norm":{"1":2.4983,"15":1.1133,"5":1.6783}}}}}}
2022-09-30T08:46:30.534Z        ERROR   metrics/metrics.go:380  error getting cgroup stats: error fetching stats for controller io: error fetching IO stats: error fetching io.pressure for path /sys/fs/cgroup:: open /sys/fs/cgroup/io.pressure: no such file or directory
[ ... no events are generated ...]
```

</details>