### PR TITLE
Fix ingress.yaml for using tls.enabled boolean variable in helm template of kibana.

### DIFF
--- a/deploy/eck-stack/charts/eck-kibana/templates/ingress.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/ingress.yaml
@@ -19,7 +19,7 @@ spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className | quote }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if .Values.ingress.tls.enabled }}
   tls:
   - hosts:
   {{- range .Values.ingress.hosts }}


### PR DESCRIPTION
This corrects a typo in the Kibana Helm template `ingress.yaml` to properly use the `tls.enabled` boolean variable.