### PR TITLE
Do not test 8.5.3 due to APM issue

### DIFF
--- a/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-stack-versions-gke.Jenkinsfile
@@ -163,7 +163,8 @@ pipeline {
                     steps {
                         unstash "source"
                         script {
-                            runWith(lib, failedTests, "eck-85-${BUILD_NUMBER}-e2e", "8.5.3")
+                            // until https://github.com/elastic/apm-server/issues/10089 is fixed don't test 8.5.3
+                            runWith(lib, failedTests, "eck-85-${BUILD_NUMBER}-e2e", "8.5.2")
                         }
                     }
                 }


### PR DESCRIPTION
Out e2e test exposed https://github.com/elastic/apm-server/issues/10089 

As a quick fix to silence our test pipeline I suggest to go back to 8.5.2 until a new (fixed) patch version of 8.5 is available. Alternatively we can just skip the APM tests for 8.5.3. (but I don't have time for that right now, can PR that tomorrow)