### PR TITLE
Update supported k8s/openshift versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Current features:
 
 Supported versions:
 
-*  Kubernetes 1.24-1.28
-*  OpenShift 4.11-4.13
+*  Kubernetes 1.25-1.29
+*  OpenShift 4.11-4.14
 *  Elasticsearch, Kibana, APM Server: 6.8+, 7.1+, 8+
 *  Enterprise Search: 7.7+, 8+
 *  Beats: 7.0+, 8+

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -1,5 +1,5 @@
-* Kubernetes 1.24-1.28
-* OpenShift 4.11-4.13
+* Kubernetes 1.25-1.29
+* OpenShift 4.11-4.14
 * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 * Helm: 3.2.0+
 * Elasticsearch, Kibana, APM Server: 6.8+, 7.1+, 8+

--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -276,9 +276,9 @@ spec:
     Supported versions:
 
 
-    * Kubernetes 1.24-1.28
+    * Kubernetes 1.25-1.29
 
-    * OpenShift 4.11-4.13
+    * OpenShift 4.11-4.14
 
     * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 


### PR DESCRIPTION
We updated our e2e tests to these new versions of k8s/ocp in #7387 and have yet to see any issues. I propose we now update our supported versions in the relevant locations.

Most recent clean nightly [e2e test run.](https://buildkite.com/elastic/cloud-on-k8s-operator-nightly/builds/417#_)