### PR TITLE
Add Helm annotation to CRDs to prevent accidental deletion.

### DIFF
--- a/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
+++ b/deploy/eck-operator/charts/eck-operator-crds/templates/all-crds.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -1146,6 +1147,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -2389,6 +2391,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -2876,6 +2879,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -3484,6 +3488,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -3840,6 +3845,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -6598,6 +6604,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -7775,6 +7782,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -9098,6 +9106,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -10338,6 +10347,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'

--- a/hack/manifest-gen/crd_patches/v1/kustomization.yaml
+++ b/hack/manifest-gen/crd_patches/v1/kustomization.yaml
@@ -6,5 +6,7 @@ commonLabels:
   app.kubernetes.io/managed-by: '{{ .Release.Service }}'
   app.kubernetes.io/name: '{{ include "eck-operator-crds.name" . }}'
   app.kubernetes.io/instance: '{{ .Release.Name }}'
+commonAnnotations:
+  helm.sh/resource-policy: keep
 resources:
   - all-crds.yaml


### PR DESCRIPTION
## What are these changes?

resolves #5117
related #7754

- This adds an annotation to existing CRDs installed via Helm `helm.sh/resource-policy: keep` which allows the CRDs to persist even after a Helm deletion/uninstall happens.

## Testing

Tested uninstalling the Helm chart, which allows the CRDs to persist:
```
❯ helm uninstall elastic-operator -n elastic-system
These resources were kept due to the resource policy:
[CustomResourceDefinition] kibanas.kibana.k8s.elastic.co
[CustomResourceDefinition] logstashes.logstash.k8s.elastic.co
[CustomResourceDefinition] stackconfigpolicies.stackconfigpolicy.k8s.elastic.co
[CustomResourceDefinition] agents.agent.k8s.elastic.co
[CustomResourceDefinition] apmservers.apm.k8s.elastic.co
[CustomResourceDefinition] beats.beat.k8s.elastic.co
[CustomResourceDefinition] elasticmapsservers.maps.k8s.elastic.co
[CustomResourceDefinition] elasticsearchautoscalers.autoscaling.k8s.elastic.co
[CustomResourceDefinition] elasticsearches.elasticsearch.k8s.elastic.co
[CustomResourceDefinition] enterprisesearches.enterprisesearch.k8s.elastic.co
```
