### PR TITLE
[2.16] Make helm charts consistent with how fields in spec are handled. (agent only) (#8246)

### DIFF
--- a/deploy/eck-stack/charts/eck-agent/examples/fleet-agents.yaml
+++ b/deploy/eck-stack/charts/eck-agent/examples/fleet-agents.yaml
@@ -3,24 +3,22 @@
 #
 version: 8.16.0
 
-spec:
-  # This must match the name of an Agent policy.
-  policyID: eck-agent
-  # This must match the name of the fleet server installed from eck-fleet-server chart.
-  fleetServerRef:
-    name: eck-fleet-server
-  kibanaRef:
-    name: eck-kibana
-  mode: fleet
-  # elasticsearchRefs must be empty when fleet mode is enabled.
-  elasticsearchRefs: []
-
-  daemonSet:
-    podTemplate:
-      spec:
-        serviceAccountName: elastic-agent
-        hostNetwork: true
-        dnsPolicy: ClusterFirstWithHostNet
-        automountServiceAccountToken: true
-        securityContext:
-          runAsUser: 0
+# This must match the name of an Agent policy.
+policyID: eck-agent
+# This must match the name of the fleet server installed from eck-fleet-server chart.
+fleetServerRef:
+  name: eck-fleet-server
+kibanaRef:
+  name: eck-kibana
+mode: fleet
+# elasticsearchRefs must be empty when fleet mode is enabled.
+elasticsearchRefs: []
+daemonSet:
+  podTemplate:
+    spec:
+      serviceAccountName: elastic-agent
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      automountServiceAccountToken: true
+      securityContext:
+        runAsUser: 0

--- a/deploy/eck-stack/charts/eck-agent/examples/system-integration.yaml
+++ b/deploy/eck-stack/charts/eck-agent/examples/system-integration.yaml
@@ -2,133 +2,132 @@
 # and should not be used when Agent is used with Fleet Server.
 #
 version: 8.16.0
-spec:
-  elasticsearchRefs:
-  - name: eck-elasticsearch
-  daemonSet:
-    podTemplate:
-      spec:
-        containers:
-        - name: agent
-          securityContext:
-            runAsUser: 0
-          volumeMounts:
-          - name: agent-data
-            mountPath: /usr/share/elastic-agent/data/elastic-agent-08e204/run
-  config:
-    id: 488e0b80-3634-11eb-8208-57893829af4e
-    revision: 2
-    agent:
-      monitoring:
-        enabled: true
-        use_output: default
-        logs: true
-        metrics: true
-    inputs:
-    - id: 4917ade0-3634-11eb-8208-57893829af4e
-      name: system-1
-      revision: 1
-      type: system/metrics
+elasticsearchRefs:
+- name: eck-elasticsearch
+daemonSet:
+  podTemplate:
+    spec:
+      containers:
+      - name: agent
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: agent-data
+          mountPath: /usr/share/elastic-agent/data/elastic-agent-08e204/run
+config:
+  id: 488e0b80-3634-11eb-8208-57893829af4e
+  revision: 2
+  agent:
+    monitoring:
+      enabled: true
       use_output: default
-      meta:
-        package:
-          name: system
-          version: 8.16.0
+      logs: true
+      metrics: true
+  inputs:
+  - id: 4917ade0-3634-11eb-8208-57893829af4e
+    name: system-1
+    revision: 1
+    type: system/metrics
+    use_output: default
+    meta:
+      package:
+        name: system
+        version: 8.17.0-SNAPSHOT
+    data_stream:
+      namespace: default
+    streams:
+    - id: system/metrics-system.cpu
       data_stream:
-        namespace: default
-      streams:
-      - id: system/metrics-system.cpu
-        data_stream:
-          dataset: system.cpu
-          type: metrics
-        metricsets:
-        - cpu
-        cpu.metrics:
-        - percentages
-        - normalized_percentages
-        period: 10s
-      - id: system/metrics-system.diskio
-        data_stream:
-          dataset: system.diskio
-          type: metrics
-        metricsets:
-        - diskio
-        diskio.include_devices: null
-        period: 10s
-      - id: system/metrics-system.filesystem
-        data_stream:
-          dataset: system.filesystem
-          type: metrics
-        metricsets:
-        - filesystem
-        period: 1m
-        processors:
-        - drop_event.when.regexp:
-            system.filesystem.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
-      - id: system/metrics-system.fsstat
-        data_stream:
-          dataset: system.fsstat
-          type: metrics
-        metricsets:
-        - fsstat
-        period: 1m
-        processors:
-        - drop_event.when.regexp:
-            system.fsstat.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
-      - id: system/metrics-system.load
-        data_stream:
-          dataset: system.load
-          type: metrics
-        metricsets:
-        - load
-        period: 10s
-      - id: system/metrics-system.memory
-        data_stream:
-          dataset: system.memory
-          type: metrics
-        metricsets:
-        - memory
-        period: 10s
-      - id: system/metrics-system.network
-        data_stream:
-          dataset: system.network
-          type: metrics
-        metricsets:
-        - network
-        period: 10s
-        network.interfaces: null
-      - id: system/metrics-system.process
-        data_stream:
-          dataset: system.process
-          type: metrics
-        metricsets:
-        - process
-        period: 10s
-        process.include_top_n.by_cpu: 5
-        process.include_top_n.by_memory: 5
-        process.cmdline.cache.enabled: true
-        process.cgroups.enabled: false
-        process.include_cpu_ticks: false
-        processes:
-        - .*
-      - id: system/metrics-system.process_summary
-        data_stream:
-          dataset: system.process_summary
-          type: metrics
-        metricsets:
-        - process_summary
-        period: 10s
-      - id: system/metrics-system.socket_summary
-        data_stream:
-          dataset: system.socket_summary
-          type: metrics
-        metricsets:
-        - socket_summary
-        period: 10s
-      - id: system/metrics-system.uptime
-        data_stream:
-          dataset: system.uptime
-          type: metrics
-        metricsets:
-        - uptime
-        period: 10s
+        dataset: system.cpu
+        type: metrics
+      metricsets:
+      - cpu
+      cpu.metrics:
+      - percentages
+      - normalized_percentages
+      period: 10s
+    - id: system/metrics-system.diskio
+      data_stream:
+        dataset: system.diskio
+        type: metrics
+      metricsets:
+      - diskio
+      diskio.include_devices: null
+      period: 10s
+    - id: system/metrics-system.filesystem
+      data_stream:
+        dataset: system.filesystem
+        type: metrics
+      metricsets:
+      - filesystem
+      period: 1m
+      processors:
+      - drop_event.when.regexp:
+          system.filesystem.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
+    - id: system/metrics-system.fsstat
+      data_stream:
+        dataset: system.fsstat
+        type: metrics
+      metricsets:
+      - fsstat
+      period: 1m
+      processors:
+      - drop_event.when.regexp:
+          system.fsstat.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
+    - id: system/metrics-system.load
+      data_stream:
+        dataset: system.load
+        type: metrics
+      metricsets:
+      - load
+      period: 10s
+    - id: system/metrics-system.memory
+      data_stream:
+        dataset: system.memory
+        type: metrics
+      metricsets:
+      - memory
+      period: 10s
+    - id: system/metrics-system.network
+      data_stream:
+        dataset: system.network
+        type: metrics
+      metricsets:
+      - network
+      period: 10s
+      network.interfaces: null
+    - id: system/metrics-system.process
+      data_stream:
+        dataset: system.process
+        type: metrics
+      metricsets:
+      - process
+      period: 10s
+      process.include_top_n.by_cpu: 5
+      process.include_top_n.by_memory: 5
+      process.cmdline.cache.enabled: true
+      process.cgroups.enabled: false
+      process.include_cpu_ticks: false
+      processes:
+      - .*
+    - id: system/metrics-system.process_summary
+      data_stream:
+        dataset: system.process_summary
+        type: metrics
+      metricsets:
+      - process_summary
+      period: 10s
+    - id: system/metrics-system.socket_summary
+      data_stream:
+        dataset: system.socket_summary
+        type: metrics
+      metricsets:
+      - socket_summary
+      period: 10s
+    - id: system/metrics-system.uptime
+      data_stream:
+        dataset: system.uptime
+        type: metrics
+      metricsets:
+      - uptime
+      period: 10s

--- a/deploy/eck-stack/charts/eck-agent/templates/elastic-agent.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/elastic-agent.yaml
@@ -11,8 +11,79 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  version: {{ required "An Elastic Agent version is required" .Values.version }}
-  {{- if and (not (hasKey .Values.spec "daemonSet")) (not (hasKey .Values.spec "deployment")) (not (hasKey .Values.spec "statefulSet")) }}
-  {{ fail "At least one of daemonSet or deployment or statefulSet is required" }}
+  version: {{ required "An Elastic Agent version is required" (or ((.Values.spec).version) (.Values.version)) }}
+  {{- $daemonSet := (or (hasKey (.Values.spec) "daemonSet") (hasKey .Values "daemonSet")) }}
+  {{- $deployment := (or (hasKey (.Values.spec) "deployment") (hasKey .Values "deployment")) }}
+  {{- $statefulSet := (or (hasKey (.Values.spec) "statefulSet") (hasKey .Values "statefulSet")) }}
+  {{- if and (not $daemonSet) (not $deployment) (not $statefulSet) }}
+  {{ fail "At least one of daemonSet, deployment or statefulSet is required" }}
   {{- end }}
-  {{- toYaml .Values.spec | nindent 2 }}
+  {{- if $daemonSet }}
+  {{- $ds := or ((.Values.spec).daemonSet) (.Values.daemonSet) }}
+  daemonSet:
+    {{- /* This is required to render the empty daemonset ( {} ) properly */}}
+    {{- $ds | default dict | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if $deployment }}
+  {{- $deploy := or ((.Values.spec).deployment) (.Values.deployment) }}
+  deployment:
+    {{- /* This is required to render the empty deployment ( {} ) properly */}}
+    {{- $deploy | default dict | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if $statefulSet }}
+  {{- $sts := or ((.Values.spec).statefulSet) (.Values.statefulSet) }}
+  statefulSet:
+    {{- /* This is required to render the empty statefulSet ( {} ) properly */}}
+    {{- $sts | default dict | toYaml | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).image) (.Values.image) }}
+  image: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).elasticsearchRefs) (.Values.elasticsearchRefs) }}
+  elasticsearchRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).kibanaRef) (.Values.kibanaRef) }}
+  kibanaRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).fleetServerRef) (.Values.fleetServerRef) }}
+  fleetServerRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- $config := or ((.Values.spec).config) (.Values.config) }}
+  {{- $configRef := or ((.Values.spec).configRef) (.Values.configRef) }}
+  {{- if and $config $configRef }}
+  {{ fail "Only one of config and configRef can be specified" }}
+  {{- end }}
+  {{- with $config }}
+  config:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $configRef }}
+  configRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).mode) (.Values.mode) }}
+  mode: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).fleetServerEnabled) (.Values.fleetServerEnabled) }}
+  fleetServerEnabled: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).http) (.Values.http) }}
+  http:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).policyID) (.Values.policyID) }}
+  policyID: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).secureSettings) (.Values.secureSettings) }}
+  secureSettings:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).revisionHistoryLimit) (.Values.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with or (((.Values.spec).serviceAccount).name) ((.Values.serviceAccount).name) }}
+  serviceAccountName: {{ . }}
+  {{- end }}

--- a/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent_test.yaml
@@ -58,3 +58,162 @@ tests:
           value:
             eck.k8s.elastic.co/license: basic
             test: annotation
+  - it: should render properly when using spec fields
+    set:
+      spec:
+        daemonSet: {}
+        elasticsearchRefs:
+        - name: eck-elasticsearch
+          namespace: default
+        kibanaRef:
+          name: eck-kibana
+          namespace: default
+        fleetServerRef:
+          name: eck-fleet-server
+          namespace: default
+        config:
+          agent:
+            monitoring:
+              enabled: true
+        mode: fleet
+        fleetServerEnabled: true
+        http:
+          service:
+            spec:
+              type: ClusterIP
+        policyID: eck-agent
+        secureSettings:
+        - secretName: eck-agent-secret
+        revisionHistoryLimit: 4
+        serviceAccount:
+          name: elastic-agent
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Agent
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: quickstart
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: eck-agent
+            helm.sh/chart: eck-agent-0.14.0-SNAPSHOT
+      - equal:
+          path: spec
+          value:
+            version: 8.17.0-SNAPSHOT
+            daemonSet: {}
+            elasticsearchRefs:
+            - name: eck-elasticsearch
+              namespace: default
+            kibanaRef:
+              name: eck-kibana
+              namespace: default
+            fleetServerRef:
+              name: eck-fleet-server
+              namespace: default
+            config:
+              agent:
+                monitoring:
+                  enabled: true
+            mode: fleet
+            fleetServerEnabled: true
+            http:
+              service:
+                spec:
+                  type: ClusterIP
+            policyID: eck-agent
+            secureSettings:
+            - secretName: eck-agent-secret
+            revisionHistoryLimit: 4
+            serviceAccountName: elastic-agent
+  - it: should render properly when not using spec fields
+    set:
+      daemonSet: {}
+      elasticsearchRefs:
+      - name: eck-elasticsearch
+        namespace: default
+      kibanaRef:
+        name: eck-kibana
+        namespace: default
+      fleetServerRef:
+        name: eck-fleet-server
+        namespace: default
+      config:
+        agent:
+          monitoring:
+            enabled: true
+      mode: fleet
+      fleetServerEnabled: true
+      http:
+        service:
+          spec:
+            type: ClusterIP
+      policyID: eck-agent
+      secureSettings:
+      - secretName: eck-agent-secret
+      revisionHistoryLimit: 4
+      serviceAccount:
+        name: elastic-agent
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Agent
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: quickstart
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: eck-agent
+            helm.sh/chart: eck-agent-0.14.0-SNAPSHOT
+      - equal:
+          path: spec
+          value:
+            version: 8.17.0-SNAPSHOT
+            daemonSet: {}
+            elasticsearchRefs:
+            - name: eck-elasticsearch
+              namespace: default
+            kibanaRef:
+              name: eck-kibana
+              namespace: default
+            fleetServerRef:
+              name: eck-fleet-server
+              namespace: default
+            config:
+              agent:
+                monitoring:
+                  enabled: true
+            mode: fleet
+            fleetServerEnabled: true
+            http:
+              service:
+                spec:
+                  type: ClusterIP
+            policyID: eck-agent
+            secureSettings:
+            - secretName: eck-agent-secret
+            revisionHistoryLimit: 4
+            serviceAccountName: elastic-agent
+  - it: not setting version should fail
+    set:
+      version: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "An Elastic Agent version is required"
+  - it: not setting any daemonset, deployment or statefulset should fail
+    asserts:
+      - failedTemplate:
+          errorMessage: "At least one of daemonSet, deployment or statefulSet is required"
+  - it: setting both config and configRef should fail
+    set:
+      deployment: {}
+      config:
+        something: here
+      configRef:
+        secretName: "elastic-agent"
+    asserts:
+      - failedTemplate:
+          errorMessage: "Only one of config and configRef can be specified"

--- a/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent_test.yaml
@@ -98,11 +98,11 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
-            helm.sh/chart: eck-agent-0.14.0-SNAPSHOT
+            helm.sh/chart: eck-agent-0.14.0
       - equal:
           path: spec
           value:
-            version: 8.17.0-SNAPSHOT
+            version: 8.17.0
             daemonSet: {}
             elasticsearchRefs:
             - name: eck-elasticsearch
@@ -167,11 +167,11 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-agent
-            helm.sh/chart: eck-agent-0.14.0-SNAPSHOT
+            helm.sh/chart: eck-agent-0.14.0
       - equal:
           path: spec
           value:
-            version: 8.17.0-SNAPSHOT
+            version: 8.17.0
             daemonSet: {}
             elasticsearchRefs:
             - name: eck-elasticsearch

--- a/deploy/eck-stack/charts/eck-agent/values.yaml
+++ b/deploy/eck-stack/charts/eck-agent/values.yaml
@@ -28,74 +28,122 @@ labels: {}
 #
 annotations: {}
 
-spec:
-  # policyID determines into which Agent Policy this Agent will be enrolled.
-  # policyID: eck-agent
+# Elastic Agent image to deploy.
+#
+# image: docker.elastic.co/beats/elastic-agent:8.17.0-SNAPSHOT
 
-  # Referenced resources are below and depending on the setup, at least one is required for a functional Agent.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-setting-referenced-resources
-  #
-  # Reference to ECK-managed Kibana instance.
-  #
-  # kibanaRef:
-  #   name: quickstart
-    # Optional namespace reference to Kibana instance.
-    # If not specified, then the namespace of the Agent instance
-    # will be assumed.
-    #
-    # namespace: default
+# ** Deprecation Notice **
+# The previous versions of this Helm Chart simply used the `spec` field here
+# and allowed the user to specify any fields below `spec` that were templated directly
+# into the final Kibana manifest. This is no longer the preferred way to specify these
+# fields and each field that is supported underneath `spec` is now directly specified
+# in this values file. Currently both patterns are supported for backwards compatibility
+# but we plan to remove the `spec` field in the future.
+# spec: {}
 
-  # Reference to ECK-managed Elasticsearch instance.
+# Referenced resources are below and depending on the setup, at least one is required for a functional Agent.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-setting-referenced-resources
+#
+# Reference to ECK-managed Kibana instance.
+#
+# kibanaRef:
+#   name: quickstart
+  # Optional namespace reference to Kibana instance.
+  # If not specified, then the namespace of the Agent instance
+  # will be assumed.
   #
-  elasticsearchRefs:
-  - name: eck-elasticsearch
-    # Optional namespace reference to Elasticsearch instance.
-    # If not specified, then the namespace of the Agent instance
-    # will be assumed.
-    #
-    # namespace: default
+  # namespace: default
+
+# Reference to ECK-managed Elasticsearch instance.
+#
+elasticsearchRefs:
+- name: eck-elasticsearch
+  # Optional namespace reference to Elasticsearch instance.
+  # If not specified, then the namespace of the Agent instance
+  # will be assumed.
+  #
+  # namespace: default
+
+# Reference to ECK-managed Fleet Server instance.
+#
+# fleetServerRef:
+#   name: eck-fleet-server
+  # Optional namespace reference to Fleet Server instance.
+  # If not specified, then the namespace of the Agent instance
+  # will be assumed.
+  #
+  # namespace: default
+
+# The Elastic Agent configuration, the ECK equivalent to agent.yml
+# NOTE: The `config` and `configRef` fields are mutually exclusive. Only one of them should be defined at a time,
+# as using both may cause conflicts.
+#
+# Configuration of Agent, specifically used in Agent standalone mode.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-configuration.html
+#
+config: null
+
+# Reference a configuration in a Secret.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-configuration.html
+#
+# configRef:
+#   secretName: ""
+
+# The mode of Agent to use. Only set to "fleet" when Fleet Server is enabled.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-fleet-mode-and-fleet-server
+#
+# mode: "fleet"
+
+# fleetServerEnabled determines whether the Agent will be run as the Fleet Server.
+#
+# NOTE: Both `mode: fleet` and `fleetServerEnabled: true` need to be set for Fleet Server to be enabled.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-fleet-mode-and-fleet-server
+#
+fleetServerEnabled: false
+
+# The HTTP layer configuration for the Fleet Server Service.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-customize-fleet-server-service
+#
+# http:
+
+# policyID determines into which Agent Policy this Agent will be enrolled.
+# policyID: eck-agent
   
-  # Reference to ECK-managed Fleet Server instance.
-  #
-  # fleetServerRef:
-  #   name: eck-fleet-server
-    # Optional namespace reference to Fleet Server instance.
-    # If not specified, then the namespace of the Agent instance
-    # will be assumed.
-    #
-    # namespace: default
+# DaemonSet, StatefulSet, or Deployment specification for Agent.
+# At least one is required of [daemonSet, deployment, statefulSet].
+# No default is currently set, refer to https://github.com/elastic/cloud-on-k8s/issues/7429.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-chose-the-deployment-model
+#
+# deployment:
+#   podTemplate:
+#     spec:
+#       containers:
+#       - name: agent
+#         securityContext:
+#           runAsUser: 0
+# daemonSet:
+#   podTemplate:
+#     spec:
+#       containers:
+#       - name: agent
+#         securityContext:
+#           runAsUser: 0
+# statefulSet:
+#   podTemplate:
+#     spec:
+#       containers:
+#       - name: agent
+#         securityContext:
+#           runAsUser: 0
 
-  # DaemonSet, StatefulSet, or Deployment specification for Agent.
-  # At least one is required of [daemonSet, deployment, statefulSet].
-  # No default is currently set, refer to https://github.com/elastic/cloud-on-k8s/issues/7429.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-chose-the-deployment-model
-  #
-  # deployment:
-  #   podTemplate:
-  #     spec:
-  #       containers:
-  #       - name: agent
-  #         securityContext:
-  #           runAsUser: 0
-  # daemonSet:
-  #   podTemplate:
-  #     spec:
-  #       containers:
-  #       - name: agent
-  #         securityContext:
-  #           runAsUser: 0
-  # statefulSet:
-  #   podTemplate:
-  #     spec:
-  #       containers:
-  #       - name: agent
-  #         securityContext:
-  #           runAsUser: 0
+# SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for Elastic Agent.
+secureSettings: []
+# - secretName: my-secret-with-secure-settings
 
-  # Configuration of Agent, specifically used in Agent standalone mode.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent.html
-  #
-  config: null
+# Number of revisions to retain to allow rollback in the underlying Deployment.
+# If not set Kubernetes sets this to 10 by default.
+#
+# revisionHistoryLimit: 2
 
 # ServiceAccount to be used by Elastic Agent. Some Elastic Agent features, such as the Kubernetes integration,
 # require that Agent Pods interact with Kubernetes APIs. This functionality requires specific permissions

--- a/deploy/eck-stack/examples/agent/fleet-agents.yaml
+++ b/deploy/eck-stack/examples/agent/fleet-agents.yaml
@@ -80,32 +80,28 @@ eck-kibana:
 eck-agent:
   enabled: true
   
-  spec:
-    # Agent policy to be used.
-    policyID: eck-agent
-    # Reference to ECK-managed Kibana instance.
-    #
-    kibanaRef:
-      name: kibana
-
-    elasticsearchRefs: []
-
-    # Reference to ECK-managed Fleet instance.
-    #
-    fleetServerRef:
-      name: fleet-server
-    
-    mode: fleet
-
-    daemonSet:
-      podTemplate:
-        spec:
-          serviceAccountName: elastic-agent
-          hostNetwork: true
-          dnsPolicy: ClusterFirstWithHostNet
-          automountServiceAccountToken: true
-          securityContext:
-            runAsUser: 0
+  # Agent policy to be used.
+  policyID: eck-agent
+  # Reference to ECK-managed Kibana instance.
+  #
+  kibanaRef:
+    name: kibana
+  elasticsearchRefs: []
+  # Reference to ECK-managed Fleet instance.
+  #
+  fleetServerRef:
+    name: fleet-server
+  
+  mode: fleet
+  daemonSet:
+    podTemplate:
+      spec:
+        serviceAccountName: elastic-agent
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
+        automountServiceAccountToken: true
+        securityContext:
+          runAsUser: 0
   
 eck-fleet-server:
   enabled: true

--- a/deploy/eck-stack/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-stack/templates/tests/elastic-agent_test.yaml
@@ -34,6 +34,9 @@ tests:
           path: spec.version
           value: 8.16.0
       - equal:
+          path: spec.elasticsearchRefs
+          value: null
+      - equal:
           path: spec.kibanaRef.name
           value: kibana
       - equal:
@@ -56,55 +59,4 @@ tests:
           value: true
       - equal:
           path: spec.daemonSet.podTemplate.spec.securityContext.runAsUser
-          value: 0
----
-suite: test fleet-agent
-templates:
-  - charts/eck-fleet-server/templates/fleet-server.yaml
-tests:
-  - it: should render quickstart properly
-    set:
-      eck-agent.enabled: true
-    release:
-      name: quickstart
-    asserts:
-      - isKind:
-          of: Agent
-      - equal:
-          path: metadata.name
-          value: quickstart-eck-fleet-server
-      - equal:
-          path: spec.version
-          value: 8.16.0
-  - it: should render fleet server in custom fleet example properly
-    values:
-      - ../../examples/agent/fleet-agents.yaml
-    release:
-      name: quickstart
-    asserts:
-      - isKind:
-          of: Agent
-      - equal:
-          path: metadata.name
-          value: fleet-server
-      - equal:
-          path: spec.version
-          value: 8.16.0
-      - equal:
-          path: spec.kibanaRef.name
-          value: kibana
-      - equal:
-          path: spec.mode
-          value: fleet
-      - equal:
-          path: spec.fleetServerEnabled
-          value: true
-      - equal:
-          path: spec.deployment.podTemplate.spec.serviceAccountName
-          value: fleet-server
-      - equal:
-          path: spec.deployment.podTemplate.spec.automountServiceAccountToken
-          value: true
-      - equal:
-          path: spec.deployment.podTemplate.spec.securityContext.runAsUser
           value: 0

--- a/deploy/eck-stack/templates/tests/elastic-fleet-agent_test.yaml
+++ b/deploy/eck-stack/templates/tests/elastic-fleet-agent_test.yaml
@@ -1,0 +1,50 @@
+---
+suite: test fleet-agent
+templates:
+  - charts/eck-fleet-server/templates/fleet-server.yaml
+tests:
+  - it: should render quickstart properly
+    set:
+      eck-agent.enabled: true
+      eck-fleet-server.enabled: true
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Agent
+      - equal:
+          path: metadata.name
+          value: quickstart-eck-fleet-server
+      - equal:
+          path: spec.version
+          value: 8.17.0-SNAPSHOT
+  - it: should render fleet server in custom fleet example properly
+    values:
+      - ../../examples/agent/fleet-agents.yaml
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Agent
+      - equal:
+          path: metadata.name
+          value: fleet-server
+      - equal:
+          path: spec
+          value: 
+            version: 8.17.0-SNAPSHOT
+            kibanaRef:
+              name: kibana
+            elasticsearchRefs:
+              - name: elasticsearch
+            mode: fleet
+            fleetServerEnabled: true
+            policyID: eck-fleet-server
+            deployment:
+              replicas: 1
+              podTemplate:
+                spec:
+                  serviceAccountName: fleet-server
+                  automountServiceAccountToken: true
+                  securityContext:
+                    runAsUser: 0

--- a/deploy/eck-stack/templates/tests/elastic-fleet-agent_test.yaml
+++ b/deploy/eck-stack/templates/tests/elastic-fleet-agent_test.yaml
@@ -17,7 +17,7 @@ tests:
           value: quickstart-eck-fleet-server
       - equal:
           path: spec.version
-          value: 8.17.0-SNAPSHOT
+          value: 8.17.0
   - it: should render fleet server in custom fleet example properly
     values:
       - ../../examples/agent/fleet-agents.yaml
@@ -32,7 +32,7 @@ tests:
       - equal:
           path: spec
           value: 
-            version: 8.17.0-SNAPSHOT
+            version: 8.17.0
             kibanaRef:
               name: kibana
             elasticsearchRefs:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.16`:
 - [Make helm charts consistent with how fields in spec are handled. (agent only) (#8246)](https://github.com/elastic/cloud-on-k8s/pull/8246)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)