### PR TITLE
Fix panic and dropped error result

### DIFF
--- a/pkg/controller/elasticsearch/driver/upgrade.go
+++ b/pkg/controller/elasticsearch/driver/upgrade.go
@@ -71,7 +71,9 @@ func (d *defaultDriver) handleUpgrades(
 	nodeShutdown := shutdown.NewNodeShutdown(esClient, nodeNameToID, esclient.Restart, d.ES.ResourceVersion, logger)
 
 	// Maybe re-enable shards allocation and delete shutdowns if upgraded nodes are back into the cluster.
-	results.WithResults(d.maybeCompleteNodeUpgrades(ctx, esClient, esState, nodeShutdown))
+	if results.WithResults(d.maybeCompleteNodeUpgrades(ctx, esClient, esState, nodeShutdown)).HasError() {
+		return results
+	}
 
 	// Get the list of pods currently existing in the StatefulSetList
 	currentPods, err := statefulSets.GetActualPods(d.Client)

--- a/pkg/controller/elasticsearch/shutdown/node.go
+++ b/pkg/controller/elasticsearch/shutdown/node.go
@@ -37,6 +37,7 @@ func NewNodeShutdown(c esclient.Client, podToNodeID map[string]string, typ escli
 		typ:         typ,
 		podToNodeID: podToNodeID,
 		reason:      reason,
+		shutdowns:   make(map[string]esclient.NodeShutdown),
 		log:         l,
 	}
 }

--- a/test/e2e/test/elasticsearch/checks_restart.go
+++ b/test/e2e/test/elasticsearch/checks_restart.go
@@ -51,7 +51,7 @@ func newNodeShutdownWatcher(es esv1.Elasticsearch) test.Watcher {
 				}
 			}
 			if len(restarts) > maxConcurrentRestarts {
-				observedErrors = append(observedErrors, fmt.Errorf("expected less than %d, got %d, restarts: %v", maxConcurrentRestarts, len(restarts), restarts))
+				observedErrors = append(observedErrors, fmt.Errorf("expected at most %d, got %d, restarts: %v", maxConcurrentRestarts, len(restarts), restarts))
 			}
 		},
 		func(k *test.K8sClient, t *testing.T) { //nolint:thelper


### PR DESCRIPTION
We were ignoring an error during a node shutdown initialisation and panicking on a subsequently uninitialised map. 

Technically it should be enough to handle the error but I chose to also intialise the map by default. 

For future reference, this was discovered through an e2e test (props to @thbkrkr for the throrough analysis). 
```
[
	expected less than 1, got 2, restarts: [
		{o44cyWaAQQuzmvh3g_iOzQ RESTART 187844 1717724317347 COMPLETE {COMPLETE 0 no shard relocation is necessary for a node restart} {COMPLETE} {COMPLETE}} 
		{LSN_PaSuRoOIsQF3QKyx3g RESTART 187995 1717724469546 COMPLETE {COMPLETE 0 no shard relocation is necessary for a node restart} {COMPLETE} {COMPLETE}}
]
```
We discovered that a previous shutdown record was still present. This should not happen as we clear shutdown records before proceeding to the next node. We then found that the operator had been restarted twice once in the middle to the upgrade process. Which lead to the discovery of the following panic:

![Capture d’écran 2024-06-07 à 11 34 46](https://github.com/elastic/cloud-on-k8s/assets/697790/8cf02b87-f776-43c3-b6f8-11e8ff9d2022)


We are lackign a bit of test coverage in this area, ~so I am probably going to push a unit test once I find a the right scope.~ I don't have the capacity right now to improve the coverage. We relied on e2e test coverage for this part of the code in the past and one could say that the e2e test found the bug eventually. 

We should however alert on panics in the e2e cluster. 