### PR TITLE
[Helm] Updated pod labels to include all standard k8s labels and updated hel…

### DIFF
--- a/deploy/eck-operator/templates/statefulset.yaml
+++ b/deploy/eck-operator/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "eck-operator.selectorLabels" . | nindent 8 }}
+        {{- include "eck-operator.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deploy/eck-operator/templates/tests/statefulset_test.yaml
+++ b/deploy/eck-operator/templates/tests/statefulset_test.yaml
@@ -62,6 +62,8 @@ tests:
         key1: value1
       statefulsetLabels:
         key2: value2
+      podLabels:
+        key3: value3
     asserts:
       - template: statefulset.yaml
         equal:
@@ -78,6 +80,16 @@ tests:
             app.kubernetes.io/version: 2.16.0-SNAPSHOT
             helm.sh/chart: eck-operator-2.16.0-SNAPSHOT
             key2: value2
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.metadata.labels
+          value:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: elastic-operator
+            app.kubernetes.io/version: 2.16.0-SNAPSHOT
+            helm.sh/chart: eck-operator-2.16.0-SNAPSHOT
+            key3: value3
   - it: should use the specified webhook secret name
     set:
       webhook:


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Updated labels to use common kubernetes labels on pods (previously it was only on statefulset and several were missing from pod) to increase traceability throughout the application.
- Added helm unittests to check for updated labels in addition to the podLabels that can be provided via values.yaml file
- Ran `make helm-test` to validate changes and updates to test
