### PR TITLE
Remove secure settings field from SCP example

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/security/managing-authentication-for-multiple-stacks/oidc-stack-config-policy.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/managing-authentication-for-multiple-stacks/oidc-stack-config-policy.asciidoc
@@ -105,8 +105,6 @@ spec:
   resourceSelector:
     matchLabels:
       env: my-label
-  secureSettings:
-  - secretName: oidc-secret
   elasticsearch:
     secureSettings:
     - secretName: oidc-secret


### PR DESCRIPTION
We no longer encourage users to use the old secureSettings field in Stack configuration policy, instead we expect the users to use the secureSettings field under the elasticsearch or kibana fields. Fixing documentation where the example had both secureSettings field set .
