### PR TITLE
Fix EnterpriseSearch upgrade with TLS disabled

### DIFF
--- a/pkg/controller/enterprisesearch/version_upgrade.go
+++ b/pkg/controller/enterprisesearch/version_upgrade.go
@@ -168,9 +168,13 @@ func (r *VersionUpgrade) setReadOnlyMode(ctx context.Context, enabled bool) erro
 	httpClient := r.httpClient
 	if httpClient == nil {
 		// build an HTTP client to reach the Enterprise Search service
-		tlsCerts, err := r.retrieveTLSCerts()
-		if err != nil {
-			return err
+		var tlsCerts []*x509.Certificate
+		if r.ent.Spec.HTTP.TLS.Enabled() {
+			var err error
+			tlsCerts, err = r.retrieveTLSCerts()
+			if err != nil {
+				return err
+			}
 		}
 		httpClient = apmhttp.WrapClient(
 			commonhttp.Client(r.dialer, tlsCerts, 0),


### PR DESCRIPTION
Correctly create the HTTP client to call the EnterpriseSearch API when TLS is disabled at the EnterpriseSearch resource level.

Resolves #6185.

Since the HTTP client is mocked in the unit test, I didn't update it. If we want to cover this with a test, one option would be to extract the client creation in another method and test that one. It didn't seem worth it to me.

I made a pass on the places where `apmhttp.WrapClient`and `commonhttp.Client` are called and I did not find any other occurrence of this bug.