### PR TITLE
[2.16] Remove additional spec references in Helm eck-stack chart. (#8286)

### DIFF
--- a/deploy/eck-stack/examples/agent/fleet-agents.yaml
+++ b/deploy/eck-stack/examples/agent/fleet-agents.yaml
@@ -24,58 +24,57 @@ eck-kibana:
   #
   fullnameOverride: kibana
   
-  spec:
-    # Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
-    #
-    elasticsearchRef:
-      name: elasticsearch
+  # Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
+  #
+  elasticsearchRef:
+    name: elasticsearch
 
-    config:
-      # Note that these are specific to the namespace into which this example is installed, and are
-      # using `elastic-stack` as configured here and detailed in the README when installing:
-      #
-      # `helm install es-kb-quickstart elastic/eck-stack -n elastic-stack`
-      #
-      # If installed outside of the `elastic-stack` namespace, the following 2 lines need modification.
-      xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.elastic-stack.svc:9200"]
-      xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.elastic-stack.svc:8220"]
-      xpack.fleet.packages:
-      - name: system
-        version: latest
-      - name: elastic_agent
-        version: latest
-      - name: fleet_server
-        version: latest
-      - name: kubernetes
-        version: latest
-      xpack.fleet.agentPolicies:
-      - name: Fleet Server on ECK policy
-        id: eck-fleet-server
-        namespace: default
-        is_managed: true
-        monitoring_enabled:
-        - logs
-        - metrics
-        package_policies:
-        - name: fleet_server-1
-          id: fleet_server-1
-          package:
-            name: fleet_server
-      - name: Elastic Agent on ECK policy
-        id: eck-agent
-        namespace: default
-        is_managed: true
-        monitoring_enabled:
-        - logs
-        - metrics
-        unenroll_timeout: 900
-        package_policies:
-        - package:
-            name: system
-          name: system-1
-        - package:
-            name: kubernetes
-          name: kubernetes-1
+  config:
+    # Note that these are specific to the namespace into which this example is installed, and are
+    # using `elastic-stack` as configured here and detailed in the README when installing:
+    #
+    # `helm install es-kb-quickstart elastic/eck-stack -n elastic-stack`
+    #
+    # If installed outside of the `elastic-stack` namespace, the following 2 lines need modification.
+    xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.elastic-stack.svc:9200"]
+    xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.elastic-stack.svc:8220"]
+    xpack.fleet.packages:
+    - name: system
+      version: latest
+    - name: elastic_agent
+      version: latest
+    - name: fleet_server
+      version: latest
+    - name: kubernetes
+      version: latest
+    xpack.fleet.agentPolicies:
+    - name: Fleet Server on ECK policy
+      id: eck-fleet-server
+      namespace: default
+      is_managed: true
+      monitoring_enabled:
+      - logs
+      - metrics
+      package_policies:
+      - name: fleet_server-1
+        id: fleet_server-1
+        package:
+          name: fleet_server
+    - name: Elastic Agent on ECK policy
+      id: eck-agent
+      namespace: default
+      is_managed: true
+      monitoring_enabled:
+      - logs
+      - metrics
+      unenroll_timeout: 900
+      package_policies:
+      - package:
+          name: system
+        name: system-1
+      - package:
+          name: kubernetes
+        name: kubernetes-1
 
 eck-agent:
   enabled: true

--- a/deploy/eck-stack/values.yaml
+++ b/deploy/eck-stack/values.yaml
@@ -14,11 +14,10 @@ eck-elasticsearch:
 #
 eck-kibana:
   enabled: true
-  spec:
-    # This is also adjusting the kibana reference to the elasticsearch resource named previously so that
-    # both the eck-elasticsearch and the eck-kibana chart work together by default in the eck-stack chart.
-    elasticsearchRef:
-      name: elasticsearch
+  # This is also adjusting the kibana reference to the elasticsearch resource named previously so that
+  # both the eck-elasticsearch and the eck-kibana chart work together by default in the eck-stack chart.
+  elasticsearchRef:
+    name: elasticsearch
 
 # If enabled, will use the eck-agent chart and deploy an Elastic Agent instance.
 #


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.16`:
 - [Remove additional spec references in Helm eck-stack chart. (#8286)](https://github.com/elastic/cloud-on-k8s/pull/8286)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)