### PR TITLE
Support global container repository

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -181,6 +181,11 @@ func Command() *cobra.Command {
 		"Container registry to use when downloading Elastic Stack container images",
 	)
 	cmd.Flags().String(
+		operator.ContainerRepositoryFlag,
+		"",
+		"Container repository to use when downloading Elastic Stack container images",
+	)
+	cmd.Flags().String(
 		operator.ContainerSuffixFlag,
 		"",
 		fmt.Sprintf("Suffix to be appended to container images by default. Cannot be combined with %s", operator.UBIOnlyFlag),
@@ -470,6 +475,13 @@ func startOperator(ctx context.Context) error {
 	containerRegistry := viper.GetString(operator.ContainerRegistryFlag)
 	log.Info("Setting default container registry", "container_registry", containerRegistry)
 	container.SetContainerRegistry(containerRegistry)
+
+	// set the default container repository
+	containerRepository := viper.GetString(operator.ContainerRepositoryFlag)
+	if containerRepository != "" {
+		log.Info("Setting default container repository", "container_repository", containerRepository)
+		container.SetContainerRepository(containerRepository)
+	}
 
 	// allow users to specify a container suffix unless --ubi-only mode is active
 	suffix := viper.GetString(operator.ContainerSuffixFlag)

--- a/deploy/eck-operator/templates/configmap.yaml
+++ b/deploy/eck-operator/templates/configmap.yaml
@@ -14,6 +14,9 @@ data:
     {{- with .Values.config.containerSuffix }}
     container-suffix: {{ . }}
     {{- end }}
+    {{- with .Values.config.containerRepository }}
+    container-repository: {{ . }}
+    {{- end }}
     max-concurrent-reconciles: {{ int .Values.config.maxConcurrentReconciles }}
     {{- with .Values.config.passwordHashCacheSize }}
     password-hash-cache-size: {{ int . }}

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -160,6 +160,9 @@ config:
   # containerRegistry to use for pulling Elasticsearch and other application container images.
   containerRegistry: docker.elastic.co
 
+  # containerRepository to use for pulling Elasticsearch and other application container images.
+  # containerRepository: ""
+
   # containerSuffix suffix to be appended to container images by default. Cannot be combined with -ubiOnly flag
   # containerSuffix: ""
 

--- a/docs/operating-eck/air-gapped.asciidoc
+++ b/docs/operating-eck/air-gapped.asciidoc
@@ -39,13 +39,24 @@ To make use of your mirrored images you can either set the image for each applic
 
 When creating custom resources ({eck_resources_list}), the operator defaults to using container images pulled from the `docker.elastic.co` registry. If you are in an environment where external network access is restricted, you can configure the operator to use a different default container registry by starting the operator with the `--container-registry` command-line flag. Check <<{p}-operator-config>> for more information on how to configure the operator using command-line flags and environment variables.
 
-The operator expects container images to be located at specific paths in the default container registry. Make sure that your container images are stored at the right path and are tagged correctly with the stack version number. For example, if your private registry is `my.registry` and you wish to deploy components from stack version {version}, the following image paths should exist:
-
+The operator expects container images to be located at specific repositories in the default container registry. Make sure that your container images are stored at the right repositories and are tagged correctly with the Stack version number. For example, if your private registry is `my.registry` and you wish to deploy components from Stack version {version}, the following image names should exist:
 
 * +my.registry/elasticsearch/elasticsearch:{version}+
 * +my.registry/kibana/kibana:{version}+
 * +my.registry/apm/apm-server:{version}+
 
+[float]
+[id="{p}-container-registry-override"]
+== Override the default container repositories
+
+If you cannot respect the default Elastic repositories, you can configure the operator to use a different container repository by starting the operator with the `--container-repository` command-line flag.
+Check <<{p}-operator-config>> for more information on how to configure the operator using command-line flags and environment variables.
+
+For example, if your private registry is `my.registry` and all Elastic images are located under the `elastic` repository, the following image names should exist:
+
+* +my.registry/elastic/elasticsearch:{version}+
+* +my.registry/elastic/kibana:{version}+
+* +my.registry/elastic/apm-server:{version}+
 
 [float]
 [id="{p}-eck-diag-air-gapped"]

--- a/docs/operating-eck/operator-config.asciidoc
+++ b/docs/operating-eck/operator-config.asciidoc
@@ -20,6 +20,7 @@ ECK can be configured using either command line flags or environment variables.
 |cert-validity |8760h |Duration representing the validity period of a generated TLS certificate.
 |config |"" | Path to a file containing the operator configuration.
 |container-registry |docker.elastic.co | Container registry to use for pulling Elastic Stack container images.
+|container-repository |"" | Container repository to use for pulling Elastic Stack container images.
 |container-suffix |"" | Suffix to be appended to container images by default. Cannot be combined with `--ubi-only` flag.
 |disable-config-watch| false| Watch the configuration file for changes and restart to apply them. Only effective when the `--config` flag is used to set the configuration file.
 |disable-telemetry| false| Disable periodically updating ECK telemetry data for Kibana to consume.

--- a/pkg/controller/common/container/container.go
+++ b/pkg/controller/common/container/container.go
@@ -12,8 +12,9 @@ import (
 const DefaultContainerRegistry = "docker.elastic.co"
 
 var (
-	containerRegistry = DefaultContainerRegistry
-	containerSuffix   = ""
+	containerRegistry   = DefaultContainerRegistry
+	containerRepository = ""
+	containerSuffix     = ""
 )
 
 // SetContainerRegistry sets the global container registry used to download Elastic stack images.
@@ -21,11 +22,24 @@ func SetContainerRegistry(registry string) {
 	containerRegistry = registry
 }
 
+// SetContainerRegistry sets a global container repository used to download Elastic stack images.
+func SetContainerRepository(repository string) {
+	containerRepository = repository
+}
+
 func SetContainerSuffix(suffix string) {
 	containerSuffix = suffix
 }
 
 type Image string
+
+func (i Image) Name() string {
+	parts := strings.Split(string(i), "/")
+	if len(parts) == 2 {
+		return parts[1]
+	}
+	return string(i)
+}
 
 const (
 	APMServerImage        Image = "apm/apm-server"
@@ -44,9 +58,16 @@ const (
 
 // ImageRepository returns the full container image name by concatenating the current container registry and the image path with the given version.
 func ImageRepository(img Image, version string) string {
+	// replace repository if defined
+	image := img
+
+	if containerRepository != "" {
+		image = Image(fmt.Sprintf("%s/%s", containerRepository, img.Name()))
+	}
+
 	// don't double append suffix if already contained as e.g. the case for maps
 	if strings.HasSuffix(string(img), containerSuffix) {
-		return fmt.Sprintf("%s/%s:%s", containerRegistry, img, version)
+		return fmt.Sprintf("%s/%s:%s", containerRegistry, image, version)
 	}
-	return fmt.Sprintf("%s/%s%s:%s", containerRegistry, img, containerSuffix, version)
+	return fmt.Sprintf("%s/%s%s:%s", containerRegistry, image, containerSuffix, version)
 }

--- a/pkg/controller/common/container/container_test.go
+++ b/pkg/controller/common/container/container_test.go
@@ -13,11 +13,12 @@ import (
 func TestImageRepository(t *testing.T) {
 	testRegistry := "my.docker.registry.com:8080"
 	testCases := []struct {
-		name    string
-		image   Image
-		suffix  string
-		version string
-		want    string
+		name       string
+		image      Image
+		repository string
+		suffix     string
+		version    string
+		want       string
 	}{
 		{
 			name:    "APM server image",
@@ -50,6 +51,21 @@ func TestImageRepository(t *testing.T) {
 			suffix:  "-ubi8",
 			want:    testRegistry + "/elastic-maps-service/elastic-maps-server-ubi8:7.12.0",
 		},
+		{
+			name:       "Elasticsearch image with custom repository",
+			image:      ElasticsearchImage,
+			version:    "42.0.0",
+			repository: "elastic",
+			want:       testRegistry + "/elastic/elasticsearch:42.0.0",
+		},
+		{
+			name:       "Elasticsearch image with custom repository and suffix",
+			image:      ElasticsearchImage,
+			version:    "42.0.0",
+			repository: "elastic",
+			suffix:     "-obi1",
+			want:       testRegistry + "/elastic/elasticsearch-obi1:42.0.0",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -63,7 +79,9 @@ func TestImageRepository(t *testing.T) {
 			}()
 
 			SetContainerRegistry(testRegistry)
+			SetContainerRepository(tc.repository)
 			SetContainerSuffix(tc.suffix)
+
 			have := ImageRepository(tc.image, tc.version)
 			assert.Equal(t, tc.want, have)
 		})

--- a/pkg/controller/common/operator/flags.go
+++ b/pkg/controller/common/operator/flags.go
@@ -13,6 +13,7 @@ const (
 	CertValidityFlag                     = "cert-validity"
 	ConfigFlag                           = "config"
 	ContainerRegistryFlag                = "container-registry"
+	ContainerRepositoryFlag              = "container-repository"
 	ContainerSuffixFlag                  = "container-suffix"
 	DebugHTTPListenFlag                  = "debug-http-listen"
 	DisableConfigWatch                   = "disable-config-watch"


### PR DESCRIPTION
This adds a new flag `--container-repository` to the operator to be able to specify a global container repository.

With this it is now possible to use DockerHub images for example:

`--container-registry docker.io --container-repository=elastic`

Resolves #6643.