### PR TITLE
Upgrade test harness fixes

### DIFF
--- a/hack/upgrade-test-harness/conf.yaml
+++ b/hack/upgrade-test-harness/conf.yaml
@@ -43,7 +43,7 @@ testParams:
     stackVersion: 8.13.2
   - name: v2130
     operatorVersion: 2.13.0
-    stackVersion: 8.14.0
+    stackVersion: 8.14.3
   - name: v2140
     operatorVersion: 2.14.0
     stackVersion: 8.15.0

--- a/hack/upgrade-test-harness/testdata/v2100/install.yaml
+++ b/hack/upgrade-test-harness/testdata/v2100/install.yaml
@@ -451,7 +451,7 @@ spec:
       securityContext:
         runAsNonRoot: true
       containers:
-      - image: "docker.elastic.co/eck-dev/eck-operator-mmontgomery:2.10.0-63c18ccf"
+      - image: "docker.elastic.co/eck/eck-operator:2.10.0"
         imagePullPolicy: IfNotPresent
         name: manager
         args:

--- a/hack/upgrade-test-harness/testdata/v2100/stack.yaml
+++ b/hack/upgrade-test-harness/testdata/v2100/stack.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: es
 spec:
-  version: 8.11.1
+  version: 8.11.4
   nodeSets:
   - name: default
     count: 3
@@ -23,7 +23,7 @@ kind: Kibana
 metadata:
   name: kb
 spec:
-  version: 8.11.1
+  version: 8.11.4
   count: 1
   elasticsearchRef:
     name: es
@@ -33,7 +33,7 @@ kind: ApmServer
 metadata:
   name: apm
 spec:
-  version: 8.11.1
+  version: 8.11.4
   count: 1
   elasticsearchRef:
     name: es
@@ -43,7 +43,7 @@ kind: EnterpriseSearch
 metadata:
   name: ent
 spec:
-  version: 8.11.1
+  version: 8.11.4
   count: 1
   elasticsearchRef:
     name: es
@@ -56,7 +56,7 @@ metadata:
   name: heartbeat
 spec:
   type: heartbeat
-  version: 8.11.1
+  version: 8.11.4
   elasticsearchRef:
     name: es
   config:
@@ -73,27 +73,3 @@ spec:
       spec:
         securityContext:
           runAsUser: 0
----
-apiVersion: logstash.k8s.elastic.co/v1alpha1
-kind: Logstash
-metadata:
-  name: ls
-spec:
-  count: 1
-  version: 8.11.1
-  elasticsearchRefs:
-    - clusterName: production
-      name: es
-  pipelines:
-    - pipeline.id: main
-      config.string: |
-        input { exec { command => 'uptime' interval => 10 } } 
-        output { 
-          elasticsearch {
-            hosts => [ "${PRODUCTION_ES_HOSTS}" ]
-            ssl => true
-            cacert => "${PRODUCTION_ES_SSL_CERTIFICATE_AUTHORITY}"
-            user => "${PRODUCTION_ES_USER}"
-            password => "${PRODUCTION_ES_PASSWORD}"
-          } 
-        }

--- a/hack/upgrade-test-harness/testdata/v2111/stack.yaml
+++ b/hack/upgrade-test-harness/testdata/v2111/stack.yaml
@@ -73,27 +73,3 @@ spec:
       spec:
         securityContext:
           runAsUser: 0
----
-apiVersion: logstash.k8s.elastic.co/v1alpha1
-kind: Logstash
-metadata:
-  name: ls
-spec:
-  count: 1
-  version: 8.12.2
-  elasticsearchRefs:
-    - clusterName: production
-      name: es
-  pipelines:
-    - pipeline.id: main
-      config.string: |
-        input { exec { command => 'uptime' interval => 10 } } 
-        output { 
-          elasticsearch {
-            hosts => [ "${PRODUCTION_ES_HOSTS}" ]
-            ssl => true
-            cacert => "${PRODUCTION_ES_SSL_CERTIFICATE_AUTHORITY}"
-            user => "${PRODUCTION_ES_USER}"
-            password => "${PRODUCTION_ES_PASSWORD}"
-          } 
-        }

--- a/hack/upgrade-test-harness/testdata/v2121/stack.yaml
+++ b/hack/upgrade-test-harness/testdata/v2121/stack.yaml
@@ -73,27 +73,3 @@ spec:
       spec:
         securityContext:
           runAsUser: 0
----
-apiVersion: logstash.k8s.elastic.co/v1alpha1
-kind: Logstash
-metadata:
-  name: ls
-spec:
-  count: 1
-  version: 8.13.2
-  elasticsearchRefs:
-    - clusterName: production
-      name: es
-  pipelines:
-    - pipeline.id: main
-      config.string: |
-        input { exec { command => 'uptime' interval => 10 } } 
-        output { 
-          elasticsearch {
-            hosts => [ "${PRODUCTION_ES_HOSTS}" ]
-            ssl => true
-            cacert => "${PRODUCTION_ES_SSL_CERTIFICATE_AUTHORITY}"
-            user => "${PRODUCTION_ES_USER}"
-            password => "${PRODUCTION_ES_PASSWORD}"
-          } 
-        }

--- a/hack/upgrade-test-harness/testdata/v2130/stack.yaml
+++ b/hack/upgrade-test-harness/testdata/v2130/stack.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: es
 spec:
-  version: 8.14.0
+  version: 8.14.3
   nodeSets:
   - name: default
     count: 3
@@ -23,7 +23,7 @@ kind: Kibana
 metadata:
   name: kb
 spec:
-  version: 8.14.0
+  version: 8.14.3
   count: 1
   elasticsearchRef:
     name: es
@@ -33,7 +33,7 @@ kind: ApmServer
 metadata:
   name: apm
 spec:
-  version: 8.14.0
+  version: 8.14.3
   count: 1
   elasticsearchRef:
     name: es
@@ -43,7 +43,7 @@ kind: EnterpriseSearch
 metadata:
   name: ent
 spec:
-  version: 8.14.0
+  version: 8.14.3
   count: 1
   elasticsearchRef:
     name: es
@@ -56,7 +56,7 @@ metadata:
   name: heartbeat
 spec:
   type: heartbeat
-  version: 8.14.0
+  version: 8.14.3
   elasticsearchRef:
     name: es
   config:
@@ -80,7 +80,7 @@ metadata:
   name: ls
 spec:
   count: 1
-  version: 8.14.0
+  version: 8.14.3
   elasticsearchRefs:
     - clusterName: production
       name: es

--- a/hack/upgrade-test-harness/testdata/v290/stack.yaml
+++ b/hack/upgrade-test-harness/testdata/v290/stack.yaml
@@ -4,7 +4,7 @@ kind: Elasticsearch
 metadata:
   name: es
 spec:
-  version: 8.9.0
+  version: 8.9.2
   nodeSets:
   - name: default
     count: 3
@@ -23,7 +23,7 @@ kind: Kibana
 metadata:
   name: kb
 spec:
-  version: 8.9.0
+  version: 8.9.2
   count: 1
   elasticsearchRef:
     name: es
@@ -33,7 +33,7 @@ kind: ApmServer
 metadata:
   name: apm
 spec:
-  version: 8.9.0
+  version: 8.9.2
   count: 1
   elasticsearchRef:
     name: es
@@ -43,7 +43,7 @@ kind: EnterpriseSearch
 metadata:
   name: ent
 spec:
-  version: 8.9.0
+  version: 8.9.2
   count: 1
   elasticsearchRef:
     name: es
@@ -56,7 +56,7 @@ metadata:
   name: heartbeat
 spec:
   type: heartbeat
-  version: 8.9.0
+  version: 8.9.2
   elasticsearchRef:
     name: es
   config:
@@ -73,27 +73,3 @@ spec:
       spec:
         securityContext:
           runAsUser: 0
----
-apiVersion: logstash.k8s.elastic.co/v1alpha1
-kind: Logstash
-metadata:
-  name: ls
-spec:
-  count: 1
-  version: 8.9.0
-  elasticsearchRefs:
-    - clusterName: production
-      name: es
-  pipelines:
-    - pipeline.id: main
-      config.string: |
-        input { exec { command => 'uptime' interval => 10 } } 
-        output { 
-          elasticsearch {
-            hosts => [ "${PRODUCTION_ES_HOSTS}" ]
-            ssl => true
-            cacert => "${PRODUCTION_ES_SSL_CERTIFICATE_AUTHORITY}"
-            user => "${PRODUCTION_ES_USER}"
-            password => "${PRODUCTION_ES_PASSWORD}"
-          } 
-        }


### PR DESCRIPTION
This PR fixes a couple of issues wrt our upgrade test harness framework:

* Only test Logstash starting ECK `2.13` since it was in tech. preview before, and also because upgrading from a version below `2.12` is not trivial because of:
  *  this bug: https://github.com/elastic/cloud-on-k8s/issues/7742
  *  the `health` field which did not exit in the first releases
* Fix a bug in the `ReplaceOrCreate` function where objects where actually not replaced (more specifically they were replaced by their current versions, not by the one in the manifest)
* Fixes a few consistencies in the expected stack versions VS what versions are actually in the stack manifests.