### PR TITLE
[2.12] Update buildkite agent image (openshift-preflight v1.9.1)

### DIFF
--- a/.buildkite/Makefile
+++ b/.buildkite/Makefile
@@ -4,7 +4,7 @@
 
 # This Makefile is used to run the buildkite agent in virtual machines when Docker access is required.
 
-CI_IMAGE               ?= docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+CI_IMAGE               ?= docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
 ROOT_DIR               := $(CURDIR)/..
 GO_MOUNT_PATH          ?= /go/src/github.com/elastic/cloud-on-k8s
 export VAULT_ROOT_PATH = secret/ci/elastic-cloud-on-k8s

--- a/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
+++ b/.buildkite/e2e/pipeline-gen/pipeline.tpl.yaml
@@ -34,7 +34,7 @@ steps:
       machineType: "{{ .KindAgentsMachineType }}"
       {{- end }}
       {{- else }}
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "4G"
       {{- end }}
 
@@ -85,7 +85,7 @@ steps:
       machineType: "{{ $.KindAgentsMachineType }}"
       {{- end }}
       {{- else }}
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "4G"
       {{- end }}
 
@@ -121,7 +121,7 @@ steps:
         {{- if not $test.Dind }}
           - make run-deployer
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
           memory: "4G"
         {{- else }}
           - make -C .buildkite TARGET="run-deployer" ci
@@ -144,5 +144,5 @@ steps:
       - ".buildkite/e2e/reporter/*.md"
       - ".buildkite/e2e/reporter/*.yml"
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "2G"

--- a/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
+++ b/.buildkite/e2e/reporter/templates/notify-failures.tpl.yml
@@ -4,7 +4,7 @@ steps:
   - label: "{{ .ShortFailuresCount }} failure(s)"
     command: exit {{ .ShortFailuresCount }}
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "2G"
 
   # notify e2e tests failures for the main branch and tags
@@ -13,7 +13,7 @@ steps:
     if: build.branch == "main" || build.tag != null
     command: echo "notify"
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "2G"
 
     notify:

--- a/.buildkite/pipeline-e2e-clusters-cleanup.yml
+++ b/.buildkite/pipeline-e2e-clusters-cleanup.yml
@@ -10,7 +10,7 @@ steps:
       - make build-deployer
       - buildkite-agent artifact upload hack/deployer/deployer
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup gke"
@@ -26,7 +26,7 @@ steps:
       - chmod u+x /usr/local/hack/deployer/deployer
       - /usr/local/hack/deployer/deployer cleanup --plans-file hack/deployer/config/plans.yml --cluster-prefix $${E2E_TEST_CLUSTER_PREFIX} --config-file deployer-config.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup aks"
@@ -55,7 +55,7 @@ steps:
       - chmod u+x /usr/local/hack/deployer/deployer
       - /usr/local/hack/deployer/deployer cleanup --plans-file hack/deployer/config/plans.yml --cluster-prefix $${E2E_TEST_CLUSTER_PREFIX} --config-file deployer-config.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup eks-arm"
@@ -71,7 +71,7 @@ steps:
       - chmod u+x /usr/local/hack/deployer/deployer
       - /usr/local/hack/deployer/deployer cleanup --plans-file hack/deployer/config/plans.yml --cluster-prefix $${E2E_TEST_CLUSTER_PREFIX} --config-file deployer-config.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: 2G
 
   - label: ":broom: e2e test cluster cleanup ocp"

--- a/.buildkite/pipeline-e2e-tests.yml
+++ b/.buildkite/pipeline-e2e-tests.yml
@@ -17,7 +17,7 @@ steps:
               E2E_PROVIDER: gke
           DEF
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
           memory: "2G"
 
       # for all tags
@@ -32,5 +32,5 @@ steps:
           cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
           cat ../nightly-main-matrix.yaml | ./pipeline-gen | buildkite-agent pipeline upload
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
           memory: "2G"

--- a/.buildkite/pipeline-release-helm.yml
+++ b/.buildkite/pipeline-release-helm.yml
@@ -10,7 +10,7 @@ steps:
       - make build
       - buildkite-agent artifact upload bin/releaser
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "2G"
 
   - label: "operator dev helm chart"
@@ -29,7 +29,7 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=dev --charts-dir=deploy/eck-operator
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "2G"
 
   - wait
@@ -50,7 +50,7 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=dev --charts-dir=deploy/eck-stack
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "2G"
 
   - wait
@@ -68,7 +68,7 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=prod --charts-dir=deploy/eck-operator
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "2G"
 
   - wait
@@ -86,5 +86,5 @@ steps:
       - chmod u+x /usr/local/bin/releaser
       - releaser --env=prod --charts-dir=deploy/eck-stack
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "2G"

--- a/.buildkite/pipeline-release-redhat.yml
+++ b/.buildkite/pipeline-release-redhat.yml
@@ -7,7 +7,7 @@ steps:
       - make build
       - buildkite-agent artifact upload bin/operatorhub
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "2G"
 
   - label: ":docker: push container"
@@ -20,7 +20,7 @@ steps:
         cd hack/operatorhub
         operatorhub container push
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "2G"
 
   - label: ":docker: preflight container check"
@@ -32,7 +32,7 @@ steps:
     commands:
       - .buildkite/scripts/release/redhat-preflight.sh
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "2G"
 
   - label: ":docker: publish container"
@@ -47,7 +47,7 @@ steps:
         cd hack/operatorhub
         operatorhub container publish
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "2G"
 
   - label: ":redhat: generate and create-pr"
@@ -62,5 +62,5 @@ steps:
         operatorhub generate-manifests
         operatorhub bundle create-pr
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "2G"

--- a/.buildkite/pipeline-release.yml
+++ b/.buildkite/pipeline-release.yml
@@ -10,7 +10,7 @@ steps:
         commands:
           - .buildkite/scripts/release/k8s-manifests.sh
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
           memory: "2G"
 
       - label: "copy images to dockerhub"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,14 +9,14 @@ steps:
       - label: ":go: lint"
         command: "make lint check-local-changes"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
           cpu: "6"
           memory: "7G"
 
       - label: ":go: generate"
         command: "make generate check-local-changes"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
           cpu: "4"
           memory: "2G"
 
@@ -25,7 +25,7 @@ steps:
           - "make check-license-header check-predicates shellcheck reattach-pv"
           - "make -C hack/helm/release build"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
           cpu: "4"
           memory: "2G"
 
@@ -35,28 +35,28 @@ steps:
       - label: ":go: unit-tests"
         command: "make unit-xml"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
           cpu: "4"
           memory: "4G"
 
       - label: ":go: integration-tests"
         command: "make integration-xml"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
           cpu: "4"
           memory: "4G"
 
       - label: ":go: manifest-gen-tests"
         command: "make manifest-gen-test"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
           cpu: "4"
           memory: "2G"
 
       - label: ":go: helm-tests"
         command: "make helm-test"
         agents:
-          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
           cpu: "4"
           memory: "2G"
 
@@ -110,7 +110,7 @@ steps:
           E2E_SKIP_CLEANUP: true
       DEF
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "2G"
 
   # for PR comment
@@ -123,14 +123,14 @@ steps:
       $$(echo ./pipeline-gen $$GITHUB_PR_COMMENT_VAR_ARGS) \
         | buildkite-agent pipeline upload
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "2G"
 
   # for the main branch (merge and nightly) and tags
   - label: ":buildkite:"
     command: buildkite-agent pipeline upload .buildkite/pipeline-e2e-tests.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "2G"
 
   # ----------
@@ -140,5 +140,5 @@ steps:
       - "operator-image-build"
     command: buildkite-agent pipeline upload .buildkite/pipeline-release.yml
     agents:
-      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:3efd6572
+      image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:99f0bc14
       memory: "2G"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,58 @@ linters-settings:
     allow-unused: false
     require-specific: true
 
+  revive:
+    ## Default rules from https://github.com/mgechev/revive/blob/75a8e403f52c9634546fbfe5ec5429560ca74494/defaults.toml
+    enable-all-rules: false
+    rules:
+      - name: blank-imports
+        disabled: false
+      - name: context-as-argument
+        disabled: false
+      - name: context-keys-type
+        disabled: false
+      - name: dot-imports
+        disabled: false
+      - name: empty-block
+        disabled: false
+      - name: error-naming
+        disabled: false
+      - name: error-return
+        disabled: false
+      - name: error-strings
+        disabled: false
+      - name: errorf
+        disabled: false
+      - name: exported
+        disabled: false
+      - name: increment-decrement
+        disabled: false
+      - name: indent-error-flow
+        disabled: false
+      - name: package-comments
+        disabled: false
+      - name: range
+        disabled: false
+      - name: receiver-naming
+        disabled: false
+      - name: redefines-builtin-id
+        disabled: false
+      - name: superfluous-else
+        disabled: false
+      - name: time-naming
+        disabled: false
+      - name: unexported-return
+        disabled: false
+      - name: unreachable-code
+        disabled: false
+      - name: unused-parameter
+        ## Disabled as it generates a lot of rule failures.
+        disabled: true
+      - name: var-declaration
+        disabled: false
+      - name: var-naming
+        disabled: false
+
 # Run `golangci-lint linters` to see the descriptions for the linters. 
 linters:
   disable:

--- a/docs/reference/api-docs.asciidoc
+++ b/docs/reference/api-docs.asciidoc
@@ -85,22 +85,36 @@ AgentSpec defines the desired state of the Agent
 |===
 | Field | Description
 | *`version`* __string__ | Version of the Agent.
-| *`elasticsearchRefs`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-agent-v1alpha1-output[$$Output$$] array__ | ElasticsearchRefs is a reference to a list of Elasticsearch clusters running in the same Kubernetes cluster. Due to existing limitations, only a single ES cluster is currently supported.
+| *`elasticsearchRefs`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-agent-v1alpha1-output[$$Output$$] array__ | ElasticsearchRefs is a reference to a list of Elasticsearch clusters running in the same Kubernetes cluster.
+Due to existing limitations, only a single ES cluster is currently supported.
 | *`image`* __string__ | Image is the Agent Docker image to deploy. Version has to match the Agent in the image.
 | *`config`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-config[$$Config$$]__ | Config holds the Agent configuration. At most one of [`Config`, `ConfigRef`] can be specified.
-| *`configRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-configsource[$$ConfigSource$$]__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Agent configuration. Agent settings must be specified as yaml, under a single "agent.yml" entry. At most one of [`Config`, `ConfigRef`] can be specified.
-| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-secretsource[$$SecretSource$$] array__ | SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for the Agent. Secrets data can be then referenced in the Agent config using the Secret's keys or as specified in `Entries` field of each SecureSetting.
-| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to an Elasticsearch resource in a different namespace. Can only be used if ECK is enforcing RBAC on references.
-| *`daemonSet`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-agent-v1alpha1-daemonsetspec[$$DaemonSetSpec$$]__ | DaemonSet specifies the Agent should be deployed as a DaemonSet, and allows providing its spec. Cannot be used along with `deployment` or `statefulSet`.
-| *`deployment`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-agent-v1alpha1-deploymentspec[$$DeploymentSpec$$]__ | Deployment specifies the Agent should be deployed as a Deployment, and allows providing its spec. Cannot be used along with `daemonSet` or `statefulSet`.
-| *`statefulSet`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-agent-v1alpha1-statefulsetspec[$$StatefulSetSpec$$]__ | StatefulSet specifies the Agent should be deployed as a StatefulSet, and allows providing its spec. Cannot be used along with `daemonSet` or `deployment`.
+| *`configRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-configsource[$$ConfigSource$$]__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Agent configuration.
+Agent settings must be specified as yaml, under a single "agent.yml" entry. At most one of [`Config`, `ConfigRef`]
+can be specified.
+| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-secretsource[$$SecretSource$$] array__ | SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for the Agent.
+Secrets data can be then referenced in the Agent config using the Secret's keys or as specified in `Entries` field of
+each SecureSetting.
+| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to an Elasticsearch resource in a different namespace.
+Can only be used if ECK is enforcing RBAC on references.
+| *`daemonSet`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-agent-v1alpha1-daemonsetspec[$$DaemonSetSpec$$]__ | DaemonSet specifies the Agent should be deployed as a DaemonSet, and allows providing its spec.
+Cannot be used along with `deployment` or `statefulSet`.
+| *`deployment`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-agent-v1alpha1-deploymentspec[$$DeploymentSpec$$]__ | Deployment specifies the Agent should be deployed as a Deployment, and allows providing its spec.
+Cannot be used along with `daemonSet` or `statefulSet`.
+| *`statefulSet`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-agent-v1alpha1-statefulsetspec[$$StatefulSetSpec$$]__ | StatefulSet specifies the Agent should be deployed as a StatefulSet, and allows providing its spec.
+Cannot be used along with `daemonSet` or `deployment`.
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying DaemonSet or Deployment or StatefulSet.
 | *`http`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-httpconfig[$$HTTPConfig$$]__ | HTTP holds the HTTP layer configuration for the Agent in Fleet mode with Fleet Server enabled.
-| *`mode`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-agent-v1alpha1-agentmode[$$AgentMode$$]__ | Mode specifies the source of configuration for the Agent. The configuration can be specified locally through `config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode). Defaults to `standalone` mode.
+| *`mode`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-agent-v1alpha1-agentmode[$$AgentMode$$]__ | Mode specifies the source of configuration for the Agent. The configuration can be specified locally through
+`config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode).
+Defaults to `standalone` mode.
 | *`fleetServerEnabled`* __boolean__ | FleetServerEnabled determines whether this Agent will launch Fleet Server. Don't set unless `mode` is set to `fleet`.
-| *`policyID`* __string__ | PolicyID determines into which Agent Policy this Agent will be enrolled. This field will become mandatory in a future release, default policies are deprecated since 8.1.0.
-| *`kibanaRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | KibanaRef is a reference to Kibana where Fleet should be set up and this Agent should be enrolled. Don't set unless `mode` is set to `fleet`.
-| *`fleetServerRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | FleetServerRef is a reference to Fleet Server that this Agent should connect to to obtain it's configuration. Don't set unless `mode` is set to `fleet`.
+| *`policyID`* __string__ | PolicyID determines into which Agent Policy this Agent will be enrolled.
+This field will become mandatory in a future release, default policies are deprecated since 8.1.0.
+| *`kibanaRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | KibanaRef is a reference to Kibana where Fleet should be set up and this Agent should be enrolled. Don't set
+unless `mode` is set to `fleet`.
+| *`fleetServerRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | FleetServerRef is a reference to Fleet Server that this Agent should connect to to obtain it's configuration.
+Don't set unless `mode` is set to `fleet`.
 |===
 
 
@@ -175,8 +189,17 @@ AgentSpec defines the desired state of the Agent
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | 
 | *`replicas`* __integer__ | 
 | *`serviceName`* __string__ | 
-| *`podManagementPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podmanagementpolicytype-v1-apps[$$PodManagementPolicyType$$]__ | PodManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `Parallel`, where pods are created in parallel to match the desired scale without waiting, and on scale down will delete all pods at once. The alternative policy is `OrderedReady`, the default for vanilla kubernetes StatefulSets, where pods are created in increasing order in increasing order (pod-0, then pod-1, etc.) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order.
-| *`volumeClaimTemplates`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$] array__ | VolumeClaimTemplates is a list of persistent volume claims to be used by each Pod. Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate. Items defined here take precedence over any default claims added by the operator with the same name.
+| *`podManagementPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podmanagementpolicytype-v1-apps[$$PodManagementPolicyType$$]__ | PodManagementPolicy controls how pods are created during initial scale up,
+when replacing pods on nodes, or when scaling down. The default policy is
+`Parallel`, where pods are created in parallel to match the desired scale
+without waiting, and on scale down will delete all pods at once.
+The alternative policy is `OrderedReady`, the default for vanilla kubernetes
+StatefulSets, where pods are created in increasing order in increasing order
+(pod-0, then pod-1, etc.) and the controller will wait until each pod is ready before
+continuing. When scaling down, the pods are removed in the opposite order.
+| *`volumeClaimTemplates`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$] array__ | VolumeClaimTemplates is a list of persistent volume claims to be used by each Pod.
+Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate.
+Items defined here take precedence over any default claims added by the operator with the same name.
 |===
 
 
@@ -228,11 +251,13 @@ ApmServerSpec holds the specification of an APM Server.
 | *`config`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-config[$$Config$$]__ | Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html
 | *`http`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-httpconfig[$$HTTPConfig$$]__ | HTTP holds the HTTP layer configuration for the APM Server resource.
 | *`elasticsearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | ElasticsearchRef is a reference to the output Elasticsearch cluster running in the same Kubernetes cluster.
-| *`kibanaRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster. It allows APM agent central configuration management in Kibana.
+| *`kibanaRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster.
+It allows APM agent central configuration management in Kibana.
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the APM Server pods.
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment.
 | *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-secretsource[$$SecretSource$$] array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for APM Server.
-| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
+Can only be used if ECK is enforcing RBAC on references.
 |===
 
 
@@ -395,18 +420,30 @@ BeatSpec defines the desired state of a Beat.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`type`* __string__ | Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, auditbeat, journalbeat, packetbeat, and so on). Any string can be used, but well-known types will have the image field defaulted and have the appropriate Elasticsearch roles created automatically. It also allows for dashboard setup when combined with a `KibanaRef`.
+| *`type`* __string__ | Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, auditbeat, journalbeat, packetbeat, and so on).
+Any string can be used, but well-known types will have the image field defaulted and have the appropriate
+Elasticsearch roles created automatically. It also allows for dashboard setup when combined with a `KibanaRef`.
 | *`version`* __string__ | Version of the Beat.
 | *`elasticsearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster.
-| *`kibanaRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster. It allows automatic setup of dashboards and visualizations.
+| *`kibanaRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster.
+It allows automatic setup of dashboards and visualizations.
 | *`image`* __string__ | Image is the Beat Docker image to deploy. Version and Type have to match the Beat in the image.
 | *`config`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-config[$$Config$$]__ | Config holds the Beat configuration. At most one of [`Config`, `ConfigRef`] can be specified.
-| *`configRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-configsource[$$ConfigSource$$]__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Beat configuration. Beat settings must be specified as yaml, under a single "beat.yml" entry. At most one of [`Config`, `ConfigRef`] can be specified.
-| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-secretsource[$$SecretSource$$] array__ | SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for the Beat. Secrets data can be then referenced in the Beat config using the Secret's keys or as specified in `Entries` field of each SecureSetting.
-| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to Elasticsearch resource in a different namespace. Can only be used if ECK is enforcing RBAC on references.
-| *`daemonSet`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-beat-v1beta1-daemonsetspec[$$DaemonSetSpec$$]__ | DaemonSet specifies the Beat should be deployed as a DaemonSet, and allows providing its spec. Cannot be used along with `deployment`. If both are absent a default for the Type is used.
-| *`deployment`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-beat-v1beta1-deploymentspec[$$DeploymentSpec$$]__ | Deployment specifies the Beat should be deployed as a Deployment, and allows providing its spec. Cannot be used along with `daemonSet`. If both are absent a default for the Type is used.
-| *`monitoring`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-monitoring[$$Monitoring$$]__ | Monitoring enables you to collect and ship logs and metrics for this Beat. Metricbeat and/or Filebeat sidecars are configured and send monitoring data to an Elasticsearch monitoring cluster running in the same Kubernetes cluster.
+| *`configRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-configsource[$$ConfigSource$$]__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Beat configuration.
+Beat settings must be specified as yaml, under a single "beat.yml" entry. At most one of [`Config`, `ConfigRef`]
+can be specified.
+| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-secretsource[$$SecretSource$$] array__ | SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for the Beat.
+Secrets data can be then referenced in the Beat config using the Secret's keys or as specified in `Entries` field of
+each SecureSetting.
+| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to Elasticsearch resource in a different namespace.
+Can only be used if ECK is enforcing RBAC on references.
+| *`daemonSet`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-beat-v1beta1-daemonsetspec[$$DaemonSetSpec$$]__ | DaemonSet specifies the Beat should be deployed as a DaemonSet, and allows providing its spec.
+Cannot be used along with `deployment`. If both are absent a default for the Type is used.
+| *`deployment`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-beat-v1beta1-deploymentspec[$$DeploymentSpec$$]__ | Deployment specifies the Beat should be deployed as a Deployment, and allows providing its spec.
+Cannot be used along with `daemonSet`. If both are absent a default for the Type is used.
+| *`monitoring`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-monitoring[$$Monitoring$$]__ | Monitoring enables you to collect and ship logs and metrics for this Beat.
+Metricbeat and/or Filebeat sidecars are configured and send monitoring data to an
+Elasticsearch monitoring cluster running in the same Kubernetes cluster.
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying DaemonSet or Deployment.
 |===
 
@@ -453,6 +490,8 @@ BeatSpec defines the desired state of a Beat.
 == common.k8s.elastic.co/v1
 
 Package v1 contains API schema definitions for common types used by all resources.
+
+
 
 
 
@@ -514,8 +553,7 @@ ConfigSource references configuration settings.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`SecretRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-secretref[$$SecretRef$$]__ | SecretName references a Kubernetes Secret in the same namespace as the resource that will consume it. 
- Examples: --- # Filebeat configuration kind: Secret apiVersion: v1 metadata: 	 name: filebeat-user-config stringData:   beat.yml: |-     filebeat.inputs:     - type: container       paths:       - /var/log/containers/*.log       processors:       - add_kubernetes_metadata:           node: ${NODE_NAME}           matchers:           - logs_path:               logs_path: "/var/log/containers/"     processors:     - add_cloud_metadata: {}     - add_host_metadata: {} --- # EnterpriseSearch configuration kind: Secret apiVersion: v1 metadata: 	name: smtp-credentials stringData:  enterprise-search.yml: |-    email.account.enabled: true    email.account.smtp.auth: plain    email.account.smtp.starttls.enable: false    email.account.smtp.host: 127.0.0.1    email.account.smtp.port: 25    email.account.smtp.user: myuser    email.account.smtp.password: mypassword    email.account.email_defaults.from: my@email.com ---
+| *`secretName`* __string__ | SecretName is the name of the secret.
 |===
 
 
@@ -563,7 +601,8 @@ KeyToPath defines how to map a key in a Secret object to a filesystem path.
 |===
 | Field | Description
 | *`key`* __string__ | Key is the key contained in the secret.
-| *`path`* __string__ | Path is the relative file path to map the key to. Path must not be an absolute file path and must not contain any ".." components.
+| *`path`* __string__ | Path is the relative file path to map the key to.
+Path must not be an absolute file path and must not contain any ".." components.
 |===
 
 
@@ -582,14 +621,17 @@ LocalObjectSelector defines a reference to a Kubernetes object corresponding to 
 | Field | Description
 | *`namespace`* __string__ | Namespace of the Kubernetes object. If empty, defaults to the current namespace.
 | *`name`* __string__ | Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
-| *`serviceName`* __string__ | ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+| *`serviceName`* __string__ | ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+the referenced resource is used.
 |===
 
 
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-logsmonitoring"]
 === LogsMonitoring 
 
-LogsMonitoring holds a list of Elasticsearch clusters which receive logs data from associated resources.
+LogsMonitoring holds a list of Elasticsearch clusters which receive logs data from
+associated resources.
 
 .Appears In:
 ****
@@ -599,14 +641,16 @@ LogsMonitoring holds a list of Elasticsearch clusters which receive logs data fr
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`elasticsearchRefs`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$] array__ | ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster. Due to existing limitations, only a single Elasticsearch cluster is currently supported.
+| *`elasticsearchRefs`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$] array__ | ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster.
+Due to existing limitations, only a single Elasticsearch cluster is currently supported.
 |===
 
 
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-metricsmonitoring"]
 === MetricsMonitoring 
 
-MetricsMonitoring holds a list of Elasticsearch clusters which receive monitoring data from associated resources.
+MetricsMonitoring holds a list of Elasticsearch clusters which receive monitoring data from
+associated resources.
 
 .Appears In:
 ****
@@ -616,14 +660,16 @@ MetricsMonitoring holds a list of Elasticsearch clusters which receive monitorin
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`elasticsearchRefs`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$] array__ | ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster. Due to existing limitations, only a single Elasticsearch cluster is currently supported.
+| *`elasticsearchRefs`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$] array__ | ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster.
+Due to existing limitations, only a single Elasticsearch cluster is currently supported.
 |===
 
 
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-monitoring"]
 === Monitoring 
 
-Monitoring holds references to both the metrics, and logs Elasticsearch clusters for configuring stack monitoring.
+Monitoring holds references to both the metrics, and logs Elasticsearch clusters for
+configuring stack monitoring.
 
 .Appears In:
 ****
@@ -644,7 +690,8 @@ Monitoring holds references to both the metrics, and logs Elasticsearch clusters
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector"]
 === ObjectSelector 
 
-ObjectSelector defines a reference to a Kubernetes object which can be an Elastic resource managed by the operator or a Secret describing an external Elastic resource not managed by the operator.
+ObjectSelector defines a reference to a Kubernetes object which can be an Elastic resource managed by the operator
+or a Secret describing an external Elastic resource not managed by the operator.
 
 .Appears In:
 ****
@@ -666,8 +713,16 @@ ObjectSelector defines a reference to a Kubernetes object which can be an Elasti
 | Field | Description
 | *`namespace`* __string__ | Namespace of the Kubernetes object. If empty, defaults to the current namespace.
 | *`name`* __string__ | Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
-| *`serviceName`* __string__ | ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
-| *`secretName`* __string__ | SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.
+| *`serviceName`* __string__ | ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+the referenced resource is used.
+| *`secretName`* __string__ | SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+Elastic resource not managed by the operator. The referenced secret must contain the following:
+- `url`: the URL to reach the Elastic resource
+- `username`: the username of the user to be authenticated to the Elastic resource
+- `password`: the password of the user to be authenticated to the Elastic resource
+- `ca.crt`: the CA certificate in PEM format (optional).
+This field cannot be used in combination with the other fields name, namespace or serviceName.
 |===
 
 
@@ -733,7 +788,9 @@ SecretSource defines a data source based on a Kubernetes Secret.
 |===
 | Field | Description
 | *`secretName`* __string__ | SecretName is the name of the secret.
-| *`entries`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-keytopath[$$KeyToPath$$] array__ | Entries define how to project each key-value pair in the secret to filesystem paths. If not defined, all keys will be projected to similarly named paths in the filesystem. If defined, only the specified keys will be projected to the corresponding paths.
+| *`entries`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-keytopath[$$KeyToPath$$] array__ | Entries define how to project each key-value pair in the secret to filesystem paths.
+If not defined, all keys will be projected to similarly named paths in the filesystem.
+If defined, only the specified keys will be projected to the corresponding paths.
 |===
 
 
@@ -753,6 +810,8 @@ SelfSignedCertificate holds configuration for the self-signed certificate genera
 | *`subjectAltNames`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-subjectalternativename[$$SubjectAlternativeName$$] array__ | SubjectAlternativeNames is a list of SANs to include in the generated HTTP TLS certificate.
 | *`disabled`* __boolean__ | Disabled indicates that the provisioning of the self-signed certifcate should be disabled.
 |===
+
+
 
 
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-servicetemplate"]
@@ -810,8 +869,13 @@ TLSOptions holds TLS configuration options.
 |===
 | Field | Description
 | *`selfSignedCertificate`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-selfsignedcertificate[$$SelfSignedCertificate$$]__ | SelfSignedCertificate allows configuring the self-signed certificate generated by the operator.
-| *`certificate`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-secretref[$$SecretRef$$]__ | Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS. The referenced secret should contain the following: 
- - `ca.crt`: The certificate authority (optional). - `tls.crt`: The certificate (or a chain). - `tls.key`: The private key to the first certificate in the certificate chain.
+| *`certificate`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-secretref[$$SecretRef$$]__ | Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.
+The referenced secret should contain the following:
+
+
+- `ca.crt`: The certificate authority (optional).
+- `tls.crt`: The certificate (or a chain).
+- `tls.key`: The private key to the first certificate in the certificate chain.
 |===
 
 
@@ -826,11 +890,12 @@ Package v1alpha1 contains API schema definitions for common types used by all re
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1alpha1-condition"]
 === Condition 
 
-Condition represents Elasticsearch resource's condition. **This API is in technical preview and may be changed or removed in a future release.**
+Condition represents Elasticsearch resource's condition.
+**This API is in technical preview and may be changed or removed in a future release.**
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-elasticsearchstatus[$$ElasticsearchStatus$$]
+- xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1alpha1-conditions[$$Conditions$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -855,10 +920,24 @@ ConditionType defines the condition of an Elasticsearch resource.
 
 
 
+[id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1alpha1-conditions"]
+=== Conditions (xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1alpha1-condition[$$Condition$$]) 
 
 
 
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-elasticsearchstatus[$$ElasticsearchStatus$$]
+****
 
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`type`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1alpha1-conditiontype[$$ConditionType$$]__ | 
+| *`status`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#conditionstatus-v1-core[$$ConditionStatus$$]__ | 
+| *`lastTransitionTime`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#time-v1-meta[$$Time$$]__ | 
+| *`message`* __string__ | 
+|===
 
 
 
@@ -933,7 +1012,8 @@ KeyToPath defines how to map a key in a Secret object to a filesystem path.
 |===
 | Field | Description
 | *`key`* __string__ | Key is the key contained in the secret.
-| *`path`* __string__ | Path is the relative file path to map the key to. Path must not be an absolute file path and must not contain any ".." components.
+| *`path`* __string__ | Path is the relative file path to map the key to.
+Path must not be an absolute file path and must not contain any ".." components.
 |===
 
 
@@ -1008,7 +1088,9 @@ SecretSource defines a data source based on a Kubernetes Secret.
 |===
 | Field | Description
 | *`secretName`* __string__ | SecretName is the name of the secret.
-| *`entries`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1beta1-keytopath[$$KeyToPath$$] array__ | Entries define how to project each key-value pair in the secret to filesystem paths. If not defined, all keys will be projected to similarly named paths in the filesystem. If defined, only the specified keys will be projected to the corresponding paths.
+| *`entries`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1beta1-keytopath[$$KeyToPath$$] array__ | Entries define how to project each key-value pair in the secret to filesystem paths.
+If not defined, all keys will be projected to similarly named paths in the filesystem.
+If defined, only the specified keys will be projected to the corresponding paths.
 |===
 
 
@@ -1081,8 +1163,13 @@ TLSOptions holds TLS configuration options.
 |===
 | Field | Description
 | *`selfSignedCertificate`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1beta1-selfsignedcertificate[$$SelfSignedCertificate$$]__ | SelfSignedCertificate allows configuring the self-signed certificate generated by the operator.
-| *`certificate`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1beta1-secretref[$$SecretRef$$]__ | Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS. The referenced secret should contain the following: 
- - `ca.crt`: The certificate authority (optional). - `tls.crt`: The certificate (or a chain). - `tls.key`: The private key to the first certificate in the certificate chain.
+| *`certificate`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1beta1-secretref[$$SecretRef$$]__ | Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.
+The referenced secret should contain the following:
+
+
+- `ca.crt`: The certificate authority (optional).
+- `tls.crt`: The certificate (or a chain).
+- `tls.key`: The private key to the first certificate in the certificate chain.
 |===
 
 
@@ -1130,8 +1217,12 @@ ChangeBudget defines the constraints to consider when applying changes to the El
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`maxUnavailable`* __integer__ | MaxUnavailable is the maximum number of Pods that can be unavailable (not ready) during the update due to circumstances under the control of the operator. Setting a negative value will disable this restriction. Defaults to 1 if not specified.
-| *`maxSurge`* __integer__ | MaxSurge is the maximum number of new Pods that can be created exceeding the original number of Pods defined in the specification. MaxSurge is only taken into consideration when scaling up. Setting a negative value will disable the restriction. Defaults to unbounded if not specified.
+| *`maxUnavailable`* __integer__ | MaxUnavailable is the maximum number of Pods that can be unavailable (not ready) during the update due to
+circumstances under the control of the operator. Setting a negative value will disable this restriction.
+Defaults to 1 if not specified.
+| *`maxSurge`* __integer__ | MaxSurge is the maximum number of new Pods that can be created exceeding the original number of Pods defined in
+the specification. MaxSurge is only taken into consideration when scaling up. Setting a negative value will
+disable the restriction. Defaults to unbounded if not specified.
 |===
 
 
@@ -1140,7 +1231,8 @@ ChangeBudget defines the constraints to consider when applying changes to the El
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-downscaleoperation"]
 === DownscaleOperation 
 
-DownscaleOperation provides details about in progress downscale operations. **This API is in technical preview and may be changed or removed in a future release.**
+DownscaleOperation provides details about in progress downscale operations.
+**This API is in technical preview and may be changed or removed in a future release.**
 
 .Appears In:
 ****
@@ -1152,14 +1244,16 @@ DownscaleOperation provides details about in progress downscale operations. **Th
 | Field | Description
 | *`lastUpdatedTime`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#time-v1-meta[$$Time$$]__ | 
 | *`nodes`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-downscalednode[$$DownscaledNode$$] array__ | Nodes which are scheduled to be removed from the cluster.
-| *`stalled`* __boolean__ | Stalled represents a state where no progress can be made. It is only available for clusters managed with the Elasticsearch shutdown API.
+| *`stalled`* __boolean__ | Stalled represents a state where no progress can be made.
+It is only available for clusters managed with the Elasticsearch shutdown API.
 |===
 
 
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-downscalednode"]
 === DownscaledNode 
 
-DownscaledNode provides an overview of in progress changes applied by the operator to remove Elasticsearch nodes from the cluster. **This API is in technical preview and may be changed or removed in a future release.**
+DownscaledNode provides an overview of in progress changes applied by the operator to remove Elasticsearch nodes from the cluster.
+**This API is in technical preview and may be changed or removed in a future release.**
 
 .Appears In:
 ****
@@ -1170,8 +1264,11 @@ DownscaledNode provides an overview of in progress changes applied by the operat
 |===
 | Field | Description
 | *`name`* __string__ | Name of the Elasticsearch node that should be removed.
-| *`shutdownStatus`* __string__ | Shutdown status as returned by the Elasticsearch shutdown API. If the Elasticsearch shutdown API is not available, the shutdown status is then inferred from the remaining shards on the nodes, as observed by the operator.
-| *`explanation`* __string__ | Explanation provides details about an in progress node shutdown. It is only available for clusters managed with the Elasticsearch shutdown API.
+| *`shutdownStatus`* __string__ | Shutdown status as returned by the Elasticsearch shutdown API.
+If the Elasticsearch shutdown API is not available, the shutdown status is then inferred from the remaining
+shards on the nodes, as observed by the operator.
+| *`explanation`* __string__ | Explanation provides details about an in progress node shutdown. It is only available for clusters managed with the
+Elasticsearch shutdown API.
 |===
 
 
@@ -1237,13 +1334,21 @@ ElasticsearchSpec holds the specification of an Elasticsearch cluster.
 | *`transport`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-transportconfig[$$TransportConfig$$]__ | Transport holds transport layer settings for Elasticsearch.
 | *`nodeSets`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-nodeset[$$NodeSet$$] array__ | NodeSets allow specifying groups of Elasticsearch nodes sharing the same configuration and Pod templates.
 | *`updateStrategy`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-updatestrategy[$$UpdateStrategy$$]__ | UpdateStrategy specifies how updates to the cluster should be performed.
-| *`podDisruptionBudget`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-poddisruptionbudgettemplate[$$PodDisruptionBudgetTemplate$$]__ | PodDisruptionBudget provides access to the default Pod disruption budget for the Elasticsearch cluster. The default budget doesn't allow any Pod to be removed in case the cluster is not green or if there is only one node of type `data` or `master`. In all other cases the default PodDisruptionBudget sets `minUnavailable` equal to the total number of nodes minus 1. To disable, set `PodDisruptionBudget` to the empty value (`{}` in YAML).
+| *`podDisruptionBudget`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-poddisruptionbudgettemplate[$$PodDisruptionBudgetTemplate$$]__ | PodDisruptionBudget provides access to the default Pod disruption budget for the Elasticsearch cluster.
+The default budget doesn't allow any Pod to be removed in case the cluster is not green or if there is only one node of type `data` or `master`.
+In all other cases the default PodDisruptionBudget sets `minUnavailable` equal to the total number of nodes minus 1.
+To disable, set `PodDisruptionBudget` to the empty value (`{}` in YAML).
 | *`auth`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-auth[$$Auth$$]__ | Auth contains user authentication and authorization security settings for Elasticsearch.
 | *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-secretsource[$$SecretSource$$] array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Elasticsearch.
-| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.
+Can only be used if ECK is enforcing RBAC on references.
 | *`remoteClusters`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-remotecluster[$$RemoteCluster$$] array__ | RemoteClusters enables you to establish uni-directional connections to a remote Elasticsearch cluster.
-| *`volumeClaimDeletePolicy`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-volumeclaimdeletepolicy[$$VolumeClaimDeletePolicy$$]__ | VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets. Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion. Defaults to DeleteOnScaledownAndClusterDeletion.
-| *`monitoring`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-monitoring[$$Monitoring$$]__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster. See https://www.elastic.co/guide/en/elasticsearch/reference/current/monitor-elasticsearch-cluster.html. Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different Elasticsearch monitoring clusters running in the same Kubernetes cluster.
+| *`volumeClaimDeletePolicy`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-volumeclaimdeletepolicy[$$VolumeClaimDeletePolicy$$]__ | VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets.
+Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion. Defaults to DeleteOnScaledownAndClusterDeletion.
+| *`monitoring`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-monitoring[$$Monitoring$$]__ | Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.
+See https://www.elastic.co/guide/en/elasticsearch/reference/current/monitor-elasticsearch-cluster.html.
+Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different
+Elasticsearch monitoring clusters running in the same Kubernetes cluster.
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying StatefulSets.
 |===
 
@@ -1262,12 +1367,18 @@ ElasticsearchStatus represents the observed state of Elasticsearch.
 |===
 | Field | Description
 | *`availableNodes`* __integer__ | AvailableNodes is the number of available instances.
-| *`version`* __string__ | Version of the stack resource currently running. During version upgrades, multiple versions may run in parallel: this value specifies the lowest version currently running.
+| *`version`* __string__ | Version of the stack resource currently running. During version upgrades, multiple versions may run
+in parallel: this value specifies the lowest version currently running.
 | *`health`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-elasticsearchhealth[$$ElasticsearchHealth$$]__ | 
 | *`phase`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-elasticsearchorchestrationphase[$$ElasticsearchOrchestrationPhase$$]__ | 
-| *`conditions`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1alpha1-condition[$$Condition$$] array__ | Conditions holds the current service state of an Elasticsearch cluster. **This API is in technical preview and may be changed or removed in a future release.**
-| *`inProgressOperations`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-inprogressoperations[$$InProgressOperations$$]__ | InProgressOperations represents changes being applied by the operator to the Elasticsearch cluster. **This API is in technical preview and may be changed or removed in a future release.**
-| *`observedGeneration`* __integer__ | ObservedGeneration is the most recent generation observed for this Elasticsearch cluster. It corresponds to the metadata generation, which is updated on mutation by the API Server. If the generation observed in status diverges from the generation in metadata, the Elasticsearch controller has not yet processed the changes contained in the Elasticsearch specification.
+| *`conditions`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1alpha1-conditions[$$Conditions$$]__ | Conditions holds the current service state of an Elasticsearch cluster.
+**This API is in technical preview and may be changed or removed in a future release.**
+| *`inProgressOperations`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-inprogressoperations[$$InProgressOperations$$]__ | InProgressOperations represents changes being applied by the operator to the Elasticsearch cluster.
+**This API is in technical preview and may be changed or removed in a future release.**
+| *`observedGeneration`* __integer__ | ObservedGeneration is the most recent generation observed for this Elasticsearch cluster.
+It corresponds to the metadata generation, which is updated on mutation by the API Server.
+If the generation observed in status diverges from the generation in metadata, the Elasticsearch
+controller has not yet processed the changes contained in the Elasticsearch specification.
 |===
 
 
@@ -1284,15 +1395,15 @@ FileRealmSource references users to create in the Elasticsearch cluster.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`SecretRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-secretref[$$SecretRef$$]__ | SecretName references a Kubernetes secret in the same namespace as the Elasticsearch resource. Multiple users and their roles mapping can be specified in a Kubernetes secret. The secret should contain 2 entries: - users: contain all users and the hash of their password (https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#password-hashing-algorithms) - users_roles: contain the role to users mapping The format of those 2 entries must correspond to the expected file realm format, as specified in Elasticsearch documentation: https://www.elastic.co/guide/en/elasticsearch/reference/7.5/file-realm.html#file-realm-configuration. 
- Example: --- # File realm in ES format (from the CLI or manually assembled) kind: Secret apiVersion: v1 metadata:   name: my-filerealm stringData:   users: |-     rdeniro:$2a$10$BBJ/ILiyJ1eBTYoRKxkqbuDEdYECplvxnqQ47uiowE7yGqvCEgj9W     alpacino:$2a$10$cNwHnElYiMYZ/T3K4PvzGeJ1KbpXZp2PfoQD.gfaVdImnHOwIuBKS     jacknich:{PBKDF2}50000$z1CLJt0MEFjkIK5iEfgvfnA6xq7lF25uasspsTKSo5Q=$XxCVLbaKDimOdyWgLCLJiyoiWpA/XDMe/xtVgn1r5Sg=   users_roles: |-     admin:rdeniro     power_user:alpacino,jacknich     user:jacknich ---
+| *`secretName`* __string__ | SecretName is the name of the secret.
 |===
 
 
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-inprogressoperations"]
 === InProgressOperations 
 
-InProgressOperations provides details about in progress changes applied by the operator on the Elasticsearch cluster. **This API is in technical preview and may be changed or removed in a future release.**
+InProgressOperations provides details about in progress changes applied by the operator on the Elasticsearch cluster.
+**This API is in technical preview and may be changed or removed in a future release.**
 
 .Appears In:
 ****
@@ -1330,12 +1441,15 @@ InProgressOperations provides details about in progress changes applied by the o
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-newnodestatus"]
 === NewNodeStatus (string) 
 
-NewNodeStatus provides details about the status of nodes which are expected to be created and added to the Elasticsearch cluster. **This API is in technical preview and may be changed or removed in a future release.**
+NewNodeStatus provides details about the status of nodes which are expected to be created and added to the Elasticsearch cluster.
+**This API is in technical preview and may be changed or removed in a future release.**
 
 .Appears In:
 ****
 - xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-newnode[$$NewNode$$]
 ****
+
+
 
 
 
@@ -1356,9 +1470,12 @@ NodeSet is the specification for a group of Elasticsearch nodes sharing the same
 | Field | Description
 | *`name`* __string__ | Name of this set of nodes. Becomes a part of the Elasticsearch node.name setting.
 | *`config`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-config[$$Config$$]__ | Config holds the Elasticsearch configuration.
-| *`count`* __integer__ | Count of Elasticsearch nodes to deploy. If the node set is managed by an autoscaling policy the initial value is automatically set by the autoscaling controller.
+| *`count`* __integer__ | Count of Elasticsearch nodes to deploy.
+If the node set is managed by an autoscaling policy the initial value is automatically set by the autoscaling controller.
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Pods belonging to this NodeSet.
-| *`volumeClaimTemplates`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$] array__ | VolumeClaimTemplates is a list of persistent volume claims to be used by each Pod in this NodeSet. Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate. Items defined here take precedence over any default claims added by the operator with the same name.
+| *`volumeClaimTemplates`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$] array__ | VolumeClaimTemplates is a list of persistent volume claims to be used by each Pod in this NodeSet.
+Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate.
+Items defined here take precedence over any default claims added by the operator with the same name.
 |===
 
 
@@ -1375,7 +1492,8 @@ RemoteCluster declares a remote Elasticsearch cluster connection.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`name`* __string__ | Name is the name of the remote cluster as it is set in the Elasticsearch settings. The name is expected to be unique for each remote clusters.
+| *`name`* __string__ | Name is the name of the remote cluster as it is set in the Elasticsearch settings.
+The name is expected to be unique for each remote clusters.
 | *`elasticsearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-localobjectselector[$$LocalObjectSelector$$]__ | ElasticsearchRef is a reference to an Elasticsearch cluster running within the same k8s cluster.
 |===
 
@@ -1393,8 +1511,7 @@ RoleSource references roles to create in the Elasticsearch cluster.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`SecretRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-secretref[$$SecretRef$$]__ | SecretName references a Kubernetes secret in the same namespace as the Elasticsearch resource. Multiple roles can be specified in a Kubernetes secret, under a single "roles.yml" entry. The secret value must match the expected file-based specification as described in https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html#roles-management-file. 
- Example: --- kind: Secret apiVersion: v1 metadata: 	name: my-roles stringData:  roles.yml: |-    click_admins:      run_as: [ 'clicks_watcher_1' ]   	cluster: [ 'monitor' ]   	indices:   	- names: [ 'events-*' ]   	  privileges: [ 'read' ]   	  field_security:   		grant: ['category', '@timestamp', 'message' ]   	  query: '{"match": {"category": "click"}}'    another_role:      cluster: [ 'all' ] ---
+| *`secretName`* __string__ | SecretName is the name of the secret.
 |===
 
 
@@ -1429,11 +1546,20 @@ TransportConfig holds the transport layer settings for Elasticsearch.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`otherNameSuffix`* __string__ | OtherNameSuffix when defined will be prefixed with the Pod name and used as the common name, and the first DNSName, as well as an OtherName required by Elasticsearch in the Subject Alternative Name extension of each Elasticsearch node's transport TLS certificate. Example: if set to "node.cluster.local", the generated certificate will have its otherName set to "<pod_name>.node.cluster.local".
+| *`otherNameSuffix`* __string__ | OtherNameSuffix when defined will be prefixed with the Pod name and used as the common name,
+and the first DNSName, as well as an OtherName required by Elasticsearch in the Subject Alternative Name
+extension of each Elasticsearch node's transport TLS certificate.
+Example: if set to "node.cluster.local", the generated certificate will have its otherName set to "<pod_name>.node.cluster.local".
 | *`subjectAltNames`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-subjectalternativename[$$SubjectAlternativeName$$] array__ | SubjectAlternativeNames is a list of SANs to include in the generated node transport TLS certificates.
-| *`certificate`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-secretref[$$SecretRef$$]__ | Certificate is a reference to a Kubernetes secret that contains the CA certificate and private key for generating node certificates. The referenced secret should contain the following: 
- - `ca.crt`: The CA certificate in PEM format. - `ca.key`: The private key for the CA certificate in PEM format.
-| *`certificateAuthorities`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-configmapref[$$ConfigMapRef$$]__ | CertificateAuthorities is a reference to a config map that contains one or more x509 certificates for trusted authorities in PEM format. The certificates need to be in a file called `ca.crt`.
+| *`certificate`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-secretref[$$SecretRef$$]__ | Certificate is a reference to a Kubernetes secret that contains the CA certificate
+and private key for generating node certificates.
+The referenced secret should contain the following:
+
+
+- `ca.crt`: The CA certificate in PEM format.
+- `ca.key`: The private key for the CA certificate in PEM format.
+| *`certificateAuthorities`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-configmapref[$$ConfigMapRef$$]__ | CertificateAuthorities is a reference to a config map that contains one or more x509 certificates for
+trusted authorities in PEM format. The certificates need to be in a file called `ca.crt`.
 |===
 
 
@@ -1457,7 +1583,8 @@ UpdateStrategy specifies how updates to the cluster should be performed.
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-upgradeoperation"]
 === UpgradeOperation 
 
-UpgradeOperation provides an overview of the pending or in progress changes applied by the operator to update the Elasticsearch nodes in the cluster. **This API is in technical preview and may be changed or removed in a future release.**
+UpgradeOperation provides an overview of the pending or in progress changes applied by the operator to update the Elasticsearch nodes in the cluster.
+**This API is in technical preview and may be changed or removed in a future release.**
 
 .Appears In:
 ****
@@ -1475,7 +1602,8 @@ UpgradeOperation provides an overview of the pending or in progress changes appl
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-upgradednode"]
 === UpgradedNode 
 
-UpgradedNode provides details about the status of nodes which are expected to be updated. **This API is in technical preview and may be changed or removed in a future release.**
+UpgradedNode provides details about the status of nodes which are expected to be updated.
+**This API is in technical preview and may be changed or removed in a future release.**
 
 .Appears In:
 ****
@@ -1486,7 +1614,8 @@ UpgradedNode provides details about the status of nodes which are expected to be
 |===
 | Field | Description
 | *`name`* __string__ | Name of the Elasticsearch node that should be upgraded.
-| *`status`* __string__ | Status states if the node is either in the process of being deleted for an upgrade, or blocked by a predicate or another condition stated in the message field.
+| *`status`* __string__ | Status states if the node is either in the process of being deleted for an upgrade,
+or blocked by a predicate or another condition stated in the message field.
 | *`message`* __string__ | Optional message to explain why a node may not be immediately restarted for upgrade.
 | *`predicate`* __string__ | Predicate is the name of the predicate currently preventing this node from being deleted for an upgrade.
 |===
@@ -1495,7 +1624,8 @@ UpgradedNode provides details about the status of nodes which are expected to be
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-upscaleoperation"]
 === UpscaleOperation 
 
-UpscaleOperation provides an overview of in progress changes applied by the operator to add Elasticsearch nodes to the cluster. **This API is in technical preview and may be changed or removed in a future release.**
+UpscaleOperation provides an overview of in progress changes applied by the operator to add Elasticsearch nodes to the cluster.
+**This API is in technical preview and may be changed or removed in a future release.**
 
 .Appears In:
 ****
@@ -1513,7 +1643,8 @@ UpscaleOperation provides an overview of in progress changes applied by the oper
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1-volumeclaimdeletepolicy"]
 === VolumeClaimDeletePolicy (string) 
 
-VolumeClaimDeletePolicy describes the delete policy for handling PersistentVolumeClaims that hold Elasticsearch data. Inspired by https://github.com/kubernetes/enhancements/pull/2440
+VolumeClaimDeletePolicy describes the delete policy for handling PersistentVolumeClaims that hold Elasticsearch data.
+Inspired by https://github.com/kubernetes/enhancements/pull/2440
 
 .Appears In:
 ****
@@ -1546,8 +1677,12 @@ ChangeBudget defines the constraints to consider when applying changes to the El
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`maxUnavailable`* __integer__ | MaxUnavailable is the maximum number of pods that can be unavailable (not ready) during the update due to circumstances under the control of the operator. Setting a negative value will disable this restriction. Defaults to 1 if not specified.
-| *`maxSurge`* __integer__ | MaxSurge is the maximum number of new pods that can be created exceeding the original number of pods defined in the specification. MaxSurge is only taken into consideration when scaling up. Setting a negative value will disable the restriction. Defaults to unbounded if not specified.
+| *`maxUnavailable`* __integer__ | MaxUnavailable is the maximum number of pods that can be unavailable (not ready) during the update due to
+circumstances under the control of the operator. Setting a negative value will disable this restriction.
+Defaults to 1 if not specified.
+| *`maxSurge`* __integer__ | MaxSurge is the maximum number of new pods that can be created exceeding the original number of pods defined in
+the specification. MaxSurge is only taken into consideration when scaling up. Setting a negative value will
+disable the restriction. Defaults to unbounded if not specified.
 |===
 
 
@@ -1572,6 +1707,30 @@ Elasticsearch represents an Elasticsearch resource in a Kubernetes cluster.
 |===
 
 
+[id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1beta1-elasticsearchhealth"]
+=== ElasticsearchHealth (string) 
+
+ElasticsearchHealth is the health of the cluster as returned by the health API.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1beta1-elasticsearchstatus[$$ElasticsearchStatus$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1beta1-elasticsearchorchestrationphase"]
+=== ElasticsearchOrchestrationPhase (string) 
+
+ElasticsearchOrchestrationPhase is the phase Elasticsearch is in from the controller point of view.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1beta1-elasticsearchstatus[$$ElasticsearchStatus$$]
+****
+
+
+
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1beta1-elasticsearchspec"]
 === ElasticsearchSpec 
 
@@ -1590,7 +1749,9 @@ ElasticsearchSpec holds the specification of an Elasticsearch cluster.
 | *`http`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1beta1-httpconfig[$$HTTPConfig$$]__ | HTTP holds HTTP layer settings for Elasticsearch.
 | *`nodeSets`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1beta1-nodeset[$$NodeSet$$] array__ | NodeSets allow specifying groups of Elasticsearch nodes sharing the same configuration and Pod templates.
 | *`updateStrategy`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1beta1-updatestrategy[$$UpdateStrategy$$]__ | UpdateStrategy specifies how updates to the cluster should be performed.
-| *`podDisruptionBudget`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1beta1-poddisruptionbudgettemplate[$$PodDisruptionBudgetTemplate$$]__ | PodDisruptionBudget provides access to the default pod disruption budget for the Elasticsearch cluster. The default budget selects all cluster pods and sets `maxUnavailable` to 1. To disable, set `PodDisruptionBudget` to the empty value (`{}` in YAML).
+| *`podDisruptionBudget`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1beta1-poddisruptionbudgettemplate[$$PodDisruptionBudgetTemplate$$]__ | PodDisruptionBudget provides access to the default pod disruption budget for the Elasticsearch cluster.
+The default budget selects all cluster pods and sets `maxUnavailable` to 1. To disable, set `PodDisruptionBudget`
+to the empty value (`{}` in YAML).
 | *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1beta1-secretsource[$$SecretSource$$] array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Elasticsearch.
 |===
 
@@ -1608,8 +1769,8 @@ ElasticsearchStatus defines the observed state of Elasticsearch
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`health`* __ElasticsearchHealth__ | 
-| *`phase`* __ElasticsearchOrchestrationPhase__ | 
+| *`health`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1beta1-elasticsearchhealth[$$ElasticsearchHealth$$]__ | 
+| *`phase`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-elasticsearch-v1beta1-elasticsearchorchestrationphase[$$ElasticsearchOrchestrationPhase$$]__ | 
 |===
 
 
@@ -1632,7 +1793,9 @@ NodeSet is the specification for a group of Elasticsearch nodes sharing the same
 | *`config`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1beta1-config[$$Config$$]__ | Config holds the Elasticsearch configuration.
 | *`count`* __integer__ | Count of Elasticsearch nodes to deploy.
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Pods belonging to this NodeSet.
-| *`volumeClaimTemplates`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$] array__ | VolumeClaimTemplates is a list of persistent volume claims to be used by each Pod in this NodeSet. Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate. Items defined here take precedence over any default claims added by the operator with the same name.
+| *`volumeClaimTemplates`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$] array__ | VolumeClaimTemplates is a list of persistent volume claims to be used by each Pod in this NodeSet.
+Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate.
+Items defined here take precedence over any default claims added by the operator with the same name.
 |===
 
 
@@ -1701,12 +1864,15 @@ EnterpriseSearchSpec holds the specification of an Enterprise Search resource.
 | *`image`* __string__ | Image is the Enterprise Search Docker image to deploy.
 | *`count`* __integer__ | Count of Enterprise Search instances to deploy.
 | *`config`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-config[$$Config$$]__ | Config holds the Enterprise Search configuration.
-| *`configRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-configsource[$$ConfigSource$$]__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Enterprise Search configuration. Configuration settings are merged and have precedence over settings specified in `config`.
+| *`configRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-configsource[$$ConfigSource$$]__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Enterprise Search configuration.
+Configuration settings are merged and have precedence over settings specified in `config`.
 | *`http`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-httpconfig[$$HTTPConfig$$]__ | HTTP holds the HTTP layer configuration for Enterprise Search resource.
 | *`elasticsearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | ElasticsearchRef is a reference to the Elasticsearch cluster running in the same Kubernetes cluster.
-| *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Enterprise Search pods.
+| *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on)
+for the Enterprise Search pods.
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment.
-| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
+Can only be used if ECK is enforcing RBAC on references.
 |===
 
 
@@ -1756,11 +1922,14 @@ EnterpriseSearchSpec holds the specification of an Enterprise Search resource.
 | *`image`* __string__ | Image is the Enterprise Search Docker image to deploy.
 | *`count`* __integer__ | Count of Enterprise Search instances to deploy.
 | *`config`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-config[$$Config$$]__ | Config holds the Enterprise Search configuration.
-| *`configRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-configsource[$$ConfigSource$$]__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Enterprise Search configuration. Configuration settings are merged and have precedence over settings specified in `config`.
+| *`configRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-configsource[$$ConfigSource$$]__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Enterprise Search configuration.
+Configuration settings are merged and have precedence over settings specified in `config`.
 | *`http`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-httpconfig[$$HTTPConfig$$]__ | HTTP holds the HTTP layer configuration for Enterprise Search resource.
 | *`elasticsearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | ElasticsearchRef is a reference to the Elasticsearch cluster running in the same Kubernetes cluster.
-| *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Enterprise Search pods.
-| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+| *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on)
+for the Enterprise Search pods.
+| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
+Can only be used if ECK is enforcing RBAC on references.
 |===
 
 
@@ -1810,14 +1979,19 @@ KibanaSpec holds the specification of a Kibana instance.
 | *`image`* __string__ | Image is the Kibana Docker image to deploy.
 | *`count`* __integer__ | Count of Kibana instances to deploy.
 | *`elasticsearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster.
-| *`enterpriseSearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | EnterpriseSearchRef is a reference to an EnterpriseSearch running in the same Kubernetes cluster. Kibana provides the default Enterprise Search UI starting version 7.14.
+| *`enterpriseSearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | EnterpriseSearchRef is a reference to an EnterpriseSearch running in the same Kubernetes cluster.
+Kibana provides the default Enterprise Search UI starting version 7.14.
 | *`config`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-config[$$Config$$]__ | Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html
 | *`http`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-httpconfig[$$HTTPConfig$$]__ | HTTP holds the HTTP layer configuration for Kibana.
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Kibana pods
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment.
 | *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-secretsource[$$SecretSource$$] array__ | SecureSettings is a list of references to Kubernetes secrets containing sensitive configuration options for Kibana.
-| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
-| *`monitoring`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-monitoring[$$Monitoring$$]__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana. See https://www.elastic.co/guide/en/kibana/current/xpack-monitoring.html. Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different Elasticsearch monitoring clusters running in the same Kubernetes cluster.
+| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
+Can only be used if ECK is enforcing RBAC on references.
+| *`monitoring`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-monitoring[$$Monitoring$$]__ | Monitoring enables you to collect and ship log and monitoring data of this Kibana.
+See https://www.elastic.co/guide/en/kibana/current/xpack-monitoring.html.
+Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different
+Elasticsearch monitoring clusters running in the same Kubernetes cluster.
 |===
 
 
@@ -1899,7 +2073,8 @@ ElasticsearchCluster is a named reference to an Elasticsearch cluster which can 
 |===
 | Field | Description
 | *`ObjectSelector`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | 
-| *`clusterName`* __string__ | ClusterName is an alias for the cluster to be used to refer to the Elasticsearch cluster in Logstash configuration files, and will be used to identify "named clusters" in Logstash
+| *`clusterName`* __string__ | ClusterName is an alias for the cluster to be used to refer to the Elasticsearch cluster in Logstash
+configuration files, and will be used to identify "named clusters" in Logstash
 |===
 
 
@@ -1920,6 +2095,18 @@ Logstash is the Schema for the logstashes API
 | *`spec`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-logstash-v1alpha1-logstashspec[$$LogstashSpec$$]__ | 
 | *`status`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-logstash-v1alpha1-logstashstatus[$$LogstashStatus$$]__ | 
 |===
+
+
+[id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-logstash-v1alpha1-logstashhealth"]
+=== LogstashHealth (string) 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-logstash-v1alpha1-logstashstatus[$$LogstashStatus$$]
+****
+
 
 
 [id="{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-logstash-v1alpha1-logstashservice"]
@@ -1959,17 +2146,30 @@ LogstashSpec defines the desired state of Logstash
 | *`image`* __string__ | Image is the Logstash Docker image to deploy. Version and Type have to match the Logstash in the image.
 | *`elasticsearchRefs`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-logstash-v1alpha1-elasticsearchcluster[$$ElasticsearchCluster$$] array__ | ElasticsearchRefs are references to Elasticsearch clusters running in the same Kubernetes cluster.
 | *`config`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-config[$$Config$$]__ | Config holds the Logstash configuration. At most one of [`Config`, `ConfigRef`] can be specified.
-| *`configRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-configsource[$$ConfigSource$$]__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Logstash configuration. Logstash settings must be specified as yaml, under a single "logstash.yml" entry. At most one of [`Config`, `ConfigRef`] can be specified.
+| *`configRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-configsource[$$ConfigSource$$]__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Logstash configuration.
+Logstash settings must be specified as yaml, under a single "logstash.yml" entry. At most one of [`Config`, `ConfigRef`]
+can be specified.
 | *`pipelines`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-config[$$Config$$] array__ | Pipelines holds the Logstash Pipelines. At most one of [`Pipelines`, `PipelinesRef`] can be specified.
-| *`pipelinesRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-configsource[$$ConfigSource$$]__ | PipelinesRef contains a reference to an existing Kubernetes Secret holding the Logstash Pipelines. Logstash pipelines must be specified as yaml, under a single "pipelines.yml" entry. At most one of [`Pipelines`, `PipelinesRef`] can be specified.
-| *`services`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-logstash-v1alpha1-logstashservice[$$LogstashService$$] array__ | Services contains details of services that Logstash should expose - similar to the HTTP layer configuration for the rest of the stack, but also applicable for more use cases than the metrics API, as logstash may need to be opened up for other services: Beats, TCP, UDP, etc, inputs.
-| *`monitoring`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-monitoring[$$Monitoring$$]__ | Monitoring enables you to collect and ship log and monitoring data of this Logstash. Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different Elasticsearch monitoring clusters running in the same Kubernetes cluster.
+| *`pipelinesRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-configsource[$$ConfigSource$$]__ | PipelinesRef contains a reference to an existing Kubernetes Secret holding the Logstash Pipelines.
+Logstash pipelines must be specified as yaml, under a single "pipelines.yml" entry. At most one of [`Pipelines`, `PipelinesRef`]
+can be specified.
+| *`services`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-logstash-v1alpha1-logstashservice[$$LogstashService$$] array__ | Services contains details of services that Logstash should expose - similar to the HTTP layer configuration for the
+rest of the stack, but also applicable for more use cases than the metrics API, as logstash may need to
+be opened up for other services: Beats, TCP, UDP, etc, inputs.
+| *`monitoring`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-monitoring[$$Monitoring$$]__ | Monitoring enables you to collect and ship log and monitoring data of this Logstash.
+Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different
+Elasticsearch monitoring clusters running in the same Kubernetes cluster.
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options for the Logstash pods.
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying StatefulSet.
-| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-secretsource[$$SecretSource$$] array__ | SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for the Logstash. Secrets data can be then referenced in the Logstash config using the Secret's keys or as specified in `Entries` field of each SecureSetting.
-| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to Elasticsearch resource in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+| *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-secretsource[$$SecretSource$$] array__ | SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for the Logstash.
+Secrets data can be then referenced in the Logstash config using the Secret's keys or as specified in `Entries` field of
+each SecureSetting.
+| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to Elasticsearch resource in a different namespace.
+Can only be used if ECK is enforcing RBAC on references.
 | *`updateStrategy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#statefulsetupdatestrategy-v1-apps[$$StatefulSetUpdateStrategy$$]__ | UpdateStrategy is a StatefulSetUpdateStrategy. The default type is "RollingUpdate".
-| *`volumeClaimTemplates`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$] array__ | VolumeClaimTemplates is a list of persistent volume claims to be used by each Pod. Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate. Items defined here take precedence over any default claims added by the operator with the same name.
+| *`volumeClaimTemplates`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$] array__ | VolumeClaimTemplates is a list of persistent volume claims to be used by each Pod.
+Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate.
+Items defined here take precedence over any default claims added by the operator with the same name.
 |===
 
 
@@ -1986,11 +2186,15 @@ LogstashStatus defines the observed state of Logstash
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`version`* __string__ | Version of the stack resource currently running. During version upgrades, multiple versions may run in parallel: this value specifies the lowest version currently running.
+| *`version`* __string__ | Version of the stack resource currently running. During version upgrades, multiple versions may run
+in parallel: this value specifies the lowest version currently running.
 | *`expectedNodes`* __integer__ | 
 | *`availableNodes`* __integer__ | 
-| *`health`* __LogstashHealth__ | 
-| *`observedGeneration`* __integer__ | ObservedGeneration is the most recent generation observed for this Logstash instance. It corresponds to the metadata generation, which is updated on mutation by the API Server. If the generation observed in status diverges from the generation in metadata, the Logstash controller has not yet processed the changes contained in the Logstash specification.
+| *`health`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-logstash-v1alpha1-logstashhealth[$$LogstashHealth$$]__ | 
+| *`observedGeneration`* __integer__ | ObservedGeneration is the most recent generation observed for this Logstash instance.
+It corresponds to the metadata generation, which is updated on mutation by the API Server.
+If the generation observed in status diverges from the generation in metadata, the Logstash
+controller has not yet processed the changes contained in the Logstash specification.
 | *`selector`* __string__ | 
 |===
 
@@ -2064,11 +2268,13 @@ MapsSpec holds the specification of an Elastic Maps Server instance.
 | *`count`* __integer__ | Count of Elastic Maps Server instances to deploy.
 | *`elasticsearchRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-objectselector[$$ObjectSelector$$]__ | ElasticsearchRef is a reference to an Elasticsearch cluster running in the same Kubernetes cluster.
 | *`config`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-config[$$Config$$]__ | Config holds the ElasticMapsServer configuration. See: https://www.elastic.co/guide/en/kibana/current/maps-connect-to-ems.html#elastic-maps-server-configuration
-| *`configRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-configsource[$$ConfigSource$$]__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Elastic Maps Server configuration. Configuration settings are merged and have precedence over settings specified in `config`.
+| *`configRef`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-configsource[$$ConfigSource$$]__ | ConfigRef contains a reference to an existing Kubernetes Secret holding the Elastic Maps Server configuration.
+Configuration settings are merged and have precedence over settings specified in `config`.
 | *`http`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-httpconfig[$$HTTPConfig$$]__ | HTTP holds the HTTP layer configuration for Elastic Maps Server.
 | *`podTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core[$$PodTemplateSpec$$]__ | PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Elastic Maps Server pods
 | *`revisionHistoryLimit`* __integer__ | RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying Deployment.
-| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+| *`serviceAccountName`* __string__ | ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
+Can only be used if ECK is enforcing RBAC on references.
 |===
 
 
@@ -2143,6 +2349,10 @@ Package v1alpha1 contains API schema definitions for managing StackConfigPolicy 
 | *`config`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-config[$$Config$$]__ | Config holds the settings that go into kibana.yml.
 | *`secureSettings`* __xref:{anchor_prefix}-github-com-elastic-cloud-on-k8s-v2-pkg-apis-common-v1-secretsource[$$SecretSource$$] array__ | SecureSettings are additional Secrets that contain data to be configured to Kibana's keystore.
 |===
+
+
+
+
 
 
 

--- a/hack/api-docs/build.sh
+++ b/hack/api-docs/build.sh
@@ -26,7 +26,7 @@ build_docs() {
     local REPO_ROOT="${SCRIPT_DIR}/../.."
     local DOCS_DIR="${SCRIPT_DIR}/../../docs"
     local REFDOCS_REPO="${REFDOCS_REPO:-github.com/elastic/crd-ref-docs}"
-    local REFDOCS_VER="${REFDOCS_VER:-v0.0.8}"
+    local REFDOCS_VER="${REFDOCS_VER:-v0.0.12}"
     local BIN_DIR=${SCRATCH_DIR}/bin
 
     (

--- a/hack/api-docs/config.yaml
+++ b/hack/api-docs/config.yaml
@@ -1,14 +1,15 @@
 processor:
   ignoreTypes:
-    - "(Elasticsearch|ElasticsearchAutoscaler|Kibana|ApmServer|EnterpriseSearch|Beat|Agent|StackConfigPolicy|Logstash)List$"
+    - "(Elasticsearch|ElasticsearchAutoscaler|Kibana|ApmServer|EnterpriseSearch|Beat|Agent|StackConfigPolicy|Logstash|NodeSetNodeCount)List$"
     - "(Kibana|ApmServer|EnterpriseSearch|Beat|Agent|StackConfigPolicy)Health$"
-    - "(ElasticsearchAutoscaler|Kibana|ApmServer|Reconciler|EnterpriseSearch|Beat|Agent|Maps|Policy)Status$"
+    - "(ElasticsearchAutoscaler|Kibana|ApmServer|Reconciler|EnterpriseSearch|Beat|Agent|Maps|Policy|Deployment)Status$"
     - "ElasticsearchSettings$"
     - "Associa(ted|tion|tionStatus|tionConf)$"
     - "AssociationStatusMap"
     - "APM(Es|Kibana)Association"
     - "NodeSet(List|ConfigError)$"
     - "Autoscaling*"
+    - "ResourceListInt64"
     - "(NodeSets|NodeSet|Cluster)Resources"
     - NamespacedSecretSource
   ignoreFields:


### PR DESCRIPTION
This updates the Buildkite agent image to get openshift-preflight `v1.9.1` in `2.12`.

Tested with:
```
curl https://api.buildkite.com/v2/organizations/elastic/pipelines/cloud-on-k8s-operator-redhat-release/builds -XPOST -H "Authorization: $auth" -d '
{
    "commit": "5a647f290",
    "branch": "2-12-bump-bk-agent-99f0bc14",
    "message": "dry-run release ECK 5a647f290 for OperatoHub/RedHat - OHUB_DISABLE_PREFLIGHT=false",
    "env": {
        "OHUB_DRY_RUN": "true",
        "OHUB_DISABLE_PREFLIGHT": "false",
        "OHUB_GITHUB_VAULT_SECRET": "secret/ci/elastic-cloud-on-k8s/operatorhub-release-github-thbkrkr"
    }
}'
```

[build](https://buildkite.com/elastic/cloud-on-k8s-operator-redhat-release/builds/173#018e7ac8-444c-43c4-884b-c3eeb745a4d0)

<img width="1035" alt="Capture d’écran 2024-03-26 à 13 59 32" src="https://github.com/elastic/cloud-on-k8s/assets/582883/fedd0a22-ecfb-488b-b47e-79648747b792">


Similar to #7657.