### PR TITLE
Version gate to deprecate node_version using update desired nodes API (7628)

### DIFF
--- a/pkg/controller/elasticsearch/client/desired_nodes.go
+++ b/pkg/controller/elasticsearch/client/desired_nodes.go
@@ -12,6 +12,7 @@ import (
 )
 
 var desiredNodesMinVersion = version.MinFor(8, 3, 0)
+var DeprecatedNodeVersionReqBodyParamMinVersion = version.MinFor(8, 13, 0)
 
 type DesiredNodesClient interface {
 	IsDesiredNodesSupported() bool
@@ -38,7 +39,7 @@ type DesiredNode struct {
 	ProcessorsRange ProcessorsRange        `json:"processors_range"`
 	Memory          string                 `json:"memory"`
 	Storage         string                 `json:"storage"`
-	NodeVersion     string                 `json:"node_version"`
+	NodeVersion     string                 `json:"node_version,omitempty"` // deprecated in 8.13+
 }
 
 type ProcessorsRange struct {

--- a/pkg/controller/elasticsearch/driver/desired_nodes.go
+++ b/pkg/controller/elasticsearch/driver/desired_nodes.go
@@ -37,7 +37,7 @@ func (d *defaultDriver) updateDesiredNodes(
 	if err != nil {
 		return results.WithError(err)
 	}
-	nodes, requeue, err := expectedResources.ToDesiredNodes(ctx, d.Client, esVersion.FinalizeVersion())
+	nodes, requeue, err := expectedResources.ToDesiredNodes(ctx, d.Client, esVersion)
 	switch {
 	case err == nil:
 		d.ReconcileState.ReportCondition(


### PR DESCRIPTION
Backport the following commit to `2.12`:
- #7628