### PR TITLE
Beats index permissions compatibility with ECS index naming

### DIFF
--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -61,7 +61,7 @@ const (
 	V77 = "v77"
 
 	// Additional index permissions for Beats users
-	BeatsAdditionalPermissions = [string]{"logs-*"}
+	BeatsAdditionalPermissions = []string{"logs-*"}
 )
 
 var (

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -200,7 +200,7 @@ func init() {
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml", "read_ilm", "cluster:admin/ingest/pipeline/get"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{fmt.Sprintf("%s-*", beat)},
+					Names:      []string{fmt.Sprintf("%s-*", beat), "logs-*"},
 					Privileges: []string{"manage", "read", "create_doc", "view_index_metadata", "create_index"},
 				},
 			},
@@ -210,7 +210,7 @@ func init() {
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml", "read_ilm", "cluster:admin/ingest/pipeline/get"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{fmt.Sprintf("%s-*", beat)},
+					Names:      []string{fmt.Sprintf("%s-*", beat), "logs-*"},
 					Privileges: []string{"manage", "read", "create_doc", "view_index_metadata", "create_index"},
 				},
 			},
@@ -220,7 +220,7 @@ func init() {
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml", "read_ilm", "manage_pipeline"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{fmt.Sprintf("%s-*", beat)},
+					Names:      []string{fmt.Sprintf("%s-*", beat), "logs-*"},
 					Privileges: []string{"manage", "read", "index", "view_index_metadata", "create_index"},
 				},
 			},
@@ -230,7 +230,7 @@ func init() {
 			Cluster: []string{"manage_index_templates", "monitor", "manage_ilm", "manage_ml", "manage_pipeline"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{fmt.Sprintf("%s-*", beat)},
+					Names:      []string{fmt.Sprintf("%s-*", beat), "logs-*"},
 					Privileges: []string{"manage", "read", "index", "create_index"},
 				},
 			},
@@ -240,7 +240,7 @@ func init() {
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{fmt.Sprintf("%s-*", beat)},
+					Names:      []string{fmt.Sprintf("%s-*", beat), "logs-*"},
 					Privileges: []string{"manage", "read"},
 				},
 			},
@@ -250,7 +250,7 @@ func init() {
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{fmt.Sprintf("%s-*", beat)},
+					Names:      []string{fmt.Sprintf("%s-*", beat), "logs-*"},
 					Privileges: []string{"manage", "read"},
 				},
 			},
@@ -260,7 +260,7 @@ func init() {
 			Cluster: []string{"manage_index_templates", "monitor", "manage_ilm", "manage_ml"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{fmt.Sprintf("%s-*", beat)},
+					Names:      []string{fmt.Sprintf("%s-*", beat), "logs-*"},
 					Privileges: []string{"manage", "read"},
 				},
 			},

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -195,6 +195,15 @@ var (
 			},
 		},
 	}
+
+	// Additional index permissions for Beats users
+	BeatsAdditionalPermissions = map[string]string{
+		"filebeat":   "logs-*",
+		"metricbeat": "metrics-*",
+		"packetbeat": "logs-*",
+		"auditbeat":  "logs-*",
+		"heartbeat":  "synthetics-*",
+	}
 )
 
 func init() {
@@ -203,7 +212,7 @@ func init() {
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml", "read_ilm", "cluster:admin/ingest/pipeline/get"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions),
+					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions[beat]),
 					Privileges: []string{"manage", "read", "create_doc", "view_index_metadata", "create_index"},
 				},
 			},
@@ -213,7 +222,7 @@ func init() {
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml", "read_ilm", "cluster:admin/ingest/pipeline/get"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions),
+					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions[beat]),
 					Privileges: []string{"manage", "read", "create_doc", "view_index_metadata", "create_index"},
 				},
 			},
@@ -223,7 +232,7 @@ func init() {
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml", "read_ilm", "manage_pipeline"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions),
+					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions[beat]),
 					Privileges: []string{"manage", "read", "index", "view_index_metadata", "create_index"},
 				},
 			},
@@ -233,7 +242,7 @@ func init() {
 			Cluster: []string{"manage_index_templates", "monitor", "manage_ilm", "manage_ml", "manage_pipeline"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions),
+					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions[beat]),
 					Privileges: []string{"manage", "read", "index", "create_index"},
 				},
 			},
@@ -243,7 +252,7 @@ func init() {
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions),
+					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions[beat]),
 					Privileges: []string{"manage", "read"},
 				},
 			},
@@ -253,7 +262,7 @@ func init() {
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions),
+					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions[beat]),
 					Privileges: []string{"manage", "read"},
 				},
 			},
@@ -263,7 +272,7 @@ func init() {
 			Cluster: []string{"manage_index_templates", "monitor", "manage_ilm", "manage_ml"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions),
+					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions[beat]),
 					Privileges: []string{"manage", "read"},
 				},
 			},

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -59,9 +59,6 @@ const (
 
 	// V77 indicates version 7.7
 	V77 = "v77"
-
-	// Additional index permissions for Beats users
-	BeatsAdditionalPermissions = []string{"logs-*"}
 )
 
 var (

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -59,6 +59,9 @@ const (
 
 	// V77 indicates version 7.7
 	V77 = "v77"
+
+	// Additional index permissions for Beats users
+	BeatsAdditionalPermissions = [string]{"logs-*"}
 )
 
 var (
@@ -200,7 +203,7 @@ func init() {
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml", "read_ilm", "cluster:admin/ingest/pipeline/get"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{fmt.Sprintf("%s-*", beat), "logs-*"},
+					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions),
 					Privileges: []string{"manage", "read", "create_doc", "view_index_metadata", "create_index"},
 				},
 			},
@@ -210,7 +213,7 @@ func init() {
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml", "read_ilm", "cluster:admin/ingest/pipeline/get"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{fmt.Sprintf("%s-*", beat), "logs-*"},
+					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions),
 					Privileges: []string{"manage", "read", "create_doc", "view_index_metadata", "create_index"},
 				},
 			},
@@ -220,7 +223,7 @@ func init() {
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml", "read_ilm", "manage_pipeline"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{fmt.Sprintf("%s-*", beat), "logs-*"},
+					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions),
 					Privileges: []string{"manage", "read", "index", "view_index_metadata", "create_index"},
 				},
 			},
@@ -230,7 +233,7 @@ func init() {
 			Cluster: []string{"manage_index_templates", "monitor", "manage_ilm", "manage_ml", "manage_pipeline"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{fmt.Sprintf("%s-*", beat), "logs-*"},
+					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions),
 					Privileges: []string{"manage", "read", "index", "create_index"},
 				},
 			},
@@ -240,7 +243,7 @@ func init() {
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{fmt.Sprintf("%s-*", beat), "logs-*"},
+					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions),
 					Privileges: []string{"manage", "read"},
 				},
 			},
@@ -250,7 +253,7 @@ func init() {
 			Cluster: []string{"monitor", "manage_ilm", "manage_ml"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{fmt.Sprintf("%s-*", beat), "logs-*"},
+					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions),
 					Privileges: []string{"manage", "read"},
 				},
 			},
@@ -260,7 +263,7 @@ func init() {
 			Cluster: []string{"manage_index_templates", "monitor", "manage_ilm", "manage_ml"},
 			Indices: []esclient.IndexRole{
 				{
-					Names:      []string{fmt.Sprintf("%s-*", beat), "logs-*"},
+					Names:      append([]string{fmt.Sprintf("%s-*", beat)}, BeatsAdditionalPermissions),
 					Privileges: []string{"manage", "read"},
 				},
 			},


### PR DESCRIPTION
Grant beats additional default permissions allowing to create indexes that follow the Elastic Common Schema.

Closes #7692 which contains context for the change.

