### PR TITLE
[2.15] Rename run-eck-diagnostics page to take-eck-dump (#8196)

### DIFF
--- a/docs/help.asciidoc
+++ b/docs/help.asciidoc
@@ -1,4 +1,4 @@
-If you are an existing Elastic customer with an active support contract, you can create a case in the link:https://support.elastic.co/[Elastic Support Portal]. Kindly attach an <<{p}-run-eck-diagnostics,ECK diagnostic>> when opening your case.
+If you are an existing Elastic customer with an active support contract, you can create a case in the link:https://support.elastic.co/[Elastic Support Portal]. Kindly attach an <<{p}-take-eck-dump,ECK diagnostic>> when opening your case.
 
 Alternatively, or if you do not have a support contract, and if you are unable to find a solution to your problem with the information provided in these documents, ask for help:
 

--- a/docs/operating-eck/air-gapped.asciidoc
+++ b/docs/operating-eck/air-gapped.asciidoc
@@ -73,6 +73,6 @@ For example, if your private registry is `my.registry` and all Elastic images ar
 [id="{p}-eck-diag-air-gapped"]
 == ECK Diagnostics in air-gapped environments
 
-The <<{p}-run-eck-diagnostics,eck-diagnostics tool>> optionally runs diagnostics for Elastic Stack applications in a separate container that is deployed into the Kubernetes cluster.
+The <<{p}-take-eck-dump,eck-diagnostics tool>> optionally runs diagnostics for Elastic Stack applications in a separate container that is deployed into the Kubernetes cluster.
 
 In air-gapped environments with no access to the `docker.elastic.co` registry, you should copy the latest support-diagnostics container image to your internal image registry and then run the tool with the additional flag `--diagnostic-image <custom-support-diagnostics-image-name>`. To find out which support diagnostics container image matches your version of eck-diagnostics run the tool once without arguments and it will print the default image in use.

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -9,10 +9,10 @@ endif::[]
 
 - <<{p}-common-problems>>
 - <<{p}-troubleshooting-methods>>
-- <<{p}-run-eck-diagnostics>>
+- <<{p}-take-eck-dump>>
 
 include::./help.asciidoc[]
 
 include::troubleshooting/common-problems.asciidoc[leveloffset=+1]
 include::troubleshooting/troubleshooting-methods.asciidoc[leveloffset=+1]
-include::troubleshooting/run-eck-diagnostics.asciidoc[leveloffset=+1]
+include::troubleshooting/take-eck-dump.asciidoc[leveloffset=+1]

--- a/docs/troubleshooting/take-eck-dump.asciidoc
+++ b/docs/troubleshooting/take-eck-dump.asciidoc
@@ -1,4 +1,4 @@
-:page_id: run-eck-diagnostics
+:page_id: take-eck-dump
 ifdef::env-github[]
 ****
 link:https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-{page_id}.html[View this document on the Elastic website]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.15`:
 - [Rename run-eck-diagnostics page to take-eck-dump (#8196)](https://github.com/elastic/cloud-on-k8s/pull/8196)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)