### PR TITLE
WIP: Add liveness/readiness agent probe.

### DIFF
--- a/pkg/controller/common/container/defaulter.go
+++ b/pkg/controller/common/container/defaulter.go
@@ -89,6 +89,13 @@ func (d Defaulter) WithImage(image string) Defaulter {
 	return d
 }
 
+func (d Defaulter) WithLivenessProbe(livenessProbe *corev1.Probe) Defaulter {
+	if d.base.LivenessProbe == nil {
+		d.base.LivenessProbe = livenessProbe
+	}
+	return d
+}
+
 func (d Defaulter) WithReadinessProbe(readinessProbe *corev1.Probe) Defaulter {
 	if d.base.ReadinessProbe == nil {
 		d.base.ReadinessProbe = readinessProbe

--- a/pkg/controller/common/defaults/pod_template.go
+++ b/pkg/controller/common/defaults/pod_template.go
@@ -115,6 +115,12 @@ func (b *PodTemplateBuilder) WithDockerImage(customImage string, defaultImage st
 	return b
 }
 
+// WithLivenessProbe sets up the given liveness probe, unless already provided in the template.
+func (b *PodTemplateBuilder) WithLivenessProbe(livenessProbe corev1.Probe) *PodTemplateBuilder {
+	b.containerDefaulter.WithLivenessProbe(&livenessProbe)
+	return b
+}
+
 // WithReadinessProbe sets up the given readiness probe, unless already provided in the template.
 func (b *PodTemplateBuilder) WithReadinessProbe(readinessProbe corev1.Probe) *PodTemplateBuilder {
 	b.containerDefaulter.WithReadinessProbe(&readinessProbe)


### PR DESCRIPTION
related: #6808 
Ignore for now please. This isn't working, and is exhibiting odd behavior. Opening for discussion.

This is attempting to add both a liveness and readiness probe to the Fleet server agent (not an agent in fleet-mode, but the actual agent running the fleet server)

Notes
1. I'm not sure what the liveness probe is getting us here, tbh (as I suspect in nearly all cases it fails, the process will completely fail), but readiness probe seems useful.

Details
1. If adding a single liveness or readiness probe, this works fine
2. If using both probes, the agent in fleet-server mode continuously goes into a crash loop (unless it's already checked in initially, which in that case it (sometimes?) works).
3. The type of liveness probe does not matter. It literally can be `/bin/sh -c "true"`.
4. I've checked the kubelet, and it is *not* killing the agent process.
5. I've checked for OOM, and it's not being OOM killed.
6. *something* is causing the whole agent process to fail, which gets reported in the lots as a `SIGTERM` being received, but looking at the agent code, it seems possible (likely) that an underlying thread failed, and sent a `SIGTERM` to the whole group of goroutines.

Logs
```
{"log.level":"info","@timestamp":"2024-05-10T14:13:52.449Z","log.origin":{"file.name":"cmd/enroll_cmd.go","file.line":862},"message":"Fleet Server - Starting","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2024-05-10T14:13:52.775Z","message":"Running on policy with Fleet Server integration: eck-fleet-server; missing config fleet.agent.id (expected during bootstrap process)","component":{"binary":"fleet-server","dataset":"elastic_agent.fleet_server","id":"fleet-server-default","type":"fleet-server"},"log":{"source":"fleet-server-default"},"ecs.version":"1.6.0","service.name":"fleet-server","service.type":"fleet-server","state":"DEGRADED","ecs.version":"1.6.0"}
{"log.level":"warn","@timestamp":"2024-05-10T14:13:52.776Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":624},"message":"Unit state changed fleet-server-default-fleet-server (STARTING->DEGRADED): Running on policy with Fleet Server integration: eck-fleet-server; missing config fleet.agent.id (expected during bootstrap process)","log":{"source":"elastic-agent"},"component":{"id":"fleet-server-default","state":"HEALTHY"},"unit":{"id":"fleet-server-default-fleet-server","type":"input","state":"DEGRADED","old_state":"STARTING"},"ecs.version":"1.6.0"}
{"log.level":"warn","@timestamp":"2024-05-10T14:13:52.776Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":624},"message":"Unit state changed fleet-server-default (STARTING->DEGRADED): Running on policy with Fleet Server integration: eck-fleet-server; missing config fleet.agent.id (expected during bootstrap process)","log":{"source":"elastic-agent"},"component":{"id":"fleet-server-default","state":"HEALTHY"},"unit":{"id":"fleet-server-default","type":"output","state":"DEGRADED","old_state":"STARTING"},"ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2024-05-10T14:13:58.291Z","message":"Running on policy with Fleet Server integration: eck-fleet-server; missing config fleet.agent.id (expected during bootstrap process)","component":{"binary":"fleet-server","dataset":"elastic_agent.fleet_server","id":"fleet-server-default","type":"fleet-server"},"log":{"source":"fleet-server-default"},"ecs.version":"1.6.0","service.name":"fleet-server","service.type":"fleet-server","state":"DEGRADED","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2024-05-10T14:14:00.458Z","log.origin":{"file.name":"cmd/enroll_cmd.go","file.line":843},"message":"Fleet Server - Running on policy with Fleet Server integration: eck-fleet-server; missing config fleet.agent.id (expected during bootstrap process)","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2024-05-10T14:14:01.411Z","log.origin":{"file.name":"cmd/enroll_cmd.go","file.line":519},"message":"Starting enrollment to URL: https://fleet-server-agent-http.default.svc:8220/","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2024-05-10T14:14:01.647Z","log.origin":{"file.name":"cmd/enroll_cmd.go","file.line":528},"message":"1st enrollment attempt failed, retrying for 10m0s, every 1m0s enrolling to URL: https://fleet-server-agent-http.default.svc:8220/","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2024-05-10T14:14:01.648Z","log.origin":{"file.name":"cmd/run.go","file.line":346},"message":"signal \"terminated\" received","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2024-05-10T14:14:01.648Z","log.origin":{"file.name":"cmd/run.go","file.line":358},"message":"Shutting down Elastic Agent and sending last events...","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2024-05-10T14:14:01.648Z","message":"On signal","component":{"binary":"fleet-server","dataset":"elastic_agent.fleet_server","id":"fleet-server-default","type":"fleet-server"},"log":{"source":"fleet-server-default"},"ecs.version":"1.6.0","service.name":"fleet-server","service.type":"fleet-server","sig":"terminated","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2024-05-10T14:14:01.848Z","log.origin":{"file.name":"cmd/run.go","file.line":367},"message":"Shutting down completed.","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2024-05-10T14:14:01.848Z","log.origin":{"file.name":"reload/reload.go","file.line":68},"message":"Stopping server","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2024-05-10T14:14:01.849Z","log.logger":"api","log.origin":{"file.name":"api/server.go","file.line":80},"message":"Stats endpoint (127.0.0.1:6791) finished: accept tcp 127.0.0.1:6791: use of closed network connection","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
Error: fail to enroll: fail to execute request to fleet-server: dial tcp 10.51.175.157:8220: connect: connection refused
For help, please see our troubleshooting guide at https://www.elastic.co/guide/en/fleet/8.13/fleet-troubleshooting.html
Error: enrollment failed: exit status 1
For help, please see our troubleshooting guide at https://www.elastic.co/guide/en/fleet/8.13/fleet-troubleshooting.html
```

To replicate:
1. download branch; ensure no other eck process is running ; `make run`
2. `kubectl apply -n default -f //raw.githubusercontent.com/elastic/cloud-on-k8s/main/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml`