### PR TITLE
[2.9] E2E set test storage class for Logstash data volume (#6994)

### DIFF
--- a/test/e2e/es/topology_test.go
+++ b/test/e2e/es/topology_test.go
@@ -53,7 +53,7 @@ func TestResourcesRequirements(t *testing.T) {
 				},
 			},
 			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
-				newPVC("2Gi", elasticsearch.DefaultStorageClass),
+				newPVC("2Gi", test.DefaultStorageClass),
 			},
 		})
 

--- a/test/e2e/es/volume_test.go
+++ b/test/e2e/es/volume_test.go
@@ -119,7 +119,7 @@ func TestVolumeMultiDataPath(t *testing.T) {
 								corev1.ResourceStorage: resource.MustParse("2Gi"),
 							},
 						},
-						StorageClassName: pointer.String(elasticsearch.DefaultStorageClass),
+						StorageClassName: pointer.String(test.DefaultStorageClass),
 					},
 				},
 				{
@@ -135,7 +135,7 @@ func TestVolumeMultiDataPath(t *testing.T) {
 								corev1.ResourceStorage: resource.MustParse("2Gi"),
 							},
 						},
-						StorageClassName: pointer.String(elasticsearch.DefaultStorageClass),
+						StorageClassName: pointer.String(test.DefaultStorageClass),
 					},
 				},
 			},

--- a/test/e2e/samples_test.go
+++ b/test/e2e/samples_test.go
@@ -116,7 +116,9 @@ func createBuilders(t *testing.T, decoder *helper.YAMLDecoder, sampleFile, testN
 				WithLogsMonitoring(logRefs...).
 				WithRestrictedSecurityContext().
 				WithLabel(run.TestNameLabel, fullTestName).
-				WithPodLabel(run.TestNameLabel, fullTestName)
+				WithPodLabel(run.TestNameLabel, fullTestName).
+				WithTestStorageClass()
+
 		default:
 			return b
 		}

--- a/test/e2e/test/default.go
+++ b/test/e2e/test/default.go
@@ -10,6 +10,12 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 )
 
+const (
+	// we setup our own storageClass with "volumeBindingMode: waitForFirstConsumer" that we
+	// reference in the VolumeClaimTemplates section of the Elasticsearch and Logstash specs
+	DefaultStorageClass = "e2e-default"
+)
+
 // DefaultSecurityContext returns a minimalist, restricted, security context.
 func DefaultSecurityContext() *corev1.PodSecurityContext {
 	// OpenShift sets the security context automatically

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -26,12 +26,6 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test"
 )
 
-const (
-	// we setup our own storageClass with "volumeBindingMode: waitForFirstConsumer" that we
-	// reference in the VolumeClaimTemplates section of the Elasticsearch spec
-	DefaultStorageClass = "e2e-default"
-)
-
 func ESPodTemplate(resources corev1.ResourceRequirements) corev1.PodTemplateSpec {
 	return corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
@@ -382,7 +376,7 @@ func (b Builder) WithEmptyDirVolumes() Builder {
 }
 
 func (b Builder) WithDefaultPersistentVolumes() Builder {
-	storageClass := DefaultStorageClass
+	storageClass := test.DefaultStorageClass
 	for i := range b.Elasticsearch.Spec.NodeSets {
 		for _, existing := range b.Elasticsearch.Spec.NodeSets[i].VolumeClaimTemplates {
 			if existing.Name == volume.ElasticsearchDataVolumeName {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.9`:
 - [E2E set test storage class for Logstash data volume (#6994)](https://github.com/elastic/cloud-on-k8s/pull/6994)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)