### PR TITLE
Fix autopilot e2e test

### DIFF
--- a/config/recipes/autopilot/elasticsearch.yaml
+++ b/config/recipes/autopilot/elasticsearch.yaml
@@ -4,15 +4,16 @@ kind: DaemonSet
 metadata:
   name: max-map-count-setter
   labels:
-    k8s-app: max-map-count-setter
+    app.kubernetes.io/name: max-map-count-setter
 spec:
   selector:
     matchLabels:
-      name: max-map-count-setter
+      app.kubernetes.io/instance: max-map-count-setter
   template:
     metadata:
       labels:
-        name: max-map-count-setter
+        app.kubernetes.io/instance: max-map-count-setter
+        app.kubernetes.io/name: max-map-count-setter
     spec:
       nodeSelector:
         cloud.google.com/compute-class: "Balanced"

--- a/config/recipes/autopilot/fleet-kubernetes-integration.yaml
+++ b/config/recipes/autopilot/fleet-kubernetes-integration.yaml
@@ -4,15 +4,16 @@ kind: DaemonSet
 metadata:
   name: max-map-count-setter
   labels:
-    k8s-app: max-map-count-setter
+    app.kubernetes.io/name: max-map-count-setter
 spec:
   selector:
     matchLabels:
-      name: max-map-count-setter
+      app.kubernetes.io/instance: max-map-count-setter
   template:
     metadata:
       labels:
-        name: max-map-count-setter
+        app.kubernetes.io/name: max-map-count-setter
+        app.kubernetes.io/instance: max-map-count-setter
     spec:
       nodeSelector:
         cloud.google.com/compute-class: "Balanced"

--- a/hack/deployer/runner/kyverno/install/policies.yaml
+++ b/hack/deployer/runner/kyverno/install/policies.yaml
@@ -32,7 +32,7 @@ spec:
               selector:
                 matchExpressions:
                   - {key: common.k8s.elastic.co/type, operator: NotIn, values: [beat, agent]}
-                  - {key: name, operator: NotIn, values: [max-map-count-setter]}
+                  - {key: app.kubernetes.io/name, operator: NotIn, values: [max-map-count-setter]}
       validate:
         message: >-
           Privileged mode is disallowed. The fields spec.containers[*].securityContext.privileged
@@ -87,7 +87,7 @@ spec:
             selector:
               matchExpressions:
                 - {key: common.k8s.elastic.co/type, operator: NotIn, values: [beat, agent]}
-                - {key: name, operator: NotIn, values: [max-map-count-setter]}
+                - {key: app.kubernetes.io/name, operator: NotIn, values: [max-map-count-setter]}
       validate:
         message: >-
           Running as root is not allowed. The fields spec.securityContext.runAsUser,
@@ -196,7 +196,7 @@ spec:
               selector:
                 matchExpressions:
                   - {key: common.k8s.elastic.co/type, operator: NotIn, values: [beat, agent]}
-                  - {key: name, operator: NotIn, values: [max-map-count-setter]}
+                  - {key: app.kubernetes.io/name, operator: NotIn, values: [max-map-count-setter]}
       validate:
         message: "Auto-mounting of Service Account tokens is not allowed."
         pattern:

--- a/test/e2e/test/helper/yaml.go
+++ b/test/e2e/test/helper/yaml.go
@@ -356,8 +356,8 @@ func transformToE2E(namespace, fullTestName, suffix string, transformers []Build
 			name := decodedObj.Name + "-" + suffix
 			decodedObj.Namespace = namespace
 			decodedObj.Name = name
-			decodedObj.Spec.Selector.MatchLabels["name"] = name
-			decodedObj.Spec.Template.ObjectMeta.Labels["name"] = name
+			decodedObj.Spec.Selector.MatchLabels["app.kubernetes.io/instance"] = name
+			decodedObj.Spec.Template.ObjectMeta.Labels["app.kubernetes.io/instance"] = name
 			maybeMutateForAgentNonRootTests(decodedObj, namespace, suffix)
 		}
 


### PR DESCRIPTION
Use standard k8s labels. 
Add a name label that is not suffixed by a random string during e2e testing. 

Fixes failing autopilot e2e tests that fail to deploy the DaemonSet due to the kyverno policies that were targeting a fixed label while the DaemonSet was using randomised labels.

Alternative implementation: 
* do not use the random suffix on the DaemonSet to begin with (I am open to that as well)