### PR TITLE
Remove experimental flag from stack config policies

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
@@ -7,8 +7,6 @@ endif::[]
 [id="{p}-{page_id}"]
 = Elastic Stack configuration policies
 
-experimental[]
-
 NOTE: This requires a valid Enterprise license or Enterprise trial license. Check <<{p}-licensing,the license documentation>> for more details about managing licenses.
 
 Starting from ECK `2.6.1` and Elasticsearch `8.6.1`, Elastic Stack configuration policies allow you to configure the following settings:


### PR DESCRIPTION
We want to remove the "tech preview" flag from the stack configuration policies in the ECK 2.9. This is the related doc change.