### PR TITLE
Update supported versions to include Elastic Stack 9.x compatibility

### DIFF
--- a/pkg/controller/common/version/version.go
+++ b/pkg/controller/common/version/version.go
@@ -23,17 +23,17 @@ var GlobalMinStackVersion Version
 
 // supported Stack versions. See https://www.elastic.co/support/matrix#matrix_compatibility
 var (
-	SupportedAPMServerVersions        = MinMaxVersion{Min: From(6, 2, 0), Max: From(8, 99, 99)}
-	SupportedEnterpriseSearchVersions = MinMaxVersion{Min: From(7, 7, 0), Max: From(8, 99, 99)}
-	SupportedKibanaVersions           = MinMaxVersion{Min: From(6, 8, 0), Max: From(8, 99, 99)}
-	SupportedBeatVersions             = MinMaxVersion{Min: From(7, 0, 0), Max: From(8, 99, 99)}
+	SupportedAPMServerVersions        = MinMaxVersion{Min: From(6, 2, 0), Max: From(9, 99, 99)}
+	SupportedEnterpriseSearchVersions = MinMaxVersion{Min: From(7, 7, 0), Max: From(9, 99, 99)}
+	SupportedKibanaVersions           = MinMaxVersion{Min: From(6, 8, 0), Max: From(9, 99, 99)}
+	SupportedBeatVersions             = MinMaxVersion{Min: From(7, 0, 0), Max: From(9, 99, 99)}
 	// Elastic Agent was introduced in 7.8.0, but as "experimental release" with no migration path forward, hence
 	// picking higher version as minimal supported.
-	SupportedAgentVersions = MinMaxVersion{Min: From(7, 10, 0), Max: From(8, 99, 99)}
+	SupportedAgentVersions = MinMaxVersion{Min: From(7, 10, 0), Max: From(9, 99, 99)}
 	// Due to bugfixes present in 7.14 that ECK depends on, this is the lowest version we support in Fleet mode.
-	SupportedFleetModeAgentVersions = MinMaxVersion{Min: MustParse("7.14.0-SNAPSHOT"), Max: From(8, 99, 99)}
-	SupportedMapsVersions           = MinMaxVersion{Min: From(7, 11, 0), Max: From(8, 99, 99)}
-	SupportedLogstashVersions       = MinMaxVersion{Min: From(8, 12, 0), Max: From(8, 99, 99)}
+	SupportedFleetModeAgentVersions = MinMaxVersion{Min: MustParse("7.14.0-SNAPSHOT"), Max: From(9, 99, 99)}
+	SupportedMapsVersions           = MinMaxVersion{Min: From(7, 11, 0), Max: From(9, 99, 99)}
+	SupportedLogstashVersions       = MinMaxVersion{Min: From(8, 12, 0), Max: From(9, 99, 99)}
 
 	// minPreReleaseVersion is the lowest prerelease identifier as numeric prerelease takes precedence before
 	// alphanumeric ones and it can't have leading zeros.

--- a/pkg/controller/elasticsearch/client/base.go
+++ b/pkg/controller/elasticsearch/client/base.go
@@ -183,7 +183,7 @@ func versioned(b *baseClient, v version.Version) Client {
 		return &clientV7{
 			clientV6: v6,
 		}
-	case 8:
+	case 8, 9:
 		return &clientV8{
 			clientV7: clientV7{clientV6: v6},
 		}

--- a/pkg/controller/elasticsearch/version/supported_versions.go
+++ b/pkg/controller/elasticsearch/version/supported_versions.go
@@ -40,6 +40,12 @@ func technicallySupportedVersions(v version.Version) *version.MinMaxVersion {
 			Min: version.MinFor(7, 17, 0), // allow snapshot builds here for testing
 			Max: version.MustParse("8.99.99"),
 		}
+	case 9:
+		return &version.MinMaxVersion{
+			// 8.16.0 is the lowest version that offers a direct upgrade path to 9.0
+			Min: version.MinFor(8, 16, 0), // allow snapshot builds here for testing
+			Max: version.MustParse("9.99.99"),
+		}
 	default:
 		return nil
 	}

--- a/pkg/controller/logstash/validation/validations_test.go
+++ b/pkg/controller/logstash/validation/validations_test.go
@@ -212,7 +212,7 @@ func Test_checkSupportedVersion(t *testing.T) {
 		},
 		{
 			name:    "above max supported",
-			version: "9.0.0",
+			version: "42.0.0",
 			wantErr: true,
 		},
 		{


### PR DESCRIPTION
This commit brings the minimal changes to enable the operator to deploy Elastic Stack 9.x components:
- update maximum version limits for all components to support up to 9.99.99
- add support for direct upgrade paths from 8.x to 9.x in the technicallySupportedVersions function
- adjust client version handling to account for version 9

Related follow-up:
- https://github.com/elastic/cloud-on-k8s/issues/8093

---

![giphy](https://github.com/user-attachments/assets/ee4270e7-a801-40b5-ae8c-dc77f8ec8b4f)
