### PR TITLE
Bump GKE version in tests to 1.26, AKS 1.29

### DIFF
--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -3,7 +3,7 @@ plans:
   operation: create
   clusterName: ci
   provider: gke
-  kubernetesVersion: 1.28
+  kubernetesVersion: 1.26
   machineType: n1-standard-8
   serviceAccount: true
   enforceSecurityPolicies: true
@@ -18,7 +18,7 @@ plans:
   operation: create
   clusterName: ci-autopilot
   provider: gke
-  kubernetesVersion: 1.28
+  kubernetesVersion: 1.26
   serviceAccount: true
   enforceSecurityPolicies: true
   # this is disabled in autopilot: container provisioner is privileged; not allowed in Autopilot
@@ -32,7 +32,7 @@ plans:
   operation: create
   clusterName: dev
   provider: gke
-  kubernetesVersion: 1.28
+  kubernetesVersion: 1.26
   machineType: n1-standard-8
   serviceAccount: false
   enforceSecurityPolicies: true
@@ -59,7 +59,7 @@ plans:
   operation: create
   clusterName: dev-autopilot
   provider: gke
-  kubernetesVersion: 1.28
+  kubernetesVersion: 1.26
   serviceAccount: false
   enforceSecurityPolicies: true
   gke:

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -70,7 +70,7 @@ plans:
   operation: create
   clusterName: ci
   provider: aks
-  kubernetesVersion: 1.27.9
+  kubernetesVersion: 1.29.2
   machineType: Standard_D8s_v3
   serviceAccount: true
   enforceSecurityPolicies: true
@@ -83,7 +83,7 @@ plans:
   operation: create
   clusterName: dev
   provider: aks
-  kubernetesVersion: 1.27.9
+  kubernetesVersion: 1.29.2
   machineType: Standard_D8s_v3
   serviceAccount: false
   enforceSecurityPolicies: true

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -3,7 +3,7 @@ plans:
   operation: create
   clusterName: ci
   provider: gke
-  kubernetesVersion: 1.25
+  kubernetesVersion: 1.28
   machineType: n1-standard-8
   serviceAccount: true
   enforceSecurityPolicies: true
@@ -18,7 +18,7 @@ plans:
   operation: create
   clusterName: ci-autopilot
   provider: gke
-  kubernetesVersion: 1.25
+  kubernetesVersion: 1.28
   serviceAccount: true
   enforceSecurityPolicies: true
   # this is disabled in autopilot: container provisioner is privileged; not allowed in Autopilot
@@ -32,7 +32,7 @@ plans:
   operation: create
   clusterName: dev
   provider: gke
-  kubernetesVersion: 1.25
+  kubernetesVersion: 1.28
   machineType: n1-standard-8
   serviceAccount: false
   enforceSecurityPolicies: true
@@ -59,7 +59,7 @@ plans:
   operation: create
   clusterName: dev-autopilot
   provider: gke
-  kubernetesVersion: 1.25
+  kubernetesVersion: 1.28
   serviceAccount: false
   enforceSecurityPolicies: true
   gke:
@@ -118,7 +118,7 @@ plans:
   machineType: c5d.2xlarge
   serviceAccount: false
   enforceSecurityPolicies: true
-  kubernetesVersion: 1.25
+  kubernetesVersion: 1.28
   diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
   eks:
     region: ap-northeast-3
@@ -131,7 +131,7 @@ plans:
   machineType: m6gd.2xlarge
   serviceAccount: false
   enforceSecurityPolicies: true
-  kubernetesVersion: 1.25
+  kubernetesVersion: 1.28
   diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
   eks:
     region: eu-west-1
@@ -143,7 +143,7 @@ plans:
   provider: eks
   machineType: c5d.2xlarge
   serviceAccount: false
-  kubernetesVersion: 1.25
+  kubernetesVersion: 1.28
   enforceSecurityPolicies: true
   eks:
     region: eu-west-2

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -118,7 +118,7 @@ plans:
   machineType: c5d.2xlarge
   serviceAccount: false
   enforceSecurityPolicies: true
-  kubernetesVersion: 1.29
+  kubernetesVersion: 1.25
   diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
   eks:
     region: ap-northeast-3
@@ -131,7 +131,7 @@ plans:
   machineType: m6gd.2xlarge
   serviceAccount: false
   enforceSecurityPolicies: true
-  kubernetesVersion: 1.29
+  kubernetesVersion: 1.25
   diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
   eks:
     region: eu-west-1
@@ -143,7 +143,7 @@ plans:
   provider: eks
   machineType: c5d.2xlarge
   serviceAccount: false
-  kubernetesVersion: 1.29
+  kubernetesVersion: 1.25
   enforceSecurityPolicies: true
   eks:
     region: eu-west-2

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -118,7 +118,7 @@ plans:
   machineType: c5d.2xlarge
   serviceAccount: false
   enforceSecurityPolicies: true
-  kubernetesVersion: 1.28
+  kubernetesVersion: 1.29
   diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
   eks:
     region: ap-northeast-3
@@ -131,7 +131,7 @@ plans:
   machineType: m6gd.2xlarge
   serviceAccount: false
   enforceSecurityPolicies: true
-  kubernetesVersion: 1.28
+  kubernetesVersion: 1.29
   diskSetup: kubectl apply -f hack/deployer/config/local-disks/ssd-provisioner.yaml
   eks:
     region: eu-west-1
@@ -143,25 +143,12 @@ plans:
   provider: eks
   machineType: c5d.2xlarge
   serviceAccount: false
-  kubernetesVersion: 1.28
+  kubernetesVersion: 1.29
   enforceSecurityPolicies: true
   eks:
     region: eu-west-2
     nodeCount: 3
     nodeAMI: auto
-- id: e2e-monitor
-  operation: create
-  clusterName: e2e-monitor
-  provider: gke
-  kubernetesVersion: 1.15
-  machineType: n1-standard-8
-  serviceAccount: false
-  enforceSecurityPolicies: false
-  gke:
-    region: europe-west2
-    localSsdCount: 1
-    nodeCountPerZone: 1
-    gcpScopes: https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append
 - id: kind-dev
   operation: create
   clusterName: eck


### PR DESCRIPTION
1.25 is no longer available.