### PR TITLE
Fix RBAC to run e2e tests with Filebeat autodiscover in 8.9.0

### DIFF
--- a/config/e2e/roles.yaml
+++ b/config/e2e/roles.yaml
@@ -13,6 +13,14 @@ rules:
   - get
   - watch
   - list
+- apiGroups: ["apps"]
+  resources:
+  - replicasets
+  verbs: ["list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  verbs: ["list", "watch"]
 ---
 # permissions needed for metricbeat
 # source: https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-kubernetes.html


### PR DESCRIPTION
Looks like Filebeat autodiscover `8.9.0` requires more permissions.

I will check why we need this (hence not closing #6946) but in the meantime, we need this to make our e2e tests build green again.

Relates to #6946.