### PR TITLE
Use provided base path for stackconfigpolicy's snapshot repository

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
@@ -35,7 +35,7 @@ Elastic Stack configuration policies can be defined in a `StackConfigPolicy` res
 * `name` is a unique name used to identify the policy.
 * `spec.elasticsearch` describes the settings to configure and at least one setting must be defined. Each of the following fields except `clusterSettings` is an associative array where keys are arbitrary names and values are definitions:
   ** `clusterSettings` are the settings that go into the elasticsearch.yml file.
-  ** `snapshotRepositories` are snapshot repositories for defining an off-cluster storage location for your snapshots (check <<{p}-{page_id}-specifics-snap-repo,specifics>>).
+  ** `snapshotRepositories` are snapshot repositories for defining an off-cluster storage location for your snapshots. Check <<{p}-{page_id}-specifics-snap-repo>> for more information.
   ** `snapshotLifecyclePolicies` are snapshot lifecycle policies, to automatically take snapshots and control how long they are retained.
   ** `securityRoleMappings` are role mappings, to define which roles are assigned to each user by identifying them through rules.
   ** `ingestPipelines` are ingest pipelines, to perform common transformations on your data before indexing.
@@ -239,7 +239,8 @@ Important events are also reported through Kubernetes events, such as when two c
 [id="{p}-{page_id}-specifics-snap-repo"]
 == Specifics for snapshot repositories
 
-In order to avoid a conflict between multiple Elasticsearch clusters writing their snapshot to the same location, ECK automatically:
-- sets the `base_path` to `snapshots/<namespace><esName>` when it is not provided, for Azure, GCS and S3 repositories
-- appends `<namespace><esName>` to `location` for a FS repository
-- appends `<namespace><esName>` to `path` for an `HDFS` repository
+In order to avoid a conflict between multiple Elasticsearch clusters writing their snapshots to the same location, ECK automatically:
+
+- sets the `base_path` to `snapshots/<namespace>-<esName>` when it is not provided, for Azure, GCS and S3 repositories
+- appends `<namespace>-<esName>` to `location` for a FS repository
+- appends `<namespace>-<esName>` to `path` for an HDFS repository

--- a/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
@@ -35,7 +35,7 @@ Elastic Stack configuration policies can be defined in a `StackConfigPolicy` res
 * `name` is a unique name used to identify the policy.
 * `spec.elasticsearch` describes the settings to configure and at least one setting must be defined. Each of the following fields except `clusterSettings` is an associative array where keys are arbitrary names and values are definitions:
   ** `clusterSettings` are the settings that go into the elasticsearch.yml file.
-  ** `snapshotRepositories` are snapshot repositories for defining an off-cluster storage location for your snapshots.
+  ** `snapshotRepositories` are snapshot repositories for defining an off-cluster storage location for your snapshots (check <<{p}-{page_id}-specifics-snap-repo,specifics>>).
   ** `snapshotLifecyclePolicies` are snapshot lifecycle policies, to automatically take snapshots and control how long they are retained.
   ** `securityRoleMappings` are role mappings, to define which roles are assigned to each user by identifying them through rules.
   ** `ingestPipelines` are ingest pipelines, to perform common transformations on your data before indexing.
@@ -49,7 +49,7 @@ The following fields are optional:
 * `resourceSelector` is a link:https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/[label selector] to identify the Elasticsearch clusters to which this policy applies in combination with the namespace(s). No `resourceSelector` means all Elasticsearch clusters in the namespace(s).
 * `secureSettings` is a list of Secrets containing Secure Settings to inject into the keystore(s) of the Elasticsearch cluster(s) to which this policy applies, similar to the <<{p}-custom-images,Elasticsearch Secure Settings>>.
 
-Secure settings may be required to configure Cloud snapshot repositories (azure, gcs, s3) if you are not using Cloud-provider specific means to leverage Kubernetes service accounts
+Secure settings may be required to configure Cloud snapshot repositories (Azure, GCS, S3) if you are not using Cloud-provider specific means to leverage Kubernetes service accounts
 (<<{p}-gke-workload-identiy,GKE Workload Identity>> or <<{p}-iam-service-accounts,AWS IAM roles for service accounts>>, for example).
 
 Example of applying a policy that configures snapshot repository, SLM Policies, and cluster settings:
@@ -234,3 +234,12 @@ Important events are also reported through Kubernetes events, such as when two c
 ----
 17s    Warning   ReconciliationError stackconfigpolicy/config-test   StackConfigPolicy is an enterprise feature. Enterprise features are disabled
 ----
+
+[float]
+[id="{p}-{page_id}-specifics-snap-repo"]
+== Specifics for snapshot repositories
+
+In order to avoid a conflict between multiple Elasticsearch clusters writing their snapshot to the same location, ECK automatically:
+- sets the `base_path` to `snapshots/<namespace><esName>` when it is not provided, for Azure, GCS and S3 repositories
+- appends `<namespace><esName>` to `location` for a FS repository
+- appends `<namespace><esName>` to `path` for an `HDFS` repository

--- a/pkg/controller/elasticsearch/filesettings/file_settings.go
+++ b/pkg/controller/elasticsearch/filesettings/file_settings.go
@@ -145,7 +145,11 @@ func mutateSnapshotRepositorySettings(snapshotRepository map[string]interface{},
 	}
 	switch snapshotRepository["type"] {
 	case "azure", "gcs", "s3":
-		settings["base_path"] = fmt.Sprintf("snapshots/%s", suffix)
+		basePath, ok := settings["base_path"].(string)
+		if !ok {
+			basePath = "snapshots"
+		}
+		settings["base_path"] = filepath.Join(basePath, suffix)
 	case "fs":
 		location, ok := settings["location"].(string)
 		if !ok {

--- a/pkg/controller/elasticsearch/filesettings/file_settings.go
+++ b/pkg/controller/elasticsearch/filesettings/file_settings.go
@@ -144,7 +144,6 @@ func mutateSnapshotRepositorySettings(snapshotRepository map[string]interface{},
 		return nil, fmt.Errorf("invalid type (%T) for snapshot repository settings", untypedSettings)
 	}
 	switch snapshotRepository["type"] {
-
 	case "azure", "gcs", "s3":
 		basePath, ok := settings["base_path"].(string)
 		if !ok {

--- a/pkg/controller/elasticsearch/filesettings/file_settings_test.go
+++ b/pkg/controller/elasticsearch/filesettings/file_settings_test.go
@@ -146,7 +146,7 @@ func Test_updateState(t *testing.T) {
 			want: newEmptySettingsState(),
 		},
 		{
-			name: "gcs, azure and s3 snapshot repository settings: adding a base_path",
+			name: "gcs, azure and s3 snapshot repository settings: default base_path",
 			args: args{policy: policyv1alpha1.StackConfigPolicy{Spec: policyv1alpha1.StackConfigPolicySpec{Elasticsearch: policyv1alpha1.ElasticsearchConfigPolicySpec{
 				SnapshotRepositories: &commonv1.Config{Data: map[string]any{
 					"repo-gcs": map[string]any{
@@ -191,6 +191,68 @@ func Test_updateState(t *testing.T) {
 						"settings": map[string]any{
 							"bucket":    "bucket",
 							"base_path": "snapshots/esNs-esName",
+						},
+					},
+				}},
+				SLM:                    &commonv1.Config{Data: map[string]any{}},
+				RoleMappings:           &commonv1.Config{Data: map[string]any{}},
+				IndexLifecyclePolicies: &commonv1.Config{Data: map[string]any{}},
+				IngestPipelines:        &commonv1.Config{Data: map[string]any{}},
+				IndexTemplates: &IndexTemplates{
+					ComponentTemplates:       &commonv1.Config{Data: map[string]any{}},
+					ComposableIndexTemplates: &commonv1.Config{Data: map[string]any{}},
+				},
+			},
+		},
+		{
+			name: "gcs, azure and s3 snapshot repository settings: set base_path",
+			args: args{policy: policyv1alpha1.StackConfigPolicy{Spec: policyv1alpha1.StackConfigPolicySpec{Elasticsearch: policyv1alpha1.ElasticsearchConfigPolicySpec{
+				SnapshotRepositories: &commonv1.Config{Data: map[string]any{
+					"repo-gcs": map[string]any{
+						"type": "gcs",
+						"settings": map[string]any{
+							"bucket":    "bucket",
+							"base_path": "es-snapshots",
+						},
+					},
+					"repo-azure": map[string]any{
+						"type": "azure",
+						"settings": map[string]any{
+							"bucket":    "bucket",
+							"base_path": "es-snapshots",
+						},
+					},
+					"repo-s3": map[string]any{
+						"type": "s3",
+						"settings": map[string]any{
+							"bucket":    "bucket",
+							"base_path": "es-snapshots",
+						},
+					},
+				}},
+			}}}},
+			want: SettingsState{
+				ClusterSettings: &commonv1.Config{Data: map[string]any{}},
+				SnapshotRepositories: &commonv1.Config{Data: map[string]any{
+					"repo-gcs": map[string]any{
+						"type": "gcs",
+						"settings": map[string]any{
+							"bucket":    "bucket",
+							"base_path": "es-snapshots/esNs-esName",
+						},
+					},
+					"repo-azure": map[string]any{
+						"type": "azure",
+						"settings": map[string]any{
+							"bucket":    "bucket",
+							"base_path": "es-snapshots/esNs-esName",
+						},
+					},
+					"repo-s3": map[string]any{
+						"type": "s3",
+						"settings": map[string]any{
+							"bucket":    "bucket",
+							"base_path": "es-snapshots/esNs-esName",
 						},
 					},
 				}},

--- a/pkg/controller/elasticsearch/filesettings/file_settings_test.go
+++ b/pkg/controller/elasticsearch/filesettings/file_settings_test.go
@@ -212,7 +212,7 @@ func Test_updateState(t *testing.T) {
 						"type": "gcs",
 						"settings": map[string]any{
 							"bucket":    "bucket",
-							"base_path": "es-snapshots",
+							"base_path": "snapshots/es",
 						},
 					},
 					"repo-azure": map[string]any{
@@ -226,7 +226,7 @@ func Test_updateState(t *testing.T) {
 						"type": "s3",
 						"settings": map[string]any{
 							"bucket":    "bucket",
-							"base_path": "es-snapshots",
+							"base_path": "a/b/c",
 						},
 					},
 				}},
@@ -238,21 +238,21 @@ func Test_updateState(t *testing.T) {
 						"type": "gcs",
 						"settings": map[string]any{
 							"bucket":    "bucket",
-							"base_path": "es-snapshots/esNs-esName",
+							"base_path": "snapshots/es",
 						},
 					},
 					"repo-azure": map[string]any{
 						"type": "azure",
 						"settings": map[string]any{
 							"bucket":    "bucket",
-							"base_path": "es-snapshots/esNs-esName",
+							"base_path": "es-snapshots",
 						},
 					},
 					"repo-s3": map[string]any{
 						"type": "s3",
 						"settings": map[string]any{
 							"bucket":    "bucket",
-							"base_path": "es-snapshots/esNs-esName",
+							"base_path": "a/b/c",
 						},
 					},
 				}},


### PR DESCRIPTION
This changes how ECK managed the `base_path` setting for stackconfigpolicy's cloud snapshot repositories.

Instead of always setting it to `snapshots/<namespace>-<esName>`, it will only set it when the user hasn't provide one.

The documentation is updated to mention this specificity.

Resolves #6692.