### PR TITLE
[E2E] Increase Filebeat memory to 512Mi

### DIFF
--- a/test/e2e/beat/config.go
+++ b/test/e2e/beat/config.go
@@ -27,14 +27,13 @@ processors:
   automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
   containers:
   - name: filebeat
-    # increase memory by +50% compared to the default value
     resources:
       requests:
         cpu: 100m
-        memory: 300Mi
+        memory: 512Mi
       limits:
         cpu: 100m
-        memory: 300Mi
+        memory: 512Mi
     volumeMounts:
     - mountPath: /var/lib/docker/containers
       name: varlibdockercontainers


### PR DESCRIPTION
Attempt to fix https://github.com/elastic/cloud-on-k8s/issues/7437 I did not manage to reproduce locally though.