### PR TITLE
[2.6] Release notes for 2.6.2 (#6321)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-2.6.2>>
 * <<release-notes-2.6.1>>
 * <<release-notes-2.6.0>>
 * <<release-notes-2.5.0>>
@@ -38,6 +39,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/2.6.2.asciidoc[]
 include::release-notes/2.6.1.asciidoc[]
 include::release-notes/2.6.0.asciidoc[]
 include::release-notes/2.5.0.asciidoc[]

--- a/docs/release-notes/2.6.2.asciidoc
+++ b/docs/release-notes/2.6.2.asciidoc
@@ -1,0 +1,17 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-2.6.2]]
+== {n} version 2.6.2
+
+
+This release is binary identical to 2.6.1 and addresses an issue with the OLM bundle for the certified operator and the community operator on OpenShift OperatorHub. It is not available on any other distribution channel. The operator logs will show version 2.6.1.
+
+[[bug-2.6.2]]
+[float]
+=== Bug fixes
+
+* StackConfigPolicy CRD missing in ECK 2.6.1 for OperatorHub (issue: {issue}6320[#6320])
+
+
+

--- a/docs/release-notes/highlights-2.6.2.asciidoc
+++ b/docs/release-notes/highlights-2.6.2.asciidoc
@@ -1,0 +1,8 @@
+[[release-highlights-2.6.2]]
+== 2.6.2 release highlights
+
+[float]
+[id="{p}-262-new-and-notable"]
+=== Bug fix
+
+This release is binary identical to 2.6.1 and addresses an issue with the OLM bundle for the certified operator and the community operator on OpenShift OperatorHub. It is not available on any other distribution channel. The operator logs will show version 2.6.1.

--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the most important changes in each release. For the full list, check <<eck-release-notes>>.
 
+* <<release-highlights-2.6.2>>
 * <<release-highlights-2.6.1>>
 * <<release-highlights-2.6.0>>
 * <<release-highlights-2.5.0>>
@@ -37,6 +38,7 @@ This section summarizes the most important changes in each release. For the full
 
 --
 
+include::highlights-2.6.2.asciidoc[]
 include::highlights-2.6.1.asciidoc[]
 include::highlights-2.6.0.asciidoc[]
 include::highlights-2.5.0.asciidoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.6`:
 - [Release notes for 2.6.2 (#6321)](https://github.com/elastic/cloud-on-k8s/pull/6321)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)