### PR TITLE
Temporarily skip Agent tests for 8.17.0-SNAPSHOT

### DIFF
--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -75,6 +75,11 @@ func (b Builder) SkipTest() bool {
 	ver := version.MustParse(b.Agent.Spec.Version)
 	supportedVersions := version.SupportedAgentVersions
 
+	// deactivation while waiting for image to be available, https://github.com/elastic/cloud-on-k8s/issues/8146
+	if ver.GTE(version.MinFor(8, 17, 0)) {
+		return true
+	}
+
 	if b.Agent.Spec.FleetModeEnabled() {
 		supportedVersions = version.SupportedFleetModeAgentVersions
 


### PR DESCRIPTION
The elastic-agent e2e tests are skipped for version 8.17.0-SNAPSHOT as the corresponding Docker image is not yet available.

Relates to #8146.

To revert once the image becomes available.





