### PR TITLE
Docs: Set Default value for set-default-security-context

### DIFF
--- a/docs/operating-eck/operator-config.asciidoc
+++ b/docs/operating-eck/operator-config.asciidoc
@@ -39,7 +39,7 @@ ECK can be configured using either command line flags or environment variables.
 |namespaces |"" |Namespaces in which this operator should manage resources. Accepts multiple comma-separated values. Defaults to all namespaces if empty or unspecified.
 |operator-namespace |"" |Namespace the operator runs in. Required.
 |password-hash-cache-size|5 x max-concurrent-reconciles|Sets the size of the password hash cache. Caching is disabled if explicitly set to 0 or any negative value.
-|set-default-security-context |true | Enables adding a default Pod Security Context to Elasticsearch Pods in Elasticsearch `8.0.0` and later. `fsGroup` is set to `1000` by default to match Elasticsearch container default UID. This behavior might not be appropriate for OpenShift and PSP-secured Kubernetes clusters, so it can be disabled.
+|set-default-security-context |auto-detect | Enables adding a default Pod Security Context to Elasticsearch Pods in Elasticsearch `8.0.0` and later. `fsGroup` is set to `1000` by default to match Elasticsearch container default UID. This behavior might not be appropriate for OpenShift and PSP-secured Kubernetes clusters, so it can be disabled.
 |ubi-only | false | Use only UBI container images to deploy Elastic Stack applications. UBI images are only available from 7.10.0 onward. Cannot be combined with `--container-suffix` flag.
 |validate-storage-class | true | Specifies whether the operator should retrieve storage classes to verify volume expansion support. Can be disabled if cluster-wide storage class RBAC access is not available.
 |webhook-cert-dir |"{TempDir}/k8s-webhook-server/serving-certs" |Path to the directory that contains the webhook server key and certificate.


### PR DESCRIPTION
Default value for set-default-security-context is "auto-detect" since 2.5.0

Fixes: https://github.com/elastic/cloud-on-k8s/issues/6335
Signed-off-by: tigerK <yanru.lv@daocloud.io>

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)?
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed.
