### PR TITLE
vault login using approle method in publish-dockerhub job

### DIFF
--- a/hack/publish-dockerhub.sh
+++ b/hack/publish-dockerhub.sh
@@ -17,6 +17,11 @@ install_docker_extension() {
     chmod a+x ~/.docker/cli-plugins/docker-buildx
 }
 
+vault_login() {
+    VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="${VAULT_ROLE_ID}" secret_id="${VAULT_SECRET_ID}")
+    export VAULT_TOKEN
+}
+
 registry_login() {
     DOCKERHUB_LOGIN=$(vault read -field=username secret/release/docker-hub-eck)
     DOCKERHUB_PASSWORD=$(vault read -field=token secret/release/docker-hub-eck)
@@ -44,6 +49,7 @@ if [[ "${DRY_RUN:-}" == "false" ]]; then
 fi
 
 install_docker_extension
+vault_login
 registry_login
 
 publish eck-operator


### PR DESCRIPTION
Compared to Buildkite, in Jenkins there is no vault token already available in the environment, it is the responsibility of the job to connect to vault to set the token.

My Jenkins skills were a bit rusty when I wrote the job in #6434.