### PR TITLE
[2.10] Ignore `remote_cluster_client` role when calculating autoscaling status. (#7269)

### DIFF
--- a/pkg/controller/autoscaling/elasticsearch/driver.go
+++ b/pkg/controller/autoscaling/elasticsearch/driver.go
@@ -78,6 +78,9 @@ func newStatusBuilder(log logr.Logger, autoscalingPolicies v1alpha1.AutoscalingP
 	sort.Strings(roles)
 
 	for _, role := range roles {
+		if role == string(esv1.RemoteClusterClientRole) {
+			continue
+		}
 		policies := policiesByRole[role]
 		if len(policies) < 2 {
 			// This role is declared in only one autoscaling policy

--- a/pkg/controller/autoscaling/elasticsearch/driver_test.go
+++ b/pkg/controller/autoscaling/elasticsearch/driver_test.go
@@ -25,17 +25,17 @@ func Test_newStatusBuilder(t *testing.T) {
 		want []v1alpha1.AutoscalingPolicyStatus
 	}{
 		{
-			name: "Initialize new status with overlapping policies",
+			name: "Initialize new status with overlapping policies ignores remote_cluster_client role",
 			args: args{
 				autoscalingPolicies: []v1alpha1.AutoscalingPolicySpec{
 					{
-						NamedAutoscalingPolicy: v1alpha1.NamedAutoscalingPolicy{Name: "policy1", AutoscalingPolicy: v1alpha1.AutoscalingPolicy{Roles: []string{"role1", "role2"}}},
+						NamedAutoscalingPolicy: v1alpha1.NamedAutoscalingPolicy{Name: "policy1", AutoscalingPolicy: v1alpha1.AutoscalingPolicy{Roles: []string{"role1", "role2", "remote_cluster_client"}}},
 					},
 					{
-						NamedAutoscalingPolicy: v1alpha1.NamedAutoscalingPolicy{Name: "policy2", AutoscalingPolicy: v1alpha1.AutoscalingPolicy{Roles: []string{"role2", "role3", "role5"}}},
+						NamedAutoscalingPolicy: v1alpha1.NamedAutoscalingPolicy{Name: "policy2", AutoscalingPolicy: v1alpha1.AutoscalingPolicy{Roles: []string{"role2", "role3", "role5", "remote_cluster_client"}}},
 					},
 					{
-						NamedAutoscalingPolicy: v1alpha1.NamedAutoscalingPolicy{Name: "policy3", AutoscalingPolicy: v1alpha1.AutoscalingPolicy{Roles: []string{"role4", "role2", "role3"}}},
+						NamedAutoscalingPolicy: v1alpha1.NamedAutoscalingPolicy{Name: "policy3", AutoscalingPolicy: v1alpha1.AutoscalingPolicy{Roles: []string{"role4", "role2", "role3", "remote_cluster_client"}}},
 					},
 				},
 			},


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.10`:
 - [Ignore `remote_cluster_client` role when calculating autoscaling status. (#7269)](https://github.com/elastic/cloud-on-k8s/pull/7269)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)