### PR TITLE
Track job stops and file downloads

### DIFF
--- a/test/e2e/cmd/run/job.go
+++ b/test/e2e/cmd/run/job.go
@@ -77,8 +77,7 @@ func (j *Job) WithResultFile(f string) *Job {
 // onPodEvent ensures that log streaming is started and also manages the internal state of the Job based on the events
 // received from the informer.
 func (j *Job) onPodEvent(client *kubernetes.Clientset, pod *corev1.Pod) {
-	switch pod.Status.Phase { //nolint:exhaustive
-	case corev1.PodRunning:
+	if pod.Status.Phase == corev1.PodRunning {
 		if !j.jobStarted {
 			j.jobStarted = true
 			j.runningWg.Done() // notify dependent that this job has started

--- a/test/e2e/cmd/run/job_manager.go
+++ b/test/e2e/cmd/run/job_manager.go
@@ -136,7 +136,7 @@ func (jm *JobsManager) Start() {
 
 				// download result file when pod is ready
 				if k8s.IsPodReady(*newPod) {
-					if job.resultFile != "" {
+					if job.resultFile != "" && !job.resultFileDownloaded {
 						log.Info("Downloading pod result file", "pod", newPod.Name)
 
 						src := fmt.Sprintf("%s/%s:%s", newPod.Namespace, newPod.Name, job.resultFile)
@@ -146,6 +146,7 @@ func (jm *JobsManager) Start() {
 						if err != nil {
 							log.Error(err, "Failed to kubectl cp", "src", src, "dst", dst)
 						}
+						job.resultFileDownloaded = true
 					}
 					jm.Stop()
 				}


### PR DESCRIPTION
To avoid panic when `jobManager.Stop()` is called more than once if the informer triggers more than one Pod update event in a ready state.