### PR TITLE
Update operator capability level from L3 => L4.

### DIFF
--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    capabilities: Full Lifecycle
+    capabilities: Deep Insights
     categories: Database
     certified: 'false'
     containerImage: {{ .OperatorRepo }}{{ .Tag }}


### PR DESCRIPTION
The ECK Operator now is certified Level 4 per Red Hat.

This updates our automation to include this change moving forward beyond `2.6.x`.

(2.6.1 has been manually updated to this capability level)