### PR TITLE
Move slack notifications from #cloud-k8s => #eck

### DIFF
--- a/.ci/pipelines/build.Jenkinsfile
+++ b/.ci/pipelines/build.Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                         script {
 
                             slackSend(
-                                channel: '#cloud-k8s',
+                                channel: '#eck',
                                 color: 'good',
                                 message: "`${TAG_NAME}` was released \r\n" +
                                     "Manifests were uploaded to https://download.elastic.co/downloads/eck/${TAG_NAME}\r\n" +
@@ -166,7 +166,7 @@ pipeline {
         }
         unsuccessful {
             script {
-                slackSend channel: '#cloud-k8s',
+                slackSend channel: '#eck',
                     color: 'danger',
                     message: "${JOB_NAME} job failed! \r\n" + "${BUILD_URL}",
                     tokenCredentialId: 'cloud-ci-slack-integration-token'

--- a/.ci/pipelines/cleanup-gke.Jenkinsfile
+++ b/.ci/pipelines/cleanup-gke.Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
                     def msg = lib.generateSlackMessage("k8s cluster cleanup failed, manual cleanup might be required!", env.BUILD_URL, [])
 
                     slackSend(
-                        channel: '#cloud-k8s',
+                        channel: '#eck',
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',

--- a/.ci/pipelines/e2e-tests-aks.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-aks.Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
                     def msg = lib.generateSlackMessage("E2E tests in AKS failed!", env.BUILD_URL, filter)
 
                     slackSend(
-                        channel: '#cloud-k8s',
+                        channel: '#eck',
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',

--- a/.ci/pipelines/e2e-tests-custom.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-custom.Jenkinsfile
@@ -84,7 +84,7 @@ pipeline {
                     def msg = lib.generateSlackMessage("Custom E2E tests run failed!", env.BUILD_URL, filter)
 
                     slackSend(
-                        channel: '#cloud-k8s',
+                        channel: '#eck',
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',

--- a/.ci/pipelines/e2e-tests-eks-arm.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-eks-arm.Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
                     def msg = lib.generateSlackMessage("E2E tests in EKS (ARM) failed!", env.BUILD_URL, filter)
 
                     slackSend(
-                        channel: '#cloud-k8s',
+                        channel: '#eck',
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',

--- a/.ci/pipelines/e2e-tests-eks.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-eks.Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
                     def msg = lib.generateSlackMessage("E2E tests in EKS failed!", env.BUILD_URL, filter)
 
                     slackSend(
-                        channel: '#cloud-k8s',
+                        channel: '#eck',
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',

--- a/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-gke-k8s-versions.Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
                     def msg = lib.generateSlackMessage("E2E tests for different k8s versions in GKE failed!", env.BUILD_URL, filter)
 
                     slackSend(
-                        channel: '#cloud-k8s',
+                        channel: '#eck',
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',

--- a/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-kind-k8s-versions.Jenkinsfile
@@ -148,7 +148,7 @@ pipeline {
                     def msg = lib.generateSlackMessage("E2E tests for different versions of vanilla K8s failed!", env.BUILD_URL, filter)
 
                     slackSend(
-                        channel: '#cloud-k8s',
+                        channel: '#eck',
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',

--- a/.ci/pipelines/e2e-tests-main-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-main-gke.Jenkinsfile
@@ -91,7 +91,7 @@ pipeline {
                      def msg = lib.generateSlackMessage("E2E tests failed!", env.BUILD_URL, failedTests)
 
                      slackSend(
-                        channel: '#cloud-k8s',
+                        channel: '#eck',
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',

--- a/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp.Jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
                     def msg = lib.generateSlackMessage("E2E tests in OCP failed!", env.BUILD_URL, filter)
 
                     slackSend(
-                        channel: '#cloud-k8s',
+                        channel: '#eck',
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',

--- a/.ci/pipelines/e2e-tests-ocp3.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-ocp3.Jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
                     def msg = lib.generateSlackMessage("E2E tests in OCP3 failed!", env.BUILD_URL, filter)
 
                     slackSend(
-                        channel: '#cloud-k8s',
+                        channel: '#eck',
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',

--- a/.ci/pipelines/e2e-tests-resilience.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-resilience.Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
                     def msg = lib.generateSlackMessage("E2E resilience tests failed!", env.BUILD_URL, filter)
 
                     slackSend(
-                        channel: '#cloud-k8s',
+                        channel: '#eck',
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',

--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -81,7 +81,7 @@ pipeline {
                     filter.addAll(failedTests)
 
                     slackSend(
-                        channel: '#cloud-k8s',
+                        channel: '#eck',
                         color: 'danger',
                         message: lib.generateSlackMessage("E2E tests for Elastic stack snapshot versions failed!", env.BUILD_URL, filter),
                         tokenCredentialId: 'cloud-ci-slack-integration-token',

--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -179,7 +179,7 @@ pipeline {
                     filter.addAll(failedTests)
 
                     slackSend(
-                        channel: '#cloud-k8s',
+                        channel: '#eck',
                         color: 'danger',
                         message: lib.generateSlackMessage("E2E tests for different Elastic stack versions failed!", env.BUILD_URL, filter),
                         tokenCredentialId: 'cloud-ci-slack-integration-token',

--- a/.ci/pipelines/e2e-tests-tanzu.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-tanzu.Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
                     def msg = lib.generateSlackMessage("E2E tests on Tanzu failed!", env.BUILD_URL, filter)
 
                     slackSend(
-                        channel: '#cloud-k8s',
+                        channel: '#eck',
                         color: 'danger',
                         message: msg,
                         tokenCredentialId: 'cloud-ci-slack-integration-token',


### PR DESCRIPTION
This will fix any e2e failure notifications after change of slack channel name internally.

