### PR TITLE
Allow unassigned nodes by REPLICA_ADDED during shutdown

### DIFF
--- a/pkg/controller/elasticsearch/client/model.go
+++ b/pkg/controller/elasticsearch/client/model.go
@@ -144,11 +144,12 @@ type Shards []Shard
 
 // Shard partially models Elasticsearch cluster shard.
 type Shard struct {
-	Index    string     `json:"index"`
-	Shard    string     `json:"shard"`
-	State    ShardState `json:"state"`
-	NodeName string     `json:"node"`
-	Type     ShardType  `json:"prirep"`
+	Index            string     `json:"index"`
+	Shard            string     `json:"shard"`
+	State            ShardState `json:"state"`
+	NodeName         string     `json:"node"`
+	Type             ShardType  `json:"prirep"`
+	UnassignedReason string     `json:"unassigned.reason"`
 }
 
 type RoutingTable struct {

--- a/pkg/controller/elasticsearch/client/shard.go
+++ b/pkg/controller/elasticsearch/client/shard.go
@@ -40,7 +40,7 @@ func (c *clientV6) ExcludeFromShardAllocation(ctx context.Context, nodes string)
 
 func (c *clientV6) GetShards(ctx context.Context) (Shards, error) {
 	var shards Shards
-	if err := c.get(ctx, "/_cat/shards?format=json", &shards); err != nil {
+	if err := c.get(ctx, "/_cat/shards?h=index,shard,prirep,state,node,unassigned.reason&format=json", &shards); err != nil {
 		return shards, err
 	}
 	return shards, nil

--- a/pkg/controller/elasticsearch/migration/migrate_data.go
+++ b/pkg/controller/elasticsearch/migration/migrate_data.go
@@ -74,8 +74,8 @@ func nodeMayHaveShard(ctx context.Context, es esv1.Elasticsearch, shardLister es
 		if shard.NodeName == podName {
 			return true, nil
 		}
-		// shard node undefined (likely unassigned)
-		if shard.NodeName == "" {
+		// shard node undefined (likely unassigned by restarting the node)
+		if shard.NodeName == "" && shard.UnassignedReason != "REPLICA_ADDED" {
 			ulog.FromContext(ctx).Info("Found orphan shard, preventing data migration",
 				"namespace", es.Namespace, "es_name", es.Name,
 				"index", shard.Index, "shard", shard.Shard, "shard_state", shard.State)

--- a/pkg/controller/elasticsearch/migration/migrate_data_test.go
+++ b/pkg/controller/elasticsearch/migration/migrate_data_test.go
@@ -72,6 +72,17 @@ func TestNodeMayHaveShard(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "Some shards have no node assigned by REPLICA_ADDED",
+			args: args{
+				podName: "A",
+				shardLister: NewFakeShardLister([]client.Shard{
+					{Index: "index-1", Shard: "0", NodeName: "", UnassignedReason: "REPLICA_ADDED"},
+					{Index: "index-1", Shard: "0", NodeName: "C"},
+				}),
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
As talked in https://github.com/elastic/cloud-on-k8s/issues/3867, current implementation is conservative.
We are using `index.routing.allocation.total_shards_per_node` and sometimes there are unassigned shards by this after increasing the number of replicas. We are changing the number of nodes and the number of replicas automatically, so unassigned shards that have unassigned reason `REPLICA_ADDED` blocks other nodeSet to be scale in. The reason `REPLICA_ADDED` is for the shards that have never been assigned so we can ignore these during shutdown.
 
<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)?
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed.
- -->
