### PR TITLE
Exclude naming test from health check

### DIFF
--- a/test/e2e/naming_test.go
+++ b/test/e2e/naming_test.go
@@ -59,7 +59,7 @@ func testLongestPossibleName(t *testing.T) {
 			Count: 1,
 		}).
 		WithRestrictedSecurityContext().
-		// TODO understand why this is necessary, test passes most of the time but sometimes is takes more than 15 minutes for Kibana to become avaialable
+		// TODO understand why this is necessary, test passes most of the time but sometimes is takes more than 15 minutes for Kibana to become available
 		// and that has knock-on effects on APM
 		SkipImmediateHealthCheck()
 

--- a/test/e2e/naming_test.go
+++ b/test/e2e/naming_test.go
@@ -58,7 +58,10 @@ func testLongestPossibleName(t *testing.T) {
 			Name:  nodeSpecName,
 			Count: 1,
 		}).
-		WithRestrictedSecurityContext()
+		WithRestrictedSecurityContext().
+		// TODO understand why this is necessary, test passes most of the time but sometimes is takes more than 15 minutes for Kibana to become avaialable
+		// and that has knock-on effects on APM
+		SkipImmediateHealthCheck()
 
 	kbNamePrefix := strings.Join([]string{esNamePrefix, "kb"}, "-")
 	kbName := strings.Join([]string{kbNamePrefix, strings.Repeat("x", name.MaxResourceNameLength-len(kbNamePrefix)-1)}, "-")


### PR DESCRIPTION
More fallout from https://github.com/elastic/cloud-on-k8s/pull/7184

I wonder if we should reverse the logic an only do the health check for specific tests that involve Beats and Agent?

Also I don't think the fix in #7184 has actually helped.