### PR TITLE
Update ECK-Beats default values to not include ElasticsearchRef.

### DIFF
--- a/deploy/eck-stack/charts/eck-beats/values.yaml
+++ b/deploy/eck-stack/charts/eck-beats/values.yaml
@@ -50,9 +50,11 @@ spec:
     # namespace: default
 
   # Reference to ECK-managed Elasticsearch instance.
+  # *Note* If Beat's output is intended to go to Elasticsearch and not something like Logstash,
+  # this elasticsearchRef must be updated to the name of the Elasticsearch instance.
   #
-  elasticsearchRef:
-    name: elasticsearch
+  elasticsearchRef: {}
+    # name: elasticsearch
     # Optional namespace reference to Elasticsearch instance.
     # If not specified, then the namespace of the Beats instance
     # will be assumed.


### PR DESCRIPTION
see https://github.com/helm/helm/issues/12469#issuecomment-1758401457
related https://github.com/elastic/cloud-on-k8s/pull/7143

The ongoing Helm parent->child default values override issue continues.

If you currently attempt to use eck-stack with eck-logstash in the above PR with the following example (based off of [logstash-eck.yaml recipe](https://github.com/elastic/cloud-on-k8s/blob/main/config/recipes/logstash/logstash-eck.yaml)  ), it will fail as you cannot `null` out the default `elasticsearchRef` in the eck-beats helm chart:
```
---
eck-elasticsearch:
  version: 8.9.0
  nodeSets:
  - name: default
    count: 3
    config:
      node.store.allow_mmap: false
    podTemplate:
      spec:
        containers:
        - name: elasticsearch
          resources:
            limits:
              memory: 2Gi
            requests:
              memory: 2Gi
eck-beats:
  enabled: true
  version: 8.9.0
  spec:
    type: filebeat
    daemonSet: null
    elasticsearchRef: null
    config:
      filebeat.inputs:
      - type: log
        paths:
          - /data/logstash-tutorial.log
      processors:
      - add_host_metadata: {}
      - add_cloud_metadata: {}
      output.logstash:
        hosts: ["logstash-ls-beats:5044"]
    deployment:
      podTemplate:
        spec:
          automountServiceAccountToken: true
          initContainers:
            - name: download-tutorial
              image: curlimages/curl
              command: ["/bin/sh"]
              args: ["-c", "curl -L https://download.elastic.co/demos/logstash/gettingstarted/logstash-tutorial.log.gz | gunzip -c > /data/logstash-tutorial.log"]
              volumeMounts:
                - name: data
                  mountPath: /data
          containers:
            - name: filebeat
              securityContext:
                runAsUser: 1000
              volumeMounts:
                - name: data
                  mountPath: /data
                - name: beat-data
                  mountPath: /usr/share/filebeat/data
          volumes:
            - name: data
              emptydir: {}
            - name: beat-data
              emptydir: {}
eck-logstash:
  enabled: true
  version: 8.9.0
  elasticsearchRefs:
    - clusterName: eck
      name: elasticsearch
  pipelines:
    - pipeline.id: main
      config.string: |
        input {
          beats {
            port => 5044
          }
        }
        filter {
          grok {
            match => { "message" => "%{HTTPD_COMMONLOG}"}
          }
          geoip {
            source => "[source][address]"
            target => "[source]"
          }
        }
        output {
          elasticsearch {
            hosts => [ "${ECK_ES_HOSTS}" ]
            user => "${ECK_ES_USER}"
            password => "${ECK_ES_PASSWORD}"
            ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
          }
        }

  services:
    - name: beats
      service:
        spec:
          type: ClusterIP
          ports:
            - port: 5044
              name: "filebeat"
              protocol: TCP
              targetPort: 5044
```

It will configure beat as such:
```
❯ kubedecode logstash-stack-eck-beats-beat-filebeat-config elastic
beat.yml: filebeat:
    inputs:
        - paths:
            - /data/logstash-tutorial.log
          type: log
output:
    elasticsearch:
        hosts:
            - https://elasticsearch-es-http.elastic.svc:9200
        password: x4R7M2812tns497DgFdPfTQ6
        ssl:
            certificate_authorities:
                - /mnt/elastic-internal/elasticsearch-certs/ca.crt
        username: elastic-logstash-stack-eck-beats-beat-user
    logstash:
        hosts:
            - logstash-ls-beats:5044
processors:
    - add_host_metadata: null
    - add_cloud_metadata: null
```

Which isn't valid as you can't have 2x outputs in beat.

With this change you will get this, which is valid:
```
kubedecode logstash-stack-eck-beats-beat-filebeat-config elastic
beat.yml: filebeat:
    inputs:
        - paths:
            - /data/logstash-tutorial.log
          type: log
output:
    logstash:
        hosts:
            - logstash-ls-beats:5044
processors:
    - add_host_metadata: null
    - add_cloud_metadata: null
```

I'm suggesting we remove the default `elasticsearchRef` we include in the eck-beast chart for now until this issue is resolved.