### PR TITLE
Update docker.io/library/golang docker tag to v1.22.2

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM docker.io/library/golang:1.22.1 as builder
+FROM docker.io/library/golang:1.22.2 as builder
 
 ARG VERSION
 ARG SHA1

--- a/build/Dockerfile-ubi
+++ b/build/Dockerfile-ubi
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM docker.io/library/golang:1.22.1 as builder
+FROM docker.io/library/golang:1.22.2 as builder
 
 ARG VERSION
 ARG SHA1

--- a/hack/manifest-gen/Dockerfile
+++ b/hack/manifest-gen/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.22.1 as builder
+FROM docker.io/library/golang:1.22.2 as builder
 ADD . /manifest-gen
 WORKDIR /manifest-gen
 ENV GO111MODULE=on CGO_ENABLED=0 GOOS=linux 

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image for the E2E tests runner
-FROM docker.io/library/golang:1.22.1
+FROM docker.io/library/golang:1.22.2
 
 ARG GO_TAGS
 


### PR DESCRIPTION
Per security release of 1.22.2:
https://github.com/golang/go/issues/65051
https://github.com/golang/go/issues/66298

This is upgrading our docker release tag to v1.22.2.