### PR TITLE
[2.11] Fix having multiple `type` keys in eck-beats chart. (#7523)

### DIFF
--- a/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
@@ -12,8 +12,8 @@ metadata:
     {{- end }}
 spec:
   version: {{ required "A Beat version is required" .Values.version }}
-  type: {{ required "A Beat type is required" .Values.spec.type }}
   {{- if and (not (hasKey .Values.spec "daemonSet")) (not (hasKey .Values.spec "deployment")) }}
   {{ fail "At least one of daemonSet or deployment is required for a functional Beat" }}
   {{- end }}
+  {{- if not .Values.spec.type }}{{ fail "A Beat type is required" }}{{- end }}
   {{- toYaml .Values.spec | nindent 2 }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.11`:
 - [Fix having multiple `type` keys in eck-beats chart. (#7523)](https://github.com/elastic/cloud-on-k8s/pull/7523)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)