### PR TITLE
[2.15] do not overwrite kibana config in test (#8141)

### DIFF
--- a/test/e2e/test/kibana/builder.go
+++ b/test/e2e/test/kibana/builder.go
@@ -240,10 +240,15 @@ func (b Builder) WithAPMIntegration() Builder {
 }
 
 func (b Builder) WithConfig(config map[string]interface{}) Builder {
-	b.Kibana.Spec.Config = &commonv1.Config{
-		Data: config,
+	if b.Kibana.Spec.Config == nil || b.Kibana.Spec.Config.Data == nil {
+		b.Kibana.Spec.Config = &commonv1.Config{
+			Data: config,
+		}
+	} else {
+		for k, v := range config {
+			b.Kibana.Spec.Config.Data[k] = v
+		}
 	}
-
 	return b
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.15`:
 - [do not overwrite kibana config in test (#8141)](https://github.com/elastic/cloud-on-k8s/pull/8141)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)