### PR TITLE
ECK Enterprise Search Helm Chart.

### DIFF
--- a/deploy/eck-stack/Chart.yaml
+++ b/deploy/eck-stack/Chart.yaml
@@ -27,3 +27,6 @@ dependencies:
   - name: eck-apm-server
     condition: eck-apm-server.enabled
     version: "0.11.0-SNAPSHOT"
+  - name: eck-enterprise-search
+    condition: eck-enterprise-search.enabled
+    version: "0.11.0-SNAPSHOT"

--- a/deploy/eck-stack/charts/eck-enterprise-search/.helmignore
+++ b/deploy/eck-stack/charts/eck-enterprise-search/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/eck-stack/charts/eck-enterprise-search/.helmignore
+++ b/deploy/eck-stack/charts/eck-enterprise-search/.helmignore
@@ -21,3 +21,4 @@
 .idea/
 *.tmproj
 .vscode/
+templates/tests

--- a/deploy/eck-stack/charts/eck-enterprise-search/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/Chart.yaml
@@ -6,5 +6,4 @@ type: application
 version: 0.11.0-SNAPSHOT
 sources:
   - https://github.com/elastic/cloud-on-k8s
-  - https://github.com/elastic/ent-search
 icon: https://github.com/elastic/ent-search/blob/main/public/app-search-favicon-196x196.png

--- a/deploy/eck-stack/charts/eck-enterprise-search/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: eck-enterprise-search
+description: Elastic Enterprise Search managed by the ECK operator
+kubeVersion: ">= 1.21.0-0"
+type: application
+version: 0.11.0-SNAPSHOT
+sources:
+  - https://github.com/elastic/cloud-on-k8s
+  - https://github.com/elastic/ent-search
+icon: https://github.com/elastic/ent-search/blob/main/public/app-search-favicon-196x196.png

--- a/deploy/eck-stack/charts/eck-enterprise-search/examples/with-custom-configuration.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/examples/with-custom-configuration.yaml
@@ -1,0 +1,19 @@
+config:
+  # define the exposed URL at which users will reach Enterprise Search
+  ent_search.external_url: https://my-custom-domain:3002
+  # define the exposed URL at which users will reach Kibana
+  kibana.host: https://kibana.my-custom-domain:5601
+  # configure app search document size limit
+  app_search.engine.document_size.limit: 100kb
+
+http:
+  service:
+    metadata:
+      labels:
+        my-custom: label
+  tls:
+    certificate:
+      secretName: my-cert
+
+elasticsearchRef:
+  name: eck-elasticsearch

--- a/deploy/eck-stack/charts/eck-enterprise-search/templates/_helpers.tpl
+++ b/deploy/eck-stack/charts/eck-enterprise-search/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "eck-enterprise-search.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "eck-enterprise-search.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "eck-enterprise-search.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "eck-enterprise-search.labels" -}}
+helm.sh/chart: {{ include "eck-enterprise-search.chart" . }}
+{{ include "eck-enterprise-search.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "eck-enterprise-search.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "eck-enterprise-search.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "eck-enterprise-search.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "eck-enterprise-search.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/eck-stack/charts/eck-enterprise-search/templates/enterprisesearch.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/templates/enterprisesearch.yaml
@@ -17,7 +17,9 @@ spec:
   version: {{ required "An Enterprise Search version is required" .Values.version }}
   count: {{ required "A pod count is required" .Values.count }}
 
-  # This is complicated, but seems required to catch both the situations where the key does not exist (commented out), and the key exists but is an empty map.
+  {{- /*
+    This is complicated, but seems required to catch both the situations where the key does not exist (commented out), and the key exists but is an empty map.
+  */ -}}
   {{- if and (or (and (hasKey .Values "configRef") (eq 0 (len .Values.configRef))) (not (hasKey .Values "configRef"))) (or (and (hasKey .Values "elasticsearchRef") (eq 0 (len .Values.elasticsearchRef))) (not (hasKey .Values "elasticsearchRef"))) }}
   {{ fail "At least one of configRef or elasticsearchRef is required" }}
   {{- end }}

--- a/deploy/eck-stack/charts/eck-enterprise-search/templates/enterprisesearch.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/templates/enterprisesearch.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: enterprisesearch.k8s.elastic.co/v1
+kind: EnterpriseSearch
+metadata:
+  name: {{ include "eck-enterprise-search.fullname" . }}
+  labels:
+    {{- include "eck-enterprise-search.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    eck.k8s.elastic.co/license: basic
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  version: {{ required "An Enterprise Search version is required" .Values.version }}
+  count: {{ required "A pod count is required" .Values.count }}
+
+  # This is complicated, but seems required to catch both the situations where the key does not exist (commented out), and the key exists but is an empty map.
+  {{- if and (or (and (hasKey .Values "configRef") (eq 0 (len .Values.configRef))) (not (hasKey .Values "configRef"))) (or (and (hasKey .Values "elasticsearchRef") (eq 0 (len .Values.elasticsearchRef))) (not (hasKey .Values "elasticsearchRef"))) }}
+  {{ fail "At least one of configRef or elasticsearchRef is required" }}
+  {{- end }}
+
+  {{- with .Values.image }}
+  image: {{ . }}
+  {{- end }}
+
+  {{- with .Values.serviceAccountName }}
+  serviceAccountName: {{ . }}
+  {{- end }}
+
+  {{- with .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
+
+  {{- with .Values.config }}
+  config:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.http }}
+  http:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.elasticsearchRef }}
+  elasticsearchRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.podTemplate }}
+  podTemplate:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.configRef }}
+  configRef:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/deploy/eck-stack/charts/eck-enterprise-search/templates/tests/entsearch_test.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/templates/tests/entsearch_test.yaml
@@ -1,0 +1,105 @@
+suite: test enterprise search
+templates:
+  - templates/enterprisesearch.yaml
+tests:
+  - it: should render quickstart properly
+    set:
+      elasticsearchRef:
+        name: eck-elasticsearch
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: EnterpriseSearch
+      - equal:
+          path: metadata.name
+          value: quickstart-eck-enterprise-search
+      - equal:
+          path: spec.version
+          value: 8.14.0-SNAPSHOT
+  - it: name override should work properly
+    set:
+      nameOverride: override
+      elasticsearchRef:
+        name: eck-elasticsearch
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: EnterpriseSearch
+      - equal:
+          path: metadata.name
+          value: quickstart-override
+  - it: fullname override should work properly
+    set:
+      fullnameOverride: override
+      elasticsearchRef:
+        name: eck-elasticsearch
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: EnterpriseSearch
+      - equal:
+          path: metadata.name
+          value: override
+  - it: should render custom labels, and annotations values properly
+    set:
+      labels:
+        test: label
+      annotations:
+        test: annotation
+      elasticsearchRef:
+        name: eck-elasticsearch
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: EnterpriseSearch
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: quickstart
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: eck-enterprise-search
+            helm.sh/chart: eck-enterprise-search-0.11.0-SNAPSHOT
+            test: label
+      - equal:
+          path: metadata.annotations
+          value:
+            eck.k8s.elastic.co/license: basic
+            test: annotation
+  - it: should render http service properly
+    set:
+      elasticsearchRef.namespace: default
+    values:
+      - ../../examples/with-custom-configuration.yaml
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: EnterpriseSearch
+      - equal:
+          path: metadata.name
+          value: quickstart-eck-enterprise-search
+      - equal:
+          path: spec.version
+          value: 8.14.0-SNAPSHOT
+      - equal:
+          path: spec.count
+          value: 1
+      - equal:
+          path: spec.elasticsearchRef.name
+          value: eck-elasticsearch
+      - equal:
+          path: spec.config
+          value:
+            app_search.engine.document_size.limit: 100kb
+            ent_search.external_url: https://my-custom-domain:3002
+            kibana.host: https://kibana.my-custom-domain:5601
+      - equal:
+          path: spec.http.service.metadata.labels.my-custom
+          value: label
+      - equal:
+          path: spec.http.tls.certificate.secretName
+          value: my-cert

--- a/deploy/eck-stack/charts/eck-enterprise-search/templates/tests/entsearch_test.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/templates/tests/entsearch_test.yaml
@@ -103,3 +103,11 @@ tests:
       - equal:
           path: spec.http.tls.certificate.secretName
           value: my-cert
+  - it: not setting elasticsearchRef should fail
+    set:
+      volumeClaimDeletePolicy: invalid
+    release:
+      name: quickstart
+    asserts:
+      - failedTemplate:
+          errorMessage: At least one of configRef or elasticsearchRef is required

--- a/deploy/eck-stack/charts/eck-enterprise-search/values.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/values.yaml
@@ -44,8 +44,15 @@ count: 1
 
 # The Enterprise Search configuration, the ECK equivalent to enterprise-search.yml
 # ref: https://www.elastic.co/guide/en/enterprise-search/current/configuration.html#configuration-configure
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-enterprise-search-configuration.html
+#
+# At a minimum, you must specify the external URL and Kibana host.
 #
 config: {}
+  # define the exposed URL at which users will reach Enterprise Search
+  # ent_search.external_url: https://my-custom-domain:3002
+  # define the exposed URL at which users will reach Kibana
+  # kibana.host: https://kibana.my-custom-domain:5601
 
 # Settings to control how Enterprise Search will be accessed.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-accessing-elastic-services.html
@@ -86,4 +93,4 @@ podTemplate: {}
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-enterprise-search-configuration.html#k8s-enterprise-search-connect-non-eck-es
 #
 configRef: {}
-  # secretName: elasticsearch-credentials
+  # secretName: enterprise-search-config

--- a/deploy/eck-stack/charts/eck-enterprise-search/values.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/values.yaml
@@ -1,0 +1,89 @@
+---
+# Default values for eck-enterprise-search.
+# This is a YAML-formatted file.
+
+# Overridable names of the Enterprise Search resource.
+# By default, this is the Release name set for the chart,
+# followed by 'eck-enterprise-search'.
+#
+# nameOverride will override the name of the Chart with the name set here,
+# so nameOverride: quickstart, would convert to '{{ Release.name }}-quickstart'
+#
+# nameOverride: "quickstart"
+#
+# fullnameOverride will override both the release name, and the chart name,
+# and will name the Enterprise Search resource exactly as specified.
+#
+# fullnameOverride: "quickstart"
+
+# Version of Enterprise Search.
+#
+version: 8.14.0-SNAPSHOT
+
+# Enterprise Search Docker image to deploy
+#
+# image:
+
+# Used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.
+# Can only be used if ECK is enforcing RBAC on references.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-restrict-cross-namespace-associations.html
+#
+# serviceAccountName: ""
+
+# Labels that will be applied to Enterprise Search.
+#
+labels: {}
+
+# Annotations that will be applied to Enterprise Search.
+#
+annotations: {}
+
+# Count of Enterprise Search replicas to create.
+#
+count: 1
+
+# The Enterprise Search configuration, the ECK equivalent to enterprise-search.yml
+# ref: https://www.elastic.co/guide/en/enterprise-search/current/configuration.html#configuration-configure
+#
+config: {}
+
+# Settings to control how Enterprise Search will be accessed.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-accessing-elastic-services.html
+#
+http: {}
+  # tls:
+  #   certificate:
+  #     secretName: my-cert
+  # service:
+  #   metadata:
+  #     labels:
+  #       my-custom: label
+
+# Reference to ECK-managed Elasticsearch resource.
+#
+elasticsearchRef: {}
+  # name: eck-elasticsearch
+  # Optional namespace reference to Elasticsearch resource.
+  # If not specified, then the namespace of the Enterprise Search resource
+  # will be assumed.
+  #
+  # namespace: default
+
+# Set podTemplate to customize the pod used by Enterprise Search
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-customize-pods.html
+#
+podTemplate: {}
+
+# Number of revisions to retain to allow rollback in the underlying Deployment.
+# If not set Kubernetes sets this to 10 by default.
+#
+# revisionHistoryLimit: 2
+
+# If you would prefer your sensitive data to be stored in a Secret, you can specify the name of the Secret reference.
+# In addition, if you do not want to use the `elasticsearchRef` mechanism or if you want to connect to an Elasticsearch
+# cluster not managed by ECK, you can manually configure Enterprise Search to access any available Elasticsearch cluster:
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-enterprise-search-configuration.html#k8s-enterprise-search-secret-configuration
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-enterprise-search-configuration.html#k8s-enterprise-search-connect-non-eck-es
+#
+configRef: {}
+  # secretName: elasticsearch-credentials

--- a/deploy/eck-stack/examples/enterprise-search/basic.yaml
+++ b/deploy/eck-stack/examples/enterprise-search/basic.yaml
@@ -34,7 +34,7 @@ eck-kibana:
 eck-enterprise-search:
   enabled: true
 
-  # Name of the Kibana instance.
+  # Name of the Enterprise Search instance.
   #
   fullnameOverride: enterprise-search
 

--- a/deploy/eck-stack/examples/enterprise-search/basic.yaml
+++ b/deploy/eck-stack/examples/enterprise-search/basic.yaml
@@ -1,0 +1,42 @@
+---
+eck-elasticsearch:
+  enabled: true
+
+  # Name of the Elasticsearch instance.
+  #
+  fullnameOverride: elasticsearch
+
+  nodeSets:
+  - name: default
+    count: 3
+    # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+    # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+    # and leave node.store.allow_mmap unset.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+    #
+    config:
+      node.store.allow_mmap: false
+
+eck-kibana:
+  enabled: true
+
+  # Name of the Kibana instance.
+  #
+  fullnameOverride: kibana
+
+  elasticsearchRef:
+    name: elasticsearch
+
+  spec:
+    enterpriseSearchRef:
+      name: enterprise-search
+
+eck-enterprise-search:
+  enabled: true
+
+  # Name of the Kibana instance.
+  #
+  fullnameOverride: enterprise-search
+
+  elasticsearchRef:
+    name: elasticsearch

--- a/deploy/eck-stack/examples/enterprise-search/with-custom-configuration.yaml
+++ b/deploy/eck-stack/examples/enterprise-search/with-custom-configuration.yaml
@@ -30,10 +30,6 @@ eck-kibana:
   spec:
     enterpriseSearchRef:
       name: enterprise-search
-    config:
-      xpack.fleet.packages:
-      - name: apm
-        version: latest
 
 eck-enterprise-search:
   enabled: true

--- a/deploy/eck-stack/examples/enterprise-search/with-custom-configuration.yaml
+++ b/deploy/eck-stack/examples/enterprise-search/with-custom-configuration.yaml
@@ -34,7 +34,7 @@ eck-kibana:
 eck-enterprise-search:
   enabled: true
 
-  # Name of the Kibana instance.
+  # Name of the Enterprise Search instance.
   #
   fullnameOverride: enterprise-search
 

--- a/deploy/eck-stack/examples/enterprise-search/with-custom-values.yaml
+++ b/deploy/eck-stack/examples/enterprise-search/with-custom-values.yaml
@@ -1,0 +1,56 @@
+---
+eck-elasticsearch:
+  enabled: true
+
+  # Name of the Elasticsearch instance.
+  #
+  fullnameOverride: elasticsearch
+
+  nodeSets:
+  - name: default
+    count: 3
+    # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+    # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+    # and leave node.store.allow_mmap unset.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+    #
+    config:
+      node.store.allow_mmap: false
+
+eck-kibana:
+  enabled: true
+
+  # Name of the Kibana instance.
+  #
+  fullnameOverride: kibana
+
+  elasticsearchRef:
+    name: elasticsearch
+
+  spec:
+    enterpriseSearchRef:
+      name: enterprise-search
+    config:
+      xpack.fleet.packages:
+      - name: apm
+        version: latest
+
+eck-enterprise-search:
+  enabled: true
+
+  # Name of the Kibana instance.
+  #
+  fullnameOverride: enterprise-search
+
+  config:
+    # configure app search document size limit
+    app_search.engine.document_size.limit: 100kb
+
+  http:
+    service:
+      metadata:
+        labels:
+          my-custom: label
+
+  elasticsearchRef:
+    name: elasticsearch

--- a/deploy/eck-stack/values.yaml
+++ b/deploy/eck-stack/values.yaml
@@ -44,3 +44,8 @@ eck-logstash:
 #
 eck-apm-server:
   enabled: false
+
+# If enabled, will use the eck-enterprise-search chart and deploy a Enterprise Search resource.
+#
+eck-enterprise-search:
+  enabled: false

--- a/docs/orchestrating-elastic-stack-applications/stack-helm-chart.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/stack-helm-chart.asciidoc
@@ -85,6 +85,19 @@ helm install eck-stack-with-apm-server elastic/eck-stack \
 ----
 
 [float]
+[id="{p}-install-enterprise-search-elasticsearch-kibana-helm"]
+== Installing an Elastic Enterprise Search Server along with Elasticsearch and Kibana using the eck-stack Helm Chart
+
+The following section builds upon the previous sections, and allows installing an Elastic Enterprise Search Server along with Elasticsearch and Kibana.
+
+[source,sh,subs="attributes"]
+----
+# Install an eck-managed Elasticsearch, Kibana, and Enterprise Search Server using custom values.
+helm install eck-stack-with-enterprise-search elastic/eck-stack \
+    --values https://raw.githubusercontent.com/elastic/cloud-on-k8s/{eck_release_branch}/deploy/enterprise-search/examples/enterprise-search/basic.yaml -n elastic-stack
+----
+
+[float]
 [id="{p}-eck-stack-individual-components"]
 === Installing individual components of the Elastic Stack using the Helm Charts
 

--- a/docs/orchestrating-elastic-stack-applications/stack-helm-chart.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/stack-helm-chart.asciidoc
@@ -94,7 +94,7 @@ The following section builds upon the previous sections, and allows installing a
 ----
 # Install an eck-managed Elasticsearch, Kibana, and Enterprise Search Server using custom values.
 helm install eck-stack-with-enterprise-search elastic/eck-stack \
-    --values https://raw.githubusercontent.com/elastic/cloud-on-k8s/{eck_release_branch}/deploy/enterprise-search/examples/enterprise-search/basic.yaml -n elastic-stack
+    --values https://raw.githubusercontent.com/elastic/cloud-on-k8s/{eck_release_branch}/deploy/eck-stack/examples/enterprise-search/basic.yaml -n elastic-stack
 ----
 
 [float]


### PR DESCRIPTION
## What is this change?

This adds an ECK EnterpriseSearch Helm Chart for deploying Enterprise Search instances using the ECK Operator.

## Testing

Installing with stack version `8.13.2` seems to work without issues (snapshot versions aren't quite working)
```
❯ helm upgrade -i eck-stack . -n elastic --create-namespace -f examples/enterprise-search/with-custom-configuration.yaml --set=eck-elasticsearch.version=8.13.2 --set=eck-kibana.version=8.13.2 --set=eck-enterprise-search.version=8.13.2
false
Release "eck-stack" has been upgraded. Happy Helming!
NAME: eck-stack
LAST DEPLOYED: Wed Apr 24 13:55:06 2024
NAMESPACE: elastic
STATUS: deployed
REVISION: 4
TEST SUITE: None
NOTES:
Elasticsearch ECK-Stack 0.11.0-SNAPSHOT has been deployed successfully!

To see status of all resources, run

kubectl get elastic -n elastic -l "app.kubernetes.io/instance"=eck-stack

More information on the Elastic ECK Operator, and its Helm chart can be found
within our documentation.

https://www.elastic.co/guide/en/cloud-on-k8s/current/index.html
```

Everything becomes healthy:
```
❯ kgp -n elastic
NAME                                    READY   STATUS    RESTARTS   AGE
elasticsearch-es-default-0              1/1     Running   0          3h40m
elasticsearch-es-default-1              1/1     Running   0          3h40m
elasticsearch-es-default-2              1/1     Running   0          3h40m
enterprise-search-ent-fc96ddf54-6dbks   1/1     Running   0          3h30m
kibana-kb-854b7dc9b4-fvlzb              1/1     Running   0          81s
```

All components green
```
❯ kubectl get elastic -n elastic -l "app.kubernetes.io/instance"=eck-stack
NAME                                                       HEALTH   NODES   VERSION   PHASE   AGE
elasticsearch.elasticsearch.k8s.elastic.co/elasticsearch   green    3       8.13.2    Ready   3h40m

NAME                                                                 HEALTH   NODES   VERSION   AGE
enterprisesearch.enterprisesearch.k8s.elastic.co/enterprise-search   green    1       8.13.2    3h40m

NAME                                  HEALTH   NODES   VERSION   AGE
kibana.kibana.k8s.elastic.co/kibana   green    1       8.13.2    3h40m
```

Required `elasticsearchRef` or `configRef` works: (i tried all variations of this from values commented out, to just being empty for one/both)
```
❯ helm template ent-search . -s templates/enterprisesearch.yaml
Error: execution error at (eck-enterprise-search/templates/enterprisesearch.yaml:22:5): At least one of configRef or elasticsearchRef is required
```

Enterprise Search integration with Kibana seems to work:
![image](https://github.com/elastic/cloud-on-k8s/assets/4429174/9e75b3e9-8200-4683-bb9a-85ab86029fcb)

TODO:
- [x] additional verification/testing.
- [x] Documentation