### PR TITLE
Revert "Skip main CI pipeline when only docs change (#8067)"

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -10,8 +10,7 @@
       "build_on_comment": true,
       "trigger_comment_regex": "^(?:(?:buildkite\\s+)?(?:build|test)\\s+(?:this|it))\\s*(?<args>.*)",
       "always_trigger_comment_regex": "^(?:(?:buildkite\\s+)?(?:build|test)\\s+(?:this|it))\\s*(?<args>.*)",
-      "skip_ci_labels": ["skip-ci"],
-      "skip_ci_on_only_changed": ["^docs/"]
+      "skip_ci_labels": ["skip-ci"]
     }
   ]
 }


### PR DESCRIPTION
This reverts commit e19979239b4a4e4e1e85727f8d2dc1f2c7a7756d.

A mixture of haste and fatigue... it doesn't work any better.
