### PR TITLE
Bump current ECK version to 2.6.1 in doc attributes

### DIFF
--- a/docs/eck-attributes.asciidoc
+++ b/docs/eck-attributes.asciidoc
@@ -1,4 +1,4 @@
-:eck_version: 2.6.0
+:eck_version: 2.6.1
 :eck_crd_version: v1
 :eck_release_branch: 2.6
 :eck_github: https://github.com/elastic/cloud-on-k8s


### PR DESCRIPTION
This bumps the "current" ECK version to 2.6.1 in the ECK docs.
