### PR TITLE
[2.3] Add known issue for #5946 (#6109)

### DIFF
--- a/docs/release-notes/highlights-2.0.0.asciidoc
+++ b/docs/release-notes/highlights-2.0.0.asciidoc
@@ -30,3 +30,4 @@ When orchestrating Elasticsearch version 7.15.2 or later ECK will use the new li
 
 - When using the Red Hat certified version of the operator, automatic upgrades from previous versions of ECK do not work. To upgrade uninstall the old ECK operator and install the new version manually. Because CRDs remain in place after uninstalling, this operation should not negatively affect existing Elastic Stack deployments managed by ECK.
 - When using the `elasticsearchRef` mechanism with Elastic Agent in version 7.17 its Pods will enter a `CrashLoopBackoff`. A workaround is described in link:https://github.com/elastic/cloud-on-k8s/issues/5323#issuecomment-1028954034[this issue].
+- Under certain circumstances the operator will keep terminating and restarting Elasticsearch Pods seemingly at random. The underlying link:https://github.com/elastic/cloud-on-k8s/issues/5946[issue] is fixed in ECK 2.4.0 and an upgrade is highly recommended.

--- a/docs/release-notes/highlights-2.1.0.asciidoc
+++ b/docs/release-notes/highlights-2.1.0.asciidoc
@@ -24,3 +24,8 @@ An additional field `observedGeneration` is now maintained within Elasticsearch 
 ==== Allowing upgrade predicates to be selectively disabled
 
 Starting with ECK 2.1, the Elasticsearch clusters can have certain upgrade 'predicates' (rules) disabled on a case-by-case basis using annotations on the Elasticsearch custom resource, which allow full control over what rules are considered during the Elasticsearch upgrade process. Selectively disabling the predicates is extremely risky, and carries a high chance of either data loss, or causing a cluster to become completely unavailable. This feature is therefore intended exclusively as a troubleshooting mechanism of last resort. Check the link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-orchestration.html#k8s-advanced-upgrade-control[documentation] for more details.
+
+[float]
+[id="{p}-210-known-issues"]
+=== Known issues
+- Under certain circumstances the operator will keep terminating and restarting Elasticsearch Pods seemingly at random. The underlying link:https://github.com/elastic/cloud-on-k8s/issues/5946[issue] is fixed in ECK 2.4.0 and an upgrade is highly recommended.

--- a/docs/release-notes/highlights-2.2.0.asciidoc
+++ b/docs/release-notes/highlights-2.2.0.asciidoc
@@ -58,3 +58,4 @@ The <<{p}-stack-monitoring,Stack Monitoring>> feature is fully operational to be
 [id="{p}-220-known-issues"]
 === Known issues
 - The migration to service account tokens can lead to unavailability of Kibana and Fleet Server which is especially noticeable on larger Elasticsearch clusters with many nodes. ECK 2.3 enables a migration without downtime. It is recommended to upgrade to ECK 2.3 to avoid this issue or to quickly restore availability on already affected installations. More details can be found in the link:https://github.com/elastic/cloud-on-k8s/issues/5684#issuecomment-1164614176[linked GitHub issue].
+- Under certain circumstances the operator will keep terminating and restarting Elasticsearch Pods seemingly at random. The underlying link:https://github.com/elastic/cloud-on-k8s/issues/5946[issue] is fixed in ECK 2.4.0 and an upgrade is highly recommended.

--- a/docs/release-notes/highlights-2.3.0.asciidoc
+++ b/docs/release-notes/highlights-2.3.0.asciidoc
@@ -54,3 +54,8 @@ status:
 ==== Distroless base image
 
 The default ECK operator container image is now based on the link:https://github.com/GoogleContainerTools/distroless[Distroless image]. A container image based on the RedHat UBI base image is however still published and is selected by default when the operator is installed through the OpenShift OperatorHub.
+
+[float]
+[id="{p}-230-known-issues"]
+=== Known issues
+- Under certain circumstances the operator will keep terminating and restarting Elasticsearch Pods seemingly at random. The underlying link:https://github.com/elastic/cloud-on-k8s/issues/5946[issue] is fixed in ECK 2.4.0 and an upgrade is highly recommended.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.3`:
 - [Add known issue for #5946 (#6109)](https://github.com/elastic/cloud-on-k8s/pull/6109)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)