### PR TITLE
Fix Logstash service to preserve user defined labels

### DIFF
--- a/pkg/controller/logstash/service.go
+++ b/pkg/controller/logstash/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/logstash/labels"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/logstash/network"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/maps"
 )
 
 const (
@@ -70,8 +71,7 @@ func newService(service logstashv1alpha1.LogstashService, logstash logstashv1alp
 	svc.ObjectMeta.Name = logstashv1alpha1.UserServiceName(logstash.Name, service.Name)
 
 	labels := labels.NewLabels(logstash)
-
-	svc.Labels = labels
+	svc.Labels = maps.MergePreservingExistingKeys(svc.Labels, labels)
 
 	if svc.Spec.Selector == nil {
 		svc.Spec.Selector = labels

--- a/pkg/controller/logstash/service_test.go
+++ b/pkg/controller/logstash/service_test.go
@@ -163,13 +163,41 @@ func TestReconcileServices(t *testing.T) {
 						},
 					},
 				},
+				DefaultAPIService(),
+			},
+		},
+		{
+			name: "Preserve user defined labels",
+			logstash: logstashv1alpha1.Logstash{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "logstash",
+					Namespace: "test",
+				},
+				Spec: logstashv1alpha1.LogstashSpec{
+					Services: []logstashv1alpha1.LogstashService{{
+						Name: "test",
+						Service: commonv1.ServiceTemplate{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{"some.label": "abc"},
+							},
+							Spec: corev1.ServiceSpec{
+								Ports: []corev1.ServicePort{
+									{Protocol: "TCP", Port: 9200},
+								},
+							},
+						},
+					}},
+				},
+			},
+			wantSvc: []corev1.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "logstash-ls-api",
+						Name:      "logstash-ls-test",
 						Namespace: "test",
 						Labels: map[string]string{
 							"common.k8s.elastic.co/type":   "logstash",
 							"logstash.k8s.elastic.co/name": "logstash",
+							"some.label":                   "abc",
 						},
 						OwnerReferences: []metav1.OwnerReference{
 							{
@@ -186,12 +214,13 @@ func TestReconcileServices(t *testing.T) {
 							"common.k8s.elastic.co/type":   "logstash",
 							"logstash.k8s.elastic.co/name": "logstash",
 						},
-						ClusterIP: "None",
+						ClusterIP: "",
 						Ports: []corev1.ServicePort{
-							{Name: "api", Protocol: "TCP", Port: 9600},
+							{Protocol: "TCP", Port: 9200},
 						},
 					},
 				},
+				DefaultAPIService(),
 			},
 		},
 	}
@@ -216,5 +245,38 @@ func TestReconcileServices(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func DefaultAPIService() corev1.Service {
+	trueVal := true
+	return corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "logstash-ls-api",
+			Namespace: "test",
+			Labels: map[string]string{
+				"common.k8s.elastic.co/type":   "logstash",
+				"logstash.k8s.elastic.co/name": "logstash",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "logstash.k8s.elastic.co/v1alpha1",
+					Kind:               "Logstash",
+					Name:               "logstash",
+					Controller:         &trueVal,
+					BlockOwnerDeletion: &trueVal,
+				},
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"common.k8s.elastic.co/type":   "logstash",
+				"logstash.k8s.elastic.co/name": "logstash",
+			},
+			ClusterIP: "None",
+			Ports: []corev1.ServicePort{
+				{Name: "api", Protocol: "TCP", Port: 9600},
+			},
+		},
 	}
 }


### PR DESCRIPTION
This commit preserves user labels in Logstash Service

Fixes: #7855

The following resource should keep customized label in service `logstash-sample-ls-beats`

```yaml
apiVersion: logstash.k8s.elastic.co/v1alpha1
kind: Logstash
metadata:
  name: logstash-sample
spec:
  count: 1
  version: 8.14.0
  pipelines:
    - pipeline.id: main
      pipeline.workers: 2
      config.string: "input { beats { port => 5044 }} output { stdout {}}"
  services:
    - name: beats
      service:
        metadata:
          labels:
            i.am.label: here
        spec:
          type: ClusterIP
          ports:
            - port: 5044
              name: "filebeat"
              protocol: TCP
              targetPort: 5044
```
