### PR TITLE
Use non latest tag for buildkite agent image version

### DIFF
--- a/.buildkite/pipeline-nightly-e2e-tests.yml
+++ b/.buildkite/pipeline-nightly-e2e-tests.yml
@@ -1,5 +1,5 @@
 agents:
-  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest
+  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:ba68d389
   memory: "4G"
 
 steps:

--- a/.buildkite/pipeline-release-operatorhub.yml
+++ b/.buildkite/pipeline-release-operatorhub.yml
@@ -1,6 +1,6 @@
 
 agents:
-  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest
+  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:ba68d389
   cpu: "4"
   memory: "2G"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 
 agents:
-  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:latest
+  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:ba68d389
   cpu: "4"
   memory: "2G"
 


### PR DESCRIPTION
It is convenient to use the "latest" tag for the buildkite agent image in pipeline definitions. Thinking about it again, I think it's too risky because you can break the CI after any agent image update and it's better to control the version despite the cost of an extra PR in this repo for each update.