### PR TITLE
Increment ECK-stack version to support addition of Agent/Fleet Server

### DIFF
--- a/deploy/eck-stack/Chart.yaml
+++ b/deploy/eck-stack/Chart.yaml
@@ -5,9 +5,11 @@ description: |
   Currently supported:
   * Elasticsearch
   * Kibana
+  * Agent
+  * Fleet Server
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.1.0
+version: 0.2.0
 
 dependencies:
   - name: eck-elasticsearch


### PR DESCRIPTION
The version of the Eck-Stack helm chart was not incremented when the Agent and Fleet servers were added in https://github.com/elastic/cloud-on-k8s/pull/5889.  This increments the version, and updates the description indicating the additional supported Stack components.