### PR TITLE
[2.13] Increase default memory for agent (#7789)

### DIFF
--- a/pkg/controller/agent/pod.go
+++ b/pkg/controller/agent/pod.go
@@ -90,13 +90,14 @@ const (
 )
 
 var (
+	// TODO: Decrease back to 350Mi once https://github.com/elastic/elastic-agent/issues/4730 is addressed
 	defaultResources = corev1.ResourceRequirements{
 		Limits: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceMemory: resource.MustParse("350Mi"),
+			corev1.ResourceMemory: resource.MustParse("400Mi"),
 			corev1.ResourceCPU:    resource.MustParse("200m"),
 		},
 		Requests: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceMemory: resource.MustParse("350Mi"),
+			corev1.ResourceMemory: resource.MustParse("400Mi"),
 			corev1.ResourceCPU:    resource.MustParse("200m"),
 		},
 	}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.13`:
 - [Increase default memory for agent (#7789)](https://github.com/elastic/cloud-on-k8s/pull/7789)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)