### PR TITLE
Skip TestVersionUpgradeAndRespecToLatest8x in 8.10.0-SNAPSHOT

### DIFF
--- a/test/e2e/kb/version_upgrade_test.go
+++ b/test/e2e/kb/version_upgrade_test.go
@@ -175,10 +175,10 @@ func TestVersionUpgradeToLatest8x(t *testing.T) {
 }
 
 func TestVersionUpgradeAndRespecToLatest8x(t *testing.T) {
-	// Skip for 8.9.0-SNAPSHOT because after a few seconds, ES is yellow because of unassigned
+	// Skip for 8.10.0-SNAPSHOT because after a few seconds, ES is yellow because of unassigned
 	// fleet-files-agent-000001 and fleet-file-data-agent-000001 shards.
 	// TODO: remove once https://github.com/elastic/cloud-on-k8s/issues/7013 is resolved
-	if test.Ctx().ElasticStackVersion == "8.9.0-SNAPSHOT" {
+	if test.Ctx().ElasticStackVersion == "8.10.0-SNAPSHOT" {
 		t.SkipNow()
 	}
 


### PR DESCRIPTION
This is #7020 with the right version 🤦‍♂️.

Relates to https://github.com/elastic/cloud-on-k8s/issues/7013.