### PR TITLE
[2.6] Add additional helm documentation for Fleet Server, and Agent (#6154)

### DIFF
--- a/deploy/eck-elasticsearch/examples/hot-warm-cold.yaml
+++ b/deploy/eck-elasticsearch/examples/hot-warm-cold.yaml
@@ -7,7 +7,7 @@ nodeSets:
     # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
     # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
     # and leave node.store.allow_mmap unset.
-    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
     #
     node.store.allow_mmap: false
   podTemplate:
@@ -35,7 +35,7 @@ nodeSets:
       #           values:
       #           - highio
   # Volume Claim settings.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/2.2/k8s-volume-claim-templates.html
+  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
   #
   volumeClaimTemplates:
   - metadata:
@@ -56,7 +56,7 @@ nodeSets:
     # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
     # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
     # and leave node.store.allow_mmap unset.
-    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
     #
     node.store.allow_mmap: false
   podTemplate:
@@ -84,7 +84,7 @@ nodeSets:
       #           values:
       #           - highio
   # Volume Claim settings.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/2.2/k8s-volume-claim-templates.html
+  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
   #
   volumeClaimTemplates:
   - metadata:
@@ -105,7 +105,7 @@ nodeSets:
     # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
     # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
     # and leave node.store.allow_mmap unset.
-    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
     #
     node.store.allow_mmap: false
   podTemplate:
@@ -133,7 +133,7 @@ nodeSets:
       #           values:
       #           - highstorage
   # Volume Claim settings.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/2.2/k8s-volume-claim-templates.html
+  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
   #
   volumeClaimTemplates:
   - metadata:
@@ -154,7 +154,7 @@ nodeSets:
     # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
     # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
     # and leave node.store.allow_mmap unset.
-    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
     #
     node.store.allow_mmap: false
   podTemplate:
@@ -182,7 +182,7 @@ nodeSets:
       #           values:
       #           - highstorage
   # Volume Claim settings.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/2.2/k8s-volume-claim-templates.html
+  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
   #
   volumeClaimTemplates:
   - metadata:

--- a/deploy/eck-elasticsearch/values.yaml
+++ b/deploy/eck-elasticsearch/values.yaml
@@ -76,7 +76,7 @@ nodeSets:
     # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
     # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
     # and leave node.store.allow_mmap unset.
-    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
     #
     node.store.allow_mmap: false
   podTemplate:

--- a/deploy/eck-stack/README.md
+++ b/deploy/eck-stack/README.md
@@ -47,8 +47,8 @@ The following will install the ECK-Stack chart using the default values, which w
 helm repo add elastic https://helm.elastic.co && helm repo update
 
 # Install the ECK-Stack helm chart
-# This will setup a 'quickstart' Elasticsearch and Kibana resource
-$ helm install my-release -n my-namespace elastic/eck-stack --create-namespace
+# This will setup a 'quickstart' Elasticsearch and Kibana resource in the 'elastic-stack' namespace
+$ helm install my-release -n elastic-stack elastic/eck-stack --create-namespace
 ```
 
 More information on the different ways to use the ECK Stack chart to deploy Elastic Stack resources
@@ -56,10 +56,10 @@ can be found in [our documentation](https://www.elastic.co/guide/en/cloud-on-k8s
 
 ## Uninstalling the Chart
 
-To uninstall/delete the `my-release` deployment from the 'my-namespace' namespace:
+To uninstall/delete the `my-release` deployment from the 'elastic-stack' namespace:
 
 ```console
-$ helm delete my-release -n my-namespace
+$ helm delete my-release -n elastic-stack
 ```
 
 The command removes all the Elastic Stack resources associated with the chart and deletes the release.

--- a/deploy/eck-stack/examples/agent/fleet-agents.yaml
+++ b/deploy/eck-stack/examples/agent/fleet-agents.yaml
@@ -6,10 +6,6 @@ eck-elasticsearch:
   #
   fullnameOverride: elasticsearch
 
-  # Version of Elasticsearch.
-  #
-  version: 8.2.3
-
   nodeSets:
   - name: default
     count: 3
@@ -28,15 +24,7 @@ eck-kibana:
   #
   fullnameOverride: kibana
   
-  # Version of Kibana.
-  #
-  version: 8.2.3
-  
   spec:
-    # Count of Kibana instances to create.
-    #
-    count: 1
-  
     # Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
     #
     elasticsearchRef:
@@ -44,10 +32,13 @@ eck-kibana:
 
     config:
       # Note that these are specific to the namespace into which this example is installed, and are
-      # using `default` as configured here.  If installed outside of the `default` namespace,
-      # these 2 lines need modification.
-      xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.default.svc:9200"]
-      xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
+      # using `elastic-stack` as configured here and detailed in the README when installing:
+      #
+      # `helm install es-kb-quickstart elastic/eck-stack -n elastic-stack`
+      #
+      # If installed outside of the `elastic-stack` namespace, the following 2 lines need modification.
+      xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.elastic-stack.svc:9200"]
+      xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.elastic-stack.svc:8220"]
       xpack.fleet.packages:
       - name: system
         version: latest
@@ -88,10 +79,6 @@ eck-kibana:
 
 eck-agent:
   enabled: true
-
-  # Version of Elastic Agent.
-  #
-  version: 8.2.3
   
   spec:
     # Reference to ECK-managed Kibana instance.

--- a/deploy/eck-stack/examples/custom-elasticsearch-kibana.yaml
+++ b/deploy/eck-stack/examples/custom-elasticsearch-kibana.yaml
@@ -15,7 +15,7 @@ eck-elasticsearch:
       # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
       # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
       # and leave node.store.allow_mmap unset.
-      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
       #
       node.store.allow_mmap: false
     volumeClaimTemplates:

--- a/deploy/eck-stack/examples/elasticsearch/hot-warm-cold.yaml
+++ b/deploy/eck-stack/examples/elasticsearch/hot-warm-cold.yaml
@@ -1,0 +1,199 @@
+---
+eck-elasticsearch:
+  nodeSets:
+  - name: masters
+    count: 1
+    config:
+      node.roles: ["master"]
+      # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+      # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+      # and leave node.store.allow_mmap unset.
+      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+      #
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 8Gi
+              cpu: 2
+        # Affinity/Anti-affinity settings for controlling the 'spreading' of Elasticsearch
+        # pods across existing hosts.
+        # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+        # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html#k8s-affinity-options
+        #
+        # affinity:
+        #   nodeAffinity:
+        #     requiredDuringSchedulingIgnoredDuringExecution:
+        #       nodeSelectorTerms:
+        #       - matchExpressions:
+        #         - key: beta.kubernetes.io/instance-type
+        #           operator: In
+        #           # This should be adjusted to the instance type according to your setup
+        #           #
+        #           values:
+        #           - highio
+    # Volume Claim settings.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
+    #
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Ti
+        # Adjust to your storage class name
+        #
+        # storageClassName: local-storage
+  - name: hot
+    count: 1
+    config:
+      node.roles: ["data_hot", "data_content", "ingest"]
+      # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+      # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+      # and leave node.store.allow_mmap unset.
+      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+      #
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 16Gi
+              cpu: 4
+        # Affinity/Anti-affinity settings for controlling the 'spreading' of Elasticsearch
+        # pods across existing hosts.
+        # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+        # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html#k8s-affinity-options
+        #
+        # affinity:
+        #   nodeAffinity:
+        #     requiredDuringSchedulingIgnoredDuringExecution:
+        #       nodeSelectorTerms:
+        #       - matchExpressions:
+        #         - key: beta.kubernetes.io/instance-type
+        #           operator: In
+        #           # This should be adjusted to the instance type according to your setup
+        #           #
+        #           values:
+        #           - highio
+    # Volume Claim settings.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
+    #
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Ti
+        # Adjust to your storage class name
+        #
+        # storageClassName: local-storage
+  - name: warm
+    count: 1
+    config:
+      node.roles: ["data_warm"]
+      # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+      # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+      # and leave node.store.allow_mmap unset.
+      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+      #
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 16Gi
+              cpu: 2
+        # Affinity/Anti-affinity settings for controlling the 'spreading' of Elasticsearch
+        # pods across existing hosts.
+        # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+        # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html#k8s-affinity-options
+        #
+        # affinity:
+        #   nodeAffinity:
+        #     requiredDuringSchedulingIgnoredDuringExecution:
+        #       nodeSelectorTerms:
+        #       - matchExpressions:
+        #         - key: beta.kubernetes.io/instance-type
+        #           operator: In
+        #           # This should be adjusted to the instance type according to your setup
+        #           #
+        #           values:
+        #           - highstorage
+    # Volume Claim settings.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
+    #
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Ti
+        # Adjust to your storage class name
+        #
+        # storageClassName: local-storage
+  - name: cold
+    count: 1
+    config:
+      node.roles: ["data_cold"]
+      # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+      # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+      # and leave node.store.allow_mmap unset.
+      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+      #
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 8Gi
+              cpu: 2
+        # Affinity/Anti-affinity settings for controlling the 'spreading' of Elasticsearch
+        # pods across existing hosts.
+        # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+        # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html#k8s-affinity-options
+        #
+        # affinity:
+        #   nodeAffinity:
+        #     requiredDuringSchedulingIgnoredDuringExecution:
+        #       nodeSelectorTerms:
+        #       - matchExpressions:
+        #         - key: beta.kubernetes.io/instance-type
+        #           operator: In
+        #           # This should be adjusted to the instance type according to your setup
+        #           #
+        #           values:
+        #           - highstorage
+    # Volume Claim settings.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
+    #
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Ti
+        # Adjust to your storage class name
+        #
+        # storageClassName: local-storage

--- a/deploy/eck-stack/examples/kibana/http-configuration.yaml
+++ b/deploy/eck-stack/examples/kibana/http-configuration.yaml
@@ -1,0 +1,24 @@
+---
+eck-kibana:
+  spec:
+    # Count of Kibana replicas to create.
+    #
+    count: 1
+
+    # Reference to ECK-managed Elasticsearch resource, ideally from {{ "elasticsearch.fullname" }}
+    #
+    elasticsearchRef:
+      name: es-quickstart-eck-elasticsearch
+      # namespace: default
+    http:
+      service:
+        spec:
+          # Type of service to deploy for Kibana.
+          # This deploys a load balancer in a cloud service provider, where supported.
+          # 
+          type: LoadBalancer
+      # tls:
+      #   selfSignedCertificate:
+      #     subjectAltNames:
+      #     - ip: 1.2.3.4
+      #     - dns: kibana.example.com

--- a/docs/orchestrating-elastic-stack-applications/stack-helm-chart.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/stack-helm-chart.asciidoc
@@ -42,7 +42,19 @@ To use one or more of these example configurations, use the `--values` Helm opti
 [source,sh]
 ----
 # Install an eck-managed Elasticsearch and Kibana using the Elasticsearch node roles example with hot, warm, and cold data tiers, and the Kibana example customizing the http service.
-helm install es-quickstart elastic/eck-stack -n elastic-stack --create-namespace --values https://github.com/elastic/cloud-on-k8s/tree/main/deploy/eck-stack/examples/elasticsearch/hot-warm-cold.yaml --values https://github.com/elastic/cloud-on-k8s/tree/main/deploy/eck-stack/examples/kibana/http-configuration.yaml
+helm install es-quickstart elastic/eck-stack -n elastic-stack --create-namespace --values https://raw.githubusercontent.com/elastic/cloud-on-k8s/{eck_release_branch}/deploy/eck-stack/examples/elasticsearch/hot-warm-cold.yaml --values https://raw.githubusercontent.com/elastic/cloud-on-k8s/{eck_release_branch}/deploy/eck-stack/examples/kibana/http-configuration.yaml
+----
+
+[float]
+[id="{p}-install-fleet-agent-elasticsearch-kibana-helm"]
+== Installing Fleet Server with Elastic Agents along with Elasticsearch and Kibana using the eck-stack Helm Chart
+
+The following section builds upon the previous section, and allows installing Fleet Server, and Fleet-managed Elastic Agents along with Elasticsearch and Kibana.
+
+[source,sh]
+----
+# Install an eck-managed Elasticsearch, Kibana, Fleet Server, and managed Elastic Agents using custom values.
+helm install eck-stack-with-fleet elastic/eck-stack --values https://raw.githubusercontent.com/elastic/cloud-on-k8s/{eck_release_branch}/deploy/eck-stack/examples/agent/fleet-agents.yaml -n elastic-stack
 ----
 
 [float]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.6`:
 - [Add additional helm documentation for Fleet Server, and Agent (#6154)](https://github.com/elastic/cloud-on-k8s/pull/6154)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)