### PR TITLE
Bump linter timeout from 5 mins to 6 mins.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 300s
+  timeout: 360s
 
 linters-settings:
   exhaustive:


### PR DESCRIPTION
Recent analysis of lint runtimes done by @thbkrkr 

```
From log of the last executions of cloud-on-k8s-nightly-build:
[2022-11-10T02:22:01.185Z] INFO Execution took 4m46.614371596s
[2022-11-10T00:06:34.810Z] INFO Execution took 4m41.686570762s
[2022-11-09T21:57:48.918Z] INFO Execution took 4m48.935058339s
We are near the limit of 5minutes.
```

Since we are consistently nearing the set 5 minute limit, we should increase this limit.