### PR TITLE
Remove deprecation note for APM Server standalone (#6601)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
@@ -7,8 +7,6 @@ endif::[]
 [id="{p}-{page_id}"]
 = Run APM Server on ECK
 
-WARNING: As of version 8.0.0, the standalone APM Server binary is deprecated and will be removed in a future release. Consider using <<{p}-elastic-agent-fleet,Elastic Agent in Fleet-managed mode with ECK>>. Refer to the link:https://www.elastic.co/guide/en/apm/guide/current/apm-quick-start.html[Elastic APM integration] for additional details.
-
 This section describes how to deploy, configure and access an APM Server with ECK.
 
 * <<{p}-apm-eck-managed-es,Use an Elasticsearch cluster managed by ECK>>

--- a/pkg/controller/apmserver/controller.go
+++ b/pkg/controller/apmserver/controller.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"sync/atomic"
 
-	"github.com/blang/semver/v4"
 	"go.elastic.co/apm/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -263,8 +262,6 @@ func (r *ReconcileApmServer) doReconcile(ctx context.Context, as *apmv1.ApmServe
 		return results, state // will eventually retry
 	}
 
-	r.warnIfDeprecated(asVersion, as)
-
 	state, err = r.reconcileApmServerDeployment(ctx, state, as)
 	if err != nil {
 		if apierrors.IsConflict(err) {
@@ -280,18 +277,6 @@ func (r *ReconcileApmServer) doReconcile(ctx context.Context, as *apmv1.ApmServe
 	_, err = results.WithError(err).Aggregate()
 	k8s.EmitErrorEvent(r.recorder, err, as, events.EventReconciliationError, "Reconciliation error: %v", err)
 	return results, state
-}
-
-func (r *ReconcileApmServer) warnIfDeprecated(version semver.Version, as *apmv1.ApmServer) {
-	if version.GTE(semver.MustParse("8.0.0")) {
-		message := "The standalone APM Server binary is deprecated as of version 8.0.0 and will be removed in a future release. Consider using Elastic Agent in Fleet-managed mode."
-		log.Info(
-			message,
-			"namespace", as.Namespace,
-			"as_name", as.Name,
-		)
-		r.Recorder().Eventf(as, corev1.EventTypeWarning, events.EventReasonValidation, message)
-	}
 }
 
 func (r *ReconcileApmServer) validate(ctx context.Context, as *apmv1.ApmServer) error {


### PR DESCRIPTION
Backport the following commit to `2.7`:
- #6601