### PR TITLE
Ignore dev license key to test non prod stack builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,9 @@ bin
 # ignore vendor/
 vendor/
 
-# Elastic public key
-license.*key
+# Elastic license keys
+license.key
+dev-private.key
 
 # test licenses used in the E2E tests
 test-license.json


### PR DESCRIPTION
Since #6465, `get-test-artifacts` is tied to the `ci` target.

In the case of dev build of the operator with the dev license to test non prod stack builds, `make -C .ci license.key TARGET=ci-check ci` is now fetching the dev private key:

https://github.com/elastic/cloud-on-k8s/blob/618f59ef7f23019a4e15943f8c570a507895c93d/.ci/Makefile#L82-L85

And then `make check-local-changes` (sub target of `ci-check`) fails due to the presence of the file `dev-private.key`.

https://github.com/elastic/cloud-on-k8s/blob/618f59ef7f23019a4e15943f8c570a507895c93d/.ci/pipelines/build.Jenkinsfile#L25-L30

This commit adds the `dev-private.key` file to `.gitignore` to fix this.

Relates to #6465.