### PR TITLE
[2.6] Fix version gate for the file-based settings volume

### DIFF
--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -315,7 +315,7 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	}
 
 	// reconcile an empty File based settings Secret if it doesn't exist
-	if minVersion.GTE(filesettings.FileBasedSettingsMinPreVersion) {
+	if d.Version.GTE(filesettings.FileBasedSettingsMinPreVersion) {
 		err = filesettings.ReconcileEmptyFileSettingsSecret(ctx, d.Client, d.ES, true)
 		if err != nil {
 			return results.WithError(err)


### PR DESCRIPTION
Backport the following commit in `2.6`:
- #6289 