### PR TITLE
Exit in error on e2e test job timeout (#6774)

### DIFF
--- a/test/e2e/cmd/run/job_manager.go
+++ b/test/e2e/cmd/run/job_manager.go
@@ -98,7 +98,8 @@ func (jm *JobsManager) Start() {
 	defer func() {
 		jm.cancelFunc()
 		if deadline, _ := jm.Deadline(); deadline.Before(time.Now()) {
-			log.Info("Test job timeout exceeded", "timeout", jobTimeout)
+			jm.err = errors.Errorf("Test job timeout exceeded (%s)", jobTimeout)
+			log.Error(jm.err, "Pod aborted")
 		}
 		runtime.HandleCrash()
 	}()


### PR DESCRIPTION
Backport the following commit to 2.8:
- #6774 