### PR TITLE
Fix regression in cloud-on-k8s-e2e-tests-snapshot-versions job

### DIFF
--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -113,7 +113,7 @@ pipeline {
 }
 
 def runWith(lib, failedTests, clusterName, stackVersion) {
-    sh ".ci/setenvconfig e2e/stack-versions $clusterName $stackVersion"
+    sh ".ci/setenvconfig e2e/stack-versions $stackVersion $clusterName"
     script {
         env.SHELL_EXIT_CODE = sh(returnStatus: true, script: "make -C .ci get-test-artifacts TARGET=ci-e2e ci")
 


### PR DESCRIPTION
To make the cluster name generated (buildkite) or provided as an argument (jenkins) I reordered the args in `.ci/setenvconfig` but not in the pipeline definition where it is called.

Similar to #6169.