### PR TITLE
Upgrade kind to 0.23.0

### DIFF
--- a/.buildkite/e2e/nightly-main-matrix.yaml
+++ b/.buildkite/e2e/nightly-main-matrix.yaml
@@ -26,14 +26,14 @@
   fixed:
     E2E_PROVIDER: kind
   mixed:
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
-    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.29.0@sha256:54a50c9354f11ce0aa56a85d2cacb1b950f85eab3fe1caf988826d1f89bf37eb
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.26.15@sha256:84333e26cae1d70361bb7339efb568df1871419f2019c80f9a12b7e2d485fe19
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.27.13@sha256:17439fa5b32290e3ead39ead1250dca1d822d94a10d26f1981756cd51b24b9d8
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.28.9@sha256:dca54bc6a6079dd34699d53d7d4ffa2e853e46a20cd12d619a09207e35300bd0
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.29.4@sha256:3abb816a5b1061fb15c6e9e60856ec40d56b7b52bcea5f5f1350bc6e2320b6f8
     # The latest version of kind/k8s needs to be listed twice at the end of this list
     # as it's tested in both ipv4 and ipv6 mode.
-    - DEPLOYER_KIND_NODE_IMAGE: barkbay/node:v1.30.0-dirty@sha256:03aae54e5ce12a2ec3220d5329a58130f9328d9e5b995c8eb4eb0807569bffbe
-    - DEPLOYER_KIND_NODE_IMAGE: barkbay/node:v1.30.0-dirty@sha256:03aae54e5ce12a2ec3220d5329a58130f9328d9e5b995c8eb4eb0807569bffbe
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
+    - DEPLOYER_KIND_NODE_IMAGE: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
       DEPLOYER_KIND_IP_FAMILY: ipv6
 
 - label: gke

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -151,24 +151,24 @@ plans:
 - id: kind-dev
   operation: create
   clusterName: eck
-  clientVersion: 0.20.0
+  clientVersion: 0.23.0
   provider: kind
-  kubernetesVersion: 1.28.0
+  kubernetesVersion: 1.30.0
   enforceSecurityPolicies: true
   kind:
     nodeCount: 3
-    nodeImage: kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
+    nodeImage: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
     ipFamily: ipv4
 - id: kind-ci
   operation: create
   clusterName: kind-ci
-  clientVersion: 0.20.0
+  clientVersion: 0.23.0
   provider: kind
-  kubernetesVersion: 1.28.0
+  kubernetesVersion: 1.30.0
   enforceSecurityPolicies: true
   kind:
     nodeCount: 3
-    nodeImage: kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
+    nodeImage: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
     ipFamily: ipv4
 - id: tanzu-ci
   operation: create


### PR DESCRIPTION
A new version of kind is now available which supports k8s 1.30 with official node images. This updates our kind version and bumps the node images in use