### PR TITLE
Fix recent Red Hat certificate api changes.

### DIFF
--- a/hack/operatorhub/internal/container/types.go
+++ b/hack/operatorhub/internal/container/types.go
@@ -10,14 +10,16 @@ type GetImagesResponse struct {
 	Images []Image `json:"data"`
 }
 
-// scanStatus defines the state of the image scanning process
+// gradingStatus defines the state of the image security scanning process
 // within the Red Hat certification API
-type scanStatus string
+type gradingStatus string
 
 const (
-	scanStatusInProgress scanStatus = "in progress"
-	scanStatusPassed     scanStatus = "passed"
-	scanStatusFailed     scanStatus = "failed"
+	gradingStatusAborted    gradingStatus = "aborted"
+	gradingStatusInProgress gradingStatus = "in progress"
+	gradingStatusCompleted  gradingStatus = "completed"
+	gradingStatusFailed     gradingStatus = "failed"
+	gradingStatusPending    gradingStatus = "pending"
 )
 
 // Image represents a Redhat certification API response
@@ -29,10 +31,18 @@ type Image struct {
 	Architecture *string `json:"architecture"`
 	// Repositories is a slice of Repository structs
 	Repositories []Repository `json:"repositories"`
-	// ScanStatus is the status indicating whether the image has been scanned.
-	ScanStatus scanStatus `json:"scan_status"`
+	// ContainerGrades details the state of grading of a container image
+	ContainerGrades Grade `json:"container_grades"`
 	// DockerImageDigest is the SHA id of the image
 	DockerImageDigest string `json:"docker_image_digest"`
+}
+
+// Grade represents the grading state of a container image.
+type Grade struct {
+	// Status is the grading status of the container image.
+	Status gradingStatus `json:"status"`
+	// StatusMessage is a message describing the grading status of the container image.
+	StatusMessage string `json:"status_message"`
 }
 
 // Repository represents an image repository, and any tags applied to a container image.


### PR DESCRIPTION
There have been new undocumented Redhat Certification API changes. These changes will attempt to adhere to the new changes.

## What changed?

The following [API call](https://catalog.redhat.com/api/containers/v1/ui/#/Certification%20projects/graphql.images.get_images_by_project_id) does not return `scan_status` any longer, but seems to return both `container_grades` and `freshness_grades`:

```
[
	{
		"_id": "6595db9d633a9665f023d364",
		"_links": {
		},
		"architecture": "amd64",
		"certified": true,
		"container_grades": {
			"status": "completed",
			"status_message": "This image does not have any unapplied Critical or Important security errata"
		},
		"creation_date": "2024-01-03T22:11:41.842000+00:00",
		"deleted": false,
		"docker_image_digest": "sha256:example",
		"docker_image_id": "sha256:example",
		"freshness_grades": [
			{
				"creation_date": "2024-01-03T22:11:54.304000+00:00",
				"grade": "A",
				"start_date": "2024-01-03T22:11:54.304000+00:00"
			}
		],
```

The new schema seems to be:

```
ContainerGrading{
description:	
Information about the state of grading of particular image.

status	string
default: pending
The request status This field is read only. Only these values can be assigned: pending, in progress, failed, completed, aborted.

status_message	string
An explanatory message to a request status. This field is read only.
}
```

Todo:
- [x] manual testing