### PR TITLE
Update upgrade-test-harness to use latest patch Elastic Stack versions

### DIFF
--- a/hack/upgrade-test-harness/conf.yaml
+++ b/hack/upgrade-test-harness/conf.yaml
@@ -28,16 +28,16 @@ testParams:
     stackVersion: 8.6.2
   - name: v270
     operatorVersion: 2.7.0
-    stackVersion: 8.7.0
+    stackVersion: 8.7.1
   - name: v280
     operatorVersion: 2.8.0
-    stackVersion: 8.8.0
+    stackVersion: 8.8.2
   - name: v290
     operatorVersion: 2.9.0
-    stackVersion: 8.9.0
+    stackVersion: 8.9.2
   - name: v2100
     operatorVersion: 2.10.0
-    stackVersion: 8.11.1
+    stackVersion: 8.11.4
   - name: v2110
     operatorVersion: 2.11.0
     stackVersion: 8.12.0


### PR DESCRIPTION
This updates `upgrade-test-harness` to use latest patch versions: `8.7.1`, `8.8.2`, `8.9.2` and `8.11.4`.

`8.12.x` will be updated in #7535.