### PR TITLE
Docsfix k8s virtual memory

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
@@ -101,7 +101,7 @@ To run an Elasticsearch instance that waits for the kernel setting to be in plac
 
 [source,yaml,subs="attributes,+macros"]
 ----
-cat $$<<$$EOF | kubectl apply -f -
+cat $$<<$$'EOF' | kubectl apply -f -
 apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
 kind: Elasticsearch
 metadata:


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/7422

The word (EOF) of the heredoc of the second scipt in https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html#k8s-virtual-memory is missing quotes.

Wrong behaviour:
```
$ cat << EOF
> ...
> command: ['sh', '-c', "while true; do mmc=$(cat /proc/sys/vm/max_map_count); if [ ${mmc} -eq 262144 ]; then exit 0; fi; sleep 1; done"]
> ...
> EOF
...
command: ['sh', '-c', "while true; do mmc=65530; if [  -eq 262144 ]; then exit 0; fi; sleep 1; done"]
...
```

Expected behaviour:
```
$ cat << 'EOF'
> ...
> command: ['sh', '-c', "while true; do mmc=$(cat /proc/sys/vm/max_map_count); if [ ${mmc} -eq 262144 ]; then exit 0; fi; sleep 1; done"]
> ...
> EOF
...
command: ['sh', '-c', "while true; do mmc=$(cat /proc/sys/vm/max_map_count); if [ ${mmc} -eq 262144 ]; then exit 0; fi; sleep 1; done"]
...
```

Compare https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Here-Documents
