### PR TITLE
Make sure file exists before reading it

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -54,7 +54,7 @@ ci-internal: ci-build-image
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(ECK_CI_VOLUME):/root/ \
 		-v $(ROOT_DIR):$(GO_MOUNT_PATH) \
-		-e SHARED_VOLUME_NAME=$(ECK_CI_VOLUME) -e ENABLE_FIPS -e BUILD_LICENSE_PUBKEY \
+		-e CI -e SHARED_VOLUME_NAME=$(ECK_CI_VOLUME) -e ENABLE_FIPS -e BUILD_LICENSE_PUBKEY \
 		-e VAULT_ADDR -e VAULT_TOKEN -e VAULT_ROLE_ID -e VAULT_SECRET_ID -e VAULT_ROOT_PATH \
 		-w $(GO_MOUNT_PATH) \
 		--network="host" \

--- a/hack/deployer/runner/client.go
+++ b/hack/deployer/runner/client.go
@@ -85,19 +85,21 @@ func clientImageName(driverID, clientVersion, dockerfileName string) (string, er
 
 func dockerLogin(client vault.Client) error {
 	// skip docker login in dev if registry exists in docker auth config file
-	if os.Getenv("CI") != "true" {
+	if os.Getenv("CI") != "true" { //nolint:nestif
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			return err
 		}
 		dockerConfig := filepath.Join(homeDir, ".docker", "config.json")
-		b, err := os.ReadFile(dockerConfig)
-		if err != nil {
-			return err
-		}
-		if bytes.Contains(b, []byte(dockerRegistry)) {
-			log.Printf("Skip docker login as %s already exists in %s", dockerRegistry, dockerConfig)
-			return nil
+		if _, err := os.Stat(dockerConfig); err == nil {
+			b, err := os.ReadFile(dockerConfig)
+			if err != nil {
+				return err
+			}
+			if bytes.Contains(b, []byte(dockerRegistry)) {
+				log.Printf("Skip docker login as %s already exists in %s", dockerRegistry, dockerConfig)
+				return nil
+			}
 		}
 	}
 


### PR DESCRIPTION
```
14:37:07  ./hack/deployer/deployer execute --plans-file hack/deployer/config/plans.yml --config-file deployer-config.yml
...
14:37:37  Error: while logging into docker registry: open /root/.docker/config.json: no such file or directory
```

This fixes the case where the file doesn't exist 🤦.

The interesting part is that CI was not set to true due to the fact that this runs inside the CI docker container and the env variable is not propagated. I've added it.

Follow-up of #6514.