### PR TITLE
[e2e] Remove disabling of Agent e2e tests because of 6331

### DIFF
--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -124,10 +124,13 @@ func TestMultipleOutputConfig(t *testing.T) {
 }
 
 func TestFleetMode(t *testing.T) {
-
-	test.SkipUntilResolution(t, 6331)
-
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
+
+	// https://github.com/elastic/cloud-on-k8s/issues/6331
+	if v.LT(version.MinFor(8, 8, 0)) && v.GE(version.MinFor(8, 6, 0)) {
+		t.SkipNow()
+	}
+
 	// installation of policies and integrations through Kibana file based configuration was broken between those versions:
 	if v.LT(version.MinFor(8, 1, 0)) && v.GTE(version.MinFor(8, 0, 0)) {
 		t.SkipNow()

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -127,7 +127,7 @@ func TestFleetMode(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
 	// https://github.com/elastic/cloud-on-k8s/issues/6331
-	if v.LT(version.MinFor(8, 8, 0)) && v.GE(version.MinFor(8, 6, 0)) {
+	if v.LT(version.MinFor(8, 7, 0)) && v.GE(version.MinFor(8, 6, 0)) {
 		t.SkipNow()
 	}
 

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -88,8 +88,12 @@ func TestMultiOutputRecipe(t *testing.T) {
 }
 
 func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
-	test.SkipUntilResolution(t, 6331)
+	// https://github.com/elastic/cloud-on-k8s/issues/6331
+	if v.LT(version.MinFor(8, 8, 0)) && v.GE(version.MinFor(8, 6, 0)) {
+		t.SkipNow()
+	}
 
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
@@ -133,8 +137,12 @@ func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
-	test.SkipUntilResolution(t, 6331)
+	// https://github.com/elastic/cloud-on-k8s/issues/6331
+	if v.LT(version.MinFor(8, 8, 0)) && v.GE(version.MinFor(8, 6, 0)) {
+		t.SkipNow()
+	}
 
 	notLoggingPod := beat.NewPodBuilder("test")
 	loggingPod := beat.NewPodBuilder("test")
@@ -162,8 +170,12 @@ func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetAPMIntegrationRecipe(t *testing.T) {
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
-	test.SkipUntilResolution(t, 6331)
+	// https://github.com/elastic/cloud-on-k8s/issues/6331
+	if v.LT(version.MinFor(8, 8, 0)) && v.GE(version.MinFor(8, 6, 0)) {
+		t.SkipNow()
+	}
 
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -91,7 +91,7 @@ func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
 	// https://github.com/elastic/cloud-on-k8s/issues/6331
-	if v.LT(version.MinFor(8, 8, 0)) && v.GE(version.MinFor(8, 6, 0)) {
+	if v.LT(version.MinFor(8, 7, 0)) && v.GE(version.MinFor(8, 6, 0)) {
 		t.SkipNow()
 	}
 
@@ -140,7 +140,7 @@ func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
 	// https://github.com/elastic/cloud-on-k8s/issues/6331
-	if v.LT(version.MinFor(8, 8, 0)) && v.GE(version.MinFor(8, 6, 0)) {
+	if v.LT(version.MinFor(8, 7, 0)) && v.GE(version.MinFor(8, 6, 0)) {
 		t.SkipNow()
 	}
 
@@ -173,7 +173,7 @@ func TestFleetAPMIntegrationRecipe(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
 	// https://github.com/elastic/cloud-on-k8s/issues/6331
-	if v.LT(version.MinFor(8, 8, 0)) && v.GE(version.MinFor(8, 6, 0)) {
+	if v.LT(version.MinFor(8, 7, 0)) && v.GE(version.MinFor(8, 6, 0)) {
 		t.SkipNow()
 	}
 

--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -18,10 +18,12 @@ import (
 
 // TestFleetAgentWithoutTLS tests a Fleet Server, and Elastic Agent with TLS disabled for the HTTP layer.
 func TestFleetAgentWithoutTLS(t *testing.T) {
-
-	test.SkipUntilResolution(t, 6331)
-
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
+
+	// https://github.com/elastic/cloud-on-k8s/issues/6331
+	if v.LT(version.MinFor(8, 8, 0)) && v.GE(version.MinFor(8, 6, 0)) {
+		t.SkipNow()
+	}
 
 	// Disabling TLS for Fleet isn't supported before 7.16, as Elasticsearch doesn't allow
 	// api keys to be enabled when TLS is disabled.

--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -21,7 +21,7 @@ func TestFleetAgentWithoutTLS(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
 	// https://github.com/elastic/cloud-on-k8s/issues/6331
-	if v.LT(version.MinFor(8, 8, 0)) && v.GE(version.MinFor(8, 6, 0)) {
+	if v.LT(version.MinFor(8, 7, 0)) && v.GE(version.MinFor(8, 6, 0)) {
 		t.SkipNow()
 	}
 

--- a/test/e2e/agent/upgrade_test.go
+++ b/test/e2e/agent/upgrade_test.go
@@ -9,6 +9,7 @@ package agent
 import (
 	"testing"
 
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test/agent"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test/elasticsearch"
@@ -17,11 +18,20 @@ import (
 
 func TestAgentVersionUpgradeToLatest8x(t *testing.T) {
 
-	test.SkipUntilResolution(t, 6331)
-
 	srcVersion, dstVersion := test.GetUpgradePathTo8x(test.Ctx().ElasticStackVersion)
 
 	test.SkipInvalidUpgrade(t, srcVersion, dstVersion)
+
+	sv := version.MustParse(srcVersion)
+	dv := version.MustParse(dstVersion)
+
+	// https://github.com/elastic/cloud-on-k8s/issues/6331
+	if sv.LT(version.MinFor(8, 8, 0)) && sv.GE(version.MinFor(8, 6, 0)) {
+		t.SkipNow()
+	}
+	if dv.LT(version.MinFor(8, 8, 0)) && dv.GE(version.MinFor(8, 6, 0)) {
+		t.SkipNow()
+	}
 
 	name := "test-agent-upgrade"
 	esBuilder := elasticsearch.NewBuilder(name).

--- a/test/e2e/agent/upgrade_test.go
+++ b/test/e2e/agent/upgrade_test.go
@@ -26,10 +26,10 @@ func TestAgentVersionUpgradeToLatest8x(t *testing.T) {
 	dv := version.MustParse(dstVersion)
 
 	// https://github.com/elastic/cloud-on-k8s/issues/6331
-	if sv.LT(version.MinFor(8, 8, 0)) && sv.GE(version.MinFor(8, 6, 0)) {
+	if sv.LT(version.MinFor(8, 7, 0)) && sv.GE(version.MinFor(8, 6, 0)) {
 		t.SkipNow()
 	}
-	if dv.LT(version.MinFor(8, 8, 0)) && dv.GE(version.MinFor(8, 6, 0)) {
+	if dv.LT(version.MinFor(8, 7, 0)) && dv.GE(version.MinFor(8, 6, 0)) {
 		t.SkipNow()
 	}
 


### PR DESCRIPTION
closes #6331 

Since issue from 6331 has been resolved, and is included in `8.8.0-SNAPSHOT`, go ahead and remove the disabling of the Agent e2e tests and do not run them on `8.6.0 <= Agent stack < 8.8.0-SNAPSHOT`

(Please someone double check my logic below, as I believe `MinFor` includes pre-release/snapshot)
```
if v.LT(version.MinFor(8, 8, 0)) && v.GE(version.MinFor(8, 6, 0)) {
```