### PR TITLE
Fix tests run dependency

### DIFF
--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -44,7 +44,12 @@ steps:
   - label: ":k8s: :go: {{ $test.Name }}"
   {{- end }}
     key: "e2e-{{ $test.SlugName }}"
-    # let's be optimistic and run the tests without dependency on the images build
+
+    {{- if $test.RemoteKubeconfig }}
+    depends_on:
+      - "e2e-cluster-{{ $test.SlugName }}"
+      # let's be optimistic and run the tests without dependency on the images build
+    {{- end }}
 
     env:
       {{- range $key, $val := $test.Env }}


### PR DESCRIPTION
I got confused at the last moment in 445aee26 with the dependencies of the step to run e2e tests. We need to depend on the step that creates the cluster, the dependencies on the build steps were already removed.

It was not catch in the PR because we use `kind` for PRs which is a provider that doesn't use a remoteConfig.

Related to #6959.