### PR TITLE
Remove explicit GKE storage class

### DIFF
--- a/config/recipes/autopilot/fleet-kubernetes-integration.yaml
+++ b/config/recipes/autopilot/fleet-kubernetes-integration.yaml
@@ -164,7 +164,6 @@ spec:
             volumeClaimTemplate:
               spec:
                 accessModes: [ "ReadWriteOnce" ]
-                storageClassName: "standard-rwo"
                 resources:
                   requests:
                     storage: 10Gi
@@ -196,7 +195,6 @@ spec:
             volumeClaimTemplate:
               spec:
                 accessModes: [ "ReadWriteOnce" ]
-                storageClassName: "standard-rwo"
                 resources:
                   requests:
                     storage: 10Gi


### PR DESCRIPTION
The recipe specified an explicit storage class. But we are no longer allowing the use of the default classes in e2e tests because we cannot label the disks created by them. I thought that the kyverno policy introduced in https://github.com/elastic/cloud-on-k8s/pull/7817 would ignore ephemeral volumes but I was wrong. This tries to work around the problem by just removing the explicit class name to fall back to the default class (not ideal but 🤷 ). 