### PR TITLE
[Backport] [2.11] Release notes and highlights for 2.11.0 release (#7428), (#7439)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-2.11.0>>
 * <<release-notes-2.10.0>>
 * <<release-notes-2.9.0>>
 * <<release-notes-2.8.0>>
@@ -43,6 +44,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/2.11.0.asciidoc[]
 include::release-notes/2.10.0.asciidoc[]
 include::release-notes/2.9.0.asciidoc[]
 include::release-notes/2.8.0.asciidoc[]

--- a/docs/release-notes/2.11.0.asciidoc
+++ b/docs/release-notes/2.11.0.asciidoc
@@ -4,6 +4,11 @@
 [[release-notes-2.11.0]]
 == {n} version 2.11.0
 
+[[breaking-2.11.0]]
+[float]
+=== Breaking changes
+
+* The `resourceStatuses` field of the status subresource of the Stack Configuration Policy has been renamed to `details`. {pull}7433[#7433]
 
 
 [[feature-2.11.0]]

--- a/docs/release-notes/2.11.0.asciidoc
+++ b/docs/release-notes/2.11.0.asciidoc
@@ -1,0 +1,69 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-2.11.0]]
+== {n} version 2.11.0
+
+
+
+[[feature-2.11.0]]
+[float]
+=== New features
+
+* Introduce Kibana config field in stack config policy {pull}7324[#7324]
+* Introduce Elasticsearch config and additional secret mounts to stack config policy {pull}7233[#7233]
+* Add StatefulSet as a deployment option for Elastic Agent {pull}7357[#7357]
+
+[[enhancement-2.11.0]]
+[float]
+=== Enhancements
+
+* Allow Agent and Elastic stack in different namespaces. {pull}7382[#7382] (issue: {issue}7352[#7352])
+* Support -ubi suffix starting 8.12.0 and 7.17.16 {pull}7368[#7368]
+* Update to ubi9 and use -ubi prefix for operator image {pull}7321[#7321]
+* Allow setting additional operator flags via the Helm chart {pull}7252[#7252] (issue: {issue}6091[#6091])
+* Support configuring "ca-dir" operator setting via helm {pull}7243[#7243] (issues: {issue}6091[#6091], {issue}6435[#6435])
+
+[[bug-2.11.0]]
+[float]
+=== Bug fixes
+
+* Update eck-elasticsearch default secureSettings values to be slice. {pull}7397[#7397]
+* Fix recipe name to run Fleet as non-root {pull}7313[#7313] (issue: {issue}7312[#7312])
+
+[[docs-2.11.0]]
+[float]
+=== Documentation improvements
+
+* Document how to use stack config policies to manage authentication {pull}7381[#7381]
+* Fix secure settings link on stack config policy page {pull}7377[#7377]
+* Document known issue with Kibana 8.11.2 using secure settings {pull}7373[#7373] (issue: {issue}7371[#7371])
+* Add details about rolling restart behavior {pull}7372[#7372]
+* Update node configuration documentation to note reserved settings. {pull}7351[#7351]
+* Use `docker.io/bash` for sleep container of max-map-count-setter Daemonset {pull}7332[#7332]
+* Update Beats stack monitoring recipe {pull}7322[#7322]
+* Document basic snapshot repository setup for Azure {pull}7308[#7308]
+* Documentation link replaced with markup in 2.10 release notes {pull}7306[#7306]
+* Make plugin installation via initContainer more robust {pull}7305[#7305]
+* Add additional details on CA requirements. {pull}7271[#7271]
+* Document how to provide container registry credentials in air-gapped environments {pull}7256[#7256]
+
+[[nogroup-2.11.0]]
+[float]
+=== Misc
+
+* Bump golang.org/x/crypto from 0.16.0 to 0.17.0 {pull}7394[#7394]
+* chore(deps): update docker.io/library/golang docker tag to v1.21.5 {pull}7366[#7366]
+* fix(deps): update module github.com/google/go-containerregistry to v0.17.0 {pull}7355[#7355]
+* fix(deps): update module go.elastic.co/apm/v2 to v2.4.7 {pull}7337[#7337]
+* Bump github.com/go-jose/go-jose/v3 from 3.0.0 to 3.0.1 {pull}7329[#7329]
+* chore(deps): update registry.access.redhat.com/ubi9/ubi-minimal docker tag to v9 {pull}7326[#7326]
+* fix(deps): update k8s to v0.28.4 {pull}7319[#7319]
+* fix(deps): update module github.com/spf13/cobra to v1.8.0 {pull}7288[#7288]
+* Update docker v24.0.7+incompatible {pull}7282[#7282]
+* fix(deps): update module k8s.io/klog/v2 to v2.110.1 {pull}7278[#7278]
+* fix(deps): update module github.com/go-logr/logr to v1.3.0 {pull}7272[#7272]
+* fix(deps): update module github.com/google/uuid to v1.4.0 {pull}7270[#7270]
+* fix(deps): update module sigs.k8s.io/controller-runtime to v0.16.3 {pull}7249[#7249]
+* fix(deps): update module github.com/prometheus/common to v0.45.0 {pull}7246[#7246]
+

--- a/docs/release-notes/highlights-2.11.0.asciidoc
+++ b/docs/release-notes/highlights-2.11.0.asciidoc
@@ -1,0 +1,20 @@
+[[release-highlights-2.11.0]]
+== 2.11.0 release highlights
+
+[float]
+[id="{p}-2110-new-and-notable"]
+=== New and notable
+
+New and notable changes in version 2.11.0 of {n}. Check <<release-notes-2.11.0>> for the full list of changes.
+
+[float]
+[id="{p}-2110-kibana-stack-config-policy"]
+=== Allowing Kibana configuration in stack configuration policies
+
+Starting with ECK 2.11.0 support has been added for Kibana and Elasticsearch configuration within the Stack Config Policies which enables a variety of new use cases such as defining common security realms via LDAP, OIDC or JWT for multiple Elasticsearch clusters, refer to <<{p}-securing-stack>> for some examples.
+
+[float]
+[id="{p}-2110-agent-statefulset-deployment-option"]
+=== StatefulSet as a deployment option for Elastic Agent
+
+ECK 2.11.0 supports running Elastic Agent as a StatefulSet. An example can be found link:{eck_github}/blob/{eck_release_branch}/config/recipes/elastic-agent/ksm-sharding.yaml[in the ECK GitHub repository].

--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the most important changes in each release. For the full list, check <<eck-release-notes>>.
 
+* <<release-highlights-2.11.0>>
 * <<release-highlights-2.10.0>>
 * <<release-highlights-2.9.0>>
 * <<release-highlights-2.8.0>>
@@ -42,6 +43,7 @@ This section summarizes the most important changes in each release. For the full
 
 --
 
+include::highlights-2.11.0.asciidoc[]
 include::highlights-2.10.0.asciidoc[]
 include::highlights-2.9.0.asciidoc[]
 include::highlights-2.8.0.asciidoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.11`:
 - [Release notes and highlights for 2.11.0 release (#7428)](https://github.com/elastic/cloud-on-k8s/pull/7428)
 - [Add breaking changes note to 2.11 release notes. (#7439)](https://github.com/elastic/cloud-on-k8s/pull/7439)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)