### PR TITLE
Change start time to trigger daily e2e tests pipeline

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -77,7 +77,7 @@ spec:
       schedules:
         Every day:
           branch: main
-          cronline: '@midnight'
+          cronline: '42 21 * * *'
           message: Nightly `main` snapshot e2e tests
       teams:
         cloud-k8s-operator: {}


### PR DESCRIPTION
This updates the schedule to trigger the daily e2e tests in order to give us a time window to fix them more aligned with our working hours: CEST: 9am-11pm / EDT: 3am-5pm.

Current time window is: CEST 1am-3pm / EDT 7pm-9am.

The current start time to trigger the daily e2e tests pipeline is set to `@midnight`which became for us `9 13 * * *` because:

> Note that if you use one of the generic cron aliases like "@hourly", "@daily", "@midnight", "@weekly", "@monthly" or "@yearly" in the cronline property Terrazzo will transparently generate a pseudorandom cron expression based on pipeline metadata that fulfills the same requirements and use that instead of the Buildkite default. This is done to avoid having all scheduled pipelines that specify "@daily" as their cronline run at the same time (midnight, by default : 0 0 * * *). If you don't want this behavior, you can use a specific value for the cronline property rather than using one of the generic aliases.


Current: `9 13 * * *` start at (3pm CEST / 9am EDT) -> +~10h -> end at (1am CEST / 7pm EDT)

New:     `42 21 * * *` start at (11pm CEST / 5pm EDT) -> +~10h -> end at (9am CEST / 3am EDT)


