### PR TITLE
Remove deprecated versions from tests, add new versions post 8.5 release

### DIFF
--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -58,14 +58,14 @@ pipeline {
                 )}"""
             }
             parallel {
-                stage("8.5.0-SNAPSHOT") {
+                stage("8.6.0-SNAPSHOT") {
                      agent {
                         label 'linux'
                     }
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-8x-snapshot-${BUILD_NUMBER}-e2e", "8.5.0-SNAPSHOT")
+                            runWith(lib, failedTests, "eck-8x-snapshot-${BUILD_NUMBER}-e2e", "8.6.0-SNAPSHOT")
                         }
                     }
                 }

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -46,17 +46,6 @@ pipeline {
                         }
                     }
                 }
-                stage("7.12.x") {
-                    agent {
-                        label 'linux'
-                    }
-                    steps {
-                        unstash "source"
-                        script {
-                            runWith(lib, failedTests, "eck-712-${BUILD_NUMBER}-e2e", "7.12.1")
-                        }
-                    }
-                }
                 stage("7.13.x") {
                     agent {
                         label 'linux'
@@ -163,7 +152,7 @@ pipeline {
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-84-${BUILD_NUMBER}-e2e", "8.4.1")
+                            runWith(lib, failedTests, "eck-84-${BUILD_NUMBER}-e2e", "8.4.3")
                         }
                     }
                }
@@ -197,7 +186,6 @@ pipeline {
             script {
                 clusters = [
                     "eck-68-${BUILD_NUMBER}-e2e",
-                    "eck-712-${BUILD_NUMBER}-e2e",
                     "eck-713-${BUILD_NUMBER}-e2e",
                     "eck-714-${BUILD_NUMBER}-e2e",
                     "eck-715-${BUILD_NUMBER}-e2e",


### PR DESCRIPTION
Stop testing 7.12 based on https://www.elastic.co/support/eol
Add test for 8.6.0-SNAPSHOT
Bump 8.4.x to 8.4.3