### PR TITLE
Revert ci image to Docker v1.19.5

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image used for continuous integration
-FROM docker.io/library/golang:1.20.1
+FROM docker.io/library/golang:1.19.5
 
 ENV GOLANGCILINT_VERSION=1.48.0
 ENV SHELLCHECK_VERSION=0.8.0


### PR DESCRIPTION
Temporarily reverts the Docker version of the ci image to `v1.19.5` because `1.20.x` causes the `lint` step to fail.