### PR TITLE
Make red-hat job not dependent on tag version of build

### DIFF
--- a/.buildkite/pipeline-release-redhat.yml
+++ b/.buildkite/pipeline-release-redhat.yml
@@ -30,7 +30,7 @@ steps:
       - "build-operatorhub-tool"
       - "redhat-container-push"
     commands:
-      - .buildkite/scripts/release/redhat-preflight.sh $$BUILDKITE_TAG
+      - .buildkite/scripts/release/redhat-preflight.sh
     agents:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:abaeba8c
       memory: "2G"

--- a/.buildkite/scripts/release/redhat-preflight.sh
+++ b/.buildkite/scripts/release/redhat-preflight.sh
@@ -9,6 +9,8 @@
 
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "$0")"; pwd)/../../.."
+
 VAULT_ROOT_PATH=${VAULT_ROOT_PATH:-secret/ci/elastic-cloud-on-k8s}
 
 tmpDir=$(mktemp -d)
@@ -20,7 +22,8 @@ container_already_verified() {
 }
 
 main() {
-    local tag="${1#v}"
+    local tag
+    tag=$(cat "$ROOT"/VERSION)
 
     API_KEY=$(vault read -field=api-key "$VAULT_ROOT_PATH/operatorhub-release-redhat")
     export API_KEY

--- a/.buildkite/scripts/release/redhat-preflight.sh
+++ b/.buildkite/scripts/release/redhat-preflight.sh
@@ -13,22 +13,20 @@ ROOT="$(cd "$(dirname "$0")"; pwd)/../../.."
 
 VAULT_ROOT_PATH=${VAULT_ROOT_PATH:-secret/ci/elastic-cloud-on-k8s}
 
+API_KEY=$(vault read -field=api-key "$VAULT_ROOT_PATH/operatorhub-release-redhat")
+PROJECT_ID=$(vault read -field=project-id "$VAULT_ROOT_PATH/operatorhub-release-redhat")
+ECK_VERSION=$(cat "$ROOT"/VERSION)
+
+
 tmpDir=$(mktemp -d)
 trap 'rm -rf "$tmpDir"' 0
 
 container_already_verified() {
-    curl -H "X-API-KEY: $API_KEY" -s "https://catalog.redhat.com/api/containers/v1/projects/certification/id/$PROJECT_ID/images?filter=repositories.tags.name==$tag" | \
+    curl -H "X-API-KEY: $API_KEY" -s "https://catalog.redhat.com/api/containers/v1/projects/certification/id/$PROJECT_ID/images?filter=repositories.tags.name==$ECK_VERSION" | \
         jq --exit-status '.data[0]' >/dev/null
 }
 
 main() {
-    local tag
-    tag=$(cat "$ROOT"/VERSION)
-
-    API_KEY=$(vault read -field=api-key "$VAULT_ROOT_PATH/operatorhub-release-redhat")
-    export API_KEY
-    PROJECT_ID=$(vault read -field=project-id "$VAULT_ROOT_PATH/operatorhub-release-redhat")
-    export PROJECT_ID
 
     if container_already_verified; then
         echo "Preflight has already been submitted ✅"
@@ -37,7 +35,7 @@ main() {
 
     vault read -format=json -field=data "$VAULT_ROOT_PATH/operatorhub-release-preflight" > "$tmpDir/auth.json"
     
-    preflight check container "quay.io/redhat-isv-containers/$PROJECT_ID:$tag" --pyxis-api-token="$API_KEY" --certification-project-id="$PROJECT_ID" --submit -d "$tmpDir/auth.json"
+    preflight check container "quay.io/redhat-isv-containers/$PROJECT_ID:$ECK_VERSION" --pyxis-api-token="$API_KEY" --certification-project-id="$PROJECT_ID" --submit -d "$tmpDir/auth.json"
     
     echo "Preflight submitted ✅"
 }

--- a/hack/operatorhub/trigger-rh-release.sh
+++ b/hack/operatorhub/trigger-rh-release.sh
@@ -25,7 +25,6 @@ curl "https://api.buildkite.com/v2/organizations/elastic/pipelines/cloud-on-k8s-
     "branch": "'"$branch"'",
     "message": "release ECK '"$ECK_VERSION"' for OperatoHub/RedHat",
     "env": {
-        "BUILDKITE_TAG": "'"$ECK_VERSION"'",
         "OHUB_DRY_RUN": "'"$DRY_RUN"'",
         "OHUB_DISABLE_PREFLIGHT": "'"$DRY_RUN"'",
         "OHUB_GITHUB_VAULT_SECRET": "secret/ci/elastic-cloud-on-k8s/operatorhub-release-github-'"$GH_USERNAME"'"


### PR DESCRIPTION
Take the version of the release branch `VERSION` instead of the `BUILDKITE_TAG` variable to allow releasing the OLM bits with fixes that came after the release version was tagged.