### PR TITLE
Update docker builder agent to fix license build issue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -87,7 +87,7 @@ steps:
       - label: "kind/TestSmoke"
         fixed:
           E2E_PROVIDER: kind
-          TESTS_MATCH: TestSmoke
+          TESTS_MATCH: TestRemoteCluster
           E2E_TAGS: "e2e,mixed"
           MONITORING_SECRETS: ""
           E2E_SKIP_CLEANUP: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,7 +50,7 @@ steps:
     steps:
       - label: ":buildkite:"
         agents:
-          image: "docker.elastic.co/ci-agent-images/serverless-docker-builder:0.0.5"
+          image: "docker.elastic.co/ci-agent-images/serverless-docker-builder:0.0.6"
         commands: make -C /agent generate-docker-images
         env:
           DOCKER_REGISTRY_VAULT_PATH: secret/ci/elastic-cloud-on-k8s/docker-registry-elastic
@@ -63,7 +63,7 @@ steps:
     steps:
       - label: ":buildkite:"
         agents:
-          image: "docker.elastic.co/ci-agent-images/serverless-docker-builder:0.0.5"
+          image: "docker.elastic.co/ci-agent-images/serverless-docker-builder:0.0.6"
         commands: make -C /agent generate-docker-images
         env:
           DOCKER_REGISTRY_VAULT_PATH: secret/ci/elastic-cloud-on-k8s/docker-registry-elastic

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -87,7 +87,7 @@ steps:
       - label: "kind/TestSmoke"
         fixed:
           E2E_PROVIDER: kind
-          TESTS_MATCH: TestRemoteCluster
+          TESTS_MATCH: TestSmoke
           E2E_TAGS: "e2e,mixed"
           MONITORING_SECRETS: ""
           E2E_SKIP_CLEANUP: true

--- a/.buildkite/scripts/common/operator-image.sh
+++ b/.buildkite/scripts/common/operator-image.sh
@@ -52,7 +52,7 @@ operator::set_build_flavors_var() {
             tag-*)           BUILD_FLAVORS="eck,eck-dev,eck-fips,eck-ubi8,eck-ubi8-fips" ;;
             *-main)          BUILD_FLAVORS="eck,eck-dev" ;;
             *-test-snapshot) BUILD_FLAVORS="eck,eck-dev" ;;
-            pr-*|merge-xyz)  BUILD_FLAVORS="eck,eck-dev" ;;
+            pr-*|merge-xyz)  BUILD_FLAVORS="eck" ;;
             dev)             BUILD_FLAVORS="dev" ;;
             *)               echo "error: trigger '$trigger' not supported"; exit ;;
         esac

--- a/.buildkite/scripts/common/operator-image.sh
+++ b/.buildkite/scripts/common/operator-image.sh
@@ -52,7 +52,7 @@ operator::set_build_flavors_var() {
             tag-*)           BUILD_FLAVORS="eck,eck-dev,eck-fips,eck-ubi8,eck-ubi8-fips" ;;
             *-main)          BUILD_FLAVORS="eck,eck-dev" ;;
             *-test-snapshot) BUILD_FLAVORS="eck,eck-dev" ;;
-            pr-*|merge-xyz)  BUILD_FLAVORS="eck" ;;
+            pr-*|merge-xyz)  BUILD_FLAVORS="eck,eck-dev" ;;
             dev)             BUILD_FLAVORS="dev" ;;
             *)               echo "error: trigger '$trigger' not supported"; exit ;;
         esac


### PR DESCRIPTION
This updates the docker-builder buildkite agent to fix a build issue where the manifests are misassembled and we end up with an eck prod image which has the eck dev image in its list of image layers.