### PR TITLE
[2.13] Fix diagnostic role pre-8.5 (#7784)

### DIFF
--- a/pkg/controller/elasticsearch/user/predefined_test.go
+++ b/pkg/controller/elasticsearch/user/predefined_test.go
@@ -168,15 +168,18 @@ func Test_reconcileElasticUser_conditionalCreation(t *testing.T) {
 }
 
 func Test_reconcileInternalUsers(t *testing.T) {
-	es := esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es"}}
+	es := esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es"}, Spec: esv1.ElasticsearchSpec{Version: "8.10.0"}}
 	tests := []struct {
 		name              string
+		es                func() esv1.Elasticsearch
 		existingSecrets   []client.Object
 		existingFileRealm filerealm.Realm
 		assertions        func(t *testing.T, u users)
+		errorExpected     bool
 	}{
 		{
 			name:              "create new internal users if they do not exist yet",
+			es:                func() esv1.Elasticsearch { return es },
 			existingSecrets:   nil,
 			existingFileRealm: filerealm.New(),
 			assertions: func(t *testing.T, u users) {
@@ -188,6 +191,7 @@ func Test_reconcileInternalUsers(t *testing.T) {
 		},
 		{
 			name: "reuse the existing passwords and hashes",
+			es:   func() esv1.Elasticsearch { return es },
 			existingSecrets: []client.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Namespace: es.Namespace, Name: esv1.InternalUsersSecret(es.Name)},
@@ -211,6 +215,7 @@ func Test_reconcileInternalUsers(t *testing.T) {
 		},
 		{
 			name: "reuse the password but generate a new hash if the existing one doesn't match",
+			es:   func() esv1.Elasticsearch { return es },
 			existingSecrets: []client.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Namespace: es.Namespace, Name: esv1.InternalUsersSecret(es.Name)},
@@ -236,6 +241,7 @@ func Test_reconcileInternalUsers(t *testing.T) {
 		},
 		{
 			name: "reuse the password but generate a new hash if there is none in the file realm",
+			es:   func() esv1.Elasticsearch { return es },
 			existingSecrets: []client.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Namespace: es.Namespace, Name: esv1.InternalUsersSecret(es.Name)},
@@ -258,12 +264,56 @@ func Test_reconcileInternalUsers(t *testing.T) {
 				require.NotEmpty(t, u[2].PasswordHash)
 			},
 		},
+		{
+			name: "ES 7.x - diagnostic user uses superuser role",
+			es: func() esv1.Elasticsearch {
+				es := es.DeepCopy()
+				es.Spec.Version = "7.10.0"
+				return *es
+			},
+			existingFileRealm: filerealm.New(),
+			assertions: func(t *testing.T, u users) {
+				t.Helper()
+				require.Len(t, u, 5)
+				require.Equal(t, []string{SuperUserBuiltinRole}, u[4].Roles)
+			},
+		},
+		{
+			name: "ES 8.4 - diagnostic user uses specific 'DiagnosticsUserRoleV80' role",
+			es: func() esv1.Elasticsearch {
+				es := es.DeepCopy()
+				es.Spec.Version = "8.4.0"
+				return *es
+			},
+			existingFileRealm: filerealm.New(),
+			assertions: func(t *testing.T, u users) {
+				t.Helper()
+				require.Len(t, u, 5)
+				require.Equal(t, []string{DiagnosticsUserRoleV80}, u[4].Roles)
+			},
+		},
+		{
+			name: "Invalid ES version returns error",
+			es: func() esv1.Elasticsearch {
+				es := es.DeepCopy()
+				es.Spec.Version = "invalid"
+				return *es
+			},
+			existingFileRealm: filerealm.New(),
+			assertions: func(t *testing.T, u users) {
+				t.Helper()
+			},
+			errorExpected: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := k8s.NewFakeClient(tt.existingSecrets...)
-			got, err := reconcileInternalUsers(context.Background(), c, es, tt.existingFileRealm, testPasswordHasher)
-			require.NoError(t, err)
+			got, err := reconcileInternalUsers(context.Background(), c, tt.es(), tt.existingFileRealm, testPasswordHasher)
+			require.True(t, ((err != nil) == tt.errorExpected), "error expected: %v, got: %v", tt.errorExpected, err)
+			if tt.errorExpected {
+				return
+			}
 			// check returned users
 			require.Len(t, got, 5)
 			controllerUser := got[0]

--- a/pkg/controller/elasticsearch/user/reconcile_test.go
+++ b/pkg/controller/elasticsearch/user/reconcile_test.go
@@ -129,6 +129,6 @@ func Test_aggregateRoles(t *testing.T) {
 	c := k8s.NewFakeClient(sampleUserProvidedRolesSecret...)
 	roles, err := aggregateRoles(context.Background(), c, sampleEsWithAuth, initDynamicWatches(), record.NewFakeRecorder(10))
 	require.NoError(t, err)
-	require.Len(t, roles, 56)
+	require.Len(t, roles, 57)
 	require.Contains(t, roles, ProbeUserRole, ClusterManageRole, "role1", "role2")
 }

--- a/pkg/controller/elasticsearch/user/user_provided_test.go
+++ b/pkg/controller/elasticsearch/user/user_provided_test.go
@@ -38,16 +38,19 @@ func initDynamicWatches(watchNames ...string) watches.DynamicWatches {
 
 var sampleEsWithAuth = esv1.Elasticsearch{
 	ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es"},
-	Spec: esv1.ElasticsearchSpec{Auth: esv1.Auth{
-		FileRealm: []esv1.FileRealmSource{
-			{SecretRef: v1.SecretRef{SecretName: "filerealm-secret-1"}},
-			{SecretRef: v1.SecretRef{SecretName: "filerealm-secret-2"}},
+	Spec: esv1.ElasticsearchSpec{
+		Auth: esv1.Auth{
+			FileRealm: []esv1.FileRealmSource{
+				{SecretRef: v1.SecretRef{SecretName: "filerealm-secret-1"}},
+				{SecretRef: v1.SecretRef{SecretName: "filerealm-secret-2"}},
+			},
+			Roles: []esv1.RoleSource{
+				{SecretRef: v1.SecretRef{SecretName: "roles-secret-1"}},
+				{SecretRef: v1.SecretRef{SecretName: "roles-secret-2"}},
+			},
 		},
-		Roles: []esv1.RoleSource{
-			{SecretRef: v1.SecretRef{SecretName: "roles-secret-1"}},
-			{SecretRef: v1.SecretRef{SecretName: "roles-secret-2"}},
-		},
-	}},
+		Version: "8.10.0",
+	},
 }
 var sampleUserProvidedFileRealmSecrets = []client.Object{
 	&corev1.Secret{


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.13`:
 - [Fix diagnostic role pre-8.5 (#7784)](https://github.com/elastic/cloud-on-k8s/pull/7784)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)