### PR TITLE
[ci/jks] Move setenv in snapshot-versions Jenkins job

### DIFF
--- a/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
+++ b/.ci/pipelines/e2e-tests-snapshot-versions-gke.Jenkinsfile
@@ -33,6 +33,11 @@ pipeline {
                 }
             }
         }
+        stage('Set env') {
+            steps {
+                sh '.ci/setenvconfig dev/build'
+            }
+        }
         stage('Validate Jenkins pipelines') {
             steps {
                 sh 'make -C .ci TARGET=validate-jenkins-pipelines ci'
@@ -40,7 +45,6 @@ pipeline {
         }
         stage('Run checks') {
             steps {
-                sh '.ci/setenvconfig dev/build'
                 sh 'make -C .ci license.key TARGET=ci-check ci'
             }
         }


### PR DESCRIPTION
This fixes a side effect of #6465 which causes an issue in the Jenkins job `cloud-on-k8s-e2e-tests-snapshot-versions` by ensuring the environment is set before any call to `make -C .ci ci`.

The first step `make -C .ci TARGET=validate-jenkins-pipelines ci` causes the fetch of the prod public license key.
Next `.ci/setenvconfig dev/build` sets `BUILD_LICENSE_PUBKEY=dev`. Because the `.ci/license.key` already exists, the dev license public key to test snapshots is not retrieved.

This is more of a quick fix as this job is revisited on Buildkite.