### PR TITLE
Helm Release: Fail to write files to bucket in some scenarios

### DIFF
--- a/hack/helm/release/internal/helm/helm.go
+++ b/hack/helm/release/internal/helm/helm.go
@@ -461,7 +461,8 @@ type copyChartToBucketConfig struct {
 }
 
 // copyChartToGCSBucket will potentially copy a Helm chart to a GCS bucket.
-// If the object already exists within the bucket, it will not be overwritten.
+// If the object already exists within the bucket, it will only be overwritten
+// if the file is a SNAPSHOT release, otherwise an error will be returned.
 func copyChartToGCSBucket(ctx context.Context, config copyChartToBucketConfig) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/hack/helm/release/internal/helm/helm.go
+++ b/hack/helm/release/internal/helm/helm.go
@@ -480,7 +480,7 @@ func copyChartToGCSBucket(ctx context.Context, config copyChartToBucketConfig) e
 	if len(files) == 0 {
 		return fmt.Errorf("couldn't file helm package with glob (%s)", config.sourceGlob)
 	}
-	isSnapshot := strings.Contains(files[0], "SNAPSHOT")
+	isSnapshot := strings.HasSuffix(files[0], "-SNAPSHOT.tgz")
 
 	destination := fmt.Sprintf("%s/%s/%s", strings.TrimPrefix(config.path, "/"), config.chartName, files[0])
 	log.Printf("Writing chart to bucket path (%s) \n", destination)


### PR DESCRIPTION
We recently had a report of the `digest/sha256sum` of `2.7.0` release reported in the Helm index of Helm Chart didn't match the actual `tgz` file itself. This is happening because we are not overwriting existing `tgz` files if they already exist.

So we are
1. Creating a new .tgz file
2. Indexing the file(s) with their new digest
3. Attempting to upload the new .tgz file, but not explicitly overwriting it
4. Uploading the new index with the new digest which doesn't match what's in the bucket.

This change allows these 2 paths:
1. If the helm chart contains `SNAPSHOT` no precondition is set, which means google will not fail when overwriting a file.
2. Otherwise we assume this is a production/tagged release and we will set a precondition, which if encountered, we throw an error and fail the whole operation.

Resolves https://github.com/elastic/cloud-on-k8s/issues/6714.

