### PR TITLE
Declare an agent to release helm charts

### DIFF
--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -2,9 +2,6 @@ agents:
   image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:abaeba8c
   memory: 2G
 
-env:
-  DRY_RUN: true
-
 steps:
   - group: helm-release
     steps:

--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -3,74 +3,72 @@ agents:
   memory: 2G
 
 steps:
-  - group: helm-release
-    steps:
 
-      - label: ":go: helm releaser tool"
-        key: "build-helm-releaser-tool"
-        commands:
-          - cd hack/helm/release
-          - make build
-          - buildkite-agent artifact upload bin/releaser
+  - label: ":go: helm releaser tool"
+    key: "build-helm-releaser-tool"
+    commands:
+      - cd hack/helm/release
+      - make build
+      - buildkite-agent artifact upload bin/releaser
 
-      - label: "operator dev helm chart"
-        if: |
-          ( build.branch == "main" && build.source != "schedule" )
-          || build.tag != null
-          || build.message =~ /^buildkite test .*release.*/
-          || build.message == "release eck-operator helm charts"
-          || build.message == "release all helm charts"
-        depends_on:
-          - "build-helm-releaser-tool"
-        key: "eck-operator-dev-helm"
-        commands:
-          - buildkite-agent artifact download "bin/releaser" /usr/local/
-          - chmod u+x /usr/local/bin/releaser
-          - echo rxeleaser --env=dev --charts-dir=deploy/eck-operator --dry-run=\$DRY_RUN
+  - label: "operator dev helm chart"
+    if: |
+      ( build.branch == "main" && build.source != "schedule" )
+      || build.tag != null
+      || build.message =~ /^buildkite test .*release.*/
+      || build.message == "release eck-operator helm charts"
+      || build.message == "release all helm charts"
+    depends_on:
+      - "build-helm-releaser-tool"
+    key: "eck-operator-dev-helm"
+    commands:
+      - buildkite-agent artifact download "bin/releaser" /usr/local/
+      - chmod u+x /usr/local/bin/releaser
+      - echo rxeleaser --env=dev --charts-dir=deploy/eck-operator --dry-run=\${DRY_RUN:-true}
 
-      - wait
+  - wait
 
-      - label: "eck-resources dev helm charts"
-        if: |
-          ( build.branch == "main" && build.source != "schedule" )
-          || build.tag != null
-          || build.message =~ /^buildkite test .*release.*/
-          || build.message == "release eck-resources helm charts"
-          || build.message == "release all helm charts"
-        depends_on:
-          - "build-helm-releaser-tool"
-        key: "eck-resources-dev-helm"
-        commands:
-          - buildkite-agent artifact download "bin/releaser" /usr/local/
-          - chmod u+x /usr/local/bin/releaser
-          - echo rxeleaser --env=dev --charts-dir=deploy/eck-stack --dry-run=\$DRY_RUN
+  - label: "eck-resources dev helm charts"
+    if: |
+      ( build.branch == "main" && build.source != "schedule" )
+      || build.tag != null
+      || build.message =~ /^buildkite test .*release.*/
+      || build.message == "release eck-resources helm charts"
+      || build.message == "release all helm charts"
+    depends_on:
+      - "build-helm-releaser-tool"
+    key: "eck-resources-dev-helm"
+    commands:
+      - buildkite-agent artifact download "bin/releaser" /usr/local/
+      - chmod u+x /usr/local/bin/releaser
+      - echo rxeleaser --env=dev --charts-dir=deploy/eck-stack --dry-run=\${DRY_RUN:-true}
 
-      - wait
+  - wait
 
-      - label: "operator prod helm chart"
-        if: |
-          build.tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+\$/
-          || build.message == "release eck-operator helm charts"
-          || build.message == "release all helm charts"
-        depends_on:
-          - "build-helm-releaser-tool"
-          - "eck-operator-dev-helm"
-        commands:
-          - buildkite-agent artifact download "bin/releaser" /usr/local/
-          - chmod u+x /usr/local/bin/releaser
-          - echo rxeleaser --env=prod --charts-dir=deploy/eck-operator --dry-run=\$DRY_RUN
+  - label: "operator prod helm chart"
+    if: |
+      build.tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+\$/
+      || build.message == "release eck-operator helm charts"
+      || build.message == "release all helm charts"
+    depends_on:
+      - "build-helm-releaser-tool"
+      - "eck-operator-dev-helm"
+    commands:
+      - buildkite-agent artifact download "bin/releaser" /usr/local/
+      - chmod u+x /usr/local/bin/releaser
+      - echo rxeleaser --env=prod --charts-dir=deploy/eck-operator --dry-run=\${DRY_RUN:-true}
 
-      - wait
+  - wait
 
-      - label: "eck-resources prod helm charts"
-        if: |
-          build.tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+\$/
-          || build.message == "release eck-resources helm charts"
-          || build.message == "release all helm charts"
-        depends_on:
-          - "build-helm-releaser-tool"
-          - "eck-resources-dev-helm"
-        commands:
-          - buildkite-agent artifact download "bin/releaser" /usr/local/
-          - chmod u+x /usr/local/bin/releaser
-          - echo rxeleaser --env=prod --charts-dir=deploy/eck-stack --dry-run=\$DRY_RUN
+  - label: "eck-resources prod helm charts"
+    if: |
+      build.tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+\$/
+      || build.message == "release eck-resources helm charts"
+      || build.message == "release all helm charts"
+    depends_on:
+      - "build-helm-releaser-tool"
+      - "eck-resources-dev-helm"
+    commands:
+      - buildkite-agent artifact download "bin/releaser" /usr/local/
+      - chmod u+x /usr/local/bin/releaser
+      - echo rxeleaser --env=prod --charts-dir=deploy/eck-stack --dry-run=\$DRY_RUN

--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -29,7 +29,7 @@ steps:
         commands:
           - buildkite-agent artifact download "bin/releaser" /usr/local/
           - chmod u+x /usr/local/bin/releaser
-          - releaser --env=dev --charts-dir=deploy/eck-operator --dry-run=\$DRY_RUN
+          - echo rxeleaser --env=dev --charts-dir=deploy/eck-operator --dry-run=\$DRY_RUN
 
       - wait
 
@@ -46,7 +46,7 @@ steps:
         commands:
           - buildkite-agent artifact download "bin/releaser" /usr/local/
           - chmod u+x /usr/local/bin/releaser
-          - releaser --env=dev --charts-dir=deploy/eck-stack --dry-run=\$DRY_RUN
+          - echo rxeleaser --env=dev --charts-dir=deploy/eck-stack --dry-run=\$DRY_RUN
 
       - wait
 
@@ -61,7 +61,7 @@ steps:
         commands:
           - buildkite-agent artifact download "bin/releaser" /usr/local/
           - chmod u+x /usr/local/bin/releaser
-          - releaser --env=prod --charts-dir=deploy/eck-operator --dry-run=\$DRY_RUN
+          - echo rxeleaser --env=prod --charts-dir=deploy/eck-operator --dry-run=\$DRY_RUN
 
       - wait
 
@@ -76,4 +76,4 @@ steps:
         commands:
           - buildkite-agent artifact download "bin/releaser" /usr/local/
           - chmod u+x /usr/local/bin/releaser
-          - releaser --env=prod --charts-dir=deploy/eck-stack --dry-run=\$DRY_RUN
+          - echo rxeleaser --env=prod --charts-dir=deploy/eck-stack --dry-run=\$DRY_RUN

--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -1,3 +1,6 @@
+agents:
+  image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:abaeba8c
+  memory: 2G
 
 env:
   DRY_RUN: true

--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -13,6 +13,8 @@ steps:
       - cd hack/helm/release
       - make build
       - buildkite-agent artifact upload bin/releaser
+    agents:
+      cpu: "4"
 
   - label: "operator dev helm chart"
     if: |

--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -2,6 +2,9 @@ agents:
   image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:abaeba8c
   memory: 2G
 
+env:
+  DRY_RUN: ${DRY_RUN:-true}
+
 steps:
 
   - label: ":go: helm releaser tool"

--- a/.buildkite/pipeline-release-redhat.yml
+++ b/.buildkite/pipeline-release-redhat.yml
@@ -1,4 +1,3 @@
-
 agents:
   image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:abaeba8c
   memory: 2G

--- a/.buildkite/pipeline-release.yml
+++ b/.buildkite/pipeline-release.yml
@@ -14,11 +14,6 @@ steps:
           - .buildkite/scripts/build/setenv.sh
           - .buildkite/scripts/release/k8s-manifests.sh
 
-      # dry run helm charts release
-      - label: ":buildkite:"
-        if: build.message =~ /^buildkite test .*release.*/
-        command: buildkite-agent pipeline upload .buildkite/pipeline-release-helm.yml
-
       - label: "copy images to dockerhub"
         if: build.tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+\$/
         trigger: unified-release-copy-elastic-images-to-dockerhub
@@ -27,23 +22,12 @@ steps:
             IMAGES_NAMES: "eck/eck-operator,eck/eck-operator-fips,eck/eck-operator-ubi8,eck/eck-operator-ubi8-fips"
             IMAGES_TAG: "${BUILDKITE_TAG}"
 
-      # live helm charts release
-      - label: ":buildkite:"
-        if: |
-          build.message !~ /^buildkite test .*release.*/
-          && (
-            ( build.branch == "main" && build.source != "schedule" )
-            || build.tag != null
-            || build.message =~ /^release eck/
-          )
-        command: |
-          sed "s|DRY_RUN: true|DRY_RUN: false|" .buildkite/pipeline-release-helm.yml | buildkite-agent pipeline upload 
-
-      - label: ":buildkite:"
-        if: |
-          build.message =~ /^buildkite test .*operatorhub.*/
-          || build.message =~ /^release eck .*operatorhub.*/
-        trigger: cloud-on-k8s-operator-redhat-release
+      - label: ":buildkite: helm charts release"
+        if: | # merge-main or tags
+          ( build.branch == "main" && build.source != "schedule" )
+          || build.tag != null
+        trigger: cloud-on-k8s-operator-helm-release
         build:
           env:
-            DRY_RUN: "${DRY_RUN:-true}"
+            DRY_RUN: false
+


### PR DESCRIPTION
- declare an agent in `pipeline-release-helm.yml` now that this pipeline is used without `pipeline.yml`
- trigger `pipeline-release-helm.yml` from `pipeline.yml`
- remove `groups`
- remove a way to trigger the helm release in dry run from the main pipeline because we now can trigger it from the dedicated pipeline