### PR TITLE
Update readiness.asciidoc to use the correct readiness script

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/readiness.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/readiness.asciidoc
@@ -30,7 +30,7 @@ spec:
                 command:
                 - bash
                 - -c
-                - /mnt/elastic-internal/scripts/readiness-probe-script.sh
+                - /mnt/elastic-internal/scripts/readiness-port-script.sh
               failureThreshold: 3
               initialDelaySeconds: 10
               periodSeconds: 12


### PR DESCRIPTION

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? => yes
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)? => yes
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed. => not code


From ECK 2.14, the readiness script was updated from `/mnt/elastic-internal/scripts/readiness-probe-script.sh` to `/mnt/elastic-internal/scripts/readiness-port-script.sh` (probe -> port). This PR is to update the script path.

Note: I didn't change https://github.com/elastic/cloud-on-k8s/compare/main...kunisen-docpr-sdhcp-7920?quick_pull=1#diff-6556278a754c915a664e7988c5de05378573d1c0d6be1a2fbd485f0d76ce6a9bR50 but unsure why it's showing up. 
