### PR TITLE
[2.8] Initial version of GKE Autopilot documentation. (#6760)

### DIFF
--- a/config/recipes/autopilot/README.md
+++ b/config/recipes/autopilot/README.md
@@ -1,0 +1,21 @@
+= GKE Autopilot Configuration Examples
+
+This directory contains yaml manifests with an configurations for running Elasticsearch, Kibana, Fleet Server, Elastic Agent and Metricbeat on GKE Autopilot. These manifests are self-contained and work out-of-the-box on any GKE Autopilot cluster with a version greater than 1.25.
+
+IMPORTANT: These examples are for illustration purposes only and should not be considered to be production-ready.
+
+NOTE: The Elasticsearch example uses a Daemonset to set to ensure that `/proc/sys/vm/max_map_count` is set on all of the underlying Kubernetes nodes for optimal performance. See https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html for more information.
+
+==== Elasticsearch, Kibana and Elastic Agent in Fleet mode
+
+===== Agent with System and Kubernetes integrations - `elasticsearch.yaml`+`fleet-kubernetes-integration.yaml`
+
+Deploys Elastic Agent as a DaemonSet in Fleet mode with System and Kubernetes integrations enabled. System integration collects syslog logs, auth logs and system metrics (for CPU, I/O, filesystem, memory, network, process and others). Kubernetes integrations collects API server, Container, Event, Node, Pod, Volume and system metrics.
+
+===== Kubernetes integration - `elasticsearch.yaml`+`kubernetes-integration.yaml`
+
+Deploys Elastic Agent as a DaemonSet in standalone mode with Kubernetes integration enabled. Collects API server, Container, Event, Node, Pod, Volume, System, Volume, and State metrics for Containers, Daemonsets, Jobs, Nodes, Persistent volumes/claims, Pods, Replicasets, ResourceQuotas, Services, Statefulsets, and StorageClasses.
+
+==== Metricbeat for Kubernetes monitoring - `elasticsearch.yaml`+`metricbeat_hosts.yaml`
+
+Deploys Metricbeat as a DaemonSet that monitors the host resource usage (CPU, memory, network, filesystem) and Kubernetes resources (Nodes, Pods, Containers, Volumes).

--- a/config/recipes/autopilot/elasticsearch.yaml
+++ b/config/recipes/autopilot/elasticsearch.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: max-map-count-setter
+  labels:
+    k8s-app: max-map-count-setter
+spec:
+  selector:
+    matchLabels:
+      name: max-map-count-setter
+  template:
+    metadata:
+      labels:
+        name: max-map-count-setter
+    spec:
+      nodeSelector:
+        cloud.google.com/compute-class: "Balanced"
+      initContainers:
+        - name: max-map-count-setter
+          image: docker.io/bash:5.2.15
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 10m
+              memory: 16Mi
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          command: ['/usr/local/bin/bash', '-e', '-c', 'echo 262144 > /proc/sys/vm/max_map_count']
+      containers:
+        - name: sleep
+          image: docker.io/bash:5.2.15
+          command: ['sleep', 'infinity']
+---
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch
+spec:
+  version: 8.7.0
+  nodeSets:
+  - name: default
+    count: 1
+    podTemplate:
+      spec:
+        nodeSelector:
+          cloud.google.com/compute-class: "Balanced"
+        containers:
+        - name: elasticsearch
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 500m
+            limits:
+              memory: 1Gi
+              cpu: 500m
+        initContainers:
+        - name: max-map-count-check
+          command: ['sh', '-c', "while true; do mmc=$(cat /proc/sys/vm/max_map_count); if [ ${mmc} -eq 262144 ]; then exit 0; fi; sleep 1; done"]
+          resources:
+            requests:
+              memory: 16Mi
+              cpu: 10m
+            limits:
+              memory: 16Mi
+              cpu: 10m
+---

--- a/config/recipes/autopilot/fleet-kubernetes-integration.yaml
+++ b/config/recipes/autopilot/fleet-kubernetes-integration.yaml
@@ -1,0 +1,263 @@
+---
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: kibana
+spec:
+  version: 8.7.0
+  count: 1
+  elasticsearchRef:
+    name: elasticsearch
+  config:
+    xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.default.svc:9200"]
+    xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.default.svc:8220"]
+    xpack.fleet.packages:
+    - name: system
+      version: latest
+    - name: elastic_agent
+      version: latest
+    - name: fleet_server
+      version: latest
+    - name: kubernetes
+      version: latest
+    xpack.fleet.agentPolicies:
+    - name: Fleet Server on ECK policy
+      id: eck-fleet-server
+      namespace: default
+      monitoring_enabled:
+      - logs
+      - metrics
+      unenroll_timeout: 900
+      package_policies:
+      - name: fleet_server-1
+        id: fleet_server-1
+        package:
+          name: fleet_server
+    - name: Elastic Agent on ECK policy
+      id: eck-agent
+      namespace: default
+      monitoring_enabled:
+      - logs
+      - metrics
+      unenroll_timeout: 900
+      package_policies:
+      - package:
+          name: system
+        name: system-1
+      - package:
+          name: kubernetes
+        name: kubernetes-1
+  podTemplate:
+    spec:
+      nodeSelector:
+        cloud.google.com/compute-class: "Balanced"
+      containers:
+      - name: kibana
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 200m
+          limits:
+            memory: 1Gi
+            cpu: 200m
+---
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: fleet-server
+spec:
+  version: 8.7.0
+  kibanaRef:
+    name: kibana
+  elasticsearchRefs:
+  - name: elasticsearch
+  mode: fleet
+  fleetServerEnabled: true
+  policyID: eck-fleet-server
+  deployment:
+    replicas: 1
+    podTemplate:
+      spec:
+        nodeSelector:
+          cloud.google.com/compute-class: "Balanced"
+        containers:
+          - name: agent
+            resources:
+              requests:
+                cpu: 200m
+              limits:
+                ephemeral-storage: "10Gi"
+        volumes:
+        - name: "agent-data"
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes: [ "ReadWriteOnce" ]
+                storageClassName: "standard-rwo"
+                resources:
+                  requests:
+                    storage: 10Gi
+        serviceAccountName: fleet-server
+        automountServiceAccountToken: true
+        securityContext:
+          runAsUser: 0
+---
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata: 
+  name: elastic-agent
+spec:
+  version: 8.7.0
+  kibanaRef:
+    name: kibana
+  fleetServerRef: 
+    name: fleet-server
+  mode: fleet
+  policyID: eck-agent
+  daemonSet:
+    podTemplate:
+      spec:
+        nodeSelector:
+          cloud.google.com/compute-class: "Balanced"
+        volumes:
+        - name: "agent-data"
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes: [ "ReadWriteOnce" ]
+                storageClassName: "standard-rwo"
+                resources:
+                  requests:
+                    storage: 10Gi
+        containers:
+          - name: agent
+            resources:
+              requests:
+                cpu: 200m
+              limits:
+                ephemeral-storage: "10Gi"
+        serviceAccountName: elastic-agent
+        automountServiceAccountToken: true
+        securityContext:
+          runAsUser: 0
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fleet-server
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  - namespaces
+  - nodes
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fleet-server
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fleet-server
+subjects:
+- kind: ServiceAccount
+  name: fleet-server
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: fleet-server
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: elastic-agent
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  - nodes
+  - namespaces
+  - events
+  - services
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
+- apiGroups: ["extensions"]
+  resources:
+    - replicasets
+  verbs: 
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - "apps"
+  resources:
+  - statefulsets
+  - deployments
+  - replicasets
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - ""
+  resources:
+  - nodes/stats
+  verbs:
+  - get
+- apiGroups:
+  - "batch"
+  resources:
+  - jobs
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: elastic-agent
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: elastic-agent
+subjects:
+- kind: ServiceAccount
+  name: elastic-agent
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: elastic-agent
+  apiGroup: rbac.authorization.k8s.io
+---

--- a/config/recipes/autopilot/kubernetes-integration.yaml
+++ b/config/recipes/autopilot/kubernetes-integration.yaml
@@ -1,0 +1,461 @@
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: elastic-agent
+spec:
+  version: 8.7.0
+  elasticsearchRefs:
+  - name: elasticsearch
+  daemonSet:
+    podTemplate:
+      spec:
+        nodeSelector:
+          cloud.google.com/compute-class: "Balanced"
+        containers:
+          - name: agent
+            securityContext:
+              runAsUser: 0
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            resources:
+              requests:
+                cpu: 200m
+              limits:
+                ephemeral-storage: "10Gi"
+            volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+        volumes:
+        - name: "agent-data"
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes: [ "ReadWriteOnce" ]
+                storageClassName: "standard-rwo"
+                resources:
+                  requests:
+                    storage: 10Gi
+        - name: varlog
+          hostPath:
+            path: /var/log
+        automountServiceAccountToken: true
+        serviceAccountName: elastic-agent
+  config:
+    id: 488e0b80-3634-11eb-8208-57893829af4e
+    revision: 2
+    agent:
+      monitoring:
+        enabled: false
+    inputs:
+    - id: 678daef0-3634-11eb-8208-57893829af4e
+      name: kubernetes-1
+      revision: 1
+      type: kubernetes/metrics
+      use_output: default
+      meta:
+        package:
+          name: kubernetes
+          version: latest
+      data_stream:
+        namespace: k8s
+      streams:
+      - id: kubernetes/metrics-kubernetes.apiserver
+        data_stream:
+          dataset: kubernetes.apiserver
+          type: metrics
+        metricsets:
+        - apiserver
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'https://${env.KUBERNETES_SERVICE_HOST}:${env.KUBERNETES_SERVICE_PORT}'
+        period: 30s
+        ssl.certificate_authorities:
+        - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - id: kubernetes/metrics-kubernetes.container
+        data_stream:
+          dataset: kubernetes.container
+          type: metrics
+        metricsets:
+        - container
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'https://${env.NODE_NAME}:10250'
+        period: 10s
+        ssl.verification_mode: none
+      - id: kubernetes/metrics-kubernetes.event
+        data_stream:
+          dataset: kubernetes.event
+          type: metrics
+        metricsets:
+        - event
+        period: 10s
+        add_metadata: true
+      - id: kubernetes/metrics-kubernetes.node
+        data_stream:
+          dataset: kubernetes.node
+          type: metrics
+        metricsets:
+        - node
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'https://${env.NODE_NAME}:10250'
+        period: 10s
+        ssl.verification_mode: none
+      - id: kubernetes/metrics-kubernetes.pod
+        data_stream:
+          dataset: kubernetes.pod
+          type: metrics
+        metricsets:
+        - pod
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'https://${env.NODE_NAME}:10250'
+        period: 10s
+        ssl.verification_mode: none
+      - id: kubernetes/metrics-kubernetes.system
+        data_stream:
+          dataset: kubernetes.system
+          type: metrics
+        metricsets:
+        - system
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'https://${env.NODE_NAME}:10250'
+        period: 10s
+        ssl.verification_mode: none
+      - id: kubernetes/metrics-kubernetes.volume
+        data_stream:
+          dataset: kubernetes.volume
+          type: metrics
+        metricsets:
+        - volume
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'https://${env.NODE_NAME}:10250'
+        period: 10s
+        ssl.verification_mode: none
+    - id: C07CC023-84F5-4623-962C-5F82E9DF7899
+      name: kubernetes-2
+      revision: 1
+      type: kubernetes/metrics
+      use_output: default
+      meta:
+        package:
+          name: kubernetes
+          version: latest
+      data_stream:
+        namespace: k8s
+      streams:
+      - id: kubernetes/metrics-kubernetes.state_container
+        data_stream:
+          dataset: kubernetes.state_container
+          type: metrics
+        metricsets:
+        - state_container
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'kube-state-metrics:8080'
+        period: 30s
+        ssl.certificate_authorities:
+        - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - id: kubernetes/metrics-kubernetes.state_container
+        data_stream:
+          dataset: kubernetes.state_container
+          type: metrics
+        metricsets:
+        - state_cronjob
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'kube-state-metrics:8080'
+        period: 30s
+        ssl.certificate_authorities:
+        - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - id: kubernetes/metrics-kubernetes.state_daemonset
+        data_stream:
+          dataset: kubernetes.state_daemonset
+          type: metrics
+        metricsets:
+        - state_daemonset
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'kube-state-metrics:8080'
+        period: 30s
+        ssl.certificate_authorities:
+        - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - id: kubernetes/metrics-kubernetes.state_deployment
+        data_stream:
+          dataset: kubernetes.state_deployment
+          type: metrics
+        metricsets:
+        - state_deployment
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'kube-state-metrics:8080'
+        period: 30s
+        ssl.certificate_authorities:
+        - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - id: kubernetes/metrics-kubernetes.state_job
+        data_stream:
+          dataset: kubernetes.state_job
+          type: metrics
+        metricsets:
+        - state_job
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'kube-state-metrics:8080'
+        period: 30s
+        ssl.certificate_authorities:
+        - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - id: kubernetes/metrics-kubernetes.state_node
+        data_stream:
+          dataset: kubernetes.state_node
+          type: metrics
+        metricsets:
+        - state_node
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'kube-state-metrics:8080'
+        period: 30s
+        ssl.certificate_authorities:
+        - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - id: kubernetes/metrics-kubernetes.state_persistentvolume
+        data_stream:
+          dataset: kubernetes.state_persistentvolume
+          type: metrics
+        metricsets:
+        - state_persistentvolume
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'kube-state-metrics:8080'
+        period: 30s
+        ssl.certificate_authorities:
+        - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - id: kubernetes/metrics-kubernetes.state_persistentvolumeclaim
+        data_stream:
+          dataset: kubernetes.state_persistentvolumeclaim
+          type: metrics
+        metricsets:
+        - state_persistentvolumeclaim
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'kube-state-metrics:8080'
+        period: 30s
+        ssl.certificate_authorities:
+        - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - id: kubernetes/metrics-kubernetes.state_pod
+        data_stream:
+          dataset: kubernetes.state_pod
+          type: metrics
+        metricsets:
+        - state_pod
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'kube-state-metrics:8080'
+        period: 30s
+        ssl.certificate_authorities:
+        - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - id: kubernetes/metrics-kubernetes.state_replicaset
+        data_stream:
+          dataset: kubernetes.state_replicaset
+          type: metrics
+        metricsets:
+        - state_replicaset
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'kube-state-metrics:8080'
+        period: 30s
+        ssl.certificate_authorities:
+        - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - id: kubernetes/metrics-kubernetes.state_resourcequota
+        data_stream:
+          dataset: kubernetes.state_resourcequota
+          type: metrics
+        metricsets:
+        - state_resourcequota
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'kube-state-metrics:8080'
+        period: 30s
+        ssl.certificate_authorities:
+        - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - id: kubernetes/metrics-kubernetes.state_service
+        data_stream:
+          dataset: kubernetes.state_service
+          type: metrics
+        metricsets:
+        - state_service
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'kube-state-metrics:8080'
+        period: 30s
+        ssl.certificate_authorities:
+        - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - id: kubernetes/metrics-kubernetes.state_statefulset
+        data_stream:
+          dataset: kubernetes.state_statefulset
+          type: metrics
+        metricsets:
+        - state_statefulset
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'kube-state-metrics:8080'
+        period: 30s
+        ssl.certificate_authorities:
+        - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - id: kubernetes/metrics-kubernetes.state_storageclass
+        data_stream:
+          dataset: kubernetes.state_storageclass
+          type: metrics
+        metricsets:
+        - state_storageclass
+        add_metadata: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        hosts:
+        - 'kube-state-metrics:8080'
+        period: 30s
+        ssl.certificate_authorities:
+        - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    # Disabled per https://github.com/elastic/beats/pull/35134
+    # - id: C07CC023-84F5-4623-962C-5F82E9DF7855
+    #   name: kubernetes-4
+    #   type: filestream
+    #   data_stream:
+    #     namespace: k8s
+    #   use_output: default
+    #   streams:
+    #   - id: kubernetes/logs-kubernetes.container_logs
+    #     data_stream:
+    #       type: logs
+    #       dataset: kubernetes.container_logs
+    #     paths:
+    #       - '/var/log/containers/*${kubernetes.container.id}.log'
+    #     prospector.scanner.symlinks: true
+    #     parsers:
+    #     - container:
+    #         stream: all
+    #         format: auto
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: elastic-agent
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - persistentvolumes
+  - persistentvolumeclaims
+  - pods
+  - nodes
+  - nodes/metrics
+  - nodes/proxy
+  - nodes/stats
+  - services
+  - events
+  verbs:
+  - get
+  - watch
+  - list
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  - statefulsets
+  - daemonsets
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["storage.k8s.io"]
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: elastic-agent
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: elastic-agent
+subjects:
+- kind: ServiceAccount
+  name: elastic-agent
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: elastic-agent
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: kibana
+spec:
+  version: 8.7.0
+  count: 1
+  elasticsearchRef:
+    name: elasticsearch
+  podTemplate:
+    spec:
+      nodeSelector:
+        cloud.google.com/compute-class: "Balanced"
+      containers:
+      - name: kibana
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 200m
+          limits:
+            memory: 1Gi
+            cpu: 200m
+---

--- a/config/recipes/autopilot/metricbeat_hosts.yaml
+++ b/config/recipes/autopilot/metricbeat_hosts.yaml
@@ -1,0 +1,182 @@
+---
+apiVersion: beat.k8s.elastic.co/v1beta1
+kind: Beat
+metadata:
+  name: metricbeat
+spec:
+  type: metricbeat
+  version: 8.7.0
+  elasticsearchRef:
+    name: elasticsearch
+  kibanaRef:
+    name: kibana
+  config:
+    metricbeat:
+      autodiscover:
+        providers:
+        - hints:
+            default_config: {}
+            enabled: "true"
+          node: ${NODE_NAME}
+          type: kubernetes
+      modules:
+      - module: system
+        period: 10s
+        metricsets:
+        - cpu
+        - load
+        - memory
+        - network
+        - process
+        - process_summary
+        process:
+          include_top_n:
+            by_cpu: 5
+            by_memory: 5
+        processes:
+        - .*
+      - module: kubernetes
+        period: 10s
+        node: ${NODE_NAME}
+        hosts:
+        - https://${NODE_NAME}:10250
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        ssl:
+          verification_mode: none
+        metricsets:
+        - node
+        - system
+        - pod
+        - container
+        - volume
+    processors:
+    - add_cloud_metadata: {}
+    - add_host_metadata: {}
+  daemonSet:
+    podTemplate:
+      spec:
+        nodeSelector:
+          cloud.google.com/compute-class: "Balanced"
+        serviceAccountName: metricbeat
+        automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+        containers:
+        - args:
+          - -e
+          - -c
+          - /etc/beat.yml
+          name: metricbeat
+          resources:
+            requests:
+              cpu: 200m
+            limits:
+              ephemeral-storage: "10Gi"
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+        dnsPolicy: ClusterFirstWithHostNet
+        hostNetwork: false # Not allowed in Autopilot
+        securityContext:
+          runAsUser: 0
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - name: "beat-data"
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes: [ "ReadWriteOnce" ]
+                storageClassName: "standard-rwo"
+                resources:
+                  requests:
+                    storage: 10Gi
+---
+# permissions needed for metricbeat
+# source: https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-kubernetes.html
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metricbeat
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  - events
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "extensions"
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/stats
+  verbs:
+  - get
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metricbeat
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metricbeat
+subjects:
+- kind: ServiceAccount
+  name: metricbeat
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: metricbeat
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: kibana
+spec:
+  version: 8.7.0
+  count: 1
+  elasticsearchRef:
+    name: elasticsearch
+  podTemplate:
+    spec:
+      nodeSelector:
+        cloud.google.com/compute-class: "Balanced"
+      containers:
+      - name: kibana
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 200m
+          limits:
+            memory: 1Gi
+            cpu: 200m
+---

--- a/docs/advanced-topics/advanced-topics.asciidoc
+++ b/docs/advanced-topics/advanced-topics.asciidoc
@@ -10,6 +10,7 @@ endif::[]
 [partintro]
 --
 - <<{p}-openshift>>
+- <<{p}-autopilot>>
 - <<{p}-custom-images>>
 - <<{p}-service-meshes>>
 - <<{p}-traffic-splitting>>
@@ -20,6 +21,7 @@ endif::[]
 --
 
 include::openshift.asciidoc[leveloffset=+1]
+include::gke-autopilot.asciidoc[leveloffset=+1]
 include::custom-images.asciidoc[leveloffset=+1]
 include::service-meshes.asciidoc[leveloffset=+1]
 include::traffic-splitting.asciidoc[leveloffset=+1]

--- a/docs/advanced-topics/gke-autopilot.asciidoc
+++ b/docs/advanced-topics/gke-autopilot.asciidoc
@@ -1,0 +1,69 @@
+:page_id: autopilot 
+ifdef::env-github[]
+****
+link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-{page_id}.html[View this document on the Elastic website]
+****
+endif::[]
+[id="{p}-{page_id}"]
+= Deploy ECK on GKE Autopilot
+
+This page shows how to run ECK on GKE Autopilot.
+
+1. It is recommended that each Kubernetes host's virtual memory kernel settings be modified. Refer to <<{p}-virtual-memory>>.
+2. It is recommended that Elasticsearch Pods have an `initContainer` that waits for virtual memory settings to be in place. Refer to <<{p}-autopilot-deploy-elasticsearch>>.
+3. For Elastic Agent/Beats there are storage limitations to be considered. Refer to <<{p}-autopilot-deploy-agent-beats>>
+
+* <<{p}-autopilot-setting-virtual-memory>>
+* <<{p}-autopilot-deploy-the-operator>>
+* <<{p}-autopilot-deploy-elasticsearch>>
+* <<{p}-autopilot-deploy-agent-beats>>
+
+[id="{p}-autopilot-setting-virtual-memory"]
+== Ensuring virtual memory kernel settings
+
+If you are intending to run production workloads on GKE Autopilot then `vm.max_map_count` should be set. The recommended way to set this kernel setting on the Autopilot hosts is with a `Daemonset` as described in the <<{p}-virtual-memory>> section. You must be running at least version 1.25 when on the `regular` channel or using the `rapid` channel, which currently runs version 1.26.
+
+CAUTION: Only use the provided `Daemonset` exactly as specified or it could be rejected by the Autopilot control plane.
+
+[id="{p}-autopilot-deploy-the-operator"]
+== Installing the ECK Operator
+
+Refer to <<{p}-installing-eck>> for more information on installation options.
+
+[id="{p}-autopilot-deploy-elasticsearch"]
+== Deploy an Elasticsearch instance
+
+Create an Elasticsearch cluster. If you are using the `Daemonset` described in the <<{p}-virtual-memory>> section to set `max_map_count` you can add the `initContainer` below is also used to ensure the setting is set prior to starting Elasticsearch.
+
+[source,shell,subs="attributes,+macros"]
+----
+cat $$<<$$EOF | kubectl apply -f -
+apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
+kind: Elasticsearch
+metadata:
+  name: elasticsearch-sample
+spec:
+  version: {version}
+  nodeSets:
+  - name: default
+    count: 1
+    # Only uncomment the below section if you are not using the Daemonset to set max_map_count.
+    # config:
+    #  node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        # This init container ensures that the `max_map_count` setting has been applied before starting Elasticsearch.
+        # This is not required, but is encouraged when using the previously mentioned Daemonset to set max_map_count.
+        # Do not use this if setting config.node.store.allow_mmap: false
+        initContainers:
+        - name: max-map-count-check
+          command: ['sh', '-c', "while true; do mmc=$(cat /proc/sys/vm/max_map_count); if [ ${mmc} -eq 262144 ]; then exit 0; fi; sleep 1; done"]
+EOF
+----
+
+[id="{p}-autopilot-deploy-agent-beats"]
+== Deploy a standalone Elastic Agent and/or Beats
+
+When running Elastic Agent and Beats within GKE Autopilot there are storage constraints to be considered. No `HostPath` volumes are allowed, which the ECK operator defaults to when unset for both `Deployments` and `Daemonsets`. Instead use link:https://kubernetes.io/docs/concepts/storage/ephemeral-volumes[Kubernetes ephemeral volumes].
+
+Refer to link:https://github.com/elastic/cloud-on-k8s/tree/main/config/recipes/autopilot[Recipes to deploy Elasticsearch, Kibana, Elastic Fleet Server and Elastic Agent and/or Beats within GKE Autopilot].

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
@@ -11,7 +11,27 @@ endif::[]
 By default, Elasticsearch uses memory mapping (`mmap`) to efficiently access indices.
 Usually, default values for virtual address space on Linux distributions are too low for Elasticsearch to work properly, which may result in out-of-memory exceptions. This is why link:k8s-quickstart.html[the quickstart example] disables `mmap` through the `node.store.allow_mmap: false` setting. For production workloads, it is strongly recommended to increase the kernel setting `vm.max_map_count` to `262144` and leave `node.store.allow_mmap` unset.
 
-The kernel setting `vm.max_map_count=262144` can be set on the host either directly or by a dedicated init container, which must be privileged. To add an init container that changes the host kernel setting before your Elasticsearch pod starts, you can use the following example Elasticsearch spec:
+The kernel setting `vm.max_map_count=262144` can be set on the host directly, by a dedicated init container which must be privileged, or a dedicated Daemonset.
+
+For more information, check the Elasticsearch documentation on
+link:https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html[Virtual memory].
+
+Optionally, you can select a different type of file system implementation for the storage. For possible options, check the
+link:https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-store.html[store module documentation].
+
+[source,yaml]
+----
+spec:
+  nodeSets:
+  - name: default
+    count: 3
+    config:
+      index.store.type: niofs
+----
+
+== Using an Init Container to set virtual memory
+
+To add an init container that changes the host kernel setting before your Elasticsearch container starts, you can use the following example Elasticsearch spec:
 [source,yaml,subs="attributes,+macros"]
 ----
 cat $$<<$$EOF | kubectl apply -f -
@@ -37,18 +57,70 @@ EOF
 
 Note that this requires the ability to run privileged containers, which is likely not the case on many secure clusters.
 
-For more information, check the Elasticsearch documentation on
-link:https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html[Virtual memory].
+== Using a Daemonset to set virtual memory
 
-Optionally, you can select a different type of file system implementation for the storage. For possible options, check the
-link:https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-store.html[store module documentation].
+To use a Daemonset that changes the host kernel setting on all nodes:
 
-[source,yaml]
+[source,yaml,subs="attributes,+macros"]
 ----
+cat $$<<$$EOF | kubectl apply -n elastic-system -f -
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: max-map-count-setter
+  labels:
+    k8s-app: max-map-count-setter
 spec:
+  selector:
+    matchLabels:
+      name: max-map-count-setter
+  template:
+    metadata:
+      labels:
+        name: max-map-count-setter
+    spec:
+      initContainers:
+        - name: max-map-count-setter
+          image: docker.io/bash:5.2.15
+          resources:
+            limits:
+              cpu: 100m
+              memory: 32Mi
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          command: ['/usr/local/bin/bash', '-e', '-c', 'echo 262144 > /proc/sys/vm/max_map_count']
+      containers:
+        - name: sleep
+          image: docker.io/bash:5.2.15
+          command: ['sleep', 'infinity']
+EOF
+----
+
+To run an Elasticsearch instance that waits for the kernel setting to be in place:
+
+[source,yaml,subs="attributes,+macros"]
+----
+cat $$<<$$EOF | kubectl apply -f -
+apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
+kind: Elasticsearch
+metadata:
+  name: elasticsearch-sample
+spec:
+  version: {version}
   nodeSets:
   - name: default
-    count: 3
-    config:
-      index.store.type: niofs
+    count: 1
+    # Only uncomment the below section if you are not using the previous Daemonset to set max_map_count.
+    # config:
+    #  node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        # This init container ensures that the `max_map_count` setting has been applied before starting Elasticsearch.
+        # This is not required, but is encouraged when using the previous Daemonset to set max_map_count.
+        # Do not use this if setting config.node.store.allow_mmap: false
+        initContainers:
+        - name: max-map-count-check
+          command: ['sh', '-c', "while true; do mmc=$(cat /proc/sys/vm/max_map_count); if [ ${mmc} -eq 262144 ]; then exit 0; fi; sleep 1; done"]
+EOF
 ----

--- a/docs/orchestrating-elastic-stack-applications/recipes.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/recipes.asciidoc
@@ -15,5 +15,6 @@ This section includes recipes that provide configuration examples for some commo
 * link:https://github.com/elastic/cloud-on-k8s/tree/main/config/recipes/maps[Expose Elastic Maps Server and Kibana using a Kubernetes Ingress]
 * link:https://github.com/elastic/cloud-on-k8s/tree/main/config/recipes/psp[Secure your cluster with Pod Security Policies]
 * link:https://github.com/elastic/cloud-on-k8s/tree/main/config/recipes/traefik[Use Traefik to expose Elastic Stack applications]
+* link:https://github.com/elastic/cloud-on-k8s/tree/main/config/recipes/autopilot[Deploy Elasticsearch, Kibana, Elastic Fleet Server and Elastic Agent within GKE Autopilot]
 
 WARNING: Compared to other configuration examples that are consistently tested, like <<{p}-elastic-agent-fleet-configuration-examples,fleet-managed Elastic Agent on ECK>>, <<{p}-elastic-agent-configuration-examples,standalone Elastic Agent on ECK>>, or <<{p}-beat-configuration-examples,Beats on ECK>>, the recipes in this section are not regularly tested by our automation system, and therefore should not be considered to be production-ready. 


### PR DESCRIPTION
Backport of the following PR into `2.8`:

* [Initial version of GKE Autopilot documentation](https://github.com/elastic/cloud-on-k8s/pull/6760) #6760 