### PR TITLE
ECK S3 wrong truststore name in example

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/snapshots.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/snapshots.asciidoc
@@ -474,7 +474,7 @@ spec:
         volumes:
         - name: custom-truststore
           secret:
-            secretName: additional-certs
+            secretName: custom-truststore
         containers:
         - name: elasticsearch
           volumeMounts:


### PR DESCRIPTION
Hello team!

I received customer feedback about this, and among other things that I'm adding as an issue to the documentation team, they mentioned this. 

In step 4, the secret name is created as `custom-truststore` but in the sample manifest, it says `additional-certs`.

I hope this fix can be merged soon! Thanks!

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/main/CONTRIBUTING.md)?
- If you submit code, is your pull request against main? We recommend pull requests against main. We will backport them as needed.
