### PR TITLE
Bump Kibana memory only for 8.1.x in e2e tests.

### DIFF
--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -69,7 +70,7 @@ func newBuilder(name, randSuffix string) Builder {
 		Name:      name,
 		Namespace: test.Ctx().ManagedNamespace(0),
 	}
-	return Builder{
+	b := Builder{
 		Kibana: kbv1.Kibana{
 			ObjectMeta: meta,
 			Spec: kbv1.KibanaSpec{
@@ -85,6 +86,20 @@ func newBuilder(name, randSuffix string) Builder {
 		WithSuffix(randSuffix).
 		WithLabel(run.TestNameLabel, name).
 		WithPodLabel(run.TestNameLabel, name)
+
+	// bump Kibana memory in 8.1.x as we see abnormal memory usage, probably due to the
+	// move to cgroups v2 (https://github.com/kubernetes/kubernetes/issues/118916)
+	ver := version.MustParse(test.Ctx().ElasticStackVersion)
+	if ver.GTE(version.MinFor(8, 1, 0)) && ver.LT(version.MinFor(8, 2, 0)) {
+		b = b.WithResources(corev1.ResourceRequirements{
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceMemory: resource.MustParse("1500Mi"),
+			},
+			Limits: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceMemory: resource.MustParse("1500Mi"),
+			}})
+	}
+	return b
 }
 
 func (b Builder) WithImage(image string) Builder {


### PR DESCRIPTION
We are seeing nightly e2e test failures with Kibana being OOM killed, which seems to be limited to Kibana 8.1.x. This increases the memory in the e2e tests for Kibana 8.1.x only to a level that we've found/tested that enables our e2e tests to pass again. This is what @thbkrkr suggested in #7819.

We suspect that the increased memory consumption is from moving to CgroupsV2.
There is a [k8s bug](https://github.com/kubernetes/kubernetes/issues/118916) and a [runc fix](https://github.com/opencontainers/runc/pull/3933)