### PR TITLE
Add retries to check for data loss by testing reversal ES mutations

### DIFF
--- a/test/e2e/test/elasticsearch/checks_reversal.go
+++ b/test/e2e/test/elasticsearch/checks_reversal.go
@@ -83,7 +83,6 @@ func (s *MutationReversalTestContext) PostMutationSteps(k *test.K8sClient) test.
 }
 
 func (s *MutationReversalTestContext) VerificationSteps(_ *test.K8sClient) test.StepList {
-	//nolint:thelper
 	return test.StepList{
 		{
 			Name: "Verify no data loss has happened during the aborted upgrade",

--- a/test/e2e/test/elasticsearch/checks_reversal.go
+++ b/test/e2e/test/elasticsearch/checks_reversal.go
@@ -87,9 +87,9 @@ func (s *MutationReversalTestContext) VerificationSteps(_ *test.K8sClient) test.
 	return test.StepList{
 		{
 			Name: "Verify no data loss has happened during the aborted upgrade",
-			Test: func(t *testing.T) {
-				require.NoError(t, s.dataIntegrity.Verify())
-			},
+			Test: test.Eventually(func() error {
+				return s.dataIntegrity.Verify()
+			}),
 		},
 	}
 }


### PR DESCRIPTION
This adds retries to verify that here was no data loss when testing changes on a resource that are immediately reverted,
because there may be a network problem at this time:

```
=== RUN   TestReversalStatefulSetRename/Verify_no_data_loss_has_happened_during_the_aborted_upgrade
checks_reversal.go:91: 
  Error Trace:	/go/src/github.com/elastic/cloud-on-k8s/test/e2e/test/elasticsearch/checks_reversal.go:91
  Error:      	Received unexpected error:
    elasticsearch client failed for https://test-sset-rename-reversal-qp9f-es-internal-http.e2e-1k6sz-mercury.svc:9200/data-integrity-check/_search?size=5: 
      Get "https://test-sset-rename-reversal-qp9f-es-internal-http.e2e-1k6sz-mercury.svc:9200/data-integrity-check/_search?size=5": 
        dial tcp 10.115.68.59:9200: connect: connection timed out
```