### PR TITLE
bump serverless-docker-builder version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -67,7 +67,7 @@ steps:
     steps:
       - label: ":buildkite:"
         agents:
-          image: "docker.elastic.co/ci-agent-images/serverless-docker-builder:0.0.6"
+          image: "docker.elastic.co/ci-agent-images/serverless-docker-builder:0.0.11"
         commands: make -C /agent generate-docker-images
         env:
           DOCKER_REGISTRY_VAULT_PATH: secret/ci/elastic-cloud-on-k8s/docker-registry-elastic
@@ -80,7 +80,7 @@ steps:
     steps:
       - label: ":buildkite:"
         agents:
-          image: "docker.elastic.co/ci-agent-images/serverless-docker-builder:0.0.6"
+          image: "docker.elastic.co/ci-agent-images/serverless-docker-builder:0.0.11"
         commands: make -C /agent generate-docker-images
         env:
           DOCKER_REGISTRY_VAULT_PATH: secret/ci/elastic-cloud-on-k8s/docker-registry-elastic


### PR DESCRIPTION
The SSH key file referenced in the drivah config that the previous version of serverless-docker-builder creates is being removed from CI agents, bump to the latest version to avoid breaking image builds.
