### PR TITLE
Document known issue with Kibana 8.11.2 using secure settings

### DIFF
--- a/docs/release-notes/highlights-2.10.0.asciidoc
+++ b/docs/release-notes/highlights-2.10.0.asciidoc
@@ -2,6 +2,14 @@
 == 2.10.0 release highlights
 
 [float]
+[id="{p}-2100-known-issues"]
+=== Known issues
+- Upgrading Kibana configured with <<{p}-kibana-secure-settings,secure settings>> to version `8.11.2` lead to Kibana pods in Error
+The underlying link:https://github.com/elastic/cloud-on-k8s/issues/6303[issue] shows a workaround if you are in this situation.
+Upgrade directly to `8.11.3` to avoid this.
+
+
+[float]
 [id="{p}-2100-new-and-notable"]
 === New and notable
 

--- a/docs/release-notes/highlights-2.10.0.asciidoc
+++ b/docs/release-notes/highlights-2.10.0.asciidoc
@@ -4,7 +4,7 @@
 [float]
 [id="{p}-2100-known-issues"]
 === Known issues
-- Upgrading Kibana configured with <<{p}-kibana-secure-settings,secure settings>> to version `8.11.2` lead to Kibana pods in Error
+- Upgrading Kibana configured with <<{p}-kibana-secure-settings,secure settings>> to version `8.11.2` leads to Kibana pods being unavailable with status `Init:Error`.
 The underlying link:https://github.com/elastic/cloud-on-k8s/issues/6303[issue] shows a workaround if you are in this situation.
 Upgrade directly to `8.11.3` to avoid this.
 


### PR DESCRIPTION
This adds a known issue in the ECK 2.10.0 release with a link to the workaround for 8.11.2 given that this has already shipped.

Relates to #7371.