### PR TITLE
Document known issue for 2.12.0

### DIFF
--- a/docs/release-notes/2.12.0.asciidoc
+++ b/docs/release-notes/2.12.0.asciidoc
@@ -5,6 +5,14 @@
 == {n} version 2.12.0
 
 
+[[known-issue-2.12.0]]
+[float]
+=== Known issue
+
+- During the upgrade of Elasticsearch to version 8.13.0, the operator may encounter a stall in the process due to a reconciler error,
+wherein the Elasticsearch client fails to request the desired nodes API. There is no workaround available to resolve this issue. 
+The only solution is to update the operator to the subsequent patch release.
+
 
 [[feature-2.12.0]]
 [float]


### PR DESCRIPTION
Similar to #7668 but in the release notes.

To backport to `2.12`.