### PR TITLE
Revert "PR testing mode" for nightly e2e-tests on buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -113,8 +113,7 @@ steps:
       # Run all e2e tests on all k8s distributions at midnight from the main branch
 
       - label: ":k8s: nightly e2e-tests"
-        #if: build.branch == "main" && build.source == "schedule"
-        if: build.branch == "thbkrkr:buildkite-ocp-tanzu-e2e-tests" #testing
+        if: build.branch == "main" && build.source == "schedule"
         commands:
             - buildkite-agent pipeline upload .buildkite/pipeline-nightly-e2e-tests.yml
         depends_on:

--- a/Makefile
+++ b/Makefile
@@ -472,7 +472,7 @@ E2E_REGISTRY_NAMESPACE     ?= eck-dev
 E2E_IMG_TAG                := $(IMG_VERSION)
 E2E_IMG                    ?= $(REGISTRY)/$(E2E_REGISTRY_NAMESPACE)/eck-e2e-tests:$(E2E_IMG_TAG)
 E2E_STACK_VERSION          ?= 8.6.0
-export TESTS_MATCH         ?= "^TestSmoke" # can be overriden to eg. TESTS_MATCH=TestMutationMoreNodes to match a single test
+export TESTS_MATCH         ?= "^Test" #testing # can be overriden to eg. TESTS_MATCH=TestMutationMoreNodes to match a single test
 export E2E_JSON            ?= false
 TEST_TIMEOUT               ?= 30m
 E2E_SKIP_CLEANUP           ?= false


### PR DESCRIPTION
This reverts commit d9a22ad3d23996f97d38cca9f6e582683a2e18e1 merged to main in #6254.

I was so happy to finally merge #6254 that I forgot to revert the commit
made to test nightly e2e tests from PR branch.

It is clearly a bit dangerous and I'm thinking about a better way to do that.
