### PR TITLE
Shorten ES cluster name in TestEnterpriseSearchTLSDisabledVersionUpgr…

### DIFF
--- a/test/e2e/ent/ent_test.go
+++ b/test/e2e/ent/ent_test.go
@@ -88,7 +88,7 @@ func TestEnterpriseSearchTLSDisabledVersionUpgradeToLatest8x(t *testing.T) {
 
 	test.SkipInvalidUpgrade(t, srcVersion, dstVersion)
 
-	name := "test-ent-notls-version-upgrade-8x"
+	name := "test-ent-notls-v-up-8x"
 	es := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
 		WithVersion(srcVersion)


### PR DESCRIPTION
Fixes:
```
Invalid value: "test-ent-notls-version-upgrade-8x-rg6h": Elasticsearch configuration would
generate resources with invalid names: name exceeds maximum allowed length of 36
```

I missed this because when I triggered a manual run of the e2e test, the current version of the stack is used, which caused us to skip the test as we are already on the latest version 8x.

Follow-up of #6224.