### PR TITLE
Schedule renovage PRs once a week

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,22 +17,6 @@
         "k8s.io/kubectl"
       ],
       "updateTypes": [
-        "major",
-        "minor",
-        "digest"
-      ],
-      "enabled": false
-    },
-    {
-      "packageNames": [
-        "k8s.io/apimachinery",
-        "k8s.io/client-go",
-        "k8s.io/api",
-        "k8s.io/cli-runtime",
-        "k8s.io/apiextensions-apiserver",
-        "k8s.io/kubectl"
-      ],
-      "updateTypes": [
         "patch"
       ],
       "groupName": "k8s"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,9 @@
     "config:base"
   ],
   "labels": [">renovate"],
+  "schedule": [
+    "after 1am on monday"
+  ],
   "packageRules": [
     {
       "packageNames": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,16 +8,8 @@
   ],
   "packageRules": [
     {
-      "packageNames": [
-        "k8s.io/apimachinery",
-        "k8s.io/client-go",
-        "k8s.io/api",
-        "k8s.io/cli-runtime",
-        "k8s.io/apiextensions-apiserver",
-        "k8s.io/kubectl"
-      ],
-      "updateTypes": [
-        "patch"
+      "matchPackagePatterns": [
+        "k8s.io"
       ],
       "groupName": "k8s"
     },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,8 +27,5 @@
       ],
       "enabled": false
     }
-  ],
-  "ignorePaths": [
-    "**/vendor/**"
   ]
 }


### PR DESCRIPTION
This adds a `after 1 a.m. Monday` schedule to reduce the number of renovate PRs.

Also do some cleaning:
* Remove unnecessary configuration (no more `vendor/` directories for a long time)
* Simplify package rule to group k8s repositories (using [matchpackagepatterns](https://docs.renovatebot.com/configuration-options/#matchpackagepatterns))
* Stop to discard major/minor k8s.io updates: the updates were pulled by other updates (e.g.: k8s v0.29.0 via #7461)

I don't know how to test this.