### PR TITLE
[ci] Run setenv_test.sh in a clean env

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,7 +23,7 @@ steps:
       - label: ":go: checks"
         commands:
           - "make check-license-header check-predicates shellcheck reattach-pv"
-          - .buildkite/scripts/build/setenv_test.sh
+          - env -i .buildkite/scripts/build/setenv_test.sh
 
   - group: tests
     steps:


### PR DESCRIPTION
`setenv_test.sh` introduced in #6538 fails when building `main` at `trigger_pr` test because environment is set for `main`...

```sh
test trigger_pr
--
 🔴 expected: docker.elastic.co/eck-ci/eck-operator-pr:4242-e3991cc3
 🔴 got:      docker.elastic.co/eck-snapshots/eck-operator:2.8.0-SNAPSHOT-e3991cc3
--
```

I hesitated between removing it or trying to fix it. Finally the fix is quite clean.