### PR TITLE
Updating Helm charts local development README (#6746)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,39 +4,34 @@
 
 This directory contains the Helm chart for deploying the ECK operator, and charts for deploying any resource in the Elastic Stack individually, or as a group.
 
+The instructions below are intended to deploy the Helm charts from a local copy of this repository. Refer to https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-install-helm.html to install the charts from the official repository.
+
 ## ECK Operator Helm Chart Usage
 
-Add the Elastic Helm repository.
+View the available settings for customizing the installation.
 
 ```sh
-helm repo add elastic https://helm.elastic.co
-helm repo update
+helm show values ./eck-operator
 ```
 
 Install the CRDs and deploy the operator with cluster-wide permissions to manage all namespaces.
 
 ```sh
-helm install elastic-operator elastic/eck-operator -n elastic-system --create-namespace 
+helm install elastic-operator ./eck-operator -n elastic-system --create-namespace
 ```
 
-Install the operator restricted to a single namespace. 
+Install the operator restricted to a single namespace.
 
 ```sh
 # This step must be done by a cluster administrator to install the CRDs -- which are global resources.
-helm install elastic-operator-crds elastic/eck-operator-crds
+helm install elastic-operator-crds ./eck-operator/charts/eck-operator-crds
 
 # This step can be done by any user with full access to the my-namespace namespace.
-helm install elastic-operator elastic/eck-operator -n my-namespace --create-namespace \
+helm install elastic-operator ./eck-operator -n my-namespace --create-namespace \
   --set=installCRDs=false \
   --set=managedNamespaces='{my-namespace}' \
   --set=createClusterScopedResources=false \
   --set=webhook.enabled=false
-```
-
-View the available settings for customizing the installation.
-
-```sh
-helm show values elastic/eck-operator
 ```
 
 ## ECK Stack Helm Chart Usage
@@ -44,7 +39,7 @@ helm show values elastic/eck-operator
 Install a quickstart Elasticsearch and Kibana resource in a cluster controlled by the ECK Operator.
 
 ```sh
-helm install es-kb-quickstart elastic/eck-stack -n elastic-stack --create-namespace
+helm install es-kb-quickstart ./eck-stack -n elastic-stack --create-namespace
 ```
 
 To see all resources installed by the helm chart:


### PR DESCRIPTION
Backport of  [Updating Helm charts local development README ](https://github.com/elastic/cloud-on-k8s/pull/6746) #6746 into `2.8`

* Updating README regarding local installation instruction.
* Add a note about how to deploy from the official repo
Co-authored-by: Michael Morello <michael.morello@elastic.co>
