### PR TITLE
[2.11.1-wip] Release Notes + Highlights for 2.11.1 (#7510)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-2.11.1>>
 * <<release-notes-2.11.0>>
 * <<release-notes-2.10.0>>
 * <<release-notes-2.9.0>>
@@ -44,6 +45,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/2.11.1.asciidoc[]
 include::release-notes/2.11.0.asciidoc[]
 include::release-notes/2.10.0.asciidoc[]
 include::release-notes/2.9.0.asciidoc[]

--- a/docs/release-notes/2.11.0.asciidoc
+++ b/docs/release-notes/2.11.0.asciidoc
@@ -8,7 +8,7 @@
 [float]
 === Breaking changes
 
-* The `resourceStatuses` field of the status subresource of the Stack Configuration Policy is no longer in use. Instead a new `details` field is populated which now also contains information about configured Kibana applications. Unless users have built automation that parses the status subresource, there should be no impact on users, as these fields serve only informational purposes. {pull}7433[#7433]
+* The `resourceStatuses` field of the status subresource of the Stack Configuration Policy is no longer in use. Instead a new `details` field is populated which now also contains information about configured Kibana applications. This change could cause errors during an upgrade of the CRDs while your operator is still running an older version, however 2.11.1 has been released to mitigate this issue. {pull}7433[#7433]
 
 
 [[feature-2.11.0]]
@@ -71,4 +71,3 @@
 * fix(deps): update module github.com/google/uuid to v1.4.0 {pull}7270[#7270]
 * fix(deps): update module sigs.k8s.io/controller-runtime to v0.16.3 {pull}7249[#7249]
 * fix(deps): update module github.com/prometheus/common to v0.45.0 {pull}7246[#7246]
-

--- a/docs/release-notes/2.11.1.asciidoc
+++ b/docs/release-notes/2.11.1.asciidoc
@@ -1,0 +1,12 @@
+:issue: https://github.com/elastic/cloud-on-k8s/issues/
+:pull: https://github.com/elastic/cloud-on-k8s/pull/
+
+[[release-notes-2.11.1]]
+== {n} version 2.11.1
+
+
+[[bug-2.11.1]]
+[float]
+=== Bug fixes
+
+* Add `resourceStatuses` back into the status subresource section of the Stack Configuration Policy for backwards compatability {pull}7500[#7500]

--- a/docs/release-notes/highlights-2.11.0.asciidoc
+++ b/docs/release-notes/highlights-2.11.0.asciidoc
@@ -2,6 +2,11 @@
 == 2.11.0 release highlights
 
 [float]
+[id="{p}-2110-known-issues"]
+=== Known issues
+- The `resourceStatuses` field of the status subresource of the Stack Configuration Policy was removed which could cause errors when running older versions of the operator with the new CRDs during upgrades.
+
+[float]
 [id="{p}-2110-new-and-notable"]
 === New and notable
 

--- a/docs/release-notes/highlights-2.11.1.asciidoc
+++ b/docs/release-notes/highlights-2.11.1.asciidoc
@@ -1,0 +1,10 @@
+[[release-highlights-2.11.1]]
+== 2.11.1 release highlights
+
+[float]
+[id="{p}-2111-new-and-notable"]
+=== Bug fix
+
+This release fixes an issue introduced in ECK 2.11.0 where the `resourceStatuses` field of the status subresource of the Stack Configuration Policy was removed.
+
+Also refer to <<{p}-2110-known-issues>> for more information.

--- a/docs/release-notes/highlights.asciidoc
+++ b/docs/release-notes/highlights.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the most important changes in each release. For the full list, check <<eck-release-notes>>.
 
+* <<release-highlights-2.11.1>>
 * <<release-highlights-2.11.0>>
 * <<release-highlights-2.10.0>>
 * <<release-highlights-2.9.0>>
@@ -43,6 +44,7 @@ This section summarizes the most important changes in each release. For the full
 
 --
 
+include::highlights-2.11.1.asciidoc[]
 include::highlights-2.11.0.asciidoc[]
 include::highlights-2.10.0.asciidoc[]
 include::highlights-2.9.0.asciidoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.11.1-wip`:
 - [Release Notes + Highlights for 2.11.1 (#7510)](https://github.com/elastic/cloud-on-k8s/pull/7510)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)