### PR TITLE
node-configuration.asciidoc: remove remote_cluster_client

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/node-configuration.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/node-configuration.asciidoc
@@ -23,7 +23,6 @@ spec:
       # node.master: true
       node.roles: ["master"]
       xpack.ml.enabled: true
-      node.remote_cluster_client: false
   - name: data
     count: 10
     config:
@@ -34,7 +33,6 @@ spec:
       # node.ml: true
       # node.transform: true
       node.roles: ["data", "ingest", "ml", "transform"]
-      node.remote_cluster_client: false
 ----
 
 For more information on Elasticsearch settings, check https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html[Configuring Elasticsearch].


### PR DESCRIPTION
admission webhook "elastic-es-validation-v1.k8s.elastic.co" denied the request: Elasticsearch.elasticsearch.k8s.elastic.co "main" is invalid: spec.nodeSets[0].config: Forbidden: Detected a combination of node.roles and node.remote_cluster_client. Use only node.roles

-

omission of the `remote_cluster_client` role already set the node to not act as a remote cluster client