### PR TITLE
Update disk-format init container base image to debian:stable-slim (#6798)

### DIFF
--- a/hack/deployer/config/local-disks/ssd-provisioner.yaml
+++ b/hack/deployer/config/local-disks/ssd-provisioner.yaml
@@ -104,7 +104,7 @@ spec:
       serviceAccountName: local-storage-admin
       initContainers:
       - name: disk-format
-        image: debian:stretch-slim
+        image: debian:stable-slim
         securityContext:
           privileged: true
         command:


### PR DESCRIPTION
Backport the following commit to `2.8`:
- #6798