### PR TITLE
[ci/jks] Disable tags discovery in release job

### DIFF
--- a/.ci/jobs/build-release.yml
+++ b/.ci/jobs/build-release.yml
@@ -13,7 +13,7 @@
             credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
           repo: 'cloud-on-k8s'
           repo-owner: 'elastic'
-          discover-tags: true
+          discover-tags: false
           wipe-workspace: true
           branch-discovery: false
           discover-pr-forks-strategy: false


### PR DESCRIPTION
Let's disable the tags discovery in the Jenkins release job to start to release with Buildkite.
We can still run it manually.

