### PR TITLE
Propate E2E_TAGS in e2e chaos job

### DIFF
--- a/config/e2e/chaos_job.yaml
+++ b/config/e2e/chaos_job.yaml
@@ -35,6 +35,8 @@ spec:
           #- "--delete-operator-delay=2m"
           #- "--update-operator-replicas-delay=5m"
           env:
+          - name: E2E_TAGS
+            value: "{{ .Context.E2ETags }}"
           - name: CHAOS
             value: "true"
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
The chaos-job uses `E2E_TAGS`, not just the e2e-job.

https://github.com/elastic/cloud-on-k8s/blob/70939e0ef273768a59eba2339b2685b9b59035a7/test/e2e/run.sh#L30-L31

Follow-up of #6433.