### PR TITLE
Update Maps Images to multi-arch

### DIFF
--- a/.buildkite/e2e/nightly-main-matrix.yaml
+++ b/.buildkite/e2e/nightly-main-matrix.yaml
@@ -45,7 +45,6 @@
   fixed:
     E2E_PROVIDER: eks-arm
     E2E_TEST_ENV_TAGS: arch:arm
-    E2E_TAGS: "es,kb,apm,ent,beat,agent"
     TEST_LICENSE: "" # disabled b/c https://github.com/elastic/elasticsearch/issues/68083
     MONITORING_SECRETS: "" # disabled b/c beats cannot run on ARM
 

--- a/.buildkite/e2e/release-branch-matrix.yaml
+++ b/.buildkite/e2e/release-branch-matrix.yaml
@@ -61,7 +61,6 @@
   fixed:
     E2E_PROVIDER: eks-arm
     E2E_TEST_ENV_TAGS: arch:arm
-    E2E_TAGS: "es,kb,apm,ent,beat,agent"
     TEST_LICENSE: "" # disabled b/c https://github.com/elastic/elasticsearch/issues/68083
     MONITORING_SECRETS: "" # disabled b/c beats cannot run on ARM
 

--- a/pkg/controller/common/container/container_test.go
+++ b/pkg/controller/common/container/container_test.go
@@ -141,6 +141,19 @@ func TestImageRepository(t *testing.T) {
 			suffix:  "-obi1",
 			want:    testRegistry + "/elastic-maps-service/elastic-maps-server-ubi8-obi1:8.11.0",
 		},
+		{
+			name:    "Maps 8 image post 8.16 wolfi-based",
+			image:   MapsImage,
+			version: "8.16.0",
+			want:    testRegistry + "/elastic-maps-service/elastic-maps-server:8.16.0",
+		},
+		{
+			name:    "Maps 8 image post 8.16 ubi requested",
+			image:   MapsImage,
+			version: "8.16.0",
+			suffix:  "-ubi",
+			want:    testRegistry + "/elastic-maps-service/elastic-maps-server-ubi:8.16.0",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/test/e2e/test/maps/builder.go
+++ b/test/e2e/test/maps/builder.go
@@ -155,7 +155,7 @@ func (b Builder) SkipTest() bool {
 	ver := version.MustParse(b.EMS.Spec.Version)
 	// ARM is only supported as of 8.16.0
 	if test.Ctx().HasTag(test.ArchARMTag) && ver.LT(container.MinMapsVersionOnARM) {
-		return false
+		return true
 	}
 	return version.SupportedMapsVersions.WithinRange(ver) != nil
 }

--- a/test/e2e/test/maps/builder.go
+++ b/test/e2e/test/maps/builder.go
@@ -12,6 +12,7 @@ import (
 
 	commonv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/apis/maps/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/container"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/controller/common/version"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/k8s"
 	"github.com/elastic/cloud-on-k8s/v2/test/e2e/cmd/run"
@@ -152,6 +153,10 @@ func (b Builder) SkipTest() bool {
 		return true
 	}
 	ver := version.MustParse(b.EMS.Spec.Version)
+	// ARM is only supported as of 8.16.0
+	if test.Ctx().HasTag(test.ArchARMTag) && ver.LT(container.MinMapsVersionOnARM) {
+		return false
+	}
 	return version.SupportedMapsVersions.WithinRange(ver) != nil
 }
 


### PR DESCRIPTION
Fixes #8034 

Removes the special casing for Map Server as of 8.16.0 when setting the container images. 

Removes the exception for Maps Server for e2e tests on ARM after 8.16.0. 

cc @jsanz 