### PR TITLE
Do not set capabilities for Elasticsearch < 8.x

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -263,9 +263,6 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 		initContainers[i].VolumeMounts = append(initContainers[i].VolumeMounts, volumeMounts...)
 		initContainers[i].Resources = DefaultResources
 		initContainers[i].SecurityContext = &corev1.SecurityContext{
-			Capabilities: &corev1.Capabilities{
-				Drop: []corev1.Capability{"ALL"},
-			},
 			Privileged:               ptr.Bool(false),
 			ReadOnlyRootFilesystem:   ptr.Bool(false),
 			AllowPrivilegeEscalation: ptr.Bool(false),
@@ -314,9 +311,6 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 				VolumeMounts: volumeMounts,
 				Resources:    DefaultResources, // inherited from main container
 				SecurityContext: &corev1.SecurityContext{
-					Capabilities: &corev1.Capabilities{
-						Drop: []corev1.Capability{"ALL"},
-					},
 					Privileged: ptr.Bool(false),
 					// ReadOnlyRootFilesystem is expected to be false in this test because there is no data volume.
 					ReadOnlyRootFilesystem:   ptr.Bool(false),
@@ -327,9 +321,6 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 				{
 					Name: "additional-container",
 					SecurityContext: &corev1.SecurityContext{
-						Capabilities: &corev1.Capabilities{
-							Drop: []corev1.Capability{"ALL"},
-						},
 						Privileged:               ptr.Bool(false),
 						ReadOnlyRootFilesystem:   ptr.Bool(false),
 						AllowPrivilegeEscalation: ptr.Bool(false),
@@ -352,9 +343,6 @@ func TestBuildPodTemplateSpec(t *testing.T) {
 						PreStop: NewPreStopHook(),
 					},
 					SecurityContext: &corev1.SecurityContext{
-						Capabilities: &corev1.Capabilities{
-							Drop: []corev1.Capability{"ALL"},
-						},
 						Privileged:               ptr.Bool(false),
 						ReadOnlyRootFilesystem:   ptr.Bool(false),
 						AllowPrivilegeEscalation: ptr.Bool(false),

--- a/pkg/controller/elasticsearch/securitycontext/securitycontext_test.go
+++ b/pkg/controller/elasticsearch/securitycontext/securitycontext_test.go
@@ -1,0 +1,76 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package securitycontext
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/blang/semver/v4"
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/pointer"
+
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
+)
+
+func TestFor(t *testing.T) {
+	type args struct {
+		ver                          version.Version
+		enableReadOnlyRootFilesystem bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want corev1.SecurityContext
+	}{
+		{
+			name: "elasticsearch v7 with no readOnlyRootFS doesn't set Capabilities",
+			args: args{
+				ver:                          semver.MustParse("7.14.2"),
+				enableReadOnlyRootFilesystem: false,
+			},
+			want: corev1.SecurityContext{
+				Capabilities:             nil,
+				Privileged:               pointer.Bool(false),
+				ReadOnlyRootFilesystem:   pointer.Bool(false),
+				AllowPrivilegeEscalation: pointer.Bool(false),
+			},
+		},
+		{
+			name: "elasticsearch v8 with no readOnlyRootFS sets Capabilities",
+			args: args{
+				ver:                          semver.MustParse("8.7.0"),
+				enableReadOnlyRootFilesystem: false,
+			},
+			want: corev1.SecurityContext{
+				Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+				Privileged:               pointer.Bool(false),
+				ReadOnlyRootFilesystem:   pointer.Bool(false),
+				AllowPrivilegeEscalation: pointer.Bool(false),
+			},
+		},
+		{
+			name: "elasticsearch v8 with readOnlyRootFS sets Capabilities",
+			args: args{
+				ver:                          semver.MustParse("8.7.0"),
+				enableReadOnlyRootFilesystem: true,
+			},
+			want: corev1.SecurityContext{
+				Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+				Privileged:               pointer.Bool(false),
+				ReadOnlyRootFilesystem:   pointer.Bool(true),
+				AllowPrivilegeEscalation: pointer.Bool(false),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := For(tt.args.ver, tt.args.enableReadOnlyRootFilesystem); !cmp.Equal(got, tt.want) {
+				t.Errorf("For() = diff: %s", cmp.Diff(got, tt.want))
+			}
+		})
+	}
+}

--- a/test/e2e/test/elasticsearch/check_securitycontext.go
+++ b/test/e2e/test/elasticsearch/check_securitycontext.go
@@ -46,7 +46,7 @@ func CheckContainerSecurityContext(es esv1.Elasticsearch, k *test.K8sClient) tes
 func assertSecurityContext(t *testing.T, ver version.Version, securityContext *corev1.SecurityContext, image string) {
 	t.Helper()
 	require.NotNil(t, securityContext)
-	if strings.HasPrefix(image, "docker.elastic.co/elasticsearch/elasticsearch") && ver.LT(securitycontext.MinStackVersion) {
+	if strings.HasPrefix(image, "docker.elastic.co/elasticsearch/elasticsearch") && ver.LT(securitycontext.RunAsNonRootMinStackVersion) {
 		require.Nil(t, securityContext.RunAsNonRoot, "RunAsNonRoot was expected to be nil")
 	} else {
 		require.Equal(t, ptr.Bool(true), securityContext.RunAsNonRoot, "RunAsNonRoot was expected to be true")


### PR DESCRIPTION
Elasticsearch v7 does not work well when `securityContext.Capabilities` is set to `Drop: "all"`. Both the initContainer that prepares the filesystem fails when attempting to preserve ownership, and the main Elasticsearch container fails with `chroot: cannot change root directory to '/': Operation not permitted` as the containers likely run as the `root` user pre v8.

