### PR TITLE
fix(doc): use single-quote EOF to avoid expanding variables

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
@@ -121,6 +121,6 @@ spec:
         # Do not use this if setting config.node.store.allow_mmap: false
         initContainers:
         - name: max-map-count-check
-          command: ['sh', '-c', "while true; do mmc=$(cat /proc/sys/vm/max_map_count); if [ ${mmc} -eq 262144 ]; then exit 0; fi; sleep 1; done"]
+          command: ['sh', '-c', "while true; do mmc=$(cat /proc/sys/vm/max_map_count); if [ \${mmc} -eq 262144 ]; then exit 0; fi; sleep 1; done"]
 EOF
 ----

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/virtual-memory.asciidoc
@@ -121,6 +121,6 @@ spec:
         # Do not use this if setting config.node.store.allow_mmap: false
         initContainers:
         - name: max-map-count-check
-          command: ['sh', '-c', "while true; do mmc=$(cat /proc/sys/vm/max_map_count); if [ \${mmc} -eq 262144 ]; then exit 0; fi; sleep 1; done"]
+          command: ['sh', '-c', "while true; do mmc=$(cat /proc/sys/vm/max_map_count); if [ ${mmc} -eq 262144 ]; then exit 0; fi; sleep 1; done"]
 EOF
 ----

--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -43,7 +43,7 @@ Add the following specification to create a minimal Logstash deployment that wil
 
 [source,yaml,subs="attributes,+macros,callouts"]
 ----
-cat $$<<$$EOF | kubectl apply -f -
+cat $$<<$$'EOF' | kubectl apply -f -
 apiVersion: logstash.k8s.elastic.co/v1alpha1
 kind: Logstash
 metadata:

--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -64,10 +64,10 @@ spec:
         }
         output {
           elasticsearch {
-            hosts => [ "\${QS_ES_HOSTS}" ]
-            user => "\${QS_ES_USER}"
-            password => "\${QS_ES_PASSWORD}"
-            ssl_certificate_authorities => "\${QS_ES_SSL_CERTIFICATE_AUTHORITY}"
+            hosts => [ "${QS_ES_HOSTS}" ]
+            user => "${QS_ES_USER}"
+            password => "${QS_ES_PASSWORD}"
+            ssl_certificate_authorities => "${QS_ES_SSL_CERTIFICATE_AUTHORITY}"
           }
         }
   services:

--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -64,10 +64,10 @@ spec:
         }
         output {
           elasticsearch {
-            hosts => [ "${QS_ES_HOSTS}" ]
-            user => "${QS_ES_USER}"
-            password => "${QS_ES_PASSWORD}"
-            ssl_certificate_authorities => "${QS_ES_SSL_CERTIFICATE_AUTHORITY}"
+            hosts => [ "\${QS_ES_HOSTS}" ]
+            user => "\${QS_ES_USER}"
+            password => "\${QS_ES_PASSWORD}"
+            ssl_certificate_authorities => "\${QS_ES_SSL_CERTIFICATE_AUTHORITY}"
           }
         }
   services:


### PR DESCRIPTION
Resolves #7572.