### PR TITLE
Conditionally set container-suffix in ECK config

### DIFF
--- a/deploy/eck-operator/templates/configmap.yaml
+++ b/deploy/eck-operator/templates/configmap.yaml
@@ -11,7 +11,9 @@ data:
     log-verbosity: {{ int .Values.config.logVerbosity }}
     metrics-port: {{ int .Values.config.metricsPort }}
     container-registry: {{ .Values.config.containerRegistry }}
-    container-suffix: {{ .Values.config.containerSuffix }}
+    {{- with .Values.config.containerSuffix }}
+    container-suffix: {{ . }}
+    {{- end }}
     max-concurrent-reconciles: {{ int .Values.config.maxConcurrentReconciles }}
     {{- if .Values.config.passwordHashCacheSize }}
     password-hash-cache-size: {{ int .Values.config.passwordHashCacheSize }}


### PR DESCRIPTION
This commit ensures that the `config.containerSuffix` Helm value is not empty before writing it to the ECK configMap data to avoid the side effect of the configMap data being formatted on a single line.

I intentionally kept the PR scoped to the bug but we could extend this to all values used in the ECK config.

Resolves to #6695.