### PR TITLE
Update eck-elasticsearch default secureSettings values to be slice.

### DIFF
--- a/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
@@ -91,7 +91,7 @@ http: {}
 # Control Elasticsearch Secure Settings.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-es-secure-settings.html#k8s-es-secure-settings
 #
-secureSettings: {}
+secureSettings: []
   # - secretName: one-secure-settings-secret
   # Projection of secret keys to specific paths
   # - secretName: gcs-secure-settings


### PR DESCRIPTION
When installing/upgrading and setting `secureSettings` for the eck-elasticsearch Helm chart you get this warning:

```shell
❯ helm upgrade -i my-deployment elastic/eck-stack -n elastic --values values-initial.yaml
Release "my-deployment" does not exist. Installing it now.
coalesce.go:286: warning: cannot overwrite table with non table for eck-stack.eck-elasticsearch.secureSettings (map[])
NAME: my-deployment
LAST DEPLOYED: Tue Dec 19 10:17:24 2023
```

With these values:
```yaml
eck-elasticsearch:
  fullnameOverride: elasticsearch01
  version: 8.11.1
  secureSettings:
    - secretName: gcs-credentials
  nodeSets:
  - name: master-data-nodes
    count: 3
    config:
      node.roles: ["master", "data", "ingest"]
    volumeClaimTemplates:
    - metadata:
        name: elasticsearch-data
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 5Gi
        storageClassName: standard
```

This is because `secureSettings` is supposed to be an array/slice, not a map.

After this update, no error is seen
```shell
❯ helm upgrade -i my-deployment . -n elastic --values /path/to/values-initial.yaml
Release "my-deployment" does not exist. Installing it now.
NAME: my-deployment
LAST DEPLOYED: Tue Dec 19 10:28:20 2023
NAMESPACE: elastic
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Elasticsearch ECK-Stack 0.9.0-SNAPSHOT has been deployed successfully!
```
