### PR TITLE
Update operator used to monitor e2e tests to 2.12.0

### DIFF
--- a/config/e2e/helm-monitoring-operator.yaml
+++ b/config/e2e/helm-monitoring-operator.yaml
@@ -6,7 +6,7 @@ managedNamespaces: [{{ .E2ENamespace }}]
 
 image:
   repository: docker.elastic.co/eck/eck-operator
-  tag: 2.11.1
+  tag: 2.12.0
 
 podAnnotations:
   co.elastic.metrics/metricsets: collector

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -5,7 +5,7 @@ metadata:
   name: e2e-agent
   namespace: {{ .E2ENamespace }}
 spec:
-  version: 8.12.1 # needs to less or equal to e2e-monitor version
+  version: 8.13.0 # needs to less or equal to e2e-monitor version
   elasticsearchRefs:
     - secretName: eck-{{ .TestRun }}
   daemonSet:


### PR DESCRIPTION
This updates the version of the operator used to monitor the e2e tests to `v2.12.0`,
and the version of the agent used to send data to this cluster to `v8.13.0`.