### PR TITLE
Update stack version in recipes

### DIFF
--- a/config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml
@@ -71,7 +71,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.7.0
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -127,7 +127,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.7.0
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -139,7 +139,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 8.7.0
+  version: 8.12.1
   kibanaRef:
     name: kibana
   elasticsearchRefs:
@@ -159,7 +159,7 @@ kind: Agent
 metadata: 
   name: elastic-agent
 spec:
-  version: 8.7.0
+  version: 8.12.1
   kibanaRef:
     name: kibana
   fleetServerRef: 

--- a/config/recipes/elastic-agent/ksm-sharding.yaml
+++ b/config/recipes/elastic-agent/ksm-sharding.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: elastic-agent
 spec:
-  version: 8.10.4
+  version: 8.12.1
   elasticsearchRefs:
   - name: elasticsearch
   statefulSet:
@@ -450,7 +450,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.10.4
+  version: 8.12.1
   nodeSets:
   - name: default
     count: 3
@@ -462,7 +462,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.10.4
+  version: 8.12.1
   count: 1
   elasticsearchRef:
     name: elasticsearch


### PR DESCRIPTION
This updates `elastic-agent/fleet-kubernetes-integration-nonroot.yaml` and `elastic-agent/ksm-sharding.yaml` recipes which were not correctly updated because they were created with a stack version different from the current stack version and as we are doing a replacement of the current stack version to update the versions, they have not been replaced.