### PR TITLE
[helm] Release parent charts with lock file (#6911)

### DIFF
--- a/hack/helm/release/Makefile
+++ b/hack/helm/release/Makefile
@@ -4,3 +4,6 @@
 
 build:
 	go build -o bin/releaser main.go
+
+go-run:
+	go run main.go --env=dev --dry-run=true --keep-tmp-dir=true --charts-dir=../../../deploy

--- a/hack/helm/release/cmd/root.go
+++ b/hack/helm/release/cmd/root.go
@@ -22,6 +22,7 @@ const (
 	chartsDirFlag       = "charts-dir"
 	credentialsFileFlag = "credentials-file"
 	dryRunFlag          = "dry-run"
+	keepTmpDirFlag      = "keep-tmp-dir"
 	envFlag             = "env"
 	enableVaultFlag     = "enable-vault"
 
@@ -66,6 +67,7 @@ func releaseCmd() *cobra.Command {
 					ChartsRepoURL:       chartsRepoURL,
 					CredentialsFilePath: viper.GetString(credentialsFileFlag),
 					DryRun:              viper.GetBool(dryRunFlag),
+					KeepTmpDir:          viper.GetBool(keepTmpDirFlag),
 				})
 		},
 	}
@@ -79,6 +81,14 @@ func releaseCmd() *cobra.Command {
 		"Do not upload files to bucket, or update Helm index (env: HELM_DRY_RUN)",
 	)
 	_ = viper.BindPFlag(dryRunFlag, flags.Lookup(dryRunFlag))
+
+	flags.BoolP(
+		keepTmpDirFlag,
+		"k",
+		false,
+		"Keep temporary directory which contains the Helm charts ready to be published (env: HELM_KEEP_TMP_DIR)",
+	)
+	_ = viper.BindPFlag(keepTmpDirFlag, flags.Lookup(keepTmpDirFlag))
 
 	flags.String(
 		chartsDirFlag,

--- a/hack/helm/release/internal/helm/helm.go
+++ b/hack/helm/release/internal/helm/helm.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -20,6 +21,7 @@ import (
 	"google.golang.org/api/googleapi"
 	"gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/downloader"
 	"helm.sh/helm/v3/pkg/repo"
 )
 
@@ -39,6 +41,8 @@ type ReleaseConfig struct {
 	CredentialsFilePath string
 	// DryRun determines whether to run the release without making any changes to the GCS bucket or the Helm repository index file.
 	DryRun bool
+	// KeepTmpDir determines whether the temporary directory should be kept or not
+	KeepTmpDir bool
 }
 
 // Release runs the Helm charts release.
@@ -50,7 +54,11 @@ func Release(conf ReleaseConfig) error {
 	if err != nil {
 		return fmt.Errorf("while creating temp dir: %w", err)
 	}
-	defer os.RemoveAll(tempDir)
+	if conf.KeepTmpDir {
+		log.Printf("Not deleting temporary directory: %s", tempDir)
+	} else {
+		defer os.RemoveAll(tempDir)
+	}
 
 	charts, err := readCharts(conf.ChartsDir)
 	if err != nil {
@@ -115,6 +123,13 @@ func uploadCharts(ctx context.Context, conf ReleaseConfig, tempDir string, chart
 		err = copy(chart.srcPath, tempChartDirPath)
 		if err != nil {
 			return fmt.Errorf("while copying chart (%s) to temporary directory: %w", chart.Name, err)
+		}
+
+		// generates Chart.lock by doing the equivalent of 'helm update dependency', which will not download or update anything
+		// as all dependencies are local without repository
+		man := &downloader.Manager{Out: ioutil.Discard, ChartPath: tempChartDirPath}
+		if err := man.Update(); err != nil {
+			return fmt.Errorf("while updating chart (%s) dependencies to generate Chart.lock: %w", chart.Name, err)
 		}
 
 		// package the chart into a chart archive


### PR DESCRIPTION
Backport the following commit to `2.8`:
- #6911