### PR TITLE
Add Logstash webhook clientConfig

### DIFF
--- a/deploy/eck-operator/templates/webhook.yaml
+++ b/deploy/eck-operator/templates/webhook.yaml
@@ -414,6 +414,37 @@ webhooks:
         - UPDATE
       resources:
       - stackconfigpolicies
+- clientConfig:
+    {{- if and (not .Values.webhook.manageCerts) (not .Values.webhook.certManagerCert) }}
+    caBundle: {{ .Values.webhook.caBundle }}
+    {{- end }}
+    service:
+      name: {{ include "eck-operator.webhookServiceName" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-logstash-k8s-elastic-co-v1alpha1-logstash
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+{{- with .Values.webhook.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.webhook.objectSelector }}
+  objectSelector:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+  name: elastic-logstash-validation-v1alpha1.k8s.elastic.co
+  matchPolicy: Exact
+  admissionReviewVersions: [v1,v1beta1]
+  sideEffects: None
+  rules:
+    - apiGroups:
+        - logstash.k8s.elastic.co
+      apiVersions:
+        - v1alpha1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - logstashes
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Add missing Logstash webhook `clientConfig`

Note that this is affecting `2.8.0`.