### PR TITLE
[2.6] Update Agent config in recipe and e2e test (#6190)

### DIFF
--- a/config/recipes/elastic-agent/multi-output.yaml
+++ b/config/recipes/elastic-agent/multi-output.yaml
@@ -27,7 +27,6 @@ spec:
             path: /var/log
           name: varlog
   config:
-    id: 2d70a6f0-33a5-11eb-bb2f-418d0388a8cf
     revision: 2
     agent:
       monitoring:
@@ -36,7 +35,7 @@ spec:
         logs: true
         metrics: true
     inputs:
-    - id: 2e187fb0-33a5-11eb-bb2f-418d0388a8cf
+    - id: logfile-system-835850a7-3f6b-4ae9-8d02-a9a15767cf39
       name: system-1
       revision: 1
       type: logfile
@@ -44,7 +43,7 @@ spec:
       meta:
         package:
           name: system
-          version: 0.9.1
+          version: 1.20.4
       data_stream:
         namespace: default
       streams:
@@ -84,7 +83,7 @@ spec:
             target: ''
             fields:
               ecs.version: 1.5.0
-    - id: 2e187fb0-33a5-11eb-bb2f-418d0388a8cf
+    - id: system/metrics-system-835850a7-3f6b-4ae9-8d02-a9a15767cf39
       name: system-1
       revision: 1
       type: system/metrics
@@ -92,7 +91,7 @@ spec:
       meta:
         package:
           name: system
-          version: 0.9.1
+          version: 1.20.4
       data_stream:
         namespace: default
       streams:

--- a/test/e2e/agent/config.go
+++ b/test/e2e/agent/config.go
@@ -14,9 +14,7 @@ const (
     - name: fleet_server
       version: latest
     - name: kubernetes
-      # pinning this version as the next one introduced a kube-proxy host setting default that breaks this recipe,
-      # see https://github.com/elastic/integrations/pull/1565 for more details
-      version: 0.14.0
+      version: latest
     xpack.fleet.agentPolicies:
     - name: Fleet Server on ECK policy
       id: eck-fleet-server
@@ -56,7 +54,7 @@ agent:
     logs: true
     metrics: true
 inputs:
-  - id: 2e187fb0-33a5-11eb-bb2f-418d0388a8cf
+  - id: logfile-system-835850a7-3f6b-4ae9-8d02-a9a15767cf39
     name: system-1
     revision: 1
     type: logfile
@@ -64,7 +62,7 @@ inputs:
     meta:
       package:
         name: system
-        version: 0.9.1
+        version: 1.20.4
     data_stream:
       namespace: default
     streams:
@@ -86,7 +84,7 @@ inputs:
               target: ''
               fields:
                 ecs.version: 1.5.0
-      - id: logfile-system.syslog
+      - id: logfile-system.syslog-835850a7-3f6b-4ae9-8d02-a9a15767cf39
         data_stream:
           dataset: system.syslog
           type: logs
@@ -100,11 +98,7 @@ inputs:
           match: after
         processors:
           - add_locale: {}
-          - add_fields:
-              target: ''
-              fields:
-                ecs.version: 1.5.0
-  - id: 2e187fb0-33a5-11eb-bb2f-418d0388a8cf
+  - id: system/metrics-system-835850a7-3f6b-4ae9-8d02-a9a15767cf39
     name: system-1
     revision: 1
     type: system/metrics
@@ -238,7 +232,7 @@ agent:
     logs: true
     metrics: true
 inputs:
-  - id: 2e187fb0-33a5-11eb-bb2f-418d0388a8cf
+  - id: logfile-system-835850a7-3f6b-4ae9-8d02-a9a15767cf39
     name: system-1
     revision: 1
     type: logfile
@@ -246,7 +240,7 @@ inputs:
     meta:
       package:
         name: system
-        version: 0.9.1
+        version: 1.20.4
     data_stream:
       namespace: default
     streams:
@@ -286,7 +280,7 @@ inputs:
               target: ''
               fields:
                 ecs.version: 1.5.0
-  - id: 2e187fb0-33a5-11eb-bb2f-418d0388a8cf
+  - id: system/metrics-system-835850a7-3f6b-4ae9-8d02-a9a15767cf39
     name: system-1
     revision: 1
     type: system/metrics
@@ -294,7 +288,7 @@ inputs:
     meta:
       package:
         name: system
-        version: 0.9.1
+        version: 1.20.4
     data_stream:
       namespace: default
     streams:

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -37,8 +37,6 @@ func TestSystemIntegrationConfig(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
-		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default")).
-		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.cpu", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.diskio", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.load", "default")).
@@ -78,8 +76,6 @@ func TestAgentConfigRef(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
-		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default")).
-		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.cpu", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.diskio", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.load", "default")).
@@ -112,8 +108,6 @@ func TestMultipleOutputConfig(t *testing.T) {
 		WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent", "default"), "monitoring").
 		WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default"), "monitoring").
 		WithESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default"), "monitoring").
-		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"), "monitoring").
-		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"), "monitoring").
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.cpu", "default"), "default").
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.diskio", "default"), "default").
 		WithESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.load", "default"), "default").


### PR DESCRIPTION
# Backport

This will backport the following commit from `main` to `2.6`:
 - [Update Agent config in recipe and e2e test (#6190)](https://github.com/elastic/cloud-on-k8s/pull/6190)