### PR TITLE
Update min version to use es file-based settings feature

### DIFF
--- a/pkg/controller/elasticsearch/filesettings/file_settings.go
+++ b/pkg/controller/elasticsearch/filesettings/file_settings.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	FileBasedSettingsMinPreVersion = version.MinFor(8, 6, 0)
+	FileBasedSettingsMinPreVersion = version.MinFor(8, 6, 1)
 	FileBasedSettingsMinVersion    = version.WithoutPre(FileBasedSettingsMinPreVersion)
 )
 

--- a/pkg/controller/stackconfigpolicy/controller.go
+++ b/pkg/controller/stackconfigpolicy/controller.go
@@ -241,7 +241,7 @@ func (r *ReconcileStackConfigPolicy) doReconcile(ctx context.Context, policy pol
 		esNsn := k8s.ExtractNamespacedName(&es)
 		configuredResources[esNsn] = es
 
-		// File based Settings is available from ES 8.5.0
+		// version gate for the ES file-based settings feature
 		v, err := version.Parse(es.Spec.Version)
 		if err != nil {
 			return results.WithError(err), status

--- a/pkg/controller/stackconfigpolicy/controller_test.go
+++ b/pkg/controller/stackconfigpolicy/controller_test.go
@@ -107,7 +107,7 @@ func TestReconcileStackConfigPolicy_Reconcile(t *testing.T) {
 		Name:      "test-es",
 		Labels:    map[string]string{"label": "test"},
 	},
-		Spec: esv1.ElasticsearchSpec{Version: "8.6.0"},
+		Spec: esv1.ElasticsearchSpec{Version: "8.6.1"},
 	}
 	secretFixture := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -280,7 +280,7 @@ func TestReconcileStackConfigPolicy_Reconcile(t *testing.T) {
 			},
 			post: func(r ReconcileStackConfigPolicy, recorder record.FakeRecorder) {
 				events := fetchEvents(&recorder)
-				assert.ElementsMatch(t, []string{"Warning Unexpected invalid version to configure resource Elasticsearch ns/test-es: actual 8.0.0, expected >= 8.6.0"}, events)
+				assert.ElementsMatch(t, []string{"Warning Unexpected invalid version to configure resource Elasticsearch ns/test-es: actual 8.0.0, expected >= 8.6.1"}, events)
 
 				policy := r.getPolicy(t, k8s.ExtractNamespacedName(&policyFixture))
 				assert.Equal(t, 1, policy.Status.Resources)
@@ -438,7 +438,7 @@ func TestReconcileStackConfigPolicy_Reconcile(t *testing.T) {
 }
 
 func Test_cleanStackTrace(t *testing.T) {
-	stacktrace := "Error processing slm state change: java.lang.IllegalArgumentException: Error on validating SLM requests\n\tat org.elasticsearch.ilm@8.6.0-SNAPSHOT/org.elasticsearch.xpack.slm.action.ReservedSnapshotAction.prepare(ReservedSnapshotAction.java:66)\n\tat org.elasticsearch.ilm@8.6.0-SNAPSHOT/org.elasticsearch.xpack.slm.action.ReservedSnapshotAction.transform(ReservedSnapshotAction.java:77)\n\tat org.elasticsearch.server@8.6.0-SNAPSHOT/org.elasticsearch.reservedstate.service.ReservedClusterStateService.trialRun(ReservedClusterStateService.java:328)\n\tat org.elasticsearch.server@8.6.0-SNAPSHOT/org.elasticsearch.reservedstate.service.ReservedClusterStateService.process(ReservedClusterStateService.java:169)\n\tat org.elasticsearch.server@8.6.0-SNAPSHOT/org.elasticsearch.reservedstate.service.ReservedClusterStateService.process(ReservedClusterStateService.java:122)\n\tat org.elasticsearch.server@8.6.0-SNAPSHOT/org.elasticsearch.reservedstate.service.FileSettingsService.processFileSettings(FileSettingsService.java:389)\n\tat org.elasticsearch.server@8.6.0-SNAPSHOT/org.elasticsearch.reservedstate.service.FileSettingsService.lambda$startWatcher$3(FileSettingsService.java:312)\n\tat java.base/java.lang.Thread.run(Thread.java:833)\n\tSuppressed: java.lang.IllegalArgumentException: no such repository [badrepo]\n\t\tat org.elasticsearch.ilm@8.6.0-SNAPSHOT/org.elasticsearch.xpack.slm.SnapshotLifecycleService.validateRepositoryExists(SnapshotLifecycleService.java:244)\n\t\tat org.elasticsearch.ilm@8.6.0-SNAPSHOT/org.elasticsearch.xpack.slm.action.ReservedSnapshotAction.prepare(ReservedSnapshotAction.java:57)\n\t\t... 7 more\n"
+	stacktrace := "Error processing slm state change: java.lang.IllegalArgumentException: Error on validating SLM requests\n\tat org.elasticsearch.ilm@8.6.1/org.elasticsearch.xpack.slm.action.ReservedSnapshotAction.prepare(ReservedSnapshotAction.java:66)\n\tat org.elasticsearch.ilm@8.6.1/org.elasticsearch.xpack.slm.action.ReservedSnapshotAction.transform(ReservedSnapshotAction.java:77)\n\tat org.elasticsearch.server@8.6.1/org.elasticsearch.reservedstate.service.ReservedClusterStateService.trialRun(ReservedClusterStateService.java:328)\n\tat org.elasticsearch.server@8.6.1/org.elasticsearch.reservedstate.service.ReservedClusterStateService.process(ReservedClusterStateService.java:169)\n\tat org.elasticsearch.server@8.6.1/org.elasticsearch.reservedstate.service.ReservedClusterStateService.process(ReservedClusterStateService.java:122)\n\tat org.elasticsearch.server@8.6.1/org.elasticsearch.reservedstate.service.FileSettingsService.processFileSettings(FileSettingsService.java:389)\n\tat org.elasticsearch.server@8.6.1/org.elasticsearch.reservedstate.service.FileSettingsService.lambda$startWatcher$3(FileSettingsService.java:312)\n\tat java.base/java.lang.Thread.run(Thread.java:833)\n\tSuppressed: java.lang.IllegalArgumentException: no such repository [badrepo]\n\t\tat org.elasticsearch.ilm@8.6.1/org.elasticsearch.xpack.slm.SnapshotLifecycleService.validateRepositoryExists(SnapshotLifecycleService.java:244)\n\t\tat org.elasticsearch.ilm@8.6.1/org.elasticsearch.xpack.slm.action.ReservedSnapshotAction.prepare(ReservedSnapshotAction.java:57)\n\t\t... 7 more\n"
 	err := cleanStackTrace([]string{stacktrace})
 	expected := "Error processing slm state change: java.lang.IllegalArgumentException: Error on validating SLM requests\n\tSuppressed: java.lang.IllegalArgumentException: no such repository [badrepo]"
 	assert.Equal(t, expected, err)

--- a/test/e2e/es/stackconfigpolicy_test.go
+++ b/test/e2e/es/stackconfigpolicy_test.go
@@ -44,9 +44,9 @@ func TestStackConfigPolicy(t *testing.T) {
 		t.SkipNow()
 	}
 
-	// StackConfigPolicy is supported since 8.6.0
+	// StackConfigPolicy is supported for ES versions with file-based settings feature
 	stackVersion := version.MustParse(test.Ctx().ElasticStackVersion)
-	if !stackVersion.GTE(version.MinFor(8, 6, 0)) {
+	if !stackVersion.GTE(filesettings.FileBasedSettingsMinPreVersion) {
 		t.SkipNow()
 	}
 

--- a/test/e2e/es/stackconfigpolicy_test.go
+++ b/test/e2e/es/stackconfigpolicy_test.go
@@ -28,6 +28,7 @@ import (
 	policyv1alpha1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/stackconfigpolicy/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/client"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/filesettings"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test/elasticsearch"
 )


### PR DESCRIPTION
This commit changes the minimum version to use the ES file-based settings feature and so the Elastic Stack configuration policies feature due to a bug in ES 8.6.0.

Relates to #6303.