### PR TITLE
Synchronize generated CRDs

### DIFF
--- a/config/crds/v1/all-crds.yaml
+++ b/config/crds/v1/all-crds.yaml
@@ -9595,28 +9595,27 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'The maximum number of pods that can be unavailable
-                          during the update. Value can be an absolute number (ex:
-                          5) or a percentage of desired pods (ex: 10%). Absolute number
-                          is calculated from percentage by rounding up. This can not
-                          be 0. Defaults to 1. This field is alpha-level and is only
-                          honored by servers that enable the MaxUnavailableStatefulSet
-                          feature. The field applies to all pods in the range 0 to
-                          Replicas-1. That means if there is any unavailable pod in
-                          the range 0 to Replicas-1, it will be counted towards MaxUnavailable.'
+                        description: |-
+                          The maximum number of pods that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          Absolute number is calculated from percentage by rounding up. This can not be 0.
+                          Defaults to 1. This field is alpha-level and is only honored by servers that enable the
+                          MaxUnavailableStatefulSet feature. The field applies to all pods in the range 0 to
+                          Replicas-1. That means if there is any unavailable pod in the range 0 to Replicas-1, it
+                          will be counted towards MaxUnavailable.
                         x-kubernetes-int-or-string: true
                       partition:
-                        description: Partition indicates the ordinal at which the
-                          StatefulSet should be partitioned for updates. During a
-                          rolling update, all pods from ordinal Replicas-1 to Partition
-                          are updated. All pods from ordinal Partition-1 to 0 remain
-                          untouched. This is helpful in being able to do a canary
-                          based deployment. The default value is 0.
+                        description: |-
+                          Partition indicates the ordinal at which the StatefulSet should be partitioned
+                          for updates. During a rolling update, all pods from ordinal Replicas-1 to
+                          Partition are updated. All pods from ordinal Partition-1 to 0 remain untouched.
+                          This is helpful in being able to do a canary based deployment. The default value is 0.
                         format: int32
                         type: integer
                     type: object
                   type:
-                    description: Type indicates the type of the StatefulSetUpdateStrategy.
+                    description: |-
+                      Type indicates the type of the StatefulSetUpdateStrategy.
                       Default is RollingUpdate.
                     type: string
                 type: object

--- a/config/crds/v1/bases/logstash.k8s.elastic.co_logstashes.yaml
+++ b/config/crds/v1/bases/logstash.k8s.elastic.co_logstashes.yaml
@@ -8214,28 +8214,27 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'The maximum number of pods that can be unavailable
-                          during the update. Value can be an absolute number (ex:
-                          5) or a percentage of desired pods (ex: 10%). Absolute number
-                          is calculated from percentage by rounding up. This can not
-                          be 0. Defaults to 1. This field is alpha-level and is only
-                          honored by servers that enable the MaxUnavailableStatefulSet
-                          feature. The field applies to all pods in the range 0 to
-                          Replicas-1. That means if there is any unavailable pod in
-                          the range 0 to Replicas-1, it will be counted towards MaxUnavailable.'
+                        description: |-
+                          The maximum number of pods that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          Absolute number is calculated from percentage by rounding up. This can not be 0.
+                          Defaults to 1. This field is alpha-level and is only honored by servers that enable the
+                          MaxUnavailableStatefulSet feature. The field applies to all pods in the range 0 to
+                          Replicas-1. That means if there is any unavailable pod in the range 0 to Replicas-1, it
+                          will be counted towards MaxUnavailable.
                         x-kubernetes-int-or-string: true
                       partition:
-                        description: Partition indicates the ordinal at which the
-                          StatefulSet should be partitioned for updates. During a
-                          rolling update, all pods from ordinal Replicas-1 to Partition
-                          are updated. All pods from ordinal Partition-1 to 0 remain
-                          untouched. This is helpful in being able to do a canary
-                          based deployment. The default value is 0.
+                        description: |-
+                          Partition indicates the ordinal at which the StatefulSet should be partitioned
+                          for updates. During a rolling update, all pods from ordinal Replicas-1 to
+                          Partition are updated. All pods from ordinal Partition-1 to 0 remain untouched.
+                          This is helpful in being able to do a canary based deployment. The default value is 0.
                         format: int32
                         type: integer
                     type: object
                   type:
-                    description: Type indicates the type of the StatefulSetUpdateStrategy.
+                    description: |-
+                      Type indicates the type of the StatefulSetUpdateStrategy.
                       Default is RollingUpdate.
                     type: string
                 type: object

--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -9649,28 +9649,27 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'The maximum number of pods that can be unavailable
-                          during the update. Value can be an absolute number (ex:
-                          5) or a percentage of desired pods (ex: 10%). Absolute number
-                          is calculated from percentage by rounding up. This can not
-                          be 0. Defaults to 1. This field is alpha-level and is only
-                          honored by servers that enable the MaxUnavailableStatefulSet
-                          feature. The field applies to all pods in the range 0 to
-                          Replicas-1. That means if there is any unavailable pod in
-                          the range 0 to Replicas-1, it will be counted towards MaxUnavailable.'
+                        description: |-
+                          The maximum number of pods that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          Absolute number is calculated from percentage by rounding up. This can not be 0.
+                          Defaults to 1. This field is alpha-level and is only honored by servers that enable the
+                          MaxUnavailableStatefulSet feature. The field applies to all pods in the range 0 to
+                          Replicas-1. That means if there is any unavailable pod in the range 0 to Replicas-1, it
+                          will be counted towards MaxUnavailable.
                         x-kubernetes-int-or-string: true
                       partition:
-                        description: Partition indicates the ordinal at which the
-                          StatefulSet should be partitioned for updates. During a
-                          rolling update, all pods from ordinal Replicas-1 to Partition
-                          are updated. All pods from ordinal Partition-1 to 0 remain
-                          untouched. This is helpful in being able to do a canary
-                          based deployment. The default value is 0.
+                        description: |-
+                          Partition indicates the ordinal at which the StatefulSet should be partitioned
+                          for updates. During a rolling update, all pods from ordinal Replicas-1 to
+                          Partition are updated. All pods from ordinal Partition-1 to 0 remain untouched.
+                          This is helpful in being able to do a canary based deployment. The default value is 0.
                         format: int32
                         type: integer
                     type: object
                   type:
-                    description: Type indicates the type of the StatefulSetUpdateStrategy.
+                    description: |-
+                      Type indicates the type of the StatefulSetUpdateStrategy.
                       Default is RollingUpdate.
                     type: string
                 type: object

--- a/pkg/controller/logstash/logstash_controller_test.go
+++ b/pkg/controller/logstash/logstash_controller_test.go
@@ -429,7 +429,7 @@ func TestReconcileLogstash_Reconcile(t *testing.T) {
 						Generation: 2,
 					},
 					Spec: logstashv1alpha1.LogstashSpec{
-						Version: "8.6.1",
+						Version: "8.12.0",
 						Count:   1,
 						UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 							Type: appsv1.RollingUpdateStatefulSetStrategyType,
@@ -489,7 +489,7 @@ func TestReconcileLogstash_Reconcile(t *testing.T) {
 					Generation: 2,
 				},
 				Spec: logstashv1alpha1.LogstashSpec{
-					Version: "8.6.1",
+					Version: "8.12.0",
 					Count:   1,
 					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 						Type: appsv1.RollingUpdateStatefulSetStrategyType,


### PR DESCRIPTION
This resynchronizes the CRDs generated following changes made by:
- #7500 

because it did not take into account the new format brought by:
- #7461

And cherry-pick from #7515.