### PR TITLE
[2.1] Add known issue for #5946 (#6109)

### DIFF
--- a/docs/release-notes/highlights-2.0.0.asciidoc
+++ b/docs/release-notes/highlights-2.0.0.asciidoc
@@ -29,3 +29,4 @@ When orchestrating Elasticsearch version 7.15.2 or later ECK will use the new li
 === Known issues
 
 - When using the `elasticsearchRef` mechanism with Elastic Agent in version 7.17 its Pods will enter a `CrashLoopBackoff`. A workaround is described in link:https://github.com/elastic/cloud-on-k8s/issues/5323#issuecomment-1028954034[this issue].
+- Under certain circumstances the operator will keep terminating and restarting Elasticsearch Pods seemingly at random. The underlying link:https://github.com/elastic/cloud-on-k8s/issues/5946[issue] is fixed in ECK 2.4.0 and an upgrade is highly recommended.

--- a/docs/release-notes/highlights-2.1.0.asciidoc
+++ b/docs/release-notes/highlights-2.1.0.asciidoc
@@ -24,3 +24,8 @@ An additional field `observedGeneration` is now maintained within Elasticsearch 
 ==== Allowing upgrade predicates to be selectively disabled
 
 Starting with ECK 2.1, the Elasticsearch clusters can have certain upgrade 'predicates' (rules) disabled on a case-by-case basis using annotations on the Elasticsearch custom resource, which allow full control over what rules are considered during the Elasticsearch upgrade process. Selectively disabling the predicates is extremely risky, and carries a high chance of either data loss, or causing a cluster to become completely unavailable. This feature is therefore intended exclusively as a troubleshooting mechanism of last resort. Check the link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-orchestration.html#k8s-advanced-upgrade-control[documentation] for more details.
+
+[float]
+[id="{p}-210-known-issues"]
+=== Known issues
+- Under certain circumstances the operator will keep terminating and restarting Elasticsearch Pods seemingly at random. The underlying link:https://github.com/elastic/cloud-on-k8s/issues/5946[issue] is fixed in ECK 2.4.0 and an upgrade is highly recommended.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.1`:
 - [Add known issue for #5946 (#6109)](https://github.com/elastic/cloud-on-k8s/pull/6109)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)