### PR TITLE
Fix incorrect auth secret_token key post 8.0

### DIFF
--- a/pkg/controller/apmserver/config_test.go
+++ b/pkg/controller/apmserver/config_test.go
@@ -16,6 +16,7 @@ import (
 	apmv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/apm/v1"
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/settings"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 )
 
@@ -25,11 +26,23 @@ func TestNewConfigFromSpec(t *testing.T) {
 		configOverrides map[string]interface{}
 		esAssocConf     *commonv1.AssociationConf
 		kbAssocConf     *commonv1.AssociationConf
+		version         version.Version
 		wantConf        map[string]interface{}
 		wantErr         bool
 	}{
 		{
-			name: "default config",
+			name:    "default config",
+			version: version.MinFor(8, 0, 0),
+			wantConf: map[string]interface{}{
+				"apm-server.auth.secret_token": "${SECRET_TOKEN}",
+			},
+		},
+		{
+			name:    "default config pre 8.0",
+			version: version.MinFor(7, 0, 0),
+			wantConf: map[string]interface{}{
+				"apm-server.secret_token": "${SECRET_TOKEN}",
+			},
 		},
 		{
 			name: "with overridden config",
@@ -39,6 +52,7 @@ func TestNewConfigFromSpec(t *testing.T) {
 			wantConf: map[string]interface{}{
 				"apm-server.secret_token": "MYSECRET",
 			},
+			version: version.MinFor(7, 0, 0),
 		},
 		{
 			name: "without Elasticsearch CA cert",
@@ -50,10 +64,13 @@ func TestNewConfigFromSpec(t *testing.T) {
 				URL:            "https://test-es-http.default.svc:9200",
 			},
 			wantConf: map[string]interface{}{
+				// version specific auth token
+				"apm-server.auth.secret_token":  "${SECRET_TOKEN}",
 				"output.elasticsearch.hosts":    []string{"https://test-es-http.default.svc:9200"},
 				"output.elasticsearch.username": "elastic",
 				"output.elasticsearch.password": "password",
 			},
+			version: version.MinFor(8, 0, 0),
 		},
 		{
 			name: "with Elasticsearch CA cert",
@@ -65,11 +82,13 @@ func TestNewConfigFromSpec(t *testing.T) {
 				URL:            "https://test-es-http.default.svc:9200",
 			},
 			wantConf: map[string]interface{}{
+				"apm-server.auth.secret_token":                     "${SECRET_TOKEN}",
 				"output.elasticsearch.hosts":                       []string{"https://test-es-http.default.svc:9200"},
 				"output.elasticsearch.username":                    "elastic",
 				"output.elasticsearch.password":                    "password",
 				"output.elasticsearch.ssl.certificate_authorities": []string{"config/elasticsearch-certs/ca.crt"},
 			},
+			version: version.MinFor(8, 0, 0),
 		},
 		{
 			name: "missing auth secret",
@@ -81,6 +100,7 @@ func TestNewConfigFromSpec(t *testing.T) {
 				URL:            "https://test-es-http.default.svc:9200",
 			},
 			wantErr: true,
+			version: version.MinFor(8, 0, 0),
 		},
 		{
 			name: "Kibana and Elasticsearch configuration",
@@ -110,7 +130,10 @@ func TestNewConfigFromSpec(t *testing.T) {
 				"apm-server.kibana.username":                    "apm-kb-user",
 				"apm-server.kibana.password":                    "password-kb-user",
 				"apm-server.kibana.ssl.certificate_authorities": []string{"config/kibana-certs/ca.crt"},
+				// version specific auth token
+				"apm-server.auth.secret_token": "${SECRET_TOKEN}",
 			},
+			version: version.MinFor(8, 0, 0),
 		},
 		{
 			name: "Elasticsearch fully configured and Kibana configuration without CA",
@@ -139,7 +162,10 @@ func TestNewConfigFromSpec(t *testing.T) {
 				"apm-server.kibana.host":     "https://test-kb-http.default.svc:9200",
 				"apm-server.kibana.username": "apm-kb-user",
 				"apm-server.kibana.password": "password-kb-user",
+				// version specific auth token
+				"apm-server.auth.secret_token": "${SECRET_TOKEN}",
 			},
+			version: version.MinFor(8, 0, 0),
 		},
 	}
 
@@ -158,7 +184,7 @@ func TestNewConfigFromSpec(t *testing.T) {
 			apmv1.NewApmEsAssociation(apmServer).SetAssociationConf(tc.esAssocConf)
 			apmv1.NewApmKibanaAssociation(apmServer).SetAssociationConf(tc.kbAssocConf)
 
-			gotConf, err := newConfigFromSpec(context.Background(), client, apmServer)
+			gotConf, err := newConfigFromSpec(context.Background(), client, apmServer, tc.version)
 			if tc.wantErr {
 				require.Error(t, err)
 				return
@@ -198,7 +224,6 @@ func mkConf(t *testing.T, overrides map[string]interface{}) *settings.CanonicalC
 	t.Helper()
 	cfg, err := settings.NewCanonicalConfigFrom(map[string]interface{}{
 		"apm-server.host":            ":8200",
-		"apm-server.secret_token":    "${SECRET_TOKEN}",
 		"apm-server.ssl.certificate": "/mnt/elastic-internal/http-certs/tls.crt",
 		"apm-server.ssl.enabled":     true,
 		"apm-server.ssl.key":         "/mnt/elastic-internal/http-certs/tls.key",

--- a/pkg/controller/apmserver/controller.go
+++ b/pkg/controller/apmserver/controller.go
@@ -262,7 +262,7 @@ func (r *ReconcileApmServer) doReconcile(ctx context.Context, as *apmv1.ApmServe
 		return results, state // will eventually retry
 	}
 
-	state, err = r.reconcileApmServerDeployment(ctx, state, as)
+	state, err = r.reconcileApmServerDeployment(ctx, state, as, asVersion)
 	if err != nil {
 		if apierrors.IsConflict(err) {
 			log.V(1).Info("Conflict while updating status")

--- a/pkg/controller/apmserver/deployment.go
+++ b/pkg/controller/apmserver/deployment.go
@@ -19,14 +19,11 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/deployment"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/keystore"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/tracing"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 )
 
-func (r *ReconcileApmServer) reconcileApmServerDeployment(
-	ctx context.Context,
-	state State,
-	as *apmv1.ApmServer,
-) (State, error) {
+func (r *ReconcileApmServer) reconcileApmServerDeployment(ctx context.Context, state State, as *apmv1.ApmServer, version version.Version) (State, error) {
 	span, ctx := apm.StartSpan(ctx, "reconcile_deployment", tracing.SpanTypeApp)
 	defer span.End()
 
@@ -34,7 +31,7 @@ func (r *ReconcileApmServer) reconcileApmServerDeployment(
 	if err != nil {
 		return state, err
 	}
-	reconciledConfigSecret, err := reconcileApmServerConfig(ctx, r.Client, as)
+	reconciledConfigSecret, err := reconcileApmServerConfig(ctx, r.Client, as, version)
 	if err != nil {
 		return state, err
 	}

--- a/pkg/controller/common/http/http_client.go
+++ b/pkg/controller/common/http/http_client.go
@@ -100,6 +100,16 @@ func IsNotFound(err error) bool {
 	return isHTTPError(err, http.StatusNotFound)
 }
 
+// IsUnauthorized checks whether the error was an HTTP 401 error.
+func IsUnauthorized(err error) bool {
+	return isHTTPError(err, http.StatusUnauthorized)
+}
+
+// IsForbidden checks whether the error was an HTTP 403 error.
+func IsForbidden(err error) bool {
+	return isHTTPError(err, http.StatusForbidden)
+}
+
 func isHTTPError(err error, statusCode int) bool {
 	apiErr := new(APIError)
 	if errors.As(err, &apiErr) {

--- a/test/e2e/test/apmserver/checks_apm.go
+++ b/test/e2e/test/apmserver/checks_apm.go
@@ -184,7 +184,6 @@ func (c *apmClusterChecks) CheckAPMSecretTokenConfiguration(apm apmv1.ApmServer,
 }
 
 func (c *apmClusterChecks) checkEventsAPI(apm apmv1.ApmServer) error {
-
 	// before sending event, get the document count in the metric, and error index
 	// and save, as it is used to calculate how many docs should be in the index after
 	// the event is sent through APM Server.

--- a/test/e2e/test/apmserver/checks_apm.go
+++ b/test/e2e/test/apmserver/checks_apm.go
@@ -176,7 +176,7 @@ func (c *apmClusterChecks) CheckAPMSecretTokenConfiguration(apm apmv1.ApmServer,
 			defer cancel()
 			_, err = client.IntakeV2Events(ctx, false, []byte(sampleEventBody))
 			if !commonhttp.IsUnauthorized(err) {
-				return fmt.Errorf("expected error 401 but was %v", err)
+				return fmt.Errorf("expected error 401 but was %w", err)
 			}
 			return nil
 		}),

--- a/test/e2e/test/apmserver/http_client.go
+++ b/test/e2e/test/apmserver/http_client.go
@@ -55,7 +55,6 @@ func NewApmServerClient(as apmv1.ApmServer, k *test.K8sClient) (*ApmClient, erro
 }
 
 func NewAPMServerClientWithSecretToken(as apmv1.ApmServer, k *test.K8sClient, secretToken string) (*ApmClient, error) {
-
 	scheme := "http"
 	var caCerts []*x509.Certificate
 	if as.Spec.HTTP.TLS.Enabled() {


### PR DESCRIPTION
Fixes #6768 

To discuss: whether we should change the e2e tests to check the case where a client tries to use an incorrect auth token to make a requests (which should be rejected). This would also IUC test for correct configuration of the APM server with a auth token. Because we did not do this check we missed the misconfiguration since 8.0 in our e2e testing. 

Marking this as breaking because we shipped versions of ECK that misconfigured 8.0+ APM servers and therefore there might be user installations out there that work only because of this misconfiguration. If we now ship the fix and their clients are not actually setting an auth token then APM server will start rejecting their requests. 