### PR TITLE
Quotes query arg containing parenthesis

### DIFF
--- a/hack/deployer/runner/tanzu.go
+++ b/hack/deployer/runner/tanzu.go
@@ -457,7 +457,7 @@ func (t *TanzuDriver) Cleanup(prefix string, olderThan time.Duration) error {
 
 	resourceGroups, err := azure.Cmd("group", "list",
 		"--query", fmt.Sprintf("[?location=='%s']", t.plan.Tanzu.Location),
-		"--query", fmt.Sprintf("[?contains(name,'%s-tanzu')]", prefix),
+		"--query", fmt.Sprintf(`"[?contains(name,'%s-tanzu')]"`, prefix),
 		"| jq -r '.[].name'").OutputList()
 	if err != nil {
 		return err


### PR DESCRIPTION
This adds quotes to the query argument containing parenthesis used in the command `az group list` to cleanup tanzu clusters.

Resolves #7137.