### PR TITLE
Reduce e2e test stack versions in main branch.

### DIFF
--- a/.buildkite/e2e/nightly-main-matrix.yaml
+++ b/.buildkite/e2e/nightly-main-matrix.yaml
@@ -6,7 +6,7 @@
     - E2E_STACK_VERSION: "7.17.8"
     # The following versions are no longer tested on the main branch
     # but should be enabled when a new release branch is cut such that
-    # these are fully tested on the run up to the release.
+    # these are fully tested on the run up to a new release.
     # - E2E_STACK_VERSION: "8.0.1"
     # - E2E_STACK_VERSION: "8.1.3"
     # - E2E_STACK_VERSION: "8.2.3"

--- a/.buildkite/e2e/nightly-main-matrix.yaml
+++ b/.buildkite/e2e/nightly-main-matrix.yaml
@@ -3,21 +3,23 @@
   fixed:
     E2E_PROVIDER: gke
   mixed:
-    - E2E_STACK_VERSION: "6.8.23"
     - E2E_STACK_VERSION: "7.17.8"
-    - E2E_STACK_VERSION: "8.0.1"
-    - E2E_STACK_VERSION: "8.1.3"
-    - E2E_STACK_VERSION: "8.2.3"
-    - E2E_STACK_VERSION: "8.3.3"
-    - E2E_STACK_VERSION: "8.4.3"
-    - E2E_STACK_VERSION: "8.5.3"
-    - E2E_STACK_VERSION: "8.6.2"
-    - E2E_STACK_VERSION: "8.7.1"
-    - E2E_STACK_VERSION: "8.8.2"
-    - E2E_STACK_VERSION: "8.9.2"
-    - E2E_STACK_VERSION: "8.10.4"
-    - E2E_STACK_VERSION: "8.11.4"
-    - E2E_STACK_VERSION: "8.12.2"
+    # The following versions are no longer tested on the main branch
+    # but should be enabled when a new release branch is cut such that
+    # these are fully tested on the run up to the release.
+    # - E2E_STACK_VERSION: "8.0.1"
+    # - E2E_STACK_VERSION: "8.1.3"
+    # - E2E_STACK_VERSION: "8.2.3"
+    # - E2E_STACK_VERSION: "8.3.3"
+    # - E2E_STACK_VERSION: "8.4.3"
+    # - E2E_STACK_VERSION: "8.5.3"
+    # - E2E_STACK_VERSION: "8.6.2"
+    # - E2E_STACK_VERSION: "8.7.1"
+    # - E2E_STACK_VERSION: "8.8.2"
+    # - E2E_STACK_VERSION: "8.9.2"
+    # - E2E_STACK_VERSION: "8.10.4"
+    # - E2E_STACK_VERSION: "8.11.4"
+    # - E2E_STACK_VERSION: "8.12.2"
     - E2E_STACK_VERSION: "8.13.0"
     # current stack version 8.14.x is tested in all other tests no need to test it again
     - E2E_STACK_VERSION: "8.15.0-SNAPSHOT"

--- a/.buildkite/e2e/nightly-main-matrix.yaml
+++ b/.buildkite/e2e/nightly-main-matrix.yaml
@@ -4,8 +4,8 @@
     E2E_PROVIDER: gke
   mixed:
     - E2E_STACK_VERSION: "7.17.8"
-    - E2E_STACK_VERSION: "8.13.0"
-    # current stack version 8.14.x is tested in all other tests no need to test it again
+    # current stack version 8.13.x is tested in all other tests no need to test it again
+    - E2E_STACK_VERSION: "8.14.0-SNAPSHOT"
     - E2E_STACK_VERSION: "8.15.0-SNAPSHOT"
 
 - label: kind

--- a/.buildkite/e2e/release-branch-matrix.yaml
+++ b/.buildkite/e2e/release-branch-matrix.yaml
@@ -3,6 +3,7 @@
   fixed:
     E2E_PROVIDER: gke
   mixed:
+    - E2E_STACK_VERSION: "6.8.23"
     - E2E_STACK_VERSION: "7.17.8"
     - E2E_STACK_VERSION: "8.0.1"
     - E2E_STACK_VERSION: "8.1.3"

--- a/.buildkite/e2e/release-branch-matrix.yaml
+++ b/.buildkite/e2e/release-branch-matrix.yaml
@@ -4,9 +4,21 @@
     E2E_PROVIDER: gke
   mixed:
     - E2E_STACK_VERSION: "7.17.8"
+    - E2E_STACK_VERSION: "8.0.1"
+    - E2E_STACK_VERSION: "8.1.3"
+    - E2E_STACK_VERSION: "8.2.3"
+    - E2E_STACK_VERSION: "8.3.3"
+    - E2E_STACK_VERSION: "8.4.3"
+    - E2E_STACK_VERSION: "8.5.3"
+    - E2E_STACK_VERSION: "8.6.2"
+    - E2E_STACK_VERSION: "8.7.1"
+    - E2E_STACK_VERSION: "8.8.2"
+    - E2E_STACK_VERSION: "8.9.2"
+    - E2E_STACK_VERSION: "8.10.4"
+    - E2E_STACK_VERSION: "8.11.4"
+    - E2E_STACK_VERSION: "8.12.2"
     - E2E_STACK_VERSION: "8.13.0"
     # current stack version 8.14.x is tested in all other tests no need to test it again
-    - E2E_STACK_VERSION: "8.15.0-SNAPSHOT"
 
 - label: kind
   fixed:

--- a/.buildkite/e2e/release-branch-matrix.yaml
+++ b/.buildkite/e2e/release-branch-matrix.yaml
@@ -18,8 +18,8 @@
     - E2E_STACK_VERSION: "8.10.4"
     - E2E_STACK_VERSION: "8.11.4"
     - E2E_STACK_VERSION: "8.12.2"
-    - E2E_STACK_VERSION: "8.13.0"
-    # current stack version 8.14.x is tested in all other tests no need to test it again
+    # current stack version 8.13.x is tested in all other tests no need to test it again
+    - E2E_STACK_VERSION: "8.14.0-SNAPSHOT"
 
 - label: kind
   fixed:

--- a/.buildkite/pipeline-e2e-tests.yml
+++ b/.buildkite/pipeline-e2e-tests.yml
@@ -20,17 +20,26 @@ steps:
           image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:ef29aa4e
           memory: "2G"
 
-      # for all tags
       # for nightly builds from main
       - label: ":buildkite: e2e"
         if: |
-          build.tag != null
-          || ( build.branch == "main" && build.source == "schedule" )
+          ( build.branch == "main" && build.source == "schedule" )
           || build.message =~ /^buildkite test .*e2e\/all.*/
         command: |
           .buildkite/scripts/build/set-images.sh
           cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
           cat ../nightly-main-matrix.yaml | ./pipeline-gen | buildkite-agent pipeline upload
+        agents:
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:ef29aa4e
+          memory: "2G"
+
+      # for all tags
+      - label: ":buildkite: e2e"
+        if: build.tag != null
+        command: |
+          .buildkite/scripts/build/set-images.sh
+          cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
+          cat ../release-branch-matrix.yaml | ./pipeline-gen | buildkite-agent pipeline upload
         agents:
           image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:ef29aa4e
           memory: "2G"


### PR DESCRIPTION
As discussed offline, we are reducing the daily testing of all old stack releases on the main branch, but will re-enable testing all old stack releases on the release branch when we are about to release a new version of ECK, which typically happens about a month prior to release.