### PR TITLE
increase agent memory for azure as well

### DIFF
--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -180,6 +180,7 @@ func (h *helper) initTestContext() error {
 		KubernetesVersion:     getKubernetesVersion(h),
 		IgnoreWebhookFailures: h.ignoreWebhookFailures,
 		OcpCluster:            isOcpCluster(h),
+		AksCluster:            isAKSCluster(h),
 		DeployChaosJob:        h.deployChaosJob,
 		TestEnvTags:           h.testEnvTags,
 		E2ETags:               h.e2eTags,
@@ -238,6 +239,10 @@ func getKubernetesVersion(h *helper) version.Version {
 func isOcpCluster(h *helper) bool {
 	_, _, err := h.kubectl("get", "clusterversion")
 	return err == nil
+}
+
+func isAKSCluster(h *helper) bool {
+	return strings.HasPrefix(h.provider, "aks")
 }
 
 // isAutopilotCluster convenience function to check the provider value for the string gke-autopilot.

--- a/test/e2e/cmd/run/run.go
+++ b/test/e2e/cmd/run/run.go
@@ -181,6 +181,7 @@ func (h *helper) initTestContext() error {
 		IgnoreWebhookFailures: h.ignoreWebhookFailures,
 		OcpCluster:            isOcpCluster(h),
 		AksCluster:            isAKSCluster(h),
+		TanzuCluster:          isTanzuCluster(h),
 		DeployChaosJob:        h.deployChaosJob,
 		TestEnvTags:           h.testEnvTags,
 		E2ETags:               h.e2eTags,
@@ -243,6 +244,10 @@ func isOcpCluster(h *helper) bool {
 
 func isAKSCluster(h *helper) bool {
 	return strings.HasPrefix(h.provider, "aks")
+}
+
+func isTanzuCluster(h *helper) bool {
+	return strings.HasPrefix(h.provider, "tanzu")
 }
 
 // isAutopilotCluster convenience function to check the provider value for the string gke-autopilot.

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -133,7 +133,7 @@ func NewBuilder(name string) Builder {
 		WithDaemonSet()
 
 	if test.Ctx().OcpCluster || test.Ctx().AksCluster {
-		// Agent requires more resources on OpenShift and aks clusters. One hypothesis is that
+		// Agent requires more resources on OpenShift and AKS clusters. One hypothesis is that
 		// there are more resources deployed on OpenShift than on other K8s clusters
 		// used for E2E tests.
 		// Relates to https://github.com/elastic/cloud-on-k8s/pull/7789

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -132,8 +132,8 @@ func NewBuilder(name string) Builder {
 		WithLabel(run.TestNameLabel, name).
 		WithDaemonSet()
 
-	if test.Ctx().OcpCluster || test.Ctx().AksCluster {
-		// Agent requires more resources on OpenShift and AKS clusters. One hypothesis is that
+	if test.Ctx().OcpCluster || test.Ctx().AksCluster || test.Ctx().TanzuCluster {
+		// Agent requires more resources on OpenShift, AKS and Tanzu clusters. One hypothesis is that
 		// there are more resources deployed on OpenShift than on other K8s clusters
 		// used for E2E tests.
 		// Relates to https://github.com/elastic/cloud-on-k8s/pull/7789

--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -132,8 +132,8 @@ func NewBuilder(name string) Builder {
 		WithLabel(run.TestNameLabel, name).
 		WithDaemonSet()
 
-	if test.Ctx().OcpCluster {
-		// Agent requires more resources on OpenShift clusters. One hypothesis is that
+	if test.Ctx().OcpCluster || test.Ctx().AksCluster {
+		// Agent requires more resources on OpenShift and aks clusters. One hypothesis is that
 		// there are more resources deployed on OpenShift than on other K8s clusters
 		// used for E2E tests.
 		// Relates to https://github.com/elastic/cloud-on-k8s/pull/7789

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -115,6 +115,7 @@ type Context struct {
 	IgnoreWebhookFailures bool              `json:"ignore_webhook_failures"`
 	OcpCluster            bool              `json:"ocp_cluster"`
 	AksCluster            bool              `json:"aks_cluster"`
+	TanzuCluster          bool              `json:"tanzu_cluster"`
 	Pipeline              string            `json:"pipeline"`
 	BuildNumber           string            `json:"build_number"`
 	Provider              string            `json:"provider"`

--- a/test/e2e/test/context.go
+++ b/test/e2e/test/context.go
@@ -114,6 +114,7 @@ type Context struct {
 	Local                 bool              `json:"local"`
 	IgnoreWebhookFailures bool              `json:"ignore_webhook_failures"`
 	OcpCluster            bool              `json:"ocp_cluster"`
+	AksCluster            bool              `json:"aks_cluster"`
 	Pipeline              string            `json:"pipeline"`
 	BuildNumber           string            `json:"build_number"`
 	Provider              string            `json:"provider"`


### PR DESCRIPTION
We see e2e tests failing on aks with agent in OOM, increase memory in e2e tests for agent in aks tests