### PR TITLE
Support loadBalancerClass in service reconciliation

### DIFF
--- a/pkg/controller/common/service_control.go
+++ b/pkg/controller/common/service_control.go
@@ -72,7 +72,7 @@ func needsRecreate(expected, reconciled *corev1.Service) bool {
 	}
 
 	// LoadBalancerClass is immutable once set if target type is load balancer
-	if expected.Spec.Type == corev1.ServiceTypeLoadBalancer && expected.Spec.LoadBalancerClass != reconciled.Spec.LoadBalancerClass {
+	if expected.Spec.Type == corev1.ServiceTypeLoadBalancer && !reflect.DeepEqual(expected.Spec.LoadBalancerClass, reconciled.Spec.LoadBalancerClass) {
 		return true
 	}
 

--- a/pkg/controller/common/service_control.go
+++ b/pkg/controller/common/service_control.go
@@ -71,6 +71,11 @@ func needsRecreate(expected, reconciled *corev1.Service) bool {
 		return true
 	}
 
+	// LoadBalancerClass is immutable once set if target type is load balancer
+	if expected.Spec.Type == corev1.ServiceTypeLoadBalancer && expected.Spec.LoadBalancerClass != reconciled.Spec.LoadBalancerClass {
+		return true
+	}
+
 	return false
 }
 
@@ -138,6 +143,11 @@ func applyServerSideValues(expected, reconciled *corev1.Service) {
 	// InternalTrafficPolicy may be defaulted by the api server starting K8S v1.22
 	if expected.Spec.InternalTrafficPolicy == nil {
 		expected.Spec.InternalTrafficPolicy = reconciled.Spec.InternalTrafficPolicy
+	}
+
+	// LoadBalancerClass may be defaulted by the API server starting K8s v.1.24
+	if expected.Spec.Type == corev1.ServiceTypeLoadBalancer && expected.Spec.LoadBalancerClass == nil {
+		expected.Spec.LoadBalancerClass = reconciled.Spec.LoadBalancerClass
 	}
 }
 

--- a/pkg/controller/common/service_control.go
+++ b/pkg/controller/common/service_control.go
@@ -145,10 +145,19 @@ func applyServerSideValues(expected, reconciled *corev1.Service) {
 		expected.Spec.InternalTrafficPolicy = reconciled.Spec.InternalTrafficPolicy
 	}
 
+	if expected.Spec.ExternalTrafficPolicy == "" {
+		expected.Spec.ExternalTrafficPolicy = reconciled.Spec.ExternalTrafficPolicy
+	}
+
 	// LoadBalancerClass may be defaulted by the API server starting K8s v.1.24
 	if expected.Spec.Type == corev1.ServiceTypeLoadBalancer && expected.Spec.LoadBalancerClass == nil {
 		expected.Spec.LoadBalancerClass = reconciled.Spec.LoadBalancerClass
 	}
+
+	if expected.Spec.AllocateLoadBalancerNodePorts == nil {
+		expected.Spec.AllocateLoadBalancerNodePorts = reconciled.Spec.AllocateLoadBalancerNodePorts
+	}
+
 }
 
 // hasNodePort returns for a given service type, if the service ports have a NodePort or not.

--- a/pkg/controller/common/service_control.go
+++ b/pkg/controller/common/service_control.go
@@ -157,7 +157,6 @@ func applyServerSideValues(expected, reconciled *corev1.Service) {
 	if expected.Spec.AllocateLoadBalancerNodePorts == nil {
 		expected.Spec.AllocateLoadBalancerNodePorts = reconciled.Spec.AllocateLoadBalancerNodePorts
 	}
-
 }
 
 // hasNodePort returns for a given service type, if the service ports have a NodePort or not.

--- a/pkg/controller/common/service_control_test.go
+++ b/pkg/controller/common/service_control_test.go
@@ -564,29 +564,39 @@ func Test_applyServerSideValues(t *testing.T) {
 			}},
 		},
 		{
-			name: "Reconciled InternalTrafficPolicy is used if the expected one is empty",
+			name: "Reconciled InternalTrafficPolicy/ExternalTrafficPolicy/AllocateLoadBalancerPorts are used if the expected one is empty",
 			args: args{
 				expected: corev1.Service{Spec: corev1.ServiceSpec{}},
 				reconciled: corev1.Service{Spec: corev1.ServiceSpec{
-					InternalTrafficPolicy: pointer(corev1.ServiceInternalTrafficPolicyCluster),
+					InternalTrafficPolicy:         pointer(corev1.ServiceInternalTrafficPolicyCluster),
+					ExternalTrafficPolicy:         corev1.ServiceExternalTrafficPolicyCluster,
+					AllocateLoadBalancerNodePorts: ptr.To(true),
 				}},
 			},
 			want: corev1.Service{Spec: corev1.ServiceSpec{
-				InternalTrafficPolicy: pointer(corev1.ServiceInternalTrafficPolicyCluster),
+				InternalTrafficPolicy:         pointer(corev1.ServiceInternalTrafficPolicyCluster),
+				ExternalTrafficPolicy:         corev1.ServiceExternalTrafficPolicyCluster,
+				AllocateLoadBalancerNodePorts: ptr.To(true),
 			}},
 		},
 		{
-			name: "Expected InternalTrafficPolicy is used if not empty",
+			name: "Expected InternalTrafficPolicy/ExternalTrafficPolicy/AllocateLoadBalancerPorts are used if not empty",
 			args: args{
 				expected: corev1.Service{Spec: corev1.ServiceSpec{
-					InternalTrafficPolicy: pointer(corev1.ServiceInternalTrafficPolicyLocal),
+					InternalTrafficPolicy:         pointer(corev1.ServiceInternalTrafficPolicyLocal),
+					ExternalTrafficPolicy:         corev1.ServiceExternalTrafficPolicyLocal,
+					AllocateLoadBalancerNodePorts: ptr.To(false),
 				}},
 				reconciled: corev1.Service{Spec: corev1.ServiceSpec{
-					InternalTrafficPolicy: pointer(corev1.ServiceInternalTrafficPolicyCluster),
+					InternalTrafficPolicy:         pointer(corev1.ServiceInternalTrafficPolicyCluster),
+					ExternalTrafficPolicy:         corev1.ServiceExternalTrafficPolicyCluster,
+					AllocateLoadBalancerNodePorts: ptr.To(true),
 				}},
 			},
 			want: corev1.Service{Spec: corev1.ServiceSpec{
-				InternalTrafficPolicy: pointer(corev1.ServiceInternalTrafficPolicyLocal),
+				InternalTrafficPolicy:         pointer(corev1.ServiceInternalTrafficPolicyLocal),
+				ExternalTrafficPolicy:         corev1.ServiceExternalTrafficPolicyLocal,
+				AllocateLoadBalancerNodePorts: ptr.To(false),
 			}},
 		},
 		{

--- a/pkg/controller/common/service_control_test.go
+++ b/pkg/controller/common/service_control_test.go
@@ -248,6 +248,20 @@ func Test_needsRecreate(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "No need to recreate if LoadBalancerClass has not changed",
+			args: args{
+				expected: corev1.Service{Spec: corev1.ServiceSpec{
+					Type:              corev1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: ptr.To("my-customer/lb"),
+				}},
+				reconciled: corev1.Service{Spec: corev1.ServiceSpec{
+					Type:              corev1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: ptr.To("my-customer/lb"),
+				}},
+			},
+			want: false,
+		},
+		{
 			name: "Needs recreate if LoadBalancerClass is changed",
 			args: args{
 				expected: corev1.Service{Spec: corev1.ServiceSpec{


### PR DESCRIPTION
Fixes  #7691

From the k8s docs: 

 > // loadBalancerClass is the class of the load balancer implementation this Service belongs to.
	// If specified, the value of this field must be a label-style identifier, with an optional prefix,
	// e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
	// This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
	// balancer implementation is used, today this is typically done through the cloud provider integration,
	// but should apply for any default implementation. If set, it is assumed that a load balancer
	// implementation is watching for Services with a matching class. Any default load balancer
	// implementation (e.g. cloud providers) should ignore Services that set this field.
	// This field can only be set when creating or updating a Service to type 'LoadBalancer'.
	// Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.

AWS EKS uses this field on EKS clusters > 1.24 that have upgraded to the new [AWS LoadBalancer Controller](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html)

Behaviour this PR should implement: 
* default the `loadBalancerClass` from the server side values if no value is set in the ECK service spec
* recreate the service if the value set in the ECK service spec differes from the server side value
* allow resetting the value only if the `type` of the service is no longer `LoadBalancer`