### PR TITLE
[2.8] Update service-account.yaml (#6915)

### DIFF
--- a/deploy/eck-stack/charts/eck-beats/templates/service-account.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/service-account.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .name }}
   namespace: {{ .namespace | default $.Release.Namespace | quote }}
   labels:
-    {{- include "beat.labels" . | nindent 4 }}
+    {{- include "beat.labels" $ | nindent 4 }}
     {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.8`:
 - [Update service-account.yaml (#6915)](https://github.com/elastic/cloud-on-k8s/pull/6915)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)