### PR TITLE
[2.9] Make red-hat job not dependent on tag version of build (#7060)

### DIFF
--- a/.buildkite/pipeline-release-redhat.yml
+++ b/.buildkite/pipeline-release-redhat.yml
@@ -30,7 +30,7 @@ steps:
       - "build-operatorhub-tool"
       - "redhat-container-push"
     commands:
-      - .buildkite/scripts/release/redhat-preflight.sh $$BUILDKITE_TAG
+      - .buildkite/scripts/release/redhat-preflight.sh
     agents:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:abaeba8c
       memory: "2G"

--- a/hack/operatorhub/trigger-rh-release.sh
+++ b/hack/operatorhub/trigger-rh-release.sh
@@ -25,7 +25,6 @@ curl "https://api.buildkite.com/v2/organizations/elastic/pipelines/cloud-on-k8s-
     "branch": "'"$branch"'",
     "message": "release ECK '"$ECK_VERSION"' for OperatoHub/RedHat",
     "env": {
-        "BUILDKITE_TAG": "'"$ECK_VERSION"'",
         "OHUB_DRY_RUN": "'"$DRY_RUN"'",
         "OHUB_DISABLE_PREFLIGHT": "'"$DRY_RUN"'",
         "OHUB_GITHUB_VAULT_SECRET": "secret/ci/elastic-cloud-on-k8s/operatorhub-release-github-'"$GH_USERNAME"'"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.9`:
 - [Make red-hat job not dependent on tag version of build (#7060)](https://github.com/elastic/cloud-on-k8s/pull/7060)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)