### PR TITLE
Correct statefulset name label for Logstash pods

### DIFF
--- a/pkg/controller/logstash/driver.go
+++ b/pkg/controller/logstash/driver.go
@@ -203,7 +203,7 @@ func ensureSTSNameLabelIsSetOnPods(params Params) error {
 	if err != nil {
 		return err
 	}
-	if _, ok := sts.Spec.Template.Labels[labels.StatefulSetNameLabelName]; ok {
+	if val, ok := sts.Spec.Template.Labels[labels.StatefulSetNameLabelName]; ok && (val == logstashv1alpha1.Name(params.Logstash.Name)) {
 		// label is already in place, great
 		return nil
 	}
@@ -211,6 +211,6 @@ func ensureSTSNameLabelIsSetOnPods(params Params) error {
 	if sts.Spec.Template.Labels == nil {
 		sts.Spec.Template.Labels = map[string]string{}
 	}
-	sts.Spec.Template.Labels[labels.StatefulSetNameLabelName] = params.Logstash.Name
+	sts.Spec.Template.Labels[labels.StatefulSetNameLabelName] = logstashv1alpha1.Name(params.Logstash.Name)
 	return params.Client.Update(params.Context, &sts)
 }


### PR DESCRIPTION
Corrected Logstash label `logstash.k8s.elastic.co/statefulset-name` to include the `-ls` suffix, fixing issue preventing pod recreation during ECK upgrade from version 2.11 to 2.12.

#7587 patched Logstash statefulset label, however, the [patched](https://github.com/elastic/cloud-on-k8s/blob/v2.12.1/pkg/controller/logstash/driver.go#L214) label missed `-ls` suffix.

Relates: https://github.com/elastic/cloud-on-k8s/pull/7587
Fixes: https://github.com/elastic/cloud-on-k8s/issues/7742