### PR TITLE
Skip CI if only ^docs/ changed

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -10,7 +10,8 @@
       "build_on_comment": true,
       "trigger_comment_regex": "^(?:(?:buildkite\\s+)?(?:build|test)\\s+(?:this|it))\\s*(?<args>.*)",
       "always_trigger_comment_regex": "^(?:(?:buildkite\\s+)?(?:build|test)\\s+(?:this|it))\\s*(?<args>.*)",
-      "skip_ci_labels": ["skip-ci"]
+      "skip_ci_labels": ["skip-ci"],
+      "skip_ci_on_only_changed": ["^docs/"]
     }
   ]
 }


### PR DESCRIPTION
This is an attempt to not run the main CI pipeline when there are only documentation changes.

Compared to the last time I tried this, the docs build has been completely revised.

Relates to #6617.