### PR TITLE
`make e2e-local` Fixes

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -38,11 +38,9 @@ main() {
     run_e2e_tests "$@" | tee "$ARTEFACTS_DIR/e2e-tests-$CLUSTER_NAME.json"
   fi
   touch /tmp/done
-  if [ "$(uname)" == "Linux" ] ; then
-    sleep infinity
-  else
-    sleep 86400
-  fi
+  while true; do
+    sleep 60
+  done
 }
 
 main "$@"

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -38,7 +38,7 @@ main() {
     run_e2e_tests "$@" | tee "$ARTEFACTS_DIR/e2e-tests-$CLUSTER_NAME.json"
   fi
   touch /tmp/done
-  if [ $(uname) == "Linux" ] ; then
+  if [ "$(uname)" == "Linux" ] ; then
     sleep infinity
   else
     sleep 86400

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -10,6 +10,7 @@ chaos=${CHAOS:-"false"}
 
 ARTEFACTS_DIR=${ARTEFACTS_DIR:-.}
 CLUSTER_NAME=${CLUSTER_NAME:-local}
+E2E_TAGS=${E2E_TAGS:-e2e}
 
 run_e2e_tests() {
   if [ "${E2E_JSON}" == "true" ]
@@ -37,7 +38,11 @@ main() {
     run_e2e_tests "$@" | tee "$ARTEFACTS_DIR/e2e-tests-$CLUSTER_NAME.json"
   fi
   touch /tmp/done
-  sleep infinity
+  if [ $(uname) == "Linux" ] ; then
+    sleep infinity
+  else
+    sleep 86400
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
## What is this changing
1. Fixes this issue running `make e2e-local`.
```
test/e2e/run.sh: line 19: E2E_TAGS: unbound variable
```
I'm honestly not 100% sure about this fix, but it seems to work locally for me. Please correct me if my syntax is slightly off.

2. `sleep infinity` doesn't work on `Darwin`, so if `uname` isn't `Linux` use `sleep 86400` which is `24 hours`.