### PR TITLE
[2.16] Fix stack version in Helm Charts to 8.17.0 in 2.16 branch.

### DIFF
--- a/deploy/eck-stack/charts/eck-agent/examples/fleet-agents.yaml
+++ b/deploy/eck-stack/charts/eck-agent/examples/fleet-agents.yaml
@@ -1,7 +1,7 @@
 # The following example should only be used in conjunction with the 'eck-fleet-server' Helm Chart,
 # and shows how the Agents can be deployed as a daemonset, and controlled by Fleet Server.
 #
-version: 8.16.0
+version: 8.17.0
 
 spec:
   # This must match the name of an Agent policy.

--- a/deploy/eck-stack/charts/eck-agent/examples/system-integration.yaml
+++ b/deploy/eck-stack/charts/eck-agent/examples/system-integration.yaml
@@ -1,7 +1,7 @@
 # The following example should only be used in Agent "standalone" mode,
 # and should not be used when Agent is used with Fleet Server.
 #
-version: 8.16.0
+version: 8.17.0
 spec:
   elasticsearchRefs:
   - name: eck-elasticsearch
@@ -33,7 +33,7 @@ spec:
       meta:
         package:
           name: system
-          version: 8.16.0
+          version: 8.17.0
       data_stream:
         namespace: default
       streams:

--- a/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-stack/charts/eck-agent/templates/tests/elastic-agent_test.yaml
@@ -22,7 +22,7 @@ tests:
           value: quickstart-eck-agent
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
       - equal:
           path: spec.config
           value: null

--- a/deploy/eck-stack/charts/eck-agent/values.yaml
+++ b/deploy/eck-stack/charts/eck-agent/values.yaml
@@ -18,7 +18,7 @@
 
 # Version of Elastic Agent.
 #
-version: 8.16.0
+version: 8.17.0
 
 # Labels that will be applied to Elastic Agent.
 #

--- a/deploy/eck-stack/charts/eck-apm-server/examples/jaeger-with-http-configuration.yaml
+++ b/deploy/eck-stack/charts/eck-apm-server/examples/jaeger-with-http-configuration.yaml
@@ -1,7 +1,7 @@
 ---
 # Version of APM Server.
 #
-version: 8.16.0
+version: 8.17.0
 
 # Count of APM Server replicas to create.
 #

--- a/deploy/eck-stack/charts/eck-apm-server/templates/tests/apmserver_test.yaml
+++ b/deploy/eck-stack/charts/eck-apm-server/templates/tests/apmserver_test.yaml
@@ -16,7 +16,7 @@ tests:
           value: quickstart-eck-apm-server
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
   - it: name override should work properly
     set:
       nameOverride: override
@@ -84,7 +84,7 @@ tests:
           value: quickstart-eck-apm-server
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
       - equal:
           path: spec.count
           value: 1

--- a/deploy/eck-stack/charts/eck-apm-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-apm-server/values.yaml
@@ -18,7 +18,7 @@
 
 # Version of APM Server.
 #
-version: 8.16.0
+version: 8.17.0
 
 # APM Server Docker image to deploy
 #

--- a/deploy/eck-stack/charts/eck-beats/examples/auditbeat_hosts.yaml
+++ b/deploy/eck-stack/charts/eck-beats/examples/auditbeat_hosts.yaml
@@ -1,5 +1,5 @@
 name: auditbeat
-version: 8.16.0
+version: 8.17.0
 spec:
   type: auditbeat
   elasticsearchRef:

--- a/deploy/eck-stack/charts/eck-beats/examples/filebeat_no_autodiscover.yaml
+++ b/deploy/eck-stack/charts/eck-beats/examples/filebeat_no_autodiscover.yaml
@@ -1,5 +1,5 @@
 name: filebeat
-version: 8.16.0
+version: 8.17.0
 spec:
   type: filebeat
   elasticsearchRef:

--- a/deploy/eck-stack/charts/eck-beats/examples/heartbeat_es_kb_health.yaml
+++ b/deploy/eck-stack/charts/eck-beats/examples/heartbeat_es_kb_health.yaml
@@ -1,5 +1,5 @@
 name: heartbeat
-version: 8.16.0
+version: 8.17.0
 spec:
   type: heartbeat
   elasticsearchRef:

--- a/deploy/eck-stack/charts/eck-beats/examples/metricbeat_hosts.yaml
+++ b/deploy/eck-stack/charts/eck-beats/examples/metricbeat_hosts.yaml
@@ -1,7 +1,7 @@
 name: metricbeat
 spec:
   type: metricbeat
-  version: 8.16.0
+  version: 8.17.0
   elasticsearchRef:
     name: eck-elasticsearch
   kibanaRef:

--- a/deploy/eck-stack/charts/eck-beats/examples/packetbeat_dns_http.yaml
+++ b/deploy/eck-stack/charts/eck-beats/examples/packetbeat_dns_http.yaml
@@ -1,7 +1,7 @@
 name: packetbeat
 spec:
   type: packetbeat
-  version: 8.16.0
+  version: 8.17.0
   elasticsearchRef:
     name: eck-elasticsearch
   kibanaRef:

--- a/deploy/eck-stack/charts/eck-beats/templates/tests/beats_test.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/tests/beats_test.yaml
@@ -17,7 +17,7 @@ tests:
           value: quickstart-eck-beats
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
       - equal:
           path: spec.type
           value: filebeat

--- a/deploy/eck-stack/charts/eck-beats/values.yaml
+++ b/deploy/eck-stack/charts/eck-beats/values.yaml
@@ -18,7 +18,7 @@
 
 # Version of Elastic Beats.
 #
-version: 8.16.0
+version: 8.17.0
 
 # Labels that will be applied to Elastic Beats.
 #

--- a/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/templates/tests/elasticsearch_test.yaml
@@ -207,11 +207,11 @@ tests:
           value: my.regis.try/es:8
   - it: should render image properly
     set:
-      image: my.registry.com/elastic/elasticsearch:8.16.0
+      image: my.registry.com/elastic/elasticsearch:8.17.0
     asserts:
       - equal:
           path: spec.image
-          value: my.registry.com/elastic/elasticsearch:8.16.0
+          value: my.registry.com/elastic/elasticsearch:8.17.0
   - it: should render no podDisruptionBudget by default
     set:
     asserts:

--- a/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
+++ b/deploy/eck-stack/charts/eck-elasticsearch/values.yaml
@@ -18,7 +18,7 @@
 
 # Version of Elasticsearch.
 #
-version: 8.16.0
+version: 8.17.0
 
 # Elasticsearch Docker image to deploy
 #

--- a/deploy/eck-stack/charts/eck-enterprise-search/templates/tests/entsearch_test.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/templates/tests/entsearch_test.yaml
@@ -16,7 +16,7 @@ tests:
           value: quickstart-eck-enterprise-search
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
   - it: name override should work properly
     set:
       nameOverride: override
@@ -84,7 +84,7 @@ tests:
           value: quickstart-eck-enterprise-search
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
       - equal:
           path: spec.count
           value: 1

--- a/deploy/eck-stack/charts/eck-enterprise-search/values.yaml
+++ b/deploy/eck-stack/charts/eck-enterprise-search/values.yaml
@@ -18,7 +18,7 @@
 
 # Version of Enterprise Search.
 #
-version: 8.16.0
+version: 8.17.0
 
 # Enterprise Search Docker image to deploy
 #

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
@@ -13,7 +13,7 @@ tests:
           value: quickstart-eck-fleet-server
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
       - equal:
           path: spec.kibanaRef.name
           value: eck-kibana

--- a/deploy/eck-stack/charts/eck-fleet-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/values.yaml
@@ -18,7 +18,7 @@
 
 # Version of Elastic Fleet Server.
 #
-version: 8.16.0
+version: 8.17.0
 
 # Labels that will be applied to Elastic Fleet Server.
 #

--- a/deploy/eck-stack/charts/eck-kibana/examples/http-configuration.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/examples/http-configuration.yaml
@@ -1,7 +1,7 @@
 ---
 # Version of Kibana.
 #
-version: 8.16.0
+version: 8.17.0
 
 # Labels that will be applied to Kibana.
 #

--- a/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/templates/tests/kibana_test.yaml
@@ -15,7 +15,7 @@ tests:
           value: quickstart-eck-kibana
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
       - equal:
           path: spec.count
           value: 1
@@ -84,7 +84,7 @@ tests:
           value: quickstart-eck-kibana
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
       - equal:
           path: spec.count
           value: 1
@@ -102,7 +102,7 @@ tests:
       spec:
         elasticsearchRef:
           name: eck-elasticsearch
-        image: quay.io/elastic/kibana:8.16.0
+        image: quay.io/elastic/kibana:8.17.0
     release:
       name: quickstart
     asserts:
@@ -110,13 +110,13 @@ tests:
           of: Kibana
       - equal:
           path: spec.image
-          value: quay.io/elastic/kibana:8.16.0
+          value: quay.io/elastic/kibana:8.17.0
   - it: values.image should work properly
     set:
       spec:
         elasticsearchRef:
           name: eck-elasticsearch
-      image: quay.io/elastic/kibana:8.16.0
+      image: quay.io/elastic/kibana:8.17.0
     release:
       name: quickstart
     asserts:
@@ -124,7 +124,7 @@ tests:
           of: Kibana
       - equal:
           path: spec.image
-          value: quay.io/elastic/kibana:8.16.0
+          value: quay.io/elastic/kibana:8.17.0
   - it: not setting elasticsearchRef should fail
     asserts:
       - failedTemplate:

--- a/deploy/eck-stack/charts/eck-kibana/values.yaml
+++ b/deploy/eck-stack/charts/eck-kibana/values.yaml
@@ -18,11 +18,11 @@
 
 # Version of Kibana.
 #
-version: 8.16.0
+version: 8.17.0
 
 # Kibana Docker image to deploy
 #
-# image: docker.elastic.co/kibana/kibana:8.16.0
+# image: docker.elastic.co/kibana/kibana:8.17.0
 
 # Labels that will be applied to Kibana.
 #

--- a/deploy/eck-stack/charts/eck-logstash/examples/basic-eck.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/examples/basic-eck.yaml
@@ -1,6 +1,6 @@
 ---
 # values corresponding to config/recipes/logstash/logstash-eck.yaml
-version: 8.16.0
+version: 8.17.0
 
 elasticsearchRefs:
   - clusterName: eck

--- a/deploy/eck-stack/charts/eck-logstash/examples/es-role.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/examples/es-role.yaml
@@ -1,6 +1,6 @@
 ---
 # values corresponding to config/recipes/logstash/logstash-es-role.yaml
-version: 8.16.0
+version: 8.17.0
 
 elasticsearchRefs:
   - clusterName: eck

--- a/deploy/eck-stack/charts/eck-logstash/examples/monitored.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/examples/monitored.yaml
@@ -1,6 +1,6 @@
 ---
 # values corresponding to config/recipes/logstash/logstash-monitored.yaml
-version: 8.16.0
+version: 8.17.0
 
 monitoring:
   metrics:

--- a/deploy/eck-stack/charts/eck-logstash/examples/multi.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/examples/multi.yaml
@@ -1,6 +1,6 @@
 ---
 # values corresponding to config/recipes/logstash/logstash-multi.yaml
-version: 8.16.0
+version: 8.17.0
 
 pipelines:
   - pipeline.id: main

--- a/deploy/eck-stack/charts/eck-logstash/examples/volumes.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/examples/volumes.yaml
@@ -1,6 +1,6 @@
 ---
 # values corresponding to config/recipes/logstash/logstash-volumes.yaml
-version: 8.16.0
+version: 8.17.0
 
 config:
   log.level: info

--- a/deploy/eck-stack/charts/eck-logstash/templates/tests/logstash_test.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/templates/tests/logstash_test.yaml
@@ -165,7 +165,7 @@ tests:
       - equal:
           path: spec
           value:
-            version: 8.16.0
+            version: 8.17.0
             count: 1
             pipelinesRef:
               secretName: pipelineLogstashSecretName

--- a/deploy/eck-stack/charts/eck-logstash/values.yaml
+++ b/deploy/eck-stack/charts/eck-logstash/values.yaml
@@ -18,7 +18,7 @@
 
 # Version of Logstash.
 #
-version: 8.16.0
+version: 8.17.0
 
 # Logstash Docker image to deploy
 #

--- a/deploy/eck-stack/examples/beats/metricbeat_hosts.yaml
+++ b/deploy/eck-stack/examples/beats/metricbeat_hosts.yaml
@@ -7,7 +7,7 @@ eck-elasticsearch:
 
   # Version of Elasticsearch.
   #
-  version: 8.16.0
+  version: 8.17.0
 
   nodeSets:
   - name: default
@@ -41,7 +41,7 @@ eck-kibana:
   
   # Version of Kibana.
   #
-  version: 8.16.0
+  version: 8.17.0
   
   spec:
     # Count of Kibana replicas to create.
@@ -58,7 +58,7 @@ eck-beats:
   name: metricbeat
   spec:
     type: metricbeat
-    version: 8.16.0
+    version: 8.17.0
     elasticsearchRef:
       name: quickstart
     kibanaRef:

--- a/deploy/eck-stack/examples/custom-elasticsearch-kibana.yaml
+++ b/deploy/eck-stack/examples/custom-elasticsearch-kibana.yaml
@@ -6,7 +6,7 @@ eck-elasticsearch:
 
   # Version of Elasticsearch.
   #
-  version: 8.16.0
+  version: 8.17.0
 
   nodeSets:
   - name: default
@@ -38,7 +38,7 @@ eck-kibana:
   
   # Version of Kibana.
   #
-  version: 8.16.0
+  version: 8.17.0
   
   spec:
     # Count of Kibana replicas to create.

--- a/deploy/eck-stack/templates/tests/beats_test.yaml
+++ b/deploy/eck-stack/templates/tests/beats_test.yaml
@@ -19,7 +19,7 @@ tests:
           value: quickstart-eck-beats
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
   - it: should render custom metricbeat example properly
     values:
       - ../../examples/beats/metricbeat_hosts.yaml
@@ -33,7 +33,7 @@ tests:
           value: quickstart-eck-beats
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
       - equal:
           path: spec.kibanaRef.name
           value: quickstart

--- a/deploy/eck-stack/templates/tests/elastic-agent_test.yaml
+++ b/deploy/eck-stack/templates/tests/elastic-agent_test.yaml
@@ -18,7 +18,7 @@ tests:
           value: quickstart-eck-agent
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
   - it: should render agent in custom fleet example properly
     values:
       - ../../examples/agent/fleet-agents.yaml
@@ -32,7 +32,7 @@ tests:
           value: quickstart-eck-agent
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
       - equal:
           path: spec.kibanaRef.name
           value: kibana
@@ -75,7 +75,7 @@ tests:
           value: quickstart-eck-fleet-server
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
   - it: should render fleet server in custom fleet example properly
     values:
       - ../../examples/agent/fleet-agents.yaml
@@ -89,7 +89,7 @@ tests:
           value: fleet-server
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
       - equal:
           path: spec.kibanaRef.name
           value: kibana

--- a/deploy/eck-stack/templates/tests/elasticsearch_test.yaml
+++ b/deploy/eck-stack/templates/tests/elasticsearch_test.yaml
@@ -4,7 +4,7 @@ templates:
 tests:
   - it: should render quickstart properly
     set:
-      eck-elasticsearch.version: 8.16.0
+      eck-elasticsearch.version: 8.17.0
       eck-kibana.enabled: false
     release:
       name: quickstart
@@ -16,7 +16,7 @@ tests:
           value: elasticsearch
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
   - it: name override should work properly
     set:
       eck-elasticsearch.nameOverride: override

--- a/deploy/eck-stack/templates/tests/kibana_test.yaml
+++ b/deploy/eck-stack/templates/tests/kibana_test.yaml
@@ -13,7 +13,7 @@ tests:
           value: quickstart-eck-kibana
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
   - it: name override should work properly
     set:
       eck-kibana.nameOverride: override
@@ -51,7 +51,7 @@ tests:
           value: quickstart
       - equal:
           path: spec.version
-          value: 8.16.0
+          value: 8.17.0
       - equal:
           path: spec.count
           value: 1


### PR DESCRIPTION
In https://github.com/elastic/cloud-on-k8s/pull/8252/files the helm chart's stack versions were improperly adjusted to 8.16.0, NOT 8.17.0.  I noticed this when dealing with this backport: https://github.com/elastic/cloud-on-k8s/pull/8292#issuecomment-2518452608.

*Note: this is merging into `2.16` branch, not `main`.*