### PR TITLE
Do not set FLEET_CA for well-known CAs

### DIFF
--- a/pkg/controller/agent/driver.go
+++ b/pkg/controller/agent/driver.go
@@ -111,18 +111,19 @@ func internalReconcile(params Params) (*reconciler.Results, agentv1alpha1.AgentS
 	if params.Agent.Spec.FleetServerEnabled && params.Agent.Spec.HTTP.TLS.Enabled() {
 		var caResults *reconciler.Results
 		fleetCerts, caResults = certificates.Reconciler{
-			K8sClient:             params.Client,
-			DynamicWatches:        params.Watches,
-			Owner:                 &params.Agent,
-			TLSOptions:            params.Agent.Spec.HTTP.TLS,
-			Namer:                 Namer,
-			Labels:                params.Agent.GetIdentityLabels(),
-			Services:              []corev1.Service{*svc},
-			GlobalCA:              params.OperatorParams.GlobalCA,
-			CACertRotation:        params.OperatorParams.CACertRotation,
-			CertRotation:          params.OperatorParams.CertRotation,
-			GarbageCollectSecrets: true,
-			ExtraHTTPSANs:         []commonv1.SubjectAlternativeName{{DNS: fmt.Sprintf("*.%s.%s.svc", HTTPServiceName(params.Agent.Name), params.Agent.Namespace)}},
+			K8sClient:                   params.Client,
+			DynamicWatches:              params.Watches,
+			Owner:                       &params.Agent,
+			TLSOptions:                  params.Agent.Spec.HTTP.TLS,
+			Namer:                       Namer,
+			Labels:                      params.Agent.GetIdentityLabels(),
+			Services:                    []corev1.Service{*svc},
+			GlobalCA:                    params.OperatorParams.GlobalCA,
+			CACertRotation:              params.OperatorParams.CACertRotation,
+			CertRotation:                params.OperatorParams.CertRotation,
+			GarbageCollectSecrets:       true,
+			DisableInternalCADefaulting: true, // we do not want placeholder CAs in the internal certificates secret as FLEET_CA replaces otherwise all well known CAs
+			ExtraHTTPSANs:               []commonv1.SubjectAlternativeName{{DNS: fmt.Sprintf("*.%s.%s.svc", HTTPServiceName(params.Agent.Name), params.Agent.Namespace)}},
 		}.ReconcileCAAndHTTPCerts(params.Context)
 		if caResults.HasError() {
 			return results.WithResults(caResults), params.Status

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -159,7 +159,7 @@ func Test_amendBuilderForFleetMode(t *testing.T) {
 			}),
 		},
 		{
-			name: "running elastic agent, with fleet server, without es/kb association with well known CA",
+			name: "running elastic agent, with fleet server, without es/kb association, with well known CA",
 			params: Params{
 				Agent: agentv1alpha1.Agent{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/agent/pod_test.go
+++ b/pkg/controller/agent/pod_test.go
@@ -25,12 +25,39 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 )
 
+var (
+	fleetCertsFixture = &certificates.CertificatesSecret{
+		Secret: corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "fleet-certs-secret-name",
+			},
+			Data: map[string][]byte{
+				"ca.crt":  []byte("a CA cert"),
+				"tls.key": []byte("a private key"),
+				"tls.crt": []byte("the server cert"),
+			},
+		},
+	}
+	wellKnownCACertsFixture = &certificates.CertificatesSecret{
+		Secret: corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "fleet-certs-secret-name",
+			},
+			Data: map[string][]byte{
+				"tls.key": []byte("a private key"),
+				"tls.crt": []byte("the server cert"),
+			},
+		},
+	}
+)
+
 func Test_amendBuilderForFleetMode(t *testing.T) {
 	optional := false
 
 	for _, tt := range []struct {
 		name        string
 		params      Params
+		fleetCerts  *certificates.CertificatesSecret
 		wantPodSpec corev1.PodSpec
 	}{
 		{
@@ -60,6 +87,7 @@ func Test_amendBuilderForFleetMode(t *testing.T) {
 					},
 				}),
 			},
+			fleetCerts: fleetCertsFixture,
 			wantPodSpec: generatePodSpec(func(ps corev1.PodSpec) corev1.PodSpec {
 				ps.Volumes = []corev1.Volume{
 					{
@@ -131,6 +159,100 @@ func Test_amendBuilderForFleetMode(t *testing.T) {
 			}),
 		},
 		{
+			name: "running elastic agent, with fleet server, without es/kb association with well known CA",
+			params: Params{
+				Agent: agentv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "agent",
+						Namespace: "default",
+					},
+					Spec: agentv1alpha1.AgentSpec{
+						FleetServerEnabled: true,
+					},
+				},
+				Client: k8s.NewFakeClient(&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "agent-agent-http",
+						Namespace: "default",
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Name: "https",
+								Port: 8220,
+							},
+						},
+					},
+				}),
+			},
+			fleetCerts: wellKnownCACertsFixture,
+			wantPodSpec: generatePodSpec(func(ps corev1.PodSpec) corev1.PodSpec {
+				ps.Volumes = []corev1.Volume{
+					{
+						Name: "fleet-certs",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "fleet-certs-secret-name",
+								Optional:   &optional,
+							},
+						},
+					},
+				}
+
+				ps.Containers[0].VolumeMounts = []corev1.VolumeMount{
+					{
+						Name:      "fleet-certs",
+						ReadOnly:  true,
+						MountPath: "/usr/share/fleet-server/config/http-certs",
+					},
+				}
+
+				ps.Containers[0].Ports = []corev1.ContainerPort{
+					{
+						Name:          "https",
+						ContainerPort: 8220,
+						Protocol:      corev1.ProtocolTCP,
+					},
+				}
+
+				ps.Containers[0].Env = []corev1.EnvVar{
+					{
+						Name:  "FLEET_SERVER_CERT",
+						Value: "/usr/share/fleet-server/config/http-certs/tls.crt",
+					},
+					{
+						Name:  "FLEET_SERVER_CERT_KEY",
+						Value: "/usr/share/fleet-server/config/http-certs/tls.key",
+					},
+					{
+						Name:  "FLEET_SERVER_ENABLE",
+						Value: "true",
+					},
+					{
+						Name:  "FLEET_URL",
+						Value: "https://agent-agent-http.default.svc:8220",
+					},
+					{
+						Name:  "CONFIG_PATH",
+						Value: "/usr/share/elastic-agent",
+					},
+				}
+
+				ps.Containers[0].Resources = corev1.ResourceRequirements{
+					Limits: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+					},
+					Requests: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+					},
+				}
+
+				return ps
+			}),
+		},
+		{
 			name: "running elastic agent, without running fleet server without kb association",
 			params: Params{
 				Agent: agentv1alpha1.Agent{
@@ -143,6 +265,7 @@ func Test_amendBuilderForFleetMode(t *testing.T) {
 				},
 				Client: k8s.NewFakeClient(),
 			},
+			fleetCerts: fleetCertsFixture,
 			wantPodSpec: generatePodSpec(func(ps corev1.PodSpec) corev1.PodSpec {
 				ps.Containers[0].Env = []corev1.EnvVar{
 					{
@@ -199,6 +322,7 @@ func Test_amendBuilderForFleetMode(t *testing.T) {
 					},
 				}),
 			},
+			fleetCerts: fleetCertsFixture,
 			wantPodSpec: generatePodSpec(func(ps corev1.PodSpec) corev1.PodSpec {
 				ps.Volumes = nil
 
@@ -255,17 +379,10 @@ func Test_amendBuilderForFleetMode(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			fleetCerts := &certificates.CertificatesSecret{
-				Secret: corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "fleet-certs-secret-name",
-					},
-				},
-			}
 			builder := generateBuilder()
 			hash := sha256.New224()
 
-			gotBuilder, gotErr := amendBuilderForFleetMode(tt.params, fleetCerts, EnrollmentAPIKey{}, builder, hash)
+			gotBuilder, gotErr := amendBuilderForFleetMode(tt.params, tt.fleetCerts, EnrollmentAPIKey{}, builder, hash)
 
 			require.Nil(t, gotErr)
 			require.NotNil(t, gotBuilder)
@@ -329,6 +446,7 @@ func Test_applyEnvVars(t *testing.T) {
 	for _, tt := range []struct {
 		name               string
 		params             Params
+		fleetCerts         *certificates.CertificatesSecret
 		fleetToken         EnrollmentAPIKey
 		podTemplateBuilder *defaults.PodTemplateBuilder
 		wantContainer      corev1.Container
@@ -341,6 +459,7 @@ func Test_applyEnvVars(t *testing.T) {
 				Agent:   agent,
 				Client:  k8s.NewFakeClient(),
 			},
+			fleetCerts:         fleetCertsFixture,
 			fleetToken:         testToken,
 			podTemplateBuilder: generateBuilder(),
 			wantContainer: corev1.Container{
@@ -367,6 +486,7 @@ func Test_applyEnvVars(t *testing.T) {
 				Agent:   agent,
 				Client:  k8s.NewFakeClient(),
 			},
+			fleetCerts:         fleetCertsFixture,
 			fleetToken:         testToken,
 			podTemplateBuilder: podTemplateBuilderWithFleetTokenSet,
 			wantContainer: corev1.Container{
@@ -405,6 +525,7 @@ func Test_applyEnvVars(t *testing.T) {
 					},
 				),
 			},
+			fleetCerts:         fleetCertsFixture,
 			fleetToken:         testToken,
 			podTemplateBuilder: generateBuilder(),
 			wantContainer: corev1.Container{
@@ -441,9 +562,70 @@ func Test_applyEnvVars(t *testing.T) {
 				"FLEET_SERVER_ELASTICSEARCH_PASSWORD": []byte("es-password"),
 			},
 		},
+		{
+			name: "elastic agent, with fleet server, with kibana ref with well-known CA",
+			params: Params{
+				Context: context.Background(),
+				Agent:   agent2,
+				Client: k8s.NewFakeClient(
+					&corev1.Service{
+						ObjectMeta: metav1.ObjectMeta{Name: "agent-agent-http", Namespace: "default"},
+						Spec: corev1.ServiceSpec{
+							Ports: []corev1.ServicePort{
+								{
+									Name: "https",
+									Port: 8220,
+								},
+							},
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: "es-secret-name", Namespace: "default"},
+						Data: map[string][]byte{
+							"es-user": []byte("es-password"),
+						},
+					},
+				),
+			},
+			fleetCerts:         wellKnownCACertsFixture,
+			fleetToken:         testToken,
+			podTemplateBuilder: generateBuilder(),
+			wantContainer: corev1.Container{
+				Name: "agent",
+				Env: []corev1.EnvVar{
+					{Name: "FLEET_ENROLL", Value: "true"},
+					{Name: "FLEET_ENROLLMENT_TOKEN", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "agent-agent-envvars"},
+						Key:                  "FLEET_ENROLLMENT_TOKEN",
+						Optional:             &f,
+					}}},
+					{Name: "FLEET_SERVER_CERT", Value: "/usr/share/fleet-server/config/http-certs/tls.crt"},
+					{Name: "FLEET_SERVER_CERT_KEY", Value: "/usr/share/fleet-server/config/http-certs/tls.key"},
+					{Name: "FLEET_SERVER_ELASTICSEARCH_HOST", Value: "es-url"},
+					{Name: "FLEET_SERVER_ELASTICSEARCH_PASSWORD", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "agent-agent-envvars"},
+						Key:                  "FLEET_SERVER_ELASTICSEARCH_PASSWORD",
+						Optional:             &f,
+					}}},
+					{Name: "FLEET_SERVER_ELASTICSEARCH_USERNAME", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "agent-agent-envvars"},
+						Key:                  "FLEET_SERVER_ELASTICSEARCH_USERNAME",
+						Optional:             &f,
+					}}},
+					{Name: "FLEET_SERVER_ENABLE", Value: "true"},
+					{Name: "FLEET_SERVER_POLICY_ID", Value: "policy-id"},
+					{Name: "FLEET_URL", Value: "https://agent-agent-http.default.svc:8220"},
+				},
+			},
+			wantSecretData: map[string][]byte{
+				"FLEET_ENROLLMENT_TOKEN":              []byte("test-token"),
+				"FLEET_SERVER_ELASTICSEARCH_USERNAME": []byte("es-user"),
+				"FLEET_SERVER_ELASTICSEARCH_PASSWORD": []byte("es-password"),
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			gotBuilder, err := applyEnvVars(tt.params, tt.fleetToken, tt.podTemplateBuilder)
+			gotBuilder, err := applyEnvVars(tt.params, tt.fleetToken, tt.fleetCerts, tt.podTemplateBuilder)
 
 			require.NoError(t, err)
 
@@ -906,7 +1088,7 @@ func Test_getFleetSetupKibanaEnvVars(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			gotEnvVars, gotErr := getFleetSetupKibanaEnvVars(context.Background(), tt.agent, k8s.NewFakeClient(), tt.fleetToken)
+			gotEnvVars, gotErr := getFleetSetupKibanaEnvVars(tt.fleetToken)(tt.agent)
 
 			require.Equal(t, tt.wantEnvVars, gotEnvVars)
 			require.Equal(t, tt.wantErr, gotErr != nil)
@@ -982,6 +1164,7 @@ func Test_getFleetSetupFleetEnvVars(t *testing.T) {
 	for _, tt := range []struct {
 		name        string
 		agent       agentv1alpha1.Agent
+		fleetCerts  *certificates.CertificatesSecret
 		wantErr     bool
 		wantEnvVars map[string]string
 		client      k8s.Client
@@ -1001,10 +1184,49 @@ func Test_getFleetSetupFleetEnvVars(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
+			fleetCerts: fleetCertsFixture,
+			wantErr:    false,
 			wantEnvVars: map[string]string{
 				"FLEET_ENROLL": "true",
 				"FLEET_CA":     "/usr/share/fleet-server/config/http-certs/ca.crt",
+				"FLEET_URL":    "https://agent-agent-http.ns.svc:8220",
+			},
+			client: k8s.NewFakeClient(&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "agent-agent-http",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:        "https",
+							Protocol:    "",
+							AppProtocol: nil,
+							Port:        8220,
+						},
+					},
+				},
+			}),
+		},
+		{
+			name: "fleet server enabled, kibana ref, well known CA",
+			agent: agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "agent",
+					Namespace: "ns",
+				},
+				Spec: agentv1alpha1.AgentSpec{
+					FleetServerEnabled: true,
+					KibanaRef: commonv1.ObjectSelector{
+						Name:      "kibana",
+						Namespace: "ns",
+					},
+				},
+			},
+			fleetCerts: wellKnownCACertsFixture,
+			wantErr:    false,
+			wantEnvVars: map[string]string{
+				"FLEET_ENROLL": "true",
 				"FLEET_URL":    "https://agent-agent-http.ns.svc:8220",
 			},
 			client: k8s.NewFakeClient(&corev1.Service{
@@ -1035,7 +1257,8 @@ func Test_getFleetSetupFleetEnvVars(t *testing.T) {
 					FleetServerEnabled: true,
 				},
 			},
-			wantErr: false,
+			fleetCerts: fleetCertsFixture,
+			wantErr:    false,
 			wantEnvVars: map[string]string{
 				"FLEET_CA":  "/usr/share/fleet-server/config/http-certs/ca.crt",
 				"FLEET_URL": "https://agent-agent-http.ns.svc:8220",
@@ -1109,7 +1332,7 @@ func Test_getFleetSetupFleetEnvVars(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			gotEnvVars, gotErr := getFleetSetupFleetEnvVars(context.Background(), tt.agent, tt.client, EnrollmentAPIKey{})
+			gotEnvVars, gotErr := getFleetSetupFleetEnvVars(tt.client, EnrollmentAPIKey{}, tt.fleetCerts)(tt.agent)
 
 			require.Equal(t, tt.wantEnvVars, gotEnvVars)
 			require.Equal(t, tt.wantErr, gotErr != nil)
@@ -1229,7 +1452,7 @@ func Test_getFleetSetupFleetServerEnvVars(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			gotEnvVars, gotErr := getFleetSetupFleetServerEnvVars(context.Background(), tt.agent, tt.client, EnrollmentAPIKey{})
+			gotEnvVars, gotErr := getFleetSetupFleetServerEnvVars(context.Background(), tt.client)(tt.agent)
 
 			require.Equal(t, tt.wantEnvVars, gotEnvVars)
 			require.Equal(t, tt.wantErr, gotErr != nil)

--- a/pkg/controller/common/certificates/http_reconcile.go
+++ b/pkg/controller/common/certificates/http_reconcile.go
@@ -140,6 +140,9 @@ func (r Reconciler) ReconcileInternalHTTPCerts(ctx context.Context, ca *CA, cust
 	return &internalCerts, nil
 }
 
+// populateFromCustomCertificateContents populates the secret passed as a parameter from the contents of customCertificates. Returns two
+// booleans: whether a CA certificate has been provided through the custom certificate secret and secondly whether data in the resulting secret
+// has been updated.
 func (r Reconciler) populateFromCustomCertificateContents(secret *corev1.Secret, customCertificates *CertificatesSecret, ca *CA) (bool, bool) {
 	caCertProvided := true
 	expectedSecretData := make(map[string][]byte)

--- a/pkg/controller/common/certificates/http_reconcile_test.go
+++ b/pkg/controller/common/certificates/http_reconcile_test.go
@@ -253,12 +253,22 @@ func TestReconcileInternalHTTPCerts(t *testing.T) {
 	testPrivateKey, err := EncodePEMPrivateKey(testRSAPrivateKey)
 	assert.NoError(t, err, "Failed to encode private key")
 
+	customCertFixture := CertificatesSecret{
+		Secret: corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-cert", Namespace: "test-namespace"},
+			Data: map[string][]byte{
+				CertFileName: tls,
+				KeyFileName:  key,
+			},
+		},
+	}
 	type args struct {
-		es             esv1.Elasticsearch
-		ca             *CA
-		custCerts      *CertificatesSecret
-		services       []corev1.Service
-		initialObjects []runtime.Object
+		es                          esv1.Elasticsearch
+		ca                          *CA
+		custCerts                   *CertificatesSecret
+		disableInternalCADefaulting bool
+		services                    []corev1.Service
+		initialObjects              []runtime.Object
 	}
 	tests := []struct {
 		name    string
@@ -334,16 +344,8 @@ func TestReconcileInternalHTTPCerts(t *testing.T) {
 						},
 					},
 				},
-				ca: testCA,
-				custCerts: &CertificatesSecret{
-					Secret: corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{Name: "my-cert", Namespace: "test-namespace"},
-						Data: map[string][]byte{
-							CertFileName: tls,
-							KeyFileName:  key,
-						},
-					},
-				},
+				ca:        testCA,
+				custCerts: &customCertFixture,
 			},
 			want: func(t *testing.T, c k8s.Client, cs *CertificatesSecret) {
 				t.Helper()
@@ -360,6 +362,41 @@ func TestReconcileInternalHTTPCerts(t *testing.T) {
 				// We are still expecting a CA cert to exist in this Secret
 				assert.True(t, len(internalSecret.Data[CAFileName]) > 0)
 				assert.Equal(t, internalSecret.Data[CAFileName], EncodePEMCert(testCA.Cert.Raw))
+			},
+		},
+		{
+			name: "should NOT default to internal CA if so requested",
+			args: args{
+				es: esv1.Elasticsearch{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-es-name", Namespace: "test-namespace"},
+					Spec: esv1.ElasticsearchSpec{
+						HTTP: commonv1.HTTPConfig{
+							TLS: commonv1.TLSOptions{
+								Certificate: commonv1.SecretRef{
+									SecretName: "my-cert",
+								},
+							},
+						},
+					},
+				},
+				ca:                          testCA,
+				disableInternalCADefaulting: true,
+				custCerts:                   &customCertFixture,
+			},
+			want: func(t *testing.T, c k8s.Client, cs *CertificatesSecret) {
+				t.Helper()
+				assert.Equal(t, cs.Data[KeyFileName], key)
+				assert.Equal(t, cs.Data[CertFileName], tls)
+
+				// We do not expect the CA to be present in the result since none has been provided by the user
+				_, hasCaCert := cs.Data[CAFileName]
+				assert.False(t, hasCaCert, "No CA cert in certificates secret struct expected")
+
+				// Retrieve the Secret that contains the data for the internal HTTP certificate
+				internalSecret := &corev1.Secret{}
+				assert.NoError(t, c.Get(context.Background(), k8s.ExtractNamespacedName(cs), internalSecret))
+				// We are also not expecting a CA cert to exist in this internal Secret
+				assert.Empty(t, internalSecret.Data[CAFileName], "no CA in internal secret expected")
 			},
 		},
 		{
@@ -420,6 +457,7 @@ func TestReconcileInternalHTTPCerts(t *testing.T) {
 					Validity:     DefaultCertValidity,
 					RotateBefore: DefaultRotateBefore,
 				},
+				DisableInternalCADefaulting: tt.args.disableInternalCADefaulting,
 			}.ReconcileInternalHTTPCerts(context.Background(), tt.args.ca, tt.args.custCerts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReconcileInternalHTTPCerts() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/controller/common/certificates/reconcile.go
+++ b/pkg/controller/common/certificates/reconcile.go
@@ -40,6 +40,7 @@ type Reconciler struct {
 	CertRotation   RotationParams // to requeue a reconciliation before cert expiration
 
 	GarbageCollectSecrets bool // if true, delete secrets if TLS is disabled
+
 	// if true the internally used secret will not default the CA certificate if it is not provided.
 	// This should only be necessary for Elasticsearch but has been used across all apps. See https://github.com/elastic/cloud-on-k8s/issues/2243
 	DisableInternalCADefaulting bool

--- a/pkg/controller/common/certificates/reconcile.go
+++ b/pkg/controller/common/certificates/reconcile.go
@@ -40,6 +40,9 @@ type Reconciler struct {
 	CertRotation   RotationParams // to requeue a reconciliation before cert expiration
 
 	GarbageCollectSecrets bool // if true, delete secrets if TLS is disabled
+	// if true the internally used secret will not default the CA certificate if it is not provided.
+	// This should only be necessary for Elasticsearch but has been used across all apps. See https://github.com/elastic/cloud-on-k8s/issues/2243
+	DisableInternalCADefaulting bool
 }
 
 // ReconcileCAAndHTTPCerts reconciles 3 TLS-related secrets for the given object:

--- a/pkg/controller/common/certificates/secret.go
+++ b/pkg/controller/common/certificates/secret.go
@@ -80,6 +80,15 @@ func NewCertificatesSecret(secret v1.Secret) (*CertificatesSecret, error) {
 	return &result, nil
 }
 
+// HasCA returns true if this secret has a CA certificate.
+func (s *CertificatesSecret) HasCA() bool {
+	if s == nil {
+		return false
+	}
+	bytes, exists := s.Data[CAFileName]
+	return exists && len(bytes) > 0
+}
+
 // CAPem returns the certificate of the certificate authority.
 func (s *CertificatesSecret) CAPem() []byte {
 	return s.Data[CAFileName]


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/6673

Added a switch to our HTTP certificate reconciler to disable the defaulting to the self-signed CA with we only introduced for Elasticsearch. 

Use that switch in Fleet/Agent to detect when a well known CA is in use and consequently not set the FLEET_CA environment variable. 

I have yet to test this and see if it is fit for purpose but wanted to open this already for CI and any comments on the general approach. 