### PR TITLE
Fix sed command to use FIPS compatible operator image in FIPS doc

### DIFF
--- a/docs/advanced-topics/fips.asciidoc
+++ b/docs/advanced-topics/fips.asciidoc
@@ -35,7 +35,7 @@ NOTE: `${ECK_VERSION}` in the following command needs to be replaced with the ve
 
 [source,sh]
 ----
-curl -s https://download.elastic.co/downloads/eck/${ECK_VERSION}/operator.yaml | sed -r 's#(image:.*eck-operator.*)"#\1-fips"#' | kubectl apply -f -
+curl -s https://download.elastic.co/downloads/eck/${ECK_VERSION}/operator.yaml | sed -r 's#(image:.*eck-operator)(:.*)#\1-fips\2#' | kubectl apply -f -
 ----
 
 If the Operator has already been installed using the manifests, the installation can be patched instead:


### PR DESCRIPTION
This corrects the `sed` command used to change the container image name to use the FIPS-enabled version in the k8s manifests to deploy the operator.

Reported in https://github.com/elastic/cloud-on-k8s/commit/3043fbf211a323c0aec6ba70f2309f8ba8bd86e2 by @emrcbrn.

Previous command was renaming the image to:
```
curl -s https://download.elastic.co/downloads/eck/2.6.1/operator.yaml | sed -r 's#(image:.*eck-operator.*)"#\1-fips"#' | grep fips
image: "docker.elastic.co/eck/eck-operator:2.6.1-fips"
```
Which isn't found:

```
docker pull docker.elastic.co/eck/eck-operator:2.6.1-fips
Error response from daemon: manifest for docker.elastic.co/eck/eck-operator:2.6.1-fips not found: manifest unknown: manifest unknown
```

The new `sed` command renames it correctly:
```
curl -s https://download.elastic.co/downloads/eck/2.6.1/operator.yaml | sed -r 's#(image:.*eck-operator)(:.*)#\1-fips\2#' | grep fips
image: "docker.elastic.co/eck/eck-operator-fips:2.6.1"
```
Which pulls correctly:

```
docker pull docker.elastic.co/eck/eck-operator-fips:2.6.1
2.6.1: Pulling from eck/eck-operator-fips
fc251a6e7981: Pull complete 
029c2b2b0b4e: Pull complete 
67be15e29e15: Pull complete 
cf5b1a76c1a2: Pull complete 
Digest: sha256:49ba2ed24db1bbb4806709226ec23262bf6adc8db63d6f87751869a4839efc1d
Status: Downloaded newer image for docker.elastic.co/eck/eck-operator-fips:2.6.1
docker.elastic.co/eck/eck-operator-fips:2.6.1
```
