### PR TITLE
Make helm charts consistent with how fields in `spec` are handled. (kibana only)

### DIFF
--- a/deploy/eck-stack/charts/eck-kibana/examples/http-configuration.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/examples/http-configuration.yaml
@@ -13,25 +13,24 @@ labels: {}
 annotations: {}
   # key: value
 
-spec:
-  # Count of Kibana replicas to create.
-  #
-  count: 1
+# Count of Kibana replicas to create.
+#
+count: 1
 
-  # Reference to ECK-managed Elasticsearch resource, ideally from {{ "elasticsearch.fullname" }}
-  #
-  elasticsearchRef:
-    name: eck-elasticsearch
-    # namespace: default
-  http:
-    service:
-      spec:
-        # Type of service to deploy for Kibana.
-        # This deploys a load balancer in a cloud service provider, where supported.
-        # 
-        type: LoadBalancer
-    # tls:
-    #   selfSignedCertificate:
-    #     subjectAltNames:
-    #     - ip: 1.2.3.4
-    #     - dns: kibana.example.com
+# Reference to ECK-managed Elasticsearch resource, ideally from {{ "elasticsearch.fullname" }}
+#
+elasticsearchRef:
+  name: eck-elasticsearch
+  # namespace: default
+http:
+  service:
+    spec:
+      # Type of service to deploy for Kibana.
+      # This deploys a load balancer in a cloud service provider, where supported.
+      #
+      type: LoadBalancer
+  # tls:
+  #   selfSignedCertificate:
+  #     subjectAltNames:
+  #     - ip: 1.2.3.4
+  #     - dns: kibana.example.com

--- a/deploy/eck-stack/charts/eck-kibana/examples/ingress/kibana-aks.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/examples/ingress/kibana-aks.yaml
@@ -5,14 +5,13 @@
 #
 fullnameOverride: kibana
 
-spec:
-  # Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
-  #
-  elasticsearchRef:
-    name: elasticsearch
-  config:
-    server:
-      publicBaseUrl: "https://kibana.company.dev"
+# Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
+#
+elasticsearchRef:
+  name: elasticsearch
+config:
+  server:
+    publicBaseUrl: "https://kibana.company.dev"
 
 ingress:
   enabled: true

--- a/deploy/eck-stack/charts/eck-kibana/examples/ingress/kibana-eks.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/examples/ingress/kibana-eks.yaml
@@ -5,14 +5,13 @@
 #
 fullnameOverride: kibana
 
-spec:
-  # Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
-  #
-  elasticsearchRef:
-    name: elasticsearch
-  config:
-    server:
-      publicBaseUrl: "https://kibana.company.dev"
+# Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
+#
+elasticsearchRef:
+  name: elasticsearch
+config:
+  server:
+    publicBaseUrl: "https://kibana.company.dev"
 
 ingress:
   enabled: true

--- a/deploy/eck-stack/charts/eck-kibana/examples/ingress/kibana-gke.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/examples/ingress/kibana-gke.yaml
@@ -5,23 +5,22 @@
 #
 fullnameOverride: kibana
 
-spec:
-  # Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
-  #
-  elasticsearchRef:
-    name: elasticsearch
-  config:
-    server:
-      publicBaseUrl: "https://kibana.company.dev"
-  http:
-    service:
-      metadata:
-        annotations:
-          # This is required for `ClusterIP` services (which are the default ECK service type) to be used with Ingress in GKE clusters.
-          cloud.google.com/neg: '{"ingress": true}'
-          # This is required to enable the GKE Ingress Controller to use HTTPS as the backend protocol.
-          cloud.google.com/app-protocols: '{"https":"HTTPS"}'
-          # cloud.google.com/backend-config: '{"default": "kibana"}'
+# Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
+#
+elasticsearchRef:
+  name: elasticsearch
+config:
+  server:
+    publicBaseUrl: "https://kibana.company.dev"
+http:
+  service:
+    metadata:
+      annotations:
+        # This is required for `ClusterIP` services (which are the default ECK service type) to be used with Ingress in GKE clusters.
+        cloud.google.com/neg: '{"ingress": true}'
+        # This is required to enable the GKE Ingress Controller to use HTTPS as the backend protocol.
+        cloud.google.com/app-protocols: '{"https":"HTTPS"}'
+        # cloud.google.com/backend-config: '{"default": "kibana"}'
 
 ingress:
   enabled: true

--- a/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
@@ -12,6 +12,10 @@ metadata:
     {{- end }}
 spec:
   version: {{ required "A Kibana version is required" .Values.version }}
+  {{- /* 
+    The following templates with 'or' are to allow both .spec.field and .field to be set for backwards 
+    compatibility purposes. See https://github.com/elastic/cloud-on-k8s/pull/8192 for details.
+  */ -}}
   {{- with or ((.Values.spec).image) (.Values.image) }}
   image: {{ . }}
   {{- end }}

--- a/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
@@ -19,7 +19,7 @@ spec:
   {{- with or ((.Values.spec).image) (.Values.image) }}
   image: {{ . }}
   {{- end }}
-  {{- with .Values.count }}
+  {{- with or ((.Values.spec).count) (.Values.count) }}
   count: {{ . }}
   {{- end }}
   {{- $esRef := or ((.Values.spec).elasticsearchRef) (.Values.elasticsearchRef) }}

--- a/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
@@ -12,4 +12,45 @@ metadata:
     {{- end }}
 spec:
   version: {{ required "A Kibana version is required" .Values.version }}
-  {{- toYaml .Values.spec | nindent 2 }}
+  {{- with or ((.Values.spec).image) (.Values.image) }}
+  image: {{ . }}
+  {{- end }}
+  {{- with .Values.count }}
+  count: {{ . }}
+  {{- end }}
+  {{- $esRef := or ((.Values.spec).elasticsearchRef) (.Values.elasticsearchRef) }}
+  {{- if not ($esRef).name }}
+  {{ fail "An elasticsearchRef is required" }}
+  {{- end }}
+  elasticsearchRef:
+  {{- toYaml $esRef | nindent 4 }}
+  {{- $entsearchRef := or ((.Values.spec).enterpriseSearchRef) (.Values.enterpriseSearchRef) }}
+  {{- if $entsearchRef }}
+  enterpriseSearchRef:
+  {{- toYaml $entsearchRef | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).config) (.Values.config) }}
+  config:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).http) (.Values.http) }}
+  http:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).podTemplate) (.Values.podTemplate) }}
+  podTemplate:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).revisionHistoryLimit) (.Values.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).secureSettings) (.Values.secureSettings) }}
+  secureSettings:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).serviceAccountName) (.Values.serviceAccountName) }}
+  serviceAccountName: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).monitoring) (.Values.monitoring) }}
+  monitoring: {{ . }}
+  {{- end }}

--- a/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
@@ -19,7 +19,9 @@ spec:
   {{- with or ((.Values.spec).image) (.Values.image) }}
   image: {{ . }}
   {{- end }}
-  count: {{ or ((.Values.spec).count) (.Values.count) | int | default 1 }}
+  {{- with or ((.Values.spec).count) (.Values.count) }}
+  count: {{ . }}
+  {{- end }}
   {{- $esRef := or ((.Values.spec).elasticsearchRef) (.Values.elasticsearchRef) }}
   {{- if not ($esRef).name }}
   {{ fail "An elasticsearchRef is required" }}

--- a/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
@@ -19,9 +19,7 @@ spec:
   {{- with or ((.Values.spec).image) (.Values.image) }}
   image: {{ . }}
   {{- end }}
-  {{- with or ((.Values.spec).count) (.Values.count) }}
-  count: {{ . }}
-  {{- end }}
+  count: {{ or ((.Values.spec).count) (.Values.count) | int | default 1 }}
   {{- $esRef := or ((.Values.spec).elasticsearchRef) (.Values.elasticsearchRef) }}
   {{- if not ($esRef).name }}
   {{ fail "An elasticsearchRef is required" }}

--- a/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/kibana.yaml
@@ -56,5 +56,6 @@ spec:
   serviceAccountName: {{ . }}
   {{- end }}
   {{- with or ((.Values.spec).monitoring) (.Values.monitoring) }}
-  monitoring: {{ . }}
+  monitoring:
+    {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
@@ -2,7 +2,7 @@ suite: test kibana
 templates:
   - templates/kibana.yaml
 tests:
-  - it: should render quickstart properly
+  - it: should render quickstart properly, with default count of 1
     set:
       spec.elasticsearchRef.name: eck-elasticsearch
     release:
@@ -16,6 +16,9 @@ tests:
       - equal:
           path: spec.version
           value: 8.17.0-SNAPSHOT
+      - equal:
+          path: spec.count
+          value: 1
   - it: name override should work properly
     set:
       nameOverride: override

--- a/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
@@ -231,3 +231,62 @@ tests:
           path: spec.secureSettings
           value:
             - secretName: oidc-secret
+  - it: values.spec.monitoring should render properly
+    set:
+      spec:
+        elasticsearchRef:
+          name: eck-elasticsearch
+        monitoring:
+          logs:
+            elasticsearchRefs:
+              - name: monitoring
+                namespace: observability
+          metrics:
+            elasticsearchRefs:
+              - name: monitoring
+                namespace: observability
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Kibana
+      - equal:
+          path: spec.monitoring
+          value:
+            logs:
+              elasticsearchRefs:
+                - name: monitoring
+                  namespace: observability
+            metrics:
+              elasticsearchRefs:
+                - name: monitoring
+                  namespace: observability
+  - it: values.monitoring should render properly
+    set:
+      elasticsearchRef:
+        name: eck-elasticsearch
+      monitoring:
+        logs:
+          elasticsearchRefs:
+            - name: monitoring
+              namespace: observability
+        metrics:
+          elasticsearchRefs:
+            - name: monitoring
+              namespace: observability
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Kibana
+      - equal:
+          path: spec.monitoring
+          value:
+            logs:
+              elasticsearchRefs:
+                - name: monitoring
+                  namespace: observability
+            metrics:
+              elasticsearchRefs:
+                - name: monitoring
+                  namespace: observability

--- a/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
@@ -3,6 +3,8 @@ templates:
   - templates/kibana.yaml
 tests:
   - it: should render quickstart properly
+    set:
+      spec.elasticsearchRef.name: eck-elasticsearch
     release:
       name: quickstart
     asserts:
@@ -17,6 +19,7 @@ tests:
   - it: name override should work properly
     set:
       nameOverride: override
+      spec.elasticsearchRef.name: eck-elasticsearch
     release:
       name: quickstart
     asserts:
@@ -28,6 +31,7 @@ tests:
   - it: fullname override should work properly
     set:
       fullnameOverride: override
+      spec.elasticsearchRef.name: eck-elasticsearch
     release:
       name: quickstart
     asserts:
@@ -38,6 +42,7 @@ tests:
           value: override
   - it: should render custom labels, and annotations values properly
     set:
+      spec.elasticsearchRef.name: eck-elasticsearch
       labels:
         test: label
       annotations:
@@ -62,6 +67,7 @@ tests:
             test: annotation
   - it: should render http service properly
     set:
+      spec.elasticsearchRef.name: eck-elasticsearch
       spec.elasticsearchRef.namespace: default
     values:
       - ../../examples/http-configuration.yaml
@@ -88,3 +94,140 @@ tests:
       - equal:
           path: spec.http.service.spec.type
           value: LoadBalancer
+  - it: values.spec.image should work properly
+    set:
+      spec:
+        elasticsearchRef:
+          name: eck-elasticsearch
+        image: quay.io/elastic/kibana:8.17.0-SNAPSHOT
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Kibana
+      - equal:
+          path: spec.image
+          value: quay.io/elastic/kibana:8.17.0-SNAPSHOT
+  - it: values.image should work properly
+    set:
+      spec:
+        elasticsearchRef:
+          name: eck-elasticsearch
+      image: quay.io/elastic/kibana:8.17.0-SNAPSHOT
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Kibana
+      - equal:
+          path: spec.image
+          value: quay.io/elastic/kibana:8.17.0-SNAPSHOT
+  - it: not setting elasticsearchRef should fail
+    asserts:
+      - failedTemplate:
+          errorMessage: "An elasticsearchRef is required"
+  - it: values.spec.config should render properly
+    set:
+      spec:
+        elasticsearchRef:
+          name: eck-elasticsearch
+        config:
+          server.name: "kibana"
+          xpack.security.enabled: true
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Kibana
+      - equal:
+          path: spec.config
+          value:
+            server.name: "kibana"
+            xpack.security.enabled: true
+  - it: values.config should render properly
+    set:
+      elasticsearchRef:
+        name: eck-elasticsearch
+      config:
+        server.name: "kibana"
+        xpack.security.enabled: true
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Kibana
+      - equal:
+          path: spec.config
+          value:
+            server.name: "kibana"
+            xpack.security.enabled: true
+  - it: values.spec.podTemplate should render properly
+    set:
+      spec:
+        elasticsearchRef:
+          name: eck-elasticsearch
+        podTemplate:
+          metadata:
+            labels:
+              app: kibana
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Kibana
+      - equal:
+          path: spec.podTemplate
+          value:
+            metadata:
+              labels:
+                app: kibana
+  - it: values.podTemplate should render properly
+    set:
+      elasticsearchRef:
+        name: eck-elasticsearch
+      podTemplate:
+        metadata:
+          labels:
+            app: kibana
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Kibana
+      - equal:
+          path: spec.podTemplate
+          value:
+            metadata:
+              labels:
+                app: kibana
+  - it: values.spec.secureSettings should render properly
+    set:
+      spec:
+        elasticsearchRef:
+          name: eck-elasticsearch
+        secureSettings:
+          - secretName: oidc-secret
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Kibana
+      - equal:
+          path: spec.secureSettings
+          value:
+            - secretName: oidc-secret
+  - it: values.secureSettings should render properly
+    set:
+      elasticsearchRef:
+        name: eck-elasticsearch
+      secureSettings:
+        - secretName: oidc-secret
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Kibana
+      - equal:
+          path: spec.secureSettings
+          value:
+            - secretName: oidc-secret

--- a/deploy/eck-stack/charts/eck-kibana/values.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/values.yaml
@@ -20,6 +20,10 @@
 #
 version: 8.17.0-SNAPSHOT
 
+# Kibana Docker image to deploy
+#
+# image:
+
 # Labels that will be applied to Kibana.
 #
 labels: {}
@@ -28,25 +32,69 @@ labels: {}
 #
 annotations: {}
 
-spec:
-  # Count of Kibana replicas to create.
-  #
-  count: 1
+# Count of Kibana replicas to create.
+#
+count: 1
 
-  # Reference to ECK-managed Elasticsearch resource.
+# Reference to ECK-managed Elasticsearch resource.
+#
+elasticsearchRef: {}
+  # name: eck-elasticsearch
+  # Optional namespace reference to Elasticsearch resource.
+  # If not specified, then the namespace of the Kibana resource
+  # will be assumed.
   #
-  elasticsearchRef:
-    name: eck-elasticsearch
-    # Optional namespace reference to Elasticsearch resource.
-    # If not specified, then the namespace of the Kibana resource
-    # will be assumed.
-    #
-    # namespace: default
+  # namespace: default
+
+# Reference to an EnterpriseSearch running in the same Kubernetes cluster
+#
+# enterpriseSearchRef:
+
+# the Kibana configuration
+#
+config: null
+
+# the HTTP layer configuration for Kibana.
+#
+# http:
+
+# PodTemplate provides customisation options (labels, annotations, affinity rules,
+# resource requests, and so on) for the Kibana pods
+#
+# podTemplate:
+
+# Number of revisions to retain to allow rollback in the underlying deployment.
+# By default, if not set, Kubernetes sets 10.
+#
+# revisionHistoryLimit: 2
+
+# Control Kibana Secure Settings.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-kibana-secure-settings.html
+#
+secureSettings: []
+
+# Used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
+# Can only be used if ECK is enforcing RBAC on references.
+#
+# serviceAccountName: ""
+
+# Settings for configuring stack monitoring.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-stack-monitoring.html
+#
+monitoring: {}
+  # metrics:
+  #   elasticsearchRefs:
+  #   - name: monitoring
+  #     namespace: observability
+  # logs:
+  #   elasticsearchRefs:
+  #   - name: monitoring
+  #     namespace: observability
 
 # Settings for controlling Kibana ingress. Enabling ingress will expose your Kibana instance
 # to the public internet, and as such is disabled by default.
 #
-# *NOTE* when configuring Kibana Ingress, ensure that `spec.config.server.publicBaseUrl` setting for
+# *NOTE* when configuring Kibana Ingress, ensure that `config.server.publicBaseUrl` setting for
 # Kibana is also set, as it is required when exposing Kibana behind a load balancer/ingress.
 # Also of note are `server.basePath`, and `server.rewriteBasePath` settings in the Kibana configuration.
 #
@@ -62,7 +110,7 @@ ingress:
   enabled: false
 
   # Annotations that will be applied to the Ingress resource. Note that some ingress controllers are controlled via annotations.
-  # 
+  #
   # Nginx Annotations: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/
   #
   # Common annotations:

--- a/deploy/eck-stack/charts/eck-kibana/values.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/values.yaml
@@ -22,7 +22,7 @@ version: 8.17.0-SNAPSHOT
 
 # Kibana Docker image to deploy
 #
-# image:
+# image: docker.elastic.co/kibana/kibana:8.17.0-SNAPSHOT
 
 # Labels that will be applied to Kibana.
 #

--- a/deploy/eck-stack/charts/eck-kibana/values.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/values.yaml
@@ -32,6 +32,15 @@ labels: {}
 #
 annotations: {}
 
+# ** Deprecation Notice **
+# The previous versions of this Helm Chart simply used the `spec` field here
+# and allowed the user to specify any fields below spec that were templated directly
+# into the final Kibana manifest. This is no long the preferred way to specify these
+# fields and each field that is supported underneath `spec` is now directly specified
+# in this values file. Currently both patterns are supported for backwards compatibility
+# but we plan to remove the `spec` field in the future.
+# spec: {}
+
 # Count of Kibana replicas to create.
 #
 count: 1
@@ -50,11 +59,12 @@ elasticsearchRef: {}
 #
 # enterpriseSearchRef:
 
-# the Kibana configuration
+# The Kibana configuration (kibana.yml)
+# ref: https://www.elastic.co/guide/en/kibana/current/settings.html
 #
 config: null
 
-# the HTTP layer configuration for Kibana.
+# The HTTP layer configuration for Kibana.
 #
 # http:
 

--- a/deploy/eck-stack/examples/kibana/http-configuration.yaml
+++ b/deploy/eck-stack/examples/kibana/http-configuration.yaml
@@ -1,24 +1,23 @@
 ---
 eck-kibana:
-  spec:
-    # Count of Kibana replicas to create.
-    #
-    count: 1
+  # Count of Kibana replicas to create.
+  #
+  count: 1
 
-    # Reference to ECK-managed Elasticsearch resource, ideally from {{ "elasticsearch.fullname" }}
-    #
-    elasticsearchRef:
-      name: es-quickstart-eck-elasticsearch
-      # namespace: default
-    http:
-      service:
-        spec:
-          # Type of service to deploy for Kibana.
-          # This deploys a load balancer in a cloud service provider, where supported.
-          # 
-          type: LoadBalancer
-      # tls:
-      #   selfSignedCertificate:
-      #     subjectAltNames:
-      #     - ip: 1.2.3.4
-      #     - dns: kibana.example.com
+  # Reference to ECK-managed Elasticsearch resource, ideally from {{ "elasticsearch.fullname" }}
+  #
+  elasticsearchRef:
+    name: es-quickstart-eck-elasticsearch
+    # namespace: default
+  http:
+    service:
+      spec:
+        # Type of service to deploy for Kibana.
+        # This deploys a load balancer in a cloud service provider, where supported.
+        # 
+        type: LoadBalancer
+    # tls:
+    #   selfSignedCertificate:
+    #     subjectAltNames:
+    #     - ip: 1.2.3.4
+    #     - dns: kibana.example.com

--- a/deploy/eck-stack/examples/kibana/ingress/kibana-gke.yaml
+++ b/deploy/eck-stack/examples/kibana/ingress/kibana-gke.yaml
@@ -54,25 +54,24 @@ eck-kibana:
   #
   fullnameOverride: kibana
   
-  spec:
-    # Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
-    #
-    elasticsearchRef:
-      name: elasticsearch
+  # Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
+  #
+  elasticsearchRef:
+    name: elasticsearch
 
-    config:
-      server:
-        publicBaseUrl: "https://kibana.company.dev"
+  config:
+    server:
+      publicBaseUrl: "https://kibana.company.dev"
 
-    http:
-      service:
-        metadata:
-          annotations:
-            # This is required for `ClusterIP` services (which are the default ECK service type) to be used with Ingress in GKE clusters.
-            cloud.google.com/neg: '{"ingress": true}'
-            cloud.google.com/app-protocols: '{"https":"HTTPS"}'
-            cloud.google.com/backend-config: '{"default": "kibana"}'
-  
+  http:
+    service:
+      metadata:
+        annotations:
+          # This is required for `ClusterIP` services (which are the default ECK service type) to be used with Ingress in GKE clusters.
+          cloud.google.com/neg: '{"ingress": true}'
+          cloud.google.com/app-protocols: '{"https":"HTTPS"}'
+          cloud.google.com/backend-config: '{"default": "kibana"}'
+
   ingress:
     enabled: true
     pathType: Prefix


### PR DESCRIPTION
related: #8184

# Details of suggested change

It was pointed out in the above PR that the helm charts aren't consistent in how they implement values that end up within the `spec` field of the associated resource. Unfortunately the changes in 8184 are not backwards compatible, and are a breaking change. I went down the path of determining what a non-breaking change would look like, and just implemented this in the `eck-kibana` chart.

The question I have:
* Is this a path we want to go down to make the charts more consistent? Because this makes the templates more complex, but on the plus side, it significantly increases the test coverage.

(The intent is to do this for all inconsistent charts; just wanted to make the initial review/discussions easier)

### Implementation Note

1. The way this is implemented makes the previous behavior (having `.spec.field` in the values take precedence over just `field` in the values.
2. Mixing these 2 forms of values (some in spec in the values file, some not in spec) likely has unpredictable behavior. (for instance setting `spec.http.something`, and also setting `http.somethingElse`)