### PR TITLE
[Backport 2.11] [E2E][Agent] Adjust expect error in TestWebhook (#7404)

### DIFF
--- a/test/e2e/agent/webhook_test.go
+++ b/test/e2e/agent/webhook_test.go
@@ -34,6 +34,6 @@ func TestWebhook(t *testing.T) {
 	require.Contains(
 		t,
 		err.Error(),
-		`either daemonset or deployment must be specified`,
+		`either daemonSet or deployment or statefulSet must be specified`,
 	)
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.11`:
 - [[E2E][Agent] Adjust expect error in TestWebhook (#7404)](https://github.com/elastic/cloud-on-k8s/pull/7404)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)