### PR TITLE
Fix diagnostic role pre-8.5

### DIFF
--- a/pkg/controller/elasticsearch/user/predefined.go
+++ b/pkg/controller/elasticsearch/user/predefined.go
@@ -97,7 +97,11 @@ func reconcileInternalUsers(
 		return nil, fmt.Errorf("while parsing Elasticsearch version (%s): %w", es.Spec.Version, err)
 	}
 	if ver.LT(version.From(8, 5, 0)) {
-		users[4].Roles = []string{DiagnosticsUserRoleV7}
+		// Diagnostics user needs superuser role in 7.x.
+		users[4].Roles = []string{SuperUserBuiltinRole}
+		if ver.GTE(version.From(8, 0, 0)) {
+			users[4].Roles = []string{DiagnosticsUserRoleV80}
+		}
 	}
 	return reconcilePredefinedUsers(
 		ctx,

--- a/pkg/controller/elasticsearch/user/predefined_test.go
+++ b/pkg/controller/elasticsearch/user/predefined_test.go
@@ -168,7 +168,7 @@ func Test_reconcileElasticUser_conditionalCreation(t *testing.T) {
 }
 
 func Test_reconcileInternalUsers(t *testing.T) {
-	es := esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es"}}
+	es := esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es"}, Spec: esv1.ElasticsearchSpec{Version: "8.10.0"}}
 	tests := []struct {
 		name              string
 		existingSecrets   []client.Object

--- a/pkg/controller/elasticsearch/user/reconcile_test.go
+++ b/pkg/controller/elasticsearch/user/reconcile_test.go
@@ -129,6 +129,6 @@ func Test_aggregateRoles(t *testing.T) {
 	c := k8s.NewFakeClient(sampleUserProvidedRolesSecret...)
 	roles, err := aggregateRoles(context.Background(), c, sampleEsWithAuth, initDynamicWatches(), record.NewFakeRecorder(10))
 	require.NoError(t, err)
-	require.Len(t, roles, 56)
+	require.Len(t, roles, 57)
 	require.Contains(t, roles, ProbeUserRole, ClusterManageRole, "role1", "role2")
 }

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -26,8 +26,11 @@ const (
 	ProbeUserRole = "elastic_internal_probe_user"
 	// RemoteMonitoringCollectorBuiltinRole is the name of the built-in remote_monitoring_collector role.
 	RemoteMonitoringCollectorBuiltinRole = "remote_monitoring_collector"
-	// DiagnosticsUserRole is the name of the built-in role for ECK diagnostics use.
-	DiagnosticsUserRole = "elastic_internal_diagnostics"
+
+	// DiagnosticsUserRoleV7 is the name of the built-in role for ECK diagnostics use from version 7.x to 8.4.
+	DiagnosticsUserRoleV7 = "elastic_internal_diagnostics_v7"
+	// DiagnosticsUserRoleV85 is the name of the built-in role for ECK diagnostics use from version 8.5.
+	DiagnosticsUserRoleV85 = "elastic_internal_diagnostics_v85"
 
 	// ApmUserRoleV6 is the name of the role used by 6.8.x APMServer instances to connect to Elasticsearch.
 	ApmUserRoleV6 = "eck_apm_user_role_v6"
@@ -65,49 +68,56 @@ const (
 )
 
 var (
+	diagnosticsRoleIndices = []esclient.IndexRole{
+		{
+			Names:                  []string{"*"},
+			Privileges:             []string{"monitor", "read", "view_index_metadata"},
+			AllowRestrictedIndices: ptr.To[bool](true),
+		},
+	}
+	diagnosticsAppsKibanaPrivileges = []esclient.ApplicationRole{
+		{
+			Application: "kibana-.kibana",
+			Resources:   []string{"*"},
+			Privileges: []string{
+				"feature_ml.read",
+				"feature_siem.read",
+				"feature_siem.read_alerts",
+				"feature_siem.policy_management_read",
+				"feature_siem.endpoint_list_read",
+				"feature_siem.trusted_applications_read",
+				"feature_siem.event_filters_read",
+				"feature_siem.host_isolation_exceptions_read",
+				"feature_siem.blocklist_read",
+				"feature_siem.actions_log_management_read",
+				"feature_securitySolutionCases.read",
+				"feature_securitySolutionAssistant.read",
+				"feature_actions.read",
+				"feature_builtInAlerts.read",
+				"feature_fleet.all",
+				"feature_fleetv2.all",
+				"feature_osquery.read",
+				"feature_indexPatterns.read",
+				"feature_discover.read",
+				"feature_dashboard.read",
+				"feature_maps.read",
+				"feature_visualize.read",
+			},
+		},
+	}
 	// PredefinedRoles to create for internal needs.
 	PredefinedRoles = RolesFileContent{
 		ProbeUserRole:     esclient.Role{Cluster: []string{"monitor"}},
 		ClusterManageRole: esclient.Role{Cluster: []string{"manage"}},
-		DiagnosticsUserRole: esclient.Role{
-			Cluster: []string{"monitor", "monitor_snapshot", "manage", "read_ilm", "read_security"},
-			Indices: []esclient.IndexRole{
-				{
-					Names:                  []string{"*"},
-					Privileges:             []string{"monitor", "read", "view_index_metadata"},
-					AllowRestrictedIndices: ptr.To[bool](true),
-				},
-			},
-			Applications: []esclient.ApplicationRole{
-				{
-					Application: "kibana-.kibana",
-					Resources:   []string{"*"},
-					Privileges: []string{
-						"feature_ml.read",
-						"feature_siem.read",
-						"feature_siem.read_alerts",
-						"feature_siem.policy_management_read",
-						"feature_siem.endpoint_list_read",
-						"feature_siem.trusted_applications_read",
-						"feature_siem.event_filters_read",
-						"feature_siem.host_isolation_exceptions_read",
-						"feature_siem.blocklist_read",
-						"feature_siem.actions_log_management_read",
-						"feature_securitySolutionCases.read",
-						"feature_securitySolutionAssistant.read",
-						"feature_actions.read",
-						"feature_builtInAlerts.read",
-						"feature_fleet.all",
-						"feature_fleetv2.all",
-						"feature_osquery.read",
-						"feature_indexPatterns.read",
-						"feature_discover.read",
-						"feature_dashboard.read",
-						"feature_maps.read",
-						"feature_visualize.read",
-					},
-				},
-			},
+		DiagnosticsUserRoleV7: esclient.Role{
+			Cluster:      []string{"monitor", "monitor_snapshot", "manage", "read_ilm", "manage_security"},
+			Indices:      diagnosticsRoleIndices,
+			Applications: diagnosticsAppsKibanaPrivileges,
+		},
+		DiagnosticsUserRoleV85: esclient.Role{
+			Cluster:      []string{"monitor", "monitor_snapshot", "manage", "read_ilm", "read_security"},
+			Indices:      diagnosticsRoleIndices,
+			Applications: diagnosticsAppsKibanaPrivileges,
 		},
 		ApmUserRoleV6: esclient.Role{
 			Cluster: []string{"monitor", "manage_index_templates"},

--- a/pkg/controller/elasticsearch/user/roles.go
+++ b/pkg/controller/elasticsearch/user/roles.go
@@ -27,8 +27,8 @@ const (
 	// RemoteMonitoringCollectorBuiltinRole is the name of the built-in remote_monitoring_collector role.
 	RemoteMonitoringCollectorBuiltinRole = "remote_monitoring_collector"
 
-	// DiagnosticsUserRoleV7 is the name of the built-in role for ECK diagnostics use from version 7.x to 8.4.
-	DiagnosticsUserRoleV7 = "elastic_internal_diagnostics_v7"
+	// DiagnosticsUserRoleV80 is the name of the built-in role for ECK diagnostics use from version 8.0 to 8.4.
+	DiagnosticsUserRoleV80 = "elastic_internal_diagnostics_v80"
 	// DiagnosticsUserRoleV85 is the name of the built-in role for ECK diagnostics use from version 8.5.
 	DiagnosticsUserRoleV85 = "elastic_internal_diagnostics_v85"
 
@@ -109,7 +109,7 @@ var (
 	PredefinedRoles = RolesFileContent{
 		ProbeUserRole:     esclient.Role{Cluster: []string{"monitor"}},
 		ClusterManageRole: esclient.Role{Cluster: []string{"manage"}},
-		DiagnosticsUserRoleV7: esclient.Role{
+		DiagnosticsUserRoleV80: esclient.Role{
 			Cluster:      []string{"monitor", "monitor_snapshot", "manage", "read_ilm", "manage_security"},
 			Indices:      diagnosticsRoleIndices,
 			Applications: diagnosticsAppsKibanaPrivileges,

--- a/pkg/controller/elasticsearch/user/user_provided_test.go
+++ b/pkg/controller/elasticsearch/user/user_provided_test.go
@@ -38,16 +38,19 @@ func initDynamicWatches(watchNames ...string) watches.DynamicWatches {
 
 var sampleEsWithAuth = esv1.Elasticsearch{
 	ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es"},
-	Spec: esv1.ElasticsearchSpec{Auth: esv1.Auth{
-		FileRealm: []esv1.FileRealmSource{
-			{SecretRef: v1.SecretRef{SecretName: "filerealm-secret-1"}},
-			{SecretRef: v1.SecretRef{SecretName: "filerealm-secret-2"}},
+	Spec: esv1.ElasticsearchSpec{
+		Auth: esv1.Auth{
+			FileRealm: []esv1.FileRealmSource{
+				{SecretRef: v1.SecretRef{SecretName: "filerealm-secret-1"}},
+				{SecretRef: v1.SecretRef{SecretName: "filerealm-secret-2"}},
+			},
+			Roles: []esv1.RoleSource{
+				{SecretRef: v1.SecretRef{SecretName: "roles-secret-1"}},
+				{SecretRef: v1.SecretRef{SecretName: "roles-secret-2"}},
+			},
 		},
-		Roles: []esv1.RoleSource{
-			{SecretRef: v1.SecretRef{SecretName: "roles-secret-1"}},
-			{SecretRef: v1.SecretRef{SecretName: "roles-secret-2"}},
-		},
-	}},
+		Version: "8.10.0",
+	},
 }
 var sampleUserProvidedFileRealmSecrets = []client.Object{
 	&corev1.Secret{


### PR DESCRIPTION
resolves #7776 

The Elasticsearch role `read_security` did not exist prior to Elasticsearch 8.5. This instead uses the `manage_security` role in previous versions of 8.x, and uses `superuser` role in 7.x which appears to be required.

Testing:
- [x] 8.5+
- [x] < 8.5 (8.4.2)
- [x] 7.17.21 (with superuser privileges)