### PR TITLE
[E2E] Handle 404 when deleting resources

### DIFF
--- a/test/e2e/test/utils.go
+++ b/test/e2e/test/utils.go
@@ -240,7 +240,7 @@ func deleteTestResources(ctx context.Context) error {
 			return fmt.Errorf("while listing all secrets in namespace %s: %w", namespace, err)
 		}
 		for _, secret := range list.Items {
-			if err := clntset.CoreV1().Secrets(namespace).Delete(ctx, secret.GetName(), v1.DeleteOptions{}); err != nil {
+			if err := clntset.CoreV1().Secrets(namespace).Delete(ctx, secret.GetName(), v1.DeleteOptions{}); err != nil && !api_errors.IsNotFound(err) {
 				return fmt.Errorf("while deleting secret %s in namespace %s: %w", secret.GetName(), namespace, err)
 			}
 		}
@@ -250,7 +250,7 @@ func deleteTestResources(ctx context.Context) error {
 			return fmt.Errorf("while listing all pods in namespace %s: %w", namespace, err)
 		}
 		for _, pod := range pods.Items {
-			if err := clntset.CoreV1().Pods(namespace).Delete(ctx, pod.GetName(), v1.DeleteOptions{}); err != nil {
+			if err := clntset.CoreV1().Pods(namespace).Delete(ctx, pod.GetName(), v1.DeleteOptions{}); err != nil && !api_errors.IsNotFound(err) {
 				return fmt.Errorf("while deleting pod %s in namespace %s: %w", pod.GetName(), namespace, err)
 			}
 		}


### PR DESCRIPTION
Fix following e2e test failure observed today in AKS:

```json
{
    "log.level": "error",
    "@timestamp": "2024-06-09T23:26:03.029Z",
    "log.logger": "e2e",
    "message": "while deleting elastic resources",
    "service.version": "0.0.0-SNAPSHOT+00000000",
    "service.type": "eck",
    "ecs.version": "1.4.0",
    "error": "while deleting secret elasticsearch-mon-p6mb-es-elastic-user in namespace e2e-0kcqt-mercury: secrets \"elasticsearch-mon-p6mb-es-elastic-user\" not found",
    "error.stack_trace": "github.com/elastic/cloud-on-k8s/v2/test/e2e/test.StepList.RunSequential\n\t/go/src/github.com/elastic/cloud-on-k8s/test/e2e/test/step.go:61\ngithub.com/elastic/cloud-on-k8s/v2/test/e2e/test/helper.RunFile\n\t/go/src/github.com/elastic/cloud-on-k8s/test/e2e/test/helper/yaml.go:171\ngithub.com/elastic/cloud-on-k8s/v2/test/e2e/agent.runAgentRecipe\n\t/go/src/github.com/elastic/cloud-on-k8s/test/e2e/agent/recipes_test.go:250\ngithub.com/elastic/cloud-on-k8s/v2/test/e2e/agent.TestMultiOutputRecipe\n\t/go/src/github.com/elastic/cloud-on-k8s/test/e2e/agent/recipes_test.go:87\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1689"
}
```