### PR TITLE
fix suggested jmap command

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/elasticsearch/jvm-heap-dumps.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/elasticsearch/jvm-heap-dumps.asciidoc
@@ -20,7 +20,7 @@ To take a heap dump before the JVM process runs out of memory you can execute th
 [source,sh,subs="attributes,+macros"]
 ----
 kubectl exec $POD_NAME -- su elasticsearch -g root -c \
-  '/usr/share/elasticsearch/jdk/bin/jmap -dump:format=b,file=data/heap.hprof $(pgrep java)'
+  '/usr/share/elasticsearch/jdk/bin/jmap -dump:format=b,file=data/heap.hprof $(pgrep -n java)'
 ----
 
 If the Elasticsearch container is running with a random user ID, as for example on OpenShift, there is no need to substitute the user identity:
@@ -28,7 +28,7 @@ If the Elasticsearch container is running with a random user ID, as for example 
 [source,sh,subs="attributes,+macros"]
 ----
 kubectl exec $POD_NAME -- bash -c \
-  '/usr/share/elasticsearch/jdk/bin/jmap -dump:format=b,file=data/heap.hprof $(pgrep java)'
+  '/usr/share/elasticsearch/jdk/bin/jmap -dump:format=b,file=data/heap.hprof $(pgrep -n java)'
 ----
 
 == Extracting heap dumps from the Elasticsearch container


### PR DESCRIPTION
selecting the most recently started java process as more than one java process can run in the container.
It shouldn't hurt on ES version where a single java process is running, if any.

```
elasticsearch@elasticsearch-es-hot-0:~$ ps -ef | grep java
elastic+       7       1  0 Nov22 ?        00:11:47 /usr/share/elasticsearch/jdk/bin/java -Xms4m -Xmx64m -XX:+UseSerialGC -Dcli.name=server -Dcli.script=/usr/share/elasticsearch/bin/elasticsearch -Dcli.libs=lib/tools/server-cli -Des.path.home=/usr/share/elasticsearch -Des.path.conf=/usr/share/elasticsearch/config -Des.distribution.type=docker -cp /usr/share/elasticsearch/lib/*:/usr/share/elasticsearch/lib/cli-launcher/* org.elasticsearch.launcher.CliToolLauncher
elastic+      66       7 40 Nov22 ?        4-21:19:25 /usr/share/elasticsearch/jdk/bin/java -Des.networkaddress.cache.ttl=60 -Des.networkaddress.cache.negative.ttl=10 -Djava.security.manager=allow -XX:+AlwaysPreTouch -Xss1m -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Djna.nosys=true -XX:-OmitStackTraceInFastThrow -Dio.netty.noUnsafe=true -Dio.netty.noKeySetOptimization=true -Dio.netty.recycler.maxCapacityPerThread=0 -Dlog4j.shutdownHookEnabled=false -Dlog4j2.disable.jmx=true -Dlog4j2.formatMsgNoLookups=true -Djava.locale.providers=CLDR --enable-native-access=org.elasticsearch.nativeaccess,org.apache.lucene.core -Des.cgroups.hierarchy.override=/ -XX:ReplayDataFile=logs/replay_pid%p.log -Des.distribution.type=docker -XX:+UseG1GC -Djava.io.tmpdir=/tmp/elasticsearch-9732793018443531440 --add-modules=jdk.incubator.vector -XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.setAsTypeCache -XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.asTypeUncached -XX:+HeapDumpOnOutOfMemoryError -XX:+ExitOnOutOfMemoryError -XX:HeapDumpPath=data -XX:ErrorFile=logs/hs_err_pid%p.log -Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,level,pid,tags:filecount=32,filesize=64m -Xms5120m -Xmx5120m -XX:MaxDirectMemorySize=2684354560 -XX:G1HeapRegionSize=4m -XX:InitiatingHeapOccupancyPercent=30 -XX:G1ReservePercent=15 --module-path /usr/share/elasticsearch/lib --add-modules=jdk.net --add-modules=ALL-MODULE-PATH -m org.elasticsearch.server/org.elasticsearch.bootstrap.Elasticsearch
elastic+ 1653972 1653279  0 22:30 pts/0    00:00:00 grep --color=auto java
elasticsearch@elasticsearch-es-hot-0:~$ pgrep java
7
66
elasticsearch@elasticsearch-es-hot-0:~$ pgrep -n java
66
```

cc @nitishaggarwal49 as discussed
