### PR TITLE
Add --disable-nodegroup-eviction to fix eks cluster deletions failing.

### DIFF
--- a/hack/deployer/runner/eks.go
+++ b/hack/deployer/runner/eks.go
@@ -283,7 +283,8 @@ func (e *EKSDriver) Cleanup(prefix string, olderThan time.Duration) error {
 func (e *EKSDriver) delete() error {
 	log.Printf("Deleting cluster %s", e.ctx["ClusterName"])
 	// --wait to surface failures to delete all resources in the Cloud formation
-	return e.newCmd("eksctl delete cluster -v 1 --name {{.ClusterName}} --region {{.Region}} --wait").Run()
+	// --disable-nodegroup-eviction to avoid pod disruption budgets causing nodegroup draining to fail.
+	return e.newCmd("eksctl delete cluster -v 1 --name {{.ClusterName}} --region {{.Region}} --wait --disable-nodegroup-eviction").Run()
 }
 
 var _ Driver = &EKSDriver{}


### PR DESCRIPTION
We are seeing eks cluster deletions failing with the following:
```
2024-01-17 14:39:43 [ℹ]  starting parallel draining, max in-flight of 1
2024-01-17 14:40:51 [!]  1 pods are unevictable from node ip-192-168-49-63.eu-west-1.compute.internal
2024-01-17 14:41:56 [!]  1 pods are unevictable from node ip-192-168-49-63.eu-west-1.compute.internal
2024-01-17 14:43:01 [!]  1 pods are unevictable from node ip-192-168-49-63.eu-west-1.compute.internal
2024-01-17 14:44:06 [!]  1 pods are unevictable from node ip-192-168-49-63.eu-west-1.compute.internal
2024-01-17 14:45:11 [!]  1 pods are unevictable from node ip-192-168-49-63.eu-west-1.compute.internal
2024-01-17 14:46:16 [!]  1 pods are unevictable from node ip-192-168-49-63.eu-west-1.compute.internal
```
According to [docs](https://eksctl.io/usage/creating-and-managing-clusters) we should set `--disable-nodegroup-eviction` in these scenarios.

Resolves #7474.