### PR TITLE
[2.15] Ensure esclient is closed after each reconcile. (#8175)

### DIFF
--- a/pkg/controller/autoscaling/elasticsearch/controller_test.go
+++ b/pkg/controller/autoscaling/elasticsearch/controller_test.go
@@ -433,3 +433,6 @@ func (f *fakeEsClient) GetAutoscalingCapacity(_ context.Context) (esclient.Autos
 func (f *fakeEsClient) UpdateMLNodesSettings(_ context.Context, _ int32, _ string) error {
 	return nil
 }
+
+func (f *fakeEsClient) Close() {
+}

--- a/pkg/controller/autoscaling/elasticsearch/driver.go
+++ b/pkg/controller/autoscaling/elasticsearch/driver.go
@@ -114,6 +114,7 @@ func (r *baseReconcileAutoscaling) attemptOnlineReconciliation(
 	if err != nil {
 		return nil, err
 	}
+	defer esClient.Close()
 
 	// Update Machine Learning settings
 	mlNodes, maxMemory := esv1.GetMLNodesSettings(autoscalingSpec)

--- a/pkg/controller/stackconfigpolicy/controller.go
+++ b/pkg/controller/stackconfigpolicy/controller.go
@@ -715,6 +715,7 @@ func (r *ReconcileStackConfigPolicy) getClusterStateFileSettings(ctx context.Con
 	if err != nil {
 		return esclient.FileSettings{}, err
 	}
+	defer esClient.Close()
 
 	clusterState, err := esClient.GetClusterState(ctx)
 	if err != nil {

--- a/pkg/controller/stackconfigpolicy/controller_test.go
+++ b/pkg/controller/stackconfigpolicy/controller_test.go
@@ -64,6 +64,8 @@ func (c fakeEsClient) GetClusterState(_ context.Context) (esclient.ClusterState,
 	return clusterState, nil
 }
 
+func (c fakeEsClient) Close() {}
+
 func (r ReconcileStackConfigPolicy) getSettings(t *testing.T, nsn types.NamespacedName) filesettings.Settings {
 	t.Helper()
 	var secret corev1.Secret


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.15`:
 - [Ensure esclient is closed after each reconcile. (#8175)](https://github.com/elastic/cloud-on-k8s/pull/8175)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)