### PR TITLE
Lazy vault client creation when reading vault file

### DIFF
--- a/cmd/license-initializer/main.go
+++ b/cmd/license-initializer/main.go
@@ -32,8 +32,7 @@ var Cmd = &cobra.Command{
 			handleErr(fmt.Errorf("%s is a required environment variable pointing to a DER encoded public key", pubKeyFlag))
 		}
 
-		c, err := vault.NewClient()
-		handleErr(err)
+		c := vault.NewClientProvider()
 
 		bytes, err := vault.ReadFile(c, vault.SecretFile{
 			Name:          pubkeyFile,

--- a/hack/deployer/runner/gcloud.go
+++ b/hack/deployer/runner/gcloud.go
@@ -34,7 +34,8 @@ func authToGCP(
 			return err
 		}
 
-		_, err := vault.ReadFile(client, vault.SecretFile{
+		clientProvider := func() (vault.Client, error) { return client, nil }
+		_, err := vault.ReadFile(clientProvider, vault.SecretFile{
 			Path:          vaultPath,
 			Name:          keyFileName,
 			FieldResolver: func() string { return serviceAccountVaultFieldName },

--- a/hack/helm/release/cmd/root.go
+++ b/hack/helm/release/cmd/root.go
@@ -140,11 +140,8 @@ func validate(_ *cobra.Command, _ []string) error {
 	}
 
 	if viper.GetBool(enableVaultFlag) {
-		c, err := vault.NewClient()
-		if err != nil {
-			return fmt.Errorf("while creating vault client: %w", err)
-		}
-		_, err = vault.ReadFile(c, vault.SecretFile{
+		c := vault.NewClientProvider()
+		_, err := vault.ReadFile(c, vault.SecretFile{
 			Name:          credentialsFilePath,
 			Path:          googleCredsVaultSecretPath,
 			FieldResolver: func() string { return googleCredsVaultSecretKey },

--- a/pkg/utils/vault/client.go
+++ b/pkg/utils/vault/client.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/hashicorp/vault/api"
 	"github.com/pkg/errors"
@@ -23,8 +24,23 @@ const (
 	ghTokenEnvVar = "GITHUB_TOKEN" //nolint:gosec
 )
 
+var once sync.Once
+
 type Client interface {
 	Read(path string) (*api.Secret, error)
+}
+
+type ClientProvider func() (Client, error)
+
+func NewClientProvider() func() (Client, error) {
+	var err error
+	var client Client
+	return func() (Client, error) {
+		once.Do(func() {
+			client, err = NewClient()
+		})
+		return client, err
+	}
 }
 
 func NewClient() (Client, error) {

--- a/pkg/utils/vault/client.go
+++ b/pkg/utils/vault/client.go
@@ -24,8 +24,6 @@ const (
 	ghTokenEnvVar = "GITHUB_TOKEN" //nolint:gosec
 )
 
-var once sync.Once
-
 type Client interface {
 	Read(path string) (*api.Secret, error)
 }
@@ -35,6 +33,7 @@ type ClientProvider func() (Client, error)
 func NewClientProvider() func() (Client, error) {
 	var err error
 	var client Client
+	var once sync.Once
 	return func() (Client, error) {
 		once.Do(func() {
 			client, err = NewClient()

--- a/pkg/utils/vault/read_test.go
+++ b/pkg/utils/vault/read_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Test_Get(t *testing.T) {
-	c := newMockClient(t, "secret", "42")
+	c, _ := newMockClient(t, "secret", "42")()
 
 	secret, err := Get(c, "fakepath", "secret")
 	assert.NoError(t, err)
@@ -22,10 +22,10 @@ func Test_Get(t *testing.T) {
 }
 
 func Test_GetMany(t *testing.T) {
-	c := newMockClient(t,
+	c, _ := newMockClient(t,
 		"secret", "42",
 		"token", "24",
-	)
+	)()
 
 	secrets, err := GetMany(c, "fakepath", "secret")
 	assert.NoError(t, err)

--- a/pkg/utils/vault/secret_file.go
+++ b/pkg/utils/vault/secret_file.go
@@ -42,12 +42,17 @@ type SecretFile struct {
 
 // ReadFile reads the file if it exists or else reads the Secret from Vault and
 // writes it to the file on disk.
-func ReadFile(c Client, f SecretFile) ([]byte, error) {
+func ReadFile(clientProvider ClientProvider, f SecretFile) ([]byte, error) {
 	if _, err := os.Stat(f.Name); err == nil {
 		return os.ReadFile(f.Name)
 	}
 
-	bytes, err := f.readFromVault(c)
+	client, err := clientProvider()
+	if err != nil {
+		return nil, err
+	}
+
+	bytes, err := f.readFromVault(client)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/vault/secret_file_test.go
+++ b/pkg/utils/vault/secret_file_test.go
@@ -175,7 +175,7 @@ type mockClient struct {
 	readCount int
 }
 
-func newMockClient(t *testing.T, data ...string) Client {
+func newMockClient(t *testing.T, data ...string) ClientProvider {
 	t.Helper()
 
 	if len(data)%2 != 0 {
@@ -187,9 +187,13 @@ func newMockClient(t *testing.T, data ...string) Client {
 		dataMap[data[i]] = data[i+1]
 	}
 
-	return &mockClient{
+	c := &mockClient{
 		data:      dataMap,
 		readCount: 0,
+	}
+
+	return func() (Client, error) {
+		return c, nil
 	}
 }
 
@@ -198,7 +202,8 @@ func (c *mockClient) Read(_ string) (*api.Secret, error) {
 	return &api.Secret{Data: c.data}, nil
 }
 
-func readCount(c Client) int {
+func readCount(client ClientProvider) int {
+	c, _ := client()
 	m, _ := c.(*mockClient)
 	return m.readCount
 }

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -251,10 +251,7 @@ func isOcpCluster(h *helper) bool {
 func (h *helper) initTestSecrets() error {
 	h.testSecrets = map[string]string{}
 
-	c, err := vault.NewClient()
-	if err != nil {
-		return err
-	}
+	c := vault.NewClientProvider()
 
 	// Only initialize gcp credentials when running in CI
 	if os.Getenv("CI") == "true" {


### PR DESCRIPTION
This allows reading a Vault file without creating a Vault client when the file already exists, which was the main purpose of the `vault.ReadFile` (reads the file if it exists or else reads the Secret from Vault and writes it to on disk).

A new `ClientProvider` type is introduced with an associated constructor and the signature of the `vault.ReadFile` func is updated to use it:

```diff
# new type
+type ClientProvider func() (Client, error)

# update signature of vault.ReadFile
-func ReadFile(c Client, f SecretFile) ([]byte, error) {
+func ReadFile(clientProvider ClientProvider, f SecretFile) ([]byte, error) {

# new constructor
+func NewClientProvider() func() (Client, error) {
+	var err error
+	var client Client
+	var once sync.Once
+	return func() (Client, error) {
+		once.Do(func() {
+			client, err = NewClient()
+		})
+		return client, err
+	}
+}
```

Motivation for this change: make the operator build (with the `go generate` step) possible in Docker, which opens the door to use the elastic docker-builder buildkite agent. By fetching the public key first, we can `go generate` during the Docker build (in the Dockerfile) without the dependency to Vault, which is a pain to manage in a Dockerfile.

Relates to https://github.com/elastic/cloud-on-k8s/pull/6881.