### PR TITLE
Allow Beats stack monitoring w/o elasticseachRef

### DIFF
--- a/pkg/controller/beat/common/stackmon/metricbeat.tpl.yml
+++ b/pkg/controller/beat/common/stackmon/metricbeat.tpl.yml
@@ -8,6 +8,10 @@ metricbeat.modules:
   xpack.enabled: true
 http.enabled: false
 monitoring.enabled: false
-monitoring.cluster_uuid: "{{ .ClusterUUID }}"
+# if no associated Elasticsearch cluster UUID known or determinable,
+# monitored application will be treated as stand-alone without cluster_uuid.
+{{ with .ClusterUUID -}}
+monitoring.cluster_uuid: "{{ . }}"
+{{- end}}
 
 # Elasticsearch output configuration is generated and added here

--- a/pkg/controller/beat/common/stackmon/stackmon.go
+++ b/pkg/controller/beat/common/stackmon/stackmon.go
@@ -128,6 +128,10 @@ type clusterUUIDResponse struct {
 func associatedESUUID(ctx context.Context, client k8s.Client, beat *v1beta1.Beat) (string, error) {
 	esAssociation := beat.EsAssociation()
 	esRef := esAssociation.AssociationRef()
+	if !esRef.IsDefined() {
+		// no association or indirect association e.g. via output configuration
+		return "", nil
+	}
 	if esRef.IsExternal() {
 		remoteES, err := association.GetUnmanagedAssociationConnectionInfoFromSecret(client, esAssociation)
 		if err != nil {


### PR DESCRIPTION
Fixes #8194 

There are cases where we cannot work out the associated Elasticsearch cluster (see the linked issue). 

This: 
* checks if the association is defined
* does not try to render the `monitoring.cluster_uuid` property

Based on my testing this should be fine. Beats will show up as "stand-alone cluster (!)" in the stack monitoring UI.
<img width="1260" alt="Screenshot 2024-11-28 at 20 17 15" src="https://github.com/user-attachments/assets/eba10c18-4ea8-496d-bb12-ce428b43086a">
