### PR TITLE
Fix namespace logged twice

### DIFF
--- a/pkg/controller/association/resources.go
+++ b/pkg/controller/association/resources.go
@@ -51,7 +51,7 @@ func deleteOrphanedResources(
 		}
 
 		// Secret for the `associated` resource doesn't match any `association` - it's not needed anymore and should be deleted.
-		ulog.FromContext(ctx).Info("Deleting secret", "namespace", secret.Namespace, "secret_name", secret.Name, "associated_name", associated.Name)
+		ulog.FromContext(ctx).Info("Deleting secret", "secret_name", secret.Name, "associated_name", associated.Name)
 		if err := c.Delete(ctx, &secret, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &secret.UID}}); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}


### PR DESCRIPTION
Fix a log in which the namespace is logged twice (which generates an invalid json document):

```json
{"log.level":"info","@timestamp":"2024-03-16T16:00:00.042Z","log.logger":"agent-es","message":"Deleting secret","service.version":"2.10.0+foo","service.type":"eck","ecs.version":"1.4.0","iteration":"14","namespace":"my-ns","agent_name":"my-fleet-server","namespace":"my-ns","secret_name":"my-fleet-server-my-ns-elasticsearch-prod-agent-user","associated_name":"my-fleet-server"}
```