### PR TITLE
Fix operatorhub container publish operation

### DIFF
--- a/hack/operatorhub/internal/container/container.go
+++ b/hack/operatorhub/internal/container/container.go
@@ -361,7 +361,7 @@ func doOperationForImage(image *Image, c CommonConfig, newTag string, operation 
 	defer cancel()
 	log.Printf("operation %s for image (%s), tag %s: ", operation, image.ID, newTag)
 	url := fmt.Sprintf(imagePublishURL, catalogAPIURL, c.ProjectID)
-	var body = []byte(fmt.Sprintf(`{"image_id": "%s", "operation": "%s"}`, operation, image.ID))
+	var body = []byte(fmt.Sprintf(`{"image_id": "%s", "operation": "%s"}`, image.ID, operation))
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
 	if err != nil {
 		log.Println("ⅹ")


### PR DESCRIPTION
This was resulting in a `400` when calling the redhat connect API.