### PR TITLE
runner: preallocate memory

### DIFF
--- a/hack/deployer/runner/tags.go
+++ b/hack/deployer/runner/tags.go
@@ -23,7 +23,7 @@ var (
 // toList transforms a map into a slice of string where each element corresponds
 // to an entry in the map represented in the form 'key=value'.
 func toList(m map[string]string) []string {
-	l := []string{}
+	l := make([]string, 0, len(m))
 	for k, v := range m {
 		l = append(l, fmt.Sprintf("%s=%s", k, v))
 	}


### PR DESCRIPTION
`toList()` knows upfront the number of tags that will end up in the list. Preallocating the exact size upfront reduces memory and GC operations.