### PR TITLE
Add Selector to LogstashStatus

### DIFF
--- a/config/crds/v1/all-crds.yaml
+++ b/config/crds/v1/all-crds.yaml
@@ -9815,11 +9815,15 @@ spec:
                   in the Logstash specification.
                 format: int64
                 type: integer
+              selector:
+                type: string
               version:
                 description: 'Version of the stack resource currently running. During
                   version upgrades, multiple versions may run in parallel: this value
                   specifies the lowest version currently running.'
                 type: string
+            required:
+            - selector
             type: object
         type: object
     served: true
@@ -9828,7 +9832,7 @@ spec:
       scale:
         labelSelectorPath: .status.selector
         specReplicasPath: .spec.count
-        statusReplicasPath: .status.count
+        statusReplicasPath: .status.expectedNodes
       status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/config/crds/v1/bases/logstash.k8s.elastic.co_logstashes.yaml
+++ b/config/crds/v1/bases/logstash.k8s.elastic.co_logstashes.yaml
@@ -8224,11 +8224,15 @@ spec:
                   in the Logstash specification.
                 format: int64
                 type: integer
+              selector:
+                type: string
               version:
                 description: 'Version of the stack resource currently running. During
                   version upgrades, multiple versions may run in parallel: this value
                   specifies the lowest version currently running.'
                 type: string
+            required:
+            - selector
             type: object
         type: object
     served: true
@@ -8237,5 +8241,5 @@ spec:
       scale:
         labelSelectorPath: .status.selector
         specReplicasPath: .spec.count
-        statusReplicasPath: .status.count
+        statusReplicasPath: .status.expectedNodes
       status: {}

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -9869,11 +9869,15 @@ spec:
                   in the Logstash specification.
                 format: int64
                 type: integer
+              selector:
+                type: string
               version:
                 description: 'Version of the stack resource currently running. During
                   version upgrades, multiple versions may run in parallel: this value
                   specifies the lowest version currently running.'
                 type: string
+            required:
+            - selector
             type: object
         type: object
     served: true
@@ -9882,7 +9886,7 @@ spec:
       scale:
         labelSelectorPath: .status.selector
         specReplicasPath: .spec.count
-        statusReplicasPath: .status.count
+        statusReplicasPath: .status.expectedNodes
       status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/docs/reference/api-docs.asciidoc
+++ b/docs/reference/api-docs.asciidoc
@@ -1963,6 +1963,7 @@ LogstashStatus defines the observed state of Logstash
 | *`expectedNodes`* __integer__ | 
 | *`availableNodes`* __integer__ | 
 | *`observedGeneration`* __integer__ | ObservedGeneration is the most recent generation observed for this Logstash instance. It corresponds to the metadata generation, which is updated on mutation by the API Server. If the generation observed in status diverges from the generation in metadata, the Logstash controller has not yet processed the changes contained in the Logstash specification.
+| *`selector`* __string__ | 
 |===
 
 

--- a/pkg/apis/logstash/v1alpha1/logstash_types.go
+++ b/pkg/apis/logstash/v1alpha1/logstash_types.go
@@ -129,6 +129,8 @@ type LogstashStatus struct {
 
 	// MonitoringAssociationStatus is the status of any auto-linking to monitoring Elasticsearch clusters.
 	MonitoringAssociationStatus commonv1.AssociationStatusMap `json:"monitoringAssociationStatus,omitempty"`
+
+	Selector           string                          `json:"selector"`
 }
 
 // +kubebuilder:object:root=true
@@ -141,7 +143,7 @@ type LogstashStatus struct {
 // +kubebuilder:printcolumn:name="expected",type="integer",JSONPath=".status.expectedNodes",description="Expected nodes"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="version",type="string",JSONPath=".status.version",description="Logstash version"
-// +kubebuilder:subresource:scale:specpath=.spec.count,statuspath=.status.count,selectorpath=.status.selector
+// +kubebuilder:subresource:scale:specpath=.spec.count,statuspath=.status.expectedNodes,selectorpath=.status.selector
 // +kubebuilder:storageversion
 type Logstash struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/logstash/v1alpha1/logstash_types.go
+++ b/pkg/apis/logstash/v1alpha1/logstash_types.go
@@ -130,7 +130,7 @@ type LogstashStatus struct {
 	// MonitoringAssociationStatus is the status of any auto-linking to monitoring Elasticsearch clusters.
 	MonitoringAssociationStatus commonv1.AssociationStatusMap `json:"monitoringAssociationStatus,omitempty"`
 
-	Selector           string                          `json:"selector"`
+	Selector string `json:"selector"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/controller/logstash/logstash_controller_test.go
+++ b/pkg/controller/logstash/logstash_controller_test.go
@@ -91,6 +91,7 @@ func TestReconcileLogstash_Reconcile(t *testing.T) {
 				},
 				Status: logstashv1alpha1.LogstashStatus{
 					ObservedGeneration: 1,
+
 				},
 			},
 			expectedObjects: []expectedObject{},
@@ -208,6 +209,7 @@ func TestReconcileLogstash_Reconcile(t *testing.T) {
 					ExpectedNodes:      1,
 					AvailableNodes:     1,
 					ObservedGeneration: 2,
+					Selector:           "common.k8s.elastic.co/type=logstash,logstash.k8s.elastic.co/name=testLogstash",
 				},
 			},
 			wantErr: false,
@@ -314,6 +316,7 @@ func TestReconcileLogstash_Reconcile(t *testing.T) {
 					ExpectedNodes:      1,
 					AvailableNodes:     1,
 					ObservedGeneration: 2,
+					Selector:           "common.k8s.elastic.co/type=logstash,logstash.k8s.elastic.co/name=testLogstash",
 				},
 			},
 			wantErr: false,
@@ -412,6 +415,7 @@ func TestReconcileLogstash_Reconcile(t *testing.T) {
 					ExpectedNodes:      1,
 					AvailableNodes:     1,
 					ObservedGeneration: 2,
+					Selector:           "common.k8s.elastic.co/type=logstash,logstash.k8s.elastic.co/name=testLogstash",
 				},
 			},
 			wantErr: false,

--- a/pkg/controller/logstash/logstash_controller_test.go
+++ b/pkg/controller/logstash/logstash_controller_test.go
@@ -91,7 +91,6 @@ func TestReconcileLogstash_Reconcile(t *testing.T) {
 				},
 				Status: logstashv1alpha1.LogstashStatus{
 					ObservedGeneration: 1,
-
 				},
 			},
 			expectedObjects: []expectedObject{},

--- a/pkg/controller/logstash/reconcile.go
+++ b/pkg/controller/logstash/reconcile.go
@@ -62,15 +62,13 @@ func reconcileStatefulSet(params Params, podTemplate corev1.PodTemplateSpec) (*r
 func calculateStatus(params *Params, sset appsv1.StatefulSet) (logstashv1alpha1.LogstashStatus, error) {
 	logstash := params.Logstash
 	status := params.Status
-	labelSelector := sset.Spec.Selector
-
 	pods, err := k8s.PodsMatchingLabels(params.Client, logstash.Namespace, map[string]string{NameLabelName: logstash.Name})
 	if err != nil {
 		return status, err
 	}
 
-	if labelSelector != nil {
-		selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if sset.Spec.Selector != nil {
+		selector, err := metav1.LabelSelectorAsSelector(sset.Spec.Selector)
 		if err != nil {
 			return logstashv1alpha1.LogstashStatus{}, err
 		}

--- a/pkg/controller/logstash/reconcile.go
+++ b/pkg/controller/logstash/reconcile.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/logstash/sset"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -49,7 +51,7 @@ func reconcileStatefulSet(params Params, podTemplate corev1.PodTemplateSpec) (*r
 
 	var status logstashv1alpha1.LogstashStatus
 
-	if status, err = calculateStatus(&params, reconciled.Status.ReadyReplicas, reconciled.Status.Replicas); err != nil {
+	if status, err = calculateStatus(&params, reconciled); err != nil {
 		results.WithError(errors.Wrap(err, "while calculating status"))
 	}
 	return results, status
@@ -57,18 +59,26 @@ func reconcileStatefulSet(params Params, podTemplate corev1.PodTemplateSpec) (*r
 
 // calculateStatus will calculate a new status from the state of the pods within the k8s cluster
 // and will return any error encountered.
-func calculateStatus(params *Params, ready, desired int32) (logstashv1alpha1.LogstashStatus, error) {
+func calculateStatus(params *Params, sset appsv1.StatefulSet) (logstashv1alpha1.LogstashStatus, error) {
 	logstash := params.Logstash
 	status := params.Status
+	labelSelector := sset.Spec.Selector
 
 	pods, err := k8s.PodsMatchingLabels(params.Client, logstash.Namespace, map[string]string{NameLabelName: logstash.Name})
 	if err != nil {
 		return status, err
 	}
 
+	if labelSelector != nil {
+		selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+		if err != nil {
+			return logstashv1alpha1.LogstashStatus{}, err
+		}
+		status.Selector = selector.String()
+	}
 	status.Version = common.LowestVersionFromPods(params.Context, status.Version, pods, VersionLabelName)
-	status.AvailableNodes = ready
-	status.ExpectedNodes = desired
+	status.AvailableNodes = sset.Status.ReadyReplicas
+	status.ExpectedNodes = sset.Status.Replicas
 	return status, nil
 }
 


### PR DESCRIPTION
While running some tests with the VerticalPodAutoscaler, I was unable to make it work with the Logstash CRD, which appears to be due to the lack of a selector in the LogstashStatus object. This commit adds the missing Selector.

