### PR TITLE
[E2E] Disable TestFleetAgentWithoutTLS

### DIFF
--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -18,6 +18,9 @@ import (
 
 // TestFleetAgentWithoutTLS tests a Fleet Server, and Elastic Agent with TLS disabled for the HTTP layer.
 func TestFleetAgentWithoutTLS(t *testing.T) {
+
+	test.SkipUntilResolution(t, 6331)
+
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
 	// Disabling TLS for Fleet isn't supported before 7.16, as Elasticsearch doesn't allow


### PR DESCRIPTION
Relates to #6494, #6331.