### PR TITLE
Make sure e2e tests reports are uploaded on failure

### DIFF
--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -66,12 +66,10 @@ steps:
       {{- end }}
 
       {{- if $test.Dind }}
-      - make -C .ci TARGET="{{ $deployerCommand }} e2e-run e2e-generate-xml" ci
+      - make -C .ci TARGET="{{ $deployerCommand }} e2e-run" ci
       {{- else }}
-      - make {{ $deployerCommand }} e2e-run e2e-generate-xml
+      - make {{ $deployerCommand }} e2e-run
       {{- end }}
-
-      - mkdir tests-report && mv e2e-tests.xml tests-report/e2e-tests-{{ $test.SlugName }}.xml
 
     agents:
       {{- if $test.Dind }}
@@ -123,6 +121,17 @@ steps:
           image: "family/elastic-buildkite-agent-ubuntu-2004-lts"
         {{- end }}
 
+
+
     {{- end }}
 {{- end }}
 
+  - wait: ~
+    continue_on_failure: true
+
+  - label: aggregate tests-results
+    commands:
+      - buildkite artifact download tests-reports/*.json
+      - .buildkite/scripts/test/generate-tests-reports.sh
+
+    

--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -133,5 +133,5 @@ steps:
     commands:
       - buildkite artifact download tests-reports/*.json
       - .buildkite/scripts/test/generate-tests-reports.sh
-
-    
+    artifact_paths:
+      - tests-reports/*.xml

--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -83,7 +83,7 @@ steps:
       {{- end }}
 
     artifact_paths:
-      - tests-report/*.xml
+      - e2e-tests-*.json
       - "eck-diagnostic*.zip"
 
 {{- end }}
@@ -131,7 +131,7 @@ steps:
 
   - label: aggregate tests-results
     commands:
-      - buildkite artifact download tests-reports/*.json
+      - buildkite-agent artifact download e2e-tests-*.json .
       - .buildkite/scripts/test/generate-tests-reports.sh
     artifact_paths:
-      - tests-reports/*.xml
+      - e2e-tests-*.xml

--- a/.buildkite/scripts/test/generate-tests-reports.sh
+++ b/.buildkite/scripts/test/generate-tests-reports.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+
+# Script to generate e2e tests reports.
+
+set -eu
+
+gen_junit_report() {
+    local input_file=${1:-"input file"}
+    local xml_report=${input_file%.*}.xml
+
+    # exit without error when there is no input file
+    if [[ ! -f $input_file ]]; then
+        echo "No $input_file to generate a JUnit XML report."
+        exit 0
+    fi
+
+    # temporary filter out lines containing a space in the timestamp,
+    # see https://github.com/elastic/cloud-on-k8s/issues/3560.
+    gotestsum \
+        --junitfile "$xml_report" \
+        --raw-command grep -v '"Time":"[^"]*\s[^"]*"' "$input_file" || \
+    ( \
+        echo "Failed to generate a JUnit XML report."
+        # print the input file for further debugging
+        echo " --- $input_file - START ---"
+        cat "$input_file"
+        echo " --- $input_file - END   ---"
+        exit 1
+    )
+}
+
+for f in $(ls e2e-reports/*.json); do
+    echo gen_junit_report "$f"
+done

--- a/.buildkite/scripts/test/generate-tests-reports.sh
+++ b/.buildkite/scripts/test/generate-tests-reports.sh
@@ -4,7 +4,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 
-# Script to generate e2e tests reports.
+# Script to generate e2e tests reports in JUnit XML format from JSON go test results.
 
 set -eu
 
@@ -33,6 +33,6 @@ gen_junit_report() {
     )
 }
 
-for f in $(ls e2e-reports/*.json); do
-    echo gen_junit_report "$f"
+for f in e2e-tests-*.json; do
+    gen_junit_report "$f"
 done

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -35,12 +35,12 @@ import (
 )
 
 const (
-	jobTimeout           = 600 * time.Minute // time to wait for the test job to finish
-	kubePollInterval     = 10 * time.Second  // Kube API polling interval
-	testRunLabel         = "test-run"        // name of the label applied to resources
-	logStreamLabel       = "stream-logs"     // name of the label enabling log streaming to e2e runner
-	testsLogFile         = "e2e-tests.json"  // name of file to keep all test logs in JSON format
-	operatorReadyTimeout = 3 * time.Minute   // time to wait for the operator pod to be ready
+	jobTimeout           = 600 * time.Minute   // time to wait for the test job to finish
+	kubePollInterval     = 10 * time.Second    // Kube API polling interval
+	testRunLabel         = "test-run"          // name of the label applied to resources
+	logStreamLabel       = "stream-logs"       // name of the label enabling log streaming to e2e runner
+	testsLogFilePattern  = "e2e-tests-%s.json" // name of file to keep all test logs in JSON format
+	operatorReadyTimeout = 3 * time.Minute     // time to wait for the operator pod to be ready
 
 	TestNameLabel = "test-name" // name of the label applied to resources during each test
 )
@@ -602,7 +602,7 @@ func (h *helper) startAndMonitorTestJobs(client *kubernetes.Clientset) error {
 
 	outputs := []io.Writer{os.Stdout}
 	if h.logToFile {
-		jl, err := newJSONLogToFile(testsLogFile)
+		jl, err := newJSONLogToFile(fmt.Sprintf(testsLogFilePattern, h.testContext.ClusterName))
 		if err != nil {
 			log.Error(err, "Failed to create log file for test output")
 			return err

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -23,6 +23,24 @@ import (
 
 const sampleFile = "../../config/samples/apm/apm_es_kibana.yaml"
 
+func TestFailA(t *testing.T) {
+	test.StepList{{
+		Name: "failing test a",
+		Test: func(t *testing.T) {
+			t.Error("fake error a")
+		},
+	}}.RunSequential(t)
+}
+
+func TestFailB(t *testing.T) {
+	test.StepList{{
+		Name: "failing test b",
+		Test: func(t *testing.T) {
+			t.Error("fake error b")
+		},
+	}}.RunSequential(t)
+}
+
 // TestSmoke runs a test suite using the ApmServer + Kibana + ES + Beat sample.
 func TestSmoke(t *testing.T) {
 	var esBuilder elasticsearch.Builder

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -23,24 +23,6 @@ import (
 
 const sampleFile = "../../config/samples/apm/apm_es_kibana.yaml"
 
-func TestFailA(t *testing.T) {
-	test.StepList{{
-		Name: "failing test a",
-		Test: func(t *testing.T) {
-			t.Error("fake error a")
-		},
-	}}.RunSequential(t)
-}
-
-func TestFailB(t *testing.T) {
-	test.StepList{{
-		Name: "failing test b",
-		Test: func(t *testing.T) {
-			t.Error("fake error b")
-		},
-	}}.RunSequential(t)
-}
-
 // TestSmoke runs a test suite using the ApmServer + Kibana + ES + Beat sample.
 func TestSmoke(t *testing.T) {
 	var esBuilder elasticsearch.Builder


### PR DESCRIPTION
This makes sure e2e tests reports are uploaded on failure with 2 changes:

- The JSON go test results are uploaded regardless of the status of the `make e2e-run` command.

<img width="948" alt="Capture d’écran 2023-03-29 à 14 07 12" src="https://user-images.githubusercontent.com/582883/228531212-e1387925-b6cf-4788-8cfb-5fcb08e99854.png">

- A new step is run to download all test results and convert them to JUnit XML reports. 
 
<img width="946" alt="Capture d’écran 2023-03-29 à 14 08 03" src="https://user-images.githubusercontent.com/582883/228531187-ea8bac59-5f00-41a8-b53a-b4d15b90e027.png">

JUnit XML reports are uploaded temporarily waiting we build a Buildkite annotation to summarize the test failures.

Resolves #6606.