### PR TITLE
[2.11] Fix typo in 2.11.1 release notes (#7532)

### DIFF
--- a/docs/release-notes/2.11.1.asciidoc
+++ b/docs/release-notes/2.11.1.asciidoc
@@ -9,4 +9,4 @@
 [float]
 === Bug fixes
 
-* Add `resourceStatuses` back into the status subresource section of the Stack Configuration Policy for backwards compatability {pull}7500[#7500]
+* Add `resourceStatuses` back into the status subresource section of the Stack Configuration Policy for backwards compatibility {pull}7500[#7500]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.11`:
 - [Fix typo in 2.11.1 release notes (#7532)](https://github.com/elastic/cloud-on-k8s/pull/7532)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)