### PR TITLE
echo username and details of .env file for debugging ci failures.

### DIFF
--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -86,7 +86,7 @@ pipeline {
     post {
         success {
             script {
-                def operatorImage = sh(returnStdout: true, script: '.ci/setenvconfig build && make print-operator-image').trim()
+                def operatorImage = sh(returnStdout: true, script: 'whoami && ls -l .env ; .ci/setenvconfig build && make print-operator-image').trim()
                 if (isWeekday()) {
                     build job: 'cloud-on-k8s-e2e-tests-stack-versions',
                         parameters: [


### PR DESCRIPTION
Currently building nightly releases is failing with:

```
16:31:26  + .ci/setenvconfig build
16:31:26  .ci/setenvconfig: line 16: .ci/../.env: Permission denied
16:31:26  [Pipeline] }
16:31:26  [Pipeline] // script
16:31:26  Error when executing success post condition:
```

This seems to indicate that writing/updating the .env file is failing, as if it was written by either
1. a different user
2. or with permissions that aren't allowing u+w

This change will at least help debug the issue, but not solve it.