### PR TITLE
Use 2 node clusters where indices are created with a replica

### DIFF
--- a/test/e2e/kb/association_test.go
+++ b/test/e2e/kb/association_test.go
@@ -61,7 +61,7 @@ func TestEntSearchAssociation(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithNamespace(esKbNamespace).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources). // TODO .ds-metrics-fleet_server.agent_status-default index is created with a replica
 		WithRestrictedSecurityContext()
 	entBuilder := enterprisesearch.NewBuilder(name).
 		WithNamespace(entNamespace).
@@ -113,7 +113,7 @@ func TestKibanaAssociationWithNonExistentES(t *testing.T) {
 func TestKibanaAssociationWhenReferencedESDisappears(t *testing.T) {
 	name := "test-kb-del-referenced-es"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources) // TODO .ds-metrics-fleet_server.agent_status-default index is created with a replica
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)

--- a/test/e2e/kb/failure_test.go
+++ b/test/e2e/kb/failure_test.go
@@ -24,7 +24,7 @@ import (
 func TestKillKibanaPod(t *testing.T) {
 	name := "test-kill-kb-pod"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources) // TODO .ds-metrics-fleet_server.agent_status-default index is created with a replica
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)
@@ -40,7 +40,7 @@ func TestKillKibanaPod(t *testing.T) {
 func TestKillKibanaDeployment(t *testing.T) {
 	name := "test-kill-kb-deploy"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources) // TODO .ds-metrics-fleet_server.agent_status-default index is created with a replica
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)

--- a/test/e2e/kb/stack_monitoring_test.go
+++ b/test/e2e/kb/stack_monitoring_test.go
@@ -31,7 +31,7 @@ func TestKBStackMonitoring(t *testing.T) {
 	logs := elasticsearch.NewBuilder("test-kb-mon-logs").
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	assocEs := elasticsearch.NewBuilder("test-kb-mon-a").
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources) // TODO .ds-metrics-fleet_server.agent_status-default index is created with a replica
 	monitored := kibana.NewBuilder("test-kb-mon-a").
 		WithElasticsearchRef(assocEs.Ref()).
 		WithNodeCount(1).


### PR DESCRIPTION
There have been a few test failures with 8.12-SNAPSHOT:
- TestEntSearchAssociation
- TestKibanaAssociationWhenReferencedESDisappears
- TestKillKibanaPod
- TestKillKibanaDeployment
- TestKBStackMonitoring

due to an index being created with a replica, when the test cluster is only running with a single node.

```
.ds-metrics-fleet_server.agent_status-default-2023.12.05-000001 0 p STARTED      1   8.9kb   8.9kb 10.117.225.40 test-kill-kb-pod-d7x5-es-masterdata-0
.ds-metrics-fleet_server.agent_status-default-2023.12.05-000001 0 r UNASSIGNED
```

This PR adds another node to these tests, until we figure out what needs to be reconfigured so that the index in question is created with `auto_expand_replicas` set to `0-1`, for example.

I think this is the relevant index template:
```json
        {
            "name": "metrics",
            "index_template": {
                "index_patterns": [
                    "metrics-*-*"
                ],
                "composed_of": [
                    "metrics@mappings",
                    "data-streams@mappings",
                    "metrics@settings"
                ],
                "priority": 100,
                "version": 4,
                "_meta": {
                    "managed": true,
                    "description": "default metrics template installed by x-pack"
                },
                "data_stream": {
                    "hidden": false,
                    "allow_custom_routing": false,
                    "failure_store": false
                },
                "allow_auto_create": true,
                "deprecated": false
            }
        },
```