### PR TITLE
soft_fail on any status code on k8s cluster deletion

### DIFF
--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -115,8 +115,7 @@ steps:
           {{$key}}: "{{$val}}"
           {{- end }}
           DEPLOYER_OPERATION: delete
-        soft_fail:
-          - exit_status: 1
+        soft_fail: true
         commands:
           - .buildkite/scripts/test/set-deployer-config.sh
         {{- if not $test.Dind }}


### PR DESCRIPTION
I wanted to be very selective on the errors that we ignore and didn't look at carefully that the exit code was `2`.

Note that:
> By design, the exit status is two if `make` encounters any errors.
https://www.gnu.org/software/make/manual/html_node/Running.html 

You need to look at failure from the top, not the bottom:

<img width="871" alt="Capture d’écran 2023-10-10 à 11 00 50" src="https://github.com/elastic/cloud-on-k8s/assets/582883/8a083cf6-16f6-40d4-ba7b-59e9f7d7200e">



After this failed attempt to be selective, I propose to just soft fail in case of any error.

Relates to #7197, #7200.