### PR TITLE
Fix version gate for the file-based settings volume

### DIFF
--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -310,7 +310,7 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	}
 
 	// reconcile an empty File based settings Secret if it doesn't exist
-	if minVersion.GTE(filesettings.FileBasedSettingsMinPreVersion) {
+	if d.Version.GTE(filesettings.FileBasedSettingsMinPreVersion) {
 		err = filesettings.ReconcileEmptyFileSettingsSecret(ctx, d.Client, d.ES, true)
 		if err != nil {
 			return results.WithError(err)


### PR DESCRIPTION
This commit fixes an issue when upgrading to `8.6.0`. We should not use the lowest version in the pods and instead the version of the Elasticsearch resource to reconcile the empty File based settings Secret if it doesn't exist, otherwise the upgrade is blocked because the new pods are created with a new volume waiting for the Secret to be present.