### PR TITLE
[ci/bk] Dry run Helm chart release only if test

### DIFF
--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -14,7 +14,7 @@ steps:
         commands:
           - buildkite-agent artifact download "bin/releaser" /usr/local/
           - chmod u+x /usr/local/bin/releaser
-          - releaser --env=dev --charts-dir=deploy/eck-operator
+          - releaser --env=dev --charts-dir=deploy/eck-operator --dry-run=\$DRY_RUN
 
       - label: "eck-resources dev helm charts"
         if: |
@@ -28,7 +28,7 @@ steps:
         commands:
           - buildkite-agent artifact download "bin/releaser" /usr/local/
           - chmod u+x /usr/local/bin/releaser
-          - releaser --env=dev --excludes=eck-operator
+          - releaser --env=dev --excludes=eck-operator --dry-run=\$DRY_RUN
 
       - label: "operator prod helm chart"
         if: build.message == "release eck-operator helm charts"
@@ -38,7 +38,7 @@ steps:
         commands:
           - buildkite-agent artifact download "bin/releaser" /usr/local/
           - chmod u+x /usr/local/bin/releaser
-          - releaser --env=prod --charts-dir=deploy/eck-operator
+          - releaser --env=prod --charts-dir=deploy/eck-operator --dry-run=\$DRY_RUN
 
       - label: "eck-resources prod helm charts"
         if: build.message == "release eck-resources helm charts"
@@ -48,4 +48,4 @@ steps:
         commands:
           - buildkite-agent artifact download "bin/releaser" /usr/local/
           - chmod u+x /usr/local/bin/releaser
-          - releaser --env=prod --excludes=eck-operator
+          - releaser --env=prod --excludes=eck-operator --dry-run=\$DRY_RUN

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -118,10 +118,20 @@ steps:
   - label: ":buildkite:"
     depends_on:
       - "operator-image-build"
+    if: build.message =~ /^buildkite test .*release.*/
+    env:
+      DRY_RUN: true
+    commands:
+      - buildkite-agent pipeline upload .buildkite/pipeline-release.yml
+
+  - label: ":buildkite:"
+    depends_on:
+      - "operator-image-build"
     if: |
       ( build.branch == "main" && build.source != "schedule" )
       || build.tag != null
       || build.message =~ /^release eck/
-      || build.message =~ /^buildkite test .*release.*/
+    env:
+      DRY_RUN: false
     commands:
       - buildkite-agent pipeline upload .buildkite/pipeline-release.yml


### PR DESCRIPTION
This makes `DRY_RUN=true` when doing Helm chart release only when this was triggered with the build message `buildkite test release`. In other contexts, for a merge-main build, a tag build or a build message starting with `release eck`, the Helm chart release is performed.