### PR TITLE
Increase the default PVC size for logstash

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -330,7 +330,7 @@ spec:
             storage: 2Gi
 ----
 
-The default volume size will likely be insufficient for production workloads, espeically when you are using:
+The default volume size will likely be insufficient for production workloads, especially when you are using:
 
 * the persistent queue (PQ) feature
 * dead letter queues (DLQ), or 

--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -338,7 +338,7 @@ The default volume size will likely be insufficient for production workloads, es
 
 Increase the storage capacity, or consider creating separate volumes for these use cases.
 
-Separate storage can be added by including an additional `spec.volumeClaimTemplate` along with a corresponding `spec.podTemplate.spec.containers.volumeMount` for each requested volume.
+You can add separate storage by including an additional `spec.volumeClaimTemplate` along with a corresponding `spec.podTemplate.spec.containers.volumeMount` for each requested volume.
 
 This example shows how to setup separate storage for a PQ:
 

--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -330,7 +330,13 @@ spec:
             storage: 2Gi
 ----
 
-In particular, when enabling the persistent queue (PQ) feature, using dead letter queues (DLQ), or certain plugins that make heavy use of temporary storage, the default volume size will likely be insufficient for production workloads and you should increase the storage capacity, or consider creating separate volumes for these use cases.
+The default volume size will likely be insufficient for production workloads, espeically when you are using:
+
+* the persistent queue (PQ) feature
+* dead letter queues (DLQ), or 
+* {ls} plugins that make heavy use of temporary storage. 
+
+Increase the storage capacity, or consider creating separate volumes for these use cases.
 
 Separate storage can be added by including an additional `spec.volumeClaimTemplate` along with a corresponding `spec.podTemplate.spec.containers.volumeMount` for each requested volume.
 

--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -301,7 +301,7 @@ WARNING: Volume support for Logstash is a breaking change to earlier versions of
 [discrete]
 == Specifying the volume claim settings
 
-By default, a PersistentVolume called `logstash-data` is created, that maps to `/usr/share/logstash/data` for persistent storage, typically used for storage from plugins. The `logstash-data` volume claim is, by default, a small (1Gi) volume, using the standard StorageClass of your Kubernetes cluster, but can be overridden by adding a `spec.volumeClaimTemplate` section named `logstash-data`.
+By default, a PersistentVolume called `logstash-data` is created, that maps to `/usr/share/logstash/data` for persistent storage, typically used for storage from plugins. The `logstash-data` volume claim is, by default, a 1.5Gi volume, using the standard StorageClass of your Kubernetes cluster, but can be overridden by adding a `spec.volumeClaimTemplate` section named `logstash-data`.
 
 For production workloads, you should define your own volume claim template with the desired storage capacity and (optionally) the Kubernetes link:https://kubernetes.io/docs/concepts/storage/storage-classes/[storage class] to associate with the persistent volume. To override this volume claim for `data` usages, the name of this volume claim must be `logstash-data`.
 

--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -326,8 +326,9 @@ spec:
             storage: 2Gi
 ----
 
+In particular, when enabling the persistent queue (PQ) feature, using dead letter queues (DLQ), or certain plugins that make heavy use of temporary storage, the default volume size will likely be insufficient for production workloads and you should increase the storage capacity, or consider creating separate volumes for these use cases.
 
-Separate storage, for example for Logstash configurations using persistent queues (PQ) and/or dead letter queues (DLQ), can be added by including an additional `spec.volumeClaimTemplate` along with a corresponding `spec.podTemplate.spec.containers.volumeMount` for each requested volume.
+Separate storage can be added by including an additional `spec.volumeClaimTemplate` along with a corresponding `spec.podTemplate.spec.containers.volumeMount` for each requested volume.
 
 This example shows how to setup separate storage for a PQ:
 

--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -304,7 +304,7 @@ WARNING: Volume support for Logstash is a breaking change to earlier versions of
 A PersistentVolume called `logstash-data` is created by default.
 It maps to `/usr/share/logstash/data` for persistent storage, which is typically used for storage from plugins. 
 
-By default, the `logstash-data` volume claim is a 1.5Gi volume, using the standard StorageClass of your Kubernetes cluster. 
+By default, the `logstash-data` volume claim is a `1.5Gi` volume, using the standard StorageClass of your Kubernetes cluster. 
 You can override the default by adding a `spec.volumeClaimTemplate` section named `logstash-data`.
 
 For production workloads, you should define your own volume claim template with the desired storage capacity and (optionally) the Kubernetes link:https://kubernetes.io/docs/concepts/storage/storage-classes/[storage class] to associate with the persistent volume. To override this volume claim for `data` usages, the name of this volume claim must be `logstash-data`.

--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -301,7 +301,11 @@ WARNING: Volume support for Logstash is a breaking change to earlier versions of
 [discrete]
 == Specifying the volume claim settings
 
-By default, a PersistentVolume called `logstash-data` is created, that maps to `/usr/share/logstash/data` for persistent storage, typically used for storage from plugins. The `logstash-data` volume claim is, by default, a 1.5Gi volume, using the standard StorageClass of your Kubernetes cluster, but can be overridden by adding a `spec.volumeClaimTemplate` section named `logstash-data`.
+A PersistentVolume called `logstash-data` is created by default.
+It maps to `/usr/share/logstash/data` for persistent storage, which is typically used for storage from plugins. 
+
+By default, the `logstash-data` volume claim is a 1.5Gi volume, using the standard StorageClass of your Kubernetes cluster. 
+You can override the default by adding a `spec.volumeClaimTemplate` section named `logstash-data`.
 
 For production workloads, you should define your own volume claim template with the desired storage capacity and (optionally) the Kubernetes link:https://kubernetes.io/docs/concepts/storage/storage-classes/[storage class] to associate with the persistent volume. To override this volume claim for `data` usages, the name of this volume claim must be `logstash-data`.
 

--- a/pkg/controller/logstash/logstash_controller_test.go
+++ b/pkg/controller/logstash/logstash_controller_test.go
@@ -191,7 +191,7 @@ func TestReconcileLogstash_Reconcile(t *testing.T) {
 									StorageClassName: ptr.To[string](sampleStorageClass.Name),
 									Resources: corev1.VolumeResourceRequirements{
 										Requests: corev1.ResourceList{
-											corev1.ResourceStorage: resource.MustParse("1Gi"),
+											corev1.ResourceStorage: resource.MustParse("1.5Gi"),
 										},
 									},
 								},
@@ -303,7 +303,7 @@ func TestReconcileLogstash_Reconcile(t *testing.T) {
 									StorageClassName: ptr.To[string](sampleStorageClass.Name),
 									Resources: corev1.VolumeResourceRequirements{
 										Requests: corev1.ResourceList{
-											corev1.ResourceStorage: resource.MustParse("1Gi"),
+											corev1.ResourceStorage: resource.MustParse("1.5Gi"),
 										},
 									},
 								},
@@ -432,7 +432,7 @@ func TestReconcileLogstash_Reconcile(t *testing.T) {
 									StorageClassName: ptr.To[string](sampleStorageClass.Name),
 									Resources: corev1.VolumeResourceRequirements{
 										Requests: corev1.ResourceList{
-											corev1.ResourceStorage: resource.MustParse("1Gi"),
+											corev1.ResourceStorage: resource.MustParse("1.5Gi"),
 										},
 									},
 								},
@@ -550,7 +550,7 @@ func TestReconcileLogstash_Reconcile(t *testing.T) {
 									StorageClassName: ptr.To[string](sampleStorageClass.Name),
 									Resources: corev1.VolumeResourceRequirements{
 										Requests: corev1.ResourceList{
-											corev1.ResourceStorage: resource.MustParse("1Gi"),
+											corev1.ResourceStorage: resource.MustParse("1.5Gi"),
 										},
 									},
 								},
@@ -650,7 +650,7 @@ func TestReconcileLogstash_Resize(t *testing.T) {
 	}{
 		{
 			name:            "Cannot increase storage with fixed storage class",
-			initialCapacity: "1Gi",
+			initialCapacity: "1.5Gi",
 			desiredCapacity: "3Gi",
 			storageClass:    fixedStorageClass,
 			wantErr:         true,
@@ -658,7 +658,7 @@ func TestReconcileLogstash_Resize(t *testing.T) {
 		{
 			name:            "Cannot decrease storage with resizable storage class",
 			initialCapacity: "3Gi",
-			desiredCapacity: "1Gi",
+			desiredCapacity: "1.5Gi",
 			storageClass:    resizableStorageClass,
 			wantErr:         true,
 		},
@@ -671,14 +671,14 @@ func TestReconcileLogstash_Resize(t *testing.T) {
 		},
 		{
 			name:            "Nothing happens when keeping the storage the same with resizable storage class",
-			initialCapacity: "1Gi",
-			desiredCapacity: "1Gi",
+			initialCapacity: "1.5Gi",
+			desiredCapacity: "1.5Gi",
 			storageClass:    resizableStorageClass,
 			wantErr:         false,
 		},
 		{
 			name:            "Can successfully resize the storage with resizable storage class",
-			initialCapacity: "1Gi",
+			initialCapacity: "1.5Gi",
 			desiredCapacity: "3Gi",
 			storageClass:    resizableStorageClass,
 			extraVerify: func(r ReconcileLogstash, desiredCapacity string) (reconcile.Result, error) {

--- a/pkg/controller/logstash/volume/defaults.go
+++ b/pkg/controller/logstash/volume/defaults.go
@@ -24,7 +24,7 @@ var (
 	DefaultPersistentVolumeSize = resource.MustParse("1.5Gi")
 
 	// DefaultDataVolumeClaim is the default data volume claim for Logstash pods.
-	// We default to a 1GB persistent volume, using the default storage class.
+	// We default to a 1.5Gi persistent volume, using the default storage class.
 	DefaultDataVolumeClaim = corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: LogstashDataVolumeName,

--- a/pkg/controller/logstash/volume/defaults.go
+++ b/pkg/controller/logstash/volume/defaults.go
@@ -21,7 +21,7 @@ var (
 		ContainerMountPath:     ConfigMountPath,
 	}
 
-	DefaultPersistentVolumeSize = resource.MustParse("1Gi")
+	DefaultPersistentVolumeSize = resource.MustParse("1.5Gi")
 
 	// DefaultDataVolumeClaim is the default data volume claim for Logstash pods.
 	// We default to a 1GB persistent volume, using the default storage class.


### PR DESCRIPTION
This commit increases the default PVC size to 1.5G for Logstash.
Persistent queue is a popular feature in Logstash. When PQ is enabled, the original PVC size 1G is too small for Logstash to start. 

This Logstash resource should start without error
```yaml
apiVersion: logstash.k8s.elastic.co/v1alpha1
kind: Logstash
metadata:
  name: logstash-sample
spec:
  count: 1
  version: 8.12.0
  config:
    queue.type: persisted
  pipelines:
    - pipeline.id: main
      config.string: input { exec { command => 'uptime' interval => 10 } } output { stdout{} }
```

relates: #7538