### PR TITLE
[doc] Update the guidance for the stack config policy/role mapping is…

### DIFF
--- a/docs/eck-attributes.asciidoc
+++ b/docs/eck-attributes.asciidoc
@@ -4,4 +4,4 @@
 :eck_github: https://github.com/elastic/cloud-on-k8s
 :eck_resources_list: Elasticsearch, Kibana, APM Server, Enterprise Search, Beats, Elastic Agent, Elastic Maps Server, and Logstash
 
-:role_mappings_warning: We have identified an issue with Elasticsearch 8.15.1 and 8.15.2 that prevents security role mappings configured via Stack configuration policies to work correctly. The only workaround is to specify the security role mappings via the link:https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html[Elasticsearch REST API]. After upgrading to these versions role mappings will be preserved but will not receive future updates from the Stack configuration policy. Follow the instructions to <<{p}-common-problems-815-reconfigure-role-mappings, reconfigure role mappings after upgrading to 8.15.3>>.
+:role_mappings_warning: We have identified an issue with Elasticsearch 8.15.1 and 8.15.2 that prevents security role mappings configured via Stack configuration policies to work correctly. Avoid these versions and upgrade to 8.16.0 to remedy this issue if you are affected.

--- a/docs/operating-eck/troubleshooting/common-problems.asciidoc
+++ b/docs/operating-eck/troubleshooting/common-problems.asciidoc
@@ -267,12 +267,11 @@ These two upgrading scenarios, however, are exceptions because Elasticsearch nev
 You have role mappings defined in a StackConfigPolicy, and you upgraded from 8.14.x or 8.15.x, to 8.15.3.
 
 Examples:
-
 - 8.14.2 -> 8.15.2 -> 8.15.3
 - 8.14.2 -> 8.15.3
 - 8.15.2 -> 8.15.3
 
-You have to perform two manual steps in order to correctly reconfigure role mappings because due to a bug the role mappings were duplicated.
+The best option is to upgrade to 8.16.0, to fix the problem automatically. If this is not possible and you are stuck on 8.15.3, you have to perform two manual steps in order to correctly reconfigure role mappings because due to a bug the role mappings were duplicated.
 
 . Force reload the StackConfigPolicy configuration
 


### PR DESCRIPTION
Backport the following commit to `2.9`:
- #8247