### PR TITLE
Set logstash api version to alpha1

### DIFF
--- a/docs/advanced-topics/stack-monitoring.asciidoc
+++ b/docs/advanced-topics/stack-monitoring.asciidoc
@@ -75,7 +75,7 @@ spec:
       - name: monitoring
         namespace: observability <1>
 ---
-apiVersion: logstash.k8s.elastic.co/v1beta1
+apiVersion: logstash.k8s.elastic.co/v1alpha1
 kind: Logstash
 metadata:
     name: monitored-sample


### PR DESCRIPTION
Error when using example due to incorrect (unknown) API version.
