### PR TITLE
fix(deploy): move '$leading_path' variable definition in eck-operator

### DIFF
--- a/deploy/eck-operator/templates/serviceMonitor.yaml
+++ b/deploy/eck-operator/templates/serviceMonitor.yaml
@@ -21,8 +21,8 @@ spec:
     tlsConfig:
       insecureSkipVerify: {{ .Values.config.metrics.secureMode.tls.insecureSkipVerify | default false }}
       {{- if (not .Values.config.metrics.secureMode.tls.insecureSkipVerify) }}
-      {{- with .Values.config.metrics.secureMode.tls.caSecret }}
       {{- $leading_path := trimSuffix "/" .Values.config.metrics.secureMode.tls.caMountDirectory }}
+      {{- with .Values.config.metrics.secureMode.tls.caSecret }}
       caFile: "{{ $leading_path }}/{{ . }}/ca.crt"
       {{- end }}
       serverName: "{{ include "eck-operator.fullname" . }}-metrics.{{ .Release.Namespace }}.svc"


### PR DESCRIPTION
## Description

This PR fixes an error that is thrown by Helm when templating the `eck-operator` chart. In this case, consider the following variables file:

```bash
config:
  metrics:
    port: "6000"
    secureMode:
      enabled: true
      tls:
        certificateSecret: "my-metrics-cert-secret"
        caSecret: "my-metrics-cert-secret"
        insecureSkipVerify: false
```

Running `helm template` with the above values generates the following error:

```bash
Error: template: eck-operator/templates/serviceMonitor.yaml:25:49: executing "eck-operator/templates/serviceMonitor.yaml" at <.Values.config.metrics.secureMode.tls.caMountDirectory>: can't evaluate field Values in type string

Use --debug flag to render out invalid YAML
```

This error occurs because when modifying the scope using `with`, the reference for `.Values`, for example, is lost ([helm docs](https://helm.sh/docs/chart_template_guide/control_structures/#modifying-scope-using-with)).

Also, unit tests pass with `make helm-test` (using Helm `v3.14` and unittest `v0.2.8`).

## PR requirements

- [x] Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [x] Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)?
- [x] If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed.
