### PR TITLE
[2.11] Reword 2.11 breaking changes for clarity (#7492)

### DIFF
--- a/docs/release-notes/2.11.0.asciidoc
+++ b/docs/release-notes/2.11.0.asciidoc
@@ -8,7 +8,7 @@
 [float]
 === Breaking changes
 
-* The `resourceStatuses` field of the status subresource of the Stack Configuration Policy has been renamed to `details`. {pull}7433[#7433]
+* The `resourceStatuses` field of the status subresource of the Stack Configuration Policy is no longer in use. Instead a new `details` field is populated which now also contains information about configured Kibana applications. Unless users have built automation that parses the status subresource, there should be no impact on users, as these fields serve only informational purposes. {pull}7433[#7433]
 
 
 [[feature-2.11.0]]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.11`:
 - [Reword 2.11 breaking changes for clarity (#7492)](https://github.com/elastic/cloud-on-k8s/pull/7492)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)