### PR TITLE
[2.13] update release notes with latest doc backport (#7827)

### DIFF
--- a/docs/release-notes/2.13.0.asciidoc
+++ b/docs/release-notes/2.13.0.asciidoc
@@ -39,6 +39,7 @@
 [float]
 === Documentation improvements
 
+* Add note that autoscalers are not yet supported by Logstash on ECK {pull}7821[#7821] (issue: {issue}7820[#7820])
 * Update indentation of ldap example {pull}7725[#7725]
 * Add Logstash Plugins on ECK documentation and remove technical preview tags {pull}7702[#7702]
 * Update saml-authentication.asciidoc {pull}7680[#7680]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.13`:
 - [update release notes with latest doc backport (#7827)](https://github.com/elastic/cloud-on-k8s/pull/7827)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)