### PR TITLE
fix logstash PV test

### DIFF
--- a/config/samples/logstash/logstash_pv.yaml
+++ b/config/samples/logstash/logstash_pv.yaml
@@ -34,4 +34,4 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 1Gi
+            storage: 2Gi


### PR DESCRIPTION
Fix: #7538

PQ require 1GB, but the available space is 958M. We need to review the default setting in Logstash on ECK.
