### PR TITLE
(Doc+) overview and support help

### DIFF
--- a/docs/help.asciidoc
+++ b/docs/help.asciidoc
@@ -1,2 +1,6 @@
+If you are an existing Elastic customer with an active support contract, you can create a case in the link:https://support.elastic.co/[Elastic Support Portal]. Kindly attach an <<{p}-take-eck-dump,ECK diagnostic>> when opening your case.
+
+Alternatively, or if you do not have a support contract, and if you are unable to find a solution to your problem with the information provided in these documents, ask for help:
+
 * link:https://discuss.elastic.co/c/eck[ECK Discuss forums] to ask any question
 * link:{eck_github}/issues[Github issues] for bugs and feature requests

--- a/docs/operating-eck/troubleshooting.asciidoc
+++ b/docs/operating-eck/troubleshooting.asciidoc
@@ -10,15 +10,6 @@ endif::[]
 - <<{p}-common-problems>>
 - <<{p}-troubleshooting-methods>>
 
-
-If you are an existing Elastic customer with a support contract, you can create a ticket in the link:https://support.elastic.co/[Elastic Support Portal] and provide the following information so that we can help you.
-
-- <<{p}-take-eck-dump, Run eck-diagnostics>>
-- link:https://github.com/elastic/support-diagnostics[Elasticsearch diagnostics package]
-
-
-Alternatively, or if you do not have a support contract, and if you are unable to find a solution to your problem with the information provided in these documents, ask for help:
-
 include::../help.asciidoc[]
 
 include::troubleshooting/common-problems.asciidoc[leveloffset=+1]

--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -28,6 +28,8 @@ include::supported-versions.asciidoc[]
 
 - link:https://www.elastic.co/elasticsearch-kubernetes[Orchestrate Elasticsearch on Kubernetes]
 - link:https://www.elastic.co/blog/introducing-elastic-cloud-on-kubernetes-the-elasticsearch-operator-and-beyond?elektra=products&storm=sub1[ECK post on the Elastic Blog]
+- link:https://www.youtube.com/watch?v=PIJmlYBIFXM[Getting Started With Elastic Cloud on Kubernetes (ECK)]
+- link:https://www.youtube.com/watch?v=Wf6E3vkvEFM[Running the Elastic Stack on Kubernetes with ECK]
 
 [float]
 [id="{p}-ask-for-help"]

--- a/docs/supported-versions.asciidoc
+++ b/docs/supported-versions.asciidoc
@@ -1,3 +1,5 @@
+ECK is compatible with:
+
 * Kubernetes 1.27-1.31
 * OpenShift 4.12-4.17
 * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)


### PR DESCRIPTION
👋 Second pass from https://github.com/elastic/cloud-on-k8s/pull/8128 affecting other content, this
1. moves how to contact Elastic Support to everywhere "Ask for help" shows
2. links the two main Elastic Youtubes about getting started with ECK
3. adds in a sentence before the supported versions list because AFAIK Docs prefers going straight into bullet points