### PR TITLE
Handle EnterpriseSearchRef in Kibana builder

### DIFF
--- a/test/e2e/samples_test.go
+++ b/test/e2e/samples_test.go
@@ -72,6 +72,7 @@ func createBuilders(t *testing.T, decoder *helper.YAMLDecoder, sampleFile, testN
 			return b.WithNamespace(namespace).
 				WithSuffix(suffix).
 				WithElasticsearchRef(tweakServiceRef(b.Kibana.Spec.ElasticsearchRef, suffix)).
+				WithEnterpriseSearchRef(tweakServiceRef(b.Kibana.Spec.EnterpriseSearchRef, suffix)).
 				WithRestrictedSecurityContext().
 				WithLabel(run.TestNameLabel, fullTestName).
 				WithPodLabel(run.TestNameLabel, fullTestName)


### PR DESCRIPTION
This updates the Kibana test/builder to be able to use `enterpriseSearchRef` in Kibana resources defined in `config/samples/*/*` manifests.

Follow-up of https://github.com/elastic/cloud-on-k8s/pull/8166.

🧪 in local 🟢.
```sh
> TESTS_MATCH=TestSample m e2e-local
...
    --- PASS: TestSamples/enterprisesearch-ent_es (166.61s)
...
    --- PASS: TestSamples/kibana-kibana_es (134.58s)
...
```