### PR TITLE
Update docs concerning intermediate CAs

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/accessing-elastic-services.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/accessing-elastic-services.asciidoc
@@ -148,13 +148,13 @@ spec:
 
 You can bring your own certificate to configure TLS to ensure that communication between HTTP clients and the Elastic Stack application is encrypted.
 
-WARNING: If your `tls.crt` is signed by an intermediate CA you may need both the Root CA and the intermediate CA combined within the `ca.crt` file depending on whether the Root CA is globally trusted.
-
 Create a Kubernetes secret with:
 
 - `ca.crt`: CA certificate (optional if `tls.crt` was issued by a well-known CA).
 - `tls.crt`: The certificate.
 - `tls.key`: The private key to the first certificate in the certificate chain.
+
+WARNING: If your `tls.crt` is signed by an intermediate CA you may need both the Root CA and the intermediate CA combined within the `ca.crt` file depending on whether the Root CA is globally trusted.
 
 [source,sh]
 ----

--- a/docs/orchestrating-elastic-stack-applications/accessing-elastic-services.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/accessing-elastic-services.asciidoc
@@ -148,6 +148,8 @@ spec:
 
 You can bring your own certificate to configure TLS to ensure that communication between HTTP clients and the Elastic Stack application is encrypted.
 
+WARNING: If your `tls.crt` is signed by an intermediate CA you will need both the Root CA, and the intermediate CA combined within the `ca.crt` file.
+
 Create a Kubernetes secret with:
 
 - `ca.crt`: CA certificate (optional if `tls.crt` was issued by a well-known CA).

--- a/docs/orchestrating-elastic-stack-applications/accessing-elastic-services.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/accessing-elastic-services.asciidoc
@@ -148,7 +148,7 @@ spec:
 
 You can bring your own certificate to configure TLS to ensure that communication between HTTP clients and the Elastic Stack application is encrypted.
 
-WARNING: If your `tls.crt` is signed by an intermediate CA you will need both the Root CA, and the intermediate CA combined within the `ca.crt` file.
+WARNING: If your `tls.crt` is signed by an intermediate CA you may need both the Root CA and the intermediate CA combined within the `ca.crt` file depending on whether the Root CA is globally trusted.
 
 Create a Kubernetes secret with:
 


### PR DESCRIPTION
Update "setup your own certificate" documentation to add a warning about using intermediate CAs.
