### PR TITLE
Use new release of eck-diagnostics (1.7.0)

### DIFF
--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -5,7 +5,7 @@ ARG GO_TAGS
 
 WORKDIR /go/src/github.com/elastic/cloud-on-k8s
 
-ENV ECK_DIAG_VERSION=1.5.2
+ENV ECK_DIAG_VERSION=1.7.0
 RUN curl -fsSLO https://github.com/elastic/eck-diagnostics/releases/download/${ECK_DIAG_VERSION}/eck-diagnostics_${ECK_DIAG_VERSION}_Linux_x86_64.tar.gz && \
     tar xzf eck-diagnostics_${ECK_DIAG_VERSION}_Linux_x86_64.tar.gz && \
     mv eck-diagnostics /usr/local/bin/eck-diagnostics


### PR DESCRIPTION
Since the release of the new version of eck-diagnostics, we need to update our e2e tests to use this new version.