### PR TITLE
[Discuss] Sample configs for standalone Elastic Agent

### DIFF
--- a/config/recipes/elastic-agent/multi-output.yaml
+++ b/config/recipes/elastic-agent/multi-output.yaml
@@ -27,8 +27,6 @@ spec:
             path: /var/log
           name: varlog
   config:
-    id: 2d70a6f0-33a5-11eb-bb2f-418d0388a8cf
-    revision: 2
     agent:
       monitoring:
         enabled: true
@@ -36,15 +34,13 @@ spec:
         logs: true
         metrics: true
     inputs:
-    - id: 2e187fb0-33a5-11eb-bb2f-418d0388a8cf
-      name: system-1
+    - name: system-1
       revision: 1
       type: logfile
       use_output: default
       meta:
         package:
           name: system
-          version: 0.9.1
       data_stream:
         namespace: default
       streams:
@@ -92,7 +88,6 @@ spec:
       meta:
         package:
           name: system
-          version: 0.9.1
       data_stream:
         namespace: default
       streams:


### PR DESCRIPTION
Playing around with ECK and Elastic Agent I stumbled over these sample configuration files. I'm opening this issue to discuss some parts I spotted in the config file which might need adjustment.

* ids: We have ids in many places but my understanding is that these are only need for the filestream input. The ids in the policy come from Fleet but are not needed in standalone mode. If these are used for some metrics reporting, I'm concerned as these are statically coded now in standalone, could it cause some unwanted side effects?
* Package version: The package version is the policy but the package installed in Fleet my have a different version. It should be removed as the info is likely incorrect.
* Config id and revision: Does not have an affect in standalone and might be confusing.

I assume the above parts in the config come from a policy that was copied from Fleet and then put here as an example. I removed an example for each, there are more similar examples in the config. Internal Fleet information should not leak into standalone sample configs. The same problem will likely apply to other sample configs.

The configs can be found here on our website: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-configuration-examples.html#k8s_multiple_elasticsearch_clusters_output