### PR TITLE
reverting LatestReleasedVersion8x in e2e test to 8.13.2

### DIFF
--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -16,9 +16,9 @@ const (
 	// LatestReleasedVersion6x is the latest released version for 6.x
 	LatestReleasedVersion6x = "6.8.23"
 	// LatestReleasedVersion7x is the latest released version for 7.x
-	LatestReleasedVersion7x = "7.17.8"
+	LatestReleasedVersion7x = "7.17.21"
 	// LatestReleasedVersion8x is the latest release version for 8.x
-	LatestReleasedVersion8x = "8.14.0"
+	LatestReleasedVersion8x = "8.13.2"
 )
 
 // SkipInvalidUpgrade skips a test that would do an invalid upgrade.

--- a/test/e2e/test/version.go
+++ b/test/e2e/test/version.go
@@ -18,6 +18,7 @@ const (
 	// LatestReleasedVersion7x is the latest released version for 7.x
 	LatestReleasedVersion7x = "7.17.21"
 	// LatestReleasedVersion8x is the latest release version for 8.x
+	// TODO: update to latest 8.14.x when released with a fix to https://github.com/elastic/cloud-on-k8s/issues/7878
 	LatestReleasedVersion8x = "8.13.2"
 )
 


### PR DESCRIPTION
we currently have a known issue with upgrading to 8.14.0 from 7.17.X, reverting the latest released 8x version so that this does not affect our nightly pipelines while a fix is being worked on
