### PR TITLE
Run full e2e tests matrix on any tag (#6775)

### DIFF
--- a/.buildkite/pipeline-e2e-tests.yml
+++ b/.buildkite/pipeline-e2e-tests.yml
@@ -50,30 +50,14 @@ steps:
           DEF
 
       # for tags
-      # TODO: run TestFullStackUpgrade when ready
-      - label: ":buildkite: e2e"
-        depends_on:
-          - "operator-image-build"
-          - "e2e-tests-image-build"
-        if: |
-            build.tag != null
-            || build.message =~ /^buildkite test .*release.*/
-        command: |
-          cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
-          cat <<DEF | ./pipeline-gen | buildkite-agent pipeline upload
-          - label: gke/TestSmoke
-            fixed:
-              E2E_PROVIDER: gke
-              TESTS_MATCH: TestSmoke
-          DEF
-
       # for nightly builds from main
       - label: ":buildkite: e2e"
         depends_on:
           - "operator-image-build"
           - "e2e-tests-image-build"
         if: |
-          ( build.branch == "main" && build.source == "schedule" )
+          build.tag != null
+          || ( build.branch == "main" && build.source == "schedule" )
           || build.message =~ /^buildkite test .*e2e\/all.*/
         command: |
           cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen


### PR DESCRIPTION
Backport the following commit to `2.8`:
- #6775