### PR TITLE
Refactoring docker registry creds

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -20,9 +20,9 @@ endif
 # BUILD_ID is present during run on Jenkins machine, but not on dev box, hence using it here to distinguish between those cases
 ifndef VAULT_TOKEN
 ifdef BUILD_ID
-VAULT_TOKEN = $(shell $(vault) write -field=token auth/approle/login role_id=$(VAULT_ROLE_ID) secret_id=$(VAULT_SECRET_ID))
+export VAULT_TOKEN = $(shell $(vault) write -field=token auth/approle/login role_id=$(VAULT_ROLE_ID) secret_id=$(VAULT_SECRET_ID))
 else
-VAULT_TOKEN = $(shell $(vault) write -field=token auth/github/login token=$(GITHUB_TOKEN))
+export VAULT_TOKEN = $(shell $(vault) write -field=token auth/github/login token=$(GITHUB_TOKEN))
 # we use roleId as a string that has to be there for authn/z for CI, but it's empty and not needed for local execution
 NOT_USED := $(shell test -e $(ROOT_DIR)/deployer-config.yml && sed "s;roleId:.*;token: $(GITHUB_TOKEN);g" $(ROOT_DIR)/deployer-config.yml > tmp && mv tmp $(ROOT_DIR)/deployer-config.yml)
 endif

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -6,24 +6,23 @@
 
 ROOT_DIR               := $(CURDIR)/..
 GO_MOUNT_PATH          ?= /go/src/github.com/elastic/cloud-on-k8s
-DOCKER_LOGIN           ?= eckadmin
-
--include $(ROOT_DIR)/.env
 
 vault := ../hack/retry.sh 5 vault
 
 # This is set to avoid the issue described in https://github.com/hashicorp/vault/issues/6710
 VAULT_CLIENT_TIMEOUT = 120
-VAULT_ROOT_PATH ?= secret/devops-ci/cloud-on-k8s
+
+export VAULT_ROOT_PATH = secret/ci/elastic-cloud-on-k8s
+ifdef BUILD_ID
+export VAULT_ROOT_PATH = secret/devops-ci/cloud-on-k8s
+endif
 
 # BUILD_ID is present during run on Jenkins machine, but not on dev box, hence using it here to distinguish between those cases
 ifndef VAULT_TOKEN
 ifdef BUILD_ID
-VAULT_TOKEN = $(shell $(vault) write -address=$(VAULT_ADDR) -field=token auth/approle/login role_id=$(VAULT_ROLE_ID) secret_id=$(VAULT_SECRET_ID))
-DOCKERHUB_LOGIN = $(shell VAULT_TOKEN=$(VAULT_TOKEN) $(vault) read -address=$(VAULT_ADDR) -field=username secret/release/docker-hub-eck)
-DOCKERHUB_PASSWORD = $(shell VAULT_TOKEN=$(VAULT_TOKEN) $(vault) read -address=$(VAULT_ADDR) -field=token secret/release/docker-hub-eck)
+VAULT_TOKEN = $(shell $(vault) write -field=token auth/approle/login role_id=$(VAULT_ROLE_ID) secret_id=$(VAULT_SECRET_ID))
 else
-VAULT_TOKEN = $(shell $(vault) write -address=$(VAULT_ADDR) -field=token auth/github/login token=$(GITHUB_TOKEN))
+VAULT_TOKEN = $(shell $(vault) write -field=token auth/github/login token=$(GITHUB_TOKEN))
 # we use roleId as a string that has to be there for authn/z for CI, but it's empty and not needed for local execution
 NOT_USED := $(shell test -e $(ROOT_DIR)/deployer-config.yml && sed "s;roleId:.*;token: $(GITHUB_TOKEN);g" $(ROOT_DIR)/deployer-config.yml > tmp && mv tmp $(ROOT_DIR)/deployer-config.yml)
 endif
@@ -53,7 +52,7 @@ ci-internal: ci-build-image
 		-v $(ECK_CI_VOLUME):/root/ \
 		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
 		-e SHARED_VOLUME_NAME=$(ECK_CI_VOLUME) -e ENABLE_FIPS \
-		-e VAULT_ADDR -e VAULT_TOKEN \
+		-e VAULT_ADDR -e VAULT_TOKEN -e VAULT_ROOT_PATH \
 		-w $(GO_MOUNT_PATH) \
 		--network="host" \
 		$(CI_IMAGE) \
@@ -61,8 +60,7 @@ ci-internal: ci-build-image
 	  docker volume rm $(ECK_CI_VOLUME) > /dev/null; exit $$exit
 
 # build and push the CI image only if it does not yet exist
-ci-build-image: DOCKER_PASSWORD = $(shell VAULT_TOKEN=$(VAULT_TOKEN) $(vault) read -address=$(VAULT_ADDR) -field=value $(VAULT_ROOT_PATH)/eckadmin)
-ci-build-image: write-ci-docker-creds
+ci-build-image:
 	@ docker pull -q $(CI_IMAGE) | grep -v -E 'Downloading|Extracting|Verifying|complete' || \
 	( \
 		../hack/retry.sh 5 docker build \
@@ -72,13 +70,6 @@ ci-build-image: write-ci-docker-creds
 			$(ROOT_DIR) && \
 		../hack/docker.sh -l -p $(CI_IMAGE) \
 	)
-
-# make Docker creds available from inside the CI container through the .registry.env file
-write-ci-docker-creds:
-	@ echo "DOCKER_LOGIN=$(DOCKER_LOGIN)"              > ${ROOT_DIR}/.registry.env
-	@ echo "DOCKER_PASSWORD=$(DOCKER_PASSWORD)"       >> ${ROOT_DIR}/.registry.env
-	@ echo "DOCKERHUB_LOGIN=$(DOCKERHUB_LOGIN)"       >> ${ROOT_DIR}/.registry.env
-	@ echo "DOCKERHUB_PASSWORD=$(DOCKERHUB_PASSWORD)" >> ${ROOT_DIR}/.registry.env
 
 ##  Test
 

--- a/.ci/jobs/publish-dockerhub.yml
+++ b/.ci/jobs/publish-dockerhub.yml
@@ -1,0 +1,14 @@
+---
+- job:
+    description: Publish ECK to dockerhub
+    name: cloud-on-k8s-publish-dockerhub
+    project-type: pipeline
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/elastic/cloud-on-k8s
+            branches:
+              - main
+            credentials-id: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'
+      script-path: .ci/pipelines/publish-dockerhub.Jenkinsfile
+      lightweight-checkout: false

--- a/.ci/pipelines/publish-dockerhub.Jenkinsfile
+++ b/.ci/pipelines/publish-dockerhub.Jenkinsfile
@@ -1,0 +1,33 @@
+// This library overrides the default checkout behavior to enable sleep+retries if there are errors
+// Added to help overcome some recurring github connection issues
+@Library('apm@current') _
+
+pipeline {
+
+    agent {
+        label 'linux'
+    }
+
+    options {
+        timeout(time: 10, unit: 'MINUTES')
+    }
+
+    environment {
+        VAULT_ADDR = credentials('vault-addr')
+        VAULT_ROLE_ID = credentials('vault-role-id')
+        VAULT_SECRET_ID = credentials('vault-secret-id')
+    }
+
+    parameters {
+        string(name: "DRY_RUN", defaultValue: "true", description: "If true, image is published to docker.elastic.co/eck-dev, otherwise to docker.io")
+        string(name: "ECK_VERSION", defaultValue: "", description: "ECK version to publish")
+    }
+
+    stages {
+        stage("Publish ECK to Docker Hub") {
+            steps {
+                sh 'hack/publish-dockerhub.sh'
+            }
+        }
+    }
+}

--- a/.ci/setenvconfig
+++ b/.ci/setenvconfig
@@ -79,7 +79,7 @@ case $environment in
 clusterName="eck-${CI_PLATFORM}-e2e-aks-${BUILD_NUMBER}"
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 
 IMG_SUFFIX=-ci
 E2E_REGISTRY_NAMESPACE=eck-ci
@@ -116,7 +116,7 @@ CFG
 clusterName="eck-${CI_PLATFORM}-e2e-custom-${BUILD_NUMBER}"
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 
 IMG_SUFFIX=-ci
 REGISTRY_NAMESPACE=eck-snapshots
@@ -194,7 +194,7 @@ generatedClusterName="eck-${CI_PLATFORM}-e2e-gke-$(sed "s|\.||g" <<< $gkeVersion
 clusterName=${3:-$generatedClusterName}
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 
 IMG_SUFFIX=-ci
 E2E_REGISTRY_NAMESPACE=eck-ci
@@ -238,7 +238,7 @@ ipFamily=$4
 clusterName="eck-${CI_PLATFORM}-e2e-kind-$(sed "s|\.||g" <<< $kindVersion)-${BUILD_NUMBER}"
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 
 IMG_SUFFIX=-ci
 E2E_REGISTRY_NAMESPACE=eck-ci
@@ -283,7 +283,7 @@ TESTS_MATCH="${TESTS_MATCH:-^Test}"
 E2E_TAGS="${E2E_TAGS:-e2e}"
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 
 IMG_SUFFIX=-ci
 REGISTRY_NAMESPACE=eck-snapshots
@@ -323,7 +323,7 @@ CFG
 clusterName="eck-${CI_PLATFORM}-e2e-resilience-${BUILD_NUMBER}"
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 
 E2E_DEPLOY_CHAOS_JOB=true
 IMG_SUFFIX=-ci
@@ -365,7 +365,7 @@ ocpVersion=$2
 clusterName="eck-${CI_PLATFORM}-e2e-ocp-$(sed "s|\.||g" <<< ${ocpVersion})-$BUILD_NUMBER"
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 
 IMG_SUFFIX=-ci
 E2E_REGISTRY_NAMESPACE=eck-ci
@@ -403,7 +403,7 @@ CFG
 ######################################
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 
 IMG_SUFFIX=-ci
 E2E_REGISTRY_NAMESPACE=eck-ci
@@ -442,7 +442,7 @@ CFG
 clusterName="eck-${CI_PLATFORM}-e2e-eks-${BUILD_NUMBER}"
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 
 IMG_SUFFIX=-ci
 E2E_REGISTRY_NAMESPACE=eck-ci
@@ -479,7 +479,7 @@ CFG
 clusterName="eck-${CI_PLATFORM}-e2e-eks-arm-${BUILD_NUMBER}"
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 
 IMG_SUFFIX=-ci
 E2E_REGISTRY_NAMESPACE=eck-ci
@@ -519,7 +519,7 @@ CFG
 clusterName="eck-${CI_PLATFORM}-e2e-tanzu-${BUILD_NUMBER}"
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 
 IMG_SUFFIX=-ci
 E2E_REGISTRY_NAMESPACE=eck-ci
@@ -562,7 +562,7 @@ testLicensePKeyPath=$(case $isSnapshotVersion in (Yes) echo "${PROJECT_PATH}/.ci
 operatorImage=${OPERATOR_IMAGE:-$JKS_PARAM_OPERATOR_IMAGE}
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 
 IMG_SUFFIX=-ci
 E2E_REGISTRY_NAMESPACE=eck-ci
@@ -603,7 +603,7 @@ CFG
 clusterName="eck-${CI_PLATFORM}-e2e-pr-${BUILD_NUMBER}"
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 
 IMG_SUFFIX=-ci
 REGISTRY_NAMESPACE=eck-snapshots
@@ -658,7 +658,7 @@ CFG
 # IMG_VERSION is generated
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 
 REGISTRY_NAMESPACE=eck-snapshots
 IMG_SUFFIX=
@@ -677,7 +677,7 @@ ENV
 ###############
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 
 REGISTRY_NAMESPACE=eck
 IMG_SUFFIX=
@@ -697,7 +697,7 @@ ENV
 ######################################
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 
 IMG_SUFFIX=-dev-ci
 REGISTRY_NAMESPACE=eck-snapshots
@@ -781,7 +781,7 @@ CFG
 clusterName="eck-${CI_PLATFORM}-e2e-aks-${BUILD_NUMBER}"
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 ENV
 
 write_deployer_config <<CFG
@@ -804,7 +804,7 @@ CFG
 clusterName="eck-${CI_PLATFORM}-e2e-tanzu-${BUILD_NUMBER}"
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 ENV
 
 write_deployer_config <<CFG
@@ -866,7 +866,7 @@ ocpVersion=$2
 clusterName="eck-${CI_PLATFORM}-e2e-ocp-$(sed "s|\.||g" <<< ${ocpVersion})-$BUILD_NUMBER"
 
 write_env <<ENV
-VAULT_ROOT_PATH=$VAULT_ROOT_PATH
+export VAULT_ROOT_PATH=$VAULT_ROOT_PATH
 ENV
 
 write_deployer_config <<CFG

--- a/Makefile
+++ b/Makefile
@@ -241,9 +241,7 @@ build-operator-image:
 
 build-operator-multiarch-image:
 	@ hack/docker.sh -l -m $(OPERATOR_IMAGE)
-	@ hack/docker.sh -l -m $(OPERATOR_DOCKERHUB_IMAGE)
-	@ (docker buildx imagetools inspect $(OPERATOR_IMAGE) | grep -q 'linux/arm64' 2>&1 >/dev/null \
-	&& docker buildx imagetools inspect $(OPERATOR_DOCKERHUB_IMAGE) | grep -q 'linux/arm64' 2>&1 >/dev/null) \
+	@ docker buildx imagetools inspect $(OPERATOR_IMAGE) | grep -q 'linux/arm64' 2>&1 >/dev/null \
 	&& echo "OK: image $(OPERATOR_IMAGE) already published" \
 	|| $(MAKE) docker-multiarch-build
 
@@ -382,14 +380,13 @@ BUILD_PLATFORM ?= "linux/amd64,linux/arm64"
 
 buildah-login:
 	@ buildah login \
-		--username="$(shell vault read -field=username $(VAULT_ROOT_PATH)/docker-registry)" \
-		--password="$(shell vault read -field=password $(VAULT_ROOT_PATH)/docker-registry)" \
+		--username="$(shell vault read -field=username $(VAULT_ROOT_PATH)/docker-registry-elastic)" \
+		--password="$(shell vault read -field=password $(VAULT_ROOT_PATH)/docker-registry-elastic)" \
 		$(REGISTRY)
 
 docker-multiarch-build: go-generate generate-config-file 
 ifeq ($(SNAPSHOT),false)
 	@ hack/docker.sh -l -m $(OPERATOR_IMAGE)
-	@ hack/docker.sh -l -m $(OPERATOR_DOCKERHUB_IMAGE)
 	docker buildx build . \
 		--progress=plain \
 		--build-arg GO_LDFLAGS='$(GO_LDFLAGS)' \
@@ -409,7 +406,6 @@ ifeq ($(SNAPSHOT),false)
 		--platform linux/amd64,linux/arm64 \
 		-f Dockerfile.ubi \
 		-t $(OPERATOR_IMAGE_UBI) \
-		-t $(OPERATOR_DOCKERHUB_IMAGE_UBI) \
 		--push
 else
 	@ hack/docker.sh -l -m $(OPERATOR_IMAGE)

--- a/hack/docker.sh
+++ b/hack/docker.sh
@@ -8,7 +8,6 @@
 #
 # Log in to docker.elastic.co if the namespace eck, eck-ci or eck-snapshots is used
 # Log in to gcloud if GCR is used
-# Log in to hub.docker.com if docker.io is used
 
 set -euo pipefail
 
@@ -40,14 +39,6 @@ docker-login() {
         *.gcr.io/*)
             echo "Authentication to ${registry}..."
             gcloud auth configure-docker --quiet 2> /dev/null
-        ;;
-
-        docker.io/*)
-            DOCKERHUB_LOGIN=$(retry vault read -field=username "${VAULT_ROOT_PATH}/release/docker-hub-eck")
-            DOCKERHUB_PASSWORD=$(retry vault read -field=token "${VAULT_ROOT_PATH}/release/docker-hub-eck")
-
-            echo "Authentication to ${registry}..."
-            docker login -u "${DOCKERHUB_LOGIN}" -p "${DOCKERHUB_PASSWORD}" 2> /dev/null
         ;;
 
         *)

--- a/hack/publish-dockerhub.sh
+++ b/hack/publish-dockerhub.sh
@@ -9,7 +9,7 @@
 set -eu
 
 install_docker_extension() {
-    [[ -f ~/.docker/cli-plugins/docker-buildx ]] && return || true
+    [[ ! -f ~/.docker/cli-plugins/docker-buildx ]] && return
 
     DOCKER_BUILDX_VERSION=0.8.2
     mkdir -p ~/.docker/cli-plugins

--- a/hack/publish-dockerhub.sh
+++ b/hack/publish-dockerhub.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+
+# Script to publish ECK operator image from docker.elastic.co registry to docker.io registry (aka Docker Hub).
+
+set -eu
+
+install_docker_extension() {
+    [[ -f ~/.docker/cli-plugins/docker-buildx ]] && return || true
+
+    DOCKER_BUILDX_VERSION=0.8.2
+    mkdir -p ~/.docker/cli-plugins
+    curl -fsSLo ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v${DOCKER_BUILDX_VERSION}/buildx-v${DOCKER_BUILDX_VERSION}.linux-arm64
+    chmod a+x ~/.docker/cli-plugins/docker-buildx
+}
+
+registry_login() {
+    DOCKERHUB_LOGIN=$(vault read -field=username secret/release/docker-hub-eck)
+    DOCKERHUB_PASSWORD=$(vault read -field=token secret/release/docker-hub-eck)
+
+    docker login -u "${DOCKERHUB_LOGIN}" -p "${DOCKERHUB_PASSWORD}" 2> /dev/null
+}
+
+publish() {
+    local name=$1
+    docker buildx imagetools create -t "$REGISTRY_DST/$name:$ECK_VERSION" "$REGISTRY_SRC/$name:$ECK_VERSION"
+}
+
+# main
+
+if [[ "${ECK_VERSION:-}" == "" ]]; then
+    echo "ECK_VERSION must be set"
+    exit 1
+fi
+
+REGISTRY_SRC="docker.elastic.co/eck"
+REGISTRY_DST="docker.elastic.co/eck-dev"
+
+if [[ "${DRY_RUN:-}" == "false" ]]; then
+    REGISTRY_DST="docker.io/elastic"
+fi
+
+install_docker_extension
+registry_login
+
+publish eck-operator
+publish eck-operator-ubi8
+publish eck-operator-fips
+publish eck-operator-ubi8-fips


### PR DESCRIPTION
- Stop writing credentials to disk by moving the vault command to `docker.sh`. The script is already smart enough to authenticate only if necessary (in dev when `CI` is not set).
- Move publishing images in DockerHub to a separate Jenkins job as there is no solution on Buildkite yet for this kind of shared Secret.
- Stop to include `.env` in `.ci/.Makefile` just to get `VAULT_ROOT_PATH` and instead duplicate the if in the Makefile.