### PR TITLE
Add validation rule for ElasticsearchAutoscaler resource

### DIFF
--- a/pkg/apis/elasticsearch/v1/elasticsearch_config.go
+++ b/pkg/apis/elasticsearch/v1/elasticsearch_config.go
@@ -192,3 +192,34 @@ func configureTransformRole(cfg *ElasticsearchSettings, ver version.Version) {
 
 	cfg.Node.Transform = pointer.BoolPtr(false)
 }
+
+func IsValidRole(role string) bool {
+	switch NodeRole(role) {
+	case DataColdRole:
+		return true
+	case DataContentRole:
+		return true
+	case DataFrozenRole:
+		return true
+	case DataHotRole:
+		return true
+	case DataRole:
+		return true
+	case DataWarmRole:
+		return true
+	case IngestRole:
+		return true
+	case MLRole:
+		return true
+	case MasterRole:
+		return true
+	case RemoteClusterClientRole:
+		return true
+	case TransformRole:
+		return true
+	case VotingOnlyRole:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/controller/autoscaling/elasticsearch/validation/webhook_test.go
+++ b/pkg/controller/autoscaling/elasticsearch/validation/webhook_test.go
@@ -110,31 +110,6 @@ func TestValidateElasticsearchAutoscaler(t *testing.T) {
 			},
 		},
 		{
-			name: "autoscaling is only supported for data tiers and ML nodes",
-			args: args{
-				es: es(map[string]string{}, map[string][]string{"nodeset-data-ml": {"ingest", "transform"}}, nil, "8.0.0"),
-				esa: v1alpha1.ElasticsearchAutoscaler{
-					ObjectMeta: metav1.ObjectMeta{Name: "esa", Namespace: "ns"},
-					Spec: v1alpha1.ElasticsearchAutoscalerSpec{
-						ElasticsearchRef: v1alpha1.ElasticsearchRef{
-							Name: "es",
-						},
-						AutoscalingPolicySpecs: commonv1alpha1.AutoscalingPolicySpecs{
-							{
-								NamedAutoscalingPolicy: commonv1alpha1.NamedAutoscalingPolicy{
-									Name:              "ingest-transform_policy",
-									AutoscalingPolicy: commonv1alpha1.AutoscalingPolicy{Roles: []string{"ingest", "transform"}},
-								},
-								AutoscalingResources: defaultResources,
-							},
-						},
-					},
-				},
-				checker: yesCheck,
-			},
-			wantValidationError: ptr.String("autoscaling is only supported for data tiers and ML nodes"),
-		},
-		{
 			name: "invalid node role",
 			args: args{
 				es: es(map[string]string{}, map[string][]string{"nodeset-data-ml": {"data", "ingest", "transform"}}, nil, "8.0.0"),

--- a/pkg/controller/common/autoscaling/validations.go
+++ b/pkg/controller/common/autoscaling/validations.go
@@ -161,16 +161,6 @@ func ValidateAutoscalingPolicies(
 			}
 		}
 
-		// at least ml or a data role is present
-		if !CanBeAutoscaled(autoscalingSpec.Roles) {
-			errs = append(
-				errs,
-				field.Invalid(
-					autoscalingSpecPath(i, "name"), strings.Join(autoscalingSpec.Roles, ","),
-					"autoscaling is only supported for data tiers and ML nodes"),
-			)
-		}
-
 		if !(autoscalingSpec.NodeCountRange.Min >= 0) {
 			errs = append(
 				errs,
@@ -282,27 +272,4 @@ func HasAtMostOnePersistentVolumeClaim(nodeSet esv1.NodeSet) (bool, *corev1.Pers
 		return true, nodeSet.VolumeClaimTemplates[0].DeepCopy()
 	}
 	return false, nil
-}
-
-// canBeAutoscaled return true if there is at least a ml role or a data role in a set of roles.
-func canBeAutoscaled(roles []string) bool {
-	for _, role := range roles {
-		switch esv1.NodeRole(role) { //nolint:exhaustive
-		case esv1.DataColdRole:
-			return true
-		case esv1.DataContentRole:
-			return true
-		case esv1.DataFrozenRole:
-			return true
-		case esv1.DataHotRole:
-			return true
-		case esv1.DataRole:
-			return true
-		case esv1.DataWarmRole:
-			return true
-		case esv1.MLRole:
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
- validate that all roles are valid
- ~validate that there is at least `ml` or a `data` role in the node roles~

Relates to #6236.