### PR TITLE
Fix Stackmon Sidecar Secret having incorrect labels.

### DIFF
--- a/pkg/apis/agent/v1alpha1/labels.go
+++ b/pkg/apis/agent/v1alpha1/labels.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package v1alpha1
 
 import (

--- a/pkg/apis/agent/v1alpha1/labels.go
+++ b/pkg/apis/agent/v1alpha1/labels.go
@@ -1,0 +1,13 @@
+package v1alpha1
+
+import (
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
+)
+
+// GetElasticLabels will return the common Elastic assigned labels for the Elastic Agent.
+func (a *Agent) GetElasticLabels() map[string]string {
+	return map[string]string{
+		commonv1.TypeLabelName:      "agent",
+		"agent.k8s.elastic.co/name": a.Name,
+	}
+}

--- a/pkg/apis/apm/v1/labels.go
+++ b/pkg/apis/apm/v1/labels.go
@@ -1,0 +1,13 @@
+package v1
+
+import (
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
+)
+
+// GetElasticLabels will return the common Elastic assigned labels for the APM Server.
+func (as *ApmServer) GetElasticLabels() map[string]string {
+	return map[string]string{
+		commonv1.TypeLabelName:    "apm-server",
+		"apm.k8s.elastic.co/name": as.Name,
+	}
+}

--- a/pkg/apis/apm/v1/labels.go
+++ b/pkg/apis/apm/v1/labels.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package v1
 
 import (

--- a/pkg/apis/beat/v1beta1/labels.go
+++ b/pkg/apis/beat/v1beta1/labels.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package v1beta1
 
 import (

--- a/pkg/apis/beat/v1beta1/labels.go
+++ b/pkg/apis/beat/v1beta1/labels.go
@@ -1,0 +1,13 @@
+package v1beta1
+
+import (
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
+)
+
+// GetElasticLabels will return the common Elastic assigned labels for the Beat.
+func (b *Beat) GetElasticLabels() map[string]string {
+	return map[string]string{
+		commonv1.TypeLabelName:     "beat",
+		"beat.k8s.elastic.co/name": b.Name,
+	}
+}

--- a/pkg/apis/common/v1/common.go
+++ b/pkg/apis/common/v1/common.go
@@ -353,6 +353,16 @@ type HasObservedGeneration interface {
 	GetObservedGeneration() int64
 }
 
+// TypeLabelName is used to represent a resource type in k8s resources
+const TypeLabelName = "common.k8s.elastic.co/type"
+
+// HasElasticLabels allows a return of Elastic assigned labels for any object.
+// +kubebuilder:object:generate=false
+type HasElasticLabels interface {
+	client.Object
+	GetElasticLabels() map[string]string
+}
+
 // DisableDowngradeValidationAnnotation allows circumventing downgrade/upgrade checks.
 const DisableDowngradeValidationAnnotation = "eck.k8s.elastic.co/disable-downgrade-validation"
 

--- a/pkg/apis/elasticsearch/v1/labels.go
+++ b/pkg/apis/elasticsearch/v1/labels.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package v1
 
 import (

--- a/pkg/apis/elasticsearch/v1/labels.go
+++ b/pkg/apis/elasticsearch/v1/labels.go
@@ -1,0 +1,13 @@
+package v1
+
+import (
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
+)
+
+// GetElasticLabels will return the common Elastic assigned labels for the Elasticsearch cluster.
+func (es *Elasticsearch) GetElasticLabels() map[string]string {
+	return map[string]string{
+		commonv1.TypeLabelName:                      "elasticsearch",
+		"elasticsearch.k8s.elastic.co/cluster-name": es.Name,
+	}
+}

--- a/pkg/apis/enterprisesearch/v1/labels.go
+++ b/pkg/apis/enterprisesearch/v1/labels.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package v1
 
 import (

--- a/pkg/apis/enterprisesearch/v1/labels.go
+++ b/pkg/apis/enterprisesearch/v1/labels.go
@@ -1,0 +1,13 @@
+package v1
+
+import (
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
+)
+
+// GetElasticLabels will return the common Elastic assigned labels for EnterpriseSearch.
+func (es *EnterpriseSearch) GetElasticLabels() map[string]string {
+	return map[string]string{
+		commonv1.TypeLabelName:                 "enterprise-search",
+		"enterprisesearch.k8s.elastic.co/name": es.Name,
+	}
+}

--- a/pkg/apis/kibana/v1/labels.go
+++ b/pkg/apis/kibana/v1/labels.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package v1
 
 import (

--- a/pkg/apis/kibana/v1/labels.go
+++ b/pkg/apis/kibana/v1/labels.go
@@ -1,0 +1,13 @@
+package v1
+
+import (
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
+)
+
+// GetElasticLabels will return the common Elastic assigned labels for Kibana.
+func (k *Kibana) GetElasticLabels() map[string]string {
+	return map[string]string{
+		commonv1.TypeLabelName:       "kibana",
+		"kibana.k8s.elastic.co/name": k.Name,
+	}
+}

--- a/pkg/apis/maps/v1alpha1/labels.go
+++ b/pkg/apis/maps/v1alpha1/labels.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package v1alpha1
 
 import (

--- a/pkg/apis/maps/v1alpha1/labels.go
+++ b/pkg/apis/maps/v1alpha1/labels.go
@@ -1,0 +1,13 @@
+package v1alpha1
+
+import (
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
+)
+
+// GetElasticLabels will return the common Elastic assigned labels for EnterprisMapsServer.
+func (m *ElasticMapsServer) GetElasticLabels() map[string]string {
+	return map[string]string{
+		commonv1.TypeLabelName:     "maps",
+		"maps.k8s.elastic.co/name": m.Name,
+	}
+}

--- a/pkg/controller/agent/config.go
+++ b/pkg/controller/agent/config.go
@@ -47,7 +47,7 @@ func reconcileConfig(params Params, configHash hash.Hash) *reconciler.Results {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: params.Agent.Namespace,
 			Name:      ConfigSecretName(params.Agent.Name),
-			Labels:    labels.AddCredentialsLabel(NewLabels(params.Agent)),
+			Labels:    labels.AddCredentialsLabel(params.Agent.GetElasticLabels()),
 		},
 		Data: map[string][]byte{
 			ConfigFileName: cfgBytes,

--- a/pkg/controller/agent/controller_test.go
+++ b/pkg/controller/agent/controller_test.go
@@ -37,7 +37,7 @@ func newReconcileAgent(objs ...runtime.Object) *ReconcileAgent {
 }
 
 func TestReconcileAgent_Reconcile(t *testing.T) {
-	defaultLabels := NewLabels(agentv1alpha1.Agent{ObjectMeta: metav1.ObjectMeta{Name: "testAgent"}})
+	defaultLabels := (&agentv1alpha1.Agent{ObjectMeta: metav1.ObjectMeta{Name: "testAgent"}}).GetElasticLabels()
 	tests := []struct {
 		name     string
 		objs     []runtime.Object

--- a/pkg/controller/agent/driver.go
+++ b/pkg/controller/agent/driver.go
@@ -116,7 +116,7 @@ func internalReconcile(params Params) (*reconciler.Results, agentv1alpha1.AgentS
 			Owner:                 &params.Agent,
 			TLSOptions:            params.Agent.Spec.HTTP.TLS,
 			Namer:                 Namer,
-			Labels:                NewLabels(params.Agent),
+			Labels:                params.Agent.GetElasticLabels(),
 			Services:              []corev1.Service{*svc},
 			GlobalCA:              params.OperatorParams.GlobalCA,
 			CACertRotation:        params.OperatorParams.CACertRotation,
@@ -185,7 +185,7 @@ func newService(agent agentv1alpha1.Agent) *corev1.Service {
 	svc.ObjectMeta.Namespace = agent.Namespace
 	svc.ObjectMeta.Name = HTTPServiceName(agent.Name)
 
-	labels := NewLabels(agent)
+	labels := agent.GetElasticLabels()
 	ports := []corev1.ServicePort{
 		{
 			Name:     agent.Spec.HTTP.Protocol(),

--- a/pkg/controller/agent/labels.go
+++ b/pkg/controller/agent/labels.go
@@ -4,11 +4,6 @@
 
 package agent
 
-import (
-	agentv1alpha1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/agent/v1alpha1"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
-)
-
 const (
 	// TypeLabelValue represents the Agent type.
 	TypeLabelValue = "agent"
@@ -19,11 +14,3 @@ const (
 	// NamespaceLabelName used to represent an Agent in k8s resources
 	NamespaceLabelName = "agent.k8s.elastic.co/namespace"
 )
-
-// NewLabels returns the set of common labels for an Elastic Agent.
-func NewLabels(agent agentv1alpha1.Agent) map[string]string {
-	return map[string]string{
-		labels.TypeLabelName: TypeLabelValue,
-		NameLabelName:        agent.Name,
-	}
-}

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -165,7 +165,7 @@ func buildPodTemplate(params Params, fleetCerts *certificates.CertificatesSecret
 	}
 	vols = append(vols, caAssocVols...)
 
-	labels := maps.Merge(NewLabels(params.Agent), map[string]string{
+	labels := maps.Merge(params.Agent.GetElasticLabels(), map[string]string{
 		VersionLabelName: spec.Version})
 
 	annotations := map[string]string{
@@ -253,7 +253,7 @@ func applyEnvVars(params Params, fleetToken EnrollmentAPIKey, builder *defaults.
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      EnvVarsSecretName(params.Agent.Name),
 			Namespace: params.Agent.Namespace,
-			Labels:    labels.AddCredentialsLabel(NewLabels(params.Agent)),
+			Labels:    labels.AddCredentialsLabel(params.Agent.GetElasticLabels()),
 		},
 		Data: map[string][]byte{},
 	}

--- a/pkg/controller/agent/reconcile.go
+++ b/pkg/controller/agent/reconcile.go
@@ -90,8 +90,8 @@ func reconcileDeployment(rp ReconciliationParams) (int32, int32, error) {
 	d := deployment.New(deployment.Params{
 		Name:                 Name(rp.agent.Name),
 		Namespace:            rp.agent.Namespace,
-		Selector:             NewLabels(rp.agent),
-		Labels:               NewLabels(rp.agent),
+		Selector:             rp.agent.GetElasticLabels(),
+		Labels:               rp.agent.GetElasticLabels(),
 		PodTemplateSpec:      rp.podTemplate,
 		Replicas:             pointer.Int32OrDefault(rp.agent.Spec.Deployment.Replicas, int32(1)),
 		RevisionHistoryLimit: rp.agent.Spec.RevisionHistoryLimit,
@@ -114,8 +114,8 @@ func reconcileDaemonSet(rp ReconciliationParams) (int32, int32, error) {
 		PodTemplate:          rp.podTemplate,
 		Name:                 Name(rp.agent.Name),
 		Owner:                &rp.agent,
-		Labels:               NewLabels(rp.agent),
-		Selectors:            NewLabels(rp.agent),
+		Labels:               rp.agent.GetElasticLabels(),
+		Selectors:            rp.agent.GetElasticLabels(),
 		RevisionHistoryLimit: rp.agent.Spec.RevisionHistoryLimit,
 		Strategy:             rp.agent.Spec.DaemonSet.UpdateStrategy,
 	})

--- a/pkg/controller/apmserver/config.go
+++ b/pkg/controller/apmserver/config.go
@@ -59,7 +59,7 @@ func reconcileApmServerConfig(ctx context.Context, client k8s.Client, as *apmv1.
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: as.Namespace,
 			Name:      Config(as.Name),
-			Labels:    NewLabels(as.Name),
+			Labels:    as.GetElasticLabels(),
 		},
 		Data: map[string][]byte{
 			ApmCfgSecretKey: cfgBytes,

--- a/pkg/controller/apmserver/controller.go
+++ b/pkg/controller/apmserver/controller.go
@@ -237,7 +237,7 @@ func (r *ReconcileApmServer) doReconcile(ctx context.Context, as *apmv1.ApmServe
 		Owner:                 as,
 		TLSOptions:            as.Spec.HTTP.TLS,
 		Namer:                 Namer,
-		Labels:                NewLabels(as.Name),
+		Labels:                as.GetElasticLabels(),
 		Services:              []corev1.Service{*svc},
 		GlobalCA:              r.GlobalCA,
 		CACertRotation:        r.CACertRotation,
@@ -322,7 +322,7 @@ func reconcileApmServerToken(ctx context.Context, c k8s.Client, as *apmv1.ApmSer
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: as.Namespace,
 			Name:      SecretToken(as.Name),
-			Labels:    labels.AddCredentialsLabel(NewLabels(as.Name)),
+			Labels:    labels.AddCredentialsLabel(as.GetElasticLabels()),
 		},
 		Data: make(map[string][]byte),
 	}
@@ -373,7 +373,7 @@ func NewService(as apmv1.ApmServer) *corev1.Service {
 	svc.ObjectMeta.Namespace = as.Namespace
 	svc.ObjectMeta.Name = HTTPService(as.Name)
 
-	labels := NewLabels(as.Name)
+	labels := as.GetElasticLabels()
 	ports := []corev1.ServicePort{
 		{
 			Name:     as.Spec.HTTP.Protocol(),

--- a/pkg/controller/apmserver/controller_test.go
+++ b/pkg/controller/apmserver/controller_test.go
@@ -25,7 +25,6 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/certificates"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/compare"
@@ -223,7 +222,7 @@ func mkService() corev1.Service {
 			Namespace: "test",
 			Labels: map[string]string{
 				ApmServerNameLabelName: "apm-test",
-				labels.TypeLabelName:   Type,
+				commonv1.TypeLabelName: Type,
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -236,7 +235,7 @@ func mkService() corev1.Service {
 			},
 			Selector: map[string]string{
 				ApmServerNameLabelName: "apm-test",
-				labels.TypeLabelName:   Type,
+				commonv1.TypeLabelName: Type,
 			},
 		},
 	}

--- a/pkg/controller/apmserver/deployment.go
+++ b/pkg/controller/apmserver/deployment.go
@@ -44,7 +44,7 @@ func (r *ReconcileApmServer) reconcileApmServerDeployment(
 		r,
 		as,
 		Namer,
-		NewLabels(as.Name),
+		as.GetElasticLabels(),
 		initContainerParameters,
 	)
 	if err != nil {
@@ -96,8 +96,8 @@ func (r *ReconcileApmServer) deploymentParams(
 		Name:                 Deployment(as.Name),
 		Namespace:            as.Namespace,
 		Replicas:             as.Spec.Count,
-		Selector:             NewLabels(as.Name),
-		Labels:               NewLabels(as.Name),
+		Selector:             as.GetElasticLabels(),
+		Labels:               as.GetElasticLabels(),
 		RevisionHistoryLimit: as.Spec.RevisionHistoryLimit,
 		PodTemplateSpec:      podSpec,
 		Strategy:             appsv1.DeploymentStrategy{Type: appsv1.RollingUpdateDeploymentStrategyType},

--- a/pkg/controller/apmserver/labels.go
+++ b/pkg/controller/apmserver/labels.go
@@ -4,8 +4,6 @@
 
 package apmserver
 
-import "github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
-
 const (
 	// ApmServerNameLabelName used to represent an ApmServer in k8s resources
 	ApmServerNameLabelName = "apm.k8s.elastic.co/name"
@@ -14,11 +12,3 @@ const (
 	// APMVersionLabelName used to propagate APMServer version from the spec to the pods
 	APMVersionLabelName = "apm.k8s.elastic.co/version"
 )
-
-// NewLabels constructs a new set of labels for an ApmServer pod
-func NewLabels(apmServerName string) map[string]string {
-	return map[string]string{
-		ApmServerNameLabelName: apmServerName,
-		labels.TypeLabelName:   Type,
-	}
-}

--- a/pkg/controller/apmserver/pod.go
+++ b/pkg/controller/apmserver/pod.go
@@ -88,7 +88,7 @@ type PodSpecParams struct {
 }
 
 func newPodSpec(c k8s.Client, as *apmv1.ApmServer, p PodSpecParams) (corev1.PodTemplateSpec, error) {
-	labels := NewLabels(as.Name)
+	labels := as.GetElasticLabels()
 	labels[APMVersionLabelName] = p.Version
 
 	// ensure the Pod gets rotated on config change

--- a/pkg/controller/association/gc.go
+++ b/pkg/controller/association/gc.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esuser "github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 	ulog "github.com/elastic/cloud-on-k8s/v2/pkg/utils/log"
@@ -89,13 +89,13 @@ func (ugc *UsersGarbageCollector) getUserSecrets() ([]v1.Secret, error) {
 
 func getUserSecretsInNamespace(c k8s.Client, namespace string) ([]v1.Secret, error) {
 	userSecrets := v1.SecretList{}
-	userLabels := client.MatchingLabels(map[string]string{labels.TypeLabelName: esuser.AssociatedUserType})
+	userLabels := client.MatchingLabels(map[string]string{commonv1.TypeLabelName: esuser.AssociatedUserType})
 	if err := c.List(context.Background(), &userSecrets, client.InNamespace(namespace), userLabels); err != nil {
 		return nil, err
 	}
 
 	serviceAccountSecrets := v1.SecretList{}
-	serviceAccountLabels := client.MatchingLabels(map[string]string{labels.TypeLabelName: esuser.ServiceAccountTokenType})
+	serviceAccountLabels := client.MatchingLabels(map[string]string{commonv1.TypeLabelName: esuser.ServiceAccountTokenType})
 	if err := c.List(context.Background(), &serviceAccountSecrets, client.InNamespace(namespace), serviceAccountLabels); err != nil {
 		return nil, err
 	}

--- a/pkg/controller/association/gc_test.go
+++ b/pkg/controller/association/gc_test.go
@@ -16,8 +16,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	apmv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/apm/v1"
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/kibana/v1"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	esuser "github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 )
@@ -41,7 +41,7 @@ func newUserSecret(
 			Labels: map[string]string{
 				associationNameLabel:      associationNameValue,
 				associationNamespaceLabel: associationNamespaceValue,
-				labels.TypeLabelName:      esuser.AssociatedUserType,
+				commonv1.TypeLabelName:    esuser.AssociatedUserType,
 			},
 		},
 	}
@@ -59,7 +59,7 @@ func newServiceAccountSecret(
 			Labels: map[string]string{
 				associationNameLabel:      associationNameValue,
 				associationNamespaceLabel: associationNamespaceValue,
-				labels.TypeLabelName:      esuser.ServiceAccountTokenType,
+				commonv1.TypeLabelName:    esuser.ServiceAccountTokenType,
 			},
 		},
 	}

--- a/pkg/controller/association/reconciler.go
+++ b/pkg/controller/association/reconciler.go
@@ -26,7 +26,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/events"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/name"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/reconciler"
@@ -119,7 +118,7 @@ func (a AssociationInfo) userLabelSelector(
 	association types.NamespacedName,
 ) client.MatchingLabels {
 	return maps.Merge(
-		map[string]string{labels.TypeLabelName: user.AssociatedUserType},
+		map[string]string{commonv1.TypeLabelName: user.AssociatedUserType},
 		a.AssociationResourceLabels(associated, association),
 	)
 }

--- a/pkg/controller/association/resources_test.go
+++ b/pkg/controller/association/resources_test.go
@@ -17,7 +17,6 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/kibana/v1"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	esuser "github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/maps"
@@ -54,7 +53,7 @@ func Test_deleteOrphanedResources(t *testing.T) {
 		"kibana.k8s.elastic.co/namespace":            esFixture.Namespace,
 	}
 
-	userSecretLabels := maps.Merge(map[string]string{labels.TypeLabelName: esuser.AssociatedUserType}, associationLabels)
+	userSecretLabels := maps.Merge(map[string]string{commonv1.TypeLabelName: esuser.AssociatedUserType}, associationLabels)
 
 	assertExpectObjectsExist := func(t *testing.T, c k8s.Client) {
 		t.Helper()

--- a/pkg/controller/association/service_account.go
+++ b/pkg/controller/association/service_account.go
@@ -52,7 +52,7 @@ func esSecretsLabels(es esv1.Elasticsearch) map[string]string {
 	return map[string]string{
 		label.ClusterNamespaceLabelName: es.Namespace,
 		label.ClusterNameLabelName:      es.Name,
-		labels.TypeLabelName:            esuser.ServiceAccountTokenType,
+		commonv1.TypeLabelName:          esuser.ServiceAccountTokenType,
 	}
 }
 

--- a/pkg/controller/association/user_test.go
+++ b/pkg/controller/association/user_test.go
@@ -19,7 +19,6 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/kibana/v1"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/label"
 	esuser "github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/user"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
@@ -91,7 +90,7 @@ func Test_reconcileEsUser(t *testing.T) {
 				assert.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: userName, Namespace: "default"}, &esUser))
 				expectedLabels := map[string]string{
 					associationLabelName:       kibanaFixture.Name,
-					labels.TypeLabelName:       esuser.AssociatedUserType,
+					commonv1.TypeLabelName:     esuser.AssociatedUserType,
 					label.ClusterNameLabelName: "es-foo",
 				}
 				for k, v := range expectedLabels {
@@ -192,7 +191,7 @@ func Test_reconcileEsUser(t *testing.T) {
 							Labels: map[string]string{
 								associationLabelName:       kibanaFixture.Name,
 								associationLabelNamespace:  kibanaFixture.Namespace,
-								labels.TypeLabelName:       esuser.AssociatedUserType,
+								commonv1.TypeLabelName:     esuser.AssociatedUserType,
 								label.ClusterNameLabelName: esFixture.Name,
 							},
 						},

--- a/pkg/controller/beat/common/config.go
+++ b/pkg/controller/beat/common/config.go
@@ -160,7 +160,7 @@ func reconcileConfig(
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: params.Beat.Namespace,
 			Name:      ConfigSecretName(params.Beat.Spec.Type, params.Beat.Name),
-			Labels:    labels.AddCredentialsLabel(NewLabels(params.Beat)),
+			Labels:    labels.AddCredentialsLabel(params.Beat.GetElasticLabels()),
 		},
 		Data: map[string][]byte{
 			ConfigFileName: cfgBytes,

--- a/pkg/controller/beat/common/labels.go
+++ b/pkg/controller/beat/common/labels.go
@@ -4,11 +4,6 @@
 
 package common
 
-import (
-	beatv1beta1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/beat/v1beta1"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
-)
-
 const (
 	// Type represents the Beat type.
 	TypeLabelValue = "beat"
@@ -16,10 +11,3 @@ const (
 	// NameLabelName is used to represent a Beat in k8s resources.
 	NameLabelName = "beat.k8s.elastic.co/name"
 )
-
-func NewLabels(beat beatv1beta1.Beat) map[string]string {
-	return map[string]string{
-		labels.TypeLabelName: TypeLabelValue,
-		NameLabelName:        beat.Name,
-	}
-}

--- a/pkg/controller/beat/common/pod.go
+++ b/pkg/controller/beat/common/pod.go
@@ -84,7 +84,7 @@ func buildPodTemplate(
 		params,
 		&params.Beat,
 		namer,
-		NewLabels(params.Beat),
+		params.Beat.GetElasticLabels(),
 		initContainerParameters(params.Beat.Spec.Type),
 	)
 	if err != nil {
@@ -188,7 +188,7 @@ func buildPodTemplate(
 		sideCars = append(sideCars, sideCar.Container)
 	}
 
-	labels := maps.Merge(NewLabels(params.Beat), map[string]string{
+	labels := maps.Merge(params.Beat.GetElasticLabels(), map[string]string{
 		VersionLabelName: spec.Version})
 
 	annotations := map[string]string{

--- a/pkg/controller/beat/common/reconcile.go
+++ b/pkg/controller/beat/common/reconcile.go
@@ -92,8 +92,8 @@ func reconcileDeployment(rp ReconciliationParams) (int32, int32, error) {
 	d := deployment.New(deployment.Params{
 		Name:                 Name(rp.beat.Name, rp.beat.Spec.Type),
 		Namespace:            rp.beat.Namespace,
-		Selector:             NewLabels(rp.beat),
-		Labels:               NewLabels(rp.beat),
+		Selector:             rp.beat.GetElasticLabels(),
+		Labels:               rp.beat.GetElasticLabels(),
 		PodTemplateSpec:      rp.podTemplate,
 		RevisionHistoryLimit: rp.beat.Spec.RevisionHistoryLimit,
 		Replicas:             pointer.Int32OrDefault(rp.beat.Spec.Deployment.Replicas, int32(1)),
@@ -116,9 +116,9 @@ func reconcileDaemonSet(rp ReconciliationParams) (int32, int32, error) {
 		PodTemplate:          rp.podTemplate,
 		Name:                 Name(rp.beat.Name, rp.beat.Spec.Type),
 		Owner:                &rp.beat,
-		Labels:               NewLabels(rp.beat),
+		Labels:               rp.beat.GetElasticLabels(),
 		RevisionHistoryLimit: rp.beat.Spec.RevisionHistoryLimit,
-		Selectors:            NewLabels(rp.beat),
+		Selectors:            rp.beat.GetElasticLabels(),
 		Strategy:             rp.beat.Spec.DaemonSet.UpdateStrategy,
 	})
 

--- a/pkg/controller/beat/common/stackmon/stackmon_test.go
+++ b/pkg/controller/beat/common/stackmon/stackmon_test.go
@@ -111,12 +111,9 @@ output:
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "beat-beat-monitoring-metricbeat-config",
 				Namespace: "test",
-				// *note* the following is a bug in the common/stackmon/NewMetricBeatSidecar func
-				// and this type should be the underlying CRD type, not hard-coded to Elasticsearch.
-				// https://github.com/elastic/cloud-on-k8s/issues/5967
 				Labels: map[string]string{
-					"common.k8s.elastic.co/type":                "elasticsearch",
-					"elasticsearch.k8s.elastic.co/cluster-name": "beat",
+					"common.k8s.elastic.co/type": "beat",
+					"beat.k8s.elastic.co/name":   "beat",
 				},
 			},
 			Data: map[string][]byte{

--- a/pkg/controller/common/labels/labels.go
+++ b/pkg/controller/common/labels/labels.go
@@ -7,13 +7,11 @@ package labels
 import (
 	"strconv"
 
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/maps"
 )
 
 const (
-	// TypeLabelName used to represent a resource type in k8s resources
-	TypeLabelName = "common.k8s.elastic.co/type"
-
 	credentialsLabel = "eck.k8s.elastic.co/credentials" //nolint:gosec
 )
 
@@ -40,4 +38,9 @@ func (l TrueFalseLabel) AsMap(value bool) map[string]string {
 // AddCredentialsLabel adds a label used to describe a resource which contains some credentials, either a clear-text password or a token.
 func AddCredentialsLabel(original map[string]string) map[string]string {
 	return maps.Merge(map[string]string{credentialsLabel: "true"}, original)
+}
+
+// New will return the common Elastic labels for any instance of the Elastic Stack.
+func New(obj commonv1.HasElasticLabels) (labels map[string]string) {
+	return obj.GetElasticLabels()
 }

--- a/pkg/controller/common/labels/labels_test.go
+++ b/pkg/controller/common/labels/labels_test.go
@@ -5,9 +5,20 @@
 package labels
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	agent "github.com/elastic/cloud-on-k8s/v2/pkg/apis/agent/v1alpha1"
+	apm "github.com/elastic/cloud-on-k8s/v2/pkg/apis/apm/v1"
+	beat "github.com/elastic/cloud-on-k8s/v2/pkg/apis/beat/v1beta1"
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
+	es "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
+	enterprisesearch "github.com/elastic/cloud-on-k8s/v2/pkg/apis/enterprisesearch/v1"
+	kibana "github.com/elastic/cloud-on-k8s/v2/pkg/apis/kibana/v1"
+	maps "github.com/elastic/cloud-on-k8s/v2/pkg/apis/maps/v1alpha1"
 )
 
 const testLabel TrueFalseLabel = "foo"
@@ -170,6 +181,106 @@ func TestTrueFalseLabel_AsMap(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.l.AsMap(tt.args.value)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name       string
+		obj        commonv1.HasElasticLabels
+		wantLabels map[string]string
+	}{
+		{
+			name: "Agent returns the correct labels",
+			obj: &agent.Agent{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test-agent",
+				},
+			},
+			wantLabels: map[string]string{
+				commonv1.TypeLabelName:      "agent",
+				"agent.k8s.elastic.co/name": "test-agent",
+			},
+		},
+		{
+			name: "ApmServer returns the correct labels",
+			obj: &apm.ApmServer{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test-apmserver",
+				},
+			},
+			wantLabels: map[string]string{
+				commonv1.TypeLabelName:    "apm-server",
+				"apm.k8s.elastic.co/name": "test-apmserver",
+			},
+		},
+		{
+			name: "Beat returns the correct labels",
+			obj: &beat.Beat{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test-beat",
+				},
+			},
+			wantLabels: map[string]string{
+				commonv1.TypeLabelName:     "beat",
+				"beat.k8s.elastic.co/name": "test-beat",
+			},
+		},
+		{
+			name: "Elasticsearch returns the correct labels",
+			obj: &es.Elasticsearch{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test-elasticsearch",
+				},
+			},
+			wantLabels: map[string]string{
+				commonv1.TypeLabelName:                      "elasticsearch",
+				"elasticsearch.k8s.elastic.co/cluster-name": "test-elasticsearch",
+			},
+		},
+		{
+			name: "EnterpriseSearch returns the correct labels",
+			obj: &enterprisesearch.EnterpriseSearch{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test-es",
+				},
+			},
+			wantLabels: map[string]string{
+				commonv1.TypeLabelName:                 "enterprise-search",
+				"enterprisesearch.k8s.elastic.co/name": "test-es",
+			},
+		},
+		{
+			name: "Kibana returns the correct labels",
+			obj: &kibana.Kibana{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test-kb",
+				},
+			},
+			wantLabels: map[string]string{
+				commonv1.TypeLabelName:       "kibana",
+				"kibana.k8s.elastic.co/name": "test-kb",
+			},
+		},
+		{
+			name: "Maps returns the correct labels",
+			obj: &maps.ElasticMapsServer{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test-ems",
+				},
+			},
+			wantLabels: map[string]string{
+				commonv1.TypeLabelName:     "maps",
+				"maps.k8s.elastic.co/name": "test-ems",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotLabels := New(tt.obj); !reflect.DeepEqual(gotLabels, tt.wantLabels) {
+				t.Errorf("New() = %v, want %v", gotLabels, tt.wantLabels)
+			}
 		})
 	}
 }

--- a/pkg/controller/common/license/crud.go
+++ b/pkg/controller/common/license/crud.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/maps"
 )
@@ -95,8 +95,8 @@ func CreateTrialLicense(ctx context.Context, c k8s.Client, nsn types.NamespacedN
 			Name:      nsn.Name,
 			Namespace: nsn.Namespace,
 			Labels: map[string]string{
-				labels.TypeLabelName: Type,
-				LicenseLabelType:     string(LicenseTypeEnterpriseTrial),
+				commonv1.TypeLabelName: Type,
+				LicenseLabelType:       string(LicenseTypeEnterpriseTrial),
 			},
 			Annotations: map[string]string{
 				EULAAnnotation: EULAAcceptedValue,

--- a/pkg/controller/common/license/detection.go
+++ b/pkg/controller/common/license/detection.go
@@ -7,12 +7,12 @@ package license
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 )
 
 func isLicenseType(secret corev1.Secret, licenseType OperatorLicenseType) bool {
 	// is it a license at all (but be lenient if user omitted label)?
-	baseType, hasLabel := secret.Labels[labels.TypeLabelName]
+	baseType, hasLabel := secret.Labels[commonv1.TypeLabelName]
 	if hasLabel && baseType != Type {
 		return false
 	}

--- a/pkg/controller/common/license/detection_test.go
+++ b/pkg/controller/common/license/detection_test.go
@@ -10,7 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 )
 
 func Test_isLicenseType(t *testing.T) {
@@ -37,8 +37,8 @@ func Test_isLicenseType(t *testing.T) {
 				secret: corev1.Secret{
 					ObjectMeta: v1.ObjectMeta{
 						Labels: map[string]string{
-							labels.TypeLabelName: "foo",
-							LicenseLabelType:     string(LicenseTypeEnterpriseTrial),
+							commonv1.TypeLabelName: "foo",
+							LicenseLabelType:       string(LicenseTypeEnterpriseTrial),
 						},
 					},
 				},
@@ -52,8 +52,8 @@ func Test_isLicenseType(t *testing.T) {
 				secret: corev1.Secret{
 					ObjectMeta: v1.ObjectMeta{
 						Labels: map[string]string{
-							labels.TypeLabelName: Type,
-							LicenseLabelType:     string(LicenseTypeEnterpriseTrial),
+							commonv1.TypeLabelName: Type,
+							LicenseLabelType:       string(LicenseTypeEnterpriseTrial),
 						},
 					},
 				},
@@ -67,8 +67,8 @@ func Test_isLicenseType(t *testing.T) {
 				secret: corev1.Secret{
 					ObjectMeta: v1.ObjectMeta{
 						Labels: map[string]string{
-							labels.TypeLabelName: Type,
-							LicenseLabelType:     string(LicenseTypeEnterprise),
+							commonv1.TypeLabelName: Type,
+							LicenseLabelType:       string(LicenseTypeEnterprise),
 						},
 					},
 				},

--- a/pkg/controller/common/license/fixtures_test.go
+++ b/pkg/controller/common/license/fixtures_test.go
@@ -17,7 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 )
 
 var (
@@ -87,9 +87,9 @@ func asRuntimeObject(l EnterpriseLicense) runtime.Object {
 			Namespace: "test-system",
 			Name:      fmt.Sprintf("test-%s-license", string(l.License.Type)),
 			Labels: map[string]string{
-				labels.TypeLabelName: Type,
-				LicenseLabelScope:    string(LicenseScopeOperator),
-				LicenseLabelType:     string(l.License.Type),
+				commonv1.TypeLabelName: Type,
+				LicenseLabelScope:      string(LicenseScopeOperator),
+				LicenseLabelType:       string(l.License.Type),
 			},
 		},
 		Data: map[string][]byte{

--- a/pkg/controller/common/license/labels.go
+++ b/pkg/controller/common/license/labels.go
@@ -7,7 +7,7 @@ package license
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 )
 
 const (
@@ -31,9 +31,9 @@ const (
 // LabelsForOperatorScope creates a map of labels for operator scope with licence type set to the given value.
 func LabelsForOperatorScope(t OperatorLicenseType) map[string]string {
 	return map[string]string{
-		labels.TypeLabelName: Type,
-		LicenseLabelScope:    string(LicenseScopeOperator),
-		LicenseLabelType:     string(t),
+		commonv1.TypeLabelName: Type,
+		LicenseLabelScope:      string(LicenseScopeOperator),
+		LicenseLabelType:       string(t),
 	}
 }
 

--- a/pkg/controller/common/stackmon/config.go
+++ b/pkg/controller/common/stackmon/config.go
@@ -21,11 +21,11 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/certificates"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/name"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/settings"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon/monitoring"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/volume"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 )
 
@@ -88,7 +88,7 @@ func newBeatConfig(ctx context.Context, client k8s.Client, beatName string, reso
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      configSecretName,
 			Namespace: resource.GetNamespace(),
-			Labels:    label.NewLabels(k8s.ExtractNamespacedName(resource)),
+			Labels:    labels.New(resource),
 		},
 		Data: map[string][]byte{
 			configFilename: configBytes,

--- a/pkg/controller/common/stackmon/monitoring/monitoring.go
+++ b/pkg/controller/common/stackmon/monitoring/monitoring.go
@@ -13,6 +13,7 @@ import (
 // HasMonitoring is the interface implemented by an Elastic Stack application that supports Stack Monitoring
 type HasMonitoring interface {
 	client.Object
+	commonv1.HasElasticLabels
 	GetMonitoringMetricsRefs() []commonv1.ObjectSelector
 	GetMonitoringLogsRefs() []commonv1.ObjectSelector
 	MonitoringAssociation(ref commonv1.ObjectSelector) commonv1.Association

--- a/pkg/controller/elasticsearch/certificates/remoteca/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/remoteca/reconcile.go
@@ -13,9 +13,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/certificates"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
@@ -29,7 +29,7 @@ const (
 func Labels(esName string) client.MatchingLabels {
 	return map[string]string{
 		label.ClusterNameLabelName: esName,
-		labels.TypeLabelName:       TypeLabelValue,
+		commonv1.TypeLabelName:     TypeLabelValue,
 	}
 }
 

--- a/pkg/controller/elasticsearch/certificates/remoteca/reconcile_test.go
+++ b/pkg/controller/elasticsearch/certificates/remoteca/reconcile_test.go
@@ -14,9 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/certificates"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 )
@@ -45,7 +45,7 @@ func TestReconcile(t *testing.T) {
 							Namespace: "ns1",
 							Labels: map[string]string{
 								label.ClusterNameLabelName: "es1",
-								labels.TypeLabelName:       TypeLabelValue,
+								commonv1.TypeLabelName:     TypeLabelValue,
 							},
 						},
 						Data: map[string][]byte{certificates.CAFileName: []byte("cert1\n")},
@@ -56,7 +56,7 @@ func TestReconcile(t *testing.T) {
 							Namespace: "ns1",
 							Labels: map[string]string{
 								label.ClusterNameLabelName: "es1",
-								labels.TypeLabelName:       TypeLabelValue,
+								commonv1.TypeLabelName:     TypeLabelValue,
 							},
 						},
 						Data: map[string][]byte{certificates.CAFileName: []byte("cert2\n")},
@@ -77,7 +77,7 @@ func TestReconcile(t *testing.T) {
 							Namespace: "ns1",
 							Labels: map[string]string{
 								label.ClusterNameLabelName: "es1",
-								labels.TypeLabelName:       TypeLabelValue,
+								commonv1.TypeLabelName:     TypeLabelValue,
 							},
 						},
 						Data: map[string][]byte{certificates.CAFileName: []byte("cert1\n")},
@@ -88,7 +88,7 @@ func TestReconcile(t *testing.T) {
 							Namespace: "ns1",
 							Labels: map[string]string{
 								label.ClusterNameLabelName: "es1",
-								labels.TypeLabelName:       "foo",
+								commonv1.TypeLabelName:     "foo",
 							},
 						},
 						Data: map[string][]byte{certificates.CAFileName: []byte("cert3\n")},
@@ -99,7 +99,7 @@ func TestReconcile(t *testing.T) {
 							Namespace: "ns1",
 							Labels: map[string]string{
 								label.ClusterNameLabelName: "es1",
-								labels.TypeLabelName:       TypeLabelValue,
+								commonv1.TypeLabelName:     TypeLabelValue,
 							},
 						},
 						Data: map[string][]byte{certificates.CAFileName: []byte("cert2\n")},

--- a/pkg/controller/elasticsearch/label/label.go
+++ b/pkg/controller/elasticsearch/label/label.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
@@ -115,8 +116,8 @@ func ExtractVersion(labels map[string]string) (version.Version, error) {
 // NewLabels constructs a new set of labels from an Elasticsearch definition.
 func NewLabels(es types.NamespacedName) map[string]string {
 	return map[string]string{
-		ClusterNameLabelName: es.Name,
-		labels.TypeLabelName: Type,
+		ClusterNameLabelName:   es.Name,
+		commonv1.TypeLabelName: Type,
 	}
 }
 

--- a/pkg/controller/elasticsearch/label/label_test.go
+++ b/pkg/controller/elasticsearch/label/label_test.go
@@ -16,8 +16,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	v1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 )
 
@@ -121,7 +121,7 @@ func TestNewPodLabels(t *testing.T) {
 			},
 			want: map[string]string{
 				ClusterNameLabelName:             "name",
-				labels.TypeLabelName:             "elasticsearch",
+				commonv1.TypeLabelName:           "elasticsearch",
 				VersionLabelName:                 "7.1.0",
 				string(NodeTypesMasterLabelName): "false",
 				string(NodeTypesDataLabelName):   "false",
@@ -150,7 +150,7 @@ func TestNewPodLabels(t *testing.T) {
 			},
 			want: map[string]string{
 				ClusterNameLabelName:                 "name",
-				labels.TypeLabelName:                 "elasticsearch",
+				commonv1.TypeLabelName:               "elasticsearch",
 				VersionLabelName:                     "7.3.0",
 				string(NodeTypesMasterLabelName):     "false",
 				string(NodeTypesDataLabelName):       "true",
@@ -179,7 +179,7 @@ func TestNewPodLabels(t *testing.T) {
 			},
 			want: map[string]string{
 				ClusterNameLabelName:                          "name",
-				labels.TypeLabelName:                          "elasticsearch",
+				commonv1.TypeLabelName:                        "elasticsearch",
 				VersionLabelName:                              "7.7.0",
 				string(NodeTypesMasterLabelName):              "false",
 				string(NodeTypesDataLabelName):                "true",
@@ -206,7 +206,7 @@ func TestNewPodLabels(t *testing.T) {
 			},
 			want: map[string]string{
 				ClusterNameLabelName:                          "name",
-				labels.TypeLabelName:                          "elasticsearch",
+				commonv1.TypeLabelName:                        "elasticsearch",
 				VersionLabelName:                              "7.10.0",
 				string(NodeTypesMasterLabelName):              "true",
 				string(NodeTypesDataLabelName):                "true",
@@ -237,7 +237,7 @@ func TestNewPodLabels(t *testing.T) {
 			},
 			want: map[string]string{
 				ClusterNameLabelName:                          "name",
-				labels.TypeLabelName:                          "elasticsearch",
+				commonv1.TypeLabelName:                        "elasticsearch",
 				VersionLabelName:                              "7.12.0",
 				string(NodeTypesMasterLabelName):              "true",
 				string(NodeTypesDataLabelName):                "true",

--- a/pkg/controller/elasticsearch/pdb/reconcile_test.go
+++ b/pkg/controller/elasticsearch/pdb/reconcile_test.go
@@ -27,7 +27,6 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/comparison"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/hash"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/sset"
 )
@@ -38,7 +37,7 @@ func TestReconcile(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      esv1.DefaultPodDisruptionBudget("cluster"),
 				Namespace: "ns",
-				Labels:    map[string]string{label.ClusterNameLabelName: "cluster", labels.TypeLabelName: label.Type},
+				Labels:    map[string]string{label.ClusterNameLabelName: "cluster", commonv1.TypeLabelName: label.Type},
 			},
 			Spec: policyv1.PodDisruptionBudgetSpec{
 				MinAvailable: intStrPtr(intstr.FromInt(3)),
@@ -90,7 +89,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      esv1.DefaultPodDisruptionBudget("cluster"),
 					Namespace: "ns",
-					Labels:    map[string]string{label.ClusterNameLabelName: "cluster", labels.TypeLabelName: label.Type},
+					Labels:    map[string]string{label.ClusterNameLabelName: "cluster", commonv1.TypeLabelName: label.Type},
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: intStrPtr(intstr.FromInt(5)),
@@ -191,7 +190,7 @@ func Test_expectedPDB(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      esv1.DefaultPodDisruptionBudget("cluster"),
 					Namespace: "ns",
-					Labels:    map[string]string{label.ClusterNameLabelName: "cluster", labels.TypeLabelName: label.Type},
+					Labels:    map[string]string{label.ClusterNameLabelName: "cluster", commonv1.TypeLabelName: label.Type},
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: intStrPtr(intstr.FromInt(3)),
@@ -222,7 +221,7 @@ func Test_expectedPDB(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      esv1.DefaultPodDisruptionBudget("cluster"),
 					Namespace: "ns",
-					Labels:    map[string]string{"a": "b", "c": "d", label.ClusterNameLabelName: "cluster", labels.TypeLabelName: label.Type},
+					Labels:    map[string]string{"a": "b", "c": "d", label.ClusterNameLabelName: "cluster", commonv1.TypeLabelName: label.Type},
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: intStrPtr(intstr.FromInt(3)),
@@ -251,7 +250,7 @@ func Test_expectedPDB(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      esv1.DefaultPodDisruptionBudget("cluster"),
 					Namespace: "ns",
-					Labels:    map[string]string{label.ClusterNameLabelName: "cluster", labels.TypeLabelName: label.Type},
+					Labels:    map[string]string{label.ClusterNameLabelName: "cluster", commonv1.TypeLabelName: label.Type},
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: intStrPtr(intstr.FromInt(42)),

--- a/pkg/controller/elasticsearch/services/services_test.go
+++ b/pkg/controller/elasticsearch/services/services_test.go
@@ -15,7 +15,6 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/network"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/compare"
@@ -265,7 +264,7 @@ func mkHTTPService() corev1.Service {
 			Namespace: "test",
 			Labels: map[string]string{
 				label.ClusterNameLabelName: "elasticsearch-test",
-				labels.TypeLabelName:       label.Type,
+				commonv1.TypeLabelName:     label.Type,
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -278,7 +277,7 @@ func mkHTTPService() corev1.Service {
 			},
 			Selector: map[string]string{
 				label.ClusterNameLabelName: "elasticsearch-test",
-				labels.TypeLabelName:       label.Type,
+				commonv1.TypeLabelName:     label.Type,
 			},
 		},
 	}
@@ -291,7 +290,7 @@ func mkTransportService() corev1.Service {
 			Namespace: "test",
 			Labels: map[string]string{
 				label.ClusterNameLabelName: "elasticsearch-test",
-				labels.TypeLabelName:       label.Type,
+				commonv1.TypeLabelName:     label.Type,
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -307,7 +306,7 @@ func mkTransportService() corev1.Service {
 			},
 			Selector: map[string]string{
 				label.ClusterNameLabelName: "elasticsearch-test",
-				labels.TypeLabelName:       label.Type,
+				commonv1.TypeLabelName:     label.Type,
 			},
 		},
 	}

--- a/pkg/controller/elasticsearch/user/associated.go
+++ b/pkg/controller/elasticsearch/user/associated.go
@@ -12,8 +12,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 )
@@ -45,7 +45,7 @@ type AssociatedUser struct {
 func AssociatedUserLabels(es esv1.Elasticsearch) map[string]string {
 	return map[string]string{
 		label.ClusterNameLabelName: es.Name,
-		labels.TypeLabelName:       AssociatedUserType,
+		commonv1.TypeLabelName:     AssociatedUserType,
 	}
 }
 

--- a/pkg/controller/elasticsearch/user/service_account.go
+++ b/pkg/controller/elasticsearch/user/service_account.go
@@ -13,8 +13,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
-	commonlabel "github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/set"
@@ -58,7 +58,7 @@ func GetServiceAccountTokens(c k8s.Client, es esv1.Elasticsearch) (ServiceAccoun
 		client.MatchingLabels(
 			map[string]string{
 				label.ClusterNameLabelName: es.Name,
-				commonlabel.TypeLabelName:  ServiceAccountTokenType,
+				commonv1.TypeLabelName:     ServiceAccountTokenType,
 			},
 		),
 	); err != nil {

--- a/pkg/controller/enterprisesearch/config.go
+++ b/pkg/controller/enterprisesearch/config.go
@@ -79,7 +79,7 @@ func ReconcileConfig(ctx context.Context, driver driver.Interface, ent entv1.Ent
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ent.Namespace,
 			Name:      ConfigName(ent.Name),
-			Labels:    labels.AddCredentialsLabel(Labels(ent.Name)),
+			Labels:    labels.AddCredentialsLabel(ent.GetElasticLabels()),
 		},
 		Data: map[string][]byte{
 			ConfigFilename:         cfgBytes,

--- a/pkg/controller/enterprisesearch/deployment.go
+++ b/pkg/controller/enterprisesearch/deployment.go
@@ -38,9 +38,9 @@ func (r *ReconcileEnterpriseSearch) deploymentParams(ent entv1.EnterpriseSearch,
 		return deployment.Params{}, err
 	}
 
-	deploymentLabels := Labels(ent.Name)
+	deploymentLabels := ent.GetElasticLabels()
 
-	podLabels := maps.Merge(Labels(ent.Name), VersionLabels(ent))
+	podLabels := maps.Merge(ent.GetElasticLabels(), VersionLabels(ent))
 	// merge with user-provided labels
 	podSpec.Labels = maps.MergePreservingExistingKeys(podSpec.Labels, podLabels)
 

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller.go
@@ -206,7 +206,7 @@ func (r *ReconcileEnterpriseSearch) doReconcile(ctx context.Context, ent entv1.E
 		Owner:                 &ent,
 		TLSOptions:            ent.Spec.HTTP.TLS,
 		Namer:                 entv1.Namer,
-		Labels:                Labels(ent.Name),
+		Labels:                ent.GetElasticLabels(),
 		Services:              []corev1.Service{*svc},
 		GlobalCA:              r.GlobalCA,
 		CACertRotation:        r.CACertRotation,
@@ -323,7 +323,7 @@ func NewService(ent entv1.EnterpriseSearch) *corev1.Service {
 	svc.ObjectMeta.Namespace = ent.Namespace
 	svc.ObjectMeta.Name = HTTPServiceName(ent.Name)
 
-	labels := Labels(ent.Name)
+	labels := ent.GetElasticLabels()
 	ports := []corev1.ServicePort{
 		{
 			Name:     ent.Spec.HTTP.Protocol(),

--- a/pkg/controller/enterprisesearch/enterprisesearch_controller_test.go
+++ b/pkg/controller/enterprisesearch/enterprisesearch_controller_test.go
@@ -23,7 +23,6 @@ import (
 	entv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/enterprisesearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/certificates"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
@@ -250,7 +249,7 @@ func TestReconcileEnterpriseSearch_doReconcile_AssociationDelaysVersionUpgrade(t
 			Name:      "ent-pod1",
 			Labels: map[string]string{
 				EnterpriseSearchNameLabelName: ent.Name,
-				labels.TypeLabelName:          Type,
+				commonv1.TypeLabelName:        Type,
 				VersionLabelName:              "7.7.0",
 			},
 		},

--- a/pkg/controller/enterprisesearch/labels.go
+++ b/pkg/controller/enterprisesearch/labels.go
@@ -6,7 +6,6 @@ package enterprisesearch
 
 import (
 	entv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/enterprisesearch/v1"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 )
 
 const (
@@ -19,14 +18,6 @@ const (
 	// VersionLabelName is a label used to track the version of an Enterprise Search Pod.
 	VersionLabelName = "enterprisesearch.k8s.elastic.co/version"
 )
-
-// Labels returns labels that identify the given Enterprise Search resource
-func Labels(entName string) map[string]string {
-	return map[string]string{
-		EnterpriseSearchNameLabelName: entName,
-		labels.TypeLabelName:          Type,
-	}
-}
 
 func VersionLabels(ent entv1.EnterpriseSearch) map[string]string {
 	return map[string]string{

--- a/pkg/controller/enterprisesearch/version_upgrade.go
+++ b/pkg/controller/enterprisesearch/version_upgrade.go
@@ -281,7 +281,7 @@ func (r *VersionUpgrade) isPriorVersionStillRunning(expectedVersion version.Vers
 func (r *VersionUpgrade) getActualPods() ([]corev1.Pod, error) {
 	var pods corev1.PodList
 	ns := client.InNamespace(r.ent.Namespace)
-	if err := r.k8sClient.List(context.Background(), &pods, client.MatchingLabels(Labels(r.ent.Name)), ns); err != nil {
+	if err := r.k8sClient.List(context.Background(), &pods, client.MatchingLabels(r.ent.GetElasticLabels()), ns); err != nil {
 		return nil, err
 	}
 	return pods.Items, nil

--- a/pkg/controller/enterprisesearch/version_upgrade_test.go
+++ b/pkg/controller/enterprisesearch/version_upgrade_test.go
@@ -20,7 +20,6 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	entv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/enterprisesearch/v1"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 )
@@ -56,7 +55,7 @@ func podWithVersion(name string, version string) *corev1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "ns", Name: name, Labels: map[string]string{
 				EnterpriseSearchNameLabelName: "ent",
-				labels.TypeLabelName:          Type,
+				commonv1.TypeLabelName:        Type,
 				VersionLabelName:              version,
 			},
 		},

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -126,7 +126,7 @@ func (d *driver) Reconcile(
 		Owner:                 kb,
 		TLSOptions:            kb.Spec.HTTP.TLS,
 		Namer:                 kbv1.KBNamer,
-		Labels:                NewLabels(kb.Name),
+		Labels:                kb.GetElasticLabels(),
 		Services:              []corev1.Service{*svc},
 		GlobalCA:              params.GlobalCA,
 		CACertRotation:        params.CACertRotation,
@@ -224,7 +224,7 @@ func (d *driver) deploymentParams(ctx context.Context, kb *kbv1.Kibana) (deploym
 		d,
 		kb,
 		kbv1.KBNamer,
-		NewLabels(kb.Name),
+		kb.GetElasticLabels(),
 		initContainersParameters,
 	)
 	if err != nil {
@@ -290,8 +290,8 @@ func (d *driver) deploymentParams(ctx context.Context, kb *kbv1.Kibana) (deploym
 		Name:                 kbv1.KBNamer.Suffix(kb.Name),
 		Namespace:            kb.Namespace,
 		Replicas:             kb.Spec.Count,
-		Selector:             NewLabels(kb.Name),
-		Labels:               NewLabels(kb.Name),
+		Selector:             kb.GetElasticLabels(),
+		Labels:               kb.GetElasticLabels(),
 		PodTemplateSpec:      kibanaPodSpec,
 		RevisionHistoryLimit: kb.Spec.RevisionHistoryLimit,
 		Strategy:             appsv1.DeploymentStrategy{Type: strategyType},
@@ -335,7 +335,7 @@ func NewService(kb kbv1.Kibana) *corev1.Service {
 	svc.ObjectMeta.Namespace = kb.Namespace
 	svc.ObjectMeta.Name = kbv1.HTTPService(kb.Name)
 
-	labels := NewLabels(kb.Name)
+	labels := kb.GetElasticLabels()
 	ports := []corev1.ServicePort{
 		{
 			Name:     kb.Spec.HTTP.Protocol(),

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -25,7 +25,6 @@ import (
 	kbv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/certificates"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/deployment"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/settings"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/kibana/network"
@@ -770,8 +769,8 @@ func mkService() corev1.Service {
 			Name:      "kibana-test-kb-http",
 			Namespace: "test",
 			Labels: map[string]string{
-				KibanaNameLabelName:  "kibana-test",
-				labels.TypeLabelName: Type,
+				KibanaNameLabelName:    "kibana-test",
+				commonv1.TypeLabelName: Type,
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -783,8 +782,8 @@ func mkService() corev1.Service {
 				},
 			},
 			Selector: map[string]string{
-				KibanaNameLabelName:  "kibana-test",
-				labels.TypeLabelName: Type,
+				KibanaNameLabelName:    "kibana-test",
+				commonv1.TypeLabelName: Type,
 			},
 		},
 	}

--- a/pkg/controller/kibana/labels.go
+++ b/pkg/controller/kibana/labels.go
@@ -4,8 +4,6 @@
 
 package kibana
 
-import "github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
-
 const (
 	// KibanaNameLabelName used to represent a Kibana in k8s resources
 	KibanaNameLabelName = "kibana.k8s.elastic.co/name"
@@ -19,11 +17,3 @@ const (
 	// Type represents the Kibana type
 	Type = "kibana"
 )
-
-// NewLabels constructs a new set of labels for a Kibana pod
-func NewLabels(kibanaName string) map[string]string {
-	return map[string]string{
-		KibanaNameLabelName:  kibanaName,
-		labels.TypeLabelName: Type,
-	}
-}

--- a/pkg/controller/kibana/pod.go
+++ b/pkg/controller/kibana/pod.go
@@ -73,7 +73,7 @@ func readinessProbe(useTLS bool) corev1.Probe {
 }
 
 func NewPodTemplateSpec(ctx context.Context, client k8sclient.Client, kb kbv1.Kibana, keystore *keystore.Resources, volumes []volume.VolumeLike) (corev1.PodTemplateSpec, error) {
-	labels := NewLabels(kb.Name)
+	labels := kb.GetElasticLabels()
 	labels[KibanaVersionLabelName] = kb.Spec.Version
 
 	ports := getDefaultContainerPorts(kb)

--- a/pkg/controller/kibana/pod_test.go
+++ b/pkg/controller/kibana/pod_test.go
@@ -156,7 +156,7 @@ func TestNewPodTemplateSpec(t *testing.T) {
 					Version: "7.4.0",
 				}},
 			assertions: func(pod corev1.PodTemplateSpec) {
-				labels := NewLabels("kibana-name")
+				labels := (&kbv1.Kibana{ObjectMeta: metav1.ObjectMeta{Name: "kibana-name"}}).GetElasticLabels()
 				labels[KibanaVersionLabelName] = "7.4.0"
 				labels["label1"] = "value1"
 				labels["label2"] = "value2"

--- a/pkg/controller/license/license_controller.go
+++ b/pkg/controller/license/license_controller.go
@@ -24,10 +24,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/events"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/license"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/reconciler"
@@ -199,7 +199,7 @@ func reconcileSecret(
 			Name:      secretName,
 			Namespace: cluster.Namespace,
 			Labels: map[string]string{
-				labels.TypeLabelName:      license.Type,
+				commonv1.TypeLabelName:    license.Type,
 				license.LicenseLabelName:  parent,
 				license.LicenseLabelScope: string(license.LicenseScopeElasticsearch),
 				license.LicenseLabelType:  esLicense.Type,

--- a/pkg/controller/maps/config.go
+++ b/pkg/controller/maps/config.go
@@ -52,7 +52,7 @@ func reconcileConfig(ctx context.Context, driver driver.Interface, ems emsv1alph
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ems.Namespace,
 			Name:      Config(ems.Name),
-			Labels:    commonlabels.AddCredentialsLabel(labels(ems.Name)),
+			Labels:    commonlabels.AddCredentialsLabel(ems.GetElasticLabels()),
 		},
 		Data: map[string][]byte{
 			ConfigFilename: cfgBytes,

--- a/pkg/controller/maps/controller.go
+++ b/pkg/controller/maps/controller.go
@@ -224,7 +224,7 @@ func (r *ReconcileMapsServer) doReconcile(ctx context.Context, ems emsv1alpha1.E
 		Owner:                 &ems,
 		TLSOptions:            ems.Spec.HTTP.TLS,
 		Namer:                 EMSNamer,
-		Labels:                labels(ems.Name),
+		Labels:                ems.GetElasticLabels(),
 		Services:              []corev1.Service{*svc},
 		GlobalCA:              r.GlobalCA,
 		CACertRotation:        r.CACertRotation,
@@ -303,7 +303,7 @@ func NewService(ems emsv1alpha1.ElasticMapsServer) *corev1.Service {
 	svc.ObjectMeta.Namespace = ems.Namespace
 	svc.ObjectMeta.Name = HTTPService(ems.Name)
 
-	labels := labels(ems.Name)
+	labels := ems.GetElasticLabels()
 	ports := []corev1.ServicePort{
 		{
 			Name:     ems.Spec.HTTP.Protocol(),
@@ -364,9 +364,9 @@ func (r *ReconcileMapsServer) deploymentParams(ems emsv1alpha1.ElasticMapsServer
 		return deployment.Params{}, err
 	}
 
-	deploymentLabels := labels(ems.Name)
+	deploymentLabels := ems.GetElasticLabels()
 
-	podLabels := maps.Merge(labels(ems.Name), versionLabels(ems))
+	podLabels := maps.Merge(ems.GetElasticLabels(), versionLabels(ems))
 	// merge with user-provided labels
 	podSpec.Labels = maps.MergePreservingExistingKeys(podSpec.Labels, podLabels)
 

--- a/pkg/controller/maps/labels.go
+++ b/pkg/controller/maps/labels.go
@@ -6,7 +6,6 @@ package maps
 
 import (
 	emsv1alpha1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/maps/v1alpha1"
-	commonlabels "github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 )
 
 const (
@@ -19,14 +18,6 @@ const (
 	// Type represents the MapsServer type
 	Type = "maps"
 )
-
-// labels constructs a new set of labels for a MapsServer pod
-func labels(emsName string) map[string]string {
-	return map[string]string{
-		NameLabelName:              emsName,
-		commonlabels.TypeLabelName: Type,
-	}
-}
 
 func versionLabels(ems emsv1alpha1.ElasticMapsServer) map[string]string {
 	return map[string]string{

--- a/pkg/controller/remoteca/controller.go
+++ b/pkg/controller/remoteca/controller.go
@@ -18,10 +18,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/license"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/operator"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/reconciler"
@@ -284,7 +284,7 @@ func remoteClustersInvolvedWith(
 	if err := c.List(ctx,
 		&remoteCAList,
 		client.MatchingLabels(map[string]string{
-			labels.TypeLabelName:            remoteca.TypeLabelValue,
+			commonv1.TypeLabelName:          remoteca.TypeLabelValue,
 			RemoteClusterNamespaceLabelName: es.Namespace,
 			RemoteClusterNameLabelName:      es.Name,
 		}),

--- a/pkg/controller/remoteca/watches.go
+++ b/pkg/controller/remoteca/watches.go
@@ -15,8 +15,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
-	commonlabels "github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/watches"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/certificates/remoteca"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/certificates/transport"
@@ -55,10 +55,10 @@ func AddWatches(c controller.Controller, r *ReconcileRemoteCa) error {
 func newRequestsFromMatchedLabels() handler.MapFunc {
 	return func(obj client.Object) []reconcile.Request {
 		labels := obj.GetLabels()
-		if !maps.ContainsKeys(labels, RemoteClusterNameLabelName, RemoteClusterNamespaceLabelName, commonlabels.TypeLabelName) {
+		if !maps.ContainsKeys(labels, RemoteClusterNameLabelName, RemoteClusterNamespaceLabelName, commonv1.TypeLabelName) {
 			return nil
 		}
-		if labels[commonlabels.TypeLabelName] != remoteca.TypeLabelValue {
+		if labels[commonv1.TypeLabelName] != remoteca.TypeLabelValue {
 			return nil
 		}
 		return []reconcile.Request{

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -19,7 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/license"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/reconciler"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/tracing"
@@ -127,7 +127,7 @@ func (r LicensingResolver) Save(ctx context.Context, info LicensingInfo) error {
 			Namespace: nsn.Namespace,
 			Name:      nsn.Name,
 			Labels: map[string]string{
-				labels.TypeLabelName: Type,
+				commonv1.TypeLabelName: Type,
 			},
 		},
 		Data: info.toMap(),

--- a/test/e2e/test/common_steps.go
+++ b/test/e2e/test/common_steps.go
@@ -15,8 +15,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/hash"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/license"
 )
 
@@ -50,7 +50,7 @@ func CreateEnterpriseLicenseSecret(t *testing.T, k *K8sClient, secretName string
 				Namespace: Ctx().ManagedNamespace(0),
 				Name:      secretName,
 				Labels: map[string]string{
-					labels.TypeLabelName:      license.Type,
+					commonv1.TypeLabelName:    license.Type,
 					license.LicenseLabelScope: string(license.LicenseScopeOperator),
 				},
 			},
@@ -67,7 +67,7 @@ func DeleteAllEnterpriseLicenseSecrets(t *testing.T, k *K8sClient) {
 	Eventually(func() error {
 		// Delete operator license secret
 		var licenseSecrets corev1.SecretList
-		err := k.Client.List(context.Background(), &licenseSecrets, k8sclient.MatchingLabels(map[string]string{labels.TypeLabelName: license.Type}))
+		err := k.Client.List(context.Background(), &licenseSecrets, k8sclient.MatchingLabels(map[string]string{commonv1.TypeLabelName: license.Type}))
 		if err != nil {
 			return err
 		}

--- a/test/e2e/test/k8s_client.go
+++ b/test/e2e/test/k8s_client.go
@@ -29,6 +29,7 @@ import (
 	agentv1alpha1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/agent/v1alpha1"
 	apmv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/apm/v1"
 	beatv1beta1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/beat/v1beta1"
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	entv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/enterprisesearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/kibana/v1"
@@ -36,7 +37,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/apmserver"
 	beatcommon "github.com/elastic/cloud-on-k8s/v2/pkg/controller/beat/common"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/certificates"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/name"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/volume"
@@ -380,7 +380,7 @@ func (k K8sClient) CreateOrUpdate(objs ...client.Object) error {
 func ESPodListOptions(esNamespace, esName string) []k8sclient.ListOption {
 	ns := k8sclient.InNamespace(esNamespace)
 	matchLabels := k8sclient.MatchingLabels(map[string]string{
-		labels.TypeLabelName:       label.Type,
+		commonv1.TypeLabelName:     label.Type,
 		label.ClusterNameLabelName: esName,
 	})
 	return []k8sclient.ListOption{ns, matchLabels}
@@ -407,7 +407,7 @@ func KibanaPodListOptions(kbNamespace, kbName string) []k8sclient.ListOption {
 func ApmServerPodListOptions(apmNamespace, apmName string) []k8sclient.ListOption {
 	ns := k8sclient.InNamespace(apmNamespace)
 	matchLabels := k8sclient.MatchingLabels(map[string]string{
-		labels.TypeLabelName:             apmserver.Type,
+		commonv1.TypeLabelName:           apmserver.Type,
 		apmserver.ApmServerNameLabelName: apmName,
 	})
 	return []k8sclient.ListOption{ns, matchLabels}
@@ -416,7 +416,7 @@ func ApmServerPodListOptions(apmNamespace, apmName string) []k8sclient.ListOptio
 func EnterpriseSearchPodListOptions(entNamespace, entName string) []k8sclient.ListOption {
 	ns := k8sclient.InNamespace(entNamespace)
 	matchLabels := k8sclient.MatchingLabels(map[string]string{
-		labels.TypeLabelName:                           enterprisesearch.Type,
+		commonv1.TypeLabelName:                         enterprisesearch.Type,
 		enterprisesearch.EnterpriseSearchNameLabelName: entName,
 	})
 	return []k8sclient.ListOption{ns, matchLabels}
@@ -425,8 +425,8 @@ func EnterpriseSearchPodListOptions(entNamespace, entName string) []k8sclient.Li
 func AgentPodListOptions(agentNamespace, agentName string) []k8sclient.ListOption {
 	ns := k8sclient.InNamespace(agentNamespace)
 	matchLabels := k8sclient.MatchingLabels(map[string]string{
-		labels.TypeLabelName: agent.TypeLabelValue,
-		agent.NameLabelName:  agent.Name(agentName),
+		commonv1.TypeLabelName: agent.TypeLabelValue,
+		agent.NameLabelName:    agent.Name(agentName),
 	})
 	return []k8sclient.ListOption{ns, matchLabels}
 }
@@ -434,7 +434,7 @@ func AgentPodListOptions(agentNamespace, agentName string) []k8sclient.ListOptio
 func BeatPodListOptions(beatNamespace, beatName, beatType string) []k8sclient.ListOption {
 	ns := k8sclient.InNamespace(beatNamespace)
 	matchLabels := k8sclient.MatchingLabels(map[string]string{
-		labels.TypeLabelName:     beatcommon.TypeLabelValue,
+		commonv1.TypeLabelName:   beatcommon.TypeLabelValue,
 		beatcommon.NameLabelName: beatcommon.Name(beatName, beatType),
 	})
 	return []k8sclient.ListOption{ns, matchLabels}
@@ -443,8 +443,8 @@ func BeatPodListOptions(beatNamespace, beatName, beatType string) []k8sclient.Li
 func MapsPodListOptions(emsNS, emsName string) []k8sclient.ListOption {
 	ns := k8sclient.InNamespace(emsNS)
 	matchLabels := k8sclient.MatchingLabels(map[string]string{
-		labels.TypeLabelName: maps.Type,
-		maps.NameLabelName:   emsName,
+		commonv1.TypeLabelName: maps.Type,
+		maps.NameLabelName:     emsName,
 	})
 	return []k8sclient.ListOption{ns, matchLabels}
 }


### PR DESCRIPTION
Resolves #5967 

Currently the Secret for the stack monitoring sidecar *always* has the labels:

```
Labels: map[string]string{
	"common.k8s.elastic.co/type":                "elasticsearch",
	"elasticsearch.k8s.elastic.co/cluster-name": "associated_cluster_name",
}
```

This fixes the labels to be associated with the actual resource that is being monitored.

To do this in a manner to avoid a Switch/Case statement for each type that can have stack monitoring enabled, I instead created a new interface

```
// HasElasticLabels allows a return of Elastic assigned labels for any object.
// +kubebuilder:object:generate=false
type HasElasticLabels interface {
	client.Object
	GetElasticLabels() map[string]string
}
```

Such that any Elastic CRD object now can call `GetElasticLabels` and have the appropriate 2 labels returned

```
	"common.k8s.elastic.co/type":                "correct_type",
	"elasticsearch.k8s.elastic.co/(name|cluster-name)": "correct_name",
```

Why not `GetLabels` instead of `GetElasticLabels`?
1. `GetLabels` already exists on the `client.Object` interface.
2. `GetElasticLabels` indicates that we're returning the Elastic specific labels in use by our operator.

To make this consistent across all CRDs controllers, I've removed the `NewLabels`, or `Labels` func within each controller, and moved to using the new method on the CRD.

Also, `TypeLabelName` was moved from `pkg/controller/common/labels` => `pkg/apis/common/v1` to avoid an import cycle.