### PR TITLE
Fix webhook certname in helm template

### DIFF
--- a/deploy/eck-operator/templates/_helpers.tpl
+++ b/deploy/eck-operator/templates/_helpers.tpl
@@ -96,6 +96,8 @@ Determine the name for the webhook secret
 {{- define "eck-operator.webhookSecretName" -}}
 {{- if .Values.global.manifestGen -}}
 elastic-webhook-server-cert
+{{- else if .Values.webhook.certsSecret -}}
+{{- .Values.webhook.certsSecret }}
 {{- else -}}
 {{- $name := include "eck-operator.name" . -}}
 {{ printf "%s-webhook-cert" $name | trunc 63 }}

--- a/deploy/eck-operator/templates/configmap.yaml
+++ b/deploy/eck-operator/templates/configmap.yaml
@@ -79,6 +79,6 @@ data:
     {{- if not .Values.config.containerSuffix }}
     ubi-only: {{ .Values.config.ubiOnly }}
     {{- end }}
-    {{- with .Values.webhook.secret }}
+    {{- with .Values.webhook.certsSecret }}
     webhook-secret: {{ . }}
     {{- end }}

--- a/deploy/eck-operator/templates/tests/statefulset_test.yaml
+++ b/deploy/eck-operator/templates/tests/statefulset_test.yaml
@@ -42,3 +42,25 @@ tests:
             app.kubernetes.io/version: 2.14.0-SNAPSHOT
             helm.sh/chart: eck-operator-2.14.0-SNAPSHOT
             key2: value2
+  - it: should use the specified webhook secret name
+    set:
+      webhook:
+        manageCerts: false
+        certsSecret: "my-webhook-server-cert"
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.volumes[1].name
+          value: cert
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.volumes[1].secret.secretName
+          value: my-webhook-server-cert
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: WEBHOOK_SECRET
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].env[2].value
+          value: my-webhook-server-cert

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -140,7 +140,7 @@ webhook:
   # port is the port that the validating webhook binds to.
   port: 9443
   # secret specifies the Kubernetes secret to be mounted into the path designated by the certsDir value to be used for webhook certificates.
-  secret: ""
+  certsSecret: ""
 
 # hostNetwork allows a Pod to use the Node network namespace.
 # This is required to allow for communication with the kube API when using some alternate CNIs in conjunction with webhook enabled.


### PR DESCRIPTION
fixes: #7771  where the webhook secret name was not being set correctly in the _helpers file.
Also renaming `webhook.secret` to `webhook.certsSecret` to match what is there in our documentation.