### PR TITLE
Accept automatic package upgrades when building the eck-ubi image

### DIFF
--- a/build/Dockerfile-ubi
+++ b/build/Dockerfile-ubi
@@ -30,7 +30,7 @@ RUN --mount=type=cache,mode=0755,target=/go/pkg/mod \
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3-1475
 
 # Update the base image packages to the latest versions
-RUN microdnf update --setopt=tsflags=nodocs && microdnf clean all
+RUN microdnf update --setopt=tsflags=nodocs --assumeyes && microdnf clean all
 
 ARG VERSION
 


### PR DESCRIPTION
This accepts automatic package upgrades when building the `eck-ubi`flavor image, by adding the `--assumeyes` flag to the `microdnf update` command, in order to avoid blocking the build when prompting for package upgrade confirmation.

Resolves #7457.