### PR TITLE
[ci/agent] Update docker.io/library/golang Docker tag to v1.20.3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:01671ac6
+  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:5827bee6
   cpu: "4"
   memory: "2G"
 

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -31,7 +31,7 @@ NOT_USED := $(shell test -e $(ROOT_DIR)/deployer-config.yml && sed "s;roleId:.*;
 endif
 endif
 
-CI_IMAGE ?= docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:01671ac6
+CI_IMAGE ?= docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:5827bee6
 
 # volume used to share files between CI container and containers launched by deployer
 ECK_CI_VOLUME := eck-ci-home-$(shell date '+%N')


### PR DESCRIPTION
Updates the CI buildkite agent tag to use the latest version, updated to golang v1.20.3.

Relates to #6650.