### PR TITLE
Fix publish dockerhub

### DIFF
--- a/hack/publish-dockerhub.sh
+++ b/hack/publish-dockerhub.sh
@@ -25,11 +25,11 @@ vault_login() {
 
 registry_login() {
     if [[ "${DRY_RUN:-}" == "false" ]]; then
+        username=$(vault read -field=username secret/release/docker-hub-eck)
+        password=$(vault read -field=token    secret/release/docker-hub-eck)
+    else
         username=$(vault read -field=username secret/devops-ci/cloud-on-k8s/docker-registry-elastic)
         password=$(vault read -field=password secret/devops-ci/cloud-on-k8s/docker-registry-elastic)
-    else
-        username=$(vault read -field=username secret/release/docker-hub-eck)
-        password=$(vault read -field=token secret/release/docker-hub-eck)
     fi
 
     docker login -u "$username" -p "$password" 2> /dev/null

--- a/hack/publish-dockerhub.sh
+++ b/hack/publish-dockerhub.sh
@@ -36,19 +36,26 @@ registry_login() {
 }
 
 publish() {
-    local name=$1
+    local image_name=$1
 
-    REGISTRY_SRC="docker.elastic.co/eck"
-    REGISTRY_DST="docker.elastic.co/eck-dev"
-
-    if [[ "${DRY_RUN:-}" == "false" ]]; then
-        REGISTRY_DST="docker.io/elastic"
-    fi
-
-    docker buildx imagetools create -t "$REGISTRY_DST/$name:$ECK_VERSION" "$REGISTRY_SRC/$name:$ECK_VERSION"
+    docker buildx imagetools create \
+        -t "$REGISTRY_DST/$NAMESPACE_DST/$image_name:$ECK_VERSION" \
+        "$REGISTRY_SRC/$NAMESPACE_SRC/$image_name:$ECK_VERSION"
 }
 
 # main
+
+REGISTRY_SRC=docker.elastic.co
+NAMESPACE_SRC=eck
+
+# default values of dry run
+REGISTRY_DST=docker.elastic.co
+NAMESPACE_DST=eck-ci
+
+if [[ "${DRY_RUN:-}" == "false" ]]; then
+    REGISTRY_DST="docker.io"
+    NAMESPACE_DST=elastic
+fi
 
 if [[ "${ECK_VERSION:-}" == "" ]]; then
     echo "ECK_VERSION must be set"

--- a/hack/publish-dockerhub.sh
+++ b/hack/publish-dockerhub.sh
@@ -12,7 +12,7 @@ set -eu
 install_docker_extension() {
     [[ -f ~/.docker/cli-plugins/docker-buildx ]] && return
 
-    DOCKER_BUILDX_VERSION=0.8.2
+    DOCKER_BUILDX_VERSION=0.10.4
     mkdir -p ~/.docker/cli-plugins
     curl -fsSLo ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v${DOCKER_BUILDX_VERSION}/buildx-v${DOCKER_BUILDX_VERSION}.linux-arm64
     chmod a+x ~/.docker/cli-plugins/docker-buildx

--- a/hack/publish-dockerhub.sh
+++ b/hack/publish-dockerhub.sh
@@ -10,7 +10,7 @@
 set -eu
 
 install_docker_extension() {
-    [[ ! -f ~/.docker/cli-plugins/docker-buildx ]] && return
+    [[ -f ~/.docker/cli-plugins/docker-buildx ]] && return
 
     DOCKER_BUILDX_VERSION=0.8.2
     mkdir -p ~/.docker/cli-plugins

--- a/hack/publish-dockerhub.sh
+++ b/hack/publish-dockerhub.sh
@@ -32,7 +32,7 @@ registry_login() {
         password=$(vault read -field=password secret/devops-ci/cloud-on-k8s/docker-registry-elastic)
     fi
 
-    docker login -u "$username" -p "$password" 2> /dev/null
+    docker login -u "$username" -p "$password" "$REGISTRY_DST" 2> /dev/null
 }
 
 publish() {

--- a/hack/publish-dockerhub.sh
+++ b/hack/publish-dockerhub.sh
@@ -14,7 +14,7 @@ install_docker_extension() {
 
     DOCKER_BUILDX_VERSION=0.10.4
     mkdir -p ~/.docker/cli-plugins
-    curl -fsSLo ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v${DOCKER_BUILDX_VERSION}/buildx-v${DOCKER_BUILDX_VERSION}.linux-arm64
+    curl -fsSLo ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v${DOCKER_BUILDX_VERSION}/buildx-v${DOCKER_BUILDX_VERSION}.linux-amd64
     chmod a+x ~/.docker/cli-plugins/docker-buildx
 }
 

--- a/hack/publish-dockerhub.sh
+++ b/hack/publish-dockerhub.sh
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 
 # Script to publish ECK operator image from docker.elastic.co/eck registry to docker.io/elastic registry (aka Docker Hub).
-# By default, the script is executed with DRY_RUN=true and images are published to docker.elastic.co/eck-dev registry.
+# By default, the script is executed with DRY_RUN=true and images are published to docker.elastic.co/eck-ci registry.
 
 set -eu
 
@@ -45,13 +45,15 @@ publish() {
 
 # main
 
+# source of images to copy
 REGISTRY_SRC=docker.elastic.co
 NAMESPACE_SRC=eck
 
+# destination of images to copy
 # default values of dry run
 REGISTRY_DST=docker.elastic.co
 NAMESPACE_DST=eck-ci
-
+# dockerhub values for live execution
 if [[ "${DRY_RUN:-}" == "false" ]]; then
     REGISTRY_DST="docker.io"
     NAMESPACE_DST=elastic


### PR DESCRIPTION
This fixes several bugs in the `publish-dockerhub.sh` script.

- The credentials stored in the `docker-registry-elastic` secret cannot push to the `eck-dev` namespace of the Elastic Docker registry, only to `eck-ci`. That is the reason of the error `server message: insufficient_scope: authorization failed`.
- The test to check if docker buildx should be installed is inverted.
- The docker buildx version `v0.8.2` does not support multiple repositories, we need to install at least `v0.9.0` to have it.
- The URL to install docker buildx is wrong, it is the one for arm instead of amd.
- The docker login command doesn't have the name of the registry, required in dry run mode to be authenticated to the Elastic Docker registry.
- The secret to use in dry-run mode to get the docker registry creds is inverted with the one to use in live mode.