### PR TITLE
Enable FIPS compliancy in Makefile

### DIFF
--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -34,11 +34,21 @@ pipeline {
                         sh 'make -C .ci TARGET=ci ci'
                     }
                 }
-                stage('Build and push Docker image') {
-                    steps {
-                        sh '.ci/setenvconfig build'
-                        sh 'make -C .ci license.key TARGET=ci-release ci'
-                        sh 'make -C .ci license.key TARGET=build-operator-multiarch-image ci ENABLE_FIPS=true'
+                stage('build') {
+                    failFast true
+                    parallel {
+                        stage("build and push operator image") {
+                            steps {
+                                sh '.ci/setenvconfig build'
+                                sh 'make -C .ci license.key TARGET=ci-release ci'
+                            }
+                        }
+                        stage("build and push operator image in FIPS mode") {
+                            steps {
+                                sh '.ci/setenvconfig build'
+                                sh 'make -C .ci license.key TARGET=ci-release ci ENABLE_FIPS=true'
+                            }
+                        }
                     }
                 }
                 stage('Upload YAML manifest to S3') {

--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -38,6 +38,7 @@ pipeline {
                     steps {
                         sh '.ci/setenvconfig build'
                         sh 'make -C .ci license.key TARGET=ci-release ci'
+                        sh 'make -C .ci license.key TARGET=build-operator-multiarch-image ci ENABLE_FIPS=true'
                     }
                 }
                 stage('Upload YAML manifest to S3') {

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,17 @@ KUBECTL_CLUSTER := $(shell kubectl config current-context 2> /dev/null)
 # Default to debug logging
 LOG_VERBOSITY ?= 1
 
+# Allow FIPS compliance by means of BoringCrypto build tag.
+ENABLE_FIPS ?= false
+
+# From https://github.com/golang/go/blob/master/src/internal/goexperiment/flags.go#L17-L18
+#
+# Experiments are exposed to the build in the following ways:
+# - Build tag goexperiment.x is set if experiment x (lower case) is enabled.
+ifeq ($(ENABLE_FIPS),true)
+	GO_TAGS += goexperiment.boringcrypto
+endif
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 GOBIN := $(or $(shell go env GOBIN 2>/dev/null), $(shell go env GOPATH 2>/dev/null)/bin)
 
@@ -127,7 +138,7 @@ generate-notice-file:
 generate-image-dependencies:
 	@hack/licence-detector/generate-image-deps.sh
 
-elastic-operator: generate
+elastic-operator:
 	go build -mod=readonly -ldflags "$(GO_LDFLAGS)" -tags='$(GO_TAGS)' -o bin/elastic-operator github.com/elastic/cloud-on-k8s/v2/cmd
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,6 @@ LOG_VERBOSITY ?= 1
 # Allow FIPS compliance by means of BoringCrypto build tag.
 ENABLE_FIPS ?= false
 
-# From https://github.com/golang/go/blob/master/src/internal/goexperiment/flags.go#L17-L18
-#
-# Experiments are exposed to the build in the following ways:
-# - Build tag goexperiment.x is set if experiment x (lower case) is enabled.
-ifeq ($(ENABLE_FIPS),true)
-	GO_TAGS += goexperiment.boringcrypto
-endif
-
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 GOBIN := $(or $(shell go env GOBIN 2>/dev/null), $(shell go env GOPATH 2>/dev/null)/bin)
 
@@ -61,6 +53,20 @@ OPERATOR_IMAGE               ?= $(BASE_IMG):$(IMG_VERSION)
 OPERATOR_IMAGE_UBI           ?= $(BASE_IMG)-ubi8:$(IMG_VERSION)
 OPERATOR_DOCKERHUB_IMAGE     ?= docker.io/elastic/$(IMG_NAME):$(IMG_VERSION)
 OPERATOR_DOCKERHUB_IMAGE_UBI ?= docker.io/elastic/$(IMG_NAME)-ubi8:$(IMG_VERSION)
+
+# From https://github.com/golang/go/blob/master/src/internal/goexperiment/flags.go#L17-L18
+#
+# Experiments are exposed to the build in the following ways:
+# - Build tag goexperiment.x is set if experiment x (lower case) is enabled.
+#
+# Also, if fips is enabled, push fips versions of all builds to container registrys.
+ifeq ($(ENABLE_FIPS),true)
+	GO_TAGS += goexperiment.boringcrypto
+	OPERATOR_IMAGE               ?= $(BASE_IMG)-fips:$(IMG_VERSION)
+	OPERATOR_IMAGE_UBI           ?= $(BASE_IMG)-ubi8-fips:$(IMG_VERSION)
+	OPERATOR_DOCKERHUB_IMAGE     ?= docker.io/elastic/$(IMG_NAME)-fips:$(IMG_VERSION)
+	OPERATOR_DOCKERHUB_IMAGE_UBI ?= docker.io/elastic/$(IMG_NAME)-ubi8-fips:$(IMG_VERSION)	
+endif
 
 print-operator-image:
 	@ echo $(OPERATOR_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ generate-notice-file:
 generate-image-dependencies:
 	@hack/licence-detector/generate-image-deps.sh
 
-elastic-operator:
+elastic-operator: generate
 	go build -mod=readonly -ldflags "$(GO_LDFLAGS)" -tags='$(GO_TAGS)' -o bin/elastic-operator github.com/elastic/cloud-on-k8s/v2/cmd
 
 clean:


### PR DESCRIPTION
This potential change will enable FIPS compliancy for the operator build by making the changes:

1. Add an `ENABLE_FIPS` environment variable which will add a build flag `goexperiment.boringcrypto` to the existing `GO_TAGS` variable which we use during `go build` and `docker build` operations.
2. Append `-fips` to all container build names that we push to existing registries.
3. Adjusts the release pipeline in Jenkins to run another docker build operation with `ENABLE_FIPS=true` environment variable set. 

~~This change does *not*~~

~~1. Add any Jenkins/Buildkite changes that would allow FIPS these changes to be triggered in our current/future CI system.~~