### PR TITLE
Default to running Elasticsearch as `ReadOnlyRootFilesystem: true`

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -128,6 +128,7 @@ func BuildPodTemplateSpec(
 		enableLog4JFormatMsgNoLookups(builder)
 	}
 
+	// default to running the "elasticsearch" container as "readOnlyRootFilesystem: true"
 	mainContainer := builder.MainContainer()
 	if mainContainer != nil {
 		mainContainer.SecurityContext = &corev1.SecurityContext{

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -12,7 +12,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-
 	"k8s.io/utils/pointer"
 
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -13,6 +13,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"k8s.io/utils/pointer"
+
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/annotation"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/container"
@@ -28,7 +30,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/stackmon"
 	esvolume "github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/volume"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
-	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/pointer"
 )
 
 const (
@@ -125,6 +126,13 @@ func BuildPodTemplateSpec(
 	if ver.LT(version.From(7, 2, 0)) {
 		// mitigate CVE-2021-44228
 		enableLog4JFormatMsgNoLookups(builder)
+	}
+
+	mainContainer := builder.MainContainer()
+	if mainContainer != nil {
+		mainContainer.SecurityContext = &corev1.SecurityContext{
+			ReadOnlyRootFilesystem: pointer.Bool(true),
+		}
 	}
 
 	return builder.PodTemplate, nil

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s_pointer "k8s.io/utils/pointer"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
@@ -324,6 +325,9 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 					ReadinessProbe: NewReadinessProbe(),
 					Lifecycle: &corev1.Lifecycle{
 						PreStop: NewPreStopHook(),
+					},
+					SecurityContext: &corev1.SecurityContext{
+						ReadOnlyRootFilesystem: k8s_pointer.Bool(true),
 					},
 				},
 			},

--- a/pkg/controller/elasticsearch/nodespec/volumes.go
+++ b/pkg/controller/elasticsearch/nodespec/volumes.go
@@ -60,6 +60,10 @@ func buildVolumes(
 		esvolume.FileSettingsVolumeName,
 		esvolume.FileSettingsVolumeMountPath,
 	)
+	tmpVolume := volume.NewEmptyDirVolume(
+		"tmp-volume",
+		"/tmp",
+	)
 	// append future volumes from PVCs (not resolved to a claim yet)
 	persistentVolumes := make([]corev1.Volume, 0, len(nodeSpec.VolumeClaimTemplates))
 	for _, claimTemplate := range nodeSpec.VolumeClaimTemplates {
@@ -89,6 +93,7 @@ func buildVolumes(
 			scriptsVolume.Volume(),
 			configVolume.Volume(),
 			downwardAPIVolume.Volume(),
+			tmpVolume.Volume(),
 		)...)
 	if keystoreResources != nil {
 		volumes = append(volumes, keystoreResources.Volume)
@@ -106,6 +111,7 @@ func buildVolumes(
 		scriptsVolume.VolumeMount(),
 		configVolume.VolumeMount(),
 		downwardAPIVolume.VolumeMount(),
+		tmpVolume.VolumeMount(),
 	)
 
 	// version gate for the file-based settings volume and volumeMounts

--- a/pkg/controller/elasticsearch/nodespec/volumes.go
+++ b/pkg/controller/elasticsearch/nodespec/volumes.go
@@ -61,8 +61,8 @@ func buildVolumes(
 		esvolume.FileSettingsVolumeMountPath,
 	)
 	tmpVolume := volume.NewEmptyDirVolume(
-		"tmp-volume",
-		"/tmp",
+		esvolume.TempVolumeName,
+		esvolume.TempVolumeMountPath,
 	)
 	// append future volumes from PVCs (not resolved to a claim yet)
 	persistentVolumes := make([]corev1.Volume, 0, len(nodeSpec.VolumeClaimTemplates))

--- a/pkg/controller/elasticsearch/volume/names.go
+++ b/pkg/controller/elasticsearch/volume/names.go
@@ -48,4 +48,7 @@ const (
 
 	FileSettingsVolumeName      = "file-settings"
 	FileSettingsVolumeMountPath = "/usr/share/elasticsearch/config/operator"
+
+	TempVolumeName      = "tmp-volume"
+	TempVolumeMountPath = "/tmp"
 )


### PR DESCRIPTION
## Primary Change

This enables running Elasticsearch with `readOnlyRootFilesystem: true` as this aligns with security best practices.

## Todo
- [ ] Full set of e2e tests on both 7.x and 8.x
- [ ] Documentation

related #6126 