### PR TITLE
Add relatedImages section to CSV template.

### DIFF
--- a/hack/operatorhub/templates/csv.tpl
+++ b/hack/operatorhub/templates/csv.tpl
@@ -390,6 +390,9 @@ spec:
   minKubeVersion: 1.21.0
   provider:
     name: Elastic
+  relatedImages:
+  - name: eck-operator
+    image: {{ .OperatorRepo }}{{ .Tag }}
   replaces: {{ .PackageName }}.v{{ .PrevVersion }}
   version: {{ .NewVersion }}
   webhookdefinitions:


### PR DESCRIPTION
We have an open issue concerning missing `relatedImages` from the operatorhub release tool, which causes the certified operators certification process to fail every time, causing a human to have to manually add this section to the `kind: ClusterServiceVersion`:

`certified example`
```
  relatedImages:
  - name: eck-operator
    image: registry.connect.redhat.com/elastic/eck-operator@sha256:349261b1e40bfd07bd4948d9ea13eb56814e46bd51da3bac9094b8b1b8978288
```

This does the "minimal" which adds this section to the template we use, which causes this to exist on both the community, and certified versions of the operator, which look like this on the community version:

`community example`
```
  relatedImages:
  - name: eck-operator
    image: docker.elastic.co/eck/eck-operator:2.11.0
```

Our tooling already properly handles updating the the SHA properly, if needed. Tested locally.