### PR TITLE
Do not assume cgroup mem info present

### DIFF
--- a/test/e2e/test/elasticsearch/checks_es.go
+++ b/test/e2e/test/elasticsearch/checks_es.go
@@ -349,6 +349,12 @@ func compareCgroupMemoryLimit(topologyElement esv1.NodeSet, nodeStats client.Nod
 		// no expected memory, consider it's ok
 		return nil
 	}
+
+	if len(nodeStats.OS.CGroup.Memory.LimitInBytes) == 0 {
+		// no cgroup info (e.g. on GKE 1.26+) consider it ok.
+		return nil
+	}
+
 	// ES returns a string, parse it as an int64, base10
 	actualCgroupMemoryLimit, err := strconv.ParseInt(
 		nodeStats.OS.CGroup.Memory.LimitInBytes, 10, 64,

--- a/test/e2e/test/elasticsearch/checks_es.go
+++ b/test/e2e/test/elasticsearch/checks_es.go
@@ -351,7 +351,8 @@ func compareCgroupMemoryLimit(topologyElement esv1.NodeSet, nodeStats client.Nod
 	}
 
 	if len(nodeStats.OS.CGroup.Memory.LimitInBytes) == 0 {
-		// no cgroup info (e.g. on GKE 1.26+) consider it ok.
+		// Elasticsearch versions before 7.16 cannot parse cgroup v2 information and
+		// will have no information in this field. Considering it ok.
 		return nil
 	}
 


### PR DESCRIPTION
It seems that on k8s > 1.26 (GKE)  the Elasticsearch node_stats response no longer contains cgroup information on 6.8.23. 

Older versions of Elasticsearch < 7.16  cannot parse cgroup v2 structures and have no cgroup information. 
https://github.com/elastic/elasticsearch/blob/4f67856884ff580d8b48a858411b8c17cb0f8cdb/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java#L499-L513