### PR TITLE
Revert "Skip upgrades to 8.9.0-SNAPSHOT (#6880)"

### DIFF
--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -31,21 +31,6 @@ func SkipInvalidUpgrade(t *testing.T, srcVersion string, dstVersion string) {
 	if !isValid {
 		t.SkipNow()
 	}
-
-	// Temporarily skip upgrades to `8.9.x-SNAPSHOT`
-	dstVer := version.MustParse(dstVersion)
-	if dstVer.Major == 8 && dstVer.Minor == 9 && isSnapshot(dstVer) {
-		t.Skip("Upgrades to 8.9.0-SNAPSHOT are temporarily disabled, refer to https://github.com/elastic/cloud-on-k8s/issues/6878")
-	}
-}
-
-func isSnapshot(v version.Version) bool {
-	for _, pre := range v.Pre {
-		if pre.VersionStr == "SNAPSHOT" {
-			return true
-		}
-	}
-	return false
 }
 
 // isValidUpgrade reports whether an upgrade from one version to another version is valid.


### PR DESCRIPTION
This PR reverts https://github.com/elastic/cloud-on-k8s/pull/6880. `TestAgentVersionUpgradeToLatest8x` is ✅  again locally:

<img width="648" alt="image" src="https://github.com/elastic/cloud-on-k8s/assets/976373/710d0e25-bc7a-4686-b22b-e222b2b4c71d">


Closes #6878 