### PR TITLE
Handle Serverless version in association versions check

### DIFF
--- a/pkg/apis/common/v1/association.go
+++ b/pkg/apis/common/v1/association.go
@@ -215,6 +215,8 @@ type AssociationConf struct {
 	// Version of the referenced resource. If a version upgrade is in progress,
 	// matches the lowest running version. May be empty if unknown.
 	Version string `json:"version"`
+	// Serverless is true when the referenced resource is a serverless project.
+	Serverless bool `json:"serverless,omitempty"`
 }
 
 // IsConfigured returns true if all the fields are set.
@@ -292,13 +294,6 @@ func (ac *AssociationConf) GetURL() string {
 		return ""
 	}
 	return ac.URL
-}
-
-func (ac *AssociationConf) GetVersion() string {
-	if ac == nil {
-		return ""
-	}
-	return ac.Version
 }
 
 func ElasticsearchConfigAnnotationName(o ObjectSelector) string {

--- a/pkg/controller/association/conf.go
+++ b/pkg/controller/association/conf.go
@@ -147,6 +147,9 @@ func AllowVersion(resourceVersion version.Version, associated commonv1.Associate
 			// unknown version (happens with an unmanaged FleetServer < 8.x), move on
 			return true, nil
 		}
+		if assocConf.Serverless {
+			return true, nil
+		}
 		refVer, err := version.Parse(assocConf.Version)
 		if err != nil {
 			logger.Error(err, "Invalid version found in association configuration", "association_version", assocConf.Version)

--- a/pkg/controller/association/conf_test.go
+++ b/pkg/controller/association/conf_test.go
@@ -443,6 +443,22 @@ func TestAllowVersion(t *testing.T) {
 		}
 		return apm
 	}
+
+	agent := &agentv1alpha1.Agent{
+		Spec: agentv1alpha1.AgentSpec{
+			ElasticsearchRefs: []agentv1alpha1.Output{
+				{
+					ObjectSelector: commonv1.ObjectSelector{
+						SecretName: "my-secret",
+					},
+				},
+			},
+		},
+	}
+	for _, assoc := range agent.GetAssociations() {
+		assoc.SetAssociationConf(&commonv1.AssociationConf{Version: "8.9.0", Serverless: true})
+	}
+
 	type args struct {
 		resourceVersion version.Version
 		associated      commonv1.Associated
@@ -453,6 +469,14 @@ func TestAllowVersion(t *testing.T) {
 		want      bool
 		wantEvent bool
 	}{
+		{
+			name: "serverless: allow",
+			args: args{
+				resourceVersion: version.MustParse("8.14.0"),
+				associated:      agent.DeepCopy(),
+			},
+			want: true,
+		},
 		{
 			name: "no association specified: allow",
 			args: args{

--- a/pkg/controller/association/controller/apm_kibana.go
+++ b/pkg/controller/association/controller/apm_kibana.go
@@ -6,6 +6,7 @@ package controller
 
 import (
 	"context"
+	ver "github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -71,28 +72,46 @@ func getKibanaExternalURL(c k8s.Client, assoc commonv1.Association) (string, err
 	return association.ServiceURL(c, nsn, kb.Spec.HTTP.Protocol())
 }
 
+type kibanaVersionResponse struct {
+	Version struct {
+		Number string `json:"number"`
+	} `json:"version"`
+}
+
+func (kibanaVersionResponse) IsServerless() bool {
+	return false
+}
+
+func (kvr kibanaVersionResponse) GetVersion() (string, error) {
+	if _, err := ver.Parse(kvr.Version.Number); err != nil {
+		return "", err
+	}
+	return kvr.Version.Number, nil
+}
+
 // referencedKibanaStatusVersion returns the currently running version of Kibana
 // reported in its status.
-func referencedKibanaStatusVersion(c k8s.Client, kbAssociation commonv1.Association) (string, error) {
+func referencedKibanaStatusVersion(c k8s.Client, kbAssociation commonv1.Association) (string, bool, error) {
 	kbRef := kbAssociation.AssociationRef()
 	if kbRef.IsExternal() {
+		kbVersionResponse := &kibanaVersionResponse{}
 		info, err := association.GetUnmanagedAssociationConnectionInfoFromSecret(c, kbAssociation)
 		if err != nil {
-			return "", err
+			return "", false, err
 		}
-		ver, err := info.Version("/api/status", "{ .version.number }")
+		ver, isServerless, err := info.Version("/api/status", kbVersionResponse)
 		if err != nil {
-			return "", err
+			return "", false, err
 		}
-		return ver, nil
+		return ver, isServerless, nil
 	}
 
 	var kb kbv1.Kibana
 	err := c.Get(context.Background(), kbRef.NamespacedName(), &kb)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
-	return kb.Status.Version, nil
+	return kb.Status.Version, false, nil
 }
 
 // getElasticsearchFromKibana returns the Elasticsearch reference in which the user must be created for this association.

--- a/pkg/controller/association/controller/apm_kibana.go
+++ b/pkg/controller/association/controller/apm_kibana.go
@@ -80,7 +80,7 @@ type kibanaVersionResponse struct {
 }
 
 func (kvr kibanaVersionResponse) IsServerless() bool {
-	return kvr.Version.BuildFlavor == "serverless"
+	return kvr.Version.BuildFlavor == serverlessBuildFlavor
 }
 
 func (kvr kibanaVersionResponse) GetVersion() (string, error) {

--- a/pkg/controller/association/controller/apm_kibana.go
+++ b/pkg/controller/association/controller/apm_kibana.go
@@ -6,7 +6,6 @@ package controller
 
 import (
 	"context"
-	ver "github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -18,6 +17,7 @@ import (
 	kbv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/operator"
+	ver "github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/user"
 	kblabel "github.com/elastic/cloud-on-k8s/v2/pkg/controller/kibana/label"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"

--- a/pkg/controller/association/controller/apm_kibana.go
+++ b/pkg/controller/association/controller/apm_kibana.go
@@ -74,12 +74,13 @@ func getKibanaExternalURL(c k8s.Client, assoc commonv1.Association) (string, err
 
 type kibanaVersionResponse struct {
 	Version struct {
-		Number string `json:"number"`
+		Number      string `json:"number"`
+		BuildFlavor string `json:"build_flavor"`
 	} `json:"version"`
 }
 
-func (kibanaVersionResponse) IsServerless() bool {
-	return false
+func (kvr kibanaVersionResponse) IsServerless() bool {
+	return kvr.Version.BuildFlavor == "serverless"
 }
 
 func (kvr kibanaVersionResponse) GetVersion() (string, error) {

--- a/pkg/controller/association/controller/kibana_ent.go
+++ b/pkg/controller/association/controller/kibana_ent.go
@@ -6,7 +6,6 @@ package controller
 
 import (
 	"context"
-	ver "github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,6 +16,7 @@ import (
 	kbv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/operator"
+	ver "github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	entctl "github.com/elastic/cloud-on-k8s/v2/pkg/controller/enterprisesearch"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/rbac"

--- a/pkg/controller/association/controller/kibana_es.go
+++ b/pkg/controller/association/controller/kibana_es.go
@@ -35,6 +35,9 @@ const (
 
 	// KibanaSystemUserBuiltinRole is the name of the built-in role for the Kibana system user.
 	KibanaSystemUserBuiltinRole = "kibana_system"
+
+	// serverlessBuildFlavor is the string returned in the version.build_flavor field when running on serverless.
+	serverlessBuildFlavor = "serverless"
 )
 
 func AddKibanaES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params operator.Parameters) error {
@@ -78,7 +81,7 @@ type elasticsearchVersionResponse struct {
 }
 
 func (evr elasticsearchVersionResponse) IsServerless() bool {
-	return evr.Version.BuildFlavor == "serverless"
+	return evr.Version.BuildFlavor == serverlessBuildFlavor
 }
 
 func (evr elasticsearchVersionResponse) GetVersion() (string, error) {

--- a/pkg/controller/association/controller/kibana_es.go
+++ b/pkg/controller/association/controller/kibana_es.go
@@ -16,6 +16,7 @@ import (
 	kbv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/association"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/operator"
+	ver "github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	eslabel "github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/label"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/rbac"
@@ -69,26 +70,45 @@ func AddKibanaES(mgr manager.Manager, accessReviewer rbac.AccessReviewer, params
 	})
 }
 
+type elasticsearchVersionResponse struct {
+	Version struct {
+		Number      string `json:"number"`
+		BuildFlavor string `json:"build_flavor"`
+	} `json:"version"`
+}
+
+func (evr elasticsearchVersionResponse) IsServerless() bool {
+	return evr.Version.BuildFlavor == "serverless"
+}
+
+func (evr elasticsearchVersionResponse) GetVersion() (string, error) {
+	if _, err := ver.Parse(evr.Version.Number); err != nil {
+		return "", err
+	}
+	return evr.Version.Number, nil
+}
+
 // referencedElasticsearchStatusVersion returns the currently running version of Elasticsearch
 // reported in its status.
-func referencedElasticsearchStatusVersion(c k8s.Client, esAssociation commonv1.Association) (string, error) {
+func referencedElasticsearchStatusVersion(c k8s.Client, esAssociation commonv1.Association) (string, bool, error) {
 	esRef := esAssociation.AssociationRef()
 	if esRef.IsExternal() {
 		info, err := association.GetUnmanagedAssociationConnectionInfoFromSecret(c, esAssociation)
 		if err != nil {
-			return "", err
+			return "", false, err
 		}
-		ver, err := info.Version("/", "{ .version.number }")
+		esVersionResponse := &elasticsearchVersionResponse{}
+		ver, isServerless, err := info.Version("/", esVersionResponse)
 		if err != nil {
-			return "", err
+			return "", false, err
 		}
-		return ver, nil
+		return ver, isServerless, nil
 	}
 
 	var es esv1.Elasticsearch
 	err := c.Get(context.Background(), esRef.NamespacedName(), &es)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
-	return es.Status.Version, nil
+	return es.Status.Version, false, nil
 }

--- a/pkg/controller/association/reconciler.go
+++ b/pkg/controller/association/reconciler.go
@@ -77,7 +77,8 @@ type AssociationInfo struct { //nolint:revive
 	// base is used to recognize annotations eligible for removal when association is removed.
 	AssociationConfAnnotationNameBase string
 	// ReferencedResourceVersion returns the currently running version of the referenced resource.
-	// It may return an empty string if the version is unknown.
+	// It may return an empty string if the version is unknown. A boolean is also returned, set to true if the referenced
+	// resource is a serverless project running in https://cloud.elastic.co/
 	ReferencedResourceVersion func(c k8s.Client, association commonv1.Association) (string, bool, error)
 	// AssociationResourceNameLabelName is a label used on resources needed for an association. It identifies the name
 	// of the associated resource (eg. user secret allowing to connect Beat to Kibana will have this label pointing to the

--- a/pkg/controller/association/reconciler.go
+++ b/pkg/controller/association/reconciler.go
@@ -78,7 +78,7 @@ type AssociationInfo struct { //nolint:revive
 	AssociationConfAnnotationNameBase string
 	// ReferencedResourceVersion returns the currently running version of the referenced resource.
 	// It may return an empty string if the version is unknown.
-	ReferencedResourceVersion func(c k8s.Client, association commonv1.Association) (string, error)
+	ReferencedResourceVersion func(c k8s.Client, association commonv1.Association) (string, bool, error)
 	// AssociationResourceNameLabelName is a label used on resources needed for an association. It identifies the name
 	// of the associated resource (eg. user secret allowing to connect Beat to Kibana will have this label pointing to the
 	// Beat resource).
@@ -291,7 +291,7 @@ func (r *Reconciler) reconcileAssociation(ctx context.Context, association commo
 
 	// propagate the currently running version of the referenced resource (example: Elasticsearch version).
 	// The Kibana controller (for example) can then delay a Kibana version upgrade if Elasticsearch is not upgraded yet.
-	ver, err := r.ReferencedResourceVersion(r.Client, association)
+	ver, isServerless, err := r.ReferencedResourceVersion(r.Client, association)
 	if err != nil {
 		return commonv1.AssociationPending, err
 	}
@@ -302,6 +302,7 @@ func (r *Reconciler) reconcileAssociation(ctx context.Context, association commo
 		CASecretName:   caSecret.Name,
 		URL:            url,
 		Version:        ver,
+		Serverless:     isServerless,
 	}
 
 	if secretsHash != nil {

--- a/pkg/controller/beat/common/stackmon/stackmon.go
+++ b/pkg/controller/beat/common/stackmon/stackmon.go
@@ -121,6 +121,10 @@ func MetricBeat(ctx context.Context, client k8s.Client, beat *v1beta1.Beat, vers
 	return sidecar, nil
 }
 
+type clusterUUIDResponse struct {
+	ClusterUUID string `json:"cluster_uuid"`
+}
+
 func associatedESUUID(ctx context.Context, client k8s.Client, beat *v1beta1.Beat) (string, error) {
 	esAssociation := beat.EsAssociation()
 	esRef := esAssociation.AssociationRef()
@@ -129,11 +133,11 @@ func associatedESUUID(ctx context.Context, client k8s.Client, beat *v1beta1.Beat
 		if err != nil {
 			return "", fmt.Errorf("while retrieving external ES connection info: %w", err)
 		}
-		uuid, err := remoteES.Request("/", "{.cluster_uuid}")
-		if err != nil {
+		clusterUUIDResponse := &clusterUUIDResponse{}
+		if err := remoteES.Request("/", clusterUUIDResponse); err != nil {
 			return "", fmt.Errorf("while retrieving remote cluster UUID %w", err)
 		}
-		return uuid, nil
+		return clusterUUIDResponse.ClusterUUID, nil
 	}
 	var es esv1.Elasticsearch
 	if err := client.Get(ctx, esRef.NamespacedName(), &es); err != nil {


### PR DESCRIPTION
This PR attempts to detect when a referenced resource is an Elasticsearch project, and skip version check if it's the case.