### PR TITLE
Fix tanzu state persistence

### DIFF
--- a/.buildkite/e2e/nightly-main-matrix.yaml
+++ b/.buildkite/e2e/nightly-main-matrix.yaml
@@ -72,10 +72,6 @@
   fixed:
     E2E_PROVIDER: aks
 
-# Disable Tanzu until the install state directory persistence bug is fixed (https://github.com/elastic/cloud-on-k8s/issues/6576)
-# to be able to separate the cluster creation from the tests runner execution. 
-# Otherwise, the tests runner fails because the vault token has expired because the cluster creation takes longer than the token lifetime.
-
-# - label: tanzu
-#   fixed:
-#     E2E_PROVIDER: tanzu
+- label: tanzu
+  fixed:
+    E2E_PROVIDER: tanzu

--- a/hack/deployer/runner/azure/azure.go
+++ b/hack/deployer/runner/azure/azure.go
@@ -68,6 +68,7 @@ func Cmd(args ...string) *exec.Command {
 	cmd := exec.NewCommand(`docker run --rm \
 		-v {{.SharedVolume}}:/home \
 		-e HOME=/home \
+		-w /home \
 		{{.ClientImage}} \
 		az {{Join .Args " "}}`)
 	return cmd.AsTemplate(params)

--- a/hack/deployer/runner/tanzu.go
+++ b/hack/deployer/runner/tanzu.go
@@ -187,7 +187,7 @@ func (t *TanzuDriver) ensureWorkDir() error {
 	if workDir == "" {
 		// base work dir in HOME dir otherwise mounting to container won't work without further settings adjustment
 		// in macOS in local mode. In CI mode we need the workdir to be in the volume shared between containers.
-		workDir := filepath.Join(os.Getenv("HOME"), t.plan.ClusterName)
+		workDir = filepath.Join(os.Getenv("HOME"), t.plan.ClusterName)
 		log.Printf("Defaulting WorkDir: %s", workDir)
 	}
 

--- a/hack/deployer/runner/tanzu.go
+++ b/hack/deployer/runner/tanzu.go
@@ -429,7 +429,7 @@ func (t TanzuDriver) deleteStorageContainer() error {
 func (t *TanzuDriver) persistInstallerState() error {
 	log.Println("Persisting installer state to Azure storage container")
 	return azure.Cmd("storage", "azcopy", "blob", "upload", "--recursive",
-		"-c", t.plan.ClusterName, "--account-name", t.azureStorageAccount, "-s", t.installerStateDirPath).
+		"-c", t.plan.ClusterName, "--account-name", t.azureStorageAccount, "-s", t.installerStateDirBasename).
 		WithoutStreaming().Run()
 }
 

--- a/hack/deployer/runner/tanzu.go
+++ b/hack/deployer/runner/tanzu.go
@@ -188,11 +188,6 @@ func (t *TanzuDriver) ensureWorkDir() error {
 		// base work dir in HOME dir otherwise mounting to container won't work without further settings adjustment
 		// in macOS in local mode. In CI mode we need the workdir to be in the volume shared between containers.
 		workDir := filepath.Join(os.Getenv("HOME"), t.plan.ClusterName)
-		if _, err := os.Stat(workDir); os.IsNotExist(err) {
-			if err := os.Mkdir(workDir, os.ModePerm); err != nil {
-				return err
-			}
-		}
 		log.Printf("Defaulting WorkDir: %s", workDir)
 	}
 

--- a/hack/deployer/runner/tanzu.go
+++ b/hack/deployer/runner/tanzu.go
@@ -428,7 +428,7 @@ func (t TanzuDriver) deleteStorageContainer() error {
 
 func (t *TanzuDriver) persistInstallerState() error {
 	log.Println("Persisting installer state to Azure storage container")
-	return azure.Cmd("storage", "azcopy", "blob", "sync",
+	return azure.Cmd("storage", "azcopy", "blob", "upload", "--recursive",
 		"-c", t.plan.ClusterName, "--account-name", t.azureStorageAccount, "-s", t.installerStateDirPath).
 		WithoutStreaming().Run()
 }

--- a/hack/deployer/runner/tanzu.go
+++ b/hack/deployer/runner/tanzu.go
@@ -429,15 +429,16 @@ func (t TanzuDriver) deleteStorageContainer() error {
 func (t *TanzuDriver) persistInstallerState() error {
 	log.Println("Persisting installer state to Azure storage container")
 	return azure.Cmd("storage", "azcopy", "blob", "upload", "--recursive",
-		"-c", t.plan.ClusterName, "--account-name", t.azureStorageAccount, "-s", t.installerStateDirBasename).
+		"-c", t.plan.ClusterName, "--account-name", t.azureStorageAccount,
+		"-s", fmt.Sprintf("'%s/*'", t.installerStateDirBasename)).
 		WithoutStreaming().Run()
 }
 
 func (t *TanzuDriver) restoreInstallerState() error {
 	log.Println("Restoring installer state from storage container if any")
-	return azure.Cmd("storage", "azcopy", "blob", "download",
+	return azure.Cmd("storage", "azcopy", "blob", "download", "--recursive",
 		"-c", t.plan.ClusterName, "--account-name", t.azureStorageAccount,
-		"-s", "'*'", "-d", t.installerStateDirPath, "--recursive").
+		"-s", "'*'", "-d", t.installerStateDirBasename).
 		WithoutStreaming().Run()
 }
 

--- a/hack/deployer/runner/tanzu.go
+++ b/hack/deployer/runner/tanzu.go
@@ -187,11 +187,7 @@ func (t *TanzuDriver) ensureWorkDir() error {
 	if workDir == "" {
 		// base work dir in HOME dir otherwise mounting to container won't work without further settings adjustment
 		// in macOS in local mode. In CI mode we need the workdir to be in the volume shared between containers.
-		var err error
-		workDir, err = os.MkdirTemp(os.Getenv("HOME"), t.plan.ClusterName)
-		if err != nil {
-			return err
-		}
+		workDir := filepath.Join(os.Getenv("HOME"), t.plan.ClusterName)
 		log.Printf("Defaulting WorkDir: %s", workDir)
 	}
 

--- a/hack/deployer/runner/tanzu.go
+++ b/hack/deployer/runner/tanzu.go
@@ -188,6 +188,11 @@ func (t *TanzuDriver) ensureWorkDir() error {
 		// base work dir in HOME dir otherwise mounting to container won't work without further settings adjustment
 		// in macOS in local mode. In CI mode we need the workdir to be in the volume shared between containers.
 		workDir := filepath.Join(os.Getenv("HOME"), t.plan.ClusterName)
+		if _, err := os.Stat(workDir); os.IsNotExist(err) {
+			if err := os.Mkdir(workDir, os.ModePerm); err != nil {
+				return err
+			}
+		}
 		log.Printf("Defaulting WorkDir: %s", workDir)
 	}
 


### PR DESCRIPTION
- Use a predictable name for the installer state directory, so that it doesn't change between an upload and a download made in different containers
- Use `az blob upload --recursive` instead of `azcopy blob sync`
- Set workdir to home for az container to work with relative paths
- Use the directory basename to get a relative path that works in the tanzu cli container and the az cli container

Resolves #6576.