### PR TITLE
Do not close channels, rem errexit

### DIFF
--- a/test/e2e/cmd/run/job.go
+++ b/test/e2e/cmd/run/job.go
@@ -22,8 +22,7 @@ type Job struct {
 	runningWg  *sync.WaitGroup // wait for the dependency to be started
 
 	// Job context
-	jobStarted    bool // keep track of the first Pod running event
-	stopRequested bool // keep track of the stop attempts
+	jobStarted bool // keep track of the first Pod running event
 
 	// Job logs management
 	timestampExtractor timestampExtractor
@@ -52,16 +51,6 @@ func NewJob(podName, templatePath string, writer io.Writer, timestampExtractor t
 		logStreamWg:        logStreamWg,
 		timestampExtractor: timestampExtractor,
 	}
-}
-
-// Stop is only a best effort to stop the streaming process
-func (j *Job) Stop() {
-	if j.stopRequested {
-		return
-	}
-	j.stopRequested = true
-	close(j.stopLogStream)
-	close(j.streamErrors)
 }
 
 func (j *Job) WithDependency(dependency *Job) *Job {

--- a/test/e2e/cmd/run/job_manager.go
+++ b/test/e2e/cmd/run/job_manager.go
@@ -170,8 +170,5 @@ func (jm *JobsManager) Start() {
 }
 
 func (jm *JobsManager) Stop() {
-	for _, job := range jm.jobs {
-		job.Stop()
-	}
 	jm.cancelFunc()
 }

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -4,7 +4,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 
-set -euo pipefail
+set -uo pipefail
 
 chaos=${CHAOS:-"false"}
 


### PR DESCRIPTION
Avoid having to wait for log completion and avoid running into "send on closed channel" errors by not closing the error and log channel in the job abstraction we use for e2e tests. The rationale is that the program will exit anyway at this point and we do not need to manager those resources. 

Remove the `errexit` shell option from `run.sh` to avoid the script exiting early on errors and preventing the job manager to download the log file.