### PR TITLE
Fix eck-stack kibana examples

### DIFF
--- a/deploy/eck-stack/examples/kibana/ingress/kibana-gke.yaml
+++ b/deploy/eck-stack/examples/kibana/ingress/kibana-gke.yaml
@@ -19,7 +19,8 @@ eck-elasticsearch:
     hosts:
     - host: "kibana.company.dev"
       path: "/"
-    tls: true
+    tls:
+      enabled: true
 
   http:
     service:
@@ -78,4 +79,5 @@ eck-kibana:
     hosts:
     - host: "kibana.company.dev"
       path: "/"
-    tls: true
+    tls:
+      enabled: true


### PR DESCRIPTION
While testing out the new eck-stack release, I found that the example was still incorrect. This fixes the example manifest.