### PR TITLE
doc: update SAML callback URL which is not deprecated

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/security/saml-authentication.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/saml-authentication.asciidoc
@@ -46,7 +46,7 @@ spec:
             idp.entity_id: https://sso.example.com/
             idp.metadata.path: /usr/share/elasticsearch/config/saml/idp-saml-metadata.xml
             order: 2
-            sp.acs: https://kibana.example.com/api/security/v1/saml
+            sp.acs: https://kibana.example.com/api/security/callback/saml
             sp.entity_id: https://kibana.example.com/
             sp.logout: https://kibana.example.com/logout
 ----


### PR DESCRIPTION
In https://github.com/elastic/kibana/blob/b33effa182bcb7c9620c5435ab252d8067732655/x-pack/plugins/security/server/routes/authentication/saml.ts#L27

`/api/security/saml/callback` is the correct URL,
while `/api/security/v1/saml` is the deprecated URL.

Fixes: #7118

Signed-off-by: Craig Rodrigues <rodrigc@crodrigues.org>