### PR TITLE
[2.9] E2E: do not reset pinned image (#6992)

### DIFF
--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -92,8 +92,10 @@ func doRun(flags runFlags) error {
 
 	for _, step := range steps {
 		if err := step(); err != nil {
-			helper.dumpEventLog()
-			helper.runECKDiagnostics()
+			if !flags.local {
+				helper.dumpEventLog()
+				helper.runECKDiagnostics()
+			}
 			return err
 		}
 	}

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -115,7 +115,10 @@ func newBuilder(name, randSuffix string) Builder {
 }
 
 func (b Builder) WithImage(image string) Builder {
-	b.Elasticsearch.Spec.Image = image
+	// do not override images set e.g. by WithVersion with empty strings
+	if len(image) > 0 {
+		b.Elasticsearch.Spec.Image = image
+	}
 	return b
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.9`:
 - [E2E: do not reset pinned image (#6992)](https://github.com/elastic/cloud-on-k8s/pull/6992)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)