### PR TITLE
Quickstart example configuration is invalid

### DIFF
--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -97,6 +97,7 @@ spec:
   - name: default
     count: 1
     config:
+      index.number_of_replicas: 0
       node.store.allow_mmap: false
 EOF
 ----
@@ -275,7 +276,7 @@ kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | ba
 
 You can add and modify most elements of the original cluster specification provided that they translate to valid transformations of the underlying Kubernetes resources (for example <<{p}-volume-claim-templates, existing volume claims cannot be downsized>>). The operator will attempt to apply your changes with minimal disruption to the existing cluster. You should ensure that the Kubernetes cluster has sufficient resources to accommodate the changes (extra storage space, sufficient memory and CPU resources to temporarily spin up new pods, and so on).
 
-For example, you can grow the cluster to three Elasticsearch nodes:
+For example, you can grow the cluster to three Elasticsearch nodes which also will allow you to set the number of replicas greater than zero:
 
 [source,yaml,subs="attributes,+macros"]
 ----
@@ -290,6 +291,7 @@ spec:
   - name: default
     count: 3
     config:
+      index.number_of_replicas: 1
       node.store.allow_mmap: false
 EOF
 ----


### PR DESCRIPTION
The Quickstart configuration example will result in indices being created with the default number of replicas (1), but the sample configuration is only deploying one node, so it can not support any replicas; this setting must be set to `0` because `spec.nodeSets[].count = 1`

This update adjusts the sample to include this setting, and also updates the "scale up example" to bump the number of replicas to 1 after increasing the count to 3.  This will avoid indices because created that are all in "yellow" health because the replicas cannot be assigned.

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? 
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)? 
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed.
