### PR TITLE
[2.8] Adjust number of replicas for Logstash stack monitoring sample (#6825)

### DIFF
--- a/config/samples/logstash/logstash_stackmonitor.yaml
+++ b/config/samples/logstash/logstash_stackmonitor.yaml
@@ -7,7 +7,7 @@ spec:
   version: 8.6.1
   nodeSets:
     - name: default
-      count: 1
+      count: 3
       config:
         node.store.allow_mmap: false
 ---


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.8`:
 - [Adjust number of replicas for Logstash stack monitoring sample (#6825)](https://github.com/elastic/cloud-on-k8s/pull/6825)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)