### PR TITLE
eck-fleet-server: fix helm tests + change defaults

### DIFF
--- a/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
@@ -34,6 +34,8 @@ tests:
               spec:
                 serviceAccountName: fleet-server
                 automountServiceAccountToken: true
+                securityContext:
+                  runAsUser: 0
   - it: should render custom labels and annotations properly.
     set:
       labels:
@@ -95,7 +97,14 @@ tests:
             mode: fleet
             policyID: eck-fleet-server
             version: 8.17.0-SNAPSHOT
-            deployment: {}
+            deployment:
+              replicas: 1
+              podTemplate:
+                spec:
+                  serviceAccountName: fleet-server
+                  automountServiceAccountToken: true
+                  securityContext:
+                    runAsUser: 0
             elasticsearchRefs:
             - name: eck-elasticsearch
               namespace: default
@@ -143,7 +152,14 @@ tests:
             mode: fleet
             policyID: eck-fleet-server
             version: 8.17.0-SNAPSHOT
-            deployment: {}
+            deployment:
+              replicas: 1
+              podTemplate:
+                spec:
+                  serviceAccountName: fleet-server
+                  automountServiceAccountToken: true
+                  securityContext:
+                    runAsUser: 0
             elasticsearchRefs:
             - name: eck-elasticsearch
               namespace: default
@@ -163,6 +179,8 @@ tests:
       - failedTemplate:
           errorMessage: "A Fleet Server version is required"
   - it: not setting a statefulset or deployment should fail
+    set:
+      deployment: null
     asserts:
       - failedTemplate:
           errorMessage: "At least one of statefulSet or deployment is required"

--- a/deploy/eck-stack/charts/eck-fleet-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/values.yaml
@@ -79,12 +79,14 @@ policyID: eck-fleet-server
 # No default is currently set, refer to https://github.com/elastic/cloud-on-k8s/issues/7429.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-chose-the-deployment-model
 #
-# deployment:
-#   replicas: 1
-#   podTemplate:
-#     spec:
-#       serviceAccountName: fleet-server
-#       automountServiceAccountToken: true
+deployment:
+  replicas: 1
+  podTemplate:
+    spec:
+      serviceAccountName: fleet-server
+      automountServiceAccountToken: true
+      securityContext:
+        runAsUser: 0
 #
 # statefulSet:
 #   podTemplate:

--- a/deploy/eck-stack/examples/agent/fleet-agents.yaml
+++ b/deploy/eck-stack/examples/agent/fleet-agents.yaml
@@ -113,6 +113,8 @@ eck-fleet-server:
       spec:
         serviceAccountName: fleet-server
         automountServiceAccountToken: true
+        securityContext:
+          runAsUser: 0
 
   # Agent policy to be used.
   policyID: eck-fleet-server

--- a/deploy/eck-stack/templates/tests/elastic-fleet-agent_test.yaml
+++ b/deploy/eck-stack/templates/tests/elastic-fleet-agent_test.yaml
@@ -39,6 +39,7 @@ tests:
               - name: elasticsearch
             mode: fleet
             fleetServerEnabled: true
+            serviceAccountName: fleet-server
             policyID: eck-fleet-server
             deployment:
               replicas: 1


### PR DESCRIPTION
Main is currently broken. This adjusts the tests and restores a default `deployment` attribute to the fleet chart.