### PR TITLE
[2.6] Set kubebuilder assets path to support latest buildkite agent (#6257)

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -3,9 +3,8 @@ FROM docker.io/library/golang:1.19.3
 
 ENV GOLANGCILINT_VERSION=1.48.0
 ENV SHELLCHECK_VERSION=0.8.0
-ENV KUBEBUILDER_VERSION=2.3.1
 ENV GCLOUD_VERSION=381.0.0
-ENV KUBECTL_VERSION=1.19.16
+ENV KUBECTL_VERSION=1.21.14
 ENV DOCKER_VERSION=19.03.14
 ENV DOCKER_BUILDX_VERSION=0.8.2
 ENV GOTESTSUM_VERSION=1.8.0
@@ -17,12 +16,14 @@ ENV HELM_VERSION=3.9.1
 RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     | sh -s -- -b $(go env GOPATH)/bin v${GOLANGCILINT_VERSION}
 
-# kubebuilder to get required tools (etcd, apiserver, etc.)
-ENV PATH=${PATH}:/usr/local/kubebuilder/bin
-RUN curl -fsSLO https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_${KUBEBUILDER_VERSION}_linux_amd64.tar.gz && \
-    tar -zxf kubebuilder_${KUBEBUILDER_VERSION}_linux_amd64.tar.gz && \
-    mv kubebuilder_${KUBEBUILDER_VERSION}_linux_amd64 /usr/local/kubebuilder && \
-    rm kubebuilder_${KUBEBUILDER_VERSION}_linux_amd64.tar.gz
+# etcd and apiserver for integration tests
+ENV KUBEAPISERVER_VERSION=1.21.14
+RUN curl -fsSL https://dl.k8s.io/v${KUBEAPISERVER_VERSION}/bin/linux/amd64/kube-apiserver -o /usr/local/bin/kube-apiserver && \
+    chmod +x /usr/local/bin/kube-apiserver
+ENV ETCD_VER=3.4.23
+RUN curl -fsSLO https://storage.googleapis.com/etcd/v${ETCD_VER}/etcd-v${ETCD_VER}-linux-amd64.tar.gz && \
+    tar zxf etcd-v${ETCD_VER}-linux-amd64.tar.gz -C /usr/local/bin --strip-components=1 && \
+    rm -f etcd-v${ETCD_VER}-linux-amd64.tar.gz
 
 # gcloud to provision GKE clusters
 ENV PATH=${PATH}:/usr/local/google-cloud-sdk/bin
@@ -36,7 +37,7 @@ RUN curl -fsSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/googl
     rm google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz
 
 # kubectl for deploying the operator and running e2e tests
-RUN curl -fsSLO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
+RUN curl -fsSLO https://dl.k8s.io/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
     mv kubectl /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 
 # Docker client to build and push images

--- a/Makefile
+++ b/Makefile
@@ -172,13 +172,11 @@ helm-test:
 
 integration: GO_TAGS += integration
 integration: clean generate-crds-v1
-	KUBEBUILDER_ASSETS=/usr/local/bin ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) \
-		go test -tags='$(GO_TAGS)' ./pkg/... ./cmd/... -cover $(TEST_OPTS)
+	ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) go test -tags='$(GO_TAGS)' ./pkg/... ./cmd/... -cover $(TEST_OPTS)
 
 integration-xml: GO_TAGS += integration
 integration-xml: clean generate-crds-v1
-	KUBEBUILDER_ASSETS=/usr/local/bin ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) \
-		gotestsum --junitfile integration-tests.xml -- -tags='$(GO_TAGS)' -cover ./pkg/... ./cmd/... $(TEST_OPTS)
+	ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) gotestsum --junitfile integration-tests.xml -- -tags='$(GO_TAGS)' -cover ./pkg/... ./cmd/... $(TEST_OPTS)
 
 lint:
 	GOGC=50 golangci-lint run --verbose

--- a/Makefile
+++ b/Makefile
@@ -172,11 +172,13 @@ helm-test:
 
 integration: GO_TAGS += integration
 integration: clean generate-crds-v1
-	ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) go test -tags='$(GO_TAGS)' ./pkg/... ./cmd/... -cover $(TEST_OPTS)
+	KUBEBUILDER_ASSETS=/usr/local/bin ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) \
+		go test -tags='$(GO_TAGS)' ./pkg/... ./cmd/... -cover $(TEST_OPTS)
 
 integration-xml: GO_TAGS += integration
 integration-xml: clean generate-crds-v1
-	ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) gotestsum --junitfile integration-tests.xml -- -tags='$(GO_TAGS)' -cover ./pkg/... ./cmd/... $(TEST_OPTS)
+	KUBEBUILDER_ASSETS=/usr/local/bin ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) \
+		gotestsum --junitfile integration-tests.xml -- -tags='$(GO_TAGS)' -cover ./pkg/... ./cmd/... $(TEST_OPTS)
 
 lint:
 	GOGC=50 golangci-lint run --verbose


### PR DESCRIPTION
Backport #6257 in `2.6` needed to fix integration tests on buildkite by setting the kubebuilder assets path since last agent image was updated to work with controller-runtime 2.4.0 in `main` and then changed the etcd binary path.