### PR TITLE
E2E set test storage class for Logstash data volume

### DIFF
--- a/test/e2e/es/topology_test.go
+++ b/test/e2e/es/topology_test.go
@@ -53,7 +53,7 @@ func TestResourcesRequirements(t *testing.T) {
 				},
 			},
 			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
-				newPVC("2Gi", elasticsearch.DefaultStorageClass),
+				newPVC("2Gi", test.DefaultStorageClass),
 			},
 		})
 

--- a/test/e2e/es/volume_test.go
+++ b/test/e2e/es/volume_test.go
@@ -119,7 +119,7 @@ func TestVolumeMultiDataPath(t *testing.T) {
 								corev1.ResourceStorage: resource.MustParse("2Gi"),
 							},
 						},
-						StorageClassName: pointer.String(elasticsearch.DefaultStorageClass),
+						StorageClassName: pointer.String(test.DefaultStorageClass),
 					},
 				},
 				{
@@ -135,7 +135,7 @@ func TestVolumeMultiDataPath(t *testing.T) {
 								corev1.ResourceStorage: resource.MustParse("2Gi"),
 							},
 						},
-						StorageClassName: pointer.String(elasticsearch.DefaultStorageClass),
+						StorageClassName: pointer.String(test.DefaultStorageClass),
 					},
 				},
 			},

--- a/test/e2e/samples_test.go
+++ b/test/e2e/samples_test.go
@@ -116,7 +116,9 @@ func createBuilders(t *testing.T, decoder *helper.YAMLDecoder, sampleFile, testN
 				WithLogsMonitoring(logRefs...).
 				WithRestrictedSecurityContext().
 				WithLabel(run.TestNameLabel, fullTestName).
-				WithPodLabel(run.TestNameLabel, fullTestName)
+				WithPodLabel(run.TestNameLabel, fullTestName).
+				WithTestStorageClass()
+
 		default:
 			return b
 		}

--- a/test/e2e/test/default.go
+++ b/test/e2e/test/default.go
@@ -10,6 +10,12 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 )
 
+const (
+	// we setup our own storageClass with "volumeBindingMode: waitForFirstConsumer" that we
+	// reference in the VolumeClaimTemplates section of the Elasticsearch spec
+	DefaultStorageClass = "e2e-default"
+)
+
 // DefaultSecurityContext returns a minimalist, restricted, security context.
 func DefaultSecurityContext() *corev1.PodSecurityContext {
 	// OpenShift sets the security context automatically

--- a/test/e2e/test/default.go
+++ b/test/e2e/test/default.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// we setup our own storageClass with "volumeBindingMode: waitForFirstConsumer" that we
-	// reference in the VolumeClaimTemplates section of the Elasticsearch spec
+	// reference in the VolumeClaimTemplates section of the Elasticsearch and Logstash specs
 	DefaultStorageClass = "e2e-default"
 )
 

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -26,8 +26,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test"
 )
 
-
-
 func ESPodTemplate(resources corev1.ResourceRequirements) corev1.PodTemplateSpec {
 	return corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -26,11 +26,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test"
 )
 
-const (
-	// we setup our own storageClass with "volumeBindingMode: waitForFirstConsumer" that we
-	// reference in the VolumeClaimTemplates section of the Elasticsearch spec
-	DefaultStorageClass = "e2e-default"
-)
+
 
 func ESPodTemplate(resources corev1.ResourceRequirements) corev1.PodTemplateSpec {
 	return corev1.PodTemplateSpec{
@@ -379,7 +375,7 @@ func (b Builder) WithEmptyDirVolumes() Builder {
 }
 
 func (b Builder) WithDefaultPersistentVolumes() Builder {
-	storageClass := DefaultStorageClass
+	storageClass := test.DefaultStorageClass
 	for i := range b.Elasticsearch.Spec.NodeSets {
 		for _, existing := range b.Elasticsearch.Spec.NodeSets[i].VolumeClaimTemplates {
 			if existing.Name == volume.ElasticsearchDataVolumeName {


### PR DESCRIPTION
Always set the storage class for Logstash to `e2e-default` in the e2e tests. This is a pragmatic deviation from the practice we have for Elasticsearch were we test with the e2e-default storage class in general but test with network attached volumes in samples and recipes to have both local and networked volume test paths. 

Adding something similar for Logstash seemed to complex with the current builders we have.

Without this change Logstash tests fail on EKS where the EBS CSI driver is not installed by default.