### PR TITLE
[WIP] Make `image` setting consistent accross all ECK Helm charts

### DIFF
--- a/deploy/eck-stack/charts/eck-agent/examples/fleet-agents.yaml
+++ b/deploy/eck-stack/charts/eck-agent/examples/fleet-agents.yaml
@@ -3,24 +3,23 @@
 #
 version: 8.17.0-SNAPSHOT
 
-spec:
-  # This must match the name of an Agent policy.
-  policyID: eck-agent
-  # This must match the name of the fleet server installed from eck-fleet-server chart.
-  fleetServerRef:
-    name: eck-fleet-server
-  kibanaRef:
-    name: eck-kibana
-  mode: fleet
-  # elasticsearchRefs must be empty when fleet mode is enabled.
-  elasticsearchRefs: []
+# This must match the name of an Agent policy.
+policyID: eck-agent
+# This must match the name of the fleet server installed from eck-fleet-server chart.
+fleetServerRef:
+  name: eck-fleet-server
+kibanaRef:
+  name: eck-kibana
+mode: fleet
+# elasticsearchRefs must be empty when fleet mode is enabled.
+elasticsearchRefs: []
 
-  daemonSet:
-    podTemplate:
-      spec:
-        serviceAccountName: elastic-agent
-        hostNetwork: true
-        dnsPolicy: ClusterFirstWithHostNet
-        automountServiceAccountToken: true
-        securityContext:
-          runAsUser: 0
+daemonSet:
+  podTemplate:
+    spec:
+      serviceAccountName: elastic-agent
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      automountServiceAccountToken: true
+      securityContext:
+        runAsUser: 0

--- a/deploy/eck-stack/charts/eck-agent/examples/system-integration.yaml
+++ b/deploy/eck-stack/charts/eck-agent/examples/system-integration.yaml
@@ -2,133 +2,132 @@
 # and should not be used when Agent is used with Fleet Server.
 #
 version: 8.17.0-SNAPSHOT
-spec:
-  elasticsearchRefs:
-  - name: eck-elasticsearch
-  daemonSet:
-    podTemplate:
-      spec:
-        containers:
-        - name: agent
-          securityContext:
-            runAsUser: 0
-          volumeMounts:
-          - name: agent-data
-            mountPath: /usr/share/elastic-agent/data/elastic-agent-08e204/run
-  config:
-    id: 488e0b80-3634-11eb-8208-57893829af4e
-    revision: 2
-    agent:
-      monitoring:
-        enabled: true
-        use_output: default
-        logs: true
-        metrics: true
-    inputs:
-    - id: 4917ade0-3634-11eb-8208-57893829af4e
-      name: system-1
-      revision: 1
-      type: system/metrics
+elasticsearchRefs:
+- name: eck-elasticsearch
+daemonSet:
+  podTemplate:
+    spec:
+      containers:
+      - name: agent
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: agent-data
+          mountPath: /usr/share/elastic-agent/data/elastic-agent-08e204/run
+config:
+  id: 488e0b80-3634-11eb-8208-57893829af4e
+  revision: 2
+  agent:
+    monitoring:
+      enabled: true
       use_output: default
-      meta:
-        package:
-          name: system
-          version: 8.17.0-SNAPSHOT
+      logs: true
+      metrics: true
+  inputs:
+  - id: 4917ade0-3634-11eb-8208-57893829af4e
+    name: system-1
+    revision: 1
+    type: system/metrics
+    use_output: default
+    meta:
+      package:
+        name: system
+        version: 8.17.0-SNAPSHOT
+    data_stream:
+      namespace: default
+    streams:
+    - id: system/metrics-system.cpu
       data_stream:
-        namespace: default
-      streams:
-      - id: system/metrics-system.cpu
-        data_stream:
-          dataset: system.cpu
-          type: metrics
-        metricsets:
-        - cpu
-        cpu.metrics:
-        - percentages
-        - normalized_percentages
-        period: 10s
-      - id: system/metrics-system.diskio
-        data_stream:
-          dataset: system.diskio
-          type: metrics
-        metricsets:
-        - diskio
-        diskio.include_devices: null
-        period: 10s
-      - id: system/metrics-system.filesystem
-        data_stream:
-          dataset: system.filesystem
-          type: metrics
-        metricsets:
-        - filesystem
-        period: 1m
-        processors:
-        - drop_event.when.regexp:
-            system.filesystem.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
-      - id: system/metrics-system.fsstat
-        data_stream:
-          dataset: system.fsstat
-          type: metrics
-        metricsets:
-        - fsstat
-        period: 1m
-        processors:
-        - drop_event.when.regexp:
-            system.fsstat.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
-      - id: system/metrics-system.load
-        data_stream:
-          dataset: system.load
-          type: metrics
-        metricsets:
-        - load
-        period: 10s
-      - id: system/metrics-system.memory
-        data_stream:
-          dataset: system.memory
-          type: metrics
-        metricsets:
-        - memory
-        period: 10s
-      - id: system/metrics-system.network
-        data_stream:
-          dataset: system.network
-          type: metrics
-        metricsets:
-        - network
-        period: 10s
-        network.interfaces: null
-      - id: system/metrics-system.process
-        data_stream:
-          dataset: system.process
-          type: metrics
-        metricsets:
-        - process
-        period: 10s
-        process.include_top_n.by_cpu: 5
-        process.include_top_n.by_memory: 5
-        process.cmdline.cache.enabled: true
-        process.cgroups.enabled: false
-        process.include_cpu_ticks: false
-        processes:
-        - .*
-      - id: system/metrics-system.process_summary
-        data_stream:
-          dataset: system.process_summary
-          type: metrics
-        metricsets:
-        - process_summary
-        period: 10s
-      - id: system/metrics-system.socket_summary
-        data_stream:
-          dataset: system.socket_summary
-          type: metrics
-        metricsets:
-        - socket_summary
-        period: 10s
-      - id: system/metrics-system.uptime
-        data_stream:
-          dataset: system.uptime
-          type: metrics
-        metricsets:
-        - uptime
-        period: 10s
+        dataset: system.cpu
+        type: metrics
+      metricsets:
+      - cpu
+      cpu.metrics:
+      - percentages
+      - normalized_percentages
+      period: 10s
+    - id: system/metrics-system.diskio
+      data_stream:
+        dataset: system.diskio
+        type: metrics
+      metricsets:
+      - diskio
+      diskio.include_devices: null
+      period: 10s
+    - id: system/metrics-system.filesystem
+      data_stream:
+        dataset: system.filesystem
+        type: metrics
+      metricsets:
+      - filesystem
+      period: 1m
+      processors:
+      - drop_event.when.regexp:
+          system.filesystem.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
+    - id: system/metrics-system.fsstat
+      data_stream:
+        dataset: system.fsstat
+        type: metrics
+      metricsets:
+      - fsstat
+      period: 1m
+      processors:
+      - drop_event.when.regexp:
+          system.fsstat.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
+    - id: system/metrics-system.load
+      data_stream:
+        dataset: system.load
+        type: metrics
+      metricsets:
+      - load
+      period: 10s
+    - id: system/metrics-system.memory
+      data_stream:
+        dataset: system.memory
+        type: metrics
+      metricsets:
+      - memory
+      period: 10s
+    - id: system/metrics-system.network
+      data_stream:
+        dataset: system.network
+        type: metrics
+      metricsets:
+      - network
+      period: 10s
+      network.interfaces: null
+    - id: system/metrics-system.process
+      data_stream:
+        dataset: system.process
+        type: metrics
+      metricsets:
+      - process
+      period: 10s
+      process.include_top_n.by_cpu: 5
+      process.include_top_n.by_memory: 5
+      process.cmdline.cache.enabled: true
+      process.cgroups.enabled: false
+      process.include_cpu_ticks: false
+      processes:
+      - .*
+    - id: system/metrics-system.process_summary
+      data_stream:
+        dataset: system.process_summary
+        type: metrics
+      metricsets:
+      - process_summary
+      period: 10s
+    - id: system/metrics-system.socket_summary
+      data_stream:
+        dataset: system.socket_summary
+        type: metrics
+      metricsets:
+      - socket_summary
+      period: 10s
+    - id: system/metrics-system.uptime
+      data_stream:
+        dataset: system.uptime
+        type: metrics
+      metricsets:
+      - uptime
+      period: 10s

--- a/deploy/eck-stack/charts/eck-agent/templates/elastic-agent.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/elastic-agent.yaml
@@ -12,7 +12,55 @@ metadata:
     {{- end }}
 spec:
   version: {{ required "An Elastic Agent version is required" .Values.version }}
-  {{- if and (not (hasKey .Values.spec "daemonSet")) (not (hasKey .Values.spec "deployment")) (not (hasKey .Values.spec "statefulSet")) }}
+  elasticsearchRefs: {{ required "An elasticsearchRefs is required" .Values.elasticsearchRefs }}
+  {{- with .Values.image }}
+  image: {{ . }}
+  {{- end }}
+  {{- if and (hasKey .Values "config") (hasKey .Values "configRef") }}
+  {{ fail "At most one of config or configRef can be specified" }}
+  {{- end }}
+  {{- with .Values.config }}
+  config: {{ . }}
+  {{- end }}
+  {{- with .Values.configRef }}
+  configRef: {{ . }}
+  {{- end }}
+  {{- with .Values.secureSettings }}
+  secureSettings: {{ . }}
+  {{- end }}
+  {{- with .Values.serviceAccount }}
+  serviceAccountName: {{ .name }}
+  {{- end }}
+  {{- if and (not (hasKey .Values "daemonSet")) (not (hasKey .Values "deployment")) (not (hasKey .Values "statefulSet")) }}
   {{ fail "At least one of daemonSet or deployment or statefulSet is required" }}
   {{- end }}
-  {{- toYaml .Values.spec | nindent 2 }}
+  {{- with .Values.daemonSet }}
+  daemonSet: {{ . }}
+  {{- end }}
+  {{- with .Values.deployment }}
+  deployment: {{ . }}
+  {{- end }}
+  {{- with .Values.statefulSet }}
+  statefulSet: {{ . }}
+  {{- end }}
+  {{- with .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with .Values.http }}
+  http: {{ . }}
+  {{- end }}
+  {{- with .Values.mode }}
+  mode: {{ . }}
+  {{- end }}
+  {{- with .Values.fleetServerEnabled }}
+  fleetServerEnabled: {{ . }}
+  {{- end }}
+  {{- with .Values.policyID }}
+  policyID: {{ . }}
+  {{- end }}
+  {{- with .Values.kibanaRef }}
+  kibanaRef: {{ . }}
+  {{- end }}
+  {{- with .Values.fleetServerRef }}
+  fleetServerRef: {{ . }}
+  {{- end }}

--- a/deploy/eck-stack/charts/eck-agent/values.yaml
+++ b/deploy/eck-stack/charts/eck-agent/values.yaml
@@ -20,6 +20,10 @@
 #
 version: 8.17.0-SNAPSHOT
 
+# Elastic Agent Docker image to deploy
+#
+# image:
+
 # Labels that will be applied to Elastic Agent.
 #
 labels: {}
@@ -28,74 +32,107 @@ labels: {}
 #
 annotations: {}
 
-spec:
-  # policyID determines into which Agent Policy this Agent will be enrolled.
-  # policyID: eck-agent
+# policyID determines into which Agent Policy this Agent will be enrolled.
+# policyID: eck-agent
 
-  # Referenced resources are below and depending on the setup, at least one is required for a functional Agent.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-setting-referenced-resources
+# Referenced resources are below and depending on the setup, at least one is required for a functional Agent.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-setting-referenced-resources
+#
+# Reference to ECK-managed Kibana instance.
+#
+# kibanaRef:
+#   name: quickstart
+  # Optional namespace reference to Kibana instance.
+  # If not specified, then the namespace of the Agent instance
+  # will be assumed.
   #
-  # Reference to ECK-managed Kibana instance.
-  #
-  # kibanaRef:
-  #   name: quickstart
-    # Optional namespace reference to Kibana instance.
-    # If not specified, then the namespace of the Agent instance
-    # will be assumed.
-    #
-    # namespace: default
+  # namespace: default
 
-  # Reference to ECK-managed Elasticsearch instance.
+# Reference to a list of Elasticsearch clusters
+#
+elasticsearchRefs:
+- name: eck-elasticsearch
+  # Optional namespace reference to Elasticsearch instance.
+  # If not specified, then the namespace of the Agent instance
+  # will be assumed.
   #
-  elasticsearchRefs:
-  - name: eck-elasticsearch
-    # Optional namespace reference to Elasticsearch instance.
-    # If not specified, then the namespace of the Agent instance
-    # will be assumed.
-    #
-    # namespace: default
-  
-  # Reference to ECK-managed Fleet Server instance.
-  #
-  # fleetServerRef:
-  #   name: eck-fleet-server
-    # Optional namespace reference to Fleet Server instance.
-    # If not specified, then the namespace of the Agent instance
-    # will be assumed.
-    #
-    # namespace: default
+  # namespace: default
 
-  # DaemonSet, StatefulSet, or Deployment specification for Agent.
-  # At least one is required of [daemonSet, deployment, statefulSet].
-  # No default is currently set, refer to https://github.com/elastic/cloud-on-k8s/issues/7429.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-chose-the-deployment-model
+# Reference to ECK-managed Fleet Server instance.
+#
+# fleetServerRef:
+#   name: eck-fleet-server
+  # Optional namespace reference to Fleet Server instance.
+  # If not specified, then the namespace of the Agent instance
+  # will be assumed.
   #
-  # deployment:
-  #   podTemplate:
-  #     spec:
-  #       containers:
-  #       - name: agent
-  #         securityContext:
-  #           runAsUser: 0
-  # daemonSet:
-  #   podTemplate:
-  #     spec:
-  #       containers:
-  #       - name: agent
-  #         securityContext:
-  #           runAsUser: 0
-  # statefulSet:
-  #   podTemplate:
-  #     spec:
-  #       containers:
-  #       - name: agent
-  #         securityContext:
-  #           runAsUser: 0
+  # namespace: default
 
-  # Configuration of Agent, specifically used in Agent standalone mode.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent.html
-  #
-  config: null
+# DaemonSet, StatefulSet, or Deployment specification for Agent.
+# At least one is required of [daemonSet, deployment, statefulSet].
+# No default is currently set, refer to https://github.com/elastic/cloud-on-k8s/issues/7429.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-chose-the-deployment-model
+#
+# deployment:
+#   podTemplate:
+#     spec:
+#       containers:
+#       - name: agent
+#         securityContext:
+#           runAsUser: 0
+# daemonSet:
+#   podTemplate:
+#     spec:
+#       containers:
+#       - name: agent
+#         securityContext:
+#           runAsUser: 0
+# statefulSet:
+#   podTemplate:
+#     spec:
+#       containers:
+#       - name: agent
+#         securityContext:
+#           runAsUser: 0
+
+# Configuration of Agent, specifically used in Agent standalone mode.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent.html
+# At most one of [Config, ConfigRef] can be specified.
+#
+config: {}
+
+# reference to an existing Kubernetes Secret holding the Agent configuration.
+# Agent settings must be specified as yaml, under a single "agent.yml" entry.
+# At most one of [Config, ConfigRef] can be specified.
+#
+# configRef:
+#   secretName: agent-config
+
+# the HTTP layer configuration for the Agent in Fleet mode with Fleet Server enabled.
+#
+# http:
+
+# Number of revisions to retain to allow rollback in the underlying Deployment/DaemonSet/StatefulSets.
+# By default, if not set, Kubernetes sets 10.
+#
+# revisionHistoryLimit: 2
+
+# Control Elastic Agent Secure Settings.
+# List of references to Kubernetes Secrets containing sensitive configuration options for the Agent.
+# Secrets data can be then referenced in the Agent config using the Secret’s keys
+# or as specified in Entries field of each SecureSetting.
+#
+secureSettings: []
+
+# the source of configuration for the Agent. The configuration can be specified
+# locally through config or configRef (standalone mode), or come from Fleet
+# during runtime (fleet mode). Defaults to standalone mode.
+#
+# mode: standalone
+
+# Whether this Agent will launch Fleet Server. Don’t set unless mode is set to fleet.
+#
+# fleetServerEnabled:
 
 # ServiceAccount to be used by Elastic Agent. Some Elastic Agent features, such as the Kubernetes integration,
 # require that Agent Pods interact with Kubernetes APIs. This functionality requires specific permissions
@@ -153,7 +190,7 @@ clusterRole:
   - apiGroups: ["extensions"]
     resources:
       - replicasets
-    verbs: 
+    verbs:
     - "get"
     - "list"
     - "watch"

--- a/deploy/eck-stack/charts/eck-beats/examples/auditbeat_hosts.yaml
+++ b/deploy/eck-stack/charts/eck-beats/examples/auditbeat_hosts.yaml
@@ -1,111 +1,110 @@
 name: auditbeat
 version: 8.17.0-SNAPSHOT
-spec:
-  type: auditbeat
-  elasticsearchRef:
-    name: eck-elasticsearch
-  kibanaRef:
-    name: eck-kibana
-  config:
-    auditbeat.modules:
-    - module: file_integrity
-      paths:
-      - /hostfs/bin
-      - /hostfs/usr/bin
-      - /hostfs/sbin
-      - /hostfs/usr/sbin
-      - /hostfs/etc
-      exclude_files:
-      - '(?i)\.sw[nop]$'
-      - '~$'
-      - '/\.git($|/)'
-      scan_at_start: true
-      scan_rate_per_sec: 50 MiB
-      max_file_size: 100 MiB
-      hash_types: [sha1]
-      recursive: true
-    - module: auditd
-      audit_rules: |
-        # Executions
-        -a always,exit -F arch=b64 -S execve,execveat -k exec
+type: auditbeat
+elasticsearchRef:
+  name: eck-elasticsearch
+kibanaRef:
+  name: eck-kibana
+config:
+  auditbeat.modules:
+  - module: file_integrity
+    paths:
+    - /hostfs/bin
+    - /hostfs/usr/bin
+    - /hostfs/sbin
+    - /hostfs/usr/sbin
+    - /hostfs/etc
+    exclude_files:
+    - '(?i)\.sw[nop]$'
+    - '~$'
+    - '/\.git($|/)'
+    scan_at_start: true
+    scan_rate_per_sec: 50 MiB
+    max_file_size: 100 MiB
+    hash_types: [sha1]
+    recursive: true
+  - module: auditd
+    audit_rules: |
+      # Executions
+      -a always,exit -F arch=b64 -S execve,execveat -k exec
 
-        # Unauthorized access attempts (amd64 only)
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access
+      # Unauthorized access attempts (amd64 only)
+      -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
+      -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access
 
-    processors:
-    - add_cloud_metadata: {}
-    - add_host_metadata: {}
-    - add_process_metadata:
-        match_pids: ['process.pid']
-  daemonSet:
-    podTemplate:
-      spec:
-        hostPID: true  # Required by auditd module
-        dnsPolicy: ClusterFirstWithHostNet
-        hostNetwork: true # Allows to provide richer host metadata
-        automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+  processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+  - add_process_metadata:
+      match_pids: ['process.pid']
+daemonSet:
+  podTemplate:
+    spec:
+      hostPID: true  # Required by auditd module
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true # Allows to provide richer host metadata
+      automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+      securityContext:
+        runAsUser: 0
+      volumes:
+      - name: bin
+        hostPath:
+          path: /bin
+      - name: usrbin
+        hostPath:
+          path: /usr/bin
+      - name: sbin
+        hostPath:
+          path: /sbin
+      - name: usrsbin
+        hostPath:
+          path: /usr/sbin
+      - name: etc
+        hostPath:
+          path: /etc
+      - name: run-containerd
+        hostPath:
+          path: /run/containerd
+          type: DirectoryOrCreate
+      # Uncomment the below when running on GKE. See https://github.com/elastic/beats/issues/8523 for more context.
+      #- name: run
+      #  hostPath:
+      #    path: /run
+      #initContainers:
+      #- name: cos-init
+      #  image: docker.elastic.co/beats/auditbeat:8.3.3
+      #  volumeMounts:
+      #  - name: run
+      #    mountPath: /run
+      #  command: ['sh', '-c', 'export SYSTEMD_IGNORE_CHROOT=1 && systemctl stop systemd-journald-audit.socket && systemctl mask systemd-journald-audit.socket && systemctl restart systemd-journald']
+      containers:
+      - name: auditbeat
         securityContext:
-          runAsUser: 0
-        volumes:
+          capabilities:
+            add:
+            # Capabilities needed for auditd module
+            - 'AUDIT_READ'
+            - 'AUDIT_WRITE'
+            - 'AUDIT_CONTROL'
+        volumeMounts:
         - name: bin
-          hostPath:
-            path: /bin
-        - name: usrbin
-          hostPath:
-            path: /usr/bin
+          mountPath: /hostfs/bin
+          readOnly: true
         - name: sbin
-          hostPath:
-            path: /sbin
+          mountPath: /hostfs/sbin
+          readOnly: true
+        - name: usrbin
+          mountPath: /hostfs/usr/bin
+          readOnly: true
         - name: usrsbin
-          hostPath:
-            path: /usr/sbin
+          mountPath: /hostfs/usr/sbin
+          readOnly: true
         - name: etc
-          hostPath:
-            path: /etc
+          mountPath: /hostfs/etc
+          readOnly: true
+        # Directory with root filesystems of containers executed with containerd, this can be
+        # different with other runtimes. This volume is needed to monitor the file integrity
+        # of files in containers.
         - name: run-containerd
-          hostPath:
-            path: /run/containerd
-            type: DirectoryOrCreate
-        # Uncomment the below when running on GKE. See https://github.com/elastic/beats/issues/8523 for more context.
-        #- name: run
-        #  hostPath:
-        #    path: /run
-        #initContainers:
-        #- name: cos-init
-        #  image: docker.elastic.co/beats/auditbeat:8.3.3
-        #  volumeMounts:
-        #  - name: run
-        #    mountPath: /run
-        #  command: ['sh', '-c', 'export SYSTEMD_IGNORE_CHROOT=1 && systemctl stop systemd-journald-audit.socket && systemctl mask systemd-journald-audit.socket && systemctl restart systemd-journald']
-        containers:
-        - name: auditbeat
-          securityContext:
-            capabilities:
-              add:
-              # Capabilities needed for auditd module
-              - 'AUDIT_READ'
-              - 'AUDIT_WRITE'
-              - 'AUDIT_CONTROL'
-          volumeMounts:
-          - name: bin
-            mountPath: /hostfs/bin
-            readOnly: true
-          - name: sbin
-            mountPath: /hostfs/sbin
-            readOnly: true
-          - name: usrbin
-            mountPath: /hostfs/usr/bin
-            readOnly: true
-          - name: usrsbin
-            mountPath: /hostfs/usr/sbin
-            readOnly: true
-          - name: etc
-            mountPath: /hostfs/etc
-            readOnly: true
-          # Directory with root filesystems of containers executed with containerd, this can be
-          # different with other runtimes. This volume is needed to monitor the file integrity
-          # of files in containers.
-          - name: run-containerd
-            mountPath: /run/containerd
-            readOnly: true
+          mountPath: /run/containerd
+          readOnly: true

--- a/deploy/eck-stack/charts/eck-beats/examples/filebeat_no_autodiscover.yaml
+++ b/deploy/eck-stack/charts/eck-beats/examples/filebeat_no_autodiscover.yaml
@@ -1,46 +1,45 @@
 name: filebeat
 version: 8.17.0-SNAPSHOT
-spec:
-  type: filebeat
-  elasticsearchRef:
-    name: eck-elasticsearch
-  kibanaRef:
-    name: eck-kibana
-  config:
-    filebeat.inputs:
-    - type: container
-      paths:
-      - /var/log/containers/*.log
-    processors:
-    - add_host_metadata: {}
-    - add_cloud_metadata: {}
-  daemonSet:
-    podTemplate:
-      spec:
-        automountServiceAccountToken: true
-        terminationGracePeriodSeconds: 30
-        dnsPolicy: ClusterFirstWithHostNet
-        hostNetwork: true # Allows to provide richer host metadata
-        containers:
-        - name: filebeat
-          securityContext:
-            runAsUser: 0
-            # If using Red Hat OpenShift uncomment this:
-            #privileged: true
-          volumeMounts:
-          - name: varlogcontainers
-            mountPath: /var/log/containers
-          - name: varlogpods
-            mountPath: /var/log/pods
-          - name: varlibdockercontainers
-            mountPath: /var/lib/docker/containers
-        volumes:
+type: filebeat
+elasticsearchRef:
+  name: eck-elasticsearch
+kibanaRef:
+  name: eck-kibana
+config:
+  filebeat.inputs:
+  - type: container
+    paths:
+    - /var/log/containers/*.log
+  processors:
+  - add_host_metadata: {}
+  - add_cloud_metadata: {}
+daemonSet:
+  podTemplate:
+    spec:
+      automountServiceAccountToken: true
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true # Allows to provide richer host metadata
+      containers:
+      - name: filebeat
+        securityContext:
+          runAsUser: 0
+          # If using Red Hat OpenShift uncomment this:
+          #privileged: true
+        volumeMounts:
         - name: varlogcontainers
-          hostPath:
-            path: /var/log/containers
+          mountPath: /var/log/containers
         - name: varlogpods
-          hostPath:
-            path: /var/log/pods
+          mountPath: /var/log/pods
         - name: varlibdockercontainers
-          hostPath:
-            path: /var/lib/docker/containers
+          mountPath: /var/lib/docker/containers
+      volumes:
+      - name: varlogcontainers
+        hostPath:
+          path: /var/log/containers
+      - name: varlogpods
+        hostPath:
+          path: /var/log/pods
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers

--- a/deploy/eck-stack/charts/eck-beats/examples/heartbeat_es_kb_health.yaml
+++ b/deploy/eck-stack/charts/eck-beats/examples/heartbeat_es_kb_health.yaml
@@ -1,24 +1,23 @@
 name: heartbeat
 version: 8.17.0-SNAPSHOT
-spec:
-  type: heartbeat
-  elasticsearchRef:
-    name: eck-elasticsearch
-  config:
-    heartbeat.monitors:
-    - type: tcp
-      schedule: '@every 5s'
-      # This should directly match the name of the Elasticsearch instance
-      # with "-es-http" appended to the name.
-      hosts: ["elasticsearch-es-http.default.svc:9200"]
-    - type: tcp
-      schedule: '@every 5s'
-      # This should directly match the names of the Kibana instance
-      # with "-kb-http" appended to the name.
-      hosts: ["eck-kibana-kb-http.default.svc:5601"]
-  deployment:
-    replicas: 1
-    podTemplate:
-      spec:
-        securityContext:
-          runAsUser: 0
+type: heartbeat
+elasticsearchRef:
+  name: eck-elasticsearch
+config:
+  heartbeat.monitors:
+  - type: tcp
+    schedule: '@every 5s'
+    # This should directly match the name of the Elasticsearch instance
+    # with "-es-http" appended to the name.
+    hosts: ["elasticsearch-es-http.default.svc:9200"]
+  - type: tcp
+    schedule: '@every 5s'
+    # This should directly match the names of the Kibana instance
+    # with "-kb-http" appended to the name.
+    hosts: ["eck-kibana-kb-http.default.svc:5601"]
+deployment:
+  replicas: 1
+  podTemplate:
+    spec:
+      securityContext:
+        runAsUser: 0

--- a/deploy/eck-stack/charts/eck-beats/examples/metricbeat_hosts.yaml
+++ b/deploy/eck-stack/charts/eck-beats/examples/metricbeat_hosts.yaml
@@ -1,104 +1,103 @@
 name: metricbeat
-spec:
-  type: metricbeat
-  version: 8.17.0-SNAPSHOT
-  elasticsearchRef:
-    name: eck-elasticsearch
-  kibanaRef:
-    name: eck-kibana
-  config:
-    metricbeat:
-      autodiscover:
-        providers:
-        - hints:
-            default_config: {}
-            enabled: "true"
-          node: ${NODE_NAME}
-          type: kubernetes
-      modules:
-      - module: system
-        period: 10s
-        metricsets:
-        - cpu
-        - load
-        - memory
-        - network
-        - process
-        - process_summary
-        process:
-          include_top_n:
-            by_cpu: 5
-            by_memory: 5
-        processes:
-        - .*
-      - module: system
-        period: 1m
-        metricsets:
-        - filesystem
-        - fsstat
-        processors:
-        - drop_event:
-            when:
-              regexp:
-                system:
-                  filesystem:
-                    mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib)($|/)
-      - module: kubernetes
-        period: 10s
+type: metricbeat
+version: 8.17.0-SNAPSHOT
+elasticsearchRef:
+  name: eck-elasticsearch
+kibanaRef:
+  name: eck-kibana
+config:
+  metricbeat:
+    autodiscover:
+      providers:
+      - hints:
+          default_config: {}
+          enabled: "true"
         node: ${NODE_NAME}
-        hosts:
-        - https://${NODE_NAME}:10250
-        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-        ssl:
-          verification_mode: none
-        metricsets:
-        - node
-        - system
-        - pod
-        - container
-        - volume
-    processors:
-    - add_cloud_metadata: {}
-    - add_host_metadata: {}
-  daemonSet:
-    podTemplate:
-      spec:
-        serviceAccountName: metricbeat
-        automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
-        containers:
-        - args:
-          - -e
-          - -c
-          - /etc/beat.yml
-          - --system.hostfs=/hostfs
-          name: metricbeat
-          volumeMounts:
-          - mountPath: /hostfs/sys/fs/cgroup
-            name: cgroup
-          - mountPath: /var/run/docker.sock
-            name: dockersock
-          - mountPath: /hostfs/proc
-            name: proc
-          env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-        dnsPolicy: ClusterFirstWithHostNet
-        hostNetwork: true # Allows to provide richer host metadata
-        securityContext:
-          runAsUser: 0
-        terminationGracePeriodSeconds: 30
-        volumes:
-        - hostPath:
-            path: /sys/fs/cgroup
+        type: kubernetes
+    modules:
+    - module: system
+      period: 10s
+      metricsets:
+      - cpu
+      - load
+      - memory
+      - network
+      - process
+      - process_summary
+      process:
+        include_top_n:
+          by_cpu: 5
+          by_memory: 5
+      processes:
+      - .*
+    - module: system
+      period: 1m
+      metricsets:
+      - filesystem
+      - fsstat
+      processors:
+      - drop_event:
+          when:
+            regexp:
+              system:
+                filesystem:
+                  mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib)($|/)
+    - module: kubernetes
+      period: 10s
+      node: ${NODE_NAME}
+      hosts:
+      - https://${NODE_NAME}:10250
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      ssl:
+        verification_mode: none
+      metricsets:
+      - node
+      - system
+      - pod
+      - container
+      - volume
+  processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+daemonSet:
+  podTemplate:
+    spec:
+      serviceAccountName: metricbeat
+      automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+      containers:
+      - args:
+        - -e
+        - -c
+        - /etc/beat.yml
+        - --system.hostfs=/hostfs
+        name: metricbeat
+        volumeMounts:
+        - mountPath: /hostfs/sys/fs/cgroup
           name: cgroup
-        - hostPath:
-            path: /var/run/docker.sock
+        - mountPath: /var/run/docker.sock
           name: dockersock
-        - hostPath:
-            path: /proc
+        - mountPath: /hostfs/proc
           name: proc
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true # Allows to provide richer host metadata
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+        name: cgroup
+      - hostPath:
+          path: /var/run/docker.sock
+        name: dockersock
+      - hostPath:
+          path: /proc
+        name: proc
 
 clusterRole:
   # permissions needed for metricbeat

--- a/deploy/eck-stack/charts/eck-beats/examples/packetbeat_dns_http.yaml
+++ b/deploy/eck-stack/charts/eck-beats/examples/packetbeat_dns_http.yaml
@@ -1,38 +1,37 @@
 name: packetbeat
-spec:
-  type: packetbeat
-  version: 8.17.0-SNAPSHOT
-  elasticsearchRef:
-    name: eck-elasticsearch
-  kibanaRef:
-    name: eck-kibana
-  config:
-    packetbeat.interfaces.device: any
-    packetbeat.protocols:
-    - type: dns
-      ports: [53]
-      include_authorities: true
-      include_additionals: true
-    - type: http
-      ports: [80, 8000, 8080, 9200]
-    packetbeat.flows:
-      timeout: 30s
-      period: 10s
-    processors:
-    - add_cloud_metadata: {}
-    - add_host_metadata: {}
-  daemonSet:
-    podTemplate:
-      spec:
-        terminationGracePeriodSeconds: 30
-        hostNetwork: true
-        automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
-        dnsPolicy: ClusterFirstWithHostNet
-        containers:
-        - name: packetbeat
-          securityContext:
-            runAsUser: 0
-            capabilities:
-              add:
-              - NET_ADMIN
-        volumes: []
+type: packetbeat
+version: 8.17.0-SNAPSHOT
+elasticsearchRef:
+  name: eck-elasticsearch
+kibanaRef:
+  name: eck-kibana
+config:
+  packetbeat.interfaces.device: any
+  packetbeat.protocols:
+  - type: dns
+    ports: [53]
+    include_authorities: true
+    include_additionals: true
+  - type: http
+    ports: [80, 8000, 8080, 9200]
+  packetbeat.flows:
+    timeout: 30s
+    period: 10s
+  processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+daemonSet:
+  podTemplate:
+    spec:
+      terminationGracePeriodSeconds: 30
+      hostNetwork: true
+      automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: packetbeat
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add:
+            - NET_ADMIN
+      volumes: []

--- a/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
@@ -12,8 +12,44 @@ metadata:
     {{- end }}
 spec:
   version: {{ required "A Beat version is required" .Values.version }}
-  {{- if and (not (hasKey .Values.spec "daemonSet")) (not (hasKey .Values.spec "deployment")) }}
+  {{- with .Values.image }}
+  image: {{ . }}
+  {{- end }}
+  type: {{ required "An Beat type is required" .Values.type }}
+  {{- if not .Values.type }}{{ fail "A Beat type is required" }}{{- end }}
+  {{- with .Values.elasticsearchRef }}
+  elasticsearchRef: {{ . }}
+  {{- end }}
+  {{- with .Values.kibanaRef }}
+  kibanaRef: {{ . }}
+  {{- end }}
+  {{- if and (hasKey .Values "config") (hasKey .Values "configRef") }}
+  {{ fail "At most one of config or configRef can be specified" }}
+  {{- end }}
+  {{- with .Values.config }}
+  config: {{ . }}
+  {{- end }}
+  {{- with .Values.configRef }}
+  configRef: {{ . }}
+  {{- end }}
+  {{- with .Values.secureSettings }}
+  secureSettings: {{ . }}
+  {{- end }}
+  {{- with .Values.serviceAccount }}
+  serviceAccountName: {{ .name }}
+  {{- end }}
+  {{- if and (not (hasKey .Values "daemonSet")) (not (hasKey .Values "deployment")) }}
   {{ fail "At least one of daemonSet or deployment is required for a functional Beat" }}
   {{- end }}
-  {{- if not .Values.spec.type }}{{ fail "A Beat type is required" }}{{- end }}
-  {{- toYaml .Values.spec | nindent 2 }}
+  {{- with .Values.daemonSet }}
+  daemonSet: {{ . }}
+  {{- end }}
+  {{- with .Values.deployment }}
+  deployment: {{ . }}
+  {{- end }}
+  {{- with .Values.monitoring }}
+  monitoring: {{ . }}
+  {{- end }}
+  {{- with .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}

--- a/deploy/eck-stack/charts/eck-beats/templates/tests/beats_test.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/tests/beats_test.yaml
@@ -6,9 +6,8 @@ tests:
     release:
       name: quickstart
     set:
-      spec:
-        type: "filebeat"
-        deployment: {}
+      type: "filebeat"
+      deployment: {}
     asserts:
       - isKind:
           of: Beat

--- a/deploy/eck-stack/charts/eck-beats/values.yaml
+++ b/deploy/eck-stack/charts/eck-beats/values.yaml
@@ -20,6 +20,10 @@
 #
 version: 8.17.0-SNAPSHOT
 
+# Elastic Beats Docker image to deploy
+#
+# image:
+
 # Labels that will be applied to Elastic Beats.
 #
 labels: {}
@@ -28,63 +32,94 @@ labels: {}
 #
 annotations: {}
 
-spec:
-  # Type of Elastic Beats. Standard types of Beat are [filebeat,metricbeat,heartbeat,auditbeat,packetbeat,journalbeat].
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-deploy-elastic-beat
-  #
-  # Note: This is required to be set, or the release install will fail.
-  #
-  type: ""
+# Type of Elastic Beats. Standard types of Beat are [filebeat,metricbeat,heartbeat,auditbeat,packetbeat,journalbeat].
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-deploy-elastic-beat
+#
+# Note: This is required to be set, or the release install will fail.
+#
+type: ""
 
-  # Referenced resources are below and depending on the setup, at least elasticsearchRef is required for a functional Beat.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-connect-es
+# Referenced resources are below and depending on the setup, at least elasticsearchRef is required for a functional Beat.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-connect-es
+#
+# Reference to ECK-managed Kibana instance.
+#
+# kibanaRef:
+#   name: quickstart
+  # Optional namespace reference to Kibana instance.
+  # If not specified, then the namespace of the Beats instance
+  # will be assumed.
   #
-  # Reference to ECK-managed Kibana instance.
-  #
-  # kibanaRef:
-  #   name: quickstart
-    # Optional namespace reference to Kibana instance.
-    # If not specified, then the namespace of the Beats instance
-    # will be assumed.
-    #
-    # namespace: default
+  # namespace: default
 
-  # Reference to ECK-managed Elasticsearch instance.
-  # *Note* If Beat's output is intended to go to Elasticsearch and not something like Logstash,
-  # this elasticsearchRef must be updated to the name of the Elasticsearch instance.
+# Reference to ECK-managed Elasticsearch instance.
+# *Note* If Beat's output is intended to go to Elasticsearch and not something like Logstash,
+# this elasticsearchRef must be updated to the name of the Elasticsearch instance.
+#
+elasticsearchRef: {}
+  # name: elasticsearch
+  # Optional namespace reference to Elasticsearch instance.
+  # If not specified, then the namespace of the Beats instance
+  # will be assumed.
   #
-  elasticsearchRef: {}
-    # name: elasticsearch
-    # Optional namespace reference to Elasticsearch instance.
-    # If not specified, then the namespace of the Beats instance
-    # will be assumed.
-    #
-    # namespace: default
+  # namespace: default
 
-  # Daemonset, or Deployment specification for the type of Beat specified.
-  # At least one is required of [daemonSet, deployment].
-  # No default is currently set, refer to https://github.com/elastic/cloud-on-k8s/issues/7429.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-chose-the-deployment-model
-  #
-  # deployment:
-  #   podTemplate:
-  #     spec:
-  #       containers:
-  #       - name: agent
-  #         securityContext:
-  #           runAsUser: 0
-  # daemonSet:
-  #   podTemplate:
-  #     spec:
-  #       containers:
-  #       - name: agent
-  #         securityContext:
-  #           runAsUser: 0
+# Daemonset, or Deployment specification for the type of Beat specified.
+# At least one is required of [daemonSet, deployment].
+# No default is currently set, refer to https://github.com/elastic/cloud-on-k8s/issues/7429.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-chose-the-deployment-model
+#
+# deployment:
+#   podTemplate:
+#     spec:
+#       containers:
+#       - name: agent
+#         securityContext:
+#           runAsUser: 0
+# daemonSet:
+#   podTemplate:
+#     spec:
+#       containers:
+#       - name: agent
+#         securityContext:
+#           runAsUser: 0
 
-  # Configuration of Beat, which is dependent on the `type` of Beat specified.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-deploy-elastic-beat
-  #
-  config: {}
+# Configuration of Beat, which is dependent on the `type` of Beat specified.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-deploy-elastic-beat
+#
+config: {}
+
+# reference to an existing Kubernetes Secret holding the Beat configuration.
+# Agent settings must be specified as yaml, under a single "agent.yml" entry.
+# At most one of [Config, ConfigRef] can be specified.
+#
+# configRef:
+#   secretName: beat-config
+
+# Number of revisions to retain to allow rollback in the underlying Deployment/DaemonSet.
+# By default, if not set, Kubernetes sets 10.
+#
+# revisionHistoryLimit: 2
+
+# Settings for configuring stack monitoring.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-stack-monitoring.html
+#
+monitoring: {}
+  # metrics:
+  #   elasticsearchRefs:
+  #   - name: monitoring
+  #     namespace: observability
+  # logs:
+  #   elasticsearchRefs:
+  #   - name: monitoring
+  #     namespace: observability
+
+# Control Beat Secure Settings.
+# List of references to Kubernetes Secrets containing sensitive configuration options for the Beat.
+# Secrets data can be then referenced in the Beat config using the Secret’s keys
+# or as specified in Entries field of each SecureSetting.
+#
+secureSettings: []
 
 # ServiceAccount to be used by Elastic Beats. Some Beats features (such as autodiscover or Kubernetes module metricsets)
 # require that Beat Pods interact with Kubernetes APIs. This functionality requires specific permissions

--- a/deploy/eck-stack/charts/eck-kibana/examples/http-configuration.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/examples/http-configuration.yaml
@@ -13,25 +13,24 @@ labels: {}
 annotations: {}
   # key: value
 
-spec:
-  # Count of Kibana replicas to create.
-  #
-  count: 1
+# Count of Kibana replicas to create.
+#
+count: 1
 
-  # Reference to ECK-managed Elasticsearch resource, ideally from {{ "elasticsearch.fullname" }}
-  #
-  elasticsearchRef:
-    name: eck-elasticsearch
-    # namespace: default
-  http:
-    service:
-      spec:
-        # Type of service to deploy for Kibana.
-        # This deploys a load balancer in a cloud service provider, where supported.
-        # 
-        type: LoadBalancer
-    # tls:
-    #   selfSignedCertificate:
-    #     subjectAltNames:
-    #     - ip: 1.2.3.4
-    #     - dns: kibana.example.com
+# Reference to ECK-managed Elasticsearch resource, ideally from {{ "elasticsearch.fullname" }}
+#
+elasticsearchRef:
+  name: eck-elasticsearch
+  # namespace: default
+http:
+  service:
+    spec:
+      # Type of service to deploy for Kibana.
+      # This deploys a load balancer in a cloud service provider, where supported.
+      #
+      type: LoadBalancer
+  # tls:
+  #   selfSignedCertificate:
+  #     subjectAltNames:
+  #     - ip: 1.2.3.4
+  #     - dns: kibana.example.com

--- a/deploy/eck-stack/charts/eck-kibana/examples/ingress/kibana-aks.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/examples/ingress/kibana-aks.yaml
@@ -5,14 +5,13 @@
 #
 fullnameOverride: kibana
 
-spec:
-  # Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
-  #
-  elasticsearchRef:
-    name: elasticsearch
-  config:
-    server:
-      publicBaseUrl: "https://kibana.company.dev"
+# Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
+#
+elasticsearchRef:
+  name: elasticsearch
+config:
+  server:
+    publicBaseUrl: "https://kibana.company.dev"
 
 ingress:
   enabled: true

--- a/deploy/eck-stack/charts/eck-kibana/examples/ingress/kibana-eks.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/examples/ingress/kibana-eks.yaml
@@ -5,14 +5,13 @@
 #
 fullnameOverride: kibana
 
-spec:
-  # Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
-  #
-  elasticsearchRef:
-    name: elasticsearch
-  config:
-    server:
-      publicBaseUrl: "https://kibana.company.dev"
+# Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
+#
+elasticsearchRef:
+  name: elasticsearch
+config:
+  server:
+    publicBaseUrl: "https://kibana.company.dev"
 
 ingress:
   enabled: true

--- a/deploy/eck-stack/charts/eck-kibana/examples/ingress/kibana-gke.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/examples/ingress/kibana-gke.yaml
@@ -5,23 +5,22 @@
 #
 fullnameOverride: kibana
 
-spec:
-  # Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
-  #
-  elasticsearchRef:
-    name: elasticsearch
-  config:
-    server:
-      publicBaseUrl: "https://kibana.company.dev"
-  http:
-    service:
-      metadata:
-        annotations:
-          # This is required for `ClusterIP` services (which are the default ECK service type) to be used with Ingress in GKE clusters.
-          cloud.google.com/neg: '{"ingress": true}'
-          # This is required to enable the GKE Ingress Controller to use HTTPS as the backend protocol.
-          cloud.google.com/app-protocols: '{"https":"HTTPS"}'
-          # cloud.google.com/backend-config: '{"default": "kibana"}'
+# Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
+#
+elasticsearchRef:
+  name: elasticsearch
+config:
+  server:
+    publicBaseUrl: "https://kibana.company.dev"
+http:
+  service:
+    metadata:
+      annotations:
+        # This is required for `ClusterIP` services (which are the default ECK service type) to be used with Ingress in GKE clusters.
+        cloud.google.com/neg: '{"ingress": true}'
+        # This is required to enable the GKE Ingress Controller to use HTTPS as the backend protocol.
+        cloud.google.com/app-protocols: '{"https":"HTTPS"}'
+        # cloud.google.com/backend-config: '{"default": "kibana"}'
 
 ingress:
   enabled: true

--- a/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
@@ -12,4 +12,34 @@ metadata:
     {{- end }}
 spec:
   version: {{ required "A Kibana version is required" .Values.version }}
-  {{- toYaml .Values.spec | nindent 2 }}
+  {{- with .Values.image }}
+  image: {{ . }}
+  {{- end }}
+  {{- with .Values.count }}
+  count: {{ . }}
+  {{- end }}
+  elasticsearchRef: {{ required "An elasticsearchRef is required" .Values.elasticsearchRef }}
+  {{- with .Values.enterpriseSearchRef }}
+  enterpriseSearchRef: {{ . }}
+  {{- end }}
+  {{- with .Values.config }}
+  config: {{ . }}
+  {{- end }}
+  {{- with .Values.http }}
+  http: {{ . }}
+  {{- end }}
+  {{- with .Values.podTemplate }}
+  podTemplate: {{ . }}
+  {{- end }}
+  {{- with .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with .Values.secureSettings }}
+  secureSettings: {{ . }}
+  {{- end }}
+  {{- with .Values.serviceAccountName }}
+  serviceAccountName: {{ . }}
+  {{- end }}
+  {{- with .Values.monitoring }}
+  monitoring: {{ . }}
+  {{- end }}

--- a/deploy/eck-stack/charts/eck-kibana/values.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/values.yaml
@@ -20,6 +20,10 @@
 #
 version: 8.17.0-SNAPSHOT
 
+# Kibana Docker image to deploy
+#
+# image:
+
 # Labels that will be applied to Kibana.
 #
 labels: {}
@@ -28,25 +32,69 @@ labels: {}
 #
 annotations: {}
 
-spec:
-  # Count of Kibana replicas to create.
-  #
-  count: 1
+# Count of Kibana replicas to create.
+#
+count: 1
 
-  # Reference to ECK-managed Elasticsearch resource.
+# Reference to ECK-managed Elasticsearch resource.
+#
+elasticsearchRef:
+  name: eck-elasticsearch
+  # Optional namespace reference to Elasticsearch resource.
+  # If not specified, then the namespace of the Kibana resource
+  # will be assumed.
   #
-  elasticsearchRef:
-    name: eck-elasticsearch
-    # Optional namespace reference to Elasticsearch resource.
-    # If not specified, then the namespace of the Kibana resource
-    # will be assumed.
-    #
-    # namespace: default
+  # namespace: default
+
+# Reference to an EnterpriseSearch running in the same Kubernetes cluster
+#
+# enterpriseSearchRef:
+
+# the Kibana configuration
+#
+config: null
+
+# the HTTP layer configuration for Kibana.
+#
+# http:
+
+# PodTemplate provides customisation options (labels, annotations, affinity rules,
+# resource requests, and so on) for the Kibana pods
+#
+# podTemplate:
+
+# Number of revisions to retain to allow rollback in the underlying deployment.
+# By default, if not set, Kubernetes sets 10.
+#
+# revisionHistoryLimit: 2
+
+# Control Kibana Secure Settings.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-kibana-secure-settings.html
+#
+secureSettings: []
+
+# Used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
+# Can only be used if ECK is enforcing RBAC on references.
+#
+# serviceAccountName: ""
+
+# Settings for configuring stack monitoring.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-stack-monitoring.html
+#
+monitoring: {}
+  # metrics:
+  #   elasticsearchRefs:
+  #   - name: monitoring
+  #     namespace: observability
+  # logs:
+  #   elasticsearchRefs:
+  #   - name: monitoring
+  #     namespace: observability
 
 # Settings for controlling Kibana ingress. Enabling ingress will expose your Kibana instance
 # to the public internet, and as such is disabled by default.
 #
-# *NOTE* when configuring Kibana Ingress, ensure that `spec.config.server.publicBaseUrl` setting for
+# *NOTE* when configuring Kibana Ingress, ensure that `config.server.publicBaseUrl` setting for
 # Kibana is also set, as it is required when exposing Kibana behind a load balancer/ingress.
 # Also of note are `server.basePath`, and `server.rewriteBasePath` settings in the Kibana configuration.
 #
@@ -62,7 +110,7 @@ ingress:
   enabled: false
 
   # Annotations that will be applied to the Ingress resource. Note that some ingress controllers are controlled via annotations.
-  # 
+  #
   # Nginx Annotations: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/
   #
   # Common annotations:


### PR DESCRIPTION
We have 4 Helm charts that implement the image setting and copy it to `.spec.image`
We have 3 others Helm charts (Kibnana, Elastic-Agent and Beat) that just copy the entire spec object from `values.yaml` to the custom resource `.spec`
The idea of this PR is to make all Helm Charts consistent while exposing the `image` setting for clarity

It implies breaking changes. I don't know (yet) how we version / handle Helm charts breaking changes at the Helm charts level.