### PR TITLE
Update operator used in e2e tests to 2.11.1

### DIFF
--- a/config/e2e/helm-monitoring-operator.yaml
+++ b/config/e2e/helm-monitoring-operator.yaml
@@ -6,7 +6,7 @@ managedNamespaces: [{{ .E2ENamespace }}]
 
 image:
   repository: docker.elastic.co/eck/eck-operator
-  tag: 2.11.0
+  tag: 2.11.1
 
 podAnnotations:
   co.elastic.metrics/metricsets: collector


### PR DESCRIPTION
Final piece from 2.11.1 release is to update e2e tests to use this new version of the operator.