### PR TITLE
[DOC] Add 2.6 and 2.7 to the triggered restart list (#6786)

### DIFF
--- a/docs/operating-eck/upgrading-eck.asciidoc
+++ b/docs/operating-eck/upgrading-eck.asciidoc
@@ -97,7 +97,7 @@ This will update the ECK installation to the latest binary and update the CRDs a
 
 Upgrading the operator results in a one-time update to existing managed resources in the cluster. This potentially triggers a rolling restart of pods by Kubernetes to apply those changes. The following list contains the ECK operator versions that would cause a rolling restart after they have been installed.
 
- 1.6, 1.9, 2.0, 2.1, 2.2, 2.4, 2.5, 2.8
+ 1.6, 1.9, 2.0, 2.1, 2.2, 2.4, 2.5, 2.6, 2.7, 2.8
 
 If you have a very large Elasticsearch cluster or multiple Elastic Stack deployments, this rolling restart might be disruptive or inconvenient. To have more control over when the pods belonging to a particular deployment should be restarted, you can <<{p}-exclude-resource,add an annotation>> to the corresponding resources to temporarily exclude them from being managed by the operator. When the time is convenient, you can remove the annotation and let the rolling restart go through.
 


### PR DESCRIPTION
Backport of [[DOC] Add 2.6 and 2.7 to the triggered restart list (#6786)](https://github.com/elastic/cloud-on-k8s/pull/6786) into `2.8`