### PR TITLE
Fix typo on SAML Authentication docs page

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/security/saml-authentication.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/saml-authentication.asciidoc
@@ -46,7 +46,7 @@ spec:
             idp.entity_id: https://sso.example.com/
             idp.metadata.path: /usr/share/elasticsearch/config/saml/idp-saml-metadata.xml
             order: 2
-            sp.acs: https://kibana.example.com/api/security/callback/saml
+            sp.acs: https://kibana.example.com/api/security/saml/callback
             sp.entity_id: https://kibana.example.com/
             sp.logout: https://kibana.example.com/logout
 ----


### PR DESCRIPTION
This was reported in the `docs` Slack channel for the [SAML Authentication](https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-saml-authentication.html) page:

---

We have `sp.acs: https://kibana.example.com/api/security/callback/saml` Where it should be `/api/security/saml/callback?`

@thbkrkr  I wasn't sure who to ask to review, so I hope you don't mind that I tagged you.
