### PR TITLE
[2.14] Fix Logstash Helm chart (#7958)

### DIFF
--- a/deploy/eck-stack/charts/eck-logstash/templates/tests/logstash_test.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/templates/tests/logstash_test.yaml
@@ -160,9 +160,8 @@ tests:
   - it: should render pipelinesRef properly
     set:
       pipelinesRef:
-        secretRef:
-          secretName: pipelineLogstashSecretName
+        secretName: pipelineLogstashSecretName
     asserts:
       - equal:
-          path: spec.pipelinesRef.secretRef.secretName
+          path: spec.pipelinesRef.secretName
           value: pipelineLogstashSecretName

--- a/deploy/eck-stack/charts/eck-logstash/values.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/values.yaml
@@ -53,7 +53,10 @@ count: 1
 config: {}
 
 configRef: {}
-#  secretRef:
+
+# Reference a pipeline configuration in a Secret.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-logstash-pipelines
+#pipelinesRef:
 #    secretName: ''
 
 # Set podTemplate to customize the pod used by Logstash


### PR DESCRIPTION
Backport of [Fix Discrepancy between Logstash Helm Chart and docs for pipelinesRef #7958](https://github.com/elastic/cloud-on-k8s/pull/7958) into `2.14`