### PR TITLE
Prepare docs attributes for 2.5

### DIFF
--- a/docs/eck-attributes.asciidoc
+++ b/docs/eck-attributes.asciidoc
@@ -1,5 +1,5 @@
-:eck_version: 2.4.0
+:eck_version: 2.5.0
 :eck_crd_version: v1
-:eck_release_branch: 2.4
+:eck_release_branch: 2.5
 :eck_github: https://github.com/elastic/cloud-on-k8s
 :eck_resources_list: Elasticsearch, Kibana, APM Server, Enterprise Search, Beats, Elastic Agent, and Elastic Maps Server


### PR DESCRIPTION
Switch to 2.5 branch for the upcoming release. Can be merged as soon as we have a [2.5 docs branch](https://github.com/elastic/docs/pull/2540) but should be done in sync with the actual release.