### PR TITLE
Do not run multiple lint operations in parallel when releasing.

### DIFF
--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -34,19 +34,24 @@ pipeline {
                         sh 'make -C .ci TARGET=ci ci'
                     }
                 }
+                stage('Run ci checks prior to build') {
+                    steps {
+                        sh 'make -C .ci TARGET=ci-check ci'
+                    }
+                }
                 stage('build') {
                     failFast true
                     parallel {
                         stage("build and push operator image") {
                             steps {
                                 sh '.ci/setenvconfig build'
-                                sh 'make -C .ci license.key TARGET=ci-release ci'
+                                sh 'make -C .ci license.key TARGET=build-operator-multiarch-image ci'
                             }
                         }
                         stage("build and push operator image in FIPS mode") {
                             steps {
                                 sh '.ci/setenvconfig build'
-                                sh 'make -C .ci license.key TARGET=ci-release ci ENABLE_FIPS=true'
+                                sh 'make -C .ci license.key TARGET=build-operator-multiarch-image ci ENABLE_FIPS=true'
                             }
                         }
                     }

--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -34,11 +34,6 @@ pipeline {
                         sh 'make -C .ci TARGET=ci ci'
                     }
                 }
-                stage('Run ci checks prior to build') {
-                    steps {
-                        sh 'make -C .ci TARGET=ci-check ci'
-                    }
-                }
                 stage('build') {
                     failFast true
                     parallel {


### PR DESCRIPTION
We recently adjusted the release flow to add a `FIPS` compatible image, and added a parallel step which was running multiple `ci-check` make targets, which include `golangci-lint`, which we have set to not allow parallel runs.  This was causing some nightly builds to timeout with the following error:

```
ERRO Timeout exceeded: try increasing it by passing --timeout option 
```

This change adjusts the flow to:
1. Run the `ci-check` target prior to any build operations.
2. Run the 2x build targets in parallel.

