### PR TITLE
Fleet server QuickStart: use emptyDir for the agent-data volumes

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -44,6 +44,9 @@ spec:
         automountServiceAccountToken: true
         securityContext:
           runAsUser: 0
+        volumes:
+        - name: agent-data
+          emptyDir: {} # may not be suited for production, the default value is to use host path volume
 ---
 apiVersion: agent.k8s.elastic.co/v1alpha1
 kind: Agent
@@ -64,6 +67,9 @@ spec:
         automountServiceAccountToken: true
         securityContext:
           runAsUser: 0
+        volumes:
+        - name: agent-data
+          emptyDir: {} # may not be suited for production, the default value is to use host path volume
 ---
 apiVersion: kibana.k8s.elastic.co/v1
 kind: Kibana

--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -44,9 +44,6 @@ spec:
         automountServiceAccountToken: true
         securityContext:
           runAsUser: 0
-        volumes:
-        - name: agent-data
-          emptyDir: {} # may not be suited for production, the default value is to use host path volume
 ---
 apiVersion: agent.k8s.elastic.co/v1alpha1
 kind: Agent
@@ -69,7 +66,7 @@ spec:
           runAsUser: 0
         volumes:
         - name: agent-data
-          emptyDir: {} # may not be suited for production, the default value is to use host path volume
+          emptyDir: {}
 ---
 apiVersion: kibana.k8s.elastic.co/v1
 kind: Kibana


### PR DESCRIPTION

The default value is to use a host path Volume, that can be restricted by a podSecurityPolicy.
When there is such a podSecurityPolicy, the pod is not created and the cause of the error is lost in the event of the ECK created ReplicaSet. But in the `fleet-server-quickstart` events you can see a reconciliation error: `Reconciliation error: failed to request https://kibana-quickstart-kb-http.default.svc:5601/api/fleet/setup, status is 401` which is not the real problem.

This proposed change would avoid this situation by following the [workaround that we have when host path is not possible](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-known-limitations.html#k8s_storing_local_state_in_host_path_volume_2). This is not optimal for production but this is a QuickStart  ;-)
 

