### PR TITLE
Update Logstash tests to minimum supported version/Fix main.

### DIFF
--- a/pkg/controller/logstash/logstash_controller_test.go
+++ b/pkg/controller/logstash/logstash_controller_test.go
@@ -429,7 +429,7 @@ func TestReconcileLogstash_Reconcile(t *testing.T) {
 						Generation: 2,
 					},
 					Spec: logstashv1alpha1.LogstashSpec{
-						Version: "8.6.1",
+						Version: "8.12.0",
 						Count:   1,
 						UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 							Type: appsv1.RollingUpdateStatefulSetStrategyType,
@@ -489,7 +489,7 @@ func TestReconcileLogstash_Reconcile(t *testing.T) {
 					Generation: 2,
 				},
 				Spec: logstashv1alpha1.LogstashSpec{
-					Version: "8.6.1",
+					Version: "8.12.0",
 					Count:   1,
 					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 						Type: appsv1.RollingUpdateStatefulSetStrategyType,


### PR DESCRIPTION
Minimum supported version was updated [here](https://github.com/elastic/cloud-on-k8s/commit/849ce1e6f6adcf7bb211893a73d2f590f67530a1#diff-a25ada9d0355ab4c251a37adc6fa681c95a88497296c79b4425bc76368e285cbR36), but somehow this [PR](https://github.com/elastic/cloud-on-k8s/pull/7466/files#diff-4ef4c9fd090be12740c7e277bbdd599aa3b428174b1c1dcc5b48cebc234e540d) passed all tests. Maybe an ordering of merge thing?

Anyway, this updates the test to pass and fix main.