### PR TITLE
Release parent charts with lock file

### DIFF
--- a/hack/helm/release/Makefile
+++ b/hack/helm/release/Makefile
@@ -6,4 +6,4 @@ build:
 	go build -o bin/releaser main.go
 
 go-run:
-	go run main.go --env=dev --dry-run=true --charts-dir=../../../deploy
+	go run main.go --env=dev --dry-run=true --keep-tmp-dir=true --charts-dir=../../../deploy

--- a/hack/helm/release/Makefile
+++ b/hack/helm/release/Makefile
@@ -4,3 +4,6 @@
 
 build:
 	go build -o bin/releaser main.go
+
+go-run:
+	go run main.go --env=dev --dry-run=true --charts-dir=../../../deploy

--- a/hack/helm/release/cmd/root.go
+++ b/hack/helm/release/cmd/root.go
@@ -22,6 +22,7 @@ const (
 	chartsDirFlag       = "charts-dir"
 	credentialsFileFlag = "credentials-file"
 	dryRunFlag          = "dry-run"
+	keepTmpDirFlag      = "keep-tmp-dir"
 	envFlag             = "env"
 	enableVaultFlag     = "enable-vault"
 
@@ -66,6 +67,7 @@ func releaseCmd() *cobra.Command {
 					ChartsRepoURL:       chartsRepoURL,
 					CredentialsFilePath: viper.GetString(credentialsFileFlag),
 					DryRun:              viper.GetBool(dryRunFlag),
+					KeepTmpDir:          viper.GetBool(keepTmpDirFlag),
 				})
 		},
 	}
@@ -79,6 +81,14 @@ func releaseCmd() *cobra.Command {
 		"Do not upload files to bucket, or update Helm index (env: HELM_DRY_RUN)",
 	)
 	_ = viper.BindPFlag(dryRunFlag, flags.Lookup(dryRunFlag))
+
+	flags.BoolP(
+		keepTmpDirFlag,
+		"k",
+		false,
+		"Keep temporary directory which contains the Helm charts ready to be published (env: HELM_KEEP_TMP_DIR)",
+	)
+	_ = viper.BindPFlag(keepTmpDirFlag, flags.Lookup(keepTmpDirFlag))
 
 	flags.String(
 		chartsDirFlag,

--- a/hack/helm/release/internal/helm/helm.go
+++ b/hack/helm/release/internal/helm/helm.go
@@ -41,6 +41,8 @@ type ReleaseConfig struct {
 	CredentialsFilePath string
 	// DryRun determines whether to run the release without making any changes to the GCS bucket or the Helm repository index file.
 	DryRun bool
+	// KeepTmpDir determines whether the temporary directory should be kept or not
+	KeepTmpDir bool
 }
 
 // Release runs the Helm charts release.
@@ -53,8 +55,8 @@ func Release(conf ReleaseConfig) error {
 		return fmt.Errorf("while creating temp dir: %w", err)
 	}
 	// keep and print the temp dir in dry run mode
-	if conf.DryRun {
-		fmt.Println("Helm release tempdir:", tempDir)
+	if conf.KeepTmpDir {
+		log.Printf("Not deleting temporary directory: %s", tempDir)
 	} else {
 		defer os.RemoveAll(tempDir)
 	}

--- a/hack/helm/release/internal/helm/helm.go
+++ b/hack/helm/release/internal/helm/helm.go
@@ -54,7 +54,6 @@ func Release(conf ReleaseConfig) error {
 	if err != nil {
 		return fmt.Errorf("while creating temp dir: %w", err)
 	}
-	// keep and print the temp dir in dry run mode
 	if conf.KeepTmpDir {
 		log.Printf("Not deleting temporary directory: %s", tempDir)
 	} else {


### PR DESCRIPTION
This restores the `Chart.lock` file in the published parent charts `eck-operator` and `eck-stack`
by doing the equivalent of `helm update dependency`, which is now safe as all dependencies are local without repository.
No index is updated locally.

This also adds a `go-run` make target and a flag `--keep-tmp-dir` to keep the temporary directory and print its name to make this more convenient to develop.

To test: `make go-run` and you can check the content of the `.tar.gz` in the temporary directory.

Resolves #6894.