### PR TITLE
Automatically adjust Elastic Agent hostPath permissions

### DIFF
--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -86,8 +86,6 @@ spec:
       spec:
         serviceAccountName: fleet-server
         automountServiceAccountToken: true
-        securityContext:
-          runAsUser: 0
 ---
 apiVersion: agent.k8s.elastic.co/v1alpha1
 kind: Agent
@@ -102,10 +100,6 @@ spec:
   mode: fleet
   deployment:
     replicas: 1
-    podTemplate:
-      spec:
-        securityContext:
-          runAsUser: 0
 ---
 apiVersion: v1
 kind: Service

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -95,8 +95,6 @@ spec:
       spec:
         serviceAccountName: fleet-server
         automountServiceAccountToken: true
-        securityContext:
-          runAsUser: 0
 ---
 apiVersion: agent.k8s.elastic.co/v1alpha1
 kind: Agent
@@ -114,8 +112,6 @@ spec:
       spec:
         serviceAccountName: elastic-agent
         automountServiceAccountToken: true
-        securityContext:
-          runAsUser: 0
         containers:
         - name: agent
           volumeMounts:

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -79,8 +79,6 @@ spec:
       spec:
         serviceAccountName: fleet-server
         automountServiceAccountToken: true
-        securityContext:
-          runAsUser: 0
 ---
 apiVersion: agent.k8s.elastic.co/v1alpha1
 kind: Agent
@@ -97,11 +95,7 @@ spec:
     podTemplate:
       spec:
         serviceAccountName: elastic-agent
-        hostNetwork: true
-        dnsPolicy: ClusterFirstWithHostNet
         automountServiceAccountToken: true
-        securityContext:
-          runAsUser: 0
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/config/recipes/elastic-agent/kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/kubernetes-integration.yaml
@@ -13,8 +13,6 @@ spec:
         serviceAccountName: elastic-agent
         containers:
         - name: agent
-          securityContext:
-            runAsUser: 0
           env:
           - name: NODE_NAME
             valueFrom:

--- a/config/recipes/elastic-agent/multi-output.yaml
+++ b/config/recipes/elastic-agent/multi-output.yaml
@@ -14,8 +14,6 @@ spec:
       spec:
         containers:
         - name: agent
-          securityContext:
-            runAsUser: 0
           volumeMounts:
           - mountPath: /var/log
             name: varlog

--- a/config/recipes/elastic-agent/system-integration.yaml
+++ b/config/recipes/elastic-agent/system-integration.yaml
@@ -11,8 +11,6 @@ spec:
       spec:
         containers:
         - name: agent
-          securityContext:
-            runAsUser: 0
   config:
     id: 488e0b80-3634-11eb-8208-57893829af4e
     revision: 2

--- a/docs/orchestrating-elastic-stack-applications/agent-standalone.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-standalone.asciidoc
@@ -32,11 +32,7 @@ spec:
   version: {version}
   elasticsearchRefs:
   - name: quickstart
-  daemonSet:
-    podTemplate:
-      spec:
-        securityContext:
-          runAsUser: 0 <1>
+  daemonSet: {}
   config:
     inputs:
       - name: system-1
@@ -62,9 +58,6 @@ spec:
             period: 10s
 EOF
 ----
-+
-<1> The root user is required to persist state in a hostPath volume. See <<{p}_storing_local_state_in_host_path_volume>> on how to disable this feature.
-+
 Check <<{p}-elastic-agent-configuration-examples>> for more ready-to-use manifests.
 
 . Monitor the status of Elastic Agent.
@@ -140,11 +133,7 @@ spec:
   version: {version}
   elasticsearchRefs:
   - name: quickstart
-  daemonSet:
-    podTemplate:
-      spec:
-        securityContext:
-          runAsUser: 0 <1>
+  daemonSet: {}
   config:
     inputs:
       - name: system-1
@@ -170,8 +159,6 @@ spec:
             period: 10s
 ----
 
-<1> The root user is required to persist state in a hostPath volume. See <<{p}_storing_local_state_in_host_path_volume>> on how to disable this feature.
-
 Alternatively, it can be provided through a Secret specified in the `configRef` element. The Secret must have an `agent.yml` entry with this configuration:
 [source,yaml,subs="attributes,+macros"]
 ----
@@ -183,11 +170,7 @@ spec:
   version: {version}
   elasticsearchRefs:
   - name: quickstart
-  daemonSet:
-    podTemplate:
-      spec:
-        securityContext:
-          runAsUser: 0
+  daemonSet: {}
   configRef:
     secretName: system-cpu-config
 ---
@@ -239,11 +222,7 @@ metadata:
   name: quickstart
 spec:
   version: {version}
-  daemonSet:
-    podTemplate:
-      spec:
-        securityContext:
-          runAsUser: 0
+  daemonSet: {}
   elasticsearchRefs:
   - name: quickstart
     outputName: default
@@ -285,11 +264,7 @@ metadata:
   name: quickstart
 spec:
   version: {version}
-  daemonSet:
-    podTemplate:
-      spec:
-        securityContext:
-          runAsUser: 0
+  daemonSet: {}
   config:
     outputs:
       default:
@@ -316,11 +291,7 @@ metadata:
   name: quickstart
 spec:
   version: {version}
-  daemonSet:
-    podTemplate:
-      spec:
-        securityContext:
-          runAsUser: 0
+  daemonSet: {}
     strategy:
       type: RollingUpdate
       rollingUpdate:
@@ -350,8 +321,6 @@ spec:
       spec:
         automountServiceAccountToken: true
         serviceAccountName: elastic-agent
-        securityContext:
-          runAsUser: 0
 ...
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -177,27 +177,13 @@ func buildPodTemplate(params Params, fleetCerts *certificates.CertificatesSecret
 		ConfigHashAnnotationName: fmt.Sprint(configHash.Sum32()),
 	}
 
-	var initContainers []corev1.Container
-	// if volume doesn't container emptydir
-	// add an initContainer that does
-	// initContainers:
-	// - command:
-	// - sh
-	// - -c
-	// - chmod g+w /usr/share/elastic-agent/state && chgrp 1000 /usr/share/elastic-agent/state
-	// image: docker.elastic.co/beats/elastic-agent:8.5.0
-	// imagePullPolicy: IfNotPresent
-	// name: permissions
-	// securityContext:
-	//   runAsUser: 0
-
 	builder = builder.
 		WithLabels(labels).
 		WithAnnotations(annotations).
 		WithDockerImage(spec.Image, container.ImageRepository(container.AgentImage, spec.Version)).
 		WithAutomountServiceAccountToken().
 		WithVolumeLikes(vols...).
-		WithInitContainers(initContainers...).
+		WithInitContainers(maybeAgentInitContainerForHostpathVolume(spec, v)...).
 		WithEnv(
 			corev1.EnvVar{Name: "NODE_NAME", ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -177,12 +177,27 @@ func buildPodTemplate(params Params, fleetCerts *certificates.CertificatesSecret
 		ConfigHashAnnotationName: fmt.Sprint(configHash.Sum32()),
 	}
 
+	var initContainers []corev1.Container
+	// if volume doesn't container emptydir
+	// add an initContainer that does
+	// initContainers:
+	// - command:
+	// - sh
+	// - -c
+	// - chmod g+w /usr/share/elastic-agent/state && chgrp 1000 /usr/share/elastic-agent/state
+	// image: docker.elastic.co/beats/elastic-agent:8.5.0
+	// imagePullPolicy: IfNotPresent
+	// name: permissions
+	// securityContext:
+	//   runAsUser: 0
+
 	builder = builder.
 		WithLabels(labels).
 		WithAnnotations(annotations).
 		WithDockerImage(spec.Image, container.ImageRepository(container.AgentImage, spec.Version)).
 		WithAutomountServiceAccountToken().
 		WithVolumeLikes(vols...).
+		WithInitContainers(initContainers...).
 		WithEnv(
 			corev1.EnvVar{Name: "NODE_NAME", ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{

--- a/pkg/controller/agent/volume.go
+++ b/pkg/controller/agent/volume.go
@@ -33,10 +33,13 @@ var (
 	}
 )
 
-// maybeAgentInitContainerForHostpathVolume if the Elastic Agent spec volume
-// doesn't contain emptyDir and version is above 7.15 and the Agent container
-// is not running as root add an initContainer that ensures that the host
-// volume's permissions are sufficient for the Agent to maintain state.
+// maybeAgentInitContainerForHostpathVolume will return an init container that ensures that the host
+// volume's permissions are sufficient for the Agent to maintain state if the Elastic Agent
+// has the following attributes:
+//
+// 1. Agent volume is not set to emptyDir.
+// 2. Agent version is above 7.15.
+// 3. Agent spec is not configured to run as root.
 func maybeAgentInitContainerForHostpathVolume(spec *agentv1alpha1.AgentSpec, v semver.Version) (initContainers []corev1.Container) {
 	// Only add initContainer to chown hostpath data volume for Agent > 7.15
 	if !v.GTE(version.MinFor(7, 15, 0)) {

--- a/pkg/controller/agent/volume.go
+++ b/pkg/controller/agent/volume.go
@@ -73,7 +73,7 @@ func maybeAgentInitContainerForHostpathVolume(spec *agentv1alpha1.AgentSpec, v s
 }
 
 // hostPathVolumeInitContainerCommand returns the container command
-// for maintaining permissions for Elastic Agent when not running as root.
+// for maintaining permissions for Elastic Agent.
 func hostPathVolumeInitContainerCommand() []string {
 	return []string{
 		"/usr/bin/env",

--- a/pkg/controller/agent/volume.go
+++ b/pkg/controller/agent/volume.go
@@ -1,0 +1,151 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package agent
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/blang/semver/v4"
+
+	agentv1alpha1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/agent/v1alpha1"
+	container "github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/container"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/pointer"
+)
+
+const (
+	hostPathVolumeInitContainerName = "permissions"
+)
+
+var (
+	hostPathVolumeInitContainerCommand = []string{
+		"/usr/bin/env",
+		"bash",
+		"-c",
+		permissionsScript(),
+	}
+	hostPathVolumeInitContainerResources = corev1.ResourceRequirements{
+		Requests: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+		},
+		Limits: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+		},
+	}
+)
+
+// if volume doesn't containe emptydir
+// and Version is above 7.15
+// and not running as root....
+// TODO WTF ABOUT OPENSHIFT?
+// add an initContainer that does
+func maybeAgentInitContainerForHostpathVolume(spec *agentv1alpha1.AgentSpec, v semver.Version) (initContainers []corev1.Container) {
+	// Only add initContainer to chown hostpath data volume for Agent > 7.15
+	if !v.GTE(version.MinFor(7, 15, 0)) {
+		return nil
+	}
+
+	image := spec.Image
+	if image == "" {
+		image = container.ImageRepository(container.AgentImage, spec.Version)
+	}
+
+	if !dataVolumeIsEmptyDir(spec) && !runningAsRoot(spec) {
+		initContainers = append(initContainers, corev1.Container{
+			Image:   image,
+			Command: hostPathVolumeInitContainerCommand,
+			Name:    hostPathVolumeInitContainerName,
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser: pointer.Int64(0),
+			},
+			Resources: hostPathVolumeInitContainerResources,
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      DataVolumeName,
+					MountPath: DataMountPath,
+				},
+			},
+		})
+	}
+
+	return initContainers
+}
+
+func permissionsScript() string {
+	return `#!/usr/bin/env bash
+set -e
+find /usr/share/elastic-agent -ls
+if [[ -d /usr/share/elastic-agent/state ]]; then
+  echo "Adjusting g+rw of /usr/share/elastic-agent/state"
+  chmod g+rw /usr/share/elastic-agent/state
+  echo "Adjusting group ownership of /usr/share/elastic-agent/state"
+  chgrp 1000 /usr/share/elastic-agent/state
+  if [ -n "$(ls -A /usr/share/elastic-agent/state 2>/dev/null)" ]; then
+    echo "Adjusting group ownership of /usr/share/elastic-agent/state/*"
+    chgrp 1000 /usr/share/elastic-agent/state/*
+    echo "Adjusting g+rw of /usr/share/elastic-agent/state/*"
+    chmod g+rw /usr/share/elastic-agent/state/*
+  fi
+fi
+`
+}
+
+// Wonder if this is right in openshift?
+func runningAsRoot(spec *agentv1alpha1.AgentSpec) bool {
+	if spec.DaemonSet != nil {
+		templateSpec := spec.DaemonSet.PodTemplate.Spec
+		if templateSpec.SecurityContext != nil &&
+			templateSpec.SecurityContext.RunAsUser != nil && *templateSpec.SecurityContext.RunAsUser == 0 {
+			return true
+		}
+		return containerRunningAsUser0(templateSpec)
+	}
+	if spec.Deployment != nil {
+		templateSpec := spec.Deployment.PodTemplate.Spec
+		if templateSpec.SecurityContext != nil &&
+			templateSpec.SecurityContext.RunAsUser != nil && *templateSpec.SecurityContext.RunAsUser == 0 {
+			return true
+		}
+		return containerRunningAsUser0(templateSpec)
+	}
+	return false
+}
+
+func containerRunningAsUser0(spec corev1.PodSpec) bool {
+	for _, container := range spec.Containers {
+		if container.Name == "agent" {
+			if container.SecurityContext == nil {
+				return false
+			}
+			if container.SecurityContext.RunAsUser != nil && *container.SecurityContext.RunAsUser == 0 {
+				return true
+			}
+			return false
+		}
+	}
+	return false
+}
+
+func dataVolumeIsEmptyDir(spec *agentv1alpha1.AgentSpec) bool {
+	if spec.DaemonSet != nil {
+		return volumeIsEmptyDir(spec.DaemonSet.PodTemplate.Spec.Volumes)
+	}
+	if spec.Deployment != nil {
+		return volumeIsEmptyDir(spec.Deployment.PodTemplate.Spec.Volumes)
+	}
+	return false
+}
+
+func volumeIsEmptyDir(vols []corev1.Volume) bool {
+	for _, vol := range vols {
+		if vol.Name == DataVolumeName && vol.VolumeSource.EmptyDir != nil {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/global_ca_test.go
+++ b/test/e2e/global_ca_test.go
@@ -35,8 +35,9 @@ func TestGlobalCA(t *testing.T) {
 
 	// Skip if it is the resilience pipeline because the ChaosJob can prevent
 	// assert_operator_has_been_restarted_once_more to pass when it deletes an operator Pod
-	// exactly on restart.
-	if test.Ctx().Pipeline == "e2e/resilience" {
+	// exactly on restart. Also skip if running tests locally as the operator
+	// namespace, and the operator configmap is not present.
+	if test.Ctx().Pipeline == "e2e/resilience" || test.Ctx().Local {
 		t.Skip()
 	}
 


### PR DESCRIPTION
closes #6239 

## Background

Currently it is required to have the following set when running Elastic Agent with a `hostPath`:

```
    podTemplate:
      spec:
        containers:
          - name: agent
            securityContext:
              runAsUser: 0
```

The only way to avoid this is configuring an `emptyDir` volume instead of `hostPath`.

## What this proposes

Detailed further in #6239 we want to automatically add an `initContainer` that maintains the Agent permissions to avoid requiring the Agent to run perpetually as root.

If the following all are true, an `initContainer` is automatically added to Elastic Agent that maintains permissions
1. Agent volume is not set to `emptyDir`.
2. Agent version is above 7.15.
3. Agent spec is not configured to run as root.

## Testing

- [x] Local testing `make e2e-local` of all Agent e2e tests using `8.7.0-SNAPSHOT` and enabling all disabled Agent tests because of #6331 
- [ ] Full remote e2e test run using 7.x
- [ ] Full remote e2e test run using 8.6
- [ ] Adding of additional Unit tests