### PR TITLE
Update elasticsearchRef when elastic is external instance in kibana.asciidoc

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -81,6 +81,8 @@ spec:
     elasticsearch.hosts:
       - https://elasticsearch.example.com:9200
     elasticsearch.username: elastic
+  elasticsearchRef:
+    name: ""
   secureSettings:
     - secretName: kibana-elasticsearch-credentials
 ----
@@ -104,6 +106,8 @@ spec:
     elasticsearch.ssl.certificateAuthorities: /etc/certs/ca.crt
   secureSettings:
     - secretName: kibana-elasticsearch-credentials
+  elasticsearchRef:
+    name: ""
   podTemplate:
     spec:
       volumes:


### PR DESCRIPTION
Set elasticsearchRef to "". Otherwise, operator won't create an instance, cause by default the instance has ref name "elasticsearch".
