### PR TITLE
Fix cert-manager API version

### DIFF
--- a/docs/orchestrating-elastic-stack-applications/security/custom-http-certificate.asciidoc
+++ b/docs/orchestrating-elastic-stack-applications/security/custom-http-certificate.asciidoc
@@ -37,7 +37,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: quickstart-es-cert


### PR DESCRIPTION
It looks like cert-manager.io/v1alpha2 has been replaced with cert-manager.io/v1.
cc @jeanfabrice 
