### PR TITLE
Bump version for 2.6.2 release

### DIFF
--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -1,5 +1,5 @@
-newVersion: 2.6.1
-prevVersion: 2.5.0
+newVersion: 2.6.2
+prevVersion: 2.6.1
 stackVersion: 8.6.0
 crds:
   - name: elasticsearches.elasticsearch.k8s.elastic.co


### PR DESCRIPTION
This updates the configuration file used by the tool to publish ECK to OperatorHub with the latest released version `2.6.2`, in branch `2.6`.