### PR TITLE
Fix preflight and dry-run mode in the operator hub pipeline (#6857)

### DIFF
--- a/.buildkite/pipeline-release-redhat.yml
+++ b/.buildkite/pipeline-release-redhat.yml
@@ -1,10 +1,7 @@
 
 agents:
-  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:5827bee6
+  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:abaeba8c
   memory: 2G
-
-env:
-  OHUB_DRY_RUN: true
 
 steps:
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:26b287eb
+  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:abaeba8c
   cpu: "4"
   memory: "2G"
 

--- a/.buildkite/scripts/release/redhat-preflight.sh
+++ b/.buildkite/scripts/release/redhat-preflight.sh
@@ -10,7 +10,6 @@
 set -euo pipefail
 
 VAULT_ROOT_PATH=${VAULT_ROOT_PATH:-secret/ci/elastic-cloud-on-k8s}
-DRY_RUN=${DRY_RUN:-true}
 
 tmpDir=$(mktemp -d)
 trap 'rm -rf "$tmpDir"' 0
@@ -31,11 +30,6 @@ main() {
     if container_already_verified; then
         echo "Preflight has already been submitted ✅"
         exit 0
-    fi
-
-    if ! which preflight; then
-        curl -sL -o "$tmpDir/preflight" "https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.2.1/preflight-linux-$(uname -m)"
-        chmod u+x "$tmpDir/preflight"
     fi
 
     vault read -format=json -field=data "$VAULT_ROOT_PATH/operatorhub-release-preflight" > "$tmpDir/auth.json"


### PR DESCRIPTION
Backport the following PRs to `2.8`:
* [Fix preflight and dry-run mode in the operator hub pipeline](https://github.com/elastic/cloud-on-k8s/pull/6857) #6857 