### PR TITLE
Retry e2e Buildkite cleanup step.

### DIFF
--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -120,6 +120,9 @@ steps:
           provider: "gcp"
           image: "family/elastic-buildkite-agent-ubuntu-2004-lts"
         {{- end }}
+        retry:
+          automatic:
+            - limit: 5
 
 
 


### PR DESCRIPTION
closes #6728

Since removal of the e2e test cluster may fail sometimes, let's try to retry a couple times to ensure that it's removed fully.