### PR TITLE
[DOC] Fix request endpoint step flow

### DIFF
--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -168,26 +168,25 @@ A default user named `elastic` is created by default with the password stored in
 ----
 PASSWORD=$(kubectl get secret quickstart-es-elastic-user -o go-template='{{.data.elastic | base64decode}}')
 ----
-
++
 NOTE: The `elastic` user creation can be disabled if desired. Check <<{p}-users-and-roles>> for more information.
 
-. Request the Elasticsearch endpoint.
-+
-From inside the Kubernetes cluster:
+. Request the Elasticsearch endpoint. You can do so from inside the Kubernetes cluster or from your local workstation.
+.. From inside the Kubernetes cluster:
 +
 [source,sh]
 ----
 curl -u "elastic:$PASSWORD" -k "https://quickstart-es-http:9200"
 ----
-+
-From your local workstation, use the following command in a separate terminal:
+.. From your local workstation:
+... Use the following command in a separate terminal:
 +
 [source,sh]
 ----
 kubectl port-forward service/quickstart-es-http 9200
 ----
 +
-Then request `localhost`:
+... Request `localhost`:
 +
 [source,sh]
 ----

--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -172,21 +172,21 @@ PASSWORD=$(kubectl get secret quickstart-es-elastic-user -o go-template='{{.data
 NOTE: The `elastic` user creation can be disabled if desired. Check <<{p}-users-and-roles>> for more information.
 
 . Request the Elasticsearch endpoint. You can do so from inside the Kubernetes cluster or from your local workstation.
-.. From inside the Kubernetes cluster:
+* From inside the Kubernetes cluster:
 +
 [source,sh]
 ----
 curl -u "elastic:$PASSWORD" -k "https://quickstart-es-http:9200"
 ----
-.. From your local workstation:
-... Use the following command in a separate terminal:
+* From your local workstation:
+.. Use the following command in a separate terminal:
 +
 [source,sh]
 ----
 kubectl port-forward service/quickstart-es-http 9200
 ----
 +
-... Request `localhost`:
+.. Request `localhost`:
 +
 [source,sh]
 ----


### PR DESCRIPTION
This PR solves some confusion around the order of two steps which represent two paths rather than steps that need to be performed in order

also fixed a numbering issue

original [here](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-elasticsearch.html#k8s_request_elasticsearch_access)

<img width="694" alt="image" src="https://github.com/user-attachments/assets/2809b08a-4bc7-4e8f-91c5-520794ef49cf">
