### PR TITLE
Revert closing of streamErrors channel in e2e tests, as it's causing panics.

### DIFF
--- a/test/e2e/cmd/run/job.go
+++ b/test/e2e/cmd/run/job.go
@@ -57,7 +57,6 @@ func NewJob(podName, templatePath string, writer io.Writer, timestampExtractor t
 // Stop is only a best effort to stop the streaming process
 func (j *Job) Stop() {
 	close(j.stopLogStream)
-	close(j.streamErrors)
 }
 
 func (j *Job) WithDependency(dependency *Job) *Job {


### PR DESCRIPTION
Reverting https://github.com/elastic/cloud-on-k8s/pull/6905/files#diff-6d9d6270835a8a89548cf170d6136ab028abf56ff8ef0767d52ffd3cc1fd1923R60

https://buildkite.com/elastic/cloud-on-k8s-operator/builds/4169#0188beda-0338-4b68-a2ac-38d347dff0d8