### PR TITLE
[DOC] Remove node.remote_cluster_client from examples (#8274)

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/advanced-node-scheduling.asciidoc
@@ -40,7 +40,6 @@ spec:
     count: 3
     config:
       node.roles: ["master"]
-      node.remote_cluster_client: false
   # 3 ingest-data nodes
   - name: ingest-data
     count: 3

--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/node-configuration.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/node-configuration.asciidoc
@@ -23,7 +23,6 @@ spec:
       # node.master: true
       node.roles: ["master"]
       xpack.ml.enabled: true
-      node.remote_cluster_client: false
   - name: data
     count: 10
     config:
@@ -34,7 +33,6 @@ spec:
       # node.ml: true
       # node.transform: true
       node.roles: ["data", "ingest", "ml", "transform"]
-      node.remote_cluster_client: false
 ----
 
 For more information on Elasticsearch settings, check https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html[Configuring Elasticsearch].


### PR DESCRIPTION
Backport of [[DOC] Remove node.remote_cluster_client from examples](https://github.com/elastic/cloud-on-k8s/pull/8274) into `2.16`

