### PR TITLE
Disable e2e testing for k8s providers not yet buildkite ready

### DIFF
--- a/.buildkite/pipeline-nightly-e2e-tests.yml
+++ b/.buildkite/pipeline-nightly-e2e-tests.yml
@@ -4,26 +4,26 @@ agents:
 
 steps:
 
-  - group: "aks"
-    steps:
+  # - group: "aks"
+  #   steps:
 
-      - label: "aks"
-        commands:
-          - .ci/setenvconfig e2e/main
-          - .ci/setenvconfig e2e/aks
-          - .buildkite/scripts/common/get-test-artifacts.sh
-          - make run-deployer
-          - make e2e-run
-        artifact_paths:
-          - "eck-diagnostic-*.zip"
+  #     - label: "aks"
+  #       commands:
+  #         - .ci/setenvconfig e2e/main
+  #         - .ci/setenvconfig e2e/aks
+  #         - .buildkite/scripts/common/get-test-artifacts.sh
+  #         - make run-deployer
+  #         - make e2e-run
+  #       artifact_paths:
+  #         - "eck-diagnostic-*.zip"
 
-      - wait: ~
-        continue_on_failure: true
+  #     - wait: ~
+  #       continue_on_failure: true
 
-      - label: "cleanup"
-        commands:
-          - .ci/setenvconfig cleanup/aks
-          - make run-deployer
+  #     - label: "cleanup"
+  #       commands:
+  #         - .ci/setenvconfig cleanup/aks
+  #         - make run-deployer
 
   - group: "eks"
     steps:
@@ -46,26 +46,26 @@ steps:
           - .ci/setenvconfig cleanup/eks
           - make run-deployer
 
-  - group: "eks-arm"
-    steps:
+  # - group: "eks-arm"
+  #   steps:
 
-      - label: "e2e/eks-arm"
-        commands:
-          - .ci/setenvconfig e2e/main
-          - .ci/setenvconfig e2e/eks-arm
-          - .buildkite/scripts/common/get-test-artifacts.sh
-          - make run-deployer
-          - make e2e-run
-        artifact_paths:
-          - "eck-diagnostic-*.zip"
+  #     - label: "e2e/eks-arm"
+  #       commands:
+  #         - .ci/setenvconfig e2e/main
+  #         - .ci/setenvconfig e2e/eks-arm
+  #         - .buildkite/scripts/common/get-test-artifacts.sh
+  #         - make run-deployer
+  #         - make e2e-run
+  #       artifact_paths:
+  #         - "eck-diagnostic-*.zip"
 
-      - wait: ~
-        continue_on_failure: true
+  #     - wait: ~
+  #       continue_on_failure: true
 
-      - label: "cleanup"
-        commands:
-          - .ci/setenvconfig cleanup/eks-arm
-          - make run-deployer
+  #     - label: "cleanup"
+  #       commands:
+  #         - .ci/setenvconfig cleanup/eks-arm
+  #         - make run-deployer
 
   - group: "gke"
     steps:
@@ -225,107 +225,107 @@ steps:
         artifact_paths:
           - "eck-diagnostic-*.zip"
 
-  - group: "ocp"
-    steps:
+  # - group: "ocp"
+  #   steps:
 
-      - label: "ocp 4.7"
-        commands:
-          - .ci/setenvconfig e2e/main
-          - .ci/setenvconfig e2e/ocp 4.7.49
-          - .buildkite/scripts/common/get-test-artifacts.sh
-          - make run-deployer
-          - make e2e-run
-        artifact_paths:
-          - "eck-diagnostic-*.zip"
+  #     - label: "ocp 4.7"
+  #       commands:
+  #         - .ci/setenvconfig e2e/main
+  #         - .ci/setenvconfig e2e/ocp 4.7.49
+  #         - .buildkite/scripts/common/get-test-artifacts.sh
+  #         - make run-deployer
+  #         - make e2e-run
+  #       artifact_paths:
+  #         - "eck-diagnostic-*.zip"
 
-      - label: "ocp 4.8"
-        commands:
-          - .ci/setenvconfig e2e/main
-          - .ci/setenvconfig e2e/ocp 4.8.50
-          - .buildkite/scripts/common/get-test-artifacts.sh
-          - make run-deployer
-          - make e2e-run
-        artifact_paths:
-          - "eck-diagnostic-*.zip"
+  #     - label: "ocp 4.8"
+  #       commands:
+  #         - .ci/setenvconfig e2e/main
+  #         - .ci/setenvconfig e2e/ocp 4.8.50
+  #         - .buildkite/scripts/common/get-test-artifacts.sh
+  #         - make run-deployer
+  #         - make e2e-run
+  #       artifact_paths:
+  #         - "eck-diagnostic-*.zip"
 
-      - label: "ocp 4.9"
-        commands:
-          - .ci/setenvconfig e2e/main
-          - .ci/setenvconfig e2e/ocp 4.9.48
-          - .buildkite/scripts/common/get-test-artifacts.sh
-          - make run-deployer
-          - make e2e-run
-        artifact_paths:
-          - "eck-diagnostic-*.zip"
+  #     - label: "ocp 4.9"
+  #       commands:
+  #         - .ci/setenvconfig e2e/main
+  #         - .ci/setenvconfig e2e/ocp 4.9.48
+  #         - .buildkite/scripts/common/get-test-artifacts.sh
+  #         - make run-deployer
+  #         - make e2e-run
+  #       artifact_paths:
+  #         - "eck-diagnostic-*.zip"
 
-      - label: "ocp 4.10"
-        commands:
-          - .ci/setenvconfig e2e/main
-          - .ci/setenvconfig e2e/ocp 4.10.34
-          - .buildkite/scripts/common/get-test-artifacts.sh
-          - make run-deployer
-          - make e2e-run
-        artifact_paths:
-          - "eck-diagnostic-*.zip"
+  #     - label: "ocp 4.10"
+  #       commands:
+  #         - .ci/setenvconfig e2e/main
+  #         - .ci/setenvconfig e2e/ocp 4.10.34
+  #         - .buildkite/scripts/common/get-test-artifacts.sh
+  #         - make run-deployer
+  #         - make e2e-run
+  #       artifact_paths:
+  #         - "eck-diagnostic-*.zip"
 
-      - label: "ocp 4.11"
-        commands:
-          - .ci/setenvconfig e2e/main
-          - .ci/setenvconfig e2e/ocp 4.11.5
-          - .buildkite/scripts/common/get-test-artifacts.sh
-          - make run-deployer
-          - make e2e-run
-        artifact_paths:
-          - "eck-diagnostic-*.zip"
+  #     - label: "ocp 4.11"
+  #       commands:
+  #         - .ci/setenvconfig e2e/main
+  #         - .ci/setenvconfig e2e/ocp 4.11.5
+  #         - .buildkite/scripts/common/get-test-artifacts.sh
+  #         - make run-deployer
+  #         - make e2e-run
+  #       artifact_paths:
+  #         - "eck-diagnostic-*.zip"
 
-      - wait: ~
-        continue_on_failure: true
+  #     - wait: ~
+  #       continue_on_failure: true
 
-      - label: "cleanup"
-        commands:
-          - .ci/setenvconfig cleanup/ocp 4.7.49
-          - make run-deployer
+  #     - label: "cleanup"
+  #       commands:
+  #         - .ci/setenvconfig cleanup/ocp 4.7.49
+  #         - make run-deployer
 
-      - label: "cleanup"
-        commands:
-          - .ci/setenvconfig cleanup/ocp 4.8.50
-          - make run-deployer
+  #     - label: "cleanup"
+  #       commands:
+  #         - .ci/setenvconfig cleanup/ocp 4.8.50
+  #         - make run-deployer
 
-      - label: "cleanup"
-        commands:
-          - .ci/setenvconfig cleanup/ocp 4.9.48
-          - make run-deployer
+  #     - label: "cleanup"
+  #       commands:
+  #         - .ci/setenvconfig cleanup/ocp 4.9.48
+  #         - make run-deployer
 
-      - label: "cleanup"
-        commands:
-          - .ci/setenvconfig cleanup/ocp 4.10.34
-          - make run-deployer
+  #     - label: "cleanup"
+  #       commands:
+  #         - .ci/setenvconfig cleanup/ocp 4.10.34
+  #         - make run-deployer
 
-      - label: "cleanup"
-        commands:
-          - .ci/setenvconfig cleanup/ocp 4.11.5
-          - make run-deployer
+  #     - label: "cleanup"
+  #       commands:
+  #         - .ci/setenvconfig cleanup/ocp 4.11.5
+  #         - make run-deployer
 
-  - group: "tanzu"
-    steps:
+  # - group: "tanzu"
+  #   steps:
 
-      - label: "e2e/tanzu"
-        commands:
-          - .ci/setenvconfig e2e/main
-          - .ci/setenvconfig e2e/tanzu
-          - .buildkite/scripts/common/get-test-artifacts.sh
-          - make run-deployer
-          - make e2e-run
-        artifact_paths:
-          - "eck-diagnostic-*.zip"
+  #     - label: "e2e/tanzu"
+  #       commands:
+  #         - .ci/setenvconfig e2e/main
+  #         - .ci/setenvconfig e2e/tanzu
+  #         - .buildkite/scripts/common/get-test-artifacts.sh
+  #         - make run-deployer
+  #         - make e2e-run
+  #       artifact_paths:
+  #         - "eck-diagnostic-*.zip"
 
-      - wait: ~
-        continue_on_failure: true
+  #     - wait: ~
+  #       continue_on_failure: true
 
-      - label: "cleanup"
-        commands:
-          - .ci/setenvconfig cleanup/tanzu
-          - make run-deployer
+  #     - label: "cleanup"
+  #       commands:
+  #         - .ci/setenvconfig cleanup/tanzu
+  #         - make run-deployer
 
   - group: "resilience"
     steps:


### PR DESCRIPTION
Let's keep only the k8s providers that are ready to buildkite and re-enable the others one by one after fixing them.