### PR TITLE
[2.6] Update 2.6 release notes for recent changes. (#6292)

### DIFF
--- a/docs/release-notes/2.6.0.asciidoc
+++ b/docs/release-notes/2.6.0.asciidoc
@@ -31,6 +31,7 @@
 
 * Fix potential panic in Elasticsearch client equal function. {pull}6128[#6128]
 * Increment ECK-stack Helm chart version to support addition of Agent/Fleet Server. {pull}6179[#6179]
+* Try to reconcile license even in absence of known health status {pull}6278[#6278] {issue}6274[#6274])
 
 [[docs-2.6.0]]
 [float]

--- a/docs/release-notes/highlights-2.6.0.asciidoc
+++ b/docs/release-notes/highlights-2.6.0.asciidoc
@@ -29,8 +29,3 @@ Read our updated <<{p}-stack-config-policy, docs>> for more details.
 ==== Helm chart for Elastic Beats
 
 We are adding a new Helm chart for workloads managed by the ECK operator. Elastic Beats are complementing the existing charts for Elasticsearch, Kibana, Agent and Fleet Agent. They can be used individually or as part of our existing Elastic Stack Helm chart. Get started by reading the  <<{p}-stack-helm-chart, docs>>.
-
-[float]
-[id="{p}-260-known-issues"]
-=== Known issues
-- If a license for an Elasticsearch cluster expires before being replaced with an updated license the ECK operator cannot automatically update the license. Refer to the underlying link:https://github.com/elastic/cloud-on-k8s/issues/6274[issue] for a description of workarounds. A fix will be released in the next release of the operator.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.6`:
 - [Update 2.6 release notes for recent changes. (#6292)](https://github.com/elastic/cloud-on-k8s/pull/6292)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)