### PR TITLE
Align stack version in Logstash samples

### DIFF
--- a/config/samples/logstash/logstash.yaml
+++ b/config/samples/logstash/logstash.yaml
@@ -4,7 +4,7 @@ metadata:
   name: logstash-sample
 spec:
   count: 3
-  version: 8.6.1
+  version: 8.8.0
   config:
     log.level: info
     api.http.host: "0.0.0.0"

--- a/config/samples/logstash/logstash_stackmonitor.yaml
+++ b/config/samples/logstash/logstash_stackmonitor.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: monitoring
 spec:
-  version: 8.6.1
+  version: 8.8.0
   nodeSets:
     - name: default
       count: 3
@@ -55,7 +55,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: 8.6.1
+  version: 8.8.0
   elasticsearchRef:
     name: monitoring
   count: 1

--- a/config/samples/logstash/logstash_svc.yaml
+++ b/config/samples/logstash/logstash_svc.yaml
@@ -3,7 +3,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 8.6.1
+  version: 8.8.0
   nodeSets:
     - name: default
       count: 3
@@ -16,7 +16,7 @@ metadata:
   name: logstash-sample
 spec:
   count: 2
-  version: 8.6.1
+  version: 8.8.0
   config:
     log.level: info
     api.http.host: "0.0.0.0"


### PR DESCRIPTION
Since #6952, wich adds a call to `association.AllowVersion` at the start of the logstash reconciliation to prevent upgrading Logstash until Elasticsearch is upgraded, `TestSamples` for `config/samples/logstash/logstash_stackmonitor.yaml` fails because the ES version (8.6.1) is lower than the Logstash version (8.8.0).

This commits aligns all stack versions in manifests samples for Logstash to the latest `8.8.0`.