### PR TITLE
Fix having multiple `type` keys in eck-beats chart.

### DIFF
--- a/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
@@ -12,8 +12,8 @@ metadata:
     {{- end }}
 spec:
   version: {{ required "A Beat version is required" .Values.version }}
-  type: {{ required "A Beat type is required" .Values.spec.type }}
   {{- if and (not (hasKey .Values.spec "daemonSet")) (not (hasKey .Values.spec "deployment")) }}
   {{ fail "At least one of daemonSet or deployment is required for a functional Beat" }}
   {{- end }}
-  {{- unset .Values.spec "type" | toYaml | nindent 2 }}
+  {{- if not .Values.spec.type }}{{ fail "A Beat type is required" }}{{- end }}
+  {{- toYaml .Values.spec | nindent 2 }}

--- a/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
@@ -16,4 +16,4 @@ spec:
   {{- if and (not (hasKey .Values.spec "daemonSet")) (not (hasKey .Values.spec "deployment")) }}
   {{ fail "At least one of daemonSet or deployment is required for a functional Beat" }}
   {{- end }}
-  {{- toYaml .Values.spec | nindent 2 }}
+  {{- unset .Values.spec "type" | toYaml | nindent 2 }}


### PR DESCRIPTION
This fixes the issue where there were multiple `type` keys in the rendered eck-beats chart.

```sh
❯ helm template . -f examples/filebeat_no_autodiscover.yaml | grep "type: filebeat"
  type: filebeat
```

Resolves #7487.