### PR TITLE
Update e2e monitoring eck operator to 2.12.1

### DIFF
--- a/config/e2e/helm-monitoring-operator.yaml
+++ b/config/e2e/helm-monitoring-operator.yaml
@@ -6,7 +6,7 @@ managedNamespaces: [{{ .E2ENamespace }}]
 
 image:
   repository: docker.elastic.co/eck/eck-operator
-  tag: 2.12.0
+  tag: 2.12.1
 
 podAnnotations:
   co.elastic.metrics/metricsets: collector


### PR DESCRIPTION
This updates the version of the operator used to monitor the e2e tests to v2.12.1.