### PR TITLE
[ci/eks] Force the use of the e2e storage class when testing recipes

### DIFF
--- a/test/e2e/test/helper/yaml.go
+++ b/test/e2e/test/helper/yaml.go
@@ -244,7 +244,8 @@ func transformToE2E(namespace, fullTestName, suffix string, transformers []Build
 				WithSuffix(suffix).
 				WithRestrictedSecurityContext().
 				WithLabel(run.TestNameLabel, fullTestName).
-				WithPodLabel(run.TestNameLabel, fullTestName)
+				WithPodLabel(run.TestNameLabel, fullTestName).
+				WithDefaultPersistentVolumes() // to force the use of our e2e storage class which relies on local volume provisioner
 		case *kbv1.Kibana:
 			b := kibana.NewBuilderWithoutSuffix(decodedObj.Name)
 			b.Kibana = *decodedObj

--- a/test/e2e/test/helper/yaml.go
+++ b/test/e2e/test/helper/yaml.go
@@ -240,12 +240,19 @@ func transformToE2E(namespace, fullTestName, suffix string, transformers []Build
 		case *esv1.Elasticsearch:
 			b := elasticsearch.NewBuilderWithoutSuffix(decodedObj.Name)
 			b.Elasticsearch = *decodedObj
-			builder = b.WithNamespace(namespace).
+			b = b.WithNamespace(namespace).
 				WithSuffix(suffix).
 				WithRestrictedSecurityContext().
 				WithLabel(run.TestNameLabel, fullTestName).
-				WithPodLabel(run.TestNameLabel, fullTestName).
-				WithDefaultPersistentVolumes() // to force the use of our e2e storage class which relies on local volume provisioner
+				WithPodLabel(run.TestNameLabel, fullTestName)
+
+			// for EKS, we set our e2e storage class to use local volumes instead of depending on the default storage class that uses
+			// network storage because from k8s 1.23 network storage requires the installation of the Amazon EBS CSI driver and the
+			// deployer does not yet support this. See https://github.com/elastic/cloud-on-k8s/issues/6515.
+			if strings.HasPrefix(test.Ctx().Provider, "eks") {
+				b = b.WithDefaultPersistentVolumes()
+			}
+			builder = b
 		case *kbv1.Kibana:
 			b := kibana.NewBuilderWithoutSuffix(decodedObj.Name)
 			b.Kibana = *decodedObj


### PR DESCRIPTION
This forces the use of our storage class and therefore stops using EBS when testing recipes for EKS.

It's a quick fix to solve #6515. It remains to be discussed later if we keep this or if we prefer to continue doing a few tests relying on network attached storage and thus do the work to install the Amazon EBS CSI driver in EKS.

Relates to #6515.