### PR TITLE
Do not fail build on k8s cluster deletion failure

### DIFF
--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -118,6 +118,8 @@ steps:
 
         commands:
           - .buildkite/scripts/test/set-deployer-config.sh
+        soft_fail:
+          - exit_status: 1
 
         {{- if not $test.Dind }}
           - make run-deployer
@@ -130,9 +132,6 @@ steps:
           provider: "gcp"
           image: "family/core-ubuntu-2004"
         {{- end }}
-        retry:
-          automatic:
-            - limit: 5
 
     {{- end }}
 {{- end }}


### PR DESCRIPTION
This updates the pipeline template used to create the pipeline that runs the e2e tests, to not fail the build when deleting a k8s cluster fails, since we now have a dedicated pipeline `cloud-on-k8s-operator-e2e-clusters-cleanup` which periodically retries these failed deletions. This also removes the retry mechanism that was here because it is completely inefficient, because lacking an exponential backoff delay.