### PR TITLE
Disable build trigger for PR and branches for redhat release pipeline

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -108,6 +108,9 @@ spec:
       pipeline_file: .buildkite/pipeline-release-redhat.yml
       provider_settings:
         build_tags: true
+        build_pull_requests: false
+        build_branches: false
+        publish_commit_status: false
       teams:
         cloud-k8s-operator: {}
         everyone:


### PR DESCRIPTION
This explicitly disables not triggering the Red Hat release pipeline for PRs and branches and not publishing GitHub status.

Follow-up of #6658.