### PR TITLE
Revert "Skip test on 8.7.0-snap due to known issue #6371"

### DIFF
--- a/test/e2e/apm/association_test.go
+++ b/test/e2e/apm/association_test.go
@@ -56,10 +56,6 @@ func TestAPMKibanaAssociation(t *testing.T) {
 		t.SkipNow()
 	}
 
-	if test.Ctx().ElasticStackVersion == "8.7.0-SNAPSHOT" {
-		t.Skipf("Skipping due to a known issue: https://github.com/elastic/cloud-on-k8s/issues/6371")
-	}
-
 	ns := test.Ctx().ManagedNamespace(0)
 	name := "test-apm-kb-assoc"
 


### PR DESCRIPTION
Reverts

- #6372

as

- #6371 

is fixed.