### PR TITLE
Add missing RBAC rules for Fleet ECK Stack Helm Chart

### DIFF
--- a/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server-cluster-role_test.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server-cluster-role_test.yaml
@@ -24,21 +24,49 @@ tests:
           path: rules[0].verbs
           value:
           - get
-          - watch
           - list
+          - watch
       - equal:
           path: rules[1].apiGroups[0]
-          value: coordination.k8s.io
+          value: apps
       - equal:
           path: rules[1].resources
           value:
-          - leases
+          - deployments
+          - replicasets
+          - statefulsets
       - equal:
           path: rules[1].verbs
           value:
           - get
+          - list
+          - watch
+      - equal:
+          path: rules[2].apiGroups[0]
+          value: coordination.k8s.io
+      - equal:
+          path: rules[2].resources
+          value:
+          - leases
+      - equal:
+          path: rules[2].verbs
+          value:
+          - get
           - create
           - update
+      - equal:
+          path: rules[3].apiGroups[0]
+          value: batch
+      - equal:
+          path: rules[3].resources
+          value:
+          - jobs
+      - equal:
+          path: rules[3].verbs
+          value:
+          - get
+          - list
+          - watch
   - it: should render custom labels and annotations properly.
     set:
       labels:

--- a/deploy/eck-stack/charts/eck-fleet-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/values.yaml
@@ -104,8 +104,8 @@ clusterRole:
     - nodes
     verbs:
     - get
-    - watch
     - list
+    - watch
   - apiGroups: ["apps"]
     resources:
     - deployments
@@ -113,8 +113,8 @@ clusterRole:
     - statefulsets
     verbs:
     - get
-    - watch
     - list
+    - watch
   - apiGroups: ["coordination.k8s.io"]
     resources:
     - leases

--- a/deploy/eck-stack/charts/eck-fleet-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/values.yaml
@@ -106,6 +106,15 @@ clusterRole:
     - get
     - watch
     - list
+  - apiGroups: ["apps"]
+    resources:
+    - deployments
+    - replicasets
+    - statefulsets
+    verbs:
+    - get
+    - watch
+    - list
   - apiGroups: ["coordination.k8s.io"]
     resources:
     - leases
@@ -113,3 +122,10 @@ clusterRole:
     - get
     - create
     - update
+  - apiGroups: ["batch"]
+    resources:
+    - jobs
+    verbs:
+    - get
+    - list
+    - watch


### PR DESCRIPTION
## What is this change?

Upon some additional testing of Fleet ECK Stack Helm Chart, I noticed some missing RBAC rules in fleet start. Although it doesn't (seemingly) affect functionality, as fleet comes online fine, it is noticeable in the logs.

```
{"log.level":"error","@timestamp":"2023-11-06T20:43:03.397Z","message":"E1106 20:43:03.397641    1117 reflector.go:138] k8s.io/client-go@v0.23.4/tools/cache/reflector.go:167: Failed to watch *v1.ReplicaSet: failed to list *v1.ReplicaSet: replicasets.apps is forbidden: User \"system:serviceaccount:elastic-stack:fleet-server\" cannot list resource \"replicasets\" in API group \"apps\" at the cluster scope","component":{"binary":"filebeat","dataset":"elastic_agent.filebeat","id":"filestream-monitoring","type":"filestream"},"log":{"source":"filestream-monitoring"},"ecs.version":"1.6.0"}
```

Also seeing similar log entries for Jobs.

Todo:
- [ ] Going to verify with Fleet team if deployments, and statefulsets (and potentially daemonsets) are required...