### PR TITLE
Improve detection of `unknown` and `merge-main` triggers

### DIFF
--- a/.buildkite/pipeline-e2e-tests.yml
+++ b/.buildkite/pipeline-e2e-tests.yml
@@ -6,7 +6,8 @@ steps:
       # for commits in main
       - label: ":buildkite: e2e"
         if: |
-          build.branch == "main" && build.source == "webhook"
+          build.branch == "main" && build.source != "schedule"
+          && build.env("GITHUB_PR_TRIGGER_COMMENT") !~ /^buildkite test this -[fm]/
         command: |
           .buildkite/scripts/build/set-images.sh
           cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen

--- a/.buildkite/scripts/common/trigger.sh
+++ b/.buildkite/scripts/common/trigger.sh
@@ -26,12 +26,11 @@ trigger::set_from_env() {
     for t in $T; do
         if "is_$t"; then
             echo "$t"
-            return 0
+            return
         fi
     done
 
     echo unknown
-    return 1
 }
 
 is_tag-final() {
@@ -74,4 +73,3 @@ is_dev() {
     [[ "${CI:-}" != "true" ]]
 }
 
-trigger::set_from_env

--- a/.buildkite/scripts/common/trigger.sh
+++ b/.buildkite/scripts/common/trigger.sh
@@ -42,7 +42,7 @@ is_tag-bc() {
 }
 
 is_merge-main() {
-    [[ "${BUILDKITE_BRANCH:-}" == "main" && "${BUILDKITE_SOURCE:-}" == "webhook" ]]
+    [[ "${BUILDKITE_BRANCH:-}" == "main" && "${BUILDKITE_SOURCE:-}" != "schedule" ]]
 }
 
 is_nightly-main() {


### PR DESCRIPTION
This changes `trigger::set_from_env` to not fail when the trigger is `unknown` as it is handled later.

```go
# before this change
> CI=true BUILDKITE_BRANCH=main .buildkite/scripts/build/pre-build-operator.sh
unknown

# now
> CI=true BUILDKITE_BRANCH=main .buildkite/scripts/build/pre-build-operator.sh
# -- pre-build-operator TRIGGER=unknown
error: trigger 'unknown' not supported
```

This also relax the condition to detect the `merge-main` trigger, so that a build of `main` from the Buildkite UI or API is now part of it.