### PR TITLE
Add PDB for eck-operator helm chart

### DIFF
--- a/deploy/eck-operator/templates/pdb.yaml
+++ b/deploy/eck-operator/templates/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "eck-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ - include "eck-operator.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end  }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end  }}
+  selector:
+    matchLabels:
+      {{- include "eck-operator.selectorLabels" . | nindent 6 }}
+  {{- end -}}

--- a/deploy/eck-operator/templates/pdb.yaml
+++ b/deploy/eck-operator/templates/pdb.yaml
@@ -5,15 +5,15 @@ metadata:
   name: {{ include "eck-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ - include "eck-operator.labels" . | nindent 4 }}
+    {{- include "eck-operator.labels" . | indent 4 }}
 spec:
-  {{- if .Values.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
   {{- end  }}
-  {{- if .Values.podDisruptionBudget.maxUnavailable }}
-  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
   {{- end  }}
   selector:
     matchLabels:
-      {{- include "eck-operator.selectorLabels" . | nindent 6 }}
-  {{- end -}}
+      {{- include "eck-operator.selectorLabels" . | indent 6 }}
+{{- end -}}

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -68,6 +68,12 @@ tolerations: []
 # affinity defines the node affinity rules for the operator pod.
 affinity: {}
 
+# Only one of minAvailable or maxUnavailable can be set
+podDisruptionBudget:
+  enabled: false
+  # minAvailable: 1
+  # maxUnavailable: 3
+
 # additional environment variables for the operator container.
 env: []
 
@@ -235,4 +241,3 @@ global:
   createOperatorNamespace: true
   # kubeVersion is the effective Kubernetes version we target when generating the all-in-one.yaml.
   kubeVersion: 1.21.0
-

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -68,7 +68,8 @@ tolerations: []
 # affinity defines the node affinity rules for the operator pod.
 affinity: {}
 
-# Only one of minAvailable or maxUnavailable can be set
+# podDisruptionBudget configures the minimum or the maxium available pods for voluntary disruptions,
+# set to either an integer (e.g. 1) or a percentage value (e.g. 25%).
 podDisruptionBudget:
   enabled: false
   # minAvailable: 1

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -72,7 +72,7 @@ affinity: {}
 # set to either an integer (e.g. 1) or a percentage value (e.g. 25%).
 podDisruptionBudget:
   enabled: false
-  # minAvailable: 1
+  minAvailable: 1
   # maxUnavailable: 3
 
 # additional environment variables for the operator container.


### PR DESCRIPTION
Allow PodDisruptionBudget be configured via parameter for eck-operator statefulset deployment. 
