### PR TITLE
Add password hash (cached) generator

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1287,6 +1287,378 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
 
 
 --------------------------------------------------------------------------------
+Module  : github.com/hashicorp/golang-lru
+Version : v0.5.4
+Time    : 2020-01-16T18:29:26Z
+Licence : MPL-2.0
+
+Contents of probable licence file $GOMODCACHE/github.com/hashicorp/golang-lru@v0.5.4/LICENSE:
+
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. "Contributor"
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+     means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the terms of
+        a Secondary License.
+
+1.6. "Executable Form"
+
+     means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+     means a work that combines Covered Software with other material, in a
+     separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+     means this document.
+
+1.9. "Licensable"
+
+     means having the right to grant, to the maximum extent possible, whether
+     at the time of the initial grant or subsequently, any and all of the
+     rights conveyed by this License.
+
+1.10. "Modifications"
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor
+
+      means any patent claim(s), including without limitation, method,
+      process, and apparatus claims, in any patent Licensable by such
+      Contributor that would be infringed, but for the grant of the License,
+      by the making, using, selling, offering for sale, having made, import,
+      or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+
+      means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, "You" includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, "control" means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution
+     become effective for each Contribution on the date the Contributor first
+     distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under
+     this License. No additional rights or licenses will be implied from the
+     distribution or licensing of Covered Software under this License.
+     Notwithstanding Section 2.1(b) above, no patent license is granted by a
+     Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party's
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+     This License does not grant any rights in the trademarks, service marks,
+     or logos of any Contributor (except as may be necessary to comply with
+     the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this
+     License (see Section 10.2) or under the terms of a Secondary License (if
+     permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its
+     Contributions are its original creation(s) or it has sufficient rights to
+     grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under
+     applicable copyright doctrines of fair use, fair dealing, or other
+     equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under
+     the terms of this License. You must inform recipients that the Source
+     Code Form of the Covered Software is governed by the terms of this
+     License, and how they can obtain a copy of this License. You may not
+     attempt to alter or restrict the recipients' rights in the Source Code
+     Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter the
+        recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for
+     the Covered Software. If the Larger Work is a combination of Covered
+     Software with a work governed by one or more Secondary Licenses, and the
+     Covered Software is not Incompatible With Secondary Licenses, this
+     License permits You to additionally distribute such Covered Software
+     under the terms of such Secondary License(s), so that the recipient of
+     the Larger Work may, at their option, further distribute the Covered
+     Software under the terms of either this License or such Secondary
+     License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices
+     (including copyright notices, patent notices, disclaimers of warranty, or
+     limitations of liability) contained within the Source Code Form of the
+     Covered Software, except that You may alter any license notices to the
+     extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on
+     behalf of any Contributor. You must make it absolutely clear that any
+     such warranty, support, indemnity, or liability obligation is offered by
+     You alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute,
+   judicial order, or regulation then You must: (a) comply with the terms of
+   this License to the maximum extent possible; and (b) describe the
+   limitations and the code they affect. Such description must be placed in a
+   text file included with all distributions of the Covered Software under
+   this License. Except to the extent prohibited by statute or regulation,
+   such description must be sufficiently detailed for a recipient of ordinary
+   skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing
+     basis, if such Contributor fails to notify You of the non-compliance by
+     some reasonable means prior to 60 days after You have come back into
+     compliance. Moreover, Your grants from a particular Contributor are
+     reinstated on an ongoing basis if such Contributor notifies You of the
+     non-compliance by some reasonable means, this is the first time You have
+     received notice of non-compliance with this License from such
+     Contributor, and You become compliant prior to 30 days after Your receipt
+     of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions,
+     counter-claims, and cross-claims) alleging that a Contributor Version
+     directly or indirectly infringes any patent, then the rights granted to
+     You by any and all Contributors for the Covered Software under Section
+     2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an "as is" basis,
+   without warranty of any kind, either expressed, implied, or statutory,
+   including, without limitation, warranties that the Covered Software is free
+   of defects, merchantable, fit for a particular purpose or non-infringing.
+   The entire risk as to the quality and performance of the Covered Software
+   is with You. Should any Covered Software prove defective in any respect,
+   You (not any Contributor) assume the cost of any necessary servicing,
+   repair, or correction. This disclaimer of warranty constitutes an essential
+   part of this License. No use of  any Covered Software is authorized under
+   this License except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from
+   such party's negligence to the extent applicable law prohibits such
+   limitation. Some jurisdictions do not allow the exclusion or limitation of
+   incidental or consequential damages, so this exclusion and limitation may
+   not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts
+   of a jurisdiction where the defendant maintains its principal place of
+   business and such litigation shall be governed by laws of that
+   jurisdiction, without reference to its conflict-of-law provisions. Nothing
+   in this Section shall prevent a party's ability to bring cross-claims or
+   counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject
+   matter hereof. If any provision of this License is held to be
+   unenforceable, such provision shall be reformed only to the extent
+   necessary to make it enforceable. Any law or regulation which provides that
+   the language of a contract shall be construed against the drafter shall not
+   be used to construe this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version
+      of the License under which You originally received the Covered Software,
+      or under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a
+      modified version of this License if you rename the license and remove
+      any references to the name of the license steward (except to note that
+      such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+      Licenses If You choose to distribute Source Code Form that is
+      Incompatible With Secondary Licenses under the terms of this version of
+      the License, the notice described in Exhibit B of this License must be
+      attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+      This Source Code Form is "Incompatible
+      With Secondary Licenses", as defined by
+      the Mozilla Public License, v. 2.0.
+
+
+--------------------------------------------------------------------------------
 Module  : github.com/hashicorp/vault/api
 Version : v1.8.0
 Time    : 2022-09-20T14:11:29Z
@@ -13901,378 +14273,6 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
       With Secondary Licenses”, as defined by
       the Mozilla Public License, v. 2.0.
 
-
-
---------------------------------------------------------------------------------
-Module  : github.com/hashicorp/golang-lru
-Version : v0.5.4
-Time    : 2020-01-16T18:29:26Z
-Licence : MPL-2.0
-
-Contents of probable licence file $GOMODCACHE/github.com/hashicorp/golang-lru@v0.5.4/LICENSE:
-
-Mozilla Public License, version 2.0
-
-1. Definitions
-
-1.1. "Contributor"
-
-     means each individual or legal entity that creates, contributes to the
-     creation of, or owns Covered Software.
-
-1.2. "Contributor Version"
-
-     means the combination of the Contributions of others (if any) used by a
-     Contributor and that particular Contributor's Contribution.
-
-1.3. "Contribution"
-
-     means Covered Software of a particular Contributor.
-
-1.4. "Covered Software"
-
-     means Source Code Form to which the initial Contributor has attached the
-     notice in Exhibit A, the Executable Form of such Source Code Form, and
-     Modifications of such Source Code Form, in each case including portions
-     thereof.
-
-1.5. "Incompatible With Secondary Licenses"
-     means
-
-     a. that the initial Contributor has attached the notice described in
-        Exhibit B to the Covered Software; or
-
-     b. that the Covered Software was made available under the terms of
-        version 1.1 or earlier of the License, but not also under the terms of
-        a Secondary License.
-
-1.6. "Executable Form"
-
-     means any form of the work other than Source Code Form.
-
-1.7. "Larger Work"
-
-     means a work that combines Covered Software with other material, in a
-     separate file or files, that is not Covered Software.
-
-1.8. "License"
-
-     means this document.
-
-1.9. "Licensable"
-
-     means having the right to grant, to the maximum extent possible, whether
-     at the time of the initial grant or subsequently, any and all of the
-     rights conveyed by this License.
-
-1.10. "Modifications"
-
-     means any of the following:
-
-     a. any file in Source Code Form that results from an addition to,
-        deletion from, or modification of the contents of Covered Software; or
-
-     b. any new file in Source Code Form that contains any Covered Software.
-
-1.11. "Patent Claims" of a Contributor
-
-      means any patent claim(s), including without limitation, method,
-      process, and apparatus claims, in any patent Licensable by such
-      Contributor that would be infringed, but for the grant of the License,
-      by the making, using, selling, offering for sale, having made, import,
-      or transfer of either its Contributions or its Contributor Version.
-
-1.12. "Secondary License"
-
-      means either the GNU General Public License, Version 2.0, the GNU Lesser
-      General Public License, Version 2.1, the GNU Affero General Public
-      License, Version 3.0, or any later versions of those licenses.
-
-1.13. "Source Code Form"
-
-      means the form of the work preferred for making modifications.
-
-1.14. "You" (or "Your")
-
-      means an individual or a legal entity exercising rights under this
-      License. For legal entities, "You" includes any entity that controls, is
-      controlled by, or is under common control with You. For purposes of this
-      definition, "control" means (a) the power, direct or indirect, to cause
-      the direction or management of such entity, whether by contract or
-      otherwise, or (b) ownership of more than fifty percent (50%) of the
-      outstanding shares or beneficial ownership of such entity.
-
-
-2. License Grants and Conditions
-
-2.1. Grants
-
-     Each Contributor hereby grants You a world-wide, royalty-free,
-     non-exclusive license:
-
-     a. under intellectual property rights (other than patent or trademark)
-        Licensable by such Contributor to use, reproduce, make available,
-        modify, display, perform, distribute, and otherwise exploit its
-        Contributions, either on an unmodified basis, with Modifications, or
-        as part of a Larger Work; and
-
-     b. under Patent Claims of such Contributor to make, use, sell, offer for
-        sale, have made, import, and otherwise transfer either its
-        Contributions or its Contributor Version.
-
-2.2. Effective Date
-
-     The licenses granted in Section 2.1 with respect to any Contribution
-     become effective for each Contribution on the date the Contributor first
-     distributes such Contribution.
-
-2.3. Limitations on Grant Scope
-
-     The licenses granted in this Section 2 are the only rights granted under
-     this License. No additional rights or licenses will be implied from the
-     distribution or licensing of Covered Software under this License.
-     Notwithstanding Section 2.1(b) above, no patent license is granted by a
-     Contributor:
-
-     a. for any code that a Contributor has removed from Covered Software; or
-
-     b. for infringements caused by: (i) Your and any other third party's
-        modifications of Covered Software, or (ii) the combination of its
-        Contributions with other software (except as part of its Contributor
-        Version); or
-
-     c. under Patent Claims infringed by Covered Software in the absence of
-        its Contributions.
-
-     This License does not grant any rights in the trademarks, service marks,
-     or logos of any Contributor (except as may be necessary to comply with
-     the notice requirements in Section 3.4).
-
-2.4. Subsequent Licenses
-
-     No Contributor makes additional grants as a result of Your choice to
-     distribute the Covered Software under a subsequent version of this
-     License (see Section 10.2) or under the terms of a Secondary License (if
-     permitted under the terms of Section 3.3).
-
-2.5. Representation
-
-     Each Contributor represents that the Contributor believes its
-     Contributions are its original creation(s) or it has sufficient rights to
-     grant the rights to its Contributions conveyed by this License.
-
-2.6. Fair Use
-
-     This License is not intended to limit any rights You have under
-     applicable copyright doctrines of fair use, fair dealing, or other
-     equivalents.
-
-2.7. Conditions
-
-     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
-     Section 2.1.
-
-
-3. Responsibilities
-
-3.1. Distribution of Source Form
-
-     All distribution of Covered Software in Source Code Form, including any
-     Modifications that You create or to which You contribute, must be under
-     the terms of this License. You must inform recipients that the Source
-     Code Form of the Covered Software is governed by the terms of this
-     License, and how they can obtain a copy of this License. You may not
-     attempt to alter or restrict the recipients' rights in the Source Code
-     Form.
-
-3.2. Distribution of Executable Form
-
-     If You distribute Covered Software in Executable Form then:
-
-     a. such Covered Software must also be made available in Source Code Form,
-        as described in Section 3.1, and You must inform recipients of the
-        Executable Form how they can obtain a copy of such Source Code Form by
-        reasonable means in a timely manner, at a charge no more than the cost
-        of distribution to the recipient; and
-
-     b. You may distribute such Executable Form under the terms of this
-        License, or sublicense it under different terms, provided that the
-        license for the Executable Form does not attempt to limit or alter the
-        recipients' rights in the Source Code Form under this License.
-
-3.3. Distribution of a Larger Work
-
-     You may create and distribute a Larger Work under terms of Your choice,
-     provided that You also comply with the requirements of this License for
-     the Covered Software. If the Larger Work is a combination of Covered
-     Software with a work governed by one or more Secondary Licenses, and the
-     Covered Software is not Incompatible With Secondary Licenses, this
-     License permits You to additionally distribute such Covered Software
-     under the terms of such Secondary License(s), so that the recipient of
-     the Larger Work may, at their option, further distribute the Covered
-     Software under the terms of either this License or such Secondary
-     License(s).
-
-3.4. Notices
-
-     You may not remove or alter the substance of any license notices
-     (including copyright notices, patent notices, disclaimers of warranty, or
-     limitations of liability) contained within the Source Code Form of the
-     Covered Software, except that You may alter any license notices to the
-     extent required to remedy known factual inaccuracies.
-
-3.5. Application of Additional Terms
-
-     You may choose to offer, and to charge a fee for, warranty, support,
-     indemnity or liability obligations to one or more recipients of Covered
-     Software. However, You may do so only on Your own behalf, and not on
-     behalf of any Contributor. You must make it absolutely clear that any
-     such warranty, support, indemnity, or liability obligation is offered by
-     You alone, and You hereby agree to indemnify every Contributor for any
-     liability incurred by such Contributor as a result of warranty, support,
-     indemnity or liability terms You offer. You may include additional
-     disclaimers of warranty and limitations of liability specific to any
-     jurisdiction.
-
-4. Inability to Comply Due to Statute or Regulation
-
-   If it is impossible for You to comply with any of the terms of this License
-   with respect to some or all of the Covered Software due to statute,
-   judicial order, or regulation then You must: (a) comply with the terms of
-   this License to the maximum extent possible; and (b) describe the
-   limitations and the code they affect. Such description must be placed in a
-   text file included with all distributions of the Covered Software under
-   this License. Except to the extent prohibited by statute or regulation,
-   such description must be sufficiently detailed for a recipient of ordinary
-   skill to be able to understand it.
-
-5. Termination
-
-5.1. The rights granted under this License will terminate automatically if You
-     fail to comply with any of its terms. However, if You become compliant,
-     then the rights granted under this License from a particular Contributor
-     are reinstated (a) provisionally, unless and until such Contributor
-     explicitly and finally terminates Your grants, and (b) on an ongoing
-     basis, if such Contributor fails to notify You of the non-compliance by
-     some reasonable means prior to 60 days after You have come back into
-     compliance. Moreover, Your grants from a particular Contributor are
-     reinstated on an ongoing basis if such Contributor notifies You of the
-     non-compliance by some reasonable means, this is the first time You have
-     received notice of non-compliance with this License from such
-     Contributor, and You become compliant prior to 30 days after Your receipt
-     of the notice.
-
-5.2. If You initiate litigation against any entity by asserting a patent
-     infringement claim (excluding declaratory judgment actions,
-     counter-claims, and cross-claims) alleging that a Contributor Version
-     directly or indirectly infringes any patent, then the rights granted to
-     You by any and all Contributors for the Covered Software under Section
-     2.1 of this License shall terminate.
-
-5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
-     license agreements (excluding distributors and resellers) which have been
-     validly granted by You or Your distributors under this License prior to
-     termination shall survive termination.
-
-6. Disclaimer of Warranty
-
-   Covered Software is provided under this License on an "as is" basis,
-   without warranty of any kind, either expressed, implied, or statutory,
-   including, without limitation, warranties that the Covered Software is free
-   of defects, merchantable, fit for a particular purpose or non-infringing.
-   The entire risk as to the quality and performance of the Covered Software
-   is with You. Should any Covered Software prove defective in any respect,
-   You (not any Contributor) assume the cost of any necessary servicing,
-   repair, or correction. This disclaimer of warranty constitutes an essential
-   part of this License. No use of  any Covered Software is authorized under
-   this License except under this disclaimer.
-
-7. Limitation of Liability
-
-   Under no circumstances and under no legal theory, whether tort (including
-   negligence), contract, or otherwise, shall any Contributor, or anyone who
-   distributes Covered Software as permitted above, be liable to You for any
-   direct, indirect, special, incidental, or consequential damages of any
-   character including, without limitation, damages for lost profits, loss of
-   goodwill, work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses, even if such party shall have been
-   informed of the possibility of such damages. This limitation of liability
-   shall not apply to liability for death or personal injury resulting from
-   such party's negligence to the extent applicable law prohibits such
-   limitation. Some jurisdictions do not allow the exclusion or limitation of
-   incidental or consequential damages, so this exclusion and limitation may
-   not apply to You.
-
-8. Litigation
-
-   Any litigation relating to this License may be brought only in the courts
-   of a jurisdiction where the defendant maintains its principal place of
-   business and such litigation shall be governed by laws of that
-   jurisdiction, without reference to its conflict-of-law provisions. Nothing
-   in this Section shall prevent a party's ability to bring cross-claims or
-   counter-claims.
-
-9. Miscellaneous
-
-   This License represents the complete agreement concerning the subject
-   matter hereof. If any provision of this License is held to be
-   unenforceable, such provision shall be reformed only to the extent
-   necessary to make it enforceable. Any law or regulation which provides that
-   the language of a contract shall be construed against the drafter shall not
-   be used to construe this License against a Contributor.
-
-
-10. Versions of the License
-
-10.1. New Versions
-
-      Mozilla Foundation is the license steward. Except as provided in Section
-      10.3, no one other than the license steward has the right to modify or
-      publish new versions of this License. Each version will be given a
-      distinguishing version number.
-
-10.2. Effect of New Versions
-
-      You may distribute the Covered Software under the terms of the version
-      of the License under which You originally received the Covered Software,
-      or under the terms of any subsequent version published by the license
-      steward.
-
-10.3. Modified Versions
-
-      If you create software not governed by this License, and you want to
-      create a new license for such software, you may create and use a
-      modified version of this License if you rename the license and remove
-      any references to the name of the license steward (except to note that
-      such modified license differs from this License).
-
-10.4. Distributing Source Code Form that is Incompatible With Secondary
-      Licenses If You choose to distribute Source Code Form that is
-      Incompatible With Secondary Licenses under the terms of this version of
-      the License, the notice described in Exhibit B of this License must be
-      attached.
-
-Exhibit A - Source Code Form License Notice
-
-      This Source Code Form is subject to the
-      terms of the Mozilla Public License, v.
-      2.0. If a copy of the MPL was not
-      distributed with this file, You can
-      obtain one at
-      http://mozilla.org/MPL/2.0/.
-
-If it is not possible or desirable to put the notice in a particular file,
-then You may include the notice in a location (such as a LICENSE file in a
-relevant directory) where a recipient would be likely to look for such a
-notice.
-
-You may add additional accurate notices of copyright ownership.
-
-Exhibit B - "Incompatible With Secondary Licenses" Notice
-
-      This Source Code Form is "Incompatible
-      With Secondary Licenses", as defined by
-      the Mozilla Public License, v. 2.0.
 
 
 --------------------------------------------------------------------------------

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -237,7 +237,7 @@ func Command() *cobra.Command {
 		operator.PasswordHashCacheSize,
 		0,
 		fmt.Sprintf(
-			"Sets the size of the password hash cache. Default size is inferred from %s. Caching is disabled if explicitly set to 0 or any negative value",
+			"Sets the size of the password hash cache. Default size is inferred from %s. Caching is disabled if explicitly set to 0 or any negative value.",
 			operator.MaxConcurrentReconcilesFlag,
 		),
 	)

--- a/deploy/eck-operator/templates/configmap.yaml
+++ b/deploy/eck-operator/templates/configmap.yaml
@@ -12,6 +12,9 @@ data:
     metrics-port: {{ int .Values.config.metricsPort }}
     container-registry: {{ .Values.config.containerRegistry }}
     max-concurrent-reconciles: {{ int .Values.config.maxConcurrentReconciles }}
+    {{- if .Values.config.passwordHashCacheSize }}
+    password-hash-cache-size: {{ int .Values.config.passwordHashCacheSize }}
+    {{- end }}
     ca-cert-validity: {{ .Values.config.caValidity }}
     ca-cert-rotate-before: {{ .Values.config.caRotateBefore }}
     cert-validity: {{ .Values.config.certificatesValidity }}

--- a/docs/operating-eck/operator-config.asciidoc
+++ b/docs/operating-eck/operator-config.asciidoc
@@ -36,6 +36,7 @@ ECK can be configured using either command line flags or environment variables.
 |metrics-port |0 |Prometheus metrics port. Set to 0 to disable the metrics endpoint.
 |namespaces |"" |Namespaces in which this operator should manage resources. Accepts multiple comma-separated values. Defaults to all namespaces if empty or unspecified.
 |operator-namespace |"" |Namespace the operator runs in. Required.
+|password-hash-cache-size|5 x max-concurrent-reconciles|Sets the size of the password hash cache. Caching is disabled if explicitly set to 0 or any negative value.
 |set-default-security-context |true | Enables adding a default Pod Security Context to Elasticsearch Pods in Elasticsearch `8.0.0` and later. `fsGroup` is set to `1000` by default to match Elasticsearch container default UID. This behavior might not be appropriate for OpenShift and PSP-secured Kubernetes clusters, so it can be disabled.
 |ubi-only | false | Use only UBI container images to deploy Elastic Stack applications. UBI images are only available from 7.10.0 onward.
 |validate-storage-class | true | Specifies whether the operator should retrieve storage classes to verify volume expansion support. Can be disabled if cluster-wide storage class RBAC access is not available.

--- a/docs/reference/dependencies.asciidoc
+++ b/docs/reference/dependencies.asciidoc
@@ -31,6 +31,7 @@ This page lists the third-party dependencies used to build {n}.
 | link:https://github.com/google/go-containerregistry[$$github.com/google/go-containerregistry$$] | v0.11.0 | Apache-2.0
 | link:https://github.com/google/uuid[$$github.com/google/uuid$$] | v1.3.0 | BSD-3-Clause
 | link:https://github.com/hashicorp/go-multierror[$$github.com/hashicorp/go-multierror$$] | v1.1.1 | MPL-2.0
+| link:https://github.com/hashicorp/golang-lru[$$github.com/hashicorp/golang-lru$$] | v0.5.4 | MPL-2.0
 | link:https://github.com/hashicorp/vault[$$github.com/hashicorp/vault/api$$] | v1.8.0 | MPL-2.0
 | link:https://github.com/imdario/mergo[$$github.com/imdario/mergo$$] | v0.3.13 | BSD-3-Clause
 | link:https://github.com/magiconair/properties[$$github.com/magiconair/properties$$] | v1.8.6 | BSD-2-Clause
@@ -125,7 +126,6 @@ This page lists the third-party dependencies used to build {n}.
 | link:https://github.com/hashicorp/go-sockaddr[$$github.com/hashicorp/go-sockaddr$$] | v1.0.2 | MPL-2.0
 | link:https://github.com/hashicorp/go-uuid[$$github.com/hashicorp/go-uuid$$] | v1.0.2 | MPL-2.0
 | link:https://github.com/hashicorp/go-version[$$github.com/hashicorp/go-version$$] | v1.2.0 | MPL-2.0
-| link:https://github.com/hashicorp/golang-lru[$$github.com/hashicorp/golang-lru$$] | v0.5.4 | MPL-2.0
 | link:https://github.com/hashicorp/hcl[$$github.com/hashicorp/hcl$$] | v1.0.0 | MPL-2.0
 | link:https://github.com/hashicorp/vault[$$github.com/hashicorp/vault/sdk$$] | v0.6.0 | MPL-2.0
 | link:https://github.com/hashicorp/yamux[$$github.com/hashicorp/yamux$$] | v0.0.0-20180604194846-3520598351bb | MPL-2.0

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/go-containerregistry v0.11.0
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hashicorp/vault/api v1.8.0
 	github.com/imdario/mergo v0.3.13
 	github.com/magiconair/properties v1.8.6
@@ -94,7 +95,6 @@ require (
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/hashicorp/go-version v1.2.0 // indirect
-	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/vault/sdk v0.6.0 // indirect
 	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect

--- a/pkg/controller/common/operator/flags.go
+++ b/pkg/controller/common/operator/flags.go
@@ -24,6 +24,7 @@ const (
 	EnableWebhookFlag                    = "enable-webhook"
 	EnforceRBACOnRefsFlag                = "enforce-rbac-on-refs"
 	ExposedNodeLabels                    = "exposed-node-labels"
+	PasswordHashCacheSize                = "password-hash-cache-size"
 	IPFamilyFlag                         = "ip-family"
 	KubeClientTimeout                    = "kube-client-timeout"
 	ManageWebhookCertsFlag               = "manage-webhook-certs"

--- a/pkg/controller/common/operator/parameters.go
+++ b/pkg/controller/common/operator/parameters.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/about"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/certificates"
 	esvalidation "github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/validation"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/cryptutil"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/net"
 )
 
@@ -28,6 +29,8 @@ type Parameters struct {
 	OperatorInfo about.OperatorInfo
 	// Dialer is used to create the Elasticsearch HTTP client.
 	Dialer net.Dialer
+	// PasswordHasher is the password hash generator used by the operator.
+	PasswordHasher cryptutil.PasswordHasher
 	// IPFamily represents the IP family to use when creating configuration and services.
 	IPFamily corev1.IPFamily
 	// GlobalCA is an optionally configured, globally shared CA to be used for all managed resources.

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -154,7 +154,7 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 
 	warnUnsupportedDistro(resourcesState.AllPods, d.ReconcileState.Recorder)
 
-	controllerUser, err := user.ReconcileUsersAndRoles(ctx, d.Client, d.ES, d.DynamicWatches(), d.Recorder())
+	controllerUser, err := user.ReconcileUsersAndRoles(ctx, d.Client, d.ES, d.DynamicWatches(), d.Recorder(), d.OperatorParameters.PasswordHasher)
 	if err != nil {
 		return results.WithError(err)
 	}

--- a/pkg/controller/elasticsearch/user/predefined_test.go
+++ b/pkg/controller/elasticsearch/user/predefined_test.go
@@ -110,7 +110,7 @@ func Test_reconcileElasticUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := k8s.NewFakeClient(tt.existingSecrets...)
-			got, err := reconcileElasticUser(context.Background(), c, es, tt.existingFileRealm, filerealm.New())
+			got, err := reconcileElasticUser(context.Background(), c, es, tt.existingFileRealm, filerealm.New(), testPasswordHasher)
 			require.NoError(t, err)
 			// check returned user
 			require.Len(t, got, 1)
@@ -154,7 +154,7 @@ func Test_reconcileElasticUser_conditionalCreation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := k8s.NewFakeClient()
-			got, err := reconcileElasticUser(context.Background(), c, es, filerealm.New(), tt.userFileReam)
+			got, err := reconcileElasticUser(context.Background(), c, es, filerealm.New(), tt.userFileReam, testPasswordHasher)
 			require.NoError(t, err)
 			// check returned user
 			wantLen := 1
@@ -261,7 +261,7 @@ func Test_reconcileInternalUsers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := k8s.NewFakeClient(tt.existingSecrets...)
-			got, err := reconcileInternalUsers(context.Background(), c, es, tt.existingFileRealm)
+			got, err := reconcileInternalUsers(context.Background(), c, es, tt.existingFileRealm, testPasswordHasher)
 			require.NoError(t, err)
 			// check returned users
 			require.Len(t, got, 3)

--- a/pkg/controller/elasticsearch/user/user_provided_test.go
+++ b/pkg/controller/elasticsearch/user/user_provided_test.go
@@ -158,7 +158,7 @@ func TestReconcileUserProvidedFileRealm(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			recorder := record.NewFakeRecorder(10)
 			c := k8s.NewFakeClient(tt.secrets...)
-			gotFileRealm, err := reconcileUserProvidedFileRealm(context.Background(), c, tt.es, filerealm.New(), tt.watched, recorder)
+			gotFileRealm, err := reconcileUserProvidedFileRealm(context.Background(), c, tt.es, filerealm.New(), tt.watched, recorder, testPasswordHasher)
 			require.NoError(t, err)
 			require.Equal(t, tt.wantFileRealm, gotFileRealm)
 			require.Equal(t, tt.wantWatched, tt.watched.Secrets.Registrations())
@@ -363,7 +363,7 @@ func Test_realmFromBasicAuthSecret(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := realmFromBasicAuthSecret(tt.args.secret, tt.args.existing)
+			got, err := realmFromBasicAuthSecret(tt.args.secret, tt.args.existing, testPasswordHasher)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("realmFromBasicAuthSecret() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/utils/cryptutil/hasher.go
+++ b/pkg/utils/cryptutil/hasher.go
@@ -1,0 +1,91 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package cryptutil
+
+import (
+	"bytes"
+
+	lru "github.com/hashicorp/golang-lru"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// NewPasswordHasher returns a bcrypt hash generator.
+// If size is greater than 0 the hashes are cached using a cache of the provided size.
+func NewPasswordHasher(size int) (PasswordHasher, error) {
+	if size > 0 {
+		lruCache, err := lru.New(size)
+		if err != nil {
+			return nil, err
+		}
+		return &lruHashCache{
+			generateFromPassword:   bcrypt.GenerateFromPassword,
+			compareHashAndPassword: bcrypt.CompareHashAndPassword,
+			hashCache:              lruCache,
+		}, nil
+	}
+	return &passwordHashProvider{}, nil
+}
+
+type PasswordHasher interface {
+	ReuseOrGenerateHash(password, existingHash []byte) ([]byte, error)
+}
+
+type generateFromPassword func(password []byte, cost int) ([]byte, error)
+type compareHashAndPassword func(hashedPassword, password []byte) error
+type lruHashCache struct {
+	hashCache *lru.Cache
+
+	// only to be changed for unit tests
+	generateFromPassword
+	compareHashAndPassword
+}
+
+func (h *lruHashCache) ReuseOrGenerateHash(password, existingHash []byte) ([]byte, error) {
+	key := string(password)
+
+	if len(existingHash) > 0 {
+		// Check if we have the hash in cache
+		cachedHash := h.get(key)
+		if cachedHash != nil && bytes.Equal(cachedHash, existingHash) {
+			return existingHash, nil
+		}
+
+		// Check if the existing hash is valid
+		if h.compareHashAndPassword(existingHash, password) == nil {
+			// existing hash is valid, save it and return
+			h.hashCache.Add(key, existingHash)
+			return existingHash, nil
+		}
+	}
+
+	// No existing hash or exiting hash is not valid
+	hash, err := h.generateFromPassword(password, bcrypt.DefaultCost)
+	if err != nil {
+		return nil, err
+	}
+	h.hashCache.Add(key, hash)
+	return hash, nil
+}
+
+func (h *lruHashCache) get(key string) []byte {
+	cachedValue, exists := h.hashCache.Get(key)
+	if !exists {
+		return nil
+	}
+	cachedHash, ok := cachedValue.([]byte)
+	if !ok {
+		return nil
+	}
+	return cachedHash
+}
+
+type passwordHashProvider struct{}
+
+func (n *passwordHashProvider) ReuseOrGenerateHash(password, existingHash []byte) ([]byte, error) {
+	if len(existingHash) > 0 && bcrypt.CompareHashAndPassword(existingHash, password) == nil {
+		return existingHash, nil
+	}
+	return bcrypt.GenerateFromPassword(password, bcrypt.DefaultCost)
+}

--- a/pkg/utils/cryptutil/hasher.go
+++ b/pkg/utils/cryptutil/hasher.go
@@ -60,7 +60,7 @@ func (h *lruHashCache) ReuseOrGenerateHash(password, existingHash []byte) ([]byt
 		}
 	}
 
-	// No existing hash or exiting hash is not valid
+	// No existing hash or existing hash is not valid
 	hash, err := h.generateFromPassword(password, bcrypt.DefaultCost)
 	if err != nil {
 		return nil, err

--- a/pkg/utils/cryptutil/hasher_test.go
+++ b/pkg/utils/cryptutil/hasher_test.go
@@ -1,0 +1,88 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package cryptutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func Test_lruHashCache_ReuseOrGenerateHash(t *testing.T) {
+	newHasher, err := NewPasswordHasher(2)
+	assert.NoError(t, err)
+	passwordHasher, ok := newHasher.(*lruHashCache)
+	assert.True(t, ok)
+
+	generatedHashes := 0
+	passwordHasher.generateFromPassword = func(password []byte, cost int) ([]byte, error) {
+		generatedHashes++
+		return bcrypt.GenerateFromPassword(password, cost)
+	}
+
+	comparedPasswords := 0
+	passwordHasher.compareHashAndPassword = func(hashedPassword, password []byte) error {
+		comparedPasswords++
+		return bcrypt.CompareHashAndPassword(hashedPassword, password)
+	}
+
+	hash1, err := passwordHasher.ReuseOrGenerateHash([]byte("password1"), nil)
+	assert.NoError(t, err)
+	assert.Nil(t, bcrypt.CompareHashAndPassword(hash1, []byte("password1")))
+	// 1 password has just been generated
+	assert.Equal(t, 1, generatedHashes)
+	// No crypto comparison so far
+	assert.Equal(t, 0, comparedPasswords)
+
+	// stored hash is valid, should not be changed
+	storedHash := "$2a$10$aAeQF8kG.AOrsp4mtzFQ4.1z5lvL0w8odQl2tvaxGdKkQTyHMOSEe"
+	hash2, err := passwordHasher.ReuseOrGenerateHash([]byte("password2"), []byte(storedHash))
+	assert.NoError(t, err)
+	assert.Equal(t, storedHash, string(hash2))
+	assert.Nil(t, bcrypt.CompareHashAndPassword(hash2, []byte("password2")))
+	// Password has just been compared using the crypto function
+	assert.Equal(t, 1, comparedPasswords)
+	// No password generated
+	assert.Equal(t, 1, generatedHashes)
+	// 2 passwords in cache
+	assert.Equal(t, 2, passwordHasher.hashCache.Len())
+
+	// hash1 should still be in cache
+	hash1_2, err := passwordHasher.ReuseOrGenerateHash([]byte("password1"), hash1)
+	assert.NoError(t, err)
+	assert.Nil(t, bcrypt.CompareHashAndPassword(hash1_2, []byte("password1")))
+	// Hash should have been read from cache
+	assert.Equal(t, 1, comparedPasswords)
+	// No password generated
+	assert.Equal(t, 1, generatedHashes)
+	// 2 passwords in cache
+	assert.Equal(t, 2, passwordHasher.hashCache.Len())
+
+	hash3, err := passwordHasher.ReuseOrGenerateHash([]byte("password3"), nil)
+	assert.NoError(t, err)
+	assert.Nil(t, bcrypt.CompareHashAndPassword(hash3, []byte("password3")))
+	// New password has been generated
+	assert.Equal(t, 2, generatedHashes)
+	// Cache size should still be 2
+	assert.Equal(t, 2, passwordHasher.hashCache.Len())
+}
+
+func Test_passwordHashProvider_ReuseOrGenerateHash(t *testing.T) {
+	passwordHasher, err := NewPasswordHasher(0)
+	assert.NoError(t, err)
+	_, ok := passwordHasher.(*passwordHashProvider)
+	assert.True(t, ok)
+
+	hash1, err := passwordHasher.ReuseOrGenerateHash([]byte("password1"), nil)
+	assert.NoError(t, err)
+	assert.Nil(t, bcrypt.CompareHashAndPassword(hash1, []byte("password1")))
+
+	// stored hash is valid, should not be changed
+	storedHash := "$2a$10$aAeQF8kG.AOrsp4mtzFQ4.1z5lvL0w8odQl2tvaxGdKkQTyHMOSEe"
+	hash2, err := passwordHasher.ReuseOrGenerateHash([]byte("password2"), []byte(storedHash))
+	assert.NoError(t, err)
+	assert.Equal(t, storedHash, string(hash2))
+}


### PR DESCRIPTION
Attempt to mitigate and close https://github.com/elastic/cloud-on-k8s/issues/6076

The cache size is arbitrarily set to 5 `x` the number of workers. It can be changed (and disabled) via a configuration flag. We could dynamically resize the cache according to the number of managed resources, but I thought it was a bit involved for a first implementation.

From a security point of view:
* It means that passwords and hashes are stored in memory for a longer time, I don't think it is a concern as they are already both in memory, and reading the process memory would require the server to be compromised.
* Password comparison is no longer "time consistent", but I can't a see how an attacker could take advantage of this behaviour in the context of a reconciliation loop.

