### PR TITLE
[2.11] Remove useless --stdin argument from logstash-keystore add command (#7414)

### DIFF
--- a/pkg/controller/logstash/keystore.go
+++ b/pkg/controller/logstash/keystore.go
@@ -23,7 +23,7 @@ var (
 	keystoreCommand          = "echo 'y' | /usr/share/logstash/bin/logstash-keystore"
 	initContainersParameters = keystore.InitContainerParameters{
 		KeystoreCreateCommand:         keystoreCommand + " create",
-		KeystoreAddCommand:            keystoreCommand + ` add "$key" --stdin < "$filename"`,
+		KeystoreAddCommand:            keystoreCommand + ` add "$key" < "$filename"`,
 		SecureSettingsVolumeMountPath: keystore.SecureSettingsVolumeMountPath,
 		KeystoreVolumePath:            volume.ConfigMountPath,
 		Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.11`:
 - [Remove useless --stdin argument from logstash-keystore add command (#7414)](https://github.com/elastic/cloud-on-k8s/pull/7414)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)