### PR TITLE
[2.11] e2e test enhancements for Stack Configuration Policy (#7448)

### DIFF
--- a/test/e2e/beat/setup_test.go
+++ b/test/e2e/beat/setup_test.go
@@ -124,7 +124,7 @@ func getDashboardCheck(esBuilder elasticsearch.Builder, kbBuilder kibana.Builder
 						// We are exploiting the fact here that Beats dashboards follow a naming convention that contains the
 						// name of the beat. This test will obviously break if future versions of Beats abandon this naming convention.
 						query := fmt.Sprintf("/api/saved_objects/_find?type=dashboard&search_fields=title&search=%s", beat)
-						body, err := kibana.DoRequest(client, kbBuilder.Kibana, password,
+						body, _, err := kibana.DoRequest(client, kbBuilder.Kibana, password,
 							"GET", query, nil, http.Header{},
 						)
 						if err != nil {

--- a/test/e2e/es/stackconfigpolicy_test.go
+++ b/test/e2e/es/stackconfigpolicy_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -57,6 +58,8 @@ func TestStackConfigPolicy(t *testing.T) {
 
 	namespace := test.Ctx().ManagedNamespace(0)
 	secureSettingsSecretName := fmt.Sprintf("test-scp-secure-settings-%s", rand.String(4))
+	secretMountsSecretName := fmt.Sprintf("test-scp-secret-mounts-%s", rand.String(4))
+	clusterNameFromConfig := fmt.Sprintf("test-scp-cluster-%s", rand.String(4))
 
 	// set the policy Elasticsearch settings the policy using the external YAML file
 	var esConfigSpec policyv1alpha1.ElasticsearchConfigPolicySpec
@@ -75,6 +78,20 @@ func TestStackConfigPolicy(t *testing.T) {
 		"/_component_template/component_template_test",
 	}
 
+	esConfigSpec.SecureSettings = []commonv1.SecretSource{
+		{SecretName: secureSettingsSecretName},
+	}
+
+	esConfigSpec.SecretMounts = []policyv1alpha1.SecretMount{
+		{
+			SecretName: secretMountsSecretName,
+			MountPath:  "/test",
+		},
+	}
+
+	scpEsConfig := commonv1.NewConfig(map[string]interface{}{"cluster.name": clusterNameFromConfig})
+	esConfigSpec.Config = &scpEsConfig
+
 	policy := policyv1alpha1.StackConfigPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -83,9 +100,6 @@ func TestStackConfigPolicy(t *testing.T) {
 		Spec: policyv1alpha1.StackConfigPolicySpec{
 			ResourceSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{"label": "test-scp"},
-			},
-			SecureSettings: []commonv1.SecretSource{
-				{SecretName: secureSettingsSecretName},
 			},
 			Elasticsearch: esConfigSpec,
 		},
@@ -113,6 +127,17 @@ func TestStackConfigPolicy(t *testing.T) {
 		},
 	}
 
+	secretsMountSecretKey := "testfile"
+	secretMountsSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretMountsSecretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			secretsMountSecretKey: []byte(`testfile content`),
+		},
+	}
+
 	esWithlicense := test.LicenseTestBuilder(es)
 
 	var noEntries []string
@@ -122,6 +147,13 @@ func TestStackConfigPolicy(t *testing.T) {
 				Name: "Create a Secure Settings secret",
 				Test: test.Eventually(func() error {
 					err := k.CreateOrUpdate(&secureSettingsSecret)
+					return err
+				}),
+			},
+			test.Step{
+				Name: "Create a Secret Mounts secret",
+				Test: test.Eventually(func() error {
+					err := k.CreateOrUpdate(&secretMountsSecret)
 					return err
 				}),
 			},
@@ -147,6 +179,22 @@ func TestStackConfigPolicy(t *testing.T) {
 					if settings.Persistent.Indices.Recovery.MaxBytesPerSec != "100mb" {
 						return errors.New("cluster settings not configured")
 					}
+					return nil
+				}),
+			},
+			test.Step{
+				Name: "Cluster Name should be as set in config",
+				Test: test.Eventually(func() error {
+					esClient, err := elasticsearch.NewElasticsearchClient(es.Elasticsearch, k)
+					assert.NoError(t, err)
+
+					var clusterName ClusterName
+					_, err = request(esClient, http.MethodGet, "/_health_report", nil, &clusterName)
+					if err != nil {
+						return err
+					}
+
+					require.Equal(t, clusterNameFromConfig, clusterName.ClusterNameFromAPI)
 					return nil
 				}),
 			},
@@ -205,6 +253,7 @@ func TestStackConfigPolicy(t *testing.T) {
 			elasticsearch.CheckESKeystoreEntries(k, es, []string{
 				secureServiceAccountSettingKey,
 			}),
+			elasticsearch.CheckStackConfigPolicyESSecretMountsVolume(k, es.Elasticsearch, policy),
 			test.Step{
 				Name: "Deleting the StackConfigPolicy should return no error",
 				Test: test.Eventually(func() error {
@@ -227,6 +276,18 @@ func TestStackConfigPolicy(t *testing.T) {
 			},
 			// keystore entries should be removed
 			elasticsearch.CheckESKeystoreEntries(k, es, noEntries),
+			test.Step{
+				Name: "Delete secure settings secret",
+				Test: test.Eventually(func() error {
+					return k.Client.Delete(context.Background(), &secureSettingsSecret)
+				}),
+			},
+			test.Step{
+				Name: "Delete secure mounts secret",
+				Test: test.Eventually(func() error {
+					return k.Client.Delete(context.Background(), &secretMountsSecret)
+				}),
+			},
 		}
 	}
 
@@ -251,6 +312,10 @@ type ClusterSettings struct {
 			} `json:"recovery"`
 		} `json:"indices"`
 	} `json:"persistent"`
+}
+
+type ClusterName struct {
+	ClusterNameFromAPI string `json:"cluster_name"`
 }
 
 type SnapshotRepositories map[string]SnapshotRepository

--- a/test/e2e/kb/fixtures/stackconfigpolicy_kb.yaml
+++ b/test/e2e/kb/fixtures/stackconfigpolicy_kb.yaml
@@ -1,0 +1,3 @@
+config:
+  server.customResponseHeaders:
+    test: kb-scp-test

--- a/test/e2e/kb/stackconfigpolicy_test.go
+++ b/test/e2e/kb/stackconfigpolicy_test.go
@@ -1,0 +1,127 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build kb || e2e
+
+package kb
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
+	policyv1alpha1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/stackconfigpolicy/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test"
+	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test/elasticsearch"
+	"github.com/elastic/cloud-on-k8s/v2/test/e2e/test/kibana"
+)
+
+var (
+	//go:embed fixtures/stackconfigpolicy_kb.yaml
+	kbConfig string
+)
+
+// TestStackConfigPolicy tests the StackConfigPolicy feature for Kibana.
+func TestStackConfigPolicyKibana(t *testing.T) {
+	// only execute this test if we have a test license to work with
+	if test.Ctx().TestLicense == "" {
+		t.SkipNow()
+	}
+
+	namespace := test.Ctx().ManagedNamespace(0)
+	// set up a 1-node Kibana deployment
+	name := "test-kb-scp"
+	esBuilder := elasticsearch.NewBuilder(name).
+		WithESMasterDataNodes(1, elasticsearch.DefaultResources)
+	kbBuilder := kibana.NewBuilder(name).
+		WithElasticsearchRef(esBuilder.Ref()).
+		WithNodeCount(1).WithLabel("label", "test-scp")
+
+	kbPodListOpts := test.KibanaPodListOptions(kbBuilder.Kibana.Namespace, kbBuilder.Kibana.Name)
+	secureSettingsSecretName := fmt.Sprintf("test-scp-secure-settings-%s", rand.String(4))
+
+	// set the policy Kibana settings the policy using the external YAML file
+	var kibanaConfigSpec policyv1alpha1.KibanaConfigPolicySpec
+	err := yaml.Unmarshal([]byte(kbConfig), &kibanaConfigSpec)
+	assert.NoError(t, err)
+
+	kibanaConfigSpec.SecureSettings = []commonv1.SecretSource{
+		{SecretName: secureSettingsSecretName},
+	}
+
+	policy := policyv1alpha1.StackConfigPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      fmt.Sprintf("test-scp-%s", rand.String(4)),
+		},
+		Spec: policyv1alpha1.StackConfigPolicySpec{
+			ResourceSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"label": "test-scp"},
+			},
+			Kibana: kibanaConfigSpec,
+		},
+	}
+
+	secureSettingsSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secureSettingsSecretName,
+			Namespace: test.Ctx().ManagedNamespace(0),
+		},
+		Data: map[string][]byte{
+			// this needs to be a valid configuration item, otherwise Kibana refuses to start
+			"elasticsearch.pingTimeout": []byte("30000"),
+		},
+	}
+
+	esWithlicense := test.LicenseTestBuilder(esBuilder)
+
+	steps := func(k *test.K8sClient) test.StepList {
+		kibanaChecks := kibana.KbChecks{
+			Client: k,
+		}
+		return test.StepList{
+			test.Step{
+				Name: "Create a Secure Settings secret",
+				Test: test.Eventually(func() error {
+					err := k.CreateOrUpdate(&secureSettingsSecret)
+					return err
+				}),
+			},
+			test.Step{
+				Name: "Create a StackConfigPolicy",
+				Test: test.Eventually(func() error {
+					err := k.CreateOrUpdate(&policy)
+					return err
+				}),
+			},
+			test.CheckKeystoreEntries(k, KibanaKeystoreCmd, []string{"elasticsearch.pingTimeout"}, kbPodListOpts...),
+			// We set test: kb-scp-test as a config for server.customResponseHeaders, so we should that see that in the response headers from Kibana
+			kibanaChecks.CheckHeaderForKey(kbBuilder, "test", "kb-scp-test"),
+			test.Step{
+				Name: "Deleting the StackConfigPolicy should return no error",
+				Test: test.Eventually(func() error {
+					return k.Client.Delete(context.Background(), &policy)
+				}),
+			},
+			// keystore should be reset
+			test.CheckKeystoreEntries(k, KibanaKeystoreCmd, nil, kbPodListOpts...),
+			test.Step{
+				Name: "Delete secure settings secret",
+				Test: test.Eventually(func() error {
+					return k.Client.Delete(context.Background(), &secureSettingsSecret)
+				}),
+			},
+		}
+	}
+
+	test.Sequence(nil, steps, esWithlicense, kbBuilder).RunSequential(t)
+}

--- a/test/e2e/test/apmserver/checks_apm.go
+++ b/test/e2e/test/apmserver/checks_apm.go
@@ -388,7 +388,7 @@ func (c *apmClusterChecks) CheckAgentConfiguration(apm apmv1.ApmServer, k *test.
 				if !apmVersion.GTE(version.MustParse("7.7.0")) {
 					uri += "/new"
 				}
-				_, err = kibana.DoRequest(k, kb, password, "PUT", uri, []byte(sampleDefaultAgentConfiguration), http.Header{})
+				_, _, err = kibana.DoRequest(k, kb, password, "PUT", uri, []byte(sampleDefaultAgentConfiguration), http.Header{})
 				return err
 			}),
 		},

--- a/test/e2e/test/kibana/checks_telemetry.go
+++ b/test/e2e/test/kibana/checks_telemetry.go
@@ -39,7 +39,7 @@ func MakeTelemetryRequest(kbBuilder Builder, k *test.K8sClient) (StackStats, err
 
 	// this call may fail (status 500) if the .security-7 index is not fully initialized yet,
 	// in which case we'll just retry that test step
-	bytes, err := DoRequest(k, kbBuilder.Kibana, password, "POST", uri, payloadBytes, extraHeaders)
+	bytes, _, err := DoRequest(k, kbBuilder.Kibana, password, "POST", uri, payloadBytes, extraHeaders)
 	if err != nil {
 		return StackStats{}, err
 	}

--- a/test/e2e/test/kibana/http_client.go
+++ b/test/e2e/test/kibana/http_client.go
@@ -33,7 +33,7 @@ func NewKibanaClient(kb kbv1.Kibana, k *test.K8sClient) (*http.Client, error) {
 }
 
 // DoRequest executes an HTTP request against a Kibana instance using the given password for the elastic user.
-func DoRequest(k *test.K8sClient, kb kbv1.Kibana, password string, method string, pathAndQuery string, body []byte, extraHeaders http.Header) ([]byte, error) {
+func DoRequest(k *test.K8sClient, kb kbv1.Kibana, password string, method string, pathAndQuery string, body []byte, extraHeaders http.Header) ([]byte, http.Header, error) {
 	scheme := "http"
 	if kb.Spec.HTTP.TLS.Enabled() {
 		scheme = "https"
@@ -41,12 +41,12 @@ func DoRequest(k *test.K8sClient, kb kbv1.Kibana, password string, method string
 	// add .svc suffix so that requests work when using the port-forwarder during local test runs
 	u, err := url.Parse(fmt.Sprintf("%s://%s.%s.svc:%d", scheme, kbv1.HTTPService(kb.Name), kb.Namespace, network.HTTPPort))
 	if err != nil {
-		return nil, errors.Wrap(err, "while parsing url")
+		return nil, http.Header{}, errors.Wrap(err, "while parsing url")
 	}
 
 	pathAndQueryURL, err := url.Parse(pathAndQuery)
 	if err != nil {
-		return nil, errors.Wrap(err, "while parsing path and query from caller")
+		return nil, http.Header{}, errors.Wrap(err, "while parsing path and query from caller")
 	}
 
 	u.Path = pathAndQueryURL.Path
@@ -54,7 +54,7 @@ func DoRequest(k *test.K8sClient, kb kbv1.Kibana, password string, method string
 
 	req, err := http.NewRequest(method, u.String(), bytes.NewBuffer(body)) //nolint:noctx
 	if err != nil {
-		return nil, errors.Wrap(err, "while creating request")
+		return nil, http.Header{}, errors.Wrap(err, "while creating request")
 	}
 
 	req.SetBasicAuth("elastic", password)
@@ -71,17 +71,22 @@ func DoRequest(k *test.K8sClient, kb kbv1.Kibana, password string, method string
 
 	client, err := NewKibanaClient(kb, k)
 	if err != nil {
-		return nil, errors.Wrap(err, "while creating kibana client")
+		return nil, http.Header{}, errors.Wrap(err, "while creating kibana client")
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "while doing request")
+		return nil, http.Header{}, errors.Wrap(err, "while doing request")
 	}
 	defer resp.Body.Close()
 	if err := commonhttp.MaybeAPIError(resp); err != nil {
-		return nil, err
+		return nil, http.Header{}, err
 	}
 
-	return io.ReadAll(resp.Body)
+	var respBody []byte
+	if respBody, err = io.ReadAll(resp.Body); err != nil {
+		return nil, http.Header{}, err
+	}
+
+	return respBody, resp.Header, nil
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.11`:
 - [e2e test enhancements for Stack Configuration Policy (#7448)](https://github.com/elastic/cloud-on-k8s/pull/7448)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)