### PR TITLE
Fix the sample tests for logstash service and stack monitoring

### DIFF
--- a/config/samples/logstash/logstash_svc.yaml
+++ b/config/samples/logstash/logstash_svc.yaml
@@ -23,7 +23,7 @@ spec:
     api.http.port: 9601
     queue.type: memory
   pipelines:
-    - pipeline.id: one
+    - pipeline.id: main
       pipeline.workers: 2
       config.string: "input { beats { port => 5044 }} output { stdout {}}"
   services:

--- a/test/e2e/logstash/stack_monitoring_test.go
+++ b/test/e2e/logstash/stack_monitoring_test.go
@@ -32,7 +32,8 @@ func TestLogstashStackMonitoring(t *testing.T) {
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	monitored := logstash.NewBuilder("test-ls-mon-a").
 		WithNodeCount(1).
-		WithMonitoring(metrics.Ref(), logs.Ref())
+		WithMetricsMonitoring(metrics.Ref()).
+		WithLogsMonitoring(logs.Ref())
 
 	// checks that the sidecar beats have sent data in the monitoring clusters
 	steps := func(k *test.K8sClient) test.StepList {

--- a/test/e2e/samples_test.go
+++ b/test/e2e/samples_test.go
@@ -100,10 +100,20 @@ func createBuilders(t *testing.T, decoder *helper.YAMLDecoder, sampleFile, testN
 					ClusterName:    ref.ClusterName,
 				})
 			}
+			metricsRefs := make([]commonv1.ObjectSelector, 0, len(b.Logstash.Spec.Monitoring.Metrics.ElasticsearchRefs))
+			for _, ref := range b.Logstash.Spec.Monitoring.Metrics.ElasticsearchRefs {
+				metricsRefs = append(metricsRefs, tweakServiceRef(ref, suffix))
+			}
+			logRefs := make([]commonv1.ObjectSelector, 0, len(b.Logstash.Spec.Monitoring.Logs.ElasticsearchRefs))
+			for _, ref := range b.Logstash.Spec.Monitoring.Logs.ElasticsearchRefs {
+				logRefs = append(logRefs, tweakServiceRef(ref, suffix))
+			}
 
 			return b.WithNamespace(namespace).
 				WithSuffix(suffix).
 				WithElasticsearchRefs(esRefs...).
+				WithMetricsMonitoring(metricsRefs...).
+				WithLogsMonitoring(logRefs...).
 				WithRestrictedSecurityContext().
 				WithLabel(run.TestNameLabel, fullTestName).
 				WithPodLabel(run.TestNameLabel, fullTestName)

--- a/test/e2e/test/logstash/builder.go
+++ b/test/e2e/test/logstash/builder.go
@@ -156,9 +156,13 @@ func (b Builder) WithElasticsearchRefs(refs ...logstashv1alpha1.ElasticsearchClu
 	return b
 }
 
-func (b Builder) WithMonitoring(metricsESRef commonv1.ObjectSelector, logsESRef commonv1.ObjectSelector) Builder {
-	b.Logstash.Spec.Monitoring.Metrics.ElasticsearchRefs = []commonv1.ObjectSelector{metricsESRef}
-	b.Logstash.Spec.Monitoring.Logs.ElasticsearchRefs = []commonv1.ObjectSelector{logsESRef}
+func (b Builder) WithMetricsMonitoring(metricsESRef ...commonv1.ObjectSelector) Builder {
+	b.Logstash.Spec.Monitoring.Metrics.ElasticsearchRefs = metricsESRef
+	return b
+}
+
+func (b Builder) WithLogsMonitoring(logsESRef ...commonv1.ObjectSelector) Builder {
+	b.Logstash.Spec.Monitoring.Logs.ElasticsearchRefs = logsESRef
 	return b
 }
 

--- a/test/e2e/test/logstash/checks.go
+++ b/test/e2e/test/logstash/checks.go
@@ -143,17 +143,13 @@ func CheckStatus(b Builder, k *test.K8sClient) test.Step {
 	}
 }
 
-func uniqueAssociationCount(refs, otherRefs []v1.ObjectSelector) int {
-	uniqueAssociations := make(map[v1.ObjectSelector]bool)
-
-	for _, val := range refs {
-		uniqueAssociations[val] = true
+func uniqueAssociationCount(refsList ...[]v1.ObjectSelector) int {
+	uniqueAssociations := make(map[v1.ObjectSelector]struct{})
+	for _, refs := range refsList {
+		for _, val := range refs {
+			uniqueAssociations[val] = struct{}{}
+		}
 	}
-
-	for _, val := range otherRefs {
-		uniqueAssociations[val] = true
-	}
-
 	return len(uniqueAssociations)
 }
 

--- a/test/e2e/test/logstash/checks.go
+++ b/test/e2e/test/logstash/checks.go
@@ -114,8 +114,8 @@ func CheckStatus(b Builder, k *test.K8sClient) test.Step {
 				return fmt.Errorf("expected status %+v but got %+v", expected, logstash.Status)
 			}
 
+			expectedMonitoringInStatus := uniqueAssociationCount(logstash.Spec.Monitoring.Metrics.ElasticsearchRefs, logstash.Spec.Monitoring.Logs.ElasticsearchRefs)
 			// monitoring status
-			expectedMonitoringInStatus := len(logstash.Spec.Monitoring.Metrics.ElasticsearchRefs) + len(logstash.Spec.Monitoring.Metrics.ElasticsearchRefs)
 			actualMonitoringInStatus := len(logstash.Status.MonitoringAssociationStatus)
 			if expectedMonitoringInStatus != actualMonitoringInStatus {
 				return fmt.Errorf("expected %d monitoring associations in status but got %d", expectedMonitoringInStatus, actualMonitoringInStatus)
@@ -141,6 +141,20 @@ func CheckStatus(b Builder, k *test.K8sClient) test.Step {
 			return nil
 		}),
 	}
+}
+
+func uniqueAssociationCount(refs, otherRefs []v1.ObjectSelector) int {
+	uniqueAssociations := make(map[v1.ObjectSelector]bool)
+
+	for _, val := range refs {
+		uniqueAssociations[val] = true
+	}
+
+	for _, val := range otherRefs {
+		uniqueAssociations[val] = true
+	}
+
+	return len(uniqueAssociations)
 }
 
 func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {


### PR DESCRIPTION
The stack monitoring tests were failing as the builder was not creating the monitoring elasticsearch references. This was added, as well as a minor refactoring to split the builder into adding metrics and logging monitoring separately.

This commit also calculates the the monitoring assocation counts correctly, as previously the metrics association was double counted.

This commit also fixes the logstash service sample end to end test - the pipeline id in the yaml definition did not match that in the test.
