### PR TITLE
Enable hostNetwork support in eck-operator Helm chart

### DIFF
--- a/deploy/eck-operator/templates/statefulset.yaml
+++ b/deploy/eck-operator/templates/statefulset.yaml
@@ -120,7 +120,7 @@ spec:
       {{- if .Values.hostNetwork }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
-      {{- end}}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 12 }}

--- a/deploy/eck-operator/templates/statefulset.yaml
+++ b/deploy/eck-operator/templates/statefulset.yaml
@@ -117,7 +117,7 @@ spec:
         {{- with .Values.volumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if .Values.hostNetwork }}
+      {{- if .Values.webhook.hostNetwork }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       {{- end }}

--- a/deploy/eck-operator/templates/statefulset.yaml
+++ b/deploy/eck-operator/templates/statefulset.yaml
@@ -117,6 +117,10 @@ spec:
         {{- with .Values.volumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end}}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 12 }}

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -119,6 +119,9 @@ webhook:
   # objectSelector corresponds to the objectSelector property of the webhook.
   # Setting this restricts the webhook to act only on objects that match the selector.
   objectSelector: {}
+  # HostNetwork allows a Pod to use the Node network namespace.
+  # This is required to allow for communication with the kube API when using some alternate CNIs in conjunction with webhook enabled.
+  hostNetwork: false
 
 softMultiTenancy:
   # enabled determines whether the operator is installed with soft multi-tenancy extensions.
@@ -235,8 +238,3 @@ global:
   createOperatorNamespace: true
   # kubeVersion is the effective Kubernetes version we target when generating the all-in-one.yaml.
   kubeVersion: 1.21.0
-
-# HostNetwork allows a Pod to use the Node network namespace.
-# This is required to allow for communication with the kube API when using some alternate CNIs in conjunction with webhook enabled.
-# communication with the kube API.
-hostNetwork: false

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -121,6 +121,7 @@ webhook:
   objectSelector: {}
   # HostNetwork allows a Pod to use the Node network namespace.
   # This is required to allow for communication with the kube API when using some alternate CNIs in conjunction with webhook enabled.
+  # CAUTION: Proceed at your own risk. This setting has security concerns such as allowing malicious users to access workloads running on the host.
   hostNetwork: false
 
 softMultiTenancy:

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -236,3 +236,6 @@ global:
   # kubeVersion is the effective Kubernetes version we target when generating the all-in-one.yaml.
   kubeVersion: 1.21.0
 
+# When using AWS EKS and an altnerate CNI inconjunction with webhook enabled, hostNetwork needs to enabled to allow for
+# communication with the kube API.
+hostNetwork: false

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -236,6 +236,7 @@ global:
   # kubeVersion is the effective Kubernetes version we target when generating the all-in-one.yaml.
   kubeVersion: 1.21.0
 
-# When using AWS EKS and an altnerate CNI inconjunction with webhook enabled, hostNetwork needs to enabled to allow for
+# HostNetwork allows a Pod to use the Node network namespace.
+# This is required to allow for communication with the kube API when using some alternate CNIs in conjunction with webhook enabled.
 # communication with the kube API.
 hostNetwork: false


### PR DESCRIPTION
Enable support for webhooks for those of us whom are using alternate CNIs. 
