### PR TITLE
Update eck-stack Helm charts (#7621)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -81,5 +81,4 @@ helm unittest -3 -f 'templates/tests/*.yaml' --with-subchart=false .
 
 ## Licensing
 
-The ECK Helm Charts are licensed under the [Elastic License 2.0](https://www.elastic.co/licensing/elastic-license) like the operator, but require different subscription levels.
-
+The ECK Helm Charts are licensed under the [Elastic License 2.0](https://www.elastic.co/licensing/elastic-license) like the operator. They can be used with a Basic license for free.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -83,4 +83,3 @@ helm unittest -3 -f 'templates/tests/*.yaml' --with-subchart=false .
 
 The ECK Helm Charts are licensed under the [Elastic License 2.0](https://www.elastic.co/licensing/elastic-license) like the operator, but require different subscription levels.
 
-The ECK Operator Helm Chart can be used with a Basic license for free, while the ECK Stack and Resources Helm Charts require an [Elastic Enterprise License](https://www.elastic.co/subscriptions) for use.

--- a/deploy/eck-stack/charts/eck-agent/templates/elastic-agent.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/elastic-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "elasticagent.labels" $ | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: enterprise
+    eck.k8s.elastic.co/license: basic
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent_test.yaml
@@ -56,5 +56,5 @@ tests:
       - equal:
           path: metadata.annotations
           value:
-            eck.k8s.elastic.co/license: enterprise
+            eck.k8s.elastic.co/license: basic
             test: annotation

--- a/deploy/eck-stack/charts/eck-apm-server/templates/apmserver.yaml
+++ b/deploy/eck-stack/charts/eck-apm-server/templates/apmserver.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "apm-server.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: enterprise
+    eck.k8s.elastic.co/license: basic
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-apm-server/templates/tests/apmserver_test.yaml
+++ b/deploy/eck-stack/charts/eck-apm-server/templates/tests/apmserver_test.yaml
@@ -67,7 +67,7 @@ tests:
       - equal:
           path: metadata.annotations
           value:
-            eck.k8s.elastic.co/license: enterprise
+            eck.k8s.elastic.co/license: basic
             test: annotation
   - it: should render http service properly
     set:

--- a/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "beat.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: enterprise
+    eck.k8s.elastic.co/license: basic
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/elasticsearch.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/elasticsearch.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "elasticsearch.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: enterprise
+    eck.k8s.elastic.co/license: basic
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
@@ -113,7 +113,7 @@ tests:
       - equal:
           path: metadata.annotations
           value:
-            eck.k8s.elastic.co/license: enterprise
+            eck.k8s.elastic.co/license: basic
             test: annotation
       - equal:
           path: spec.monitoring

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "fleet-server.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: enterprise
+    eck.k8s.elastic.co/license: basic
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
@@ -51,5 +51,5 @@ tests:
       - equal:
           path: metadata.annotations
           value:
-            eck.k8s.elastic.co/license: enterprise
+            eck.k8s.elastic.co/license: basic
             test: annotation

--- a/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "kibana.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: enterprise
+    eck.k8s.elastic.co/license: basic
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
@@ -58,7 +58,7 @@ tests:
       - equal:
           path: metadata.annotations
           value:
-            eck.k8s.elastic.co/license: enterprise
+            eck.k8s.elastic.co/license: basic
             test: annotation
   - it: should render http service properly
     set:

--- a/deploy/eck-stack/charts/eck-logstash/templates/logstash.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/templates/logstash.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "logstash.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: enterprise
+    eck.k8s.elastic.co/license: basic
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-logstash/templates/tests/logstash_test.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/templates/tests/logstash_test.yaml
@@ -106,7 +106,7 @@ tests:
       - equal:
           path: metadata.annotations
           value:
-            eck.k8s.elastic.co/license: enterprise
+            eck.k8s.elastic.co/license: basic
             test: annotation
       - equal:
           path: spec.services

--- a/docs/orchestrating-elastic-stack-applications/stack-helm-chart.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/stack-helm-chart.asciidoc
@@ -17,8 +17,6 @@ helm repo update
 
 NOTE: The minimum supported version of Helm is 3.2.0.
 
-NOTE: ECK Stack Helm Charts are currently being released as an Enterprise licensed feature.
-
 [float]
 [id="{p}-install-elasticsearch-kibana-helm"]
 == Installing Elasticsearch and Kibana using the eck-stack Helm Chart


### PR DESCRIPTION
Backport the following commits to `2.12`:
- #7621
- #7623 