### PR TITLE
Fix dry-run of helm charts during release.

### DIFF
--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -24,7 +24,7 @@ steps:
     commands:
       - buildkite-agent artifact download "bin/releaser" /usr/local/
       - chmod u+x /usr/local/bin/releaser
-      - releaser --env=dev --charts-dir=deploy/eck-operator
+      - releaser --env=dev --charts-dir=deploy/eck-operator --dry-run=false
     agents:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:bfddf2b3
       memory: "2G"
@@ -45,7 +45,7 @@ steps:
     commands:
       - buildkite-agent artifact download "bin/releaser" /usr/local/
       - chmod u+x /usr/local/bin/releaser
-      - releaser --env=dev --charts-dir=deploy/eck-stack
+      - releaser --env=dev --charts-dir=deploy/eck-stack --dry-run=false
     agents:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:bfddf2b3
       memory: "2G"
@@ -63,7 +63,7 @@ steps:
     commands:
       - buildkite-agent artifact download "bin/releaser" /usr/local/
       - chmod u+x /usr/local/bin/releaser
-      - releaser --env=prod --charts-dir=deploy/eck-operator
+      - releaser --env=prod --charts-dir=deploy/eck-operator --dry-run=false
     agents:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:bfddf2b3
       memory: "2G"
@@ -81,7 +81,7 @@ steps:
     commands:
       - buildkite-agent artifact download "bin/releaser" /usr/local/
       - chmod u+x /usr/local/bin/releaser
-      - releaser --env=prod --charts-dir=deploy/eck-stack
+      - releaser --env=prod --charts-dir=deploy/eck-stack --dry-run=false
     agents:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:bfddf2b3
       memory: "2G"

--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -1,3 +1,6 @@
+env:
+  HELM_DRY_RUN: ${HELM_DRY_RUN:-true}
+
 steps:
 
   - label: ":go: helm releaser tool"
@@ -24,7 +27,7 @@ steps:
     commands:
       - buildkite-agent artifact download "bin/releaser" /usr/local/
       - chmod u+x /usr/local/bin/releaser
-      - releaser --env=dev --charts-dir=deploy/eck-operator --dry-run=false
+      - releaser --env=dev --charts-dir=deploy/eck-operator
     agents:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:bfddf2b3
       memory: "2G"
@@ -45,7 +48,7 @@ steps:
     commands:
       - buildkite-agent artifact download "bin/releaser" /usr/local/
       - chmod u+x /usr/local/bin/releaser
-      - releaser --env=dev --charts-dir=deploy/eck-stack --dry-run=false
+      - releaser --env=dev --charts-dir=deploy/eck-stack
     agents:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:bfddf2b3
       memory: "2G"
@@ -63,7 +66,7 @@ steps:
     commands:
       - buildkite-agent artifact download "bin/releaser" /usr/local/
       - chmod u+x /usr/local/bin/releaser
-      - releaser --env=prod --charts-dir=deploy/eck-operator --dry-run=false
+      - releaser --env=prod --charts-dir=deploy/eck-operator
     agents:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:bfddf2b3
       memory: "2G"
@@ -81,7 +84,7 @@ steps:
     commands:
       - buildkite-agent artifact download "bin/releaser" /usr/local/
       - chmod u+x /usr/local/bin/releaser
-      - releaser --env=prod --charts-dir=deploy/eck-stack --dry-run=false
+      - releaser --env=prod --charts-dir=deploy/eck-stack
     agents:
       image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:bfddf2b3
       memory: "2G"

--- a/.buildkite/pipeline-release.yml
+++ b/.buildkite/pipeline-release.yml
@@ -29,4 +29,6 @@ steps:
         if: | # merge-main or tags
           ( build.branch == "main" && build.source != "schedule" )
           || build.tag != null
-        command: buildkite-agent pipeline upload .buildkite/pipeline-release-helm.yml
+        command: |
+          sed "s|HELM_DRY_RUN:.*|HELM_DRY_RUN: false|" .buildkite/pipeline-release-helm.yml \
+            | buildkite-agent pipeline upload

--- a/.buildkite/pipeline-release.yml
+++ b/.buildkite/pipeline-release.yml
@@ -30,5 +30,3 @@ steps:
           ( build.branch == "main" && build.source != "schedule" )
           || build.tag != null
         command: buildkite-agent pipeline upload .buildkite/pipeline-release-helm.yml
-        env:
-          HELM_DRY_RUN: false


### PR DESCRIPTION
We've seen multiple issues in this area: https://github.com/elastic/cloud-on-k8s/pull/6953, https://github.com/elastic/cloud-on-k8s/pull/7045

It appears we can't pass environment variables when uploading buildkite pipelines. This explicitly sets the `dry-run` flag to `false` during the release pipeline.