### PR TITLE
2.9.0 release notes and highlights and Logstash volume docs

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -286,6 +286,10 @@ NOTE: Logstash persistent queues (PQs) and dead letter queues (DLQs) are not cur
 
 [id="{p}-logstash-volumes"]
 === Defining data volumes for Logstash
+added:[2.9.0]
+
+WARNING: Volume support for Logstash is a breaking change to earlier versions of ECK and requires you to recreate your Logstash objects.
+
 By default, a PersistentVolume called `logstash-data` is created, that maps to `/usr/share/logstash/data`` for persistent storage, typically used for storage from plugins. The `logstash-data` volume claim is, by default, a small (1Gi) volume, using the standard StorageClass of your Kubernetes cluster, but can be overridden by adding a `spec.volumeClaimTemplate` section named `logstash-data`.
 
 [source,yaml,subs="attributes,+macros,callouts"]
@@ -308,7 +312,7 @@ spec:
 ----
 
 
-Separate storage (for example for Logstash configurations using persistent queues (PQ) and/or dead letter queues (DLQ) can be added by including an additional `spec.volumeClaimTemplate` along with a corresponding `spec.podTemplate.spec.containers.volumeMount` for each requested volume, as shown in the following example:
+Separate storage, for example for Logstash configurations using persistent queues (PQ) and/or dead letter queues (DLQ), can be added by including an additional `spec.volumeClaimTemplate` along with a corresponding `spec.podTemplate.spec.containers.volumeMount` for each requested volume, as shown in the following example:
 
 [source,yaml,subs="attributes,+macros,callouts"]
 ----
@@ -318,7 +322,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: {version} 
+  version: {version}
   podTemplate:
     spec:
       containers:

--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -284,6 +284,65 @@ spec:
 
 NOTE: Logstash persistent queues (PQs) and dead letter queues (DLQs) are not currently managed by the Logstash operator, and using them will require you to create and manage your own Volumes and VolumeMounts
 
+[id="{p}-logstash-volumes"]
+=== Defining data volumes for Logstash
+By default, a PersistentVolume called `logstash-data` is created, that maps to `/usr/share/logstash/data`` for persistent storage, typically used for storage from plugins. The `logstash-data` volume claim is, by default, a small (1Gi) volume, using the standard StorageClass of your Kubernetes cluster, but can be overridden by adding a `spec.volumeClaimTemplate` section named `logstash-data`.
+
+[source,yaml,subs="attributes,+macros,callouts"]
+----
+apiVersion: logstash.k8s.elastic.co/v1alpha1
+kind: Logstash
+metadata:
+  name: logstash
+spec:
+  # some configuration attributes omitted for brevity here
+  volumeClaimTemplates:
+    - metadata:
+        name: logstash-data # Do not change this name unless you set up a volume mount for the data path.
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Gi
+----
+
+
+Separate storage (for example for Logstash configurations using persistent queues (PQ) and/or dead letter queues (DLQ) can be added by including an additional `spec.volumeClaimTemplate` along with a corresponding `spec.podTemplate.spec.containers.volumeMount` for each requested volume, as shown in the following example:
+
+[source,yaml,subs="attributes,+macros,callouts"]
+----
+apiVersion: logstash.k8s.elastic.co/v1alpha1
+kind: Logstash
+metadata:
+  name: logstash
+spec:
+  count: 1
+  version: {version} 
+  podTemplate:
+    spec:
+      containers:
+      - name: logstash
+        volumeMounts:
+          - mountPath: /usr/share/logstash/pq
+            name: pq
+            readOnly: false
+  volumeClaimTemplates:
+    - metadata:
+        name: pq # needs to match the volume mount in the podTemplate section
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+  config: 
+    log.level: info
+    queue.type: persisted
+    path.queue: /usr/share/logstash/pq
+----
+
+NOTE: The current implementation does not allow resizing of volumes even if your chosen storage class would support it. To resize a volume you have to fully delete the Logstash object, delete and recreate or resize the volume and create a new Logstash object. Also note that volume claims will not be deleted when you delete the Logstash object and have to be deleted manually. This behaviour might change in future versions of the ECK operator. 
 
 [id="{p}-logstash-pipelines-es"]
 === Using Elasticsearch in Logstash pipelines

--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -290,7 +290,7 @@ added:[2.9.0]
 
 WARNING: Volume support for Logstash is a breaking change to earlier versions of ECK and requires you to recreate your Logstash objects.
 
-By default, a PersistentVolume called `logstash-data` is created, that maps to `/usr/share/logstash/data`` for persistent storage, typically used for storage from plugins. The `logstash-data` volume claim is, by default, a small (1Gi) volume, using the standard StorageClass of your Kubernetes cluster, but can be overridden by adding a `spec.volumeClaimTemplate` section named `logstash-data`.
+By default, a PersistentVolume called `logstash-data` is created, that maps to `/usr/share/logstash/data` for persistent storage, typically used for storage from plugins. The `logstash-data` volume claim is, by default, a small (1Gi) volume, using the standard StorageClass of your Kubernetes cluster, but can be overridden by adding a `spec.volumeClaimTemplate` section named `logstash-data`.
 
 [source,yaml,subs="attributes,+macros,callouts"]
 ----

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-2.9.0>>
 * <<release-notes-2.8.0>>
 * <<release-notes-2.7.0>>
 * <<release-notes-2.6.2>>
@@ -41,6 +42,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/2.9.0.asciidoc[]
 include::release-notes/2.8.0.asciidoc[]
 include::release-notes/2.7.0.asciidoc[]
 include::release-notes/2.6.2.asciidoc[]

--- a/docs/release-notes/2.9.0.asciidoc
+++ b/docs/release-notes/2.9.0.asciidoc
@@ -12,13 +12,13 @@
 === Enhancements
 
 * Add Support for volumeClaimTemplates for Logstash controller {pull}6884[#6884]
-* Add back runAsNonRoot=true to Beats >= 8.8.x {pull}6793[#6793]
+* Enable runAsNonRoot=true for Beats >= 8.8.x {pull}6793[#6793]
 
 [[bug-2.9.0]]
 [float]
 === Bug fixes
 
-* Validating policy ID only when running in fleet mode for Elastic Agent {pull}6938[#6938] (issue: {issue}6903[#6903])
+* Validating policy ID only when running in Fleet mode for Elastic Agent {pull}6938[#6938] (issue: {issue}6903[#6903])
 * Add Selector to Logstash status {pull}6854[#6854]
 
 [[docs-2.9.0]]
@@ -26,7 +26,6 @@
 === Documentation improvements
 
 * Document Logstash connection to external Elasticsearch {pull}6895[#6895]
-* Fix rendering of autopilot recipes README {pull}6856[#6856]
 
 [[nogroup-2.9.0]]
 [float]

--- a/docs/release-notes/2.9.0.asciidoc
+++ b/docs/release-notes/2.9.0.asciidoc
@@ -1,0 +1,52 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-2.9.0]]
+== {n} version 2.9.0
+
+
+
+
+[[enhancement-2.9.0]]
+[float]
+=== Enhancements
+
+* Add Support for volumeClaimTemplates for Logstash controller {pull}6884[#6884]
+* Add back runAsNonRoot=true to Beats >= 8.8.x {pull}6793[#6793]
+
+[[bug-2.9.0]]
+[float]
+=== Bug fixes
+
+* Validating policy ID only when running in fleet mode for Elastic Agent {pull}6938[#6938] (issue: {issue}6903[#6903])
+* Add Selector to Logstash status {pull}6854[#6854]
+
+[[docs-2.9.0]]
+[float]
+=== Documentation improvements
+
+* Document Logstash connection to external Elasticsearch {pull}6895[#6895]
+* Fix rendering of autopilot recipes README {pull}6856[#6856]
+
+[[nogroup-2.9.0]]
+[float]
+=== Misc
+
+* Update module golang.org/x/text to v0.11.0 {pull}6976[#6976]
+* Update registry.access.redhat.com/ubi8/ubi-minimal Docker tag to v8.8-1014 {pull}6962[#6962]
+* Disable test agent with fleet mode in 8.0.1 {pull}6957[#6957] (issues: {issue}6331[#6331], {issue}6956[#6956])
+* Update module go.elastic.co/apm/v2 to v2.4.3 {pull}6942[#6942]
+* Update module github.com/hashicorp/golang-lru/v2 to v2.0.4 {pull}6935[#6935]
+* Update module github.com/imdario/mergo to v1 {pull}6925[#6925]
+* Update module github.com/prometheus/client_golang to v1.16.0 {pull}6909[#6909]
+* Update k8s to v0.27.3 {pull}6908[#6908]
+* Update module golang.org/x/crypto to v0.10.0 {pull}6900[#6900]
+* Update docker.io/library/golang Docker tag to v1.20.5 {pull}6887[#6887]
+* Update module github.com/spf13/viper to v1.16.0 {pull}6867[#6867]
+* Update module github.com/stretchr/testify to v1.8.4 {pull}6866[#6866]
+* Update module sigs.k8s.io/controller-runtime to v0.15.0 {pull}6847[#6847]
+* Update module github.com/prometheus/common to v0.44.0 {pull}6835[#6835]
+* Update module github.com/google/go-containerregistry to v0.15.2 {pull}6817[#6817]
+* Update module golang.org/x/oauth2 to v0.8.0 {pull}6771[#6771]
+* Update module golang.org/x/net to v0.10.0 {pull}6770[#6770]
+

--- a/docs/release-notes/2.9.0.asciidoc
+++ b/docs/release-notes/2.9.0.asciidoc
@@ -5,13 +5,16 @@
 == {n} version 2.9.0
 
 
+[[breaking-2.9.0]]
+[float]
+=== Breaking changes
 
+* Add Support for volumeClaimTemplates for Logstash controller {pull}6884[#6884]
 
 [[enhancement-2.9.0]]
 [float]
 === Enhancements
 
-* Add Support for volumeClaimTemplates for Logstash controller {pull}6884[#6884]
 * Enable runAsNonRoot=true for Beats >= 8.8.x {pull}6793[#6793]
 
 [[bug-2.9.0]]

--- a/docs/release-notes/highlights-2.9.0.asciidoc
+++ b/docs/release-notes/highlights-2.9.0.asciidoc
@@ -11,6 +11,6 @@ New and notable changes in version 2.9.0 of {n}. Check <<release-notes-2.9.0>> f
 [id="{p}-290-logstash"]
 === Logstash support for persistent volumes
 
-ECK 2.9.0 includes a technical preview for persistent volumes for link:https://www.elastic.co/logstash/[Logstash] resources. A default data volume is now created for each Logstash and additional volumes can be defined for example for Logstash's persistent queue feature.
+ECK 2.9.0 includes a technical preview for persistent volumes for link:https://www.elastic.co/logstash/[Logstash] resources. A default data volume is now created for each Logstash and additional volumes can be defined for example for Logstash's persistent queue feature. This is a breaking change from  version 2.8.0 of the ECK operator and requires re-creation of existing Logstash objects.
 
 Refer to the <<{p}-logstash-volumes>> for more information.

--- a/docs/release-notes/highlights-2.9.0.asciidoc
+++ b/docs/release-notes/highlights-2.9.0.asciidoc
@@ -1,0 +1,16 @@
+[[release-highlights-2.9.0]]
+== 2.9.0 release highlights
+
+[float]
+[id="{p}-290-new-and-notable"]
+=== New and notable
+
+New and notable changes in version 2.9.0 of {n}. Check <<release-notes-2.9.0>> for the full list of changes.
+
+[float]
+[id="{p}-290-logstash"]
+=== Logstash support for persistent volumes
+
+ECK 2.9.0 includes a technical preview for persistent volumes for link:https://www.elastic.co/logstash/[Logstash] resources. A default data volume is now created for each Logstash and additional volumes can be defined for example for Logstash's persistent queue feature.
+
+Refer to the <<{p}-logstash-volumes>> for more information.

--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the most important changes in each release. For the full list, check <<eck-release-notes>>.
 
+* <<release-highlights-2.9.0>>
 * <<release-highlights-2.8.0>>
 * <<release-highlights-2.7.0>>
 * <<release-highlights-2.6.2>>
@@ -40,6 +41,7 @@ This section summarizes the most important changes in each release. For the full
 
 --
 
+include::highlights-2.9.0.asciidoc[]
 include::highlights-2.8.0.asciidoc[]
 include::highlights-2.7.0.asciidoc[]
 include::highlights-2.6.2.asciidoc[]


### PR DESCRIPTION
~I am going to open a separate PR for the highlights and add some documentation for the Logstash volume support.~

Actually I am going to push the highlights and Logstash docs to this branch as well, because of the links.

Preview https://cloud-on-k8s_7003.docs-preview.app.elstc.co/diff