### PR TITLE
Exit in error on e2e test job timeout 

### DIFF
--- a/test/e2e/cmd/run/job_manager.go
+++ b/test/e2e/cmd/run/job_manager.go
@@ -98,7 +98,8 @@ func (jm *JobsManager) Start() {
 	defer func() {
 		jm.cancelFunc()
 		if deadline, _ := jm.Deadline(); deadline.Before(time.Now()) {
-			log.Info("Test job timeout exceeded", "timeout", jobTimeout)
+			jm.err = errors.Errorf("Test job timeout exceeded (%s)", jobTimeout)
+			log.Error(jm.err, "Pod aborted")
 		}
 		runtime.HandleCrash()
 	}()


### PR DESCRIPTION
This sets an error in the job manager when the test job timeout exceeded, so the error propagates and the go process exits with status code 1.