### PR TITLE
[2.9] Fix manifest image name (#7034)

### DIFF
--- a/.buildkite/pipeline-release.yml
+++ b/.buildkite/pipeline-release.yml
@@ -8,7 +8,6 @@ steps:
           || build.tag != null
           || build.message =~ /^buildkite test .*release.*/
         commands:
-          - make generate-manifests
           - .buildkite/scripts/release/k8s-manifests.sh
         agents:
           image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:abaeba8c

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,8 @@ export ARCH         ?= $(shell uname -m | sed -e "s|x86_|amd|" -e "s|aarch|arm|"
 # for dev, suffix image name with current user name
 IMAGE_SUFFIX        ?= -$(subst _,,$(shell whoami))
 REGISTRY_NAMESPACE  ?= eck-dev
-OPERATOR_NAME       ?= eck-operator$(IMAGE_SUFFIX)
 
-export IMAGE_NAME   := $(REGISTRY)/$(REGISTRY_NAMESPACE)/$(OPERATOR_NAME)
+export IMAGE_NAME   ?= $(REGISTRY)/$(REGISTRY_NAMESPACE)/eck-operator$(IMAGE_SUFFIX)
 export IMAGE_TAG    ?= $(VERSION)-$(SHA1)
 OPERATOR_IMAGE      ?= $(IMAGE_NAME):$(IMAGE_TAG)
 
@@ -117,7 +116,7 @@ generate-manifests: controller-gen
 	# -- generate  crds manifest
 	@ ./hack/manifest-gen/manifest-gen.sh -c -g > config/crds.yaml
 	# -- generate  operator manifest
-	@ ./hack/manifest-gen/manifest-gen.sh -g \
+	./hack/manifest-gen/manifest-gen.sh -g \
 		--namespace=$(OPERATOR_NAMESPACE) \
 		--profile=global \
 		--set=installCRDs=false \


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.9`:
 - [Fix manifest image name (#7034)](https://github.com/elastic/cloud-on-k8s/pull/7034)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)