### PR TITLE
Add container-suffix operator flag

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -280,7 +280,7 @@ func Command() *cobra.Command {
 	cmd.Flags().Bool(
 		operator.UBIOnlyFlag,
 		false,
-		"Use only UBI container images to deploy Elastic Stack applications. UBI images are only available from 7.10.0 onward.",
+		fmt.Sprintf("Use only UBI container images to deploy Elastic Stack applications. UBI images are only available from 7.10.0 onward. Cannot be combined with %s", operator.ContainerSuffixFlag),
 	)
 	cmd.Flags().Bool(
 		operator.ValidateStorageClassFlag,

--- a/deploy/eck-operator/templates/configmap.yaml
+++ b/deploy/eck-operator/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
     log-verbosity: {{ int .Values.config.logVerbosity }}
     metrics-port: {{ int .Values.config.metricsPort }}
     container-registry: {{ .Values.config.containerRegistry }}
+    container-suffix: {{ .Values.config.containerSuffix }}
     max-concurrent-reconciles: {{ int .Values.config.maxConcurrentReconciles }}
     ca-cert-validity: {{ .Values.config.caValidity }}
     ca-cert-rotate-before: {{ .Values.config.caRotateBefore }}

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -151,6 +151,9 @@ config:
   # containerRegistry to use for pulling Elasticsearch and other application container images.
   containerRegistry: docker.elastic.co
 
+  # containerSuffix suffix to be appended to container images by default. Cannot be combined with -ubiOnly flag
+  # containerSuffix: ""
+
   # maxConcurrentReconciles is the number of concurrent reconciliation operations to perform per controller.
   maxConcurrentReconciles: "3"
 

--- a/docs/operating-eck/operator-config.asciidoc
+++ b/docs/operating-eck/operator-config.asciidoc
@@ -38,7 +38,7 @@ ECK can be configured using either command line flags or environment variables.
 |namespaces |"" |Namespaces in which this operator should manage resources. Accepts multiple comma-separated values. Defaults to all namespaces if empty or unspecified.
 |operator-namespace |"" |Namespace the operator runs in. Required.
 |set-default-security-context |true | Enables adding a default Pod Security Context to Elasticsearch Pods in Elasticsearch `8.0.0` and later. `fsGroup` is set to `1000` by default to match Elasticsearch container default UID. This behavior might not be appropriate for OpenShift and PSP-secured Kubernetes clusters, so it can be disabled.
-|ubi-only | false | Use only UBI container images to deploy Elastic Stack applications. UBI images are only available from 7.10.0 onward.
+|ubi-only | false | Use only UBI container images to deploy Elastic Stack applications. UBI images are only available from 7.10.0 onward. Cannot be combined with `--container-suffix` flag.
 |validate-storage-class | true | Specifies whether the operator should retrieve storage classes to verify volume expansion support. Can be disabled if cluster-wide storage class RBAC access is not available.
 |webhook-cert-dir |"{TempDir}/k8s-webhook-server/serving-certs" |Path to the directory that contains the webhook server key and certificate.
 |webhook-name |"elastic-webhook.k8s.elastic.co" |Name of the Kubernetes ValidatingWebhookConfiguration resource. Only used when `enable-webhook` is true.

--- a/docs/operating-eck/operator-config.asciidoc
+++ b/docs/operating-eck/operator-config.asciidoc
@@ -20,6 +20,7 @@ ECK can be configured using either command line flags or environment variables.
 |cert-validity |8760h |Duration representing the validity period of a generated TLS certificate.
 |config |"" | Path to a file containing the operator configuration.
 |container-registry |docker.elastic.co | Container registry to use for pulling Elastic Stack container images.
+|container-suffix |"" | Suffix to be appended to container images by default. Cannot be combined with `--ubi-only` flag.
 |disable-config-watch| false| Watch the configuration file for changes and restart to apply them. Only effective when the `--config` flag is used to set the configuration file.
 |disable-telemetry| false| Disable periodically updating ECK telemetry data for Kibana to consume.
 |elasticsearch-client-timeout| 180s| Default timeout for requests made by the Elasticsearch client.

--- a/pkg/controller/common/operator/flags.go
+++ b/pkg/controller/common/operator/flags.go
@@ -13,6 +13,7 @@ const (
 	CertValidityFlag                     = "cert-validity"
 	ConfigFlag                           = "config"
 	ContainerRegistryFlag                = "container-registry"
+	ContainerSuffixFlag                  = "container-suffix"
 	DebugHTTPListenFlag                  = "debug-http-listen"
 	DisableConfigWatch                   = "disable-config-watch"
 	DisableTelemetryFlag                 = "disable-telemetry"


### PR DESCRIPTION
Fixes #6064 

`--container-suffix` allows users to set a default suffix for container images that will be applied whenever the operator defaults to setting the image used. That is the case whenever the user does not explicitly specify the `image` attribute on a Elastic Stack resource manifest. 

It is illegal to combine both `--ubi-only` and `--container-suffix` because `--ubi-only` already implies a container suffix of `-ubi`