### PR TITLE
[2.13] Corrected Logstash label logstash.k8s.elastic.co/statefulset-name 

### DIFF
--- a/pkg/controller/logstash/driver.go
+++ b/pkg/controller/logstash/driver.go
@@ -203,7 +203,7 @@ func ensureSTSNameLabelIsSetOnPods(params Params) error {
 	if err != nil {
 		return err
 	}
-	if _, ok := sts.Spec.Template.Labels[labels.StatefulSetNameLabelName]; ok {
+	if val, ok := sts.Spec.Template.Labels[labels.StatefulSetNameLabelName]; ok && (val == logstashv1alpha1.Name(params.Logstash.Name)) {
 		// label is already in place, great
 		return nil
 	}
@@ -211,6 +211,6 @@ func ensureSTSNameLabelIsSetOnPods(params Params) error {
 	if sts.Spec.Template.Labels == nil {
 		sts.Spec.Template.Labels = map[string]string{}
 	}
-	sts.Spec.Template.Labels[labels.StatefulSetNameLabelName] = params.Logstash.Name
+	sts.Spec.Template.Labels[labels.StatefulSetNameLabelName] = logstashv1alpha1.Name(params.Logstash.Name)
 	return params.Client.Update(params.Context, &sts)
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.13`:
 - [Corrected Logstash label logstash.k8s.elastic.co/statefulset-name to include the -ls suffix, fixing issues preventing pod recreation during ECK upgrade from version 2.11 to 2.12. (#7788)](https://github.com/elastic/cloud-on-k8s/pull/7788)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)