### PR TITLE
Activate enterprise license in TestStackConfigPolicy

### DIFF
--- a/test/e2e/ems/ems_test.go
+++ b/test/e2e/ems/ems_test.go
@@ -31,8 +31,7 @@ func TestElasticMapsServerCrossNSAssociation(t *testing.T) {
 		WithNodeCount(1).
 		WithRestrictedSecurityContext()
 
-	esWithLicense := test.LicenseTestBuilder()
-	esWithLicense.BuildingThis = esBuilder
+	esWithLicense := test.LicenseTestBuilder(esBuilder)
 
 	test.Sequence(nil, test.EmptySteps, esWithLicense, emsBuilder).RunSequential(t)
 }
@@ -48,8 +47,7 @@ func TestElasticMapsServerStandalone(t *testing.T) {
 		WithNodeCount(1).
 		WithRestrictedSecurityContext()
 
-	emsWithLicense := test.LicenseTestBuilder()
-	emsWithLicense.BuildingThis = emsBuilder
+	emsWithLicense := test.LicenseTestBuilder(emsBuilder)
 
 	test.Sequence(nil, test.EmptySteps, emsWithLicense).RunSequential(t)
 }
@@ -66,8 +64,7 @@ func TestElasticMapsServerTLSDisabled(t *testing.T) {
 		WithTLSDisabled(true).
 		WithRestrictedSecurityContext()
 
-	esWithLicense := test.LicenseTestBuilder()
-	esWithLicense.BuildingThis = esBuilder
+	esWithLicense := test.LicenseTestBuilder(esBuilder)
 
 	test.Sequence(nil, test.EmptySteps, esWithLicense, emsBuilder).RunSequential(t)
 }
@@ -91,8 +88,7 @@ func TestElasticMapsServerVersionUpgradeToLatest7x(t *testing.T) {
 
 	emsUpgraded := ems.WithVersion(dstVersion).WithMutatedFrom(&ems)
 
-	esWithLicense := test.LicenseTestBuilder()
-	esWithLicense.BuildingThis = es
+	esWithLicense := test.LicenseTestBuilder(es)
 
 	test.RunMutations(t, []test.Builder{esWithLicense, ems}, []test.Builder{emsUpgraded})
 }
@@ -115,8 +111,7 @@ func TestElasticMapsServerVersionUpgradeToLatest8x(t *testing.T) {
 
 	emsUpgraded := ems.WithVersion(dstVersion).WithMutatedFrom(&ems)
 
-	esWithLicense := test.LicenseTestBuilder()
-	esWithLicense.BuildingThis = es
+	esWithLicense := test.LicenseTestBuilder(es)
 
 	test.RunMutations(t, []test.Builder{esWithLicense, ems}, []test.Builder{emsUpgraded})
 }

--- a/test/e2e/es/autoscaling_legacy_test.go
+++ b/test/e2e/es/autoscaling_legacy_test.go
@@ -117,8 +117,7 @@ func TestAutoscalingLegacy(t *testing.T) {
 		newNodeSet("ml", []string{"ml"}, 0, corev1.ResourceList{}, initialPVC),
 	)
 
-	esWithLicense := test.LicenseTestBuilder()
-	esWithLicense.BuildingThis = esBuilder
+	esWithLicense := test.LicenseTestBuilder(esBuilder)
 
 	autoscalingCapacityTest := autoscaling.NewAutoscalingCapacityTest(esBuilder.Elasticsearch, k8sClient)
 

--- a/test/e2e/es/autoscaling_test.go
+++ b/test/e2e/es/autoscaling_test.go
@@ -114,8 +114,7 @@ func TestAutoscaling(t *testing.T) {
 		newNodeSet("ml", []string{"ml"}, 0, corev1.ResourceList{}, initialPVC),
 	)
 
-	autoscalerWithLicense := test.LicenseTestBuilder()
-	autoscalerWithLicense.BuildingThis = autoscalingBuilder
+	autoscalerWithLicense := test.LicenseTestBuilder(autoscalingBuilder)
 
 	autoscalingCapacityTest := autoscaling.NewAutoscalingCapacityTest(esBuilder.Elasticsearch, k8sClient)
 

--- a/test/e2e/es/stackconfigpolicy_test.go
+++ b/test/e2e/es/stackconfigpolicy_test.go
@@ -113,8 +113,7 @@ func TestStackConfigPolicy(t *testing.T) {
 		},
 	}
 
-	esWithlicense := test.LicenseTestBuilder()
-	esWithlicense.BuildingThis = es
+	esWithlicense := test.LicenseTestBuilder(es)
 
 	var noEntries []string
 	steps := func(k *test.K8sClient) test.StepList {

--- a/test/e2e/es/stackconfigpolicy_test.go
+++ b/test/e2e/es/stackconfigpolicy_test.go
@@ -113,6 +113,9 @@ func TestStackConfigPolicy(t *testing.T) {
 		},
 	}
 
+	esWithlicense := test.LicenseTestBuilder()
+	esWithlicense.BuildingThis = es
+
 	var noEntries []string
 	steps := func(k *test.K8sClient) test.StepList {
 		return test.StepList{
@@ -228,7 +231,7 @@ func TestStackConfigPolicy(t *testing.T) {
 		}
 	}
 
-	test.Sequence(nil, steps, es).RunSequential(t)
+	test.Sequence(nil, steps, esWithlicense).RunSequential(t)
 }
 
 func checkAPIStatusCode(esClient client.Client, url string, expectedStatusCode int) error {

--- a/test/e2e/test/common_steps.go
+++ b/test/e2e/test/common_steps.go
@@ -84,8 +84,9 @@ func DeleteAllEnterpriseLicenseSecrets(t *testing.T, k *K8sClient) {
 // LicenseTestBuilder is a wrapped builder for tests that require a valid Enterprise license to be installed in the operator.
 // It creates an Enterprise license secret before the test and deletes it again after the test. Callers are responsible for
 // making sure that Ctx().TestLicense contains a valid test license.
-func LicenseTestBuilder() WrappedBuilder {
+func LicenseTestBuilder(b Builder) WrappedBuilder {
 	return WrappedBuilder{
+		BuildingThis: b,
 		PreInitSteps: func(k *K8sClient) StepList {
 			//nolint:thelper
 			return StepList{


### PR DESCRIPTION
This commit updates `TestStackConfigPolicy` so that an Enterprise license is created/removed at the start/end of the test, which is the license level required to use the SCP feature.

First commit is the change in `TestStackConfigPolicy`.
Second commit is a a little refactoring to simplify the use of the `LicenseTestBuilder`.