### PR TITLE
[2.10] Update oldest supported Openshift version (#7244)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Current features:
 Supported versions:
 
 *  Kubernetes 1.24-1.28
-*  OpenShift 4.9-4.13
+*  OpenShift 4.11-4.13
 *  Elasticsearch, Kibana, APM Server: 6.8+, 7.1+, 8+
 *  Enterprise Search: 7.7+, 8+
 *  Beats: 7.0+, 8+

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -1,5 +1,5 @@
 * Kubernetes 1.24-1.28
-* OpenShift 4.9-4.13
+* OpenShift 4.11-4.13
 * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 * Helm: 3.2.0+
 * Elasticsearch, Kibana, APM Server: 6.8+, 7.1+, 8+

--- a/hack/operatorhub/config.yaml
+++ b/hack/operatorhub/config.yaml
@@ -42,7 +42,7 @@ packages:
   - outputPath: certified-operators
     packageName: elasticsearch-eck-operator-certified
     distributionChannel: certified-operators
-    minSupportedOpenshiftVersion: v4.9
+    minSupportedOpenshiftVersion: v4.11
     operatorRepo: registry.connect.redhat.com/elastic/eck-operator
     ubiOnly: true
     ## digestPinning should only be set to true for certified operator.

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -278,7 +278,7 @@ spec:
 
     * Kubernetes 1.24-1.28
 
-    * OpenShift 4.9-4.13
+    * OpenShift 4.11-4.13
 
     * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.10`:
 - [Update oldest supported Openshift version (#7244)](https://github.com/elastic/cloud-on-k8s/pull/7244)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)