### PR TITLE
[2.9] Remove experimental flag from stack config policies (#7044)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
@@ -7,8 +7,6 @@ endif::[]
 [id="{p}-{page_id}"]
 = Elastic Stack configuration policies
 
-experimental[]
-
 NOTE: This requires a valid Enterprise license or Enterprise trial license. Check <<{p}-licensing,the license documentation>> for more details about managing licenses.
 
 Starting from ECK `2.6.1` and Elasticsearch `8.6.1`, Elastic Stack configuration policies allow you to configure the following settings:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.9`:
 - [Remove experimental flag from stack config policies (#7044)](https://github.com/elastic/cloud-on-k8s/pull/7044)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)