### PR TITLE
Fix artifacts path for diagnostics in e2e test template

### DIFF
--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -86,7 +86,7 @@ steps:
 
     artifact_paths:
       - tests-report/*.xml
-      - "eck-diagnostic-*.zip"
+      - "eck-diagnostics-*.zip"
 
 {{- end }}
 


### PR DESCRIPTION
```
2023/03/28 17:22:35 ECK diagnostics written to eck-diagnostics-2023-03-28T17-21-25.zip
~~~ Uploading artifacts
[90m$[0m buildkite-agent artifact upload tests-report/*.xml;eck-diagnostic-*.zip
[38;5;48m2023-03-28 17:23:25 INFO  [0m [0mNo files matched paths: tests-report/*.xml;eck-diagnostic-*.zip[0m
```
