### PR TITLE
Add latest APM fleet package in Kibana examples when using standalone APM server.

### DIFF
--- a/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
+++ b/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
@@ -99,6 +99,10 @@ metadata:
 spec:
   version: 8.4.2
   count: 1
+  config:
+    xpack.fleet.packages:
+    - name: apm
+      version: latest
   elasticsearchRef:
     name: "elasticsearch-sample"
     namespace: "elasticsearch-ns"

--- a/config/recipes/traefik/02-elastic-stack.yaml
+++ b/config/recipes/traefik/02-elastic-stack.yaml
@@ -41,12 +41,12 @@ metadata:
   labels:
     app: hulk
 spec:
+  version: 8.4.2
+  count: 1
   config:
     xpack.fleet.packages:
     - name: apm
       version: latest
-  version: 8.4.2
-  count: 1
   elasticsearchRef:
     name: hulk
 ---

--- a/config/recipes/traefik/02-elastic-stack.yaml
+++ b/config/recipes/traefik/02-elastic-stack.yaml
@@ -41,6 +41,10 @@ metadata:
   labels:
     app: hulk
 spec:
+  config:
+    xpack.fleet.packages:
+    - name: apm
+      version: latest
   version: 8.4.2
   count: 1
   elasticsearchRef:


### PR DESCRIPTION
resolves #5059 

This change updates all of our standalone APM Server examples to include the latest APM fleet package in the Kibana resource.