### PR TITLE
[2.16] Enterprise Search EOL (#8323)

### DIFF
--- a/pkg/controller/common/version/version.go
+++ b/pkg/controller/common/version/version.go
@@ -24,7 +24,7 @@ var GlobalMinStackVersion Version
 // supported Stack versions. See https://www.elastic.co/support/matrix#matrix_compatibility
 var (
 	SupportedAPMServerVersions        = MinMaxVersion{Min: From(6, 2, 0), Max: From(9, 99, 99)}
-	SupportedEnterpriseSearchVersions = MinMaxVersion{Min: From(7, 7, 0), Max: From(9, 99, 99)}
+	SupportedEnterpriseSearchVersions = MinMaxVersion{Min: From(7, 7, 0), Max: From(8, 99, 99)}
 	SupportedKibanaVersions           = MinMaxVersion{Min: From(6, 8, 0), Max: From(9, 99, 99)}
 	SupportedBeatVersions             = MinMaxVersion{Min: From(7, 0, 0), Max: From(9, 99, 99)}
 	// Elastic Agent was introduced in 7.8.0, but as "experimental release" with no migration path forward, hence


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.16`:
 - [Enterprise Search EOL (#8323)](https://github.com/elastic/cloud-on-k8s/pull/8323)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)