### PR TITLE
[E2E] Disable TestJournalbeatHostsRecipe on Kind (#6058)

### DIFF
--- a/test/e2e/beat/recipes_test.go
+++ b/test/e2e/beat/recipes_test.go
@@ -223,6 +223,12 @@ func TestPacketbeatDnsHttpRecipe(t *testing.T) {
 }
 
 func TestJournalbeatHostsRecipe(t *testing.T) {
+	if test.Ctx().Provider == "kind" {
+		// Journalbeat does not generate events on latest Kind node images.
+		// Since Journalbeat is no longer maintained and developed we skip this test on Kind.
+		t.SkipNow()
+	}
+
 	customize := func(builder beat.Builder) beat.Builder {
 		return builder
 	}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.5`:
 - [[E2E] Disable TestJournalbeatHostsRecipe on Kind (#6058)](https://github.com/elastic/cloud-on-k8s/pull/6058)