### PR TITLE
Always build helm release tool

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,6 +23,7 @@ steps:
       - label: ":go: checks"
         commands:
           - "make check-license-header check-predicates shellcheck reattach-pv"
+          - "make -C hack/helm/release build"
         agents:
           image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:bfddf2b3
           cpu: "4"


### PR DESCRIPTION
Resolves https://github.com/elastic/cloud-on-k8s/issues/7141#issuecomment-1702465680.

I plugged into the existing `checks` step to not use a new bk agent just for that.