### PR TITLE
Allow setting additional Operator flags.

### DIFF
--- a/config/eck.yaml
+++ b/config/eck.yaml
@@ -6,6 +6,7 @@ ca-cert-validity: 8760h
 ca-cert-rotate-before: 24h
 cert-validity: 8760h
 cert-rotate-before: 24h
+disable-config-watch: false
 exposed-node-labels: [topology.kubernetes.io/.*,failure-domain.beta.kubernetes.io/.*]
 set-default-security-context: auto-detect
 kube-client-timeout: 60s
@@ -14,5 +15,7 @@ disable-telemetry: false
 distribution-channel: image
 validate-storage-class: true
 enable-webhook: false
+operator-namespace: elastic-system
 enable-leader-election: true
 elasticsearch-observation-interval: 10s
+ubi-only: false

--- a/deploy/eck-operator/templates/configmap.yaml
+++ b/deploy/eck-operator/templates/configmap.yaml
@@ -25,8 +25,12 @@ data:
     ca-cert-rotate-before: {{ .Values.config.caRotateBefore }}
     cert-validity: {{ .Values.config.certificatesValidity }}
     cert-rotate-before: {{ .Values.config.certificatesRotateBefore }}
+    disable-config-watch: {{ .Values.config.disableConfigWatch }}
     {{- with .Values.config.exposedNodeLabels }}
     exposed-node-labels: [{{ join "," .  }}]
+    {{- end }}
+    {{- with .Values.config.ipFamily }}
+    ip-family: {{ . }}
     {{- end }}
     set-default-security-context: {{ .Values.config.setDefaultSecurityContext }}
     kube-client-timeout: {{ .Values.config.kubeClientTimeout }}
@@ -58,5 +62,12 @@ data:
     {{- with .Values.managedNamespaces }}
     namespaces: [{{ join "," . }}]
     {{- end }}
+    operator-namespace: {{ .Release.Namespace }}
     enable-leader-election: {{ .Values.config.enableLeaderElection }}
     elasticsearch-observation-interval: {{ .Values.config.elasticsearchObservationInterval }}
+    {{- if not .Values.config.containerSuffix }}
+    ubi-only: {{ .Values.config.ubiOnly }}
+    {{- end }}
+    {{- with .Values.webhook.secret }}
+    webhook-secret: {{ . }}
+    {{- end }}

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -128,6 +128,8 @@ webhook:
   objectSelector: {}
   # port is the port that the validating webhook binds to.
   port: 9443
+  # secret specifies the Kubernetes secret to be mounted into the path designated by the certsDir value to be used for webhook certificates.
+  secret: ""
 
 # hostNetwork allows a Pod to use the Node network namespace.
 # This is required to allow for communication with the kube API when using some alternate CNIs in conjunction with webhook enabled.
@@ -184,8 +186,14 @@ config:
   # certificatesRotateBefore defines when to rotate a certificate that is due to expire.
   certificatesRotateBefore: 24h
 
+  # disableConfigWatch specifies whether the operator watches the configuration file for changes.
+  disableConfigWatch: false
+
   # exposedNodeLabels is an array of regular expressions of node labels which are allowed to be copied as annotations on Elasticsearch Pods.
   exposedNodeLabels: [ "topology.kubernetes.io/.*", "failure-domain.beta.kubernetes.io/.*" ]
+
+  # ipFamily specifies the IP family to use. Possible values: IPv4, IPv6 and "" (auto-detect)
+  ipFamily: ""
 
   # setDefaultSecurityContext determines whether a default security context is set on application containers created by the operator.
   # *note* that the default option now is "auto-detect" to attempt to set this properly automatically when both running
@@ -210,6 +218,10 @@ config:
 
   # Interval between observations of Elasticsearch health, non-positive values disable asynchronous observation.
   elasticsearchObservationInterval: 10s
+
+  # ubiOnly specifies whether the operator will use only UBI container images to deploy Elastic Stack applications. UBI images are only available from 7.10.0 onward.
+  # Cannot be combined with the containerSuffix value.
+  ubiOnly: false
 
 # Prometheus PodMonitor configuration
 # Reference: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#podmonitor


### PR DESCRIPTION
closes #6091 

## What is this change?

Allows setting the following Operator flags via the Helm chart:
- `-disable-config-watch`
- `-ip-family`
- `-operator-namespace` # is set indirectly via `.Release.Namespace`
- `-ubi-only`
- `-webhook-secret`

## Notes for review
`-operator-namespace` isn't allowed to be set directly, but is set indirectly via whatever namespace the Helm chart is installed within {{ `.Release.Namespace` }}.
`-config` is not allowed to be set at all, as it doesn't make sense in the context of a Helm chart. (It's used in the statefulset template `--config=/conf/eck.yaml`.

### Testing done
```
❯ helm upgrade -i elastic-operator . -n elastic-system --create-namespace --set=config.disableConfigWatch=true --set=config.ipFamily=IPv4 --set=config.ubiOnly=true --set=image.tag=2.9.0

❯ kubectl get cm -n elastic-system elastic-operator -o yaml | yq '.data["eck.yaml"]'
log-verbosity: 0
metrics-port: 0
container-registry: docker.elastic.co
max-concurrent-reconciles: 3
ca-cert-validity: 8760h
ca-cert-rotate-before: 24h
cert-validity: 8760h
cert-rotate-before: 24h
disable-config-watch: true
exposed-node-labels: [topology.kubernetes.io/.*,failure-domain.beta.kubernetes.io/.*]
ip-family: IPv4
set-default-security-context: auto-detect
kube-client-timeout: 60s
elasticsearch-client-timeout: 180s
disable-telemetry: false
distribution-channel: helm
validate-storage-class: true
enable-webhook: true
webhook-name: elastic-operator.elastic-system.k8s.elastic.co
webhook-port: 9443
operator-namespace: elastic-system
enable-leader-election: true
elasticsearch-observation-interval: 10s
ubi-only: true
```