### PR TITLE
[2.5] Increment ECK-stack version to support addition of Agent/Fleet Server (#6179)

### DIFF
--- a/deploy/eck-stack/Chart.yaml
+++ b/deploy/eck-stack/Chart.yaml
@@ -5,9 +5,11 @@ description: |
   Currently supported:
   * Elasticsearch
   * Kibana
+  * Agent
+  * Fleet Server
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.1.0
+version: 0.2.0
 
 dependencies:
   - name: eck-elasticsearch


### PR DESCRIPTION
Backports the following commits to 2.5:
 - Increment ECK-stack version to support addition of Agent/Fleet Server (#6179)