### PR TITLE
Update supported-versions.asciidoc

### DIFF
--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -2,6 +2,7 @@
 * OpenShift 4.11-4.14
 * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 * Helm: 3.2.0+
+* VMware Tanzu Kubernetes Grid Versions: 	1.4, 1.5.4
 * Elasticsearch, Kibana, APM Server: 6.8+, 7.1+, 8+
 * Enterprise Search: 7.7+, 8+
 * Beats: 7.0+, 8+


### PR DESCRIPTION
Following the Support Matrix (https://www.elastic.co/support/matrix#matrix_kubernetes) ECK is supported on VMware Tanzu ... 

I think we need to review the both documents (Support Matrix and this one)
