### PR TITLE
Telemetry test cases support 8.10 and later Kibana versions

### DIFF
--- a/test/e2e/beat/setup_test.go
+++ b/test/e2e/beat/setup_test.go
@@ -9,6 +9,7 @@ package beat
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"testing"
 
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
@@ -124,7 +125,7 @@ func getDashboardCheck(esBuilder elasticsearch.Builder, kbBuilder kibana.Builder
 						// name of the beat. This test will obviously break if future versions of Beats abandon this naming convention.
 						query := fmt.Sprintf("/api/saved_objects/_find?type=dashboard&search_fields=title&search=%s", beat)
 						body, err := kibana.DoRequest(client, kbBuilder.Kibana, password,
-							"GET", query, nil,
+							"GET", query, nil, http.Header{},
 						)
 						if err != nil {
 							return err

--- a/test/e2e/test/apmserver/checks_apm.go
+++ b/test/e2e/test/apmserver/checks_apm.go
@@ -388,7 +388,7 @@ func (c *apmClusterChecks) CheckAgentConfiguration(apm apmv1.ApmServer, k *test.
 				if !apmVersion.GTE(version.MustParse("7.7.0")) {
 					uri += "/new"
 				}
-				_, err = kibana.DoRequest(k, kb, password, "PUT", uri, []byte(sampleDefaultAgentConfiguration))
+				_, err = kibana.DoRequest(k, kb, password, "PUT", uri, []byte(sampleDefaultAgentConfiguration), http.Header{})
 				return err
 			}),
 		},

--- a/test/e2e/test/kibana/checks_kb.go
+++ b/test/e2e/test/kibana/checks_kb.go
@@ -7,6 +7,7 @@ package kibana
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/pkg/errors"
 
@@ -54,7 +55,7 @@ func (check *kbChecks) CheckKbStatusHealthy(b Builder) test.Step {
 			if err != nil {
 				return errors.Wrap(err, "while getting elastic password")
 			}
-			body, err := DoRequest(check.client, b.Kibana, password, "GET", "/api/status", nil)
+			body, err := DoRequest(check.client, b.Kibana, password, "GET", "/api/status", nil, http.Header{})
 			if err != nil {
 				return err
 			}
@@ -94,7 +95,7 @@ func (check *kbChecks) CheckEntSearchAccess(b Builder) test.Step {
 			if version.MustParse(b.Kibana.Spec.Version).GTE(version.MinFor(7, 16, 0)) {
 				path = "/internal/workplace_search/overview"
 			}
-			_, err = DoRequest(check.client, b.Kibana, password, "GET", path, nil)
+			_, err = DoRequest(check.client, b.Kibana, password, "GET", path, nil, http.Header{})
 			return err
 		}),
 	}

--- a/test/e2e/test/kibana/checks_telemetry.go
+++ b/test/e2e/test/kibana/checks_telemetry.go
@@ -29,11 +29,12 @@ func MakeTelemetryRequest(kbBuilder Builder, k *test.K8sClient) (StackStats, err
 		return StackStats{}, err
 	}
 
-	// TODO clean this up - verify w/ kibana team
+	// a few extra headers a required by Kibana for this internal API
 	extraHeaders := http.Header{}
 	if version.WithoutPre(kbVersion).GTE(version.From(8, 10, 0)) {
 		extraHeaders.Add("elastic-api-version", "2")
 		extraHeaders.Add("kbn-xsrf", "reporting")
+		extraHeaders.Add("x-elastic-internal-origin", "eck-e2e-tests")
 	}
 
 	// this call may fail (status 500) if the .security-7 index is not fully initialized yet,

--- a/test/e2e/test/kibana/checks_telemetry.go
+++ b/test/e2e/test/kibana/checks_telemetry.go
@@ -18,7 +18,7 @@ import (
 func MakeTelemetryRequest(kbBuilder Builder, k *test.K8sClient) (StackStats, error) {
 	kbVersion := version.MustParse(kbBuilder.Kibana.Spec.Version)
 	apiVersion, payload := apiVersionAndTelemetryRequestBody(kbVersion)
-	uri := telemetryApiUri(kbVersion, apiVersion)
+	uri := telemetryAPIURI(kbVersion, apiVersion)
 	password, err := k.GetElasticPassword(kbBuilder.ElasticsearchRef().NamespacedName())
 	if err != nil {
 		return StackStats{}, err
@@ -36,7 +36,7 @@ func MakeTelemetryRequest(kbBuilder Builder, k *test.K8sClient) (StackStats, err
 	return unmarshalTelemetryResponse(bytes, kbVersion)
 }
 
-func telemetryApiUri(kbVersion version.Version, apiVersion string) string {
+func telemetryAPIURI(kbVersion version.Version, apiVersion string) string {
 	uri := fmt.Sprintf("/api/telemetry/%s/clusters/_stats", apiVersion)
 	if kbVersion.GTE(version.From(8, 10, 0)) {
 		uri = "/internal/telemetry/clusters/_stats"

--- a/test/e2e/test/kibana/checks_telemetry.go
+++ b/test/e2e/test/kibana/checks_telemetry.go
@@ -38,7 +38,7 @@ func MakeTelemetryRequest(kbBuilder Builder, k *test.K8sClient) (StackStats, err
 
 func telemetryAPIURI(kbVersion version.Version, apiVersion string) string {
 	uri := fmt.Sprintf("/api/telemetry/%s/clusters/_stats", apiVersion)
-	if kbVersion.GTE(version.From(8, 10, 0)) {
+	if version.WithoutPre(kbVersion).GTE(version.From(8, 10, 0)) {
 		uri = "/internal/telemetry/clusters/_stats"
 	}
 	return uri

--- a/test/e2e/test/kibana/checks_telemetry.go
+++ b/test/e2e/test/kibana/checks_telemetry.go
@@ -29,7 +29,7 @@ func MakeTelemetryRequest(kbBuilder Builder, k *test.K8sClient) (StackStats, err
 		return StackStats{}, err
 	}
 
-	// a few extra headers a required by Kibana for this internal API
+	// a few extra headers are required by Kibana for this internal API
 	extraHeaders := http.Header{}
 	if version.WithoutPre(kbVersion).GTE(version.From(8, 10, 0)) {
 		extraHeaders.Add("elastic-api-version", "2")


### PR DESCRIPTION
This PR updates the Telemetry test suite.

Since 8.10, the telemetry API URLs have changed: https://github.com/elastic/kibana/pull/159839

Old URL: `/api/telemetry/%s/clusters/_stats`
New URL: `/internal/telemetry/clusters/_stats`

There's a simple branching which this PR adds that will generate the appropriate URL based on the stack version. For the new API a few extra headers are also added to the HTTP request.