### PR TITLE
Use text/template instead of html/template

### DIFF
--- a/cmd/license-initializer/main.go
+++ b/cmd/license-initializer/main.go
@@ -6,10 +6,10 @@ package main
 
 import (
 	"fmt"
-	"html/template"
 	"io"
 	"os"
 	"strings"
+	"text/template"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/hack/deployer/runner/eks.go
+++ b/hack/deployer/runner/eks.go
@@ -7,10 +7,10 @@ package runner
 import (
 	"bytes"
 	"fmt"
-	"html/template"
 	"log"
 	"os"
 	"path/filepath"
+	"text/template"
 
 	"github.com/elastic/cloud-on-k8s/v2/hack/deployer/exec"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/vault"

--- a/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
+++ b/pkg/controller/elasticsearch/initcontainer/prepare_fs_script.go
@@ -7,7 +7,7 @@ package initcontainer
 import (
 	"bytes"
 	"fmt"
-	"html/template"
+	"text/template"
 
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/volume"
 )


### PR DESCRIPTION
This replaces the use of `text/template` with `html/template` which has a lower attack surface (less CVE).