### PR TITLE
Fix docs example for deploying Elasticsearch with max-map-count-check (#7426)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
@@ -101,7 +101,7 @@ To run an Elasticsearch instance that waits for the kernel setting to be in plac
 
 [source,yaml,subs="attributes,+macros"]
 ----
-cat $$<<$$EOF | kubectl apply -f -
+cat $$<<$$'EOF' | kubectl apply -f -
 apiVersion: elasticsearch.k8s.elastic.co/{eck_crd_version}
 kind: Elasticsearch
 metadata:


### PR DESCRIPTION
Backport the following commit to `2.11`:
- #7426