### PR TITLE
Fix Helm Release Tool: Missing parent helm charts.

### DIFF
--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -34,15 +34,15 @@ steps:
           - chmod u+x /usr/local/bin/releaser
           - releaser --env=dev --excludes=eck-operator --dry-run=\$DRY_RUN
 
-      # - label: "operator prod helm chart"
-      #   if: build.message == "release eck-operator helm charts"
-      #   depends_on:
-      #     - "build-helm-releaser-tool"
-      #     - "eck-operator-dev-helm"
-      #   commands:
-      #     - buildkite-agent artifact download "bin/releaser" /usr/local/
-      #     - chmod u+x /usr/local/bin/releaser
-      #     - releaser --env=prod --charts-dir=deploy/eck-operator --dry-run=\$DRY_RUN
+      - label: "operator prod helm chart"
+        if: build.message == "release eck-operator helm charts"
+        depends_on:
+          - "build-helm-releaser-tool"
+          - "eck-operator-dev-helm"
+        commands:
+          - buildkite-agent artifact download "bin/releaser" /usr/local/
+          - chmod u+x /usr/local/bin/releaser
+          - releaser --env=prod --charts-dir=deploy/eck-operator --dry-run=\$DRY_RUN
 
       - label: "eck-resources prod helm charts"
         if: build.message == "release eck-resources helm charts"

--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -34,15 +34,15 @@ steps:
           - chmod u+x /usr/local/bin/releaser
           - releaser --env=dev --excludes=eck-operator --dry-run=\$DRY_RUN
 
-      - label: "operator prod helm chart"
-        if: build.message == "release eck-operator helm charts"
-        depends_on:
-          - "build-helm-releaser-tool"
-          - "eck-operator-dev-helm"
-        commands:
-          - buildkite-agent artifact download "bin/releaser" /usr/local/
-          - chmod u+x /usr/local/bin/releaser
-          - releaser --env=prod --charts-dir=deploy/eck-operator --dry-run=\$DRY_RUN
+      # - label: "operator prod helm chart"
+      #   if: build.message == "release eck-operator helm charts"
+      #   depends_on:
+      #     - "build-helm-releaser-tool"
+      #     - "eck-operator-dev-helm"
+      #   commands:
+      #     - buildkite-agent artifact download "bin/releaser" /usr/local/
+      #     - chmod u+x /usr/local/bin/releaser
+      #     - releaser --env=prod --charts-dir=deploy/eck-operator --dry-run=\$DRY_RUN
 
       - label: "eck-resources prod helm charts"
         if: build.message == "release eck-resources helm charts"

--- a/hack/helm/release/internal/helm/helm.go
+++ b/hack/helm/release/internal/helm/helm.go
@@ -243,7 +243,7 @@ func uploadChartsAndUpdateIndex(conf uploadChartsConfig) error {
 	// eck-resources charts, and that new version is just released, then
 	// it will take ~ one hour for it to show up, so we will continue trying
 	// to get all dependencies of the helm charts, and upload them for 1 hour.
-	retry.Do(
+	err = retry.Do(
 		func() error {
 			log.Printf("attempting to update helm repository for charts with dependencies")
 			if err := updateHelmRepositories(); err != nil {
@@ -273,6 +273,9 @@ func uploadChartsAndUpdateIndex(conf uploadChartsConfig) error {
 			log.Printf("retry #%d: %s\n", n, err)
 		}),
 	)
+	if err != nil {
+		return fmt.Errorf("while processing charts with dependencies: %w", err)
+	}
 
 	return nil
 }

--- a/hack/helm/release/internal/helm/helm.go
+++ b/hack/helm/release/internal/helm/helm.go
@@ -363,7 +363,7 @@ func uploadCharts(ctx context.Context, tempDir string, charts []chart, conf Rele
 // to the local Helm configuration.
 func addHelmRepository(name, url string) error {
 	settings := cli.New()
-	// Ensure the file directory exists
+	// Ensure the configuration file's directory path exists
 	err := os.MkdirAll(filepath.Dir(settings.RepositoryConfig), os.ModePerm)
 	if err != nil && !os.IsExist(err) {
 		return err
@@ -388,7 +388,9 @@ func addHelmRepository(name, url string) error {
 
 	c := repo.Entry{
 		Name: name,
-		URL:  strings.TrimSuffix(url, "/helm"),
+		// The index (index.yaml) for both production and dev exist at '/', not '/helm'
+		// which is where the helm data exists so trim the '/helm' suffix.
+		URL: strings.TrimSuffix(url, "/helm"),
 	}
 
 	f.Update(&c)

--- a/hack/helm/release/internal/helm/helm_test.go
+++ b/hack/helm/release/internal/helm/helm_test.go
@@ -101,11 +101,6 @@ func Test_separateChartsWithDependencies(t *testing.T) {
 }
 
 func Test_readCharts(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.FailNow()
-		return
-	}
 	tests := []struct {
 		name          string
 		existingPath  string
@@ -140,61 +135,25 @@ func Test_readCharts(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		{
-			name:          "existing charts is correct",
-			existingPath:  filepath.Join(cwd, "..", "..", "..", "..", "..", "deploy", "eck-operator"),
-			chartsToWrite: nil,
-			excludes:      nil,
-			want: []chart{
-				{
-					Name:    "eck-operator",
-					Version: "2.8.0-SNAPSHOT",
-					Dependencies: []dependency{
-						{
-							Name:    "eck-operator-crds",
-							Version: "2.8.0-SNAPSHOT",
-						},
-					},
-				},
-				{
-					Name:         "eck-operator-crds",
-					Version:      "2.8.0-SNAPSHOT",
-					Dependencies: nil,
-				},
-			},
-			wantErr: false,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			path := tt.existingPath
-			if tt.existingPath == "" {
-				dir, err := os.MkdirTemp(os.TempDir(), "readCharts")
-				if err != nil {
-					t.Errorf(fmt.Sprintf("failed making temporary directory: %s", err))
-					return
-				}
-				path = dir
-				for _, ch := range tt.chartsToWrite {
-					mustWriteChart(t, dir, ch)
-				}
-				defer os.RemoveAll(dir)
-			} else {
-				t.Logf("using path: %s", tt.existingPath)
+			dir, err := os.MkdirTemp(os.TempDir(), "readCharts")
+			if err != nil {
+				t.Errorf(fmt.Sprintf("failed making temporary directory: %s", err))
+				return
 			}
-			got, err := readCharts(path, tt.excludes)
+			defer os.RemoveAll(dir)
+			for _, ch := range tt.chartsToWrite {
+				mustWriteChart(t, dir, ch)
+			}
+			got, err := readCharts(dir, tt.excludes)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("readCharts() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !cmp.Equal(got, tt.want, cmpopts.IgnoreFields(chart{}, "fullPath")) {
 				t.Errorf("readCharts() = diff: %s", cmp.Diff(got, tt.want, cmpopts.IgnoreFields(chart{}, "fullPath")))
-			}
-			noDeps, withDeps := separateChartsWithDependencies(got)
-			t.Logf("got no deps: %+v", noDeps)
-			t.Logf("got deps: %+v", withDeps)
-			if len(noDeps)+len(withDeps) != len(got) {
-				t.Errorf("separateChartsWithDependencies: total deps (%d) + no deps (%d) != charts from readCharts (%d)", len(withDeps), len(noDeps), len(got))
 			}
 		})
 	}


### PR DESCRIPTION
resolves #6552 

The actual error that was causing this was:

```
2023/03/21 14:44:29 attempting to update helm repository for charts with dependencies
Error: while processing charts with dependencies: All attempts fail:
#1: while loading repository file: couldn't load repositories file (/root/.config/helm/repositories.yaml): open /root/.config/helm/repositories.yaml: no such file or directory
```

which was getting ignored/swallowed as we weren't checking the return value of `retry.Do`, which is only used in the case of helm charts with dependencies, which is why the parent helm charts were missing.

## Changes
1. Check the error coming back from `retry.Do`
2. Actually write the repository information to the `RepositoryConfig`, which in the case of docker is `/root/.config/helm/repositories.yaml`.