### PR TITLE
doc: clarify how to reset the default user's password

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/security/users-and-roles.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/users-and-roles.asciidoc
@@ -23,6 +23,8 @@ For example, the password of the `elastic` user for an Elasticsearch cluster nam
 kubectl get secret quickstart-es-elastic-user -o go-template='{{.data.elastic | base64decode}}'
 ----
 
+To rotate this password, refer to: <<{p}-rotate-credentials>>.
+
 == Creating custom users
 
 WARNING: Do not run the `elasticsearch-service-tokens` command inside an Elasticsearch Pod managed by the operator. This would overwrite the service account tokens used internally to authenticate the Elastic stack applications.


### PR DESCRIPTION
This blog post has some good details on how to reset the default user's password by deleting the Kubernetes secret:

https://www.gooksu.com/2022/03/elasticsearch-on-k8s-eck-all-about-passwords/

It would be good to incorporate this tip into the official operator documentation.

Fixes: #7182 