### PR TITLE
Update the owner in the catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,7 +11,7 @@ metadata:
     buildkite.com/project-slug: elastic/cloud-on-k8s
 spec:
   type: service
-  owner: group:cloud-on-k8s
+  owner: group:cloud-k8s-operator
   system: control-plane
   lifecycle: production
 


### PR DESCRIPTION

The owner needs to be a valid github group and https://github.com/orgs/elastic/teams/cloud-on-k8s does not exist. Is `cloud-on-k8s-operator` the correct value?