### PR TITLE
[2.7] Add warning for role mappings for 8.15 (#8057)

### DIFF
--- a/docs/eck-attributes.asciidoc
+++ b/docs/eck-attributes.asciidoc
@@ -3,3 +3,5 @@
 :eck_release_branch: 2.7
 :eck_github: https://github.com/elastic/cloud-on-k8s
 :eck_resources_list: Elasticsearch, Kibana, APM Server, Enterprise Search, Beats, Elastic Agent, and Elastic Maps Server
+
+:role_mappings_warning: We have identified an issue with Elasticsearch 8.15 that prevents security role mappings configured via Stack configuration policies to work correctly. The only workaround is to specify the security role mappings via the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html[Elasticsearch REST API]. After an upgrade from a previous Elasticsearch version to 8.15 role mappings will be preserved but will not receive future updates from the Stack configuration policy. We are working on a fix to restore the functionality in a future Elasticsearch release.

--- a/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/stack-config-policy.asciidoc
@@ -9,6 +9,8 @@ endif::[]
 
 experimental[]
 
+CAUTION: {role_mappings_warning}
+
 NOTE: This requires a valid Enterprise license or Enterprise trial license. Check <<{p}-licensing,the license documentation>> for more details about managing licenses.
 
 Starting from ECK `2.6.1` and Elasticsearch `8.6.1`, Elastic Stack configuration policies allow you to configure the following settings:

--- a/docs/orchestrating-elastic-stack-applications/upgrading-stack.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/upgrading-stack.asciidoc
@@ -7,6 +7,8 @@ endif::[]
 [id="{p}-{page_id}"]
 = Upgrade the Elastic Stack version
 
+CAUTION: {role_mappings_warning}
+
 The operator can safely perform upgrades to newer versions of the various Elastic Stack resources.
 
 Follow the instructions in the link:https://www.elastic.co/guide/en/elastic-stack/current/upgrading-elastic-stack.html[Elasticsearch documentation]. Make sure that your cluster is compatible with the target version, take backups, and follow the specific upgrade instructions for each resource type. When you are ready, modify the `version` field in the resource spec to the desired stack version and the operator will start the upgrade process automatically.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.7`:
 - [Add warning for role mappings for 8.15 (#8057)](https://github.com/elastic/cloud-on-k8s/pull/8057)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)