### PR TITLE
[2.9] Kubernetes 1.28 added to supported versions in docs (#7147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Current features:
 
 Supported versions:
 
-*  Kubernetes 1.24-1.27
+*  Kubernetes 1.24-1.28
 *  OpenShift 4.9-4.13
 *  Elasticsearch, Kibana, APM Server: 6.8+, 7.1+, 8+
 *  Enterprise Search: 7.7+, 8+

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -1,4 +1,4 @@
-* Kubernetes 1.24-1.27
+* Kubernetes 1.24-1.28
 * OpenShift 4.9-4.13
 * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 * Helm: 3.2.0+

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -276,7 +276,7 @@ spec:
     Supported versions:
 
 
-    * Kubernetes 1.24-1.27
+    * Kubernetes 1.24-1.28
 
     * OpenShift 4.9-4.13
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.9`:
 - [Kubernetes 1.28 added to supported versions in docs (#7147)](https://github.com/elastic/cloud-on-k8s/pull/7147)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)