### PR TITLE
[E2E] Retry Agent mutation

### DIFF
--- a/test/e2e/test/agent/steps.go
+++ b/test/e2e/test/agent/steps.go
@@ -240,12 +240,17 @@ func (b Builder) UpgradeTestSteps(k *test.K8sClient) test.StepList {
 	return test.StepList{
 		{
 			Name: "Applying the Agent mutation should succeed",
-			Test: func(t *testing.T) {
+			Test: test.Eventually(func() error {
 				var agent agentv1alpha1.Agent
-				require.NoError(t, k.Client.Get(context.Background(), k8s.ExtractNamespacedName(&b.Agent), &agent))
+				if err := k.Client.Get(context.Background(), k8s.ExtractNamespacedName(&b.Agent), &agent); err != nil {
+					return err
+				}
 				agent.Spec = b.Agent.Spec
-				require.NoError(t, k.Client.Update(context.Background(), &agent))
-			},
+				if err := k.Client.Update(context.Background(), &agent); err != nil {
+					return err
+				}
+				return nil
+			}),
 		}}
 }
 

--- a/test/e2e/test/agent/steps.go
+++ b/test/e2e/test/agent/steps.go
@@ -236,7 +236,6 @@ func (b Builder) CheckStackTestSteps(k *test.K8sClient) test.StepList {
 }
 
 func (b Builder) UpgradeTestSteps(k *test.K8sClient) test.StepList {
-	//nolint:thelper
 	return test.StepList{
 		{
 			Name: "Applying the Agent mutation should succeed",


### PR DESCRIPTION
Should fix the following test failure:

```
=== RUN   TestAgentVersionUpgradeToLatest8x/Applying_the_Agent_mutation_should_succeed#01
    steps.go:247: 
        	Error Trace:	/go/src/github.com/elastic/cloud-on-k8s/test/e2e/test/agent/steps.go:247
        	Error:      	Received unexpected error:
        	            	Operation cannot be fulfilled on agents.agent.k8s.elastic.co "test-agent-upgrade-ea-p4sx": the object has been modified; please apply your changes to the latest version and try again
        	Test:       	TestAgentVersionUpgradeToLatest8x/Applying_the_Agent_mutation_should_succeed#01
```

I'm not sure why we are observing this failure now while this code has been there for a while. I was not able to reproduce locally and did not observe anything suspicious in the operator logs 🤷‍♂️ 