### PR TITLE
Update APM Server documentation for use since 8.x requiring Kibana.

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
@@ -23,7 +23,7 @@ This section describes how to deploy, configure and access an APM Server with EC
 [id="{p}-apm-eck-managed-es"]
 == Use an Elasticsearch cluster managed by ECK
 
-Managing the APM Server a Kibana instance and Elasticsearch with ECK allows a smooth and secured integration between the stack components. The output configuration of the APM Server is setup automatically to establish a trust relationship with Elasticsearch. Specifying the Kibana reference allows ECK to automatically configure the Kibana endpoint as described in https://www.elastic.co/guide/en/apm/server/current/setup-kibana-endpoint.html
+Managing APM Server, Kibana and Elasticsearch with ECK allows a smooth and secured integration between the stack components. The output configuration of the APM Server is setup automatically to establish a trust relationship with Elasticsearch. Specifying the Kibana reference allows ECK to automatically configure the link:https://www.elastic.co/guide/en/apm/server/current/setup-kibana-endpoint.html[Kibana endpoint].
 
 . To deploy an APM Server and connect it to the Elasticsearch cluster and Kibana instance you created in the <<{p}-quickstart,quickstart>>, apply the following specification:
 +
@@ -47,7 +47,7 @@ EOF
 
 <1> A reference to a Kibana instance is only required for APM Server versions 8.0.0 and later.
 
-NOTE: If Kibana is referenced in the APM Server specification then the following configuration is required in the Kibana specification to install the APM ILM templates:
+NOTE: Starting with version 8.0.0 the following Kibana configuration is required to run APM Server
 
 [source,yaml,subs="attributes"]
 ----
@@ -122,7 +122,7 @@ spec:
 EOF
 ----
 
-You will also need to ensure that your Kibana instance has the following configuration:
+Starting with version 8.0.0 you will also need to ensure that your Kibana instance has the following configuration:
 
 [source,yaml,subs="attributes"]
 ----

--- a/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/apm-server.asciidoc
@@ -23,11 +23,11 @@ This section describes how to deploy, configure and access an APM Server with EC
 [id="{p}-apm-eck-managed-es"]
 == Use an Elasticsearch cluster managed by ECK
 
-Managing both APM Server and Elasticsearch by ECK allows a smooth and secured integration between the two. The output configuration of the APM Server is setup automatically to establish a trust relationship with Elasticsearch.
+Managing the APM Server a Kibana instance and Elasticsearch with ECK allows a smooth and secured integration between the stack components. The output configuration of the APM Server is setup automatically to establish a trust relationship with Elasticsearch. Specifying the Kibana reference allows ECK to automatically configure the Kibana endpoint as described in https://www.elastic.co/guide/en/apm/server/current/setup-kibana-endpoint.html
 
-. To deploy an APM Server and connect it to the cluster you created in the <<{p}-quickstart,quickstart>>, apply the following specification:
+. To deploy an APM Server and connect it to the Elasticsearch cluster and Kibana instance you created in the <<{p}-quickstart,quickstart>>, apply the following specification:
 +
-[source,yaml,subs="attributes,+macros"]
+[source,yaml,subs="attributes,callouts,+macros"]
 ----
 cat $$<<$$EOF | kubectl apply -f -
 apiVersion: apm.k8s.elastic.co/{eck_crd_version}
@@ -40,7 +40,23 @@ spec:
   count: 1
   elasticsearchRef:
     name: quickstart
+  kibanaRef: <1>
+    name: quickstart
 EOF
+----
+
+<1> A reference to a Kibana instance is only required for APM Server versions 8.0.0 and later.
+
+NOTE: If Kibana is referenced in the APM Server specification then the following configuration is required in the Kibana specification to install the APM ILM templates:
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: kibana.k8s.elastic.co/{eck_crd_version}
+kind: Kibana
+config:
+  xpack.fleet.packages:
+  - name: apm
+    version: latest
 ----
 
 By default `elasticsearchRef` targets all nodes in your Elasticsearch cluster. If you want to direct traffic to specific nodes of your cluster, refer to <<{p}-traffic-splitting>> for more information and examples.
@@ -104,6 +120,18 @@ spec:
   kibanaRef:
     name: quickstart
 EOF
+----
+
+You will also need to ensure that your Kibana instance has the following configuration:
+
+[source,yaml,subs="attributes"]
+----
+apiVersion: kibana.k8s.elastic.co/{eck_crd_version}
+kind: Kibana
+config:
+  xpack.fleet.packages:
+  - name: apm
+    version: latest
 ----
 
 [id="{p}-apm-customize-configuration"]


### PR DESCRIPTION
related: #7541 

Since Kibana is now a requirement for APM Server since 8.x this updates the documentation appropriately.