### PR TITLE
Separate pipeline to release ECK on RedHat channels

### DIFF
--- a/.buildkite/pipeline-build.yml
+++ b/.buildkite/pipeline-build.yml
@@ -61,13 +61,6 @@ steps:
           image: "family/elastic-buildkite-agent-ubuntu-2004-lts"
           machineType: "n1-standard-16"
 
-      - label: ":go: operatorhub tool"
-        key: "build-operatorhub-tool"
-        commands:
-          - cd hack/operatorhub
-          - make build
-          - buildkite-agent artifact upload bin/operatorhub
-
       - label: ":go: helm releaser tool"
         key: "build-helm-releaser-tool"
         commands:

--- a/.buildkite/pipeline-release-redhat.yml
+++ b/.buildkite/pipeline-release-redhat.yml
@@ -2,6 +2,13 @@ steps:
   - group: redhat-release
     steps:
 
+      - label: ":go: operatorhub tool"
+        key: "build-operatorhub-tool"
+        commands:
+          - cd hack/operatorhub
+          - make build
+          - buildkite-agent artifact upload bin/operatorhub
+
       - label: "generate crds"
         key: "generate-crds"
         depends_on:

--- a/.buildkite/pipeline-release.yml
+++ b/.buildkite/pipeline-release.yml
@@ -35,4 +35,4 @@ steps:
         if: |
           build.message =~ /^buildkite test .*operatorhub.*/
           || build.message =~ /^release eck .*operatorhub.*/
-        command: buildkite-agent pipeline upload .buildkite/pipeline-release-operatorhub.yml
+        command: buildkite-agent pipeline upload .buildkite/pipeline-release-redhat.yml

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -83,3 +83,32 @@ spec:
         cloud-k8s-operator: {}
         everyone:
           access_level: READ_ONLY
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: cloud-on-k8s-operator-redhat-release-buildkite-pipeline
+  description: Buildkite Pipeline cloud-on-k8s-operator-redhat-release
+  links:
+  - title: Pipeline
+    url: https://buildkite.com/elastic/cloud-on-k8s-operator-redhat-release
+spec:
+  type: buildkite-pipeline
+  owner: group:cloud-k8s-operator
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: cloud-on-k8s-operator-redhat-release
+      description: Release Elastic Cloud on Kubernetes (ECK) on RedHat channels
+    spec:
+      repository: elastic/cloud-on-k8s
+      pipeline_file: .buildkite/pipeline-release-redhat.yml
+      provider_settings:
+        trigger_mode: none
+      teams:
+        cloud-k8s-operator: {}
+        everyone:
+          access_level: READ_ONLY


### PR DESCRIPTION
This declares a separate pipeline to release ECK on RedHat channels.

Related minor changes:
- rename `pipeline-release-operatorhub.yml` to `pipeline-release-redhat.yml`
- move `build-operatorhub-tool` step from `pipeline-build.yml` to `pipeline-release-redhat.yml`