### PR TITLE
E2E: retry setup of data integrity check

### DIFF
--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -106,11 +106,16 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 	//nolint:thelper
 	steps := test.StepList{
 		test.Step{
-			Name: "Add some data to the cluster before starting the mutation",
+			Name: "Set up a data integrity check",
 			Test: func(t *testing.T) {
 				dataIntegrityCheck = NewDataIntegrityCheck(k, b)
-				require.NoError(t, dataIntegrityCheck.Init())
 			},
+		},
+		test.Step{
+			Name: "Add some data to the cluster before starting the mutation",
+			Test: test.Eventually(func() error {
+				return dataIntegrityCheck.Init()
+			}),
 		},
 		test.Step{
 			Name: "Start querying Elasticsearch cluster health while mutation is going on",


### PR DESCRIPTION
We have seen some test failures on builds where the cluster rejects connection attempts, even though it has previously already responded to health checks.  The setup of the data integrity check is one of the few places where we do not retry requests on failures. I looked at the logs and it seems the requests are made only a few seconds after the cluster reached ready state so I am wondering if we should be more lenient here and allow for retries.