### PR TITLE
Use hash for secure settings secret updates

### DIFF
--- a/pkg/controller/apmserver/deployment.go
+++ b/pkg/controller/apmserver/deployment.go
@@ -110,7 +110,7 @@ func buildConfigHash(c k8s.Client, as *apmv1.ApmServer, params PodSpecParams) (s
 
 	// - in the APMServer keystore
 	if params.keystoreResources != nil {
-		_, _ = configHash.Write([]byte(params.keystoreResources.Version))
+		_, _ = configHash.Write([]byte(params.keystoreResources.Hash))
 	}
 
 	// - in the APMServer TLS certificates

--- a/pkg/controller/apmserver/deployment_test.go
+++ b/pkg/controller/apmserver/deployment_test.go
@@ -434,7 +434,7 @@ func TestReconcileApmServer_deploymentParams(t *testing.T) {
 							Name: "keystore-volume",
 						},
 						InitContainer: corev1.Container{},
-						Version:       "1",
+						Hash:          "1",
 					}
 					return params
 				}(),

--- a/pkg/controller/beat/common/pod.go
+++ b/pkg/controller/beat/common/pod.go
@@ -132,7 +132,7 @@ func buildPodTemplate(
 	}
 
 	if keystoreResources != nil {
-		_, _ = configHash.Write([]byte(keystoreResources.Version))
+		_, _ = configHash.Write([]byte(keystoreResources.Hash))
 		volumes = append(volumes, keystoreResources.Volume)
 		initContainers = append(initContainers, keystoreResources.InitContainer)
 	}

--- a/pkg/controller/beat/common/pod_test.go
+++ b/pkg/controller/beat/common/pod_test.go
@@ -271,7 +271,7 @@ func Test_buildPodTemplate(t *testing.T) {
 				},
 				annotations: map[string]string{
 					// The sum below should reflect the version of the Secret which contain the secure settings.
-					"beat.k8s.elastic.co/config-hash": "4263282862",
+					"beat.k8s.elastic.co/config-hash": "900468277",
 				},
 			},
 		},

--- a/pkg/controller/common/keystore/resources.go
+++ b/pkg/controller/common/keystore/resources.go
@@ -23,7 +23,7 @@ type Resources struct {
 	// init container used to create the keystore
 	InitContainer corev1.Container
 	// hash of the secret data provided by the user
-	Version string
+	Hash string
 }
 
 // HasKeystore interface represents an Elastic Stack application that offers a keystore which in ECK
@@ -78,6 +78,6 @@ func ReconcileResources(
 	return &Resources{
 		Volume:        secretVolume.Volume(),
 		InitContainer: initContainer,
-		Version:       hash,
+		Hash:          hash,
 	}, nil
 }

--- a/pkg/controller/common/keystore/resources.go
+++ b/pkg/controller/common/keystore/resources.go
@@ -22,7 +22,7 @@ type Resources struct {
 	Volume corev1.Volume
 	// init container used to create the keystore
 	InitContainer corev1.Container
-	// version of the secret provided by the user
+	// hash of the secret data provided by the user
 	Version string
 }
 
@@ -60,7 +60,7 @@ func ReconcileResources(
 	initContainerParams InitContainerParameters,
 ) (*Resources, error) {
 	// setup a volume from the user-provided secure settings secret
-	secretVolume, version, err := secureSettingsVolume(ctx, r, hasKeystore, labels, namer)
+	secretVolume, hash, err := secureSettingsVolume(ctx, r, hasKeystore, labels, namer)
 	if err != nil {
 		return nil, err
 	}
@@ -78,6 +78,6 @@ func ReconcileResources(
 	return &Resources{
 		Volume:        secretVolume.Volume(),
 		InitContainer: initContainer,
-		Version:       version,
+		Version:       hash,
 	}, nil
 }

--- a/pkg/controller/common/keystore/resources_test.go
+++ b/pkg/controller/common/keystore/resources_test.go
@@ -231,7 +231,7 @@ echo "Keystore initialization successful."
 				assert.Equal(t, resources.InitContainer.VolumeMounts, tt.wantContainers.VolumeMounts)
 				assert.Equal(t, resources.InitContainer.SecurityContext, tt.wantContainers.SecurityContext)
 				assert.Equal(t, resources.InitContainer.Resources, tt.wantContainers.Resources)
-				assert.Equal(t, resources.Version, tt.wantVersion)
+				assert.Equal(t, resources.Hash, tt.wantVersion)
 			}
 		})
 	}

--- a/pkg/controller/common/keystore/resources_test.go
+++ b/pkg/controller/common/keystore/resources_test.go
@@ -115,7 +115,7 @@ func TestReconcileResources(t *testing.T) {
 		initContainerParameters InitContainerParameters
 		wantNil                 bool
 		wantContainers          *corev1.Container
-		wantVersion             string
+		wantHash                string
 	}{
 		{
 			name:                    "no secure settings specified: no resources",
@@ -123,7 +123,7 @@ func TestReconcileResources(t *testing.T) {
 			kb:                      testKibana,
 			initContainerParameters: fakeFlagInitContainersParameters(false),
 			wantContainers:          nil,
-			wantVersion:             "",
+			wantHash:                "",
 			wantNil:                 true,
 		},
 		{
@@ -159,8 +159,8 @@ touch /bar/data/elastic-internal-init-keystore.ok
 echo "Keystore initialization successful."
 `),
 			// since this will be created, it will be incremented
-			wantVersion: "1",
-			wantNil:     false,
+			wantHash: "896069204",
+			wantNil:  false,
 		},
 		{
 			name:                    "Skip create keystore flag",
@@ -187,15 +187,15 @@ done
 echo "Keystore initialization successful."
 `),
 			// since this will be created, it will be incremented
-			wantVersion: "1",
-			wantNil:     false,
+			wantHash: "896069204",
+			wantNil:  false,
 		},
 		{
 			name:           "secure settings specified but secret not there: no resources",
 			client:         k8s.NewFakeClient(),
 			kb:             testKibanaWithSecureSettings,
 			wantContainers: nil,
-			wantVersion:    "",
+			wantHash:       "",
 			wantNil:        true,
 		},
 		{
@@ -209,8 +209,8 @@ echo "Keystore initialization successful."
 			},
 			wantContainers: wantContainer(`echo "custom script"`),
 			// since this will be created, it will be incremented
-			wantVersion: "1",
-			wantNil:     false,
+			wantHash: "896069204",
+			wantNil:  false,
 		},
 	}
 	for _, tt := range tests {
@@ -231,7 +231,7 @@ echo "Keystore initialization successful."
 				assert.Equal(t, resources.InitContainer.VolumeMounts, tt.wantContainers.VolumeMounts)
 				assert.Equal(t, resources.InitContainer.SecurityContext, tt.wantContainers.SecurityContext)
 				assert.Equal(t, resources.InitContainer.Resources, tt.wantContainers.Resources)
-				assert.Equal(t, resources.Hash, tt.wantVersion)
+				assert.Equal(t, resources.Hash, tt.wantHash)
 			}
 		})
 	}

--- a/pkg/controller/common/keystore/user_secret_test.go
+++ b/pkg/controller/common/keystore/user_secret_test.go
@@ -52,7 +52,7 @@ func Test_secureSettingsVolume(t *testing.T) {
 		w           watches.DynamicWatches
 		kb          kbv1.Kibana
 		wantVolume  *volume.SecretVolume
-		wantVersion string
+		wantHash    string
 		wantWatches []string
 		wantEvent   string
 	}{
@@ -62,7 +62,7 @@ func Test_secureSettingsVolume(t *testing.T) {
 			w:           createWatches(""),
 			kb:          testKibana,
 			wantVolume:  nil,
-			wantVersion: "",
+			wantHash:    "",
 			wantWatches: []string{},
 		},
 		{
@@ -72,7 +72,7 @@ func Test_secureSettingsVolume(t *testing.T) {
 			kb:         testKibanaWithSecureSettings,
 			wantVolume: &expectedSecretVolume,
 			// since this is being created the RV will increment
-			wantVersion: "1",
+			wantHash:    "896069204",
 			wantWatches: []string{SecureSettingsWatchName(k8s.ExtractNamespacedName(&testKibanaWithSecureSettings))},
 		},
 		{
@@ -81,7 +81,7 @@ func Test_secureSettingsVolume(t *testing.T) {
 			w:           createWatches(SecureSettingsWatchName(k8s.ExtractNamespacedName(&testKibanaWithSecureSettings))),
 			kb:          testKibanaWithSecureSettings,
 			wantVolume:  nil,
-			wantVersion: "",
+			wantHash:    "",
 			wantWatches: []string{SecureSettingsWatchName(k8s.ExtractNamespacedName(&testKibanaWithSecureSettings))},
 			wantEvent:   "Warning Unexpected Secure settings secret not found: namespace/secure-settings-secret",
 		},
@@ -91,7 +91,7 @@ func Test_secureSettingsVolume(t *testing.T) {
 			w:           createWatches(SecureSettingsWatchName(k8s.ExtractNamespacedName(&testKibanaWithSecureSettings))),
 			kb:          testKibana,
 			wantVolume:  nil,
-			wantVersion: "",
+			wantHash:    "",
 			wantWatches: []string{},
 		},
 	}
@@ -102,10 +102,10 @@ func Test_secureSettingsVolume(t *testing.T) {
 				Watches:      tt.w,
 				FakeRecorder: record.NewFakeRecorder(1000),
 			}
-			vol, version, err := secureSettingsVolume(context.Background(), testDriver, &tt.kb, nil, kbNamer)
+			vol, hash, err := secureSettingsVolume(context.Background(), testDriver, &tt.kb, nil, kbNamer)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantVolume, vol)
-			assert.Equal(t, tt.wantVersion, version)
+			assert.Equal(t, tt.wantHash, hash)
 
 			require.Equal(t, tt.wantWatches, tt.w.Secrets.Registrations())
 

--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -218,7 +218,7 @@ func buildAnnotations(
 
 	if keystoreResources != nil {
 		// resource version of the secure settings secret to rotate the pod on secure settings change
-		_, _ = configHash.Write([]byte(keystoreResources.Version))
+		_, _ = configHash.Write([]byte(keystoreResources.Hash))
 	}
 
 	// set the annotation in place

--- a/pkg/controller/elasticsearch/nodespec/podspec_test.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec_test.go
@@ -438,7 +438,7 @@ func Test_buildAnnotations(t *testing.T) {
 			name: "With keystore and scripts content",
 			args: args{
 				keystoreResources: &keystore.Resources{
-					Version: "42",
+					Hash: "42",
 				},
 				scriptsContent: "scripts content",
 			},
@@ -450,7 +450,7 @@ func Test_buildAnnotations(t *testing.T) {
 			name: "With another keystore version",
 			args: args{
 				keystoreResources: &keystore.Resources{
-					Version: "43",
+					Hash: "43",
 				},
 				scriptsContent: "scripts content",
 			},
@@ -462,7 +462,7 @@ func Test_buildAnnotations(t *testing.T) {
 			name: "With another script version",
 			args: args{
 				keystoreResources: &keystore.Resources{
-					Version: "42",
+					Hash: "42",
 				},
 				scriptsContent: "another scripts content",
 			},

--- a/pkg/controller/kibana/driver.go
+++ b/pkg/controller/kibana/driver.go
@@ -252,7 +252,7 @@ func (d *driver) deploymentParams(ctx context.Context, kb *kbv1.Kibana, policyAn
 	// This is done because Kibana does not support updating those without restarting the process.
 	configHash := fnv.New32a()
 	if keystoreResources != nil {
-		_, _ = configHash.Write([]byte(keystoreResources.Version))
+		_, _ = configHash.Write([]byte(keystoreResources.Hash))
 	}
 
 	// we need to deref the secret here to include it in the checksum otherwise Kibana will not be rolled on contents changes

--- a/pkg/controller/logstash/keystore.go
+++ b/pkg/controller/logstash/keystore.go
@@ -95,7 +95,7 @@ func reconcileKeystore(params Params, configHash hash.Hash) (*keystore.Resources
 	); err != nil {
 		return nil, err
 	} else if keystoreResources != nil {
-		_, _ = configHash.Write([]byte(keystoreResources.Version))
+		_, _ = configHash.Write([]byte(keystoreResources.Hash))
 		// set keystore password in init container
 		if env := getKeystorePass(params.Logstash); env != nil {
 			keystoreResources.InitContainer.Env = append(keystoreResources.InitContainer.Env, *env)


### PR DESCRIPTION
This uses the hash of the `-es-secure-settings` Secret data instead of its resource version to know if Pods need to be recreated to update the Keystore.
This will avoid unnecessary restarts of Elasticsearch restarts if the Secret resource version changes without changing the data.

Note: upgrading to the eck version including this new change will result in a graceful restart.

Resolves #7842.