### PR TITLE
Remove parallelism from fips build

### DIFF
--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -34,21 +34,16 @@ pipeline {
                         sh 'make -C .ci TARGET=ci ci'
                     }
                 }
-                stage('build') {
-                    failFast true
-                    parallel {
-                        stage("build and push operator image") {
-                            steps {
-                                sh '.ci/setenvconfig build'
-                                sh 'make -C .ci license.key TARGET=build-operator-multiarch-image ci'
-                            }
-                        }
-                        stage("build and push operator image in FIPS mode") {
-                            steps {
-                                sh '.ci/setenvconfig build'
-                                sh 'make -C .ci license.key TARGET=build-operator-multiarch-image ci ENABLE_FIPS=true'
-                            }
-                        }
+                stage("build and push operator image") {
+                    steps {
+                        sh '.ci/setenvconfig build'
+                        sh 'make -C .ci license.key TARGET=build-operator-multiarch-image ci'
+                    }
+                }
+                stage("build and push operator image in FIPS mode") {
+                    steps {
+                        sh '.ci/setenvconfig build'
+                        sh 'make -C .ci license.key TARGET=build-operator-multiarch-image ci ENABLE_FIPS=true'
                     }
                 }
                 stage('Upload YAML manifest to S3') {


### PR DESCRIPTION
The nightly build, which is now including a FIPS build is failing without any specific error:

```
18:16:44  docker.elastic.co/eck-ci/eck-ci-tools:f2e52f24
18:16:45  >> Image == docker.elastic.co/eck-snapshots/eck-operator:2.6.0-SNAPSHOT-2022-11-05-0d0dbea3
18:16:45  >> Image == docker.elastic.co/eck-snapshots/eck-operator:2.6.0-SNAPSHOT-2022-11-05-0d0dbea3
18:16:53  make: *** [Makefile:238: build-operator-multiarch-image] Error 1
18:16:54  Makefile:48: recipe for target 'ci-internal' failed
18:16:54  make[1]: *** [ci-internal] Error 2
18:16:54  eck-multi-arch already exists
18:16:54  make: *** [Makefile:239: build-operator-multiarch-image] Terminated
```

I'm wondering if the parallelism is more trouble than it's worth here, and am just removing it.