### PR TITLE
Fix az command to list tanzu clusters to cleanup

### DIFF
--- a/hack/deployer/runner/aks.go
+++ b/hack/deployer/runner/aks.go
@@ -204,7 +204,7 @@ func (d *AKSDriver) Cleanup(prefix string, olderThan time.Duration) error {
 		"-l", d.plan.Aks.Location,
 		"-g", d.plan.Aks.ResourceGroup,
 		`--resource-type "Microsoft.ContainerService/managedClusters"`,
-		`--query "[?tags.project == 'eck-ci']"`,
+		"--query", fmt.Sprintf(`"[?tags.project == '%s']"`, ProjectTag),
 		`| jq -r --arg d`, sinceDate.Format(time.RFC3339),
 		fmt.Sprintf(`'map(select((.createdTime | . <= $d) and (.name|test("%s"))))|.[].name'`, prefix)).OutputList()
 	if err != nil {

--- a/hack/deployer/runner/client.go
+++ b/hack/deployer/runner/client.go
@@ -22,7 +22,7 @@ import (
 const (
 	dockerRegistry          = "docker.elastic.co"
 	dockerRegistryVaultPath = "docker-registry-elastic"
-	clientBaseImageName     = dockerRegistry + "/eck-ci/deployer"
+	clientBaseImageName     = dockerRegistry + "/" + ProjectTag + "/deployer"
 )
 
 func ensureClientImage(driverID string, vaultClient vault.Client, clientVersion string, clientBuildDefDir string) (string, error) {

--- a/hack/deployer/runner/tags.go
+++ b/hack/deployer/runner/tags.go
@@ -8,13 +8,15 @@ import (
 	"fmt"
 )
 
+const ProjectTag = "eck-ci"
+
 var (
 	// elasticTags are tags to apply the Elastic Cloud resources tagging policy
 	elasticTags = map[string]string{
 		"division": "engineering",
 		"org":      "controlplane",
 		"team":     "cloud-k8s-operator",
-		"project":  "eck-ci",
+		"project":  ProjectTag,
 	}
 )
 

--- a/hack/deployer/runner/tanzu.go
+++ b/hack/deployer/runner/tanzu.go
@@ -470,7 +470,7 @@ func (t *TanzuDriver) Cleanup(prefix string, olderThan time.Duration) error {
 			"-l", t.plan.Tanzu.Location,
 			"-g", rg,
 			`--resource-type "Microsoft.Compute/virtualMachines"`,
-			"--query", "[?tags.project == 'eck-ci']",
+			"--query", fmt.Sprintf(`"[?tags.project == '%s']"`, ProjectTag),
 			"| jq -r --arg d", sinceDate.Format(time.RFC3339),
 			fmt.Sprintf(`'map(select((.createdTime | . <= $d) and (.name|test("%s-tanzu"))))|.[].name'`, prefix),
 			fmt.Sprintf("| grep -o '%s-tanzu-[a-z]*-[0-9]*' | sort | uniq", prefix)).OutputList()


### PR DESCRIPTION
Similar to #7138 but this time because the query argument contains a dot.
By the way, I moved the project tag in a constant.

This time I verified that there is no other command to fix. Previous time I bypassed the deletion too early to check the fix.

Resolves #7137.