### PR TITLE
Add old readiness probe related ENVs 

### DIFF
--- a/pkg/controller/elasticsearch/nodespec/__snapshots__/podspec_test.snap
+++ b/pkg/controller/elasticsearch/nodespec/__snapshots__/podspec_test.snap
@@ -94,6 +94,10 @@
       }
      },
      {
+      "name": "HEADLESS_SERVICE_NAME",
+      "value": "name-es-nodeset-1"
+     },
+     {
       "name": "PROBE_PASSWORD_PATH",
       "value": "/mnt/elastic-internal/pod-mounted-users/elastic-internal-probe"
      },
@@ -104,10 +108,6 @@
      {
       "name": "READINESS_PROBE_PROTOCOL",
       "value": "https"
-     },
-     {
-      "name": "HEADLESS_SERVICE_NAME",
-      "value": "name-es-nodeset-1"
      },
      {
       "name": "NSS_SDB_USE_CACHE",
@@ -289,6 +289,10 @@
       "value": "my-value"
      },
      {
+      "name": "HEADLESS_SERVICE_NAME",
+      "value": "name-es-nodeset-1"
+     },
+     {
       "name": "PROBE_PASSWORD_PATH",
       "value": "/mnt/elastic-internal/pod-mounted-users/elastic-internal-probe"
      },
@@ -299,10 +303,6 @@
      {
       "name": "READINESS_PROBE_PROTOCOL",
       "value": "https"
-     },
-     {
-      "name": "HEADLESS_SERVICE_NAME",
-      "value": "name-es-nodeset-1"
      },
      {
       "name": "NSS_SDB_USE_CACHE",
@@ -443,6 +443,10 @@
       "value": "my-value"
      },
      {
+      "name": "HEADLESS_SERVICE_NAME",
+      "value": "name-es-nodeset-1"
+     },
+     {
       "name": "PROBE_PASSWORD_PATH",
       "value": "/mnt/elastic-internal/pod-mounted-users/elastic-internal-probe"
      },
@@ -453,10 +457,6 @@
      {
       "name": "READINESS_PROBE_PROTOCOL",
       "value": "https"
-     },
-     {
-      "name": "HEADLESS_SERVICE_NAME",
-      "value": "name-es-nodeset-1"
      },
      {
       "name": "NSS_SDB_USE_CACHE",
@@ -599,6 +599,10 @@
       "value": "my-value"
      },
      {
+      "name": "HEADLESS_SERVICE_NAME",
+      "value": "name-es-nodeset-1"
+     },
+     {
       "name": "PROBE_PASSWORD_PATH",
       "value": "/mnt/elastic-internal/pod-mounted-users/elastic-internal-probe"
      },
@@ -609,10 +613,6 @@
      {
       "name": "READINESS_PROBE_PROTOCOL",
       "value": "https"
-     },
-     {
-      "name": "HEADLESS_SERVICE_NAME",
-      "value": "name-es-nodeset-1"
      },
      {
       "name": "NSS_SDB_USE_CACHE",
@@ -751,6 +751,10 @@
       "value": "my-value"
      },
      {
+      "name": "HEADLESS_SERVICE_NAME",
+      "value": "name-es-nodeset-1"
+     },
+     {
       "name": "PROBE_PASSWORD_PATH",
       "value": "/mnt/elastic-internal/pod-mounted-users/elastic-internal-probe"
      },
@@ -761,10 +765,6 @@
      {
       "name": "READINESS_PROBE_PROTOCOL",
       "value": "https"
-     },
-     {
-      "name": "HEADLESS_SERVICE_NAME",
-      "value": "name-es-nodeset-1"
      },
      {
       "name": "NSS_SDB_USE_CACHE",
@@ -1088,6 +1088,22 @@
      {
       "name": "HEADLESS_SERVICE_NAME",
       "value": "name-es-nodeset-1"
+     },
+     {
+      "name": "PROBE_PASSWORD_PATH",
+      "value": "/mnt/elastic-internal/pod-mounted-users/elastic-internal-probe"
+     },
+     {
+      "name": "PROBE_USERNAME",
+      "value": "elastic-internal-probe"
+     },
+     {
+      "name": "READINESS_PROBE_PROTOCOL",
+      "value": "https"
+     },
+     {
+      "name": "NSS_SDB_USE_CACHE",
+      "value": "no"
      }
     ],
     "image": "docker.elastic.co/elasticsearch/elasticsearch:8.14.0",
@@ -1273,6 +1289,22 @@
      {
       "name": "HEADLESS_SERVICE_NAME",
       "value": "name-es-nodeset-1"
+     },
+     {
+      "name": "PROBE_PASSWORD_PATH",
+      "value": "/mnt/elastic-internal/pod-mounted-users/elastic-internal-probe"
+     },
+     {
+      "name": "PROBE_USERNAME",
+      "value": "elastic-internal-probe"
+     },
+     {
+      "name": "READINESS_PROBE_PROTOCOL",
+      "value": "https"
+     },
+     {
+      "name": "NSS_SDB_USE_CACHE",
+      "value": "no"
      }
     ],
     "image": "docker.elastic.co/elasticsearch/elasticsearch:8.14.0",
@@ -1422,6 +1454,22 @@
      {
       "name": "HEADLESS_SERVICE_NAME",
       "value": "name-es-nodeset-1"
+     },
+     {
+      "name": "PROBE_PASSWORD_PATH",
+      "value": "/mnt/elastic-internal/pod-mounted-users/elastic-internal-probe"
+     },
+     {
+      "name": "PROBE_USERNAME",
+      "value": "elastic-internal-probe"
+     },
+     {
+      "name": "READINESS_PROBE_PROTOCOL",
+      "value": "https"
+     },
+     {
+      "name": "NSS_SDB_USE_CACHE",
+      "value": "no"
      }
     ],
     "image": "docker.elastic.co/elasticsearch/elasticsearch:8.14.0",
@@ -1564,6 +1612,22 @@
      {
       "name": "HEADLESS_SERVICE_NAME",
       "value": "name-es-nodeset-1"
+     },
+     {
+      "name": "PROBE_PASSWORD_PATH",
+      "value": "/mnt/elastic-internal/pod-mounted-users/elastic-internal-probe"
+     },
+     {
+      "name": "PROBE_USERNAME",
+      "value": "elastic-internal-probe"
+     },
+     {
+      "name": "READINESS_PROBE_PROTOCOL",
+      "value": "https"
+     },
+     {
+      "name": "NSS_SDB_USE_CACHE",
+      "value": "no"
      }
     ],
     "image": "docker.elastic.co/elasticsearch/elasticsearch:8.14.0",

--- a/pkg/controller/elasticsearch/nodespec/defaults.go
+++ b/pkg/controller/elasticsearch/nodespec/defaults.go
@@ -46,6 +46,9 @@ var (
 func DefaultEnvVars(v version.Version, httpCfg commonv1.HTTPConfig, headlessServiceName string) []corev1.EnvVar {
 	vars := []corev1.EnvVar{
 		// needed in elasticsearch.yml
+		// We do not recommend overriding the default readiness probe on Elasticsearch 8.2.0 and later.
+		// ECK configures a socket based readiness probe using the Elasticsearch which is not influenced by the load on the Elasticsearch cluster.
+		// These settings are added only for backwards compatibility and will be removed in a future release.
 		{Name: settings.HeadlessServiceName, Value: headlessServiceName},
 		{Name: settings.EnvProbePasswordPath, Value: path.Join(esvolume.PodMountedUsersSecretMountPath, user.ProbeUserName)},
 		{Name: settings.EnvProbeUsername, Value: user.ProbeUserName},

--- a/pkg/controller/elasticsearch/nodespec/defaults.go
+++ b/pkg/controller/elasticsearch/nodespec/defaults.go
@@ -12,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
-	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/defaults"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/elasticsearch/label"
@@ -48,27 +47,23 @@ func DefaultEnvVars(v version.Version, httpCfg commonv1.HTTPConfig, headlessServ
 	vars := []corev1.EnvVar{
 		// needed in elasticsearch.yml
 		{Name: settings.HeadlessServiceName, Value: headlessServiceName},
-	}
-	if v.LT(esv1.MinReadinessPortVersion) {
-		vars = []corev1.EnvVar{
-			{Name: settings.EnvProbePasswordPath, Value: path.Join(esvolume.PodMountedUsersSecretMountPath, user.ProbeUserName)},
-			{Name: settings.EnvProbeUsername, Value: user.ProbeUserName},
-			{Name: settings.EnvReadinessProbeProtocol, Value: httpCfg.Protocol()},
-			{Name: settings.HeadlessServiceName, Value: headlessServiceName},
+		{Name: settings.EnvProbePasswordPath, Value: path.Join(esvolume.PodMountedUsersSecretMountPath, user.ProbeUserName)},
+		{Name: settings.EnvProbeUsername, Value: user.ProbeUserName},
+		{Name: settings.EnvReadinessProbeProtocol, Value: httpCfg.Protocol()},
+		{Name: settings.HeadlessServiceName, Value: headlessServiceName},
 
-			// Disable curl/libnss use of sqlite caching to avoid triggering an issue in linux/kubernetes
-			// where the kernel's dentry cache grows by 5mb every time curl is invoked. This cache usage
-			// is charged against the pod which created it. In our case, the elasticsearch nodes trigger
-			// this problem with the readinessProbe invoking curl.
-			//
-			// In production testing, no negative impact on curl's behavior is observed from this setting.
-			// This setting is primarily targeted at curl invocation in the readinessProbe.
-			// References:
-			//   https://github.com/elastic/cloud-on-k8s/issues/1581#issuecomment-525527334
-			//   https://github.com/elastic/cloud-on-k8s/issues/1635
-			//   https://issuetracker.google.com/issues/140577001
-			{Name: "NSS_SDB_USE_CACHE", Value: "no"},
-		}
+		// Disable curl/libnss use of sqlite caching to avoid triggering an issue in linux/kubernetes
+		// where the kernel's dentry cache grows by 5mb every time curl is invoked. This cache usage
+		// is charged against the pod which created it. In our case, the elasticsearch nodes trigger
+		// this problem with the readinessProbe invoking curl.
+		//
+		// In production testing, no negative impact on curl's behavior is observed from this setting.
+		// This setting is primarily targeted at curl invocation in the readinessProbe.
+		// References:
+		//   https://github.com/elastic/cloud-on-k8s/issues/1581#issuecomment-525527334
+		//   https://github.com/elastic/cloud-on-k8s/issues/1635
+		//   https://issuetracker.google.com/issues/140577001
+		{Name: "NSS_SDB_USE_CACHE", Value: "no"},
 	}
 	return defaults.ExtendPodDownwardEnvVars(vars...)
 }

--- a/pkg/controller/elasticsearch/nodespec/defaults.go
+++ b/pkg/controller/elasticsearch/nodespec/defaults.go
@@ -50,7 +50,6 @@ func DefaultEnvVars(v version.Version, httpCfg commonv1.HTTPConfig, headlessServ
 		{Name: settings.EnvProbePasswordPath, Value: path.Join(esvolume.PodMountedUsersSecretMountPath, user.ProbeUserName)},
 		{Name: settings.EnvProbeUsername, Value: user.ProbeUserName},
 		{Name: settings.EnvReadinessProbeProtocol, Value: httpCfg.Protocol()},
-		{Name: settings.HeadlessServiceName, Value: headlessServiceName},
 
 		// Disable curl/libnss use of sqlite caching to avoid triggering an issue in linux/kubernetes
 		// where the kernel's dentry cache grows by 5mb every time curl is invoked. This cache usage


### PR DESCRIPTION
We are seeing issues with upgrading to 2.14.0 when there are overrides present for the readiness probe, adding the ENVs that have the credentials for the old readiness probe to run successfully should fix that issues
fixes: https://github.com/elastic/cloud-on-k8s/issues/8006