### PR TITLE
Revert "Disable packetbeat test on snapshot versions (#6348)"

### DIFF
--- a/test/e2e/beat/config_test.go
+++ b/test/e2e/beat/config_test.go
@@ -269,12 +269,6 @@ func TestAuditbeatConfig(t *testing.T) {
 func TestPacketbeatConfig(t *testing.T) {
 	name := "test-pb-cfg"
 
-	// https://github.com/elastic/cloud-on-k8s/issues/6346 packetbeat snapshots are panicking let's disable the test
-	// until this is addressed
-	if version.MustParse(test.Ctx().ElasticStackVersion).GTE(version.MinFor(8, 7, 0)) {
-		t.SkipNow()
-	}
-
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
 


### PR DESCRIPTION
This reverts commit 5dbc6e2ca2b0f85620bdcf957ff3beb56c4b5433.

The underlying issue has been fixed in https://github.com/elastic/beats/commit/7356c98624eeac01b545804d0e10acfde8e180c7 and is available in the most recent 8.7.0-SNAPSHOT build