### PR TITLE
[Autoscaling] Do not delete existing resources

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/autoscaling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/autoscaling.asciidoc
@@ -31,6 +31,8 @@ Autoscaling policies can be defined in an `ElasticsearchAutoscaler` resource. Ea
 ** `cpu` and `memory` enforce minimum and maximum compute resources usage for the Elasticsearch container.
 ** `storage` enforces minimum and maximum storage request per PersistentVolumeClaim.
 
+If there is no recommendation from the Autoscaling API for a given resource, and if this resource is not set in the policy, then the resource is not managed by the operator and existing requirements in the NodeSets remain unchanged.
+
 [source,yaml]
 ----
 apiVersion: autoscaling.k8s.elastic.co/v1alpha1

--- a/pkg/apis/common/v1alpha1/resources.go
+++ b/pkg/apis/common/v1alpha1/resources.go
@@ -88,7 +88,7 @@ func newNodeSetNodeCountList(nodeSetNames []string) NodeSetNodeCountList {
 
 // ToContainerResourcesWith builds new ResourceRequirements for Memory and CPU, overriding existing values from the provided
 // ResourceRequirements with the values from the NodeResources.
-// If a value in the NodeResources is not present then the value in the result is removed.
+// If there is no recommendations for a given resource, then its current value remains unchanged.
 // Values for extended resources (e.g. GPU), are left untouched.
 // This function has no side effect and does not modify the original ResourceRequirements.
 func (nr *NodeResources) ToContainerResourcesWith(sourceRequirements corev1.ResourceRequirements) corev1.ResourceRequirements {
@@ -101,8 +101,6 @@ func (nr *NodeResources) ToContainerResourcesWith(sourceRequirements corev1.Reso
 	for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
 		if nr.HasRequest(resourceName) {
 			mergedResources.Requests[resourceName] = nr.GetRequest(resourceName)
-		} else {
-			delete(mergedResources.Requests, resourceName)
 		}
 	}
 
@@ -113,8 +111,6 @@ func (nr *NodeResources) ToContainerResourcesWith(sourceRequirements corev1.Reso
 	for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
 		if nr.HasLimit(resourceName) {
 			mergedResources.Limits[resourceName] = nr.GetLimit(resourceName)
-		} else {
-			delete(mergedResources.Limits, resourceName)
 		}
 	}
 	return *mergedResources

--- a/pkg/apis/common/v1alpha1/resources_test.go
+++ b/pkg/apis/common/v1alpha1/resources_test.go
@@ -57,34 +57,34 @@ func TestNodeResources_ToContainerResourcesWith(t *testing.T) {
 			},
 		},
 		{
-			name: "Remove a requirements if not present",
+			name: "Preserve original requirements if not present",
 			fields: fields{
 				Requests: map[corev1.ResourceName]resource.Quantity{
-					corev1.ResourceCPU:    resource.MustParse("2"),
+					// no recommendation for corev1.ResourceCPU
 					corev1.ResourceMemory: resource.MustParse("8Gi"),
 				},
 				Limits: map[corev1.ResourceName]resource.Quantity{
-					// corev1.ResourceCPU is not expected
+					// no recommendation for corev1.ResourceCPU
 					corev1.ResourceMemory: resource.MustParse("8Gi"),
 				},
 			},
 			args: args{into: corev1.ResourceRequirements{
 				Requests: map[corev1.ResourceName]resource.Quantity{
-					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceCPU:    resource.MustParse("1"), // should be preserved in the result
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
 				},
 				Limits: map[corev1.ResourceName]resource.Quantity{
-					corev1.ResourceCPU:    resource.MustParse("2"), // should be removed in the result
+					corev1.ResourceCPU:    resource.MustParse("2"), // should be preserved in the result
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
 				},
 			}},
 			want: corev1.ResourceRequirements{
 				Requests: map[corev1.ResourceName]resource.Quantity{
-					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("8Gi"),
 				},
 				Limits: map[corev1.ResourceName]resource.Quantity{
-					// corev1.ResourceCPU is not expected
+					corev1.ResourceCPU:    resource.MustParse("2"),
 					corev1.ResourceMemory: resource.MustParse("8Gi"),
 				},
 			},


### PR DESCRIPTION
This PR prevents the autoscaling controller from removing resources managed by the user if there is no recommendation.