### PR TITLE
Retry bk cleanup step. (#6747)

### DIFF
--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -120,6 +120,9 @@ steps:
           provider: "gcp"
           image: "family/elastic-buildkite-agent-ubuntu-2004-lts"
         {{- end }}
+        retry:
+          automatic:
+            - limit: 5
 
 
 


### PR DESCRIPTION
Backport of [Retry bk cleanup step](https://github.com/elastic/cloud-on-k8s/pull/6747). (#6747)  into `2.8`