### PR TITLE
[2.6] Update registry.access.redhat.com/ubi8/ubi-minimal Docker tag to v8.7-923.1669829893 (#6204)

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -24,7 +24,7 @@ RUN CGO_ENABLED=0 GOOS=linux \
       -o elastic-operator github.com/elastic/cloud-on-k8s/v2/cmd
 
 # Copy the operator binary into a lighter image
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-923
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-923.1669829893
 
 # Update the base image packages to the latest versions
 RUN microdnf update --setopt=tsflags=nodocs && microdnf clean all

--- a/hack/deployer/clients/ocp/Dockerfile
+++ b/hack/deployer/clients/ocp/Dockerfile
@@ -12,6 +12,6 @@ RUN curl -fsSLO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${CLIE
     mv oc /usr/local/bin/oc && \
     rm openshift-client-linux-${CLIENT_VERSION}.tar.gz
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-923
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-923.1669829893
 COPY --from=builder /usr/local/bin/openshift-install .
 COPY --from=builder /usr/local/bin/oc .


### PR DESCRIPTION
# Backport

This backport is required as while during testing of redhat/operatorhub release tool in preparation for 2.6 release, the previous ubi image we built RC1 from (8.7-923), has a vulnerability which makes it's health index "B", which does not allow the container image to be published.

This will backport the following commits from `main` to `2.6`:
 - [Update registry.access.redhat.com/ubi8/ubi-minimal Docker tag to v8.7-923.1669829893 (#6204)](https://github.com/elastic/cloud-on-k8s/pull/6204)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)