### PR TITLE
[2.11] Remove secure settings field from SCP example (#7493)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/security/managing-authentication-for-multiple-stacks/oidc-stack-config-policy.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/managing-authentication-for-multiple-stacks/oidc-stack-config-policy.asciidoc
@@ -105,8 +105,6 @@ spec:
   resourceSelector:
     matchLabels:
       env: my-label
-  secureSettings:
-  - secretName: oidc-secret
   elasticsearch:
     secureSettings:
     - secretName: oidc-secret


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.11`:
 - [Remove secure settings field from SCP example (#7493)](https://github.com/elastic/cloud-on-k8s/pull/7493)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)