### PR TITLE
Updating operator chart name

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -19,7 +19,7 @@ Install the operator restricted to a single namespace.
 helm install elastic-operator-crds ./eck-operator/charts/eck-operator-crds
 
 # This step can be done by any user with full access to the my-namespace namespace.
-helm install elastic-operator eck-operator -n my-namespace --create-namespace \
+helm install elastic-operator elastic/eck-operator -n my-namespace --create-namespace \
   --set=installCRDs=false \
   --set=managedNamespaces='{my-namespace}' \
   --set=createClusterScopedResources=false \


### PR DESCRIPTION
This PR is updating the operator chart name,

```
helm install elastic-operator eck-operator -n elastic-system --create-namespace
Error: INSTALLATION FAILED: failed to download "eck-operator"
```

The right name to install the chart is elastic/eck-operator, see:

```
helm install elastic-operator elastic/eck-operator -n elastic-system --create-namespace
NAME: elastic-operator
LAST DEPLOYED: Mon May  1 09:52:49 2023
NAMESPACE: elastic-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
1. Inspect the operator logs by running the following command:
   kubectl logs -n elastic-system sts/elastic-operator
```

