### PR TITLE
Update eck stack Helm charts to 0.12.1

### DIFF
--- a/deploy/eck-stack/Chart.yaml
+++ b/deploy/eck-stack/Chart.yaml
@@ -3,30 +3,30 @@ name: eck-stack
 description: Elastic Stack managed by the ECK Operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.12.0
+version: 0.12.1
 
 dependencies:
   - name: eck-elasticsearch
     condition: eck-elasticsearch.enabled
-    version: "0.12.0"
+    version: "0.12.1"
   - name: eck-kibana
     condition: eck-kibana.enabled
-    version: "0.12.0"
+    version: "0.12.1"
   - name: eck-agent
     condition: eck-agent.enabled
-    version: "0.12.0"
+    version: "0.12.1"
   - name: eck-fleet-server
     condition: eck-fleet-server.enabled
-    version: "0.12.0"
+    version: "0.12.1"
   - name: eck-beats
     condition: eck-beats.enabled
-    version: "0.12.0"
+    version: "0.12.1"
   - name: eck-logstash
     condition: eck-logstash.enabled
-    version: "0.12.0"
+    version: "0.12.1"
   - name: eck-apm-server
     condition: eck-apm-server.enabled
-    version: "0.12.0"
+    version: "0.12.1"
   - name: eck-enterprise-search
     condition: eck-enterprise-search.enabled
-    version: "0.12.0"
+    version: "0.12.1"

--- a/deploy/eck-stack/charts/eck-agent/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-agent
 description: Elastic Agent managed by the ECK operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.12.0
+version: 0.12.1
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/elastic-agent

--- a/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent-cluster-role-binding_test.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent-cluster-role-binding_test.yaml
@@ -79,7 +79,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
             clusterRoleBinding: label
-            helm.sh/chart: eck-agent-0.12.0
+            helm.sh/chart: eck-agent-0.12.1
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent-cluster-role_test.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent-cluster-role_test.yaml
@@ -136,7 +136,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
             clusterRole: label
-            helm.sh/chart: eck-agent-0.12.0
+            helm.sh/chart: eck-agent-0.12.1
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent-service-account_test.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent-service-account_test.yaml
@@ -49,7 +49,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
             serviceAccount: label
-            helm.sh/chart: eck-agent-0.12.0
+            helm.sh/chart: eck-agent-0.12.1
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent_test.yaml
@@ -51,7 +51,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
-            helm.sh/chart: eck-agent-0.12.0
+            helm.sh/chart: eck-agent-0.12.1
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-apm-server/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-apm-server/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-apm-server
 description: Elastic APM Server managed by the ECK operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.12.0
+version: 0.12.1
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/apm-server

--- a/deploy/eck-stack/charts/eck-apm-server/templates/tests/apmserver_test.yaml
+++ b/deploy/eck-stack/charts/eck-apm-server/templates/tests/apmserver_test.yaml
@@ -62,7 +62,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-apm-server
-            helm.sh/chart: eck-apm-server-0.12.0
+            helm.sh/chart: eck-apm-server-0.12.1
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-beats/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-beats/Chart.yaml
@@ -4,7 +4,7 @@ description: Elastic Beats managed by the ECK operator
 # Requirement comes from minimum version supported for eck-operator (https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s_supported_versions.html)
 kubeVersion: ">= 1.20.0-0"
 type: application
-version: 0.12.0
+version: 0.12.1
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/beats

--- a/deploy/eck-stack/charts/eck-beats/templates/tests/beats-metricbeat-example_test.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/tests/beats-metricbeat-example_test.yaml
@@ -233,7 +233,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-beats
             serviceAccount: label
-            helm.sh/chart: eck-beats-0.12.0
+            helm.sh/chart: eck-beats-0.12.1
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-elasticsearch/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-elasticsearch
 description: Elasticsearch managed by the ECK operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.12.0
+version: 0.12.1
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/elasticsearch/

--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
@@ -108,7 +108,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-elasticsearch
-            helm.sh/chart: eck-elasticsearch-0.12.0
+            helm.sh/chart: eck-elasticsearch-0.12.1
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/ingress_test.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/ingress_test.yaml
@@ -56,7 +56,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-elasticsearch
-            helm.sh/chart: eck-elasticsearch-0.12.0
+            helm.sh/chart: eck-elasticsearch-0.12.1
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-enterprise-search/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-enterprise-search
 description: Elastic Enterprise Search managed by the ECK operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.12.0
+version: 0.12.1
 sources:
   - https://github.com/elastic/cloud-on-k8s
 icon: https://github.com/elastic/ent-search/blob/main/public/app-search-favicon-196x196.png

--- a/deploy/eck-stack/charts/eck-enterprise-search/templates/tests/entsearch_test.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/templates/tests/entsearch_test.yaml
@@ -62,7 +62,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-enterprise-search
-            helm.sh/chart: eck-enterprise-search-0.12.0
+            helm.sh/chart: eck-enterprise-search-0.12.1
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-fleet-server/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-fleet-server
 description: Elastic Fleet Server as an Agent managed by the ECK operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.12.0
+version: 0.12.1
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/elastic-agent

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server-cluster-role-binding_test.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server-cluster-role-binding_test.yaml
@@ -49,7 +49,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
             clusterRoleBinding: label
-            helm.sh/chart: eck-fleet-server-0.12.0
+            helm.sh/chart: eck-fleet-server-0.12.1
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server-cluster-role_test.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server-cluster-role_test.yaml
@@ -88,7 +88,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
             clusterRole: label
-            helm.sh/chart: eck-fleet-server-0.12.0
+            helm.sh/chart: eck-fleet-server-0.12.1
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server-service-account_test.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server-service-account_test.yaml
@@ -34,7 +34,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
             serviceAccount: label
-            helm.sh/chart: eck-fleet-server-0.12.0
+            helm.sh/chart: eck-fleet-server-0.12.1
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
@@ -46,7 +46,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
-            helm.sh/chart: eck-fleet-server-0.12.0
+            helm.sh/chart: eck-fleet-server-0.12.1
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-kibana/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-kibana
 description: Kibana managed by the ECK operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.12.0
+version: 0.12.1
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/kibana

--- a/deploy/eck-stack/charts/eck-kibana/templates/tests/ingress_test.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/tests/ingress_test.yaml
@@ -56,7 +56,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-kibana
-            helm.sh/chart: eck-kibana-0.12.0
+            helm.sh/chart: eck-kibana-0.12.1
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
@@ -53,7 +53,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-kibana
-            helm.sh/chart: eck-kibana-0.12.0
+            helm.sh/chart: eck-kibana-0.12.1
             test: label
       - equal:
           path: metadata.annotations

--- a/deploy/eck-stack/charts/eck-logstash/Chart.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/Chart.yaml
@@ -3,7 +3,7 @@ name: eck-logstash
 description: Logstash managed by the ECK operator
 kubeVersion: ">= 1.21.0-0"
 type: application
-version: 0.12.0
+version: 0.12.1
 sources:
   - https://github.com/elastic/cloud-on-k8s
   - https://github.com/elastic/logstash

--- a/deploy/eck-stack/charts/eck-logstash/templates/tests/logstash_test.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/templates/tests/logstash_test.yaml
@@ -101,7 +101,7 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-logstash
-            helm.sh/chart: eck-logstash-0.12.0
+            helm.sh/chart: eck-logstash-0.12.1
             test: label
       - equal:
           path: metadata.annotations


### PR DESCRIPTION
Increase versions of eck-stack helm charts in 2.14 branch to release https://github.com/elastic/cloud-on-k8s/pull/8032.