### PR TITLE
Ensure when dry-run isn't set that 'latest' tag is set on pushed image.

### DIFF
--- a/hack/operatorhub/internal/container/container.go
+++ b/hack/operatorhub/internal/container/container.go
@@ -220,7 +220,7 @@ func getFirstUndeletedImage(images []Image) *Image {
 // container image locally, and push it to Quay.io registry using the
 // provided credentials.
 func pushImageToRegistry(c PushConfig) error {
-	if c.DryRun {
+	if c.DryRun && !c.Force {
 		log.Printf("not pushing image as dry-run is set.")
 		return nil
 	}
@@ -236,7 +236,8 @@ func pushImageToRegistry(c PushConfig) error {
 		log.Println("ⅹ")
 		return fmt.Errorf("while pulling (%s): %w", imageToPull, err)
 	}
-	log.Printf("pushing image (%s) to quay.io registry: ", formattedEckOperatorRedhatReference)
+	log.Println("✓")
+	log.Printf("pushing image (%s) to quay.io registry\n", formattedEckOperatorRedhatReference)
 	err = crane.Push(
 		image,
 		formattedEckOperatorRedhatReference,
@@ -251,7 +252,19 @@ func pushImageToRegistry(c PushConfig) error {
 		log.Println("ⅹ")
 		return fmt.Errorf("while pushing (%s): %w", formattedEckOperatorRedhatReference, err)
 	}
-	log.Println("✓")
+	// Since we only push when dry-run isn't set, go ahead and
+	// tag this image as 'latest' such that it shows up at the
+	// top of the RedHat Catalog.
+	log.Printf("tagging (%s) as 'latest' in quay.io registry\n", formattedEckOperatorRedhatReference)
+	err = crane.Tag(
+		formattedEckOperatorRedhatReference, "latest",
+		crane.WithAuth(&authn.Basic{
+			Username: username,
+			Password: c.RegistryPassword}),
+	)
+	if err != nil {
+		return fmt.Errorf("while tagging (%s) as 'latest': %w", formattedEckOperatorRedhatReference, err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
closes #6511 

Recent releases of ECK Operator into operatorhub/Redhat ecosystem hasn't had the image tagged as `latest`. This change ensure that when `dry-run` is set to `false` the image is tagged as `latest` in `quay.io`.

Local test run below on recent `2.6.1` image successfully added the `latest` tag
```
❯ make build && ./bin/operatorhub container push --redacted-flags-- --enable-vault=false -F --dry-run=false
go build -o bin/operatorhub main.go
2023/03/20 13:53:24 Determining if image already exists within project with tag: 2.6.1
2023/03/20 13:53:25 pushing image as force was set
2023/03/20 13:53:25 pulling image (docker.elastic.co/eck/eck-operator-ubi8:2.6.1) in preparation to push (quay.io/redhat-isv-containers/5fa1f9fc4bbec60adbc8cc94:2.6.1) to quay.io registry:
2023/03/20 13:53:27 pushing image (quay.io/redhat-isv-containers/5fa1f9fc4bbec60adbc8cc94:2.6.1) to quay.io registry:
2023/03/20 13:53:29 ✓
2023/03/20 13:53:29 tagging (quay.io/redhat-isv-containers/5fa1f9fc4bbec60adbc8cc94:2.6.1) as 'latest' in quay.io registry:
2023/03/20 13:53:30 ✓
```

![image](https://user-images.githubusercontent.com/4429174/226439758-a8772689-56d4-4758-8d2a-ed1c8ad68895.png)
