### PR TITLE
Kibana: Set default hardened security context

### DIFF
--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -383,7 +382,7 @@ func TestDriverDeploymentParams(t *testing.T) {
 			}
 
 			if diff := deep.Equal(got, tt.want); diff != nil {
-				t.Error(cmp.Diff(got, tt.want))
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/controller/kibana/driver_test.go
+++ b/pkg/controller/kibana/driver_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -382,7 +383,7 @@ func TestDriverDeploymentParams(t *testing.T) {
 			}
 
 			if diff := deep.Equal(got, tt.want); diff != nil {
-				t.Error(diff)
+				t.Error(cmp.Diff(got, tt.want))
 			}
 		})
 	}
@@ -496,9 +497,7 @@ func expectedDeploymentParams() deployment.Params {
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Image:           "my-image",
 					Command:         []string{"/usr/bin/env", "bash", "-c", InitConfigScript},
-					SecurityContext: &corev1.SecurityContext{
-						Privileged: &falseVal,
-					},
+					SecurityContext: &defaultSecurityContext,
 					Env: []corev1.EnvVar{
 						{Name: settings.EnvPodIP, Value: "", ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIP"},
@@ -591,9 +590,11 @@ func expectedDeploymentParams() deployment.Params {
 							},
 						},
 					},
-					Resources: DefaultResources,
+					Resources:       DefaultResources,
+					SecurityContext: &defaultSecurityContext,
 				}},
 				AutomountServiceAccountToken: &falseVal,
+				SecurityContext:              &defaultPodSecurityContext,
 			},
 		},
 	}

--- a/pkg/controller/kibana/init_configuration.go
+++ b/pkg/controller/kibana/init_configuration.go
@@ -38,16 +38,11 @@ echo "Kibana configuration successfully prepared."
 // The script creates symbolic links from the generated configuration files in /mnt/elastic-internal/kibana-config/ to
 // an empty directory later mounted in /use/share/kibana/config
 func initConfigContainer(kb kbv1.Kibana) corev1.Container {
-	privileged := false
-
 	return corev1.Container{
 		// Image will be inherited from pod template defaults
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Name:            InitConfigContainerName,
-		SecurityContext: &corev1.SecurityContext{
-			Privileged: &privileged,
-		},
-		Command: []string{"/usr/bin/env", "bash", "-c", InitConfigScript},
+		Command:         []string{"/usr/bin/env", "bash", "-c", InitConfigScript},
 		VolumeMounts: []corev1.VolumeMount{
 			ConfigSharedVolume.InitContainerVolumeMount(),
 			ConfigVolume(kb).VolumeMount(),

--- a/pkg/controller/kibana/pod.go
+++ b/pkg/controller/kibana/pod.go
@@ -110,9 +110,9 @@ func NewPodTemplateSpec(ctx context.Context, client k8sclient.Client, kb kbv1.Ki
 		WithDockerImage(kb.Spec.Image, container.ImageRepository(container.KibanaImage, v)).
 		WithReadinessProbe(readinessProbe(kb.Spec.HTTP.TLS.Enabled(), kibanaBasePath)).
 		WithPorts(ports).
+		WithInitContainers(initConfigContainer(kb)).
 		WithContainersSecurityContext(defaultSecurityContext).
-		WithPodSecurityContext(defaultPodSecurityContext).
-		WithInitContainers(initConfigContainer(kb))
+		WithPodSecurityContext(defaultPodSecurityContext)
 
 	for _, volume := range volumes {
 		builder.WithVolumes(volume.Volume()).WithVolumeMounts(volume.VolumeMount())

--- a/pkg/controller/kibana/pod.go
+++ b/pkg/controller/kibana/pod.go
@@ -110,6 +110,8 @@ func NewPodTemplateSpec(ctx context.Context, client k8sclient.Client, kb kbv1.Ki
 		WithDockerImage(kb.Spec.Image, container.ImageRepository(container.KibanaImage, v)).
 		WithReadinessProbe(readinessProbe(kb.Spec.HTTP.TLS.Enabled(), kibanaBasePath)).
 		WithPorts(ports).
+		WithContainersSecurityContext(defaultSecurityContext).
+		WithPodSecurityContext(defaultPodSecurityContext).
 		WithInitContainers(initConfigContainer(kb))
 
 	for _, volume := range volumes {

--- a/pkg/controller/kibana/securitycontext.go
+++ b/pkg/controller/kibana/securitycontext.go
@@ -1,0 +1,24 @@
+package kibana
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+var (
+	defaultSecurityContext = corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.To(bool(false)),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				corev1.Capability("ALL"),
+			},
+		},
+		Privileged:             ptr.To(bool(false)),
+		ReadOnlyRootFilesystem: ptr.To(bool(true)),
+		RunAsUser:              ptr.To(int64(1000)),
+		RunAsGroup:             ptr.To(int64(1000)),
+	}
+	defaultPodSecurityContext = corev1.PodSecurityContext{
+		FSGroup: ptr.To(int64(1000)),
+	}
+)


### PR DESCRIPTION
Closes: #7787

## What is this change?

This sets the security context for Kibana to be more secure/hardened by default.

### Testing/Todo

- [ ] Test v8 Kibana in e2e tests
- [ ] Test v7 Kibana in e2e tests