### PR TITLE
Allow HTTPs/TLS for metrics endpoint

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -288,6 +288,11 @@ func Command() *cobra.Command {
 		DefaultMetricPort,
 		"Port to use for exposing metrics in the Prometheus format (set 0 to disable)",
 	)
+	cmd.Flags().Bool(
+		operator.EnableSecureMetricsFlag,
+		false,
+		"Enables serving metrics over HTTPS (Will be enabled by default in v2.14.0)",
+	)
 	cmd.Flags().StringSlice(
 		operator.NamespacesFlag,
 		nil,
@@ -581,7 +586,8 @@ func startOperator(ctx context.Context) error {
 		log.Info("Exposing Prometheus metrics on /metrics", "port", metricsPort)
 	}
 	opts.Metrics = metricsserver.Options{
-		BindAddress: fmt.Sprintf(":%d", metricsPort), // 0 to disable
+		BindAddress:   fmt.Sprintf(":%d", metricsPort), // 0 to disable
+		SecureServing: viper.GetBool(operator.EnableSecureMetricsFlag),
 	}
 
 	webhookPort := viper.GetInt(operator.WebhookPortFlag)

--- a/config/eck.yaml
+++ b/config/eck.yaml
@@ -1,5 +1,6 @@
 log-verbosity: 0
 metrics-port: 0
+enable-secure-metrics: false
 container-registry: docker.elastic.co
 max-concurrent-reconciles: 3
 ca-cert-validity: 8760h

--- a/deploy/eck-operator/templates/configmap.yaml
+++ b/deploy/eck-operator/templates/configmap.yaml
@@ -10,6 +10,7 @@ data:
   eck.yaml: |-
     log-verbosity: {{ int .Values.config.logVerbosity }}
     metrics-port: {{ int .Values.config.metricsPort }}
+    enable-secure-metrics: {{ .Values.config.enableSecureMetrics }}
     container-registry: {{ .Values.config.containerRegistry }}
     {{- with .Values.config.containerSuffix }}
     container-suffix: {{ . }}

--- a/deploy/eck-operator/templates/podMonitor.yaml
+++ b/deploy/eck-operator/templates/podMonitor.yaml
@@ -28,6 +28,11 @@ spec:
       {{- with .Values.podMonitor.podMetricsEndpointConfig }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
+      {{- if .Values.config.enableSecureMetrics }}
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -162,6 +162,9 @@ config:
   # metricsPort defines the port to expose operator metrics. Set to 0 to disable metrics reporting.
   metricsPort: "0"
 
+  # enableSecureMetrics specifies whether to enable secure metrics. When enabled, the operator will serve metrics over HTTPS. (Will be enabled by default in v2.14.0)
+  enableSecureMetrics: false
+
   # containerRegistry to use for pulling Elasticsearch and other application container images.
   containerRegistry: docker.elastic.co
 

--- a/docs/operating-eck/operator-config.asciidoc
+++ b/docs/operating-eck/operator-config.asciidoc
@@ -37,6 +37,7 @@ ECK can be configured using either command line flags or environment variables.
 |manage-webhook-certs |true |Enables automatic webhook certificate management.
 |max-concurrent-reconciles |3 | Maximum number of concurrent reconciles per controller (Elasticsearch, Kibana, APM Server). Affects the ability of the operator to process changes concurrently.
 |metrics-port |0 |Prometheus metrics port. Set to 0 to disable the metrics endpoint.
+|enable-secure-metrics|false |Enables service of Prometheus metrics over HTTPS. (Requires `--metrics-port` to be set. Will be enabled by default in v2.14.0)
 |namespaces |"" |Namespaces in which this operator should manage resources. Accepts multiple comma-separated values. Defaults to all namespaces if empty or unspecified.
 |operator-namespace |"" |Namespace the operator runs in. Required.
 |password-hash-cache-size|5 x max-concurrent-reconciles|Sets the size of the password hash cache. Caching is disabled if explicitly set to 0 or any negative value.

--- a/docs/operating-eck/operator-config.asciidoc
+++ b/docs/operating-eck/operator-config.asciidoc
@@ -37,7 +37,7 @@ ECK can be configured using either command line flags or environment variables.
 |manage-webhook-certs |true |Enables automatic webhook certificate management.
 |max-concurrent-reconciles |3 | Maximum number of concurrent reconciles per controller (Elasticsearch, Kibana, APM Server). Affects the ability of the operator to process changes concurrently.
 |metrics-port |0 |Prometheus metrics port. Set to 0 to disable the metrics endpoint.
-|enable-secure-metrics|false |Enables service of Prometheus metrics over HTTPS. (Requires `--metrics-port` to be set. Will be enabled by default in v2.14.0)
+|enable-secure-metrics|false |Enables serving of Prometheus metrics over HTTPS. (Requires `--metrics-port` to be set. Will be enabled by default in v2.14.0)
 |namespaces |"" |Namespaces in which this operator should manage resources. Accepts multiple comma-separated values. Defaults to all namespaces if empty or unspecified.
 |operator-namespace |"" |Namespace the operator runs in. Required.
 |password-hash-cache-size|5 x max-concurrent-reconciles|Sets the size of the password hash cache. Caching is disabled if explicitly set to 0 or any negative value.

--- a/pkg/controller/common/operator/flags.go
+++ b/pkg/controller/common/operator/flags.go
@@ -33,6 +33,7 @@ const (
 	ManageWebhookCertsFlag               = "manage-webhook-certs"
 	MaxConcurrentReconcilesFlag          = "max-concurrent-reconciles"
 	MetricsPortFlag                      = "metrics-port"
+	EnableSecureMetricsFlag              = "enable-secure-metrics"
 	NamespacesFlag                       = "namespaces"
 	OperatorNamespaceFlag                = "operator-namespace"
 	SetDefaultSecurityContextFlag        = "set-default-security-context"


### PR DESCRIPTION
## What is this change?

This allows users to configure HTTPs on the exposed Prometheus metrics port.

### Details

* This is disabled by default, but we note the intent to enable by default in v2.14.0.
* This uses a self-signed certificate for this initial implementation (which is handled purely within controller-runtime). If we want to potentially allow for providing a certificate we can add that as a feature in a future PR prior to enabling by default in v2.14.0 (or future decided release).

### Local testing

Target configuration:
![image](https://github.com/elastic/cloud-on-k8s/assets/4429174/380c6ecc-c12b-4841-a0e3-fb14bd027ee6)

Metrics data:
![image](https://github.com/elastic/cloud-on-k8s/assets/4429174/c081a882-b0bf-41fd-8945-5e6ba65af596)

```
❯ cat ~/tmp/kube-prometheus.values.yaml
prometheus:
  prometheusSpec:
    serviceMonitorNamespaceSelector: {}
    podMonitorNamespaceSelector: {}
    podMonitorSelectorNilUsesHelmValues: false # allows not having to set release labels on podmonitor to have it scraped
    serviceMonitorSelectorNilUsesHelmValues: false

❯ helm upgrade -i elastic-operator -n elastic-system . --reuse-values --set=installCRDs=true --set=image.repository=---cut--- --set=image.tag=---cut--- --set=config.metricsPort=9090 --set=config.enableSecureMetrics=true --set=podMonitor.enabled=true
```

Podmonitor:
```
❯ kc get podMonitor -n elastic-system elastic-operator -o yaml
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  annotations:
    meta.helm.sh/release-name: elastic-operator
    meta.helm.sh/release-namespace: elastic-system
  creationTimestamp: "2024-02-14T16:38:34Z"
  generation: 1
  labels:
    app.kubernetes.io/instance: elastic-operator
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: elastic-operator
    app.kubernetes.io/version: 2.12.0-SNAPSHOT
    helm.sh/chart: eck-operator-2.12.0-SNAPSHOT
  name: elastic-operator
  namespace: elastic-system
  resourceVersion: "184783956"
  uid: b3d5e92a-b3a8-4a10-9271-5bd58d58e5f8
spec:
  namespaceSelector:
    matchNames:
    - elastic-system
  podMetricsEndpoints:
  - interval: 5m
    path: /metrics
    port: metrics
    scheme: https
    scrapeTimeout: 30s
    tlsConfig:
      insecureSkipVerify: true
  selector:
    matchLabels:
      app.kubernetes.io/instance: elastic-operator
      app.kubernetes.io/name: elastic-operator
```