### PR TITLE
ES: Use full certificate chain in the trusted certificates slice.

### DIFF
--- a/pkg/controller/elasticsearch/certificates/reconcile.go
+++ b/pkg/controller/elasticsearch/certificates/reconcile.go
@@ -75,7 +75,7 @@ func ReconcileHTTP(
 		return nil, results
 	}
 
-	trustedHTTPCertificates, err := certificates.ParsePEMCerts(httpCerts.CertPem())
+	trustedHTTPCertificates, err := certificates.ParsePEMCerts(httpCerts.CertChain())
 	if err != nil {
 		return nil, results.WithError(err)
 	}


### PR DESCRIPTION
resolves #6574 

This change will add the full certificate chain to the list of trusted certificates that are used when communicating with Elasticsearch clusters. This should resolve the temporary issue where errors are seen when certificates are renewed, and the new certificate(s) are not fully distributed to all nodes of the Elasticsearch cluster.

## TODO
- [x] full e2e testing run