### PR TITLE
Add further documentation for Logstash volumes

### DIFF
--- a/config/recipes/logstash/logstash-eck.yaml
+++ b/config/recipes/logstash/logstash-eck.yaml
@@ -93,7 +93,7 @@ spec:
             hosts => [ "${ECK_ES_HOSTS}" ]
             user => "${ECK_ES_USER}"
             password => "${ECK_ES_PASSWORD}"
-            cacert => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
+            ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
           }
         }
   services:

--- a/config/recipes/logstash/logstash-es-role.yaml
+++ b/config/recipes/logstash/logstash-es-role.yaml
@@ -42,8 +42,8 @@ spec:
         output { 
           elasticsearch {
             hosts => [ "${ECK_ES_HOSTS}" ]
-            ssl => true
-            cacert => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
+            ssl_enabled => true
+            ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
             user => "${ECK_ES_USER}"
             password => "${ECK_ES_PASSWORD}"
             index => "my-index"

--- a/config/recipes/logstash/logstash-monitored.yaml
+++ b/config/recipes/logstash/logstash-monitored.yaml
@@ -97,7 +97,7 @@ spec:
             hosts => [ "${ECK_ES_HOSTS}" ]
             user => "${ECK_ES_USER}"
             password => "${ECK_ES_PASSWORD}"
-            cacert => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
+            ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
           }
         }
   services:

--- a/config/recipes/logstash/logstash-multi.yaml
+++ b/config/recipes/logstash/logstash-multi.yaml
@@ -122,7 +122,7 @@ spec:
             hosts => [ "${PROD_ES_ES_HOSTS}" ]
             user => "${PROD_ES_ES_USER}"
             password => "${PROD_ES_ES_PASSWORD}"
-            cacert => "${PROD_ES_ES_SSL_CERTIFICATE_AUTHORITY}"
+            ssl_certificate_authorities => "${PROD_ES_ES_SSL_CERTIFICATE_AUTHORITY}"
           }
         }
     - pipeline.id: qa
@@ -137,7 +137,7 @@ spec:
             hosts => [ "${QA_ES_ES_HOSTS}" ]
             user => "${QA_ES_ES_USER}"
             password => "${QA_ES_ES_PASSWORD}"
-            cacert => "${QA_ES_ES_SSL_CERTIFICATE_AUTHORITY}"
+            ssl_certificate_authorities => "${QA_ES_ES_SSL_CERTIFICATE_AUTHORITY}"
           }
         }
   services:

--- a/config/recipes/logstash/logstash-pipeline-as-secret.yaml
+++ b/config/recipes/logstash/logstash-pipeline-as-secret.yaml
@@ -111,6 +111,6 @@ stringData:
             hosts => [ "${ECK_ES_HOSTS}" ]
             user => "${ECK_ES_USER}"
             password => "${ECK_ES_PASSWORD}"
-            cacert => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
+            ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
           }
         }

--- a/config/recipes/logstash/logstash-pipeline-as-volume.yaml
+++ b/config/recipes/logstash/logstash-pipeline-as-volume.yaml
@@ -124,6 +124,6 @@ stringData:
         hosts => [ "${ECK_ES_HOSTS}" ]
         user => "${ECK_ES_USER}"
         password => "${ECK_ES_PASSWORD}"
-        cacert => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
+        ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
       }
     }

--- a/config/recipes/logstash/logstash-volumes.yaml
+++ b/config/recipes/logstash/logstash-volumes.yaml
@@ -1,0 +1,156 @@
+---
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch
+spec:
+  version: 8.8.0
+  nodeSets:
+    - name: default
+      count: 3
+      config:
+        # This setting has performance implications. See the README for more details.
+        node.store.allow_mmap: false
+---
+apiVersion: beat.k8s.elastic.co/v1beta1
+kind: Beat
+metadata:
+  name: filebeat
+spec:
+  type: filebeat
+  version: 8.8.0
+  config:
+    filebeat.inputs:
+      - type: log
+        paths:
+          - /data/logstash-tutorial.log
+    output.logstash:
+      hosts: ["logstash-ls-beats:5044"]
+  deployment:
+    podTemplate:
+      spec:
+        automountServiceAccountToken: true
+        initContainers:
+          - name: download-tutorial
+            image: curlimages/curl
+            command: ["/bin/sh"]
+            args: ["-c", "curl -L https://download.elastic.co/demos/logstash/gettingstarted/logstash-tutorial.log.gz | gunzip -c > /data/logstash-tutorial.log"]
+            volumeMounts:
+              - name: data
+                mountPath: /data
+        containers:
+          - name: filebeat
+            volumeMounts:
+              - name: data
+                mountPath: /data
+              - name: beat-data
+                mountPath: /usr/share/filebeat/data
+        volumes:
+          - name: data
+            emptydir: {}
+          - name: beat-data
+            emptydir: {}
+---
+apiVersion: logstash.k8s.elastic.co/v1alpha1
+kind: Logstash
+metadata:
+  name: logstash
+spec:
+  count: 1
+  version: 8.8.0
+  elasticsearchRefs:
+    - clusterName: eck
+      name: elasticsearch
+  podTemplate:
+    spec:
+      containers:
+        - name: logstash
+          volumeMounts:
+            - mountPath: /usr/share/logstash/pq
+              name: pq
+              readOnly: false
+            - mountPath: /usr/share/logstash/dlq
+              name: dlq
+              readOnly: false
+  volumeClaimTemplates:
+    - metadata:
+        name: pq
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+    - metadata:
+        name: dlq
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi
+  pipelines:
+    - pipeline.id: dlq_read
+      dead_letter_queue.enable: false
+      config.string: |
+        input {
+          dead_letter_queue {
+            path => "/usr/share/logstash/dlq"
+            commit_offsets => true
+            pipeline_id => "beats"
+            clean_consumed => true
+          }
+        }
+        filter {
+          mutate {
+            remove_field => "[geoip][location]"
+          }
+        }
+        output {
+          elasticsearch {
+            hosts => [ "${ECK_ES_HOSTS}" ]
+            user => "${ECK_ES_USER}"
+            password => "${ECK_ES_PASSWORD}"
+            ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
+          }
+        }
+    - pipeline.id: beats
+      dead_letter_queue.enable: true
+      path.dead_letter_queue: /usr/share/logstash/dlq
+      config.string: |
+        input {
+          beats {
+            port => 5044
+          }
+        }
+        filter {
+          grok {
+            match => { "message" => "%{HTTPD_COMMONLOG}"}
+          }
+          geoip {
+            source => "[source][address]"
+            target => "[source]"
+          }
+        }
+        output {
+          elasticsearch {
+            hosts => [ "${ECK_ES_HOSTS}" ]
+            user => "${ECK_ES_USER}"
+            password => "${ECK_ES_PASSWORD}"
+            ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
+          }
+        }
+  config:
+    log.level: info
+    queue.type: persisted
+    path.queue: /usr/share/logstash/pq
+  services:
+    - name: beats
+      service:
+        spec:
+          type: ClusterIP
+          ports:
+            - port: 5044
+              name: "filebeat"
+              protocol: TCP
+              targetPort: 5044

--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -21,6 +21,7 @@ This section describes how to configure and deploy Logstash with ECK.
 * <<{p}-logstash-configuration-examples,Configuration examples>>
 * <<{p}-logstash-advanced-configuration,Advanced Configuration>>
 ** <<{p}-logstash-jvm-options,Setting JVM Options>>
+** <<{p}-logstash-volume-claim-templates,Configuring Volumes>>
 ** <<{p}-logstash-scaling-logstash,Scaling Logstash>>
 * <<{p}-logstash-technical-preview-limitations,Technical Preview Limitations>>
 
@@ -369,6 +370,7 @@ NOTE: The `clusterName` value should be unique across all referenced Elasticsear
 [NOTE]
 --
 The Logstash ECK operator creates a user called `eck_logstash_user_role` when an `elasticsearchRef` is specified. This user has the following permissions:
+
 ```
   "cluster": ["monitor", "manage_ilm", "read_ilm", "manage_logstash_pipelines", "manage_index_templates", "cluster:admin/ingest/pipeline/get",],
   "indices": [
@@ -378,6 +380,8 @@ The Logstash ECK operator creates a user called `eck_logstash_user_role` when an
     }
 
 ```
+
+
 You can <<{p}-users-and-roles,update user permissions>> to include more indices if the Elasticsearch plugin is expected to use indices other than the default. See the <<{p}-logstash-configuration-custom-index, Logstash configuration with a custom index>> sample configuration that creates a user that writes to a custom index.
 --
 
@@ -597,6 +601,16 @@ kubectl apply -f {logstash_recipes}/logstash-es-role.yaml
 
 Deploys Logstash and Elasticsearch, and creates an updated version of the `eck_logstash_user_role` to write to a user specified index.
 
+[id="{p}-logstash-configuration-pq-dlq"]
+=== Creating persitent volumes for PQ and DLQ
+
+[source,sh,subs="attributes"]
+----
+kubectl apply -f {logstash_recipes}/logstash-volumes.yaml
+----
+
+Deploys Logstash, Beats and Elasticsearch. Logstash is configured with two pipelines - a main pipeline for reading from the beats instance, which will send to the DLQ if it is unable to write to Elasticsearch, and a second pipeline, that will read from the DLQ. In addition, persistent queues are set up. This example shows how to configure persistent volumes outside of the default `logstash-data` persistent volume.
+
 
 [id="{p}-logstash-configuration-stack-monitoring"]
 === Elasticsearch and Kibana Stack Monitoring
@@ -646,6 +660,205 @@ spec:
 ----
 <1> This will change the maximum and minimum heap size of the JVM on each pod to 2GB
 
+
+[id="{p}-logstash-volume-claim-templates"]
+= Logstash Volume claim templates
+
+[float]
+== Specifying the volume claim settings
+
+By default, the operator creates a https://kubernetes.io/docs/concepts/storage/persistent-volumes/[`PersistentVolumeClaim`] with a capacity of 1Gi for each Logstash pod to store Logstash data that would normally be placed in the `data` folder. This typically includes data files used by logstash and its plugins for any persistence needs.
+
+For production workloads, you should define your own volume claim template with the desired storage capacity and (optionally) the Kubernetes link:https://kubernetes.io/docs/concepts/storage/storage-classes/[storage class] to associate with the persistent volume. To override this volume claim for `data` usages, the name of this volume claim must be `logtash-data`.
+
+
+This example updates the default data template to increase the storage to `5Gi` for the logstash data folder.
+
+[source,yaml]
+----
+spec:
+  count: 3
+  volumeClaimTemplates:
+  - metadata:
+    name: logstash-data # Do not change this name unless you set up a volume mount for the data path.
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+            storageClassName: standard
+----
+
+Additional volume claims can be configured for data that you may want to keep outside of the `data` folder, such as persistent queues, and dead letter queues.
+
+The following example shows how to configure logstash with a separate volume for a persistent queue:
+
+[source,yaml,subs="attributes,+macros,callouts"]
+----
+apiVersion: logstash.k8s.elastic.co/v1alpha1
+kind: Logstash
+metadata:
+  name: logstash
+spec:
+  count: 1
+  version: {version}
+  volumeClaimTemplates:
+    - metadata:
+        name: pq <1>
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+  podTemplate:
+    spec:
+      containers:
+      - name: logstash
+        volumeMounts:
+        - mountPath: /usr/share/logstash/pq <2>
+          name: pq  <1>
+          readOnly: false
+  config:
+    log.level: info
+    queue.type: persisted
+    path.queue: /usr/share/logstash/pq <2>
+----
+<1> The `name` values in the `volumeMount` for the container in the podTemplate section and the name of the `volumeClaimTemplate` must match
+<2> Set the `path.queue` setting in the configuration to match the `mountPath` in the `volumeMount`.
+
+The following example shows how to configure Logstash with a Dead Letter Queue setup on the main pipeline, and a separate pipeline to read items from the DLQ.
+
+[source,yaml,subs="attributes,+macros,callouts"]
+----
+apiVersion: logstash.k8s.elastic.co/v1alpha1
+kind: Logstash
+metadata:
+  name: logstash
+spec:
+  count: 1
+  version: {version}
+   elasticsearchRefs:
+   - clusterName: eck
+     name: elasticsearch
+  podTemplate:
+    spec:
+      containers:
+      - name: logstash
+        volumeMounts:
+        - mountPath: /usr/share/logstash/dlq <2>
+          name: dlq  <1>
+          readOnly: false
+  volumeClaimTemplates:
+    - metadata:
+      name: dlq <1>
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+  pipelines:
+    - pipeline.id: beats
+      dead_letter_queue.enable: true
+      path.dead_letter_queue: /usr/share/logstash/dlq <2>
+      config.string: |
+        input {
+          beats {
+            port => 5044
+          }
+        }
+        output {
+          elasticsearch {
+            hosts => [ "${ECK_ES_HOSTS}" ]
+            user => "${ECK_ES_USER}"
+            password => "${ECK_ES_PASSWORD}"
+            ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
+          }
+        }
+    - pipeline.id: dlq_read
+      dead_letter_queue.enable: false
+      config.string: |
+        input {
+          dead_letter_queue {
+            path => "/usr/share/logstash/dlq" <2>
+            commit_offsets => true
+            pipeline_id => "beats"
+            clean_consumed => true
+          }
+        }
+        filter {
+          mutate {
+            remove_field => "[geoip][location]"
+          }
+        }
+        output {
+          elasticsearch {
+            hosts => [ "${ECK_ES_HOSTS}" ]
+            user => "${ECK_ES_USER}"
+            password => "${ECK_ES_PASSWORD}"
+            ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
+          }
+        }
+----
+<1> The `name` values in the `volumeMount` for the container in the podTemplate section and the name of the `volumeClaimTemplate` must match
+<2> Set the `path.dead_letter_queue` setting in the pipeline config to match the `mountPath` in the `volumeMount` for pipelines that are writing to the Dead Letter Queue, and set the `path` setting of the `dead_letter_queue` plugin for the pipeline that will read from the Dead Letter Queue.
+
+
+[float]
+== Updating the volume claim settings
+
+Changes are currently forbidden in the volumeClaimTemplates, such as changing the storage class or changing the volume size. To make these changes, you have to fully delete the Logstash object, delete and recreate or resize the volume and create a new Logstash object.
+
+Before deleting or resizing a persistent queue volume, ensure that the queue is empty. When using the persistent queue, we recommend setting `queue.drain: true` on the logstash pods to ensure that the persistent queue is drained when pods are shutdown. In conjunction with this, note that you should also increase the `terminationGracePeriodSeconds` to a large enough value to drain your queue.
+
+
+
+Example:
+
+[source,yaml,subs="attributes,+macros,callouts"]
+----
+apiVersion: logstash.k8s.elastic.co/v1alpha1
+kind: Logstash
+metadata:
+  name: logstash
+spec:
+  config:
+    queue.drain: true
+  podTemplate:
+    spec:
+      terminationGracePeriodSeconds: 604800
+----
+
+NOTE: When used in conjunction with an autoscaler, such as the Horizontal Pod Autoscaler, Kubernetes may not honor  `terminationGracePeriodSeconds` settings greater than 600. This may mean that a queue of a terminated pod may not be fully drained, even when `queue.drain: true` is set and a high `terminationGracePeriodSeconds` is configured.
+
+[NOTE]
+--
+In the technical preview, there is currently no way to drain a dead letter queue automatically before Logstash shuts down. To manually drain a Dead Letter Queue, first stop sending data to it, by either disabling the DLQ feature, or disabling any pipelines that send to a DLQ, and wait for events to stop flowing through any pipelines reading from the input.
+
+[float]
+== EmptyDir
+
+If you are not concerned about data loss, you can use an `emptyDir` volume for Logstash data.
+
+CAUTION: The use of `emptyDir` in a production environment may generate permanent data loss. Do not use with persistent queues, or dead letter queues, or when using any plugin that requires persistent storage to keep track of state between restarts of Logstash.
+
+
+[source,yaml]
+----
+spec:
+  count: 5
+  podTemplate:
+    spec:
+      volumeClaimTemplates:
+      - name: logstash-data
+        emptyDir: {}
+----
+
+
+
+
 [id="{p}-logstash-scaling-logstash"]
 == Scaling Logstash
 
@@ -684,8 +897,12 @@ experimental[]
 Note that this release is a technical preview. It is still under active development and has additional limitations:
 
 [id="{p}-logstash-technical-preview-persistence"]
-=== No integrated support for persistence
-The operator provides no integrated support for persistence, including PQ, DLQ support and plugins that may require persistent storage to keep track of state - any persistence should be added manually.
+=== Experimental support for persistence
+NOTE: This is a breaking change from  version 2.8.0 of the ECK operator and requires re-creation of existing Logstash objects.
+
+The operator now includes support for persistence, with a small (`1Gi`) default `PersistentVolume` called `logstash-data` created, that maps to `/usr/share/logstash/data`, which should be typically used for storage from plugins, which can be overridden but can be overridden by adding a `spec.volumeClaimTemplate` section named `logstash-data` to add more storage, or do use a different `storageClass` from the default, for example. Additional `persistentVolumeClaims` can also be defined in `spec.volumeClaimTemplate` for use with PQ, or DLQ, for example.
+
+ The current implementation does not allow resizing of volumes even if your chosen storage class would support it. To resize a volume you have to fully delete the Logstash object, delete and recreate or resize the volume and create a new Logstash object. Also note that volume claims will not be deleted when you delete the Logstash object and have to be deleted manually. This behaviour might change in future versions of the ECK operator.
 
 [id="{p}-logstash-technical-preview-elasticsearchref"]
 === `ElasticsearchRef` implementation in plugins is in preview mode

--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -458,7 +458,7 @@ spec:
       terminationGracePeriodSeconds: 604800
 ----
 
-NOTE: When used in conjunction with an autoscaler, such as the Horizontal Pod Autoscaler, Kubernetes may not honor  `terminationGracePeriodSeconds` settings greater than 600. This may mean that a queue of a terminated pod may not be fully drained, even when `queue.drain: true` is set and a high `terminationGracePeriodSeconds` is configured.
+NOTE: A https://github.com/kubernetes/kubernetes/issues/94435[known issue] in Kubernetes, means that Kubernetes may not honor  `terminationGracePeriodSeconds` settings greater than 600. This may mean that a queue of a terminated Pod may not be fully drained, even when `queue.drain: true` is set and a high `terminationGracePeriodSeconds` is configured.
 
 NOTE: In the technical preview, there is currently no way to drain a dead letter queue automatically before Logstash shuts down. To manually drain a Dead Letter Queue, first stop sending data to it, by either disabling the DLQ feature, or disabling any pipelines that send to a DLQ, and wait for events to stop flowing through any pipelines reading from the input.
 

--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -356,7 +356,7 @@ spec:
     queue.type: persisted
     path.queue: /usr/share/logstash/pq <2>
 ----
-<1> The `name` values in the `volumeMount` for the container in the podTemplate section and the name of the `volumeClaimTemplate` must match
+<1> The `name` values in the `volumeMount` for the container in the `podTemplate` section and the name of the `volumeClaimTemplate` must match.
 <2> Set the `path.queue` setting in the configuration to match the `mountPath` in the `volumeMount`.
 
 
@@ -430,14 +430,14 @@ spec:
           }
         }
 ----
-<1> The `name` values in the `volumeMount` for the container in the podTemplate section and the name of the `volumeClaimTemplate` must match
+<1> The `name` values in the `volumeMount` for the container in the `podTemplate` section and the name of the `volumeClaimTemplate` must match.
 <2> Set the `path.dead_letter_queue` setting in the pipeline config to match the `mountPath` in the `volumeMount` for pipelines that are writing to the Dead Letter Queue, and set the `path` setting of the `dead_letter_queue` plugin for the pipeline that will read from the Dead Letter Queue.
 
 
 [float]
 == Updating the volume claim settings
 
-Changes are currently forbidden in `spec.volumeClaimTemplates`, such as changing the storage class or volume size. To make these changes, you have to fully delete the Logstash object, delete and recreate or resize the volume and create a new Logstash object.
+Changes are currently forbidden in `spec.volumeClaimTemplates`, such as changing the storage class or volume size. To make these changes, you have to fully delete the Logstash object, delete and recreate or resize the volume and create a new Logstash resource.
 
 Before deleting or resizing a persistent queue volume, ensure that the queue is empty. When using the persistent queue, we recommend setting `queue.drain: true` on the Logstash Pods to ensure that the persistent queue is drained when Pods are shutdown. In conjunction with this, note that you should also increase the `terminationGracePeriodSeconds` to a large enough value to drain your queue.
 
@@ -458,7 +458,7 @@ spec:
       terminationGracePeriodSeconds: 604800
 ----
 
-NOTE: A https://github.com/kubernetes/kubernetes/issues/94435[known issue] in Kubernetes, means that Kubernetes may not honor  `terminationGracePeriodSeconds` settings greater than 600. This may mean that a queue of a terminated Pod may not be fully drained, even when `queue.drain: true` is set and a high `terminationGracePeriodSeconds` is configured.
+NOTE: A https://github.com/kubernetes/kubernetes/issues/94435[known issue] in Kubernetes, means that Kubernetes may not honor `terminationGracePeriodSeconds` settings greater than 600. This may mean that a queue of a terminated Pod may not be fully drained, even when `queue.drain: true` is set and a high `terminationGracePeriodSeconds` is configured.
 
 NOTE: In the technical preview, there is currently no way to drain a dead letter queue automatically before Logstash shuts down. To manually drain a Dead Letter Queue, first stop sending data to it, by either disabling the DLQ feature, or disabling any pipelines that send to a DLQ, and wait for events to stop flowing through any pipelines reading from the input.
 
@@ -834,11 +834,11 @@ Note that this release is a technical preview. It is still under active developm
 
 [id="{p}-logstash-technical-preview-persistence"]
 === Experimental support for persistence
-NOTE: This is a breaking change from  version 2.8.0 of the ECK operator and requires re-creation of existing Logstash objects.
+NOTE: This is a breaking change from version 2.8.0 of the ECK operator and requires re-creation of existing Logstash objects.
 
 The operator now includes support for persistence, with a small (`1Gi`) default `PersistentVolume` called `logstash-data` created, that maps to `/usr/share/logstash/data`, which should be typically used for storage from plugins. The default volume can be overridden by adding a `spec.volumeClaimTemplate` section named `logstash-data` to add more storage, or to use a different `storageClass` from the default, for example. Additional `persistentVolumeClaims` can also be defined in `spec.volumeClaimTemplate` for use with PQ, or DLQ, for example.
 
-The current implementation does not allow resizing of volumes even if your chosen storage class would support it. To resize a volume you have to fully delete the Logstash object, delete and recreate or resize the volume and create a new Logstash object. Also note that volume claims will not be deleted when you delete the Logstash object and have to be deleted manually. This behaviour might change in future versions of the ECK operator.
+The current implementation does not allow resizing of volumes even if your chosen storage class would support it. To resize a volume you have to fully delete the Logstash object, delete and recreate or resize the volume and create a new Logstash object. Also note that volume claims will not be deleted when you delete the Logstash resource and have to be deleted manually. This behaviour might change in future versions of the ECK operator.
 
 [id="{p}-logstash-technical-preview-elasticsearchref"]
 === `ElasticsearchRef` implementation in plugins is in preview mode

--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -62,7 +62,7 @@ spec:
             hosts => [ "${QS_ES_HOSTS}" ]
             user => "${QS_ES_USER}"
             password => "${QS_ES_PASSWORD}"
-            cacert => "${QS_ES_SSL_CERTIFICATE_AUTHORITY}"
+            ssl_certificate_authorities => "${QS_ES_SSL_CERTIFICATE_AUTHORITY}"
           }
         }
   services:
@@ -204,7 +204,7 @@ spec:
             hosts => [ "${QS_ES_HOSTS}" ]
             user => "${QS_ES_USER}"
             password => "${QS_ES_PASSWORD}"
-            cacert => "${QS_ES_SSL_CERTIFICATE_AUTHORITY}"
+            ssl_certificate_authorities => "${QS_ES_SSL_CERTIFICATE_AUTHORITY}"
           }
         }
 ----
@@ -243,7 +243,7 @@ stringData:
             hosts => [ "${QS_ES_HOSTS}" ]
             user => "${QS_ES_USER}"
             password => "${QS_ES_PASSWORD}"
-            cacert => "${QS_ES_SSL_CERTIFICATE_AUTHORITY}"
+            ssl_certificate_authorities => "${QS_ES_SSL_CERTIFICATE_AUTHORITY}"
           }
         }
 
@@ -278,7 +278,7 @@ spec:
             hosts => [ "${QS_ES_HOSTS}" ]
             user => "${QS_ES_USER}"
             password => "${QS_ES_PASSWORD}"
-            cacert => "${QS_ES_SSL_CERTIFICATE_AUTHORITY}"
+            ssl_certificate_authorities => "${QS_ES_SSL_CERTIFICATE_AUTHORITY}"
           }
         }
 ----
@@ -416,13 +416,13 @@ spec:
             hosts => [ "${PROD_ES_ES_HOSTS}" ]
             user => "${PROD_ES_ES_USER}"
             password => "${PROD_ES_ES_PASSWORD}"
-            cacert => "${PROD_ES_ES_SSL_CERTIFICATE_AUTHORITY}"
+            ssl_certificate_authorities => "${PROD_ES_ES_SSL_CERTIFICATE_AUTHORITY}"
           }
           elasticsearch {   <4>
             hosts => [ "${QA_ES_ES_HOSTS}" ]
             user => "${QA_ES_ES_USER}"
             password => "${QA_ES_ES_PASSWORD}"
-            cacert => "${QA_ES_ES_SSL_CERTIFICATE_AUTHORITY}"
+            ssl_certificate_authorities => "${QA_ES_ES_SSL_CERTIFICATE_AUTHORITY}"
           }
         }
 

--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -16,12 +16,12 @@ This section describes how to configure and deploy Logstash with ECK.
 * <<{p}-logstash-configuration,Configuration>>
 ** <<{p}-logstash-configuring-logstash,Configuring Logstash>>
 ** <<{p}-logstash-pipelines,Configuring Pipelines>>
+** <<{p}-logstash-volumes,Configuring Volumes>>
 ** <<{p}-logstash-pipelines-es,Using Elasticsearch in Logstash Pipelines>>
 ** <<{p}-logstash-expose-services,Exposing Services>>
 * <<{p}-logstash-configuration-examples,Configuration examples>>
 * <<{p}-logstash-advanced-configuration,Advanced Configuration>>
 ** <<{p}-logstash-jvm-options,Setting JVM Options>>
-** <<{p}-logstash-volume-claim-templates,Configuring Volumes>>
 ** <<{p}-logstash-scaling-logstash,Scaling Logstash>>
 * <<{p}-logstash-technical-preview-limitations,Technical Preview Limitations>>
 
@@ -291,7 +291,15 @@ added:[2.9.0]
 
 WARNING: Volume support for Logstash is a breaking change to earlier versions of ECK and requires you to recreate your Logstash objects.
 
+
+[float]
+== Specifying the volume claim settings
+
 By default, a PersistentVolume called `logstash-data` is created, that maps to `/usr/share/logstash/data` for persistent storage, typically used for storage from plugins. The `logstash-data` volume claim is, by default, a small (1Gi) volume, using the standard StorageClass of your Kubernetes cluster, but can be overridden by adding a `spec.volumeClaimTemplate` section named `logstash-data`.
+
+For production workloads, you should define your own volume claim template with the desired storage capacity and (optionally) the Kubernetes link:https://kubernetes.io/docs/concepts/storage/storage-classes/[storage class] to associate with the persistent volume. To override this volume claim for `data` usages, the name of this volume claim must be `logstash-data`.
+
+This example updates the default data template to increase the storage to `2Gi` for the logstash data folder:
 
 [source,yaml,subs="attributes,+macros,callouts"]
 ----
@@ -313,7 +321,10 @@ spec:
 ----
 
 
-Separate storage, for example for Logstash configurations using persistent queues (PQ) and/or dead letter queues (DLQ), can be added by including an additional `spec.volumeClaimTemplate` along with a corresponding `spec.podTemplate.spec.containers.volumeMount` for each requested volume, as shown in the following example:
+Separate storage, for example for Logstash configurations using persistent queues (PQ) and/or dead letter queues (DLQ), can be added by including an additional `spec.volumeClaimTemplate` along with a corresponding `spec.podTemplate.spec.containers.volumeMount` for each requested volume.
+
+The following example shows how to setup separate storage for a PQ:
+
 
 [source,yaml,subs="attributes,+macros,callouts"]
 ----
@@ -322,32 +333,155 @@ kind: Logstash
 metadata:
   name: logstash
 spec:
-  count: 1
-  version: {version}
+  # some configuration attributes omitted for brevity here
+  volumeClaimTemplates:
+    - metadata:
+        name: pq <1>
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
   podTemplate:
     spec:
       containers:
       - name: logstash
         volumeMounts:
-          - mountPath: /usr/share/logstash/pq
-            name: pq
-            readOnly: false
+        - mountPath: /usr/share/logstash/pq <2>
+          name: pq  <1>
+          readOnly: false
+  config:
+    log.level: info
+    queue.type: persisted
+    path.queue: /usr/share/logstash/pq <2>
+----
+<1> The `name` values in the `volumeMount` for the container in the podTemplate section and the name of the `volumeClaimTemplate` must match
+<2> Set the `path.queue` setting in the configuration to match the `mountPath` in the `volumeMount`.
+
+
+The following example shows how to configure Logstash with a Dead Letter Queue setup on the main pipeline, and a separate pipeline to read items from the DLQ.
+
+[source,yaml,subs="attributes,+macros,callouts"]
+----
+apiVersion: logstash.k8s.elastic.co/v1alpha1
+kind: Logstash
+metadata:
+  name: logstash
+spec:
+   # some configuration attributes omitted for brevity here
+   podTemplate:
+    spec:
+      containers:
+      - name: logstash
+        volumeMounts:
+        - mountPath: /usr/share/logstash/dlq <2>
+          name: dlq  <1>
+          readOnly: false
   volumeClaimTemplates:
     - metadata:
-        name: pq # needs to match the volume mount in the podTemplate section
+      name: dlq <1>
       spec:
         accessModes:
-          - ReadWriteOnce
+        - ReadWriteOnce
         resources:
           requests:
             storage: 10Gi
-  config: 
-    log.level: info
-    queue.type: persisted
-    path.queue: /usr/share/logstash/pq
+  pipelines:
+    - pipeline.id: beats
+      dead_letter_queue.enable: true
+      path.dead_letter_queue: /usr/share/logstash/dlq <2>
+      config.string: |
+        input {
+          beats {
+            port => 5044
+          }
+        }
+        output {
+          elasticsearch {
+            hosts => [ "${ECK_ES_HOSTS}" ]
+            user => "${ECK_ES_USER}"
+            password => "${ECK_ES_PASSWORD}"
+            ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
+          }
+        }
+    - pipeline.id: dlq_read
+      dead_letter_queue.enable: false
+      config.string: |
+        input {
+          dead_letter_queue {
+            path => "/usr/share/logstash/dlq" <2>
+            commit_offsets => true
+            pipeline_id => "beats"
+            clean_consumed => true
+          }
+        }
+        filter {
+          mutate {
+            remove_field => "[geoip][location]"
+          }
+        }
+        output {
+          elasticsearch {
+            hosts => [ "${ECK_ES_HOSTS}" ]
+            user => "${ECK_ES_USER}"
+            password => "${ECK_ES_PASSWORD}"
+            ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
+          }
+        }
+----
+<1> The `name` values in the `volumeMount` for the container in the podTemplate section and the name of the `volumeClaimTemplate` must match
+<2> Set the `path.dead_letter_queue` setting in the pipeline config to match the `mountPath` in the `volumeMount` for pipelines that are writing to the Dead Letter Queue, and set the `path` setting of the `dead_letter_queue` plugin for the pipeline that will read from the Dead Letter Queue.
+
+
+[float]
+== Updating the volume claim settings
+
+Changes are currently forbidden in `spec.volumeClaimTemplates`, such as changing the storage class or volume size. To make these changes, you have to fully delete the Logstash object, delete and recreate or resize the volume and create a new Logstash object.
+
+Before deleting or resizing a persistent queue volume, ensure that the queue is empty. When using the persistent queue, we recommend setting `queue.drain: true` on the logstash pods to ensure that the persistent queue is drained when pods are shutdown. In conjunction with this, note that you should also increase the `terminationGracePeriodSeconds` to a large enough value to drain your queue.
+
+The following is example shows how to configure a logstash resource to drain the queue and increase the termination grace period:
+
+[source,yaml,subs="attributes,+macros,callouts"]
+----
+apiVersion: logstash.k8s.elastic.co/v1alpha1
+kind: Logstash
+metadata:
+  name: logstash
+spec:
+  # some configuration attributes omitted for brevity here
+  config:
+    queue.drain: true
+  podTemplate:
+    spec:
+      terminationGracePeriodSeconds: 604800
 ----
 
-NOTE: The current implementation does not allow resizing of volumes even if your chosen storage class would support it. To resize a volume you have to fully delete the Logstash object, delete and recreate or resize the volume and create a new Logstash object. Also note that volume claims will not be deleted when you delete the Logstash object and have to be deleted manually. This behaviour might change in future versions of the ECK operator. 
+NOTE: When used in conjunction with an autoscaler, such as the Horizontal Pod Autoscaler, Kubernetes may not honor  `terminationGracePeriodSeconds` settings greater than 600. This may mean that a queue of a terminated pod may not be fully drained, even when `queue.drain: true` is set and a high `terminationGracePeriodSeconds` is configured.
+
+NOTE: In the technical preview, there is currently no way to drain a dead letter queue automatically before Logstash shuts down. To manually drain a Dead Letter Queue, first stop sending data to it, by either disabling the DLQ feature, or disabling any pipelines that send to a DLQ, and wait for events to stop flowing through any pipelines reading from the input.
+
+
+[float]
+== EmptyDir
+
+If you are not concerned about data loss, you can use an `emptyDir` volume for Logstash data.
+
+CAUTION: The use of `emptyDir` in a production environment may generate permanent data loss. Do not use with persistent queues, or dead letter queues, or when using any plugin that requires persistent storage to keep track of state between restarts of Logstash.
+
+
+[source,yaml]
+----
+spec:
+  count: 5
+  podTemplate:
+    spec:
+      volumeClaimTemplates:
+      - name: logstash-data
+        emptyDir: {}
+----
+
 
 [id="{p}-logstash-pipelines-es"]
 === Using Elasticsearch in Logstash pipelines
@@ -659,204 +793,6 @@ spec:
           value: "-Xmx2g -Xms2g"
 ----
 <1> This will change the maximum and minimum heap size of the JVM on each pod to 2GB
-
-
-[id="{p}-logstash-volume-claim-templates"]
-= Logstash Volume claim templates
-
-[float]
-== Specifying the volume claim settings
-
-By default, the operator creates a https://kubernetes.io/docs/concepts/storage/persistent-volumes/[`PersistentVolumeClaim`] with a capacity of 1Gi for each Logstash pod to store Logstash data that would normally be placed in the `data` folder. This typically includes data files used by logstash and its plugins for any persistence needs.
-
-For production workloads, you should define your own volume claim template with the desired storage capacity and (optionally) the Kubernetes link:https://kubernetes.io/docs/concepts/storage/storage-classes/[storage class] to associate with the persistent volume. To override this volume claim for `data` usages, the name of this volume claim must be `logtash-data`.
-
-
-This example updates the default data template to increase the storage to `5Gi` for the logstash data folder.
-
-[source,yaml]
-----
-spec:
-  count: 3
-  volumeClaimTemplates:
-  - metadata:
-    name: logstash-data # Do not change this name unless you set up a volume mount for the data path.
-    spec:
-      accessModes:
-        - ReadWriteOnce
-      resources:
-        requests:
-          storage: 5Gi
-            storageClassName: standard
-----
-
-Additional volume claims can be configured for data that you may want to keep outside of the `data` folder, such as persistent queues, and dead letter queues.
-
-The following example shows how to configure logstash with a separate volume for a persistent queue:
-
-[source,yaml,subs="attributes,+macros,callouts"]
-----
-apiVersion: logstash.k8s.elastic.co/v1alpha1
-kind: Logstash
-metadata:
-  name: logstash
-spec:
-  count: 1
-  version: {version}
-  volumeClaimTemplates:
-    - metadata:
-        name: pq <1>
-      spec:
-        accessModes:
-        - ReadWriteOnce
-        resources:
-          requests:
-            storage: 10Gi
-  podTemplate:
-    spec:
-      containers:
-      - name: logstash
-        volumeMounts:
-        - mountPath: /usr/share/logstash/pq <2>
-          name: pq  <1>
-          readOnly: false
-  config:
-    log.level: info
-    queue.type: persisted
-    path.queue: /usr/share/logstash/pq <2>
-----
-<1> The `name` values in the `volumeMount` for the container in the podTemplate section and the name of the `volumeClaimTemplate` must match
-<2> Set the `path.queue` setting in the configuration to match the `mountPath` in the `volumeMount`.
-
-The following example shows how to configure Logstash with a Dead Letter Queue setup on the main pipeline, and a separate pipeline to read items from the DLQ.
-
-[source,yaml,subs="attributes,+macros,callouts"]
-----
-apiVersion: logstash.k8s.elastic.co/v1alpha1
-kind: Logstash
-metadata:
-  name: logstash
-spec:
-  count: 1
-  version: {version}
-   elasticsearchRefs:
-   - clusterName: eck
-     name: elasticsearch
-  podTemplate:
-    spec:
-      containers:
-      - name: logstash
-        volumeMounts:
-        - mountPath: /usr/share/logstash/dlq <2>
-          name: dlq  <1>
-          readOnly: false
-  volumeClaimTemplates:
-    - metadata:
-      name: dlq <1>
-      spec:
-        accessModes:
-        - ReadWriteOnce
-        resources:
-          requests:
-            storage: 10Gi
-  pipelines:
-    - pipeline.id: beats
-      dead_letter_queue.enable: true
-      path.dead_letter_queue: /usr/share/logstash/dlq <2>
-      config.string: |
-        input {
-          beats {
-            port => 5044
-          }
-        }
-        output {
-          elasticsearch {
-            hosts => [ "${ECK_ES_HOSTS}" ]
-            user => "${ECK_ES_USER}"
-            password => "${ECK_ES_PASSWORD}"
-            ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
-          }
-        }
-    - pipeline.id: dlq_read
-      dead_letter_queue.enable: false
-      config.string: |
-        input {
-          dead_letter_queue {
-            path => "/usr/share/logstash/dlq" <2>
-            commit_offsets => true
-            pipeline_id => "beats"
-            clean_consumed => true
-          }
-        }
-        filter {
-          mutate {
-            remove_field => "[geoip][location]"
-          }
-        }
-        output {
-          elasticsearch {
-            hosts => [ "${ECK_ES_HOSTS}" ]
-            user => "${ECK_ES_USER}"
-            password => "${ECK_ES_PASSWORD}"
-            ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
-          }
-        }
-----
-<1> The `name` values in the `volumeMount` for the container in the podTemplate section and the name of the `volumeClaimTemplate` must match
-<2> Set the `path.dead_letter_queue` setting in the pipeline config to match the `mountPath` in the `volumeMount` for pipelines that are writing to the Dead Letter Queue, and set the `path` setting of the `dead_letter_queue` plugin for the pipeline that will read from the Dead Letter Queue.
-
-
-[float]
-== Updating the volume claim settings
-
-Changes are currently forbidden in the volumeClaimTemplates, such as changing the storage class or changing the volume size. To make these changes, you have to fully delete the Logstash object, delete and recreate or resize the volume and create a new Logstash object.
-
-Before deleting or resizing a persistent queue volume, ensure that the queue is empty. When using the persistent queue, we recommend setting `queue.drain: true` on the logstash pods to ensure that the persistent queue is drained when pods are shutdown. In conjunction with this, note that you should also increase the `terminationGracePeriodSeconds` to a large enough value to drain your queue.
-
-
-
-Example:
-
-[source,yaml,subs="attributes,+macros,callouts"]
-----
-apiVersion: logstash.k8s.elastic.co/v1alpha1
-kind: Logstash
-metadata:
-  name: logstash
-spec:
-  config:
-    queue.drain: true
-  podTemplate:
-    spec:
-      terminationGracePeriodSeconds: 604800
-----
-
-NOTE: When used in conjunction with an autoscaler, such as the Horizontal Pod Autoscaler, Kubernetes may not honor  `terminationGracePeriodSeconds` settings greater than 600. This may mean that a queue of a terminated pod may not be fully drained, even when `queue.drain: true` is set and a high `terminationGracePeriodSeconds` is configured.
-
-[NOTE]
---
-In the technical preview, there is currently no way to drain a dead letter queue automatically before Logstash shuts down. To manually drain a Dead Letter Queue, first stop sending data to it, by either disabling the DLQ feature, or disabling any pipelines that send to a DLQ, and wait for events to stop flowing through any pipelines reading from the input.
-
-[float]
-== EmptyDir
-
-If you are not concerned about data loss, you can use an `emptyDir` volume for Logstash data.
-
-CAUTION: The use of `emptyDir` in a production environment may generate permanent data loss. Do not use with persistent queues, or dead letter queues, or when using any plugin that requires persistent storage to keep track of state between restarts of Logstash.
-
-
-[source,yaml]
-----
-spec:
-  count: 5
-  podTemplate:
-    spec:
-      volumeClaimTemplates:
-      - name: logstash-data
-        emptyDir: {}
-----
-
-
 
 
 [id="{p}-logstash-scaling-logstash"]

--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -439,9 +439,9 @@ spec:
 
 Changes are currently forbidden in `spec.volumeClaimTemplates`, such as changing the storage class or volume size. To make these changes, you have to fully delete the Logstash object, delete and recreate or resize the volume and create a new Logstash object.
 
-Before deleting or resizing a persistent queue volume, ensure that the queue is empty. When using the persistent queue, we recommend setting `queue.drain: true` on the logstash pods to ensure that the persistent queue is drained when pods are shutdown. In conjunction with this, note that you should also increase the `terminationGracePeriodSeconds` to a large enough value to drain your queue.
+Before deleting or resizing a persistent queue volume, ensure that the queue is empty. When using the persistent queue, we recommend setting `queue.drain: true` on the Logstash Pods to ensure that the persistent queue is drained when Pods are shutdown. In conjunction with this, note that you should also increase the `terminationGracePeriodSeconds` to a large enough value to drain your queue.
 
-The following is example shows how to configure a logstash resource to drain the queue and increase the termination grace period:
+The following example shows how to configure a Logstash resource to drain the queue and increase the termination grace period:
 
 [source,yaml,subs="attributes,+macros,callouts"]
 ----
@@ -743,7 +743,7 @@ Deploys Logstash and Elasticsearch, and creates an updated version of the `eck_l
 kubectl apply -f {logstash_recipes}/logstash-volumes.yaml
 ----
 
-Deploys Logstash, Beats and Elasticsearch. Logstash is configured with two pipelines - a main pipeline for reading from the beats instance, which will send to the DLQ if it is unable to write to Elasticsearch, and a second pipeline, that will read from the DLQ. In addition, persistent queues are set up. This example shows how to configure persistent volumes outside of the default `logstash-data` persistent volume.
+Deploys Logstash, Beats and Elasticsearch. Logstash is configured with two pipelines - a main pipeline for reading from the Beats instance, which will send to the DLQ if it is unable to write to Elasticsearch, and a second pipeline, that will read from the DLQ. In addition, persistent queues are set up. This example shows how to configure persistent volumes outside of the default `logstash-data` persistent volume.
 
 
 [id="{p}-logstash-configuration-stack-monitoring"]
@@ -836,9 +836,9 @@ Note that this release is a technical preview. It is still under active developm
 === Experimental support for persistence
 NOTE: This is a breaking change from  version 2.8.0 of the ECK operator and requires re-creation of existing Logstash objects.
 
-The operator now includes support for persistence, with a small (`1Gi`) default `PersistentVolume` called `logstash-data` created, that maps to `/usr/share/logstash/data`, which should be typically used for storage from plugins, which can be overridden but can be overridden by adding a `spec.volumeClaimTemplate` section named `logstash-data` to add more storage, or do use a different `storageClass` from the default, for example. Additional `persistentVolumeClaims` can also be defined in `spec.volumeClaimTemplate` for use with PQ, or DLQ, for example.
+The operator now includes support for persistence, with a small (`1Gi`) default `PersistentVolume` called `logstash-data` created, that maps to `/usr/share/logstash/data`, which should be typically used for storage from plugins. The default volume can be overridden by adding a `spec.volumeClaimTemplate` section named `logstash-data` to add more storage, or to use a different `storageClass` from the default, for example. Additional `persistentVolumeClaims` can also be defined in `spec.volumeClaimTemplate` for use with PQ, or DLQ, for example.
 
- The current implementation does not allow resizing of volumes even if your chosen storage class would support it. To resize a volume you have to fully delete the Logstash object, delete and recreate or resize the volume and create a new Logstash object. Also note that volume claims will not be deleted when you delete the Logstash object and have to be deleted manually. This behaviour might change in future versions of the ECK operator.
+The current implementation does not allow resizing of volumes even if your chosen storage class would support it. To resize a volume you have to fully delete the Logstash object, delete and recreate or resize the volume and create a new Logstash object. Also note that volume claims will not be deleted when you delete the Logstash object and have to be deleted manually. This behaviour might change in future versions of the ECK operator.
 
 [id="{p}-logstash-technical-preview-elasticsearchref"]
 === `ElasticsearchRef` implementation in plugins is in preview mode


### PR DESCRIPTION
This commit adds some further details, examples and a recipe to document the use of Logstash volumes. 

This commit also updates examples using the logstash elasticsearch output to use updated SSL settings after [SSL standardization effort](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1118) 