### PR TITLE
Validating policy ID only when running in fleet mode for Elastic Agent

### DIFF
--- a/pkg/apis/agent/v1alpha1/webhook.go
+++ b/pkg/apis/agent/v1alpha1/webhook.go
@@ -38,7 +38,7 @@ func (a *Agent) GetWarnings() []string {
 	if a == nil {
 		return nil
 	}
-	if len(a.Spec.PolicyID) == 0 {
+	if a.Spec.Mode == AgentFleetMode && len(a.Spec.PolicyID) == 0 {
 		return []string{fmt.Sprintf("%s %s/%s: %s", Kind, a.Namespace, a.Name, MissingPolicyIDMessage)}
 	}
 	return nil

--- a/pkg/controller/common/webhook/webhook_test.go
+++ b/pkg/controller/common/webhook/webhook_test.go
@@ -69,7 +69,7 @@ func Test_validatingWebhook_Handle(t *testing.T) {
 			want: admission.Allowed(""),
 		},
 		{
-			name: "no policy id is allowed but it should return a warning.",
+			name: "no policy id when agent running in standalone mode should not return a warning",
 			fields: fields{
 				set.Make("elastic"),
 				&agentv1alpha1.Agent{},
@@ -89,6 +89,35 @@ func Test_validatingWebhook_Handle(t *testing.T) {
 							Spec: agentv1alpha1.AgentSpec{
 								Version:    "7.10.0",
 								Deployment: &agentv1alpha1.DeploymentSpec{},
+							},
+						}),
+					},
+				},
+			},
+			want: admission.Allowed(""),
+		},
+		{
+			name: "no policy id is allowed when agent running in fleet mode but it should return a warning",
+			fields: fields{
+				set.Make("elastic"),
+				&agentv1alpha1.Agent{},
+			},
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: asJSON(&agentv1alpha1.Agent{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "testAgent",
+								Namespace: "elastic",
+								Labels: map[string]string{
+									"test": "label1",
+								},
+							},
+							Spec: agentv1alpha1.AgentSpec{
+								Version:    "7.14.0",
+								Deployment: &agentv1alpha1.DeploymentSpec{},
+								Mode:       agentv1alpha1.AgentFleetMode,
 							},
 						}),
 					},


### PR DESCRIPTION
The Agent webhook attempts to check if PolicyID is set whether or not the Agent is running in fleet or standalone mode, This check should only be done in fleet mode. Fixes #6903 