### PR TITLE
Allow Elastic Agent in different namespace than Elasticsearch

### DIFF
--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -333,7 +333,7 @@ func applyRelatedEsAssoc(agent agentv1alpha1.Agent, esAssociation commonv1.Assoc
 		return builder, nil
 	}
 
-	esRef := esAssociation.AssociationRef()
+	// esRef := esAssociation.AssociationRef()
 	// if !esRef.IsExternal() && !agent.Spec.FleetServerEnabled && agent.Namespace != esRef.Namespace {
 	// 	// check agent and ES share the same namespace
 	// 	return nil, fmt.Errorf(

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -333,16 +333,6 @@ func applyRelatedEsAssoc(agent agentv1alpha1.Agent, esAssociation commonv1.Assoc
 		return builder, nil
 	}
 
-	// esRef := esAssociation.AssociationRef()
-	// if !esRef.IsExternal() && !agent.Spec.FleetServerEnabled && agent.Namespace != esRef.Namespace {
-	// 	// check agent and ES share the same namespace
-	// 	return nil, fmt.Errorf(
-	// 		"agent namespace %s is different than referenced Elasticsearch namespace %s, this is not supported yet",
-	// 		agent.Namespace,
-	// 		esAssociation.AssociationRef().Namespace,
-	// 	)
-	// }
-
 	// no ES CA to configure, skip
 	assocConf, err := esAssociation.AssociationConf()
 	if err != nil {

--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -334,14 +334,14 @@ func applyRelatedEsAssoc(agent agentv1alpha1.Agent, esAssociation commonv1.Assoc
 	}
 
 	esRef := esAssociation.AssociationRef()
-	if !esRef.IsExternal() && !agent.Spec.FleetServerEnabled && agent.Namespace != esRef.Namespace {
-		// check agent and ES share the same namespace
-		return nil, fmt.Errorf(
-			"agent namespace %s is different than referenced Elasticsearch namespace %s, this is not supported yet",
-			agent.Namespace,
-			esAssociation.AssociationRef().Namespace,
-		)
-	}
+	// if !esRef.IsExternal() && !agent.Spec.FleetServerEnabled && agent.Namespace != esRef.Namespace {
+	// 	// check agent and ES share the same namespace
+	// 	return nil, fmt.Errorf(
+	// 		"agent namespace %s is different than referenced Elasticsearch namespace %s, this is not supported yet",
+	// 		agent.Namespace,
+	// 		esAssociation.AssociationRef().Namespace,
+	// 	)
+	// }
 
 	// no ES CA to configure, skip
 	assocConf, err := esAssociation.AssociationConf()


### PR DESCRIPTION
resolves #7352 

## What does this change?

Both root and non-root, fleet and non-fleet Agent installations were being blocked from Agent running in a different namespace because of a legacy association check. We've verified that it's no longer valid by testing various permutations of Agent. The initial [check](https://github.com/elastic/cloud-on-k8s/pull/4614/files#r666970945) for this comes from the first PR for the Agent CRD. The [next change](https://github.com/elastic/cloud-on-k8s/pull/5240/files#diff-4df662e0c3607749f3636339227faa2f180610a399151e31d0a1600312bd545fR323) comes from when custom secrets were put in place for references to non-eck ES installations.