### PR TITLE
[2.14] Report memory usage by application (#7966)

### DIFF
--- a/docs/operating-eck/licensing.asciidoc
+++ b/docs/operating-eck/licensing.asciidoc
@@ -105,13 +105,23 @@ The operator periodically writes the total amount of Elastic resources under man
 ----
 > kubectl -n elastic-system get configmap elastic-licensing -o json | jq .data
 {
+  "apm_memory": "0.50GiB",
+  "apm_memory_bytes": "536870912",
+  "eck_license_expiry_date": "2025-01-01T00:59:59+01:00",
   "eck_license_level": "enterprise",
-  "eck_license_expiry_date": "2022-01-01T00:59:59+01:00",
+  "elasticsearch_memory": "18.00GiB",
+  "elasticsearch_memory_bytes": "19327352832",
   "enterprise_resource_units": "1",
-  "max_enterprise_resource_units": "10",
-  "timestamp": "2020-01-03T23:38:20Z",
-  "total_managed_memory": "64GiB",
-  "total_managed_memory_bytes": "68719476736"
+  "enterprise_search_memory": "4.00GiB",
+  "enterprise_search_memory_bytes": "4294967296",
+  "kibana_memory": "1.00GiB",
+  "kibana_memory_bytes": "1073741824",
+  "logstash_memory": "2.00GiB",
+  "logstash_memory_bytes": "2147483648",
+  "max_enterprise_resource_units": "250",
+  "timestamp": "2024-07-26T12:40:42+02:00",
+  "total_managed_memory": "25.50GiB",
+  "total_managed_memory_bytes": "27380416512"
 }
 ----
 
@@ -120,12 +130,30 @@ If the operator metrics endpoint is enabled with the `--metrics-port` flag (chec
 [source,shell]
 ----
 > curl "$ECK_METRICS_ENDPOINT" | grep elastic_licensing
+# HELP elastic_licensing_enterprise_resource_units_max Maximum number of enterprise resource units available
+# TYPE elastic_licensing_enterprise_resource_units_max gauge
+elastic_licensing_enterprise_resource_units_max{license_level="enterprise"} 250
 # HELP elastic_licensing_enterprise_resource_units_total Total enterprise resource units used
 # TYPE elastic_licensing_enterprise_resource_units_total gauge
-elastic_licensing_enterprise_resource_units_total{license_level="basic"} 6
-# HELP elastic_licensing_memory_gigabytes_total Total memory used in GB
-# TYPE elastic_licensing_memory_gigabytes_total gauge
-elastic_licensing_memory_gigabytes_total{license_level="basic"} 357.01915648
+elastic_licensing_enterprise_resource_units_total{license_level="enterprise"} 1
+# HELP elastic_licensing_memory_gibibytes_apm Memory used by APM server in GiB
+# TYPE elastic_licensing_memory_gibibytes_apm gauge
+elastic_licensing_memory_gibibytes_apm{license_level="enterprise"} 0.5
+# HELP elastic_licensing_memory_gibibytes_elasticsearch Memory used by Elasticsearch in GiB
+# TYPE elastic_licensing_memory_gibibytes_elasticsearch gauge
+elastic_licensing_memory_gibibytes_elasticsearch{license_level="enterprise"} 18
+# HELP elastic_licensing_memory_gibibytes_enterprise_search Memory used by Enterprise Search in GiB
+# TYPE elastic_licensing_memory_gibibytes_enterprise_search gauge
+elastic_licensing_memory_gibibytes_enterprise_search{license_level="enterprise"} 4
+# HELP elastic_licensing_memory_gibibytes_kibana Memory used by Kibana in GiB
+# TYPE elastic_licensing_memory_gibibytes_kibana gauge
+elastic_licensing_memory_gibibytes_kibana{license_level="enterprise"} 1
+# HELP elastic_licensing_memory_gibibytes_logstash Memory used by Logstash in GiB
+# TYPE elastic_licensing_memory_gibibytes_logstash gauge
+elastic_licensing_memory_gibibytes_logstash{license_level="enterprise"} 2
+# HELP elastic_licensing_memory_gibibytes_total Total memory used in GiB
+# TYPE elastic_licensing_memory_gibibytes_total gauge
+elastic_licensing_memory_gibibytes_total{license_level="enterprise"} 25.5
 ----
 
 NOTE: Logstash resources managed by ECK will be counted towards ERU usage for informational purposes. Billable consumption depends on license terms on a per customer basis (See link:https://www.elastic.co/agreements/global/self-managed[Self Managed Subscription Agreement])

--- a/pkg/license/aggregator.go
+++ b/pkg/license/aggregator.go
@@ -30,16 +30,16 @@ import (
 	ulog "github.com/elastic/cloud-on-k8s/v2/pkg/utils/log"
 )
 
-// Aggregator aggregates the total of resources of all Elastic managed components
-type Aggregator struct {
+// aggregator aggregates the total of resources of all Elastic managed components
+type aggregator struct {
 	client k8s.Client
 }
 
-type aggregate func(ctx context.Context) (resource.Quantity, error)
+type aggregate func(ctx context.Context) (managedMemory, error)
 
-// AggregateMemory aggregates the total memory of all Elastic managed components
-func (a Aggregator) AggregateMemory(ctx context.Context) (resource.Quantity, error) {
-	var totalMemory resource.Quantity
+// aggregateMemory aggregates the total memory of all Elastic managed components
+func (a aggregator) aggregateMemory(ctx context.Context) (memoryUsage, error) {
+	usage := newMemoryUsage()
 
 	for _, f := range []aggregate{
 		a.aggregateElasticsearchMemory,
@@ -50,19 +50,19 @@ func (a Aggregator) AggregateMemory(ctx context.Context) (resource.Quantity, err
 	} {
 		memory, err := f(ctx)
 		if err != nil {
-			return resource.Quantity{}, err
+			return memoryUsage{}, err
 		}
-		totalMemory.Add(memory)
+		usage.add(memory)
 	}
 
-	return totalMemory, nil
+	return usage, nil
 }
 
-func (a Aggregator) aggregateElasticsearchMemory(ctx context.Context) (resource.Quantity, error) {
+func (a aggregator) aggregateElasticsearchMemory(ctx context.Context) (managedMemory, error) {
 	var esList esv1.ElasticsearchList
 	err := a.client.List(context.Background(), &esList)
 	if err != nil {
-		return resource.Quantity{}, errors.Wrap(err, "failed to aggregate Elasticsearch memory")
+		return managedMemory{}, errors.Wrap(err, "failed to aggregate Elasticsearch memory")
 	}
 
 	var total resource.Quantity
@@ -75,7 +75,7 @@ func (a Aggregator) aggregateElasticsearchMemory(ctx context.Context) (resource.
 				nodespec.DefaultMemoryLimits,
 			)
 			if err != nil {
-				return resource.Quantity{}, errors.Wrap(err, "failed to aggregate Elasticsearch memory")
+				return managedMemory{}, errors.Wrap(err, "failed to aggregate Elasticsearch memory")
 			}
 
 			total.Add(multiply(mem, nodeSet.Count))
@@ -84,14 +84,14 @@ func (a Aggregator) aggregateElasticsearchMemory(ctx context.Context) (resource.
 		}
 	}
 
-	return total, nil
+	return managedMemory{total, elasticsearchKey}, nil
 }
 
-func (a Aggregator) aggregateEnterpriseSearchMemory(ctx context.Context) (resource.Quantity, error) {
+func (a aggregator) aggregateEnterpriseSearchMemory(ctx context.Context) (managedMemory, error) {
 	var entList entv1.EnterpriseSearchList
 	err := a.client.List(context.Background(), &entList)
 	if err != nil {
-		return resource.Quantity{}, errors.Wrap(err, "failed to aggregate Enterprise Search memory")
+		return managedMemory{}, errors.Wrap(err, "failed to aggregate Enterprise Search memory")
 	}
 
 	var total resource.Quantity
@@ -103,7 +103,7 @@ func (a Aggregator) aggregateEnterpriseSearchMemory(ctx context.Context) (resour
 			enterprisesearch.DefaultMemoryLimits,
 		)
 		if err != nil {
-			return resource.Quantity{}, errors.Wrap(err, "failed to aggregate Enterprise Search memory")
+			return managedMemory{}, errors.Wrap(err, "failed to aggregate Enterprise Search memory")
 		}
 
 		total.Add(multiply(mem, ent.Spec.Count))
@@ -111,14 +111,14 @@ func (a Aggregator) aggregateEnterpriseSearchMemory(ctx context.Context) (resour
 			"memory", mem.String(), "count", ent.Spec.Count)
 	}
 
-	return total, nil
+	return managedMemory{total, entSearchKey}, nil
 }
 
-func (a Aggregator) aggregateKibanaMemory(ctx context.Context) (resource.Quantity, error) {
+func (a aggregator) aggregateKibanaMemory(ctx context.Context) (managedMemory, error) {
 	var kbList kbv1.KibanaList
 	err := a.client.List(context.Background(), &kbList)
 	if err != nil {
-		return resource.Quantity{}, errors.Wrap(err, "failed to aggregate Kibana memory")
+		return managedMemory{}, errors.Wrap(err, "failed to aggregate Kibana memory")
 	}
 
 	var total resource.Quantity
@@ -130,7 +130,7 @@ func (a Aggregator) aggregateKibanaMemory(ctx context.Context) (resource.Quantit
 			kibana.DefaultMemoryLimits,
 		)
 		if err != nil {
-			return resource.Quantity{}, errors.Wrap(err, "failed to aggregate Kibana memory")
+			return managedMemory{}, errors.Wrap(err, "failed to aggregate Kibana memory")
 		}
 
 		total.Add(multiply(mem, kb.Spec.Count))
@@ -138,14 +138,14 @@ func (a Aggregator) aggregateKibanaMemory(ctx context.Context) (resource.Quantit
 			"memory", mem.String(), "count", kb.Spec.Count)
 	}
 
-	return total, nil
+	return managedMemory{total, kibanaKey}, nil
 }
 
-func (a Aggregator) aggregateLogstashMemory(ctx context.Context) (resource.Quantity, error) {
+func (a aggregator) aggregateLogstashMemory(ctx context.Context) (managedMemory, error) {
 	var lsList lsv1alpha1.LogstashList
 	err := a.client.List(context.Background(), &lsList)
 	if err != nil {
-		return resource.Quantity{}, errors.Wrap(err, "failed to aggregate Logstash memory")
+		return managedMemory{}, errors.Wrap(err, "failed to aggregate Logstash memory")
 	}
 
 	var total resource.Quantity
@@ -157,7 +157,7 @@ func (a Aggregator) aggregateLogstashMemory(ctx context.Context) (resource.Quant
 			logstash.DefaultMemoryLimit,
 		)
 		if err != nil {
-			return resource.Quantity{}, errors.Wrap(err, "failed to aggregate Logstash memory")
+			return managedMemory{}, errors.Wrap(err, "failed to aggregate Logstash memory")
 		}
 
 		total.Add(multiply(mem, ls.Spec.Count))
@@ -165,14 +165,14 @@ func (a Aggregator) aggregateLogstashMemory(ctx context.Context) (resource.Quant
 			"memory", mem.String(), "count", ls.Spec.Count)
 	}
 
-	return total, nil
+	return managedMemory{total, logstashKey}, nil
 }
 
-func (a Aggregator) aggregateApmServerMemory(ctx context.Context) (resource.Quantity, error) {
+func (a aggregator) aggregateApmServerMemory(ctx context.Context) (managedMemory, error) {
 	var asList apmv1.ApmServerList
 	err := a.client.List(context.Background(), &asList)
 	if err != nil {
-		return resource.Quantity{}, errors.Wrap(err, "failed to aggregate APM Server memory")
+		return managedMemory{}, errors.Wrap(err, "failed to aggregate APM Server memory")
 	}
 
 	var total resource.Quantity
@@ -184,7 +184,7 @@ func (a Aggregator) aggregateApmServerMemory(ctx context.Context) (resource.Quan
 			apmserver.DefaultMemoryLimits,
 		)
 		if err != nil {
-			return resource.Quantity{}, errors.Wrap(err, "failed to aggregate APM Server memory")
+			return managedMemory{}, errors.Wrap(err, "failed to aggregate APM Server memory")
 		}
 
 		total.Add(multiply(mem, as.Spec.Count))
@@ -192,7 +192,7 @@ func (a Aggregator) aggregateApmServerMemory(ctx context.Context) (resource.Quan
 			"memory", mem.String(), "count", as.Spec.Count)
 	}
 
-	return total, nil
+	return managedMemory{total, apmKey}, nil
 }
 
 // containerMemLimits reads the container memory limits from the resource specification with fallback

--- a/pkg/license/aggregator_test.go
+++ b/pkg/license/aggregator_test.go
@@ -138,11 +138,20 @@ func TestMemFromNodeOpts(t *testing.T) {
 func TestAggregator(t *testing.T) {
 	objects := readObjects(t, "testdata/stack.yaml")
 	client := k8s.NewFakeClient(objects...)
-	aggregator := Aggregator{client: client}
+	aggregator := aggregator{client: client}
 
-	val, err := aggregator.AggregateMemory(context.Background())
+	val, err := aggregator.aggregateMemory(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, 329.9073486328125, inGiB(val))
+	for k, v := range map[string]float64{
+		elasticsearchKey: 294.0,
+		kibanaKey:        5.9073486328125,
+		apmKey:           2.0,
+		entSearchKey:     24.0,
+		logstashKey:      4.0,
+	} {
+		require.Equal(t, v, val.appUsage[k].inGiB(), k)
+	}
+	require.Equal(t, 329.9073486328125, val.totalMemory.inGiB(), "total")
 }
 
 func readObjects(t *testing.T, filePath string) []client.Object {

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -17,7 +17,7 @@ func TestToMap(t *testing.T) {
 	dateFixture := time.Date(2021, 11, 03, 0, 0, 0, 0, time.UTC)
 
 	t.Run("empty_object", func(t *testing.T) {
-		i := LicensingInfo{}
+		i := LicensingInfo{memoryUsage: newMemoryUsage()}
 		have := i.toMap()
 		want := map[string]string{
 			"timestamp":                  "",
@@ -31,24 +31,42 @@ func TestToMap(t *testing.T) {
 
 	t.Run("complete_object", func(t *testing.T) {
 		i := LicensingInfo{
+			memoryUsage: memoryUsage{
+				appUsage: map[string]managedMemory{
+					elasticsearchKey: newManagedMemory(21474836480, elasticsearchKey),
+					kibanaKey:        newManagedMemory(8589934592, kibanaKey),
+					apmKey:           newManagedMemory(4294967296, apmKey),
+					entSearchKey:     newManagedMemory(17179869184, entSearchKey),
+					logstashKey:      newManagedMemory(17179869184, logstashKey),
+				},
+				totalMemory: newManagedMemory(68719476736, totalKey),
+			},
 			Timestamp:                  "2020-05-28T11:15:31Z",
 			EckLicenseLevel:            "enterprise",
 			EckLicenseExpiryDate:       &dateFixture,
-			TotalManagedMemoryGiB:      64,
-			TotalManagedMemoryBytes:    68719476736,
 			EnterpriseResourceUnits:    1,
 			MaxEnterpriseResourceUnits: 10,
 		}
 
 		have := i.toMap()
 		want := map[string]string{
-			"timestamp":                     "2020-05-28T11:15:31Z",
-			"eck_license_level":             "enterprise",
-			"eck_license_expiry_date":       "2021-11-03T00:00:00Z",
-			"total_managed_memory":          "64.00GiB",
-			"total_managed_memory_bytes":    "68719476736",
-			"enterprise_resource_units":     "1",
-			"max_enterprise_resource_units": "10",
+			"timestamp":                      "2020-05-28T11:15:31Z",
+			"eck_license_level":              "enterprise",
+			"eck_license_expiry_date":        "2021-11-03T00:00:00Z",
+			"elasticsearch_memory":           "20.00GiB",
+			"elasticsearch_memory_bytes":     "21474836480",
+			"kibana_memory":                  "8.00GiB",
+			"kibana_memory_bytes":            "8589934592",
+			"apm_memory":                     "4.00GiB",
+			"apm_memory_bytes":               "4294967296",
+			"enterprise_search_memory":       "16.00GiB",
+			"enterprise_search_memory_bytes": "17179869184",
+			"logstash_memory":                "16.00GiB",
+			"logstash_memory_bytes":          "17179869184",
+			"total_managed_memory":           "64.00GiB",
+			"total_managed_memory_bytes":     "68719476736",
+			"enterprise_resource_units":      "1",
+			"max_enterprise_resource_units":  "10",
 		}
 		assert.Equal(t, want, have)
 	})

--- a/pkg/license/reporter.go
+++ b/pkg/license/reporter.go
@@ -21,7 +21,7 @@ const ResourceReporterFrequency = 2 * time.Minute
 // ResourceReporter aggregates resources of all Elastic components managed by the operator
 // and reports them in a config map in the form of licensing information
 type ResourceReporter struct {
-	aggregator        Aggregator
+	aggregator        aggregator
 	licensingResolver LicensingResolver
 	tracer            *apm.Tracer
 }
@@ -29,7 +29,7 @@ type ResourceReporter struct {
 // NewResourceReporter returns a new ResourceReporter
 func NewResourceReporter(c client.Client, operatorNs string, tracer *apm.Tracer) ResourceReporter {
 	return ResourceReporter{
-		aggregator: Aggregator{
+		aggregator: aggregator{
 			client: c,
 		},
 		licensingResolver: LicensingResolver{
@@ -77,10 +77,10 @@ func (r ResourceReporter) Report(ctx context.Context) error {
 func (r ResourceReporter) Get(ctx context.Context) (LicensingInfo, error) {
 	span, _ := apm.StartSpan(ctx, "get_license_info", tracing.SpanTypeApp)
 	defer span.End()
-	totalMemory, err := r.aggregator.AggregateMemory(ctx)
+	usage, err := r.aggregator.aggregateMemory(ctx)
 	if err != nil {
 		return LicensingInfo{}, err
 	}
 
-	return r.licensingResolver.ToInfo(ctx, totalMemory)
+	return r.licensingResolver.ToInfo(ctx, usage)
 }

--- a/pkg/utils/metrics/operator.go
+++ b/pkg/utils/metrics/operator.go
@@ -52,6 +52,46 @@ var (
 		Name:      "memory_gibibytes_total",
 		Help:      "Total memory used in GiB",
 	}, []string{LicenseLevelLabel}))
+
+	// LicensingESMemoryGauge reports the Elasticsearch memory usage for licensing purposes.
+	LicensingESMemoryGauge = registerGauge(prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: licensingSubsystem,
+		Name:      "memory_gibibytes_elasticsearch",
+		Help:      "Memory used by Elasticsearch in GiB",
+	}, []string{LicenseLevelLabel}))
+
+	// LicensingKBMemoryGauge reports the Kibana memory usage for licensing purposes.
+	LicensingKBMemoryGauge = registerGauge(prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: licensingSubsystem,
+		Name:      "memory_gibibytes_kibana",
+		Help:      "Memory used by Kibana in GiB",
+	}, []string{LicenseLevelLabel}))
+
+	// LicensingAPMMemoryGauge reports the APM server memory usage for licensing purposes.
+	LicensingAPMMemoryGauge = registerGauge(prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: licensingSubsystem,
+		Name:      "memory_gibibytes_apm",
+		Help:      "Memory used by APM server in GiB",
+	}, []string{LicenseLevelLabel}))
+
+	// LicensingEntSearchMemoryGauge reports the Enterprise Search memory usage for licensing purposes.
+	LicensingEntSearchMemoryGauge = registerGauge(prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: licensingSubsystem,
+		Name:      "memory_gibibytes_enterprise_search",
+		Help:      "Memory used by Enterprise Search in GiB",
+	}, []string{LicenseLevelLabel}))
+
+	// LicensingLogstashMemoryGauge reports the Logstash memory usage for licensing purposes.
+	LicensingLogstashMemoryGauge = registerGauge(prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: licensingSubsystem,
+		Name:      "memory_gibibytes_logstash",
+		Help:      "Memory used by Logstash in GiB",
+	}, []string{LicenseLevelLabel}))
 )
 
 func registerGauge(gauge *prometheus.GaugeVec) *prometheus.GaugeVec {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.14`:
 - [Report memory usage by application (#7966)](https://github.com/elastic/cloud-on-k8s/pull/7966)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)