### PR TITLE
[2.16] Make helm charts consistent with how fields in spec are handled. (fleet-server only) (#8285)

### DIFF
--- a/deploy/eck-stack/charts/eck-fleet-server/examples/fleet-server.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/examples/fleet-server.yaml
@@ -1,0 +1,17 @@
+version: 8.17.0-SNAPSHOT
+deployment:
+  replicas: 1
+  podTemplate:
+    spec:
+      serviceAccountName: fleet-server
+      automountServiceAccountToken: true
+elasticsearchRefs:
+- name: eck-elasticsearch
+kibanaRef:
+  name: eck-kibana
+http:
+  service:
+    spec:
+      type: ClusterIP
+serviceAccount:
+  name: fleet-server

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
@@ -11,13 +11,54 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  version: {{ required "A Fleet Server version is required" .Values.version }}
+  version: {{ required "A Fleet Server version is required" (or ((.Values.spec).version) (.Values.version)) }}
   mode: fleet
   fleetServerEnabled: true
-  {{- if (hasKey .Values.spec "mode") }}
-  {{- fail "spec.mode cannot be changed" }}
+  {{- if (or (hasKey (.Values.spec) "mode") (hasKey .Values "mode")) }}
+  {{- fail "mode cannot be changed" }}
   {{- end }}
-  {{- if (hasKey .Values.spec "fleetServerEnabled") }}
-  {{- fail "spec.fleetServerEnabled cannot be changed" }}
+  {{- if (or (hasKey (.Values.spec) "fleetServerEnabled") (hasKey .Values "fleetServerEnabled"))}}
+  {{- fail "fleetServerEnabled cannot be changed" }}
   {{- end }}
-  {{- toYaml .Values.spec | nindent 2 }}
+
+  {{- $statefulSet := (or (hasKey (.Values.spec) "statefulSet") (hasKey .Values "statefulSet")) }}
+  {{- $deployment := (or (hasKey (.Values.spec) "deployment") (hasKey .Values "deployment")) }}
+  {{- if and (not $statefulSet) (not $deployment) }}
+  {{ fail "At least one of statefulSet or deployment is required" }}
+  {{- end }}
+  {{- if $statefulSet }}
+  {{- $ss := or ((.Values.spec).statefulSet) (.Values.statefulSet) }}
+  statefulSet:
+    {{- /* This is required to render the empty statefulSet ( {} ) properly */}}
+    {{- $ss | default dict | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if $deployment }}
+  {{- $deploy := or ((.Values.spec).deployment) (.Values.deployment) }}
+  deployment:
+    {{- /* This is required to render the empty deployment ( {} ) properly */}}
+    {{- $deploy | default dict | toYaml | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).image) (.Values.image) }}
+  image: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).elasticsearchRefs) (.Values.elasticsearchRefs) }}
+  elasticsearchRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).kibanaRef) (.Values.kibanaRef) }}
+  kibanaRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).policyID) (.Values.policyID) }}
+  policyID: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).http) (.Values.http) }}
+  http:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).revisionHistoryLimit) (.Values.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with or (((.Values.spec).serviceAccount).name) ((.Values.serviceAccount).name) }}
+  serviceAccountName: {{ . }}
+  {{- end }}

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
@@ -3,6 +3,15 @@ templates:
   - templates/fleet-server.yaml
 tests:
   - it: should render default fleet server properly
+    set:
+      deployment:
+        replicas: 1
+        podTemplate:
+          spec:
+            serviceAccountName: fleet-server
+            automountServiceAccountToken: true
+      kibanaRef:
+        name: eck-kibana
     release:
       name: quickstart
     asserts:
@@ -18,23 +27,20 @@ tests:
           path: spec.kibanaRef.name
           value: eck-kibana
       - equal:
-          path: spec.deployment.replicas
-          value: 1
-      - equal:
-          path: spec.deployment.podTemplate.spec.serviceAccountName
-          value: fleet-server
-      - equal:
-          path: spec.deployment.podTemplate.spec.automountServiceAccountToken
-          value: true
-      - equal:
-          path: spec.deployment.podTemplate.spec.securityContext.runAsUser
-          value: 0
+          path: spec.deployment
+          value:
+            replicas: 1
+            podTemplate:
+              spec:
+                serviceAccountName: fleet-server
+                automountServiceAccountToken: true
   - it: should render custom labels and annotations properly.
     set:
       labels:
         test: label
       annotations:
         test: annotation
+      deployment: {}
     release:
       name: quickstart
     asserts:
@@ -53,3 +59,110 @@ tests:
           value:
             eck.k8s.elastic.co/license: basic
             test: annotation
+  - it: should render properly when using spec fields
+    set:
+      spec:
+        deployment: {}
+        elasticsearchRefs:
+        - name: eck-elasticsearch
+          namespace: default
+        kibanaRef:
+          name: eck-kibana
+          namespace: default
+        http:
+          service:
+            spec:
+              type: ClusterIP
+        revisionHistoryLimit: 4
+        serviceAccount:
+          name: elastic-fleet-server
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Agent
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: quickstart
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: eck-fleet-server
+            helm.sh/chart: eck-fleet-server-0.14.0-SNAPSHOT
+      - equal:
+          path: spec
+          value:
+            fleetServerEnabled: true
+            mode: fleet
+            policyID: eck-fleet-server
+            version: 8.17.0-SNAPSHOT
+            deployment: {}
+            elasticsearchRefs:
+            - name: eck-elasticsearch
+              namespace: default
+            kibanaRef:
+              name: eck-kibana
+              namespace: default
+            http:
+              service:
+                spec:
+                  type: ClusterIP
+            revisionHistoryLimit: 4
+            serviceAccountName: elastic-fleet-server
+  - it: should render properly when not using spec fields
+    set:
+      deployment: {}
+      elasticsearchRefs:
+      - name: eck-elasticsearch
+        namespace: default
+      kibanaRef:
+        name: eck-kibana
+        namespace: default
+      http:
+        service:
+          spec:
+            type: ClusterIP
+      revisionHistoryLimit: 4
+      serviceAccount:
+        name: elastic-fleet-server
+    release:
+      name: quickstart
+    asserts:
+      - isKind:
+          of: Agent
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: quickstart
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: eck-fleet-server
+            helm.sh/chart: eck-fleet-server-0.14.0-SNAPSHOT
+      - equal:
+          path: spec
+          value:
+            fleetServerEnabled: true
+            mode: fleet
+            policyID: eck-fleet-server
+            version: 8.17.0-SNAPSHOT
+            deployment: {}
+            elasticsearchRefs:
+            - name: eck-elasticsearch
+              namespace: default
+            kibanaRef:
+              name: eck-kibana
+              namespace: default
+            http:
+              service:
+                spec:
+                  type: ClusterIP
+            revisionHistoryLimit: 4
+            serviceAccountName: elastic-fleet-server
+  - it: not setting version should fail
+    set:
+      version: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "A Fleet Server version is required"
+  - it: not setting a statefulset or deployment should fail
+    asserts:
+      - failedTemplate:
+          errorMessage: "At least one of statefulSet or deployment is required"

--- a/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/templates/tests/fleet-server_test.yaml
@@ -87,14 +87,14 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
-            helm.sh/chart: eck-fleet-server-0.14.0-SNAPSHOT
+            helm.sh/chart: eck-fleet-server-0.14.0
       - equal:
           path: spec
           value:
             fleetServerEnabled: true
             mode: fleet
             policyID: eck-fleet-server
-            version: 8.17.0-SNAPSHOT
+            version: 8.17.0
             deployment: {}
             elasticsearchRefs:
             - name: eck-elasticsearch
@@ -135,14 +135,14 @@ tests:
             app.kubernetes.io/instance: quickstart
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: eck-fleet-server
-            helm.sh/chart: eck-fleet-server-0.14.0-SNAPSHOT
+            helm.sh/chart: eck-fleet-server-0.14.0
       - equal:
           path: spec
           value:
             fleetServerEnabled: true
             mode: fleet
             policyID: eck-fleet-server
-            version: 8.17.0-SNAPSHOT
+            version: 8.17.0
             deployment: {}
             elasticsearchRefs:
             - name: eck-elasticsearch

--- a/deploy/eck-stack/charts/eck-fleet-server/values.yaml
+++ b/deploy/eck-stack/charts/eck-fleet-server/values.yaml
@@ -28,46 +28,74 @@ labels: {}
 #
 annotations: {}
 
-spec:
-  # policyID determines into which Agent Policy this Fleet Server will be enrolled.
-  policyID: eck-fleet-server
+# Elastic Fleet Server Agent image to deploy.
+#
+# image: docker.elastic.co/beats/elastic-agent:8.17.0-SNAPSHOT
 
-  # Referenced resources are below and both elasticsearchRefs and kibanaRef are required for a functional Fleet Server.
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-connect-es
-  #
-  # Reference to ECK-managed Kibana resource.
-  #
-  kibanaRef:
-    name: eck-kibana
-    # Optional namespace reference to Kibana resource.
-    # If not specified, then the namespace of the Fleet Server resource
-    # will be assumed.
-    #
-    # namespace: default
+# ** Deprecation Notice **
+# The previous versions of this Helm Chart simply used the `spec` field here
+# and allowed the user to specify any fields below `spec` that were templated directly
+# into the final Agent/Fleet Server manifest. This is no longer the preferred way to specify these
+# fields and each field that is supported underneath `spec` is now directly specified
+# in this values file. Currently both patterns are supported for backwards compatibility
+# but we plan to remove the `spec` field in the future.
+# spec: {}
 
-  # References to ECK-managed Elasticsearch resource.
-  # This is required for fleet server.
+# Referenced resources are below and both elasticsearchRefs and kibanaRef are required for a functional Fleet Server.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-setting-referenced-resources
+#
+# Reference to ECK-managed Kibana instance.
+# This is required for Fleet Server.
+#
+# kibanaRef:
+#   name: quickstart
+  # Optional namespace reference to Kibana instance.
+  # If not specified, then the namespace of the Fleet Server resource
+  # will be assumed.
   #
-  elasticsearchRefs:
-  - name: eck-elasticsearch
-    # Optional namespace reference to Elasticsearch resource.
-    # If not specified, then the namespace of the Fleet Server resource
-    # will be assumed.
-    #
-    # namespace: default
-  
-  # Daemonset, or Deployment specification for the type of Fleet Server specified.
-  # At least one is required of [daemonSet, deployment].
-  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-chose-the-deployment-model
+  # namespace: default
+
+# Reference to ECK-managed Elasticsearch instance.
+# This is required for Fleet Server.
+#
+elasticsearchRefs: []
+# - name: eck-elasticsearch
+  # Optional namespace reference to Elasticsearch instance.
+  # If not specified, then the namespace of the Fleet Server resource
+  # will be assumed.
   #
-  deployment:
-    replicas: 1
-    podTemplate:
-      spec:
-        serviceAccountName: fleet-server
-        automountServiceAccountToken: true
-        securityContext:
-          runAsUser: 0
+  # namespace: default
+
+# policyID determines into which Agent Policy this Fleet Server will be enrolled.
+policyID: eck-fleet-server
+
+# The HTTP layer configuration for the Fleet Server Service.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-customize-fleet-server-service
+#
+# http:
+
+# Deployment or StatefulSet specification for Fleet Server.
+# At least one is required of [deployment, statefulSet].
+# No default is currently set, refer to https://github.com/elastic/cloud-on-k8s/issues/7429.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-chose-the-deployment-model
+#
+# deployment:
+#   replicas: 1
+#   podTemplate:
+#     spec:
+#       serviceAccountName: fleet-server
+#       automountServiceAccountToken: true
+#
+# statefulSet:
+#   podTemplate:
+#     spec:
+#       serviceAccountName: fleet-server
+#       automountServiceAccountToken: true
+
+# Number of revisions to retain to allow rollback in the underlying Deployment.
+# If not set Kubernetes sets this to 10 by default.
+#
+# revisionHistoryLimit: 2
 
 # ServiceAccount to be used by Elastic Fleet Server. Some Fleet Server features (such as autodiscover or Kubernetes module metricsets)
 # require that Fleet Server Pods interact with Kubernetes APIs. This functionality requires specific permissions

--- a/deploy/eck-stack/examples/agent/fleet-agents.yaml
+++ b/deploy/eck-stack/examples/agent/fleet-agents.yaml
@@ -107,10 +107,16 @@ eck-fleet-server:
 
   fullnameOverride: "fleet-server"
 
-  spec:
-    # Agent policy to be used.
-    policyID: eck-fleet-server
-    kibanaRef:
-      name: kibana
-    elasticsearchRefs:
-    - name: elasticsearch
+  deployment:
+    replicas: 1
+    podTemplate:
+      spec:
+        serviceAccountName: fleet-server
+        automountServiceAccountToken: true
+
+  # Agent policy to be used.
+  policyID: eck-fleet-server
+  kibanaRef:
+    name: kibana
+  elasticsearchRefs:
+  - name: elasticsearch

--- a/deploy/eck-stack/templates/tests/elastic-fleet-agent_test.yaml
+++ b/deploy/eck-stack/templates/tests/elastic-fleet-agent_test.yaml
@@ -33,7 +33,7 @@ tests:
           value: fleet-server
       - equal:
           path: spec
-          value: 
+          value:
             version: 8.17.0
             kibanaRef:
               name: kibana
@@ -48,5 +48,4 @@ tests:
                 spec:
                   serviceAccountName: fleet-server
                   automountServiceAccountToken: true
-                  securityContext:
-                    runAsUser: 0
+            serviceAccountName: fleet-server


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.16`:
 - [Make helm charts consistent with how fields in spec are handled. (fleet-server only) (#8285)](https://github.com/elastic/cloud-on-k8s/pull/8285)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)