### PR TITLE
Disable test agent with fleet mode in 8.0.1

### DIFF
--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -131,11 +131,6 @@ func TestFleetMode(t *testing.T) {
 		t.SkipNow()
 	}
 
-	// installation of policies and integrations through Kibana file based configuration was broken between those versions:
-	if v.LT(version.MinFor(8, 1, 0)) && v.GTE(version.MinFor(8, 0, 0)) {
-		t.SkipNow()
-	}
-
 	name := "test-agent-fleet"
 
 	esBuilder := elasticsearch.NewBuilder(name).

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -124,13 +124,6 @@ func TestMultipleOutputConfig(t *testing.T) {
 }
 
 func TestFleetMode(t *testing.T) {
-	v := version.MustParse(test.Ctx().ElasticStackVersion)
-
-	// https://github.com/elastic/cloud-on-k8s/issues/6331
-	if v.LT(version.MinFor(8, 7, 0)) && v.GE(version.MinFor(8, 6, 0)) {
-		t.SkipNow()
-	}
-
 	name := "test-agent-fleet"
 
 	esBuilder := elasticsearch.NewBuilder(name).

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -88,13 +88,6 @@ func TestMultiOutputRecipe(t *testing.T) {
 }
 
 func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
-	v := version.MustParse(test.Ctx().ElasticStackVersion)
-
-	// https://github.com/elastic/cloud-on-k8s/issues/6331
-	if v.LT(version.MinFor(8, 7, 0)) && v.GE(version.MinFor(8, 6, 0)) {
-		t.SkipNow()
-	}
-
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
 			return builder
@@ -143,11 +136,6 @@ func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
 		t.Skip("Disabled since 8.8.0, refer to https://github.com/elastic/cloud-on-k8s/issues/5105")
 	}
 
-	// https://github.com/elastic/cloud-on-k8s/issues/6331
-	if v.LT(version.MinFor(8, 7, 0)) && v.GE(version.MinFor(8, 6, 0)) {
-		t.Skip("Disabled for 8.6.x, refer to https://github.com/elastic/cloud-on-k8s/issues/6331")
-	}
-
 	notLoggingPod := beat.NewPodBuilder("test")
 	loggingPod := beat.NewPodBuilder("test")
 	loggingPod.Pod.Namespace = "default"
@@ -174,13 +162,6 @@ func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetAPMIntegrationRecipe(t *testing.T) {
-	v := version.MustParse(test.Ctx().ElasticStackVersion)
-
-	// https://github.com/elastic/cloud-on-k8s/issues/6331
-	if v.LT(version.MinFor(8, 7, 0)) && v.GE(version.MinFor(8, 6, 0)) {
-		t.SkipNow()
-	}
-
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
 			return builder

--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -20,11 +20,6 @@ import (
 func TestFleetAgentWithoutTLS(t *testing.T) {
 	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
-	// https://github.com/elastic/cloud-on-k8s/issues/6331
-	if v.LT(version.MinFor(8, 7, 0)) && v.GE(version.MinFor(8, 6, 0)) {
-		t.SkipNow()
-	}
-
 	// Disabling TLS for Fleet isn't supported before 7.16, as Elasticsearch doesn't allow
 	// api keys to be enabled when TLS is disabled.
 	if v.LT(version.MustParse("7.16.0")) {

--- a/test/e2e/agent/upgrade_test.go
+++ b/test/e2e/agent/upgrade_test.go
@@ -9,7 +9,6 @@ package agent
 import (
 	"testing"
 
-	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test/agent"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test/elasticsearch"
@@ -17,21 +16,8 @@ import (
 )
 
 func TestAgentVersionUpgradeToLatest8x(t *testing.T) {
-
 	srcVersion, dstVersion := test.GetUpgradePathTo8x(test.Ctx().ElasticStackVersion)
-
 	test.SkipInvalidUpgrade(t, srcVersion, dstVersion)
-
-	sv := version.MustParse(srcVersion)
-	dv := version.MustParse(dstVersion)
-
-	// https://github.com/elastic/cloud-on-k8s/issues/6331
-	if sv.LT(version.MinFor(8, 7, 0)) && sv.GE(version.MinFor(8, 6, 0)) {
-		t.SkipNow()
-	}
-	if dv.LT(version.MinFor(8, 7, 0)) && dv.GE(version.MinFor(8, 6, 0)) {
-		t.SkipNow()
-	}
 
 	name := "test-agent-upgrade"
 	esBuilder := elasticsearch.NewBuilder(name).

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -53,12 +53,18 @@ type Builder struct {
 }
 
 func (b Builder) SkipTest() bool {
+	ver := version.MustParse(b.Agent.Spec.Version)
 	supportedVersions := version.SupportedAgentVersions
+
 	if b.Agent.Spec.FleetModeEnabled() {
 		supportedVersions = version.SupportedFleetModeAgentVersions
+
+		// Kibana bug "index conflict on install policy", https://github.com/elastic/kibana/issues/126611
+		if ver.GTE(version.MinFor(8, 0, 0)) && ver.LT(version.MinFor(8, 1, 0)) {
+			return true
+		}
 	}
 
-	ver := version.MustParse(b.Agent.Spec.Version)
 	return supportedVersions.WithinRange(ver) != nil
 }
 

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -63,6 +63,10 @@ func (b Builder) SkipTest() bool {
 		if ver.GTE(version.MinFor(8, 0, 0)) && ver.LT(version.MinFor(8, 1, 0)) {
 			return true
 		}
+		// Elastic agent bug "deadlock on startup", https://github.com/elastic/cloud-on-k8s/issues/6331#issuecomment-1478320487
+		if ver.GE(version.MinFor(8, 6, 0)) && ver.LT(version.MinFor(8, 7, 0)) {
+			return true
+		}
 	}
 
 	return supportedVersions.WithinRange(ver) != nil


### PR DESCRIPTION
Move version checks to agent builder to skip tests due to the following stack bugs:
- Kibana bug "index conflict on install policy"
  - https://github.com/elastic/kibana/issues/126611
- Elastic agent bug "deadlock on startup"
  - https://github.com/elastic/cloud-on-k8s/issues/6331#issuecomment-1478320487

Resolves #6956. 