### PR TITLE
Document FIPS image and Openshift default namespace limitation

### DIFF
--- a/docs/advanced-topics/advanced-topics.asciidoc
+++ b/docs/advanced-topics/advanced-topics.asciidoc
@@ -16,6 +16,7 @@ endif::[]
 - <<{p}-network-policies>>
 - <<{p}-webhook-namespace-selectors>>
 - <<{p}-stack-monitoring>>
+- <<{p}-fips>>
 --
 
 include::openshift.asciidoc[leveloffset=+1]
@@ -25,3 +26,4 @@ include::traffic-splitting.asciidoc[leveloffset=+1]
 include::network-policies.asciidoc[leveloffset=+1]
 include::webhook-namespace-selectors.asciidoc[leveloffset=+1]
 include::stack-monitoring.asciidoc[leveloffset=+1]
+include::fips.asciidoc[leveloffset=+1]

--- a/docs/advanced-topics/fips.asciidoc
+++ b/docs/advanced-topics/fips.asciidoc
@@ -1,0 +1,39 @@
+:page_id: fips
+ifdef::env-github[]
+****
+link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-{page_id}.html[View this document on the Elastic website]
+****
+endif::[]
+[id="{p}-{page_id}"]
+= Deploy a FIPS compatible version of ECK
+
+The Federal Information Processing Standard (FIPS) Publication 140-2, (FIPS PUB 140-2), titled "Security Requirements for Cryptographic Modules" is a U.S. government computer security standard used to approve cryptographic modules. ECK offers a FIPS compliant image that is a drop-in replacement for the standard image.
+
+For the ECK operator, adherence to FIPS 140-2 is ensured by
+
+- Using FIPS approved / NIST recommended cryptographic algorithms
+- Compiling the operator using the link:https://github.com/golang/go/blob/dev.boringcrypto/README.boringcrypto.md[BoringCrypto] library for various cryptographic primitives.
+
+== Installation
+
+=== FIPS compliant installation using Helm
+
+Simply modify the `image.repository` Helm chart value to append `-fips` to install a FIPS compliant version of the ECK Operator.  Reference <<{p}-install-helm,Instsall ECK using the Helm chart>> for full Helm installation instructions.
+
+[source,sh]
+----
+helm install elastic-operator elastic/eck-operator \
+  -n elastic-system --create-namespace \
+  --set=image.repository=docker.elastic.co/eck/eck-operator-fips
+----
+
+=== FIPS compliant installation using manifests
+
+The `StatefulSet` will need to be patched after installation using manifests to append `-fips` to the `spec.template.spec.containers[*].image` to install a FIPS compliant version of the ECK Operator.  Reference <<{p}-deploy-eck,Instsall ECK using manifests>> for full manifest installation instructions.
+
+NOTE: `${ECK_VERSION}` in the following patch command needs to be replaced with the version of the Operator that is being installed.
+
+[source,sh]
+----
+kubectl patch sts elastic-operator -n elastic-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager", "image":"docker.elastic.co/eck/eck-operator-fips:${ECK_VERSION}"}]}}}}'
+----

--- a/docs/advanced-topics/fips.asciidoc
+++ b/docs/advanced-topics/fips.asciidoc
@@ -7,7 +7,7 @@ endif::[]
 [id="{p}-{page_id}"]
 = Deploy a FIPS compatible version of ECK
 
-The Federal Information Processing Standard (FIPS) Publication 140-2, (FIPS PUB 140-2), titled "Security Requirements for Cryptographic Modules" is a U.S. government computer security standard used to approve cryptographic modules. ECK offers a FIPS compliant image that is a drop-in replacement for the standard image.
+The Federal Information Processing Standard (FIPS) Publication 140-2, (FIPS PUB 140-2), titled "Security Requirements for Cryptographic Modules" is a U.S. government computer security standard used to approve cryptographic modules. Since version 2.6 ECK offers a FIPS compliant image that is a drop-in replacement for the standard image.
 
 For the ECK operator, adherence to FIPS 140-2 is ensured by
 

--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -52,6 +52,8 @@ oc adm pod-network make-projects-global elastic-system
 
 . Create a namespace to hold the Elastic resources ({eck_resources_list}):
 +
+NOTE: A namespace outside of the `default` namespace is required such that default https://docs.openshift.com/container-platform/4.1/authentication/managing-security-context-constraints.html[Security Context Constraint] (SCC) permissions are applied automatically. Elastic resources will not work in the `default` namespace, using the `default` service account.
+
 [source,shell]
 ----
 oc new-project elastic # creates the elastic project
@@ -70,6 +72,8 @@ In this example the user `developer` is allowed to manage Elastic resources in t
 == Deploy an Elasticsearch instance with a route
 
 Use the following code to create an Elasticsearch cluster `elasticsearch-sample` and a "passthrough" route to access it:
+
+NOTE: A namespace outside of the `default` namespace is required such that default https://docs.openshift.com/container-platform/4.1/authentication/managing-security-context-constraints.html[Security Context Constraint] (SCC) permissions are applied automatically. Elastic resources will not work in the `default` namespace, using the `default` service account.
 
 [source,shell,subs="attributes,+macros"]
 ----

--- a/docs/release-notes/2.6.0.asciidoc
+++ b/docs/release-notes/2.6.0.asciidoc
@@ -24,6 +24,7 @@
 * Improve user password hash comparison performance by utilizing an LRU cache. {pull}6080[#6080] (issue: {issue}6076[#6076])
 * Add default securityContext to the manager container in Operator Helm Chart. {pull}6047[#6047]
 * Allow Fleet Server to be run without TLS. {pull}6020[#6020] (issue: {issue}6000[#6000])
+* Release a FIPS-compliant operator image. {pull}6071[#6071]
 
 [[bug-2.6.0]]
 [float]


### PR DESCRIPTION
closes #6332 

This change adds public documentation for the FIPS image that was released with the 2.6 version of the ECK Operator. This also adds additional documentation surrounding an Openshift limitation on using the default namespace.