### PR TITLE
Make helm charts consistent with how fields in spec are handled. (fleet-server only)

### DIFF
--- a/deploy/eck-stack/charts/eck-fleet-server/examples/fleet-server.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/examples/fleet-server.yaml
@@ -14,4 +14,4 @@ http:
     spec:
       type: ClusterIP
 serviceAccount:
-  name: elastic-fleet-server
+  name: fleet-server

--- a/deploy/eck-stack/charts/eck-fleet-server/examples/fleet-server.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/examples/fleet-server.yaml
@@ -1,0 +1,19 @@
+version: 8.17.0-SNAPSHOT
+deployment:
+  replicas: 1
+  podTemplate:
+    spec:
+      serviceAccountName: fleet-server
+      automountServiceAccountToken: true
+elasticsearchRefs:
+- name: eck-elasticsearch
+  namespace: default
+kibanaRef:
+  name: eck-kibana
+  namespace: default
+http:
+  service:
+    spec:
+      type: ClusterIP
+serviceAccount:
+  name: elastic-fleet-server

--- a/deploy/eck-stack/charts/eck-fleet-server/examples/fleet-server.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/examples/fleet-server.yaml
@@ -7,10 +7,8 @@ deployment:
       automountServiceAccountToken: true
 elasticsearchRefs:
 - name: eck-elasticsearch
-  namespace: default
 kibanaRef:
   name: eck-kibana
-  namespace: default
 http:
   service:
     spec:

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
@@ -21,16 +21,16 @@ spec:
   {{- fail "fleetServerEnabled cannot be changed" }}
   {{- end }}
 
-  {{- $daemonSet := (or (hasKey (.Values.spec) "daemonSet") (hasKey .Values "daemonSet")) }}
+  {{- $statefulSet := (or (hasKey (.Values.spec) "statefulSet") (hasKey .Values "statefulSet")) }}
   {{- $deployment := (or (hasKey (.Values.spec) "deployment") (hasKey .Values "deployment")) }}
-  {{- if and (not $daemonSet) (not $deployment) }}
-  {{ fail "At least one of daemonSet or deployment is required" }}
+  {{- if and (not $statefulSet) (not $deployment) }}
+  {{ fail "At least one of statefulSet or deployment is required" }}
   {{- end }}
-  {{- if $daemonSet }}
-  {{- $ds := or ((.Values.spec).daemonSet) (.Values.daemonSet) }}
-  daemonSet:
-    {{- /* This is required to render the empty daemonset ( {} ) properly */}}
-    {{- $ds | default dict | toYaml | nindent 4 }}
+  {{- if $statefulSet }}
+  {{- $ss := or ((.Values.spec).statefulSet) (.Values.statefulSet) }}
+  statefulSet:
+    {{- /* This is required to render the empty statefulSet ( {} ) properly */}}
+    {{- $ss | default dict | toYaml | nindent 4 }}
   {{- end }}
   {{- if $deployment }}
   {{- $deploy := or ((.Values.spec).deployment) (.Values.deployment) }}

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
@@ -14,8 +14,8 @@ spec:
   version: {{ required "A Fleet Server version is required" (or ((.Values.spec).version) (.Values.version)) }}
   mode: fleet
   fleetServerEnabled: true
-  {{- if (hasKey .Values.spec "mode") }}
-  {{- fail "spec.mode cannot be changed" }}
+  {{- if (or (hasKey (.Values.spec) "mode") (hasKey .Values "mode")) }}
+  {{- fail "mode cannot be changed" }}
   {{- end }}
   {{- if (or (hasKey (.Values.spec) "fleetServerEnabled") (hasKey .Values "fleetServerEnabled"))}}
   {{- fail "fleetServerEnabled cannot be changed" }}
@@ -49,12 +49,11 @@ spec:
   kibanaRef:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with or ((.Values.spec).policyID) (.Values.policyID) }}
+  policyID: {{ . }}
+  {{- end }}
   {{- with or ((.Values.spec).http) (.Values.http) }}
   http:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- with or ((.Values.spec).secureSettings) (.Values.secureSettings) }}
-  secureSettings:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with or ((.Values.spec).revisionHistoryLimit) (.Values.revisionHistoryLimit) }}

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
@@ -11,13 +11,55 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  version: {{ required "A Fleet Server version is required" .Values.version }}
+  version: {{ required "A Fleet Server version is required" (or ((.Values.spec).version) (.Values.version)) }}
   mode: fleet
   fleetServerEnabled: true
   {{- if (hasKey .Values.spec "mode") }}
   {{- fail "spec.mode cannot be changed" }}
   {{- end }}
-  {{- if (hasKey .Values.spec "fleetServerEnabled") }}
-  {{- fail "spec.fleetServerEnabled cannot be changed" }}
+  {{- if (or (hasKey (.Values.spec) "fleetServerEnabled") (hasKey .Values "fleetServerEnabled"))}}
+  {{- fail "fleetServerEnabled cannot be changed" }}
   {{- end }}
-  {{- toYaml .Values.spec | nindent 2 }}
+
+  {{- $daemonSet := (or (hasKey (.Values.spec) "daemonSet") (hasKey .Values "daemonSet")) }}
+  {{- $deployment := (or (hasKey (.Values.spec) "deployment") (hasKey .Values "deployment")) }}
+  {{- if and (not $daemonSet) (not $deployment) }}
+  {{ fail "At least one of daemonSet or deployment is required" }}
+  {{- end }}
+  {{- if $daemonSet }}
+  {{- $ds := or ((.Values.spec).daemonSet) (.Values.daemonSet) }}
+  daemonSet:
+    {{- /* This is required to render the empty daemonset ( {} ) properly */}}
+    {{- $ds | default dict | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if $deployment }}
+  {{- $deploy := or ((.Values.spec).deployment) (.Values.deployment) }}
+  deployment:
+    {{- /* This is required to render the empty deployment ( {} ) properly */}}
+    {{- $deploy | default dict | toYaml | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).image) (.Values.image) }}
+  image: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).elasticsearchRefs) (.Values.elasticsearchRefs) }}
+  elasticsearchRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).kibanaRef) (.Values.kibanaRef) }}
+  kibanaRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).http) (.Values.http) }}
+  http:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).secureSettings) (.Values.secureSettings) }}
+  secureSettings:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).revisionHistoryLimit) (.Values.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with or (((.Values.spec).serviceAccount).name) ((.Values.serviceAccount).name) }}
+  serviceAccountName: {{ . }}
+  {{- end }}

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
@@ -3,6 +3,15 @@ templates:
   - templates/fleet-server.yaml
 tests:
   - it: should render default fleet server properly
+    set:
+      deployment:
+        replicas: 1
+        podTemplate:
+          spec:
+            serviceAccountName: fleet-server
+            automountServiceAccountToken: true
+      kibanaRef:
+        name: eck-kibana
     release:
       name: quickstart
     asserts:
@@ -18,23 +27,20 @@ tests:
           path: spec.kibanaRef.name
           value: eck-kibana
       - equal:
-          path: spec.deployment.replicas
-          value: 1
-      - equal:
-          path: spec.deployment.podTemplate.spec.serviceAccountName
-          value: fleet-server
-      - equal:
-          path: spec.deployment.podTemplate.spec.automountServiceAccountToken
-          value: true
-      - equal:
-          path: spec.deployment.podTemplate.spec.securityContext.runAsUser
-          value: 0
+          path: spec.deployment
+          value:
+            replicas: 1
+            podTemplate:
+              spec:
+                serviceAccountName: fleet-server
+                automountServiceAccountToken: true
   - it: should render custom labels and annotations properly.
     set:
       labels:
         test: label
       annotations:
         test: annotation
+      deployment: {}
     release:
       name: quickstart
     asserts:
@@ -53,3 +59,110 @@ tests:
           value:
             eck.k8s.elastic.co/license: basic
             test: annotation
+  - it: should render properly when using spec fields
+    set:
+      spec:
+        daemonSet: {}
+        elasticsearchRefs:
+        - name: eck-elasticsearch
+          namespace: default
+        kibanaRef:
+          name: eck-kibana
+          namespace: default
+        http:
+          service:
+            spec:
+              type: ClusterIP
+        revisionHistoryLimit: 4
+        serviceAccount:
+          name: elastic-fleet-server
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Agent
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: quickstart
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: eck-fleet-server
+            helm.sh/chart: eck-fleet-server-0.14.0-SNAPSHOT
+      - equal:
+          path: spec
+          value:
+            fleetServerEnabled: true
+            mode: fleet
+            policyID: eck-fleet-server
+            version: 8.17.0-SNAPSHOT
+            daemonSet: {}
+            elasticsearchRefs:
+            - name: eck-elasticsearch
+              namespace: default
+            kibanaRef:
+              name: eck-kibana
+              namespace: default
+            http:
+              service:
+                spec:
+                  type: ClusterIP
+            revisionHistoryLimit: 4
+            serviceAccountName: elastic-fleet-server
+  - it: should render properly when not using spec fields
+    set:
+      daemonSet: {}
+      elasticsearchRefs:
+      - name: eck-elasticsearch
+        namespace: default
+      kibanaRef:
+        name: eck-kibana
+        namespace: default
+      http:
+        service:
+          spec:
+            type: ClusterIP
+      revisionHistoryLimit: 4
+      serviceAccount:
+        name: elastic-fleet-server
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Agent
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: quickstart
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: eck-fleet-server
+            helm.sh/chart: eck-fleet-server-0.14.0-SNAPSHOT
+      - equal:
+          path: spec
+          value:
+            fleetServerEnabled: true
+            mode: fleet
+            policyID: eck-fleet-server
+            version: 8.17.0-SNAPSHOT
+            daemonSet: {}
+            elasticsearchRefs:
+            - name: eck-elasticsearch
+              namespace: default
+            kibanaRef:
+              name: eck-kibana
+              namespace: default
+            http:
+              service:
+                spec:
+                  type: ClusterIP
+            revisionHistoryLimit: 4
+            serviceAccountName: elastic-fleet-server
+  - it: not setting version should fail
+    set:
+      version: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "A Fleet Server version is required"
+  - it: not setting a daemonset or deployment should fail
+    asserts:
+      - failedTemplate:
+          errorMessage: "At least one of daemonSet or deployment is required"

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
@@ -62,7 +62,7 @@ tests:
   - it: should render properly when using spec fields
     set:
       spec:
-        daemonSet: {}
+        deployment: {}
         elasticsearchRefs:
         - name: eck-elasticsearch
           namespace: default
@@ -95,7 +95,7 @@ tests:
             mode: fleet
             policyID: eck-fleet-server
             version: 8.17.0-SNAPSHOT
-            daemonSet: {}
+            deployment: {}
             elasticsearchRefs:
             - name: eck-elasticsearch
               namespace: default
@@ -110,7 +110,7 @@ tests:
             serviceAccountName: elastic-fleet-server
   - it: should render properly when not using spec fields
     set:
-      daemonSet: {}
+      deployment: {}
       elasticsearchRefs:
       - name: eck-elasticsearch
         namespace: default
@@ -143,7 +143,7 @@ tests:
             mode: fleet
             policyID: eck-fleet-server
             version: 8.17.0-SNAPSHOT
-            daemonSet: {}
+            deployment: {}
             elasticsearchRefs:
             - name: eck-elasticsearch
               namespace: default
@@ -162,7 +162,7 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "A Fleet Server version is required"
-  - it: not setting a daemonset or deployment should fail
+  - it: not setting a statefulset or deployment should fail
     asserts:
       - failedTemplate:
-          errorMessage: "At least one of daemonSet or deployment is required"
+          errorMessage: "At least one of statefulSet or deployment is required"

--- a/deploy/eck-stack/charts/eck-fleet-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/values.yaml
@@ -69,6 +69,132 @@ spec:
         securityContext:
           runAsUser: 0
 
+# Elastic Agent image to deploy.
+#
+# image: docker.elastic.co/beats/elastic-agent:8.17.0-SNAPSHOT
+
+# ** Deprecation Notice **
+# The previous versions of this Helm Chart simply used the `spec` field here
+# and allowed the user to specify any fields below `spec` that were templated directly
+# into the final Kibana manifest. This is no longer the preferred way to specify these
+# fields and each field that is supported underneath `spec` is now directly specified
+# in this values file. Currently both patterns are supported for backwards compatibility
+# but we plan to remove the `spec` field in the future.
+# spec: {}
+
+# Referenced resources are below and depending on the setup, at least one is required for a functional Agent.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-setting-referenced-resources
+#
+# Reference to ECK-managed Kibana instance.
+#
+# kibanaRef:
+#   name: quickstart
+  # Optional namespace reference to Kibana instance.
+  # If not specified, then the namespace of the Agent instance
+  # will be assumed.
+  #
+  # namespace: default
+
+# Reference to ECK-managed Elasticsearch instance.
+#
+elasticsearchRefs:
+- name: eck-elasticsearch
+  # Optional namespace reference to Elasticsearch instance.
+  # If not specified, then the namespace of the Agent instance
+  # will be assumed.
+  #
+  # namespace: default
+
+# Reference to ECK-managed Fleet Server instance.
+#
+# fleetServerRef:
+#   name: eck-fleet-server
+  # Optional namespace reference to Fleet Server instance.
+  # If not specified, then the namespace of the Agent instance
+  # will be assumed.
+  #
+  # namespace: default
+
+# The Elastic Agent configuration, the ECK equivalent to agent.yml
+# NOTE: The `config` and `configRef` fields are mutually exclusive. Only one of them should be defined at a time,
+# as using both may cause conflicts.
+#
+# Configuration of Agent, specifically used in Agent standalone mode.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-configuration.html
+#
+config: null
+
+# Reference a configuration in a Secret.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-configuration.html
+#
+# configRef:
+#   secretName: ""
+
+# The mode of Agent to use. Only set to "fleet" when Fleet Server is enabled.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-fleet-mode-and-fleet-server
+#
+# mode: "fleet"
+
+# fleetServerEnabled determines whether the Agent will be run as the Fleet Server.
+#
+# NOTE: Both `mode: fleet` and `fleetServerEnabled: true` need to be set for Fleet Server to be enabled.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-fleet-mode-and-fleet-server
+#
+fleetServerEnabled: false
+
+# The HTTP layer configuration for the Fleet Server Service.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-customize-fleet-server-service
+#
+# http:
+
+# policyID determines into which Agent Policy this Agent will be enrolled.
+# policyID: eck-agent
+  
+# DaemonSet, StatefulSet, or Deployment specification for Agent.
+# At least one is required of [daemonSet, deployment, statefulSet].
+# No default is currently set, refer to https://github.com/elastic/cloud-on-k8s/issues/7429.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-chose-the-deployment-model
+#
+# deployment:
+#   podTemplate:
+#     spec:
+#       containers:
+#       - name: agent
+#         securityContext:
+#           runAsUser: 0
+# daemonSet:
+#   podTemplate:
+#     spec:
+#       containers:
+#       - name: agent
+#         securityContext:
+#           runAsUser: 0
+# statefulSet:
+#   podTemplate:
+#     spec:
+#       containers:
+#       - name: agent
+#         securityContext:
+#           runAsUser: 0
+
+# SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for Elastic Agent.
+secureSettings: []
+# - secretName: my-secret-with-secure-settings
+
+# Number of revisions to retain to allow rollback in the underlying Deployment.
+# If not set Kubernetes sets this to 10 by default.
+#
+# revisionHistoryLimit: 2
+
+# ServiceAccount to be used by Elastic Agent. Some Elastic Agent features, such as the Kubernetes integration,
+# require that Agent Pods interact with Kubernetes APIs. This functionality requires specific permissions
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-role-based-access-control
+#
+serviceAccount:
+  name: elastic-agent
+  # { .Release.Namespace } is used here by default, but can be specified.
+  # namespace: optional-namespace
+
 # ServiceAccount to be used by Elastic Fleet Server. Some Fleet Server features (such as autodiscover or Kubernetes module metricsets)
 # require that Fleet Server Pods interact with Kubernetes APIs. This functionality requires specific permissions
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-role-based-access-control

--- a/deploy/eck-stack/charts/eck-fleet-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/values.yaml
@@ -35,7 +35,7 @@ annotations: {}
 # ** Deprecation Notice **
 # The previous versions of this Helm Chart simply used the `spec` field here
 # and allowed the user to specify any fields below `spec` that were templated directly
-# into the final Agent/Fleet Servermanifest. This is no longer the preferred way to specify these
+# into the final Agent/Fleet Server manifest. This is no longer the preferred way to specify these
 # fields and each field that is supported underneath `spec` is now directly specified
 # in this values file. Currently both patterns are supported for backwards compatibility
 # but we plan to remove the `spec` field in the future.
@@ -45,7 +45,7 @@ annotations: {}
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-setting-referenced-resources
 #
 # Reference to ECK-managed Kibana instance.
-# This is required for fleet server.
+# This is required for Fleet Server.
 #
 # kibanaRef:
 #   name: quickstart
@@ -56,7 +56,7 @@ annotations: {}
   # namespace: default
 
 # Reference to ECK-managed Elasticsearch instance.
-# This is required for fleet server.
+# This is required for Fleet Server.
 #
 elasticsearchRefs: []
 # - name: eck-elasticsearch

--- a/deploy/eck-stack/charts/eck-fleet-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/values.yaml
@@ -28,130 +28,54 @@ labels: {}
 #
 annotations: {}
 
-spec:
-  # policyID determines into which Agent Policy this Fleet Server will be enrolled.
-  policyID: eck-fleet-server
-
-  # Referenced resources are below and both elasticsearchRefs and kibanaRef are required for a functional Fleet Server.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-connect-es
-  #
-  # Reference to ECK-managed Kibana resource.
-  #
-  kibanaRef:
-    name: eck-kibana
-    # Optional namespace reference to Kibana resource.
-    # If not specified, then the namespace of the Fleet Server resource
-    # will be assumed.
-    #
-    # namespace: default
-
-  # References to ECK-managed Elasticsearch resource.
-  # This is required for fleet server.
-  #
-  elasticsearchRefs:
-  - name: eck-elasticsearch
-    # Optional namespace reference to Elasticsearch resource.
-    # If not specified, then the namespace of the Fleet Server resource
-    # will be assumed.
-    #
-    # namespace: default
-  
-  # Daemonset, or Deployment specification for the type of Fleet Server specified.
-  # At least one is required of [daemonSet, deployment].
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-chose-the-deployment-model
-  #
-  deployment:
-    replicas: 1
-    podTemplate:
-      spec:
-        serviceAccountName: fleet-server
-        automountServiceAccountToken: true
-        securityContext:
-          runAsUser: 0
-
-# Elastic Agent image to deploy.
+# Elastic Fleet Server Agent image to deploy.
 #
 # image: docker.elastic.co/beats/elastic-agent:8.17.0-SNAPSHOT
 
 # ** Deprecation Notice **
 # The previous versions of this Helm Chart simply used the `spec` field here
 # and allowed the user to specify any fields below `spec` that were templated directly
-# into the final Kibana manifest. This is no longer the preferred way to specify these
+# into the final Agent/Fleet Servermanifest. This is no longer the preferred way to specify these
 # fields and each field that is supported underneath `spec` is now directly specified
 # in this values file. Currently both patterns are supported for backwards compatibility
 # but we plan to remove the `spec` field in the future.
 # spec: {}
 
-# Referenced resources are below and depending on the setup, at least one is required for a functional Agent.
+# Referenced resources are below and both elasticsearchRefs and kibanaRef are required for a functional Fleet Server.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-setting-referenced-resources
 #
 # Reference to ECK-managed Kibana instance.
+# This is required for fleet server.
 #
 # kibanaRef:
 #   name: quickstart
   # Optional namespace reference to Kibana instance.
-  # If not specified, then the namespace of the Agent instance
+  # If not specified, then the namespace of the Fleet Server resource
   # will be assumed.
   #
   # namespace: default
 
 # Reference to ECK-managed Elasticsearch instance.
+# This is required for fleet server.
 #
-elasticsearchRefs:
-- name: eck-elasticsearch
+elasticsearchRefs: []
+# - name: eck-elasticsearch
   # Optional namespace reference to Elasticsearch instance.
-  # If not specified, then the namespace of the Agent instance
+  # If not specified, then the namespace of the Fleet Server resource
   # will be assumed.
   #
   # namespace: default
 
-# Reference to ECK-managed Fleet Server instance.
-#
-# fleetServerRef:
-#   name: eck-fleet-server
-  # Optional namespace reference to Fleet Server instance.
-  # If not specified, then the namespace of the Agent instance
-  # will be assumed.
-  #
-  # namespace: default
-
-# The Elastic Agent configuration, the ECK equivalent to agent.yml
-# NOTE: The `config` and `configRef` fields are mutually exclusive. Only one of them should be defined at a time,
-# as using both may cause conflicts.
-#
-# Configuration of Agent, specifically used in Agent standalone mode.
-# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-configuration.html
-#
-config: null
-
-# Reference a configuration in a Secret.
-# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-configuration.html
-#
-# configRef:
-#   secretName: ""
-
-# The mode of Agent to use. Only set to "fleet" when Fleet Server is enabled.
-# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-fleet-mode-and-fleet-server
-#
-# mode: "fleet"
-
-# fleetServerEnabled determines whether the Agent will be run as the Fleet Server.
-#
-# NOTE: Both `mode: fleet` and `fleetServerEnabled: true` need to be set for Fleet Server to be enabled.
-# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-fleet-mode-and-fleet-server
-#
-fleetServerEnabled: false
+# policyID determines into which Agent Policy this Fleet Server will be enrolled.
+policyID: eck-fleet-server
 
 # The HTTP layer configuration for the Fleet Server Service.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-customize-fleet-server-service
 #
 # http:
 
-# policyID determines into which Agent Policy this Agent will be enrolled.
-# policyID: eck-agent
-  
-# DaemonSet, StatefulSet, or Deployment specification for Agent.
-# At least one is required of [daemonSet, deployment, statefulSet].
+# DaemonSet or Deployment specification for Fleet Server.
+# At least one is required of [daemonSet, deployment].
 # No default is currently set, refer to https://github.com/elastic/cloud-on-k8s/issues/7429.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-chose-the-deployment-model
 #
@@ -169,31 +93,11 @@ fleetServerEnabled: false
 #       - name: agent
 #         securityContext:
 #           runAsUser: 0
-# statefulSet:
-#   podTemplate:
-#     spec:
-#       containers:
-#       - name: agent
-#         securityContext:
-#           runAsUser: 0
-
-# SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for Elastic Agent.
-secureSettings: []
-# - secretName: my-secret-with-secure-settings
 
 # Number of revisions to retain to allow rollback in the underlying Deployment.
 # If not set Kubernetes sets this to 10 by default.
 #
 # revisionHistoryLimit: 2
-
-# ServiceAccount to be used by Elastic Agent. Some Elastic Agent features, such as the Kubernetes integration,
-# require that Agent Pods interact with Kubernetes APIs. This functionality requires specific permissions
-# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-role-based-access-control
-#
-serviceAccount:
-  name: elastic-agent
-  # { .Release.Namespace } is used here by default, but can be specified.
-  # namespace: optional-namespace
 
 # ServiceAccount to be used by Elastic Fleet Server. Some Fleet Server features (such as autodiscover or Kubernetes module metricsets)
 # require that Fleet Server Pods interact with Kubernetes APIs. This functionality requires specific permissions

--- a/deploy/eck-stack/charts/eck-fleet-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/values.yaml
@@ -74,25 +74,23 @@ policyID: eck-fleet-server
 #
 # http:
 
-# DaemonSet or Deployment specification for Fleet Server.
-# At least one is required of [daemonSet, deployment].
+# Deployment or StatefulSet specification for Fleet Server.
+# At least one is required of [deployment, statefulSet].
 # No default is currently set, refer to https://github.com/elastic/cloud-on-k8s/issues/7429.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-chose-the-deployment-model
 #
 # deployment:
+#   replicas: 1
 #   podTemplate:
 #     spec:
-#       containers:
-#       - name: agent
-#         securityContext:
-#           runAsUser: 0
-# daemonSet:
+#       serviceAccountName: fleet-server
+#       automountServiceAccountToken: true
+#
+# statefulSet:
 #   podTemplate:
 #     spec:
-#       containers:
-#       - name: agent
-#         securityContext:
-#           runAsUser: 0
+#       serviceAccountName: fleet-server
+#       automountServiceAccountToken: true
 
 # Number of revisions to retain to allow rollback in the underlying Deployment.
 # If not set Kubernetes sets this to 10 by default.

--- a/deploy/eck-stack/examples/agent/fleet-agents.yaml
+++ b/deploy/eck-stack/examples/agent/fleet-agents.yaml
@@ -112,10 +112,16 @@ eck-fleet-server:
 
   fullnameOverride: "fleet-server"
 
-  spec:
-    # Agent policy to be used.
-    policyID: eck-fleet-server
-    kibanaRef:
-      name: kibana
-    elasticsearchRefs:
-    - name: elasticsearch
+  deployment:
+    replicas: 1
+    podTemplate:
+      spec:
+        serviceAccountName: fleet-server
+        automountServiceAccountToken: true
+
+  # Agent policy to be used.
+  policyID: eck-fleet-server
+  kibanaRef:
+    name: kibana
+  elasticsearchRefs:
+  - name: elasticsearch


### PR DESCRIPTION
related: #8192 
related: #8264
related: #8248

# Details of suggested change

This is the follow-up to the above PRs, where we are making the eck-fleet-server helm chart consistent in how it handles values that end up within `spec`, and making it backwards compatible.

### Implementation Note

1. The way this is implemented makes the previous behavior (having `.spec.field` in the values take precedence over just `field` in the values.
2. Mixing these 2 forms of values (some in spec in the values file, some not in spec) likely has unpredictable behavior. (for instance setting `spec.http.something`, and also setting `http.somethingElse`)