### PR TITLE
Fix cluster name label of es scripts config map

### DIFF
--- a/pkg/controller/elasticsearch/configmap/configmap.go
+++ b/pkg/controller/elasticsearch/configmap/configmap.go
@@ -22,11 +22,11 @@ import (
 )
 
 // NewConfigMapWithData constructs a new config map with the given data
-func NewConfigMapWithData(es types.NamespacedName, data map[string]string) corev1.ConfigMap {
+func NewConfigMapWithData(cm, es types.NamespacedName, data map[string]string) corev1.ConfigMap {
 	return corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      es.Name,
-			Namespace: es.Namespace,
+			Name:      cm.Name,
+			Namespace: cm.Namespace,
 			Labels:    label.NewLabels(es),
 		},
 		Data: data,
@@ -51,6 +51,7 @@ func ReconcileScriptsConfigMap(ctx context.Context, c k8s.Client, es esv1.Elasti
 
 	scriptsConfigMap := NewConfigMapWithData(
 		types.NamespacedName{Namespace: es.Namespace, Name: esv1.ScriptsConfigMap(es.Name)},
+		k8s.ExtractNamespacedName(&es),
 		map[string]string{
 			nodespec.ReadinessProbeScriptConfigKey: nodespec.ReadinessProbeScript,
 			nodespec.PreStopHookScriptConfigKey:    preStopScript,

--- a/pkg/controller/elasticsearch/configmap/configmap_test.go
+++ b/pkg/controller/elasticsearch/configmap/configmap_test.go
@@ -1,0 +1,24 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package configmap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func Test_NewConfigMapWithData(t *testing.T) {
+	cmNsn := types.NamespacedName{Namespace: "ns1", Name: "cm-name"}
+	esNsn := types.NamespacedName{Namespace: "ns1", Name: "es-name"}
+	data := map[string]string{"foo": "42"}
+	cm := NewConfigMapWithData(cmNsn, esNsn, data)
+
+	assert.Equal(t, "cm-name", cm.Name)
+	assert.Equal(t, "es-name", cm.Labels["elasticsearch.k8s.elastic.co/cluster-name"])
+	assert.Equal(t, "elasticsearch", cm.Labels["common.k8s.elastic.co/type"])
+	assert.Equal(t, "42", cm.Data["foo"])
+}


### PR DESCRIPTION
This fixes a small bug where we were using the configMap name to set the label value of the cluster name, instead of the cluster name.

Testing:
```
> k get cm elasticsearch-sample-es-scripts -o json | jq .metadata.labels
```

Before:
```json
{
  "common.k8s.elastic.co/type": "elasticsearch",
  "elasticsearch.k8s.elastic.co/cluster-name": "elasticsearch-sample-es-scripts"
}
```
After:
```json
{
  "common.k8s.elastic.co/type": "elasticsearch",
  "elasticsearch.k8s.elastic.co/cluster-name": "elasticsearch-sample"
}
```