### PR TITLE
Observer improvements

### DIFF
--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -181,6 +181,12 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	if min == nil {
 		min = &d.Version
 	}
+
+	isServiceReady, err := services.IsServiceReady(d.Client, *internalService)
+	if err != nil {
+		return results.WithError(err)
+	}
+
 	observedState := d.Observers.ObservedStateResolver(
 		ctx,
 		d.ES,
@@ -191,6 +197,7 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 			*min,
 			trustedHTTPCertificates,
 		),
+		isServiceReady,
 	)
 
 	// Always update the Elasticsearch state bits with the latest observed state.
@@ -232,11 +239,6 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 		trustedHTTPCertificates,
 	)
 	defer esClient.Close()
-
-	isServiceReady, err := services.IsServiceReady(d.Client, *internalService)
-	if err != nil {
-		return results.WithError(err)
-	}
 
 	// use unknown health as a proxy for a cluster not responding to requests
 	hasKnownHealthState := observedState() != esv1.ElasticsearchUnknownHealth

--- a/pkg/controller/elasticsearch/observer/manager.go
+++ b/pkg/controller/elasticsearch/observer/manager.go
@@ -110,6 +110,7 @@ func (m *Manager) extractObserverSettings(ctx context.Context, cluster esv1.Elas
 // createOrReplaceObserver creates a new observer and adds it to the observers map, replacing existing observers if necessary.
 // The new observer is not started, it is up to the caller to invoke observer.Start(ctx)
 func (m *Manager) createOrReplaceObserver(ctx context.Context, cluster types.NamespacedName, settings Settings, esClient client.Client) *Observer {
+	defer tracing.Span(&ctx)()
 	m.observerLock.Lock()
 	defer m.observerLock.Unlock()
 
@@ -126,6 +127,7 @@ func (m *Manager) createOrReplaceObserver(ctx context.Context, cluster types.Nam
 
 // getAndObserveSynchronously retrieves the currently configured observer and trigger a synchronous observation.
 func (m *Manager) getAndObserveSynchronously(ctx context.Context, cluster types.NamespacedName) *Observer {
+	defer tracing.Span(&ctx)()
 	m.observerLock.RLock()
 	defer m.observerLock.RUnlock()
 

--- a/pkg/controller/elasticsearch/observer/manager_test.go
+++ b/pkg/controller/elasticsearch/observer/manager_test.go
@@ -112,7 +112,7 @@ func TestManager_Observe(t *testing.T) {
 			if initial, exists := tt.initiallyObserved[tt.clusterToObserve]; exists {
 				initialCreationTime = initial.creationTime
 			}
-			observer := m.Observe(context.Background(), esObject(tt.clusterToObserve), tt.clusterToObserveClient)
+			observer := m.Observe(context.Background(), esObject(tt.clusterToObserve), tt.clusterToObserveClient, true)
 			// returned observer should be the correct one
 			require.Equal(t, tt.clusterToObserve, observer.cluster)
 			// list of observers should have been updated
@@ -181,8 +181,8 @@ func TestManager_ObserveSync(t *testing.T) {
 			name := cluster("es1")
 			cluster := esObject(name)
 			results := []esv1.ElasticsearchHealth{
-				tt.manager.ObservedStateResolver(context.Background(), cluster, esClient)(),
-				tt.manager.ObservedStateResolver(context.Background(), cluster, esClient)(),
+				tt.manager.ObservedStateResolver(context.Background(), cluster, esClient, true)(),
+				tt.manager.ObservedStateResolver(context.Background(), cluster, esClient, true)(),
 			}
 			require.Equal(t, tt.expectedHealth, results)
 			tt.manager.StopObserving(name) // let's clean up the go-routines
@@ -277,9 +277,9 @@ func TestManager_AddObservationListener(t *testing.T) {
 		close(doneCh)
 	}()
 	// observe 2 clusters
-	obs1 := m.Observe(ctx, cluster1, fakeEsClient200(client.BasicAuth{}))
+	obs1 := m.Observe(ctx, cluster1, fakeEsClient200(client.BasicAuth{}), true)
 	defer obs1.Stop()
-	obs2 := m.Observe(ctx, cluster2, fakeEsClient200(client.BasicAuth{}))
+	obs2 := m.Observe(ctx, cluster2, fakeEsClient200(client.BasicAuth{}), true)
 	defer obs2.Stop()
 	<-doneCh
 }

--- a/pkg/controller/elasticsearch/observer/observer.go
+++ b/pkg/controller/elasticsearch/observer/observer.go
@@ -71,10 +71,10 @@ func NewObserver(cluster types.NamespacedName, esClient client.Client, settings 
 // Start starts the Observer in a separate goroutine after a first synchronous observation.
 // The first observation is synchronous to allow to retrieve the cluster state immediately after the start.
 // Then, observations are performed periodically in a separate goroutine until the observer stop channel is closed.
-func (o *Observer) Start(doFirstObservation bool) {
+func (o *Observer) Start(ctx context.Context, doFirstObservation bool) {
 	if doFirstObservation {
 		// initial synchronous observation
-		o.observe()
+		o.observe(ctx)
 	}
 	if o.settings.ObservationInterval <= 0 {
 		return // asynchronous observations are effectively disabled
@@ -87,7 +87,7 @@ func (o *Observer) Start(doFirstObservation bool) {
 		for {
 			select {
 			case <-ticker.C:
-				o.observe()
+				o.observe(context.Background())
 			case <-o.stopChan:
 				log.Info("Stopping observer for cluster", "namespace", o.cluster.Namespace, "es_name", o.cluster.Name)
 				return
@@ -113,11 +113,12 @@ func (o *Observer) LastHealth() esv1.ElasticsearchHealth {
 
 // observe retrieves the current ES state, executes onObservation,
 // and stores the new state
-func (o *Observer) observe() {
-	ctx, cancelFunc := context.WithTimeout(context.Background(), nonNegativeTimeout(o.settings.ObservationInterval))
+func (o *Observer) observe(ctx context.Context) {
+	defer tracing.Span(&ctx)()
+	ctx, cancelFunc := context.WithTimeout(ctx, nonNegativeTimeout(o.settings.ObservationInterval))
 	defer cancelFunc()
 
-	if o.settings.Tracer != nil {
+	if o.settings.Tracer != nil && apm.TransactionFromContext(ctx) == nil {
 		tx := o.settings.Tracer.StartTransaction(name, string(tracing.PeriodicTxType))
 		defer tx.End()
 		ctx = apm.ContextWithTransaction(ctx, tx)
@@ -130,10 +131,13 @@ func (o *Observer) observe() {
 	if o.onObservation != nil {
 		o.onObservation(o.cluster, o.LastHealth(), newHealth)
 	}
+	o.updateHealth(ctx, newHealth)
+}
 
+func (o *Observer) updateHealth(ctx context.Context, newHealth esv1.ElasticsearchHealth) {
 	o.mutex.Lock()
+	defer o.mutex.Unlock()
 	o.lastHealth = newHealth
-	o.mutex.Unlock()
 }
 
 func nonNegativeTimeout(observationInterval time.Duration) time.Duration {

--- a/pkg/controller/elasticsearch/observer/observer.go
+++ b/pkg/controller/elasticsearch/observer/observer.go
@@ -131,10 +131,10 @@ func (o *Observer) observe(ctx context.Context) {
 	if o.onObservation != nil {
 		o.onObservation(o.cluster, o.LastHealth(), newHealth)
 	}
-	o.updateHealth(ctx, newHealth)
+	o.updateHealth(newHealth)
 }
 
-func (o *Observer) updateHealth(ctx context.Context, newHealth esv1.ElasticsearchHealth) {
+func (o *Observer) updateHealth(newHealth esv1.ElasticsearchHealth) {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
 	o.lastHealth = newHealth

--- a/pkg/controller/elasticsearch/observer/observer.go
+++ b/pkg/controller/elasticsearch/observer/observer.go
@@ -71,11 +71,7 @@ func NewObserver(cluster types.NamespacedName, esClient client.Client, settings 
 // Start starts the Observer in a separate goroutine after a first synchronous observation.
 // The first observation is synchronous to allow to retrieve the cluster state immediately after the start.
 // Then, observations are performed periodically in a separate goroutine until the observer stop channel is closed.
-func (o *Observer) Start(ctx context.Context, doFirstObservation bool) {
-	if doFirstObservation {
-		// initial synchronous observation
-		o.observe(ctx)
-	}
+func (o *Observer) Start() {
 	if o.settings.ObservationInterval <= 0 {
 		return // asynchronous observations are effectively disabled
 	}

--- a/pkg/controller/elasticsearch/observer/observer.go
+++ b/pkg/controller/elasticsearch/observer/observer.go
@@ -71,9 +71,11 @@ func NewObserver(cluster types.NamespacedName, esClient client.Client, settings 
 // Start starts the Observer in a separate goroutine after a first synchronous observation.
 // The first observation is synchronous to allow to retrieve the cluster state immediately after the start.
 // Then, observations are performed periodically in a separate goroutine until the observer stop channel is closed.
-func (o *Observer) Start() {
-	// initial synchronous observation
-	o.observe()
+func (o *Observer) Start(doFirstObservation bool) {
+	if doFirstObservation {
+		// initial synchronous observation
+		o.observe()
+	}
 	if o.settings.ObservationInterval <= 0 {
 		return // asynchronous observations are effectively disabled
 	}

--- a/pkg/controller/elasticsearch/observer/observer_test.go
+++ b/pkg/controller/elasticsearch/observer/observer_test.go
@@ -41,7 +41,7 @@ func fakeEsClient200(user client.BasicAuth) client.Client {
 func createAndRunTestObserver(onObs OnObservation) *Observer {
 	fakeEsClient := fakeEsClient200(client.BasicAuth{})
 	obs := NewObserver(cluster("cluster"), fakeEsClient, Settings{ObservationInterval: 1 * time.Microsecond}, onObs)
-	obs.Start(true)
+	obs.Start(context.Background(), true)
 	return obs
 }
 
@@ -55,9 +55,9 @@ func TestObserver_observe(t *testing.T) {
 		esClient:      fakeEsClient,
 		onObservation: onObservation,
 	}
-	observer.observe()
+	observer.observe(context.Background())
 	require.Equal(t, int32(1), atomic.LoadInt32(&counter))
-	observer.observe()
+	observer.observe(context.Background())
 	require.Equal(t, int32(2), atomic.LoadInt32(&counter))
 }
 
@@ -69,7 +69,7 @@ func TestObserver_observe_nilFunction(t *testing.T) {
 		onObservation: nilFunc,
 	}
 	// should not panic
-	observer.observe()
+	observer.observe(context.Background())
 }
 
 func TestNewObserver(t *testing.T) {
@@ -97,7 +97,7 @@ func TestObserver_Stop(t *testing.T) {
 	}
 	observer := createAndRunTestObserver(onObservation)
 	// force at least one observation
-	observer.observe()
+	observer.observe(context.Background())
 	// stop the observer
 	observer.Stop()
 	// should be safe to call multiple times

--- a/pkg/controller/elasticsearch/observer/observer_test.go
+++ b/pkg/controller/elasticsearch/observer/observer_test.go
@@ -41,7 +41,7 @@ func fakeEsClient200(user client.BasicAuth) client.Client {
 func createAndRunTestObserver(onObs OnObservation) *Observer {
 	fakeEsClient := fakeEsClient200(client.BasicAuth{})
 	obs := NewObserver(cluster("cluster"), fakeEsClient, Settings{ObservationInterval: 1 * time.Microsecond}, onObs)
-	obs.Start(context.Background(), true)
+	obs.Start()
 	return obs
 }
 

--- a/pkg/controller/elasticsearch/observer/observer_test.go
+++ b/pkg/controller/elasticsearch/observer/observer_test.go
@@ -41,7 +41,7 @@ func fakeEsClient200(user client.BasicAuth) client.Client {
 func createAndRunTestObserver(onObs OnObservation) *Observer {
 	fakeEsClient := fakeEsClient200(client.BasicAuth{})
 	obs := NewObserver(cluster("cluster"), fakeEsClient, Settings{ObservationInterval: 1 * time.Microsecond}, onObs)
-	obs.Start()
+	obs.Start(true)
 	return obs
 }
 


### PR DESCRIPTION
This PR implements a few improvements on the observer:

* The first synchronous observation implemented in https://github.com/elastic/cloud-on-k8s/pull/5783 is no longer invoked if the Elasticsearch `Service` is not "ready"
* `observer.Start()` is invoked outside of any lock-protected section
* An APM span added around `observer.observe(...)`

I eventually decided to not introduce a custom, low, timeout as suggested in https://github.com/elastic/cloud-on-k8s/issues/6078 for the following reasons:
* Moving the first synchronous observation out of the lock-protected section should solve the main bottleneck.
* Adding an additional timeout value means adding a new flag or/and implement an implicit default value.
* If the call to `_cluster/health` is slow then chances are that it'll also be the case for subsequent API calls, not sure why we would treat this one as a special case.

Fixes https://github.com/elastic/cloud-on-k8s/issues/6078