### PR TITLE
[2.15] ECK S3 wrong truststore name in example (#8185)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/snapshots.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/snapshots.asciidoc
@@ -474,7 +474,7 @@ spec:
         volumes:
         - name: custom-truststore
           secret:
-            secretName: additional-certs
+            secretName: custom-truststore
         containers:
         - name: elasticsearch
           volumeMounts:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.15`:
 - [ECK S3 wrong truststore name in example (#8185)](https://github.com/elastic/cloud-on-k8s/pull/8185)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)