### PR TITLE
Add breaking changes note to 2.11 release notes.

### DIFF
--- a/docs/release-notes/2.11.0.asciidoc
+++ b/docs/release-notes/2.11.0.asciidoc
@@ -4,6 +4,11 @@
 [[release-notes-2.11.0]]
 == {n} version 2.11.0
 
+[[breaking-2.11.0]]
+[float]
+=== Breaking changes
+
+* The `resourceStatuses` field of the status subresource of the Stack Configuration Policy has been renamed to `details`. {pull}7433[#7433]
 
 
 [[feature-2.11.0]]


### PR DESCRIPTION
Add notes to the release notes of 2.11 referencing the renaming of a field.