### PR TITLE
Allow e2e job to delete collections

### DIFF
--- a/config/e2e/rbac.yaml
+++ b/config/e2e/rbac.yaml
@@ -102,6 +102,7 @@ rules:
       - list
       - watch
       - delete
+      - deletecollection
       - create
       - update
   - apiGroups:
@@ -199,6 +200,7 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups:
       - autoscaling.k8s.elastic.co
     resources:
@@ -212,6 +214,7 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups:
       - apm.k8s.elastic.co
     resources:
@@ -225,6 +228,7 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups:
       - kibana.k8s.elastic.co
     resources:
@@ -238,6 +242,7 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups:
       - apm.k8s.elastic.co
     resources:
@@ -251,6 +256,7 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups:
       - enterprisesearch.k8s.elastic.co
     resources:
@@ -264,6 +270,7 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups:
       - beat.k8s.elastic.co
     resources:
@@ -277,6 +284,7 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups:
       - agent.k8s.elastic.co
     resources:
@@ -290,6 +298,7 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups:
       - maps.k8s.elastic.co
     resources:
@@ -303,6 +312,7 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups:
       - stackconfigpolicy.k8s.elastic.co
     resources:
@@ -316,6 +326,7 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups :
       - logstash.k8s.elastic.co
     resources:
@@ -329,6 +340,7 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups:
       - storage.k8s.io
     resources:


### PR DESCRIPTION
This PR adds the `deletecollection ` permission in order to fix the following error raised when the E2E job attempts to run [`deleteTestResources`](https://github.com/elastic/cloud-on-k8s/blob/c5b9a70487d6bb4c6e238c935f56525ab100257f/test/e2e/test/step.go#L60) to clean up the test namespaces:

```json
{
	"log.level": "error",
	"@timestamp": "2023-06-04T15:16:50.464Z",
	"log.logger": "e2e",
	"message": "while deleting elastic resources in e2e-kute4-system",
	"service.version": "0.0.0-SNAPSHOT+00000000",
	"service.type": "eck",
	"ecs.version": "1.4.0",
	"group": "kibana.k8s.elastic.co",
	"resource": "kibanas",
	"version": "v1",
	"error": "kibanas.kibana.k8s.elastic.co is forbidden: User \"system:serviceaccount:e2e-kute4-system:e2e-kute4\" cannot deletecollection resource \"kibanas\" in API group \"kibana.k8s.elastic.co\" in the namespace \"e2e-kute4-system\""
}
```