### PR TITLE
Initial pipeline steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,5 @@
+agents:
+  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest
+
+steps:
+  - command: 'echo "pipeline is coming"'


### PR DESCRIPTION
Add initial pipeline steps to avoid issues as we are in a transient state until #5773 is merged because the pipeline exists in Buildkite (defined through our internal framework) but there are no initial pipeline steps to upload yet.