### PR TITLE
Version gate for the file-based settings volume

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -236,7 +236,7 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 	terminationGracePeriodSeconds := DefaultTerminationGracePeriodSeconds
 	varFalse := false
 
-	volumes, volumeMounts := buildVolumes(sampleES.Name, nodeSet, nil, volume.DownwardAPI{})
+	volumes, volumeMounts := buildVolumes(sampleES.Name, ver, nodeSet, nil, volume.DownwardAPI{})
 	// should be sorted
 	sort.Slice(volumes, func(i, j int) bool { return volumes[i].Name < volumes[j].Name })
 	sort.Slice(volumeMounts, func(i, j int) bool { return volumeMounts[i].Name < volumeMounts[j].Name })


### PR DESCRIPTION
Adds a version gate to configure the file-based settings volume and volumeMounts in the Elasticsearch pods and to reconcile the file-based settings Secret.

Resolves #6199.