### PR TITLE
Fix gke cluster deletion during e2e tests

### DIFF
--- a/.ci/pipelines/e2e-tests-main-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-main-gke.Jenkinsfile
@@ -104,7 +104,7 @@ pipeline {
             script {
                 if (notOnlyDocs()) {
                     build job: 'cloud-on-k8s-e2e-cleanup',
-                        parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-e2e-${BUILD_NUMBER}")],
+                        parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-jks-e2e-main-${BUILD_NUMBER}")],
                         wait: false
                 }
             }

--- a/.ci/pipelines/e2e-tests-resilience.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-resilience.Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
         cleanup {
             script {
                 build job: 'cloud-on-k8s-e2e-cleanup',
-                    parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-resilience-${BUILD_NUMBER}-e2e")],
+                    parameters: [string(name: 'JKS_PARAM_GKE_CLUSTER', value: "eck-jks-e2e-resilience-${BUILD_NUMBER}")],
                     wait: false
             }
             cleanWs()

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -733,6 +733,27 @@ CFG
 ;;
 
 ######################################
+  cleanup/resilience)
+######################################
+
+clusterName="eck-${CI_PLATFORM}-e2e-resilience-${BUILD_NUMBER}"
+
+write_deployer_config <<CFG
+id: gke-ci
+overrides:
+  operation: delete
+  clusterName: ${clusterName}
+  vaultInfo:
+    address: $VAULT_ADDR
+    roleId: $VAULT_ROLE_ID
+    secretId: $VAULT_SECRET_ID
+    rootPath: $VAULT_ROOT_PATH
+  gke:
+    gCloudProject: $GCLOUD_PROJECT
+CFG
+;;
+
+######################################
   cleanup/aks)
 ######################################
 


### PR DESCRIPTION
This quickfixes regressions introduced in the change to support cluster name passed as argument in the job and cluster name auto-generated (#5773). These are quickfixes since we will soon remove the whole jenkins part.

- Fix deletion of eck-**jks**-e2e-**main**-xx gke cluster
- Fix deletion of eck-**jks**-e2e-**resilience**-xx gke cluster
- Fix deletion of eck-**bk**-e2e-**resilience**-xx gke cluster
