### PR TITLE
[2.11.1-wip] Fix dry-run of helm charts during release. (#7477) | Fix recent Red Hat certificate api changes. (#7453)

### DIFF
--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -1,3 +1,6 @@
+env:
+  HELM_DRY_RUN: ${HELM_DRY_RUN:-true}
+
 steps:
 
   - label: ":go: helm releaser tool"

--- a/.buildkite/pipeline-release.yml
+++ b/.buildkite/pipeline-release.yml
@@ -29,6 +29,6 @@ steps:
         if: | # merge-main or tags
           ( build.branch == "main" && build.source != "schedule" )
           || build.tag != null
-        command: buildkite-agent pipeline upload .buildkite/pipeline-release-helm.yml
-        env:
-          HELM_DRY_RUN: false
+        command: |
+          sed "s|HELM_DRY_RUN:.*|HELM_DRY_RUN: false|" .buildkite/pipeline-release-helm.yml \
+            | buildkite-agent pipeline upload

--- a/hack/operatorhub/internal/container/container.go
+++ b/hack/operatorhub/internal/container/container.go
@@ -280,16 +280,16 @@ func syncImagesTaggedAsLatest(c CommonConfig, newTag Tag) error {
 	return nil
 }
 
-// publishImageInProject will wait until the image with the given tag is scanned, and then attempt to publish
-// the image within the Red Hat certification API.  If imageScanTimeout is reached waiting for the image to
-// be set as scanned within the API and error will be returned.
+// publishImageInProject will wait until the image with the given tag has been graded, and then attempt to publish
+// the image within the Red Hat certification API. If imageScanTimeout is reached waiting for the image to
+// be set as graded within the API an error will be returned.
 func publishImageInProject(c CommonConfig, newTag Tag, imageScanTimeout time.Duration) error {
 	ticker := time.NewTicker(5 * time.Minute)
 	ctx, cancel := context.WithTimeout(context.Background(), imageScanTimeout)
 	defer cancel()
 
-	log.Printf("waiting for image to complete scan process... ")
-	image, done, err := isImageScanned(c, newTag.Name)
+	log.Printf("waiting for image to complete grading process... ")
+	image, done, err := hasBeenGraded(c, newTag.Name)
 	if err != nil {
 		return err
 	}
@@ -304,7 +304,7 @@ func publishImageInProject(c CommonConfig, newTag Tag, imageScanTimeout time.Dur
 	for {
 		select {
 		case <-ticker.C:
-			image, done, err := isImageScanned(c, newTag.Name)
+			image, done, err := hasBeenGraded(c, newTag.Name)
 			if err != nil {
 				return err
 			}
@@ -323,29 +323,34 @@ func publishImageInProject(c CommonConfig, newTag Tag, imageScanTimeout time.Dur
 	}
 }
 
-// isImageScanned will get the first valid image tag within the Red Hat certification API
-// and ensure that the scan status is set to "passed", returning the image.
-func isImageScanned(c CommonConfig, tag string) (image *Image, done bool, err error) {
+// hasBeenGraded will get the first valid image tag within the Red Hat certification API
+// and ensure that the grades status is set to "completed", returning the image.
+func hasBeenGraded(c CommonConfig, tag string) (*Image, bool, error) {
 	images, err := getImagesByTag(c, tag)
 	if err != nil {
-		log.Printf("failed to find image in redhat catlog api, retrying: %s", err)
+		log.Printf("failed to find image in redhat catalog api, retrying: %s", err)
 		return nil, false, nil
 	}
 	if len(images) == 0 {
 		return nil, false, nil
 	}
-	image = getFirstUndeletedImage(images)
+	image := getFirstUndeletedImage(images)
 	if image == nil {
 		return nil, false, nil
 	}
-	switch image.ScanStatus {
-	case scanStatusPassed:
+	switch image.ContainerGrades.Status {
+	case gradingStatusCompleted:
 		log.Println("✓")
 		return image, true, nil
-	case scanStatusFailed:
-		return nil, true, fmt.Errorf("image scan failed")
-	case scanStatusInProgress:
-		log.Println("scan still in progress")
+	case gradingStatusFailed:
+		return nil, true, fmt.Errorf("image grading failed: message: %s", image.ContainerGrades.StatusMessage)
+	case gradingStatusInProgress:
+		log.Println("grading still in progress")
+		return nil, false, nil
+	case gradingStatusAborted:
+		return nil, true, fmt.Errorf("image grading aborted: message: %s", image.ContainerGrades.StatusMessage)
+	case gradingStatusPending:
+		log.Println("grading pending")
 		return nil, false, nil
 	}
 	return nil, false, nil

--- a/hack/operatorhub/internal/container/types.go
+++ b/hack/operatorhub/internal/container/types.go
@@ -10,14 +10,16 @@ type GetImagesResponse struct {
 	Images []Image `json:"data"`
 }
 
-// scanStatus defines the state of the image scanning process
+// gradingStatus defines the state of the image security scanning process
 // within the Red Hat certification API
-type scanStatus string
+type gradingStatus string
 
 const (
-	scanStatusInProgress scanStatus = "in progress"
-	scanStatusPassed     scanStatus = "passed"
-	scanStatusFailed     scanStatus = "failed"
+	gradingStatusAborted    gradingStatus = "aborted"
+	gradingStatusInProgress gradingStatus = "in progress"
+	gradingStatusCompleted  gradingStatus = "completed"
+	gradingStatusFailed     gradingStatus = "failed"
+	gradingStatusPending    gradingStatus = "pending"
 )
 
 // Image represents a Redhat certification API response
@@ -29,10 +31,18 @@ type Image struct {
 	Architecture *string `json:"architecture"`
 	// Repositories is a slice of Repository structs
 	Repositories []Repository `json:"repositories"`
-	// ScanStatus is the status indicating whether the image has been scanned.
-	ScanStatus scanStatus `json:"scan_status"`
+	// ContainerGrades details the state of grading of a container image
+	ContainerGrades Grade `json:"container_grades"`
 	// DockerImageDigest is the SHA id of the image
 	DockerImageDigest string `json:"docker_image_digest"`
+}
+
+// Grade represents the grading state of a container image.
+type Grade struct {
+	// Status is the grading status of the container image.
+	Status gradingStatus `json:"status"`
+	// StatusMessage is a message describing the grading status of the container image.
+	StatusMessage string `json:"status_message"`
 }
 
 // Repository represents an image repository, and any tags applied to a container image.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.11.1-wip`:
 - [Fix dry-run of helm charts during release. (#7477)](https://github.com/elastic/cloud-on-k8s/pull/7477)
 - [Fix recent Red Hat certificate api changes. (#7453)](https://github.com/elastic/cloud-on-k8s/pull/7453)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)