### PR TITLE
[2.10] Allow setting additional Operator flags. (#7252)

### DIFF
--- a/config/eck.yaml
+++ b/config/eck.yaml
@@ -6,6 +6,7 @@ ca-cert-validity: 8760h
 ca-cert-rotate-before: 24h
 cert-validity: 8760h
 cert-rotate-before: 24h
+disable-config-watch: false
 exposed-node-labels: [topology.kubernetes.io/.*,failure-domain.beta.kubernetes.io/.*]
 set-default-security-context: auto-detect
 kube-client-timeout: 60s
@@ -14,5 +15,7 @@ disable-telemetry: false
 distribution-channel: image
 validate-storage-class: true
 enable-webhook: false
+operator-namespace: elastic-system
 enable-leader-election: true
 elasticsearch-observation-interval: 10s
+ubi-only: false

--- a/deploy/eck-operator/templates/configmap.yaml
+++ b/deploy/eck-operator/templates/configmap.yaml
@@ -28,8 +28,12 @@ data:
     {{- end }}
     cert-validity: {{ .Values.config.certificatesValidity }}
     cert-rotate-before: {{ .Values.config.certificatesRotateBefore }}
+    disable-config-watch: {{ .Values.config.disableConfigWatch }}
     {{- with .Values.config.exposedNodeLabels }}
     exposed-node-labels: [{{ join "," .  }}]
+    {{- end }}
+    {{- with .Values.config.ipFamily }}
+    ip-family: {{ . }}
     {{- end }}
     set-default-security-context: {{ .Values.config.setDefaultSecurityContext }}
     kube-client-timeout: {{ .Values.config.kubeClientTimeout }}
@@ -61,5 +65,12 @@ data:
     {{- with .Values.managedNamespaces }}
     namespaces: [{{ join "," . }}]
     {{- end }}
+    operator-namespace: {{ .Release.Namespace }}
     enable-leader-election: {{ .Values.config.enableLeaderElection }}
     elasticsearch-observation-interval: {{ .Values.config.elasticsearchObservationInterval }}
+    {{- if not .Values.config.containerSuffix }}
+    ubi-only: {{ .Values.config.ubiOnly }}
+    {{- end }}
+    {{- with .Values.webhook.secret }}
+    webhook-secret: {{ . }}
+    {{- end }}

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -128,6 +128,8 @@ webhook:
   objectSelector: {}
   # port is the port that the validating webhook binds to.
   port: 9443
+  # secret specifies the Kubernetes secret to be mounted into the path designated by the certsDir value to be used for webhook certificates.
+  secret: ""
 
 # hostNetwork allows a Pod to use the Node network namespace.
 # This is required to allow for communication with the kube API when using some alternate CNIs in conjunction with webhook enabled.
@@ -188,8 +190,14 @@ config:
   # certificatesRotateBefore defines when to rotate a certificate that is due to expire.
   certificatesRotateBefore: 24h
 
+  # disableConfigWatch specifies whether the operator watches the configuration file for changes.
+  disableConfigWatch: false
+
   # exposedNodeLabels is an array of regular expressions of node labels which are allowed to be copied as annotations on Elasticsearch Pods.
   exposedNodeLabels: [ "topology.kubernetes.io/.*", "failure-domain.beta.kubernetes.io/.*" ]
+
+  # ipFamily specifies the IP family to use. Possible values: IPv4, IPv6 and "" (auto-detect)
+  ipFamily: ""
 
   # setDefaultSecurityContext determines whether a default security context is set on application containers created by the operator.
   # *note* that the default option now is "auto-detect" to attempt to set this properly automatically when both running
@@ -214,6 +222,10 @@ config:
 
   # Interval between observations of Elasticsearch health, non-positive values disable asynchronous observation.
   elasticsearchObservationInterval: 10s
+
+  # ubiOnly specifies whether the operator will use only UBI container images to deploy Elastic Stack applications. UBI images are only available from 7.10.0 onward.
+  # Cannot be combined with the containerSuffix value.
+  ubiOnly: false
 
 # Prometheus PodMonitor configuration
 # Reference: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#podmonitor


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.10`:
 - [Allow setting additional Operator flags. (#7252)](https://github.com/elastic/cloud-on-k8s/pull/7252)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)