### PR TITLE
Fix potential panic in Elasticsearch client equal function

### DIFF
--- a/pkg/controller/elasticsearch/client/base.go
+++ b/pkg/controller/elasticsearch/client/base.go
@@ -45,8 +45,8 @@ func (c *baseClient) Close() {
 
 func (c *baseClient) equal(c2 *baseClient) bool {
 	// handle nil case
-	if c2 == nil && c != nil {
-		return false
+	if c2 == nil {
+		return c == nil
 	}
 	// compare ca certs
 	if len(c.caCerts) != len(c2.caCerts) {


### PR DESCRIPTION
When c2 is nil and c is nil, the program can go on. But executing c2.User should panic, because c2 is nil.

```diff
func (c *baseClient) equal(c2 *baseClient) bool {
	// handle nil case
+	if c2 == nil {
+		return c == nil
+	}
-        if c2 == nil && c != nil {
- 		return false
-       }
	// compare ca certs
	if len(c.caCerts) != len(c2.caCerts) {
		return false
	}
	for i := range c.caCerts {
		if !c.caCerts[i].Equal(c2.caCerts[i]) {
			return false
		}
	}
	// compare endpoint and user creds
	return c.Endpoint == c2.Endpoint &&
		c.User == c2.User
}
```


- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)?
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed.
