### PR TITLE
Fix handling of unmanaged esRef in Beats stack monitoring

### DIFF
--- a/pkg/controller/association/controller/agent_fleetserver.go
+++ b/pkg/controller/association/controller/agent_fleetserver.go
@@ -70,7 +70,7 @@ func referencedFleetServerStatusVersion(c k8s.Client, fsRef commonv1.ObjectSelec
 		if err != nil {
 			return "", err
 		}
-		ver, err := info.Request("/api/status", "{ .version.number }")
+		ver, err := info.Version("/api/status", "{ .version.number }")
 		if err != nil {
 			// version is in the status API from version 8.0
 			if err.Error() == "version is not found" {

--- a/pkg/controller/association/controller/apm_kibana.go
+++ b/pkg/controller/association/controller/apm_kibana.go
@@ -79,7 +79,7 @@ func referencedKibanaStatusVersion(c k8s.Client, kbRef commonv1.ObjectSelector) 
 		if err != nil {
 			return "", err
 		}
-		ver, err := info.Request("/api/status", "{ .version.number }")
+		ver, err := info.Version("/api/status", "{ .version.number }")
 		if err != nil {
 			return "", err
 		}

--- a/pkg/controller/association/controller/kibana_ent.go
+++ b/pkg/controller/association/controller/kibana_ent.go
@@ -70,7 +70,7 @@ func referencedEntStatusVersion(c k8s.Client, entRef commonv1.ObjectSelector) (s
 		if err != nil {
 			return "", err
 		}
-		ver, err := info.Request("/api/ent/v1/internal/version", "{ .number }")
+		ver, err := info.Version("/api/ent/v1/internal/version", "{ .number }")
 		if err != nil {
 			return "", err
 		}

--- a/pkg/controller/association/controller/kibana_es.go
+++ b/pkg/controller/association/controller/kibana_es.go
@@ -77,7 +77,7 @@ func referencedElasticsearchStatusVersion(c k8s.Client, esRef commonv1.ObjectSel
 		if err != nil {
 			return "", err
 		}
-		ver, err := info.Request("/", "{ .version.number }")
+		ver, err := info.Version("/", "{ .version.number }")
 		if err != nil {
 			return "", err
 		}

--- a/pkg/controller/association/reconciler_test.go
+++ b/pkg/controller/association/reconciler_test.go
@@ -75,7 +75,7 @@ var (
 				if err != nil {
 					return "", err
 				}
-				// Bypass: ver, err := ref.Request("/", "{ .version.number }") and just return the version
+				// Bypass: ver, err := ref.Version("/", "{ .version.number }") and just return the version
 				return stackVersion, nil
 			}
 

--- a/pkg/controller/association/secret.go
+++ b/pkg/controller/association/secret.go
@@ -100,6 +100,22 @@ func GetUnmanagedAssociationConnectionInfoFromSecret(c k8s.Client, o commonv1.Ob
 	return &ref, nil
 }
 
+// Version performs an HTTP GET request to the unmanaged Elastic resource at the given path and returns a string extracted
+// from the returned result using the given json path and validates it is a valid semver version.
+func (r UnmanagedAssociationConnectionInfo) Version(path string, jsonPath string) (string, error) {
+	ver, err := r.Request(path, jsonPath)
+	if err != nil {
+		return "", err
+	}
+
+	// validate the version
+	if _, err := version.Parse(ver); err != nil {
+		return "", err
+	}
+
+	return ver, nil
+}
+
 // Request performs an HTTP GET request to the unmanaged Elastic resource at the given path and returns a string extracted
 // from the returned result using the given json path.
 func (r UnmanagedAssociationConnectionInfo) Request(path string, jsonPath string) (string, error) {
@@ -149,14 +165,7 @@ func (r UnmanagedAssociationConnectionInfo) Request(path string, jsonPath string
 	if err := j.Execute(buf, obj); err != nil {
 		return "", err
 	}
-	ver := buf.String()
-
-	// validate the version
-	if _, err := version.Parse(ver); err != nil {
-		return "", err
-	}
-
-	return ver, nil
+	return buf.String(), nil
 }
 
 // filterUnmanagedElasticRef returns those associations that reference using a Kubernetes secret an Elastic resource not managed by ECK.

--- a/pkg/controller/beat/common/driver.go
+++ b/pkg/controller/beat/common/driver.go
@@ -105,7 +105,7 @@ func Reconcile(
 		if errors.Is(err, beat_stackmon.ErrMonitoringClusterUUIDUnavailable) {
 			results.WithReconciliationState(reconciler.RequeueAfter(10 * time.Second).WithReason("ElasticsearchRef UUID unavailable while configuring Beats stack monitoring"))
 		}
-		return results, params.Status
+		return results.WithError(err), params.Status
 	}
 	var reconcileResults *reconciler.Results
 	reconcileResults, params.Status = reconcilePodVehicle(podTemplate, params)

--- a/pkg/controller/beat/common/driver.go
+++ b/pkg/controller/beat/common/driver.go
@@ -104,8 +104,10 @@ func Reconcile(
 	if err != nil {
 		if errors.Is(err, beat_stackmon.ErrMonitoringClusterUUIDUnavailable) {
 			results.WithReconciliationState(reconciler.RequeueAfter(10 * time.Second).WithReason("ElasticsearchRef UUID unavailable while configuring Beats stack monitoring"))
+		} else {
+			results.WithError(err)
 		}
-		return results.WithError(err), params.Status
+		return results, params.Status
 	}
 	var reconcileResults *reconciler.Results
 	reconcileResults, params.Status = reconcilePodVehicle(podTemplate, params)

--- a/pkg/controller/kibana/stackmon/sidecar.go
+++ b/pkg/controller/kibana/stackmon/sidecar.go
@@ -45,7 +45,7 @@ func Metricbeat(ctx context.Context, client k8s.Client, kb kbv1.Kibana) (stackmo
 
 	var username, password string
 	if kb.Spec.ElasticsearchRef.IsExternal() {
-		info, err := association.GetUnmanagedAssociationConnectionInfoFromSecret(client, kb.Spec.ElasticsearchRef)
+		info, err := association.GetUnmanagedAssociationConnectionInfoFromSecret(client, kb.Spec.ElasticsearchRef.WithDefaultNamespace(kb.Namespace))
 		if err != nil {
 			return stackmon.BeatSidecar{}, err
 		}


### PR DESCRIPTION
Fixes #6230 
Fixes #5880

Beats stack monitoring assumed that the associated Elasticsearch cluster is a local cluster managed by ECK. However a Beats definition as follows would break the stack monitoring feature:
```yaml
apiVersion: beat.k8s.elastic.co/v1beta1
kind: Beat
metadata:
  name: filebeat
spec:
  type: filebeat
  version: 8.6.1
  elasticsearchRef:
    secretName: es-ref
  kibanaRef:
    secretName: kibana-ref
  monitoring:
    metrics:
      elasticsearchRefs:
        - secretName: monitoring-metrics-es-ref
    logs:
      elasticsearchRefs:
        - secretName: monitoring-metrics-es-ref
```

Worse still we would silently swallow the error creating the appearance of normalcy when the situation was in fact not normal. 

This PR tries to address these issues by: 
* handling the error correctly
* special casing external references to Elasticsearch correctly by 
    1. distinguishing between external references and internal references when generating Beats configuration 
    2. making a request in case of a remote unmanaged cluster to find out the cluster UUID which we seem to need for stack monitoring configuration (I have not tested what happens if we don't set it ) 

Known issues: 
* if the external Elasticsearch cluster has stack monitoring for the cluster itself turned off then the Beats monitoring data will not show up in the Kibana UI (a known issue that we already document). However monitoring data will still flow into the cluster for use in custom dashboards etc.