### PR TITLE
Update OLM CSV previous version to 2.6.2

### DIFF
--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -1,5 +1,5 @@
 newVersion: 2.7.0-SNAPSHOT
-prevVersion: 2.6.0
+prevVersion: 2.6.2
 stackVersion: 8.7.0-SNAPSHOT
 crds:
   - name: elasticsearches.elasticsearch.k8s.elastic.co


### PR DESCRIPTION
This updates the configuration file used by the tool to publish ECK to OperatorHub with the latest released version 2.6.2.