### PR TITLE
Fix logstash templating issue.

### DIFF
--- a/deploy/eck-stack/charts/eck-logstash/templates/logstash.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/templates/logstash.yaml
@@ -23,16 +23,15 @@ spec:
   revisionHistoryLimit: {{ . }}
   {{- end }}
 
+  {{- if and .Values.config .Values.configRef }}
+  {{- fail "config and configRef are mutually exclusive!" }}
+  {{- end }}
   {{- with .Values.config }}
   config:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.configRef }}
   configRef:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- with .Values.pipelinesRef }}
-  pipelinesRef:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.podTemplate }}
@@ -43,8 +42,14 @@ spec:
   monitoring:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-
-  {{- if not (.Values.pipelinesRef)  }}
+  {{- if and .Values.pipelines .Values.pipelinesRef }}
+  {{- fail "pipelines and pipelinesRef are mutually exclusive!" }}
+  {{- end }}
+  {{- with .Values.pipelinesRef }}
+  pipelinesRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.pipelines  }}
   pipelines: {{ toYaml .Values.pipelines | nindent 4 }}
   {{- end }}
   volumeClaimTemplates: {{ toYaml .Values.volumeClaimTemplates | nindent 4 }}

--- a/deploy/eck-stack/charts/eck-logstash/templates/logstash.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/templates/logstash.yaml
@@ -44,7 +44,9 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 
+  {{- if not (.Values.pipelinesRef)  }}
   pipelines: {{ toYaml .Values.pipelines | nindent 4 }}
+  {{- end }}
   volumeClaimTemplates: {{ toYaml .Values.volumeClaimTemplates | nindent 4 }}
   elasticsearchRefs: {{ toYaml .Values.elasticsearchRefs | nindent 4 }}
   services: {{ toYaml .Values.services | nindent 4 }}

--- a/deploy/eck-stack/charts/eck-logstash/templates/tests/logstash_test.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/templates/tests/logstash_test.yaml
@@ -157,11 +157,19 @@ tests:
       - equal:
           path: spec.configRef.secretRef.secretName
           value: configLogstashSecretName
-  - it: should render pipelinesRef properly
+  - it: should render pipelinesRef properly without pipelines field
     set:
       pipelinesRef:
         secretName: pipelineLogstashSecretName
     asserts:
       - equal:
-          path: spec.pipelinesRef.secretName
-          value: pipelineLogstashSecretName
+          path: spec
+          value:
+            version: 8.16.0-SNAPSHOT
+            count: 1
+            pipelinesRef:
+              secretName: pipelineLogstashSecretName
+            volumeClaimTemplates: []
+            elasticsearchRefs: []
+            services: []
+            secureSettings: []

--- a/deploy/eck-stack/charts/eck-logstash/templates/tests/logstash_test.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/templates/tests/logstash_test.yaml
@@ -173,3 +173,21 @@ tests:
             elasticsearchRefs: []
             services: []
             secureSettings: []
+  - it: setting config and configRef together should fail
+    set:
+      configRef:
+        secretName: configLogstashSecretName
+      config:
+        test: config
+    asserts:
+      - failedTemplate:
+          errorMessage: config and configRef are mutually exclusive!
+  - it: setting pipelines and pipelinesRef together should fail
+    set:
+      pipelinesRef:
+        secretName: pipelineLogstashSecretName
+      pipelines:
+        - pipeline.id: main
+    asserts:
+      - failedTemplate:
+          errorMessage: pipelines and pipelinesRef are mutually exclusive!

--- a/deploy/eck-stack/charts/eck-logstash/values.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/values.yaml
@@ -48,16 +48,18 @@ annotations: {}
 count: 1
 
 # The logstash configuration, the ECK equivalent to logstash.yml
+#
+# NOTE: The `config` and `configRef` fields are mutually exclusive. Only one of them should be defined at a time,
+# as using both may cause conflicts.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-logstash-configuring-logstash
 #
 config: {}
 
-configRef: {}
-
-# Reference a pipeline configuration in a Secret.
-# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-logstash-pipelines
-#pipelinesRef:
-#    secretName: ''
+# Reference a configuration in a Secret.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-logstash-configuring-logstash
+#
+# configRef:
+#   secretName: ''
 
 # Set podTemplate to customize the pod used by Logstash
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-customize-pods.html
@@ -78,14 +80,18 @@ monitoring: {}
   #     namespace: observability
 
 # The Logstash pipelines, the ECK equivalent to pipelines.yml
+#
+# NOTE: The `pipelines` and `pipelinesRef` fields are mutually exclusive. Only one of them should be defined at a time,
+# as using both may cause conflicts.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-logstash-pipelines
 #
 pipelines: []
 
-pipelinesRef: {}
-#  secretRef:
-#    secretName: ''
-
+# Reference a pipelines configuration in a Secret.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-logstash-pipelines
+#
+# pipelinesRef:
+#   secretName: ''
 
 # volumeClaimTemplates
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-volume-claim-settings


### PR DESCRIPTION
Fixes #8000 

This change fixes a bug in the helm templating of Logstash and does not add `.spec.pipelines` when `.spec.pipelinesRef` is also defined. In addition this adds a test to ensure that the field `pipelines` is missing in `spec` when `pipelinesRef` is also defined.