### PR TITLE
Bump supported aks version in both CI and Dev for Deployer.

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -45,7 +45,7 @@ plans:
   operation: create
   clusterName: ci
   provider: aks
-  kubernetesVersion: 1.24.6
+  kubernetesVersion: 1.24.10
   machineType: Standard_D8s_v3
   serviceAccount: true
   enforceSecurityPolicies: true
@@ -58,7 +58,7 @@ plans:
   operation: create
   clusterName: dev
   provider: aks
-  kubernetesVersion: 1.24.6
+  kubernetesVersion: 1.24.10
   machineType: Standard_D8s_v3
   serviceAccount: false
   enforceSecurityPolicies: true

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -45,7 +45,7 @@ plans:
   operation: create
   clusterName: ci
   provider: aks
-  kubernetesVersion: 1.24.10
+  kubernetesVersion: 1.26.0
   machineType: Standard_D8s_v3
   serviceAccount: true
   enforceSecurityPolicies: true
@@ -58,7 +58,7 @@ plans:
   operation: create
   clusterName: dev
   provider: aks
-  kubernetesVersion: 1.24.10
+  kubernetesVersion: 1.26.0
   machineType: Standard_D8s_v3
   serviceAccount: false
   enforceSecurityPolicies: true


### PR DESCRIPTION
resolves #6676 

`1.24.6` is no longer supported in AKS.