### PR TITLE
Support auth for custom users and roles in eck-elasticsearch Helm chart

### DIFF
--- a/deploy/eck-elasticsearch/templates/elasticsearch.yaml
+++ b/deploy/eck-elasticsearch/templates/elasticsearch.yaml
@@ -11,6 +11,10 @@ metadata:
     {{- toYaml .Values.annotations | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.auth }}
+  auth:
+    {{- toYaml .Values.auth | nindent 4 }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml .Values.updateStrategy | nindent 4 }}

--- a/deploy/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
+++ b/deploy/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
@@ -165,3 +165,17 @@ tests:
       - equal:
           path: spec.nodeSets[3].name
           value: cold
+  - it: should render es user and roles properly
+    set:
+      auth:
+        fileRealm:
+          - secretName: filerealm-secret-1
+        roles:
+          - secretName: roles-secret-1
+    asserts:
+      - equal:
+          path: spec.auth.fileRealm[0].secretName
+          value: filerealm-secret-1
+      - equal:
+          path: spec.auth.roles[0].secretName
+          value: roles-secret-1

--- a/deploy/eck-elasticsearch/values.yaml
+++ b/deploy/eck-elasticsearch/values.yaml
@@ -28,8 +28,9 @@ labels: {}
 #
 annotations: {}
 
-# Control the Elasticsearch Users and Roles
+# Settings for configuring Elasticsearch users and roles.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-users-and-roles.html
+#
 auth: {}
 
 # Settings for configuring stack monitoring.

--- a/deploy/eck-elasticsearch/values.yaml
+++ b/deploy/eck-elasticsearch/values.yaml
@@ -28,6 +28,10 @@ labels: {}
 #
 annotations: {}
 
+# Control the Elasticsearch Users and Roles
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-users-and-roles.html
+auth: {}
+
 # Settings for configuring stack monitoring.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-stack-monitoring.html
 #


### PR DESCRIPTION
Adding "auth" block to Elasticsearch template to use a secret and manage users and roles