### PR TITLE
Fix panic when JobManager.Stop is being called twice.

### DIFF
--- a/test/e2e/cmd/run/job.go
+++ b/test/e2e/cmd/run/job.go
@@ -57,6 +57,7 @@ func NewJob(podName, templatePath string, writer io.Writer, timestampExtractor t
 // Stop is only a best effort to stop the streaming process
 func (j *Job) Stop() {
 	close(j.stopLogStream)
+	close(j.streamErrors)
 }
 
 func (j *Job) WithDependency(dependency *Job) *Job {

--- a/test/e2e/cmd/run/job.go
+++ b/test/e2e/cmd/run/job.go
@@ -57,7 +57,6 @@ func NewJob(podName, templatePath string, writer io.Writer, timestampExtractor t
 // Stop is only a best effort to stop the streaming process
 func (j *Job) Stop() {
 	close(j.stopLogStream)
-	close(j.streamErrors)
 }
 
 func (j *Job) WithDependency(dependency *Job) *Job {

--- a/test/e2e/cmd/run/job_manager.go
+++ b/test/e2e/cmd/run/job_manager.go
@@ -28,6 +28,7 @@ type JobsManager struct {
 	context.Context
 	cancelFunc context.CancelFunc
 	*kubernetes.Clientset
+	stopRequested bool
 
 	jobs map[string]*Job
 	err  error // used to notify that an error occurred in this session
@@ -169,6 +170,10 @@ func (jm *JobsManager) Start() {
 }
 
 func (jm *JobsManager) Stop() {
+	if jm.stopRequested {
+		return
+	}
+	jm.stopRequested = true
 	for _, job := range jm.jobs {
 		job.Stop()
 	}


### PR DESCRIPTION
Recent changes in e2e tests are causing a panic: https://buildkite.com/elastic/cloud-on-k8s-operator/builds/4169#0188beda-0338-4b68-a2ac-38d347dff0d8

Do not attempt to

1. Download the e2e pod logs twice.
2. Stop the Job Manager twice.