### PR TITLE
[docs] Add explanation line for es ingress 9300 port

### DIFF
--- a/docs/advanced-topics/network-policies.asciidoc
+++ b/docs/advanced-topics/network-policies.asciidoc
@@ -143,6 +143,7 @@ spec:
 | Ingress (incoming) a|
 
 * TCP port {es_http_port} from the operator and other pods in the namespace.
+* TCP port {es_transport_port} from other {es} nodes in the namespace (transport port).
 
 |===
 


### PR DESCRIPTION
As described in the #7833 :

The network policy page refers does not specify in text that Elasticsearch needs to accept incoming (ingress) traffic from other elasticsearch nodes on port 9300. While the code does configure that.