### PR TITLE
Run tests in AKS with k8s 1.24.6

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -45,7 +45,7 @@ plans:
   operation: create
   clusterName: ci
   provider: aks
-  kubernetesVersion: 1.22.6
+  kubernetesVersion: 1.24.6
   machineType: Standard_D8s_v3
   serviceAccount: true
   enforceSecurityPolicies: true
@@ -58,7 +58,7 @@ plans:
   operation: create
   clusterName: dev
   provider: aks
-  kubernetesVersion: 1.22.6
+  kubernetesVersion: 1.24.6
   machineType: Standard_D8s_v3
   serviceAccount: false
   enforceSecurityPolicies: true


### PR DESCRIPTION
The version we used up to now is no longer available. This bumps versions to the latest available. 