### PR TITLE
Document known issue for 2.12.0

### DIFF
--- a/docs/release-notes/highlights-2.12.0.asciidoc
+++ b/docs/release-notes/highlights-2.12.0.asciidoc
@@ -5,8 +5,9 @@
 [id="{p}-2120-known-issues"]
 === Known issues
 
-- When upgrading Elasticsearch to 8.13.0, the operator will be stalled in the upgrade process due to a reconciler error where the Elasticsearch client failed
-to request the desired nodes API. There is no workaround to resolve this issue. You must update the operator to the next patch release.
+- During the upgrade of Elasticsearch to version 8.13.0, the operator may encounter a stall in the process due to a reconciler error,
+wherein the Elasticsearch client fails to request the desired nodes API. There is no workaround available to resolve this issue. 
+The only solution is to update the operator to the subsequent patch release.
 
 [float]
 [id="{p}-2120-new-and-notable"]

--- a/docs/release-notes/highlights-2.12.0.asciidoc
+++ b/docs/release-notes/highlights-2.12.0.asciidoc
@@ -6,7 +6,7 @@
 === Known issues
 
 - When upgrading Elasticsearch to 8.13.0, the operator will be stalled in the upgrade process due to a reconciler error where the Elasticsearch client failed
-to request the desired nodes API.
+to request the desired nodes API. There is no workaround to resolve this issue. You must update the operator to the next patch release.
 
 [float]
 [id="{p}-2120-new-and-notable"]

--- a/docs/release-notes/highlights-2.12.0.asciidoc
+++ b/docs/release-notes/highlights-2.12.0.asciidoc
@@ -2,6 +2,13 @@
 == 2.12.0 release highlights
 
 [float]
+[id="{p}-190-known-issues"]
+=== Known issues
+
+- When upgrading Elasticsearch to 8.13.0, the operator will be stalled in the upgrade process due to a reconciler error where the Elasticsearch client failed
+to request the desired nodes API.
+
+[float]
 [id="{p}-2120-new-and-notable"]
 === New and notable
 

--- a/docs/release-notes/highlights-2.12.0.asciidoc
+++ b/docs/release-notes/highlights-2.12.0.asciidoc
@@ -2,8 +2,8 @@
 == 2.12.0 release highlights
 
 [float]
-[id="{p}-2120-known-issues"]
-=== Known issues
+[id="{p}-2120-known-issue"]
+=== Known issue
 
 - During the upgrade of Elasticsearch to version 8.13.0, the operator may encounter a stall in the process due to a reconciler error,
 wherein the Elasticsearch client fails to request the desired nodes API. There is no workaround available to resolve this issue. 

--- a/docs/release-notes/highlights-2.12.0.asciidoc
+++ b/docs/release-notes/highlights-2.12.0.asciidoc
@@ -2,7 +2,7 @@
 == 2.12.0 release highlights
 
 [float]
-[id="{p}-190-known-issues"]
+[id="{p}-2120-known-issues"]
 === Known issues
 
 - When upgrading Elasticsearch to 8.13.0, the operator will be stalled in the upgrade process due to a reconciler error where the Elasticsearch client failed


### PR DESCRIPTION
This adds https://github.com/elastic/cloud-on-k8s/issues/7664 as known issue in the 2.12.0 release highlights.