### PR TITLE
Update Elastic Stack version to v8.12.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,7 +421,7 @@ drivah-build-e2e:
 
 # -- run
 
-E2E_STACK_VERSION          ?= 8.12.0
+E2E_STACK_VERSION          ?= 8.12.1
 # regexp to filter tests to run
 export TESTS_MATCH         ?= "^Test"
 export E2E_JSON            ?= false

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -5,7 +5,7 @@ metadata:
   name: e2e-agent
   namespace: {{ .E2ENamespace }}
 spec:
-  version: 8.12.0 # needs to less or equal to e2e-monitor version
+  version: 8.12.1 # needs to less or equal to e2e-monitor version
   elasticsearchRefs:
     - secretName: eck-{{ .TestRun }}
   daemonSet:
@@ -188,7 +188,7 @@ spec:
       meta:
         package:
           name: system
-          version: 8.12.0
+          version: 8.12.1
       data_stream:
         namespace: default
       processors:

--- a/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
+++ b/config/recipes/apm-server-jaeger/apm-server-jaeger.yaml
@@ -4,7 +4,7 @@ metadata:
   name: apm-server-quickstart
   namespace: default
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   config:
     name: elastic-apm

--- a/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
+++ b/config/recipes/associations-rbac/apm_es_kibana_rbac.yaml
@@ -84,7 +84,7 @@ metadata:
   name: elasticsearch-sample
   namespace: elasticsearch-ns
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
     - name: default
       count: 1
@@ -97,7 +97,7 @@ metadata:
   name: kibana-sample
   namespace: kibana-ns
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   config:
     xpack.fleet.packages:
@@ -115,7 +115,7 @@ metadata:
   name: apm-apm-sample
   namespace: apmserver-ns
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/config/recipes/autopilot/elasticsearch.yaml
+++ b/config/recipes/autopilot/elasticsearch.yaml
@@ -41,7 +41,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 1

--- a/config/recipes/autopilot/fleet-kubernetes-integration.yaml
+++ b/config/recipes/autopilot/fleet-kubernetes-integration.yaml
@@ -41,7 +41,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 1
@@ -74,7 +74,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -136,7 +136,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 8.12.0
+  version: 8.12.1
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -178,7 +178,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 8.12.0
+  version: 8.12.1
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/autopilot/kubernetes-integration.yaml
+++ b/config/recipes/autopilot/kubernetes-integration.yaml
@@ -4,7 +4,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -27,7 +27,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRefs:
   - name: elasticsearch
   daemonSet:

--- a/config/recipes/autopilot/metricbeat_hosts.yaml
+++ b/config/recipes/autopilot/metricbeat_hosts.yaml
@@ -4,7 +4,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -28,7 +28,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:

--- a/config/recipes/autoscaling/elasticsearch.yaml
+++ b/config/recipes/autoscaling/elasticsearch.yaml
@@ -51,7 +51,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
     - name: master
       count: 3

--- a/config/recipes/beats/auditbeat_hosts.yaml
+++ b/config/recipes/beats/auditbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: auditbeat
 spec:
   type: auditbeat
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -76,7 +76,7 @@ spec:
         #    path: /run
         #initContainers:
         #- name: cos-init
-        #  image: docker.elastic.co/beats/auditbeat:8.12.0
+        #  image: docker.elastic.co/beats/auditbeat:8.12.1
         #  volumeMounts:
         #  - name: run
         #    mountPath: /run
@@ -118,7 +118,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -130,7 +130,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -114,7 +114,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -126,7 +126,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
+++ b/config/recipes/beats/filebeat_autodiscover_by_metadata.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -102,7 +102,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -114,7 +114,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/filebeat_no_autodiscover.yaml
+++ b/config/recipes/beats/filebeat_no_autodiscover.yaml
@@ -4,7 +4,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -53,7 +53,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -65,7 +65,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/heartbeat_es_kb_health.yaml
+++ b/config/recipes/beats/heartbeat_es_kb_health.yaml
@@ -4,7 +4,7 @@ metadata:
   name: heartbeat
 spec:
   type: heartbeat
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRef:
     name: elasticsearch
   config:
@@ -27,7 +27,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -39,7 +39,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/metricbeat_hosts.yaml
+++ b/config/recipes/beats/metricbeat_hosts.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -174,7 +174,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -186,7 +186,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/openshift_monitoring.yaml
+++ b/config/recipes/beats/openshift_monitoring.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -221,7 +221,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -316,7 +316,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -328,7 +328,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/packetbeat_dns_http.yaml
+++ b/config/recipes/beats/packetbeat_dns_http.yaml
@@ -4,7 +4,7 @@ metadata:
   name: packetbeat
 spec:
   type: packetbeat
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRef:
     name: elasticsearch
   kibanaRef:
@@ -44,7 +44,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -56,7 +56,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -6,7 +6,7 @@ metadata:
   name: metricbeat
 spec:
   type: metricbeat
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRef:
     name: elasticsearch-monitoring
   config:
@@ -132,7 +132,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRef:
     name: elasticsearch-monitoring
   kibanaRef:
@@ -244,7 +244,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -260,7 +260,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -277,7 +277,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-monitoring
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -289,7 +289,7 @@ kind: Kibana
 metadata:
   name: kibana-monitoring
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch-monitoring

--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -59,7 +59,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -71,7 +71,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 8.12.0
+  version: 8.12.1
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -93,7 +93,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 8.12.0
+  version: 8.12.1
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -68,7 +68,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -80,7 +80,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 8.12.0
+  version: 8.12.1
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -102,7 +102,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 8.12.0
+  version: 8.12.1
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -52,7 +52,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -64,7 +64,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 8.12.0
+  version: 8.12.1
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -86,7 +86,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 8.12.0
+  version: 8.12.1
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/kubernetes-integration.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRefs:
   - name: elasticsearch
   daemonSet:
@@ -193,7 +193,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -205,7 +205,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/elastic-agent/multi-output.yaml
+++ b/config/recipes/elastic-agent/multi-output.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRefs:
   - outputName: default
     name: elasticsearch
@@ -196,7 +196,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -208,7 +208,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -218,7 +218,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-mon
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -230,7 +230,7 @@ kind: Kibana
 metadata:
   name: kibana-mon
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch-mon

--- a/config/recipes/elastic-agent/system-integration.yaml
+++ b/config/recipes/elastic-agent/system-integration.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRefs:
   - name: elasticsearch
   daemonSet:
@@ -31,7 +31,7 @@ spec:
       meta:
         package:
           name: system
-          version: 8.12.0
+          version: 8.12.1
       data_stream:
         namespace: default
       streams:
@@ -136,7 +136,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -148,7 +148,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/config/recipes/gclb/01-elastic-stack.yaml
+++ b/config/recipes/gclb/01-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.12.0
+  version: 8.12.1
   http:
     service:
       metadata:
@@ -45,7 +45,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   http:
     service:

--- a/config/recipes/gclb/99-kibana-path.yaml
+++ b/config/recipes/gclb/99-kibana-path.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: thor
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   config:
     # Make Kibana aware of the fact that it is behind a proxy

--- a/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
+++ b/config/recipes/istio-gateway/03-elasticsearch-kibana.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 8.12.0
+  version: 8.12.1
   http:
     tls:
       selfSignedCertificate:
@@ -82,7 +82,7 @@ metadata:
   labels:
     app: ekmnt
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   http:
     tls:

--- a/config/recipes/logstash/logstash-eck.yaml
+++ b/config/recipes/logstash/logstash-eck.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
     - name: default
       count: 3
@@ -17,7 +17,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -28,7 +28,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.12.0
+  version: 8.12.1
   config:
     filebeat.inputs:
       - type: log
@@ -67,7 +67,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRefs:
     - clusterName: eck
       name: elasticsearch

--- a/config/recipes/logstash/logstash-es-role.yaml
+++ b/config/recipes/logstash/logstash-es-role.yaml
@@ -15,7 +15,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   auth:
     roles:
       - secretName: my-roles-secret
@@ -31,7 +31,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRefs:
     - name: elasticsearch
       clusterName: eck

--- a/config/recipes/logstash/logstash-monitored.yaml
+++ b/config/recipes/logstash/logstash-monitored.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
     - name: default
       count: 3
@@ -17,7 +17,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -28,7 +28,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.12.0
+  version: 8.12.1
   config:
     filebeat.inputs:
       - type: log
@@ -67,7 +67,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRefs:
     - clusterName: eck
       name: elasticsearch
@@ -116,7 +116,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-monitoring
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
     - name: default
       count: 3
@@ -128,7 +128,7 @@ kind: Kibana
 metadata:
   name: kibana-monitoring
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch-monitoring

--- a/config/recipes/logstash/logstash-multi.yaml
+++ b/config/recipes/logstash/logstash-multi.yaml
@@ -12,7 +12,7 @@ metadata:
   name: qa
   namespace: qa
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
     - name: default
       count: 3
@@ -25,7 +25,7 @@ kind: Elasticsearch
 metadata:
   name: production
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
     - name: default
       count: 3
@@ -39,7 +39,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.12.0
+  version: 8.12.1
   config:
     filebeat.inputs:
       - type: log
@@ -78,7 +78,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRefs:
   - clusterName: prod-es
     name: production

--- a/config/recipes/logstash/logstash-pipeline-as-secret.yaml
+++ b/config/recipes/logstash/logstash-pipeline-as-secret.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
     - name: default
       count: 3
@@ -17,7 +17,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -28,7 +28,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.12.0
+  version: 8.12.1
   config:
     filebeat.inputs:
       - type: log
@@ -67,7 +67,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRefs:
     - clusterName: eck
       name: elasticsearch

--- a/config/recipes/logstash/logstash-pipeline-as-volume.yaml
+++ b/config/recipes/logstash/logstash-pipeline-as-volume.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
     - name: default
       count: 3
@@ -17,7 +17,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -28,7 +28,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.12.0
+  version: 8.12.1
   config:
     filebeat.inputs:
       - type: log
@@ -67,7 +67,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRefs:
     - clusterName: eck
       name: elasticsearch

--- a/config/recipes/logstash/logstash-volumes.yaml
+++ b/config/recipes/logstash/logstash-volumes.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
     - name: default
       count: 3
@@ -18,7 +18,7 @@ metadata:
   name: filebeat
 spec:
   type: filebeat
-  version: 8.12.0
+  version: 8.12.1
   config:
     filebeat.inputs:
       - type: log
@@ -57,7 +57,7 @@ metadata:
   name: logstash
 spec:
   count: 1
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRefs:
     - clusterName: eck
       name: elasticsearch

--- a/config/recipes/maps/01-ems.yaml
+++ b/config/recipes/maps/01-ems.yaml
@@ -3,5 +3,5 @@ kind: ElasticMapsServer
 metadata:
   name: ems-sample
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1

--- a/config/recipes/maps/02-es-kb.yaml
+++ b/config/recipes/maps/02-es-kb.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
     - name: default
       count: 3
@@ -27,7 +27,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   config:
     # Configure this to a domain you control

--- a/config/recipes/traefik/02-elastic-stack.yaml
+++ b/config/recipes/traefik/02-elastic-stack.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: master
     count: 1
@@ -41,7 +41,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   config:
     xpack.fleet.packages:
@@ -57,7 +57,7 @@ metadata:
   labels:
     app: hulk
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: hulk

--- a/config/samples/apm/apm_es_kibana.yaml
+++ b/config/samples/apm/apm_es_kibana.yaml
@@ -5,7 +5,7 @@ kind: Elasticsearch
 metadata:
   name: es-apm-sample
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -19,7 +19,7 @@ kind: Kibana
 metadata:
   name: kb-apm-sample
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"
@@ -33,7 +33,7 @@ kind: ApmServer
 metadata:
   name: apm-apm-sample
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: "es-apm-sample"

--- a/config/samples/elasticsearch/elasticsearch.yaml
+++ b/config/samples/elasticsearch/elasticsearch.yaml
@@ -7,7 +7,7 @@ metadata:
   #  eck.k8s.elastic.co/downward-node-labels: "topology.kubernetes.io/zone"
   name: elasticsearch-sample
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     config:

--- a/config/samples/enterprisesearch/ent_es.yaml
+++ b/config/samples/enterprisesearch/ent_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
     - name: default
       count: 1
@@ -18,7 +18,7 @@ kind: EnterpriseSearch
 metadata:
   name: ent-sample
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch-sample

--- a/config/samples/kibana/kibana_es.yaml
+++ b/config/samples/kibana/kibana_es.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 1
@@ -18,7 +18,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: "elasticsearch-sample"

--- a/config/samples/logstash/logstash.yaml
+++ b/config/samples/logstash/logstash.yaml
@@ -3,7 +3,7 @@ kind: Logstash
 metadata:
   name: logstash-sample
 spec:
-  version: 8.12.0
+  version: 8.12.1
   count: 3
   config:
     log.level: info

--- a/config/samples/logstash/logstash_es.yaml
+++ b/config/samples/logstash/logstash_es.yaml
@@ -3,7 +3,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
     - name: default
       count: 2
@@ -16,7 +16,7 @@ metadata:
   name: logstash-sample
 spec:
   count: 1
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRefs:
     - clusterName: production
       name: elasticsearch-sample

--- a/config/samples/logstash/logstash_pv.yaml
+++ b/config/samples/logstash/logstash_pv.yaml
@@ -4,7 +4,7 @@ metadata:
   name: d
 spec:
   count: 1
-  version: 8.12.0
+  version: 8.12.1
   config:
     queue.type: persisted
   pipelines:

--- a/config/samples/logstash/logstash_stackmonitor.yaml
+++ b/config/samples/logstash/logstash_stackmonitor.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: monitoring
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
     - name: default
       count: 3
@@ -17,7 +17,7 @@ metadata:
   name: logstash-sample
 spec:
   count: 1
-  version: 8.12.0
+  version: 8.12.1
   config:
     log.level: info
     api.http.host: "0.0.0.0"
@@ -55,7 +55,7 @@ kind: Kibana
 metadata:
   name: kibana-sample
 spec:
-  version: 8.12.0
+  version: 8.12.1
   elasticsearchRef:
     name: monitoring
   count: 1

--- a/config/samples/logstash/logstash_svc.yaml
+++ b/config/samples/logstash/logstash_svc.yaml
@@ -3,7 +3,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch-sample
 spec:
-  version: 8.12.0
+  version: 8.12.1
   nodeSets:
     - name: default
       count: 3
@@ -16,7 +16,7 @@ metadata:
   name: logstash-sample
 spec:
   count: 2
-  version: 8.12.0
+  version: 8.12.1
   config:
     log.level: info
     api.http.host: "0.0.0.0"

--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
@@ -207,11 +207,11 @@ tests:
           value: my.regis.try/es:8
   - it: should render image properly
     set:
-      image: my.registry.com/elastic/elasticsearch:8.12.0
+      image: my.registry.com/elastic/elasticsearch:8.12.1
     asserts:
       - equal:
           path: spec.image
-          value: my.registry.com/elastic/elasticsearch:8.12.0
+          value: my.registry.com/elastic/elasticsearch:8.12.1
   - it: should render no podDisruptionBudget by default
     set:
     asserts:

--- a/hack/upgrade-test-harness/conf.yaml
+++ b/hack/upgrade-test-harness/conf.yaml
@@ -40,7 +40,7 @@ testParams:
     stackVersion: 8.11.1
   - name: v2110
     operatorVersion: 2.11.0
-    stackVersion: 8.12.0
+    stackVersion: 8.12.1
   - name: upcoming
     operatorVersion: 2.12.0-SNAPSHOT
     stackVersion: 8.13.0-SNAPSHOT

--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -18,7 +18,7 @@ const (
 	// LatestReleasedVersion7x is the latest released version for 7.x
 	LatestReleasedVersion7x = "7.17.8"
 	// LatestReleasedVersion8x is the latest release version for 8.x
-	LatestReleasedVersion8x = "8.12.0"
+	LatestReleasedVersion8x = "8.12.1"
 )
 
 // SkipInvalidUpgrade skips a test that would do an invalid upgrade.


### PR DESCRIPTION
This bumps the current Elastic Stack version from `8.12.0` to `8.12.1`

using `hack/update-stack-version.sh 8\.12\.0 8.12.1`.

Also `mv config/samples/logstash/logstash_pv.yml config/samples/logstash/logstash_pv.yaml` so it is updated by the above script.

And finally updates `hack/upgrade-test-harness/conf.yaml`.