### PR TITLE
Remove unnecessary println

### DIFF
--- a/test/e2e/test/maps/checks.go
+++ b/test/e2e/test/maps/checks.go
@@ -136,7 +136,6 @@ type emsStatus struct {
 }
 
 func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
-	println(test.Ctx().TestTimeout)
 	return test.StepList{
 		{
 			Name: "Elastic Maps Server should respond to requests",


### PR DESCRIPTION
This removes a `println` that was probably committed by mistake in #4444.