### PR TITLE
[helm/eck-elasticsearch] Support disabling podDisruptionBudget

### DIFF
--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/elasticsearch.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/elasticsearch.yaml
@@ -56,8 +56,15 @@ spec:
   image: {{ . }}
   {{- end }}
   {{- with .Values.podDisruptionBudget }}
+    {{- if .disabled }}
+  podDisruptionBudget: {}
+    {{- else }}
+      {{- with .spec }}
   podDisruptionBudget:
-    {{- toYaml . | nindent 4 }}
+    spec:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- end }}
   {{- end }}
   {{- with .Values.serviceAccountName }}
   serviceAccountName: {{ . }}

--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
@@ -212,6 +212,12 @@ tests:
       - equal:
           path: spec.image
           value: my.registry.com/elastic/elasticsearch:8.8.0
+  - it: should render no podDisruptionBudget by default
+    set:
+    asserts:
+      - equal:
+          path: spec.podDisruptionBudget
+          value: null
   - it: should render podDisruptionBudget properly
     set:
       podDisruptionBudget:
@@ -229,6 +235,13 @@ tests:
               selector:
                 matchLabels:
                   elasticsearch.k8s.elastic.co/cluster-name: quickstart
+  - it: should render empty podDisruptionBudget if disabled
+    set:
+      podDisruptionBudget: {}
+    asserts:
+      - equal:
+          path: spec.podDisruptionBudget
+          value: {}
   - it: should render serviceAccountName properly
     set:
       serviceAccountName: my-sa

--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
@@ -237,7 +237,7 @@ tests:
                   elasticsearch.k8s.elastic.co/cluster-name: quickstart
   - it: should render empty podDisruptionBudget if disabled
     set:
-      podDisruptionBudget: {}
+      podDisruptionBudget.disabled: true
     asserts:
       - equal:
           path: spec.podDisruptionBudget

--- a/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
@@ -126,8 +126,8 @@ remoteClusters: {}
 volumeClaimDeletePolicy: ""
 
 # Settings to limit the disruption when pods need to be rescheduled for some reason such as upgrades or routine maintenance.
-# Default budget selects all cluster pods and sets `maxUnavailable` to 1.
-# To disable, set `disabled` to true.
+# Defaults to a budget that selects all Elasticsearch cluster pods and sets `maxUnavailable` to 1 if unset.
+# To completely disable the pod disruption budget set `disabled` to true.
 #
 # podDisruptionBudget:
 #   spec:

--- a/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
@@ -127,7 +127,7 @@ volumeClaimDeletePolicy: ""
 
 # Settings to limit the disruption when pods need to be rescheduled for some reason such as upgrades or routine maintenance.
 # Default budget selects all cluster pods and sets `maxUnavailable` to 1.
-# To disable, set to the empty value (`{}`).
+# To disable, set `disabled` to true.
 #
 # podDisruptionBudget:
 #   spec:
@@ -135,7 +135,7 @@ volumeClaimDeletePolicy: ""
 #     selector:
 #       matchLabels:
 #         elasticsearch.k8s.elastic.co/cluster-name: quickstart
-
+#   disabled: true
 
 # Used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.
 # Can only be used if ECK is enforcing RBAC on references.

--- a/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
@@ -121,12 +121,12 @@ remoteClusters: {}
 
 # VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets.
 # Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion.
-# Defaults to DeleteOnScaledownAndClusterDeletion if unset.
+# By default, if not set or empty, the operator sets DeleteOnScaledownAndClusterDeletion.
 #
 volumeClaimDeletePolicy: ""
 
 # Settings to limit the disruption when pods need to be rescheduled for some reason such as upgrades or routine maintenance.
-# By default when it is unset, the operator sets a default budget that selects all Elastisearch cluster pods and sets `maxUnavailable` to 1.
+# By default, if not set, the operator sets a budget that selects all Elastisearch cluster pods and sets `maxUnavailable` to 1.
 # To completely disable the pod disruption budget set `disabled` to true.
 #
 # podDisruptionBudget:
@@ -143,7 +143,7 @@ volumeClaimDeletePolicy: ""
 # serviceAccountName: ""
 
 # Number of revisions to retain to allow rollback in the underlying StatefulSets.
-# Defaults to 10.
+# By default, if not set, Kubernetes sets 10.
 #
 # revisionHistoryLimit: 2
 

--- a/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
@@ -126,7 +126,7 @@ remoteClusters: {}
 volumeClaimDeletePolicy: ""
 
 # Settings to limit the disruption when pods need to be rescheduled for some reason such as upgrades or routine maintenance.
-# Defaults to a budget that selects all Elasticsearch cluster pods and sets `maxUnavailable` to 1 if unset.
+# By default when it is unset, the operator sets a default budget that selects all Elastisearch cluster pods and sets `maxUnavailable` to 1.
 # To completely disable the pod disruption budget set `disabled` to true.
 #
 # podDisruptionBudget:


### PR DESCRIPTION
Adds a new explicit `podDisruptionBudget.disabled` value to be able to explicitely disable the PDB for Elasticsearch because we can't differentiate no `podDisruptionBudget` set (which means ECK sets a default PDB) from an explicit empty `podDisruptionBudget: {}` (which means I want to disable the PDB).

```sh
> test() { helm template . "$@" | yq .spec.podDisruptionBudget; }
echo "# default PDB"
test
echo "# custom PDB"
test --set=podDisruptionBudget.spec.minAvailable=2 --set='podDisruptionBudget.spec.selector.matchLabels.elasticsearch\.k8s\.elastic\.co\/cluster-name=quickstart'
echo "# no PDB"
test --set=podDisruptionBudget.disabled=true

# default PDB
null
# custom PDB
spec:
  minAvailable: 2
  selector:
    matchLabels:
      elasticsearch.k8s.elastic.co/cluster-name: quickstart
# no PDB
{}
```
Resolves #6871.