### PR TITLE
Revert "Temporarily skip Agent tests for 8.17.0-SNAPSHOT due to unavailable image (#8147)"

### DIFF
--- a/test/e2e/test/agent/builder.go
+++ b/test/e2e/test/agent/builder.go
@@ -75,11 +75,6 @@ func (b Builder) SkipTest() bool {
 	ver := version.MustParse(b.Agent.Spec.Version)
 	supportedVersions := version.SupportedAgentVersions
 
-	// deactivation while waiting for image to be available, https://github.com/elastic/cloud-on-k8s/issues/8146
-	if ver.GTE(version.MinFor(8, 17, 0)) {
-		return true
-	}
-
 	if b.Agent.Spec.FleetModeEnabled() {
 		supportedVersions = version.SupportedFleetModeAgentVersions
 


### PR DESCRIPTION
This reverts commit 505ed333d75356ac1b039f882563a1f95f2b0102.

The image is now available.
```sh
> d pull docker.elastic.co/beats/elastic-agent:8.17.0-SNAPSHOT
8.17.0-SNAPSHOT: Pulling from beats/elastic-agent
0a0588bb8a6f: Pulling fs layer
0ae67ad66af4: Pulling fs layer
```

Relates to #8146.