### PR TITLE
Make 'RUN go generate' specific between prod and dev builds

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,9 +5,7 @@ ARG VERSION
 ARG SHA1
 ARG SNAPSHOT
 ARG GO_TAGS
-ARG LICENSE_PUBKEY_PATH
-
-ENV LICENSE_PUBKEY=/license.key
+ARG LICENSE_PUBKEY
 
 WORKDIR /go/src/github.com/elastic/cloud-on-k8s
 
@@ -21,11 +19,11 @@ COPY config/eck.yaml .
 # Copy the sources
 COPY pkg/ pkg/
 COPY cmd/ cmd/
-COPY $LICENSE_PUBKEY_PATH /license.key
+COPY build/$LICENSE_PUBKEY /$LICENSE_PUBKEY
 
 # Build
 RUN --mount=type=cache,mode=0755,target=/go/pkg/mod \
-      CGO_ENABLED=0 GOOS=linux LICENSE_PUBKEY=/license.key make go-build
+      CGO_ENABLED=0 GOOS=linux LICENSE_PUBKEY=/$LICENSE_PUBKEY make go-build
 
 # ---------------------------------------------
 # Copy the operator binary into a lighter image

--- a/build/Dockerfile-ubi
+++ b/build/Dockerfile-ubi
@@ -5,9 +5,7 @@ ARG VERSION
 ARG SHA1
 ARG SNAPSHOT
 ARG GO_TAGS
-ARG LICENSE_PUBKEY_PATH
-
-ENV LICENSE_PUBKEY=/license.key
+ARG LICENSE_PUBKEY
 
 WORKDIR /go/src/github.com/elastic/cloud-on-k8s
 
@@ -19,13 +17,13 @@ RUN --mount=type=cache,mode=0755,target=/go/pkg/mod go mod download
 COPY config/eck.yaml .
 
 # Copy the sources
-COPY $LICENSE_PUBKEY_PATH /license.key
 COPY pkg/ pkg/
 COPY cmd/ cmd/
+COPY build/$LICENSE_PUBKEY /$LICENSE_PUBKEY
 
 # Build
 RUN --mount=type=cache,mode=0755,target=/go/pkg/mod \
-      CGO_ENABLED=0 GOOS=linux make go-build
+      CGO_ENABLED=0 GOOS=linux LICENSE_PUBKEY=/$LICENSE_PUBKEY make go-build
 
 # ---------------------------------------------
 # Copy the operator binary into a lighter image

--- a/build/gen-drivah.toml.sh
+++ b/build/gen-drivah.toml.sh
@@ -31,7 +31,7 @@ generate_drivah_config() {
     local name=$1
     local tag=$2
     local go_tags=$3
-    local license_pub_key=$4
+    local license_pubkey=$4
 cat <<END
 [container.image]
 names = ["${name}"]
@@ -43,7 +43,7 @@ VERSION = "${VERSION}"
 SHA1 = "${SHA1}"
 GO_TAGS = "${go_tags}"
 SNAPSHOT = "${SNAPSHOT}"
-LICENSE_PUBKEY = "$license_pub_key"
+LICENSE_PUBKEY = "$license_pubkey"
 END
 }
 

--- a/build/gen-drivah.toml.sh
+++ b/build/gen-drivah.toml.sh
@@ -43,7 +43,7 @@ VERSION = "${VERSION}"
 SHA1 = "${SHA1}"
 GO_TAGS = "${go_tags}"
 SNAPSHOT = "${SNAPSHOT}"
-LICENSE_PUBKEY_PATH = "build/$license_pub_key"
+LICENSE_PUBKEY = "$license_pub_key"
 END
 }
 


### PR DESCRIPTION
This fixes a regression introduced in #6959, where the `eck` flavor build uses the layer that generates the public key of the `eck-dev` flavor build, using the specific name of the public license key in the `RUN go-generate` instruction.