### PR TITLE
Adjust sample command outputs in the Agent Fleet documentation

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -215,7 +215,7 @@ kubectl get pods --selector='agent.k8s.elastic.co/name=elastic-agent-quickstart'
 +
 [source,sh]
 ----
-NAME                        READY   STATUS    RESTARTS   AGE
+NAME                                   READY   STATUS    RESTARTS   AGE
 elastic-agent-quickstart-agent-t49fd   1/1     Running   0          54s
 elastic-agent-quickstart-agent-xbcxr   1/1     Running   0          54s
 elastic-agent-quickstart-agent-zqp55   1/1     Running   0          54s

--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -200,9 +200,9 @@ kubectl get agent
 +
 [source,sh,subs="attributes"]
 ----
-NAME            HEALTH   AVAILABLE   EXPECTED   VERSION      AGE
-elastic-agent   green    3           3          {version}    14s
-fleet-server    green    1           1          {version}    19s
+NAME                       HEALTH   AVAILABLE   EXPECTED   VERSION      AGE
+elastic-agent-quickstart   green    3           3          {version}    14s
+fleet-server-quickstart    green    1           1          {version}    19s
 
 ----
 
@@ -210,22 +210,22 @@ fleet-server    green    1           1          {version}    19s
 +
 [source,sh]
 ----
-kubectl get pods --selector='agent.k8s.elastic.co/name=elastic-agent'
+kubectl get pods --selector='agent.k8s.elastic.co/name=elastic-agent-quickstart'
 ----
 +
 [source,sh]
 ----
 NAME                        READY   STATUS    RESTARTS   AGE
-elastic-agent-agent-t49fd   1/1     Running   0          54s
-elastic-agent-agent-xbcxr   1/1     Running   0          54s
-elastic-agent-agent-zqp55   1/1     Running   0          54s
+elastic-agent-quickstart-agent-t49fd   1/1     Running   0          54s
+elastic-agent-quickstart-agent-xbcxr   1/1     Running   0          54s
+elastic-agent-quickstart-agent-zqp55   1/1     Running   0          54s
 ----
 
 . Access logs for one of the Pods.
 +
 [source,sh]
 ----
-kubectl logs -f elastic-agent-agent-xbcxr
+kubectl logs -f elastic-agent-quickstart-agent-xbcxr
 ----
 
 . Configure the policy used by Elastic Agents. Check link:https://www.elastic.co/guide/en/fleet/current/agent-policy.html[Elastic Agent policies] for more details.


### PR DESCRIPTION
- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? 
  - Yes
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)? 
  - Yes
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed. 
  - It's not code.

### Background:
- The manifest says `xxx-quickstart`, i.e. `fleet-server-quickstart`,
- however, the sample response says things without `-quickstart`…

![image](https://github.com/elastic/cloud-on-k8s/assets/30574753/be3fbe8a-184c-4212-ad6c-1831840c8e7d)


### TL;DR:

This PR is to add `-quickstart` in sample response part, i.e. change pod name from `elastic-agent-agent-t49fd` to `elastic-agent-quickstart-agent-t49fd`, so as to keep the sample yaml manifest and the sample response aligned and easy to follow.

---

cc @thbkrkr as we chatted this internally. Thanks for your quick response! 🙏 