### PR TITLE
Extend cgroup version gate to all cgroup comparisons

### DIFF
--- a/pkg/controller/elasticsearch/client/model.go
+++ b/pkg/controller/elasticsearch/client/model.go
@@ -111,16 +111,18 @@ type NodesStats struct {
 type NodeStats struct {
 	Name string `json:"name"`
 	OS   struct {
-		CGroup struct {
-			Memory struct {
-				LimitInBytes string `json:"limit_in_bytes"`
-			} `json:"memory"`
-			CPU struct {
-				CFSPeriodMicros int `json:"cfs_period_micros"`
-				CFSQuotaMicros  int `json:"cfs_quota_micros"`
-			} `json:"cpu"`
-		} `json:"cgroup"`
+		CGroup *CGroup `json:"cgroup"`
 	} `json:"os"`
+}
+
+type CGroup struct {
+	Memory struct {
+		LimitInBytes string `json:"limit_in_bytes"`
+	} `json:"memory"`
+	CPU struct {
+		CFSPeriodMicros int `json:"cfs_period_micros"`
+		CFSQuotaMicros  int `json:"cfs_quota_micros"`
+	} `json:"cpu"`
 }
 
 // ClusterStateNode represents an element in the `node` structure in

--- a/test/e2e/test/elasticsearch/checks_es.go
+++ b/test/e2e/test/elasticsearch/checks_es.go
@@ -358,7 +358,8 @@ func canCompareCgroupLimits(nodeStats client.NodeStats, nodeVersion string) (boo
 		// will have no information in this field. Considering it ok.
 		return false, nil
 	}
-	return true, nil
+	// nok: cgroup is nil but we are on a version that should correctly be able to parse the cgroup data
+	return false, fmt.Errorf("Unexpected: no cgroup information in node stats response")
 }
 
 // compareCgroupMemoryLimit compares the memory limit specified in a nodeSet with the limit set in the memory control group at the OS level


### PR DESCRIPTION
https://github.com/elastic/cloud-on-k8s/pull/7750 had a few flaws: 

* I did allow the CPU related cgroup comparisons to do ahead even if we had no cgroup data
* On k8s versions running cgroup v1 the cgroup based comparison was unnecessarily skipped

This PR tries to address these problems by:

* modelling the cgroup section as optional in the API to check for its presence
* gating all cgroup based comparisons on the presence of the cgroup info in node stats if running ES < 7.16
* but make the absence of cgroup information an error for ES versions that should support it