### PR TITLE
Move to 8.6.1 and re-enable Fleet tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,7 +471,7 @@ E2E_REGISTRY_NAMESPACE     ?= eck-dev
 
 E2E_IMG_TAG                := $(IMG_VERSION)
 E2E_IMG                    ?= $(REGISTRY)/$(E2E_REGISTRY_NAMESPACE)/eck-e2e-tests:$(E2E_IMG_TAG)
-E2E_STACK_VERSION          ?= 8.6.0
+E2E_STACK_VERSION          ?= 8.6.1
 export TESTS_MATCH         ?= "^Test" #testing # can be overriden to eg. TESTS_MATCH=TestMutationMoreNodes to match a single test
 export E2E_JSON            ?= false
 TEST_TIMEOUT               ?= 30m

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -174,7 +174,7 @@ spec:
       meta:
         package:
           name: system
-          version: 8.6.0
+          version: 8.6.1
       data_stream:
         namespace: default
       processors:

--- a/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
+++ b/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
@@ -4,7 +4,7 @@ metadata:
   name: apm-server-quickstart
   namespace: default
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   config:
     name: elastic-apm

--- a/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
+++ b/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
@@ -84,7 +84,7 @@ metadata:
   name: elasticsearch-sample
   namespace: elasticsearch-ns
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
     - name: default
       count: 1
@@ -97,7 +97,7 @@ metadata:
   name: kibana-sample
   namespace: kibana-ns
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   config:
     xpack.fleet.packages:
@@ -115,7 +115,7 @@ metadata:
   name: apm-apm-sample
   namespace: apmserver-ns
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/config/recipes/autoscaling/elasticsearch.yaml
+++ b/config/recipes/autoscaling/elasticsearch.yaml
@@ -51,7 +51,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
     - name: master
       count: 3

--- a/config/recipes/beats/auditbeat_hosts.yaml
+++ b/config/recipes/beats/auditbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: auditbeat
 spec:
   type: auditbeat
-  version: 8.6.0
+  version: 8.6.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -76,7 +76,7 @@ spec:
         #    path: /run
         #initContainers:
         #- name: cos-init
-        #  image: docker.elastic.co/beats/auditbeat:8.6.0
+        #  image: docker.elastic.co/beats/auditbeat:8.6.1
         #  volumeMounts:
         #  - name: run
         #    mountPath: /run
@@ -118,7 +118,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -130,7 +130,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.6.0
+  version: 8.6.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -100,7 +100,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -112,7 +112,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
+++ b/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.6.0
+  version: 8.6.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -102,7 +102,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -114,7 +114,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_no_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_no_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.6.0
+  version: 8.6.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -53,7 +53,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -65,7 +65,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/heartbeat_es_kb_health.yaml
+++ b/config/recipes/beats/heartbeat_es_kb_health.yaml
@@ -4,7 +4,7 @@ metadata:
   name: heartbeat
 spec:
   type: heartbeat
-  version: 8.6.0
+  version: 8.6.1
   elasticsearchRef:
     name: elasticsearch
   config:
@@ -27,7 +27,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -39,7 +39,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/metricbeat_hosts.yaml
+++ b/config/recipes/beats/metricbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 8.6.0
+  version: 8.6.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -174,7 +174,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -186,7 +186,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/openshift_monitoring.yaml
+++ b/config/recipes/beats/openshift_monitoring.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 8.6.0
+  version: 8.6.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -221,7 +221,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.6.0
+  version: 8.6.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -316,7 +316,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -328,7 +328,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/packetbeat_dns_http.yaml
+++ b/config/recipes/beats/packetbeat_dns_http.yaml
@@ -4,7 +4,7 @@ metadata:
   name: packetbeat
 spec:
   type: packetbeat
-  version: 8.6.0
+  version: 8.6.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -44,7 +44,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -56,7 +56,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -6,7 +6,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 8.6.0
+  version: 8.6.1
   elasticsearchRef:
     name: elasticsearch-monitoring
   config:
@@ -118,7 +118,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.6.0
+  version: 8.6.1
   elasticsearchRef:
     name: elasticsearch-monitoring
   kibanaRef:
@@ -216,7 +216,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -232,7 +232,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -249,7 +249,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-monitoring
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -261,7 +261,7 @@ kind: Kibana
 metadata:
   name: kibana-monitoring
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch-monitoring

--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -61,7 +61,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -73,7 +73,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 8.6.0
+  version: 8.6.1
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -94,7 +94,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 8.6.0
+  version: 8.6.1
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -70,7 +70,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -82,7 +82,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 8.6.0
+  version: 8.6.1
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -103,7 +103,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 8.6.0
+  version: 8.6.1
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -54,7 +54,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -66,7 +66,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 8.6.0
+  version: 8.6.1
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -87,7 +87,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 8.6.0
+  version: 8.6.1
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/kubernetes-integration.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 8.6.0
+  version: 8.6.1
   elasticsearchRefs:
   - name: elasticsearch
   daemonSet:
@@ -179,7 +179,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -191,7 +191,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/elastic-agent/multi-output.yaml
+++ b/config/recipes/elastic-agent/multi-output.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 8.6.0
+  version: 8.6.1
   elasticsearchRefs:
   - outputName: default
     name: elasticsearch
@@ -196,7 +196,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -208,7 +208,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -218,7 +218,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-mon
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -230,7 +230,7 @@ kind: Kibana
 metadata:
   name: kibana-mon
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch-mon

--- a/config/recipes/elastic-agent/system-integration.yaml
+++ b/config/recipes/elastic-agent/system-integration.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 8.6.0
+  version: 8.6.1
   elasticsearchRefs:
   - name: elasticsearch
   daemonSet:
@@ -31,7 +31,7 @@ spec:
       meta:
         package:
           name: system
-          version: 8.6.0
+          version: 8.6.1
       data_stream:
         namespace: default
       streams:
@@ -136,7 +136,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -148,7 +148,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/gclb/01-elastic-stack.yaml
+++ b/config/recipes/gclb/01-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.6.0
+  version: 8.6.1
   http:
     service:
       metadata:
@@ -45,7 +45,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   http:
     service:

--- a/config/recipes/gclb/99-kibana-path.yaml
+++ b/config/recipes/gclb/99-kibana-path.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: thor
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   config:
     # Make Kibana aware of the fact that it is behind a proxy

--- a/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
+++ b/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 8.6.0
+  version: 8.6.1
   http:
     tls:
       selfSignedCertificate:
@@ -82,7 +82,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   http:
     tls:

--- a/config/recipes/logstash/logstash.yaml
+++ b/config/recipes/logstash/logstash.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: eck-logstash
     app.kubernetes.io/component: elasticsearch
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
     - name: default
       count: 3
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/name: eck-logstash
     app.kubernetes.io/component: kibana
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -93,7 +93,7 @@ spec:
     spec:
       containers:
         - name: logstash
-          image: docker.elastic.co/logstash/logstash:8.6.0
+          image: docker.elastic.co/logstash/logstash:8.6.1
           ports:
             - name: "tcp-beats"
               containerPort: 5044
@@ -151,7 +151,7 @@ metadata:
     app.kubernetes.io/component: filebeat
 spec:
   type: filebeat
-  version: 8.6.0
+  version: 8.6.1
   config:
     filebeat.inputs:
       - type: log

--- a/config/recipes/maps/01-ems.yaml
+++ b/config/recipes/maps/01-ems.yaml
@@ -3,5 +3,5 @@ kind: ElasticMapsServer
 metadata:
   name: ems-sample
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1

--- a/config/recipes/maps/02-es-kb.yaml
+++ b/config/recipes/maps/02-es-kb.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
     - name: default
       count: 3
@@ -27,7 +27,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   config:
     # Configure this to a domain you control

--- a/config/recipes/traefik/02-elastic-stack.yaml
+++ b/config/recipes/traefik/02-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: master
     count: 1
@@ -41,7 +41,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   config:
     xpack.fleet.packages:
@@ -57,7 +57,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: hulk

--- a/config/samples/apm/apm_es_kibana.yaml
+++ b/config/samples/apm/apm_es_kibana.yaml
@@ -5,7 +5,7 @@ kind: Elasticsearch
 metadata:
   name: es-apm-sample
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 3
@@ -19,7 +19,7 @@ kind: Kibana
 metadata:
   name: kb-apm-sample
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"
@@ -33,7 +33,7 @@ kind: ApmServer
 metadata:
   name: apm-apm-sample
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"

--- a/config/samples/elasticsearch/elasticsearch.yaml
+++ b/config/samples/elasticsearch/elasticsearch.yaml
@@ -7,7 +7,7 @@ metadata:
   #  eck.k8s.elastic.co/downward-node-labels: "topology.kubernetes.io/zone"
   name: elasticsearch-sample
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     config:

--- a/config/samples/enterprisesearch/ent_es.yaml
+++ b/config/samples/enterprisesearch/ent_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
     - name: default
       count: 1
@@ -18,7 +18,7 @@ kind: EnterpriseSearch
 metadata:
   name: ent-sample
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: elasticsearch-sample

--- a/config/samples/kibana/kibana_es.yaml
+++ b/config/samples/kibana/kibana_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 8.6.0
+  version: 8.6.1
   nodeSets:
   - name: default
     count: 1
@@ -18,7 +18,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: 8.6.0
+  version: 8.6.1
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/deploy/eck-agent/Chart.yaml
+++ b/deploy/eck-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-agent
 description: A Helm chart to deploy Elastic Agent managed by the ECK Operator.
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.2.0
+version: 0.3.0
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/elastic-agent

--- a/deploy/eck-agent/examples/fleet-agents.yaml
+++ b/deploy/eck-agent/examples/fleet-agents.yaml
@@ -1,7 +1,7 @@
 # The following example should only be used in conjunction with the 'eck-fleet-server' Helm Chart,
 # and shows how the Agents can be deployed as a daemonset, and controlled by Fleet Server.
 #
-version: 8.6.0
+version: 8.6.1
 
 spec:
   # This must match the name of the fleet server installed from eck-fleet-server chart.

--- a/deploy/eck-agent/examples/system-integration.yaml
+++ b/deploy/eck-agent/examples/system-integration.yaml
@@ -1,7 +1,7 @@
 # The following example should only be used in Agent "standalone" mode,
 # and should not be used when Agent is used with Fleet Server.
 #
-version: 8.6.0
+version: 8.6.1
 spec:
   elasticsearchRefs:
   - name: eck-elasticsearch
@@ -33,7 +33,7 @@ spec:
       meta:
         package:
           name: system
-          version: 8.6.0
+          version: 8.6.1
       data_stream:
         namespace: default
       streams:

--- a/deploy/eck-agent/templates/tests/elastic-agent-cluster-role-binding_test.yaml
+++ b/deploy/eck-agent/templates/tests/elastic-agent-cluster-role-binding_test.yaml
@@ -79,7 +79,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
             clusterRoleBinding: label
-            helm.sh/chart: eck-agent-0.2.0
+            helm.sh/chart: eck-agent-0.3.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-agent/templates/tests/elastic-agent-cluster-role_test.yaml
+++ b/deploy/eck-agent/templates/tests/elastic-agent-cluster-role_test.yaml
@@ -136,7 +136,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
             clusterRole: label
-            helm.sh/chart: eck-agent-0.2.0
+            helm.sh/chart: eck-agent-0.3.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-agent/templates/tests/elastic-agent-service-account_test.yaml
+++ b/deploy/eck-agent/templates/tests/elastic-agent-service-account_test.yaml
@@ -49,7 +49,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
             serviceAccount: label
-            helm.sh/chart: eck-agent-0.2.0
+            helm.sh/chart: eck-agent-0.3.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-agent/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-agent/templates/tests/elastic-agent_test.yaml
@@ -40,7 +40,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
-            helm.sh/chart: eck-agent-0.2.0
+            helm.sh/chart: eck-agent-0.3.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-agent/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-agent/templates/tests/elastic-agent_test.yaml
@@ -13,7 +13,7 @@ tests:
           value: quickstart-eck-agent
       - equal:
           path: spec.version
-          value: 8.6.0
+          value: 8.6.1
       - equal:
           path: spec.config
           value: null

--- a/deploy/eck-agent/values.yaml
+++ b/deploy/eck-agent/values.yaml
@@ -18,7 +18,7 @@
 
 # Version of Elastic Agent.
 #
-version: 8.6.0
+version: 8.6.1
 
 # Labels that will be applied to Elastic Agent.
 #

--- a/deploy/eck-beats/Chart.yaml
+++ b/deploy/eck-beats/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to deploy Elastic Beats managed by the ECK Operator.
 # Requirement comes from minimum version supported for eck-operator (https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s_supported_versions.html)
 kubeVersion: ">= 1.20.0-0"
 type: application
-version: 0.1.0
+version: 0.2.0
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/beats

--- a/deploy/eck-beats/examples/auditbeat_hosts.yaml
+++ b/deploy/eck-beats/examples/auditbeat_hosts.yaml
@@ -1,5 +1,5 @@
 name: auditbeat
-version: 8.6.0
+version: 8.6.1
 spec:
   type: auditbeat
   elasticsearchRef:

--- a/deploy/eck-beats/examples/filebeat_no_autodiscover.yaml
+++ b/deploy/eck-beats/examples/filebeat_no_autodiscover.yaml
@@ -1,5 +1,5 @@
 name: filebeat
-version: 8.6.0
+version: 8.6.1
 spec:
   type: filebeat
   elasticsearchRef:

--- a/deploy/eck-beats/examples/heartbeat_es_kb_health.yaml
+++ b/deploy/eck-beats/examples/heartbeat_es_kb_health.yaml
@@ -1,5 +1,5 @@
 name: heartbeat
-version: 8.6.0
+version: 8.6.1
 spec:
   type: heartbeat
   elasticsearchRef:

--- a/deploy/eck-beats/examples/metricbeat_hosts.yaml
+++ b/deploy/eck-beats/examples/metricbeat_hosts.yaml
@@ -1,7 +1,7 @@
 name: metricbeat
 spec:
   type: metricbeat
-  version: 8.6.0
+  version: 8.6.1
   elasticsearchRef:
     name: eck-elasticsearch
   kibanaRef:

--- a/deploy/eck-beats/examples/packetbeat_dns_http.yaml
+++ b/deploy/eck-beats/examples/packetbeat_dns_http.yaml
@@ -1,7 +1,7 @@
 name: packetbeat
 spec:
   type: packetbeat
-  version: 8.6.0
+  version: 8.6.1
   elasticsearchRef:
     name: eck-elasticsearch
   kibanaRef:

--- a/deploy/eck-beats/templates/tests/beats-metricbeat-example_test.yaml
+++ b/deploy/eck-beats/templates/tests/beats-metricbeat-example_test.yaml
@@ -233,7 +233,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-beats
             serviceAccount: label
-            helm.sh/chart: eck-beats-0.1.0
+            helm.sh/chart: eck-beats-0.2.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-beats/templates/tests/beats_test.yaml
+++ b/deploy/eck-beats/templates/tests/beats_test.yaml
@@ -15,7 +15,7 @@ tests:
           value: quickstart-eck-beats
       - equal:
           path: spec.version
-          value: 8.6.0
+          value: 8.6.1
       - equal:
           path: spec.type
           value: filebeat

--- a/deploy/eck-beats/values.yaml
+++ b/deploy/eck-beats/values.yaml
@@ -18,7 +18,7 @@
 
 # Version of Elastic Beats.
 #
-version: 8.6.0
+version: 8.6.1
 
 # Labels that will be applied to Elastic Beats.
 #

--- a/deploy/eck-elasticsearch/Chart.yaml
+++ b/deploy/eck-elasticsearch/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-elasticsearch
 description: A Helm chart to deploy Elasticsearch managed by the ECK Operator.
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.2.0
+version: 0.3.0
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/elasticsearch/

--- a/deploy/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
+++ b/deploy/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
@@ -89,7 +89,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-elasticsearch
-            helm.sh/chart: eck-elasticsearch-0.2.0
+            helm.sh/chart: eck-elasticsearch-0.3.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-elasticsearch/values.yaml
+++ b/deploy/eck-elasticsearch/values.yaml
@@ -18,7 +18,7 @@
 
 # Version of Elasticsearch.
 #
-version: 8.6.0
+version: 8.6.1
 
 # Labels that will be applied to Elasticsearch.
 #

--- a/deploy/eck-fleet-server/Chart.yaml
+++ b/deploy/eck-fleet-server/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-fleet-server
 description: A Helm chart to deploy Elastic Fleet Server as an Agent managed by the ECK Operator.
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.2.0
+version: 0.3.0
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/elastic-agent

--- a/deploy/eck-fleet-server/templates/tests/fleet-server-cluster-role-binding_test.yaml
+++ b/deploy/eck-fleet-server/templates/tests/fleet-server-cluster-role-binding_test.yaml
@@ -49,7 +49,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
             clusterRoleBinding: label
-            helm.sh/chart: eck-fleet-server-0.2.0
+            helm.sh/chart: eck-fleet-server-0.3.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-fleet-server/templates/tests/fleet-server-cluster-role_test.yaml
+++ b/deploy/eck-fleet-server/templates/tests/fleet-server-cluster-role_test.yaml
@@ -62,7 +62,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
             clusterRole: label
-            helm.sh/chart: eck-fleet-server-0.2.0
+            helm.sh/chart: eck-fleet-server-0.3.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-fleet-server/templates/tests/fleet-server-service-account_test.yaml
+++ b/deploy/eck-fleet-server/templates/tests/fleet-server-service-account_test.yaml
@@ -34,7 +34,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
             serviceAccount: label
-            helm.sh/chart: eck-fleet-server-0.2.0
+            helm.sh/chart: eck-fleet-server-0.3.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-fleet-server/templates/tests/fleet-server_test.yaml
+++ b/deploy/eck-fleet-server/templates/tests/fleet-server_test.yaml
@@ -13,7 +13,7 @@ tests:
           value: quickstart-eck-fleet-server
       - equal:
           path: spec.version
-          value: 8.6.0
+          value: 8.6.1
       - equal:
           path: spec.kibanaRef.name
           value: eck-kibana

--- a/deploy/eck-fleet-server/templates/tests/fleet-server_test.yaml
+++ b/deploy/eck-fleet-server/templates/tests/fleet-server_test.yaml
@@ -46,7 +46,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
-            helm.sh/chart: eck-fleet-server-0.2.0
+            helm.sh/chart: eck-fleet-server-0.3.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-fleet-server/values.yaml
+++ b/deploy/eck-fleet-server/values.yaml
@@ -18,7 +18,7 @@
 
 # Version of Elastic Fleet Server.
 #
-version: 8.6.0
+version: 8.6.1
 
 # Labels that will be applied to Elastic Fleet Server.
 #

--- a/deploy/eck-kibana/Chart.yaml
+++ b/deploy/eck-kibana/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-kibana
 description: A Helm chart to deploy Kibana managed by the ECK Operator.
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.2.0
+version: 0.3.0
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/kibana

--- a/deploy/eck-kibana/examples/http-configuration.yaml
+++ b/deploy/eck-kibana/examples/http-configuration.yaml
@@ -1,7 +1,7 @@
 ---
 # Version of Kibana.
 #
-version: 8.6.0
+version: 8.6.1
 
 # Labels that will be applied to Kibana.
 #

--- a/deploy/eck-kibana/templates/tests/kibana_test.yaml
+++ b/deploy/eck-kibana/templates/tests/kibana_test.yaml
@@ -53,7 +53,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-kibana
-            helm.sh/chart: eck-kibana-0.2.0
+            helm.sh/chart: eck-kibana-0.3.0
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-kibana/templates/tests/kibana_test.yaml
+++ b/deploy/eck-kibana/templates/tests/kibana_test.yaml
@@ -13,7 +13,7 @@ tests:
           value: quickstart-eck-kibana
       - equal:
           path: spec.version
-          value: 8.6.0
+          value: 8.6.1
   - it: name override should work properly
     set:
       nameOverride: override
@@ -75,7 +75,7 @@ tests:
           value: quickstart-eck-kibana
       - equal:
           path: spec.version
-          value: 8.6.0
+          value: 8.6.1
       - equal:
           path: spec.count
           value: 1

--- a/deploy/eck-kibana/values.yaml
+++ b/deploy/eck-kibana/values.yaml
@@ -18,7 +18,7 @@
 
 # Version of Kibana.
 #
-version: 8.6.0
+version: 8.6.1
 
 # Labels that will be applied to Kibana.
 #

--- a/deploy/eck-stack/Chart.yaml
+++ b/deploy/eck-stack/Chart.yaml
@@ -9,40 +9,40 @@ description: |
   * Fleet Server
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.3.0
+version: 0.4.0
 
 dependencies:
   - name: eck-elasticsearch
     condition: eck-elasticsearch.enabled
-    version: "0.2.0"
+    version: "0.3.0"
     # uncomment for local testing, and comment
     # the helm.elastic.co repository.
     # repository: "file://../eck-elasticsearch"
     repository: "https://helm.elastic.co"
   - name: eck-kibana
     condition: eck-kibana.enabled
-    version: "0.2.0"
+    version: "0.3.0"
     # uncomment for local testing, and comment
     # the helm.elastic.co repository.
     # repository: "file://../eck-kibana"
     repository: "https://helm.elastic.co"
   - name: eck-agent
     condition: eck-agent.enabled
-    version: "0.2.0"
+    version: "0.3.0"
     # uncomment for local testing, and comment
     # the helm.elastic.co repository.
     # repository: "file://../eck-agent"
     repository: "https://helm.elastic.co"
   - name: eck-fleet-server
     condition: eck-fleet-server.enabled
-    version: "0.2.0"
+    version: "0.3.0"
     # uncomment for local testing, and comment
     # the helm.elastic.co repository.
     # repository: "file://../eck-fleet-server"
     repository: "https://helm.elastic.co"
   - name: eck-beats
     condition: eck-beats.enabled
-    version: "0.1.0"
+    version: "0.2.0"
     # uncomment for local testing, and comment
     # the helm.elastic.co repository.
     # repository: "file://../eck-beats"

--- a/deploy/eck-stack/examples/custom-elasticsearch-kibana.yaml
+++ b/deploy/eck-stack/examples/custom-elasticsearch-kibana.yaml
@@ -6,7 +6,7 @@ eck-elasticsearch:
 
   # Version of Elasticsearch.
   #
-  version: 8.6.0
+  version: 8.6.1
 
   nodeSets:
   - name: default
@@ -38,7 +38,7 @@ eck-kibana:
   
   # Version of Kibana.
   #
-  version: 8.6.0
+  version: 8.6.1
   
   spec:
     # Count of Kibana replicas to create.

--- a/deploy/eck-stack/examples/metricbeat_hosts.yaml
+++ b/deploy/eck-stack/examples/metricbeat_hosts.yaml
@@ -7,7 +7,7 @@ eck-elasticsearch:
 
   # Version of Elasticsearch.
   #
-  version: 8.6.0
+  version: 8.6.1
 
   nodeSets:
   - name: default
@@ -41,7 +41,7 @@ eck-kibana:
   
   # Version of Kibana.
   #
-  version: 8.6.0
+  version: 8.6.1
   
   spec:
     # Count of Kibana replicas to create.
@@ -58,7 +58,7 @@ eck-beats:
   name: metricbeat
   spec:
     type: metricbeat
-    version: 8.6.0
+    version: 8.6.1
     elasticsearchRef:
       name: quickstart
     kibanaRef:

--- a/deploy/eck-stack/templates/tests/beats_test.yaml
+++ b/deploy/eck-stack/templates/tests/beats_test.yaml
@@ -16,7 +16,7 @@ tests:
           value: quickstart-eck-beats
       - equal:
           path: spec.version
-          value: 8.6.0
+          value: 8.6.1
   - it: should render custom metricbeat example properly
     values:
       - ../../examples/metricbeat_hosts.yaml
@@ -30,7 +30,7 @@ tests:
           value: quickstart-eck-beats
       - equal:
           path: spec.version
-          value: 8.6.0
+          value: 8.6.1
       - equal:
           path: spec.kibanaRef.name
           value: quickstart

--- a/deploy/eck-stack/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-stack/templates/tests/elastic-agent_test.yaml
@@ -15,7 +15,7 @@ tests:
           value: quickstart-eck-agent
       - equal:
           path: spec.version
-          value: 8.6.0
+          value: 8.6.1
   - it: should render agent in custom fleet example properly
     values:
       - ../../examples/agent/fleet-agents.yaml
@@ -29,7 +29,7 @@ tests:
           value: quickstart-eck-agent
       - equal:
           path: spec.version
-          value: 8.6.0
+          value: 8.6.1
       - equal:
           path: spec.kibanaRef.name
           value: kibana
@@ -72,7 +72,7 @@ tests:
           value: quickstart-eck-fleet-server
       - equal:
           path: spec.version
-          value: 8.6.0
+          value: 8.6.1
   - it: should render fleet server in custom fleet example properly
     values:
       - ../../examples/agent/fleet-agents.yaml
@@ -86,7 +86,7 @@ tests:
           value: fleet-server
       - equal:
           path: spec.version
-          value: 8.6.0
+          value: 8.6.1
       - equal:
           path: spec.kibanaRef.name
           value: kibana

--- a/deploy/eck-stack/templates/tests/kibana_test.yaml
+++ b/deploy/eck-stack/templates/tests/kibana_test.yaml
@@ -13,7 +13,7 @@ tests:
           value: quickstart-eck-kibana
       - equal:
           path: spec.version
-          value: 8.6.0
+          value: 8.6.1
   - it: name override should work properly
     set:
       eck-kibana.nameOverride: override
@@ -51,7 +51,7 @@ tests:
           value: quickstart
       - equal:
           path: spec.version
-          value: 8.6.0
+          value: 8.6.1
       - equal:
           path: spec.count
           value: 1

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -124,10 +124,6 @@ func TestMultipleOutputConfig(t *testing.T) {
 }
 
 func TestFleetMode(t *testing.T) {
-
-	// This test is disabled until we understand why it is failing
-	t.Skip("TestFleetMode is disabled, see https://github.com/elastic/cloud-on-k8s/issues/6308")
-
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	// installation of policies and integrations through Kibana file based configuration was broken between those versions:
 	if v.LT(version.MinFor(8, 1, 0)) && v.GTE(version.MinFor(8, 0, 0)) {

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -88,9 +88,6 @@ func TestMultiOutputRecipe(t *testing.T) {
 }
 
 func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
-	// This test is disabled until we understand why it is failing
-	t.Skip("TestFleetKubernetesIntegrationRecipe is disabled, see https://github.com/elastic/cloud-on-k8s/issues/6331")
-
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
 			return builder
@@ -133,10 +130,6 @@ func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
-
-	// This test is disabled until we understand why it is failing
-	t.Skip("TestFleetCustomLogsIntegrationRecipe is disabled, see https://github.com/elastic/cloud-on-k8s/issues/6331")
-
 	notLoggingPod := beat.NewPodBuilder("test")
 	loggingPod := beat.NewPodBuilder("test")
 	loggingPod.Pod.Namespace = "default"
@@ -163,10 +156,6 @@ func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetAPMIntegrationRecipe(t *testing.T) {
-
-	// This test is disabled until we understand why it is failing
-	t.Skip("TestFleetAPMIntegrationRecipe is disabled, see https://github.com/elastic/cloud-on-k8s/issues/6331")
-
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
 			return builder

--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -18,10 +18,6 @@ import (
 
 // TestFleetAgentWithoutTLS tests a Fleet Server, and Elastic Agent with TLS disabled for the HTTP layer.
 func TestFleetAgentWithoutTLS(t *testing.T) {
-
-	// This test is disabled until we understand why it is failing
-	t.Skip("TestFleetAgentWithoutTLS is disabled, see https://github.com/elastic/cloud-on-k8s/issues/6308")
-
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
 	// Disabling TLS for Fleet isn't supported before 7.16, as Elasticsearch doesn't allow

--- a/test/e2e/agent/upgrade_test.go
+++ b/test/e2e/agent/upgrade_test.go
@@ -16,9 +16,6 @@ import (
 )
 
 func TestAgentVersionUpgradeToLatest8x(t *testing.T) {
-	// This test is disabled until we have 8.6.1
-	t.Skip("TestAgentVersionUpgradeToLatest8x is disabled, see https://github.com/elastic/cloud-on-k8s/issues/6331")
-
 	srcVersion, dstVersion := test.GetUpgradePathTo8x(test.Ctx().ElasticStackVersion)
 
 	test.SkipInvalidUpgrade(t, srcVersion, dstVersion)

--- a/test/e2e/es/version_upgrade_test.go
+++ b/test/e2e/es/version_upgrade_test.go
@@ -90,10 +90,6 @@ func TestVersionUpgradeSingleMaster68xToNewNodeSet7x(t *testing.T) {
 		t.Skipf("Skipping test because Elasticsearch 6.8.x does not have an ARM build")
 	}
 
-	if test.Ctx().ElasticStackVersion == "7.16.0-SNAPSHOT" {
-		t.Skipf("Skipping due to a known issue: https://github.com/elastic/elasticsearch/issues/80265")
-	}
-
 	srcVersion := test.LatestReleasedVersion6x
 	dstVersion := test.Ctx().ElasticStackVersion
 

--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -18,7 +18,7 @@ const (
 	// LatestReleasedVersion7x is the latest released version for 7.x
 	LatestReleasedVersion7x = "7.17.8"
 	// LatestReleasedVersion8x is the latest release version for 8.x
-	LatestReleasedVersion8x = "8.6.0"
+	LatestReleasedVersion8x = "8.6.1"
 )
 
 // SkipInvalidUpgrade skips a test that would do an invalid upgrade.


### PR DESCRIPTION
Related: I think we need indeed a better mechanism for bumping Helm chart versions (something like `-SNAPSHOT`) otherwise it is going to be really hard to make sure we don't bump unnecessarily (or forget to do it)