### PR TITLE
Fix .env permission in CI pipelines

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,6 +35,7 @@ steps:
 
       - label: ":go: checks"
         commands:
+          - .ci/setenvconfig pr
           - make check-license-header check-predicates shellcheck reattach-pv
 
   - group: tests

--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -87,7 +87,7 @@ pipeline {
     post {
         success {
             script {
-                def operatorImage = sh(returnStdout: true, script: 'whoami && ls -l .env ; .ci/setenvconfig build && make print-operator-image').trim()
+                def operatorImage = sh(returnStdout: true, script: '.ci/setenvconfig build && make print-operator-image').trim()
                 if (isWeekday()) {
                     build job: 'cloud-on-k8s-e2e-tests-stack-versions',
                         parameters: [

--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -26,6 +26,7 @@ pipeline {
             stages {
                 stage('Run checks') {
                     steps {
+                        sh '.ci/setenvconfig build'
                         sh 'make -C .ci TARGET=ci-check ci'
                     }
                 }

--- a/.ci/pipelines/e2e-tests-main-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-main-gke.Jenkinsfile
@@ -47,6 +47,7 @@ pipeline {
                 }
             }
             steps {
+                sh '.ci/setenvconfig e2e/main'
                 sh 'make -C .ci TARGET=ci-check ci'
             }
         }
@@ -61,7 +62,6 @@ pipeline {
                 E2E_TAGS = lib.extractValueByKey(env.ghprbCommentBody, "tags", params.E2E_TAGS)
             }
             steps {
-                sh '.ci/setenvconfig e2e/main'
                 script {
                     env.SHELL_EXIT_CODE = sh(returnStatus: true, script: 'make -C .ci get-test-artifacts TARGET=ci-build-operator-e2e-run ci')
 

--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -40,12 +40,12 @@ pipeline {
         }
         stage('Run checks') {
             steps {
+                sh '.ci/setenvconfig dev/build'
                 sh 'make -C .ci TARGET=ci-check ci'
             }
         }
          stage("Build dev operator image") {
             steps {
-                sh '.ci/setenvconfig dev/build'
                 sh('make -C .ci license.key TARGET=ci-release ci')
             }
          }

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,6 @@ manifest-gen-test:
 
 shellcheck:
 	# --external-sources because .buildkite/scripts/common/get-test-artifacts.sh source .env
-	@[[ ! -f .env ]] && touch .env || true
 	shellcheck --external-sources $(shell find . -type f -name "*.sh" -not -path "./vendor/*")
 
 upgrade-test: docker-build docker-push


### PR DESCRIPTION
Creating the `.env` file inside the ci docker container just to pass shellcheck was a bad idea. The file is created as root and this prevents `setenvconfig` which is run outside the docker ci container from updating it.

```sh
08:33:22  + .ci/setenvconfig e2e/main
08:33:22  .ci/setenvconfig: line 16: .ci/../.env: Permission denied
```

This commit removes the creation of `.env` in the shellcheck make target and instead moves the `setenvconfig` call before `make ci-check`.

Following of #6161.