### PR TITLE
Make autopilot e2e test run on 1.26

### DIFF
--- a/config/e2e/e2e_job.yaml
+++ b/config/e2e/e2e_job.yaml
@@ -61,8 +61,6 @@ spec:
           env:
             - name: GOCACHE
               value: "/tmp/go-cache/"
-            - name: GOMODCACHE
-              value: "/tmp/go-mod-cache"
             - name: E2E_JSON
               value: "{{ .Context.LogToFile }}"
             - name: E2E_TAGS

--- a/config/e2e/e2e_job.yaml
+++ b/config/e2e/e2e_job.yaml
@@ -61,6 +61,8 @@ spec:
           env:
             - name: GOCACHE
               value: "/tmp/go-cache/"
+            - name: GOMODCACHE
+              value: "/tmp/go-mod-cache"
             - name: E2E_JSON
               value: "{{ .Context.LogToFile }}"
             - name: E2E_TAGS

--- a/config/e2e/e2e_job.yaml
+++ b/config/e2e/e2e_job.yaml
@@ -59,6 +59,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
           env:
+            - name: GOCACHE
+              value: "/tmp/go-cache/"
             - name: E2E_JSON
               value: "{{ .Context.LogToFile }}"
             - name: E2E_TAGS

--- a/config/e2e/e2e_job.yaml
+++ b/config/e2e/e2e_job.yaml
@@ -59,8 +59,6 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
           env:
-            - name: GOCACHE
-              value: "/tmp/go-cache/"
             - name: E2E_JSON
               value: "{{ .Context.LogToFile }}"
             - name: E2E_TAGS

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -240,12 +240,9 @@ func isOcpCluster(h *helper) bool {
 	return err == nil
 }
 
-// isAutopilotCluster will detect whether we are running within an autopilot cluster
-// by using the `remotenodes` resource, which only seems to exist on autopilot clusters
-// not standard GKE clusters.
+// isAutopilotCluster convenience function to check the provider value for the string gke-autopilot.
 func isAutopilotCluster(h *helper) bool {
-	_, _, err := h.kubectl("get", "remotenodes")
-	return err == nil
+	return strings.HasPrefix(h.provider, "gke-autopilot")
 }
 
 func (h *helper) initTestSecrets() error {


### PR DESCRIPTION
Fixes #7751 