### PR TITLE
[2.11] use cluster health endpoint instead of the health report endpoint for scp e2e test (#7455)

### DIFF
--- a/test/e2e/es/stackconfigpolicy_test.go
+++ b/test/e2e/es/stackconfigpolicy_test.go
@@ -183,18 +183,17 @@ func TestStackConfigPolicy(t *testing.T) {
 				}),
 			},
 			test.Step{
-				Name: "Cluster Name should be as set in config",
+				Name: "Cluster name should be as set in the config",
 				Test: test.Eventually(func() error {
 					esClient, err := elasticsearch.NewElasticsearchClient(es.Elasticsearch, k)
 					assert.NoError(t, err)
 
-					var clusterName ClusterName
-					_, err = request(esClient, http.MethodGet, "/_health_report", nil, &clusterName)
-					if err != nil {
+					var apiResponse ClusterInfoResponse
+					if _, err = request(esClient, http.MethodGet, "/", nil, &apiResponse); err != nil {
 						return err
 					}
 
-					require.Equal(t, clusterNameFromConfig, clusterName.ClusterNameFromAPI)
+					require.Equal(t, clusterNameFromConfig, apiResponse.ClusterName)
 					return nil
 				}),
 			},
@@ -314,8 +313,8 @@ type ClusterSettings struct {
 	} `json:"persistent"`
 }
 
-type ClusterName struct {
-	ClusterNameFromAPI string `json:"cluster_name"`
+type ClusterInfoResponse struct {
+	ClusterName string `json:"cluster_name"`
 }
 
 type SnapshotRepositories map[string]SnapshotRepository


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.11`:
 - [use cluster health endpoint instead of the health report endpoint for scp e2e test (#7455)](https://github.com/elastic/cloud-on-k8s/pull/7455)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)