### PR TITLE
[2.13] Reduce e2e test stack versions in main branch. (#7837)

### DIFF
--- a/.buildkite/e2e/release-branch-matrix.yaml
+++ b/.buildkite/e2e/release-branch-matrix.yaml
@@ -3,10 +3,23 @@
   fixed:
     E2E_PROVIDER: gke
   mixed:
+    - E2E_STACK_VERSION: "6.8.23"
     - E2E_STACK_VERSION: "7.17.8"
+    - E2E_STACK_VERSION: "8.0.1"
+    - E2E_STACK_VERSION: "8.1.3"
+    - E2E_STACK_VERSION: "8.2.3"
+    - E2E_STACK_VERSION: "8.3.3"
+    - E2E_STACK_VERSION: "8.4.3"
+    - E2E_STACK_VERSION: "8.5.3"
+    - E2E_STACK_VERSION: "8.6.2"
+    - E2E_STACK_VERSION: "8.7.1"
+    - E2E_STACK_VERSION: "8.8.2"
+    - E2E_STACK_VERSION: "8.9.2"
+    - E2E_STACK_VERSION: "8.10.4"
+    - E2E_STACK_VERSION: "8.11.4"
+    - E2E_STACK_VERSION: "8.12.2"
     # current stack version 8.13.x is tested in all other tests no need to test it again
     - E2E_STACK_VERSION: "8.14.0-SNAPSHOT"
-    - E2E_STACK_VERSION: "8.15.0-SNAPSHOT"
 
 - label: kind
   fixed:

--- a/.buildkite/pipeline-e2e-tests.yml
+++ b/.buildkite/pipeline-e2e-tests.yml
@@ -20,12 +20,10 @@ steps:
           image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:2333e538
           memory: "2G"
 
-      # for all tags
       # for nightly builds from main
       - label: ":buildkite: e2e"
         if: |
-          build.tag != null
-          || ( build.branch == "main" && build.source == "schedule" )
+          ( build.branch == "main" && build.source == "schedule" )
           || build.message =~ /^buildkite test .*e2e\/all.*/
         command: |
           .buildkite/scripts/build/set-images.sh
@@ -33,4 +31,15 @@ steps:
           cat ../nightly-main-matrix.yaml | ./pipeline-gen | buildkite-agent pipeline upload
         agents:
           image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:2333e538
+          memory: "2G"
+
+      # for all tags
+      - label: ":buildkite: e2e"
+        if: build.tag != null
+        command: |
+          .buildkite/scripts/build/set-images.sh
+          cd .buildkite/e2e/pipeline-gen && go build -o pipeline-gen
+          cat ../release-branch-matrix.yaml | ./pipeline-gen | buildkite-agent pipeline upload
+        agents:
+          image: docker.elastic.co/ci-agent-images/cloud-k8s-operator/buildkite-agent:ef29aa4e
           memory: "2G"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.13`:
 - [Reduce e2e test stack versions in main branch. (#7837)](https://github.com/elastic/cloud-on-k8s/pull/7837)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)