### PR TITLE
Disabling Elastic Agent Fleet e2e tests temporarily due to EPR issues.

### DIFF
--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -124,6 +124,8 @@ func TestMultipleOutputConfig(t *testing.T) {
 }
 
 func TestFleetMode(t *testing.T) {
+	// Current issues with Elastic Package Registry is causing Fleet tests to fail.  Temporarily disabling until resolved.
+	t.SkipNow()
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	// installation of policies and integrations through Kibana file based configuration was broken between those versions:
 	if v.LT(version.MinFor(8, 1, 0)) && v.GTE(version.MinFor(8, 0, 0)) {

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -88,6 +88,8 @@ func TestMultiOutputRecipe(t *testing.T) {
 }
 
 func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
+	// Current issues with Elastic Package Registry is causing Fleet tests to fail.  Temporarily disabling until resolved.
+	t.SkipNow()
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
 			return builder
@@ -130,6 +132,8 @@ func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
+	// Current issues with Elastic Package Registry is causing Fleet tests to fail.  Temporarily disabling until resolved.
+	t.SkipNow()
 	notLoggingPod := beat.NewPodBuilder("test")
 	loggingPod := beat.NewPodBuilder("test")
 	loggingPod.Pod.Namespace = "default"
@@ -156,6 +160,8 @@ func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetAPMIntegrationRecipe(t *testing.T) {
+	// Current issues with Elastic Package Registry is causing Fleet tests to fail.  Temporarily disabling until resolved.
+	t.SkipNow()
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
 			return builder

--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -18,6 +18,8 @@ import (
 
 // TestFleetAgentWithoutTLS tests a Fleet Server, and Elastic Agent with TLS disabled for the HTTP layer.
 func TestFleetAgentWithoutTLS(t *testing.T) {
+	// Current issues with Elastic Package Registry is causing Fleet tests to fail.  Temporarily disabling until resolved.
+	t.SkipNow()
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
 	// Disabling TLS for Fleet isn't supported before 7.16, as Elasticsearch doesn't allow

--- a/test/e2e/agent/upgrade_test.go
+++ b/test/e2e/agent/upgrade_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestAgentVersionUpgradeToLatest8x(t *testing.T) {
+	// Current issues with Elastic Package Registry is causing Fleet tests to fail.  Temporarily disabling until resolved.
+	t.SkipNow()
 	srcVersion, dstVersion := test.GetUpgradePathTo8x(test.Ctx().ElasticStackVersion)
 
 	test.SkipInvalidUpgrade(t, srcVersion, dstVersion)


### PR DESCRIPTION
EPR is currently having issues that are causing all Elastic Agent Fleet e2e tests to fail with errors similar to

```
[2022-12-07T16:49:17.464+00:00][WARN ][plugins.fleet] Failed installing package [kubernetes] due to error: [PackageInvalidArchiveError: Error during extraction of package: Error: end of central directory record signature not found. Assumed content type was application/zip, check if this matches the archive type.]
```

This will disable the Agent Fleet e2e tests temporarily until resolved.