### PR TITLE
Revert e2e tests temporary fix that increases cluster size

### DIFF
--- a/test/e2e/apm/association_test.go
+++ b/test/e2e/apm/association_test.go
@@ -61,8 +61,7 @@ func TestAPMKibanaAssociation(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithNamespace(ns).
-		WithESMasterDataNodes(2, elasticsearch.DefaultResources). // TODO revert when https://github.com/elastic/cloud-on-k8s/issues/7376 is resolved.
-
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
 		WithRestrictedSecurityContext()
 
 	kbBuilder := kibana.NewBuilder(name).

--- a/test/e2e/kb/association_test.go
+++ b/test/e2e/kb/association_test.go
@@ -61,7 +61,7 @@ func TestEntSearchAssociation(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithNamespace(esKbNamespace).
-		WithESMasterDataNodes(2, elasticsearch.DefaultResources). // TODO .ds-metrics-fleet_server.agent_status-default index is created with a replica
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
 		WithRestrictedSecurityContext()
 	entBuilder := enterprisesearch.NewBuilder(name).
 		WithNamespace(entNamespace).
@@ -113,7 +113,7 @@ func TestKibanaAssociationWithNonExistentES(t *testing.T) {
 func TestKibanaAssociationWhenReferencedESDisappears(t *testing.T) {
 	name := "test-kb-del-referenced-es"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(2, elasticsearch.DefaultResources) // TODO .ds-metrics-fleet_server.agent_status-default index is created with a replica
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)

--- a/test/e2e/kb/association_test.go
+++ b/test/e2e/kb/association_test.go
@@ -34,7 +34,7 @@ func TestCrossNSAssociation(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithNamespace(esNamespace).
-		WithESMasterDataNodes(2, elasticsearch.DefaultResources). // TODO revert when https://github.com/elastic/cloud-on-k8s/issues/7376 is resolved.
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
 		WithRestrictedSecurityContext()
 	kbBuilder := kibana.NewBuilder(name).
 		WithNamespace(kbNamespace).
@@ -61,7 +61,7 @@ func TestEntSearchAssociation(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithNamespace(esKbNamespace).
-		WithESMasterDataNodes(2, elasticsearch.DefaultResources). // TODO revert when https://github.com/elastic/cloud-on-k8s/issues/7376 is resolved.
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources). // TODO .ds-metrics-fleet_server.agent_status-default index is created with a replica
 		WithRestrictedSecurityContext()
 	entBuilder := enterprisesearch.NewBuilder(name).
 		WithNamespace(entNamespace).
@@ -113,7 +113,7 @@ func TestKibanaAssociationWithNonExistentES(t *testing.T) {
 func TestKibanaAssociationWhenReferencedESDisappears(t *testing.T) {
 	name := "test-kb-del-referenced-es"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(2, elasticsearch.DefaultResources) // TODO revert when https://github.com/elastic/cloud-on-k8s/issues/7376 is resolved.
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources) // TODO .ds-metrics-fleet_server.agent_status-default index is created with a replica
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)

--- a/test/e2e/kb/failure_test.go
+++ b/test/e2e/kb/failure_test.go
@@ -24,7 +24,7 @@ import (
 func TestKillKibanaPod(t *testing.T) {
 	name := "test-kill-kb-pod"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(2, elasticsearch.DefaultResources) // TODO revert when https://github.com/elastic/cloud-on-k8s/issues/7376 is resolved.
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources) // TODO .ds-metrics-fleet_server.agent_status-default index is created with a replica
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)
@@ -40,7 +40,7 @@ func TestKillKibanaPod(t *testing.T) {
 func TestKillKibanaDeployment(t *testing.T) {
 	name := "test-kill-kb-deploy"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(2, elasticsearch.DefaultResources) // TODO revert when https://github.com/elastic/cloud-on-k8s/issues/7376 is resolved.
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources) // TODO .ds-metrics-fleet_server.agent_status-default index is created with a replica
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)

--- a/test/e2e/kb/failure_test.go
+++ b/test/e2e/kb/failure_test.go
@@ -24,7 +24,7 @@ import (
 func TestKillKibanaPod(t *testing.T) {
 	name := "test-kill-kb-pod"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(2, elasticsearch.DefaultResources) // TODO .ds-metrics-fleet_server.agent_status-default index is created with a replica
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)
@@ -40,7 +40,7 @@ func TestKillKibanaPod(t *testing.T) {
 func TestKillKibanaDeployment(t *testing.T) {
 	name := "test-kill-kb-deploy"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(2, elasticsearch.DefaultResources) // TODO .ds-metrics-fleet_server.agent_status-default index is created with a replica
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 	kbBuilder := kibana.NewBuilder(name).
 		WithElasticsearchRef(esBuilder.Ref()).
 		WithNodeCount(1)

--- a/test/e2e/kb/stack_monitoring_test.go
+++ b/test/e2e/kb/stack_monitoring_test.go
@@ -31,7 +31,7 @@ func TestKBStackMonitoring(t *testing.T) {
 	logs := elasticsearch.NewBuilder("test-kb-mon-logs").
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	assocEs := elasticsearch.NewBuilder("test-kb-mon-a").
-		WithESMasterDataNodes(2, elasticsearch.DefaultResources) // TODO .ds-metrics-fleet_server.agent_status-default index is created with a replica
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
 	monitored := kibana.NewBuilder("test-kb-mon-a").
 		WithElasticsearchRef(assocEs.Ref()).
 		WithNodeCount(1).

--- a/test/e2e/kb/stack_monitoring_test.go
+++ b/test/e2e/kb/stack_monitoring_test.go
@@ -31,7 +31,7 @@ func TestKBStackMonitoring(t *testing.T) {
 	logs := elasticsearch.NewBuilder("test-kb-mon-logs").
 		WithESMasterDataNodes(2, elasticsearch.DefaultResources)
 	assocEs := elasticsearch.NewBuilder("test-kb-mon-a").
-		WithESMasterDataNodes(2, elasticsearch.DefaultResources) // TODO revert when https://github.com/elastic/cloud-on-k8s/issues/7376 is resolved.
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources) // TODO .ds-metrics-fleet_server.agent_status-default index is created with a replica
 	monitored := kibana.NewBuilder("test-kb-mon-a").
 		WithElasticsearchRef(assocEs.Ref()).
 		WithNodeCount(1).

--- a/test/e2e/kb/standalone_test.go
+++ b/test/e2e/kb/standalone_test.go
@@ -68,9 +68,7 @@ func TestKibanaStandalone(t *testing.T) {
 	// set up a 1-node Kibana deployment manually connected to Elasticsearch
 	name := "test-kb-standalone"
 	esBuilder := elasticsearch.NewBuilder(name).
-		WithESMasterDataNodes(2, elasticsearch.DefaultResources). // TODO revert when https://github.com/elastic/cloud-on-k8s/issues/7376 is resolved.
-		// Fleet integration is now enabled by default and has a replica enabled by default.
-		// https://github.com/elastic/cloud-on-k8s/issues/7376#issuecomment-1863353206
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
 		WithRestrictedSecurityContext()
 	esBuilder.Elasticsearch.Spec.Auth = esv1.Auth{
 		FileRealm: []esv1.FileRealmSource{

--- a/test/e2e/kb/version_upgrade_test.go
+++ b/test/e2e/kb/version_upgrade_test.go
@@ -16,7 +16,7 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/reconcile"
-	kibana2 "github.com/elastic/cloud-on-k8s/v2/pkg/controller/kibana"
+	kblabel "github.com/elastic/cloud-on-k8s/v2/pkg/controller/kibana/label"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test/elasticsearch"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test/kibana"
@@ -48,8 +48,8 @@ func TestVersionUpgradeToLatest7x(t *testing.T) {
 	opts := []client.ListOption{
 		client.InNamespace(kbBuilder.Kibana.Namespace),
 		client.MatchingLabels(map[string]string{
-			commonv1.TypeLabelName:      kibana2.Type,
-			kibana2.KibanaNameLabelName: kbBuilder.Kibana.Name,
+			commonv1.TypeLabelName:      kblabel.Type,
+			kblabel.KibanaNameLabelName: kbBuilder.Kibana.Name,
 		}),
 	}
 
@@ -61,7 +61,7 @@ func TestVersionUpgradeToLatest7x(t *testing.T) {
 		t,
 		[]test.Builder{esBuilder, kbBuilder},
 		[]test.Builder{esBuilder, kbBuilder.WithVersion(dstVersion).WithNodeCount(3).WithMutatedFrom(&kbBuilder)},
-		[]test.Watcher{NewReadinessWatcher(opts...), test.NewVersionWatcher(kibana2.KibanaVersionLabelName, opts...)},
+		[]test.Watcher{NewReadinessWatcher(opts...), test.NewVersionWatcher(kblabel.KibanaVersionLabelName, opts...)},
 	)
 }
 
@@ -97,8 +97,8 @@ func TestVersionUpgradeAndRespecToLatest7x(t *testing.T) {
 	opts := []client.ListOption{
 		client.InNamespace(kbBuilder1.Kibana.Namespace),
 		client.MatchingLabels(map[string]string{
-			commonv1.TypeLabelName:      kibana2.Type,
-			kibana2.KibanaNameLabelName: kbBuilder1.Kibana.Name,
+			commonv1.TypeLabelName:      kblabel.Type,
+			kblabel.KibanaNameLabelName: kbBuilder1.Kibana.Name,
 		}),
 	}
 
@@ -131,7 +131,7 @@ func TestVersionUpgradeAndRespecToLatest7x(t *testing.T) {
 		t,
 		[]test.Builder{esBuilder, kbBuilder1},
 		[]test.Builder{esBuilder, kbBuilder2, kbBuilder3},
-		[]test.Watcher{w, test.NewVersionWatcher(kibana2.KibanaVersionLabelName, opts...)},
+		[]test.Watcher{w, test.NewVersionWatcher(kblabel.KibanaVersionLabelName, opts...)},
 	)
 }
 
@@ -155,8 +155,8 @@ func TestVersionUpgradeToLatest8x(t *testing.T) {
 	opts := []client.ListOption{
 		client.InNamespace(kbBuilder.Kibana.Namespace),
 		client.MatchingLabels(map[string]string{
-			commonv1.TypeLabelName:      kibana2.Type,
-			kibana2.KibanaNameLabelName: kbBuilder.Kibana.Name,
+			commonv1.TypeLabelName:      kblabel.Type,
+			kblabel.KibanaNameLabelName: kbBuilder.Kibana.Name,
 		}),
 	}
 
@@ -171,7 +171,7 @@ func TestVersionUpgradeToLatest8x(t *testing.T) {
 			esBuilder.WithVersion(dstVersion).WithMutatedFrom(&esBuilder),
 			kbBuilder.WithVersion(dstVersion).WithMutatedFrom(&kbBuilder),
 		},
-		[]test.Watcher{NewReadinessWatcher(opts...), test.NewVersionWatcher(kibana2.KibanaVersionLabelName, opts...)},
+		[]test.Watcher{NewReadinessWatcher(opts...), test.NewVersionWatcher(kblabel.KibanaVersionLabelName, opts...)},
 	)
 }
 
@@ -207,8 +207,8 @@ func TestVersionUpgradeAndRespecToLatest8x(t *testing.T) {
 	opts := []client.ListOption{
 		client.InNamespace(kbBuilder1.Kibana.Namespace),
 		client.MatchingLabels(map[string]string{
-			commonv1.TypeLabelName:      kibana2.Type,
-			kibana2.KibanaNameLabelName: kbBuilder1.Kibana.Name,
+			commonv1.TypeLabelName:      kblabel.Type,
+			kblabel.KibanaNameLabelName: kbBuilder1.Kibana.Name,
 		}),
 	}
 
@@ -241,7 +241,7 @@ func TestVersionUpgradeAndRespecToLatest8x(t *testing.T) {
 		t,
 		[]test.Builder{esBuilder, kbBuilder1},
 		[]test.Builder{esBuilder, kbBuilder2, kbBuilder3},
-		[]test.Watcher{w, test.NewVersionWatcher(kibana2.KibanaVersionLabelName, opts...)},
+		[]test.Watcher{w, test.NewVersionWatcher(kblabel.KibanaVersionLabelName, opts...)},
 	)
 }
 

--- a/test/e2e/kb/version_upgrade_test.go
+++ b/test/e2e/kb/version_upgrade_test.go
@@ -16,7 +16,7 @@ import (
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/reconcile"
-	kblabel "github.com/elastic/cloud-on-k8s/v2/pkg/controller/kibana/label"
+	kibana2 "github.com/elastic/cloud-on-k8s/v2/pkg/controller/kibana"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test/elasticsearch"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test/kibana"
@@ -48,8 +48,8 @@ func TestVersionUpgradeToLatest7x(t *testing.T) {
 	opts := []client.ListOption{
 		client.InNamespace(kbBuilder.Kibana.Namespace),
 		client.MatchingLabels(map[string]string{
-			commonv1.TypeLabelName:      kblabel.Type,
-			kblabel.KibanaNameLabelName: kbBuilder.Kibana.Name,
+			commonv1.TypeLabelName:      kibana2.Type,
+			kibana2.KibanaNameLabelName: kbBuilder.Kibana.Name,
 		}),
 	}
 
@@ -61,7 +61,7 @@ func TestVersionUpgradeToLatest7x(t *testing.T) {
 		t,
 		[]test.Builder{esBuilder, kbBuilder},
 		[]test.Builder{esBuilder, kbBuilder.WithVersion(dstVersion).WithNodeCount(3).WithMutatedFrom(&kbBuilder)},
-		[]test.Watcher{NewReadinessWatcher(opts...), test.NewVersionWatcher(kblabel.KibanaVersionLabelName, opts...)},
+		[]test.Watcher{NewReadinessWatcher(opts...), test.NewVersionWatcher(kibana2.KibanaVersionLabelName, opts...)},
 	)
 }
 
@@ -97,8 +97,8 @@ func TestVersionUpgradeAndRespecToLatest7x(t *testing.T) {
 	opts := []client.ListOption{
 		client.InNamespace(kbBuilder1.Kibana.Namespace),
 		client.MatchingLabels(map[string]string{
-			commonv1.TypeLabelName:      kblabel.Type,
-			kblabel.KibanaNameLabelName: kbBuilder1.Kibana.Name,
+			commonv1.TypeLabelName:      kibana2.Type,
+			kibana2.KibanaNameLabelName: kbBuilder1.Kibana.Name,
 		}),
 	}
 
@@ -131,7 +131,7 @@ func TestVersionUpgradeAndRespecToLatest7x(t *testing.T) {
 		t,
 		[]test.Builder{esBuilder, kbBuilder1},
 		[]test.Builder{esBuilder, kbBuilder2, kbBuilder3},
-		[]test.Watcher{w, test.NewVersionWatcher(kblabel.KibanaVersionLabelName, opts...)},
+		[]test.Watcher{w, test.NewVersionWatcher(kibana2.KibanaVersionLabelName, opts...)},
 	)
 }
 
@@ -155,8 +155,8 @@ func TestVersionUpgradeToLatest8x(t *testing.T) {
 	opts := []client.ListOption{
 		client.InNamespace(kbBuilder.Kibana.Namespace),
 		client.MatchingLabels(map[string]string{
-			commonv1.TypeLabelName:      kblabel.Type,
-			kblabel.KibanaNameLabelName: kbBuilder.Kibana.Name,
+			commonv1.TypeLabelName:      kibana2.Type,
+			kibana2.KibanaNameLabelName: kbBuilder.Kibana.Name,
 		}),
 	}
 
@@ -171,7 +171,7 @@ func TestVersionUpgradeToLatest8x(t *testing.T) {
 			esBuilder.WithVersion(dstVersion).WithMutatedFrom(&esBuilder),
 			kbBuilder.WithVersion(dstVersion).WithMutatedFrom(&kbBuilder),
 		},
-		[]test.Watcher{NewReadinessWatcher(opts...), test.NewVersionWatcher(kblabel.KibanaVersionLabelName, opts...)},
+		[]test.Watcher{NewReadinessWatcher(opts...), test.NewVersionWatcher(kibana2.KibanaVersionLabelName, opts...)},
 	)
 }
 
@@ -207,8 +207,8 @@ func TestVersionUpgradeAndRespecToLatest8x(t *testing.T) {
 	opts := []client.ListOption{
 		client.InNamespace(kbBuilder1.Kibana.Namespace),
 		client.MatchingLabels(map[string]string{
-			commonv1.TypeLabelName:      kblabel.Type,
-			kblabel.KibanaNameLabelName: kbBuilder1.Kibana.Name,
+			commonv1.TypeLabelName:      kibana2.Type,
+			kibana2.KibanaNameLabelName: kbBuilder1.Kibana.Name,
 		}),
 	}
 
@@ -241,7 +241,7 @@ func TestVersionUpgradeAndRespecToLatest8x(t *testing.T) {
 		t,
 		[]test.Builder{esBuilder, kbBuilder1},
 		[]test.Builder{esBuilder, kbBuilder2, kbBuilder3},
-		[]test.Watcher{w, test.NewVersionWatcher(kblabel.KibanaVersionLabelName, opts...)},
+		[]test.Watcher{w, test.NewVersionWatcher(kibana2.KibanaVersionLabelName, opts...)},
 	)
 }
 


### PR DESCRIPTION
Reverts d8f4407bf and 485d5114a as the latest `docker.elastic.co/kibana/kibana:8.12.0-SNAPSHOT` has now https://github.com/elastic/kibana/pull/173689. 

Relates to https://github.com/elastic/cloud-on-k8s/issues/7376.