### PR TITLE
[2.16] eck-fleet-server: fix helm tests + change defaults (#8296)

### DIFF
--- a/deploy/eck-stack/templates/tests/elastic-fleet-agent_test.yaml
+++ b/deploy/eck-stack/templates/tests/elastic-fleet-agent_test.yaml
@@ -6,7 +6,9 @@ tests:
   - it: should render quickstart properly
     set:
       eck-agent.enabled: true
-      eck-fleet-server.enabled: true
+      eck-fleet-server:
+        enabled: true
+        deployment: {}
     release:
       name: quickstart
     asserts:
@@ -40,11 +42,10 @@ tests:
             mode: fleet
             fleetServerEnabled: true
             policyID: eck-fleet-server
+            serviceAccountName: fleet-server
             deployment:
               replicas: 1
               podTemplate:
                 spec:
                   serviceAccountName: fleet-server
                   automountServiceAccountToken: true
-                  securityContext:
-                    runAsUser: 0

--- a/deploy/eck-stack/templates/tests/elastic-fleet-agent_test.yaml
+++ b/deploy/eck-stack/templates/tests/elastic-fleet-agent_test.yaml
@@ -42,10 +42,11 @@ tests:
             mode: fleet
             fleetServerEnabled: true
             policyID: eck-fleet-server
-            serviceAccountName: fleet-server
             deployment:
               replicas: 1
               podTemplate:
                 spec:
                   serviceAccountName: fleet-server
                   automountServiceAccountToken: true
+                  securityContext:
+                    runAsUser: 0


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.16`:
 - [eck-fleet-server: fix helm tests + change defaults (#8296)](https://github.com/elastic/cloud-on-k8s/pull/8296)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)