### PR TITLE
[2.5][Autoscaling] Update documentation for the new resource (#6067)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/autoscaling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/autoscaling.asciidoc
@@ -10,8 +10,6 @@ endif::[]
 
 NOTE: Elasticsearch autoscaling requires a valid Enterprise license or Enterprise trial license. Check <<{p}-licensing,the license documentation>> for more details about managing licenses.
 
-experimental[]
-
 ECK can leverage the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-apis.html[autoscaling API] introduced in Elasticsearch 7.11 to adjust automatically the number of Pods and the allocated resources in a tier. Currently, autoscaling is supported for Elasticsearch link:https://www.elastic.co/guide/en/elasticsearch/reference/current/data-tiers.html[data tiers] and machine learning nodes.
 
 [float]
@@ -24,7 +22,7 @@ To enable autoscaling on an Elasticsearch cluster, you need to define one or mor
 [id="{p}-{page_id}-policies"]
 === Define autoscaling policies
 
-Autoscaling policies can be defined in the `elasticsearch.alpha.elastic.co/autoscaling-spec` annotation of the Elasticsearch resource. Each autoscaling policy must have the following fields:
+Autoscaling policies can be defined in an `ElasticsearchAutoscaler` resource. Each autoscaling policy must have the following fields:
 
 * `name` is a unique name used to identify the autoscaling policy.
 * `roles` contains a set of node roles, unique across all the autoscaling policies, used to identify the NodeSets to which this policy applies. At least one NodeSet with the exact same set of roles must exist in the Elasticsearch resource specification.
@@ -33,29 +31,49 @@ Autoscaling policies can be defined in the `elasticsearch.alpha.elastic.co/autos
 ** `cpu` and `memory` enforce minimum and maximum compute resources usage for the Elasticsearch container.
 ** `storage` enforces minimum and maximum storage request per PersistentVolumeClaim.
 
-[source,json]
+[source,yaml]
 ----
-{
-    "policies": [{
-      "name": "data-ingest",
-      "roles": ["data", "ingest" , "transform"],
-      "resources": {
-          "nodeCount": { "min": 3, "max": 8 },
-          "cpu": { "min": 2, "max": 8 },
-          "memory": { "min": "2Gi", "max": "16Gi" },
-          "storage": { "min": "64Gi", "max": "512Gi" }
-      }
-    },
-    {
-      "name": "ml",
-      "roles": ["ml"],
-      "resources": {
-          "nodeCount": { "min": 1, "max": 9 },
-          "cpu": { "min": 1, "max": 4 },
-          "memory": { "min": "2Gi", "max": "8Gi" }
-      }
-    }]
-}
+apiVersion: autoscaling.k8s.elastic.co/v1alpha1
+kind: ElasticsearchAutoscaler
+metadata:
+  name: autoscaling-sample
+spec:
+  ## The name of the Elasticsearch cluster to be scaled automatically.
+  elasticsearchRef:
+    name: elasticsearch-sample
+  ## The autoscaling policies.
+  policies:
+    - name: data-ingest
+      roles: ["data", "ingest" , "transform"]
+      resources:
+        nodeCount:
+          min: 3
+          max: 8
+        cpu:
+          min: 2
+          max: 8
+        memory:
+          min: 2Gi
+          max: 16Gi
+        storage:
+          min: 64Gi
+          max: 512Gi
+    - name: ml
+      roles:
+        - ml
+      resources:
+        nodeCount:
+          min: 1
+          max: 9
+        cpu:
+          min: 1
+          max: 4
+        memory:
+          min: 2Gi
+          max: 8Gi
+        storage:
+          min: 1Gi
+          max: 1Gi
 ----
 
 WARNING: A node role should not be referenced in more than one autoscaling policy.
@@ -76,20 +94,31 @@ If each individual node has reached the limits specified in the autoscaling poli
 
 WARNING: Scaling up (vertically) is only supported if the actual storage capacity of the persistent volumes matches the capacity claimed. If the physical capacity of a PersistentVolume may be greater than the capacity claimed in the PersistentVolumeClaim, it is advised to set the same value for the `min` and the `max` setting of each resource. It is however still possible to let the operator scale out the NodeSets automatically, as in the following example:
 
-[source,json]
+[source,yaml]
 ----
-{
-    "policies": [{
-      "name": "data-ingest",
-      "roles": ["data", "ingest" , "transform"],
-      "resources": {
-          "nodeCount": { "min": 3, "max": 9 },
-          "cpu": { "min": 4, "max": 4 },
-          "memory": { "min": "16Gi", "max": "16Gi" },
-          "storage": { "min": "512Gi", "max": "512Gi" }
-      }
-    }]
-}
+apiVersion: autoscaling.k8s.elastic.co/v1alpha1
+kind: ElasticsearchAutoscaler
+metadata:
+  name: autoscaling-sample
+spec:
+  elasticsearchRef:
+    name: elasticsearch-sample
+  policies:
+    - name: data-ingest
+      roles: ["data", "ingest" , "transform"]
+      resources:
+        nodeCount:
+          min: 3
+          max: 9
+        cpu:
+          min: 4
+          max: 4
+        memory:
+          min: 16Gi
+          max: 16Gi
+        storage:
+          min: 512Gi
+          max: 512Gi
 ----
 
 
@@ -97,34 +126,36 @@ WARNING: Scaling up (vertically) is only supported if the actual storage capacit
 [id="{p}-{page_id}-resources"]
 === Set the limits
 
-The value set for memory and CPU limits are computed by applying a ratio to the calculated resource request. For memory, the default ratio between the request and the limit is 1. This means that request and limit have the same value. For CPU the default ratio is 0, which means that no limit is set. You can change the default ratio between the request and the limit for both the CPU and memory ranges by using the `requestsToLimitsRatio` field.
+The value set for memory and CPU limits are computed by applying a ratio to the calculated resource request. The default ratio between the request and the limit for both CPU and memory is 1. This means that request and limit have the same value. You can change the default ratio between the request and the limit for both the CPU and memory ranges by using the `requestsToLimitsRatio` field.
 
-For example, you can remove the memory limit and set a CPU limit to twice the value of the request, as follows:
+For example, you can set a CPU limit to twice the value of the request, as follows:
 
-[source,json]
+[source,yaml]
 ----
-{
-    "policies": [{
-        "name": "data-ingest-hot",
-        "roles": ["data_hot", "ingest", "transform"],
-        "resources": {
-            "nodeCount": {
-                "min": 2,
-                "max": 5
-            },
-            "cpu": {
-                "min": 1,
-                "max": 2,
-                "requestsToLimitsRatio": 2
-            },
-            "memory": {
-                "min": "2Gi",
-                "max": "6Gi",
-                "requestsToLimitsRatio": 0
-            }
-        }
-    }]
-}
+apiVersion: autoscaling.k8s.elastic.co/v1alpha1
+kind: ElasticsearchAutoscaler
+metadata:
+  name: autoscaling-sample
+spec:
+  elasticsearchRef:
+    name: elasticsearch-sample
+  policies:
+    - name: data-ingest
+      roles: ["data", "ingest" , "transform"]
+      resources:
+        nodeCount:
+          min: 2
+          max: 5
+        cpu:
+          min: 1
+          max: 2
+          requestsToLimitsRatio: 2
+        memory:
+          min: 2Gi
+          max: 6Gi
+        storage:
+          min: 512Gi
+          max: 512Gi
 ----
 
 You can find link:{eck_github}/blob/{eck_release_branch}/config/recipes/autoscaling/elasticsearch.yaml[a complete example in the ECK GitHub repository] which will also show you how to fine-tune the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-deciders.html[autoscaling deciders].
@@ -135,69 +166,120 @@ You can find link:{eck_github}/blob/{eck_release_branch}/config/recipes/autoscal
 
 The Elasticsearch autoscaling capacity endpoint is polled every minute by the operator. This interval duration can be controlled using the `pollingPeriod` field in the autoscaling specification:
 
-[source,json]
+[source,yaml]
 ----
-{
-    "pollingPeriod": "42s",
-    "policies": [{
-        "name": "data-ingest-hot",
-        "roles": ["data_hot", "ingest", "transform"],
-        "resources": {
-            "nodeCount": {
-                "min": 2,
-                "max": 5
-            },
-            "cpu": {
-                "min": 1,
-                "max": 2
-            },
-            "memory": {
-                "min": "2Gi",
-                "max": "6Gi"
-            }
-        }
-    }]
-}
+apiVersion: autoscaling.k8s.elastic.co/v1alpha1
+kind: ElasticsearchAutoscaler
+metadata:
+  name: autoscaling-sample
+spec:
+  pollingPeriod: "42s"
+  elasticsearchRef:
+    name: elasticsearch-sample
+  policies:
+    - name: data-ingest
+      roles: ["data", "ingest" , "transform"]
+      resources:
+        nodeCount:
+          min: 2
+          max: 5
+        cpu:
+          min: 1
+          max: 2
+        memory:
+          min: 2Gi
+          max: 6Gi
+        storage:
+          min: 512Gi
+          max: 512Gi
 ----
 
 [float]
 [id="{p}-monitoring"]
 == Monitoring
 
-In addition to the logs generated by the operator, an autoscaling status is stored in the `elasticsearch.alpha.elastic.co/autoscaling-status` annotation. The autoscaling status is a JSON document which describes the expected resources for each NodeSet managed by an autoscaling policy. It may also contain important messages about the state of the tier.
+[float]
+[id="{p}-{page_id}-status"]
+=== Autoscaling status
+
+In addition to the logs generated by the operator, an autoscaling status is maintained in the `ElasticsearchAutoscaler` resource. This status holds several `Conditions` to summarize the health and the status of the autoscaling mechanism. For example, dedicated `Conditions` may report if the controller cannot connect to the Elasticsearch cluster, or if a resource limit has been reached:
+
+[source,sh,subs="attributes,+macros"]
+----
+kubectl get elasticsearchautoscaler autoscaling-sample \
+    -o jsonpath='{ .status.conditions }' | jq
+----
 
 [source,json]
 ----
-{
-	"policies": [
-		{
-			"name": "data-ingest-hot",
-			"nodeSets": [{
-				"name": "data-ingest-hot",
-				"nodeCount": 5
-			}],
-			"resources": {
-				"limits": {
-					"cpu": "2",
-					"memory": "6Gi"
-				},
-				"requests": {
-					"cpu": "2",
-					"memory": "6Gi",
-					"storage": "6Gi"
-				}
-			},
-			"state": [{
-				"type": "HorizontalScalingLimitReached",
-				"messages": [
-					"Can't provide total required storage 32588740338, max number of nodes is 5, requires 6 nodes"
-				]
-			}],
-			"lastModificationTime": "2021-03-09T17:01:25Z"
-		}
-	]
-}
+[
+ {
+   "lastTransitionTime": "2022-09-09T08:07:10Z",
+   "message": "Limit reached for policies data-ingest",
+   "status": "True",
+   "type": "Limited"
+ },
+  {
+   "lastTransitionTime": "2022-09-09T07:55:08Z",
+   "status": "True",
+   "type": "Active"
+ },
+ {
+   "lastTransitionTime": "2022-09-09T08:07:10Z",
+   "status": "True",
+   "type": "Healthy"
+ },
+ {
+   "lastTransitionTime": "2022-09-09T07:56:22Z",
+   "message": "Elasticsearch is available",
+   "status": "True",
+   "type": "Online"
+ }
+]
 ----
+
+[float]
+[id="{p}-{page_id}-expected-resources"]
+=== Expected resources
+
+The autoscaler status also contains a `policies` section which describes the expected resources for each NodeSet managed by an autoscaling policy.
+
+[source,sh,subs="attributes,+macros"]
+----
+kubectl get elasticsearchautoscaler.autoscaling.k8s.elastic.co/autoscaling-sample \
+    -o jsonpath='{ .status.policies }' | jq
+----
+
+[source,json]
+----
+[
+  {
+    "lastModificationTime": "2022-10-05T05:47:13Z",
+    "name": "data-ingest",
+    "nodeSets": [
+      {
+        "name": "nodeset-1",
+        "nodeCount": 2
+      }
+    ],
+    "resources": {
+      "limits": {
+        "cpu": "1",
+        "memory": "2Gi"
+      },
+      "requests": {
+        "cpu": "500m",
+        "memory": "2Gi",
+        "storage": "1Gi"
+      }
+    }
+  }
+]
+----
+
+[float]
+[id="{p}-events"]
+=== Events
 
 Important events are also reported through Kubernetes events, for example when the maximum autoscaling size limit is reached:
 
@@ -212,9 +294,7 @@ Important events are also reported through Kubernetes events, for example when t
 [id="{p}-disable"]
 == Disable autoscaling
 
-You can disable autoscaling at any time by removing the `elasticsearch.alpha.elastic.co/autoscaling-spec` annotation from the Elasticsearch resource metadata.
-
-For machine learning the following settings are not automatically reset:
+You can disable autoscaling at any time by deleting the `ElasticsearchAutoscaler` resource. For machine learning the following settings are not automatically reset:
 
 - `xpack.ml.max_ml_node_size`
 - `xpack.ml.max_lazy_ml_nodes`


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.5`:
 - [[Autoscaling] Update documentation for the new resource (#6067)](https://github.com/elastic/cloud-on-k8s/pull/6067)