### PR TITLE
Use eck-operator UBI image when ubiOnly=true.

### DIFF
--- a/deploy/eck-operator/templates/statefulset.yaml
+++ b/deploy/eck-operator/templates/statefulset.yaml
@@ -43,7 +43,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+        - image: "{{ .Values.image.repository }}{{- if .Values.config.ubiOnly -}}-ubi{{- end -}}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: manager
           args:


### PR DESCRIPTION
resolves #7485 

Ensure we use the `-ubi` operator image when `ubiOnly` is set to `true`.

```
❯ helm template eck-operator . -s templates/statefulset.yaml | yq '.spec.template.spec.containers[0].image'
docker.elastic.co/eck/eck-operator:2.12.0-SNAPSHOT

❯ helm template eck-operator . -s templates/statefulset.yaml --set=config.ubiOnly=true | yq '.spec.template.spec.containers[0].image'
docker.elastic.co/eck/eck-operator-ubi:2.12.0-SNAPSHOT
```