### PR TITLE
Better support dev operator build to test snapshot stack versions

### DIFF
--- a/.buildkite/e2e/nightly-main-matrix.yaml
+++ b/.buildkite/e2e/nightly-main-matrix.yaml
@@ -15,8 +15,6 @@
     - E2E_STACK_VERSION: "8.3.3"
     - E2E_STACK_VERSION: "8.4.3"
     - E2E_STACK_VERSION: "8.7.0-SNAPSHOT"
-      BUILD_LICENSE_PUBKEY: dev
-      TEST_LICENSE_PKEY_PATH: "in-memory"
 
 - label: kind
   fixed:

--- a/.buildkite/e2e/pipeline-gen/main.go
+++ b/.buildkite/e2e/pipeline-gen/main.go
@@ -34,6 +34,7 @@ const (
 	EnvVarClusterName          = "CLUSTER_NAME"
 	EnvVarTestOpts             = "TEST_OPTS"
 	EnvVarTestsMatch           = "TESTS_MATCH"
+	EnvVarTestLicensePKeyPath  = "TEST_LICENSE_PKEY_PATH"
 	EnvVarBuildLicensePubkey   = "BUILD_LICENSE_PUBKEY"
 	EnvVarLicensePubKey        = "export LICENSE_PUBKEY"
 	EnvVarTestLicense          = "TEST_LICENSE"
@@ -232,16 +233,15 @@ func newTestsSuite(groupLabel string, fixed Env, mixedLen int, mixed Env) (Tests
 		return TestsSuiteRun{}, fmt.Errorf("%s not defined", EnvVarProvider)
 	}
 
-	// when the variable to build the operator with a specific public license key is used,
-	// it involves using an operator image suffixed with the value of this variable
-	operatorImageSuffix, _ := lookupEnv(EnvVarBuildLicensePubkey, fixed, mixed)
+	stackVersion, _ := lookupEnv(EnvVarStackVersion, fixed, mixed)
 
 	name := getName(groupLabel, provider, mixedLen, mixed)
 	slugName := getSlugName(name)
-	env, err := commonTestEnv(name, slugName, operatorImageSuffix)
+	env, err := commonTestEnv(name, slugName, stackVersion)
 	if err != nil {
 		return TestsSuiteRun{}, err
 	}
+
 	t := TestsSuiteRun{
 		Name:             name,
 		Provider:         provider,
@@ -348,7 +348,7 @@ func getSlugName(name string) string {
 	return fmt.Sprintf("%s-%s", name, string(id))
 }
 
-func commonTestEnv(name string, slugName string, operatorImageSuffix string) (map[string]string, error) {
+func commonTestEnv(name string, slugName string, stackVersion string) (map[string]string, error) {
 	buildNumber, ok := os.LookupEnv(EnvVarBuildkiteBuildNumber)
 	if !ok {
 		buildNumber = "0"
@@ -357,9 +357,6 @@ func commonTestEnv(name string, slugName string, operatorImageSuffix string) (ma
 	operatorImage, err := getMetadata("operator-image")
 	if err != nil {
 		return nil, err
-	}
-	if operatorImageSuffix != "" {
-		operatorImage = fmt.Sprintf("%s-%s", operatorImage, operatorImageSuffix)
 	}
 	e2eImage, err := getMetadata("e2e-image")
 	if err != nil {
@@ -378,6 +375,16 @@ func commonTestEnv(name string, slugName string, operatorImageSuffix string) (ma
 		EnvVarMonitoringSecrets: "in-memory",
 		EnvVarOperatorImage:     operatorImage,
 		EnvVarE2EImage:          e2eImage,
+	}
+
+	// automatically add special vars to test snapshot stack versions
+	if strings.HasSuffix(stackVersion, "-SNAPSHOT") {
+		// dev operator image build
+		env[EnvVarOperatorImage] = fmt.Sprintf("%s-%s", env[EnvVarOperatorImage], "dev")
+		// dev public key to verify test licenses
+		env[EnvVarBuildLicensePubkey] = "dev"
+		// dev private key to generate test licenses
+		env[EnvVarTestLicensePKeyPath] = "in-memory"
 	}
 
 	// dev mode

--- a/.buildkite/pipeline-build.yml
+++ b/.buildkite/pipeline-build.yml
@@ -38,6 +38,7 @@ steps:
         key: "dev-operator-image-build"
         env:
           BUILD_LICENSE_PUBKEY: "dev"
+          OPERATOR_VERSION_SUFFIX: "dev"
         commands:
           - .buildkite/scripts/build/setenv.sh
           - make -C .ci TARGET="publish-operator-multiarch-image" ci

--- a/.buildkite/scripts/build/setenv.sh
+++ b/.buildkite/scripts/build/setenv.sh
@@ -86,11 +86,7 @@ main() {
 
     set_env "REGISTRY_NAMESPACE=$REGISTRY_NAMESPACE"
     set_env "IMG_SUFFIX=$IMG_SUFFIX"
-    image_version_suffix="${BUILD_LICENSE_PUBKEY:+-$BUILD_LICENSE_PUBKEY}"
-    set_env "IMG_VERSION=$IMG_VERSION$image_version_suffix"
-    # force old schema as long as setenvconfig is used to run e2e tests
-    # to be removed once pipeline-gen is used
-    set_env "E2E_IMG_TAG=$version-$sha1"
+    set_env "IMG_VERSION=$IMG_VERSION${OPERATOR_VERSION_SUFFIX:+-$OPERATOR_VERSION_SUFFIX}"
 }
 
 main "$@"

--- a/.buildkite/scripts/build/setenv_test.sh
+++ b/.buildkite/scripts/build/setenv_test.sh
@@ -40,7 +40,7 @@ assert_image "docker.elastic.co/eck-ci/eck-operator-pr:4242-${current_sha1}"
 echo "test trigger_nightly_main"; BUILDKITE_BRANCH="main" BUILDKITE_SOURCE="schedule" $setenv > /dev/null
 assert_image "docker.elastic.co/eck-snapshots/eck-operator:${current_version}-${current_sha1}"
 
-echo "test trigger_nightly_main-dev"; BUILDKITE_BRANCH="main" BUILDKITE_SOURCE="schedule" BUILD_LICENSE_PUBKEY=dev $setenv > /dev/null
+echo "test trigger_nightly_main-dev"; BUILDKITE_BRANCH="main" BUILDKITE_SOURCE="schedule" OPERATOR_VERSION_SUFFIX=dev $setenv > /dev/null
 assert_image "docker.elastic.co/eck-snapshots/eck-operator:${current_version}-${current_sha1}-dev"
 
 echo "test trigger_merge_main"; BUILDKITE_BRANCH="main" $setenv > /dev/null


### PR DESCRIPTION
- Explicit OPERATOR_VERSION_SUFFIX var for the build pipeline
- Automatically add special vars to test snapshot stack versions in pipeline-gen

Resolves #6567.