### PR TITLE
Bump Kibana memory to 1500Mi

### DIFF
--- a/pkg/controller/kibana/pod.go
+++ b/pkg/controller/kibana/pod.go
@@ -36,7 +36,7 @@ var (
 	// Since Kibana is stateless and the keystore is created on pod start, an EmptyDir is fine here.
 	DataVolume = volume.NewEmptyDirVolume(DataVolumeName, DataVolumeMountPath)
 
-	DefaultMemoryLimits = resource.MustParse("1Gi")
+	DefaultMemoryLimits = resource.MustParse("1.2Gi")
 	DefaultResources    = corev1.ResourceRequirements{
 		Requests: map[corev1.ResourceName]resource.Quantity{
 			corev1.ResourceMemory: DefaultMemoryLimits,

--- a/pkg/controller/kibana/pod.go
+++ b/pkg/controller/kibana/pod.go
@@ -36,7 +36,7 @@ var (
 	// Since Kibana is stateless and the keystore is created on pod start, an EmptyDir is fine here.
 	DataVolume = volume.NewEmptyDirVolume(DataVolumeName, DataVolumeMountPath)
 
-	DefaultMemoryLimits = resource.MustParse("1.2Gi")
+	DefaultMemoryLimits = resource.MustParse("1300Mi")
 	DefaultResources    = corev1.ResourceRequirements{
 		Requests: map[corev1.ResourceName]resource.Quantity{
 			corev1.ResourceMemory: DefaultMemoryLimits,

--- a/pkg/controller/kibana/pod.go
+++ b/pkg/controller/kibana/pod.go
@@ -36,7 +36,7 @@ var (
 	// Since Kibana is stateless and the keystore is created on pod start, an EmptyDir is fine here.
 	DataVolume = volume.NewEmptyDirVolume(DataVolumeName, DataVolumeMountPath)
 
-	DefaultMemoryLimits = resource.MustParse("1300Mi")
+	DefaultMemoryLimits = resource.MustParse("1500Mi")
 	DefaultResources    = corev1.ResourceRequirements{
 		Requests: map[corev1.ResourceName]resource.Quantity{
 			corev1.ResourceMemory: DefaultMemoryLimits,

--- a/pkg/license/reporter_test.go
+++ b/pkg/license/reporter_test.go
@@ -130,8 +130,8 @@ func TestGet(t *testing.T) {
 		require.NoError(t, err)
 
 		want := LicensingInfo{
-			TotalManagedMemoryGiB:   100.00,
-			TotalManagedMemoryBytes: 107374182400,
+			TotalManagedMemoryGiB:   120.00,
+			TotalManagedMemoryBytes: 128849018900,
 			EnterpriseResourceUnits: 2,
 			EckLicenseLevel:         "basic",
 		}
@@ -244,8 +244,8 @@ func Test_Start(t *testing.T) {
 		return cm.Data["timestamp"] != "" &&
 			cm.Data["eck_license_level"] == defaultOperatorLicenseLevel &&
 			cm.Data["enterprise_resource_units"] == "2" &&
-			cm.Data["total_managed_memory"] == "83.00GiB" &&
-			cm.Data["total_managed_memory_bytes"] == "89120571392"
+			cm.Data["total_managed_memory"] == "83.40GiB" &&
+			cm.Data["total_managed_memory_bytes"] == "89550068122"
 	}, waitFor, tick)
 
 	// increase the Elasticsearch nodes count
@@ -266,8 +266,8 @@ func Test_Start(t *testing.T) {
 		return cm.Data["timestamp"] != "" &&
 			cm.Data["eck_license_level"] == defaultOperatorLicenseLevel &&
 			cm.Data["enterprise_resource_units"] == "3" &&
-			cm.Data["total_managed_memory"] == "163.00GiB" &&
-			cm.Data["total_managed_memory_bytes"] == "175019917312"
+			cm.Data["total_managed_memory"] == "163.40GiB" &&
+			cm.Data["total_managed_memory_bytes"] == "175449414042"
 	}, waitFor, tick)
 
 	startTrial(t, k8sClient)
@@ -285,8 +285,8 @@ func Test_Start(t *testing.T) {
 		return cm.Data["timestamp"] != "" &&
 			cm.Data["eck_license_level"] == string(commonlicense.LicenseTypeEnterpriseTrial) &&
 			cm.Data["enterprise_resource_units"] == "3" &&
-			cm.Data["total_managed_memory"] == "163.00GiB" &&
-			cm.Data["total_managed_memory_bytes"] == "175019917312"
+			cm.Data["total_managed_memory"] == "163.40GiB" &&
+			cm.Data["total_managed_memory_bytes"] == "175449414042"
 	}, waitFor, tick)
 }
 

--- a/pkg/license/reporter_test.go
+++ b/pkg/license/reporter_test.go
@@ -130,8 +130,8 @@ func TestGet(t *testing.T) {
 		require.NoError(t, err)
 
 		want := LicensingInfo{
-			TotalManagedMemoryGiB:   120.00,
-			TotalManagedMemoryBytes: 128849018900,
+			TotalManagedMemoryGiB:   126.95,
+			TotalManagedMemoryBytes: 136314880000,
 			EnterpriseResourceUnits: 2,
 			EckLicenseLevel:         "basic",
 		}
@@ -244,8 +244,8 @@ func Test_Start(t *testing.T) {
 		return cm.Data["timestamp"] != "" &&
 			cm.Data["eck_license_level"] == defaultOperatorLicenseLevel &&
 			cm.Data["enterprise_resource_units"] == "2" &&
-			cm.Data["total_managed_memory"] == "83.40GiB" &&
-			cm.Data["total_managed_memory_bytes"] == "89550068122"
+			cm.Data["total_managed_memory"] == "83.54GiB" &&
+			cm.Data["total_managed_memory_bytes"] == "89699385344"
 	}, waitFor, tick)
 
 	// increase the Elasticsearch nodes count
@@ -266,8 +266,8 @@ func Test_Start(t *testing.T) {
 		return cm.Data["timestamp"] != "" &&
 			cm.Data["eck_license_level"] == defaultOperatorLicenseLevel &&
 			cm.Data["enterprise_resource_units"] == "3" &&
-			cm.Data["total_managed_memory"] == "163.40GiB" &&
-			cm.Data["total_managed_memory_bytes"] == "175449414042"
+			cm.Data["total_managed_memory"] == "163.54GiB" &&
+			cm.Data["total_managed_memory_bytes"] == "175598731264"
 	}, waitFor, tick)
 
 	startTrial(t, k8sClient)
@@ -285,8 +285,8 @@ func Test_Start(t *testing.T) {
 		return cm.Data["timestamp"] != "" &&
 			cm.Data["eck_license_level"] == string(commonlicense.LicenseTypeEnterpriseTrial) &&
 			cm.Data["enterprise_resource_units"] == "3" &&
-			cm.Data["total_managed_memory"] == "163.40GiB" &&
-			cm.Data["total_managed_memory_bytes"] == "175449414042"
+			cm.Data["total_managed_memory"] == "163.54GiB" &&
+			cm.Data["total_managed_memory_bytes"] == "175598731264"
 	}, waitFor, tick)
 }
 

--- a/pkg/license/reporter_test.go
+++ b/pkg/license/reporter_test.go
@@ -130,9 +130,9 @@ func TestGet(t *testing.T) {
 		require.NoError(t, err)
 
 		want := LicensingInfo{
-			TotalManagedMemoryGiB:   126.95,
-			TotalManagedMemoryBytes: 136314880000,
-			EnterpriseResourceUnits: 2,
+			TotalManagedMemoryGiB:   146.48,
+			TotalManagedMemoryBytes: 157286400000,
+			EnterpriseResourceUnits: 3,
 			EckLicenseLevel:         "basic",
 		}
 
@@ -244,8 +244,8 @@ func Test_Start(t *testing.T) {
 		return cm.Data["timestamp"] != "" &&
 			cm.Data["eck_license_level"] == defaultOperatorLicenseLevel &&
 			cm.Data["enterprise_resource_units"] == "2" &&
-			cm.Data["total_managed_memory"] == "83.54GiB" &&
-			cm.Data["total_managed_memory_bytes"] == "89699385344"
+			cm.Data["total_managed_memory"] == "83.93GiB" &&
+			cm.Data["total_managed_memory_bytes"] == "90118815744"
 	}, waitFor, tick)
 
 	// increase the Elasticsearch nodes count
@@ -266,8 +266,8 @@ func Test_Start(t *testing.T) {
 		return cm.Data["timestamp"] != "" &&
 			cm.Data["eck_license_level"] == defaultOperatorLicenseLevel &&
 			cm.Data["enterprise_resource_units"] == "3" &&
-			cm.Data["total_managed_memory"] == "163.54GiB" &&
-			cm.Data["total_managed_memory_bytes"] == "175598731264"
+			cm.Data["total_managed_memory"] == "163.93GiB" &&
+			cm.Data["total_managed_memory_bytes"] == "176018161664"
 	}, waitFor, tick)
 
 	startTrial(t, k8sClient)
@@ -285,8 +285,8 @@ func Test_Start(t *testing.T) {
 		return cm.Data["timestamp"] != "" &&
 			cm.Data["eck_license_level"] == string(commonlicense.LicenseTypeEnterpriseTrial) &&
 			cm.Data["enterprise_resource_units"] == "3" &&
-			cm.Data["total_managed_memory"] == "163.54GiB" &&
-			cm.Data["total_managed_memory_bytes"] == "175598731264"
+			cm.Data["total_managed_memory"] == "163.93GiB" &&
+			cm.Data["total_managed_memory_bytes"] == "176018161664"
 	}, waitFor, tick)
 }
 


### PR DESCRIPTION
We are seeing nightly e2e test failures with Kibana being killed with OOM. Bumping the default Kibana memory to 1500Mi and it seems like Kibana memory consumption as increased. We suspect that the increased memory consumption is from moving to CgroupsV2. There is a bug 
https://github.com/kubernetes/kubernetes/issues/118916