### PR TITLE
[ADD] Enhancement: Set Default License Annotation for Elasticsearch in Helm Chart

### DIFF
--- a/deploy/eck-stack/charts/eck-agent/templates/elastic-agent.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/elastic-agent.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     {{- include "elasticagent.labels" $ | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: enterprise
-    {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    eck.k8s.elastic.co/license: {{ default "enterprise" .Values.annotations.eckLicense }}
+    {{- if .Values.annotations }}
+    {{- toYaml .Values.annotations | indent 4 }}
     {{- end }}
 spec:
   version: {{ required "An Elastic Agent version is required" .Values.version }}

--- a/deploy/eck-stack/charts/eck-agent/templates/elastic-agent.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/elastic-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "elasticagent.labels" $ | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: {{ default "enterprise" .Values.annotations.eckLicense }}
+    eck.k8s.elastic.co/license: {{ default "enterprise" .Values.annotations.licenseType }}
     {{- if .Values.annotations }}
     {{- toYaml .Values.annotations | indent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-agent/values.yaml
+++ b/deploy/eck-stack/charts/eck-agent/values.yaml
@@ -27,7 +27,7 @@ labels: {}
 # Annotations that will be applied to Elastic Agent.
 #
 annotations: {}
-  #eckLicense: "basic"
+  #licenseType: "basic"
   
 spec:
   # policyID determines into which Agent Policy this Agent will be enrolled.

--- a/deploy/eck-stack/charts/eck-agent/values.yaml
+++ b/deploy/eck-stack/charts/eck-agent/values.yaml
@@ -27,7 +27,8 @@ labels: {}
 # Annotations that will be applied to Elastic Agent.
 #
 annotations: {}
-
+  #eckLicense: "basic"
+  
 spec:
   # policyID determines into which Agent Policy this Agent will be enrolled.
   # policyID: eck-agent

--- a/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "beat.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: {{ default "enterprise" .Values.annotations.eckLicense }}
+    eck.k8s.elastic.co/license: {{ default "enterprise" .Values.annotations.licenseType }}
     {{- if .Values.annotations }}
     {{- toYaml .Values.annotations | indent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     {{- include "beat.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: enterprise
-    {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    eck.k8s.elastic.co/license: {{ default "enterprise" .Values.annotations.eckLicense }}
+    {{- if .Values.annotations }}
+    {{- toYaml .Values.annotations | indent 4 }}
     {{- end }}
 spec:
   version: {{ required "A Beat version is required" .Values.version }}

--- a/deploy/eck-stack/charts/eck-beats/values.yaml
+++ b/deploy/eck-stack/charts/eck-beats/values.yaml
@@ -27,7 +27,7 @@ labels: {}
 # Annotations that will be applied to Elastic Beats.
 #
 annotations: {}
-  #eckLicense: "basic"
+  #licenseType: "basic"
 
 spec:
   # Type of Elastic Beats. Standard types of Beat are [filebeat,metricbeat,heartbeat,auditbeat,packetbeat,journalbeat].

--- a/deploy/eck-stack/charts/eck-beats/values.yaml
+++ b/deploy/eck-stack/charts/eck-beats/values.yaml
@@ -27,6 +27,7 @@ labels: {}
 # Annotations that will be applied to Elastic Beats.
 #
 annotations: {}
+  #eckLicense: "basic"
 
 spec:
   # Type of Elastic Beats. Standard types of Beat are [filebeat,metricbeat,heartbeat,auditbeat,packetbeat,journalbeat].

--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/elasticsearch.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/elasticsearch.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "elasticsearch.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: {{ default "enterprise" .Values.annotations.eckLicense }}
+    eck.k8s.elastic.co/license: {{ default "enterprise" .Values.annotations.licenseType }}
     {{- if .Values.annotations }}
     {{- toYaml .Values.annotations | indent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/elasticsearch.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/elasticsearch.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     {{- include "elasticsearch.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: enterprise
-    {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    eck.k8s.elastic.co/license: {{ default "enterprise" .Values.annotations.eckLicense }}
+    {{- if .Values.annotations }}
+    {{- toYaml .Values.annotations | indent 4 }}
     {{- end }}
 spec:
   {{- with .Values.auth }}

--- a/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
@@ -31,7 +31,7 @@ labels: {}
 # Annotations that will be applied to Elasticsearch.
 #
 annotations: {}
-  #eckLicense: "basic"
+  #licenseType: "basic"
 
 # Settings for configuring Elasticsearch users and roles.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-users-and-roles.html

--- a/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
@@ -31,6 +31,7 @@ labels: {}
 # Annotations that will be applied to Elasticsearch.
 #
 annotations: {}
+  #eckLicense: "basic"
 
 # Settings for configuring Elasticsearch users and roles.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-users-and-roles.html

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "fleet-server.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: {{ default "enterprise" .Values.annotations.eckLicense }}
+    eck.k8s.elastic.co/license: {{ default "enterprise" .Values.annotations.licenseType }}
     {{- if .Values.annotations }}
     {{- toYaml .Values.annotations | indent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     {{- include "fleet-server.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: enterprise
-    {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    eck.k8s.elastic.co/license: {{ default "enterprise" .Values.annotations.eckLicense }}
+    {{- if .Values.annotations }}
+    {{- toYaml .Values.annotations | indent 4 }}
     {{- end }}
 spec:
   version: {{ required "A Fleet Server version is required" .Values.version }}

--- a/deploy/eck-stack/charts/eck-fleet-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/values.yaml
@@ -27,6 +27,7 @@ labels: {}
 # Annotations that will be applied to Elastic Fleet Server.
 #
 annotations: {}
+  #eckLicense: "basic"
 
 spec:
   # policyID determines into which Agent Policy this Fleet Server will be enrolled.

--- a/deploy/eck-stack/charts/eck-fleet-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/values.yaml
@@ -27,7 +27,7 @@ labels: {}
 # Annotations that will be applied to Elastic Fleet Server.
 #
 annotations: {}
-  #eckLicense: "basic"
+  #licenseType: "basic"
 
 spec:
   # policyID determines into which Agent Policy this Fleet Server will be enrolled.

--- a/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     {{- include "kibana.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: enterprise
-    {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    eck.k8s.elastic.co/license: {{ default "enterprise" .Values.annotations.eckLicense }}
+    {{- if .Values.annotations }}
+    {{- toYaml .Values.annotations | indent 4 }}
     {{- end }}
 spec:
   version: {{ required "A Kibana version is required" .Values.version }}

--- a/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "kibana.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: {{ default "enterprise" .Values.annotations.eckLicense }}
+    eck.k8s.elastic.co/license: {{ default "enterprise" .Values.annotations.licenseType }}
     {{- if .Values.annotations }}
     {{- toYaml .Values.annotations | indent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-kibana/values.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/values.yaml
@@ -27,7 +27,7 @@ labels: {}
 # Annotations that will be applied to Kibana.
 #
 annotations: {}
-  #eckLicense: "basic"
+  #licenseType: "basic"
 
 spec:
   # Count of Kibana replicas to create.

--- a/deploy/eck-stack/charts/eck-kibana/values.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/values.yaml
@@ -27,6 +27,7 @@ labels: {}
 # Annotations that will be applied to Kibana.
 #
 annotations: {}
+  #eckLicense: "basic"
 
 spec:
   # Count of Kibana replicas to create.


### PR DESCRIPTION

## Proposed Fix: Set Default License Annotation for Elasticsearch in Helm Chart

### Description

This pull request aims to improve the default behaviour of the Elasticsearch deployment in our Helm chart by setting a default value for the `eck.k8s.elastic.co/license` annotation. This enhancement allows users to specify a default license type for Elasticsearch deployments while still maintaining the flexibility to override it using a values file during installation.

### Changes Made

- Modified the `templates` Helm template to set a default value for the `eck.k8s.elastic.co/license` annotation.
- Utilized the `default` function to check for an override value in the values file. If no override is provided, the default value "enterprise" is used.
- Updated the documentation to reflect this enhancement and how to use the values file to customize the license annotation.

### Proposed Usage

Users can now customize the license annotation using the `values.yaml` or another values file during Helm installation. For example:

Template update:
```yaml
  annotations:
    eck.k8s.elastic.co/license: {{ default "enterprise" .Values.annotations.eckLicense }}
    {{- if .Values.annotations }}
    {{- toYaml .Values.annotations | indent 4 }}
    {{- end }}
```

Usage:
```yaml
annotations:
  eckLicense: "basic"
```


- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- yes
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)?
- yes
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed.
