### PR TITLE
Update eck-attributes for 2.11 release

### DIFF
--- a/docs/eck-attributes.asciidoc
+++ b/docs/eck-attributes.asciidoc
@@ -1,5 +1,5 @@
-:eck_version: 2.10.0
+:eck_version: 2.11.0
 :eck_crd_version: v1
-:eck_release_branch: 2.10
+:eck_release_branch: 2.11
 :eck_github: https://github.com/elastic/cloud-on-k8s
 :eck_resources_list: Elasticsearch, Kibana, APM Server, Enterprise Search, Beats, Elastic Agent, Elastic Maps Server, and Logstash


### PR DESCRIPTION
Update Eck-attributes for 2.11 release.

_Should not be merged until after 2.11 release_