### PR TITLE
Update broken pod template spec link

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/customize-pods.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/customize-pods.asciidoc
@@ -101,4 +101,4 @@ spec:
 For further information:
 
 - https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates[Pod templates overview]
-- https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#podtemplatespec-v1-core[Pod template spec API reference]
+- https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podtemplatespec-v1-core[Pod template spec API reference]


### PR DESCRIPTION
The current link for pod template spec api docs is broken.  Unfortunately there doesn't seem to be a `current` or `latest` link for this to stay updated automatically.