### PR TITLE
Move desired nodes version gate in the client

### DIFF
--- a/pkg/controller/elasticsearch/client/desired_nodes.go
+++ b/pkg/controller/elasticsearch/client/desired_nodes.go
@@ -12,7 +12,6 @@ import (
 )
 
 var desiredNodesMinVersion = version.MinFor(8, 3, 0)
-var DeprecatedNodeVersionReqBodyParamMinVersion = version.MinFor(8, 13, 0)
 
 type DesiredNodesClient interface {
 	IsDesiredNodesSupported() bool
@@ -39,7 +38,7 @@ type DesiredNode struct {
 	ProcessorsRange ProcessorsRange        `json:"processors_range"`
 	Memory          string                 `json:"memory"`
 	Storage         string                 `json:"storage"`
-	NodeVersion     string                 `json:"node_version,omitempty"` // deprecated in 8.13+
+	NodeVersion     string                 `json:"node_version"`
 }
 
 type ProcessorsRange struct {

--- a/pkg/controller/elasticsearch/client/desired_nodes.go
+++ b/pkg/controller/elasticsearch/client/desired_nodes.go
@@ -39,7 +39,7 @@ type DesiredNode struct {
 	ProcessorsRange ProcessorsRange        `json:"processors_range"`
 	Memory          string                 `json:"memory"`
 	Storage         string                 `json:"storage"`
-	NodeVersion     string                 `json:"node_version"` // deprecated in 8.13+
+	NodeVersion     string                 `json:"node_version,omitempty"` // deprecated in 8.13+
 }
 
 type ProcessorsRange struct {

--- a/pkg/controller/elasticsearch/client/desired_nodes.go
+++ b/pkg/controller/elasticsearch/client/desired_nodes.go
@@ -12,6 +12,7 @@ import (
 )
 
 var desiredNodesMinVersion = version.MinFor(8, 3, 0)
+var deprecatedNodeVersionReqBodyParamMinVersion = version.MinFor(8, 13, 0)
 
 type DesiredNodesClient interface {
 	IsDesiredNodesSupported() bool
@@ -38,7 +39,7 @@ type DesiredNode struct {
 	ProcessorsRange ProcessorsRange        `json:"processors_range"`
 	Memory          string                 `json:"memory"`
 	Storage         string                 `json:"storage"`
-	NodeVersion     string                 `json:"node_version"`
+	NodeVersion     string                 `json:"node_version"` // deprecated in 8.13+
 }
 
 type ProcessorsRange struct {
@@ -73,6 +74,12 @@ func (c *clientV8) GetLatestDesiredNodes(ctx context.Context) (LatestDesiredNode
 }
 
 func (c *clientV8) UpdateDesiredNodes(ctx context.Context, historyID string, version int64, desiredNodes DesiredNodes) error {
+	// remove deprecated field depending on the version
+	if c.version.GTE(deprecatedNodeVersionReqBodyParamMinVersion) {
+		for i := range desiredNodes.DesiredNodes {
+			desiredNodes.DesiredNodes[i].NodeVersion = ""
+		}
+	}
 	return c.put(
 		ctx,
 		fmt.Sprintf("/_internal/desired_nodes/%s/%d", historyID, version),

--- a/pkg/controller/elasticsearch/driver/desired_nodes.go
+++ b/pkg/controller/elasticsearch/driver/desired_nodes.go
@@ -37,7 +37,7 @@ func (d *defaultDriver) updateDesiredNodes(
 	if err != nil {
 		return results.WithError(err)
 	}
-	nodes, requeue, err := expectedResources.ToDesiredNodes(ctx, d.Client, esVersion)
+	nodes, requeue, err := expectedResources.ToDesiredNodes(ctx, d.Client, esVersion.FinalizeVersion())
 	switch {
 	case err == nil:
 		d.ReconcileState.ReportCondition(


### PR DESCRIPTION
This moves the version gate for removing the deprecated nodes field when using the desired nodes API in the es client,
so it uses the minimum version of Elasticsearch in the cluster instead of the Elasticsearch version in the Spec.

Resolves #7664.