### PR TITLE
Add a new role for APM Server 8.7.0+

### DIFF
--- a/pkg/controller/association/controller/apm_es.go
+++ b/pkg/controller/association/controller/apm_es.go
@@ -100,6 +100,14 @@ func getAPMElasticsearchRoles(associated commonv1.Associated) (string, error) {
 		return "", err
 	}
 
+	// 8.7.x and above
+	if v.GTE(version.MinFor(8, 7, 0)) {
+		return strings.Join([]string{
+			user.ApmUserRoleV87, // Retrieve cluster details (e.g. version) and manage apm-* indices
+			"apm_system",        // To collect metrics about APM Server
+		}, ","), nil
+	}
+
 	// 8.0.x and above
 	if v.GTE(version.MinFor(8, 0, 0)) {
 		return strings.Join([]string{

--- a/pkg/controller/association/controller/apm_es_test.go
+++ b/pkg/controller/association/controller/apm_es_test.go
@@ -75,6 +75,24 @@ func Test_getAPMElasticsearchRoles(t *testing.T) {
 			},
 			want: "eck_apm_user_role_v75,ingest_admin,apm_system",
 		},
+		{
+			name: "Test roles for APM Server v8.6.99",
+			args: args{
+				associated: &apmv1.ApmServer{
+					Spec: apmv1.ApmServerSpec{Version: "8.6.99"},
+				},
+			},
+			want: "eck_apm_user_role_v80,apm_system",
+		},
+		{
+			name: "Test roles for APM Server v8.7.0",
+			args: args{
+				associated: &apmv1.ApmServer{
+					Spec: apmv1.ApmServerSpec{Version: "8.7.0"},
+				},
+			},
+			want: "eck_apm_user_role_v87,apm_system",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/elasticsearch/client/client.go
+++ b/pkg/controller/elasticsearch/client/client.go
@@ -37,8 +37,9 @@ type BasicAuth struct {
 }
 
 type IndexRole struct {
-	Names      []string `json:"names,omitempty"`
-	Privileges []string `json:",omitempty"`
+	Names                  []string `json:"names,omitempty"`
+	Privileges             []string `json:",omitempty"`
+	AllowRestrictedIndices *bool    `json:"allow_restricted_indices,omitempty" yaml:"allow_restricted_indices,omitempty"`
 }
 
 type ApplicationRole struct {

--- a/pkg/controller/elasticsearch/user/reconcile_test.go
+++ b/pkg/controller/elasticsearch/user/reconcile_test.go
@@ -96,6 +96,6 @@ func Test_aggregateRoles(t *testing.T) {
 	c := k8s.NewFakeClient(sampleUserProvidedRolesSecret...)
 	roles, err := aggregateRoles(context.Background(), c, sampleEsWithAuth, initDynamicWatches(), record.NewFakeRecorder(10))
 	require.NoError(t, err)
-	require.Len(t, roles, 53)
+	require.Len(t, roles, 54)
 	require.Contains(t, roles, ProbeUserRole, ClusterManageRole, "role1", "role2")
 }

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -34,6 +34,8 @@ const (
 	ApmUserRoleV75 = "eck_apm_user_role_v75"
 	// ApmUserRoleV80 is the name of the role used by APMServer instances to connect to Elasticsearch from version 8.0
 	ApmUserRoleV80 = "eck_apm_user_role_v80"
+	// ApmUserRoleV87 is the name of the role used by APMServer instances to connect to Elasticsearch from version 8.7
+	ApmUserRoleV87 = "eck_apm_user_role_v87"
 
 	// ApmAgentUserRole is the name of the role used by APMServer instances to connect to Kibana
 	ApmAgentUserRole = "eck_apm_agent_user_role"
@@ -99,6 +101,27 @@ var (
 				{
 					Names:      []string{"traces-apm.sampled-*"},
 					Privileges: []string{"maintenance", "monitor", "read"},
+				},
+			},
+		},
+		ApmUserRoleV87: esclient.Role{
+			Cluster: []string{"cluster:monitor/main", "manage_index_templates"},
+			Indices: []esclient.IndexRole{
+				{
+					Names:      []string{"traces-apm*", "metrics-apm*", "logs-apm*"},
+					Privileges: []string{"auto_configure", "create_doc"},
+				},
+				{
+					Names:      []string{"traces-apm.sampled-*"},
+					Privileges: []string{"maintenance", "monitor", "read"},
+				},
+				{
+					Names:      []string{".apm-agent-configuration", ".apm-source-map"},
+					Privileges: []string{"read"},
+					AllowRestrictedIndices: func() *bool {
+						allow := true
+						return &allow
+					}(),
 				},
 			},
 		},


### PR DESCRIPTION
Add a new role for APM Server 8.7.0+, adding read privileges for the system indices `.apm-agent-configuration` and `.apm-source-map`.