### PR TITLE
Replaced node.attr.data in the documentation (#7104)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
@@ -279,7 +279,7 @@ spec:
   - name: hot
     count: 3
     config:
-      node.attr.data: hot
+      node.roles: ["data_hot, "ingest", "master"]
     podTemplate:
       spec:
         containers:
@@ -311,7 +311,7 @@ spec:
   - name: warm
     count: 3
     config:
-      node.attr.data: warm
+      node.roles: ["data_warm"]
     podTemplate:
       spec:
         containers:

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
@@ -279,7 +279,7 @@ spec:
   - name: hot
     count: 3
     config:
-      node.roles: ["data_hot, "ingest", "master"]
+      node.roles: ["data_hot", "ingest", "master"]
     podTemplate:
       spec:
         containers:


### PR DESCRIPTION
Backport of [Replaced node.attr.data in the documentation #7104](https://github.com/elastic/cloud-on-k8s/pull/7104) into `2.9`