### PR TITLE
Update logstash recipe

### DIFF
--- a/config/recipes/logstash/logstash.yaml
+++ b/config/recipes/logstash/logstash.yaml
@@ -60,6 +60,7 @@ data:
       }
       geoip {
         source => "clientip"
+        target => "clientgeo"
       }
     }
     output {
@@ -176,8 +177,6 @@ spec:
                 mountPath: /data
         containers:
           - name: filebeat
-            securityContext:
-              runAsUser: 0
             volumeMounts:
               - name: data
                 mountPath: /data


### PR DESCRIPTION
Fix the following issues:
* [ECS-Compatiblity mode GeoIP Filter configuration syntax in logstash.conf map prevents "Logstash with ECK" recipe from starting up a Logstash pod](https://github.com/elastic/cloud-on-k8s/issues/6258) [#6258]
* [Requesting Beats to run as root in "Logstash with ECK" recipe prevents ReplicaSet from starting any pods on OpenShift 4.x as it violates Pod Security Policy](https://github.com/elastic/cloud-on-k8s/issues/6328) [#6328]