### PR TITLE
Expose all fields below spec in eck-elasticsearch Helm chart

### DIFF
--- a/deploy/eck-elasticsearch/templates/elasticsearch.yaml
+++ b/deploy/eck-elasticsearch/templates/elasticsearch.yaml
@@ -52,3 +52,19 @@ spec:
   {{- end }}
   nodeSets:
 {{ toYaml .Values.nodeSets | nindent 4 }}
+  {{- if .Values.image }}
+  image:
+    {{- toYaml .Values.image | nindent 4 }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget }}
+  podDisruptionBudget:
+    {{- toYaml .Values.podDisruptionBudget | nindent 4 }}
+  {{- end }}
+  {{- if .Values.serviceAccountName }}
+  serviceAccountName:
+    {{- toYaml .Values.serviceAccountName | nindent 4 }}
+  {{- end }}
+  {{- if .Values.revisionHistoryLimit }}
+  revisionHistoryLimit:
+    {{- toYaml .Values.revisionHistoryLimit | nindent 4 }}
+  {{- end }}

--- a/deploy/eck-elasticsearch/templates/elasticsearch.yaml
+++ b/deploy/eck-elasticsearch/templates/elasticsearch.yaml
@@ -53,18 +53,15 @@ spec:
   nodeSets:
 {{ toYaml .Values.nodeSets | nindent 4 }}
   {{- if .Values.image }}
-  image:
-    {{- toYaml .Values.image | nindent 4 }}
+  image: {{ .Values.image }}
   {{- end }}
   {{- if .Values.podDisruptionBudget }}
   podDisruptionBudget:
     {{- toYaml .Values.podDisruptionBudget | nindent 4 }}
   {{- end }}
   {{- if .Values.serviceAccountName }}
-  serviceAccountName:
-    {{- toYaml .Values.serviceAccountName | nindent 4 }}
+  serviceAccountName: {{ .Values.serviceAccountName }}
   {{- end }}
   {{- if .Values.revisionHistoryLimit }}
-  revisionHistoryLimit:
-    {{- toYaml .Values.revisionHistoryLimit | nindent 4 }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   {{- end }}

--- a/deploy/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
+++ b/deploy/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
@@ -198,3 +198,48 @@ tests:
       - equal:
           path: spec.auth.roles[0].secretName
           value: roles-secret-1
+  - it: should render image properly
+    set:
+      image: my.regis.try/es:8
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.regis.try/es:8
+  - it: should render image properly
+    set:
+      image: my.registry.com/elastic/elasticsearch:8.7.0
+    asserts:
+      - equal:
+          path: spec.image
+          value: my.registry.com/elastic/elasticsearch:8.7.0
+  - it: should render podDisruptionBudget properly
+    set:
+      podDisruptionBudget:
+        spec:
+          minAvailable: 2
+          selector:
+            matchLabels:
+              elasticsearch.k8s.elastic.co/cluster-name: quickstart
+    asserts:
+      - equal:
+          path: spec.podDisruptionBudget
+          value:
+             spec:
+              minAvailable: 2
+              selector:
+                matchLabels:
+                  elasticsearch.k8s.elastic.co/cluster-name: quickstart
+  - it: should render serviceAccountName properly
+    set:
+      serviceAccountName: my-sa
+    asserts:
+      - equal:
+          path: spec.serviceAccountName
+          value: my-sa
+  - it: should render revisionHistoryLimit properly
+    set:
+      revisionHistoryLimit: 2
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 2

--- a/deploy/eck-elasticsearch/values.yaml
+++ b/deploy/eck-elasticsearch/values.yaml
@@ -20,6 +20,10 @@
 #
 version: 8.6.1
 
+# Elasticsearch Docker image to deploy
+#
+# image:
+
 # Labels that will be applied to Elasticsearch.
 #
 labels: {}
@@ -118,7 +122,30 @@ remoteClusters: {}
 # VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets.
 # Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion.
 # Defaults to DeleteOnScaledownAndClusterDeletion if unset.
+#
 volumeClaimDeletePolicy: ""
+
+# Settings to limit the disruption when pods need to be rescheduled for some reason such as upgrades or routine maintenance.
+# Default budget selects all cluster pods and sets `maxUnavailable` to 1.
+# To disable, set to the empty value (`{}`).
+#
+# podDisruptionBudget:
+#   spec:
+#     minAvailable: 2
+#     selector:
+#       matchLabels:
+#         elasticsearch.k8s.elastic.co/cluster-name: quickstart
+
+
+# Used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.
+# Can only be used if ECK is enforcing RBAC on references.
+#
+# serviceAccountName: ""
+
+# Number of revisions to retain to allow rollback in the underlying StatefulSets.
+# Defaults to 10.
+#
+# revisionHistoryLimit: 2
 
 # Node configuration settings.
 # The node roles which can be configured here are:


### PR DESCRIPTION
This exposes the 4 fields `image`, `podDisruptionBudget`, `serviceAccountName` and  `revisionHistoryLimit` in the eck-elasticsearch Helm chart.

Relates to #6451.