### PR TITLE
[E2E] Update Logstash health check with the new health API standard

### DIFF
--- a/test/e2e/logstash/pipeline_test.go
+++ b/test/e2e/logstash/pipeline_test.go
@@ -65,7 +65,11 @@ func TestPipelineConfigRefLogstash(t *testing.T) {
 				logstash.Want{
 					Match: map[string]string{
 						"pipelines.generator.workers": "1",
-						"status":                      "green",
+					},
+					MatchFunc: map[string]func(string) bool{
+						"status": func(status string) bool {
+							return status != "red"
+						},
 					},
 				}),
 			test.Step{
@@ -146,7 +150,11 @@ func TestPipelineConfigLogstash(t *testing.T) {
 				logstash.Want{
 					Match: map[string]string{
 						"pipelines.split.batch_size": "125",
-						"status":                     "green",
+					},
+					MatchFunc: map[string]func(string) bool{
+						"status": func(status string) bool {
+							return status != "red"
+						},
 					},
 				}),
 			test.Step{
@@ -200,7 +208,11 @@ func TestLogstashPipelineReload(t *testing.T) {
 					logstash.Want{
 						Match: map[string]string{
 							"pipelines.main.workers": "1",
-							"status":                 "green",
+						},
+						MatchFunc: map[string]func(string) bool{
+							"status": func(status string) bool {
+								return status != "red"
+							},
 						},
 					}),
 			).
@@ -214,7 +226,11 @@ func TestLogstashPipelineReload(t *testing.T) {
 					logstash.Want{
 						Match: map[string]string{
 							"pipelines.main.workers": "2",
-							"status":                 "green",
+						},
+						MatchFunc: map[string]func(string) bool{
+							"status": func(status string) bool {
+								return status != "red"
+							},
 						},
 					}),
 			)

--- a/test/e2e/logstash/pipeline_test.go
+++ b/test/e2e/logstash/pipeline_test.go
@@ -67,9 +67,7 @@ func TestPipelineConfigRefLogstash(t *testing.T) {
 						"pipelines.generator.workers": "1",
 					},
 					MatchFunc: map[string]func(string) bool{
-						"status": func(status string) bool {
-							return status != "red"
-						},
+						"status": isGreenOrYellow,
 					},
 				}),
 			test.Step{
@@ -152,9 +150,7 @@ func TestPipelineConfigLogstash(t *testing.T) {
 						"pipelines.split.batch_size": "125",
 					},
 					MatchFunc: map[string]func(string) bool{
-						"status": func(status string) bool {
-							return status != "red"
-						},
+						"status": isGreenOrYellow,
 					},
 				}),
 			test.Step{
@@ -210,9 +206,7 @@ func TestLogstashPipelineReload(t *testing.T) {
 							"pipelines.main.workers": "1",
 						},
 						MatchFunc: map[string]func(string) bool{
-							"status": func(status string) bool {
-								return status != "red"
-							},
+							"status": isGreenOrYellow,
 						},
 					}),
 			).
@@ -228,13 +222,16 @@ func TestLogstashPipelineReload(t *testing.T) {
 							"pipelines.main.workers": "2",
 						},
 						MatchFunc: map[string]func(string) bool{
-							"status": func(status string) bool {
-								return status != "red"
-							},
+							"status": isGreenOrYellow,
 						},
 					}),
 			)
 	}
 
 	test.Sequence(nil, stepsFn, logstashFirstPipeline).RunSequential(t)
+}
+
+// isGreenOrYellow returns true if the status is either green or yellow, red is considered as failure in health API.
+func isGreenOrYellow(status string) bool {
+	return status == "green" || status == "yellow"
 }

--- a/test/e2e/test/logstash/checks.go
+++ b/test/e2e/test/logstash/checks.go
@@ -176,7 +176,12 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 				Password: password,
 			},
 			Want{
-				Match: map[string]string{"status": "green"},
+				MatchFunc: map[string]func(string) bool{
+					// only red is considered as failure in health API
+					"status": func(status string) bool {
+						return status != "red"
+					},
+				},
 			}),
 		b.CheckMetricsRequest(k,
 			Request{
@@ -190,7 +195,7 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 					"pipelines.main.batch_size": "125",
 				},
 				MatchFunc: map[string]func(string) bool{
-					// only red is considered as not working in health API
+					// only red is considered as failure in health API
 					"status": func(status string) bool {
 						return status != "red"
 					},

--- a/test/e2e/test/logstash/checks.go
+++ b/test/e2e/test/logstash/checks.go
@@ -188,7 +188,15 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 			Want{
 				Match: map[string]string{
 					"pipelines.main.batch_size": "125",
-					"status":                    "green",
+				},
+				MatchFunc: map[string]func(string) bool{
+					// only red is considered as not working in health API
+					"status": func(status string) bool {
+						if status != "red" {
+							return true
+						}
+						return false
+					},
 				},
 			}),
 	}

--- a/test/e2e/test/logstash/checks.go
+++ b/test/e2e/test/logstash/checks.go
@@ -192,10 +192,7 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 				MatchFunc: map[string]func(string) bool{
 					// only red is considered as not working in health API
 					"status": func(status string) bool {
-						if status != "red" {
-							return true
-						}
-						return false
+						return status != "red"
 					},
 				},
 			}),

--- a/test/e2e/test/logstash/checks.go
+++ b/test/e2e/test/logstash/checks.go
@@ -177,10 +177,7 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 			},
 			Want{
 				MatchFunc: map[string]func(string) bool{
-					// only red is considered as failure in health API
-					"status": func(status string) bool {
-						return status != "red"
-					},
+					"status": isGreenOrYellow,
 				},
 			}),
 		b.CheckMetricsRequest(k,
@@ -195,10 +192,7 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 					"pipelines.main.batch_size": "125",
 				},
 				MatchFunc: map[string]func(string) bool{
-					// only red is considered as failure in health API
-					"status": func(status string) bool {
-						return status != "red"
-					},
+					"status": isGreenOrYellow,
 				},
 			}),
 	}
@@ -314,4 +308,9 @@ func CheckServicesEndpoints(b Builder, k *test.K8sClient) test.Step {
 			return nil
 		}),
 	}
+}
+
+// isGreenOrYellow returns true if the status is either green or yellow, red is considered as failure in health API.
+func isGreenOrYellow(status string) bool {
+	return status == "green" || status == "yellow"
 }


### PR DESCRIPTION
This commit updated Logstash health check to align with the new definition for green status.
Only red status is considered as a failure.

Fix: https://github.com/elastic/cloud-on-k8s/issues/8102