### PR TITLE
feat(elasticsearch): Add more info to status

### DIFF
--- a/pkg/controller/elasticsearch/client/model.go
+++ b/pkg/controller/elasticsearch/client/model.go
@@ -110,7 +110,14 @@ type NodesStats struct {
 // NodeStats partially models an Elasticsearch node retrieved from /_nodes/stats
 type NodeStats struct {
 	Name string `json:"name"`
-	OS   struct {
+	FS   struct {
+		Data struct {
+			TotalInBytes     int `json:"total_in_bytes"`
+			FreeInBytes      int `json:"free_in_bytes"`
+			AvailableInBytes int `json:"available_in_bytes"`
+		} `json:"data"`
+	} `json:"fs"`
+	OS struct {
 		CGroup struct {
 			Memory struct {
 				LimitInBytes string `json:"limit_in_bytes"`
@@ -121,6 +128,7 @@ type NodeStats struct {
 			} `json:"cpu"`
 		} `json:"cgroup"`
 	} `json:"os"`
+	Roles []string `json:"roles"`
 }
 
 // ClusterStateNode represents an element in the `node` structure in

--- a/pkg/controller/elasticsearch/client/v6.go
+++ b/pkg/controller/elasticsearch/client/v6.go
@@ -118,7 +118,7 @@ func (c *clientV6) GetNodes(ctx context.Context) (Nodes, error) {
 func (c *clientV6) GetNodesStats(ctx context.Context) (NodesStats, error) {
 	var nodesStats NodesStats
 	// restrict call to basic node info only
-	err := c.get(ctx, "/_nodes/_all/stats/os", &nodesStats)
+	err := c.get(ctx, "/_nodes/_all/stats/os,fs", &nodesStats)
 	return nodesStats, err
 }
 

--- a/pkg/controller/elasticsearch/driver/driver.go
+++ b/pkg/controller/elasticsearch/driver/driver.go
@@ -205,6 +205,7 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	// Always update the Elasticsearch state bits with the latest observed state.
 	d.ReconcileState.
 		UpdateClusterHealth(observedState()).         // Elasticsearch cluster health
+		UpdatePercentDataUsed(observedState()).       // Elasticsearch Percent Data Used
 		UpdateAvailableNodes(*resourcesState).        // Available nodes
 		UpdateMinRunningVersion(ctx, *resourcesState) // Min running version
 
@@ -243,7 +244,7 @@ func (d *defaultDriver) Reconcile(ctx context.Context) *reconciler.Results {
 	defer esClient.Close()
 
 	// use unknown health as a proxy for a cluster not responding to requests
-	hasKnownHealthState := observedState() != esv1.ElasticsearchUnknownHealth
+	hasKnownHealthState := observedState().ElasticsearchHealth != esv1.ElasticsearchUnknownHealth
 	esReachable := isServiceReady && hasKnownHealthState
 	// report condition in Pod status
 	if esReachable {

--- a/pkg/controller/elasticsearch/observer/manager.go
+++ b/pkg/controller/elasticsearch/observer/manager.go
@@ -50,10 +50,10 @@ func (m *Manager) ObservedStateResolver(
 	cluster esv1.Elasticsearch,
 	esClientProvider func(client.Client) client.Client,
 	isServiceReady bool,
-) func() esv1.ElasticsearchHealth {
+) func() esv1.ElasticsearchState {
 	observer := m.Observe(ctx, cluster, esClientProvider, isServiceReady)
-	return func() esv1.ElasticsearchHealth {
-		return observer.LastHealth()
+	return func() esv1.ElasticsearchState {
+		return observer.LastState()
 	}
 }
 
@@ -167,7 +167,7 @@ func (m *Manager) AddObservationListener(listener OnObservation) {
 }
 
 // notifyListeners notifies all listeners that an observation occurred.
-func (m *Manager) notifyListeners(cluster types.NamespacedName, previousState, newState esv1.ElasticsearchHealth) {
+func (m *Manager) notifyListeners(cluster types.NamespacedName, previousState, newState esv1.ElasticsearchState) {
 	m.listenerLock.RLock()
 	switch len(m.listeners) {
 	case 0:

--- a/pkg/controller/elasticsearch/reconcile/state.go
+++ b/pkg/controller/elasticsearch/reconcile/state.go
@@ -92,12 +92,17 @@ func (s *State) fetchMinRunningVersion(ctx context.Context, resourcesState Resou
 	return minPodVersion, nil
 }
 
-func (s *State) UpdateClusterHealth(clusterHealth esv1.ElasticsearchHealth) *State {
-	if clusterHealth == "" {
+func (s *State) UpdateClusterHealth(clusterState esv1.ElasticsearchState) *State {
+	if clusterState.ElasticsearchHealth == "" {
 		s.status.Health = esv1.ElasticsearchUnknownHealth
 		return s
 	}
-	s.status.Health = clusterHealth
+	s.status.Health = clusterState.ElasticsearchHealth
+	return s
+}
+
+func (s *State) UpdatePercentDataUsed(clusterState esv1.ElasticsearchState) *State {
+	s.status.PercentDataUsed = clusterState.ComputedPercentDataUsed()
 	return s
 }
 

--- a/pkg/controller/elasticsearch/reconcile/state_test.go
+++ b/pkg/controller/elasticsearch/reconcile/state_test.go
@@ -170,7 +170,7 @@ func TestState_Apply(t *testing.T) {
 				},
 			},
 			effects: func(s *State) {
-				s.UpdateClusterHealth(esv1.ElasticsearchUnknownHealth)
+				s.UpdateClusterHealth(esv1.ElasticsearchState{ElasticsearchHealth: esv1.ElasticsearchUnknownHealth})
 			},
 			wantEvents: []events.Event{},
 			wantStatus: &esv1.ElasticsearchStatus{
@@ -187,7 +187,7 @@ func TestState_Apply(t *testing.T) {
 				},
 			},
 			effects: func(s *State) {
-				s.UpdateWithPhase(esv1.ElasticsearchApplyingChangesPhase).UpdateClusterHealth(esv1.ElasticsearchRedHealth)
+				s.UpdateWithPhase(esv1.ElasticsearchApplyingChangesPhase).UpdateClusterHealth(esv1.ElasticsearchState{ElasticsearchHealth: esv1.ElasticsearchRedHealth})
 			},
 			wantEvents: []events.Event{{EventType: corev1.EventTypeWarning, Reason: events.EventReasonUnhealthy, Message: "Elasticsearch cluster health degraded"}},
 			wantStatus: &esv1.ElasticsearchStatus{
@@ -204,7 +204,7 @@ func TestState_Apply(t *testing.T) {
 				},
 			},
 			effects: func(s *State) {
-				s.UpdateWithPhase(esv1.ElasticsearchApplyingChangesPhase).UpdateClusterHealth(esv1.ElasticsearchRedHealth)
+				s.UpdateWithPhase(esv1.ElasticsearchApplyingChangesPhase).UpdateClusterHealth(esv1.ElasticsearchState{ElasticsearchHealth: esv1.ElasticsearchRedHealth})
 			},
 			wantEvents: []events.Event{},
 			wantStatus: &esv1.ElasticsearchStatus{
@@ -255,7 +255,7 @@ func assertSemanticEqualStatuses(t *testing.T, actual, expected *esv1.Elasticsea
 func TestState_UpdateElasticsearchState(t *testing.T) {
 	type args struct {
 		resourcesState ResourcesState
-		observedHealth esv1.ElasticsearchHealth
+		observedState  esv1.ElasticsearchState
 	}
 	tests := []struct {
 		name            string
@@ -331,7 +331,7 @@ func TestState_UpdateElasticsearchState(t *testing.T) {
 			name:    "health is set if returned by Elasticsearch",
 			cluster: esv1.Elasticsearch{},
 			args: args{
-				observedHealth: esv1.ElasticsearchGreenHealth,
+				observedState: esv1.ElasticsearchState{ElasticsearchHealth: esv1.ElasticsearchGreenHealth},
 			},
 			stateAssertions: func(s *State) {
 				assert.EqualValues(t, "green", s.status.Health)
@@ -341,7 +341,7 @@ func TestState_UpdateElasticsearchState(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := MustNewState(tt.cluster)
-			s.UpdateClusterHealth(tt.args.observedHealth).UpdateMinRunningVersion(context.Background(), tt.args.resourcesState)
+			s.UpdateClusterHealth(tt.args.observedState).UpdateMinRunningVersion(context.Background(), tt.args.resourcesState)
 			if tt.stateAssertions != nil {
 				tt.stateAssertions(s)
 			}


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

Allow more info about the Elasticsearch cluster to be added to status field.

Changes the struct from `ElasticsearchHealth` which is a string to an object called `ElasticsearchState` which can contain whatever other information about the cluster that can be later used to populate status field.

In this case - the goal is to be able to expose `PercentDataUsed` for the cluster.  This is a key performance indicator for the cluster.
The eventual goal is to be able to enable autoscaling for data nodes.  Once the cluster approaches the high water mark for disk, it would be great if the operator could automatically scale up and add an additional data node.

Submitting this as WIP PR in order to get feedback.
Currently working through a circular dependency issue with imports.


<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)?
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed.
