### PR TITLE
[DOC] Document the need for an ingest node for Enterprise Search analytics

### DIFF
--- a/config/samples/enterprisesearch/ent_es.yaml
+++ b/config/samples/enterprisesearch/ent_es.yaml
@@ -9,6 +9,11 @@ spec:
     - name: default
       count: 1
       config:
+        ## Ingest node is required to index API and analytics logs.
+        #node.roles:
+        #  - data
+        #  - master
+        #  - ingest
         # This setting could have performance implications for production clusters.
         # See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
         node.store.allow_mmap: false


### PR DESCRIPTION
It seems that having at least one ingest node is a recent requirement to get Enterprise Search API and analytics logs ingested correctly. One of our user hit this problem (analytics was suddenly no longer working with recent stack versions).

It feels like something that should be in the product documentation, but maybe having a comment in our example may help.