### PR TITLE
Update k8s supported versions to 1.22-1.26 (#6593)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Current features:
 
 Supported versions:
 
-*  Kubernetes 1.21-1.25
+*  Kubernetes 1.22-1.26
 *  OpenShift 4.7-4.11
 *  Elasticsearch, Kibana, APM Server: 6.8+, 7.1+, 8+
 *  Enterprise Search: 7.7+, 8+

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -1,4 +1,4 @@
-* Kubernetes 1.21-1.25
+* Kubernetes 1.22-1.26
 * OpenShift 4.7-4.11
 * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 * Helm: 3.2.0+

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -265,7 +265,7 @@ spec:
     Supported versions:
 
 
-    * Kubernetes 1.21-1.25
+    * Kubernetes 1.22-1.26
 
     * OpenShift 4.7-4.11
 


### PR DESCRIPTION
Backport the following commit to `2.7`:
- #6593