### PR TITLE
Generate the trigger step to remove v prefix from BUILDKITE_TAG

### DIFF
--- a/.buildkite/pipeline-release.yml
+++ b/.buildkite/pipeline-release.yml
@@ -13,11 +13,15 @@ steps:
 
       - label: "copy images to dockerhub"
         if: build.tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+\$/
-        trigger: unified-release-copy-elastic-images-to-dockerhub
-        build:
-          env:
-            IMAGES_NAMES: "eck/eck-operator,eck/eck-operator-fips,eck/eck-operator-ubi8,eck/eck-operator-ubi8-fips"
-            IMAGES_TAG: "${BUILDKITE_TAG}"
+        command: |
+          cat <<- YAML | buildkite-agent pipeline upload
+          steps:
+            - trigger: unified-release-copy-elastic-images-to-dockerhub
+              build:
+                env:
+                  IMAGES_NAMES: "eck/eck-operator,eck/eck-operator-fips,eck/eck-operator-ubi8,eck/eck-operator-ubi8-fips"
+                  IMAGES_TAG: "$${BUILDKITE_TAG#v}"
+          YAML
 
       - label: ":buildkite: helm charts release"
         if: | # merge-main or tags


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/elastic/cloud-on-k8s/pull/6879 where we can't just trigger the pipeline that copies the images with
`IMAGES_TAG: "${BUILDKITE_TAG}"` because the tag contains the `v` prefix and ECK images are tagged 
without it.

The fix is to go through a bit of bash to generate the step with the variable set without the `v` using shell parameter expansion.