### PR TITLE
Prevent Buildkite job annotation to be larger than 1MB

### DIFF
--- a/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
+++ b/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
@@ -11,8 +11,8 @@ steps:
             - "#eck"
           message: |
           {{- range $envName, $sortedTests := .Tests }}
-            {{- range $test := $sortedTests.Failed }}
-            🐞 `{{ splitTestName $test.Name }}` {{ $envName }}
+            {{- range $test := $sortedTests.ShortFailed }}
+            🐞 `{{ $test.Name }}` {{ $envName }}
             {{- end }}
           {{- end }}
       {{- end }}


### PR DESCRIPTION
This change prevents reaching the 1MB maximum size of a Buildkite annotation by reducing the size of the string corresponding to the go error associated to the e2e tests failure to `3000 bytes`.
This also remove duplicates in notifications where we only kept the parent test name before the / that can be duplicated when multiple steps of the same parent tests failed.
Finally it sorts the tests by name.

`3000 bytes` is a bit arbitrary but the formula used is: 1 000 000 (max-size 1MB) / (150 bytes (summary content and anchors) + 3000 bytes (details content)) = 317, which corresponds to the total number of tests failures that we could have with an error trimed to 3000 bytes, which is impossible now (we have 145 tests) and will be extremely unlikely in the future.




Resolves #6697.