### PR TITLE
Reenable fleet tests and temporarily test against 8.6.1-SNAPSHOT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,7 +471,7 @@ E2E_REGISTRY_NAMESPACE     ?= eck-dev
 
 E2E_IMG_TAG                := $(IMG_VERSION)
 E2E_IMG                    ?= $(REGISTRY)/$(E2E_REGISTRY_NAMESPACE)/eck-e2e-tests:$(E2E_IMG_TAG)
-E2E_STACK_VERSION          ?= 8.6.0
+E2E_STACK_VERSION          ?= 8.6.1-SNAPSHOT
 export TESTS_MATCH         ?= "^Test" # can be overriden to eg. TESTS_MATCH=TestMutationMoreNodes to match a single test
 export E2E_JSON            ?= false
 TEST_TIMEOUT               ?= 30m

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -125,9 +125,6 @@ func TestMultipleOutputConfig(t *testing.T) {
 
 func TestFleetMode(t *testing.T) {
 
-	// This test is disabled until we understand why it is failing
-	t.Skip("TestFleetMode is disabled, see https://github.com/elastic/cloud-on-k8s/issues/6308")
-
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	// installation of policies and integrations through Kibana file based configuration was broken between those versions:
 	if v.LT(version.MinFor(8, 1, 0)) && v.GTE(version.MinFor(8, 0, 0)) {

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -88,8 +88,6 @@ func TestMultiOutputRecipe(t *testing.T) {
 }
 
 func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
-	// This test is disabled until we understand why it is failing
-	t.Skip("TestFleetKubernetesIntegrationRecipe is disabled, see https://github.com/elastic/cloud-on-k8s/issues/6331")
 
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
@@ -134,9 +132,6 @@ func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
 
 func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
 
-	// This test is disabled until we understand why it is failing
-	t.Skip("TestFleetCustomLogsIntegrationRecipe is disabled, see https://github.com/elastic/cloud-on-k8s/issues/6331")
-
 	notLoggingPod := beat.NewPodBuilder("test")
 	loggingPod := beat.NewPodBuilder("test")
 	loggingPod.Pod.Namespace = "default"
@@ -163,9 +158,6 @@ func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetAPMIntegrationRecipe(t *testing.T) {
-
-	// This test is disabled until we understand why it is failing
-	t.Skip("TestFleetAPMIntegrationRecipe is disabled, see https://github.com/elastic/cloud-on-k8s/issues/6331")
 
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {

--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -19,9 +19,6 @@ import (
 // TestFleetAgentWithoutTLS tests a Fleet Server, and Elastic Agent with TLS disabled for the HTTP layer.
 func TestFleetAgentWithoutTLS(t *testing.T) {
 
-	// This test is disabled until we understand why it is failing
-	t.Skip("TestFleetAgentWithoutTLS is disabled, see https://github.com/elastic/cloud-on-k8s/issues/6308")
-
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
 	// Disabling TLS for Fleet isn't supported before 7.16, as Elasticsearch doesn't allow


### PR DESCRIPTION
This reenables the Fleet tests and moves the default version under test to 8.6.1-SNAPSHOT in anticipation of the release of 8.6.1. This should in theory fix the Agent test failures we have seen and we can then follow up with another PR to test against the final version of 8.6.1 per default (and also update all of the other version references)