### PR TITLE
Fix typo in managing-compute-resources documentation

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
@@ -52,7 +52,7 @@ spec:
 [id="{p}-elasticsearch-memory"]
 ==== Memory limit and JVM Heap settings
 
-Starting with Elasticsearch 7.11, the heap size of the JVM is automatically calculated based on the node roles and the available memory. The available memory is defined by the value of `resources.limits.memory` set on the `elasticsearch` container in the Pod template, or the available memory on the Kubernetes node is no limit is set.
+Starting with Elasticsearch 7.11, the heap size of the JVM is automatically calculated based on the node roles and the available memory. The available memory is defined by the value of `resources.limits.memory` set on the `elasticsearch` container in the Pod template, or the available memory on the Kubernetes node if no limit is set.
 
 For Elasticsearch before 7.11, or if you want to override the default calculated heap size on newer versions, set the `ES_JAVA_OPTS` environment variable in the `podTemplate` to an appropriate value:
 


### PR DESCRIPTION
Fixing typo - replace 'is' by 'if' in the sentence : "...the heap size of the JVM is automatically calculated based on the node roles and the available memory....on the Kubernetes node [ is replaced by if] no limit is set."
