### PR TITLE
Prepare doc attributes for 2.6 release

### DIFF
--- a/docs/eck-attributes.asciidoc
+++ b/docs/eck-attributes.asciidoc
@@ -1,5 +1,5 @@
-:eck_version: 2.5.0
+:eck_version: v2.6.0
 :eck_crd_version: v1
-:eck_release_branch: 2.5
+:eck_release_branch: 2.6
 :eck_github: https://github.com/elastic/cloud-on-k8s
 :eck_resources_list: Elasticsearch, Kibana, APM Server, Enterprise Search, Beats, Elastic Agent, and Elastic Maps Server

--- a/docs/eck-attributes.asciidoc
+++ b/docs/eck-attributes.asciidoc
@@ -1,4 +1,4 @@
-:eck_version: v2.6.0
+:eck_version: 2.6.0
 :eck_crd_version: v1
 :eck_release_branch: 2.6
 :eck_github: https://github.com/elastic/cloud-on-k8s


### PR DESCRIPTION
Switch to 2.6 branch for the upcoming release. Can be merged as soon as we have a https://github.com/elastic/docs/pull/2590 but should be done in sync with the actual release.