### PR TITLE
Fix regression in cloud-on-k8s-e2e-tests-stack-versions job

### DIFF
--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -210,7 +210,7 @@ pipeline {
 }
 
 def runWith(lib, failedTests, clusterName, stackVersion) {
-    sh ".ci/setenvconfig e2e/stack-versions $clusterName $stackVersion"
+    sh ".ci/setenvconfig e2e/stack-versions $stackVersion $clusterName"
     script {
         env.SHELL_EXIT_CODE = sh(returnStatus: true, script: "make -C .ci get-test-artifacts TARGET=ci-e2e ci")
 

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -554,7 +554,8 @@ CFG
 ######################################
 
 stackVersion=$2
-clusterName="eck-${CI_PLATFORM}-e2e-stack-$(sed "s|\.||g" <<< $stackVersion)-${BUILD_NUMBER}"
+generatedClusterName="eck-${CI_PLATFORM}-e2e-stack-$(sed "s|\.||g" <<< $stackVersion)-${BUILD_NUMBER}"
+clusterName=${3:-$generatedClusterName}
 
 isSnapshotVersion=$(case $stackVersion in (*-SNAPSHOT)  echo Yes;; esac)
 testLicensePKeyPath=$(case $isSnapshotVersion in (Yes) echo "${PROJECT_PATH}/.ci/dev-private.key";; esac)

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -813,7 +813,7 @@ CFG
 ######################################
 
 ocpVersion=$2
-clusterName="eck-${CI_PLATFORM}-e2e-ocp-$(sed "s|\.||g" <<< ${ocp_version})-$BUILD_NUMBER"
+clusterName="eck-${CI_PLATFORM}-e2e-ocp-$(sed "s|\.||g" <<< ${ocpVersion})-$BUILD_NUMBER"
 
 write_deployer_config <<CFG
 id: ocp-ci


### PR DESCRIPTION
Fixes a regression in the job `cloud-on-k8s-e2e-tests-stack-versions` introduced by the refactoring of the k8s cluster names created to run the e2e tests (770b4da). 

The generated cluster name (for buildkite) was used as the stack version:

```
--- FAIL: TestGlobalCA (1.26s)
panic: semver: Parse(eck-715-869-e2e): No Major.Minor.Patch elements found [recovered]
	panic: semver: Parse(eck-715-869-e2e): No Major.Minor.Patch elements found
```

The cluster name can be generated (buildkite) or provided as an argument (jenkins) and I forgot to remain compliant with the latter and I also missed the reorder of the two args.