### PR TITLE
[2.13] update release notes and highlights (#7813)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/managing-compute-resources.asciidoc
@@ -303,7 +303,7 @@ If `resources` is not defined in the specification of an object, then the operat
 |Elasticsearch |2Gi |2Gi
 |Kibana |1Gi |1Gi
 |Beat   |300Mi |300Mi
-|Elastic Agent |350Mi |350Mi
+|Elastic Agent |400Mi |400Mi
 |Elastic Maps Server |200Mi |200Mi
 |Enterprise Search |4Gi |4Gi
 |Logstash |2Gi |2Gi

--- a/docs/release-notes/2.13.0.asciidoc
+++ b/docs/release-notes/2.13.0.asciidoc
@@ -16,6 +16,7 @@
 [float]
 === Enhancements
 
+* Add Helm annotation to CRDs to prevent accidental deletion. {pull}7811[#7811] (issue: {issue}5117[#5117])
 * Allow disabling of elastic user. {pull}7723[#7723] (issue: {issue}7719[#7719])
 * Make automountServiceAccountToken configurable on operator Pods via Helm {pull}7690[#7690]
 * Support setting labels and annotations on operator statefulset via Helm {pull}7688[#7688]
@@ -27,6 +28,7 @@
 === Bug fixes
 
 * Increase default memory for agent {pull}7789[#7789]
+* Correct StatefulSet name label for Logstash pods {pull}7788[#7788] (issue: {issue}7742[#7742])
 * Fix webhook certname in Helm template {pull}7775[#7775] (issue: {issue}7771[#7771])
 * Support loadBalancerClass in service reconciliation {pull}7706[#7706] (issue: {issue}7691[#7691])
 * [Autoscaling] Do not delete existing resources {pull}7678[#7678]
@@ -38,6 +40,7 @@
 === Documentation improvements
 
 * Update indentation of ldap example {pull}7725[#7725]
+* Add Logstash Plugins on ECK documentation and remove technical preview tags {pull}7702[#7702]
 * Update saml-authentication.asciidoc {pull}7680[#7680]
 * Update stack version in recipes {pull}7651[#7651]
 

--- a/docs/release-notes/highlights-2.13.0.asciidoc
+++ b/docs/release-notes/highlights-2.13.0.asciidoc
@@ -21,3 +21,10 @@ ECK 2.13.0 supports managing Enterprise search resources via Helm charts, simila
 ECK 2.13.0 introduces a new option that allows a user to disable the elastic user from being created upon Elasticsearch creation. A use case for this would be when an organization/user would prefer to manage all users/roles via SSO (SAML/IDP/LDAP/etc)
 (see https://github.com/elastic/cloud-on-k8s/blob/main/docs/orchestrating-elastic-stack-applications/security/users-and-roles.asciidoc#disabling-the-default-elastic-user[documentation]).
 
+[float]
+[id="{p}-2130-eck-logstash-ga"]
+=== Logstash on ECK generally available
+
+With ECK 2.13.0, support for Logstash is moving out of technical preview and is now generally available (GA). 
+Logstash managed by ECK is now considered production-ready.
+


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.13`:
 - [update release notes and highlights (#7813)](https://github.com/elastic/cloud-on-k8s/pull/7813)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)