### PR TITLE
Use Docker run cache in dockerfile to speed up "go mod download" step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,14 @@ WORKDIR /go/src/github.com/elastic/cloud-on-k8s
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 COPY ["go.mod", "go.sum", "./"]
-RUN go mod download
+RUN --mount=type=cache,mode=0755,target=/go/pkg/mod go mod download
 
 # Copy the go source
 COPY pkg/    pkg/
 COPY cmd/    cmd/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux \
+RUN --mount=type=cache,mode=0755,target=/go/pkg/mod CGO_ENABLED=0 GOOS=linux \
       go build \
       -mod readonly \
       -ldflags "$GO_LDFLAGS" -tags="$GO_TAGS" -a \


### PR DESCRIPTION
This change may not benefit CI, but it certainly makes a difference locally:
https://docs.docker.com/build/cache/#use-the-dedicated-run-cache

Before:
```
#11 [builder 4/7] RUN go mod download
#11 sha256:afb98e5b1dc5bdaece9b7d6cf4d492ad40326f5fd2bff431cb752685e0e644d8
#11 DONE 37.1s
```

After:
```
#11 [builder 4/7] RUN --mount=type=cache,mode=0755,target=/go/pkg/mod go mod download
#11 sha256:2209421556ce85002e395ad4af5cc292b67bb5fef026f4e418721b1890afb92e
#11 DONE 0.3s
```