### PR TITLE
Bumping Aks version for both CI and Dev for deployer

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -70,7 +70,7 @@ plans:
   operation: create
   clusterName: ci
   provider: aks
-  kubernetesVersion: 1.26.6
+  kubernetesVersion: 1.27.9
   machineType: Standard_D8s_v3
   serviceAccount: true
   enforceSecurityPolicies: true
@@ -83,7 +83,7 @@ plans:
   operation: create
   clusterName: dev
   provider: aks
-  kubernetesVersion: 1.26.6
+  kubernetesVersion: 1.27.9
   machineType: Standard_D8s_v3
   serviceAccount: false
   enforceSecurityPolicies: true


### PR DESCRIPTION
We see that 1.26 Kubernetes version is end of life on AKS. bumping the versions to 1.27 as these seem to have support till Jul 2025.
https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#supported-version-list
```

1.27* | Apr 2023 | Jun 2023 | Jul 2023 | Jul 2024, LTS until Jul 2025 | Until 1.31 GA
-- | -- | -- | -- | -- | --


```