### PR TITLE
Add missing ReplicaSet RBAC for Fleet e2e test

### DIFF
--- a/config/e2e/roles.yaml
+++ b/config/e2e/roles.yaml
@@ -97,6 +97,14 @@ rules:
   - watch
   - list
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - nodes


### PR DESCRIPTION


```
{"log.level":"error","@timestamp":"2023-09-28T18:42:56.550Z","message":"E0928 18:42:56.550581    1035 reflector.go:138] k8s.io/client-go@v0.23.4/tools/cache/reflector.go:167: Failed to watch *v1.ReplicaSet: failed to list *v1.ReplicaSet: replicasets.apps is forbidden: User \"system:serviceaccount:e2e-gwm83-mercury:test-agent-fleet-ea-82px-sa\" cannot list resource \"replicasets\" in API group \"apps\" at the cluster scope","component":{"binary":"metricbeat","dataset":"elastic_agent.metricbeat","id":"http/metrics-monitoring","type":"http/metrics"},"log":{"source":"http/metrics-monitoring"},"ecs.version":"1.6.0"}
```