### PR TITLE
Run only integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,14 +171,18 @@ helm-test:
 	@hack/helm/test.sh
 
 integration: GO_TAGS += integration
-integration: clean generate-manifests
-	KUBEBUILDER_ASSETS=/usr/local/bin ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) \
-		go test -tags='$(GO_TAGS)' ./pkg/... ./cmd/... -cover $(TEST_OPTS)
+integration: clean
+	@ for pkg in $$(grep 'go:build integration' -rl | grep _test.go | xargs -n1 dirname | uniq); do \
+		KUBEBUILDER_ASSETS=/usr/local/bin ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) \
+			go test $$(pwd)/$$pkg -tags='$(GO_TAGS)' -cover $(TEST_OPTS) ; \
+	done
 
 integration-xml: GO_TAGS += integration
-integration-xml: clean generate-manifests
+integration-xml: clean
+	@ for pkg in $$(grep 'go:build integration' -rl | grep _test.go | xargs -n1 dirname | uniq); do \
 	KUBEBUILDER_ASSETS=/usr/local/bin ECK_TEST_LOG_LEVEL=$(LOG_VERBOSITY) \
-		gotestsum --junitfile integration-tests.xml -- -tags='$(GO_TAGS)' -cover ./pkg/... ./cmd/... $(TEST_OPTS)
+		gotestsum --junitfile integration-tests.xml -- $$(pwd)/$$pkg -tags='$(GO_TAGS)' -cover $(TEST_OPTS) ; \
+	done
 
 lint:
 	GOGC=50 golangci-lint run --verbose


### PR DESCRIPTION
This runs integration tests only in packages where there are integration tests, to not run all unit tests along with integration tests.

The duration of the step `integration-tests` which is the longest before running the e2e tests is reduced from `4m` to `2m`.

Relates to #6950.