### PR TITLE
[DOC] Add is_managed: true to Agent policies

### DIFF
--- a/config/recipes/autopilot/fleet-kubernetes-integration.yaml
+++ b/config/recipes/autopilot/fleet-kubernetes-integration.yaml
@@ -94,6 +94,7 @@ spec:
     - name: Fleet Server on ECK policy
       id: eck-fleet-server
       namespace: default
+      is_managed: true
       monitoring_enabled:
       - logs
       - metrics
@@ -106,6 +107,7 @@ spec:
     - name: Elastic Agent on ECK policy
       id: eck-agent
       namespace: default
+      is_managed: true
       monitoring_enabled:
       - logs
       - metrics

--- a/config/recipes/elastic-agent/fleet-apm-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-apm-integration.yaml
@@ -23,6 +23,7 @@ spec:
     - name: Fleet Server on ECK policy
       id: eck-fleet-server
       namespace: default
+      is_managed: true
       monitoring_enabled:
       - logs
       - metrics
@@ -35,6 +36,7 @@ spec:
     - name: Elastic Agent on ECK policy
       id: eck-agent
       namespace: default
+      is_managed: true
       monitoring_enabled:
       - logs
       - metrics

--- a/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-custom-logs-integration.yaml
@@ -23,6 +23,7 @@ spec:
     - name: Fleet Server on ECK policy
       id: eck-fleet-server
       namespace: default
+      is_managed: true
       monitoring_enabled:
       - logs
       - metrics
@@ -35,6 +36,7 @@ spec:
     - name: Elastic Agent on ECK policy
       id: eck-agent
       namespace: default
+      is_managed: true
       monitoring_enabled:
       - logs
       - metrics

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml
@@ -98,6 +98,7 @@ spec:
     - name: Fleet Server on ECK policy
       id: eck-fleet-server
       namespace: default
+      is_managed: true
       monitoring_enabled:
       - logs
       - metrics
@@ -110,6 +111,7 @@ spec:
     - name: Elastic Agent on ECK policy
       id: eck-agent
       namespace: default
+      is_managed: true
       monitoring_enabled:
       - logs
       - metrics

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -23,6 +23,7 @@ spec:
     - name: Fleet Server on ECK policy
       id: eck-fleet-server
       namespace: default
+      is_managed: true
       monitoring_enabled:
       - logs
       - metrics
@@ -35,6 +36,7 @@ spec:
     - name: Elastic Agent on ECK policy
       id: eck-agent
       namespace: default
+      is_managed: true
       monitoring_enabled:
       - logs
       - metrics

--- a/deploy/eck-stack/examples/agent/fleet-agents.yaml
+++ b/deploy/eck-stack/examples/agent/fleet-agents.yaml
@@ -52,6 +52,7 @@ eck-kibana:
       - name: Fleet Server on ECK policy
         id: eck-fleet-server
         namespace: default
+        is_managed: true
         monitoring_enabled:
         - logs
         - metrics
@@ -63,6 +64,7 @@ eck-kibana:
       - name: Elastic Agent on ECK policy
         id: eck-agent
         namespace: default
+        is_managed: true
         monitoring_enabled:
         - logs
         - metrics

--- a/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/agent-fleet.asciidoc
@@ -94,6 +94,7 @@ spec:
       - name: Fleet Server on ECK policy
         id: eck-fleet-server
         namespace: default
+        is_managed: true
         monitoring_enabled:
           - logs
           - metrics
@@ -106,6 +107,7 @@ spec:
       - name: Elastic Agent on ECK policy
         id: eck-agent
         namespace: default
+        is_managed: true
         monitoring_enabled:
           - logs
           - metrics
@@ -291,6 +293,7 @@ spec:
       - name: Fleet Server on ECK policy
         id: eck-fleet-server
         namespace: default
+        is_managed: true
         monitoring_enabled:
           - logs
           - metrics
@@ -303,6 +306,7 @@ spec:
       - name: Elastic Agent on ECK policy
         id: eck-agent
         namespace: default
+        is_managed: true
         monitoring_enabled:
           - logs
           - metrics

--- a/test/e2e/agent/config.go
+++ b/test/e2e/agent/config.go
@@ -19,6 +19,7 @@ const (
     - name: Fleet Server on ECK policy
       id: eck-fleet-server
       namespace: default
+      is_managed: true
       monitoring_enabled:
       - logs
       - metrics
@@ -32,6 +33,7 @@ const (
     - name: Elastic Agent on ECK policy
       id: eck-agent
       namespace: default
+      is_managed: true
       monitoring_enabled:
       - logs
       - metrics


### PR DESCRIPTION
This PR adds `is_managed: true` [[kb doc](https://www.elastic.co/guide/en/kibana/current/fleet-settings-kb.html)] to all our sample Agent policies.

Should hopefully fix https://github.com/elastic/cloud-on-k8s/issues/7290, refer to my comments [here](https://github.com/elastic/cloud-on-k8s/issues/8109#issuecomment-2422409211) and [here](https://github.com/elastic/cloud-on-k8s/issues/7290#issuecomment-2422417298).