### PR TITLE
[ci/agent] Update kubectl to v1.26.3

### DIFF
--- a/.buildkite/pipeline-release-redhat.yml
+++ b/.buildkite/pipeline-release-redhat.yml
@@ -1,6 +1,6 @@
 
 agents:
-  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:5827bee6
+  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:9271a955
   memory: 2G
 
 env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:26b287eb
+  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:9271a955
   cpu: "4"
   memory: "2G"
 

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -31,7 +31,7 @@ NOT_USED := $(shell test -e $(ROOT_DIR)/deployer-config.yml && sed "s;roleId:.*;
 endif
 endif
 
-CI_IMAGE ?= docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:26b287eb
+CI_IMAGE ?= docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:9271a955
 
 # volume used to share files between CI container and containers launched by deployer
 ECK_CI_VOLUME := eck-ci-home-$(shell date '+%N')


### PR DESCRIPTION
Updates the CI buildkite agent tag to use the latest version, updated to kubectl v1.26.3.