### PR TITLE
Extend Elasticsearch pre-stop hooks

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/prestop.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/prestop.asciidoc
@@ -36,3 +36,6 @@ spec:
             - name: PRE_STOP_ADDITIONAL_WAIT_SECONDS
               value: "5"
 ----
+
+It is possible to specify additional actions to be carried out before the `Pod` is stopped via the environment variable `PRE_STOP_ACTIONS` (different actions separated by a comma).
+The only supported action at the moment is `flush` which performs a flush as suggested in link:https://www.elastic.co/guide/en/elasticsearch/reference/current/restart-cluster.html#restart-cluster-rolling[Rolling restart].

--- a/pkg/controller/elasticsearch/nodespec/defaults.go
+++ b/pkg/controller/elasticsearch/nodespec/defaults.go
@@ -45,6 +45,9 @@ var (
 func DefaultEnvVars(httpCfg commonv1.HTTPConfig, headlessServiceName string) []corev1.EnvVar {
 	return defaults.ExtendPodDownwardEnvVars(
 		[]corev1.EnvVar{
+			{Name: settings.EnvLifecycleHookPasswordPath, Value: path.Join(esvolume.LifecycleHookUserSecretMountPath, user.LifecycleHookUserName)},
+			{Name: settings.EnvLifecycleHookUsername, Value: user.LifecycleHookUserName},
+			{Name: settings.EnvLifecycleHookProtocol, Value: httpCfg.Protocol()},
 			{Name: settings.EnvProbePasswordPath, Value: path.Join(esvolume.ProbeUserSecretMountPath, user.ProbeUserName)},
 			{Name: settings.EnvProbeUsername, Value: user.ProbeUserName},
 			{Name: settings.EnvReadinessProbeProtocol, Value: httpCfg.Protocol()},

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -248,6 +248,9 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 	initContainerEnv := defaults.ExtendPodDownwardEnvVars(
 		[]corev1.EnvVar{
 			{Name: "my-env", Value: "my-value"},
+			{Name: settings.EnvLifecycleHookPasswordPath, Value: path.Join(esvolume.LifecycleHookUserSecretMountPath, user.LifecycleHookUserName)},
+			{Name: settings.EnvLifecycleHookUsername, Value: user.LifecycleHookUserName},
+			{Name: settings.EnvLifecycleHookProtocol, Value: sampleES.Spec.HTTP.Protocol()},
 			{Name: settings.EnvProbePasswordPath, Value: path.Join(esvolume.ProbeUserSecretMountPath, user.ProbeUserName)},
 			{Name: settings.EnvProbeUsername, Value: user.ProbeUserName},
 			{Name: settings.EnvReadinessProbeProtocol, Value: sampleES.Spec.HTTP.Protocol()},

--- a/pkg/controller/elasticsearch/nodespec/volumes.go
+++ b/pkg/controller/elasticsearch/nodespec/volumes.go
@@ -24,6 +24,10 @@ func buildVolumes(
 	downwardAPIVolume volume.DownwardAPI,
 ) ([]corev1.Volume, []corev1.VolumeMount) {
 	configVolume := settings.ConfigSecretVolume(esv1.StatefulSet(esName, nodeSpec.Name))
+	lifecycleHookSecret := volume.NewSelectiveSecretVolumeWithMountPath(
+		esv1.InternalUsersSecret(esName), esvolume.LifecycleHookUserVolumeName,
+		esvolume.LifecycleHookUserSecretMountPath, []string{user.LifecycleHookUserName},
+	)
 	probeSecret := volume.NewSelectiveSecretVolumeWithMountPath(
 		esv1.InternalUsersSecret(esName), esvolume.ProbeUserVolumeName,
 		esvolume.ProbeUserSecretMountPath, []string{user.ProbeUserName},
@@ -79,6 +83,7 @@ func buildVolumes(
 			esvolume.DefaultLogsVolume,
 			usersSecretVolume.Volume(),
 			unicastHostsVolume.Volume(),
+			lifecycleHookSecret.Volume(),
 			probeSecret.Volume(),
 			transportCertificatesVolume.Volume(),
 			remoteCertificateAuthoritiesVolume.Volume(),
@@ -97,6 +102,7 @@ func buildVolumes(
 		esvolume.DefaultLogsVolumeMount,
 		usersSecretVolume.VolumeMount(),
 		unicastHostsVolume.VolumeMount(),
+		lifecycleHookSecret.VolumeMount(),
 		probeSecret.VolumeMount(),
 		transportCertificatesVolume.VolumeMount(),
 		remoteCertificateAuthoritiesVolume.VolumeMount(),

--- a/pkg/controller/elasticsearch/settings/environment.go
+++ b/pkg/controller/elasticsearch/settings/environment.go
@@ -8,10 +8,13 @@ package settings
 const (
 	EnvEsJavaOpts = "ES_JAVA_OPTS"
 
-	EnvProbePasswordPath      = "PROBE_PASSWORD_PATH"
-	EnvProbeUsername          = "PROBE_USERNAME"
-	EnvReadinessProbeProtocol = "READINESS_PROBE_PROTOCOL"
-	HeadlessServiceName       = "HEADLESS_SERVICE_NAME"
+	EnvLifecycleHookPasswordPath = "LIFECYCLE_HOOK_PASSWORD_PATH" // #nosec G101
+	EnvLifecycleHookUsername     = "LIFECYCLE_HOOK_USERNAME"
+	EnvLifecycleHookProtocol     = "LIFECYCLE_HOOK_PROTOCOL"
+	EnvProbePasswordPath         = "PROBE_PASSWORD_PATH"
+	EnvProbeUsername             = "PROBE_USERNAME"
+	EnvReadinessProbeProtocol    = "READINESS_PROBE_PROTOCOL"
+	HeadlessServiceName          = "HEADLESS_SERVICE_NAME"
 
 	// These are injected as env var into the ES pod at runtime,
 	// to be referenced in ES configuration file

--- a/pkg/controller/elasticsearch/user/predefined.go
+++ b/pkg/controller/elasticsearch/user/predefined.go
@@ -29,6 +29,8 @@ const (
 
 	// ControllerUserName is the controller user to interact with ES.
 	ControllerUserName = "elastic-internal"
+	// LifecycleHookUserName is used for the Elasticsearch lifecycle hooks.
+	LifecycleHookUserName = "elastic-internal-lifecycle-hook"
 	// ProbeUserName is used for the Elasticsearch readiness probe.
 	ProbeUserName = "elastic-internal-probe"
 	// MonitoringUserName is used for the Elasticsearch monitoring.
@@ -84,6 +86,7 @@ func reconcileInternalUsers(
 		existingFileRealm,
 		users{
 			{Name: ControllerUserName, Roles: []string{SuperUserBuiltinRole}},
+			{Name: LifecycleHookUserName, Roles: []string{LifecycleHookUserRole}},
 			{Name: ProbeUserName, Roles: []string{ProbeUserRole}},
 			{Name: MonitoringUserName, Roles: []string{RemoteMonitoringCollectorBuiltinRole}},
 		},

--- a/pkg/controller/elasticsearch/user/reconcile_test.go
+++ b/pkg/controller/elasticsearch/user/reconcile_test.go
@@ -89,13 +89,13 @@ func Test_aggregateFileRealm(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, controllerUser.Password)
 	actualUsers := fileRealm.UserNames()
-	require.ElementsMatch(t, []string{"elastic", "elastic-internal", "elastic-internal-probe", "elastic-internal-monitoring", "user1", "user2", "user3"}, actualUsers)
+	require.ElementsMatch(t, []string{"elastic", "elastic-internal", "elastic-internal-lifecycle-hook", "elastic-internal-probe", "elastic-internal-monitoring", "user1", "user2", "user3"}, actualUsers)
 }
 
 func Test_aggregateRoles(t *testing.T) {
 	c := k8s.NewFakeClient(sampleUserProvidedRolesSecret...)
 	roles, err := aggregateRoles(context.Background(), c, sampleEsWithAuth, initDynamicWatches(), record.NewFakeRecorder(10))
 	require.NoError(t, err)
-	require.Len(t, roles, 52)
-	require.Contains(t, roles, ProbeUserRole, "role1", "role2")
+	require.Len(t, roles, 53)
+	require.Contains(t, roles, LifecycleHookUserRole, ProbeUserRole, "role1", "role2")
 }

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -19,6 +19,8 @@ const (
 
 	// SuperUserBuiltinRole is the name of the built-in superuser role.
 	SuperUserBuiltinRole = "superuser"
+	// LifecycleHookUserRole is the name of the role used by the internal lifecycle hook user.
+	LifecycleHookUserRole = "elastic_internal_lifecycle_hook_user"
 	// ProbeUserRole is the name of the role used by the internal probe user.
 	ProbeUserRole = "elastic_internal_probe_user"
 	// RemoteMonitoringCollectorBuiltinRole is the name of the built-in remote_monitoring_collector role.
@@ -58,6 +60,14 @@ const (
 var (
 	// PredefinedRoles to create for internal needs.
 	PredefinedRoles = RolesFileContent{
+		LifecycleHookUserRole: esclient.Role{
+			Indices: []esclient.IndexRole{
+				{
+					Names:      []string{"*"},
+					Privileges: []string{"maintenance"},
+				},
+			},
+		},
 		ProbeUserRole: esclient.Role{Cluster: []string{"monitor"}},
 		ApmUserRoleV6: esclient.Role{
 			Cluster: []string{"monitor", "manage_index_templates"},

--- a/pkg/controller/elasticsearch/volume/names.go
+++ b/pkg/controller/elasticsearch/volume/names.go
@@ -6,8 +6,10 @@ package volume
 
 // Default values for the volume name and paths
 const (
-	ProbeUserSecretMountPath = "/mnt/elastic-internal/probe-user" //nolint:gosec
-	ProbeUserVolumeName      = "elastic-internal-probe-user"
+	LifecycleHookUserSecretMountPath = "/mnt/elastic-internal/lifecycle-hook-user" //nolint:gosec
+	LifecycleHookUserVolumeName      = "elastic-internal-lifecycle-hook-user"
+	ProbeUserSecretMountPath         = "/mnt/elastic-internal/probe-user" //nolint:gosec
+	ProbeUserVolumeName              = "elastic-internal-probe-user"
 
 	ConfigVolumeMountPath               = "/usr/share/elasticsearch/config"
 	NodeTransportCertificatePathSegment = "node-transport-cert"


### PR DESCRIPTION
This PR adds the possibility to add additional actions to the Elasticsearch pre-stop hook via the environment variable `PRE_STOP_ACTIONS`. The first (and at the moment only) action is `flush` see [Rolling restart](https://www.elastic.co/guide/en/elasticsearch/reference/current/restart-cluster.html#restart-cluster-rolling).

Also a bug in some tests is fixed (assertions where not called).
