### PR TITLE
[2.8] Fix annotation label clash between monitoring and plugin elasticsearchRefs (#6816)

### DIFF
--- a/config/samples/logstash/logstash_stackmonitor.yaml
+++ b/config/samples/logstash/logstash_stackmonitor.yaml
@@ -22,6 +22,9 @@ spec:
     log.level: info
     api.http.host: "0.0.0.0"
     queue.type: memory
+  elasticsearchRefs:
+    - clusterName: test
+      name: monitoring
   podTemplate:
     spec:
       containers:
@@ -33,6 +36,19 @@ spec:
     logs:
       elasticsearchRefs:
         - name: monitoring
+  pipelines:
+    - pipeline.id: main
+      config.string: |
+        input { exec { command => 'uptime' interval => 10 } }
+        output {
+          elasticsearch {
+            hosts => [ "${TEST_ES_HOSTS}" ]
+            ssl => true
+            cacert => "${TEST_ES_SSL_CERTIFICATE_AUTHORITY}"
+            user => "${TEST_ES_USER}"
+            password => "${TEST_ES_PASSWORD}"
+          }
+        }
 ---
 apiVersion: kibana.k8s.elastic.co/v1
 kind: Kibana

--- a/pkg/apis/logstash/v1alpha1/logstash_types.go
+++ b/pkg/apis/logstash/v1alpha1/logstash_types.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/hash"
 )
 
 const (
@@ -333,7 +334,8 @@ func (lsmon *LogstashMonitoringAssociation) Associated() commonv1.Associated {
 }
 
 func (lsmon *LogstashMonitoringAssociation) AssociationConfAnnotationName() string {
-	return commonv1.ElasticsearchConfigAnnotationName(lsmon.ref)
+	// Use a custom suffix for monitoring elasticsearchRefs to avoid clashes with other elasticsearchRefs
+	return commonv1.FormatNameWithID(commonv1.ElasticsearchConfigAnnotationNameBase+"%s-sm", hash.HashObject(lsmon.ref))
 }
 
 func (lsmon *LogstashMonitoringAssociation) AssociationType() commonv1.AssociationType {

--- a/pkg/apis/logstash/v1alpha1/logstash_types_test.go
+++ b/pkg/apis/logstash/v1alpha1/logstash_types_test.go
@@ -1,0 +1,96 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+package v1alpha1
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
+)
+
+func TestLogstashEsAssociation_AssociationConfAnnotationName(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		cluster ElasticsearchCluster
+		want    string
+	}{
+		{
+			name: "average length names",
+			cluster: ElasticsearchCluster{
+				ObjectSelector: commonv1.ObjectSelector{Namespace: "namespace1", Name: "elasticsearch1"},
+				ClusterName:    "test",
+			},
+			want: "association.k8s.elastic.co/es-conf-2150608354",
+		},
+		{
+			name: "max length namespace and name (63 and 36 respectively)",
+			cluster: ElasticsearchCluster{
+				ObjectSelector: commonv1.ObjectSelector{
+					Namespace: "longnamespacelongnamespacelongnamespacelongnamespacelongnamespa",
+					Name:      "elasticsearch1elasticsearch1elastics"},
+				ClusterName: "test",
+			},
+			want: "association.k8s.elastic.co/es-conf-3419573237",
+		},
+		{
+			name: "secret name gives a different hash",
+			cluster: ElasticsearchCluster{
+				ObjectSelector: commonv1.ObjectSelector{Namespace: "namespace1", SecretName: "elasticsearch1"},
+				ClusterName:    "test",
+			},
+			want: "association.k8s.elastic.co/es-conf-851285294",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			aea := LogstashESAssociation{ElasticsearchCluster: tt.cluster}
+			got := aea.AssociationConfAnnotationName()
+
+			require.Equal(t, tt.want, got)
+			tokens := strings.Split(got, "/")
+			require.Equal(t, 2, len(tokens))
+			require.LessOrEqual(t, len(tokens[0]), 253)
+			require.LessOrEqual(t, len(tokens[1]), 63)
+		})
+	}
+}
+
+func TestLogstashMonitoringAssociation_AssociationConfAnnotationName(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		ref  commonv1.ObjectSelector
+		want string
+	}{
+		{
+			name: "average length names",
+			ref:  commonv1.ObjectSelector{Namespace: "namespace1", Name: "elasticsearch1"},
+			want: "association.k8s.elastic.co/es-conf-2150608354-sm",
+		},
+		{
+			name: "max length namespace and name (63 and 36 respectively)",
+			ref: commonv1.ObjectSelector{
+				Namespace: "longnamespacelongnamespacelongnamespacelongnamespacelongnamespa",
+				Name:      "elasticsearch1elasticsearch1elastics"},
+			want: "association.k8s.elastic.co/es-conf-3419573237-sm",
+		},
+		{
+			name: "secret name gives a different hash",
+			ref:  commonv1.ObjectSelector{Namespace: "namespace1", SecretName: "elasticsearch1"},
+			want: "association.k8s.elastic.co/es-conf-851285294-sm",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			aea := LogstashMonitoringAssociation{ref: tt.ref}
+			got := aea.AssociationConfAnnotationName()
+
+			require.Equal(t, tt.want, got)
+			tokens := strings.Split(got, "/")
+			require.Equal(t, 2, len(tokens))
+			require.LessOrEqual(t, len(tokens[0]), 253)
+			require.LessOrEqual(t, len(tokens[1]), 63)
+		})
+	}
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.8`:
 - [Fix annotation label clash between monitoring and plugin elasticsearchRefs (#6816)](https://github.com/elastic/cloud-on-k8s/pull/6816)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)