### PR TITLE
Add experimental label to the StackConfigPolicy doc

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
@@ -7,6 +7,8 @@ endif::[]
 [id="{p}-{page_id}"]
 = Elastic Stack configuration policies
 
+experimental[]
+
 NOTE: This requires a valid Enterprise license or Enterprise trial license. Check <<{p}-licensing,the license documentation>> for more details about managing licenses.
 
 Starting from ECK `2.6.0` and Elasticsearch `8.6.0`, Elastic Stack configuration policies allow you to configure the following settings:


### PR DESCRIPTION
This adds the experimental label to the Elastic Stack configuration policies documentation.