### PR TITLE
Add back runAsNonRoot=true to Beats >= 8.8.x

### DIFF
--- a/pkg/controller/elasticsearch/securitycontext/securitycontext.go
+++ b/pkg/controller/elasticsearch/securitycontext/securitycontext.go
@@ -42,15 +42,18 @@ func For(ver version.Version, enableReadOnlyRootFilesystem bool) corev1.Security
 	return sc
 }
 
-func DefaultBeatSecurityContext() *corev1.SecurityContext {
-	return &corev1.SecurityContext{
+func DefaultBeatSecurityContext(ver version.Version) *corev1.SecurityContext {
+	sc := &corev1.SecurityContext{
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
-		Privileged: ptr.Bool(false),
-		// Update to true when https://github.com/elastic/beats/pull/35272 is merged.
-		// RunAsNonRoot:             ptr.Bool(true),
+		Privileged:               ptr.Bool(false),
 		ReadOnlyRootFilesystem:   ptr.Bool(true),
 		AllowPrivilegeEscalation: ptr.Bool(false),
 	}
+	if ver.LT(RunAsNonRootMinStackVersion) {
+		return sc
+	}
+	sc.RunAsNonRoot = ptr.Bool(true)
+	return sc
 }

--- a/pkg/controller/elasticsearch/securitycontext/securitycontext.go
+++ b/pkg/controller/elasticsearch/securitycontext/securitycontext.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	// RunAsNonRootMinStackVersion is the minimum Stack version to use RunAsNonRoot with the Elasticsearch image.
-	// Before 8.8.0 Elasticsearch image runs has non-numeric user.
-	// Refer to https://github.com/elastic/elasticsearch/pull/95390 for more information.
+	// RunAsNonRootMinStackVersion is the minimum Stack version to use RunAsNonRoot with the Elasticsearch and Beats images.
+	// Before 8.8.0 Elasticsearch and Beats images ran as a non-numeric user.
+	// Refer to https://github.com/elastic/elasticsearch/pull/95390 and https://github.com/elastic/beats/pull/35272 for more information.
 	RunAsNonRootMinStackVersion = version.MustParse("8.8.0-SNAPSHOT")
 
 	// DropCapabilitiesMinStackVersion is the minimum Stack version to Drop all the capabilities.

--- a/pkg/controller/elasticsearch/stackmon/sidecar.go
+++ b/pkg/controller/elasticsearch/stackmon/sidecar.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/stackmon/monitoring"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/network"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/securitycontext"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/user"
@@ -50,7 +51,11 @@ func Metricbeat(ctx context.Context, client k8s.Client, es esv1.Elasticsearch) (
 	if err != nil {
 		return stackmon.BeatSidecar{}, err
 	}
-	metricbeat.Container.SecurityContext = securitycontext.DefaultBeatSecurityContext()
+	ver, err := version.Parse(es.Spec.Version)
+	if err != nil {
+		return stackmon.BeatSidecar{}, err
+	}
+	metricbeat.Container.SecurityContext = securitycontext.DefaultBeatSecurityContext(ver)
 	return metricbeat, nil
 }
 
@@ -59,7 +64,11 @@ func Filebeat(ctx context.Context, client k8s.Client, es esv1.Elasticsearch) (st
 	if err != nil {
 		return stackmon.BeatSidecar{}, err
 	}
-	fileBeat.Container.SecurityContext = securitycontext.DefaultBeatSecurityContext()
+	ver, err := version.Parse(es.Spec.Version)
+	if err != nil {
+		return stackmon.BeatSidecar{}, err
+	}
+	fileBeat.Container.SecurityContext = securitycontext.DefaultBeatSecurityContext(ver)
 	return fileBeat, nil
 }
 

--- a/test/e2e/test/elasticsearch/check_securitycontext.go
+++ b/test/e2e/test/elasticsearch/check_securitycontext.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	ptr "k8s.io/utils/pointer"
 
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
@@ -47,6 +48,8 @@ func assertSecurityContext(t *testing.T, ver version.Version, securityContext *c
 	require.NotNil(t, securityContext)
 	if strings.HasPrefix(image, "docker.elastic.co/elasticsearch/elasticsearch") && ver.LT(securitycontext.RunAsNonRootMinStackVersion) {
 		require.Nil(t, securityContext.RunAsNonRoot, "RunAsNonRoot was expected to be nil")
+	} else {
+		require.Equal(t, ptr.Bool(true), securityContext.RunAsNonRoot, "RunAsNonRoot was expected to be true")
 	}
 	require.NotNil(t, securityContext.Privileged)
 	require.False(t, *securityContext.Privileged)

--- a/test/e2e/test/elasticsearch/check_securitycontext.go
+++ b/test/e2e/test/elasticsearch/check_securitycontext.go
@@ -5,7 +5,6 @@
 package elasticsearch
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,20 +32,20 @@ func CheckContainerSecurityContext(es esv1.Elasticsearch, k *test.K8sClient) tes
 			ver := version.MustParse(es.Spec.Version)
 			for _, p := range pods {
 				for _, c := range p.Spec.Containers {
-					assertSecurityContext(t, ver, c.SecurityContext, c.Image)
+					assertSecurityContext(t, ver, c.SecurityContext)
 				}
 				for _, c := range p.Spec.InitContainers {
-					assertSecurityContext(t, ver, c.SecurityContext, c.Image)
+					assertSecurityContext(t, ver, c.SecurityContext)
 				}
 			}
 		},
 	}
 }
 
-func assertSecurityContext(t *testing.T, ver version.Version, securityContext *corev1.SecurityContext, image string) {
+func assertSecurityContext(t *testing.T, ver version.Version, securityContext *corev1.SecurityContext) {
 	t.Helper()
 	require.NotNil(t, securityContext)
-	if strings.HasPrefix(image, "docker.elastic.co/elasticsearch/elasticsearch") && ver.LT(securitycontext.RunAsNonRootMinStackVersion) {
+	if ver.LT(securitycontext.RunAsNonRootMinStackVersion) {
 		require.Nil(t, securityContext.RunAsNonRoot, "RunAsNonRoot was expected to be nil")
 	} else {
 		require.Equal(t, ptr.Bool(true), securityContext.RunAsNonRoot, "RunAsNonRoot was expected to be true")


### PR DESCRIPTION
Since https://github.com/elastic/beats/pull/35272 was merged, and [backported](https://github.com/elastic/beats/pull/35337) into upcoming 8.8 Beats release, we should be able to enable `runAsNonRoot=true` for beats now > 8.8.x.

## Testing Done

### With manifest at `8.8.0-SNAPSHOT`
```
---
apiVersion: elasticsearch.k8s.elastic.co/v1
kind: Elasticsearch
metadata:
  name: testing
spec:
  version: 8.8.0-SNAPSHOT
  monitoring:
    metrics:
      elasticsearchRefs:
      - name: monitoring
  nodeSets:
    - name: masters
      count: 1
      config:
        node.roles: ["master", "data"]
        node.store.allow_mmap: false
      podTemplate:
        spec:
          containers:
            - name: elasticsearch
              resources:
                requests:
                  memory: 100Mi
                  cpu: 0.1
                limits:
                  memory: 1000Mi
                  cpu: 1
---
apiVersion: elasticsearch.k8s.elastic.co/v1
kind: Elasticsearch
metadata:
  name: monitoring
spec:
  version: 8.8.0-SNAPSHOT
  nodeSets:
    - name: masters
      count: 1
      config:
        node.roles: ["master", "data"]
        node.store.allow_mmap: false
      podTemplate:
        spec:
          containers:
            - name: elasticsearch
              resources:
                requests:
                  memory: 100Mi
                  cpu: 0.1
                limits:
                  memory: 1000Mi
                  cpu: 1
```

```
❯ kc get sts -n default testing-es-masters -o yaml | yq e '.spec.template.spec.containers[]|select(.name == "metricbeat")|.securityContext' -
allowPrivilegeEscalation: false
capabilities:
  drop:
    - ALL
privileged: false
readOnlyRootFilesystem: true
runAsNonRoot: true

❯ kc get pod -n default testing-es-masters-0 -o yaml | yq e '.status.containerStatuses[]|select(.name=="metricbeat")' -
containerID: containerd://fff7cca18a4c3a17564277b66ae106d7d3865fb915d1857f83c82d0697b53f41
image: docker.elastic.co/beats/metricbeat:8.8.0-SNAPSHOT
imageID: docker.elastic.co/beats/metricbeat@sha256:d3c4b47bbed4aa2eab5ad5cbdc5757d85d5ae90e8960ec4ed05cd7e1ebc0be42
lastState: {}
name: metricbeat
ready: true
restartCount: 0
started: true
state:
  running:
    startedAt: "2023-05-10T14:38:23Z"
```

### With same manifest with `8.7.0`
```
❯ kc get sts -n default testing-es-masters -o yaml | yq e '.spec.template.spec.containers[]|select(.name == "metricbeat")|.securityContext' -
allowPrivilegeEscalation: false
capabilities:
  drop:
    - ALL
privileged: false
readOnlyRootFilesystem: true

❯ kc get pods -n default testing-es-masters-0 -o yaml | yq e '.status.containerStatuses[]|select(.name=="metricbeat")' -
containerID: containerd://5779b2e36e829ccbbef9e75bf7da43f1f7a2d8e710223e582d0162458c4b62c0
image: docker.elastic.co/beats/metricbeat:8.7.0
imageID: docker.elastic.co/beats/metricbeat@sha256:6ba26079ed2631c1a52e2464620571220432173f4196d28d6c16e1a81407b56f
lastState: {}
name: metricbeat
ready: true
restartCount: 0
started: true
state:
  running:
    startedAt: "2023-05-10T15:04:07Z"
```

### TODO: e2e tests verification
- [ ] verifying e2e tests for `es` on `8.8.0-SNAPSHOT`
- [ ] verifying e2e tests for `es` on `8.7.0`