### PR TITLE
Remove duplicate import

### DIFF
--- a/test/e2e/test/k8s_client.go
+++ b/test/e2e/test/k8s_client.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
@@ -372,7 +371,7 @@ func (k *K8sClient) DeleteSecrets(secrets ...corev1.Secret) error {
 	return nil
 }
 
-func (k K8sClient) CreateOrUpdate(objs ...client.Object) error {
+func (k K8sClient) CreateOrUpdate(objs ...k8sclient.Object) error {
 	for _, obj := range objs {
 		// create a copy to ensure that the original object is not modified
 		obj := k8s.DeepCopyObject(obj)


### PR DESCRIPTION
This removes the import `"sigs.k8s.io/controller-runtime/pkg/client"` already imported with `k8sclient "sigs.k8s.io/controller-runtime/pkg/client"`. I kept the one that was used the most.

(This generates a warning in my IDE.)