### PR TITLE
Get license key to run ci-check

### DIFF
--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
                 stage('Run checks') {
                     steps {
                         sh '.ci/setenvconfig build'
-                        sh 'make -C .ci TARGET=ci-check ci'
+                        sh 'make -C .ci license.key TARGET=ci-check ci'
                     }
                 }
                 stage('Run unit and integration tests') {

--- a/.ci/pipelines/e2e-tests-main-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-main-gke.Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
             }
             steps {
                 sh '.ci/setenvconfig e2e/main'
-                sh 'make -C .ci TARGET=ci-check ci'
+                sh 'make -C .ci license.key TARGET=ci-check ci'
             }
         }
         stage("E2E tests") {

--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -41,12 +41,12 @@ pipeline {
         stage('Run checks') {
             steps {
                 sh '.ci/setenvconfig dev/build'
-                sh 'make -C .ci TARGET=ci-check ci'
+                sh 'make -C .ci license.key TARGET=ci-check ci'
             }
         }
          stage("Build dev operator image") {
             steps {
-                sh('make -C .ci license.key TARGET=ci-release ci')
+                sh('make -C .ci TARGET=ci-release ci')
             }
          }
         stage('Run tests for different stack versions in GKE') {


### PR DESCRIPTION
`setenvconfig` is now called first and sets `GO_TAGS=release` and `LICENSE_PUBKEY=/go/src/github.com/elastic/cloud-on-k8s/.ci/license.key`. 
It causes an issue when we run `make ci-check` which executes `make go-generate` which depends on the `license.key` file when `GO_TAGS=release`.

```
# reminder
> grep go: pkg/controller/common/license/pubkey.go
//go:build release
//go:generate go run ../../../../cmd/license-initializer/main.go --out zz_generated.pubkey.go
```

Let's just recover the missing file. It's already fetched later via `get-test-artifacts` in the main/snapshot jobs but I want to avoid more changes. 

