### PR TITLE
Upgrade gke k8s version to v1.27 for testing

### DIFF
--- a/docs/advanced-topics/gke-autopilot.asciidoc
+++ b/docs/advanced-topics/gke-autopilot.asciidoc
@@ -22,7 +22,7 @@ This page shows how to run ECK on GKE Autopilot.
 [id="{p}-autopilot-setting-virtual-memory"]
 == Ensuring virtual memory kernel settings
 
-If you are intending to run production workloads on GKE Autopilot then `vm.max_map_count` should be set. The recommended way to set this kernel setting on the Autopilot hosts is with a `Daemonset` as described in the <<{p}-virtual-memory>> section. You must be running at least version 1.25 when on the `regular` channel or using the `rapid` channel, which currently runs version 1.26.
+If you are intending to run production workloads on GKE Autopilot then `vm.max_map_count` should be set. The recommended way to set this kernel setting on the Autopilot hosts is with a `Daemonset` as described in the <<{p}-virtual-memory>> section. You must be running at least version 1.25 when on the `regular` channel or using the `rapid` channel, which currently runs version 1.27.
 
 CAUTION: Only use the provided `Daemonset` exactly as specified or it could be rejected by the Autopilot control plane.
 

--- a/hack/deployer/config/plans.yml
+++ b/hack/deployer/config/plans.yml
@@ -3,7 +3,7 @@ plans:
   operation: create
   clusterName: ci
   provider: gke
-  kubernetesVersion: 1.26
+  kubernetesVersion: 1.27
   machineType: n1-standard-8
   serviceAccount: true
   enforceSecurityPolicies: true
@@ -18,7 +18,7 @@ plans:
   operation: create
   clusterName: ci-autopilot
   provider: gke
-  kubernetesVersion: 1.26
+  kubernetesVersion: 1.27
   serviceAccount: true
   enforceSecurityPolicies: true
   # this is disabled in autopilot: container provisioner is privileged; not allowed in Autopilot
@@ -31,7 +31,7 @@ plans:
   operation: create
   clusterName: dev
   provider: gke
-  kubernetesVersion: 1.26
+  kubernetesVersion: 1.27
   machineType: n1-standard-8
   serviceAccount: false
   enforceSecurityPolicies: true
@@ -58,7 +58,7 @@ plans:
   operation: create
   clusterName: dev-autopilot
   provider: gke
-  kubernetesVersion: 1.26
+  kubernetesVersion: 1.27
   serviceAccount: false
   enforceSecurityPolicies: true
   gke:


### PR DESCRIPTION
Upgrade gke k8s version to `1.27` in deployer used for testing as `1.26` is no longer valid.

```
ERROR: (gcloud.beta.container.clusters.create) ResponseError: code=400, message=No valid versions with the prefix "1.26" found.
```