### PR TITLE
[2.16] Make helm charts consistent with how fields in `spec` are handled. (kibana only) (#8192)

### DIFF
--- a/deploy/eck-stack/charts/eck-kibana/values.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/values.yaml
@@ -24,6 +24,10 @@ version: 8.16.0
 #
 # image: docker.elastic.co/kibana/kibana:8.16.0
 
+# Kibana Docker image to deploy
+#
+# image: docker.elastic.co/kibana/kibana:8.17.0-SNAPSHOT
+
 # Labels that will be applied to Kibana.
 #
 labels: {}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.16`:
 - [Make helm charts consistent with how fields in &#x60;spec&#x60; are handled. (kibana only) (#8192)](https://github.com/elastic/cloud-on-k8s/pull/8192)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)