### PR TITLE
update docs and release highlights to note logstash licensing

### DIFF
--- a/docs/operating-eck/licensing.asciidoc
+++ b/docs/operating-eck/licensing.asciidoc
@@ -127,3 +127,5 @@ elastic_licensing_enterprise_resource_units_total{license_level="basic"} 6
 # TYPE elastic_licensing_memory_gigabytes_total gauge
 elastic_licensing_memory_gigabytes_total{license_level="basic"} 357.01915648
 ----
+
+NOTE: Logstash resources managed by ECK will be counted towards ERU usage for informational purposes. Billable consumption depends on license terms on a per customer basis (See link:https://www.elastic.co/agreements/global/self-managed[Self Managed Subscription Agreement])

--- a/docs/release-notes/2.13.0.asciidoc
+++ b/docs/release-notes/2.13.0.asciidoc
@@ -16,6 +16,7 @@
 [float]
 === Enhancements
 
+* Account for Logstash memory in resource aggregator {pull}7853[#7853]
 * Add Helm annotation to CRDs to prevent accidental deletion. {pull}7811[#7811] (issue: {issue}5117[#5117])
 * Allow disabling of elastic user. {pull}7723[#7723] (issue: {issue}7719[#7719])
 * Make automountServiceAccountToken configurable on operator Pods via Helm {pull}7690[#7690]

--- a/docs/release-notes/highlights-2.13.0.asciidoc
+++ b/docs/release-notes/highlights-2.13.0.asciidoc
@@ -32,5 +32,5 @@ Logstash managed by ECK is now considered production-ready.
 [id="{p}-2130-eck-logstash-licensing"]
 === Logstash licensing on ECK
 
-ECK's resource https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-licensing.html#k8s-get-usage-data[management accounting] has been modified to include Logstash resources managed by ECK, this is provided for informational purposes. Billable consumption depends on license terms on a per customer basis (See https://www.elastic.co/agreements/global/self-managed[Self Managed Subscription Agreement]).
+ECK's resource https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-licensing.html#k8s-get-usage-data[management accounting] has been modified to include Logstash resources managed by ECK, which is provided for informational purposes. Billable consumption depends on license terms on a per customer basis (See https://www.elastic.co/agreements/global/self-managed[Self Managed Subscription Agreement]).
 

--- a/docs/release-notes/highlights-2.13.0.asciidoc
+++ b/docs/release-notes/highlights-2.13.0.asciidoc
@@ -32,5 +32,5 @@ Logstash managed by ECK is now considered production-ready.
 [id="{p}-2130-eck-logstash-licensing"]
 === Logstash licensing on ECK
 
-ECKs resource https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-licensing.html#k8s-get-usage-data[management accounting] has been modified to include Logstash resources managed by ECK, this is provided for informational purposes. Billable consumption depends on license terms on a per customer basis (See https://www.elastic.co/agreements/global/self-managed[Self Managed Subscription Agreement]).
+ECK's resource https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-licensing.html#k8s-get-usage-data[management accounting] has been modified to include Logstash resources managed by ECK, this is provided for informational purposes. Billable consumption depends on license terms on a per customer basis (See https://www.elastic.co/agreements/global/self-managed[Self Managed Subscription Agreement]).
 

--- a/docs/release-notes/highlights-2.13.0.asciidoc
+++ b/docs/release-notes/highlights-2.13.0.asciidoc
@@ -28,3 +28,9 @@ ECK 2.13.0 introduces a new option that allows a user to disable the elastic use
 With ECK 2.13.0, support for Logstash is moving out of technical preview and is now generally available (GA). 
 Logstash managed by ECK is now considered production-ready.
 
+[float]
+[id="{p}-2130-eck-logstash-licensing"]
+=== Logstash licensing on ECK
+
+ECKs resource https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-licensing.html#k8s-get-usage-data[management accounting] has been modified to include Logstash resources managed by ECK, this is provided for informational purposes. Billable consumption depends on license terms on a per customer basis (See https://www.elastic.co/agreements/global/self-managed[Self Managed Subscription Agreement]).
+


### PR DESCRIPTION
Update licensing doc and 2.13 release highlights to note the licensing changes for Logstash on ECK
