### PR TITLE
Avoid negative sleep in pre-stop hook

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/lifecycle_hook.go
+++ b/pkg/controller/elasticsearch/nodespec/lifecycle_hook.go
@@ -121,6 +121,9 @@ function delayed_exit() {
   local elapsed
   elapsed=$(duration "$script_start")
   local remaining=$((PRE_STOP_ADDITIONAL_WAIT_SECONDS - elapsed))
+  if (( remaining < 0 )); then
+    exit ${1-0}
+  fi
   log "delaying termination for $remaining seconds"
   sleep $remaining
   exit ${1-0}


### PR DESCRIPTION
GNU sleep does not allow negative numbers. I did a lot of testing on a Mac which is of BSD heritage and does not have a problem with that 😞 

```
"reason":"FailedPreStopHook","message":"Exec lifecycle hook ([bash -c /mnt/elastic-internal/scripts/pre-stop-hook-script.sh]) for Container \"elasticsearch\" in Pod \"test-agent-configref-9j99-es-masterdata-2_e2e-ev8ff-mercury(dd79323a-2a4b-4d3b-847c-e0f02866bf3b)\" failed - error: command 'bash -c /mnt/elastic-internal/scripts/pre-stop-hook-script.sh' exited with 1: curl: (28) Failed to connect to test-agent-configref-9j99-es-internal-http.e2e-ev8ff-mercury.svc port 9200: Connection timed out\ncurl: (6) Could not resolve host: test-agent-configref-9j99-es-internal-http.e2e-ev8ff-mercury.svc\ncurl: (6) Could not resolve host: test-agent-configref-9j99-es-internal-http.e2e-ev8ff-mercury.svc\ncurl: (6) Could not resolve host: test-agent-configref-9j99-es-internal-http.e2e-ev8ff-mercury.svc\nsleep: invalid option -- '1'\nTry 'sleep --help' for more information.\n
```