### PR TITLE
[2.6] ECK resources Helm chart - Beats

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -46,6 +46,37 @@ To see all resources installed by the helm chart
 kubectl get elastic -l "app.kubernetes.io/instance"=es-kb-quickstart -n elastic-stack
 ```
 
+## ECK Helm Chart Development
+
+### ECK Helm Chart test suite
+
+[Helm UnitTest Plugin](https://github.com/quintush/helm-unittest) is used to ensure Helm Charts render properly.
+
+#### Installation
+
+```
+helm plugin install https://github.com/quintush/helm-unittest --version 0.2.8
+```
+
+#### Running Test Suite
+
+The test suite can be run from the Makefile in the root of the project with the following command:
+
+```
+make helm-test
+```
+
+*Note* that the Makefile target runs the script in `{root}/hack/helm/test.sh`
+
+#### Manually invoking the Helm Unit Tests for a particular Chart
+
+The Helm unit tests can be manually invoked for any of the charts with the following command:
+
+```
+cd deploy/eck-stack
+helm unittest -3 -f 'templates/tests/*.yaml' .
+``````
+
 ## Licensing
 
 The ECK Helm Charts are licensed under the [Elastic License 2.0](https://www.elastic.co/licensing/elastic-license) like the operator, but require different subscription levels.

--- a/deploy/eck-agent/Chart.yaml
+++ b/deploy/eck-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-agent
 description: A Helm chart to deploy Elastic Agent managed by the ECK Operator.
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.1.0
+version: 0.2.0
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/elastic-agent

--- a/deploy/eck-agent/examples/fleet-agents.yaml
+++ b/deploy/eck-agent/examples/fleet-agents.yaml
@@ -1,12 +1,12 @@
 # The following example should only be used in conjunction with the 'eck-fleet-server' Helm Chart,
 # and shows how the Agents can be deployed as a daemonset, and controlled by Fleet Server.
 #
-version: 8.2.3
+version: 8.5.0
 
 spec:
   # This must match the name of the fleet server installed from eck-fleet-server chart.
   fleetServerRef:
-    name: fleet-server
+    name: eck-fleet-server
   kibanaRef:
     name: eck-kibana
   mode: fleet

--- a/deploy/eck-agent/examples/system-integration.yaml
+++ b/deploy/eck-agent/examples/system-integration.yaml
@@ -1,10 +1,10 @@
 # The following example should only be used in Agent "standalone" mode,
 # and should not be used when Agent is used with Fleet Server.
 #
-version: 8.2.3
+version: 8.5.0
 spec:
   elasticsearchRefs:
-  - name: elasticsearch
+  - name: eck-elasticsearch
   daemonSet:
     podTemplate:
       spec:
@@ -33,7 +33,7 @@ spec:
       meta:
         package:
           name: system
-          version: 8.2.3
+          version: 8.5.0
       data_stream:
         namespace: default
       streams:

--- a/deploy/eck-agent/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-agent/templates/tests/elastic-agent_test.yaml
@@ -13,7 +13,7 @@ tests:
           value: quickstart-eck-agent
       - equal:
           path: spec.version
-          value: 8.2.3
+          value: 8.5.0
       - equal:
           path: spec.config
           value: null

--- a/deploy/eck-agent/values.yaml
+++ b/deploy/eck-agent/values.yaml
@@ -18,7 +18,7 @@
 
 # Version of Elastic Agent.
 #
-version: 8.2.3
+version: 8.5.0
 
 # Labels that will be applied to Elastic Agent.
 #
@@ -45,7 +45,7 @@ spec:
   # Reference to ECK-managed Elasticsearch instance.
   #
   elasticsearchRefs:
-  - name: elasticsearch
+  - name: eck-elasticsearch
     # Optional namespace reference to Elasticsearch instance.
     # If not specified, then the namespace of the Agent instance
     # will be assumed.
@@ -55,7 +55,7 @@ spec:
   # Reference to ECK-managed Fleet Server instance.
   #
   # fleetServerRef:
-  #   name: fleet-server
+  #   name: eck-fleet-server
     # Optional namespace reference to Fleet Server instance.
     # If not specified, then the namespace of the Agent instance
     # will be assumed.

--- a/deploy/eck-beats/.helmignore
+++ b/deploy/eck-beats/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+templates/tests

--- a/deploy/eck-beats/Chart.yaml
+++ b/deploy/eck-beats/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: eck-beats
+description: A Helm chart to deploy Elastic Beats managed by the ECK Operator.
+# Requirement comes from minimum version supported for eck-operator (https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s_supported_versions.html)
+kubeVersion: ">= 1.20.0-0"
+type: application
+version: 0.1.0
+sources:
+  - https://github.com/elastic/cloud-on-k8s
+  - https://github.com/elastic/beats
+icon: https://helm.elastic.co/icons/beats.png

--- a/deploy/eck-beats/LICENSE
+++ b/deploy/eck-beats/LICENSE
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/deploy/eck-beats/examples/auditbeat_hosts.yaml
+++ b/deploy/eck-beats/examples/auditbeat_hosts.yaml
@@ -1,0 +1,111 @@
+name: auditbeat
+version: 8.5.0
+spec:
+  type: auditbeat
+  elasticsearchRef:
+    name: eck-elasticsearch
+  kibanaRef:
+    name: eck-kibana
+  config:
+    auditbeat.modules:
+    - module: file_integrity
+      paths:
+      - /hostfs/bin
+      - /hostfs/usr/bin
+      - /hostfs/sbin
+      - /hostfs/usr/sbin
+      - /hostfs/etc
+      exclude_files:
+      - '(?i)\.sw[nop]$'
+      - '~$'
+      - '/\.git($|/)'
+      scan_at_start: true
+      scan_rate_per_sec: 50 MiB
+      max_file_size: 100 MiB
+      hash_types: [sha1]
+      recursive: true
+    - module: auditd
+      audit_rules: |
+        # Executions
+        -a always,exit -F arch=b64 -S execve,execveat -k exec
+
+        # Unauthorized access attempts (amd64 only)
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access
+
+    processors:
+    - add_cloud_metadata: {}
+    - add_host_metadata: {}
+    - add_process_metadata:
+        match_pids: ['process.pid']
+  daemonSet:
+    podTemplate:
+      spec:
+        hostPID: true  # Required by auditd module
+        dnsPolicy: ClusterFirstWithHostNet
+        hostNetwork: true # Allows to provide richer host metadata
+        automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+        securityContext:
+          runAsUser: 0
+        volumes:
+        - name: bin
+          hostPath:
+            path: /bin
+        - name: usrbin
+          hostPath:
+            path: /usr/bin
+        - name: sbin
+          hostPath:
+            path: /sbin
+        - name: usrsbin
+          hostPath:
+            path: /usr/sbin
+        - name: etc
+          hostPath:
+            path: /etc
+        - name: run-containerd
+          hostPath:
+            path: /run/containerd
+            type: DirectoryOrCreate
+        # Uncomment the below when running on GKE. See https://github.com/elastic/beats/issues/8523 for more context.
+        #- name: run
+        #  hostPath:
+        #    path: /run
+        #initContainers:
+        #- name: cos-init
+        #  image: docker.elastic.co/beats/auditbeat:8.3.3
+        #  volumeMounts:
+        #  - name: run
+        #    mountPath: /run
+        #  command: ['sh', '-c', 'export SYSTEMD_IGNORE_CHROOT=1 && systemctl stop systemd-journald-audit.socket && systemctl mask systemd-journald-audit.socket && systemctl restart systemd-journald']
+        containers:
+        - name: auditbeat
+          securityContext:
+            capabilities:
+              add:
+              # Capabilities needed for auditd module
+              - 'AUDIT_READ'
+              - 'AUDIT_WRITE'
+              - 'AUDIT_CONTROL'
+          volumeMounts:
+          - name: bin
+            mountPath: /hostfs/bin
+            readOnly: true
+          - name: sbin
+            mountPath: /hostfs/sbin
+            readOnly: true
+          - name: usrbin
+            mountPath: /hostfs/usr/bin
+            readOnly: true
+          - name: usrsbin
+            mountPath: /hostfs/usr/sbin
+            readOnly: true
+          - name: etc
+            mountPath: /hostfs/etc
+            readOnly: true
+          # Directory with root filesystems of containers executed with containerd, this can be
+          # different with other runtimes. This volume is needed to monitor the file integrity
+          # of files in containers.
+          - name: run-containerd
+            mountPath: /run/containerd
+            readOnly: true

--- a/deploy/eck-beats/examples/filebeat_no_autodiscover.yaml
+++ b/deploy/eck-beats/examples/filebeat_no_autodiscover.yaml
@@ -1,0 +1,46 @@
+name: filebeat
+version: 8.5.0
+spec:
+  type: filebeat
+  elasticsearchRef:
+    name: eck-elasticsearch
+  kibanaRef:
+    name: eck-kibana
+  config:
+    filebeat.inputs:
+    - type: container
+      paths:
+      - /var/log/containers/*.log
+    processors:
+    - add_host_metadata: {}
+    - add_cloud_metadata: {}
+  daemonSet:
+    podTemplate:
+      spec:
+        automountServiceAccountToken: true
+        terminationGracePeriodSeconds: 30
+        dnsPolicy: ClusterFirstWithHostNet
+        hostNetwork: true # Allows to provide richer host metadata
+        containers:
+        - name: filebeat
+          securityContext:
+            runAsUser: 0
+            # If using Red Hat OpenShift uncomment this:
+            #privileged: true
+          volumeMounts:
+          - name: varlogcontainers
+            mountPath: /var/log/containers
+          - name: varlogpods
+            mountPath: /var/log/pods
+          - name: varlibdockercontainers
+            mountPath: /var/lib/docker/containers
+        volumes:
+        - name: varlogcontainers
+          hostPath:
+            path: /var/log/containers
+        - name: varlogpods
+          hostPath:
+            path: /var/log/pods
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers

--- a/deploy/eck-beats/examples/heartbeat_es_kb_health.yaml
+++ b/deploy/eck-beats/examples/heartbeat_es_kb_health.yaml
@@ -1,0 +1,24 @@
+name: heartbeat
+version: 8.5.0
+spec:
+  type: heartbeat
+  elasticsearchRef:
+    name: eck-elasticsearch
+  config:
+    heartbeat.monitors:
+    - type: tcp
+      schedule: '@every 5s'
+      # This should directly match the name of the Elasticsearch instance
+      # with "-es-http" appended to the name.
+      hosts: ["elasticsearch-es-http.default.svc:9200"]
+    - type: tcp
+      schedule: '@every 5s'
+      # This should directly match the names of the Kibana instance
+      # with "-kb-http" appended to the name.
+      hosts: ["eck-kibana-kb-http.default.svc:5601"]
+  deployment:
+    replicas: 1
+    podTemplate:
+      spec:
+        securityContext:
+          runAsUser: 0

--- a/deploy/eck-beats/examples/metricbeat_hosts.yaml
+++ b/deploy/eck-beats/examples/metricbeat_hosts.yaml
@@ -1,0 +1,159 @@
+name: metricbeat
+spec:
+  type: metricbeat
+  version: 8.5.0
+  elasticsearchRef:
+    name: eck-elasticsearch
+  kibanaRef:
+    name: eck-kibana
+  config:
+    metricbeat:
+      autodiscover:
+        providers:
+        - hints:
+            default_config: {}
+            enabled: "true"
+          node: ${NODE_NAME}
+          type: kubernetes
+      modules:
+      - module: system
+        period: 10s
+        metricsets:
+        - cpu
+        - load
+        - memory
+        - network
+        - process
+        - process_summary
+        process:
+          include_top_n:
+            by_cpu: 5
+            by_memory: 5
+        processes:
+        - .*
+      - module: system
+        period: 1m
+        metricsets:
+        - filesystem
+        - fsstat
+        processors:
+        - drop_event:
+            when:
+              regexp:
+                system:
+                  filesystem:
+                    mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib)($|/)
+      - module: kubernetes
+        period: 10s
+        node: ${NODE_NAME}
+        hosts:
+        - https://${NODE_NAME}:10250
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        ssl:
+          verification_mode: none
+        metricsets:
+        - node
+        - system
+        - pod
+        - container
+        - volume
+    processors:
+    - add_cloud_metadata: {}
+    - add_host_metadata: {}
+  daemonSet:
+    podTemplate:
+      spec:
+        serviceAccountName: metricbeat
+        automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+        containers:
+        - args:
+          - -e
+          - -c
+          - /etc/beat.yml
+          - -system.hostfs=/hostfs
+          name: metricbeat
+          volumeMounts:
+          - mountPath: /hostfs/sys/fs/cgroup
+            name: cgroup
+          - mountPath: /var/run/docker.sock
+            name: dockersock
+          - mountPath: /hostfs/proc
+            name: proc
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+        dnsPolicy: ClusterFirstWithHostNet
+        hostNetwork: true # Allows to provide richer host metadata
+        securityContext:
+          runAsUser: 0
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - hostPath:
+            path: /sys/fs/cgroup
+          name: cgroup
+        - hostPath:
+            path: /var/run/docker.sock
+          name: dockersock
+        - hostPath:
+            path: /proc
+          name: proc
+
+clusterRole:
+  # permissions needed for metricbeat
+  # source: https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-kubernetes.html
+  name: metricbeat
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    - namespaces
+    - events
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - "extensions"
+    resources:
+    - replicasets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - statefulsets
+    - deployments
+    - replicasets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/stats
+    verbs:
+    - get
+  - nonResourceURLs:
+    - /metrics
+    verbs:
+    - get
+
+serviceAccount:
+  name: metricbeat
+
+clusterRoleBinding:
+  name: metricbeat
+  subjects:
+  - kind: ServiceAccount
+    name: metricbeat
+  roleRef:
+    kind: ClusterRole
+    name: metricbeat
+    apiGroup: rbac.authorization.k8s.io

--- a/deploy/eck-beats/examples/packetbeat_dns_http.yaml
+++ b/deploy/eck-beats/examples/packetbeat_dns_http.yaml
@@ -1,0 +1,38 @@
+name: packetbeat
+spec:
+  type: packetbeat
+  version: 8.5.0
+  elasticsearchRef:
+    name: eck-elasticsearch
+  kibanaRef:
+    name: eck-kibana
+  config:
+    packetbeat.interfaces.device: any
+    packetbeat.protocols:
+    - type: dns
+      ports: [53]
+      include_authorities: true
+      include_additionals: true
+    - type: http
+      ports: [80, 8000, 8080, 9200]
+    packetbeat.flows:
+      timeout: 30s
+      period: 10s
+    processors:
+    - add_cloud_metadata: {}
+    - add_host_metadata: {}
+  daemonSet:
+    podTemplate:
+      spec:
+        terminationGracePeriodSeconds: 30
+        hostNetwork: true
+        automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+        dnsPolicy: ClusterFirstWithHostNet
+        containers:
+        - name: packetbeat
+          securityContext:
+            runAsUser: 0
+            capabilities:
+              add:
+              - NET_ADMIN
+        volumes: []

--- a/deploy/eck-beats/templates/NOTES.txt
+++ b/deploy/eck-beats/templates/NOTES.txt
@@ -1,0 +1,6 @@
+
+1. Check Beat status
+  $ kubectl get beat {{ include "beat.fullname" . }} -n {{ .Release.Namespace }}
+
+2. Check Beat pod status
+  $ kubectl get pods --namespace={{ .Release.Namespace }} -l beat.k8s.elastic.co/name={{ include "beat.fullname" . }}

--- a/deploy/eck-beats/templates/_helpers.tpl
+++ b/deploy/eck-beats/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "beat.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "beat.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "beat.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "beat.labels" -}}
+helm.sh/chart: {{ include "beat.chart" . }}
+{{ include "beat.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "beat.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "beat.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deploy/eck-beats/templates/beats.yaml
+++ b/deploy/eck-beats/templates/beats.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: beat.k8s.elastic.co/v1beta1
+kind: Beat
+metadata:
+  name: {{ include "beat.fullname" . }}
+  labels:
+    {{- include "beat.labels" . | nindent 4 }}
+  annotations:
+    eck.k8s.elastic.co/license: enterprise
+    {{- if .Values.annotations }}
+    {{- toYaml .Values.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  version: {{ required "A Beat version is required" .Values.version }}
+  type: {{ required "A Beat type is required" .Values.spec.type }}
+  {{- if and (not (hasKey .Values.spec "daemonSet")) (not (hasKey .Values.spec "deployment")) }}
+  {{ fail "At least one of daemonSet or deployment is required for a functional Beat" }}
+  {{- end }}
+  {{- toYaml .Values.spec | nindent 2 }}

--- a/deploy/eck-beats/templates/cluster-role-binding.yaml
+++ b/deploy/eck-beats/templates/cluster-role-binding.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.clusterRoleBinding }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.clusterRoleBinding.name }}
+  labels:
+    {{- include "beat.labels" . | nindent 4 }}
+    {{- if .Values.clusterRoleBinding.labels }}
+    {{- toYaml .Values.clusterRoleBinding.labels | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.annotations .Values.clusterRoleBinding.annotations }}
+  annotations:
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.clusterRoleBinding.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- if .Values.clusterRoleBinding.subjects }}
+subjects:
+{{- range .Values.clusterRoleBinding.subjects }}
+  - kind: {{ .kind }}
+    name: {{ .name }}
+    namespace: {{ .namespace | default $.Release.Namespace | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.clusterRoleBinding.roleRef }}
+roleRef:
+  kind: {{ .Values.clusterRoleBinding.roleRef.kind }}
+  name: {{ .Values.clusterRoleBinding.roleRef.name }}
+  apiGroup: {{ .Values.clusterRoleBinding.roleRef.apiGroup }}
+{{- end }}
+{{- end }}

--- a/deploy/eck-beats/templates/cluster-role.yaml
+++ b/deploy/eck-beats/templates/cluster-role.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.clusterRole }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.clusterRole.name }}
+  labels:
+    {{- include "beat.labels" . | nindent 4 }}
+    {{- if .Values.clusterRole.labels }}
+    {{- toYaml .Values.clusterRole.labels | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.annotations .Values.clusterRole.annotations }}
+  annotations:
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.clusterRole.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+rules: {{- toYaml .Values.clusterRole.rules | nindent 2 }}
+{{- end }}

--- a/deploy/eck-beats/templates/service-account.yaml
+++ b/deploy/eck-beats/templates/service-account.yaml
@@ -1,0 +1,23 @@
+
+{{- if .Values.serviceAccount }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Values.serviceAccount.namespace | default $.Release.Namespace | quote }}
+  labels:
+    {{- include "beat.labels" . | nindent 4 }}
+    {{- if .Values.serviceAccount.labels }}
+    {{- toYaml .Values.serviceAccount.labels | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.annotations .Values.serviceAccount.annotations }}
+  annotations:
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/deploy/eck-beats/templates/tests/beats-auditbeat-example_test.yaml
+++ b/deploy/eck-beats/templates/tests/beats-auditbeat-example_test.yaml
@@ -1,0 +1,59 @@
+suite: test auditbeat
+templates:
+  - templates/beats.yaml
+tests:
+  - it: should render audibeat configuration properly.
+    values:
+      - ../../examples/auditbeat_hosts.yaml
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Beat
+      - equal:
+          path: spec.elasticsearchRef.name
+          value: eck-elasticsearch
+      - equal:
+          path: spec.kibanaRef.name
+          value: eck-kibana
+      - equal:
+          path: spec.config.[auditbeat.modules][0].module
+          value: file_integrity
+      - equal:
+          path: spec.config.[auditbeat.modules][0].paths
+          value:
+          - /hostfs/bin
+          - /hostfs/usr/bin
+          - /hostfs/sbin
+          - /hostfs/usr/sbin
+          - /hostfs/etc
+      - equal:
+          path: spec.config.[auditbeat.modules][0].scan_at_start
+          value: true
+      - equal:
+          path: spec.config.[auditbeat.modules][0].recursive
+          value: true
+      - equal:
+          path: spec.config.[auditbeat.modules][1].module
+          value: auditd
+      - equal:
+          path: spec.daemonSet.podTemplate.spec.hostPID
+          value: true
+      - equal:
+          path: spec.daemonSet.podTemplate.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+      - equal:
+          path: spec.daemonSet.podTemplate.spec.hostNetwork
+          value: true
+      - equal:
+          path: spec.daemonSet.podTemplate.spec.securityContext.runAsUser
+          value: 0
+      - equal:
+          path: spec.daemonSet.podTemplate.spec.containers[0].name
+          value: auditbeat
+      - equal:
+          path: spec.daemonSet.podTemplate.spec.containers[0].securityContext.capabilities.add
+          value:
+            - 'AUDIT_READ'
+            - 'AUDIT_WRITE'
+            - 'AUDIT_CONTROL'

--- a/deploy/eck-beats/templates/tests/beats-filebeat-example_test.yaml
+++ b/deploy/eck-beats/templates/tests/beats-filebeat-example_test.yaml
@@ -1,0 +1,40 @@
+suite: test filebeat
+templates:
+  - templates/beats.yaml
+tests:
+  - it: should render filebeat configuration properly.
+    values:
+      - ../../examples/filebeat_no_autodiscover.yaml
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Beat
+      - equal:
+          path: spec.elasticsearchRef.name
+          value: eck-elasticsearch
+      - equal:
+          path: spec.kibanaRef.name
+          value: eck-kibana
+      - equal:
+          path: spec.config.[filebeat.inputs][0].type
+          value: container
+      - equal:
+          path: spec.config.[filebeat.inputs][0].paths
+          value:
+          - /var/log/containers/*.log
+      - equal:
+          path: spec.daemonSet.podTemplate.spec.automountServiceAccountToken
+          value: true
+      - equal:
+          path: spec.daemonSet.podTemplate.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+      - equal:
+          path: spec.daemonSet.podTemplate.spec.hostNetwork
+          value: true
+      - equal:
+          path: spec.daemonSet.podTemplate.spec.containers[0].name
+          value: filebeat
+      - equal:
+          path: spec.daemonSet.podTemplate.spec.containers[0].securityContext.runAsUser
+          value: 0

--- a/deploy/eck-beats/templates/tests/beats-heartbeat-example_test.yaml
+++ b/deploy/eck-beats/templates/tests/beats-heartbeat-example_test.yaml
@@ -1,0 +1,41 @@
+suite: test heartbeat
+templates:
+  - templates/beats.yaml
+tests:
+  - it: should render heartbeat configuration properly.
+    values:
+      - ../../examples/heartbeat_es_kb_health.yaml
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Beat
+      - equal:
+          path: spec.elasticsearchRef.name
+          value: eck-elasticsearch
+      - equal:
+          path: spec.config.[heartbeat.monitors][0].type
+          value: tcp
+      - equal:
+          path: spec.config.[heartbeat.monitors][0].schedule
+          value: '@every 5s'
+      - equal:
+          path: spec.config.[heartbeat.monitors][0].hosts
+          value:
+          - "elasticsearch-es-http.default.svc:9200"
+      - equal:
+          path: spec.config.[heartbeat.monitors][1].type
+          value: tcp
+      - equal:
+          path: spec.config.[heartbeat.monitors][1].schedule
+          value: '@every 5s'
+      - equal:
+          path: spec.config.[heartbeat.monitors][1].hosts
+          value:
+          - "eck-kibana-kb-http.default.svc:5601"
+      - equal:
+          path: spec.deployment.replicas
+          value: 1
+      - equal:
+          path: spec.deployment.podTemplate.spec.securityContext.runAsUser
+          value: 0

--- a/deploy/eck-beats/templates/tests/beats-metricbeat-example_test.yaml
+++ b/deploy/eck-beats/templates/tests/beats-metricbeat-example_test.yaml
@@ -1,0 +1,242 @@
+suite: test metricbeat
+templates:
+  - templates/beats.yaml
+tests:
+  - it: should render metricbeat configuration properly.
+    values:
+      - ../../examples/metricbeat_hosts.yaml
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Beat
+      - equal:
+          path: spec.config.metricbeat.autodiscover.providers[0].hints.enabled
+          value: "true"
+      - equal:
+          path: spec.config.metricbeat.autodiscover.providers[0].type
+          value: kubernetes
+      - equal:
+          path: spec.config.metricbeat.modules[0].module
+          value: system
+      - equal:
+          path: spec.config.metricbeat.modules[0].period
+          value: 10s
+      - equal:
+          path: spec.config.metricbeat.modules[0].metricsets
+          value:
+          - cpu
+          - load
+          - memory
+          - network
+          - process
+          - process_summary
+      - equal:
+          path: spec.config.metricbeat.modules[1].metricsets
+          value:
+          - filesystem
+          - fsstat
+      - equal:
+          path: spec.config.metricbeat.modules[2].module
+          value: kubernetes
+      - equal:
+          path: spec.config.metricbeat.modules[2].hosts
+          value:
+          - https://${NODE_NAME}:10250
+      - equal:
+          path: spec.config.metricbeat.modules[2].bearer_token_file
+          value: /var/run/secrets/kubernetes.io/serviceaccount/token
+      - equal:
+          path: spec.daemonSet.podTemplate.spec.serviceAccountName
+          value: metricbeat
+      - equal:
+          path: spec.daemonSet.podTemplate.spec.hostNetwork
+          value: true
+---
+suite: test beat cluster role
+templates:
+  - templates/cluster-role.yaml
+tests:
+  - it: should render cluster role in metricbeat example properly
+    values:
+      - ../../examples/metricbeat_hosts.yaml
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: metricbeat
+      - equal:
+          path: rules[0].apiGroups[0]
+          value: ""
+      - equal:
+          path: rules[0].resources
+          value:
+          - nodes
+          - namespaces
+          - events
+          - pods
+      - equal:
+          path: rules[0].verbs
+          value:
+          - get
+          - list
+          - watch
+      - equal:
+          path: rules[1].apiGroups[0]
+          value: extensions
+      - equal:
+          path: rules[1].resources
+          value:
+          - replicasets
+      - equal:
+          path: rules[1].verbs
+          value:
+          - get
+          - list
+          - watch
+  - it: should render custom labels and annotations properly.
+    values:
+      - ../../examples/metricbeat_hosts.yaml
+    set:
+      labels:
+        test: label
+      annotations:
+        test: annotation
+      clusterRole:
+        annotations:
+          clusterRole: annotation
+        labels:
+          clusterRole: label
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: quickstart
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: eck-beats
+            clusterRole: label
+            helm.sh/chart: eck-beats-0.1.0
+            test: label
+      - equal:
+          path: metadata.annotations
+          value:
+            clusterRole: annotation
+            test: annotation
+---
+suite: test beat cluster role binding
+templates:
+  - templates/cluster-role-binding.yaml
+tests:
+  - it: should render cluster role binding in metricbeat example properly
+    values:
+      - ../../examples/metricbeat_hosts.yaml
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: metadata.name
+          value: metricbeat
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - equal:
+          path: subjects[0].name
+          value: metricbeat
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+      - equal:
+          path: roleRef.name
+          value: metricbeat
+      - equal:
+          path: roleRef.apiGroup
+          value: rbac.authorization.k8s.io
+  - it: should render custom labels and annotations properly.
+    values:
+      - ../../examples/metricbeat_hosts.yaml
+    set:
+      labels:
+        test: label
+      annotations:
+        test: annotation
+      clusterRoleBinding:
+        annotations:
+          clusterRoleBinding: annotation
+        labels:
+          clusterRoleBinding: label
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: quickstart
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: eck-beats
+            clusterRoleBinding: label
+            helm.sh/chart: eck-beats-0.1.0
+            test: label
+      - equal:
+          path: metadata.annotations
+          value:
+            clusterRoleBinding: annotation
+            test: annotation
+---
+suite: test beat service account
+templates:
+  - templates/service-account.yaml
+tests:
+  - it: should render service account in metricbeat example properly
+    values:
+      - ../../examples/metricbeat_hosts.yaml
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: metricbeat
+  - it: should render custom labels and annotations properly.
+    values:
+      - ../../examples/metricbeat_hosts.yaml
+    set:
+      labels:
+        test: label
+      annotations:
+        test: annotation
+      serviceAccount:
+        annotations:
+          serviceAccount: annotation
+        labels:
+          serviceAccount: label
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: quickstart
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: eck-beats
+            serviceAccount: label
+            helm.sh/chart: eck-beats-0.1.0
+            test: label
+      - equal:
+          path: metadata.annotations
+          value:
+            serviceAccount: annotation
+            test: annotation

--- a/deploy/eck-beats/templates/tests/beats-packetbeat-example_test.yaml
+++ b/deploy/eck-beats/templates/tests/beats-packetbeat-example_test.yaml
@@ -1,0 +1,55 @@
+suite: test packetbeat
+templates:
+  - templates/beats.yaml
+tests:
+  - it: should render packetbeat configuration properly.
+    values:
+      - ../../examples/packetbeat_dns_http.yaml
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Beat
+      - equal:
+          path: spec.elasticsearchRef.name
+          value: eck-elasticsearch
+      - equal:
+          path: spec.kibanaRef.name
+          value: eck-kibana
+      - equal:
+          path: spec.config.[packetbeat.interfaces.device]
+          value: any
+      - equal:
+          path: spec.config.[packetbeat.protocols]
+          value:
+          - type: dns
+            ports:
+            - 53
+            include_authorities: true
+            include_additionals: true
+          - type: http
+            ports:
+            - 80
+            - 8000
+            - 8080
+            - 9200
+      - equal:
+          path: spec.config.[packetbeat.flows]
+          value:
+            timeout: 30s
+            period: 10s
+      - equal:
+          path: spec.daemonSet.podTemplate.spec
+          value:
+            terminationGracePeriodSeconds: 30
+            hostNetwork: true
+            automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+            dnsPolicy: ClusterFirstWithHostNet
+            containers:
+            - name: packetbeat
+              securityContext:
+                runAsUser: 0
+                capabilities:
+                  add:
+                  - NET_ADMIN
+            volumes: []

--- a/deploy/eck-beats/templates/tests/beats_test.yaml
+++ b/deploy/eck-beats/templates/tests/beats_test.yaml
@@ -1,0 +1,21 @@
+suite: test beats
+templates:
+  - templates/beats.yaml
+tests:
+  - it: should render filebeat properly, when type is set
+    release:
+      name: quickstart
+    set:
+      spec.type: "filebeat"
+    asserts:
+      - isKind:
+          of: Beat
+      - equal:
+          path: metadata.name
+          value: quickstart-eck-beats
+      - equal:
+          path: spec.version
+          value: 8.5.0
+      - equal:
+          path: spec.type
+          value: filebeat

--- a/deploy/eck-beats/values.yaml
+++ b/deploy/eck-beats/values.yaml
@@ -1,0 +1,111 @@
+---
+# Default values for eck-beats.
+# This is a YAML-formatted file.
+
+# Overridable names of the Beats resource.
+# By default, this is the Release name set for the chart,
+# followed by 'eck-beats'.
+#
+# nameOverride will override the name of the Chart with the name set here,
+# so nameOverride: quickstart, would convert to '{{ Release.name }}-quickstart'
+#
+# nameOverride: "quickstart"
+#
+# fullnameOverride will override both the release name, and the chart name,
+# and will name the Beats resource exactly as specified.
+#
+# fullnameOverride: "quickstart"
+
+# Version of Elastic Beats.
+#
+version: 8.5.0
+
+# Labels that will be applied to Elastic Beats.
+#
+labels: {}
+
+# Annotations that will be applied to Elastic Beats.
+#
+annotations: {}
+
+spec:
+  # Type of Elastic Beats. Standard types of Beat are [filebeat,metricbeat,heartbeat,auditbeat,packetbeat,journalbeat].
+  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-deploy-elastic-beat
+  #
+  # Note: This is required to be set, or the release install will fail.
+  #
+  type: ""
+
+  # Referenced resources are below and depending on the setup, at least elasticsearchRef is required for a functional Beat.
+  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-connect-es
+  #
+  # Reference to ECK-managed Kibana instance.
+  #
+  # kibanaRef:
+  #   name: quickstart
+    # Optional namespace reference to Kibana instance.
+    # If not specified, then the namespace of the Beats instance
+    # will be assumed.
+    #
+    # namespace: default
+
+  # Reference to ECK-managed Elasticsearch instance.
+  #
+  elasticsearchRef:
+    name: elasticsearch
+    # Optional namespace reference to Elasticsearch instance.
+    # If not specified, then the namespace of the Beats instance
+    # will be assumed.
+    #
+    # namespace: default
+
+  # Daemonset, or Deployment specification for the type of Beat specified.
+  # At least one is required of [daemonSet, deployment].
+  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-chose-the-deployment-model
+  #
+  daemonSet: {}
+  # deployment: {}
+
+  # Configuration of Beat, which is dependent on the `type` of Beat specified.
+  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-deploy-elastic-beat
+  #
+  config: {}
+
+# ServiceAccount to be used by Elastic Beats. Some Beats features (such as autodiscover or Kubernetes module metricsets)
+# require that Beat Pods interact with Kubernetes APIs. This functionality requires specific permissions
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-role-based-access-control-for-beats
+#
+serviceAccount: {}
+#  name: elastic-beat-filebeat-quickstart
+#  namespace: optional-namespace
+
+# ClusterRoleBinding to be used by Elastic Beats. Similar to ServiceAccount, this is required in some scenarios.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-role-based-access-control-for-beats
+#
+clusterRoleBinding: {}
+#  name: elastic-beat-autodiscover-binding
+#  subjects:
+#  - kind: ServiceAccount
+#    name: elastic-beat-filebeat-quickstart
+#    namespace: default
+#  roleRef:
+#    kind: ClusterRole
+#    name: elastic-beat-autodiscover
+#    apiGroup: rbac.authorization.k8s.io
+
+# ClusterRole to be used by Elastic Beats. Similar to ServiceAccount, this is required in some scenarios.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-role-based-access-control-for-beats
+#
+clusterRole: {}
+#  name: elastic-beat-autodiscover
+#  rules:
+#  - apiGroups: [""]
+#    resources:
+#    - events
+#    - pods
+#    - namespaces
+#    - nodes
+#    verbs:
+#    - get
+#    - watch
+#    - list

--- a/deploy/eck-elasticsearch/Chart.yaml
+++ b/deploy/eck-elasticsearch/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-elasticsearch
 description: A Helm chart to deploy Elasticsearch managed by the ECK Operator.
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.1.1
+version: 0.2.0
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/elasticsearch/

--- a/deploy/eck-fleet-server/Chart.yaml
+++ b/deploy/eck-fleet-server/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-fleet-server
 description: A Helm chart to deploy Elastic Fleet Server as an Agent managed by the ECK Operator.
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.1.0
+version: 0.2.0
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/elastic-agent

--- a/deploy/eck-fleet-server/templates/tests/fleet-server_test.yaml
+++ b/deploy/eck-fleet-server/templates/tests/fleet-server_test.yaml
@@ -13,10 +13,10 @@ tests:
           value: quickstart-eck-fleet-server
       - equal:
           path: spec.version
-          value: 8.2.3
+          value: 8.5.0
       - equal:
           path: spec.kibanaRef.name
-          value: quickstart
+          value: eck-kibana
       - equal:
           path: spec.deployment.replicas
           value: 1

--- a/deploy/eck-fleet-server/values.yaml
+++ b/deploy/eck-fleet-server/values.yaml
@@ -18,7 +18,7 @@
 
 # Version of Elastic Fleet Server.
 #
-version: 8.2.3
+version: 8.5.0
 
 # Labels that will be applied to Elastic Fleet Server.
 #
@@ -35,7 +35,7 @@ spec:
   # Reference to ECK-managed Kibana resource.
   #
   kibanaRef:
-    name: quickstart
+    name: eck-kibana
     # Optional namespace reference to Kibana resource.
     # If not specified, then the namespace of the Fleet Server resource
     # will be assumed.
@@ -46,7 +46,7 @@ spec:
   # This is required for fleet server.
   #
   elasticsearchRefs:
-  - name: quickstart
+  - name: eck-elasticsearch
     # Optional namespace reference to Elasticsearch resource.
     # If not specified, then the namespace of the Fleet Server resource
     # will be assumed.

--- a/deploy/eck-kibana/Chart.yaml
+++ b/deploy/eck-kibana/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-kibana
 description: A Helm chart to deploy Kibana managed by the ECK Operator.
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.1.1
+version: 0.2.0
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/kibana

--- a/deploy/eck-kibana/examples/http-configuration.yaml
+++ b/deploy/eck-kibana/examples/http-configuration.yaml
@@ -1,7 +1,7 @@
 ---
 # Version of Kibana.
 #
-version: 8.2.3
+version: 8.5.0
 
 # Labels that will be applied to Kibana.
 #
@@ -21,7 +21,7 @@ spec:
   # Reference to ECK-managed Elasticsearch resource, ideally from {{ "elasticsearch.fullname" }}
   #
   elasticsearchRef:
-    name: quickstart-eck-elasticsearch
+    name: eck-elasticsearch
     # namespace: default
   http:
     service:

--- a/deploy/eck-kibana/templates/tests/kibana_test.yaml
+++ b/deploy/eck-kibana/templates/tests/kibana_test.yaml
@@ -13,7 +13,7 @@ tests:
           value: quickstart-eck-kibana
       - equal:
           path: spec.version
-          value: 8.2.3
+          value: 8.5.0
   - it: name override should work properly
     set:
       nameOverride: override
@@ -75,13 +75,13 @@ tests:
           value: quickstart-eck-kibana
       - equal:
           path: spec.version
-          value: 8.2.3
+          value: 8.5.0
       - equal:
           path: spec.count
           value: 1
       - equal:
           path: spec.elasticsearchRef.name
-          value: quickstart-eck-elasticsearch
+          value: eck-elasticsearch
       - equal:
           path: spec.elasticsearchRef.namespace
           value: default

--- a/deploy/eck-stack/Chart.yaml
+++ b/deploy/eck-stack/Chart.yaml
@@ -9,34 +9,41 @@ description: |
   * Fleet Server
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.2.0
+version: 0.3.0
 
 dependencies:
   - name: eck-elasticsearch
     condition: eck-elasticsearch.enabled
-    version: "0.1.1"
+    version: "0.2.0"
     # uncomment for local testing, and comment
     # the helm.elastic.co repository.
     # repository: "file://../eck-elasticsearch"
     repository: "https://helm.elastic.co"
   - name: eck-kibana
     condition: eck-kibana.enabled
-    version: "0.1.1"
+    version: "0.2.0"
     # uncomment for local testing, and comment
     # the helm.elastic.co repository.
     # repository: "file://../eck-kibana"
     repository: "https://helm.elastic.co"
   - name: eck-agent
     condition: eck-agent.enabled
-    version: "0.1.0"
+    version: "0.2.0"
     # uncomment for local testing, and comment
     # the helm.elastic.co repository.
     # repository: "file://../eck-agent"
     repository: "https://helm.elastic.co"
   - name: eck-fleet-server
     condition: eck-fleet-server.enabled
-    version: "0.1.0"
+    version: "0.2.0"
     # uncomment for local testing, and comment
     # the helm.elastic.co repository.
     # repository: "file://../eck-fleet-server"
+    repository: "https://helm.elastic.co"
+  - name: eck-beats
+    condition: eck-beats.enabled
+    version: "0.1.0"
+    # uncomment for local testing, and comment
+    # the helm.elastic.co repository.
+    # repository: "file://../eck-beats"
     repository: "https://helm.elastic.co"

--- a/deploy/eck-stack/README.md
+++ b/deploy/eck-stack/README.md
@@ -11,6 +11,7 @@ The following Elastic Stack resources are currently supported.
 - Kibana
 - Elastic Agent
 - Fleet Server
+- Beats
 
 Additional resources will be supported in future releases of this Helm Chart.
 

--- a/deploy/eck-stack/examples/custom-elasticsearch-kibana.yaml
+++ b/deploy/eck-stack/examples/custom-elasticsearch-kibana.yaml
@@ -6,7 +6,7 @@ eck-elasticsearch:
 
   # Version of Elasticsearch.
   #
-  version: 8.2.3
+  version: 8.5.0
 
   nodeSets:
   - name: default
@@ -38,7 +38,7 @@ eck-kibana:
   
   # Version of Kibana.
   #
-  version: 8.2.3
+  version: 8.5.0
   
   spec:
     # Count of Kibana replicas to create.

--- a/deploy/eck-stack/examples/metricbeat_hosts.yaml
+++ b/deploy/eck-stack/examples/metricbeat_hosts.yaml
@@ -1,0 +1,218 @@
+eck-elasticsearch:
+  enabled: true
+
+  # Name of the Elasticsearch resource.
+  #
+  fullnameOverride: quickstart
+
+  # Version of Elasticsearch.
+  #
+  version: 8.5.0
+
+  nodeSets:
+  - name: default
+    count: 3
+    config:
+      # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+      # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+      # and leave node.store.allow_mmap unset.
+      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+      #
+      node.store.allow_mmap: false
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Gi
+        # Adjust to your storage class name
+        #
+        # storageClassName: local-storage
+
+eck-kibana:
+  enabled: true
+
+  # Name of the Kibana resource.
+  #
+  fullnameOverride: quickstart
+  
+  # Version of Kibana.
+  #
+  version: 8.5.0
+  
+  spec:
+    # Count of Kibana replicas to create.
+    #
+    count: 1
+  
+    # Reference to ECK-managed Elasticsearch resource, ideally from {{ "elasticsearch.fullname" }}
+    #
+    elasticsearchRef:
+      name: quickstart
+
+eck-beats:
+  enabled: true
+  name: metricbeat
+  spec:
+    type: metricbeat
+    version: 8.5.0
+    elasticsearchRef:
+      name: quickstart
+    kibanaRef:
+      name: quickstart
+    config:
+      # Since filebeat is used in the default values, this needs to be removed with an empty list. 
+      filebeat.inputs: []
+      metricbeat:
+        autodiscover:
+          providers:
+          - hints:
+              default_config: {}
+              enabled: "true"
+            node: ${NODE_NAME}
+            type: kubernetes
+        modules:
+        - module: system
+          period: 10s
+          metricsets:
+          - cpu
+          - load
+          - memory
+          - network
+          - process
+          - process_summary
+          process:
+            include_top_n:
+              by_cpu: 5
+              by_memory: 5
+          processes:
+          - .*
+        - module: system
+          period: 1m
+          metricsets:
+          - filesystem
+          - fsstat
+          processors:
+          - drop_event:
+              when:
+                regexp:
+                  system:
+                    filesystem:
+                      mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib)($|/)
+        - module: kubernetes
+          period: 10s
+          node: ${NODE_NAME}
+          hosts:
+          - https://${NODE_NAME}:10250
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          ssl:
+            verification_mode: none
+          metricsets:
+          - node
+          - system
+          - pod
+          - container
+          - volume
+      processors:
+      - add_cloud_metadata: {}
+      - add_host_metadata: {}
+    daemonSet:
+      podTemplate:
+        spec:
+          serviceAccountName: metricbeat
+          automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+          containers:
+          - args:
+            - -e
+            - -c
+            - /etc/beat.yml
+            - -system.hostfs=/hostfs
+            name: metricbeat
+            volumeMounts:
+            - mountPath: /hostfs/sys/fs/cgroup
+              name: cgroup
+            - mountPath: /var/run/docker.sock
+              name: dockersock
+            - mountPath: /hostfs/proc
+              name: proc
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          dnsPolicy: ClusterFirstWithHostNet
+          hostNetwork: true # Allows to provide richer host metadata
+          securityContext:
+            runAsUser: 0
+          terminationGracePeriodSeconds: 30
+          volumes:
+          - hostPath:
+              path: /sys/fs/cgroup
+            name: cgroup
+          - hostPath:
+              path: /var/run/docker.sock
+            name: dockersock
+          - hostPath:
+              path: /proc
+            name: proc
+  
+  clusterRole:
+    # permissions needed for metricbeat
+    # source: https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-kubernetes.html
+    name: metricbeat
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      - namespaces
+      - events
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - "extensions"
+      resources:
+      - replicasets
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - apps
+      resources:
+      - statefulsets
+      - deployments
+      - replicasets
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/stats
+      verbs:
+      - get
+    - nonResourceURLs:
+      - /metrics
+      verbs:
+      - get
+  
+  serviceAccount:
+    name: metricbeat
+  
+  clusterRoleBinding:
+    name: metricbeat
+    subjects:
+    - kind: ServiceAccount
+      name: metricbeat
+    roleRef:
+      kind: ClusterRole
+      name: metricbeat
+      apiGroup: rbac.authorization.k8s.io

--- a/deploy/eck-stack/templates/tests/beats_test.yaml
+++ b/deploy/eck-stack/templates/tests/beats_test.yaml
@@ -1,0 +1,51 @@
+suite: test beats
+templates:
+  - charts/eck-beats/templates/beats.yaml
+tests:
+  - it: should render specified beat properly
+    set:
+      eck-beats.enabled: true
+      eck-beats.spec.type: metricbeat
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Beat
+      - equal:
+          path: metadata.name
+          value: quickstart-eck-beats
+      - equal:
+          path: spec.version
+          value: 8.5.0
+  - it: should render custom metricbeat example properly
+    values:
+      - ../../examples/metricbeat_hosts.yaml
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Beat
+      - equal:
+          path: metadata.name
+          value: quickstart-eck-beats
+      - equal:
+          path: spec.version
+          value: 8.5.0
+      - equal:
+          path: spec.kibanaRef.name
+          value: quickstart
+      - equal:
+          path: spec.elasticsearchRef.name
+          value: quickstart
+      - equal:
+          path: spec.type
+          value: metricbeat
+      - equal:
+          path: spec.daemonSet.podTemplate.spec.securityContext.runAsUser
+          value: 0
+      - equal:
+          path: spec.daemonSet.podTemplate.spec.serviceAccountName
+          value: metricbeat
+      - equal:
+          path: spec.daemonSet.podTemplate.spec.hostNetwork
+          value: true

--- a/deploy/eck-stack/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-stack/templates/tests/elastic-agent_test.yaml
@@ -15,7 +15,7 @@ tests:
           value: quickstart-eck-agent
       - equal:
           path: spec.version
-          value: 8.2.3
+          value: 8.5.0
   - it: should render agent in custom fleet example properly
     values:
       - ../../examples/fleet-agents.yaml
@@ -29,7 +29,7 @@ tests:
           value: quickstart-eck-agent
       - equal:
           path: spec.version
-          value: 8.2.3
+          value: 8.5.0
       - equal:
           path: spec.kibanaRef.name
           value: kibana
@@ -72,7 +72,7 @@ tests:
           value: quickstart-eck-fleet-server
       - equal:
           path: spec.version
-          value: 8.2.3
+          value: 8.5.0
   - it: should render fleet server in custom fleet example properly
     values:
       - ../../examples/fleet-agents.yaml
@@ -86,7 +86,7 @@ tests:
           value: fleet-server
       - equal:
           path: spec.version
-          value: 8.2.3
+          value: 8.5.0
       - equal:
           path: spec.kibanaRef.name
           value: kibana

--- a/deploy/eck-stack/templates/tests/kibana_test.yaml
+++ b/deploy/eck-stack/templates/tests/kibana_test.yaml
@@ -13,7 +13,7 @@ tests:
           value: quickstart-eck-kibana
       - equal:
           path: spec.version
-          value: 8.2.3
+          value: 8.5.0
   - it: name override should work properly
     set:
       eck-kibana.nameOverride: override
@@ -51,7 +51,7 @@ tests:
           value: quickstart
       - equal:
           path: spec.version
-          value: 8.2.3
+          value: 8.5.0
       - equal:
           path: spec.count
           value: 1

--- a/deploy/eck-stack/values.yaml
+++ b/deploy/eck-stack/values.yaml
@@ -29,3 +29,8 @@ eck-agent:
 #
 eck-fleet-server:
   enabled: false
+
+# If enabled, will use the eck-beats chart and deploy a Beats resource.
+#
+eck-beats:
+  enabled: false

--- a/hack/update-stack-version.sh
+++ b/hack/update-stack-version.sh
@@ -34,7 +34,7 @@ for_all_yaml_do() {
 	local function="$1"
 	# Directories containing Yaml files with version references to replace
 	# Note: hack/operatorhub/config.yaml will need to be updated manually
-	local dirs=(config/samples config/recipes config/e2e test/e2e)
+	local dirs=(config/samples config/recipes config/e2e test/e2e deploy/eck-stack deploy/eck-beats deploy/eck-kibana deploy/eck-elasticsearch deploy/eck-agent deploy/eck-fleet-server)
 	LC_CTYPE=C LANG=C find "${dirs[@]}" -type f -iname \*.yaml \
 		| while read -r file; do "$function" "$file"; done
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.6`:
 - [ECK resources Helm chart - Beats (#5899)](https://github.com/elastic/cloud-on-k8s/pull/5899)
