### PR TITLE
Add missing metricsets

### DIFF
--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -30,8 +30,11 @@ spec:
                       - index_recovery
                       - index_summary
                       - ml_job
+                      - node
                       - node_stats
                       - shard
+                      - ingest_pipeline
+                      - pending_tasks
                     period: 10s
                     hosts: "https://${data.host}:${data.ports.https}"
                     username: ${MONITORED_ES_USERNAME}

--- a/config/recipes/beats/stack_monitoring.yaml
+++ b/config/recipes/beats/stack_monitoring.yaml
@@ -29,12 +29,12 @@ spec:
                       - index
                       - index_recovery
                       - index_summary
+                      - ingest_pipeline
                       - ml_job
                       - node
                       - node_stats
-                      - shard
-                      - ingest_pipeline
                       - pending_tasks
+                      - shard
                     period: 10s
                     hosts: "https://${data.host}:${data.ports.https}"
                     username: ${MONITORED_ES_USERNAME}

--- a/pkg/controller/common/stackmon/sidecar.go
+++ b/pkg/controller/common/stackmon/sidecar.go
@@ -33,6 +33,11 @@ func NewMetricBeatSidecar(
 	password string,
 	isTLS bool,
 ) (BeatSidecar, error) {
+	v, err := version.Parse(imageVersion)
+	if err != nil {
+		return BeatSidecar{}, err // error unlikely and should have been caught during validation
+	}
+
 	baseConfig, sourceCaVolume, err := buildMetricbeatBaseConfig(
 		client,
 		associationType,
@@ -43,15 +48,12 @@ func NewMetricBeatSidecar(
 		password,
 		isTLS,
 		baseConfigTemplate,
+		v,
 	)
 	if err != nil {
 		return BeatSidecar{}, err
 	}
 
-	v, err := version.Parse(imageVersion)
-	if err != nil {
-		return BeatSidecar{}, err // error unlikely and should have been caught during validation
-	}
 	image := container.ImageRepository(container.MetricbeatImage, v)
 
 	// EmptyDir volume so that MetricBeat does not write in the container image, which allows ReadOnlyRootFilesystem: true

--- a/pkg/controller/elasticsearch/stackmon/metricbeat.tpl.yml
+++ b/pkg/controller/elasticsearch/stackmon/metricbeat.tpl.yml
@@ -9,9 +9,15 @@ metricbeat.modules:
       - index_recovery
       - index_summary
       - ml_job
+      - node
       - node_stats
       - pending_tasks
       - shard
+      {{- if isVersionGTE "8.7.0" }}
+      - ingest_pipeline
+      {{- end }}
+      - pending_tasks
+
     period: 10s
     xpack.enabled: true
     hosts: ["{{ .URL }}"]

--- a/pkg/controller/elasticsearch/stackmon/metricbeat.tpl.yml
+++ b/pkg/controller/elasticsearch/stackmon/metricbeat.tpl.yml
@@ -8,14 +8,14 @@ metricbeat.modules:
       - index
       - index_recovery
       - index_summary
+      {{- if isVersionGTE "8.7.0" }}
+      - ingest_pipeline
+      {{- end }}
       - ml_job
       - node
       - node_stats
       - pending_tasks
       - shard
-      {{- if isVersionGTE "8.7.0" }}
-      - ingest_pipeline
-      {{- end }}
 
     period: 10s
     xpack.enabled: true

--- a/pkg/controller/elasticsearch/stackmon/metricbeat.tpl.yml
+++ b/pkg/controller/elasticsearch/stackmon/metricbeat.tpl.yml
@@ -16,7 +16,6 @@ metricbeat.modules:
       {{- if isVersionGTE "8.7.0" }}
       - ingest_pipeline
       {{- end }}
-      - pending_tasks
 
     period: 10s
     xpack.enabled: true


### PR DESCRIPTION
This PR adds some of the missing metricsets to the stack monitoring configuration
fixes: #7277 

