### PR TITLE
[2.8][docs] Update Maps for 8.8.1 indication fix

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/maps.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/maps.asciidoc
@@ -41,9 +41,18 @@ kind: ElasticMapsServer
 metadata:
   name: quickstart
 spec:
+ifeval::["{version}"=="8.8.2"]
+  version: 8.8.1
+endif::[]
+ifeval::["{version}"!="8.8.2"]
   version: {version}
+endif::[]
   count: 1
 ----
+
+ifeval::["{version}"=="8.8.2"]
+WARNING: {ems} `8.8.2` was released with a bug that prevents the Docker image to start. Please use the `8.8.1` tag instead indicated in the snippet above.
+endif::[]
 
 Versions of {ems} prior to 7.14 need a connection to Elasticseach to verify the installed license. You define the connection with the `elasticsearchRef` attribute:
 


### PR DESCRIPTION
Related to elastic/kibana#161572

This is a `8.8` documentation change proposal to address an issue in the Elastic Maps Server `8.8.2` that prevents the image from loading. After discussing with the Release Engineering Team we agreed on updating docs since `8.8.3` is not planned and we are effectively leaving the `8.8` branch for the Maps Server with this issue.

I understand `2.8` is the base branch at this repo where this change should be applied so this shows in the documentation for the `8.8` stack.