### PR TITLE
Release notes and highlights for 2.6.1

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
@@ -11,7 +11,7 @@ experimental[]
 
 NOTE: This requires a valid Enterprise license or Enterprise trial license. Check <<{p}-licensing,the license documentation>> for more details about managing licenses.
 
-Starting from ECK `2.6.0` and Elasticsearch `8.6.0`, Elastic Stack configuration policies allow you to configure the following settings:
+Starting from ECK `2.6.1` and Elasticsearch `8.6.1`, Elastic Stack configuration policies allow you to configure the following settings:
 
 - link:https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html[Cluster Settings]
 - link:https://www.elastic.co/guide/en/elasticsearch/reference/current/put-snapshot-repo-api.html[Snapshot Repositories]

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-2.6.1>>
 * <<release-notes-2.6.0>>
 * <<release-notes-2.5.0>>
 * <<release-notes-2.4.0>>
@@ -37,6 +38,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/2.6.1.asciidoc[]
 include::release-notes/2.6.0.asciidoc[]
 include::release-notes/2.5.0.asciidoc[]
 include::release-notes/2.4.0.asciidoc[]

--- a/docs/release-notes/2.6.1.asciidoc
+++ b/docs/release-notes/2.6.1.asciidoc
@@ -1,0 +1,17 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-2.6.1]]
+== {n} version 2.6.1
+
+
+
+
+
+[[bug-2.6.1]]
+[float]
+=== Bug fixes
+
+* Update minimum version to use Elasticsearch file-based settings feature {pull}6305[#6305] (issue: {issue}6303[#6303])
+
+

--- a/docs/release-notes/highlights-2.6.0.asciidoc
+++ b/docs/release-notes/highlights-2.6.0.asciidoc
@@ -2,6 +2,12 @@
 == 2.6.0 release highlights
 
 [float]
+[id="{p}-260-known-issues"]
+=== Known issues
+- Upgrading ECK to 2.6.0 and then Elasticsearch to 8.6.0 may fail the Elasticsearch cluster. Upgrade to ECK 2.6.1 before attempting to upgrade Elasticsearch to 8.6.0. The underlying link:https://github.com/elastic/cloud-on-k8s/issues/6303[issue] will be fixed in a future Elasticsearch release.
+
+
+[float]
 [id="{p}-260-new-and-notable"]
 === New and notable
 

--- a/docs/release-notes/highlights-2.6.0.asciidoc
+++ b/docs/release-notes/highlights-2.6.0.asciidoc
@@ -4,7 +4,7 @@
 [float]
 [id="{p}-260-known-issues"]
 === Known issues
-- Upgrading ECK to 2.6.0 and then Elasticsearch to 8.6.0 may fail the Elasticsearch cluster. Upgrade to ECK 2.6.1 before attempting to upgrade Elasticsearch to 8.6.0. The underlying link:https://github.com/elastic/cloud-on-k8s/issues/6303[issue] will be fixed in a future Elasticsearch release.
+- Upgrading ECK to 2.6.0 and then Elasticsearch to 8.6.0 may lead to Elasticsearch master nodes unable to join the cluster. Upgrade to ECK 2.6.1 before attempting to upgrade Elasticsearch to 8.6.0. The underlying link:https://github.com/elastic/cloud-on-k8s/issues/6303[issue] will be fixed in a future Elasticsearch release.
 
 
 [float]

--- a/docs/release-notes/highlights-2.6.1.asciidoc
+++ b/docs/release-notes/highlights-2.6.1.asciidoc
@@ -1,8 +1,8 @@
-[[release-highlights-1.7.1]]
-== 1.7.1 release highlights
+[[release-highlights-2.6.1]]
+== 2.6.1 release highlights
 
 [float]
-[id="{p}-171-new-and-notable"]
+[id="{p}-261-new-and-notable"]
 === Bug fix
 
 This release fixes an issue introduced in ECK 2.6.0 when upgrading Elasticsearch to 8.6.0 by making the new Elastic Stack configuration policies feature available only from Elasticsearch 8.6.1.

--- a/docs/release-notes/highlights-2.6.1.asciidoc
+++ b/docs/release-notes/highlights-2.6.1.asciidoc
@@ -1,0 +1,10 @@
+[[release-highlights-1.7.1]]
+== 1.7.1 release highlights
+
+[float]
+[id="{p}-171-new-and-notable"]
+=== Bug fix
+
+This release fixes an issue introduced in ECK 2.6.0 when upgrading Elasticsearch to 8.6.0 by making the new Elastic Stack configuration policies feature available only from Elasticsearch 8.6.1.
+
+Also refer to <<{p}-260-known-issues>> for more information.

--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the most important changes in each release. For the full list, check <<eck-release-notes>>.
 
+* <<release-highlights-2.6.1>>
 * <<release-highlights-2.6.0>>
 * <<release-highlights-2.5.0>>
 * <<release-highlights-2.4.0>>
@@ -36,6 +37,7 @@ This section summarizes the most important changes in each release. For the full
 
 --
 
+include::highlights-2.6.1.asciidoc[]
 include::highlights-2.6.0.asciidoc[]
 include::highlights-2.5.0.asciidoc[]
 include::highlights-2.4.0.asciidoc[]


### PR DESCRIPTION
- Adds release notes and highlights for the upcoming `2.6.1` release
- Adds a know issue section in the `2.6.0` release highlights
- Updates versions in the StackConfigPolicy doc