### PR TITLE
Adjusting the version check to disable fleet e2e test validation

### DIFF
--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -192,7 +192,7 @@ func (b Builder) WithFleetAgentDataStreamsValidation() Builder {
 		WithDefaultESValidation(HasWorkingDataStream(MetricsType, "elastic_agent.fleet_server", "default")).
 		WithDefaultESValidation(HasWorkingDataStream(MetricsType, "elastic_agent.metricbeat", "default"))
 	// https://github.com/elastic/cloud-on-k8s/issues/7389
-	if v.LT(version.MinFor(8, 12, 0)) || v.GE(version.MinFor(8, 14, 0)) {
+	if v.LT(version.MinFor(8, 12, 0)) || v.GE(version.MinFor(8, 15, 0)) {
 		b = b.WithDefaultESValidation(HasWorkingDataStream(MetricsType, "elastic_agent.filebeat", "default"))
 	}
 	return b

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -192,7 +192,7 @@ func (b Builder) WithFleetAgentDataStreamsValidation() Builder {
 		WithDefaultESValidation(HasWorkingDataStream(MetricsType, "elastic_agent.fleet_server", "default")).
 		WithDefaultESValidation(HasWorkingDataStream(MetricsType, "elastic_agent.metricbeat", "default"))
 	// https://github.com/elastic/cloud-on-k8s/issues/7389
-	if v.LT(version.MinFor(8, 12, 0)) || v.GE(version.MinFor(8, 15, 0)) {
+	if v.LT(version.MinFor(8, 12, 0)) {
 		b = b.WithDefaultESValidation(HasWorkingDataStream(MetricsType, "elastic_agent.filebeat", "default"))
 	}
 	return b


### PR DESCRIPTION
Disable the fleet e2e test validation for version 8.14.0 as well, since ware seeing test failures https://elastic.slack.com/archives/C8RU9J1C2/p1709282906128319

Like the original issue 
https://github.com/elastic/cloud-on-k8s/issues/7389
