### PR TITLE
Add pipeline to release Helm charts (#6923)

### DIFF
--- a/.buildkite/pipeline-build.yml
+++ b/.buildkite/pipeline-build.yml
@@ -64,8 +64,6 @@ steps:
           machineType: "n1-standard-16"
 
       - label: ":go: helm releaser tool"
-        key: "build-helm-releaser-tool"
         commands:
           - cd hack/helm/release
           - make build
-          - buildkite-agent artifact upload bin/releaser

--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -6,6 +6,13 @@ steps:
   - group: helm-release
     steps:
 
+      - label: ":go: helm releaser tool"
+        key: "build-helm-releaser-tool"
+        commands:
+          - cd hack/helm/release
+          - make build
+          - buildkite-agent artifact upload bin/releaser
+
       - label: "operator dev helm chart"
         if: |
           ( build.branch == "main" && build.source != "schedule" )
@@ -15,7 +22,6 @@ steps:
           || build.message == "release all helm charts"
         depends_on:
           - "build-helm-releaser-tool"
-          - "operator-image-build"
         key: "eck-operator-dev-helm"
         commands:
           - buildkite-agent artifact download "bin/releaser" /usr/local/
@@ -33,7 +39,6 @@ steps:
           || build.message == "release all helm charts"
         depends_on:
           - "build-helm-releaser-tool"
-          - "operator-image-build"
         key: "eck-resources-dev-helm"
         commands:
           - buildkite-agent artifact download "bin/releaser" /usr/local/

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -51,4 +51,6 @@ steps:
     command: buildkite-agent pipeline upload .buildkite/pipeline-e2e-tests.yml
 
   - label: ":buildkite:"
+    depends_on:
+      - "operator-image-build"
     command: buildkite-agent pipeline upload .buildkite/pipeline-release.yml

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -107,10 +107,36 @@ spec:
       repository: elastic/cloud-on-k8s
       pipeline_file: .buildkite/pipeline-release-redhat.yml
       provider_settings:
-        build_tags: true
-        build_pull_requests: false
-        build_branches: false
-        publish_commit_status: false
+        trigger_mode: none
+      teams:
+        cloud-k8s-operator: {}
+        everyone:
+          access_level: READ_ONLY
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: cloud-on-k8s-operator-helm-release-buildkite-pipeline
+  description: Buildkite Pipeline cloud-on-k8s-operator-helm-release
+  links:
+  - title: Pipeline
+    url: https://buildkite.com/elastic/cloud-on-k8s-operator-helm-release
+spec:
+  type: buildkite-pipeline
+  owner: group:cloud-k8s-operator
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: cloud-on-k8s-operator-helm-release
+      description: Release Elastic Cloud on Kubernetes (ECK) Helm charts
+    spec:
+      repository: elastic/cloud-on-k8s
+      pipeline_file: .buildkite/pipeline-release-helm.yml
+      provider_settings:
+        trigger_mode: none
       teams:
         cloud-k8s-operator: {}
         everyone:


### PR DESCRIPTION
Backport the following commit to `2.8`:
- #6923