### PR TITLE
Fix permissions to run e2e tests on OCP with arbitrary user ID

### DIFF
--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -31,6 +31,9 @@ USER 1001
 COPY test/e2e/license.key /license.key
 RUN LICENSE_PUBKEY=/license.key go generate -tags="${GO_TAGS}" ./pkg/... ./cmd/...
 
-RUN chmod 777 /.cache/go-build/* /go/src/github.com/elastic/cloud-on-k8s
+# Set r/w permissions for user members of root group (GID=0) to support OpenShift Container Platform running containers
+# using arbitrarily assigned user ID, which is always member of the root group.
+RUN chgrp -R 0 /.cache/go-build/ /go/src/github.com/elastic/cloud-on-k8s && \
+    chmod -R g=u /.cache/go-build/ /go/src/github.com/elastic/cloud-on-k8s
 
 ENTRYPOINT ["test/e2e/run.sh"]

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -31,4 +31,6 @@ USER 1001
 COPY test/e2e/license.key /license.key
 RUN LICENSE_PUBKEY=/license.key go generate -tags="${GO_TAGS}" ./pkg/... ./cmd/...
 
+RUN chmod 777 /.cache/go-build/* /go/src/github.com/elastic/cloud-on-k8s
+
 ENTRYPOINT ["test/e2e/run.sh"]


### PR DESCRIPTION
This adds write permissions to `/.cache/go-build/*` and `/go/src/github.com/elastic/cloud-on-k8s` after `go generate` was executed in the Dockerfile for the e2e-tests image in order to make it possible to run `test/e2e/run.sh` with an arbitrary user ID.

Resolves #6977.