### PR TITLE
Route apiVersion must be route.openshift.io/v1

### DIFF
--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -138,7 +138,7 @@ spec:
             memory: 1Gi
             cpu: 1
 ---
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: kibana-sample
@@ -200,7 +200,7 @@ spec:
     spec:
       serviceAccountName: apm-server
 ---
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: apm-server-sample


### PR DESCRIPTION
OpenShift Route apiVersion is now route.openshift.io/v1 

If set to v1 we will get a Fatal error:
```
error: resource mapping not found for name: "kibana-sample" namespace: "" from "STDIN": no matches for kind "Route" in version "v1"
```