### PR TITLE
Fix typo in 2.11.1 release notes

### DIFF
--- a/docs/release-notes/2.11.1.asciidoc
+++ b/docs/release-notes/2.11.1.asciidoc
@@ -9,4 +9,4 @@
 [float]
 === Bug fixes
 
-* Add `resourceStatuses` back into the status subresource section of the Stack Configuration Policy for backwards compatability {pull}7500[#7500]
+* Add `resourceStatuses` back into the status subresource section of the Stack Configuration Policy for backwards compatibility {pull}7500[#7500]


### PR DESCRIPTION
Spotted a spelling mistake.