### PR TITLE
Temporarily disable data stream check in TestFleet*IntegrationRecipe e2e tests in 8.12.0

### DIFF
--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -124,6 +124,7 @@ func TestMultipleOutputConfig(t *testing.T) {
 }
 
 func TestFleetMode(t *testing.T) {
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	name := "test-agent-fleet"
 
 	agentNS := test.Ctx().ManagedNamespace(0)
@@ -150,9 +151,13 @@ func TestFleetMode(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.elastic_agent", "default")).
-			// to be re-enabled when https://github.com/elastic/cloud-on-k8s/issues/7389 is resolved
-			//WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
+
+		// https://github.com/elastic/cloud-on-k8s/issues/7389
+		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 13, 0)) {
+			fleetServerBuilder = fleetServerBuilder.
+				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
+		}
 
 		kbBuilder = kbBuilder.WithConfig(fleetConfigForKibana(t, fleetServerBuilder.Agent.Spec.Version, esBuilder.Ref(), fleetServerBuilder.Ref(), true))
 
@@ -182,9 +187,13 @@ func TestFleetMode(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.elastic_agent", "default")).
-			// to be re-enabled when https://github.com/elastic/cloud-on-k8s/issues/7389 is resolved
-			//WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
+
+		// https://github.com/elastic/cloud-on-k8s/issues/7389
+		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 13, 0)) {
+			fleetServerBuilder = fleetServerBuilder.
+				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
+		}
 
 		kbBuilder = kbBuilder.WithConfig(fleetConfigForKibana(t, fleetServerBuilder.Agent.Spec.Version, esBuilder.Ref(), fleetServerBuilder.Ref(), true))
 

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -154,7 +154,7 @@ func TestFleetMode(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
 		// https://github.com/elastic/cloud-on-k8s/issues/7389
-		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
+		if v.LT(version.MinFor(8, 12, 0)) || v.GE(version.MinFor(8, 14, 0)) {
 			fleetServerBuilder = fleetServerBuilder.
 				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
 		}
@@ -190,7 +190,7 @@ func TestFleetMode(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
 		// https://github.com/elastic/cloud-on-k8s/issues/7389
-		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
+		if v.LT(version.MinFor(8, 12, 0)) || v.GE(version.MinFor(8, 14, 0)) {
 			fleetServerBuilder = fleetServerBuilder.
 				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
 		}

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -154,7 +154,7 @@ func TestFleetMode(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
 		// https://github.com/elastic/cloud-on-k8s/issues/7389
-		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 13, 0)) {
+		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
 			fleetServerBuilder = fleetServerBuilder.
 				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
 		}
@@ -190,7 +190,7 @@ func TestFleetMode(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
 		// https://github.com/elastic/cloud-on-k8s/issues/7389
-		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 13, 0)) {
+		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
 			fleetServerBuilder = fleetServerBuilder.
 				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
 		}

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -124,7 +124,7 @@ func TestMultipleOutputConfig(t *testing.T) {
 }
 
 func TestFleetMode(t *testing.T) {
-	v := version.MustParse(test.Ctx().ElasticStackVersion)
+	//v := version.MustParse(test.Ctx().ElasticStackVersion)
 	name := "test-agent-fleet"
 
 	agentNS := test.Ctx().ManagedNamespace(0)
@@ -153,11 +153,11 @@ func TestFleetMode(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.elastic_agent", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
-		// https://github.com/elastic/cloud-on-k8s/issues/7389
-		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
-			fleetServerBuilder = fleetServerBuilder.
-				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
-		}
+			// https://github.com/elastic/cloud-on-k8s/issues/7389
+			//if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
+		fleetServerBuilder = fleetServerBuilder.
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
+		//}
 
 		kbBuilder = kbBuilder.WithConfig(fleetConfigForKibana(t, fleetServerBuilder.Agent.Spec.Version, esBuilder.Ref(), fleetServerBuilder.Ref(), true))
 
@@ -189,11 +189,11 @@ func TestFleetMode(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.elastic_agent", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
-		// https://github.com/elastic/cloud-on-k8s/issues/7389
-		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
-			fleetServerBuilder = fleetServerBuilder.
-				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
-		}
+			// https://github.com/elastic/cloud-on-k8s/issues/7389
+			//if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
+		fleetServerBuilder = fleetServerBuilder.
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
+		//}
 
 		kbBuilder = kbBuilder.WithConfig(fleetConfigForKibana(t, fleetServerBuilder.Agent.Spec.Version, esBuilder.Ref(), fleetServerBuilder.Ref(), true))
 

--- a/test/e2e/agent/config_test.go
+++ b/test/e2e/agent/config_test.go
@@ -124,7 +124,7 @@ func TestMultipleOutputConfig(t *testing.T) {
 }
 
 func TestFleetMode(t *testing.T) {
-	//v := version.MustParse(test.Ctx().ElasticStackVersion)
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
 	name := "test-agent-fleet"
 
 	agentNS := test.Ctx().ManagedNamespace(0)
@@ -153,11 +153,11 @@ func TestFleetMode(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.elastic_agent", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
-			// https://github.com/elastic/cloud-on-k8s/issues/7389
-			//if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
-		fleetServerBuilder = fleetServerBuilder.
-			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
-		//}
+		// https://github.com/elastic/cloud-on-k8s/issues/7389
+		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
+			fleetServerBuilder = fleetServerBuilder.
+				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
+		}
 
 		kbBuilder = kbBuilder.WithConfig(fleetConfigForKibana(t, fleetServerBuilder.Agent.Spec.Version, esBuilder.Ref(), fleetServerBuilder.Ref(), true))
 
@@ -189,11 +189,11 @@ func TestFleetMode(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.elastic_agent", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
-			// https://github.com/elastic/cloud-on-k8s/issues/7389
-			//if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
-		fleetServerBuilder = fleetServerBuilder.
-			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
-		//}
+		// https://github.com/elastic/cloud-on-k8s/issues/7389
+		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
+			fleetServerBuilder = fleetServerBuilder.
+				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
+		}
 
 		kbBuilder = kbBuilder.WithConfig(fleetConfigForKibana(t, fleetServerBuilder.Agent.Spec.Version, esBuilder.Ref(), fleetServerBuilder.Ref(), true))
 

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -88,7 +88,7 @@ func TestMultiOutputRecipe(t *testing.T) {
 }
 
 func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
-	v := version.MustParse(test.Ctx().ElasticStackVersion)
+	//v := version.MustParse(test.Ctx().ElasticStackVersion)
 
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
@@ -126,11 +126,11 @@ func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.socket_summary", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"))
 
-		// https://github.com/elastic/cloud-on-k8s/issues/7389
-		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
-			builder = builder.
-				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
-		}
+			// https://github.com/elastic/cloud-on-k8s/issues/7389
+			//if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
+		builder = builder.
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
+		//}
 
 		return builder
 	}
@@ -225,7 +225,7 @@ func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetAPMIntegrationRecipe(t *testing.T) {
-	v := version.MustParse(test.Ctx().ElasticStackVersion)
+	//v := version.MustParse(test.Ctx().ElasticStackVersion)
 
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
@@ -241,11 +241,11 @@ func TestFleetAPMIntegrationRecipe(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.fleet_server", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
-		// https://github.com/elastic/cloud-on-k8s/issues/7389
-		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
-			builder = builder.
-				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
-		}
+			// https://github.com/elastic/cloud-on-k8s/issues/7389
+			//if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
+		builder = builder.
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
+		//}
 
 		return builder
 	}

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -127,7 +127,7 @@ func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"))
 
 		// https://github.com/elastic/cloud-on-k8s/issues/7389
-		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 13, 0)) {
+		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
 			builder = builder.
 				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
 		}
@@ -242,7 +242,7 @@ func TestFleetAPMIntegrationRecipe(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
 		// https://github.com/elastic/cloud-on-k8s/issues/7389
-		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 13, 0)) {
+		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
 			builder = builder.
 				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
 		}

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -88,6 +88,8 @@ func TestMultiOutputRecipe(t *testing.T) {
 }
 
 func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
+
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
 			return builder
@@ -124,7 +126,6 @@ func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.socket_summary", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"))
 
-		v := version.MustParse(test.Ctx().ElasticStackVersion)
 		// https://github.com/elastic/cloud-on-k8s/issues/7389
 		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 13, 0)) {
 			builder = builder.
@@ -224,6 +225,8 @@ func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetAPMIntegrationRecipe(t *testing.T) {
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
+
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
 			return builder
@@ -238,7 +241,6 @@ func TestFleetAPMIntegrationRecipe(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.fleet_server", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
-		v := version.MustParse(test.Ctx().ElasticStackVersion)
 		// https://github.com/elastic/cloud-on-k8s/issues/7389
 		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 13, 0)) {
 			builder = builder.

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -127,7 +127,7 @@ func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"))
 
 		// https://github.com/elastic/cloud-on-k8s/issues/7389
-		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
+		if v.LT(version.MinFor(8, 12, 0)) || v.GE(version.MinFor(8, 14, 0)) {
 			builder = builder.
 				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
 		}
@@ -242,7 +242,7 @@ func TestFleetAPMIntegrationRecipe(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
 		// https://github.com/elastic/cloud-on-k8s/issues/7389
-		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
+		if v.LT(version.MinFor(8, 12, 0)) || v.GE(version.MinFor(8, 14, 0)) {
 			builder = builder.
 				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
 		}

--- a/test/e2e/agent/recipes_test.go
+++ b/test/e2e/agent/recipes_test.go
@@ -88,7 +88,7 @@ func TestMultiOutputRecipe(t *testing.T) {
 }
 
 func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
-	//v := version.MustParse(test.Ctx().ElasticStackVersion)
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
@@ -126,11 +126,11 @@ func TestFleetKubernetesIntegrationRecipe(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.socket_summary", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "system.uptime", "default"))
 
-			// https://github.com/elastic/cloud-on-k8s/issues/7389
-			//if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
-		builder = builder.
-			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
-		//}
+		// https://github.com/elastic/cloud-on-k8s/issues/7389
+		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
+			builder = builder.
+				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
+		}
 
 		return builder
 	}
@@ -225,7 +225,7 @@ func TestFleetCustomLogsIntegrationRecipe(t *testing.T) {
 }
 
 func TestFleetAPMIntegrationRecipe(t *testing.T) {
-	//v := version.MustParse(test.Ctx().ElasticStackVersion)
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
 
 	customize := func(builder agent.Builder) agent.Builder {
 		if !builder.Agent.Spec.FleetServerEnabled {
@@ -241,11 +241,11 @@ func TestFleetAPMIntegrationRecipe(t *testing.T) {
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.fleet_server", "default")).
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
-			// https://github.com/elastic/cloud-on-k8s/issues/7389
-			//if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
-		builder = builder.
-			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
-		//}
+		// https://github.com/elastic/cloud-on-k8s/issues/7389
+		if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
+			builder = builder.
+				WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
+		}
 
 		return builder
 	}

--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -62,11 +62,11 @@ func TestFleetAgentWithoutTLS(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.elastic_agent", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
-	// https://github.com/elastic/cloud-on-k8s/issues/7389
-	if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
-		fleetServerBuilder = fleetServerBuilder.
-			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
-	}
+		// https://github.com/elastic/cloud-on-k8s/issues/7389
+		//if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
+	fleetServerBuilder = fleetServerBuilder.
+		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
+	//}
 
 	kbBuilder = kbBuilder.WithConfig(fleetConfigForKibana(t, fleetServerBuilder.Agent.Spec.Version, esBuilder.Ref(), fleetServerBuilder.Ref(), false))
 

--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -60,9 +60,13 @@ func TestFleetAgentWithoutTLS(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.filebeat", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.LogsType, "elastic_agent.metricbeat", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.elastic_agent", "default")).
-		// to be re-enabled when https://github.com/elastic/cloud-on-k8s/issues/7389 is resolved
-		//WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
+
+	// https://github.com/elastic/cloud-on-k8s/issues/7389
+	if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 13, 0)) {
+		fleetServerBuilder = fleetServerBuilder.
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
+	}
 
 	kbBuilder = kbBuilder.WithConfig(fleetConfigForKibana(t, fleetServerBuilder.Agent.Spec.Version, esBuilder.Ref(), fleetServerBuilder.Ref(), false))
 

--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -63,7 +63,7 @@ func TestFleetAgentWithoutTLS(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
 	// https://github.com/elastic/cloud-on-k8s/issues/7389
-	if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
+	if v.LT(version.MinFor(8, 12, 0)) || v.GE(version.MinFor(8, 14, 0)) {
 		fleetServerBuilder = fleetServerBuilder.
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
 	}

--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -62,11 +62,11 @@ func TestFleetAgentWithoutTLS(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.elastic_agent", "default")).
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
-		// https://github.com/elastic/cloud-on-k8s/issues/7389
-		//if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
-	fleetServerBuilder = fleetServerBuilder.
-		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
-	//}
+	// https://github.com/elastic/cloud-on-k8s/issues/7389
+	if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
+		fleetServerBuilder = fleetServerBuilder.
+			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
+	}
 
 	kbBuilder = kbBuilder.WithConfig(fleetConfigForKibana(t, fleetServerBuilder.Agent.Spec.Version, esBuilder.Ref(), fleetServerBuilder.Ref(), false))
 

--- a/test/e2e/agent/tls_test.go
+++ b/test/e2e/agent/tls_test.go
@@ -63,7 +63,7 @@ func TestFleetAgentWithoutTLS(t *testing.T) {
 		WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.metricbeat", "default"))
 
 	// https://github.com/elastic/cloud-on-k8s/issues/7389
-	if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 13, 0)) {
+	if v.LT(version.MinFor(8, 12, 0)) && v.GE(version.MinFor(8, 14, 0)) {
 		fleetServerBuilder = fleetServerBuilder.
 			WithDefaultESValidation(agent.HasWorkingDataStream(agent.MetricsType, "elastic_agent.filebeat", "default"))
 	}


### PR DESCRIPTION
This disables the check of the existence of the data stream `metrics-elastic_agent.filebeat-default` with stack version `8.12.x and 8.13.x` in the following e2e tests:
- TestFleetAgentWithoutTLS
- TestFleetMode
- TestFleetKubernetesIntegrationRecipe
- TestFleetAPMIntegrationRecipe

Relates to #7389.