### PR TITLE
Do not prepopulate file-based settings with empty objects

### DIFF
--- a/pkg/controller/elasticsearch/filesettings/file_settings.go
+++ b/pkg/controller/elasticsearch/filesettings/file_settings.go
@@ -51,6 +51,20 @@ type IndexTemplates struct {
 	ComposableIndexTemplates *commonv1.Config `json:"composable_index_templates,omitempty"`
 }
 
+func (st *SettingsState) SetComponentTemplates(t *commonv1.Config) {
+	if st.IndexTemplates == nil {
+		st.IndexTemplates = &IndexTemplates{}
+	}
+	st.IndexTemplates.ComponentTemplates = t
+}
+
+func (st *SettingsState) SetComposableIndexTemplates(t *commonv1.Config) {
+	if st.IndexTemplates == nil {
+		st.IndexTemplates = &IndexTemplates{}
+	}
+	st.IndexTemplates.ComposableIndexTemplates = t
+}
+
 // hash returns the hash of the Settings, considering only the State without the Metadata.
 func (s *Settings) hash() string {
 	return hash.HashObject(s.State)
@@ -66,18 +80,7 @@ func NewEmptySettings(version int64) Settings {
 
 // newEmptySettingsState returns an empty new Settings state.
 func newEmptySettingsState() SettingsState {
-	return SettingsState{
-		ClusterSettings:        &commonv1.Config{Data: map[string]interface{}{}},
-		SnapshotRepositories:   &commonv1.Config{Data: map[string]interface{}{}},
-		SLM:                    &commonv1.Config{Data: map[string]interface{}{}},
-		RoleMappings:           &commonv1.Config{Data: map[string]interface{}{}},
-		IndexLifecyclePolicies: &commonv1.Config{Data: map[string]interface{}{}},
-		IngestPipelines:        &commonv1.Config{Data: map[string]interface{}{}},
-		IndexTemplates: &IndexTemplates{
-			ComponentTemplates:       &commonv1.Config{Data: map[string]interface{}{}},
-			ComposableIndexTemplates: &commonv1.Config{Data: map[string]interface{}{}},
-		},
-	}
+	return SettingsState{}
 }
 
 // updateState updates the Settings state from a StackConfigPolicy for a given Elasticsearch.
@@ -116,10 +119,10 @@ func (s *Settings) updateState(es types.NamespacedName, policy policyv1alpha1.St
 		state.IngestPipelines = p.Spec.Elasticsearch.IngestPipelines
 	}
 	if p.Spec.Elasticsearch.IndexTemplates.ComposableIndexTemplates != nil {
-		state.IndexTemplates.ComposableIndexTemplates = p.Spec.Elasticsearch.IndexTemplates.ComposableIndexTemplates
+		state.SetComposableIndexTemplates(p.Spec.Elasticsearch.IndexTemplates.ComposableIndexTemplates)
 	}
 	if p.Spec.Elasticsearch.IndexTemplates.ComponentTemplates != nil {
-		state.IndexTemplates.ComponentTemplates = p.Spec.Elasticsearch.IndexTemplates.ComponentTemplates
+		state.SetComponentTemplates(p.Spec.Elasticsearch.IndexTemplates.ComponentTemplates)
 	}
 	s.State = state
 	return nil

--- a/pkg/controller/elasticsearch/filesettings/file_settings_test.go
+++ b/pkg/controller/elasticsearch/filesettings/file_settings_test.go
@@ -170,7 +170,6 @@ func Test_updateState(t *testing.T) {
 				}},
 			}}}},
 			want: SettingsState{
-				ClusterSettings: &commonv1.Config{Data: map[string]any{}},
 				SnapshotRepositories: &commonv1.Config{Data: map[string]any{
 					"repo-gcs": map[string]any{
 						"type": "gcs",
@@ -194,14 +193,6 @@ func Test_updateState(t *testing.T) {
 						},
 					},
 				}},
-				SLM:                    &commonv1.Config{Data: map[string]any{}},
-				RoleMappings:           &commonv1.Config{Data: map[string]any{}},
-				IndexLifecyclePolicies: &commonv1.Config{Data: map[string]any{}},
-				IngestPipelines:        &commonv1.Config{Data: map[string]any{}},
-				IndexTemplates: &IndexTemplates{
-					ComponentTemplates:       &commonv1.Config{Data: map[string]any{}},
-					ComposableIndexTemplates: &commonv1.Config{Data: map[string]any{}},
-				},
 			},
 		},
 		{
@@ -232,7 +223,6 @@ func Test_updateState(t *testing.T) {
 				}},
 			}}}},
 			want: SettingsState{
-				ClusterSettings: &commonv1.Config{Data: map[string]any{}},
 				SnapshotRepositories: &commonv1.Config{Data: map[string]any{
 					"repo-gcs": map[string]any{
 						"type": "gcs",
@@ -256,14 +246,6 @@ func Test_updateState(t *testing.T) {
 						},
 					},
 				}},
-				SLM:                    &commonv1.Config{Data: map[string]any{}},
-				RoleMappings:           &commonv1.Config{Data: map[string]any{}},
-				IndexLifecyclePolicies: &commonv1.Config{Data: map[string]any{}},
-				IngestPipelines:        &commonv1.Config{Data: map[string]any{}},
-				IndexTemplates: &IndexTemplates{
-					ComponentTemplates:       &commonv1.Config{Data: map[string]any{}},
-					ComposableIndexTemplates: &commonv1.Config{Data: map[string]any{}},
-				},
 			},
 		},
 		{
@@ -285,7 +267,6 @@ func Test_updateState(t *testing.T) {
 				}},
 			}}}},
 			want: SettingsState{
-				ClusterSettings: &commonv1.Config{Data: map[string]any{}},
 				SnapshotRepositories: &commonv1.Config{Data: map[string]any{
 					"repo-fs": map[string]any{
 						"type": "fs",
@@ -300,14 +281,6 @@ func Test_updateState(t *testing.T) {
 						},
 					},
 				}},
-				SLM:                    &commonv1.Config{Data: map[string]any{}},
-				RoleMappings:           &commonv1.Config{Data: map[string]any{}},
-				IndexLifecyclePolicies: &commonv1.Config{Data: map[string]any{}},
-				IngestPipelines:        &commonv1.Config{Data: map[string]any{}},
-				IndexTemplates: &IndexTemplates{
-					ComponentTemplates:       &commonv1.Config{Data: map[string]any{}},
-					ComposableIndexTemplates: &commonv1.Config{Data: map[string]any{}},
-				},
 			},
 		},
 		{
@@ -330,7 +303,6 @@ func Test_updateState(t *testing.T) {
 				}},
 			}}}},
 			want: SettingsState{
-				ClusterSettings: &commonv1.Config{Data: map[string]any{}},
 				SnapshotRepositories: &commonv1.Config{Data: map[string]any{
 					"repo-url": map[string]any{
 						"type": "url",
@@ -346,14 +318,6 @@ func Test_updateState(t *testing.T) {
 						},
 					},
 				}},
-				SLM:                    &commonv1.Config{Data: map[string]any{}},
-				RoleMappings:           &commonv1.Config{Data: map[string]any{}},
-				IndexLifecyclePolicies: &commonv1.Config{Data: map[string]any{}},
-				IngestPipelines:        &commonv1.Config{Data: map[string]any{}},
-				IndexTemplates: &IndexTemplates{
-					ComponentTemplates:       &commonv1.Config{Data: map[string]any{}},
-					ComposableIndexTemplates: &commonv1.Config{Data: map[string]any{}},
-				},
 			},
 		},
 		{
@@ -408,7 +372,6 @@ func Test_updateState(t *testing.T) {
 			name: "other settings: no mutation",
 			args: args{policy: policyv1alpha1.StackConfigPolicy{Spec: policyv1alpha1.StackConfigPolicySpec{Elasticsearch: policyv1alpha1.ElasticsearchConfigPolicySpec{
 				ClusterSettings:           clusterSettings,
-				SnapshotRepositories:      &commonv1.Config{Data: map[string]any{}},
 				SnapshotLifecyclePolicies: snapshotLifecyclePolicies,
 				SecurityRoleMappings:      roleMappings,
 				IndexLifecyclePolicies:    indexLifecyclePolicies,
@@ -420,7 +383,6 @@ func Test_updateState(t *testing.T) {
 			}}}},
 			want: SettingsState{
 				ClusterSettings:        clusterSettings,
-				SnapshotRepositories:   &commonv1.Config{Data: map[string]any{}},
 				SLM:                    snapshotLifecyclePolicies,
 				RoleMappings:           roleMappings,
 				IndexLifecyclePolicies: indexLifecyclePolicies,

--- a/pkg/controller/elasticsearch/filesettings/reconciler_test.go
+++ b/pkg/controller/elasticsearch/filesettings/reconciler_test.go
@@ -253,9 +253,9 @@ func Test_ReconcileEmptyFileSettingsSecret(t *testing.T) {
 	err = json.Unmarshal(secret.Data[SettingsSecretKey], &settings)
 	assert.NoError(t, err)
 	// check that the Secret is empty
-	assert.Empty(t, settings.State.ClusterSettings.Data)
-	assert.Empty(t, settings.State.SnapshotRepositories.Data)
-	assert.Empty(t, settings.State.SLM.Data)
+	assert.Nil(t, settings.State.ClusterSettings)
+	assert.Nil(t, settings.State.SnapshotRepositories)
+	assert.Nil(t, settings.State.SLM)
 
 	// reconcile again with create only: secret is not reconciled
 	err = ReconcileEmptyFileSettingsSecret(context.Background(), fakeClient, es, true)

--- a/pkg/controller/elasticsearch/filesettings/secret_test.go
+++ b/pkg/controller/elasticsearch/filesettings/secret_test.go
@@ -41,7 +41,7 @@ func Test_NewSettingsSecret(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "esNs", secret.Namespace)
 	assert.Equal(t, "esName-es-file-settings", secret.Name)
-	assert.Equal(t, 0, len(parseSettings(t, secret).State.ClusterSettings.Data))
+	assert.Nil(t, parseSettings(t, secret).State.ClusterSettings)
 	assert.Equal(t, expectedVersion, reconciledVersion)
 
 	// policy

--- a/pkg/controller/stackconfigpolicy/controller_test.go
+++ b/pkg/controller/stackconfigpolicy/controller_test.go
@@ -182,7 +182,7 @@ func TestReconcileStackConfigPolicy_Reconcile(t *testing.T) {
 				commonlabels.StackConfigPolicyOnDeleteLabelName: commonlabels.OrphanSecretResetOnPolicyDelete,
 			},
 		},
-		Data: map[string][]byte{"settings.json": []byte(`{"metadata":{"version":"42","compatibility":"8.4.0"},"state":{"cluster_settings":{"indices.recovery.max_bytes_per_sec":"42mb"},"snapshot_repositories":{},"slm":{},"role_mappings":{},"autoscaling":{},"ilm":{},"ingest_pipelines":{},"index_templates":{"component_templates":{},"composable_index_templates":{}}}}`)},
+		Data: map[string][]byte{"settings.json": []byte(`{"metadata":{"version":"42","compatibility":"8.4.0"},"state":{"cluster_settings":{"indices.recovery.max_bytes_per_sec":"42mb"}}}`)},
 	}
 	secretHash, err := getSettingsHash(secretFixture)
 	assert.NoError(t, err)
@@ -300,7 +300,7 @@ func TestReconcileStackConfigPolicy_Reconcile(t *testing.T) {
 			post: func(r ReconcileStackConfigPolicy, recorder record.FakeRecorder) {
 				// after the reconciliation, settings are empty
 				settings := r.getSettings(t, k8s.ExtractNamespacedName(&secretFixture))
-				assert.Empty(t, settings.State.ClusterSettings.Data)
+				assert.Nil(t, settings.State.ClusterSettings)
 			},
 			wantErr: false,
 		},
@@ -319,7 +319,7 @@ func TestReconcileStackConfigPolicy_Reconcile(t *testing.T) {
 			post: func(r ReconcileStackConfigPolicy, recorder record.FakeRecorder) {
 				// after the reconciliation, settings are empty
 				settings := r.getSettings(t, k8s.ExtractNamespacedName(orphanSecretFixture))
-				assert.Empty(t, settings.State.ClusterSettings.Data)
+				assert.Nil(t, settings.State.ClusterSettings)
 			},
 			wantErr: false,
 		},
@@ -340,9 +340,9 @@ func TestReconcileStackConfigPolicy_Reconcile(t *testing.T) {
 			post: func(r ReconcileStackConfigPolicy, recorder record.FakeRecorder) {
 				// after the reconciliation, settings are empty
 				settings := r.getSettings(t, k8s.ExtractNamespacedName(&secretFixture))
-				assert.Empty(t, settings.State.ClusterSettings.Data)
+				assert.Nil(t, settings.State.ClusterSettings)
 				settings = r.getSettings(t, k8s.ExtractNamespacedName(orphanSecretFixture))
-				assert.Empty(t, settings.State.ClusterSettings.Data)
+				assert.Nil(t, settings.State.ClusterSettings)
 			},
 			wantErr: false,
 		},
@@ -583,7 +583,7 @@ func TestReconcileStackConfigPolicy_Reconcile(t *testing.T) {
 			post: func(r ReconcileStackConfigPolicy, recorder record.FakeRecorder) {
 				// after the reconciliation, settings are empty
 				settings := r.getSettings(t, k8s.ExtractNamespacedName(orphanSecretFixture))
-				assert.Empty(t, settings.State.ClusterSettings.Data)
+				assert.Nil(t, settings.State.ClusterSettings)
 
 				var esConfigSecret, secretMountsSecretInEsNamespace corev1.Secret
 				// after the reconciliation, the config and secret mount secrets do not exist


### PR DESCRIPTION
A operator `settings.json` even with empty settings for each supported setting requires the appropriate handlers in Elasticsearch to be loaded. 

```
{
  "metadata": {
    "version": "1728032913938346943",
    "compatibility": "8.6.1"
  },
  "state": {
    "cluster_settings": {},
    "snapshot_repositories": {},
    "slm": {},
    "role_mappings": {},
    "ilm": {},
    "ingest_pipelines": {},
    "index_templates": {
      "component_templates": {},
      "composable_index_templates": {}
    }
  }
}
```

This causes problems when Elasticsearch is configured in a way that certain handlers are not available. In https://github.com/elastic/cloud-on-k8s/issues/8042 a user was running with `xpack.security.enabled: false` which meant that the security related handlers for role mappings were not available and the cluster never became ready. 

While we do not support running with security disabled in ECK it still seems appropriate to orchestrate ES in such a way that this problem is avoided. This PR suggests to move the following default file instead: 

```
{
  "metadata": {
    "version": "1728032913938346943",
    "compatibility": "8.6.1"
  },
  "state": {}
}
```