### PR TITLE
Update disk-format init container base image to debian:stable-slim

### DIFF
--- a/hack/deployer/config/local-disks/ssd-provisioner.yaml
+++ b/hack/deployer/config/local-disks/ssd-provisioner.yaml
@@ -104,7 +104,7 @@ spec:
       serviceAccountName: local-storage-admin
       initContainers:
       - name: disk-format
-        image: debian:bookworm-slim
+        image: debian:stable-slim
         securityContext:
           privileged: true
         command:

--- a/hack/deployer/config/local-disks/ssd-provisioner.yaml
+++ b/hack/deployer/config/local-disks/ssd-provisioner.yaml
@@ -104,7 +104,7 @@ spec:
       serviceAccountName: local-storage-admin
       initContainers:
       - name: disk-format
-        image: debian:stretch-slim
+        image: debian:bookworm-slim
         securityContext:
           privileged: true
         command:


### PR DESCRIPTION
This updates the base image of the `disk-format` init container which is used to setup disks on EKS before running e2e tests because `debian:stretch` has reached EOL.

I chose `debian:stable` to stop sticking to one distro name and not have the same problem in a few years.

Resolves #6797.