### PR TITLE
moves the annotation eck.k8s.elastic.co/license to values.yaml

### DIFF
--- a/deploy/eck-stack/charts/eck-agent/templates/elastic-agent.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/elastic-agent.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "elasticagent.labels" $ | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: basic
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-agent/values.yaml
+++ b/deploy/eck-stack/charts/eck-agent/values.yaml
@@ -26,7 +26,8 @@ labels: {}
 
 # Annotations that will be applied to Elastic Agent.
 #
-annotations: {}
+annotations:
+  eck.k8s.elastic.co/license: basic
 
 spec:
   # policyID determines into which Agent Policy this Agent will be enrolled.

--- a/deploy/eck-stack/charts/eck-apm-server/templates/apmserver.yaml
+++ b/deploy/eck-stack/charts/eck-apm-server/templates/apmserver.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "apm-server.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: basic
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-apm-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-apm-server/values.yaml
@@ -35,7 +35,8 @@ labels: {}
 
 # Annotations that will be applied to APM Server.
 #
-annotations: {}
+annotations:
+  eck.k8s.elastic.co/license: basic
 
 # Count of APM Server replicas to create.
 #

--- a/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "beat.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: basic
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-beats/values.yaml
+++ b/deploy/eck-stack/charts/eck-beats/values.yaml
@@ -26,7 +26,8 @@ labels: {}
 
 # Annotations that will be applied to Elastic Beats.
 #
-annotations: {}
+annotations:
+  eck.k8s.elastic.co/license: basic
 
 spec:
   # Type of Elastic Beats. Standard types of Beat are [filebeat,metricbeat,heartbeat,auditbeat,packetbeat,journalbeat].

--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/elasticsearch.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/elasticsearch.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "elasticsearch.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: basic
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
@@ -30,7 +30,8 @@ labels: {}
 
 # Annotations that will be applied to Elasticsearch.
 #
-annotations: {}
+annotations:
+  eck.k8s.elastic.co/license: basic
 
 # Settings for configuring Elasticsearch users and roles.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-users-and-roles.html

--- a/deploy/eck-stack/charts/eck-enterprise-search/templates/enterprisesearch.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/templates/enterprisesearch.yaml
@@ -9,7 +9,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    eck.k8s.elastic.co/license: basic
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-enterprise-search/values.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/values.yaml
@@ -36,7 +36,8 @@ labels: {}
 
 # Annotations that will be applied to Enterprise Search.
 #
-annotations: {}
+annotations:
+  eck.k8s.elastic.co/license: basic
 
 # Count of Enterprise Search replicas to create.
 #

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "fleet-server.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: basic
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-fleet-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/values.yaml
@@ -26,7 +26,8 @@ labels: {}
 
 # Annotations that will be applied to Elastic Fleet Server.
 #
-annotations: {}
+annotations:
+  eck.k8s.elastic.co/license: basic
 
 spec:
   # policyID determines into which Agent Policy this Fleet Server will be enrolled.

--- a/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "kibana.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: basic
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-kibana/values.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/values.yaml
@@ -26,7 +26,8 @@ labels: {}
 
 # Annotations that will be applied to Kibana.
 #
-annotations: {}
+annotations:
+  eck.k8s.elastic.co/license: basic
 
 spec:
   # Count of Kibana replicas to create.

--- a/deploy/eck-stack/charts/eck-logstash/templates/logstash.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/templates/logstash.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "logstash.labels" . | nindent 4 }}
   annotations:
-    eck.k8s.elastic.co/license: basic
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deploy/eck-stack/charts/eck-logstash/values.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/values.yaml
@@ -35,7 +35,8 @@ labels: {}
 
 # Annotations that will be applied to Logstash.
 #
-annotations: {}
+annotations:
+  eck.k8s.elastic.co/license: basic
 
 # Number of revisions to retain to allow rollback in the underlying StatefulSets.
 # By default, if not set, Kubernetes sets 10.


### PR DESCRIPTION
Moves the annotation eck.k8s.elastic.co/license to values.yaml to make it configurable. This fixes #6261. 
