### PR TITLE
Ensure esclient is closed after each reconcile.

### DIFF
--- a/pkg/controller/autoscaling/elasticsearch/controller_test.go
+++ b/pkg/controller/autoscaling/elasticsearch/controller_test.go
@@ -433,3 +433,6 @@ func (f *fakeEsClient) GetAutoscalingCapacity(_ context.Context) (esclient.Autos
 func (f *fakeEsClient) UpdateMLNodesSettings(_ context.Context, _ int32, _ string) error {
 	return nil
 }
+
+func (f *fakeEsClient) Close() {
+}

--- a/pkg/controller/autoscaling/elasticsearch/driver.go
+++ b/pkg/controller/autoscaling/elasticsearch/driver.go
@@ -114,6 +114,7 @@ func (r *baseReconcileAutoscaling) attemptOnlineReconciliation(
 	if err != nil {
 		return nil, err
 	}
+	defer esClient.Close()
 
 	// Update Machine Learning settings
 	mlNodes, maxMemory := esv1.GetMLNodesSettings(autoscalingSpec)

--- a/pkg/controller/stackconfigpolicy/controller.go
+++ b/pkg/controller/stackconfigpolicy/controller.go
@@ -715,6 +715,7 @@ func (r *ReconcileStackConfigPolicy) getClusterStateFileSettings(ctx context.Con
 	if err != nil {
 		return esclient.FileSettings{}, err
 	}
+	defer esClient.Close()
 
 	clusterState, err := esClient.GetClusterState(ctx)
 	if err != nil {

--- a/pkg/controller/stackconfigpolicy/controller_test.go
+++ b/pkg/controller/stackconfigpolicy/controller_test.go
@@ -64,6 +64,8 @@ func (c fakeEsClient) GetClusterState(_ context.Context) (esclient.ClusterState,
 	return clusterState, nil
 }
 
+func (c fakeEsClient) Close() {}
+
 func (r ReconcileStackConfigPolicy) getSettings(t *testing.T, nsn types.NamespacedName) filesettings.Settings {
 	t.Helper()
 	var secret corev1.Secret


### PR DESCRIPTION
Resolves #8174 

While investigating #8174 a couple pprof heap dumps were taken over the course of a couple of days, and compared using the diff capabilities of pprof:
```
go tool pprof -http=:8082 -no_browser -diff_base dump-1.out.gz dump-2.out.gz dump-3.out.gz
```
This brought to light the following function in the autoscaling controller (`attemptOnlineReconciliation`), which seems to have had it's heap allocations grow by about %2000 since the first dump:
![image](https://github.com/user-attachments/assets/752c95c3-ad84-4e02-b06a-3e5cc4a7e3ed)

Upon further investigation, we don't appear to be closing idle connections in the underlying http client, which could be leaking goroutines, and therefore leading to this memory increase.