### PR TITLE
Document how to provide container registry credentials in air-gapped environment

### DIFF
--- a/docs/operating-eck/air-gapped.asciidoc
+++ b/docs/operating-eck/air-gapped.asciidoc
@@ -56,7 +56,6 @@ The operator expects container images to be located at specific repositories in 
 * +my.registry/kibana/kibana:{version}+
 * +my.registry/apm/apm-server:{version}+
 
-
 [float]
 [id="{p}-container-repository-override"]
 == Use a global container repository

--- a/docs/operating-eck/air-gapped.asciidoc
+++ b/docs/operating-eck/air-gapped.asciidoc
@@ -19,24 +19,15 @@ kind: Elasticsearch
 metadata:
   name: quickstart
 spec:
-  version: 7.6.0
-  count: 1
-  image: my-custom-repo/kibana:7.6.0
-  elasticsearchRef:
-    name: "elasticsearch-sample"
+  version: {version}
+  # image: docker.elastic.co/elasticsearch/elasticsearch:{version} <1>
+  nodeSets:
+  - name: default
+    count: 1
   podTemplate:
-    metadata:
-      labels:
-        foo: bar
     spec:
-      imagePullSecrets:  <<Use this parameter to use credentials for a custom repo 
-      - name: regcred
-      containers:
-      - name: kibana
-        resources:
-          limits:
-            memory: 1Gi
-            cpu: 1
+      imagePullSecrets:
+      - name: private-registry-credentials-secret
 ----
 
 <1> The ECK operator will set this value by default. You can explicitly set it to your mirrored container image when running in an air-gapped environment
@@ -66,7 +57,7 @@ The operator expects container images to be located at specific repositories in 
 * +my.registry/kibana/kibana:{version}+
 * +my.registry/apm/apm-server:{version}+
 
-You can provide credentials to a custom repo by adding the imagePullSecrets parameter to your configuration as shown here - https://github.com/elastic/cloud-on-k8s/issues/2580#issuecomment-589602837
+You can provide credentials to your private container registry by setting the `imagePullSecrets` field through the `spec.podTemplate` section of your Elastic resource specification, check <<{p}-customize-pods,how to customize the Elastic resources Pods>> and link:https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/[how to setup a Secret containing your registry credentials].
 
 [float]
 [id="{p}-container-repository-override"]

--- a/docs/operating-eck/air-gapped.asciidoc
+++ b/docs/operating-eck/air-gapped.asciidoc
@@ -24,18 +24,17 @@ spec:
   nodeSets:
   - name: default
     count: 1
-  podTemplate:
-    spec:
-      imagePullSecrets:
-      - name: private-registry-credentials-secret
+  # podTemplate:
+  #   spec:
+  #     imagePullSecrets: <2>
+  #     - name: private-registry-credentials-secret
 ----
 
 <1> The ECK operator will set this value by default. You can explicitly set it to your mirrored container image when running in an air-gapped environment
+<2> You can provide credentials to your private container registry by setting the `imagePullSecrets` field through the `spec.podTemplate` section of your Elastic resource specification, check <<{p}-customize-pods,how to customize the Elastic resources Pods>> and link:https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/[how to setup a Secret containing your registry credentials].
 
 ECK will automatically set the correct container image for each application. When running in an air-gapped or offline environment you will have to mirror the official Elastic container images in a private container image registry.
 To make use of your mirrored images you can either set the image for each application explicitly as shown in the preceding example or more conveniently override the default container registry as explained in the next section.
-
-
 
 [float]
 [id="{p}-use-mirrored-operator-image"]
@@ -57,7 +56,6 @@ The operator expects container images to be located at specific repositories in 
 * +my.registry/kibana/kibana:{version}+
 * +my.registry/apm/apm-server:{version}+
 
-You can provide credentials to your private container registry by setting the `imagePullSecrets` field through the `spec.podTemplate` section of your Elastic resource specification, check <<{p}-customize-pods,how to customize the Elastic resources Pods>> and link:https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/[how to setup a Secret containing your registry credentials].
 
 [float]
 [id="{p}-container-repository-override"]

--- a/docs/operating-eck/air-gapped.asciidoc
+++ b/docs/operating-eck/air-gapped.asciidoc
@@ -19,11 +19,24 @@ kind: Elasticsearch
 metadata:
   name: quickstart
 spec:
-  version: {version}
-  # image: docker.elastic.co/elasticsearch/elasticsearch:{version} <1>
-  nodeSets:
-  - name: default
-    count: 1
+  version: 7.6.0
+  count: 1
+  image: my-custom-repo/kibana:7.6.0
+  elasticsearchRef:
+    name: "elasticsearch-sample"
+  podTemplate:
+    metadata:
+      labels:
+        foo: bar
+    spec:
+      imagePullSecrets:  <<Use this parameter to use credentials for a custom repo 
+      - name: regcred
+      containers:
+      - name: kibana
+        resources:
+          limits:
+            memory: 1Gi
+            cpu: 1
 ----
 
 <1> The ECK operator will set this value by default. You can explicitly set it to your mirrored container image when running in an air-gapped environment
@@ -52,6 +65,8 @@ The operator expects container images to be located at specific repositories in 
 * +my.registry/elasticsearch/elasticsearch:{version}+
 * +my.registry/kibana/kibana:{version}+
 * +my.registry/apm/apm-server:{version}+
+
+You can provide credentials to a custom repo by adding the imagePullSecrets parameter to your configuration as shown here - https://github.com/elastic/cloud-on-k8s/issues/2580#issuecomment-589602837
 
 [float]
 [id="{p}-container-repository-override"]


### PR DESCRIPTION
Adding information on how to use credentials with a custom repo.

Added details to initial custom repo example.

Also provided a link later on to another example in Github.
