### PR TITLE
Remove trailing dot in 'gsutil rm' command

### DIFF
--- a/.buildkite/scripts/common/cp-diagnostics.sh
+++ b/.buildkite/scripts/common/cp-diagnostics.sh
@@ -8,7 +8,7 @@ main() {
     # If diagnostics exist in remote bucket, copy them from bucket to the local agent to be picked up as buildkite artifacts
     if gsutil ls "gs://eck-e2e-buildkite-artifacts/jobs/$CLUSTER_NAME/eck-diagnostic*.zip" 2> /dev/null ; then
         gsutil cp "gs://eck-e2e-buildkite-artifacts/jobs/$CLUSTER_NAME/eck-diagnostic*.zip" .
-        gsutil rm "gs://eck-e2e-buildkite-artifacts/jobs/$CLUSTER_NAME/eck-diagnostic*.zip" .
+        gsutil rm "gs://eck-e2e-buildkite-artifacts/jobs/$CLUSTER_NAME/eck-diagnostic*.zip"
     fi
 }
 


### PR DESCRIPTION
The trailing dot isn't needed, but isn't causing failures.