### PR TITLE
Update advanced-node-scheduling.asciidoc

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
@@ -209,7 +209,7 @@ Starting with ECK 2.0 the operator can make Kubernetes Node labels available as 
 
 . First, ensure that the operator's flag `exposed-node-labels` contains the list of the Kubernetes node labels that should be exposed in the Elasticsearch Pods. If you are using the provided installation manifest, or the Helm chart, then this flag is already preset with two wildcard patterns for well-known node labels that describe Kubernetes cluster topology, like `topology.kubernetes.io/.*` and `failure-domain.beta.kubernetes.io/.*`.
 . On the Elasticsearch resources set the `eck.k8s.elastic.co/downward-node-labels` annotations with the list of the Kubernetes node labels that should be copied as Pod annotations.
-. Use the link:https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/[Kubernetes downward API] in the `podTemplate` to make those annotations available as environment variables in Elasticsearch Pods.
+. Use the link:https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/[Kubernetes downward API] in the `podTemplate` to make those labels available as environment variables in Elasticsearch Pods.
 
 Refer to the next section or to the link:{eck_github}/tree/{eck_release_branch}/config/samples/elasticsearch/elasticsearch.yaml[Elasticsearch sample resource in the ECK source repository] for a complete example.
 
@@ -244,7 +244,7 @@ spec:
           - name: ZONE
             valueFrom:
               fieldRef:
-                fieldPath: metadata.annotations['topology.kubernetes.io/zone']
+                fieldPath: metadata.labels['topology.kubernetes.io/zone']
         topologySpreadConstraints:
           - maxSkew: 1
             topologyKey: topology.kubernetes.io/zone


### PR DESCRIPTION
When trying to setup the `ZONE` environment variable to be used by `topologySpreadConstraints` on Kubernetes version 1.26 (haven't tested in other versions), the `fieldPath` must reference the value from `metadata.labels` instead of `metadata.annotations`.

Deployment details:
Platform: AWS EKS w/ Managed Node Group
ECK version: 8.7.0
Kubernetes version: 1.26

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Yes
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)? Yes
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed. Yes
