### PR TITLE
[E2E] Disable TestFleetAgentWithoutTLS and TestFleetMode (#6309)

### DIFF
--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -124,6 +124,10 @@ func TestMultipleOutputConfig(t *testing.T) {
 }
 
 func TestFleetMode(t *testing.T) {
+
+	// This test is disabled until we understand why it is failing
+	t.Skip("TestFleetMode is disabled, see https://github.com/elastic/cloud-on-k8s/issues/6308")
+
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	// installation of policies and integrations through Kibana file based configuration was broken between those versions:
 	if v.LT(version.MinFor(8, 1, 0)) && v.GTE(version.MinFor(8, 0, 0)) {

--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -18,6 +18,10 @@ import (
 
 // TestFleetAgentWithoutTLS tests a Fleet Server, and Elastic Agent with TLS disabled for the HTTP layer.
 func TestFleetAgentWithoutTLS(t *testing.T) {
+
+	// This test is disabled until we understand why it is failing
+	t.Skip("TestFleetAgentWithoutTLS is disabled, see https://github.com/elastic/cloud-on-k8s/issues/6308")
+
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
 	// Disabling TLS for Fleet isn't supported before 7.16, as Elasticsearch doesn't allow


### PR DESCRIPTION
Backport of [[E2E] Disable TestFleetAgentWithoutTLS and TestFleetMode](https://github.com/elastic/cloud-on-k8s/pull/6309) into `2.6.1-wip`