### PR TITLE
Use 2-node clusters for apm e2e tests

### DIFF
--- a/test/e2e/apm/association_test.go
+++ b/test/e2e/apm/association_test.go
@@ -33,7 +33,7 @@ func TestCrossNSAssociation(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithNamespace(esNamespace).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources). // TODO: revert when https://github.com/elastic/cloud-on-k8s/issues/7418 is resolved.
 		WithRestrictedSecurityContext()
 	apmBuilder := apmserver.NewBuilder(name).
 		WithNamespace(apmNamespace).
@@ -61,7 +61,7 @@ func TestAPMKibanaAssociation(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithNamespace(ns).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources). // TODO: revert when https://github.com/elastic/cloud-on-k8s/issues/7418 is resolved.
 		WithRestrictedSecurityContext()
 
 	kbBuilder := kibana.NewBuilder(name).


### PR DESCRIPTION
related #7418

Adjust APM e2e tests to use a 2-node ES cluster temporarily.