### PR TITLE
E2E: do not reset pinned image

### DIFF
--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -92,8 +92,10 @@ func doRun(flags runFlags) error {
 
 	for _, step := range steps {
 		if err := step(); err != nil {
-			helper.dumpEventLog()
-			helper.runECKDiagnostics()
+			if !flags.local {
+				helper.dumpEventLog()
+				helper.runECKDiagnostics()
+			}
 			return err
 		}
 	}

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -115,7 +115,10 @@ func newBuilder(name, randSuffix string) Builder {
 }
 
 func (b Builder) WithImage(image string) Builder {
-	b.Elasticsearch.Spec.Image = image
+	// do not override images set e.g. by WithVersion with empty strings
+	if len(image) > 0 {
+		b.Elasticsearch.Spec.Image = image
+	}
 	return b
 }
 


### PR DESCRIPTION
We have test failures for SNAPSHOT builds due to mixed Elasticsearch SNAPSHOT images with incompatible transport versions: 

```
 jq '.items[].status.containerStatuses[].imageID'
"docker.elastic.co/elasticsearch/elasticsearch@sha256:9da141b4501e7c7530db935a18339a7ea43b2958e9fa9199f3a3b1343e429f8d"
"docker.elastic.co/elasticsearch/elasticsearch@sha256:b7e991e1c0a99c55e9721c47f38010b8eda3ef742646e4fa386fb196920412b7"
"docker.elastic.co/elasticsearch/elasticsearch@sha256:9da141b4501e7c7530db935a18339a7ea43b2958e9fa9199f3a3b1343e429f8d"
```

Also don't try to run diagnostics in local mode