### PR TITLE
Fix dev license public key setup

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -79,7 +79,7 @@ ci-build-image:
 # all artifacts needed to run e2e tests
 get-test-artifacts: monitoring-secrets.json test-license.json license.key
 
-ifneq (,$(IS_SNAPSHOT_BUILD))
+ifeq (dev,$(BUILD_LICENSE_PUBKEY))
        SECRET_FIELD_PREFIX ?= dev-
 get-test-artifacts: dev-private.key
 endif


### PR DESCRIPTION
This fixes how the dev license public key is setup to run e2e-tests.

In https://github.com/elastic/cloud-on-k8s/pull/6418, `IS_SNAPSHOT_BUILD=Yes` was changed to `BUILD_LICENSE_PUBKEY=dev` but there is one place that was not updated.

This should fix `TestElasticMapsServerCrossNSAssociation`that is failing in job `cloud-on-k8s-e2e-tests-snapshot-versions`.