### PR TITLE
Document known issue

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/readiness.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/readiness.asciidoc
@@ -8,6 +8,8 @@ endif::[]
 [id="{p}-{page_id}"]
 = Readiness probe
 
+== Elasticsearch versions before 8.2.0
+
 By default, the readiness probe checks that the Pod responds to HTTP requests within a timeout of three seconds. This is acceptable in most cases. However, when the cluster is under heavy load, you might need to increase the timeout. This allows the Pod to stay in a `Ready` state and be part of the Elasticsearch service even if it is responding slowly. To adjust the timeout, set the `READINESS_PROBE_TIMEOUT` environment variable in the Pod template and update the readiness probe configuration with the new timeout. 
 
 This example describes how to increase the API call timeout to ten seconds and the overall check time to twelve seconds:
@@ -42,3 +44,7 @@ spec:
 ----
 
 Note that this requires restarting the Pods.
+
+== Elasticsearch versions 8.2.0 and later
+
+We do not recommend overriding the default readiness probe on Elasticsearch 8.2.0 and later. ECK configures a socket based readiness probe using the Elasticsearch link:https://www.elastic.co/guide/en/elasticsearch/reference/current/advanced-configuration.html#readiness-tcp-port[readiness port feature] which is not influenced by the load on the Elasticsearch cluster.

--- a/docs/release-notes/2.14.0.asciidoc
+++ b/docs/release-notes/2.14.0.asciidoc
@@ -7,7 +7,7 @@
 [[known-issue-short-2.14.0]]
 [float]
 === Known issue
-Users who have defined a <<{p}-readiness,custom readiness probe>> for Elasticsearch 8.2.0 or later will have to either remove the custom readiness probe after upgrading to 2.14 or have adjust the readiness probe script as documented <<known-issue-2.14.0,here>>.
+Users who have defined a <<{p}-readiness,custom readiness probe>> for Elasticsearch 8.2.0 or later will have to either remove the custom readiness probe before upgrading to 2.14 or if that is not possible have adjust the readiness probe script as documented <<known-issue-2.14.0,here>> after the upgrade.
 
 
 

--- a/docs/release-notes/2.14.0.asciidoc
+++ b/docs/release-notes/2.14.0.asciidoc
@@ -4,6 +4,11 @@
 [[release-notes-2.14.0]]
 == {n} version 2.14.0
 
+[[known-issue-short-2.14.0]]
+[float]
+=== Known issue
+Users who have defined a <<{p}-readiness,custom readiness probe>> for Elasticsearch 8.2.0 or later will have to either remove the custom readiness probe after upgrading to 2.14 or have adjust the readiness probe script as documented <<known-issue-2.14.0,here>>.
+
 
 
 [[feature-2.14.0]]

--- a/docs/release-notes/highlights-2.14.0.asciidoc
+++ b/docs/release-notes/highlights-2.14.0.asciidoc
@@ -4,7 +4,7 @@
 [[known-issue-2.14.0]]
 [float]
 === Known issue
-Users who have defined a <<{p}-readiness,custom readiness probe>> for Elasticsearch 8.2.0 or later will have to either remove the custom readiness probe after upgrading to 2.14 or have adjust the readiness probe script as follows:
+Users who have defined a <<{p}-readiness,custom readiness probe>> for Elasticsearch 8.2.0 or later will have to either remove the custom readiness probe before upgrading to 2.14 or if that is not possible have adjust the readiness probe script as follows after the upgrade:
 [source,yaml]
 ----
 podTemplate:

--- a/docs/release-notes/highlights-2.14.0.asciidoc
+++ b/docs/release-notes/highlights-2.14.0.asciidoc
@@ -1,6 +1,24 @@
 [[release-highlights-2.14.0]]
 == 2.14.0 release highlights
 
+[[known-issue-2.14.0]]
+[float]
+=== Known issue
+Users who have defined a <<{p}-readiness,custom readiness probe>> for Elasticsearch 8.2.0 or later will have to either remove the custom readiness probe after upgrading to 2.14 or have adjust the readiness probe script as follows:
+[source,yaml]
+----
+podTemplate:
+  spec:
+    containers:
+    - name: elasticsearch
+      readinessProbe:
+         exec:
+           command:
+           - bash
+           - -c
+           - /mnt/elastic-internal/scripts/readiness-port-script.sh
+----
+
 [float]
 [id="{p}-2140-new-and-notable"]
 === New and notable


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud-on-k8s/issues/8007

Adds a known issue to the release notes and highlights. 
Updates the readiness prot documentation to mention the new feature. 

I thought about adding a sentence to the upgrade docs but it did not fit well into the structure there and we already mention that users should check the release notes before upgrading, which seemed sufficient.

Preview https://cloud-on-k8s_bk_8010.docs-preview.app.elstc.co/guide/en/cloud-on-k8s/master/release-highlights-2.14.0.html

I think this documentation update should be backported to the 2.14. branch.