### PR TITLE
Fix yaml docs example to configure emptydir logstash data volume

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -507,7 +507,7 @@ spec:
   count: 5
   podTemplate:
     spec:
-      volumeClaimTemplates:
+      volumes:
       - name: logstash-data
         emptyDir: {}
 ----


### PR DESCRIPTION
This commit fixes the YAML example in the documentation to configure an `emptydir` volume for the `logstash-data` volume.

Resolves #7546.