### PR TITLE
Operator leader election: use Leases only

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -99,7 +99,7 @@ const (
 	DefaultWebhookName = "elastic-webhook.k8s.elastic.co"
 	WebhookPort        = 9443
 
-	LeaderElectionConfigMapName = "elastic-operator-leader"
+	LeaderElectionLeaseName = "elastic-operator-leader"
 
 	debugHTTPShutdownTimeout = 5 * time.Second // time to allow for the debug HTTP server to shutdown
 )
@@ -527,8 +527,8 @@ func startOperator(ctx context.Context) error {
 		Scheme:                     clientgoscheme.Scheme,
 		CertDir:                    viper.GetString(operator.WebhookCertDirFlag),
 		LeaderElection:             viper.GetBool(operator.EnableLeaderElection),
-		LeaderElectionResourceLock: resourcelock.ConfigMapsLeasesResourceLock, // TODO: use 'lease' after operator is released with 'configmapsleases'
-		LeaderElectionID:           LeaderElectionConfigMapName,
+		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
+		LeaderElectionID:           LeaderElectionLeaseName,
 		LeaderElectionNamespace:    operatorNamespace,
 		Logger:                     log.WithName("eck-operator"),
 	}


### PR DESCRIPTION
Fix #4150 

Note that this PR does not remove the `ConfigMap`, I wasn't sure if it's really worth making an API call every time the operator starts? (no strong opinion though...)