### PR TITLE
Do not parse the version twice.

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/podspec.go
+++ b/pkg/controller/elasticsearch/nodespec/podspec.go
@@ -114,22 +114,17 @@ func BuildPodTemplateSpec(
 		}
 	}
 
-	v, err := version.Parse(es.Spec.Version)
-	if err != nil {
-		return corev1.PodTemplateSpec{}, err // error unlikely and should have been caught during validation
-	}
-
 	// build the podTemplate until we have the effective resources configured
 	builder = builder.
 		WithLabels(labels).
 		WithAnnotations(annotations).
-		WithDockerImage(es.Spec.Image, container.ImageRepository(container.ElasticsearchImage, v)).
+		WithDockerImage(es.Spec.Image, container.ImageRepository(container.ElasticsearchImage, ver)).
 		WithResources(DefaultResources).
 		WithTerminationGracePeriod(DefaultTerminationGracePeriodSeconds).
 		WithPorts(defaultContainerPorts).
-		WithReadinessProbe(*NewReadinessProbe(v)).
+		WithReadinessProbe(*NewReadinessProbe(ver)).
 		WithAffinity(DefaultAffinity(es.Name)).
-		WithEnv(DefaultEnvVars(v, es.Spec.HTTP, headlessServiceName)...).
+		WithEnv(DefaultEnvVars(ver, es.Spec.HTTP, headlessServiceName)...).
 		WithVolumes(volumes...).
 		WithVolumeMounts(volumeMounts...).
 		WithInitContainers(initContainers...).


### PR DESCRIPTION
We appear to parse the version twice while building the pod template spec. This removes the second parsing, and just uses the results of the first parsing.