### PR TITLE
Add to air-gapped doc how to use a mirrored operator image (#7019)

### DIFF
--- a/docs/operating-eck/air-gapped.asciidoc
+++ b/docs/operating-eck/air-gapped.asciidoc
@@ -34,6 +34,14 @@ To make use of your mirrored images you can either set the image for each applic
 
 
 [float]
+[id="{p}-use-mirrored-operator-image"]
+== Use a mirrored image of the ECK operator
+
+To deploy the ECK operator in an air-gapped environment, you first have to mirror the operator image itself from `docker.elastic.co` to a private container registry, for example `my.registry`.
+
+Once the ECK operator image is copied internally, replace the original image name +docker.elastic.co/eck/eck-operator:{eck_version}+ with the private name of the image, for example +my.registry/eck/eck-operator:{eck_version}+, in the <<{p}-install-yaml-manifests,operator manifests>>. When using <<{p}-install-helm,Helm charts>>, replace the `image.repository` Helm value with, for example, `my.registry/eck/eck-operator`.
+
+[float]
 [id="{p}-container-registry-override"]
 == Override the default container registry
 


### PR DESCRIPTION
Backport the following commit to `2.9`:
- #7019