### PR TITLE
[2.13] Doc: Add note that autoscalers are not yet supported with Logstash on ECK (#7821)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/logstash.asciidoc
@@ -1145,6 +1145,8 @@ spec:
 [id="{p}-logstash-working-with-plugins-scaling"]
 === Scaling {ls} on ECK
 
+IMPORTANT: The use of autoscalers, such as the HorizontalPodAutoscaler or the VerticalPodAutoscaler, with {ls} on ECK is not yet supported.
+
 {ls} scalability is highly dependent on the plugins in your pipelines. 
 Some plugins can restrict how you can scale out your Logstash deployment, based on the way that the plugins gather or enrich data.
 
@@ -1169,7 +1171,6 @@ spec:
 ----
 
 .Horizontal scaling for {ls} plugins
-
 ****
 * Not all {ls} deployments can be scaled horizontally by increasing the number of {ls} Pods defined in the {ls} resource. 
 Depending on the types of plugins in a {ls} installation, increasing the number of pods may cause data duplication, data loss, incorrect data, or may waste resources with pods unable to be utilized correctly.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.13`:
 - [Doc: Add note that autoscalers are not yet supported with Logstash on ECK (#7821)](https://github.com/elastic/cloud-on-k8s/pull/7821)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)