### PR TITLE
[2.16] Make helm charts consistent with how fields in spec are handled. (beat only) (#8248)

### DIFF
--- a/deploy/eck-stack/charts/eck-beats/examples/auditbeat_hosts.yaml
+++ b/deploy/eck-stack/charts/eck-beats/examples/auditbeat_hosts.yaml
@@ -1,111 +1,110 @@
 name: auditbeat
 version: 8.17.0
-spec:
-  type: auditbeat
-  elasticsearchRef:
-    name: eck-elasticsearch
-  kibanaRef:
-    name: eck-kibana
-  config:
-    auditbeat.modules:
-    - module: file_integrity
-      paths:
-      - /hostfs/bin
-      - /hostfs/usr/bin
-      - /hostfs/sbin
-      - /hostfs/usr/sbin
-      - /hostfs/etc
-      exclude_files:
-      - '(?i)\.sw[nop]$'
-      - '~$'
-      - '/\.git($|/)'
-      scan_at_start: true
-      scan_rate_per_sec: 50 MiB
-      max_file_size: 100 MiB
-      hash_types: [sha1]
-      recursive: true
-    - module: auditd
-      audit_rules: |
-        # Executions
-        -a always,exit -F arch=b64 -S execve,execveat -k exec
+type: auditbeat
+elasticsearchRef:
+  name: eck-elasticsearch
+kibanaRef:
+  name: eck-kibana
+config:
+  auditbeat.modules:
+  - module: file_integrity
+    paths:
+    - /hostfs/bin
+    - /hostfs/usr/bin
+    - /hostfs/sbin
+    - /hostfs/usr/sbin
+    - /hostfs/etc
+    exclude_files:
+    - '(?i)\.sw[nop]$'
+    - '~$'
+    - '/\.git($|/)'
+    scan_at_start: true
+    scan_rate_per_sec: 50 MiB
+    max_file_size: 100 MiB
+    hash_types: [sha1]
+    recursive: true
+  - module: auditd
+    audit_rules: |
+      # Executions
+      -a always,exit -F arch=b64 -S execve,execveat -k exec
 
-        # Unauthorized access attempts (amd64 only)
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access
+      # Unauthorized access attempts (amd64 only)
+      -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
+      -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access
 
-    processors:
-    - add_cloud_metadata: {}
-    - add_host_metadata: {}
-    - add_process_metadata:
-        match_pids: ['process.pid']
-  daemonSet:
-    podTemplate:
-      spec:
-        hostPID: true  # Required by auditd module
-        dnsPolicy: ClusterFirstWithHostNet
-        hostNetwork: true # Allows to provide richer host metadata
-        automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+  processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+  - add_process_metadata:
+      match_pids: ['process.pid']
+daemonSet:
+  podTemplate:
+    spec:
+      hostPID: true  # Required by auditd module
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true # Allows to provide richer host metadata
+      automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+      securityContext:
+        runAsUser: 0
+      volumes:
+      - name: bin
+        hostPath:
+          path: /bin
+      - name: usrbin
+        hostPath:
+          path: /usr/bin
+      - name: sbin
+        hostPath:
+          path: /sbin
+      - name: usrsbin
+        hostPath:
+          path: /usr/sbin
+      - name: etc
+        hostPath:
+          path: /etc
+      - name: run-containerd
+        hostPath:
+          path: /run/containerd
+          type: DirectoryOrCreate
+      # Uncomment the below when running on GKE. See https://github.com/elastic/beats/issues/8523 for more context.
+      #- name: run
+      #  hostPath:
+      #    path: /run
+      #initContainers:
+      #- name: cos-init
+      #  image: docker.elastic.co/beats/auditbeat:8.3.3
+      #  volumeMounts:
+      #  - name: run
+      #    mountPath: /run
+      #  command: ['sh', '-c', 'export SYSTEMD_IGNORE_CHROOT=1 && systemctl stop systemd-journald-audit.socket && systemctl mask systemd-journald-audit.socket && systemctl restart systemd-journald']
+      containers:
+      - name: auditbeat
         securityContext:
-          runAsUser: 0
-        volumes:
+          capabilities:
+            add:
+            # Capabilities needed for auditd module
+            - 'AUDIT_READ'
+            - 'AUDIT_WRITE'
+            - 'AUDIT_CONTROL'
+        volumeMounts:
         - name: bin
-          hostPath:
-            path: /bin
-        - name: usrbin
-          hostPath:
-            path: /usr/bin
+          mountPath: /hostfs/bin
+          readOnly: true
         - name: sbin
-          hostPath:
-            path: /sbin
+          mountPath: /hostfs/sbin
+          readOnly: true
+        - name: usrbin
+          mountPath: /hostfs/usr/bin
+          readOnly: true
         - name: usrsbin
-          hostPath:
-            path: /usr/sbin
+          mountPath: /hostfs/usr/sbin
+          readOnly: true
         - name: etc
-          hostPath:
-            path: /etc
+          mountPath: /hostfs/etc
+          readOnly: true
+        # Directory with root filesystems of containers executed with containerd, this can be
+        # different with other runtimes. This volume is needed to monitor the file integrity
+        # of files in containers.
         - name: run-containerd
-          hostPath:
-            path: /run/containerd
-            type: DirectoryOrCreate
-        # Uncomment the below when running on GKE. See https://github.com/elastic/beats/issues/8523 for more context.
-        #- name: run
-        #  hostPath:
-        #    path: /run
-        #initContainers:
-        #- name: cos-init
-        #  image: docker.elastic.co/beats/auditbeat:8.3.3
-        #  volumeMounts:
-        #  - name: run
-        #    mountPath: /run
-        #  command: ['sh', '-c', 'export SYSTEMD_IGNORE_CHROOT=1 && systemctl stop systemd-journald-audit.socket && systemctl mask systemd-journald-audit.socket && systemctl restart systemd-journald']
-        containers:
-        - name: auditbeat
-          securityContext:
-            capabilities:
-              add:
-              # Capabilities needed for auditd module
-              - 'AUDIT_READ'
-              - 'AUDIT_WRITE'
-              - 'AUDIT_CONTROL'
-          volumeMounts:
-          - name: bin
-            mountPath: /hostfs/bin
-            readOnly: true
-          - name: sbin
-            mountPath: /hostfs/sbin
-            readOnly: true
-          - name: usrbin
-            mountPath: /hostfs/usr/bin
-            readOnly: true
-          - name: usrsbin
-            mountPath: /hostfs/usr/sbin
-            readOnly: true
-          - name: etc
-            mountPath: /hostfs/etc
-            readOnly: true
-          # Directory with root filesystems of containers executed with containerd, this can be
-          # different with other runtimes. This volume is needed to monitor the file integrity
-          # of files in containers.
-          - name: run-containerd
-            mountPath: /run/containerd
-            readOnly: true
+          mountPath: /run/containerd
+          readOnly: true

--- a/deploy/eck-stack/charts/eck-beats/examples/filebeat_no_autodiscover.yaml
+++ b/deploy/eck-stack/charts/eck-beats/examples/filebeat_no_autodiscover.yaml
@@ -1,46 +1,45 @@
 name: filebeat
 version: 8.17.0
-spec:
-  type: filebeat
-  elasticsearchRef:
-    name: eck-elasticsearch
-  kibanaRef:
-    name: eck-kibana
-  config:
-    filebeat.inputs:
-    - type: container
-      paths:
-      - /var/log/containers/*.log
-    processors:
-    - add_host_metadata: {}
-    - add_cloud_metadata: {}
-  daemonSet:
-    podTemplate:
-      spec:
-        automountServiceAccountToken: true
-        terminationGracePeriodSeconds: 30
-        dnsPolicy: ClusterFirstWithHostNet
-        hostNetwork: true # Allows to provide richer host metadata
-        containers:
-        - name: filebeat
-          securityContext:
-            runAsUser: 0
-            # If using Red Hat OpenShift uncomment this:
-            #privileged: true
-          volumeMounts:
-          - name: varlogcontainers
-            mountPath: /var/log/containers
-          - name: varlogpods
-            mountPath: /var/log/pods
-          - name: varlibdockercontainers
-            mountPath: /var/lib/docker/containers
-        volumes:
+type: filebeat
+elasticsearchRef:
+  name: eck-elasticsearch
+kibanaRef:
+  name: eck-kibana
+config:
+  filebeat.inputs:
+  - type: container
+    paths:
+    - /var/log/containers/*.log
+  processors:
+  - add_host_metadata: {}
+  - add_cloud_metadata: {}
+daemonSet:
+  podTemplate:
+    spec:
+      automountServiceAccountToken: true
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true # Allows to provide richer host metadata
+      containers:
+      - name: filebeat
+        securityContext:
+          runAsUser: 0
+          # If using Red Hat OpenShift uncomment this:
+          #privileged: true
+        volumeMounts:
         - name: varlogcontainers
-          hostPath:
-            path: /var/log/containers
+          mountPath: /var/log/containers
         - name: varlogpods
-          hostPath:
-            path: /var/log/pods
+          mountPath: /var/log/pods
         - name: varlibdockercontainers
-          hostPath:
-            path: /var/lib/docker/containers
+          mountPath: /var/lib/docker/containers
+      volumes:
+      - name: varlogcontainers
+        hostPath:
+          path: /var/log/containers
+      - name: varlogpods
+        hostPath:
+          path: /var/log/pods
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers

--- a/deploy/eck-stack/charts/eck-beats/examples/heartbeat_es_kb_health.yaml
+++ b/deploy/eck-stack/charts/eck-beats/examples/heartbeat_es_kb_health.yaml
@@ -1,24 +1,23 @@
 name: heartbeat
 version: 8.17.0
-spec:
-  type: heartbeat
-  elasticsearchRef:
-    name: eck-elasticsearch
-  config:
-    heartbeat.monitors:
-    - type: tcp
-      schedule: '@every 5s'
-      # This should directly match the name of the Elasticsearch instance
-      # with "-es-http" appended to the name.
-      hosts: ["elasticsearch-es-http.default.svc:9200"]
-    - type: tcp
-      schedule: '@every 5s'
-      # This should directly match the names of the Kibana instance
-      # with "-kb-http" appended to the name.
-      hosts: ["eck-kibana-kb-http.default.svc:5601"]
-  deployment:
-    replicas: 1
-    podTemplate:
-      spec:
-        securityContext:
-          runAsUser: 0
+type: heartbeat
+elasticsearchRef:
+  name: eck-elasticsearch
+config:
+  heartbeat.monitors:
+  - type: tcp
+    schedule: '@every 5s'
+    # This should directly match the name of the Elasticsearch instance
+    # with "-es-http" appended to the name.
+    hosts: ["elasticsearch-es-http.default.svc:9200"]
+  - type: tcp
+    schedule: '@every 5s'
+    # This should directly match the names of the Kibana instance
+    # with "-kb-http" appended to the name.
+    hosts: ["eck-kibana-kb-http.default.svc:5601"]
+deployment:
+  replicas: 1
+  podTemplate:
+    spec:
+      securityContext:
+        runAsUser: 0

--- a/deploy/eck-stack/charts/eck-beats/examples/metricbeat_hosts.yaml
+++ b/deploy/eck-stack/charts/eck-beats/examples/metricbeat_hosts.yaml
@@ -1,104 +1,103 @@
 name: metricbeat
-spec:
-  type: metricbeat
-  version: 8.17.0
-  elasticsearchRef:
-    name: eck-elasticsearch
-  kibanaRef:
-    name: eck-kibana
-  config:
-    metricbeat:
-      autodiscover:
-        providers:
-        - hints:
-            default_config: {}
-            enabled: "true"
-          node: ${NODE_NAME}
-          type: kubernetes
-      modules:
-      - module: system
-        period: 10s
-        metricsets:
-        - cpu
-        - load
-        - memory
-        - network
-        - process
-        - process_summary
-        process:
-          include_top_n:
-            by_cpu: 5
-            by_memory: 5
-        processes:
-        - .*
-      - module: system
-        period: 1m
-        metricsets:
-        - filesystem
-        - fsstat
-        processors:
-        - drop_event:
-            when:
-              regexp:
-                system:
-                  filesystem:
-                    mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib)($|/)
-      - module: kubernetes
-        period: 10s
+type: metricbeat
+version: 8.17.0
+elasticsearchRef:
+  name: eck-elasticsearch
+kibanaRef:
+  name: eck-kibana
+config:
+  metricbeat:
+    autodiscover:
+      providers:
+      - hints:
+          default_config: {}
+          enabled: "true"
         node: ${NODE_NAME}
-        hosts:
-        - https://${NODE_NAME}:10250
-        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-        ssl:
-          verification_mode: none
-        metricsets:
-        - node
-        - system
-        - pod
-        - container
-        - volume
-    processors:
-    - add_cloud_metadata: {}
-    - add_host_metadata: {}
-  daemonSet:
-    podTemplate:
-      spec:
-        serviceAccountName: metricbeat
-        automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
-        containers:
-        - args:
-          - -e
-          - -c
-          - /etc/beat.yml
-          - --system.hostfs=/hostfs
-          name: metricbeat
-          volumeMounts:
-          - mountPath: /hostfs/sys/fs/cgroup
-            name: cgroup
-          - mountPath: /var/run/docker.sock
-            name: dockersock
-          - mountPath: /hostfs/proc
-            name: proc
-          env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-        dnsPolicy: ClusterFirstWithHostNet
-        hostNetwork: true # Allows to provide richer host metadata
-        securityContext:
-          runAsUser: 0
-        terminationGracePeriodSeconds: 30
-        volumes:
-        - hostPath:
-            path: /sys/fs/cgroup
+        type: kubernetes
+    modules:
+    - module: system
+      period: 10s
+      metricsets:
+      - cpu
+      - load
+      - memory
+      - network
+      - process
+      - process_summary
+      process:
+        include_top_n:
+          by_cpu: 5
+          by_memory: 5
+      processes:
+      - .*
+    - module: system
+      period: 1m
+      metricsets:
+      - filesystem
+      - fsstat
+      processors:
+      - drop_event:
+          when:
+            regexp:
+              system:
+                filesystem:
+                  mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib)($|/)
+    - module: kubernetes
+      period: 10s
+      node: ${NODE_NAME}
+      hosts:
+      - https://${NODE_NAME}:10250
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      ssl:
+        verification_mode: none
+      metricsets:
+      - node
+      - system
+      - pod
+      - container
+      - volume
+  processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+daemonSet:
+  podTemplate:
+    spec:
+      serviceAccountName: metricbeat
+      automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+      containers:
+      - args:
+        - -e
+        - -c
+        - /etc/beat.yml
+        - --system.hostfs=/hostfs
+        name: metricbeat
+        volumeMounts:
+        - mountPath: /hostfs/sys/fs/cgroup
           name: cgroup
-        - hostPath:
-            path: /var/run/docker.sock
+        - mountPath: /var/run/docker.sock
           name: dockersock
-        - hostPath:
-            path: /proc
+        - mountPath: /hostfs/proc
           name: proc
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true # Allows to provide richer host metadata
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+        name: cgroup
+      - hostPath:
+          path: /var/run/docker.sock
+        name: dockersock
+      - hostPath:
+          path: /proc
+        name: proc
 
 clusterRole:
   # permissions needed for metricbeat

--- a/deploy/eck-stack/charts/eck-beats/examples/packetbeat_dns_http.yaml
+++ b/deploy/eck-stack/charts/eck-beats/examples/packetbeat_dns_http.yaml
@@ -1,38 +1,37 @@
 name: packetbeat
-spec:
-  type: packetbeat
-  version: 8.17.0
-  elasticsearchRef:
-    name: eck-elasticsearch
-  kibanaRef:
-    name: eck-kibana
-  config:
-    packetbeat.interfaces.device: any
-    packetbeat.protocols:
-    - type: dns
-      ports: [53]
-      include_authorities: true
-      include_additionals: true
-    - type: http
-      ports: [80, 8000, 8080, 9200]
-    packetbeat.flows:
-      timeout: 30s
-      period: 10s
-    processors:
-    - add_cloud_metadata: {}
-    - add_host_metadata: {}
-  daemonSet:
-    podTemplate:
-      spec:
-        terminationGracePeriodSeconds: 30
-        hostNetwork: true
-        automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
-        dnsPolicy: ClusterFirstWithHostNet
-        containers:
-        - name: packetbeat
-          securityContext:
-            runAsUser: 0
-            capabilities:
-              add:
-              - NET_ADMIN
-        volumes: []
+type: packetbeat
+version: 8.17.0
+elasticsearchRef:
+  name: eck-elasticsearch
+kibanaRef:
+  name: eck-kibana
+config:
+  packetbeat.interfaces.device: any
+  packetbeat.protocols:
+  - type: dns
+    ports: [53]
+    include_authorities: true
+    include_additionals: true
+  - type: http
+    ports: [80, 8000, 8080, 9200]
+  packetbeat.flows:
+    timeout: 30s
+    period: 10s
+  processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+daemonSet:
+  podTemplate:
+    spec:
+      terminationGracePeriodSeconds: 30
+      hostNetwork: true
+      automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: packetbeat
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add:
+            - NET_ADMIN
+      volumes: []

--- a/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/beats.yaml
@@ -11,9 +11,65 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  version: {{ required "A Beat version is required" .Values.version }}
-  {{- if and (not (hasKey .Values.spec "daemonSet")) (not (hasKey .Values.spec "deployment")) }}
+  version: {{ required "A Beat version is required" (or ((.Values.spec).version) (.Values.version)) }}
+  {{- $daemonSet := (or (hasKey (.Values.spec) "daemonSet") (hasKey .Values "daemonSet")) }}
+  {{- $deployment := (or (hasKey (.Values.spec) "deployment") (hasKey .Values "deployment")) }}
+  {{- if and (not $daemonSet) (not $deployment) }}
   {{ fail "At least one of daemonSet or deployment is required for a functional Beat" }}
   {{- end }}
-  {{- if not .Values.spec.type }}{{ fail "A Beat type is required" }}{{- end }}
-  {{- toYaml .Values.spec | nindent 2 }}
+  {{- if not (or ((.Values.spec).type) (.Values.type)) }}{{ fail "A Beat type is required" }}{{- end }}
+  type: {{ or ((.Values.spec).type) (.Values.type) }}
+  {{- if $daemonSet }}
+  {{- $ds := or ((.Values.spec).daemonSet) (.Values.daemonSet) }}
+  daemonSet:
+    {{- /* This is required to render the empty daemonset ( {} ) properly */}}
+    {{- $ds | default dict | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if $deployment }}
+  {{- $deploy := or ((.Values.spec).deployment) (.Values.deployment) }}
+  deployment:
+    {{- /* This is required to render the empty deployment ( {} ) properly */}}
+    {{- $deploy | default dict | toYaml | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).image) (.Values.image) }}
+  image: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).elasticsearchRef) (.Values.elasticsearchRef) }}
+  elasticsearchRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).kibanaRef) (.Values.kibanaRef) }}
+  kibanaRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- $config := or ((.Values.spec).config) (.Values.config) }}
+  {{- $configRef := or ((.Values.spec).configRef) (.Values.configRef) }}
+  {{- if and $config $configRef }}
+  {{ fail "Only one of config and configRef can be specified" }}
+  {{- end }}
+  {{- with $config }}
+  config:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $configRef }}
+  configRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).http) (.Values.http) }}
+  http:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).monitoring) (.Values.monitoring) }}
+  monitoring:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).secureSettings) (.Values.secureSettings) }}
+  secureSettings:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).revisionHistoryLimit) (.Values.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with or (((.Values.spec).serviceAccount).name) ((.Values.serviceAccount).name) }}
+  serviceAccountName: {{ . }}
+  {{- end }}

--- a/deploy/eck-stack/charts/eck-beats/templates/tests/beats_test.yaml
+++ b/deploy/eck-stack/charts/eck-beats/templates/tests/beats_test.yaml
@@ -21,3 +21,150 @@ tests:
       - equal:
           path: spec.type
           value: filebeat
+  - it: should render properly when using spec fields
+    set:
+      spec:
+        daemonSet: {}
+        elasticsearchRef:
+          name: eck-elasticsearch
+          namespace: default
+        kibanaRef:
+          name: eck-kibana
+          namespace: default
+        config:
+          name: "filebeat"
+        type: filebeat
+        http:
+          service:
+            spec:
+              type: ClusterIP
+        monitoring:
+          metrics:
+            elasticsearchRefs:
+            - name: monitoring
+              namespace: observability
+          logs:
+            elasticsearchRefs:
+            - name: monitoring
+              namespace: observability
+        secureSettings:
+        - secretName: eck-beat-secret
+        revisionHistoryLimit: 4
+        serviceAccount:
+          name: elastic-beat
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Beat
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: quickstart
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: eck-beats
+            helm.sh/chart: eck-beats-0.14.0-SNAPSHOT
+      - equal:
+          path: spec
+          value:
+            version: 8.17.0-SNAPSHOT
+            daemonSet: {}
+            elasticsearchRef:
+              name: eck-elasticsearch
+              namespace: default
+            kibanaRef:
+              name: eck-kibana
+              namespace: default
+            config:
+              name: "filebeat"
+            type: filebeat
+            http:
+              service:
+                spec:
+                  type: ClusterIP
+            monitoring:
+              metrics:
+                elasticsearchRefs:
+                - name: monitoring
+                  namespace: observability
+              logs:
+                elasticsearchRefs:
+                - name: monitoring
+                  namespace: observability
+            secureSettings:
+            - secretName: eck-beat-secret
+            revisionHistoryLimit: 4
+            serviceAccountName: elastic-beat
+  - it: should render properly when not using spec fields
+    set:
+      daemonSet: {}
+      elasticsearchRef:
+        name: eck-elasticsearch
+        namespace: default
+      kibanaRef:
+        name: eck-kibana
+        namespace: default
+      config:
+        name: "filebeat"
+      type: filebeat
+      http:
+        service:
+          spec:
+            type: ClusterIP
+      monitoring:
+        metrics:
+          elasticsearchRefs:
+          - name: monitoring
+            namespace: observability
+        logs:
+          elasticsearchRefs:
+          - name: monitoring
+            namespace: observability
+      secureSettings:
+      - secretName: eck-beat-secret
+      revisionHistoryLimit: 4
+      serviceAccount:
+        name: elastic-beat
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Beat
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: quickstart
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: eck-beats
+            helm.sh/chart: eck-beats-0.14.0-SNAPSHOT
+      - equal:
+          path: spec
+          value:
+            version: 8.17.0-SNAPSHOT
+            daemonSet: {}
+            elasticsearchRef:
+              name: eck-elasticsearch
+              namespace: default
+            kibanaRef:
+              name: eck-kibana
+              namespace: default
+            config:
+              name: "filebeat"
+            type: filebeat
+            http:
+              service:
+                spec:
+                  type: ClusterIP
+            monitoring:
+              metrics:
+                elasticsearchRefs:
+                - name: monitoring
+                  namespace: observability
+              logs:
+                elasticsearchRefs:
+                - name: monitoring
+                  namespace: observability
+            secureSettings:
+            - secretName: eck-beat-secret
+            revisionHistoryLimit: 4
+            serviceAccountName: elastic-beat

--- a/deploy/eck-stack/charts/eck-beats/values.yaml
+++ b/deploy/eck-stack/charts/eck-beats/values.yaml
@@ -28,63 +28,106 @@ labels: {}
 #
 annotations: {}
 
-spec:
-  # Type of Elastic Beats. Standard types of Beat are [filebeat,metricbeat,heartbeat,auditbeat,packetbeat,journalbeat].
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-deploy-elastic-beat
-  #
-  # Note: This is required to be set, or the release install will fail.
-  #
-  type: ""
+# ** Deprecation Notice **
+# The previous versions of this Helm Chart simply used the `spec` field here
+# and allowed the user to specify any fields below spec that were templated directly
+# into the final Beats manifest. This is no longer the preferred way to specify these
+# fields and each field that is supported underneath `spec` is now directly specified
+# in this values file. Currently both patterns are supported for backwards compatibility
+# but we plan to remove the `spec` field in the future.
+# spec: {}
 
-  # Referenced resources are below and depending on the setup, at least elasticsearchRef is required for a functional Beat.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-connect-es
-  #
-  # Reference to ECK-managed Kibana instance.
-  #
-  # kibanaRef:
-  #   name: quickstart
-    # Optional namespace reference to Kibana instance.
-    # If not specified, then the namespace of the Beats instance
-    # will be assumed.
-    #
-    # namespace: default
+# Type of Elastic Beats. Standard types of Beat are [filebeat,metricbeat,heartbeat,auditbeat,packetbeat,journalbeat].
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-deploy-elastic-beat
+#
+# Note: This is required to be set, or the release install will fail.
+#
+type: ""
 
-  # Reference to ECK-managed Elasticsearch instance.
-  # *Note* If Beat's output is intended to go to Elasticsearch and not something like Logstash,
-  # this elasticsearchRef must be updated to the name of the Elasticsearch instance.
-  #
-  elasticsearchRef: {}
-    # name: elasticsearch
-    # Optional namespace reference to Elasticsearch instance.
-    # If not specified, then the namespace of the Beats instance
-    # will be assumed.
-    #
-    # namespace: default
+# Beats image to deploy.
+#
+# image: docker.elastic.co/beats/metricbeat:8.17.0-SNAPSHOT
 
-  # Daemonset, or Deployment specification for the type of Beat specified.
-  # At least one is required of [daemonSet, deployment].
-  # No default is currently set, refer to https://github.com/elastic/cloud-on-k8s/issues/7429.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-chose-the-deployment-model
+# Referenced resources are below and depending on the setup, at least elasticsearchRef is required for a functional Beat.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-connect-es
+#
+# Reference to ECK-managed Kibana instance.
+#
+# kibanaRef:
+#   name: quickstart
+  # Optional namespace reference to Kibana instance.
+  # If not specified, then the namespace of the Beats instance
+  # will be assumed.
   #
-  # deployment:
-  #   podTemplate:
-  #     spec:
-  #       containers:
-  #       - name: agent
-  #         securityContext:
-  #           runAsUser: 0
-  # daemonSet:
-  #   podTemplate:
-  #     spec:
-  #       containers:
-  #       - name: agent
-  #         securityContext:
-  #           runAsUser: 0
+  # namespace: default
 
-  # Configuration of Beat, which is dependent on the `type` of Beat specified.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-deploy-elastic-beat
+# Reference to ECK-managed Elasticsearch instance.
+# *Note* If Beat's output is intended to go to Elasticsearch and not something like Logstash,
+# this elasticsearchRef must be updated to the name of the Elasticsearch instance.
+#
+elasticsearchRef: {}
+  # name: elasticsearch
+  # Optional namespace reference to Elasticsearch instance.
+  # If not specified, then the namespace of the Beats instance
+  # will be assumed.
   #
-  config: {}
+  # namespace: default
+
+# Daemonset, or Deployment specification for the type of Beat specified.
+# At least one is required of [daemonSet, deployment].
+# No default is currently set, refer to https://github.com/elastic/cloud-on-k8s/issues/7429.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-chose-the-deployment-model
+#
+# deployment:
+#   podTemplate:
+#     spec:
+#       securityContext:
+#         runAsUser: 0
+# daemonSet:
+#   podTemplate:
+#     spec:
+#       securityContext:
+#         runAsUser: 0
+
+# Configuration of Beat, which is dependent on the `type` of Beat specified.
+# NOTE: The `config` and `configRef` fields are mutually exclusive. Only one of them should be defined at a time,
+# as using both may cause conflicts.
+#
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-custom-configuration
+#
+config: {}
+
+# Reference a configuration in a Secret.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-custom-configuration
+#
+# configRef:
+#   secretName: ""
+
+# The HTTP layer configuration for the Beats Service.
+#
+# http:
+
+# Settings for configuring stack monitoring.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-stack-monitoring.html
+#
+# monitoring: {}
+  # metrics:
+  #   elasticsearchRefs:
+  #   - name: monitoring
+  #     namespace: observability
+  # logs:
+  #   elasticsearchRefs:
+  #   - name: monitoring
+  #     namespace: observability
+
+# SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for Elastic Beats.
+secureSettings: []
+# - secretName: my-secret-with-secure-settings
+
+# Number of revisions to retain to allow rollback in the underlying Deployment.
+# If not set Kubernetes sets this to 10 by default.
+#
+# revisionHistoryLimit: 2
 
 # ServiceAccount to be used by Elastic Beats. Some Beats features (such as autodiscover or Kubernetes module metricsets)
 # require that Beat Pods interact with Kubernetes APIs. This functionality requires specific permissions

--- a/deploy/eck-stack/examples/beats/metricbeat_hosts.yaml
+++ b/deploy/eck-stack/examples/beats/metricbeat_hosts.yaml
@@ -56,108 +56,107 @@ eck-kibana:
 eck-beats:
   enabled: true
   name: metricbeat
-  spec:
-    type: metricbeat
-    version: 8.17.0
-    elasticsearchRef:
-      name: quickstart
-    kibanaRef:
-      name: quickstart
-    config:
-      # Since filebeat is used in the default values, this needs to be removed with an empty list. 
-      filebeat.inputs: []
-      metricbeat:
-        autodiscover:
-          providers:
-          - hints:
-              default_config: {}
-              enabled: "true"
-            node: ${NODE_NAME}
-            type: kubernetes
-        modules:
-        - module: system
-          period: 10s
-          metricsets:
-          - cpu
-          - load
-          - memory
-          - network
-          - process
-          - process_summary
-          process:
-            include_top_n:
-              by_cpu: 5
-              by_memory: 5
-          processes:
-          - .*
-        - module: system
-          period: 1m
-          metricsets:
-          - filesystem
-          - fsstat
-          processors:
-          - drop_event:
-              when:
-                regexp:
-                  system:
-                    filesystem:
-                      mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib)($|/)
-        - module: kubernetes
-          period: 10s
+  type: metricbeat
+  version: 8.17.0
+  elasticsearchRef:
+    name: quickstart
+  kibanaRef:
+    name: quickstart
+  config:
+    # Since filebeat is used in the default values, this needs to be removed with an empty list. 
+    filebeat.inputs: []
+    metricbeat:
+      autodiscover:
+        providers:
+        - hints:
+            default_config: {}
+            enabled: "true"
           node: ${NODE_NAME}
-          hosts:
-          - https://${NODE_NAME}:10250
-          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-          ssl:
-            verification_mode: none
-          metricsets:
-          - node
-          - system
-          - pod
-          - container
-          - volume
-      processors:
-      - add_cloud_metadata: {}
-      - add_host_metadata: {}
-    daemonSet:
-      podTemplate:
-        spec:
-          serviceAccountName: metricbeat
-          automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
-          containers:
-          - args:
-            - -e
-            - -c
-            - /etc/beat.yml
-            - --system.hostfs=/hostfs
-            name: metricbeat
-            volumeMounts:
-            - mountPath: /hostfs/sys/fs/cgroup
-              name: cgroup
-            - mountPath: /var/run/docker.sock
-              name: dockersock
-            - mountPath: /hostfs/proc
-              name: proc
-            env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-          dnsPolicy: ClusterFirstWithHostNet
-          hostNetwork: true # Allows to provide richer host metadata
-          securityContext:
-            runAsUser: 0
-          terminationGracePeriodSeconds: 30
-          volumes:
-          - hostPath:
-              path: /sys/fs/cgroup
+          type: kubernetes
+      modules:
+      - module: system
+        period: 10s
+        metricsets:
+        - cpu
+        - load
+        - memory
+        - network
+        - process
+        - process_summary
+        process:
+          include_top_n:
+            by_cpu: 5
+            by_memory: 5
+        processes:
+        - .*
+      - module: system
+        period: 1m
+        metricsets:
+        - filesystem
+        - fsstat
+        processors:
+        - drop_event:
+            when:
+              regexp:
+                system:
+                  filesystem:
+                    mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib)($|/)
+      - module: kubernetes
+        period: 10s
+        node: ${NODE_NAME}
+        hosts:
+        - https://${NODE_NAME}:10250
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        ssl:
+          verification_mode: none
+        metricsets:
+        - node
+        - system
+        - pod
+        - container
+        - volume
+    processors:
+    - add_cloud_metadata: {}
+    - add_host_metadata: {}
+  daemonSet:
+    podTemplate:
+      spec:
+        serviceAccountName: metricbeat
+        automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+        containers:
+        - args:
+          - -e
+          - -c
+          - /etc/beat.yml
+          - --system.hostfs=/hostfs
+          name: metricbeat
+          volumeMounts:
+          - mountPath: /hostfs/sys/fs/cgroup
             name: cgroup
-          - hostPath:
-              path: /var/run/docker.sock
+          - mountPath: /var/run/docker.sock
             name: dockersock
-          - hostPath:
-              path: /proc
+          - mountPath: /hostfs/proc
             name: proc
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+        dnsPolicy: ClusterFirstWithHostNet
+        hostNetwork: true # Allows to provide richer host metadata
+        securityContext:
+          runAsUser: 0
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - hostPath:
+            path: /sys/fs/cgroup
+          name: cgroup
+        - hostPath:
+            path: /var/run/docker.sock
+          name: dockersock
+        - hostPath:
+            path: /proc
+          name: proc
   
   clusterRole:
     # permissions needed for metricbeat


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.16`:
 - [Make helm charts consistent with how fields in spec are handled. (beat only) (#8248)](https://github.com/elastic/cloud-on-k8s/pull/8248)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)