### PR TITLE
[2.14] Update openshift.asciidoc (#7964)

### DIFF
--- a/docs/advanced-topics/openshift.asciidoc
+++ b/docs/advanced-topics/openshift.asciidoc
@@ -138,7 +138,7 @@ spec:
             memory: 1Gi
             cpu: 1
 ---
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: kibana-sample
@@ -200,7 +200,7 @@ spec:
     spec:
       serviceAccountName: apm-server
 ---
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: apm-server-sample


### PR DESCRIPTION
Backport of [Update Kibana and APM routes in openshift.asciidoc #7964](https://github.com/elastic/cloud-on-k8s/pull/7964) into `2.4`