### PR TITLE
fix: bind all k8sclient funcs to pointer receivers

### DIFF
--- a/test/e2e/test/k8s_client.go
+++ b/test/e2e/test/k8s_client.go
@@ -356,7 +356,7 @@ func (k *K8sClient) CheckSecretsRemoved(secretRefs []types.NamespacedName) error
 }
 
 // CreateOrUpdateSecrets creates the given secrets, or updates them if they already exist.
-func (k K8sClient) CreateOrUpdateSecrets(secrets ...corev1.Secret) error {
+func (k *K8sClient) CreateOrUpdateSecrets(secrets ...corev1.Secret) error {
 	for i := range secrets {
 		if err := k.CreateOrUpdate(&secrets[i]); err != nil {
 			return err
@@ -374,7 +374,7 @@ func (k *K8sClient) DeleteSecrets(secrets ...corev1.Secret) error {
 	return nil
 }
 
-func (k K8sClient) CreateOrUpdate(objs ...k8sclient.Object) error {
+func (k *K8sClient) CreateOrUpdate(objs ...k8sclient.Object) error {
 	for _, obj := range objs {
 		// create a copy to ensure that the original object is not modified
 		obj := k8s.DeepCopyObject(obj)
@@ -520,7 +520,7 @@ func OnAllPods(pods []corev1.Pod, f func(corev1.Pod) error) error {
 }
 
 // GetFirstNodeExternalIP gets the external IP address of the first k8s node in the current k8s cluster.
-func (k K8sClient) GetFirstNodeExternalIP() (string, error) {
+func (k *K8sClient) GetFirstNodeExternalIP() (string, error) {
 	var nodes corev1.NodeList
 	if err := k.Client.List(context.Background(), &nodes); err != nil {
 		return "", err


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

Struct `K8sClient` had methods on both value and pointer receivers. As this is not recommended by Go Documentation this PR makes all of them targeting a pointer receiver
