### PR TITLE
Update OpenShift supported versions to 4.8-4.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Current features:
 Supported versions:
 
 *  Kubernetes 1.22-1.26
-*  OpenShift 4.7-4.11
+*  OpenShift 4.8-4.12
 *  Elasticsearch, Kibana, APM Server: 6.8+, 7.1+, 8+
 *  Enterprise Search: 7.7+, 8+
 *  Beats: 7.0+, 8+

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -1,5 +1,5 @@
 * Kubernetes 1.22-1.26
-* OpenShift 4.7-4.11
+* OpenShift 4.8-4.12
 * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 * Helm: 3.2.0+
 * Elasticsearch, Kibana, APM Server: 6.8+, 7.1+, 8+

--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -1,7 +1,7 @@
 newVersion: 2.8.0-SNAPSHOT
 prevVersion: 2.7.0
 stackVersion: 8.8.0-SNAPSHOT
-minSupportedOpenshiftVersion: v4.7
+minSupportedOpenshiftVersion: v4.8
 crds:
   - name: elasticsearches.elasticsearch.k8s.elastic.co
     displayName: Elasticsearch Cluster

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -267,7 +267,7 @@ spec:
 
     * Kubernetes 1.22-1.26
 
-    * OpenShift 4.7-4.11
+    * OpenShift 4.8-4.12
 
     * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 


### PR DESCRIPTION
Update OpenShift supported versions to `4.8-4.12`.

Relates to #6592.