### PR TITLE
Increase mutation health checks tolerance

### DIFF
--- a/test/e2e/agent/upgrade_test.go
+++ b/test/e2e/agent/upgrade_test.go
@@ -23,7 +23,7 @@ func TestAgentVersionUpgradeToLatest8x(t *testing.T) {
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithVersion(srcVersion).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		TolerateMutationChecksFailures(10)
+		TolerateMutationChecksFailures(15)
 
 	kbBuilder := kibana.NewBuilder(name).
 		WithVersion(srcVersion).

--- a/test/e2e/agent/upgrade_test.go
+++ b/test/e2e/agent/upgrade_test.go
@@ -23,7 +23,7 @@ func TestAgentVersionUpgradeToLatest8x(t *testing.T) {
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithVersion(srcVersion).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		TolerateMutationChecksFailures(15)
+		TolerateMutationChecksFailures()
 
 	kbBuilder := kibana.NewBuilder(name).
 		WithVersion(srcVersion).

--- a/test/e2e/apm/upgrade_test.go
+++ b/test/e2e/apm/upgrade_test.go
@@ -24,7 +24,7 @@ func TestAPMServerVersionUpgradeToLatest8x(t *testing.T) {
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithVersion(srcVersion).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		TolerateMutationChecksFailures(15)
+		TolerateMutationChecksFailures()
 
 	apmServerBuilder := apmserver.NewBuilder(name).WithVersion(srcVersion).WithElasticsearchRef(esBuilder.Ref()).WithoutIntegrationCheck()
 

--- a/test/e2e/apm/upgrade_test.go
+++ b/test/e2e/apm/upgrade_test.go
@@ -24,7 +24,7 @@ func TestAPMServerVersionUpgradeToLatest8x(t *testing.T) {
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithVersion(srcVersion).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
-		TolerateMutationChecksFailures(10)
+		TolerateMutationChecksFailures(15)
 
 	apmServerBuilder := apmserver.NewBuilder(name).WithVersion(srcVersion).WithElasticsearchRef(esBuilder.Ref()).WithoutIntegrationCheck()
 

--- a/test/e2e/beat/upgrade_test.go
+++ b/test/e2e/beat/upgrade_test.go
@@ -72,7 +72,7 @@ func TestVersionUpgradeToLatest8x(t *testing.T) {
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
 		WithVersion(dstVersion).
-		TolerateMutationChecksFailures(15)
+		TolerateMutationChecksFailures()
 
 	fbBuilder := beat.NewBuilder(name).
 		WithRoles(beat.AutodiscoverClusterRoleName).

--- a/test/e2e/beat/upgrade_test.go
+++ b/test/e2e/beat/upgrade_test.go
@@ -72,7 +72,7 @@ func TestVersionUpgradeToLatest8x(t *testing.T) {
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
 		WithVersion(dstVersion).
-		TolerateMutationChecksFailures(10)
+		TolerateMutationChecksFailures(15)
 
 	fbBuilder := beat.NewBuilder(name).
 		WithRoles(beat.AutodiscoverClusterRoleName).

--- a/test/e2e/kb/version_upgrade_test.go
+++ b/test/e2e/kb/version_upgrade_test.go
@@ -143,7 +143,7 @@ func TestVersionUpgradeToLatest8x(t *testing.T) {
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
 		WithVersion(srcVersion).
-		TolerateMutationChecksFailures(10)
+		TolerateMutationChecksFailures(15)
 
 	srcNodeCount := 3
 	kbBuilder := kibana.NewBuilder(name).

--- a/test/e2e/kb/version_upgrade_test.go
+++ b/test/e2e/kb/version_upgrade_test.go
@@ -143,7 +143,7 @@ func TestVersionUpgradeToLatest8x(t *testing.T) {
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithESMasterDataNodes(3, elasticsearch.DefaultResources).
 		WithVersion(srcVersion).
-		TolerateMutationChecksFailures(15)
+		TolerateMutationChecksFailures()
 
 	srcNodeCount := 3
 	kbBuilder := kibana.NewBuilder(name).

--- a/test/e2e/test/elasticsearch/builder.go
+++ b/test/e2e/test/elasticsearch/builder.go
@@ -26,6 +26,9 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test"
 )
 
+// defaultMutationToleratedFailures is the number of continuous health checks failures tolerated during a mutation.
+const defaultMutationToleratedFailures = 15
+
 func ESPodTemplate(resources corev1.ResourceRequirements) corev1.PodTemplateSpec {
 	return corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
@@ -544,8 +547,8 @@ func (b Builder) GetMetricsCluster() *types.NamespacedName {
 // When a new index is created at the same time as the mutation, the shutdown node API currently does not prevent shutting down a node
 // which has a new uninitialized replica, resulting in a cluster with red health status for a few seconds while the node comes back.
 // https://github.com/elastic/cloud-on-k8s/issues/5795.
-func (b Builder) TolerateMutationChecksFailures(c int) Builder {
-	b.mutationToleratedChecksFailureCount = c
+func (b Builder) TolerateMutationChecksFailures() Builder {
+	b.mutationToleratedChecksFailureCount = defaultMutationToleratedFailures
 	return b
 }
 


### PR DESCRIPTION
This increases a little the mutation health checks tolerance from `10` to `15`.

Relates to [#5795](https://github.com/elastic/cloud-on-k8s/issues/5795#issuecomment-1633774968).