### PR TITLE
Update EKS Kubernetes version to 1.21

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -108,7 +108,7 @@ plans:
   machineType: c5d.2xlarge
   serviceAccount: false
   enforceSecurityPolicies: true
-  kubernetesVersion: 1.24
+  kubernetesVersion: 1.21
   diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
   eks:
     region: ap-northeast-3
@@ -121,7 +121,7 @@ plans:
   machineType: m6gd.2xlarge
   serviceAccount: false
   enforceSecurityPolicies: true
-  kubernetesVersion: 1.24
+  kubernetesVersion: 1.21
   diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
   eks:
     region: eu-west-1

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -108,7 +108,7 @@ plans:
   machineType: c5d.2xlarge
   serviceAccount: false
   enforceSecurityPolicies: true
-  kubernetesVersion: 1.20
+  kubernetesVersion: 1.24
   diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
   eks:
     region: ap-northeast-3
@@ -121,7 +121,7 @@ plans:
   machineType: m6gd.2xlarge
   serviceAccount: false
   enforceSecurityPolicies: true
-  kubernetesVersion: 1.20
+  kubernetesVersion: 1.24
   diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
   eks:
     region: eu-west-1


### PR DESCRIPTION
This commits updates the Kubernetes version used to create EKS cluster for CI
to ~the most recent version `1.24`~ version `1.21` because `1.20` is no longer supported.
