### PR TITLE
[ci/bk] Support release for tags prefixed with 'v'

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,7 +21,9 @@ steps:
         command: "make generate check-local-changes"
 
       - label: ":go: checks"
-        commands: "make check-license-header check-predicates shellcheck reattach-pv"
+        commands:
+          - "make check-license-header check-predicates shellcheck reattach-pv"
+          - .buildkite/scripts/build/setenv_test.sh
 
   - group: tests
     steps:

--- a/.buildkite/scripts/build/setenv_test.sh
+++ b/.buildkite/scripts/build/setenv_test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")"; pwd)/../../.."
+
+current_version=$(cat VERSION)
+current_sha1=$(git rev-parse --short=8 --verify HEAD)
+
+setenv=$ROOT/.buildkite/scripts/build/setenv.sh 
+
+TOTAL=0
+OK=0
+KO=0
+assert_image() {
+    TOTAL=$((TOTAL+1))
+    expected=$1
+    got=$(make print-operator-image)
+    grep -q "$expected$" <<< "$got"
+    if [[ $? != 0 ]]; then
+        KO=$((KO+1))
+        echo " 🔴 expected: $expected"
+        echo " 🔴 got:      $got"
+    else
+        OK=$((OK+1))
+        echo " 🟢  $got"
+    fi
+    echo "--"
+}
+
+export BUILDKITE_BUILD_NUMBER=999999999999999
+
+echo "test trigger_pr"; BUILDKITE_PULL_REQUEST="4242" $setenv > /dev/null
+assert_image "docker.elastic.co/eck-ci/eck-operator-pr:4242-${current_sha1}"
+
+echo "test trigger_nightly_main"; BUILDKITE_BRANCH="main" BUILDKITE_SOURCE="schedule" $setenv > /dev/null
+assert_image "docker.elastic.co/eck-ci/eck-operator-nightly:${current_version}-${current_sha1}"
+
+echo "test trigger_nightly_main-dev"; BUILDKITE_BRANCH="main" BUILDKITE_SOURCE="schedule" BUILD_LICENSE_PUBKEY=dev $setenv > /dev/null
+assert_image "docker.elastic.co/eck-ci/eck-operator-nightly:${current_version}-${current_sha1}-dev"
+
+echo "test trigger_merge_main"; BUILDKITE_BRANCH="main" $setenv > /dev/null
+assert_image "docker.elastic.co/eck-snapshots/eck-operator:${current_version}-${current_sha1}"
+
+echo "test trigger_tag"; BUILDKITE_TAG="v1.2.3" $setenv build > /dev/null
+assert_image "docker.elastic.co/eck/eck-operator:v1.2.3"
+
+echo "test trigger_vtag"; BUILDKITE_TAG="v1.2.3" $setenv build > /dev/null
+assert_image "docker.elastic.co/eck/eck-operator:v1.2.3"
+
+echo "test trigger_vtagbc"; BUILDKITE_TAG="v1.2.3-bc1" $setenv build > /dev/null
+assert_image "docker.elastic.co/eck/eck-operator:v1.2.3-bc1"
+
+echo "test trigger_branch"; BUILDKITE_BRANCH="4.2" BUILDKITE_PULL_REQUEST="false" $setenv > /dev/null
+assert_image "docker.elastic.co/eck-ci/eck-operator-branch:${current_version}-${current_sha1}"
+
+echo "Passed: $OK/$TOTAL"
+if [[ "$KO" -gt 0 ]]; then
+    exit 1
+fi

--- a/.buildkite/scripts/build/setenv_test.sh
+++ b/.buildkite/scripts/build/setenv_test.sh
@@ -4,9 +4,10 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 
-set -u
+set -eu
 
-ROOT="$(cd "$(dirname "$0")"; pwd)/../../.."
+WD="$(cd "$(dirname "$0")"; pwd)"
+ROOT="$WD/../../.."
 
 current_version=$(cat VERSION)
 current_sha1=$(git rev-parse --short=8 --verify HEAD)
@@ -20,8 +21,7 @@ assert_image() {
     TOTAL=$((TOTAL+1))
     expected=$1
     got=$(make print-operator-image)
-    grep -q "$expected$" <<< "$got"
-    if [[ $? != 0 ]]; then
+    if ! grep -q "$expected$" <<< "$got"; then
         KO=$((KO+1))
         echo " 🔴 expected: $expected"
         echo " 🔴 got:      $got"

--- a/.buildkite/scripts/common/lib.sh
+++ b/.buildkite/scripts/common/lib.sh
@@ -49,7 +49,7 @@ is_not_buildkite() {
 }
 
 is_tag() {
-    [[ "${BUILDKITE_TAG:-}" =~ ^[0-9]+.[0-9]+.[0-9]+ ]] && return 0 || return 1
+    [[ "${BUILDKITE_TAG:-}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+ ]] && return 0 || return 1
 }
 
 is_merge_main() {


### PR DESCRIPTION
This changes the tag detection function to support tags prefixed with 'v'. This function is used to set the build context and so and influences the name of artifacts ([code](https://github.com/elastic/cloud-on-k8s/blob/41b7b9df5dae5bb45976d9c40ef669a737d958f7/.buildkite/scripts/build/setenv.sh#L60-L88)). We could just check that `BUILDKITE_TAG` is not empty in this function, but it seemed to me that a basic check couldn't hurt. I was a bit wrong.