### PR TITLE
Increase memory for the agent building amd64 images

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -73,6 +73,7 @@ steps:
           DOCKER_REGISTRY_VAULT_PATH: secret/ci/elastic-cloud-on-k8s/docker-registry-elastic
           PRE_BUILD_SCRIPT: ".buildkite/scripts/build/pre-build-operator.sh"
           DRIVAH_BUILD_PATH: "build"
+          DRIVAH_AMD_AGENT_MEMORY: "5G"
           RECURSIVE: true
 
   - group: build e2e-tests


### PR DESCRIPTION
This change gives a bit more memory for the agent that creates amd64 images.

In the last 2 nightly builds, the amd64 image build failed due to lack of memory. The need for more memory seems to be correlated with the go update to `v1.23` introduced in #8074. Before the update, the amd64 image build was already consuming almost 4G. Since the update, we hit sometimes 100% and the ci agent is killed.