### PR TITLE
Revert "Update beats stack monitoring recipe (#7322)"

### DIFF
--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -36,7 +36,9 @@ spec:
                     hosts: "https://${data.host}:${data.ports.https}"
                     username: ${MONITORED_ES_USERNAME}
                     password: ${MONITORED_ES_PASSWORD}
-                    ssl.verification_mode: "certificate"
+                    # WARNING: disables TLS as the default certificate is not valid for the pod FQDN
+                    # TODO: switch this to "certificate" when available: https://github.com/elastic/beats/issues/8164
+                    ssl.verification_mode: "none"
                     xpack.enabled: true
               - condition:
                   contains:
@@ -49,7 +51,9 @@ spec:
                     hosts: "https://${data.host}:${data.ports.https}"
                     username: ${MONITORED_ES_USERNAME}
                     password: ${MONITORED_ES_PASSWORD}
-                    ssl.verification_mode: "certificate"
+                    # WARNING: disables TLS as the default certificate is not valid for the pod FQDN
+                    # TODO: switch this to "certificate" when available: https://github.com/elastic/beats/issues/8164
+                    ssl.verification_mode: "none"
                     xpack.enabled: true
     processors:
     - add_cloud_metadata: {}


### PR DESCRIPTION
This reverts commit bba23de8c39f6c44467b644ef5ef1ed8bf7c6b5c.

According to e2e testing (`TestMetricbeatStackMonitoringRecipe`), `ssl.verification_mode: "certificate"` doesn't seem to work as expected.