### PR TITLE
Fix continuousHealthCheck mutation step

### DIFF
--- a/test/e2e/test/elasticsearch/steps_mutation.go
+++ b/test/e2e/test/elasticsearch/steps_mutation.go
@@ -159,10 +159,10 @@ func (b Builder) MutationTestSteps(k *test.K8sClient) test.StepList {
 				Test: func(t *testing.T) {
 					continuousHealthChecks.Stop()
 
-					log.Info("continuousHealthChecks %d failures (tolerated %d)",
-						continuousHealthChecks.FailureCount,
-						b.mutationToleratedChecksFailureCount,
-						continuousHealthChecks.FailuresAsString())
+					log.Info("ContinuousHealthChecks failures",
+						"count", continuousHealthChecks.FailureCount,
+						"tolerance", b.mutationToleratedChecksFailureCount,
+						"detail", continuousHealthChecks.FailuresAsString())
 
 					require.LessOrEqual(t, continuousHealthChecks.FailureCount, b.mutationToleratedChecksFailureCount)
 				},


### PR DESCRIPTION
This fixes the issue where we have the step 'Elasticsearch cluster health should not have been red during mutation process' that is failing despite the number of failures is lower than the number of tolerated failures by moving the `t.Errorf`, which is equivalent to `Logf` followed by `Fail`.

https://github.com/elastic/cloud-on-k8s/blob/58b5a7302240500f0fd3d0ab13dde2d1385470b6/test/e2e/test/elasticsearch/steps_mutation.go#L159-L161

Using `t.Errorf`, the step failed whenever there was at least one failure, which made sense initially but should have been removed in #7000.

Resolves https://github.com/elastic/cloud-on-k8s/issues/5795#issuecomment-1755450818.