### PR TITLE
Fix Logstash crashes with env

### DIFF
--- a/pkg/controller/logstash/initcontainer.go
+++ b/pkg/controller/logstash/initcontainer.go
@@ -16,6 +16,8 @@ const (
 	InitConfigContainerName = "logstash-internal-init-config"
 
 	// InitConfigScript is a small bash script to prepare the logstash configuration directory
+	// Logstash rewrites the configuration file (logstash.yml) in the presence of ${VAR} environment variable,
+	// therefore the file is copied to the path instead of creating symbolic link.
 	InitConfigScript = `#!/usr/bin/env bash
 set -eu
 

--- a/pkg/controller/logstash/initcontainer.go
+++ b/pkg/controller/logstash/initcontainer.go
@@ -32,7 +32,7 @@ mount_path=` + volume.InitContainerConfigVolumeMountPath + `
 
 cp -f /usr/share/logstash/config/*.* "$mount_path"
 
-ln -sf ` + volume.InternalConfigVolumeMountPath + `/` + ConfigFileName + ` $mount_path
+cp ` + volume.InternalConfigVolumeMountPath + `/` + ConfigFileName + ` $mount_path
 ln -sf ` + volume.InternalPipelineVolumeMountPath + `/` + PipelineFileName + ` $mount_path
 
 touch "${init_config_initialized_flag}"

--- a/test/e2e/logstash/logstash_test.go
+++ b/test/e2e/logstash/logstash_test.go
@@ -23,6 +23,28 @@ func TestSingleLogstash(t *testing.T) {
 	test.Sequence(nil, test.EmptySteps, logstashBuilder).RunSequential(t)
 }
 
+func TestLogstashWithEnv(t *testing.T) {
+	name := "test-env-logstash"
+	logstashBuilder := logstash.NewBuilder(name).
+		WithNodeCount(1).
+		WithPodTemplate(corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "logstash",
+						Env: []corev1.EnvVar{
+							{
+								Name:  "NODE_NAME",
+								Value: "node01",
+							},
+						},
+					},
+				},
+			},
+		})
+	test.Sequence(nil, test.EmptySteps, logstashBuilder).RunSequential(t)
+}
+
 func TestLogstashWithCustomService(t *testing.T) {
 	name := "test-multiple-custom-logstash"
 	service := logstashv1alpha1.LogstashService{
@@ -35,9 +57,9 @@ func TestLogstashWithCustomService(t *testing.T) {
 			},
 		},
 	}
-	logstashBuilder := (logstash.NewBuilder(name).
+	logstashBuilder := logstash.NewBuilder(name).
 		WithNodeCount(1).
-		WithServices(service))
+		WithServices(service)
 
 	test.Sequence(nil, test.EmptySteps, logstashBuilder).RunSequential(t)
 }
@@ -55,13 +77,13 @@ func TestLogstashWithReworkedApiService(t *testing.T) {
 			},
 		},
 	}
-	logstashBuilder := (logstash.NewBuilder(name).
+	logstashBuilder := logstash.NewBuilder(name).
 		WithNodeCount(1).
 		// Change the Logstash API service port
 		WithConfig(map[string]interface{}{
 			"api.http.port": 9200,
 		}).
-		WithServices(service))
+		WithServices(service)
 
 	test.Sequence(nil, test.EmptySteps, logstashBuilder).RunSequential(t)
 }
@@ -91,13 +113,13 @@ func TestLogstashWithCustomServiceAndAmendedApi(t *testing.T) {
 		},
 	}
 
-	logstashBuilder := (logstash.NewBuilder(name).
+	logstashBuilder := logstash.NewBuilder(name).
 		WithNodeCount(1).
 		// Change the Logstash API service port
 		WithConfig(map[string]interface{}{
 			"api.http.port": 9601,
 		}).
-		WithServices(apiService, customService))
+		WithServices(apiService, customService)
 
 	test.Sequence(nil, test.EmptySteps, logstashBuilder).RunSequential(t)
 }


### PR DESCRIPTION
Fixed: https://github.com/elastic/cloud-on-k8s/issues/7450

Logstash crashes when env variable name is in the list of [env2yaml](https://github.com/elastic/logstash/blob/main/docker/data/logstash/env2yaml/env2yaml.go#L50-L155)
This PR changes the config init container to copy the `logstash.yml` to `config` Volume to allow updating the file.

The following resource should start without error
```yaml
apiVersion: logstash.k8s.elastic.co/v1alpha1
kind: Logstash
metadata:
  name: logstash-sample
spec:
  count: 1
  version: 8.11.1
  podTemplate:
    spec:
      containers:
        - name: logstash
          env:
            - name: "NODE_NAME"
              value: "No_Crash!"
```
