### PR TITLE
Expose K8S client QPS as a flag

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -256,6 +256,11 @@ func Command() *cobra.Command {
 		60*time.Second,
 		"Timeout for requests made by the Kubernetes API client.",
 	)
+	cmd.Flags().Float32(
+		operator.KubeClientQPS,
+		0,
+		"Kubernetes API client queries per second.",
+	)
 	cmd.Flags().Bool(
 		operator.ManageWebhookCertsFlag,
 		true,
@@ -488,6 +493,11 @@ func startOperator(ctx context.Context) error {
 	if err != nil {
 		log.Error(err, "Failed to obtain client configuration")
 		return err
+	}
+
+	if qps := float32(viper.GetFloat64(operator.KubeClientQPS)); qps > 0 {
+		cfg.QPS = qps
+		cfg.Burst = int(qps * 2)
 	}
 
 	// set up APM  tracing if configured

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -259,7 +259,7 @@ func Command() *cobra.Command {
 	cmd.Flags().Float32(
 		operator.KubeClientQPS,
 		0,
-		"Kubernetes API client queries per second.",
+		"Maximum number of queries per second to the Kubernetes API.",
 	)
 	cmd.Flags().Bool(
 		operator.ManageWebhookCertsFlag,

--- a/deploy/eck-operator/templates/configmap.yaml
+++ b/deploy/eck-operator/templates/configmap.yaml
@@ -25,6 +25,9 @@ data:
     {{- end }}
     set-default-security-context: {{ .Values.config.setDefaultSecurityContext }}
     kube-client-timeout: {{ .Values.config.kubeClientTimeout }}
+    {{- if .Values.config.kubeClientQPS }}
+    telemetry-interval: {{ .Values.config.kubeClientQPS }}
+    {{- end }}
     elasticsearch-client-timeout: {{ .Values.config.elasticsearchClientTimeout }}
     disable-telemetry: {{ .Values.telemetry.disabled }}
     distribution-channel: {{ .Values.telemetry.distributionChannel }}

--- a/deploy/eck-operator/templates/configmap.yaml
+++ b/deploy/eck-operator/templates/configmap.yaml
@@ -26,7 +26,7 @@ data:
     set-default-security-context: {{ .Values.config.setDefaultSecurityContext }}
     kube-client-timeout: {{ .Values.config.kubeClientTimeout }}
     {{- if .Values.config.kubeClientQPS }}
-    telemetry-interval: {{ .Values.config.kubeClientQPS }}
+    kube-client-qps: {{ int .Values.config.kubeClientQPS }}
     {{- end }}
     elasticsearch-client-timeout: {{ .Values.config.elasticsearchClientTimeout }}
     disable-telemetry: {{ .Values.telemetry.disabled }}

--- a/docs/operating-eck/operator-config.asciidoc
+++ b/docs/operating-eck/operator-config.asciidoc
@@ -30,6 +30,7 @@ ECK can be configured using either command line flags or environment variables.
 |enforce-rbac-on-refs| false | Enables restrictions on cross-namespace resource association through RBAC.
 |exposed-node-labels|""| List of Kubernetes node labels which are allowed to be copied as annotations on the Elasticsearch Pods. Check <<{p}-availability-zone-awareness>> for more details.
 |ip-family|""| Set the IP family to use. Possible values: IPv4, IPv6, "" (= auto-detect)
+|kube-client-qps|0| Set the maximum number of queries per second to the Kubernetes API. Default value is inherited from the link:https://github.com/kubernetes/client-go/blob/e6538dd42b4fe55b6c754e41c66b43133ba41a59/rest/config.go#L44[Go client].
 |kube-client-timeout|60s| Set the request timeout for Kubernetes API calls made by the operator.
 |log-verbosity |0 |Verbosity level of logs. `-2`=Error, `-1`=Warn, `0`=Info, `0` and above=Debug.
 |manage-webhook-certs |true |Enables automatic webhook certificate management.

--- a/pkg/controller/common/operator/flags.go
+++ b/pkg/controller/common/operator/flags.go
@@ -28,6 +28,7 @@ const (
 	PasswordHashCacheSize                = "password-hash-cache-size"
 	IPFamilyFlag                         = "ip-family"
 	KubeClientTimeout                    = "kube-client-timeout"
+	KubeClientQPS                        = "kube-client-qps"
 	ManageWebhookCertsFlag               = "manage-webhook-certs"
 	MaxConcurrentReconcilesFlag          = "max-concurrent-reconciles"
 	MetricsPortFlag                      = "metrics-port"


### PR DESCRIPTION
This is a proposal to expose the QPS setting from the K8S Go client as a new operator flag.

FWIW here is a comparison of the throughput and latency with the default QPS and a QPS of 100 during a benchmark with a same workload:

## Default QPS of 5

<img width="2339" alt="image" src="https://user-images.githubusercontent.com/976373/200840630-c95e1071-81e6-4daf-9406-7f69eeac4458.png">

## QPS of 100

<img width="2339" alt="image" src="https://user-images.githubusercontent.com/976373/200842189-8d944f0b-b2d7-46f2-9ea5-0a3315fb5505.png">

With a QPS of 100 the latency is significantly reduced (~from `8 sec` to less than `1 sec` for the 2/3 of the test), even if the throughput drops at the end. First investigation indicates that this seems to be related to the CPU being throttled.

Burst is set to twice the QPS value to keep the default ratio from the Go client. I did not have the opportunity to play with it so far.