### PR TITLE
[Helm] Add a setting to deploy FIPS compliant ECK image (#8272)

### DIFF
--- a/deploy/eck-operator/templates/statefulset.yaml
+++ b/deploy/eck-operator/templates/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - image: "{{ .Values.image.repository }}{{- if .Values.config.ubiOnly -}}-ubi{{- end -}}:{{ default .Chart.AppVersion .Values.image.tag }}"
+        - image: "{{ .Values.image.repository }}{{- if .Values.config.ubiOnly -}}-ubi{{- end -}}{{- if .Values.image.fips -}}-fips{{- end -}}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: manager
           args:

--- a/deploy/eck-operator/templates/tests/statefulset_test.yaml
+++ b/deploy/eck-operator/templates/tests/statefulset_test.yaml
@@ -4,6 +4,42 @@ templates:
   - statefulset.yaml
   - configmap.yaml
 tests:
+  - it: ECK image, fips + ubi
+    set:
+      config.ubiOnly: true
+      image.fips: true
+      image.tag: "2.16.0"
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator-ubi-fips:2.16.0"
+  - it: ECK image, no fips, no ubi
+    set:
+      image.tag: "2.16.0"
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator:2.16.0"
+  - it: ECK image, fips, no ubi
+    set:
+      image.fips: true
+      image.tag: "2.16.0"
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator-fips:2.16.0"
+  - it: ECK image, no fips, ubi
+    set:
+      config.ubiOnly: true
+      image.tag: "2.16.0"
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.elastic.co/eck/eck-operator-ubi:2.16.0"
   - it: should have automount service account tokens set by default
     asserts:
       - template: statefulset.yaml

--- a/deploy/eck-operator/values.yaml
+++ b/deploy/eck-operator/values.yaml
@@ -24,6 +24,10 @@ image:
   pullPolicy: IfNotPresent
   # tag is the container image tag. If not defined, defaults to chart appVersion.
   tag: null
+  # fips specifies whether the operator will use a FIPS compliant container image for its own StatefulSet image.
+  # This setting does not apply to Elastic Stack applications images.
+  # Can be combined with config.ubiOnly.
+  fips: false
 
 # priorityClassName defines the PriorityClass to be used by the operator pods.
 priorityClassName: ""

--- a/docs/advanced-topics/fips.asciidoc
+++ b/docs/advanced-topics/fips.asciidoc
@@ -18,13 +18,13 @@ For the ECK operator, adherence to FIPS 140-2 is ensured by:
 
 === FIPS compliant installation using Helm
 
-Modify the `image.repository` Helm chart value to append `-fips` to install a FIPS compliant version of the ECK Operator. Refer to <<{p}-install-helm>> for full Helm installation instructions.
+Set `image.fips=true` to install a FIPS-enabled version of the ECK Operator. Refer to <<{p}-install-helm>> for full Helm installation instructions.
 
 [source,sh]
 ----
 helm install elastic-operator elastic/eck-operator \
   -n elastic-system --create-namespace \
-  --set=image.repository=docker.elastic.co/eck/eck-operator-fips
+  --set=image.fips=true
 ----
 
 === FIPS compliant installation using manifests


### PR DESCRIPTION
Backport of [[Helm] Add a setting to deploy FIPS compliant ECK image](https://github.com/elastic/cloud-on-k8s/pull/8272) into `2.16`.

This is only a proposal as the original issue https://github.com/elastic/cloud-on-k8s/issues/8204 was labeled for `2.16`, happy to close it as we are beyond feature freeze. 