### PR TITLE
DRAFT: Agent running without `securityContext.runAsUser: 0` fails.

### DIFF
--- a/config/recipes/elastic-agent/quickstart.yaml
+++ b/config/recipes/elastic-agent/quickstart.yaml
@@ -1,0 +1,54 @@
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: quickstart
+spec:
+  version: 8.5.0
+  elasticsearchRefs:
+  - name: elasticsearch
+  daemonSet: {}
+  config:
+    inputs:
+      - name: system-1
+        revision: 1
+        type: system/metrics
+        use_output: default
+        meta:
+          package:
+            name: system
+            version: 0.9.1
+        data_stream:
+          namespace: default
+        streams:
+          - id: system/metrics-system.cpu
+            data_stream:
+              dataset: system.cpu
+              type: metrics
+            metricsets:
+              - cpu
+            cpu.metrics:
+              - percentages
+              - normalized_percentages
+            period: 10s
+---
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch
+spec:
+  version: 8.5.0
+  nodeSets:
+  - name: default
+    count: 3
+    config:
+      node.store.allow_mmap: false
+---
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: kibana
+spec:
+  version: 8.5.0
+  count: 1
+  elasticsearchRef:
+    name: elasticsearch

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -44,6 +44,17 @@ func TestSystemIntegrationRecipe(t *testing.T) {
 	runAgentRecipe(t, "system-integration.yaml", customize)
 }
 
+func TestQuickstartRecipe(t *testing.T) {
+
+	customize := func(builder agent.Builder) agent.Builder {
+		return builder.
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default")).
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.cpu", "default"))
+	}
+
+	runAgentRecipe(t, "quickstart.yaml", customize)
+}
+
 func TestKubernetesIntegrationRecipe(t *testing.T) {
 	customize := func(builder agent.Builder) agent.Builder {
 		return builder.
@@ -218,7 +229,7 @@ func runAgentRecipe(
 	helper.RunFile(t, filePath, namespace, suffix, additionalObjects, transformationsWrapped)
 }
 
-// isStackIncompatible returns true iff Agent version is higher than tested Stack version
+// isStackIncompatible returns true if Agent version is higher than tested Stack version
 func isStackIncompatible(agent agentv1alpha1.Agent) bool {
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
 	agentVersion := version.MustParse(agent.Spec.Version)

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -45,7 +45,6 @@ func TestSystemIntegrationRecipe(t *testing.T) {
 }
 
 func TestQuickstartRecipe(t *testing.T) {
-
 	customize := func(builder agent.Builder) agent.Builder {
 		return builder.
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default")).


### PR DESCRIPTION
This change adds an e2e test for our [Agent Quickstart](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-quickstart.html) in our documentation.  We current run e2e tests on Agent, but do not run any tests without

```
securityContext:
  runAsUser: 0
```

If run, it will currently fail, showing the existing failure:

```
kubectl logs -n e2e-5uvhg-mercury quickstart-9nzv-agent-6tfkb
Error: preparing STATE_PATH(/usr/share/elastic-agent/state) failed: mkdir /usr/share/elastic-agent/state/data: permission denied
For help, please see our troubleshooting guide at https://www.elastic.co/guide/en/fleet/8.5/fleet-troubleshooting.html
```

See #6193

This draft is a starting point for both:

- [ ] Resolving the issue running Agent without `runAsuser: 0`
- [x] Adding e2e tests to ensure future state.

TODO: 

Fix the underlying issue allowing Agent to run successfully without `runAsuser: 0`.