### PR TITLE
[buildkite] Limit notified failures to not exceed message longer than 3000 bytes

### DIFF
--- a/.buildkite/e2e/reporter/go.mod
+++ b/.buildkite/e2e/reporter/go.mod
@@ -2,7 +2,4 @@ module e2e-reporter
 
 go 1.19
 
-require (
-	github.com/joshdk/go-junit v1.0.0
-	gopkg.in/yaml.v3 v3.0.1
-)
+require github.com/joshdk/go-junit v1.0.0

--- a/.buildkite/e2e/reporter/go.mod
+++ b/.buildkite/e2e/reporter/go.mod
@@ -2,4 +2,7 @@ module e2e-reporter
 
 go 1.19
 
-require github.com/joshdk/go-junit v1.0.0 // indirect
+require (
+	github.com/joshdk/go-junit v1.0.0
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/.buildkite/e2e/reporter/go.sum
+++ b/.buildkite/e2e/reporter/go.sum
@@ -1,8 +1,15 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/.buildkite/e2e/reporter/go.sum
+++ b/.buildkite/e2e/reporter/go.sum
@@ -7,9 +7,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/.buildkite/e2e/reporter/main.go
+++ b/.buildkite/e2e/reporter/main.go
@@ -228,17 +228,19 @@ func truncateNotifyMessage(yamlDef []byte, length int) ([]byte, error) {
 	}
 	err := yaml.Unmarshal(yamlDef, &pipeline)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	for i, s := range pipeline.Steps {
 		for j, n := range s.Notify {
-			// truncate message and replace last 3 chars by '...'
-			pipeline.Steps[i].Notify[j].Slack.Message = n.Slack.Message[0:length-1-3] + "..."
+			if len(n.Slack.Message) >= length {
+				// truncate message and replace last 3 chars by '...'
+				pipeline.Steps[i].Notify[j].Slack.Message = n.Slack.Message[0:length-1-3] + "..."
+			}
 		}
 	}
 	yamlDefBytes, err := yaml.Marshal(pipeline)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	return yamlDefBytes, nil
 }

--- a/.buildkite/e2e/reporter/main.go
+++ b/.buildkite/e2e/reporter/main.go
@@ -22,7 +22,7 @@ const (
 
 	maxErrorSizeBytes        = 3000 // to display more than 300 errors with a total below 1 MB
 	maxSlackMessageSizeBytes = 3000
-	maxNotifiedShortFailures = 10
+	maxNotifiedShortFailures = 15
 )
 
 var (

--- a/.buildkite/e2e/reporter/templates/annotate-failures.tpl.md
+++ b/.buildkite/e2e/reporter/templates/annotate-failures.tpl.md
@@ -1,4 +1,4 @@
-{{- range $envName, $sortedTests := .Tests }}
+{{- range $envName, $sortedTests := .TestsMap }}
 {{- range $test := $sortedTests.Failed }}
 
 <p>

--- a/.buildkite/e2e/reporter/templates/annotate-success.tpl.md
+++ b/.buildkite/e2e/reporter/templates/annotate-success.tpl.md
@@ -1,4 +1,4 @@
-{{- range $envName, $sortedTests := .Tests }}
+{{- range $envName, $sortedTests := .TestsMap }}
 {{- if gt (len $sortedTests.Passed) 0 }}
 
 <p>

--- a/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
+++ b/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
@@ -12,12 +12,12 @@ steps:
           message: |
           {{- range $i, $test := .ShortFailures }}
             🐞 `{{ $test.Name }}` {{ $test.EnvName }}
-          {{- if gt $i $.MaxNotifiedShortFailures }}
-            {{- break }}
-          {{- end }}
+            {{- if gt $i $.MaxNotifiedShortFailures }}
+              {{- break }}
+            {{- end }}
           {{- end }}
           {{- if gt .ShortFailuresCount $.MaxNotifiedShortFailures }}
-            Go to build to see more.
+            Go to build to see all {{ .ShortFailuresCount }} failures.
           {{- end }}
 
       {{- end }}

--- a/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
+++ b/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
@@ -1,10 +1,10 @@
 steps:
   - label: ""
     if: build.branch == "main"
-    {{- if eq .FailuresCount 0 }}
+    {{- if eq .ShortFailuresCount 0 }}
     command: echo "no failures to notify"
     {{- else }}
-    command: echo "{{ .FailuresCount }} failures to notify"; exit 1
+    command: echo "{{ .ShortFailuresCount }} failures to notify"; exit 1
     notify:
       - slack:
           channels:

--- a/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
+++ b/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
@@ -10,9 +10,14 @@ steps:
           channels:
             - "#eck"
           message: |
-          {{- range $envName, $sortedTests := .Tests }}
-            {{- range $test := $sortedTests.ShortFailed }}
-            🐞 `{{ $test.Name }}` {{ $envName }}
-            {{- end }}
+          {{- range $i, $test := .ShortFailures }}
+            🐞 `{{ $test.Name }}` {{ $test.EnvName }}
+          {{- if gt $i $.MaxNotifiedShortFailures }}
+            {{- break }}
           {{- end }}
+          {{- end }}
+          {{- if gt .ShortFailuresCount $.MaxNotifiedShortFailures }}
+            Go to build to see more.
+          {{- end }}
+
       {{- end }}


### PR DESCRIPTION
This prevents to send a Slack notification with a message greater than 3000 chars by limiting the number of notified test failures to 15 and adding the text `Go to build to see all xyz failures.` at the end when there are more.

To make this workable from the template, the map of list of short failures by env is flattened and the total count of short failures is injected in the template.

Not related to this, this also renames trimError in truncateError for consistency.
