### PR TITLE
[E2E] Fix Monitoring Agent on OCP and add journald integration

### DIFF
--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -17,6 +17,9 @@ spec:
           - name: agent
             securityContext:
               runAsUser: 0
+  {{ if .OcpCluster }}
+              privileged: true
+  {{ end }}
             resources:
               limits:
                 memory: 768Mi

--- a/config/e2e/monitoring.yaml
+++ b/config/e2e/monitoring.yaml
@@ -22,10 +22,10 @@ spec:
   {{ end }}
             resources:
               limits:
-                memory: 768Mi
+                memory: 1Gi
                 cpu: 1
               requests:
-                memory: 768Mi
+                memory: 1Gi
                 cpu: 100m
             env:
               - name: NODE_NAME
@@ -83,6 +83,30 @@ spec:
       node: ${NODE_NAME}
       scope: node
     inputs:
+    - id: journald-log
+      type: journald
+      processors:
+        - add_fields:
+            target: ''
+            fields:
+              cluster.name: {{ .ClusterName }}
+        - add_fields:
+            target: kubernetes
+            fields:
+              node.name: ${kubernetes.node.name}
+      use_output: default
+      seek: tail
+      meta:
+        package:
+          name: journald
+          version: 1.1.0
+      data_stream:
+        namespace: default
+      streams:
+        - data_stream:
+            dataset: journald.log
+          paths:
+            - /var/log/journal/
     - name: kubernetes-1
       revision: 1
       type: kubernetes/metrics


### PR DESCRIPTION
This PR fixes a permission issue for the E2E monitoring Agents on OpenShift (the ones which are collecting the logs, not the ones being tested)

It also adds the `journald` integration to capture OOM events:

<img width="1961" alt="image" src="https://github.com/elastic/cloud-on-k8s/assets/976373/3eea3d4c-b627-46be-b2a6-5ac1a5484f7a">

An unfortunate side effect is that I need to increase the Agent memory from `768Mi` to `1Gi`, not sure if it is related to OpenShift or the the `journald` integration though (or both).