### PR TITLE
Downgrade e2e monitoring agent

### DIFF
--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -5,7 +5,7 @@ metadata:
   name: e2e-agent
   namespace: {{ .E2ENamespace }}
 spec:
-  version: 8.13.2 # needs to less or equal to e2e-monitor version
+  version: 8.11.0 # needs to be less or equal to e2e-monitor version. Serverless reports 8.11.0 as its version.
   elasticsearchRefs:
     - secretName: eck-{{ .TestRun }}
   daemonSet:


### PR DESCRIPTION
I was analysing a e2e failure and noticed we did not have any data for the test in the e2e-monitor project. 