### PR TITLE
Update docs attributes after 2.12.1

### DIFF
--- a/docs/eck-attributes.asciidoc
+++ b/docs/eck-attributes.asciidoc
@@ -1,4 +1,4 @@
-:eck_version: 2.12.0
+:eck_version: 2.12.1
 :eck_crd_version: v1
 :eck_release_branch: 2.12
 :eck_github: https://github.com/elastic/cloud-on-k8s


### PR DESCRIPTION
This sets `2.12.1` as the latest current ECK version in the docs.