### PR TITLE
Make `E2E_JSON` and `E2E_TAGS` usable at runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -486,8 +486,7 @@ E2E_TAGS += $(GO_TAGS)
 export E2E_TAGS
 
 e2e-docker-build: go-generate
-	DOCKER_BUILDKIT=1 docker build --progress=plain --build-arg E2E_JSON=$(E2E_JSON) --build-arg E2E_TAGS='$(E2E_TAGS)' \
-       -t $(E2E_IMG) -f test/e2e/Dockerfile .
+	DOCKER_BUILDKIT=1 docker build --progress=plain -t $(E2E_IMG) -f test/e2e/Dockerfile .
 
 e2e-docker-push:
 	@ hack/docker.sh -l -p $(E2E_IMG)
@@ -497,8 +496,6 @@ e2e-docker-multiarch-build: go-generate
 	docker buildx build \
 		--progress=plain \
 		--file test/e2e/Dockerfile \
-		--build-arg E2E_JSON=$(E2E_JSON) \
-		--build-arg E2E_TAGS='$(E2E_TAGS)' \
 		--platform $(BUILD_PLATFORM) \
 		--push \
 		-t $(E2E_IMG) .
@@ -507,8 +504,6 @@ e2e-buildah: go-generate buildah-login
 	buildah bud \
 		--isolation=chroot --storage-driver=vfs \
 		--platform $(BUILD_PLATFORM) \
-		--build-arg E2E_JSON='$(E2E_JSON)' \
-		--build-arg E2E_TAGS='$(E2E_TAGS)' \
 		-f test/e2e/Dockerfile \
 		-t $(E2E_IMG) \
 		.
@@ -520,6 +515,7 @@ e2e-run: go-generate
 	@go run -tags='$(GO_TAGS)' test/e2e/cmd/main.go run \
 		--operator-image=$(OPERATOR_IMAGE) \
 		--e2e-image=$(E2E_IMG) \
+		--e2e-tags='$(E2E_TAGS)' \
 		--test-regex=$(TESTS_MATCH) \
 		--test-license=$(TEST_LICENSE) \
 		--test-license-pkey-path=$(TEST_LICENSE_PKEY_PATH) \

--- a/config/e2e/e2e_job.yaml
+++ b/config/e2e/e2e_job.yaml
@@ -50,6 +50,10 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
           env:
+            - name: E2E_JSON
+              value: "{{ .Context.LogToFile }}"
+            - name: E2E_TAGS
+              value: "{{ .Context.E2ETags }}"
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -3,10 +3,6 @@ FROM --platform=$TARGETPLATFORM docker.io/library/golang:1.20.1
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
-ARG E2E_JSON
-ENV E2E_JSON $E2E_JSON
-ARG E2E_TAGS
-ENV E2E_TAGS $E2E_TAGS
 
 WORKDIR /go/src/github.com/elastic/cloud-on-k8s
 

--- a/test/e2e/cmd/run/command.go
+++ b/test/e2e/cmd/run/command.go
@@ -49,6 +49,7 @@ type runFlags struct {
 	logToFile              bool
 	ignoreWebhookFailures  bool
 	deployChaosJob         bool
+	e2eTags                string
 	testEnvTags            []string
 }
 
@@ -105,6 +106,7 @@ func Command() *cobra.Command {
 	cmd.Flags().BoolVar(&flags.logToFile, "log-to-file", false, "Specifies if should log test output to file. Disabled by default.")
 	cmd.Flags().BoolVar(&flags.ignoreWebhookFailures, "ignore-webhook-failures", false, "Specifies if webhook errors should be ignored. Useful when running test locally. False by default")
 	cmd.Flags().BoolVar(&flags.deployChaosJob, "deploy-chaos-job", false, "Deploy the chaos job")
+	cmd.Flags().StringVar(&flags.e2eTags, "e2e-tags", "e2e", "Go tags to specify a subset of the tests using Go build constraints")
 	cmd.Flags().StringSliceVar(&flags.testEnvTags, "test-env-tags", nil, "Tags describing the environment for this test run")
 	logutil.BindFlags(cmd.PersistentFlags())
 

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -189,6 +189,8 @@ func (h *helper) initTestContext() error {
 		Ocp3Cluster:           isOcp3Cluster(h),
 		DeployChaosJob:        h.deployChaosJob,
 		TestEnvTags:           h.testEnvTags,
+		E2ETags:               h.e2eTags,
+		LogToFile:             h.logToFile,
 	}
 
 	for i, ns := range h.managedNamespaces {

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -122,6 +122,8 @@ type Context struct {
 	ClusterName           string             `json:"clusterName"`
 	KubernetesVersion     version.Version    `json:"kubernetes_version"`
 	TestEnvTags           []string           `json:"test_tags"`
+	E2ETags               string             `json:"e2e_tags"`
+	LogToFile             bool               `json:"log_to_file"`
 }
 
 // ManagedNamespace returns the nth managed namespace.


### PR DESCRIPTION
This commit changes how to configure the variables `E2E_JSON` and `E2E_TAGS` for the test runner.

Instead of injecting them at build time in the docker image, we let the variables be propagated in the job container and used at runtime by [run.sh](https://github.com/elastic/cloud-on-k8s/blob/6f819294421171759503cf82ca790fdf6aac9048/test/e2e/run.sh#L16-L18).

This gives the ability to build the image once and not 32 times to run nightly e2e-tests.

We already build once on Buildkite but without `eks-arm` which requires `E2E_TAGS="es kb apm ent beat agent"`.
Jenkins jobs are not migrated to take advantage of this.