### PR TITLE
Fix test helm charts script exit code

### DIFF
--- a/deploy/eck-agent/templates/tests/elastic-agent-cluster-role-binding_test.yaml
+++ b/deploy/eck-agent/templates/tests/elastic-agent-cluster-role-binding_test.yaml
@@ -79,7 +79,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
             clusterRoleBinding: label
-            helm.sh/chart: eck-agent-0.1.0
+            helm.sh/chart: eck-agent-0.2.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-agent/templates/tests/elastic-agent-cluster-role_test.yaml
+++ b/deploy/eck-agent/templates/tests/elastic-agent-cluster-role_test.yaml
@@ -136,7 +136,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
             clusterRole: label
-            helm.sh/chart: eck-agent-0.1.0
+            helm.sh/chart: eck-agent-0.2.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-agent/templates/tests/elastic-agent-service-account_test.yaml
+++ b/deploy/eck-agent/templates/tests/elastic-agent-service-account_test.yaml
@@ -49,7 +49,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
             serviceAccount: label
-            helm.sh/chart: eck-agent-0.1.0
+            helm.sh/chart: eck-agent-0.2.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-agent/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-agent/templates/tests/elastic-agent_test.yaml
@@ -40,7 +40,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
-            helm.sh/chart: eck-agent-0.1.0
+            helm.sh/chart: eck-agent-0.2.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
+++ b/deploy/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
@@ -89,7 +89,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-elasticsearch
-            helm.sh/chart: eck-elasticsearch-0.1.1
+            helm.sh/chart: eck-elasticsearch-0.2.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-fleet-server/templates/tests/fleet-server-cluster-role-binding_test.yaml
+++ b/deploy/eck-fleet-server/templates/tests/fleet-server-cluster-role-binding_test.yaml
@@ -49,7 +49,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
             clusterRoleBinding: label
-            helm.sh/chart: eck-fleet-server-0.1.0
+            helm.sh/chart: eck-fleet-server-0.2.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-fleet-server/templates/tests/fleet-server-cluster-role_test.yaml
+++ b/deploy/eck-fleet-server/templates/tests/fleet-server-cluster-role_test.yaml
@@ -62,7 +62,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
             clusterRole: label
-            helm.sh/chart: eck-fleet-server-0.1.0
+            helm.sh/chart: eck-fleet-server-0.2.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-fleet-server/templates/tests/fleet-server-service-account_test.yaml
+++ b/deploy/eck-fleet-server/templates/tests/fleet-server-service-account_test.yaml
@@ -34,7 +34,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
             serviceAccount: label
-            helm.sh/chart: eck-fleet-server-0.1.0
+            helm.sh/chart: eck-fleet-server-0.2.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-fleet-server/templates/tests/fleet-server_test.yaml
+++ b/deploy/eck-fleet-server/templates/tests/fleet-server_test.yaml
@@ -46,7 +46,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
-            helm.sh/chart: eck-fleet-server-0.1.0
+            helm.sh/chart: eck-fleet-server-0.2.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-kibana/templates/tests/kibana_test.yaml
+++ b/deploy/eck-kibana/templates/tests/kibana_test.yaml
@@ -53,7 +53,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-kibana
-            helm.sh/chart: eck-kibana-0.1.1
+            helm.sh/chart: eck-kibana-0.2.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-stack/templates/tests/elastic-agent_test.yaml
@@ -18,7 +18,7 @@ tests:
           value: 8.5.0
   - it: should render agent in custom fleet example properly
     values:
-      - ../../examples/fleet-agents.yaml
+      - ../../examples/agent/fleet-agents.yaml
     release:
       name: quickstart
     asserts:
@@ -75,7 +75,7 @@ tests:
           value: 8.5.0
   - it: should render fleet server in custom fleet example properly
     values:
-      - ../../examples/fleet-agents.yaml
+      - ../../examples/agent/fleet-agents.yaml
     release:
       name: quickstart
     asserts:

--- a/hack/helm/test.sh
+++ b/hack/helm/test.sh
@@ -1,16 +1,21 @@
 #!/usr/bin/env bash
-
+#
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
-
+#
 # Script to test helm charts
+#
+set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+sed_gnu() { sed -i "$@"; }
+sed_bsd() { sed -i '' "$@"; }
+
 check() {
     local TEST_DIR="$1"
-    cd "${TEST_DIR}" || exit
+    cd "${TEST_DIR}"
 
     local SED="sed_gnu"
     if [[ "$OSTYPE" =~ "darwin" ]]; then
@@ -33,21 +38,10 @@ check() {
     # restore changes to Chart.yaml
     git checkout Chart.yaml
 
-    cd - || exit
+    cd -
 }
 
-sed_gnu() {
-    sed -i "$@"
-}
-
-sed_bsd() {
-    sed -i '' "$@"
-}
-
-for i in "${SCRIPT_DIR}"/../../deploy/[a-zA-Z0-9]*; do
-    if [[ ! -d "${i}" ]]; then
-        continue
-    fi
+for i in $(find "${SCRIPT_DIR}"/../../deploy -type d); do
     if [[ -d "${i}"/templates/tests ]]; then
         check "${i}"
     fi

--- a/hack/helm/test.sh
+++ b/hack/helm/test.sh
@@ -8,12 +8,9 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-STATUS=0
-
 check() {
     local TEST_DIR="$1"
-    echo ""
-    cd "${TEST_DIR}" || return
+    cd "${TEST_DIR}" || exit
 
     local SED="sed_gnu"
     if [[ "$OSTYPE" =~ "darwin" ]]; then
@@ -32,14 +29,11 @@ check() {
     helm lint --strict .
 
     helm unittest -3 -f 'templates/tests/*.yaml' .
-    if [[ "$?" -eq 1 ]]; then
-        STATUS=1
-    fi
 
     # restore changes to Chart.yaml
     git checkout Chart.yaml
 
-    cd - || return
+    cd - || exit
 }
 
 sed_gnu() {
@@ -58,5 +52,3 @@ for i in "${SCRIPT_DIR}"/../../deploy/[a-zA-Z0-9]*; do
         check "${i}"
     fi
 done
-
-exit $STATUS

--- a/hack/helm/test.sh
+++ b/hack/helm/test.sh
@@ -13,6 +13,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 sed_gnu() { sed -i "$@"; }
 sed_bsd() { sed -i '' "$@"; }
 
+list_chart_dirs() {
+    find "${SCRIPT_DIR}/../../deploy" -type f -name "Chart.yaml" -exec dirname "{}" \;| sort -u
+}
+
 check() {
     local TEST_DIR="$1"
     cd "${TEST_DIR}"
@@ -33,7 +37,9 @@ check() {
     echo "Running 'helm lint' on $(basename "${TEST_DIR}") chart."
     helm lint --strict .
 
-    helm unittest -3 -f 'templates/tests/*.yaml' .
+    if [[ -d templates/tests ]]; then
+        helm unittest -3 -f 'templates/tests/*.yaml' .
+    fi
 
     # restore changes to Chart.yaml
     git checkout Chart.yaml
@@ -41,8 +47,6 @@ check() {
     cd -
 }
 
-for i in $(find "${SCRIPT_DIR}"/../../deploy -type d); do
-    if [[ -d "${i}"/templates/tests ]]; then
-        check "${i}"
-    fi
+for i in $(list_chart_dirs); do
+    check "${i}"
 done

--- a/hack/helm/test.sh
+++ b/hack/helm/test.sh
@@ -8,9 +8,12 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+STATUS=0
+
 check() {
     local TEST_DIR="$1"
-    cd "${TEST_DIR}" || exit
+    echo ""
+    cd "${TEST_DIR}" || return
 
     local SED="sed_gnu"
     if [[ "$OSTYPE" =~ "darwin" ]]; then
@@ -29,11 +32,14 @@ check() {
     helm lint --strict .
 
     helm unittest -3 -f 'templates/tests/*.yaml' .
+    if [[ "$?" -eq 1 ]]; then
+        STATUS=1
+    fi
 
     # restore changes to Chart.yaml
     git checkout Chart.yaml
 
-    cd - || exit
+    cd - || return
 }
 
 sed_gnu() {
@@ -52,3 +58,5 @@ for i in "${SCRIPT_DIR}"/../../deploy/[a-zA-Z0-9]*; do
         check "${i}"
     fi
 done
+
+exit $STATUS


### PR DESCRIPTION
This commit fixes the script to test Helm charts by enabling `set -eu` to exit at the first error, otherwise the script passes regardless of the status of the tests.