### PR TITLE
Configuration to trigger Buildkite builds for pull requests

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -1,0 +1,17 @@
+{
+  "jobs": [
+    {
+      "enabled": true,
+      "pipeline_slug": "cloud-on-k8s-operator",
+      "allow_org_users": true,
+      "allowed_repo_permissions": ["admin", "write"],
+      "allowed_list": ["renovate[bot]"],
+      "build_on_commit": true,
+      "build_on_comment": true,
+      "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+      "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+      "skip_ci_labels": ["skip-ci"],
+      "skip_ci_on_only_changed": ["\\.asciidoc$"]
+    }
+  ]
+}


### PR DESCRIPTION
Configuration for [buildkite-pr-bot](https://github.com/elastic/buildkite-pr-bot) to trigger Buildkite builds for pull requests.