### PR TITLE
e2e tests timeout tuning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,7 +421,7 @@ E2E_STACK_VERSION          ?= 8.8.0
 # regexp to filter tests to run
 export TESTS_MATCH         ?= "^Test"
 export E2E_JSON            ?= false
-TEST_TIMEOUT               ?= 30m
+TEST_TIMEOUT               ?= 15m
 E2E_SKIP_CLEANUP           ?= false
 E2E_DEPLOY_CHAOS_JOB       ?= false
 # go build constraints potentially restricting the tests to run

--- a/test/e2e/cmd/run/command.go
+++ b/test/e2e/cmd/run/command.go
@@ -98,7 +98,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&flags.scratchDirRoot, "scratch-dir", "/tmp/eck-e2e", "Path under which temporary files should be created")
 	cmd.Flags().StringVar(&flags.testRegex, "test-regex", "", "Regex to pass to the test runner")
 	cmd.Flags().StringVar(&flags.testRunName, "test-run-name", randomTestRunName(), "Name of this test run")
-	cmd.Flags().DurationVar(&flags.testTimeout, "test-timeout", 30*time.Minute, "Timeout before failing a test")
+	cmd.Flags().DurationVar(&flags.testTimeout, "test-timeout", 15*time.Minute, "Timeout before failing a test")
 	cmd.Flags().StringVar(&flags.pipeline, "pipeline", "", "E2E test pipeline name")
 	cmd.Flags().StringVar(&flags.buildNumber, "build-number", "", "E2E test build number")
 	cmd.Flags().StringVar(&flags.provider, "provider", "", "E2E test infrastructure provider")

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -40,7 +40,7 @@ const (
 	testRunLabel         = "test-run"        // name of the label applied to resources
 	logStreamLabel       = "stream-logs"     // name of the label enabling log streaming to e2e runner
 	testsLogFilePattern  = "job-%s.json"     // name of file to keep all test logs in JSON format
-	operatorReadyTimeout = 3 * time.Minute   // time to wait for the operator pod to be ready
+	operatorReadyTimeout = 12 * time.Minute  // time to wait for the operator pod to be ready
 
 	TestNameLabel = "test-name" // name of the label applied to resources during each test
 

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	jobTimeout           = 600 * time.Minute // time to wait for the test job to finish
+	jobTimeout           = 900 * time.Minute // time to wait for the test job to finish
 	kubePollInterval     = 10 * time.Second  // Kube API polling interval
 	testRunLabel         = "test-run"        // name of the label applied to resources
 	logStreamLabel       = "stream-logs"     // name of the label enabling log streaming to e2e runner


### PR DESCRIPTION
This updates different timeouts for the e2e tests:

- Increase operatorReadyTimeout from `3min` to `12min`: so that we have more chances to be able to run the e2e tests when there are multiple images to build (example of a build triggered by a tag), as we don't wait for the end of the images build since #6959 to start to run the e2e tests.

- Increase total job timeout from `10h` to `15h`: with the addition of #6952, we are near 10h so as soon as there is just a few failures we hit the total job timeout. We also hit this timeout when we have a few e2e test failures caused by a test hitting the test timeout (decrease below), since we no longer fail fast.

- Decrease single test timeout from `30min` to `15min`: I did some research and the single test that takes the most of the time is `TestMutationNodeSetReplacementWithChangeBudget/All_expected_Pods_should_eventually_be_ready` that takes ~8min. By decreasing this timeout, we give ourselves more chances of not hitting the total timeout when there are many test failures, as we no longer fail fast.


```
# top 10 of the longest single tests
{"Elapsed":478.12,"Test":"TestMutationNodeSetReplacementWithChangeBudget/All_expected_Pods_should_eventually_be_ready#01"}
{"Elapsed":472.2,"Test":"TestMutationNodeSetReplacementWithChangeBudget/All_expected_Pods_should_eventually_be_ready#01"}
{"Elapsed":395.62,"Test":"TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready#01"}
{"Elapsed":389.39,"Test":"TestESSuspendPod/All_expected_Pods_should_eventually_be_ready#01"}
{"Elapsed":383.79,"Test":"TestESSuspendPod/All_expected_Pods_should_eventually_be_ready#01"}
{"Elapsed":370.98,"Test":"TestMutationHTTPToHTTPS/All_expected_Pods_should_eventually_be_ready#01"}
{"Elapsed":370.88,"Test":"TestMutationHTTPSToHTTP/All_expected_Pods_should_eventually_be_ready#01"}
{"Elapsed":366.22,"Test":"TestAPMServerVersionUpgradeToLatest8x/All_expected_Pods_should_eventually_be_ready#01"}
{"Elapsed":365.06,"Test":"TestSamples/logstash-logstash_svc"}
{"Elapsed":361.76,"Test":"TestSamples/elasticsearch-elasticsearch"}

```
