### PR TITLE
[docs] Add note on how to access generated Kibana encryptionKeys

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -214,7 +214,7 @@ The secret is named after the corresponding Kibana instance. For example, for a 
 
 [source,shell,subs="attributes"]
 ----
-kubectl get secret my-kibana-kb-config -o jsonpath '{ .data.kibana\.yml }' | base64 --decode | grep -B 1 encryptionKey
+kubectl get secret c14-kb-config -o jsonpath='{ .data.kibana\.yml }' | base64 --decode | grep -A1 encryptedSavedObjects
 ----
 ====
 

--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -214,7 +214,7 @@ The secret is named after the corresponding Kibana instance. For example, for a 
 
 [source,shell,subs="attributes"]
 ----
-kubectl get secret my-kibana-kb-config -o json | jq -r '.data["kibana.yml"] | @base64d' | grep encryptionKey
+kubectl get secret my-kibana-kb-config -o json | jq -r '.data["kibana.yml"] | @base64d' | grep -B 1 encryptionKey
 ----
 ====
 

--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -208,7 +208,7 @@ To deploy more than one instance of Kibana, all the instances must share a same 
 
 [TIP]
 ====
-If you need to access these encryption keys, you can find them using the `kubectl get secrets` command. The secret is named after the corresponding Kibana instance.
+If you need to access these encryption keys, you can find them using the `kubectl get secrets` command. For example, when link:{kibana-ref}/xpack-security-secure-saved-objects.html#encryption-key-rotation[rotating encryption keys] extract the current value of `xpack.encryptedSavedObjects.encryptionKey` in order to set it as a historical encryption value under `xpack.encryptedSavedObjects.keyRotation.decryptionOnlyKeys`.
 
 The secret is named after the corresponding Kibana instance. For example, for a Kibana named `my-kibana`, you can run the following command to retrieve the `xpack.security.encryptionKey` key:
 

--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -210,7 +210,7 @@ To deploy more than one instance of Kibana, all the instances must share a same 
 ====
 If you need to access these encryption keys, you can find them using the `kubectl get secrets` command. The secret is named after the corresponding Kibana instance.
 
-For example, for a Kibana named `my-kibana`, you can run the following command to retrieve the `xpack.security.encryptionKey` key:
+The secret is named after the corresponding Kibana instance. For example, for a Kibana named `my-kibana`, you can run the following command to retrieve the `xpack.security.encryptionKey` key:
 
 [source,shell,subs="attributes"]
 ----

--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -214,7 +214,7 @@ The secret is named after the corresponding Kibana instance. For example, for a 
 
 [source,shell,subs="attributes"]
 ----
-kubectl get secret my-kibana-kb-config -o json | jq -r '.data["kibana.yml"] | @base64d' | grep -B 1 encryptionKey
+kubectl get secret my-kibana-kb-config -o jsonpath '{ .data.kibana\.yml }' | base64 --decode | grep -B 1 encryptionKey
 ----
 ====
 

--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -208,7 +208,7 @@ To deploy more than one instance of Kibana, all the instances must share a same 
 
 [TIP]
 ====
-If you need to access these encryption keys, you can find them using the `kubectl get secrets` command. For example, link:{kibana-ref}/xpack-security-secure-saved-objects.html#encryption-key-rotation[to rotate the encryption keys] extract the current value of `xpack.encryptedSavedObjects.encryptionKey` in order to set it as a decryption-only key under `xpack.encryptedSavedObjects.keyRotation.decryptionOnlyKeys`.
+If you need to access these encryption keys, you can find them using the `kubectl get secrets` command. 
 
 The secret is named after the corresponding Kibana instance. For example, for a Kibana named `my-kibana`, you can run the following command to retrieve the current encryption keys:
 

--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -208,7 +208,7 @@ To deploy more than one instance of Kibana, all the instances must share a same 
 
 [TIP]
 ====
-If you need to access these encryption keys, you can find them using the `kubectl get secrets` command. For example, link:{kibana-ref}/xpack-security-secure-saved-objects.html#encryption-key-rotation[rotating encryption keys] extract the current value of `xpack.encryptedSavedObjects.encryptionKey` in order to set it as an historical encryption value under `xpack.encryptedSavedObjects.keyRotation.decryptionOnlyKeys`.
+If you need to access these encryption keys, you can find them using the `kubectl get secrets` command. For example, link:{kibana-ref}/xpack-security-secure-saved-objects.html#encryption-key-rotation[to rotate the encryption keys] extract the current value of `xpack.encryptedSavedObjects.encryptionKey` in order to set it as a decryption-only key under `xpack.encryptedSavedObjects.keyRotation.decryptionOnlyKeys`.
 
 The secret is named after the corresponding Kibana instance. For example, for a Kibana named `my-kibana`, you can run the following command to retrieve the `xpack.security.encryptionKey` key:
 

--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -206,6 +206,18 @@ To deploy more than one instance of Kibana, all the instances must share a same 
 * `xpack.reporting.encryptionKey`
 * `xpack.encryptedSavedObjects.encryptionKey`
 
+[TIP]
+====
+If you need to access these encryption keys, you can find them using the `kubectl get secrets` command. The secret is named after the corresponding Kibana instance.
+
+For example, for a Kibana named `my-kibana`, you can run the following command to retrieve the `xpack.security.encryptionKey` key:
+
+[source,shell,subs="attributes"]
+----
+kubectl get secret my-kibana-kb-config -o json | jq -r '.data["kibana.yml"] | @base64d' | yq .xpack.security.encryptionKey
+----
+====
+
 You can provide your own encryption keys using a secure setting, as described in <<{p}-kibana-secure-settings,Secure settings>>.
 
 NOTE: While most reconfigurations of your Kibana instances are carried out in rolling upgrade fashion, all version upgrades will cause Kibana downtime. This happens because you can only run a single version of Kibana at any given time. For more information, check link:https://www.elastic.co/guide/en/kibana/current/upgrade.html[Upgrade Kibana].

--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -208,7 +208,7 @@ To deploy more than one instance of Kibana, all the instances must share a same 
 
 [TIP]
 ====
-If you need to access these encryption keys, you can find them using the `kubectl get secrets` command. For example, when link:{kibana-ref}/xpack-security-secure-saved-objects.html#encryption-key-rotation[rotating encryption keys] extract the current value of `xpack.encryptedSavedObjects.encryptionKey` in order to set it as a historical encryption value under `xpack.encryptedSavedObjects.keyRotation.decryptionOnlyKeys`.
+If you need to access these encryption keys, you can find them using the `kubectl get secrets` command. For example, link:{kibana-ref}/xpack-security-secure-saved-objects.html#encryption-key-rotation[rotating encryption keys] extract the current value of `xpack.encryptedSavedObjects.encryptionKey` in order to set it as an historical encryption value under `xpack.encryptedSavedObjects.keyRotation.decryptionOnlyKeys`.
 
 The secret is named after the corresponding Kibana instance. For example, for a Kibana named `my-kibana`, you can run the following command to retrieve the `xpack.security.encryptionKey` key:
 

--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -210,7 +210,7 @@ To deploy more than one instance of Kibana, all the instances must share a same 
 ====
 If you need to access these encryption keys, you can find them using the `kubectl get secrets` command. For example, link:{kibana-ref}/xpack-security-secure-saved-objects.html#encryption-key-rotation[to rotate the encryption keys] extract the current value of `xpack.encryptedSavedObjects.encryptionKey` in order to set it as a decryption-only key under `xpack.encryptedSavedObjects.keyRotation.decryptionOnlyKeys`.
 
-The secret is named after the corresponding Kibana instance. For example, for a Kibana named `my-kibana`, you can run the following command to retrieve the  current encryption keys:
+The secret is named after the corresponding Kibana instance. For example, for a Kibana named `my-kibana`, you can run the following command to retrieve the current encryption keys:
 
 [source,shell,subs="attributes"]
 ----

--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -214,7 +214,7 @@ For example, for a Kibana named `my-kibana`, you can run the following command t
 
 [source,shell,subs="attributes"]
 ----
-kubectl get secret my-kibana-kb-config -o json | jq -r '.data["kibana.yml"] | @base64d' | yq .xpack.security.encryptionKey
+kubectl get secret my-kibana-kb-config -o json | jq -r '.data["kibana.yml"] | @base64d' | grep encryptionKey
 ----
 ====
 

--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -214,7 +214,7 @@ The secret is named after the corresponding Kibana instance. For example, for a 
 
 [source,shell,subs="attributes"]
 ----
-kubectl get secret c14-kb-config -o jsonpath='{ .data.kibana\.yml }' | base64 --decode | grep -A1 encryptedSavedObjects
+kubectl get secret my-kibana-kb-config -o jsonpath='{ .data.kibana\.yml }' | base64 --decode | grep -A1 encryptedSavedObjects
 ----
 ====
 

--- a/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/kibana.asciidoc
@@ -210,7 +210,7 @@ To deploy more than one instance of Kibana, all the instances must share a same 
 ====
 If you need to access these encryption keys, you can find them using the `kubectl get secrets` command. For example, link:{kibana-ref}/xpack-security-secure-saved-objects.html#encryption-key-rotation[to rotate the encryption keys] extract the current value of `xpack.encryptedSavedObjects.encryptionKey` in order to set it as a decryption-only key under `xpack.encryptedSavedObjects.keyRotation.decryptionOnlyKeys`.
 
-The secret is named after the corresponding Kibana instance. For example, for a Kibana named `my-kibana`, you can run the following command to retrieve the `xpack.security.encryptionKey` key:
+The secret is named after the corresponding Kibana instance. For example, for a Kibana named `my-kibana`, you can run the following command to retrieve the  current encryption keys:
 
 [source,shell,subs="attributes"]
 ----


### PR DESCRIPTION
This updates the [Advanced configuration](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-kibana-advanced-configuration.html) page with a tip about how to access the operator-generated encryption keys.

Closes: https://github.com/elastic/cloud-on-k8s/issues/8129

---

![Screenshot 2024-10-24 at 9 44 53 AM](https://github.com/user-attachments/assets/06cea400-cdd2-40cb-a954-6191fc4fc5d7)

