### PR TITLE
Switch docs to 2.9 post-release

### DIFF
--- a/docs/eck-attributes.asciidoc
+++ b/docs/eck-attributes.asciidoc
@@ -1,5 +1,5 @@
-:eck_version: 2.8.0
+:eck_version: 2.9.0
 :eck_crd_version: v1
-:eck_release_branch: 2.8
+:eck_release_branch: 2.9
 :eck_github: https://github.com/elastic/cloud-on-k8s
 :eck_resources_list: Elasticsearch, Kibana, APM Server, Enterprise Search, Beats, Elastic Agent, Elastic Maps Server, and Logstash


### PR DESCRIPTION
Switch ECK docs to 2.9 and 2.9 branch post-release.