### PR TITLE
Fix preflight and dry-run mode in the operator hub pipeline

### DIFF
--- a/.buildkite/pipeline-release-redhat.yml
+++ b/.buildkite/pipeline-release-redhat.yml
@@ -3,9 +3,6 @@ agents:
   image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:abaeba8c
   memory: 2G
 
-env:
-  OHUB_DRY_RUN: true
-
 steps:
 
   - label: ":go: build operatorhub tool"

--- a/.buildkite/pipeline-release-redhat.yml
+++ b/.buildkite/pipeline-release-redhat.yml
@@ -1,6 +1,6 @@
 
 agents:
-  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:d8e4780b
+  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:abaeba8c
   memory: 2G
 
 env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:d8e4780b
+  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:abaeba8c
   cpu: "4"
   memory: "2G"
 

--- a/.buildkite/scripts/release/redhat-preflight.sh
+++ b/.buildkite/scripts/release/redhat-preflight.sh
@@ -10,7 +10,6 @@
 set -euo pipefail
 
 VAULT_ROOT_PATH=${VAULT_ROOT_PATH:-secret/ci/elastic-cloud-on-k8s}
-DRY_RUN=${DRY_RUN:-true}
 
 tmpDir=$(mktemp -d)
 trap 'rm -rf "$tmpDir"' 0

--- a/.buildkite/scripts/release/redhat-preflight.sh
+++ b/.buildkite/scripts/release/redhat-preflight.sh
@@ -33,11 +33,6 @@ main() {
         exit 0
     fi
 
-    if ! which preflight; then
-        curl -sL -o "$tmpDir/preflight" "https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.2.1/preflight-linux-$(uname -m)"
-        chmod u+x "$tmpDir/preflight"
-    fi
-
     vault read -format=json -field=data "$VAULT_ROOT_PATH/operatorhub-release-preflight" > "$tmpDir/auth.json"
     
     preflight check container "quay.io/redhat-isv-containers/$PROJECT_ID:$tag" --pyxis-api-token="$API_KEY" --certification-project-id="$PROJECT_ID" --submit -d "$tmpDir/auth.json"


### PR DESCRIPTION
This PR fixes a few issues with the operator hub pipeline:
* Rely on the `preflight` binary provided by the buildkite-agent image
* Remove `OHUB_DRY_RUN: true`. We assume that the "dry run" mode is always enabled by default in our publishing tooling.