### PR TITLE
Fix rendering of autopilot recipes README

### DIFF
--- a/config/recipes/autopilot/README.asciidoc
+++ b/config/recipes/autopilot/README.asciidoc
@@ -4,18 +4,39 @@ This directory contains yaml manifests with an configurations for running Elasti
 
 IMPORTANT: These examples are for illustration purposes only and should not be considered to be production-ready.
 
-NOTE: The Elasticsearch example uses a Daemonset to set to ensure that `/proc/sys/vm/max_map_count` is set on all of the underlying Kubernetes nodes for optimal performance. See https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html for more information.
+NOTE: These examples use a Daemonset to set to ensure that `/proc/sys/vm/max_map_count` is set on all of the underlying Kubernetes nodes for optimal performance. See https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html for more information.
 
-== Elasticsearch, Kibana and Elastic Agent in Fleet mode
+=== Elasticsearch, Kibana and Elastic Agent in Fleet mode
 
-=== Agent with System and Kubernetes integrations - `elasticsearch.yaml`+`fleet-kubernetes-integration.yaml`
+==== Agent with System and Kubernetes integrations
 
-Deploys Elastic Agent as a DaemonSet in Fleet mode with System and Kubernetes integrations enabled. System integration collects syslog logs, auth logs and system metrics (for CPU, I/O, filesystem, memory, network, process and others). Kubernetes integrations collects API server, Container, Event, Node, Pod, Volume and system metrics.
+[source,sh]
+----
+kubectl apply -f elasticsearch.yaml -f fleet-kubernetes-integration.yaml
+----
 
-=== Kubernetes integration - `elasticsearch.yaml`+`kubernetes-integration.yaml`
+Deploys Elastic Agent as a DaemonSet in Fleet mode with System and Kubernetes integrations enabled.
 
-Deploys Elastic Agent as a DaemonSet in standalone mode with Kubernetes integration enabled. Collects API server, Container, Event, Node, Pod, Volume, System, Volume, and State metrics for Containers, Daemonsets, Jobs, Nodes, Persistent volumes/claims, Pods, Replicasets, ResourceQuotas, Services, Statefulsets, and StorageClasses.
+System integration collects syslog logs, auth logs and system metrics (for CPU, I/O, filesystem, memory, network, process and others). 
 
-=== Metricbeat for Kubernetes monitoring - `elasticsearch.yaml`+`metricbeat_hosts.yaml`
+Kubernetes integrations collects API server, Container, Event, Node, Pod, Volume and system metrics.
+
+==== Kubernetes integration
+
+[source,sh]
+----
+kubectl apply -f elasticsearch.yaml -f kubernetes-integration.yaml
+----
+
+Deploys Elastic Agent as a DaemonSet in standalone mode with Kubernetes integration enabled. 
+
+Collects API server, Container, Event, Node, Pod, Volume, System, Volume, and State metrics for Containers, Daemonsets, Jobs, Nodes, Persistent volumes/claims, Pods, Replicasets, ResourceQuotas, Services, Statefulsets, and StorageClasses.
+
+==== Metricbeat for Kubernetes monitoring
+
+[source,sh]
+----
+kubectl apply -f elasticsearch.yaml -f metricbeat_hosts.yaml
+----
 
 Deploys Metricbeat as a DaemonSet that monitors the host resource usage (CPU, memory, network, filesystem) and Kubernetes resources (Nodes, Pods, Containers, Volumes).

--- a/config/recipes/autopilot/README.asciidoc
+++ b/config/recipes/autopilot/README.asciidoc
@@ -6,16 +6,16 @@ IMPORTANT: These examples are for illustration purposes only and should not be c
 
 NOTE: The Elasticsearch example uses a Daemonset to set to ensure that `/proc/sys/vm/max_map_count` is set on all of the underlying Kubernetes nodes for optimal performance. See https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html for more information.
 
-==== Elasticsearch, Kibana and Elastic Agent in Fleet mode
+== Elasticsearch, Kibana and Elastic Agent in Fleet mode
 
-===== Agent with System and Kubernetes integrations - `elasticsearch.yaml`+`fleet-kubernetes-integration.yaml`
+=== Agent with System and Kubernetes integrations - `elasticsearch.yaml`+`fleet-kubernetes-integration.yaml`
 
 Deploys Elastic Agent as a DaemonSet in Fleet mode with System and Kubernetes integrations enabled. System integration collects syslog logs, auth logs and system metrics (for CPU, I/O, filesystem, memory, network, process and others). Kubernetes integrations collects API server, Container, Event, Node, Pod, Volume and system metrics.
 
-===== Kubernetes integration - `elasticsearch.yaml`+`kubernetes-integration.yaml`
+=== Kubernetes integration - `elasticsearch.yaml`+`kubernetes-integration.yaml`
 
 Deploys Elastic Agent as a DaemonSet in standalone mode with Kubernetes integration enabled. Collects API server, Container, Event, Node, Pod, Volume, System, Volume, and State metrics for Containers, Daemonsets, Jobs, Nodes, Persistent volumes/claims, Pods, Replicasets, ResourceQuotas, Services, Statefulsets, and StorageClasses.
 
-==== Metricbeat for Kubernetes monitoring - `elasticsearch.yaml`+`metricbeat_hosts.yaml`
+=== Metricbeat for Kubernetes monitoring - `elasticsearch.yaml`+`metricbeat_hosts.yaml`
 
 Deploys Metricbeat as a DaemonSet that monitors the host resource usage (CPU, memory, network, filesystem) and Kubernetes resources (Nodes, Pods, Containers, Volumes).

--- a/config/recipes/autopilot/kubernetes-integration.yaml
+++ b/config/recipes/autopilot/kubernetes-integration.yaml
@@ -1,3 +1,27 @@
+---
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: kibana
+spec:
+  version: 8.7.0
+  count: 1
+  elasticsearchRef:
+    name: elasticsearch
+  podTemplate:
+    spec:
+      nodeSelector:
+        cloud.google.com/compute-class: "Balanced"
+      containers:
+      - name: kibana
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 200m
+          limits:
+            memory: 1Gi
+            cpu: 200m
+---
 apiVersion: agent.k8s.elastic.co/v1alpha1
 kind: Agent
 metadata:
@@ -435,27 +459,4 @@ roleRef:
   kind: ClusterRole
   name: elastic-agent
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: kibana.k8s.elastic.co/v1
-kind: Kibana
-metadata:
-  name: kibana
-spec:
-  version: 8.7.0
-  count: 1
-  elasticsearchRef:
-    name: elasticsearch
-  podTemplate:
-    spec:
-      nodeSelector:
-        cloud.google.com/compute-class: "Balanced"
-      containers:
-      - name: kibana
-        resources:
-          requests:
-            memory: 1Gi
-            cpu: 200m
-          limits:
-            memory: 1Gi
-            cpu: 200m
 ---

--- a/config/recipes/autopilot/metricbeat_hosts.yaml
+++ b/config/recipes/autopilot/metricbeat_hosts.yaml
@@ -1,4 +1,27 @@
 ---
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: kibana
+spec:
+  version: 8.7.0
+  count: 1
+  elasticsearchRef:
+    name: elasticsearch
+  podTemplate:
+    spec:
+      nodeSelector:
+        cloud.google.com/compute-class: "Balanced"
+      containers:
+      - name: kibana
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 200m
+          limits:
+            memory: 1Gi
+            cpu: 200m
+---
 apiVersion: beat.k8s.elastic.co/v1beta1
 kind: Beat
 metadata:
@@ -156,27 +179,4 @@ roleRef:
   kind: ClusterRole
   name: metricbeat
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: kibana.k8s.elastic.co/v1
-kind: Kibana
-metadata:
-  name: kibana
-spec:
-  version: 8.7.0
-  count: 1
-  elasticsearchRef:
-    name: elasticsearch
-  podTemplate:
-    spec:
-      nodeSelector:
-        cloud.google.com/compute-class: "Balanced"
-      containers:
-      - name: kibana
-        resources:
-          requests:
-            memory: 1Gi
-            cpu: 200m
-          limits:
-            memory: 1Gi
-            cpu: 200m
 ---


### PR DESCRIPTION
This fixes the rendering of the autopilot recipes README that is written in the AsciiDoc format by:
- renaming `README.md` to `README.asciidoc`

Also:
- add some line breaks to space the text
- move Kibana at the top in manifests where it is not
- move manifest names from the titles to a command