### PR TITLE
Version gate for deprecated `node_version` in desired nodes requests in +8.13

### DIFF
--- a/pkg/controller/elasticsearch/client/desired_nodes.go
+++ b/pkg/controller/elasticsearch/client/desired_nodes.go
@@ -12,6 +12,7 @@ import (
 )
 
 var desiredNodesMinVersion = version.MinFor(8, 3, 0)
+var DeprecatedNodeVersionReqBodyParamMinVersion = version.MinFor(8, 13, 0)
 
 type DesiredNodesClient interface {
 	IsDesiredNodesSupported() bool
@@ -38,7 +39,7 @@ type DesiredNode struct {
 	ProcessorsRange ProcessorsRange        `json:"processors_range"`
 	Memory          string                 `json:"memory"`
 	Storage         string                 `json:"storage"`
-	NodeVersion     string                 `json:"node_version"`
+	NodeVersion     string                 `json:"node_version,omitempty"` // deprecated in 8.13+
 }
 
 type ProcessorsRange struct {

--- a/pkg/controller/elasticsearch/driver/desired_nodes.go
+++ b/pkg/controller/elasticsearch/driver/desired_nodes.go
@@ -37,7 +37,7 @@ func (d *defaultDriver) updateDesiredNodes(
 	if err != nil {
 		return results.WithError(err)
 	}
-	nodes, requeue, err := expectedResources.ToDesiredNodes(ctx, d.Client, esVersion.FinalizeVersion())
+	nodes, requeue, err := expectedResources.ToDesiredNodes(ctx, d.Client, esVersion)
 	switch {
 	case err == nil:
 		d.ReconcileState.ReportCondition(


### PR DESCRIPTION
This adds a version gate to not set `node_version` in desired nodes requests in +8.13, 
as it is deprecated (https://github.com/elastic/elasticsearch/pull/104209).

Avoiding having the deprecated log:

`[version removal] Specifying node_version in desired nodes requests is deprecated.`

Relates to https://github.com/elastic/cloud-on-k8s/issues/7618#issuecomment-1996902375.

