### PR TITLE
[2.14] Fix tls.enabled in Kibana Helm template ingress.yaml (#8032)

### DIFF
--- a/deploy/eck-stack/charts/eck-kibana/templates/ingress.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/ingress.yaml
@@ -19,7 +19,7 @@ spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className | quote }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if .Values.ingress.tls.enabled }}
   tls:
   - hosts:
   {{- range .Values.ingress.hosts }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.14`:
 - [Fix tls.enabled in Kibana Helm template ingress.yaml (#8032)](https://github.com/elastic/cloud-on-k8s/pull/8032)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)