### PR TITLE
Skip TestAPMKibanaAssociation on 8.7.0-snapshot due to a known 

### DIFF
--- a/test/e2e/apm/association_test.go
+++ b/test/e2e/apm/association_test.go
@@ -56,6 +56,10 @@ func TestAPMKibanaAssociation(t *testing.T) {
 		t.SkipNow()
 	}
 
+	if test.Ctx().ElasticStackVersion == "8.7.0-SNAPSHOT" {
+		t.Skipf("Skipping due to a known issue: https://github.com/elastic/cloud-on-k8s/issues/6371")
+	}
+
 	ns := test.Ctx().ManagedNamespace(0)
 	name := "test-apm-kb-assoc"
 


### PR DESCRIPTION
relates to #6371 

Disable `TestAPMKibanaAssociation` using `8.7.0-SNAPSHOT` until https://github.com/elastic/kibana/pull/149979 is verified fixed within the SNAPSHOT image.