### PR TITLE
TestFleet* Bump memory a bit

### DIFF
--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -179,11 +179,11 @@ func (b Builder) MoreResourcesForIssue4730() Builder {
 	return b.WithResources(
 		corev1.ResourceRequirements{
 			Limits: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceMemory: resource.MustParse("512Mi"),
+				corev1.ResourceMemory: resource.MustParse("640Mi"),
 				corev1.ResourceCPU:    resource.MustParse("200m"),
 			},
 			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceMemory: resource.MustParse("512Mi"),
+				corev1.ResourceMemory: resource.MustParse("640Mi"),
 				corev1.ResourceCPU:    resource.MustParse("200m"),
 			},
 		},


### PR DESCRIPTION
Debugging TestFleet* failures. In local runs I saw a bunch of OOMs, tyring to validate this in CI now. 