### PR TITLE
[ci] Stop using .env file in set-deployer-script.sh script

### DIFF
--- a/.buildkite/e2e/nightly-main-matrix.yaml
+++ b/.buildkite/e2e/nightly-main-matrix.yaml
@@ -54,7 +54,7 @@
   fixed:
     E2E_PROVIDER: eks-arm
     E2E_TEST_ENV_TAGS: arch:arm
-    E2E_TAGS: "es kb apm ent beat agent"
+    E2E_TAGS: "es,kb,apm,ent,beat,agent"
     TEST_LICENSE: "" # disabled b/c https://github.com/elastic/elasticsearch/issues/68083
     MONITORING_SECRETS: "" # disabled b/c beats cannot run on ARM
 

--- a/.buildkite/e2e/pipeline-gen/main.go
+++ b/.buildkite/e2e/pipeline-gen/main.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"html/template"
 	"io"
 	"math/rand"
 	"os"
@@ -19,6 +18,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"text/template"
 
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
@@ -153,7 +153,14 @@ func main() {
 		return
 	}
 
-	tpl, err := template.New("pipeline.yaml").Parse(pipelineTemplate)
+	tpl, err := template.New("pipeline.yaml").Funcs(template.FuncMap{
+		"quotesIfSpaces": func(val string) string {
+			if strings.Contains(val, " ") {
+				return fmt.Sprintf(`\"%s\"`, val)
+			}
+			return val
+		},
+	}).Parse(pipelineTemplate)
 	handleErr("Failed to parse template", err)
 
 	err = tpl.Execute(os.Stdout, map[string]interface{}{

--- a/.buildkite/e2e/pipeline-gen/main.go
+++ b/.buildkite/e2e/pipeline-gen/main.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"html/template"
 	"io"
 	"math/rand"
 	"os"
@@ -18,7 +19,6 @@ import (
 	"runtime"
 	"sort"
 	"strings"
-	"text/template"
 
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
@@ -153,14 +153,7 @@ func main() {
 		return
 	}
 
-	tpl, err := template.New("pipeline.yaml").Funcs(template.FuncMap{
-		"quotesIfSpaces": func(val string) string {
-			if strings.Contains(val, " ") {
-				return fmt.Sprintf(`\"%s\"`, val)
-			}
-			return val
-		},
-	}).Parse(pipelineTemplate)
+	tpl, err := template.New("pipeline.yaml").Parse(pipelineTemplate)
 	handleErr("Failed to parse template", err)
 
 	err = tpl.Execute(os.Stdout, map[string]interface{}{

--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -18,7 +18,7 @@ steps:
 
     commands:
       {{- range $key, $val := $test.Env }}
-      - echo "{{$key}}={{$val}}" >> .env
+      - echo "{{$key}}={{ quotesIfSpaces $val }}" >> .env
       {{- end }}
 
       - .buildkite/scripts/test/set-deployer-config.sh
@@ -59,7 +59,7 @@ steps:
 
     commands:
       {{- range $key, $val := $test.Env }}
-      - echo "{{$key}}={{$val}}" >> .env
+      - echo "{{$key}}={{ quotesIfSpaces $val }}" >> .env
       {{- end }}
 
       - .buildkite/scripts/test/set-deployer-config.sh
@@ -116,7 +116,7 @@ steps:
 
         commands:
           {{- range $key, $val := $test.Env }}
-          - echo "{{$key}}={{$val}}" >> .env
+          - echo "{{$key}}={{ quotesIfSpaces $val }}" >> .env
           {{- end }}
           - .buildkite/scripts/test/set-deployer-config.sh
 

--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -18,7 +18,7 @@ steps:
 
     commands:
       {{- range $key, $val := $test.Env }}
-      - echo "{{$key}}={{ quotesIfSpaces $val }}" >> .env
+      - echo "{{$key}}={{$val}}" >> .env
       {{- end }}
 
       - .buildkite/scripts/test/set-deployer-config.sh
@@ -59,7 +59,7 @@ steps:
 
     commands:
       {{- range $key, $val := $test.Env }}
-      - echo "{{$key}}={{ quotesIfSpaces $val }}" >> .env
+      - echo "{{$key}}={{$val}}" >> .env
       {{- end }}
 
       - .buildkite/scripts/test/set-deployer-config.sh
@@ -116,7 +116,7 @@ steps:
 
         commands:
           {{- range $key, $val := $test.Env }}
-          - echo "{{$key}}={{ quotesIfSpaces $val }}" >> .env
+          - echo "{{$key}}={{$val}}" >> .env
           {{- end }}
           - .buildkite/scripts/test/set-deployer-config.sh
 

--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -17,10 +17,6 @@ steps:
       {{- end }}
 
     commands:
-      {{- range $key, $val := $test.Env }}
-      - echo "{{$key}}={{$val}}" >> .env
-      {{- end }}
-
       - .buildkite/scripts/test/set-deployer-config.sh
 
       {{- if $test.Dind }}
@@ -115,9 +111,6 @@ steps:
           DEPLOYER_OPERATION: delete
 
         commands:
-          {{- range $key, $val := $test.Env }}
-          - echo "{{$key}}={{$val}}" >> .env
-          {{- end }}
           - .buildkite/scripts/test/set-deployer-config.sh
 
         {{- if not $test.Dind }}

--- a/.buildkite/pipeline-e2e-tests.yml
+++ b/.buildkite/pipeline-e2e-tests.yml
@@ -19,7 +19,7 @@ steps:
             fixed:
               E2E_PROVIDER: kind
               TESTS_MATCH: TestSmoke
-              E2E_TAGS: "e2e es kb"
+              E2E_TAGS: "e2e,es,kb"
           DEF
 
       # for PR comment

--- a/.buildkite/pipeline-e2e-tests.yml
+++ b/.buildkite/pipeline-e2e-tests.yml
@@ -19,6 +19,7 @@ steps:
             fixed:
               E2E_PROVIDER: kind
               TESTS_MATCH: TestSmoke
+              E2E_TAGS: "e2e es kb"
           DEF
 
       # for PR comment

--- a/.buildkite/pipeline-e2e-tests.yml
+++ b/.buildkite/pipeline-e2e-tests.yml
@@ -10,7 +10,7 @@ steps:
           - "e2e-tests-image-build"
         if: |
             ( build.branch != "main" )
-            && build.env("GITHUB_PR_TRIGGER_COMMENT") !~ /^buildkite test this/
+            && build.env("GITHUB_PR_TRIGGER_COMMENT") !~ /^buildkite test this -[fm]/
             && ( build.message !~ /^buildkite test .*e2e.*/ || build.message !~ /^buildkite test .*release.*/ )
         command: |
           cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
@@ -26,11 +26,11 @@ steps:
         depends_on:
           - "operator-image-build"
           - "e2e-tests-image-build"
-        if: build.env("GITHUB_PR_TRIGGER_COMMENT") =~ /^buildkite test this/
+        if: build.env("GITHUB_PR_TRIGGER_COMMENT") =~ /^buildkite test this -[fm]/
         command: |
           cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
-          args="\$(sed "s|.*this ||" <<< \$GITHUB_PR_TRIGGER_COMMENT)"
-          ./pipeline-gen \$args | buildkite-agent pipeline upload
+          $$(echo ./pipeline-gen $$GITHUB_PR_COMMENT_VAR_ARGS) \
+            | buildkite-agent pipeline upload
 
       # for commits in main
       - label: ":buildkite: e2e"

--- a/.buildkite/scripts/test/set-deployer-config.sh
+++ b/.buildkite/scripts/test/set-deployer-config.sh
@@ -22,8 +22,6 @@ set -eu
 
 WD="$(cd "$(dirname "$0")"; pwd)"
 ROOT="$WD/../../.."
-# shellcheck disable=SC1091
-source "$ROOT/.env"
 
 write_stack_version_def() {
     # TODO

--- a/Makefile
+++ b/Makefile
@@ -469,18 +469,21 @@ E2E_REGISTRY_NAMESPACE     ?= eck-dev
 E2E_IMG_TAG                ?= $(IMG_VERSION)
 E2E_IMG                    ?= $(REGISTRY)/$(E2E_REGISTRY_NAMESPACE)/eck-e2e-tests:$(E2E_IMG_TAG)
 E2E_STACK_VERSION          ?= 8.6.1
-export TESTS_MATCH         ?= "^Test" #testing # can be overriden to eg. TESTS_MATCH=TestMutationMoreNodes to match a single test
+# regexp to filter tests to run
+export TESTS_MATCH         ?= "^Test"
 export E2E_JSON            ?= false
 TEST_TIMEOUT               ?= 30m
 E2E_SKIP_CLEANUP           ?= false
 E2E_DEPLOY_CHAOS_JOB       ?= false
-E2E_TAGS                   ?= e2e  # go build constraints potentially restricting the tests to run
-E2E_TEST_ENV_TAGS          ?= ""   # tags conveying information about the test environment to the test runner
+# go build constraints potentially restricting the tests to run
+E2E_TAGS                   ?= e2e
+# tags conveying information about the test environment to the test runner
+E2E_TEST_ENV_TAGS          ?= ""
 
 # combine e2e tags (es, kb, apm etc.)  with go tags (release) to ensure test code that imports generated code works
-# this relies on the deprecated space separated build constraints in Go which makes construction in make easier
-E2E_TAGS += $(GO_TAGS)
-export E2E_TAGS
+ifneq (,$(GO_TAGS))
+E2E_TAGS := $(GO_TAGS),$(E2E_TAGS)
+endif
 
 print-e2e-image:
 	@ echo $(E2E_IMG)


### PR DESCRIPTION
Quick fix the issue when an env var has spaces by stopping to use `.env` file in `set-deployer-script.sh` script.
Also switch to a comma separated list for the Go build tags as spaces separated list is deprecated.

Limitation: E2E_TAGS with multiple tags does not work with the pipeline-gen used with flags because the comma is already used to separate the k=v tuples in --mixed and --fixed.

Relates to #6596.