### PR TITLE
[2.16] Allow metrics stack monitoring w/o elasticseachRef (#8273)

### DIFF
--- a/pkg/controller/beat/common/stackmon/metricbeat.tpl.yml
+++ b/pkg/controller/beat/common/stackmon/metricbeat.tpl.yml
@@ -8,6 +8,10 @@ metricbeat.modules:
   xpack.enabled: true
 http.enabled: false
 monitoring.enabled: false
-monitoring.cluster_uuid: "{{ .ClusterUUID }}"
+# if no associated Elasticsearch cluster UUID known or determinable,
+# monitored application will be treated as stand-alone without cluster_uuid.
+{{ with .ClusterUUID -}}
+monitoring.cluster_uuid: "{{ . }}"
+{{- end}}
 
 # Elasticsearch output configuration is generated and added here

--- a/pkg/controller/beat/common/stackmon/stackmon.go
+++ b/pkg/controller/beat/common/stackmon/stackmon.go
@@ -128,6 +128,10 @@ type clusterUUIDResponse struct {
 func associatedESUUID(ctx context.Context, client k8s.Client, beat *v1beta1.Beat) (string, error) {
 	esAssociation := beat.EsAssociation()
 	esRef := esAssociation.AssociationRef()
+	if !esRef.IsDefined() {
+		// no association or indirect association e.g. via output configuration
+		return "", nil
+	}
 	if esRef.IsExternal() {
 		remoteES, err := association.GetUnmanagedAssociationConnectionInfoFromSecret(client, esAssociation)
 		if err != nil {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.16`:
 - [Allow metrics stack monitoring w/o elasticseachRef (#8273)](https://github.com/elastic/cloud-on-k8s/pull/8273)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)