### PR TITLE
Fix variable name for dry run mode in helm release

### DIFF
--- a/.buildkite/pipeline-release.yml
+++ b/.buildkite/pipeline-release.yml
@@ -26,5 +26,5 @@ steps:
         trigger: cloud-on-k8s-operator-helm-release
         build:
           env:
-            DRY_RUN: false
+            HELM_DRY_RUN: false
 


### PR DESCRIPTION
The new approach taken in #6936 which removes the explicit flag `--dry-run=\$DRY_RUN` from the releaser command line means that we now have to use the environment variable expected by the tool, which is `HELM_DRY_RUN`.

https://github.com/elastic/cloud-on-k8s/blob/8ca856dc3ef371c3bf3e9413cf14b5853664cd8b/hack/helm/release/cmd/root.go#L81