### PR TITLE
Replaced node.attr.data in the documentation

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
@@ -279,7 +279,7 @@ spec:
   - name: hot
     count: 3
     config:
-      node.attr.data: hot
+      node.roles: ["data_hot, "ingest", "master"]
     podTemplate:
       spec:
         containers:
@@ -311,7 +311,7 @@ spec:
   - name: warm
     count: 3
     config:
-      node.attr.data: warm
+      node.roles: ["data_warm"]
     podTemplate:
       spec:
         containers:


### PR DESCRIPTION
Replaced the old node.attr.data to the new node.roles in the [node role example](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html#k8s-hot-warm-topologies)
closes #6196