### PR TITLE
Fix operatorhub  manifest generator

### DIFF
--- a/hack/operatorhub/cmd/manifests/manifests.go
+++ b/hack/operatorhub/cmd/manifests/manifests.go
@@ -18,7 +18,7 @@ func Command() *cobra.Command {
 		Short: "Generate operator lifecycle manager format files",
 		Long: `Generate operator lifecycle manager format files within 
 'community-operators', 'certified-operators', and 'upstream-community-operators' directories.`,
-		Example:      "operatorhub generate-manifests -c ./config.yaml -y ../../config/crds.yaml -y ./../config/operator.yaml",
+		Example:      "operatorhub generate-manifests -c ./config.yaml -y ../../config/crds.yaml -y ../../config/operator.yaml",
 		SilenceUsage: true,
 		PreRunE:      preRunE,
 		RunE:         doRun,

--- a/hack/operatorhub/cmd/root.go
+++ b/hack/operatorhub/cmd/root.go
@@ -37,12 +37,12 @@ and potentially creating pull requests to community/certified operator repositor
 func init() {
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
-	Cmd.Flags().StringVarP(
+	Cmd.PersistentFlags().StringVarP(
 		&flags.ConfigPath,
 		flags.ConfFlag,
 		"c",
 		"./config.yaml",
-		"Path to configiguration file (OHUB_CONF)",
+		"Path to configuration file (OHUB_CONF)",
 	)
 
 	Cmd.PersistentFlags().StringVarP(
@@ -179,7 +179,7 @@ func setVariablesFromConfigurationFile() error {
 	if err != nil {
 		return fmt.Errorf("while reading configuration file %s: %w", confFilePath, err)
 	}
-	err = gyaml.Unmarshal(b, flags.Conf)
+	err = gyaml.Unmarshal(b, &flags.Conf)
 	if err != nil {
 		return fmt.Errorf("while unmarshaling config file into configuration struct: %w", err)
 	}


### PR DESCRIPTION
`generate-manifests` seems to be broken:

```
operatorhub generate-manifests -c ./config.yaml -y ../../config/crds.yaml -y ../../config/operator.yaml
Error: unknown shorthand flag: 'c' in -c
2023/03/02 14:30:44 failed to run command: unknown shorthand flag: 'c' in -c
```

Also `flags.Conf` is always `nil`  