### PR TITLE
Docs: Use `docker.io/bash` for sleep container of max-map-count-setter Daemonset

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
@@ -92,7 +92,8 @@ spec:
           command: ['/usr/local/bin/bash', '-e', '-c', 'echo 262144 > /proc/sys/vm/max_map_count']
       containers:
         - name: sleep
-          image: gcr.io/google-containers/pause-amd64:3.2
+          image: docker.io/bash:5.2.21
+          command: ['sleep', 'infinity']
 EOF
 ----
 

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
@@ -81,7 +81,7 @@ spec:
     spec:
       initContainers:
         - name: max-map-count-setter
-          image: docker.io/bash:5.2.15
+          image: docker.io/bash:5.2.21
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
On GKE Autopilot the Daemonset only works if a `docker.io/bash` image is used for the sleep container. For other images trying to apply this gives the follwing error message:

```
Error from server (GKE Warden constraints violations): error when creating "daemonset.yaml": admission webhook "warden-validating.common-webhooks.networking.gke.io" denied the request: GKE Warden rejected the request because it violates one or more constraints.
Violations details: {"[denied by autogke-disallow-privilege]":["container max-map-count-setter is privileged; not allowed in Autopilot"]}
```

I could not find official documentation from Google on this but I tested myself and it only works this way.
