### PR TITLE
[DOCFIX] makes plugin installation via initContainer more robust

### DIFF
--- a/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
@@ -267,7 +267,7 @@ nodeSets:
     # - command:
     #   - sh
     #   - "-c"
-    #   - bin/elasticsearch-plugin remove --purge repository-s3 ; bin/elasticsearch-plugin install --batch repository-s3
+    #   - bin/elasticsearch-plugin remove --purge analysis-icu ; bin/elasticsearch-plugin install --batch analysis-icu
     #   name: install-plugins
     #   securityContext:
     #     privileged: true

--- a/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
@@ -44,7 +44,7 @@ monitoring: {}
   # metrics:
   #   elasticsearchRefs:
   #   - name: monitoring
-  #     namespace: observability 
+  #     namespace: observability
   # logs:
   #   elasticsearchRefs:
   #   - name: monitoring
@@ -176,7 +176,7 @@ nodeSets:
     # https://v1-24.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#podtemplatespec-v1-core
     #
     # Only the commonly overridden/used fields will be noted below.
-    # 
+    #
     spec:
 
     # If specified, the pod's scheduling constraints
@@ -207,7 +207,7 @@ nodeSets:
         resources:
           # Requests describes the minimum amount of compute resources required. If Requests is omitted for a container,
           # it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value.
-          # 
+          #
           # Defaults used by the ECK Operator, if not specified, are below
           limits:
             # cpu: 1
@@ -267,7 +267,7 @@ nodeSets:
     # - command:
     #   - sh
     #   - "-c"
-    #   - bin/elasticsearch-plugin install --batch repository-s3
+    #   - bin/elasticsearch-plugin remove --purge repository-s3 ; bin/elasticsearch-plugin install --batch repository-s3
     #   name: install-plugins
     #   securityContext:
     #     privileged: true

--- a/docs/advanced-topics/service-meshes.asciidoc
+++ b/docs/advanced-topics/service-meshes.asciidoc
@@ -178,6 +178,7 @@ spec:
               - sh
               - -c
               - |
+                bin/elasticsearch-plugin remove --purge analysis-icu
                 bin/elasticsearch-plugin install --batch analysis-icu
 ----
 

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/bundles-plugins.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/bundles-plugins.asciidoc
@@ -105,6 +105,7 @@ spec:
           - |
             #!/usr/bin/env bash
             set -e
+            bin/elasticsearch-plugin remove --purge repository-s3 || true
             bin/elasticsearch-plugin install --batch repository-s3
             /bin/tini -- /usr/local/bin/docker-entrypoint.sh
 ----

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/bundles-plugins.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/bundles-plugins.asciidoc
@@ -11,7 +11,7 @@ endif::[]
 To run Elasticsearch with specific plugins or configuration files installed on ECK, you have two options. Each option has its own pros and cons.
 
 . Create a custom container image with the required plugins and configuration files.
-+ 
++
 * *Pros*
 ** Deployment is reproducible and reusable.
 ** Does not require internet access at runtime.
@@ -51,6 +51,7 @@ spec:
           - sh
           - -c
           - |
+            bin/elasticsearch-plugin remove --purge repository-azure
             bin/elasticsearch-plugin install --batch repository-azure
 ----
 

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/init-containers-plugin-downloads.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/init-containers-plugin-downloads.asciidoc
@@ -24,7 +24,7 @@ spec:
           - sh
           - -c
           - |
-            bin/elasticsearch-plugin install --batch analysis-icu
+            bin/elasticsearch-plugin remove --purge analysis-icu ; bin/elasticsearch-plugin install --batch analysis-icu
 ----
 
 You can also override the Elasticsearch container image to use your own image with the plugins already installed, as described in <<{p}-custom-images,custom images>>. For more information on both these options, you can check the <<{p}-snapshots,Create automated snapshots>> section and the Kubernetes documentation on https://kubernetes.io/docs/concepts/workloads/pods/init-containers/[init containers].

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/init-containers-plugin-downloads.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/init-containers-plugin-downloads.asciidoc
@@ -24,7 +24,8 @@ spec:
           - sh
           - -c
           - |
-            bin/elasticsearch-plugin remove --purge analysis-icu ; bin/elasticsearch-plugin install --batch analysis-icu
+            bin/elasticsearch-plugin remove --purge analysis-icu
+            bin/elasticsearch-plugin install --batch analysis-icu
 ----
 
 You can also override the Elasticsearch container image to use your own image with the plugins already installed, as described in <<{p}-custom-images,custom images>>. For more information on both these options, you can check the <<{p}-snapshots,Create automated snapshots>> section and the Kubernetes documentation on https://kubernetes.io/docs/concepts/workloads/pods/init-containers/[init containers].

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/snapshots.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/snapshots.asciidoc
@@ -429,6 +429,7 @@ spec:
           - sh
           - -c
           - |
+            bin/elasticsearch-plugin remove --purge repository-gcs
             bin/elasticsearch-plugin install --batch repository-gcs
 ----
 
@@ -438,7 +439,3 @@ Assuming you stored this in a file called `elasticsearch.yaml` you can in both c
 ----
 kubectl apply -f elasticsearch.yaml
 ----
-
-
-
-


### PR DESCRIPTION
Removes plugin before installing it to prevent edge cases where initContainer starts crashing loopback when plugin installation failed partially.

