### PR TITLE
[2.12] Update broken value file link for APM server Helm chart (#7699)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/stack-helm-chart.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/stack-helm-chart.asciidoc
@@ -81,7 +81,7 @@ The following section builds upon the previous sections, and allows installing a
 ----
 # Install an eck-managed Elasticsearch, Kibana, and standalone APM Server using custom values.
 helm install eck-stack-with-apm-server elastic/eck-stack \
-    --values https://raw.githubusercontent.com/elastic/cloud-on-k8s/{eck_release_branch}/deploy/eck-stack/examples/logstash/basic.yaml -n elastic-stack
+    --values https://raw.githubusercontent.com/elastic/cloud-on-k8s/{eck_release_branch}/deploy/eck-stack/examples/apm-server/basic.yaml -n elastic-stack
 ----
 
 [float]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.12`:
 - [Update broken value file link for APM server Helm chart (#7699)](https://github.com/elastic/cloud-on-k8s/pull/7699)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)