### PR TITLE
Fix detecting multiarch image already pushed

### DIFF
--- a/.buildkite/scripts/build/is_published.sh
+++ b/.buildkite/scripts/build/is_published.sh
@@ -25,7 +25,7 @@ main() {
   local platform=$2
 
   set +e
-  inspect_out="$(docker buildx imagetools inspect $image)"
+  inspect_out=$(docker buildx imagetools inspect "$image")
   set -e
 
   case "$platform" in

--- a/.buildkite/scripts/build/is_published.sh
+++ b/.buildkite/scripts/build/is_published.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+
+# Script to check if a multi arch image has already been published.
+#
+# Usage: is_published.sh IMAGE PLATFORM
+
+set -eu
+
+is_amd64_build() {
+  grep -c "^Name:\s*$image$" <<< "$inspect_out" >/dev/null
+}
+
+is_amd64_arm64_build() {
+  grep -c "^Name:\s*$image$"        <<< "$inspect_out" >/dev/null && \
+  grep -c "Platform:\s*linux/amd64" <<< "$inspect_out" >/dev/null && \
+  grep -c "Platform:\s*linux/amd64" <<< "$inspect_out" >/dev/null
+}
+
+main() {
+  local image=$1
+  local platform=$2
+
+  set +e
+  inspect_out="$(docker buildx imagetools inspect $image)"
+  set -e
+
+  case "$platform" in
+    "linux/amd64")             test=is_amd64_build        ;;
+    "linux/amd64,linux/arm64") test=is_amd64_arm64_build  ;;
+    *)
+      echo "platform not supported"
+      exit 1
+  esac
+
+  if $test; then
+    echo "🟢 $image already published for platform $platform"
+  else
+    echo "🔴 $image not published for platform $platform"
+    exit 1
+  fi
+}
+
+main "$@"

--- a/.buildkite/scripts/build/is_published.sh
+++ b/.buildkite/scripts/build/is_published.sh
@@ -17,7 +17,7 @@ is_amd64_build() {
 is_amd64_arm64_build() {
   grep -c "^Name:\s*$image$"        <<< "$inspect_out" >/dev/null && \
   grep -c "Platform:\s*linux/amd64" <<< "$inspect_out" >/dev/null && \
-  grep -c "Platform:\s*linux/amd64" <<< "$inspect_out" >/dev/null
+  grep -c "Platform:\s*linux/arm64" <<< "$inspect_out" >/dev/null
 }
 
 main() {

--- a/.buildkite/scripts/build/setenv.sh
+++ b/.buildkite/scripts/build/setenv.sh
@@ -66,16 +66,9 @@ main() {
         set_env SNAPSHOT=false
         set_env PUBLISH_IMAGE_UBI=true
 
-    elif is_merge_main; then
+    elif is_merge_main || is_nightly_main; then
         REGISTRY_NAMESPACE=eck-snapshots
         IMG_SUFFIX=""
-        IMG_VERSION="$version-$sha1"
-
-        set_env BUILD_PLATFORM=linux/amd64
-   
-    elif is_nightly_main; then
-        REGISTRY_NAMESPACE=eck-ci
-        IMG_SUFFIX="-nightly"
         IMG_VERSION="$version-$sha1"
    
     elif is_pr; then

--- a/.buildkite/scripts/build/setenv_test.sh
+++ b/.buildkite/scripts/build/setenv_test.sh
@@ -38,10 +38,10 @@ echo "test trigger_pr"; BUILDKITE_PULL_REQUEST="4242" $setenv > /dev/null
 assert_image "docker.elastic.co/eck-ci/eck-operator-pr:4242-${current_sha1}"
 
 echo "test trigger_nightly_main"; BUILDKITE_BRANCH="main" BUILDKITE_SOURCE="schedule" $setenv > /dev/null
-assert_image "docker.elastic.co/eck-ci/eck-operator-nightly:${current_version}-${current_sha1}"
+assert_image "docker.elastic.co/eck-snapshots/eck-operator:${current_version}-${current_sha1}"
 
 echo "test trigger_nightly_main-dev"; BUILDKITE_BRANCH="main" BUILDKITE_SOURCE="schedule" BUILD_LICENSE_PUBKEY=dev $setenv > /dev/null
-assert_image "docker.elastic.co/eck-ci/eck-operator-nightly:${current_version}-${current_sha1}-dev"
+assert_image "docker.elastic.co/eck-snapshots/eck-operator:${current_version}-${current_sha1}-dev"
 
 echo "test trigger_merge_main"; BUILDKITE_BRANCH="main" $setenv > /dev/null
 assert_image "docker.elastic.co/eck-snapshots/eck-operator:${current_version}-${current_sha1}"

--- a/Makefile
+++ b/Makefile
@@ -368,8 +368,7 @@ switch-tanzu:
 BUILD_PLATFORM ?= "linux/amd64,linux/arm64"	
 
 publish-operator-multiarch-image:
-	@ docker buildx imagetools inspect $(OPERATOR_IMAGE) 2>&1 >/dev/null \
-	&& echo "OK: image $(OPERATOR_IMAGE) already published" \
+	@ .buildkite/scripts/build/is_published.sh $(OPERATOR_IMAGE) $(BUILD_PLATFORM) \
 	|| $(MAKE) docker-multiarch-build
 
 docker-multiarch-build: go-generate generate-config-file
@@ -495,8 +494,7 @@ e2e-docker-push:
 	@ hack/docker.sh -l -p $(E2E_IMG)
 
 publish-e2e-multiarch-image:
-	@ docker buildx imagetools inspect $(E2E_IMG) 2>&1 >/dev/null \
-	&& echo "OK: image $(E2E_IMG) already published" \
+	@ .buildkite/scripts/build/is_published.sh $(E2E_IMG) $(BUILD_PLATFORM) \
 	|| $(MAKE) e2e-docker-multiarch-build
 
 e2e-docker-multiarch-build: go-generate


### PR DESCRIPTION
* Reuse images built on merge-main in nightly-main and also build the two platforms on merge-main: there is no point in rebuilding the images in the nightly build when they were built during the merge.

* Fix detection of multiarch image publishing for correctness: by adding a script that checks if an image has been published for given platforms.

Resolves #6624.