### PR TITLE
Fix vault client being nil in Azure deployer.

### DIFF
--- a/hack/deployer/runner/aks.go
+++ b/hack/deployer/runner/aks.go
@@ -38,12 +38,10 @@ type AKSDriver struct {
 }
 
 func (gdf *AKSDriverFactory) Create(plan Plan) (Driver, error) {
-	var (
-		c   vault.Client
-		err error
-	)
+	var c vault.Client
 	// plan.ServiceAccount = true typically means a CI run vs a local run on a dev machine
 	if plan.ServiceAccount {
+		var err error
 		c, err = vault.NewClient()
 		if err != nil {
 			return nil, err

--- a/hack/deployer/runner/aks.go
+++ b/hack/deployer/runner/aks.go
@@ -38,10 +38,13 @@ type AKSDriver struct {
 }
 
 func (gdf *AKSDriverFactory) Create(plan Plan) (Driver, error) {
-	var c vault.Client
+	var (
+		c   vault.Client
+		err error
+	)
 	// plan.ServiceAccount = true typically means a CI run vs a local run on a dev machine
 	if plan.ServiceAccount {
-		c, err := vault.NewClient()
+		c, err = vault.NewClient()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Currently the main Azure e2e tests are failing with

```
./hack/deployer/deployer execute --plans-file hack/deployer/config/plans.yml --config-file deployer-config.yml
2023/02/27 19:22:49 Authenticating as service account...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x7dee5b]
goroutine 40 [running]:
github.com/elastic/cloud-on-k8s/v2/pkg/utils/vault.read.func1()
	/go/src/github.com/elastic/cloud-on-k8s/pkg/utils/vault/read.go:67 +0x3b
github.com/elastic/cloud-on-k8s/v2/pkg/utils/retry.UntilSuccess.func2()
	/go/src/github.com/elastic/cloud-on-k8s/pkg/utils/retry/retry.go:41 +0x29
created by github.com/elastic/cloud-on-k8s/v2/pkg/utils/retry.UntilSuccess
	/go/src/github.com/elastic/cloud-on-k8s/pkg/utils/retry/retry.go:40 +0x115
make: *** [Makefile:573: run-deployer] Error 2
make[1]: *** [Makefile:49: ci-internal] Error 2

make[1]: Leaving directory '/opt/buildkite-agent/builds/bk-agent-elastic-gcp-1677525607247974208/elastic/cloud-on-k8s-operator-nightly/.ci'

make: *** [Makefile:42: ci] Error 2

make: Leaving directory '/opt/buildkite-agent/builds/bk-agent-elastic-gcp-1677525607247974208/elastic/cloud-on-k8s-operator-nightly/.ci'

Error: The command exited with status 2
user command error: exit status 2
```

This is because the Vault client in azure was defined outside a block, but re-created/assigned in a block, and therefore the client was still nil outside of the serviceaccount block.