### PR TITLE
Relax mutation health checks for TestVersionUpgrade e2e tests (#7000)

### DIFF
--- a/test/e2e/agent/upgrade_test.go
+++ b/test/e2e/agent/upgrade_test.go
@@ -22,7 +22,8 @@ func TestAgentVersionUpgradeToLatest8x(t *testing.T) {
 	name := "test-agent-upgrade"
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithVersion(srcVersion).
-		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
+		TolerateMutationChecksFailures(10)
 
 	kbBuilder := kibana.NewBuilder(name).
 		WithVersion(srcVersion).

--- a/test/e2e/apm/upgrade_test.go
+++ b/test/e2e/apm/upgrade_test.go
@@ -23,7 +23,8 @@ func TestAPMServerVersionUpgradeToLatest8x(t *testing.T) {
 	name := "apmserver-upgrade"
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithVersion(srcVersion).
-		WithESMasterDataNodes(3, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
+		TolerateMutationChecksFailures(10)
 
 	apmServerBuilder := apmserver.NewBuilder(name).WithVersion(srcVersion).WithElasticsearchRef(esBuilder.Ref()).WithoutIntegrationCheck()
 

--- a/test/e2e/beat/upgrade_test.go
+++ b/test/e2e/beat/upgrade_test.go
@@ -71,7 +71,8 @@ func TestVersionUpgradeToLatest8x(t *testing.T) {
 	name := "test-beat-upgrade-to-8x"
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		WithVersion(dstVersion)
+		WithVersion(dstVersion).
+		TolerateMutationChecksFailures(10)
 
 	fbBuilder := beat.NewBuilder(name).
 		WithRoles(beat.AutodiscoverClusterRoleName).

--- a/test/e2e/kb/version_upgrade_test.go
+++ b/test/e2e/kb/version_upgrade_test.go
@@ -142,7 +142,8 @@ func TestVersionUpgradeToLatest8x(t *testing.T) {
 	name := "test-version-upgrade-to-8x"
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		WithVersion(srcVersion)
+		WithVersion(srcVersion).
+		TolerateMutationChecksFailures(10)
 
 	srcNodeCount := 3
 	kbBuilder := kibana.NewBuilder(name).

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -52,6 +52,8 @@ type Builder struct {
 	expectedElasticsearch *esv1.Elasticsearch
 
 	GlobalCA bool
+
+	mutationToleratedChecksFailureCount int
 }
 
 func (b Builder) DeepCopy() *Builder {
@@ -536,6 +538,15 @@ func (b Builder) GetMetricsCluster() *types.NamespacedName {
 	}
 	metricsCluster := b.Elasticsearch.Spec.Monitoring.Metrics.ElasticsearchRefs[0].NamespacedName()
 	return &metricsCluster
+}
+
+// TolerateMutationChecksFailures relaxes the continuous health check performed during a mutation by accepting a given number of failures.
+// When a new index is created at the same time as the mutation, the shutdown node API currently does not prevent shutting down a node
+// which has a new uninitialized replica, resulting in a cluster with red health status for a few seconds while the node comes back.
+// https://github.com/elastic/cloud-on-k8s/issues/5795.
+func (b Builder) TolerateMutationChecksFailures(c int) Builder {
+	b.mutationToleratedChecksFailureCount = c
+	return b
 }
 
 // -- Helper functions

--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -155,10 +155,12 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 				},
 				Test: func(t *testing.T) {
 					continuousHealthChecks.Stop()
+
 					for _, f := range continuousHealthChecks.Failures {
 						t.Errorf("Elasticsearch cluster health check failure at %s: %s", f.timestamp, f.err.Error())
 					}
-					assert.Equal(t, 0, continuousHealthChecks.FailureCount)
+
+					assert.LessOrEqual(t, continuousHealthChecks.FailureCount, b.mutationToleratedChecksFailureCount)
 				},
 			},
 			test.Step{


### PR DESCRIPTION
Backport the following commit to `2.9`:
- #7000