### PR TITLE
Update pipelines provider settings

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -39,8 +39,9 @@ spec:
     spec:
       repository: elastic/cloud-on-k8s
       provider_settings:
+        trigger_mode: "code"
+        build_pull_requests: true
         build_branches: true
-        build_pull_request_ready_for_review: true
         build_tags: true
         publish_blocked_as_pending: true
         publish_commit_status: true
@@ -74,6 +75,9 @@ spec:
       repository: elastic/cloud-on-k8s
       provider_settings:
         trigger_mode: none
+        build_pull_requests: true
+        build_branches: true
+        build_tags: true
       schedules:
         Every day:
           branch: main
@@ -109,6 +113,9 @@ spec:
       pipeline_file: .buildkite/pipeline-release-redhat.yml
       provider_settings:
         trigger_mode: none
+        build_pull_requests: true
+        build_branches: true
+        build_tags: true
       teams:
         cloud-k8s-operator: {}
         everyone:
@@ -138,6 +145,9 @@ spec:
       pipeline_file: .buildkite/pipeline-release-helm.yml
       provider_settings:
         trigger_mode: none
+        build_pull_requests: true
+        build_branches: true
+        build_tags: true
       teams:
         cloud-k8s-operator: {}
         everyone:


### PR DESCRIPTION
This configures the `nightly`, `redhat-release` and `helm-release` pipelines to not be triggered when code is pushed but triggerable via the API for branches, PRs and tags.

I didn't understand how it works in https://github.com/elastic/cloud-on-k8s/pull/6814#discussion_r1195131276.

The thing is that we have some special code in the tooling that processes the `catalog-info.yml` file that made me think that `trigger_mode: none` was incompatible with `build_branches: true` but they are two different independent things.

```py
# These fields have been set in the past for many pipelines with no
# build trigger. Maintaining them here prevents excessive state
# mutation.
if provider_settings.get("trigger_mode") == "none":
    expanded |= {
        "build_branches": False,
        "build_pull_requests": False,
        "publish_commit_status": False,
        "skip_pull_request_builds_for_existing_commits": False,
    }
```
