### PR TITLE
Add script to check generated release notes

### DIFF
--- a/hack/release-notes/check.sh
+++ b/hack/release-notes/check.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+
+# Script that helps identifying changes that have been labeled as belonging to certain release version
+# where the corresponding commits are not in the release branch.
+# Its main purpose is to discover missing backports.
+
+set -uo pipefail
+
+WD="$(cd "$(dirname "$0")" || return; pwd)"
+ROOT="$WD/../.."
+
+get-prev-version() {
+    local version=$1
+    git tag | grep -v '-' | grep -B1 "$version" | head -1
+}
+
+list-merged-commits() {
+    local nextVersion=$1
+    local prevVersion=$2
+    git log --pretty=oneline "$prevVersion..$nextVersion" | grep -o "#[0-9]*" | sort
+}
+
+list-release-notes-pr-commits() {
+    local version=$1
+    version=${version#v} # strip v prefix
+    grep -o 'pull}[0-9]*' "$ROOT/docs/release-notes/$version.asciidoc" | sed 's/pull}/#/' | sort
+}
+
+count-release-notes-pr-without-merged-commit() {
+    local nextVersion=$1
+    local prevVersion=$2
+    local grepOpts=${3:-}
+    # shellcheck disable=SC2086
+    diff \
+        <(list-merged-commits "$nextVersion" "$prevVersion") \
+        <(list-release-notes-pr-commits "$nextVersion") \
+        | grep $grepOpts '>'
+}
+
+main() {
+    local nextVersion=$1
+    local prevVersion=${2:-$(get-prev-version "$nextVersion")}
+
+    echo "Compare 'merged PR from $prevVersion to $nextVersion' with 'release-notes/$nextVersion'"
+    
+    count=$(count-release-notes-pr-without-merged-commit "$nextVersion" "$prevVersion" -c)
+    if [[ "$count" -eq 0 ]]; then
+        echo "✅ LGTM"
+    else
+        echo "❌ Error: no commit found for the following issues:"
+        count-release-notes-pr-without-merged-commit "$nextVersion" "$prevVersion"
+    fi
+}
+
+main "$@"

--- a/hack/release-notes/check.sh
+++ b/hack/release-notes/check.sh
@@ -33,12 +33,10 @@ list-release-notes-pr-commits() {
 count-release-notes-pr-without-merged-commit() {
     local nextVersion=$1
     local prevVersion=$2
-    local grepOpts=${3:-}
-    # shellcheck disable=SC2086
     diff \
         <(list-merged-commits "$nextVersion" "$prevVersion") \
         <(list-release-notes-pr-commits "$nextVersion") \
-        | grep $grepOpts '>'
+        | grep '>'
 }
 
 main() {
@@ -47,8 +45,8 @@ main() {
 
     echo "Compare 'merged PR from $prevVersion to $nextVersion' with 'release-notes/$nextVersion'"
     
-    count=$(count-release-notes-pr-without-merged-commit "$nextVersion" "$prevVersion" -c)
-    if [[ "$count" -eq 0 ]]; then
+    prs=$(count-release-notes-pr-without-merged-commit "$nextVersion" "$prevVersion")
+    if [[ -z "$prs" ]]; then
         echo "✅ LGTM"
     else
         echo "❌ Error: no commit found for the following issues:"

--- a/hack/release-notes/check.sh
+++ b/hack/release-notes/check.sh
@@ -7,6 +7,8 @@
 # Script that helps identifying changes that have been labeled as belonging to certain release version
 # where the corresponding commits are not in the release branch.
 # Its main purpose is to discover missing backports.
+#
+# Usage: check.sh TAG
 
 set -uo pipefail
 


### PR DESCRIPTION
This adds a script that helps identifying changes that have been labeled as belonging to certain release version where the corresponding commits are not in the release branch. Its main purpose is to discover missing backports.

Testing:

- Success:

```sh
> hack/release-notes/check-release-notes.sh v2.7.0
Compare 'merged PR from 2.6.1 to v2.7.0' with 'release-notes/v2.7.0'
✅ LGTM
```

- Failure:

Simulate an invalid generated release note by deleting an entry:
```diff
diff --git a/docs/release-notes/2.7.0.asciidoc b/docs/release-notes/2.7.0.asciidoc
index 1518c41e6..ba3580da8 100644
--- a/docs/release-notes/2.7.0.asciidoc
+++ b/docs/release-notes/2.7.0.asciidoc
@@ -11,7 +11,6 @@
 [float]
 === Enhancements

-* Add a new role for APM Server 8.7.0+ {pull}6605[#6605]
+* Add a new role for APM Server 8.7.0+ {pull}16605[#6605]


```

```sh
> hack/release-notes/check-release-notes.sh v2.7.0
Compare 'merged PR from 2.6.1 to v2.7.0' with 'release-notes/v2.7.0'
❌ Error: no commit found for the following issues:
> #16605
```