### PR TITLE
Add script to call Buildkite API to trigger RedHat ECK release

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -109,7 +109,7 @@ spec:
       provider_settings:
         build_tags: true
         build_pull_requests: false
-        build_branches: false
+        build_branches: true
         publish_commit_status: false
       teams:
         cloud-k8s-operator: {}

--- a/hack/operatorhub/trigger-bk-release.sh
+++ b/hack/operatorhub/trigger-bk-release.sh
@@ -25,7 +25,7 @@ curl "https://api.buildkite.com/v2/organizations/elastic/pipelines/cloud-on-k8s-
     "branch": "'"$branch"'",
     "message": "release ECK '"$ECK_VERSION"' for OperatoHub/RedHat",
     "env": {
-        "DRY_RUN": "'"$DRY_RUN"'",
+        "OHUB_DRY_RUN": "'"$DRY_RUN"'",
         "OHUB_GITHUB_VAULT_SECRET": "secret/ci/elastic-cloud-on-k8s/'"$gh_vault_secret_name"'"
     }
 }'

--- a/hack/operatorhub/trigger-bk-release.sh
+++ b/hack/operatorhub/trigger-bk-release.sh
@@ -6,17 +6,17 @@
 
 # Script to call the Buildkite API to trigger the release of ECK for OperatoHub/RedHat.
 #
-# Usage: BK_TOKEN=$(jq .graphql_token ~/.buildkite/config.json -r) USERNAME=you ECK_VERSION=v2.8.0 DRY_RUN=false ./trigger-bk-release.sh
+# Usage: BK_TOKEN=$(jq .graphql_token ~/.buildkite/config.json -r) GH_USERNAME=thb ECK_VERSION=v2.8.0-bc4 DRY_RUN=true ./trigger-bk-release.sh
 
 set -eu
 
 : "$BK_TOKEN"
-: "$USERNAME"
+: "$GH_USERNAME"
 : "$ECK_VERSION"
 : "$DRY_RUN"
 
 branch=$(sed -r "s|v([0-9]\.[0-9])\..*|\1|" <<< "$ECK_VERSION")
-gh_vault_secret_name="operatorhub-release-github-$USERNAME"
+gh_vault_secret_name="operatorhub-release-github-$GH_USERNAME"
 
 curl "https://api.buildkite.com/v2/organizations/elastic/pipelines/cloud-on-k8s-operator-redhat-release/builds" -XPOST \
     -H "Authorization: Bearer $BK_TOKEN" \

--- a/hack/operatorhub/trigger-bk-release.sh
+++ b/hack/operatorhub/trigger-bk-release.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+
+# Script to call the Buildkite API to trigger the release of ECK for OperatoHub/RedHat.
+#
+# Usage: BK_TOKEN=$(jq .graphql_token ~/.buildkite/config.json -r) USERNAME=you ECK_VERSION=v2.8.0 DRY_RUN=false ./trigger-bk-release.sh
+
+set -eu
+
+: "$BK_TOKEN"
+: "$USERNAME"
+: "$ECK_VERSION"
+: "$DRY_RUN"
+
+branch=$(sed -r "s|v([0-9]\.[0-9])\..*|\1|" <<< "$ECK_VERSION")
+gh_vault_secret_name="operatorhub-release-github-$USERNAME"
+
+curl "https://api.buildkite.com/v2/organizations/elastic/pipelines/cloud-on-k8s-operator-redhat-release/builds" -XPOST \
+    -H "Authorization: Bearer $BK_TOKEN" \
+    -d '{
+    "commit": "'"$ECK_VERSION"'",
+    "branch": "'"$branch"'",
+    "message": "release ECK '"$ECK_VERSION"' for OperatoHub/RedHat",
+    "env": {
+        "DRY_RUN": "'"$DRY_RUN"'",
+        "OHUB_GITHUB_VAULT_SECRET": "secret/ci/elastic-cloud-on-k8s/'"$gh_vault_secret_name"'"
+    }
+}'

--- a/hack/operatorhub/trigger-bk-release.sh
+++ b/hack/operatorhub/trigger-bk-release.sh
@@ -15,17 +15,19 @@ set -eu
 : "$ECK_VERSION"
 : "$DRY_RUN"
 
+# extract branch from the tag
 branch=$(sed -r "s|v([0-9]\.[0-9])\..*|\1|" <<< "$ECK_VERSION")
-gh_vault_secret_name="operatorhub-release-github-$GH_USERNAME"
 
 curl "https://api.buildkite.com/v2/organizations/elastic/pipelines/cloud-on-k8s-operator-redhat-release/builds" -XPOST \
-    -H "Authorization: Bearer $BK_TOKEN" \
-    -d '{
+    -H "Authorization: Bearer $BK_TOKEN" -d '
+{
     "commit": "'"$ECK_VERSION"'",
     "branch": "'"$branch"'",
     "message": "release ECK '"$ECK_VERSION"' for OperatoHub/RedHat",
     "env": {
+        "BUILDKITE_TAG": "'"$ECK_VERSION"'",
         "OHUB_DRY_RUN": "'"$DRY_RUN"'",
-        "OHUB_GITHUB_VAULT_SECRET": "secret/ci/elastic-cloud-on-k8s/'"$gh_vault_secret_name"'"
+        "OHUB_DISABLE_PREFLIGHT": "'"$DRY_RUN"'",
+        "OHUB_GITHUB_VAULT_SECRET": "secret/ci/elastic-cloud-on-k8s/operatorhub-release-github-'"$GH_USERNAME"'"
     }
 }'


### PR DESCRIPTION
This adds a script with the curl command to call the Buildkite API to trigger the pipeline `cloud-on-k8s-operator-redhat-release`that releases ECK for OperatoHub/RedHat. This also enables building branches for this pipeline.

Test:
```
BK_TOKEN=$(jq .graphql_token ~/.buildkite/config.json -r) USERNAME=thb \
  ECK_VERSION=v2.8.0-bc4 DRY_RUN=true ./trigger-bk-release.sh
```
https://buildkite.com/elastic/cloud-on-k8s-operator-redhat-release/builds/29