### PR TITLE
Setup admission decoder in webhooks

### DIFF
--- a/pkg/controller/autoscaling/elasticsearch/validation/webhook.go
+++ b/pkg/controller/autoscaling/elasticsearch/validation/webhook.go
@@ -35,6 +35,7 @@ var esalog = ulog.Log.WithName("esa-validation")
 func RegisterWebhook(mgr ctrl.Manager, validateStorageClass bool, licenseChecker license.Checker, managedNamespaces []string) {
 	wh := &validatingWebhook{
 		client:               mgr.GetClient(),
+		decoder:              admission.NewDecoder(mgr.GetScheme()),
 		validateStorageClass: validateStorageClass,
 		licenseChecker:       licenseChecker,
 		managedNamespaces:    set.Make(managedNamespaces...),
@@ -49,12 +50,6 @@ type validatingWebhook struct {
 	validateStorageClass bool
 	licenseChecker       license.Checker
 	managedNamespaces    set.StringSet
-}
-
-// InjectDecoder injects the decoder automatically.
-func (wh *validatingWebhook) InjectDecoder(d *admission.Decoder) error {
-	wh.decoder = d
-	return nil
 }
 
 func (wh *validatingWebhook) validate(ctx context.Context, esa v1alpha1.ElasticsearchAutoscaler) error {

--- a/pkg/controller/common/webhook/webhook.go
+++ b/pkg/controller/common/webhook/webhook.go
@@ -36,6 +36,7 @@ func SetupValidatingWebhookWithConfig(config *Config) error {
 		config.WebhookPath,
 		&webhook.Admission{
 			Handler: &validatingWebhook{
+				decoder:           admission.NewDecoder(config.Manager.GetScheme()),
 				validator:         config.Validator,
 				licenseChecker:    config.LicenseChecker,
 				managedNamespaces: set.Make(config.ManagedNamespace...)}})
@@ -56,12 +57,6 @@ type validatingWebhook struct {
 	managedNamespaces set.StringSet
 	licenseChecker    license.Checker
 	validator         admission.Validator
-}
-
-// InjectDecoder injects the decoder automatically.
-func (v *validatingWebhook) InjectDecoder(d *admission.Decoder) error {
-	v.decoder = d
-	return nil
 }
 
 // Handle satisfies the admission.Handler interface

--- a/pkg/controller/elasticsearch/validation/webhook.go
+++ b/pkg/controller/elasticsearch/validation/webhook.go
@@ -35,6 +35,7 @@ var eslog = ulog.Log.WithName("es-validation")
 func RegisterWebhook(mgr ctrl.Manager, validateStorageClass bool, exposedNodeLabels NodeLabels, licenseChecker license.Checker, managedNamespaces []string) {
 	wh := &validatingWebhook{
 		client:               mgr.GetClient(),
+		decoder:              admission.NewDecoder(mgr.GetScheme()),
 		validateStorageClass: validateStorageClass,
 		exposedNodeLabels:    exposedNodeLabels,
 		licenseChecker:       licenseChecker,
@@ -51,12 +52,6 @@ type validatingWebhook struct {
 	exposedNodeLabels    NodeLabels
 	licenseChecker       license.Checker
 	managedNamespaces    set.StringSet
-}
-
-// InjectDecoder injects the decoder automatically.
-func (wh *validatingWebhook) InjectDecoder(d *admission.Decoder) error {
-	wh.decoder = d
-	return nil
 }
 
 func (wh *validatingWebhook) validateCreate(ctx context.Context, es esv1.Elasticsearch) error {


### PR DESCRIPTION
This commit initializes correctly the decoder of the `validatingWebhook`s because it is no longer injected since the update to controller-runtime v0.15.0.

Resolves #6873.