### PR TITLE
[2.13] Account for Logstash memory in resource aggregator (#7853)

### DIFF
--- a/pkg/controller/logstash/pod.go
+++ b/pkg/controller/logstash/pod.go
@@ -38,16 +38,20 @@ const (
 
 	// VersionLabelName is a label used to track the version of a Logstash Pod.
 	VersionLabelName = "logstash.k8s.elastic.co/version"
+
+	// EnvJavaOpts is the documented environment variable to set JVM options for Logstash.
+	EnvJavaOpts = "LS_JAVA_OPTS"
 )
 
 var (
-	DefaultResources = corev1.ResourceRequirements{
+	DefaultMemoryLimit = resource.MustParse("2Gi")
+	DefaultResources   = corev1.ResourceRequirements{
 		Limits: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceMemory: resource.MustParse("2Gi"),
+			corev1.ResourceMemory: DefaultMemoryLimit,
 			corev1.ResourceCPU:    resource.MustParse("2000m"),
 		},
 		Requests: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceMemory: resource.MustParse("2Gi"),
+			corev1.ResourceMemory: DefaultMemoryLimit,
 			corev1.ResourceCPU:    resource.MustParse("1000m"),
 		},
 	}

--- a/pkg/license/aggregator_test.go
+++ b/pkg/license/aggregator_test.go
@@ -24,6 +24,7 @@ import (
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	entv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/enterprisesearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/kibana/v1"
+	lsv1alpha1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/logstash/v1alpha1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 )
 
@@ -141,7 +142,7 @@ func TestAggregator(t *testing.T) {
 
 	val, err := aggregator.AggregateMemory(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, 325.9073486328125, inGiB(val))
+	require.Equal(t, 329.9073486328125, inGiB(val))
 }
 
 func readObjects(t *testing.T, filePath string) []client.Object {
@@ -152,6 +153,7 @@ func readObjects(t *testing.T, filePath string) []client.Object {
 	scheme.AddKnownTypes(kbv1.GroupVersion, &kbv1.Kibana{}, &kbv1.KibanaList{})
 	scheme.AddKnownTypes(apmv1.GroupVersion, &apmv1.ApmServer{}, &apmv1.ApmServerList{})
 	scheme.AddKnownTypes(entv1.GroupVersion, &entv1.EnterpriseSearch{}, &entv1.EnterpriseSearchList{})
+	scheme.AddKnownTypes(lsv1alpha1.GroupVersion, &lsv1alpha1.Logstash{}, &lsv1alpha1.LogstashList{})
 	decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
 
 	f, err := os.Open(filePath)

--- a/pkg/license/testdata/stack.yaml
+++ b/pkg/license/testdata/stack.yaml
@@ -144,3 +144,23 @@ spec:
           env:
             - name: JAVA_OPTS
               value: -Xms7500m -Xmx7500m
+---
+apiVersion: logstash.k8s.elastic.co/v1alpha1
+kind: Logstash
+metadata:
+  name: logstash-sample
+spec:
+  count: 1
+  podTemplate:
+    spec:
+      containers:
+        - name: logstash
+          resources:
+            requests:
+              cpu: 3
+              memory: 1Gi
+            limits:
+              memory: 4Gi
+          env:
+            - name: LS_JAVA_OPTS
+              value: -Xms3g -Xmx3g


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.13`:
 - [Account for Logstash memory in resource aggregator (#7853)](https://github.com/elastic/cloud-on-k8s/pull/7853)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)