### PR TITLE
[2.11] Use 2-node clusters for apm e2e tests (#7419)

### DIFF
--- a/test/e2e/apm/association_test.go
+++ b/test/e2e/apm/association_test.go
@@ -33,7 +33,7 @@ func TestCrossNSAssociation(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithNamespace(esNamespace).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources). // TODO: revert when https://github.com/elastic/cloud-on-k8s/issues/7418 is resolved.
 		WithRestrictedSecurityContext()
 	apmBuilder := apmserver.NewBuilder(name).
 		WithNamespace(apmNamespace).
@@ -61,7 +61,7 @@ func TestAPMKibanaAssociation(t *testing.T) {
 
 	esBuilder := elasticsearch.NewBuilder(name).
 		WithNamespace(ns).
-		WithESMasterDataNodes(1, elasticsearch.DefaultResources).
+		WithESMasterDataNodes(2, elasticsearch.DefaultResources). // TODO: revert when https://github.com/elastic/cloud-on-k8s/issues/7418 is resolved.
 		WithRestrictedSecurityContext()
 
 	kbBuilder := kibana.NewBuilder(name).


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.11`:
 - [Use 2-node clusters for apm e2e tests (#7419)](https://github.com/elastic/cloud-on-k8s/pull/7419)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)