### PR TITLE
E2E-monitor server change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -404,6 +404,7 @@ E2E_REGISTRY_NAMESPACE     ?= eck-dev
 E2E_TEST_CLUSTER_PREFIX    ?= "eck-e2e"
 export E2E_IMAGE_NAME      ?= $(REGISTRY)/$(E2E_REGISTRY_NAMESPACE)/eck-e2e-tests
 export E2E_IMAGE_TAG       ?= $(SHA1)
+E2E_IMG                    ?= $(E2E_IMAGE_NAME):$(E2E_IMAGE_TAG)
 
 # push amd64 image for dev purposes
 docker-push-e2e:

--- a/config/e2e/helm-operator-under-test.yaml
+++ b/config/e2e/helm-operator-under-test.yaml
@@ -29,11 +29,11 @@ env:
       secretKeyRef:
         name: "eck-{{ .TestRun }}"
         key: apm_server_url
-  - name: ELASTIC_APM_SECRET_TOKEN
+  - name: ELASTIC_APM_API_KEY
     valueFrom:
       secretKeyRef:
         name: "eck-{{ .TestRun }}"
-        key: apm_secret_token
+        key: apm_api_key
 
 {{ end }}
   

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -5,7 +5,7 @@ metadata:
   name: e2e-agent
   namespace: {{ .E2ENamespace }}
 spec:
-  version: 8.9.0 # needs to less or equal to e2e-monitor version
+  version: 8.10.4 # needs to less or equal to e2e-monitor version
   elasticsearchRefs:
     - secretName: eck-{{ .TestRun }}
   daemonSet:

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -5,7 +5,7 @@ metadata:
   name: e2e-agent
   namespace: {{ .E2ENamespace }}
 spec:
-  version: 8.4.0 # needs to less or equal to e2e-monitor version
+  version: 8.9.0 # needs to less or equal to e2e-monitor version
   elasticsearchRefs:
     - secretName: eck-{{ .TestRun }}
   daemonSet:

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -362,6 +362,15 @@ rules:
       - get
       - watch
       - list
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
   - nonResourceURLs:
       - /metrics
     verbs:

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -87,7 +87,7 @@ spec:
       meta:
         package:
           name: kubernetes
-          version: 0.2.8
+          version: 1.49.0
       data_stream:
         namespace: k8s
       processors:
@@ -304,7 +304,7 @@ spec:
       meta:
         package:
           name: log
-          version: 0.4.6
+          version: 2.3.0
       data_stream:
         namespace: default
       processors:

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -362,6 +362,13 @@ rules:
       - get
       - watch
       - list
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
   - apiGroups: ["apps"]
     resources:
       - deployments

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -294,7 +294,7 @@ func (h *helper) initTestSecrets() error {
 			MonitoringURL  string `json:"monitoring_url"`
 			MonitoringUser string `json:"monitoring_user"`
 			MonitoringPass string `json:"monitoring_pass"`
-			APMSecretToken string `json:"apm_secret_token"`
+			APMApiKey      string `json:"apm_api_key"`
 			APMServerURL   string `json:"apm_server_url"`
 		}{}
 
@@ -308,7 +308,7 @@ func (h *helper) initTestSecrets() error {
 		h.testSecrets["password"] = monitoringSecrets.MonitoringPass
 
 		h.operatorSecrets = map[string]string{}
-		h.operatorSecrets["apm_secret_token"] = monitoringSecrets.APMSecretToken
+		h.operatorSecrets["apm_api_key"] = monitoringSecrets.APMApiKey
 		h.operatorSecrets["apm_server_url"] = monitoringSecrets.APMServerURL
 	}
 

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -282,9 +282,8 @@ func (h *helper) initTestSecrets() error {
 
 	if h.monitoringSecrets != "" {
 		bytes, err := vault.ReadFile(c, vault.SecretFile{
-			Name: h.monitoringSecrets,
-			// This will be reverted back once verification is complete.
-			Path:       "monitoring-cluster-v2",
+			Name:       h.monitoringSecrets,
+			Path:       "monitoring-cluster",
 			FormatJSON: true,
 		})
 		if err != nil {

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -282,8 +282,9 @@ func (h *helper) initTestSecrets() error {
 
 	if h.monitoringSecrets != "" {
 		bytes, err := vault.ReadFile(c, vault.SecretFile{
-			Name:       h.monitoringSecrets,
-			Path:       "monitoring-cluster",
+			Name: h.monitoringSecrets,
+			// This will be reverted back once verification is complete.
+			Path:       "monitoring-cluster-v2",
 			FormatJSON: true,
 		})
 		if err != nil {


### PR DESCRIPTION
## What is this change?
* This primarily updates our e2e tests to use a new e2e-monitor server defined in a new vault path, as our previous server is using an old k8s version and we thought it would be good to use our new offering as a test for this.
* This adds (back?) a missing variable needed when running our e2e tests `E2E-IMG` which is used here: https://github.com/elastic/cloud-on-k8s/blob/20f11e756989d9811d3f22f638949a81409a4ef6/Makefile#L443
* Migrates E2E tests to use an `api_key` instead of a `secret` for integrating with APM Server, which is required in our new offering.
* Updates the version of Elastic Agent we are using in our monitoring of e2e tests.

## TODO
- [x] Test locally with a limited set of e2e tests `make e2e-run  E2E_STACK_VERSION=8.9.0 TESTS_MATCH=TestFleetKubernetesNonRootIntegrationRecipe`
- [ ] Run a full set of e2e tests via our CI Pipeline