### PR TITLE
Docs: Daemonset to manage Agent hostpath Permissions

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/agent-standalone.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-standalone.asciidoc
@@ -63,7 +63,7 @@ spec:
 EOF
 ----
 +
-<1> The root user is required to persist state in a hostPath volume. See <<{p}_storing_local_state_in_host_path_volume>> on how to disable this feature.
+<1> The root user is required to persist state in a hostPath volume. See <<{p}_storing_local_state_in_host_path_volume>> for options to not run the Agent container as root.
 +
 Check <<{p}-elastic-agent-configuration-examples>> for more ready-to-use manifests.
 
@@ -170,7 +170,7 @@ spec:
             period: 10s
 ----
 
-<1> The root user is required to persist state in a hostPath volume. See <<{p}_storing_local_state_in_host_path_volume>> on how to disable this feature.
+<1> The root user is required to persist state in a hostPath volume. See <<{p}_storing_local_state_in_host_path_volume>> for options to not run the Agent container as root.
 
 Alternatively, it can be provided through a Secret specified in the `configRef` element. The Secret must have an `agent.yml` entry with this configuration:
 [source,yaml,subs="attributes,+macros"]
@@ -441,11 +441,14 @@ kubectl apply -f {agent_recipes}/multi-output.yaml
 Deploys two Elasticsearch clusters and two Kibana instances together with single Elastic Agent DaemonSet in standalone mode with System integration enabled. System metrics are sent to the `elasticsearch` cluster. Elastic Agent monitoring data is sent to `elasticsearch-mon` cluster.
 
 === Storing local state in host path volume
-Elastic Agent when managed by ECK stores local state in a host path volume. This ensures that integrations run by the agent can continue their work without duplicating work that has already been done after the Pod has been recreated for example because of a Pod configuration change.
-If local state storage in host path volumes is not desired this can be turned off by configuring an `emptyDir` volume instead:
+Elastic Agent managed by ECK stores local state in a host path volume by default. This ensures that integrations run by the agent can continue their work without duplicating work that has already been done after the Pod has been recreated for example because of a Pod configuration change. There are 2 options for managing this feature:
+
+1. If local state storage in `hostPath` volumes is not desired this can be turned off by configuring an `emptyDir` volume instead.
+2. If local state storage is still desired but running the Agent container as root is not allowed, then you can can run a `DaemonSet` that adjusts the permissions for the Agent local state on each Node prior to running Elastic Agent. *Note that this `DaemonSet` must be `runAsUser: 0` and possibly `privileged: true`*.
 
 [source,yaml]
 ----
+# Using an emptyDir instead of a hostPath volume.
 apiVersion: agent.k8s.elastic.co/v1alpha1
 kind: Agent
 metadata:
@@ -454,8 +457,99 @@ spec:
   deployment:
     podTemplate:
       spec:
+        securityContext:
+          # Gid 1000 is the default group at which the Agent container runs.
+          # Adjust as necessary if `runAsGroup` has been modified.
+          fsGroup: 1000
+        # runAsUser: 0 can be disabled when running with an `emptyDir`
+        # as opposed to a `hostPath` volume.
+        # securityContext:
+          # runAsUser: 0
         volumes:
         - name: agent-data
           emptyDir: {}
 ...
+----
+
+
+[source,yaml]
+----
+# Using a DaemonSet to manage permissions for Elastic Agent using hostPath volume.
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: elastic-agent
+  namespace: elastic-apps
+spec:
+  daemonSet: {}
+...
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: manage-agent-hostpath-permissions
+  namespace: elastic-apps
+spec:
+  selector:
+    matchLabels:
+      name: manage-agent-hostpath-permissions
+  template:
+    metadata:
+      labels:
+        name: manage-agent-hostpath-permissions
+    spec:
+      # This is only required when running in an selinux-enabled/Openshift environment.
+      # Ensure this user has been added to the privileged scc in the correct namespace.
+      # oc adm policy add-scc-to-user privileged -z elastic-agent -n elastic-apps
+      # serviceAccountName: elastic-agent
+      volumes:
+        - hostPath:
+            path: /var/lib/elastic-agent
+            type: DirectoryOrCreate
+          name: "agent-data"
+      initContainers:
+        - name: manage-agent-hostpath-permissions
+          # fedora is only required when needing the `chcon` binary when running
+          # in an senlinux-enabled/Openshift environment. If that
+          # is not required then the following smaller image can be used instead:
+          # image: fedora:39
+          image: docker.io/bash:5.2.15
+          resources:
+            limits:
+              cpu: 100m
+              memory: 32Mi
+          securityContext:
+            # privileged is only required when running in an selinux-enabled/Openshift environment.
+            # privileged: true
+            runAsUser: 0
+          volumeMounts:
+            - mountPath: /var/lib/elastic-agent
+              name: agent-data
+          command:
+          - 'bash'
+          - '-e'
+          - '-c'
+          - |-
+            # Adjust this be /var/lib/elastic-agent/YOUR-NAMESPACE/YOUR-AGENT-NAME/state
+            DIRECTORY="/var/lib/elastic-agent/elastic-apps/elastic-agent/state"
+            if [[ ! -d "${DIRECTORY}" ]]
+            then
+              echo "creating ${DIRECTORY} directory"
+              mkdir -p "${DIRECTORY}"
+            fi
+            # chcon is only required when running an an selinux-enabled/Openshift environment.
+            chcon -Rt svirt_sandbox_file_t "${DIRECTORY}"
+            chmod g+rw "${DIRECTORY}"
+            # Gid 1000 is the default group at which the Agent container runs. Adjust as necessary if `runAsGroup` has been modified.
+            chgrp 1000 "${DIRECTORY}"
+            if [ -n "$(ls -A ${DIRECTORY} 2>/dev/null)" ]
+            then
+              # Gid 1000 is the default group at which the Agent container runs. Adjust as necessary if `runAsGroup` has been modified.
+              chgrp 1000 "${DIRECTORY}"/*
+              chmod g+rw "${DIRECTORY}"/*
+            fi
+      containers:
+        - name: sleep
+          image: docker.io/bash:5.2.15
+          command: ['sleep', 'infinity']
 ----


### PR DESCRIPTION
relates #6599

This adds documentation to allow a user to run a `DaemonSet` to automatically adjust Agent `hostPath` permissions and allow the user to not run the Agent as `runAsUser: 0`.

## TODO
- [ ] Test the `update-ca-trust` requirement for running with Fleet.
- [ ] Update the Agent+Fleet documentation

## Open question

1. Do we want to convert our e2e tests for agent to use this instead of always running as root?