### PR TITLE
Disable TestFleetAgentWithoutTLS and TestFleetKubernetesIntegrationRecipe

### DIFF
--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -88,6 +88,9 @@ func TestMultiOutputRecipe(t *testing.T) {
 }
 
 func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
+	// This test is disabled until we understand why it is failing
+	t.Skip("TestFleetKubernetesIntegrationRecipe is disabled, see https://github.com/elastic/cloud-on-k8s/issues/6331")
+
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
 			return builder

--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -18,6 +18,9 @@ import (
 
 // TestFleetAgentWithoutTLS tests a Fleet Server, and Elastic Agent with TLS disabled for the HTTP layer.
 func TestFleetAgentWithoutTLS(t *testing.T) {
+	// This test is disabled until the regression is fixed in the Agent
+	t.Skip("TestFleetAgentWithoutTLS is disabled, see https://github.com/elastic/cloud-on-k8s/issues/6367")
+
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
 	// Disabling TLS for Fleet isn't supported before 7.16, as Elasticsearch doesn't allow


### PR DESCRIPTION
We re-enabled them yesterday with the `8.6.1` update (#6364) thinking they were failing for the same reason as `TestFleetMode` (#6308) but that is not the case.

This disables:
- `TestFleetAgentWithoutTLS` due to a known issue 
- `TestFleetKubernetesIntegrationRecipe` for yet unknown issue 

I kept `TestFleetAPMIntegrationRecipe` and `TestFleetCustomLogsIntegrationRecipe` but I would not be surprised if they are affected by the same problem as `TestFleetKubernetesIntegrationRecipe`. I'm going to trigger a few runs from this PR to try to confirm that.

Relates to:
- #6331
- #6367