### PR TITLE
Reword 2.11 breaking changes for clarity

### DIFF
--- a/docs/release-notes/2.11.0.asciidoc
+++ b/docs/release-notes/2.11.0.asciidoc
@@ -8,7 +8,7 @@
 [float]
 === Breaking changes
 
-* The `resourceStatuses` field of the status subresource of the Stack Configuration Policy has been renamed to `details`. {pull}7433[#7433]
+* The `resourceStatuses` field of the status subresource of the Stack Configuration Policy is no longer in use. Instead a new `details` field is being populated which now also contains information about configured Kibana applications. Unless users have build automation that parses the status subresource there should be no user impact as these fields have only informational purpose. {pull}7433[#7433]
 
 
 [[feature-2.11.0]]

--- a/docs/release-notes/2.11.0.asciidoc
+++ b/docs/release-notes/2.11.0.asciidoc
@@ -8,7 +8,7 @@
 [float]
 === Breaking changes
 
-* The `resourceStatuses` field of the status subresource of the Stack Configuration Policy is no longer in use. Instead a new `details` field is being populated which now also contains information about configured Kibana applications. Unless users have build automation that parses the status subresource there should be no user impact as these fields have only informational purpose. {pull}7433[#7433]
+* The `resourceStatuses` field of the status subresource of the Stack Configuration Policy is no longer in use. Instead a new `details` field is populated which now also contains information about configured Kibana applications. Unless users have built automation that parses the status subresource, there should be no impact on users, as these fields serve only informational purposes. {pull}7433[#7433]
 
 
 [[feature-2.11.0]]


### PR DESCRIPTION
The current wording makes the breaking change seem more dramatic than it is for most users. This PR is trying to amend the wording to include: 
* the reason why the change was made (new Kibana support)
* the likely impact (none for most users)