### PR TITLE
Add recommened roles for Elastic Agent on Kubernetes

### DIFF
--- a/config/e2e/rbac.yaml
+++ b/config/e2e/rbac.yaml
@@ -38,6 +38,7 @@ rules:
       - list
       - delete
       - create
+      - watch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/e2e/rbac.yaml
+++ b/config/e2e/rbac.yaml
@@ -184,6 +184,7 @@ rules:
     - "batch"
     resources:
     - jobs
+    - cronjobs
     verbs:
     - "get"
     - "list"

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration-nonroot.yaml
@@ -271,6 +271,7 @@ rules:
   - statefulsets
   - deployments
   - replicasets
+  - daemonsets
   verbs:
   - "get"
   - "list"
@@ -281,10 +282,23 @@ rules:
   - nodes/stats
   verbs:
   - get
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
 - apiGroups:
   - "batch"
   resources:
   - jobs
+  - cronjobs
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - "storage.k8s.io"
+  resources:
+  - storageclasses
   verbs:
   - "get"
   - "list"

--- a/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/fleet-kubernetes-integration.yaml
@@ -201,6 +201,7 @@ rules:
   - statefulsets
   - deployments
   - replicasets
+  - daemonsets
   verbs:
   - "get"
   - "list"
@@ -211,10 +212,23 @@ rules:
   - nodes/stats
   verbs:
   - get
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
 - apiGroups:
   - "batch"
   resources:
   - jobs
+  - cronjobs
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - "storage.k8s.io"
+  resources:
+  - storageclasses
   verbs:
   - "get"
   - "list"

--- a/config/recipes/elastic-agent/kubernetes-integration.yaml
+++ b/config/recipes/elastic-agent/kubernetes-integration.yaml
@@ -161,13 +161,33 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - "apps"
+  resources:
+  - statefulsets
+  - deployments
+  - replicasets
+  - daemonsets
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
 - apiGroups: ["batch"]
   resources:
   - jobs
+  - cronjobs
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - "storage.k8s.io"
+  resources:
+  - storageclasses
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent-cluster-role_test.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent-cluster-role_test.yaml
@@ -83,6 +83,7 @@ tests:
           - statefulsets
           - deployments
           - replicasets
+          - daemonsets
       - equal:
           path: rules[4].verbs
           value:
@@ -101,14 +102,15 @@ tests:
           value:
           - get
       - equal:
-          path: rules[6].apiGroups[0]
+          path: rules[7].apiGroups[0]
           value: batch
       - equal:
-          path: rules[6].resources
+          path: rules[7].resources
           value:
           - jobs
+          - cronjobs
       - equal:
-          path: rules[6].verbs
+          path: rules[7].verbs
           value:
           - get
           - list

--- a/deploy/eck-stack/charts/eck-agent/values.yaml
+++ b/deploy/eck-stack/charts/eck-agent/values.yaml
@@ -127,57 +127,71 @@ clusterRoleBinding:
 clusterRole:
   name: elastic-agent
   rules:
-  - apiGroups: [""]
-    resources:
-    - pods
-    - nodes
-    - namespaces
-    - events
-    - services
-    - configmaps
-    verbs:
-    - get
-    - watch
-    - list
-  - apiGroups: ["coordination.k8s.io"]
-    resources:
-    - leases
-    verbs:
-    - get
-    - create
-    - update
-  - nonResourceURLs:
-    - "/metrics"
-    verbs:
-    - get
-  - apiGroups: ["extensions"]
-    resources:
-      - replicasets
-    verbs: 
-    - "get"
-    - "list"
-    - "watch"
-  - apiGroups:
-    - "apps"
-    resources:
-    - statefulsets
-    - deployments
+ - apiGroups: [""]
+  resources:
+  - pods
+  - nodes
+  - namespaces
+  - events
+  - services
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
+- apiGroups: ["extensions"]
+  resources:
     - replicasets
-    verbs:
-    - "get"
-    - "list"
-    - "watch"
-  - apiGroups:
-    - ""
-    resources:
-    - nodes/stats
-    verbs:
-    - get
-  - apiGroups:
-    - "batch"
-    resources:
-    - jobs
-    verbs:
-    - "get"
-    - "list"
-    - "watch"
+  verbs: 
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - "apps"
+  resources:
+  - statefulsets
+  - deployments
+  - replicasets
+  - daemonsets
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - ""
+  resources:
+  - nodes/stats
+  verbs:
+  - get
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
+- apiGroups:
+  - "batch"
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:  
+  - "storage.k8s.io" 
+  resources:
+  - storageclasses
+  verbs:  
+  - "get"
+  - "list"
+  - "watch" 

--- a/deploy/eck-stack/charts/eck-agent/values.yaml
+++ b/deploy/eck-stack/charts/eck-agent/values.yaml
@@ -127,71 +127,71 @@ clusterRoleBinding:
 clusterRole:
   name: elastic-agent
   rules:
- - apiGroups: [""]
-  resources:
-  - pods
-  - nodes
-  - namespaces
-  - events
-  - services
-  - configmaps
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups: ["coordination.k8s.io"]
-  resources:
-  - leases
-  verbs:
-  - get
-  - create
-  - update
-- nonResourceURLs:
-  - "/metrics"
-  verbs:
-  - get
-- apiGroups: ["extensions"]
-  resources:
+  - apiGroups: [""]
+    resources:
+    - pods
+    - nodes
+    - namespaces
+    - events
+    - services
+    - configmaps
+    verbs:
+    - get
+    - watch
+    - list
+  - apiGroups: ["coordination.k8s.io"]
+    resources:
+    - leases
+    verbs:
+    - get
+    - create
+    - update
+  - nonResourceURLs:
+    - "/metrics"
+    verbs:
+    - get
+  - apiGroups: ["extensions"]
+    resources:
+      - replicasets
+    verbs: 
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - "apps"
+    resources:
+    - statefulsets
+    - deployments
     - replicasets
-  verbs: 
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - "apps"
-  resources:
-  - statefulsets
-  - deployments
-  - replicasets
-  - daemonsets
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - ""
-  resources:
-  - nodes/stats
-  verbs:
-  - get
-- nonResourceURLs:
-  - "/metrics"
-  verbs:
-  - get
-- apiGroups:
-  - "batch"
-  resources:
-  - jobs
-  - cronjobs
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:  
-  - "storage.k8s.io" 
-  resources:
-  - storageclasses
-  verbs:  
-  - "get"
-  - "list"
-  - "watch" 
+    - daemonsets
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/stats
+    verbs:
+    - get
+  - nonResourceURLs:
+    - "/metrics"
+    verbs:
+    - get
+  - apiGroups:
+    - "batch"
+    resources:
+    - jobs
+    - cronjobs
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - "storage.k8s.io"
+    resources:
+    - storageclasses
+    verbs:
+    - "get"
+    - "list"
+    - "watch"


### PR DESCRIPTION
Fixes #8168 

I tried to amend the roles based on https://raw.githubusercontent.com/elastic/elastic-agent/v8.15.3/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml 

I left out the cloudbeat recommendations, because I think we cannot cater for all integrations in the defaults. 
But we can also go for a the maximal set of permissions, to avoid problems and allow scurity conscious users to trim them down to what is necessary for them.

It is problematic that we need to update ~ 4 places and effectively duplicate the roles that the Elastic Agent team defines without having a good process to update them when the source of truth changes. 