### PR TITLE
Skip Beats stack monitoring e2e test when version >= 8.16

### DIFF
--- a/test/e2e/beat/recipes_test.go
+++ b/test/e2e/beat/recipes_test.go
@@ -99,6 +99,14 @@ func TestMetricbeatHostsRecipe(t *testing.T) {
 }
 
 func TestMetricbeatStackMonitoringRecipe(t *testing.T) {
+	v := version.MustParse(test.Ctx().ElasticStackVersion)
+
+	// https://github.com/elastic/cloud-on-k8s/issues/8250
+	// Update when the referenced issue is resolved.
+	if v.GE(version.MinFor(8, 16, 0)) {
+		t.SkipNow()
+	}
+
 	name := "fb-autodiscover"
 	pod, loggedString := loggingTestPod(name)
 	customize := func(builder beat.Builder) beat.Builder {


### PR DESCRIPTION
related: https://github.com/elastic/cloud-on-k8s/issues/8250

Let's skip the beats stack monitoring test in 8.16+ until we resolve the above issue.