### PR TITLE
Update eck-diagnostics in e2e image

### DIFF
--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -5,7 +5,7 @@ ARG GO_TAGS
 
 WORKDIR /go/src/github.com/elastic/cloud-on-k8s
 
-ENV ECK_DIAG_VERSION=1.4.0
+ENV ECK_DIAG_VERSION=1.5.2
 RUN curl -fsSLO https://github.com/elastic/eck-diagnostics/releases/download/${ECK_DIAG_VERSION}/eck-diagnostics_${ECK_DIAG_VERSION}_Linux_x86_64.tar.gz && \
     tar xzf eck-diagnostics_${ECK_DIAG_VERSION}_Linux_x86_64.tar.gz && \
     mv eck-diagnostics /usr/local/bin/eck-diagnostics


### PR DESCRIPTION
In #7134 I did not realise that we haven another Docker image for the tests that run on a VM and use Docker itself like kind. 