### PR TITLE
[2.10] Documentation link replaced with markup in 2.10 release notes (#7306)

### DIFF
--- a/docs/release-notes/highlights-2.10.0.asciidoc
+++ b/docs/release-notes/highlights-2.10.0.asciidoc
@@ -17,4 +17,4 @@ ECK 2.10.0 supports managing Logstash resources via Helm charts, similarly to ot
 [id="{p}-2100-agent-non-root"]
 === Running Elastic Agent as non-root
 
-ECK 2.10.0 supports running Elastic Agent without running the Pod as the root user (see https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-running-as-a-non-root-user[documentation]).
+ECK 2.10.0 supports running Elastic Agent without running the Pod as the root user (see <<{p}-elastic-agent-running-as-a-non-root-user,documentation>>).


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.10`:
 - [Documentation link replaced with markup in 2.10 release notes (#7306)](https://github.com/elastic/cloud-on-k8s/pull/7306)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)