### PR TITLE
Add missing " in the documentation page

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
@@ -279,7 +279,7 @@ spec:
   - name: hot
     count: 3
     config:
-      node.roles: ["data_hot, "ingest", "master"]
+      node.roles: ["data_hot", "ingest", "master"]
     podTemplate:
       spec:
         containers:


### PR DESCRIPTION
I've missed a typo in my change in the documentation. I was missing a closing quote in the node.roles. 
