### PR TITLE
Remove e2e tests on 8.15.0-SNAPSHOT

### DIFF
--- a/.buildkite/e2e/nightly-main-matrix.yaml
+++ b/.buildkite/e2e/nightly-main-matrix.yaml
@@ -4,8 +4,7 @@
     E2E_PROVIDER: gke
   mixed:
     - E2E_STACK_VERSION: "7.17.8"
-    # current stack version 8.14.x is tested in all other tests no need to test it again
-    - E2E_STACK_VERSION: "8.15.0-SNAPSHOT"
+    # current stack version 8.15.x is tested in all other tests no need to test it again
     - E2E_STACK_VERSION: "8.16.0-SNAPSHOT"
 
 - label: kind


### PR DESCRIPTION
I forgot to remove e2e tests on `8.15.0-SNAPSHOT` in https://github.com/elastic/cloud-on-k8s/pull/7995