### PR TITLE
Ensure Elasticsearch (7.x) api keys are enabled in agent+fleet e2e tests with TLS disabled

### DIFF
--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -20,14 +20,20 @@ import (
 func TestFleetAgentWithoutTLS(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
+	// Disabling TLS for fleet isn't supported before 7.16, as Elasticsearch doesn't allow
+	// api keys to be enabled when TLS is disabled.
+	if v.LT(version.MustParse("7.16.0")) {
+		t.SkipNow()
+	}
+
 	name := "test-fleet-agent-notls"
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithVersion(v.String()).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
 		WithTLSDisabled(true)
 
-	// API keys are not automatically enabled in versions < 8.0.0 when TLS is disabled.
-	if v.LT(version.MustParse("8.0.0")) {
+	// API keys are not automatically enabled in versions >= 7.16.0 and < 8.0.0 when TLS is disabled.
+	if v.LT(version.MustParse("8.0.0")) && v.GTE(version.MustParse("7.16.0")) {
 		esBuilder = esBuilder.WithAdditionalConfig(map[string]map[string]interface{}{
 			"masterdata": {
 				"xpack.security.authc.api_key.enabled": "true",

--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -20,7 +20,7 @@ import (
 func TestFleetAgentWithoutTLS(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
-	// Disabling TLS for fleet isn't supported before 7.16, as Elasticsearch doesn't allow
+	// Disabling TLS for Fleet isn't supported before 7.16, as Elasticsearch doesn't allow
 	// api keys to be enabled when TLS is disabled.
 	if v.LT(version.MustParse("7.16.0")) {
 		t.SkipNow()
@@ -32,7 +32,7 @@ func TestFleetAgentWithoutTLS(t *testing.T) {
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
 		WithTLSDisabled(true)
 
-	// API keys are not automatically enabled in versions >= 7.16.0 and < 8.0.0 when TLS is disabled.
+	// Elasticsearch API keys are not automatically enabled in versions >= 7.16.0 and < 8.0.0 when TLS is disabled.
 	if v.LT(version.MustParse("8.0.0")) && v.GTE(version.MustParse("7.16.0")) {
 		esBuilder = esBuilder.WithAdditionalConfig(map[string]map[string]interface{}{
 			"masterdata": {

--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -23,7 +23,12 @@ func TestFleetAgentWithoutTLS(t *testing.T) {
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithVersion(version).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		WithTLSDisabled(true)
+		WithTLSDisabled(true).
+		WithAdditionalConfig(map[string]map[string]interface{}{
+			"masterdata": {
+				"xpack.security.authc.api_key.enabled": "true",
+			},
+		})
 
 	kbBuilder := kibana.NewBuilder(name).
 		WithVersion(version).

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -356,6 +356,7 @@ func (b Builder) WithTLSDisabled(disabled bool) Builder {
 		b.Agent.Spec.HTTP.TLS.SelfSignedCertificate = b.Agent.Spec.HTTP.TLS.SelfSignedCertificate.DeepCopy()
 	}
 	b.Agent.Spec.HTTP.TLS.SelfSignedCertificate.Disabled = disabled
+	b.Agent.Spec.HTTP.TLS.Certificate.SecretName = ""
 	return b
 }
 

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -356,7 +356,6 @@ func (b Builder) WithTLSDisabled(disabled bool) Builder {
 		b.Agent.Spec.HTTP.TLS.SelfSignedCertificate = b.Agent.Spec.HTTP.TLS.SelfSignedCertificate.DeepCopy()
 	}
 	b.Agent.Spec.HTTP.TLS.SelfSignedCertificate.Disabled = disabled
-	b.Agent.Spec.HTTP.TLS.Certificate.SecretName = ""
 	return b
 }
 


### PR DESCRIPTION
[8.4 api keys docs](https://www.elastic.co/guide/en/elasticsearch/reference/8.4/security-api-create-api-key.html#security-api-create-api-key-desc)
[7.16 api keys docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/security-api-create-api-key.html#security-api-create-api-key-desc)

It appears that api keys are not automatically enabled in Elasticsearch in versions 7.x when TLS is disabled on the HTTP interface, but they are automatically enabled in 8.x, even when TLS is disabled.  This causes issues with Fleet integration, and causes the below Kibana exception during fleet setup:

```
{"type":"log","@timestamp":"2022-10-05T14:38:17+00:00","tags":["error","plugins","fleet"],"pid":7,"message":"Error: Impossible to create an api key: feature_not_enabled_exception: [feature_not_enabled_exception] Reason: api keys are not enabled\n    at /usr/share/kibana/x-pack/plugins/fleet/server/services/api_keys/enrollment_api_key.js:224:11\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at Object.generateEnrollmentAPIKey (/usr/share/kibana/x-pack/plugins/fleet/server/services/api_keys/enrollment_api_key.js:201:7)\n    at postEnrollmentApiKeyHandler (/usr/share/kibana/x-pack/plugins/fleet/server/routes/enrollment_api_key/handler.js:108:20)\n    at Router.handle (/usr/share/kibana/src/core/server/http/router/router.js:163:30)\n    at handler (/usr/share/kibana/src/core/server/http/router/router.js:124:50)\n    at exports.Manager.execute (/usr/share/kibana/node_modules/@hapi/hapi/lib/toolkit.js:60:28)\n    at Object.internals.handler (/usr/share/kibana/node_modules/@hapi/hapi/lib/handler.js:46:20)\n    at exports.execute (/usr/share/kibana/node_modules/@hapi/hapi/lib/handler.js:31:20)\n    at Request._lifecycle (/usr/share/kibana/node_modules/@hapi/hapi/lib/request.js:371:32)\n    at Request._execute (/usr/share/kibana/node_modules/@hapi/hapi/lib/request.js:281:9)"}
```

~~This does beg the question, how can we make this easier for the consumer of ECK?~~ After a discussion, we'll fix the e2e tests in this PR, and create an issue+pr for documentation updates, and some additional validation around this feature as this won't work at all in ES < 7.16.0, as you cannot enable api keys when TLS is disabled.